### PR TITLE
feat(multitable): S2 template install dry-run + detail view (zero-write)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -58,6 +58,7 @@ import type {
   FormShareConfigUpdate,
   InstallTemplateInput,
   InstallTemplateResult,
+  TemplateDryRunResult,
   ApiToken,
   ApiTokenCreateResult,
   MetaTemplate,
@@ -912,6 +913,17 @@ export class MultitableApiClient {
 
   async installTemplate(templateId: string, input: InstallTemplateInput = {}): Promise<InstallTemplateResult> {
     const res = await this.fetch(`/api/multitable/templates/${encodeURIComponent(templateId)}/install`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return this.parseJson(res)
+  }
+
+  // S2 — zero-write install simulation (design 20260611 §2.1). Same body
+  // shape as install; the server only runs SELECT occupancy probes.
+  async dryRunTemplate(templateId: string, input: InstallTemplateInput = {}): Promise<TemplateDryRunResult> {
+    const res = await this.fetch(`/api/multitable/templates/${encodeURIComponent(templateId)}/dry-run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),

--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -17,14 +17,26 @@
       {{ cardFields(fieldCount, isZh) }} ·
       {{ cardViews(viewCount, isZh) }}
     </small>
-    <button
-      type="button"
-      class="meta-template-card__install"
-      :disabled="installing"
-      @click="emit('install', template)"
-    >
-      {{ installing ? workbenchLabel('card.installing', isZh) : workbenchLabel('card.install', isZh) }}
-    </button>
+    <div class="meta-template-card__actions">
+      <!-- S2: opt-in detail entry (template center only); other consumers
+           (home view, workbench modal) keep the install-only card. -->
+      <button
+        v-if="showDetail"
+        type="button"
+        class="meta-template-card__detail"
+        @click="emit('detail', template)"
+      >
+        {{ workbenchLabel('card.viewDetail', isZh) }}
+      </button>
+      <button
+        type="button"
+        class="meta-template-card__install"
+        :disabled="installing"
+        @click="emit('install', template)"
+      >
+        {{ installing ? workbenchLabel('card.installing', isZh) : workbenchLabel('card.install', isZh) }}
+      </button>
+    </div>
   </article>
 </template>
 
@@ -43,10 +55,12 @@ import {
 const props = defineProps<{
   template: MetaTemplate
   installing?: boolean
+  showDetail?: boolean
 }>()
 
 const emit = defineEmits<{
   (e: 'install', template: MetaTemplate): void
+  (e: 'detail', template: MetaTemplate): void
 }>()
 
 // useLocale().isZh is already a ComputedRef<boolean>; template auto-unwraps it,
@@ -125,8 +139,29 @@ const viewCount = computed(() => {
   color: #94a3b8;
 }
 
-.meta-template-card__install {
+.meta-template-card__actions {
   margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.meta-template-card__detail {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.meta-template-card__detail:hover {
+  border-color: #94a3b8;
+}
+
+.meta-template-card__install {
+  flex: 1 1 auto;
   border: 1px solid #2563eb;
   background: #2563eb;
   color: #ffffff;

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -552,6 +552,40 @@ export interface InstallTemplateResult {
   views: MetaView[]
 }
 
+// S2 — POST /templates/:id/dry-run (design 20260611 §2.1). Zero-write install
+// simulation: wouldCreate ids derive through the same generator path install
+// uses but are illustrative, NOT a promise of the ids a later install creates.
+export type TemplateDryRunConflictKind =
+  | 'base_exists'
+  | 'sheet_exists'
+  | 'view_exists'
+  // Plan-level self-collision inside a (mis-authored) template (review
+  // 2026-06-11 F1) — derived sheet/field/view ids duplicate each other.
+  | 'template_duplicate_id'
+
+export interface TemplateDryRunConflict {
+  severity: 'error'
+  kind: TemplateDryRunConflictKind
+  id: string
+  name: string
+  /** English + stable kind; localize by kind (formula dry-run convention). */
+  message: string
+}
+
+export interface TemplateDryRunWouldCreate {
+  base: { id: string; name: string }
+  sheets: Array<{ id: string; name: string; fieldCount: number; viewCount: number }>
+  fields: Array<{ id: string; sheetId: string; name: string; type: string }>
+  views: Array<{ id: string; sheetId: string; name: string; type: string }>
+}
+
+export interface TemplateDryRunResult {
+  templateId: string
+  wouldCreate: TemplateDryRunWouldCreate
+  conflicts: TemplateDryRunConflict[]
+  installable: boolean
+}
+
 // --- Input types ---
 export interface CreateBaseInput {
   id?: string

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -56,6 +56,14 @@ export type WorkbenchLabelKey =
   | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
   // §3.6 MetaTemplateCard button (counts use the card* helpers below)
   | 'card.install' | 'card.installing'
+  // S2 template detail + dry-run (design 20260611 §2.2)
+  | 'card.viewDetail'
+  | 'detail.back' | 'detail.loading' | 'detail.notFound'
+  | 'detail.fieldsTitle' | 'detail.viewsTitle'
+  | 'detail.colFieldName' | 'detail.colFieldType' | 'detail.groupBy'
+  | 'detail.checkInstallable' | 'detail.checking' | 'detail.dryRunFailed'
+  | 'detail.installableYes' | 'detail.installableNo'
+  | 'detail.wouldCreateTitle' | 'detail.conflictsTitle' | 'detail.conflictHint'
   // final audit closure follow-up: composable fallback messages (backend e.message remains raw)
   | 'error.loadSheets' | 'error.loadSheetMetadata' | 'error.loadBaseMetadata'
 
@@ -200,6 +208,36 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'card.install': { en: 'Use template', zh: '使用模板' },
   'card.installing': { en: 'Installing...', zh: '创建中...' },
 
+  'card.viewDetail': { en: 'View details', zh: '查看详情' },
+  'detail.back': { en: '← Back to template center', zh: '← 返回模板中心' },
+  'detail.loading': { en: 'Loading template...', zh: '正在加载模板...' },
+  'detail.notFound': { en: 'Template not found.', zh: '未找到该模板。' },
+  'detail.fieldsTitle': { en: 'Fields', zh: '字段' },
+  'detail.viewsTitle': { en: 'Views', zh: '视图' },
+  'detail.colFieldName': { en: 'Field', zh: '字段名称' },
+  'detail.colFieldType': { en: 'Type', zh: '类型' },
+  'detail.groupBy': { en: 'Grouped by', zh: '分组字段' },
+  'detail.checkInstallable': { en: 'Check installability', zh: '检查可安装性' },
+  'detail.checking': { en: 'Checking...', zh: '检查中...' },
+  'detail.dryRunFailed': { en: 'Installability check failed', zh: '可安装性检查失败' },
+  'detail.installableYes': {
+    en: 'Ready to install — no conflicts detected.',
+    zh: '可以安装——未检测到冲突。',
+  },
+  'detail.installableNo': {
+    en: 'Conflicts detected — install is blocked.',
+    zh: '检测到冲突——安装已被阻止。',
+  },
+  'detail.wouldCreateTitle': { en: 'Will create', zh: '将创建' },
+  'detail.conflictsTitle': { en: 'Conflicts', zh: '冲突' },
+  // Review 2026-06-11 F4: truthful copy — baseName never enters id
+  // derivation (and the detail page has no baseName input), so the hint must
+  // not suggest renaming; a re-check is what can change the outcome.
+  'detail.conflictHint': {
+    en: 'Existing objects conflict with this template. Re-check before installing.',
+    zh: '存在与模板冲突的对象，安装前请重新检查。',
+  },
+
   'error.loadSheets': { en: 'Failed to load sheets', zh: '加载 Sheet 失败' },
   'error.loadSheetMetadata': { en: 'Failed to load sheet metadata', zh: '加载 Sheet 元数据失败' },
   'error.loadBaseMetadata': { en: 'Failed to load base metadata', zh: '加载 Base 元数据失败' },
@@ -295,6 +333,19 @@ export function recordsDeleted(n: number, isZh: boolean): string {
 
 export function recordNotFound(recordId: string, isZh: boolean): string {
   return isZh ? `未找到记录：${recordId}` : `Record not found: ${recordId}`
+}
+
+// S2 dry-run conflicts: the server emits English messages plus a stable
+// `kind`; the client localizes by kind (formula dry-run convention) and may
+// show the raw message as secondary detail. Unknown kinds pass through raw.
+export function templateConflictKindLabel(kind: string, isZh: boolean): string {
+  switch (kind) {
+    case 'base_exists': return isZh ? 'Base 已存在' : 'Base already exists'
+    case 'sheet_exists': return isZh ? 'Sheet 已存在' : 'Sheet already exists'
+    case 'view_exists': return isZh ? '视图已存在' : 'View already exists'
+    case 'template_duplicate_id': return isZh ? '模板内部 id 重复' : 'Duplicate id inside template'
+    default: return kind
+  }
 }
 
 // MetaTemplateCard counts: zh "{n} 个 Sheet/字段/视图"; en pluralized.

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -122,6 +122,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Templates', titleZh: '模板中心', requiresAuth: true },
   },
   {
+    path: ROUTE_PATHS.MULTITABLE_TEMPLATE_DETAIL,
+    name: AppRouteNames.MULTITABLE_TEMPLATE_DETAIL,
+    component: () => import('../views/MultitableTemplateDetailView.vue'),
+    meta: { title: 'Template Details', titleZh: '模板详情', requiresAuth: true },
+  },
+  {
     path: '/data-sources',
     name: 'data-sources',
     component: () => import('../views/DataSourcesView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -76,6 +76,7 @@ export const AppRouteNames = {
   ATTENDANCE: 'attendance',
   MULTITABLE_HOME: 'multitable-home',
   MULTITABLE_TEMPLATES: 'multitable-templates',
+  MULTITABLE_TEMPLATE_DETAIL: 'multitable-template-detail',
   MULTITABLE: 'multitable',
   MULTITABLE_PUBLIC_FORM: 'multitable-public-form',
   MULTITABLE_COMMENT_INBOX: 'multitable-comment-inbox',
@@ -156,6 +157,7 @@ export interface AppRouteParams {
   'attendance': Record<string, never>
   'multitable-home': Record<string, never>
   'multitable-templates': Record<string, never>
+  'multitable-template-detail': { templateId: string }
   'multitable': { sheetId: string; viewId: string }
   'multitable-public-form': { sheetId: string; viewId: string }
   'multitable-comment-inbox': Record<string, never>
@@ -451,6 +453,9 @@ export const ROUTE_PATHS = {
   ATTENDANCE: '/attendance',
   MULTITABLE_HOME: '/multitable',
   MULTITABLE_TEMPLATES: '/multitable/templates',
+  // Static 'templates' segment outranks MULTITABLE's ':sheetId' param in
+  // vue-router scoring, so this never shadows /multitable/:sheetId/:viewId.
+  MULTITABLE_TEMPLATE_DETAIL: '/multitable/templates/:templateId',
   MULTITABLE: '/multitable/:sheetId/:viewId',
   MULTITABLE_PUBLIC_FORM: '/multitable/public-form/:sheetId/:viewId',
   MULTITABLE_COMMENT_INBOX: '/multitable/comments/inbox',

--- a/apps/web/src/views/MultitableTemplateCenterView.vue
+++ b/apps/web/src/views/MultitableTemplateCenterView.vue
@@ -81,7 +81,9 @@
         :key="template.id"
         :template="template"
         :installing="installingTemplateId === template.id"
+        show-detail
         @install="onInstall"
+        @detail="onDetail"
       />
     </div>
   </section>
@@ -89,6 +91,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import MetaTemplateCard from '../multitable/components/MetaTemplateCard.vue'
 import { multitableClient } from '../multitable/api/client'
 import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
@@ -99,6 +102,7 @@ import { AppRouteNames } from '../router/types'
 const ALL_CATEGORY = '__all__'
 const HomeRouteName = AppRouteNames.MULTITABLE_HOME
 
+const router = useRouter()
 const templates = ref<MetaTemplate[]>([])
 const loading = ref(false)
 const errorMessage = ref('')
@@ -159,6 +163,13 @@ async function loadTemplates(): Promise<void> {
 
 async function onInstall(template: MetaTemplate): Promise<void> {
   await installAndOpen(template)
+}
+
+function onDetail(template: MetaTemplate): void {
+  void router.push({
+    name: AppRouteNames.MULTITABLE_TEMPLATE_DETAIL,
+    params: { templateId: template.id },
+  })
 }
 
 onMounted(() => {

--- a/apps/web/src/views/MultitableTemplateDetailView.vue
+++ b/apps/web/src/views/MultitableTemplateDetailView.vue
@@ -1,0 +1,529 @@
+<template>
+  <section class="multitable-template-detail" data-testid="multitable-template-detail">
+    <header class="multitable-template-detail__top">
+      <router-link class="multitable-template-detail__back" :to="{ name: TemplatesRouteName }">
+        {{ workbenchLabel('detail.back', isZh) }}
+      </router-link>
+    </header>
+
+    <div v-if="loading" class="multitable-template-detail__state">
+      {{ workbenchLabel('detail.loading', isZh) }}
+    </div>
+    <p v-else-if="errorMessage" class="multitable-template-detail__error" role="alert">
+      {{ errorMessage }}
+    </p>
+    <div v-else-if="!template" class="multitable-template-detail__state">
+      {{ workbenchLabel('detail.notFound', isZh) }}
+    </div>
+    <template v-else>
+      <header class="multitable-template-detail__hero">
+        <span
+          class="multitable-template-detail__icon"
+          :style="{ background: template.color || '#2563eb' }"
+        >
+          {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
+        </span>
+        <div class="multitable-template-detail__heading">
+          <h1>{{ template.name }}</h1>
+          <p class="multitable-template-detail__description">{{ template.description }}</p>
+          <small class="multitable-template-detail__meta">
+            {{ categoryDisplay }} ·
+            {{ cardSheets(template.sheets.length, isZh) }} ·
+            {{ cardFields(fieldCount, isZh) }} ·
+            {{ cardViews(viewCount, isZh) }}
+          </small>
+        </div>
+      </header>
+
+      <section
+        v-for="sheet in template.sheets"
+        :key="sheet.id"
+        class="multitable-template-detail__sheet"
+      >
+        <h2>{{ sheet.name }}</h2>
+        <p v-if="sheet.description" class="multitable-template-detail__sheet-desc">
+          {{ sheet.description }}
+        </p>
+
+        <h3>{{ workbenchLabel('detail.fieldsTitle', isZh) }}</h3>
+        <table class="multitable-template-detail__fields" data-testid="template-detail-fields">
+          <thead>
+            <tr>
+              <th>{{ workbenchLabel('detail.colFieldName', isZh) }}</th>
+              <th>{{ workbenchLabel('detail.colFieldType', isZh) }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="field in sheet.fields" :key="field.id">
+              <td>{{ field.name }}</td>
+              <td><code>{{ field.type }}</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>{{ workbenchLabel('detail.viewsTitle', isZh) }}</h3>
+        <ul class="multitable-template-detail__views" data-testid="template-detail-views">
+          <li v-for="view in sheet.views" :key="view.id">
+            <strong>{{ view.name }}</strong>
+            <code>{{ view.type }}</code>
+            <span v-if="groupByFieldName(sheet, view)">
+              {{ workbenchLabel('detail.groupBy', isZh) }}: {{ groupByFieldName(sheet, view) }}
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- EXTENSION POINT (PM-gated, G-4 — design 20260611 §4): the sample-data
+           preview renders here once PM/SME provides per-template sample
+           records. S2 deliberately renders NO sample data. -->
+
+      <section class="multitable-template-detail__dryrun">
+        <button
+          type="button"
+          class="multitable-template-detail__check"
+          data-testid="template-detail-dryrun"
+          :disabled="checking"
+          @click="runDryRun"
+        >
+          {{ checking ? workbenchLabel('detail.checking', isZh) : workbenchLabel('detail.checkInstallable', isZh) }}
+        </button>
+        <p v-if="dryRunError" class="multitable-template-detail__error" role="alert">
+          {{ dryRunError }}
+        </p>
+        <div
+          v-if="dryRun"
+          class="multitable-template-detail__dryrun-result"
+          data-testid="template-detail-dryrun-result"
+        >
+          <p
+            class="multitable-template-detail__verdict"
+            :class="dryRun.installable
+              ? 'multitable-template-detail__verdict--ok'
+              : 'multitable-template-detail__verdict--blocked'"
+            role="status"
+          >
+            {{ dryRun.installable
+              ? workbenchLabel('detail.installableYes', isZh)
+              : workbenchLabel('detail.installableNo', isZh) }}
+          </p>
+          <p class="multitable-template-detail__would-create">
+            {{ workbenchLabel('detail.wouldCreateTitle', isZh) }}: {{ dryRun.wouldCreate.base.name }} —
+            {{ cardSheets(dryRun.wouldCreate.sheets.length, isZh) }} ·
+            {{ cardFields(dryRun.wouldCreate.fields.length, isZh) }} ·
+            {{ cardViews(dryRun.wouldCreate.views.length, isZh) }}
+          </p>
+          <template v-if="dryRun.conflicts.length">
+            <h3>{{ workbenchLabel('detail.conflictsTitle', isZh) }}</h3>
+            <ul class="multitable-template-detail__conflicts" data-testid="template-detail-conflicts">
+              <li v-for="conflict in dryRun.conflicts" :key="`${conflict.kind}:${conflict.id}`">
+                <strong>{{ templateConflictKindLabel(conflict.kind, isZh) }}</strong>
+                <span>{{ conflict.message }}</span>
+              </li>
+            </ul>
+          </template>
+          <p
+            v-if="!dryRun.installable"
+            class="multitable-template-detail__hint"
+            data-testid="template-detail-conflict-hint"
+          >
+            {{ workbenchLabel('detail.conflictHint', isZh) }}
+          </p>
+        </div>
+      </section>
+
+      <footer class="multitable-template-detail__footer">
+        <p v-if="installError" class="multitable-template-detail__warning" role="status">
+          {{ installError }}
+        </p>
+        <button
+          type="button"
+          class="multitable-template-detail__install"
+          data-testid="template-detail-install"
+          :disabled="installDisabled"
+          @click="onInstall"
+        >
+          {{ installing ? workbenchLabel('card.installing', isZh) : workbenchLabel('card.install', isZh) }}
+        </button>
+      </footer>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+// S2 template detail (design 20260611 §2.2): descriptor structure + dry-run
+// installability check + the existing install flow (useTemplateInstall).
+import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { multitableClient } from '../multitable/api/client'
+import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
+import { useLocale } from '../composables/useLocale'
+import { categoryLabel } from '../multitable/utils/category-labels'
+import {
+  cardFields,
+  cardSheets,
+  cardViews,
+  templateConflictKindLabel,
+  workbenchLabel,
+} from '../multitable/utils/workbench-labels'
+import type {
+  MetaTemplate,
+  MetaTemplateSheet,
+  MetaTemplateView,
+  TemplateDryRunResult,
+} from '../multitable/types'
+import { AppRouteNames } from '../router/types'
+
+const TemplatesRouteName = AppRouteNames.MULTITABLE_TEMPLATES
+
+const route = useRoute()
+const { isZh } = useLocale()
+
+const template = ref<MetaTemplate | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+
+const dryRun = ref<TemplateDryRunResult | null>(null)
+const checking = ref(false)
+const dryRunError = ref('')
+
+const { installingTemplateId, errorMessage: installError, installAndOpen } = useTemplateInstall()
+
+const templateId = computed(() => String(route.params.templateId ?? '').trim())
+const installing = computed(() => installingTemplateId.value === template.value?.id)
+// Conflicts block install (design §2.2); no dry-run yet keeps the existing
+// optimistic install path (the server still 409s as the hard backstop).
+const installDisabled = computed(
+  () => installing.value || (dryRun.value !== null && !dryRun.value.installable),
+)
+
+const categoryDisplay = computed(() => {
+  if (!template.value) return ''
+  return categoryLabel(template.value.category, isZh.value ? 'zh-CN' : 'en')
+})
+
+const fieldCount = computed(
+  () => template.value?.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0) ?? 0,
+)
+
+const viewCount = computed(
+  () => template.value?.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0) ?? 0,
+)
+
+// Mirrors the default baseName useTemplateInstall sends on install, so the
+// dry-run answers the question for the install the button would actually run.
+function defaultBaseName(tpl: MetaTemplate): string {
+  return `${tpl.name} Base`
+}
+
+function groupByFieldName(sheet: MetaTemplateSheet, view: MetaTemplateView): string {
+  if (!view.groupByFieldId) return ''
+  return sheet.fields.find((field) => field.id === view.groupByFieldId)?.name ?? view.groupByFieldId
+}
+
+async function loadTemplate(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await multitableClient.listTemplates()
+    template.value = (data.templates ?? []).find((tpl) => tpl.id === templateId.value) ?? null
+  } catch (error) {
+    errorMessage.value = error instanceof Error
+      ? error.message
+      : workbenchLabel('tpl.errorLoad', isZh.value)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function runDryRun(): Promise<void> {
+  if (!template.value || checking.value) return
+  checking.value = true
+  dryRunError.value = ''
+  try {
+    dryRun.value = await multitableClient.dryRunTemplate(template.value.id, {
+      baseName: defaultBaseName(template.value),
+    })
+  } catch (error) {
+    dryRun.value = null
+    dryRunError.value = error instanceof Error
+      ? error.message
+      : workbenchLabel('detail.dryRunFailed', isZh.value)
+  } finally {
+    checking.value = false
+  }
+}
+
+async function onInstall(): Promise<void> {
+  if (!template.value) return
+  await installAndOpen(template.value)
+}
+
+onMounted(() => {
+  void loadTemplate()
+})
+</script>
+
+<style scoped>
+.multitable-template-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.multitable-template-detail__back {
+  font-size: 0.875rem;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.multitable-template-detail__back:hover {
+  text-decoration: underline;
+}
+
+.multitable-template-detail__state {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.875rem;
+  background: #f8fafc;
+  border-radius: 8px;
+}
+
+.multitable-template-detail__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #b91c1c;
+  border-radius: 8px;
+}
+
+.multitable-template-detail__hero {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.multitable-template-detail__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 10px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1.125rem;
+  flex: 0 0 auto;
+}
+
+.multitable-template-detail__heading h1 {
+  margin: 0;
+  font-size: 1.375rem;
+  color: #0f172a;
+}
+
+.multitable-template-detail__description {
+  margin: 0.25rem 0;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.multitable-template-detail__meta {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.multitable-template-detail__sheet {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+}
+
+.multitable-template-detail__sheet h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.multitable-template-detail__sheet h3 {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.8125rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.multitable-template-detail__sheet-desc {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: #64748b;
+}
+
+.multitable-template-detail__fields {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.multitable-template-detail__fields th,
+.multitable-template-detail__fields td {
+  text-align: left;
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid #f1f5f9;
+  color: #0f172a;
+}
+
+.multitable-template-detail__fields th {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.multitable-template-detail__views {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.multitable-template-detail__views li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.875rem;
+  color: #0f172a;
+}
+
+.multitable-template-detail__views span {
+  color: #64748b;
+  font-size: 0.8125rem;
+}
+
+.multitable-template-detail__dryrun {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.multitable-template-detail__check {
+  align-self: flex-start;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.multitable-template-detail__check:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.multitable-template-detail__dryrun-result {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.875rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.multitable-template-detail__dryrun-result h3 {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #475569;
+}
+
+.multitable-template-detail__verdict {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.multitable-template-detail__verdict--ok {
+  color: #15803d;
+}
+
+.multitable-template-detail__verdict--blocked {
+  color: #b91c1c;
+}
+
+.multitable-template-detail__would-create {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #475569;
+}
+
+.multitable-template-detail__conflicts {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.multitable-template-detail__conflicts li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.8125rem;
+  color: #b91c1c;
+}
+
+.multitable-template-detail__conflicts span {
+  color: #7f1d1d;
+}
+
+.multitable-template-detail__hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #92400e;
+}
+
+.multitable-template-detail__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.multitable-template-detail__warning {
+  margin: 0;
+  padding: 0.5rem 0.875rem;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  color: #92400e;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.multitable-template-detail__install {
+  align-self: flex-start;
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.multitable-template-detail__install:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.multitable-template-detail__install:hover:not(:disabled) {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+</style>

--- a/apps/web/tests/multitable-template-center-view.spec.ts
+++ b/apps/web/tests/multitable-template-center-view.spec.ts
@@ -295,6 +295,25 @@ describe('MultitableTemplateCenterView', () => {
     expect(root.textContent).toContain('没有匹配的模板')
   })
 
+  // S2: the card's detail entry navigates to the template detail route.
+  it('查看详情 navigates to the template detail view', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [makeTemplate({ id: 'project-tracker', name: 'Project Tracker' })],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '查看详情').click()
+    await flushUi()
+
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE_TEMPLATE_DETAIL,
+      params: { templateId: 'project-tracker' },
+    })
+    expect(mocks.installTemplate).not.toHaveBeenCalled()
+  })
+
   it('hero shows a link back to multitable home', async () => {
     mocks.listTemplates.mockResolvedValue({ templates: [] })
 

--- a/apps/web/tests/multitable-template-detail-view.spec.ts
+++ b/apps/web/tests/multitable-template-detail-view.spec.ts
@@ -1,0 +1,280 @@
+// S2-T5 — template detail view (design 20260611 §2.2): descriptor structure
+// rendering, dry-run trigger + result rendering, and the conflicts→install-
+// button-disable flow. NO sample-data rendering (PM-gated, G-4).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import MultitableTemplateDetailView from '../src/views/MultitableTemplateDetailView.vue'
+import { AppRouteNames } from '../src/router/types'
+import { useLocale } from '../src/composables/useLocale'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  listTemplates: vi.fn(),
+  installTemplate: vi.fn(),
+  dryRunTemplate: vi.fn(),
+  routeParams: { templateId: 'project-tracker' } as Record<string, string>,
+}))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: mocks.push }),
+    useRoute: () => ({ params: mocks.routeParams }),
+  }
+})
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listTemplates: mocks.listTemplates,
+    installTemplate: mocks.installTemplate,
+    dryRunTemplate: mocks.dryRunTemplate,
+  },
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const PROJECT_TRACKER = {
+  id: 'project-tracker',
+  name: 'Project Tracker',
+  description: 'Track owners, priorities, due dates, status, and execution notes.',
+  category: 'Project management',
+  icon: 'kanban',
+  color: '#2563eb',
+  sheets: [
+    {
+      id: 'tasks',
+      name: 'Tasks',
+      description: 'Project task pipeline',
+      fields: [
+        { id: 'task', name: 'Task', type: 'string', order: 0 },
+        { id: 'status', name: 'Status', type: 'select', order: 1, options: ['Not started', 'Done'] },
+        { id: 'dueDate', name: 'Due Date', type: 'date', order: 2 },
+      ],
+      views: [
+        { id: 'grid', name: 'All Tasks', type: 'grid' },
+        { id: 'kanban', name: 'By Status', type: 'kanban', groupByFieldId: 'status' },
+      ],
+    },
+  ],
+}
+
+function cleanDryRunResult() {
+  return {
+    templateId: 'project-tracker',
+    wouldCreate: {
+      base: { id: 'base_abc', name: 'Project Tracker Base' },
+      sheets: [{ id: 'sheet_abc', name: 'Tasks', fieldCount: 3, viewCount: 2 }],
+      fields: [
+        { id: 'fld_1', sheetId: 'sheet_abc', name: 'Task', type: 'string' },
+        { id: 'fld_2', sheetId: 'sheet_abc', name: 'Status', type: 'select' },
+        { id: 'fld_3', sheetId: 'sheet_abc', name: 'Due Date', type: 'date' },
+      ],
+      views: [
+        { id: 'view_1', sheetId: 'sheet_abc', name: 'All Tasks', type: 'grid' },
+        { id: 'view_2', sheetId: 'sheet_abc', name: 'By Status', type: 'kanban' },
+      ],
+    },
+    conflicts: [],
+    installable: true,
+  }
+}
+
+function conflictedDryRunResult() {
+  const result = cleanDryRunResult()
+  return {
+    ...result,
+    conflicts: [
+      {
+        severity: 'error',
+        kind: 'sheet_exists',
+        id: 'sheet_abc',
+        name: 'Tasks',
+        message: 'Sheet already exists: sheet_abc',
+      },
+    ],
+    installable: false,
+  }
+}
+
+function findButton(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((node) =>
+    (node.textContent?.trim() ?? '').includes(text),
+  )
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  return button
+}
+
+describe('MultitableTemplateDetailView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    useLocale().setLocale('zh-CN')
+    mocks.routeParams.templateId = 'project-tracker'
+    mocks.listTemplates.mockResolvedValue({ templates: [PROJECT_TRACKER] })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    useLocale().setLocale('en')
+    vi.clearAllMocks()
+  })
+
+  function mountView() {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(MultitableTemplateDetailView as Component)
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        const href = typeof this.$props.to === 'string' ? this.$props.to : JSON.stringify(this.$props.to)
+        return h('a', { href, 'data-router-link-to': href }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+    app.mount(container)
+    return container
+  }
+
+  it('renders the descriptor structure: sheet, field table (name/type), views with group-by field', async () => {
+    const root = mountView()
+    await flushUi()
+
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
+    expect(root.textContent).toContain('Project Tracker')
+    expect(root.textContent).toContain('Tasks')
+
+    const fieldRows = Array.from(root.querySelectorAll('[data-testid="template-detail-fields"] tbody tr'))
+    expect(fieldRows.map((row) =>
+      Array.from(row.querySelectorAll('td')).map((cell) => cell.textContent?.trim()).join(' | '),
+    )).toEqual([
+      'Task | string',
+      'Status | select',
+      'Due Date | date',
+    ])
+
+    const viewItems = Array.from(root.querySelectorAll('[data-testid="template-detail-views"] li'))
+    expect(viewItems).toHaveLength(2)
+    expect(viewItems[0].textContent).toContain('All Tasks')
+    expect(viewItems[0].textContent).toContain('grid')
+    expect(viewItems[1].textContent).toContain('By Status')
+    // groupByFieldId resolved to the field NAME, not the raw id.
+    expect(viewItems[1].textContent).toContain('Status')
+
+    // No dry-run result before the user asks for one.
+    expect(root.querySelector('[data-testid="template-detail-dryrun-result"]')).toBeNull()
+    // Install stays enabled until a dry-run reports conflicts.
+    expect(findButton(root, '使用模板').disabled).toBe(false)
+  })
+
+  it('shows a not-found state for an unknown templateId', async () => {
+    mocks.routeParams.templateId = 'no-such-template'
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('未找到该模板')
+  })
+
+  it('检查可安装性 runs the dry-run and renders the wouldCreate summary (installable)', async () => {
+    mocks.dryRunTemplate.mockResolvedValue(cleanDryRunResult())
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '检查可安装性').click()
+    await flushUi()
+
+    expect(mocks.dryRunTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    const result = root.querySelector('[data-testid="template-detail-dryrun-result"]')
+    expect(result).not.toBeNull()
+    expect(result?.textContent).toContain('可以安装')
+    expect(result?.textContent).toContain('Project Tracker Base')
+    expect(result?.textContent).toContain('1 个 Sheet')
+    expect(result?.textContent).toContain('3 个字段')
+    expect(result?.textContent).toContain('2 个视图')
+    expect(root.querySelector('[data-testid="template-detail-conflicts"]')).toBeNull()
+    expect(findButton(root, '使用模板').disabled).toBe(false)
+  })
+
+  it('conflicts disable the install button and show the re-check hint', async () => {
+    mocks.dryRunTemplate.mockResolvedValue(conflictedDryRunResult())
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '检查可安装性').click()
+    await flushUi()
+
+    expect(root.textContent).toContain('检测到冲突')
+    const conflictItems = Array.from(root.querySelectorAll('[data-testid="template-detail-conflicts"] li'))
+    expect(conflictItems).toHaveLength(1)
+    expect(conflictItems[0].textContent).toContain('Sheet 已存在')
+    expect(conflictItems[0].textContent).toContain('Sheet already exists: sheet_abc')
+    // Review 2026-06-11 F4: truthful copy — must NOT suggest changing the
+    // base name (baseName never enters id derivation; no such input exists).
+    const hint = root.querySelector('[data-testid="template-detail-conflict-hint"]')?.textContent ?? ''
+    expect(hint).toContain('安装前请重新检查')
+    expect(hint).not.toContain('Base 名称')
+    expect(findButton(root, '使用模板').disabled).toBe(true)
+  })
+
+  it('dry-run failure surfaces an error and leaves install enabled', async () => {
+    mocks.dryRunTemplate.mockRejectedValue(new Error('boom-dry-run'))
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '检查可安装性').click()
+    await flushUi()
+
+    expect(root.textContent).toContain('boom-dry-run')
+    expect(root.querySelector('[data-testid="template-detail-dryrun-result"]')).toBeNull()
+    expect(findButton(root, '使用模板').disabled).toBe(false)
+  })
+
+  it('install reuses useTemplateInstall: installs and navigates to the new base', async () => {
+    mocks.installTemplate.mockResolvedValue({
+      template: { id: 'project-tracker', name: 'Project Tracker' },
+      base: { id: 'base_new', name: 'Project Tracker Base' },
+      sheets: [{ id: 'sheet_new', baseId: 'base_new', name: 'Tasks' }],
+      fields: [],
+      views: [{ id: 'view_new', sheetId: 'sheet_new', name: 'Grid', type: 'grid' }],
+    })
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '使用模板').click()
+    await flushUi()
+
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: 'sheet_new', viewId: 'view_new' },
+      query: { baseId: 'base_new' },
+    })
+  })
+
+  it('load failure shows the error message', async () => {
+    mocks.listTemplates.mockRejectedValue(new Error('网络断了'))
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('网络断了')
+  })
+
+  it('hero shows a link back to the template center', async () => {
+    const root = mountView()
+    await flushUi()
+
+    const backLink = root.querySelector<HTMLElement>('.multitable-template-detail__back')
+    expect(backLink).not.toBeNull()
+    expect(backLink?.getAttribute('data-router-link-to')).toContain(AppRouteNames.MULTITABLE_TEMPLATES)
+  })
+})

--- a/docs/development/multitable-template-dryrun-detail-s2-design-20260611.md
+++ b/docs/development/multitable-template-dryrun-detail-s2-design-20260611.md
@@ -49,6 +49,8 @@ S2(工程版)= ①`POST /templates/:id/dry-run`:**零写**模拟 install,返回 
 
 不动 install 语义/事务;无迁移;无 OpenAPI(两路由维持 internal 姿态——GET /templates 本就不在 spec,核实后保持一致);无 onboarding;无回滚语义变更(T7);不为 8 个模板authoring 任何内容。
 
+> **勘误(2026-06-11,S2 评审 F2)**:上行"GET /templates 本就不在 spec"与事实不符——GET /templates 与 POST install 均已在 `packages/openapi`(`scripts/ops/multitable-openapi-parity.test.mjs` 断言其存在);操作性锁定不变(dry-run 维持 spec 外),补录 dry-run 进 spec 为可选的后续 docs PR。
+
 ## 3. 测试矩阵(fail-first)
 
 | # | 场景 | 断言 |

--- a/packages/core-backend/src/multitable/template-library.ts
+++ b/packages/core-backend/src/multitable/template-library.ts
@@ -71,6 +71,35 @@ export type InstallMultitableTemplateResult = {
   views: MultitableProvisioningView[]
 }
 
+export type MultitableTemplateConflictKind =
+  | 'base_exists'
+  | 'sheet_exists'
+  | 'view_exists'
+  // Plan-level self-collision (review 2026-06-11 F1): a mis-authored template
+  // whose sheets/views/fields derive identical ids — invisible to DB-occupancy
+  // probes, but install's per-table ON CONFLICT would 409 on the second write.
+  | 'template_duplicate_id'
+
+export type MultitableTemplateConflict = {
+  severity: 'error'
+  kind: MultitableTemplateConflictKind
+  id: string
+  name: string
+  message: string
+}
+
+export type MultitableTemplateWouldCreate = {
+  base: { id: string; name: string }
+  sheets: Array<{ id: string; name: string; fieldCount: number; viewCount: number }>
+  fields: Array<{ id: string; sheetId: string; name: string; type: string }>
+  views: Array<{ id: string; sheetId: string; name: string; type: string }>
+}
+
+export type TemplateConflictDetectionOptions = {
+  baseId: string
+  baseName: string
+}
+
 export class MultitableTemplateNotFoundError extends Error {
   constructor(templateId: string) {
     super(`Template not found: ${templateId}`)
@@ -383,6 +412,153 @@ export function getMultitableTemplate(templateId: string): MultitableTemplate | 
   return template ? normalizeTemplate(template) : null
 }
 
+/**
+ * S2 — id plan for a template install (design 20260611 §2.1).
+ *
+ * Derives base/sheet/field/view ids through EXACTLY the same path
+ * installMultitableTemplate uses (stableChildId / mapFieldIds keyed off the
+ * provided baseId), so a dry-run shows ids shaped like the ones a real install
+ * would write. The base id itself comes from the caller's idGenerator, which
+ * install draws FRESH per call — plan ids are therefore illustrative, not a
+ * promise of the exact ids a later install will create.
+ * (Derivation parity is locked by multitable-template-dryrun-routes.test.ts.)
+ */
+export function buildTemplateWouldCreate(
+  template: MultitableTemplate,
+  opts: TemplateConflictDetectionOptions,
+): MultitableTemplateWouldCreate {
+  const sheets: MultitableTemplateWouldCreate['sheets'] = []
+  const fields: MultitableTemplateWouldCreate['fields'] = []
+  const views: MultitableTemplateWouldCreate['views'] = []
+
+  for (const templateSheet of template.sheets) {
+    const sheetId = stableChildId('sheet', opts.baseId, template.id, templateSheet.id)
+    sheets.push({
+      id: sheetId,
+      name: templateSheet.name,
+      fieldCount: templateSheet.fields.length,
+      viewCount: templateSheet.views.length,
+    })
+
+    const fieldIds = mapFieldIds(sheetId, template.id, templateSheet)
+    for (const field of templateSheet.fields) {
+      fields.push({ id: fieldIds[field.id], sheetId, name: field.name, type: field.type })
+    }
+
+    for (const templateView of templateSheet.views) {
+      views.push({
+        id: stableChildId('view', sheetId, template.id, templateSheet.id, templateView.id),
+        sheetId,
+        name: templateView.name,
+        type: templateView.type,
+      })
+    }
+  }
+
+  return { base: { id: opts.baseId, name: opts.baseName }, sheets, fields, views }
+}
+
+/**
+ * S2 — shared base/sheet/view id-occupancy detection (design 20260611 §2.1).
+ *
+ * PURE SELECT-only: never opens a transaction, never writes. Single source for
+ * conflict semantics — installMultitableTemplate consumes this as its
+ * pre-check and the dry-run route consumes it directly, so the two paths
+ * cannot drift (wire-vs-fixture discipline).
+ *
+ * Occupancy probes deliberately do NOT filter on deleted_at: install collides
+ * via INSERT ... ON CONFLICT (id), which a soft-deleted row still triggers, and
+ * this function must answer exactly the question install asks.
+ *
+ * Conflicts are collected in install's write order (base, then per sheet: the
+ * sheet, then its views), so conflicts[0].message is verbatim the first error
+ * install would throw in the same scenario.
+ *
+ * Before the occupancy probes, the derived plan itself is checked for
+ * duplicate ids (review 2026-06-11 F1): DB probes only answer occupancy, so a
+ * mis-authored template whose sheets/views derive IDENTICAL ids would
+ * otherwise dry-run clean yet 409 on install's per-table ON CONFLICT
+ * (duplicate field ids would silently upsert-merge — fewer fields than
+ * declared). Pure compute, zero-write invariant untouched.
+ */
+export async function detectTemplateConflicts(
+  query: MultitableProvisioningQueryFn,
+  template: MultitableTemplate,
+  opts: TemplateConflictDetectionOptions,
+): Promise<MultitableTemplateConflict[]> {
+  const plan = buildTemplateWouldCreate(template, opts)
+  const conflicts: MultitableTemplateConflict[] = []
+
+  // Plan-level duplicate-id self-collision check — BEFORE any DB probe.
+  // Per-kind sets: install's collision surface is per table (meta_sheets /
+  // meta_fields / meta_views), and the check order mirrors install's per-sheet
+  // write order (sheet → fields → views).
+  const duplicateProbes: Array<{
+    entity: 'sheet' | 'field' | 'view'
+    items: Array<{ id: string; name: string }>
+  }> = [
+    { entity: 'sheet', items: plan.sheets },
+    { entity: 'field', items: plan.fields },
+    { entity: 'view', items: plan.views },
+  ]
+  for (const { entity, items } of duplicateProbes) {
+    const seen = new Set<string>()
+    for (const item of items) {
+      if (seen.has(item.id)) {
+        conflicts.push({
+          severity: 'error',
+          kind: 'template_duplicate_id',
+          id: item.id,
+          name: item.name,
+          message: `Template derives duplicate ${entity} id: ${item.id}`,
+        })
+        continue
+      }
+      seen.add(item.id)
+    }
+  }
+
+  const baseResult = await query('SELECT id FROM meta_bases WHERE id = $1', [opts.baseId])
+  if (baseResult.rows.length > 0) {
+    conflicts.push({
+      severity: 'error',
+      kind: 'base_exists',
+      id: opts.baseId,
+      name: opts.baseName,
+      message: `Base already exists: ${opts.baseId}`,
+    })
+  }
+
+  for (const sheet of plan.sheets) {
+    const sheetResult = await query('SELECT id FROM meta_sheets WHERE id = $1', [sheet.id])
+    if (sheetResult.rows.length > 0) {
+      conflicts.push({
+        severity: 'error',
+        kind: 'sheet_exists',
+        id: sheet.id,
+        name: sheet.name,
+        message: `Sheet already exists: ${sheet.id}`,
+      })
+    }
+
+    for (const view of plan.views) {
+      if (view.sheetId !== sheet.id) continue
+      const viewResult = await query('SELECT id FROM meta_views WHERE id = $1', [view.id])
+      if (viewResult.rows.length > 0) {
+        conflicts.push({
+          severity: 'error',
+          kind: 'view_exists',
+          id: view.id,
+          name: view.name,
+          message: `View already exists: ${view.id}`,
+        })
+      }
+    }
+  }
+
+  return conflicts
+}
+
 export async function installMultitableTemplate(
   input: InstallMultitableTemplateInput,
 ): Promise<InstallMultitableTemplateResult> {
@@ -394,6 +570,16 @@ export async function installMultitableTemplate(
   const makeId = input.idGenerator ?? generatedId
   const baseId = (input.baseId?.trim() || makeId('base')).slice(0, 50)
   const baseName = (input.baseName?.trim() || template.name).slice(0, 255)
+
+  // S2: single-source conflict pre-check (SELECT-only). The write-time
+  // rowCount checks below stay as a TOCTOU backstop for ids occupied between
+  // this probe and the INSERTs; they throw the same messages this pre-check
+  // derives, so external behavior is unchanged.
+  const conflicts = await detectTemplateConflicts(input.query, template, { baseId, baseName })
+  if (conflicts.length > 0) {
+    throw new MultitableTemplateConflictError(conflicts[0].message)
+  }
+
   const baseInsert = await input.query(
     `INSERT INTO meta_bases (id, name, icon, color, owner_id, workspace_id)
      VALUES ($1, $2, $3, $4, $5, $6)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -71,6 +71,9 @@ import { ensureLegacyBase as ensureLegacyBaseShared } from '../multitable/provis
 import {
   MultitableTemplateConflictError,
   MultitableTemplateNotFoundError,
+  buildTemplateWouldCreate,
+  detectTemplateConflicts,
+  getMultitableTemplate,
   installMultitableTemplate,
   listMultitableTemplates,
 } from '../multitable/template-library'
@@ -187,7 +190,9 @@ const DRY_RUN_MAX_PAREN_DEPTH = 32
 
 // Observation-readiness logger for the multitable H-series. Emits the stable
 // `[multitable.template.install]` event consumed by the H-series observation
-// SOP (docs/operations/multitable-h-series-observation-sop-20260519.md).
+// SOP (docs/operations/multitable-h-series-observation-sop-20260519.md), plus
+// the symmetric `[multitable.template.dry-run]` event (S2 review 2026-06-11
+// F5; distinct token, so the SOP's install grep stays single-counted).
 // Structured fields only — never logs baseName / request body / token / email
 // / template content / arbitrary user text.
 const templateInstallLogger = new Logger('MultitableTemplates')
@@ -3758,6 +3763,113 @@ export function univerMetaRouter(): Router {
         }
       }
       templateInstallLogger.info('[multitable.template.install]', {
+        templateId,
+        ok: false,
+        userId,
+        statusCode,
+        errorCode,
+      })
+      return res.status(statusCode).json({ ok: false, error: { code: errorCode, message } })
+    }
+  })
+
+  // S2 (design 20260611 §2.1): ZERO-WRITE install simulation — no transaction,
+  // no INSERT; pure SELECT id-occupancy probes via the shared
+  // detectTemplateConflicts (same source install consumes). Guarded with the
+  // same gate as install: dry-run answers "can I install", which is
+  // meaningless for read-only users. Conflict messages are English + a stable
+  // kind; clients localize by kind (formula dry-run convention).
+  router.post('/templates/:templateId/dry-run', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
+    // Request body is install-shaped on purpose (workspaceId accepted for
+    // parity; it does not influence id occupancy).
+    const schema = z.object({
+      baseName: z.string().min(1).max(255).optional(),
+      workspaceId: z.string().min(1).max(100).optional(),
+    })
+
+    const parsed = schema.safeParse(req.body ?? {})
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    const templateId = typeof req.params.templateId === 'string' ? req.params.templateId.trim() : ''
+    if (!templateId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'templateId is required' } })
+    }
+
+    // Observability userId (review 2026-06-11 F5): token-derived only — same
+    // claim fallbacks resolveRequestAccess reads, WITHOUT its DB-backed
+    // permission lookups, so the route's query surface stays exactly the
+    // SELECT-only occupancy probes (zero-write proof unchanged).
+    const userId =
+      req.user?.id?.toString() ??
+      req.user?.sub?.toString() ??
+      req.user?.userId?.toString() ??
+      null
+
+    const template = getMultitableTemplate(templateId)
+    if (!template) {
+      templateInstallLogger.info('[multitable.template.dry-run]', {
+        templateId,
+        ok: false,
+        userId,
+        statusCode: 404,
+        errorCode: 'NOT_FOUND',
+      })
+      // 404 semantics shared with install — same error type supplies the message.
+      return res.status(404).json({
+        ok: false,
+        error: { code: 'NOT_FOUND', message: new MultitableTemplateNotFoundError(templateId).message },
+      })
+    }
+
+    try {
+      const pool = poolManager.get()
+      // Ids derive through the same generator path install uses (buildId +
+      // the shared stableChildId derivation in template-library). Install
+      // draws a FRESH base id per call, so the ids returned here are
+      // illustrative of shape/derivation — NOT a promise of the exact ids a
+      // subsequent install will create.
+      const baseId = buildId('base').slice(0, 50)
+      const baseName = (parsed.data.baseName?.trim() || template.name).slice(0, 255)
+      const wouldCreate = buildTemplateWouldCreate(template, { baseId, baseName })
+      const conflicts = await detectTemplateConflicts(
+        (sql, params) => pool.query(sql, params),
+        template,
+        { baseId, baseName },
+      )
+      const installable = !conflicts.some((conflict) => conflict.severity === 'error')
+      templateInstallLogger.info('[multitable.template.dry-run]', {
+        templateId,
+        ok: true,
+        userId,
+        installable,
+        conflictCount: conflicts.length,
+      })
+      return res.json({ ok: true, data: { templateId, wouldCreate, conflicts, installable } })
+    } catch (err) {
+      let statusCode: number
+      let errorCode: string
+      let message: string
+      const hint = getDbNotReadyMessage(err)
+      if (hint) {
+        statusCode = 503
+        errorCode = 'DB_NOT_READY'
+        message = hint
+      } else {
+        statusCode = 500
+        errorCode = 'INTERNAL_ERROR'
+        message = 'Failed to dry-run template'
+        // Raw exception/stack kept separate from the structured event, and the
+        // message omits the stable `[multitable.template.dry-run]` token so an
+        // event-name grep is not double-counted on the 500 path (install-route
+        // convention).
+        templateInstallLogger.error(
+          'Dry-run multitable template failed',
+          err instanceof Error ? err : new Error(String(err)),
+        )
+      }
+      templateInstallLogger.info('[multitable.template.dry-run]', {
         templateId,
         ok: false,
         userId,

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -619,6 +619,12 @@ describe('Multitable context API', () => {
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params = []) => {
         const normalized = sql.replace(/\s+/g, ' ').trim()
+        // S2 conflict pre-check probe (detectTemplateConflicts) — SELECT-only
+        // base-id occupancy; sheet/view probes reuse the SELECT handlers below.
+        if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_bases') && normalized.includes('WHERE id = $1')) {
+          const [baseId] = params as [string]
+          return { rows: bases.filter((base) => base.id === baseId).map((base) => ({ id: base.id })) }
+        }
         if (normalized.startsWith('INSERT INTO meta_bases')) {
           const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
           const base = { id, name, icon, color, owner_id: ownerId, workspace_id: workspaceId }
@@ -709,6 +715,12 @@ describe('Multitable context API', () => {
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params = []) => {
         const normalized = sql.replace(/\s+/g, ' ').trim()
+        // S2 conflict pre-check probe (detectTemplateConflicts) — SELECT-only
+        // base-id occupancy; sheet/view probes reuse the SELECT handlers below.
+        if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_bases') && normalized.includes('WHERE id = $1')) {
+          const [baseId] = params as [string]
+          return { rows: bases.filter((base) => base.id === baseId).map((base) => ({ id: base.id })) }
+        }
         if (normalized.startsWith('INSERT INTO meta_bases')) {
           const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
           const base = { id, name, icon, color, owner_id: ownerId, workspace_id: workspaceId }

--- a/packages/core-backend/tests/unit/multitable-template-dryrun-routes.test.ts
+++ b/packages/core-backend/tests/unit/multitable-template-dryrun-routes.test.ts
@@ -1,0 +1,584 @@
+/**
+ * S2 — template install dry-run (route-level) + shared conflict detection.
+ * Design: docs/development/multitable-template-dryrun-detail-s2-design-20260611.md §2.1/§3.
+ *
+ * Matrix coverage:
+ *   S2-T1 clean store → installable=true, wouldCreate counts match the descriptor.
+ *   S2-T2 base/sheet/view occupancy → matching conflict entries + installable=false,
+ *         AND the real install route 409s in the SAME scenario (shared-source parity);
+ *         plus an exact-message parity assertion against installMultitableTemplate
+ *         with pinned ids, and an id-derivation parity lock between
+ *         buildTemplateWouldCreate and the ids install actually writes.
+ *   S2-T3 ZERO-WRITE proof: the dry-run request issues SELECTs only — no INSERT/
+ *         UPDATE/DELETE, no transaction.
+ *   S2-T4 RBAC: read-only user → 403; unknown template → 404 (install-shaped body).
+ *
+ * Harness follows the mock-pool route precedent
+ * (multitable-formula-reference-guard.test.ts): real express app + real
+ * univerMetaRouter, poolManager.get() stubbed with an in-memory store.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+import {
+  buildTemplateWouldCreate,
+  detectTemplateConflicts,
+  getMultitableTemplate,
+  installMultitableTemplate,
+  type MultitableTemplate,
+} from '../../src/multitable/template-library'
+import type { MultitableProvisioningQueryFn } from '../../src/multitable/provisioning'
+
+type QueryResult = { rows: any[]; rowCount?: number }
+
+type StoreOptions = {
+  /** Pretend EVERY base id is taken (dry-run base ids are random, so occupancy
+   * is simulated id-agnostically). */
+  occupyAllBases?: boolean
+  occupyAllSheets?: boolean
+  occupyAllViews?: boolean
+  /** Seed concrete ids (used with pinned idGenerator in library-level tests). */
+  baseIds?: string[]
+  sheetIds?: string[]
+  viewIds?: string[]
+}
+
+/**
+ * In-memory store covering the full install SQL surface (INSERT + readback)
+ * plus the SELECT-only occupancy probes detectTemplateConflicts issues.
+ */
+function createStore(opts: StoreOptions = {}) {
+  const bases: Array<Record<string, unknown>> = (opts.baseIds ?? []).map((id) => ({
+    id, name: 'seeded', icon: null, color: null, owner_id: null, workspace_id: null,
+  }))
+  const sheets: Array<Record<string, unknown>> = (opts.sheetIds ?? []).map((id) => ({
+    id, base_id: 'base_seed', name: 'seeded', description: null,
+  }))
+  const fields: Array<Record<string, unknown>> = []
+  const views: Array<Record<string, unknown>> = (opts.viewIds ?? []).map((id) => ({
+    id, sheet_id: 'sheet_seed', name: 'seeded', type: 'grid',
+    filter_info: {}, sort_info: {}, group_info: {}, hidden_field_ids: [], config: {},
+  }))
+
+  const handler = (sql: string, params: unknown[] = []): QueryResult => {
+    const normalized = sql.replace(/\s+/g, ' ').trim()
+
+    if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_bases') && normalized.includes('WHERE id = $1')) {
+      const [id] = params as [string]
+      if (opts.occupyAllBases) return { rows: [{ id }] }
+      return { rows: bases.filter((base) => base.id === id) }
+    }
+    if (normalized.startsWith('INSERT INTO meta_bases')) {
+      const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
+      if (opts.occupyAllBases || bases.some((base) => base.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      const base = { id, name, icon, color, owner_id: ownerId, workspace_id: workspaceId }
+      bases.push(base)
+      return { rows: [base], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_sheets') && normalized.includes('WHERE id = $1')) {
+      const [id] = params as [string]
+      if (opts.occupyAllSheets) return { rows: [{ id, base_id: 'base_other', name: 'occupied', description: null }] }
+      return { rows: sheets.filter((sheet) => sheet.id === id) }
+    }
+    if (normalized.startsWith('INSERT INTO meta_sheets')) {
+      const [id, baseId, name, description] = params as [string, string, string, string | null]
+      if (opts.occupyAllSheets || sheets.some((sheet) => sheet.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      sheets.push({ id, base_id: baseId, name, description })
+      return { rows: [], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('INSERT INTO meta_fields')) {
+      const [id, sheetId, name, type, propertyJson, order] = params as [string, string, string, string, string, number]
+      fields.push({ id, sheet_id: sheetId, name, type, property: JSON.parse(propertyJson), order })
+      return { rows: [], rowCount: 1 }
+    }
+    if (normalized.includes('FROM meta_fields') && normalized.includes('id = ANY($2::text[])')) {
+      const [sheetId, ids] = params as [string, string[]]
+      const idSet = new Set(ids)
+      return {
+        rows: fields
+          .filter((field) => field.sheet_id === sheetId && idSet.has(field.id as string))
+          .sort((a, b) => (a.order as number) - (b.order as number)),
+      }
+    }
+
+    if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_views') && normalized.includes('WHERE id = $1')) {
+      const [id] = params as [string]
+      if (opts.occupyAllViews) {
+        return {
+          rows: [{
+            id, sheet_id: 'sheet_other', name: 'occupied', type: 'grid',
+            filter_info: {}, sort_info: {}, group_info: {}, hidden_field_ids: [], config: {},
+          }],
+        }
+      }
+      return { rows: views.filter((view) => view.id === id) }
+    }
+    if (normalized.startsWith('INSERT INTO meta_views')) {
+      const [id, sheetId, name, type, filterInfoJson, sortInfoJson, groupInfoJson, hiddenFieldIdsJson, configJson] = params as [
+        string, string, string, string, string, string, string, string, string,
+      ]
+      if (opts.occupyAllViews || views.some((view) => view.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      views.push({
+        id,
+        sheet_id: sheetId,
+        name,
+        type,
+        filter_info: JSON.parse(filterInfoJson),
+        sort_info: JSON.parse(sortInfoJson),
+        group_info: JSON.parse(groupInfoJson),
+        hidden_field_ids: JSON.parse(hiddenFieldIdsJson),
+        config: JSON.parse(configJson),
+      })
+      return { rows: [], rowCount: 1 }
+    }
+
+    throw new Error(`Unhandled SQL in test: ${normalized}`)
+  }
+
+  const query: MultitableProvisioningQueryFn = async (sql, params = []) => handler(sql, params)
+
+  return { bases, sheets, fields, views, handler, query }
+}
+
+function createMockPool(handler: (sql: string, params?: unknown[]) => QueryResult) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => handler(sql, params))
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(
+  handler: (sql: string, params?: unknown[]) => QueryResult,
+  opts: { perms?: string[] } = {},
+) {
+  const perms = opts.perms ?? ['multitable:read', 'multitable:write']
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue(perms),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(handler)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    // rbacGuard reads user.permissions; the install route's
+    // resolveRequestAccess reads user.perms — set both.
+    req.user = { id: 'user_s2', roles: [], permissions: perms, perms } as Express.Request['user']
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return { app, mockPool }
+}
+
+describe('S2 — POST /templates/:templateId/dry-run (route)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('S2-T1: clean store → installable=true, wouldCreate matches the descriptor', async () => {
+    const store = createStore()
+    const { app } = await createApp(store.handler)
+
+    const res = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({ baseName: 'Launch Plan' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    const data = res.body.data
+    expect(data.templateId).toBe('project-tracker')
+    expect(data.installable).toBe(true)
+    expect(data.conflicts).toEqual([])
+
+    const descriptor = getMultitableTemplate('project-tracker')!
+    expect(data.wouldCreate.base.name).toBe('Launch Plan')
+    expect(data.wouldCreate.base.id).toMatch(/^base_/)
+    expect(data.wouldCreate.sheets).toHaveLength(descriptor.sheets.length)
+    expect(data.wouldCreate.sheets[0]).toMatchObject({
+      name: 'Tasks',
+      fieldCount: descriptor.sheets[0].fields.length,
+      viewCount: descriptor.sheets[0].views.length,
+    })
+    expect(data.wouldCreate.sheets[0].id).toMatch(/^sheet_/)
+    expect(data.wouldCreate.fields).toHaveLength(6)
+    expect(data.wouldCreate.fields.map((f: any) => f.name)).toEqual([
+      'Task', 'Status', 'Owner', 'Priority', 'Due Date', 'Notes',
+    ])
+    for (const field of data.wouldCreate.fields) {
+      expect(field.id).toMatch(/^fld_/)
+      expect(field.sheetId).toBe(data.wouldCreate.sheets[0].id)
+      expect(typeof field.type).toBe('string')
+    }
+    expect(data.wouldCreate.views).toHaveLength(3)
+    expect(data.wouldCreate.views.map((v: any) => v.type)).toEqual(['grid', 'kanban', 'calendar'])
+    for (const view of data.wouldCreate.views) {
+      expect(view.id).toMatch(/^view_/)
+      expect(view.sheetId).toBe(data.wouldCreate.sheets[0].id)
+    }
+  })
+
+  it('S2-T1: baseName defaults to the template name (install parity)', async () => {
+    const store = createStore()
+    const { app } = await createApp(store.handler)
+
+    const res = await request(app)
+      .post('/api/multitable/templates/sales-crm/dry-run')
+      .send({})
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.wouldCreate.base.name).toBe('Sales CRM')
+  })
+
+  it('S2-T2: base occupancy → base_exists conflict AND install 409s in the same scenario', async () => {
+    const store = createStore({ occupyAllBases: true })
+    const { app } = await createApp(store.handler)
+
+    const dryRun = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({ baseName: 'Launch Plan' })
+
+    expect(dryRun.status).toBe(200)
+    expect(dryRun.body.data.installable).toBe(false)
+    const conflict = dryRun.body.data.conflicts[0]
+    expect(conflict).toMatchObject({ severity: 'error', kind: 'base_exists', name: 'Launch Plan' })
+    expect(conflict.message).toMatch(/^Base already exists: base_/)
+    expect(conflict.message).toContain(conflict.id)
+
+    const install = await request(app)
+      .post('/api/multitable/templates/project-tracker/install')
+      .send({ baseName: 'Launch Plan' })
+
+    expect(install.status).toBe(409)
+    expect(install.body.error.code).toBe('CONFLICT')
+    expect(install.body.error.message).toMatch(/^Base already exists: base_/)
+  })
+
+  it('S2-T2: sheet occupancy → sheet_exists conflict AND install 409s in the same scenario', async () => {
+    const store = createStore({ occupyAllSheets: true })
+    const { app } = await createApp(store.handler)
+
+    const dryRun = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({})
+
+    expect(dryRun.status).toBe(200)
+    expect(dryRun.body.data.installable).toBe(false)
+    const conflict = dryRun.body.data.conflicts[0]
+    expect(conflict).toMatchObject({ severity: 'error', kind: 'sheet_exists', name: 'Tasks' })
+    expect(conflict.message).toMatch(/^Sheet already exists: sheet_/)
+
+    const install = await request(app)
+      .post('/api/multitable/templates/project-tracker/install')
+      .send({})
+
+    expect(install.status).toBe(409)
+    expect(install.body.error.code).toBe('CONFLICT')
+    expect(install.body.error.message).toMatch(/^Sheet already exists: sheet_/)
+  })
+
+  it('S2-T2: view occupancy → view_exists conflicts (one per view) AND install 409s in the same scenario', async () => {
+    const store = createStore({ occupyAllViews: true })
+    const { app } = await createApp(store.handler)
+
+    const dryRun = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({})
+
+    expect(dryRun.status).toBe(200)
+    expect(dryRun.body.data.installable).toBe(false)
+    expect(dryRun.body.data.conflicts).toHaveLength(3)
+    expect(dryRun.body.data.conflicts.map((c: any) => c.kind)).toEqual([
+      'view_exists', 'view_exists', 'view_exists',
+    ])
+    expect(dryRun.body.data.conflicts[0].message).toMatch(/^View already exists: view_/)
+
+    const install = await request(app)
+      .post('/api/multitable/templates/project-tracker/install')
+      .send({})
+
+    expect(install.status).toBe(409)
+    expect(install.body.error.code).toBe('CONFLICT')
+    expect(install.body.error.message).toMatch(/^View already exists: view_/)
+  })
+
+  it('S2-T3: ZERO-WRITE proof — dry-run issues SELECTs only, no transaction', async () => {
+    const store = createStore({ occupyAllSheets: true })
+    const { app, mockPool } = await createApp(store.handler)
+
+    const res = await request(app)
+      .post('/api/multitable/templates/contract-management/dry-run')
+      .send({ baseName: 'Q3 Contracts' })
+
+    expect(res.status).toBe(200)
+    expect(mockPool.transaction).not.toHaveBeenCalled()
+    const sqls = mockPool.query.mock.calls.map(([sql]) => String(sql).trim().toUpperCase())
+    expect(sqls.length).toBeGreaterThan(0)
+    for (const sql of sqls) {
+      expect(sql.startsWith('SELECT')).toBe(true)
+      expect(sql).not.toContain('INSERT')
+      expect(sql).not.toContain('UPDATE')
+      expect(sql).not.toContain('DELETE')
+    }
+  })
+
+  // Review 2026-06-11 F5: dry-run emits structured observability events
+  // symmetric to install's `[multitable.template.install]` (distinct token —
+  // the H-series SOP grep stays single-counted). Structured fields only.
+  it('F5: emits [multitable.template.dry-run] events on success and failure paths', async () => {
+    const store = createStore({ occupyAllSheets: true })
+    const { app } = await createApp(store.handler)
+    const { Logger } = await import('../../src/core/logger')
+    const infoSpy = vi.spyOn(Logger.prototype, 'info')
+
+    await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({ baseName: 'Launch Plan' })
+      .expect(200)
+
+    const successCall = infoSpy.mock.calls.find(
+      ([msg, meta]) => msg === '[multitable.template.dry-run]' && (meta as Record<string, unknown>)?.ok === true,
+    )
+    expect(successCall).toBeDefined()
+    const successMeta = successCall![1] as Record<string, unknown>
+    expect(successMeta).toMatchObject({
+      templateId: 'project-tracker',
+      ok: true,
+      userId: 'user_s2',
+      installable: false,
+      conflictCount: 1,
+    })
+    // Never the baseName / request body (install-event privacy contract).
+    expect(successMeta).not.toHaveProperty('baseName')
+    expect(JSON.stringify(successMeta)).not.toContain('Launch Plan')
+
+    await request(app)
+      .post('/api/multitable/templates/no-such-template/dry-run')
+      .send({})
+      .expect(404)
+
+    const failCall = infoSpy.mock.calls.find(
+      ([msg, meta]) => msg === '[multitable.template.dry-run]' && (meta as Record<string, unknown>)?.ok === false,
+    )
+    expect(failCall).toBeDefined()
+    expect(failCall![1]).toMatchObject({
+      templateId: 'no-such-template',
+      ok: false,
+      userId: 'user_s2',
+      statusCode: 404,
+      errorCode: 'NOT_FOUND',
+    })
+  })
+
+  it('S2-T4: read-only user gets 403', async () => {
+    const store = createStore()
+    const { app, mockPool } = await createApp(store.handler, { perms: ['multitable:read'] })
+
+    const res = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({})
+
+    expect(res.status).toBe(403)
+    expect(mockPool.query).not.toHaveBeenCalled()
+  })
+
+  it('S2-T4: unknown template → 404 with the install-shaped error body, no DB queries', async () => {
+    const store = createStore()
+    const { app, mockPool } = await createApp(store.handler)
+
+    const res = await request(app)
+      .post('/api/multitable/templates/no-such-template/dry-run')
+      .send({})
+
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Template not found: no-such-template' },
+    })
+    expect(mockPool.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid body (empty baseName) like install does', async () => {
+    const store = createStore()
+    const { app } = await createApp(store.handler)
+
+    const res = await request(app)
+      .post('/api/multitable/templates/project-tracker/dry-run')
+      .send({ baseName: '' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+})
+
+describe('S2 — shared conflict detection (library-level, pinned ids)', () => {
+  it('id-derivation parity: buildTemplateWouldCreate ids === ids a real install writes', async () => {
+    const store = createStore()
+    await installMultitableTemplate({
+      query: store.query,
+      templateId: 'project-tracker',
+      baseName: 'Launch Plan',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })
+
+    const template = getMultitableTemplate('project-tracker')!
+    const plan = buildTemplateWouldCreate(template, { baseId: 'base_fixed', baseName: 'Launch Plan' })
+
+    expect(plan.base.id).toBe('base_fixed')
+    expect(store.sheets.map((sheet) => sheet.id)).toEqual(plan.sheets.map((sheet) => sheet.id))
+    expect(store.fields.map((field) => field.id).sort()).toEqual(plan.fields.map((field) => field.id).sort())
+    expect(store.views.map((view) => view.id)).toEqual(plan.views.map((view) => view.id))
+  })
+
+  it('exact-message parity: install throws conflicts[0].message verbatim (base conflict)', async () => {
+    const store = createStore({ baseIds: ['base_fixed'] })
+    const template = getMultitableTemplate('project-tracker')!
+
+    const conflicts = await detectTemplateConflicts(store.query, template, {
+      baseId: 'base_fixed',
+      baseName: 'Launch Plan',
+    })
+    expect(conflicts[0]).toMatchObject({ severity: 'error', kind: 'base_exists', id: 'base_fixed' })
+
+    await expect(installMultitableTemplate({
+      query: store.query,
+      templateId: 'project-tracker',
+      baseName: 'Launch Plan',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })).rejects.toThrow(conflicts[0].message)
+  })
+
+  it('exact-message parity: sheet conflict (occupied sheet id learned from a real install)', async () => {
+    // Learn the real derived sheet id by running a clean install with pinned ids.
+    const clean = createStore()
+    await installMultitableTemplate({
+      query: clean.query,
+      templateId: 'project-tracker',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })
+    const occupiedSheetId = clean.sheets[0].id as string
+
+    const store = createStore({ sheetIds: [occupiedSheetId] })
+    const template = getMultitableTemplate('project-tracker')!
+    const conflicts = await detectTemplateConflicts(store.query, template, {
+      baseId: 'base_fixed',
+      baseName: 'Project Tracker',
+    })
+    expect(conflicts[0]).toMatchObject({ severity: 'error', kind: 'sheet_exists', id: occupiedSheetId, name: 'Tasks' })
+
+    await expect(installMultitableTemplate({
+      query: store.query,
+      templateId: 'project-tracker',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })).rejects.toThrow(conflicts[0].message)
+    // Pre-check fires before any write: the occupied store stays write-free.
+    expect(store.bases).toHaveLength(0)
+  })
+
+  // Review 2026-06-11 F1 — the reviewer's probe, kept as a real test: a
+  // (mis-authored) template whose two sheets share the SAME template-sheet id
+  // derives IDENTICAL sheet ids (stableChildId is deterministic on identical
+  // inputs), so install's second `INSERT INTO meta_sheets ... ON CONFLICT (id)
+  // DO NOTHING` would hit rowCount=0 → 409 — while DB-occupancy probes alone
+  // see an EMPTY store and would report clean. The plan-level duplicate-id
+  // check must surface this before any probe.
+  it('F1: intra-template duplicate sheet ids → template_duplicate_id conflict on a CLEAN store', async () => {
+    const template: MultitableTemplate = {
+      id: 'synthetic-duplicate',
+      name: 'Synthetic Duplicate',
+      description: 'two sheets colliding on the same template-sheet id',
+      category: 'test',
+      icon: 'kanban',
+      color: '#000000',
+      sheets: [
+        {
+          id: 'dup',
+          name: 'Sheet One',
+          fields: [{ id: 'a', name: 'A', type: 'text', order: 0 }],
+          views: [{ id: 'v1', name: 'Grid', type: 'grid' }],
+        },
+        {
+          id: 'dup',
+          name: 'Sheet Two',
+          fields: [{ id: 'b', name: 'B', type: 'text', order: 0 }],
+          views: [{ id: 'v2', name: 'Grid 2', type: 'grid' }],
+        },
+      ],
+    }
+
+    // The self-collision install's ON CONFLICT would hit:
+    const plan = buildTemplateWouldCreate(template, { baseId: 'base_fixed', baseName: 'Synthetic' })
+    expect(plan.sheets).toHaveLength(2)
+    expect(plan.sheets[0].id).toBe(plan.sheets[1].id)
+
+    const store = createStore() // EMPTY — occupancy probes find nothing
+    const conflicts = await detectTemplateConflicts(store.query, template, {
+      baseId: 'base_fixed',
+      baseName: 'Synthetic',
+    })
+
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]).toMatchObject({
+      severity: 'error',
+      kind: 'template_duplicate_id',
+      id: plan.sheets[1].id,
+      name: 'Sheet Two',
+    })
+    expect(conflicts[0].message).toBe(`Template derives duplicate sheet id: ${plan.sheets[1].id}`)
+  })
+
+  it('F1: duplicate field/view ids within a sheet are reported per entity, BEFORE occupancy conflicts', async () => {
+    const template: MultitableTemplate = {
+      id: 'synthetic-duplicate-children',
+      name: 'Synthetic Duplicate Children',
+      description: 'one sheet with colliding field ids and colliding view ids',
+      category: 'test',
+      icon: 'kanban',
+      color: '#000000',
+      sheets: [
+        {
+          id: 'main',
+          name: 'Main',
+          fields: [
+            { id: 'f', name: 'First', type: 'text', order: 0 },
+            { id: 'f', name: 'Second', type: 'text', order: 1 },
+          ],
+          views: [
+            { id: 'v', name: 'Grid', type: 'grid' },
+            { id: 'v', name: 'Grid Copy', type: 'grid' },
+          ],
+        },
+      ],
+    }
+
+    const store = createStore({ occupyAllBases: true })
+    const conflicts = await detectTemplateConflicts(store.query, template, {
+      baseId: 'base_fixed',
+      baseName: 'Synthetic',
+    })
+
+    // Plan-level duplicates come FIRST (emitted before any DB probe) in
+    // sheet → field → view order; the occupied base follows them.
+    expect(conflicts.map((conflict) => conflict.kind)).toEqual([
+      'template_duplicate_id', 'template_duplicate_id', 'base_exists',
+    ])
+    expect(conflicts[0].message).toMatch(/^Template derives duplicate field id: fld_/)
+    expect(conflicts[1].message).toMatch(/^Template derives duplicate view id: view_/)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-template-library.test.ts
+++ b/packages/core-backend/tests/unit/multitable-template-library.test.ts
@@ -52,6 +52,13 @@ function createQuery(seed?: { bases?: MultitableTemplateBase[] }): {
   const query: MultitableProvisioningQueryFn = async (sql, params = []) => {
     const normalized = sql.replace(/\s+/g, ' ').trim()
 
+    // S2 conflict pre-check probe (detectTemplateConflicts) — SELECT-only
+    // base-id occupancy; sheet/view probes reuse the SELECT handlers below.
+    if (normalized.startsWith('SELECT') && normalized.includes('FROM meta_bases') && normalized.includes('WHERE id = $1')) {
+      const [baseId] = params as [string]
+      return { rows: bases.filter((base) => base.id === baseId).map((base) => ({ id: base.id })) }
+    }
+
     if (normalized.startsWith('INSERT INTO meta_bases')) {
       const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
       if (bases.some((base) => base.id === id)) {


### PR DESCRIPTION
## Summary

Implements **S2** (engineering split per #2493) — the final runtime slice of the AI-field staged arc's side line.

- **Shared conflict detection**: `detectTemplateConflicts()` extracted from `installMultitableTemplate` and consumed by BOTH install and dry-run (single source, anti-drift). Install behavior externally **byte-identical** (pre-check throws the exact same `MultitableTemplateConflictError` messages in install write-order; write-time `rowCount` checks retained as TOCTOU backstop). Review F1 hardening: a plan-level duplicate-id scan (per-table Sets, install write-order) runs before any DB probe — a synthesized colliding multi-sheet template now dry-runs to the same conflict install's `ON CONFLICT` would hit.
- **`POST /templates/:id/dry-run`**: `rbacGuard('multitable','write')` (same gate as install), **zero-write proven by query-spy** (every SQL `SELECT`-only, no transaction); response `{wouldCreate, conflicts[], installable}`; ids derived via the same `buildId`/stableChildId path (non-promissory comment); structured `[multitable.template.dry-run]` events symmetric to install's (review F5; `userId` token-derived so the query surface stays SELECT-only).
- **Detail view**: new `/multitable/templates/:templateId` route + opt-in `showDetail` card entry (7 existing consumer suites untouched-green); descriptor structure rendering; dry-run check drives the install-button state; truthful conflict copy (review F4 — baseName never enters id derivation); sample-data area left as a **PM-gated G-4 extension point** (no scope creep into the #1571 gates).
- Install-parity locked at library level with pinned idGenerator (verbatim message equality + id-derivation parity); route-level parity asserts kind+prefix (fresh random base ids per call — documented).

## Known semantics (review F3, design-inherited)

Over the HTTP pair both calls draw fresh random base ids, so wire-level conflicts are practically unreachable today — the conflict machinery's value is at the library/parity level and for future deterministic/imported-id scenarios. Recorded, not hidden.

## Tests (fail-first)

Backend route suite red pre-impl (12/12 failed: route 404 / export missing) → 33/33 green incl. zero-write proof + parity + dup-id probes; FE detail spec red (unresolved import) → 18/18; existing template/install suites 18/18 + 22/22; full backend `test:unit` 236 files / 2996; backend tsc + `vue-tsc -b` + openapi parity + eslint clean.

## Review

Adversarial review (`/tmp/s2-review-claude-20260611.md`): **APPROVE-WITH-NITS** — F1/F2/F4/F5 fixed pre-merge (dup-id scan, design §2.3 errata: GET/install ARE in the OpenAPI spec — operative lock unchanged, truthful hint copy, structured observability), F3 recorded above.

Design: #2493 · Side line: S1 ✅ S3 ✅ S4 ✅ S5a ✅ → this closes S2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)