### PR TITLE
feat(attendance): add C5 delivery worker with fake channel

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -79,13 +79,13 @@
 | 1 | **C5 design-lock** | ✅ #2483 | 锁定 `dispatched_at` 不是 delivery success、outbox/delivery-status/retry、本人 + owner/sub_owner fan-out、channel env-gating、staging smoke 口径 |
 | 2 | **C5-0 outbox DDL** | ✅ #2487 | `attendance_notification_deliveries` 表 + CHECK/unique/index；不发送 |
 | 3 | **C5-1a unscheduled fan-out producer** | ✅ #2498 | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；CI real-DB gate 实跑 `attendance-unscheduled-reminder` + outbox spec |
-| 4 | **C5-1b comp-time expiry reminder producer** | 🟡 本 PR | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；pending CI/review/merge 后回填 ✅ |
-| 5 | **C5-2 delivery worker + fake channel** | 🔒 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖 |
+| 4 | **C5-1b comp-time expiry reminder producer** | ✅ #2502 | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；CI real-DB gate 实跑 comp-time expiry reminder producer spec |
+| 5 | **C5-2 delivery worker + fake channel** | 🟡 本 PR | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；pending CI/review/merge 后回填 ✅ |
 | 6 | **C5-3 DingTalk work-notification channel** | 🔒 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible |
 | 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel），C5-1b 正在本 PR 中接入调休到期提醒 producer。C5 整体仍保持 🟡，直到 C5-1b/C5-2/C5-3/C5-5b 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 正在本 PR 中接入 delivery worker + fake channel。C5 整体仍保持 🟡，直到 C5-2/C5-3/C5-5b 完整闭环。
 
 ### Out of this target
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -93,6 +93,7 @@ import {
 import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
+  resolveAttendanceNotificationDeliveryJob,
   resolveCompTimeExpiryReminderJob,
   resolveUnscheduledReminderJob,
   registerAttendanceSchedulerJob,
@@ -2036,7 +2037,12 @@ export class MetaSheetServer {
       const attendanceLeaderOptions = await resolveAttendanceSchedulerLeaderOptions()
       const unscheduledReminderJob = resolveUnscheduledReminderJob()
       const compTimeExpiryReminderJob = resolveCompTimeExpiryReminderJob()
-      const attendanceSchedulerJobs = [unscheduledReminderJob, compTimeExpiryReminderJob].filter((job): job is NonNullable<typeof job> => Boolean(job))
+      const attendanceNotificationDeliveryJob = resolveAttendanceNotificationDeliveryJob()
+      const attendanceSchedulerJobs = [
+        unscheduledReminderJob,
+        compTimeExpiryReminderJob,
+        attendanceNotificationDeliveryJob,
+      ].filter((job): job is NonNullable<typeof job> => Boolean(job))
       const scheduler = startAttendanceScheduler({
         leaderOptions: attendanceLeaderOptions,
         intervalMs: resolveAttendanceSchedulerIntervalMs(),

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -1,0 +1,323 @@
+import { randomBytes } from 'crypto'
+import { query as defaultQuery } from '../db/pg'
+import { Logger } from '../core/logger'
+
+/**
+ * C5-2 delivery worker.
+ *
+ * Consumes `attendance_notification_deliveries` outbox rows, claims due rows with a short lease, sends
+ * each row through its named channel, and writes per-delivery status. This worker is the first component
+ * allowed to turn C5 outbox rows into sends; source producers must only insert rows.
+ */
+
+export type AttendanceNotificationDeliveryQuery = <T = unknown>(
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: T[]; rowCount?: number | null }>
+
+export interface AttendanceDeliveryMessage {
+  id: string
+  orgId: string
+  sourceType: string
+  sourceId: string | null
+  sourceKey: string
+  recipientUserId: string
+  recipientRole: string
+  channel: string
+  payload: Record<string, unknown>
+}
+
+export type AttendanceDeliveryChannelResult =
+  | { ok: true }
+  | { ok: false; retryable: boolean; error: string }
+
+export interface AttendanceDeliveryChannel {
+  readonly name: string
+  send(message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult>
+}
+
+export interface AttendanceNotificationDeliveryWorkerOptions {
+  query?: AttendanceNotificationDeliveryQuery
+  channels?: AttendanceDeliveryChannel[]
+  batchSize?: number
+  leaseMs?: number
+  maxAttempts?: number
+  workerId?: string
+  now?: () => Date
+  logger?: Logger
+}
+
+export interface AttendanceNotificationDeliveryResult {
+  claimed: number
+  sent: number
+  retrying: number
+  failed: number
+  lostLease?: number
+}
+
+interface DeliveryRow {
+  id: string
+  org_id: string
+  source_type: string
+  source_id: string | null
+  source_key: string
+  recipient_user_id: string
+  recipient_role: string
+  channel: string
+  attempt_count: number | string
+  payload: unknown
+}
+
+const DEFAULT_BATCH_SIZE = 50
+const DEFAULT_LEASE_MS = 60_000
+const DEFAULT_MAX_ATTEMPTS = 5
+const MIN_BATCH_SIZE = 1
+const MAX_BATCH_SIZE = 200
+const MIN_LEASE_MS = 5_000
+const MAX_LEASE_MS = 10 * 60_000
+const FAKE_CHANNEL_NAME = 'dingtalk_work_notification'
+
+export function clampDeliveryBatchSize(value: number | undefined): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return DEFAULT_BATCH_SIZE
+  return Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, Math.floor(n)))
+}
+
+export function clampDeliveryLeaseMs(value: number | undefined): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return DEFAULT_LEASE_MS
+  return Math.min(MAX_LEASE_MS, Math.max(MIN_LEASE_MS, Math.floor(n)))
+}
+
+export function computeDeliveryBackoffMs(attemptCount: number): number {
+  if (attemptCount <= 1) return 60_000
+  if (attemptCount === 2) return 5 * 60_000
+  if (attemptCount === 3) return 15 * 60_000
+  if (attemptCount === 4) return 60 * 60_000
+  return 6 * 60 * 60_000
+}
+
+export class DeterministicFakeAttendanceDeliveryChannel implements AttendanceDeliveryChannel {
+  readonly name = FAKE_CHANNEL_NAME
+
+  async send(message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult> {
+    const mode = String(message.payload.fakeDelivery ?? message.payload.deliveryMode ?? 'ok')
+    if (mode === 'retry' || mode === 'retryable_failure') {
+      return { ok: false, retryable: true, error: 'fake_retryable_failure' }
+    }
+    if (mode === 'fail' || mode === 'non_retryable_failure') {
+      return { ok: false, retryable: false, error: 'fake_non_retryable_failure' }
+    }
+    return { ok: true }
+  }
+}
+
+export function createAttendanceDeliveryChannelsFromEnv(env: NodeJS.ProcessEnv = process.env): AttendanceDeliveryChannel[] {
+  if (env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED !== 'true') return []
+  return [new DeterministicFakeAttendanceDeliveryChannel()]
+}
+
+export class AttendanceNotificationDeliveryWorker {
+  private readonly query: AttendanceNotificationDeliveryQuery
+  private readonly channelsByName: Map<string, AttendanceDeliveryChannel>
+  private readonly batchSize: number
+  private readonly leaseMs: number
+  private readonly maxAttempts: number
+  private readonly workerId: string
+  private readonly now: () => Date
+  private readonly logger: Logger
+  private running = false
+
+  constructor(options: AttendanceNotificationDeliveryWorkerOptions = {}) {
+    this.query = options.query ?? (defaultQuery as AttendanceNotificationDeliveryQuery)
+    this.channelsByName = new Map((options.channels ?? []).map((channel) => [channel.name, channel]))
+    this.batchSize = clampDeliveryBatchSize(options.batchSize)
+    this.leaseMs = clampDeliveryLeaseMs(options.leaseMs)
+    this.maxAttempts = Number.isFinite(Number(options.maxAttempts)) && Number(options.maxAttempts) > 0
+      ? Math.floor(Number(options.maxAttempts))
+      : DEFAULT_MAX_ATTEMPTS
+    this.workerId = options.workerId ?? `attendance-delivery:${process.pid}:${randomBytes(4).toString('hex')}`
+    this.now = options.now ?? (() => new Date())
+    this.logger = options.logger ?? new Logger('AttendanceNotificationDeliveryWorker')
+  }
+
+  async claimDueDeliveries(): Promise<DeliveryRow[]> {
+    const asOf = this.now().toISOString()
+    const { rows } = await this.query<DeliveryRow>(
+      `WITH claim AS (
+         SELECT id
+           FROM attendance_notification_deliveries
+          WHERE (
+                  status IN ('pending','retrying')
+              AND next_attempt_at <= $1::timestamptz
+            )
+             OR (
+                  status = 'sending'
+              AND claim_expires_at <= $1::timestamptz
+            )
+          ORDER BY COALESCE(next_attempt_at, claim_expires_at) ASC, created_at ASC
+          LIMIT $2::int
+          FOR UPDATE SKIP LOCKED
+       ),
+       claimed AS (
+         UPDATE attendance_notification_deliveries d
+            SET status = 'sending',
+                attempt_count = attempt_count + 1,
+                last_attempt_at = $1::timestamptz,
+                claimed_at = $1::timestamptz,
+                claim_expires_at = $1::timestamptz + ($3::int * interval '1 millisecond'),
+                claim_worker_id = $4,
+                updated_at = $1::timestamptz
+           FROM claim
+          WHERE d.id = claim.id
+          RETURNING d.id::text AS id,
+                    d.org_id,
+                    d.source_type,
+                    d.source_id,
+                    d.source_key,
+                    d.recipient_user_id,
+                    d.recipient_role,
+                    d.channel,
+                    d.attempt_count,
+                    d.payload
+       )
+       SELECT *
+         FROM claimed
+        ORDER BY id`,
+      [asOf, this.batchSize, this.leaseMs, this.workerId],
+    )
+    return rows
+  }
+
+  async runBatch(): Promise<AttendanceNotificationDeliveryResult> {
+    if (this.running) return { claimed: 0, sent: 0, retrying: 0, failed: 0 }
+    this.running = true
+    const result: AttendanceNotificationDeliveryResult = { claimed: 0, sent: 0, retrying: 0, failed: 0 }
+    try {
+      const rows = await this.claimDueDeliveries()
+      result.claimed = rows.length
+      let lostLease = 0
+      for (const row of rows) {
+        const outcome = await this.deliver(row)
+        if (outcome === 'sent') result.sent += 1
+        else if (outcome === 'retrying') result.retrying += 1
+        else if (outcome === 'failed') result.failed += 1
+        else lostLease += 1
+      }
+      if (lostLease > 0) {
+        result.lostLease = lostLease
+      }
+      if (result.claimed > 0) {
+        this.logger.info(`Attendance deliveries claimed=${result.claimed} sent=${result.sent} retrying=${result.retrying} failed=${result.failed} lostLease=${lostLease}`)
+      }
+      return result
+    } finally {
+      this.running = false
+    }
+  }
+
+  private async deliver(row: DeliveryRow): Promise<'sent' | 'retrying' | 'failed' | 'lost-lease'> {
+    const channel = this.channelsByName.get(row.channel)
+    const attemptCount = Number(row.attempt_count)
+    if (!channel) {
+      return await this.markFailed(row.id, 'attendance_delivery_channel_not_configured', attemptCount)
+        ? 'failed'
+        : 'lost-lease'
+    }
+
+    const message: AttendanceDeliveryMessage = {
+      id: row.id,
+      orgId: row.org_id,
+      sourceType: row.source_type,
+      sourceId: row.source_id,
+      sourceKey: row.source_key,
+      recipientUserId: row.recipient_user_id,
+      recipientRole: row.recipient_role,
+      channel: row.channel,
+      payload: parsePayload(row.payload),
+    }
+
+    let channelResult: AttendanceDeliveryChannelResult
+    try {
+      channelResult = await channel.send(message)
+    } catch (error) {
+      channelResult = { ok: false, retryable: true, error: error instanceof Error ? error.message : String(error) }
+    }
+
+    if (channelResult.ok) {
+      return await this.markSent(row.id, attemptCount) ? 'sent' : 'lost-lease'
+    }
+
+    const failure = channelResult as Extract<AttendanceDeliveryChannelResult, { ok: false }>
+    if (!failure.retryable || attemptCount >= this.maxAttempts) {
+      return await this.markFailed(row.id, failure.error, attemptCount) ? 'failed' : 'lost-lease'
+    }
+
+    return await this.markRetrying(row.id, failure.error, attemptCount) ? 'retrying' : 'lost-lease'
+  }
+
+  private async markSent(id: string, attemptCount: number): Promise<boolean> {
+    const now = this.now().toISOString()
+    const result = await this.query(
+      `UPDATE attendance_notification_deliveries
+          SET status = 'sent',
+              delivered_at = $2::timestamptz,
+              last_error = NULL,
+              claim_expires_at = NULL,
+              claim_worker_id = NULL,
+              updated_at = $2::timestamptz
+        WHERE id = $1::uuid
+          AND status = 'sending'
+          AND claim_worker_id = $3
+          AND attempt_count = $4::int`,
+      [id, now, this.workerId, attemptCount],
+    )
+    return Number(result.rowCount ?? 0) === 1
+  }
+
+  private async markRetrying(id: string, error: string, attemptCount: number): Promise<boolean> {
+    const now = this.now()
+    const next = new Date(now.getTime() + computeDeliveryBackoffMs(attemptCount)).toISOString()
+    const result = await this.query(
+      `UPDATE attendance_notification_deliveries
+          SET status = 'retrying',
+              next_attempt_at = $2::timestamptz,
+              last_error = $3,
+              claim_expires_at = NULL,
+              claim_worker_id = NULL,
+              updated_at = $4::timestamptz
+        WHERE id = $1::uuid
+          AND status = 'sending'
+          AND claim_worker_id = $5
+          AND attempt_count = $6::int`,
+      [id, next, error.slice(0, 1000), now.toISOString(), this.workerId, attemptCount],
+    )
+    return Number(result.rowCount ?? 0) === 1
+  }
+
+  private async markFailed(id: string, error: string, attemptCount: number): Promise<boolean> {
+    const now = this.now().toISOString()
+    const result = await this.query(
+      `UPDATE attendance_notification_deliveries
+          SET status = 'failed',
+              last_error = $2,
+              claim_expires_at = NULL,
+              claim_worker_id = NULL,
+              updated_at = $3::timestamptz
+        WHERE id = $1::uuid
+          AND status = 'sending'
+          AND claim_worker_id = $4
+          AND attempt_count = $5::int`,
+      [id, error.slice(0, 1000), now, this.workerId, attemptCount],
+    )
+    return Number(result.rowCount ?? 0) === 1
+  }
+}
+
+function parsePayload(value: unknown): Record<string, unknown> {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try { return JSON.parse(value) as Record<string, unknown> } catch { return {} }
+  }
+  return value as Record<string, unknown>
+}

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -28,6 +28,10 @@ import {
   type AttendanceExpiryService,
   type ExpiredCompTimeBalance,
 } from './AttendanceExpiryService'
+import {
+  AttendanceNotificationDeliveryWorker,
+  createAttendanceDeliveryChannelsFromEnv,
+} from './AttendanceNotificationDeliveryWorker'
 import { CompTimeExpiryReminderService } from './CompTimeExpiryReminderService'
 import { UnscheduledReminderService } from './UnscheduledReminderService'
 
@@ -379,5 +383,24 @@ export function resolveCompTimeExpiryReminderJob(): AttendanceSchedulerJob | nul
   return {
     name: 'comp-time-expiry-reminder',
     run: () => service.run(),
+  }
+}
+
+/**
+ * C5-2 opt-in: delivery worker job. It consumes C5 outbox rows and updates per-row delivery state.
+ * Default OFF; C5-2 can use the deterministic fake channel via ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true.
+ * Real DingTalk channel registration is C5-3.
+ */
+export function resolveAttendanceNotificationDeliveryJob(): AttendanceSchedulerJob | null {
+  if (process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED !== 'true') return null
+  const worker = new AttendanceNotificationDeliveryWorker({
+    batchSize: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_BATCH_SIZE),
+    leaseMs: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_LEASE_MS),
+    maxAttempts: Number(process.env.ATTENDANCE_NOTIFICATION_DELIVERY_MAX_ATTEMPTS),
+    channels: createAttendanceDeliveryChannelsFromEnv(),
+  })
+  return {
+    name: 'attendance-notification-delivery',
+    run: () => worker.runBatch(),
   }
 }

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -3,6 +3,11 @@ import { randomUUID } from 'crypto'
 import { Kysely, PostgresDialect } from 'kysely'
 import { Pool } from 'pg'
 import { up as createAttendanceNotificationDeliveries } from '../../src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries'
+import {
+  AttendanceNotificationDeliveryWorker,
+  DeterministicFakeAttendanceDeliveryChannel,
+  type AttendanceNotificationDeliveryQuery,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -185,6 +190,237 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
       ]))
     } finally {
       await pool.query('DELETE FROM attendance_notification_deliveries WHERE org_id = $1', [orgId]).catch(() => undefined)
+    }
+  })
+
+  it('C5-2 delivery worker claims due rows, sends via fake channel, retries/fails visibly, reclaims stale sending, and does not repeat sent rows', async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    const workerSchemaName = createIsolatedSchemaName()
+    await createSchema(dbUrl, workerSchemaName)
+    const workerDbUrl = withSearchPath(dbUrl, workerSchemaName)
+    const workerDb = createTestDb(workerDbUrl)
+    const workerPool = new Pool({ connectionString: workerDbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = `c5-worker-${runSuffix}`
+    const fixedNow = new Date('2026-08-01T00:00:00.000Z')
+    const liveLease = new Date('2026-08-01T00:10:00.000Z').toISOString()
+    const pastLease = new Date('2026-07-31T23:00:00.000Z').toISOString()
+    const sourceId = randomUUID()
+    const insertDelivery = async (label: string, overrides: Record<string, unknown> = {}) => {
+      const status = String(overrides.status ?? 'pending')
+      const channel = String(overrides.channel ?? 'dingtalk_work_notification')
+      const attemptCount = Number(overrides.attemptCount ?? 0)
+      const payload = overrides.payload ?? {}
+      const claimedAt = overrides.claimedAt ?? null
+      const claimExpiresAt = overrides.claimExpiresAt ?? null
+      const claimWorkerId = overrides.claimWorkerId ?? null
+      const deliveredAt = overrides.deliveredAt ?? null
+      const result = await workerPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status,
+            attempt_count, claimed_at, claim_expires_at, claim_worker_id, delivered_at, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,$4,'subject',$5,$6,$7,$8::timestamptz,$9::timestamptz,$10,$11::timestamptz,$12::jsonb)
+         RETURNING id::text AS id`,
+        [
+          orgId,
+          sourceId,
+          `worker:${runSuffix}:${label}`,
+          `u-${label}-${runSuffix}`,
+          channel,
+          status,
+          attemptCount,
+          claimedAt,
+          claimExpiresAt,
+          claimWorkerId,
+          deliveredAt,
+          JSON.stringify(payload),
+        ],
+      )
+      return result.rows[0].id
+    }
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await workerPool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    try {
+      await createAttendanceNotificationDeliveries(workerDb)
+      await requireTable(workerPool, 'attendance_notification_deliveries')
+
+      const okId = await insertDelivery('ok')
+      const retryId = await insertDelivery('retry', { payload: { fakeDelivery: 'retry' } })
+      const maxRetryId = await insertDelivery('maxretry', { attemptCount: 1, payload: { fakeDelivery: 'retry' } })
+      const failId = await insertDelivery('fail', { payload: { fakeDelivery: 'fail' } })
+      const missingChannelId = await insertDelivery('missing-channel', { channel: 'unknown_channel' })
+      const staleSendingId = await insertDelivery('stale-sending', {
+        status: 'sending',
+        attemptCount: 1,
+        claimedAt: pastLease,
+        claimExpiresAt: pastLease,
+        claimWorkerId: 'old-worker',
+      })
+      const liveSendingId = await insertDelivery('live-sending', {
+        status: 'sending',
+        attemptCount: 1,
+        claimedAt: fixedNow.toISOString(),
+        claimExpiresAt: liveLease,
+        claimWorkerId: 'live-worker',
+      })
+      const alreadySentId = await insertDelivery('sent', {
+        status: 'sent',
+        deliveredAt: fixedNow.toISOString(),
+      })
+
+      const worker = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [new DeterministicFakeAttendanceDeliveryChannel()],
+        now: () => fixedNow,
+        leaseMs: 60_000,
+        maxAttempts: 2,
+        workerId: 'worker-test',
+      })
+
+      await expect(worker.runBatch()).resolves.toEqual({ claimed: 6, sent: 2, retrying: 1, failed: 3 })
+
+      const row = async (id: string) => (await workerPool.query(
+        `SELECT status, attempt_count, delivered_at, next_attempt_at, last_error, claim_expires_at, claim_worker_id
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [id],
+      )).rows[0]
+
+      expect(await row(okId)).toMatchObject({
+        status: 'sent',
+        attempt_count: 1,
+        last_error: null,
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect((await row(okId)).delivered_at).toBeTruthy()
+      expect(await row(staleSendingId)).toMatchObject({
+        status: 'sent',
+        attempt_count: 2,
+        last_error: null,
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      const retry = await row(retryId)
+      expect(retry).toMatchObject({
+        status: 'retrying',
+        attempt_count: 1,
+        last_error: 'fake_retryable_failure',
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect(new Date(retry.next_attempt_at).getTime()).toBeGreaterThan(fixedNow.getTime())
+      expect(await row(maxRetryId)).toMatchObject({
+        status: 'failed',
+        attempt_count: 2,
+        last_error: 'fake_retryable_failure',
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect(await row(failId)).toMatchObject({
+        status: 'failed',
+        attempt_count: 1,
+        last_error: 'fake_non_retryable_failure',
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect(await row(missingChannelId)).toMatchObject({
+        status: 'failed',
+        attempt_count: 1,
+        last_error: 'attendance_delivery_channel_not_configured',
+        claim_expires_at: null,
+        claim_worker_id: null,
+      })
+      expect(await row(liveSendingId)).toMatchObject({
+        status: 'sending',
+        attempt_count: 1,
+        claim_worker_id: 'live-worker',
+      })
+      expect(await row(alreadySentId)).toMatchObject({
+        status: 'sent',
+        attempt_count: 0,
+      })
+
+      await expect(worker.runBatch()).resolves.toEqual({ claimed: 0, sent: 0, retrying: 0, failed: 0 })
+      expect(await row(okId)).toMatchObject({ status: 'sent', attempt_count: 1 })
+      expect(await row(retryId)).toMatchObject({ status: 'retrying', attempt_count: 1 })
+    } finally {
+      await workerPool.end().catch(() => undefined)
+      await workerDb.destroy().catch(() => undefined)
+      await dropSchema(dbUrl, workerSchemaName).catch(() => undefined)
+    }
+  })
+
+  it('C5-2 delivery worker does not let an expired lease owner overwrite a reclaimed worker result', async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    const workerSchemaName = createIsolatedSchemaName()
+    await createSchema(dbUrl, workerSchemaName)
+    const workerDbUrl = withSearchPath(dbUrl, workerSchemaName)
+    const workerDb = createTestDb(workerDbUrl)
+    const workerPool = new Pool({ connectionString: workerDbUrl })
+    const orgId = `c5-worker-lease-${Date.now().toString(36)}`
+    const sourceId = randomUUID()
+    const claimNow = new Date('2026-08-01T00:00:00.000Z')
+    const reclaimNow = new Date('2026-08-01T00:00:10.000Z')
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await workerPool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    try {
+      await createAttendanceNotificationDeliveries(workerDb)
+      await requireTable(workerPool, 'attendance_notification_deliveries')
+      const insert = await workerPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,'u-lease','subject','dingtalk_work_notification',$4::jsonb)
+         RETURNING id::text AS id`,
+        [orgId, sourceId, `lease-race:${sourceId}`, JSON.stringify({ fakeDelivery: 'retry' })],
+      )
+      const deliveryId = insert.rows[0].id
+
+      const workerB = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [new DeterministicFakeAttendanceDeliveryChannel()],
+        now: () => reclaimNow,
+        leaseMs: 60_000,
+        workerId: 'worker-b',
+      })
+      const workerA = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [{
+          name: 'dingtalk_work_notification',
+          async send() {
+            await expect(workerB.runBatch()).resolves.toEqual({ claimed: 1, sent: 0, retrying: 1, failed: 0 })
+            return { ok: true }
+          },
+        }],
+        now: () => claimNow,
+        leaseMs: 5_000,
+        workerId: 'worker-a',
+      })
+
+      await expect(workerA.runBatch()).resolves.toEqual({ claimed: 1, sent: 0, retrying: 0, failed: 0, lostLease: 1 })
+
+      const row = (await workerPool.query(
+        `SELECT status, attempt_count, delivered_at, last_error, claim_worker_id, claim_expires_at
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [deliveryId],
+      )).rows[0]
+      expect(row).toMatchObject({
+        status: 'retrying',
+        attempt_count: 2,
+        delivered_at: null,
+        last_error: 'fake_retryable_failure',
+        claim_worker_id: null,
+        claim_expires_at: null,
+      })
+    } finally {
+      await workerPool.end().catch(() => undefined)
+      await workerDb.destroy().catch(() => undefined)
+      await dropSchema(dbUrl, workerSchemaName).catch(() => undefined)
     }
   })
 })

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -3,12 +3,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   AttendanceScheduler,
   registerAttendanceSchedulerJob,
+  resolveAttendanceNotificationDeliveryJob,
   resolveCompTimeExpiryReminderJob,
   resolveUnscheduledReminderJob,
   startAttendanceScheduler,
   stopAttendanceScheduler,
 } from '../../src/services/AttendanceScheduler'
 import type { AttendanceExpiryService, ExpiredCompTimeBalance } from '../../src/services/AttendanceExpiryService'
+import {
+  AttendanceNotificationDeliveryWorker,
+  createAttendanceDeliveryChannelsFromEnv,
+  DeterministicFakeAttendanceDeliveryChannel,
+  computeDeliveryBackoffMs,
+} from '../../src/services/AttendanceNotificationDeliveryWorker'
 import {
   AttendanceNotifier,
   createAttendanceNotifierChannelsFromEnv,
@@ -31,6 +38,8 @@ describe('AttendanceScheduler (④ C4)', () => {
     delete process.env.ATTENDANCE_SCHEDULER_ENABLED
     delete process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED
     delete process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED
+    delete process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
+    delete process.env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED
     vi.restoreAllMocks()
   })
 
@@ -154,6 +163,26 @@ describe('AttendanceScheduler (④ C4)', () => {
 
     expect(instances.size).toBe(1)
   })
+
+  it('resolves the notification delivery worker job with one stable worker instance', async () => {
+    expect(resolveAttendanceNotificationDeliveryJob()).toBeNull()
+
+    process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED = 'true'
+    process.env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED = 'true'
+    const instances = new Set<unknown>()
+    vi.spyOn(AttendanceNotificationDeliveryWorker.prototype, 'runBatch').mockImplementation(function (this: AttendanceNotificationDeliveryWorker) {
+      instances.add(this)
+      return Promise.resolve({ claimed: 0, sent: 0, retrying: 0, failed: 0 })
+    })
+
+    const job = resolveAttendanceNotificationDeliveryJob()
+    expect(job?.name).toBe('attendance-notification-delivery')
+
+    await job?.run()
+    await job?.run()
+
+    expect(instances.size).toBe(1)
+  })
 })
 
 describe('AttendanceNotifier scaffold (④ C4 — no messages)', () => {
@@ -179,5 +208,48 @@ describe('AttendanceNotifier scaffold (④ C4 — no messages)', () => {
     const result = await notifier.notify([{ orgId: 'default', userId: 'u1', kind: 'k', text: 't' }])
     expect(result).toEqual({ requested: 1, sent: 1, failed: 1 })
     expect(calls).toEqual(['ok', 'bad'])
+  })
+})
+
+describe('Attendance C5 delivery worker primitives', () => {
+  it('keeps delivery channels default-off and registers the deterministic fake channel only by env', () => {
+    expect(createAttendanceDeliveryChannelsFromEnv({})).toEqual([])
+    const channels = createAttendanceDeliveryChannelsFromEnv({ ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED: 'true' } as NodeJS.ProcessEnv)
+    expect(channels).toHaveLength(1)
+    expect(channels[0].name).toBe('dingtalk_work_notification')
+  })
+
+  it('fake channel deterministically returns ok, retryable, and non-retryable outcomes', async () => {
+    const channel = new DeterministicFakeAttendanceDeliveryChannel()
+    const base = {
+      id: 'delivery-1',
+      orgId: 'default',
+      sourceType: 'unscheduled_reminder',
+      sourceId: 'source-1',
+      sourceKey: 'source-key',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+    }
+    await expect(channel.send({ ...base, payload: {} })).resolves.toEqual({ ok: true })
+    await expect(channel.send({ ...base, payload: { fakeDelivery: 'retry' } })).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: 'fake_retryable_failure',
+    })
+    await expect(channel.send({ ...base, payload: { fakeDelivery: 'fail' } })).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: 'fake_non_retryable_failure',
+    })
+  })
+
+  it('uses bounded exponential retry backoff', () => {
+    expect(computeDeliveryBackoffMs(1)).toBe(60_000)
+    expect(computeDeliveryBackoffMs(2)).toBe(5 * 60_000)
+    expect(computeDeliveryBackoffMs(3)).toBe(15 * 60_000)
+    expect(computeDeliveryBackoffMs(4)).toBe(60 * 60_000)
+    expect(computeDeliveryBackoffMs(5)).toBe(6 * 60 * 60_000)
+    expect(computeDeliveryBackoffMs(99)).toBe(6 * 60 * 60_000)
   })
 })


### PR DESCRIPTION
## Summary

C5-2: add the delivery worker + deterministic fake channel for attendance notification outbox rows.

- Adds `AttendanceNotificationDeliveryWorker`:
  - claims due `pending` / `retrying` rows and stale `sending` leases with `FOR UPDATE SKIP LOCKED`;
  - marks claimed rows `sending`, increments `attempt_count`, writes lease fields;
  - sends through exactly one channel adapter matching `delivery.channel`;
  - success → `sent` + `delivered_at`;
  - retryable failure → `retrying` + bounded backoff;
  - non-retryable / max attempts / missing channel → `failed` with explicit `last_error`;
  - clears lease fields on terminal/retry transitions.
- Adds deterministic fake channel behind `ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED=true`; no real DingTalk network in this slice.
- Wires worker as an opt-in secondary `AttendanceScheduler` job behind `ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED=true`.
- Extends the existing C5 outbox integration spec to cover worker state-flow, stale lease reclaim, live lease non-reclaim, max-attempt failure, missing-channel failure, and repeat no-send.
- Backfills tracker: C5-1b #2502 is ✅; C5-2 is this PR and remains 🟡 pending CI/review/merge.

## Verification

Local targeted checks:

- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-scheduler.test.ts --reporter=dot` → 15/15 pass.
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-notification-deliveries.test.ts --reporter=dot` → 2/2 pass.
- C4/C5 DB subset (`attendance-expiry-service`, `attendance-unscheduled-reminder`, `attendance-notification-deliveries`, `attendance-comp-time-expiry-reminder`) → 4 files / 5 tests pass.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` → pass.
- `git diff --check` → pass.

## Deferred

- C5-3 real DingTalk work-notification channel.
- C5-4 admin observability.
- C5-5 staging smoke; fake-channel smoke does not flip C5 ✅ by itself.
