### PR TITLE
feat(attendance): add C5 DingTalk work notification channel

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -80,12 +80,12 @@
 | 2 | **C5-0 outbox DDL** | ✅ #2487 | `attendance_notification_deliveries` 表 + CHECK/unique/index；不发送 |
 | 3 | **C5-1a unscheduled fan-out producer** | ✅ #2498 | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；CI real-DB gate 实跑 `attendance-unscheduled-reminder` + outbox spec |
 | 4 | **C5-1b comp-time expiry reminder producer** | ✅ #2502 | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；CI real-DB gate 实跑 comp-time expiry reminder producer spec |
-| 5 | **C5-2 delivery worker + fake channel** | 🟡 本 PR | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；pending CI/review/merge 后回填 ✅ |
-| 6 | **C5-3 DingTalk work-notification channel** | 🔒 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible |
+| 5 | **C5-2 delivery worker + fake channel** | ✅ #2504 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；CI real-DB gate 实跑 outbox spec + stale-lease race |
+| 6 | **C5-3 DingTalk work-notification channel** | 🟡 本 PR | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible；pending CI/review/merge 后回填 ✅ |
 | 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 正在本 PR 中接入 delivery worker + fake channel。C5 整体仍保持 🟡，直到 C5-2/C5-3/C5-5b 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 正在本 PR 中接入真实 DingTalk work-notification channel。C5 整体仍保持 🟡，直到 C5-3/C5-5b 完整闭环。
 
 ### Out of this target
 

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -81,11 +81,11 @@
 | 3 | **C5-1a unscheduled fan-out producer** | ✅ #2498 | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；CI real-DB gate 实跑 `attendance-unscheduled-reminder` + outbox spec |
 | 4 | **C5-1b comp-time expiry reminder producer** | ✅ #2502 | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；CI real-DB gate 实跑 comp-time expiry reminder producer spec |
 | 5 | **C5-2 delivery worker + fake channel** | ✅ #2504 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；CI real-DB gate 实跑 outbox spec + stale-lease race |
-| 6 | **C5-3 DingTalk work-notification channel** | 🟡 本 PR | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible；pending CI/review/merge 后回填 ✅ |
+| 6 | **C5-3 DingTalk work-notification channel** | ✅ #2507 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible；CI real-DB gate 实跑绑定解析 + worker sent 状态流 |
 | 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 正在本 PR 中接入真实 DingTalk work-notification channel。C5 整体仍保持 🟡，直到 C5-3/C5-5b 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 #2507 接入真实 DingTalk work-notification channel，复用现有 `readDingTalkMessageConfigFromRuntime` / `fetchDingTalkAppAccessToken` / `sendDingTalkWorkNotification`，缺配置/缺绑定 fail-visible，真实外发仍由 env/store 配置 gate 控制。C5 整体仍保持 🟡，直到 C5-5b 真实 DingTalk staging smoke 完整闭环。
 
 ### Out of this target
 

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -465,14 +465,26 @@ function buildDeliveryContent(message: AttendanceDeliveryMessage): string {
 
 function normalizeErrorText(error: unknown, fallback: string): string {
   const raw = error instanceof Error ? error.message : String(error ?? '')
-  const text = raw.trim() || fallback
+  const text = redactDingTalkErrorText(raw.trim() || fallback)
   return text.length > 240 ? `${text.slice(0, 237)}...` : text
+}
+
+function redactDingTalkErrorText(text: string): string {
+  return text
+    .replace(/([?&](?:access_token|accessToken|appsecret|appSecret|app_secret|client_secret|clientSecret)=)[^&\s'")]+/gi, '$1[redacted]')
+    .replace(/((?:access_token|accessToken|appsecret|appSecret|app_secret|client_secret|clientSecret)\s*[:=]\s*)[^&\s'")]+/gi, '$1[redacted]')
 }
 
 function classifyConfigError(error: unknown): AttendanceDeliveryChannelResult {
   const message = normalizeErrorText(error, 'DingTalk work-notification config unavailable')
   const retryable = !/not configured|required|not found|Agent ID/i.test(message)
   return { ok: false, retryable, error: `dingtalk_work_notification_config_unavailable: ${message}` }
+}
+
+function isRetryableDingTalkBusinessError(error: DingTalkBusinessError): boolean {
+  const responseText = typeof error.responseBody?.errmsg === 'string' ? error.responseBody.errmsg : ''
+  const message = `${error.message} ${responseText}`.toLowerCase()
+  return /rate.?limit|too many|throttl|system busy|server busy|temporar|timeout|timed out|try again|retry|busy|限流|频繁|繁忙|超时|稍后|重试|系统异常|服务异常/i.test(message)
 }
 
 function classifyDingTalkSendError(error: unknown): AttendanceDeliveryChannelResult {
@@ -486,7 +498,7 @@ function classifyDingTalkSendError(error: unknown): AttendanceDeliveryChannelRes
   if (error instanceof DingTalkBusinessError) {
     return {
       ok: false,
-      retryable: false,
+      retryable: isRetryableDingTalkBusinessError(error),
       error: `dingtalk_business_error: ${normalizeErrorText(error, 'DingTalk business error')}`,
     }
   }

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -230,10 +230,17 @@ export class DingTalkAttendanceDeliveryChannel implements AttendanceDeliveryChan
         result: { ok: false, retryable: false, error: 'dingtalk_recipient_ambiguous' },
       }
     }
+    const dingTalkUserId = String(rows[0].external_user_id ?? '').trim()
+    if (!dingTalkUserId) {
+      return {
+        ok: false,
+        result: { ok: false, retryable: false, error: 'dingtalk_recipient_external_user_id_missing' },
+      }
+    }
     return {
       ok: true,
       integrationId: rows[0].integration_id,
-      dingTalkUserId: rows[0].external_user_id,
+      dingTalkUserId,
     }
   }
 }
@@ -470,9 +477,10 @@ function normalizeErrorText(error: unknown, fallback: string): string {
 }
 
 function redactDingTalkErrorText(text: string): string {
-  return text
-    .replace(/([?&](?:access_token|accessToken|appsecret|appSecret|app_secret|client_secret|clientSecret)=)[^&\s'")]+/gi, '$1[redacted]')
-    .replace(/((?:access_token|accessToken|appsecret|appSecret|app_secret|client_secret|clientSecret)\s*[:=]\s*)[^&\s'")]+/gi, '$1[redacted]')
+  const redactedSecrets = text
+    .replace(/([?&](?:access_token|accessToken|appkey|appKey|appsecret|appSecret|app_secret|client_secret|clientSecret)=)[^&\s'")]+/gi, '$1[redacted]')
+    .replace(/((?:access_token|accessToken|appkey|appKey|appsecret|appSecret|app_secret|client_secret|clientSecret)\s*[:=]\s*)[^&\s'")]+/gi, '$1[redacted]')
+  return redactedSecrets.replace(/(?:https?:\/\/)?(?:[a-z0-9-]+\.)+[a-z]{2,}(?::\d+)?(?:\/[^\s'")]*)?/gi, '[redacted-url]')
 }
 
 function classifyConfigError(error: unknown): AttendanceDeliveryChannelResult {
@@ -482,16 +490,34 @@ function classifyConfigError(error: unknown): AttendanceDeliveryChannelResult {
 }
 
 function isRetryableDingTalkBusinessError(error: DingTalkBusinessError): boolean {
+  const code = readDingTalkErrorNumber(error.responseBody, 'errcode', 'code', 'statusCode', 'status')
+  if (code !== null && isRetryableDingTalkErrorCode(code)) return true
   const responseText = typeof error.responseBody?.errmsg === 'string' ? error.responseBody.errmsg : ''
   const message = `${error.message} ${responseText}`.toLowerCase()
   return /rate.?limit|too many|throttl|system busy|server busy|temporar|timeout|timed out|try again|retry|busy|限流|频繁|繁忙|超时|稍后|重试|系统异常|服务异常/i.test(message)
+}
+
+function readDingTalkErrorNumber(body: Record<string, unknown> | null, ...keys: string[]): number | null {
+  if (!body) return null
+  for (const key of keys) {
+    const value = body[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+    if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) {
+      return Number(value)
+    }
+  }
+  return null
+}
+
+function isRetryableDingTalkErrorCode(code: number): boolean {
+  return code === 408 || code === 429 || (code >= 500 && code < 600) || code === 50001
 }
 
 function classifyDingTalkSendError(error: unknown): AttendanceDeliveryChannelResult {
   if (error instanceof DingTalkRequestError) {
     return {
       ok: false,
-      retryable: error.statusCode === 429 || error.statusCode >= 500,
+      retryable: isRetryableDingTalkErrorCode(error.statusCode),
       error: `dingtalk_request_${error.statusCode}: ${normalizeErrorText(error, 'DingTalk request failed')}`,
     }
   }

--- a/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
+++ b/packages/core-backend/src/services/AttendanceNotificationDeliveryWorker.ts
@@ -1,6 +1,17 @@
 import { randomBytes } from 'crypto'
 import { query as defaultQuery } from '../db/pg'
 import { Logger } from '../core/logger'
+import {
+  DingTalkBusinessError,
+  DingTalkRequestError,
+  fetchDingTalkAppAccessToken,
+  sendDingTalkWorkNotification,
+  type DingTalkMessageConfig,
+  type DingTalkWorkNotificationResult,
+} from '../integrations/dingtalk/client'
+import {
+  readDingTalkMessageConfigFromRuntime,
+} from '../integrations/dingtalk/work-notification-settings'
 
 /**
  * C5-2 delivery worker.
@@ -47,6 +58,17 @@ export interface AttendanceNotificationDeliveryWorkerOptions {
   logger?: Logger
 }
 
+export interface DingTalkAttendanceDeliveryChannelOptions {
+  query?: AttendanceNotificationDeliveryQuery
+  readConfig?: (integrationId?: string) => Promise<DingTalkMessageConfig>
+  fetchAccessToken?: (config: DingTalkMessageConfig) => Promise<string>
+  sendWorkNotification?: (
+    accessToken: string,
+    input: { userIds: string[]; title: string; content: string },
+    config: DingTalkMessageConfig,
+  ) => Promise<DingTalkWorkNotificationResult>
+}
+
 export interface AttendanceNotificationDeliveryResult {
   claimed: number
   sent: number
@@ -75,7 +97,7 @@ const MIN_BATCH_SIZE = 1
 const MAX_BATCH_SIZE = 200
 const MIN_LEASE_MS = 5_000
 const MAX_LEASE_MS = 10 * 60_000
-const FAKE_CHANNEL_NAME = 'dingtalk_work_notification'
+export const DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME = 'dingtalk_work_notification'
 
 export function clampDeliveryBatchSize(value: number | undefined): number {
   const n = Number(value)
@@ -98,7 +120,7 @@ export function computeDeliveryBackoffMs(attemptCount: number): number {
 }
 
 export class DeterministicFakeAttendanceDeliveryChannel implements AttendanceDeliveryChannel {
-  readonly name = FAKE_CHANNEL_NAME
+  readonly name = DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
 
   async send(message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult> {
     const mode = String(message.payload.fakeDelivery ?? message.payload.deliveryMode ?? 'ok')
@@ -113,8 +135,107 @@ export class DeterministicFakeAttendanceDeliveryChannel implements AttendanceDel
 }
 
 export function createAttendanceDeliveryChannelsFromEnv(env: NodeJS.ProcessEnv = process.env): AttendanceDeliveryChannel[] {
-  if (env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED !== 'true') return []
-  return [new DeterministicFakeAttendanceDeliveryChannel()]
+  if (env.ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED === 'true') {
+    return [new DingTalkAttendanceDeliveryChannel()]
+  }
+  if (env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED === 'true') {
+    return [new DeterministicFakeAttendanceDeliveryChannel()]
+  }
+  return []
+}
+
+interface DingTalkRecipientRow {
+  integration_id: string
+  external_user_id: string
+}
+
+export class DingTalkAttendanceDeliveryChannel implements AttendanceDeliveryChannel {
+  readonly name = DINGTALK_WORK_NOTIFICATION_CHANNEL_NAME
+  private readonly query: AttendanceNotificationDeliveryQuery
+  private readonly readConfig: (integrationId?: string) => Promise<DingTalkMessageConfig>
+  private readonly fetchAccessToken: (config: DingTalkMessageConfig) => Promise<string>
+  private readonly sendWorkNotification: (
+    accessToken: string,
+    input: { userIds: string[]; title: string; content: string },
+    config: DingTalkMessageConfig,
+  ) => Promise<DingTalkWorkNotificationResult>
+
+  constructor(options: DingTalkAttendanceDeliveryChannelOptions = {}) {
+    this.query = options.query ?? (defaultQuery as AttendanceNotificationDeliveryQuery)
+    this.readConfig = options.readConfig ?? readDingTalkMessageConfigFromRuntime
+    this.fetchAccessToken = options.fetchAccessToken ?? fetchDingTalkAppAccessToken
+    this.sendWorkNotification = options.sendWorkNotification ?? sendDingTalkWorkNotification
+  }
+
+  async send(message: AttendanceDeliveryMessage): Promise<AttendanceDeliveryChannelResult> {
+    const recipient = await this.resolveRecipient(message)
+    if (recipient.ok === false) return recipient.result
+
+    let config: DingTalkMessageConfig
+    try {
+      config = await this.readConfig(recipient.integrationId)
+    } catch (error) {
+      return classifyConfigError(error)
+    }
+
+    try {
+      const accessToken = await this.fetchAccessToken(config)
+      await this.sendWorkNotification(
+        accessToken,
+        {
+          userIds: [recipient.dingTalkUserId],
+          title: buildDeliveryTitle(message),
+          content: buildDeliveryContent(message),
+        },
+        config,
+      )
+      return { ok: true }
+    } catch (error) {
+      return classifyDingTalkSendError(error)
+    }
+  }
+
+  private async resolveRecipient(message: AttendanceDeliveryMessage): Promise<
+    | { ok: true; integrationId: string; dingTalkUserId: string }
+    | { ok: false; result: AttendanceDeliveryChannelResult }
+  > {
+    const { rows } = await this.query<DingTalkRecipientRow>(
+      `SELECT i.id::text AS integration_id,
+              a.external_user_id
+         FROM directory_account_links l
+         JOIN directory_accounts a
+           ON a.id = l.directory_account_id
+          AND a.provider = 'dingtalk'
+          AND a.is_active = true
+         JOIN directory_integrations i
+           ON i.id = a.integration_id
+          AND i.provider = 'dingtalk'
+          AND i.status = 'active'
+          AND i.org_id = $2
+        WHERE l.local_user_id = $1
+          AND l.link_status = 'linked'
+        ORDER BY i.updated_at DESC, a.updated_at DESC, a.id ASC
+        LIMIT 2`,
+      [message.recipientUserId, message.orgId],
+    )
+    if (rows.length === 0) {
+      return {
+        ok: false,
+        result: { ok: false, retryable: false, error: 'dingtalk_recipient_not_bound' },
+      }
+    }
+    if (rows.length > 1) {
+      return {
+        ok: false,
+        result: { ok: false, retryable: false, error: 'dingtalk_recipient_ambiguous' },
+      }
+    }
+    return {
+      ok: true,
+      integrationId: rows[0].integration_id,
+      dingTalkUserId: rows[0].external_user_id,
+    }
+  }
 }
 
 export class AttendanceNotificationDeliveryWorker {
@@ -320,4 +441,58 @@ function parsePayload(value: unknown): Record<string, unknown> {
     try { return JSON.parse(value) as Record<string, unknown> } catch { return {} }
   }
   return value as Record<string, unknown>
+}
+
+function normalizePayloadText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function buildDeliveryTitle(message: AttendanceDeliveryMessage): string {
+  const title = normalizePayloadText(message.payload.title)
+  if (title) return title
+  if (message.sourceType === 'comp_time_expiry_reminder') return 'Comp-time expiry reminder'
+  if (message.sourceType === 'unscheduled_reminder') return 'Unscheduled shift reminder'
+  return 'Attendance notification'
+}
+
+function buildDeliveryContent(message: AttendanceDeliveryMessage): string {
+  const body = normalizePayloadText(message.payload.body)
+  if (body) return body
+  const content = normalizePayloadText(message.payload.content)
+  if (content) return content
+  return `Attendance notification source: ${message.sourceType}`
+}
+
+function normalizeErrorText(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : String(error ?? '')
+  const text = raw.trim() || fallback
+  return text.length > 240 ? `${text.slice(0, 237)}...` : text
+}
+
+function classifyConfigError(error: unknown): AttendanceDeliveryChannelResult {
+  const message = normalizeErrorText(error, 'DingTalk work-notification config unavailable')
+  const retryable = !/not configured|required|not found|Agent ID/i.test(message)
+  return { ok: false, retryable, error: `dingtalk_work_notification_config_unavailable: ${message}` }
+}
+
+function classifyDingTalkSendError(error: unknown): AttendanceDeliveryChannelResult {
+  if (error instanceof DingTalkRequestError) {
+    return {
+      ok: false,
+      retryable: error.statusCode === 429 || error.statusCode >= 500,
+      error: `dingtalk_request_${error.statusCode}: ${normalizeErrorText(error, 'DingTalk request failed')}`,
+    }
+  }
+  if (error instanceof DingTalkBusinessError) {
+    return {
+      ok: false,
+      retryable: false,
+      error: `dingtalk_business_error: ${normalizeErrorText(error, 'DingTalk business error')}`,
+    }
+  }
+  return {
+    ok: false,
+    retryable: true,
+    error: `dingtalk_send_failed: ${normalizeErrorText(error, 'DingTalk send failed')}`,
+  }
 }

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -6,8 +6,10 @@ import { up as createAttendanceNotificationDeliveries } from '../../src/db/migra
 import {
   AttendanceNotificationDeliveryWorker,
   DeterministicFakeAttendanceDeliveryChannel,
+  DingTalkAttendanceDeliveryChannel,
   type AttendanceNotificationDeliveryQuery,
 } from '../../src/services/AttendanceNotificationDeliveryWorker'
+import type { DingTalkMessageConfig } from '../../src/integrations/dingtalk/client'
 
 const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
 const describeIfDatabase = dbUrl ? describe : describe.skip
@@ -421,6 +423,131 @@ describeIfDatabase('Attendance C5 notification delivery outbox', () => {
       await workerPool.end().catch(() => undefined)
       await workerDb.destroy().catch(() => undefined)
       await dropSchema(dbUrl, workerSchemaName).catch(() => undefined)
+    }
+  })
+
+  it('C5-3 real DingTalk channel resolves linked directory users and lets the worker mark delivery sent without external network', async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    const publicPool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = `c5-dingtalk-${runSuffix}`
+    const localUserId = `u-c5-dingtalk-${runSuffix}`
+    const integrationId = randomUUID()
+    const directoryAccountId = randomUUID()
+    const sourceId = randomUUID()
+    let deliveryId = ''
+    const config: DingTalkMessageConfig = {
+      appKey: 'dt-app-key',
+      appSecret: 'dt-app-secret',
+      agentId: '123456789',
+      baseUrl: 'https://oapi.dingtalk.com',
+    }
+    const query: AttendanceNotificationDeliveryQuery = async (sqlText, params) => {
+      const r = await publicPool.query(sqlText, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+    const sentMessages: unknown[] = []
+
+    try {
+      await requireTable(publicPool, 'users')
+      await requireTable(publicPool, 'directory_integrations')
+      await requireTable(publicPool, 'directory_accounts')
+      await requireTable(publicPool, 'directory_account_links')
+      await requireTable(publicPool, 'attendance_notification_deliveries')
+
+      await publicPool.query(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active)
+         VALUES ($1,$2,'hash',$3,'user',true)
+         ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+        [localUserId, `${localUserId}@example.test`, localUserId],
+      )
+      await publicPool.query(
+        `INSERT INTO directory_integrations (id, org_id, provider, name, status, corp_id, config)
+         VALUES ($1,$2,'dingtalk',$3,'active','corp-c5',$4::jsonb)`,
+        [integrationId, orgId, `C5 DingTalk ${runSuffix}`, JSON.stringify({})],
+      )
+      await publicPool.query(
+        `INSERT INTO directory_accounts
+           (id, integration_id, provider, corp_id, external_user_id, external_key, name, is_active)
+         VALUES ($1,$2,'dingtalk','corp-c5','dt-user-c5','dt-key-c5',$3,true)`,
+        [directoryAccountId, integrationId, localUserId],
+      )
+      await publicPool.query(
+        `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+         VALUES ($1,$2,'linked','manual')`,
+        [directoryAccountId, localUserId],
+      )
+      const delivery = await publicPool.query<{ id: string }>(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, payload)
+         VALUES ($1,'unscheduled_reminder',$2,$3,$4,'subject','dingtalk_work_notification',$5::jsonb)
+         RETURNING id::text AS id`,
+        [
+          orgId,
+          sourceId,
+          `c5-dingtalk:${sourceId}:recipient:${localUserId}:channel:dingtalk_work_notification`,
+          localUserId,
+          JSON.stringify({ title: 'C5 DingTalk smoke', body: 'Please check the attendance reminder.' }),
+        ],
+      )
+      deliveryId = delivery.rows[0].id
+
+      const channel = new DingTalkAttendanceDeliveryChannel({
+        query,
+        readConfig: async (receivedIntegrationId) => {
+          expect(receivedIntegrationId).toBe(integrationId)
+          return config
+        },
+        fetchAccessToken: async (receivedConfig) => {
+          expect(receivedConfig).toBe(config)
+          return 'access-token'
+        },
+        sendWorkNotification: async (accessToken, input, receivedConfig) => {
+          sentMessages.push({ accessToken, input, receivedConfig })
+          return { taskId: 'task-c5', requestId: 'req-c5', raw: {} }
+        },
+      })
+      const worker = new AttendanceNotificationDeliveryWorker({
+        query,
+        channels: [channel],
+        now: () => new Date('2026-08-02T00:00:00.000Z'),
+        workerId: 'worker-c5-dingtalk',
+      })
+
+      await expect(worker.runBatch()).resolves.toEqual({ claimed: 1, sent: 1, retrying: 0, failed: 0 })
+
+      expect(sentMessages).toEqual([{
+        accessToken: 'access-token',
+        input: {
+          userIds: ['dt-user-c5'],
+          title: 'C5 DingTalk smoke',
+          content: 'Please check the attendance reminder.',
+        },
+        receivedConfig: config,
+      }])
+      const row = (await publicPool.query(
+        `SELECT status, delivered_at, last_error, attempt_count, claim_worker_id, claim_expires_at
+           FROM attendance_notification_deliveries
+          WHERE id = $1`,
+        [deliveryId],
+      )).rows[0]
+      expect(row).toMatchObject({
+        status: 'sent',
+        last_error: null,
+        attempt_count: 1,
+        claim_worker_id: null,
+        claim_expires_at: null,
+      })
+      expect(row.delivered_at).toBeTruthy()
+    } finally {
+      if (deliveryId) {
+        await publicPool.query('DELETE FROM attendance_notification_deliveries WHERE id = $1', [deliveryId]).catch(() => undefined)
+      }
+      await publicPool.query('DELETE FROM directory_account_links WHERE directory_account_id = $1', [directoryAccountId]).catch(() => undefined)
+      await publicPool.query('DELETE FROM directory_accounts WHERE id = $1', [directoryAccountId]).catch(() => undefined)
+      await publicPool.query('DELETE FROM directory_integrations WHERE id = $1', [integrationId]).catch(() => undefined)
+      await publicPool.query('DELETE FROM users WHERE id = $1', [localUserId]).catch(() => undefined)
+      await publicPool.end().catch(() => undefined)
     }
   })
 })

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -355,6 +355,18 @@ describe('Attendance C5 delivery worker primitives', () => {
       retryable: false,
       error: 'dingtalk_recipient_ambiguous',
     })
+
+    const blankExternalUser = new DingTalkAttendanceDeliveryChannel({
+      query: async () => ({
+        rows: [{ integration_id: 'dir-1', external_user_id: '   ' }],
+        rowCount: 1,
+      }),
+    })
+    await expect(blankExternalUser.send(base)).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: 'dingtalk_recipient_external_user_id_missing',
+    })
   })
 
   it('real DingTalk channel classifies config, network, and DingTalk business failures', async () => {
@@ -397,6 +409,16 @@ describe('Attendance C5 delivery worker primitives', () => {
     await expect(new DingTalkAttendanceDeliveryChannel({
       query,
       readConfig: async () => config,
+      fetchAccessToken: async () => { throw new DingTalkRequestError('request timed out', 408, null) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('dingtalk_request_408'),
+    })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
       fetchAccessToken: async () => 'access-token',
       sendWorkNotification: async () => { throw new DingTalkBusinessError('invalid userid', { errcode: 40001 }) },
     }).send(base)).resolves.toEqual({
@@ -410,6 +432,17 @@ describe('Attendance C5 delivery worker primitives', () => {
       readConfig: async () => config,
       fetchAccessToken: async () => 'access-token',
       sendWorkNotification: async () => { throw new DingTalkBusinessError('system busy, try again later', { errcode: 50001, errmsg: 'system busy' }) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('dingtalk_business_error'),
+    })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => 'access-token',
+      sendWorkNotification: async () => { throw new DingTalkBusinessError('upstream rejected request', { errcode: 429 }) },
     }).send(base)).resolves.toEqual({
       ok: false,
       retryable: true,
@@ -455,9 +488,12 @@ describe('Attendance C5 delivery worker primitives', () => {
     expect(result).toEqual({
       ok: false,
       retryable: true,
-      error: expect.stringContaining('appsecret=[redacted]'),
+      error: expect.stringContaining('[redacted-url]'),
     })
     expect(JSON.stringify(result)).not.toContain('super-secret')
+    expect(JSON.stringify(result)).not.toContain('bad.invalid')
+    expect(JSON.stringify(result)).not.toContain('appkey=k')
+    expect(JSON.stringify(result)).not.toContain('/gettoken')
 
     const sendResult = await new DingTalkAttendanceDeliveryChannel({
       query,
@@ -481,8 +517,38 @@ describe('Attendance C5 delivery worker primitives', () => {
     expect(sendResult).toEqual({
       ok: false,
       retryable: true,
-      error: expect.stringContaining('access_token=[redacted]'),
+      error: expect.stringContaining('[redacted-url]'),
     })
     expect(JSON.stringify(sendResult)).not.toContain('token-secret')
+    expect(JSON.stringify(sendResult)).not.toContain('bad.invalid')
+    expect(JSON.stringify(sendResult)).not.toContain('/topapi/message')
+
+    const schemelessResult = await new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => {
+        throw new Error('Failed to parse URL from oapi.dingtalk.com/gettoken?appkey=k&appsecret=super-secret')
+      },
+    }).send({
+      id: 'delivery-3',
+      orgId: 'default',
+      sourceType: 'comp_time_expiry_reminder',
+      sourceId: 'balance-1',
+      sourceKey: 'balance-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    })
+
+    expect(schemelessResult).toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('[redacted-url]'),
+    })
+    expect(JSON.stringify(schemelessResult)).not.toContain('super-secret')
+    expect(JSON.stringify(schemelessResult)).not.toContain('oapi.dingtalk.com')
+    expect(JSON.stringify(schemelessResult)).not.toContain('appkey=k')
+    expect(JSON.stringify(schemelessResult)).not.toContain('/gettoken')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -404,5 +404,85 @@ describe('Attendance C5 delivery worker primitives', () => {
       retryable: false,
       error: expect.stringContaining('dingtalk_business_error'),
     })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => 'access-token',
+      sendWorkNotification: async () => { throw new DingTalkBusinessError('system busy, try again later', { errcode: 50001, errmsg: 'system busy' }) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('dingtalk_business_error'),
+    })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => 'access-token',
+      sendWorkNotification: async () => { throw new DingTalkBusinessError('rate limit exceeded', { errcode: 429, errmsg: 'too many requests' }) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('dingtalk_business_error'),
+    })
+  })
+
+  it('real DingTalk channel redacts DingTalk URL secrets before returning retryable errors', async () => {
+    const query: AttendanceNotificationDeliveryQuery = async () => ({
+      rows: [{ integration_id: 'dir-1', external_user_id: 'dt-user-1' }],
+      rowCount: 1,
+    })
+    const config: DingTalkMessageConfig = { appKey: 'k', appSecret: 'super-secret', agentId: '1' }
+    const result = await new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => {
+        throw new Error('Failed to parse URL from https://bad.invalid/gettoken?appkey=k&appsecret=super-secret')
+      },
+    }).send({
+      id: 'delivery-1',
+      orgId: 'default',
+      sourceType: 'comp_time_expiry_reminder',
+      sourceId: 'balance-1',
+      sourceKey: 'balance-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('appsecret=[redacted]'),
+    })
+    expect(JSON.stringify(result)).not.toContain('super-secret')
+
+    const sendResult = await new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => 'token-secret',
+      sendWorkNotification: async () => {
+        throw new Error('Failed to parse URL from https://bad.invalid/topapi/message?access_token=token-secret')
+      },
+    }).send({
+      id: 'delivery-2',
+      orgId: 'default',
+      sourceType: 'unscheduled_reminder',
+      sourceId: 'dispatch-1',
+      sourceKey: 'dispatch-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    })
+
+    expect(sendResult).toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('access_token=[redacted]'),
+    })
+    expect(JSON.stringify(sendResult)).not.toContain('token-secret')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -12,10 +12,13 @@ import {
 import type { AttendanceExpiryService, ExpiredCompTimeBalance } from '../../src/services/AttendanceExpiryService'
 import {
   AttendanceNotificationDeliveryWorker,
+  DingTalkAttendanceDeliveryChannel,
   createAttendanceDeliveryChannelsFromEnv,
   DeterministicFakeAttendanceDeliveryChannel,
   computeDeliveryBackoffMs,
+  type AttendanceNotificationDeliveryQuery,
 } from '../../src/services/AttendanceNotificationDeliveryWorker'
+import { DingTalkBusinessError, DingTalkRequestError, type DingTalkMessageConfig } from '../../src/integrations/dingtalk/client'
 import {
   AttendanceNotifier,
   createAttendanceNotifierChannelsFromEnv,
@@ -40,6 +43,7 @@ describe('AttendanceScheduler (④ C4)', () => {
     delete process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED
     delete process.env.ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED
     delete process.env.ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED
+    delete process.env.ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED
     vi.restoreAllMocks()
   })
 
@@ -217,6 +221,25 @@ describe('Attendance C5 delivery worker primitives', () => {
     const channels = createAttendanceDeliveryChannelsFromEnv({ ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED: 'true' } as NodeJS.ProcessEnv)
     expect(channels).toHaveLength(1)
     expect(channels[0].name).toBe('dingtalk_work_notification')
+    expect(channels[0]).toBeInstanceOf(DeterministicFakeAttendanceDeliveryChannel)
+  })
+
+  it('registers the real DingTalk work-notification channel only by explicit env', () => {
+    const channels = createAttendanceDeliveryChannelsFromEnv({
+      ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED: 'true',
+    } as NodeJS.ProcessEnv)
+    expect(channels).toHaveLength(1)
+    expect(channels[0].name).toBe('dingtalk_work_notification')
+    expect(channels[0]).toBeInstanceOf(DingTalkAttendanceDeliveryChannel)
+  })
+
+  it('prefers the real DingTalk channel over fake when both env gates are accidentally enabled', () => {
+    const channels = createAttendanceDeliveryChannelsFromEnv({
+      ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED: 'true',
+      ATTENDANCE_NOTIFICATION_FAKE_CHANNEL_ENABLED: 'true',
+    } as NodeJS.ProcessEnv)
+    expect(channels).toHaveLength(1)
+    expect(channels[0]).toBeInstanceOf(DingTalkAttendanceDeliveryChannel)
   })
 
   it('fake channel deterministically returns ok, retryable, and non-retryable outcomes', async () => {
@@ -251,5 +274,135 @@ describe('Attendance C5 delivery worker primitives', () => {
     expect(computeDeliveryBackoffMs(4)).toBe(60 * 60_000)
     expect(computeDeliveryBackoffMs(5)).toBe(6 * 60 * 60_000)
     expect(computeDeliveryBackoffMs(99)).toBe(6 * 60 * 60_000)
+  })
+
+  it('real DingTalk channel resolves a linked recipient and sends through the existing work-notification client seam', async () => {
+    const query: AttendanceNotificationDeliveryQuery = vi.fn(async () => ({
+      rows: [{ integration_id: 'dir-1', external_user_id: 'dt-user-1' }],
+      rowCount: 1,
+    }))
+    const config: DingTalkMessageConfig = {
+      appKey: 'dt-app-key',
+      appSecret: 'dt-app-secret',
+      agentId: '123456789',
+      baseUrl: 'https://oapi.dingtalk.com',
+    }
+    const readConfig = vi.fn(async () => config)
+    const fetchAccessToken = vi.fn(async () => 'access-token')
+    const sendWorkNotification = vi.fn(async () => ({ taskId: 'task-1', raw: {} }))
+    const channel = new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig,
+      fetchAccessToken,
+      sendWorkNotification,
+    })
+
+    await expect(channel.send({
+      id: 'delivery-1',
+      orgId: 'default',
+      sourceType: 'unscheduled_reminder',
+      sourceId: 'dispatch-1',
+      sourceKey: 'dispatch-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: { title: '排班提醒', body: '明天还没有排班。' },
+    })).resolves.toEqual({ ok: true })
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('directory_account_links'), ['u1', 'default'])
+    expect(readConfig).toHaveBeenCalledWith('dir-1')
+    expect(fetchAccessToken).toHaveBeenCalledWith(config)
+    expect(sendWorkNotification).toHaveBeenCalledWith(
+      'access-token',
+      { userIds: ['dt-user-1'], title: '排班提醒', content: '明天还没有排班。' },
+      config,
+    )
+  })
+
+  it('real DingTalk channel fails visibly without a unique active recipient binding', async () => {
+    const base = {
+      id: 'delivery-1',
+      orgId: 'default',
+      sourceType: 'comp_time_expiry_reminder',
+      sourceId: 'balance-1',
+      sourceKey: 'balance-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    }
+    const noBinding = new DingTalkAttendanceDeliveryChannel({
+      query: async () => ({ rows: [], rowCount: 0 }),
+      readConfig: async () => { throw new Error('should not read config') },
+    })
+    await expect(noBinding.send(base)).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: 'dingtalk_recipient_not_bound',
+    })
+
+    const ambiguous = new DingTalkAttendanceDeliveryChannel({
+      query: async () => ({
+        rows: [
+          { integration_id: 'dir-1', external_user_id: 'dt-user-1' },
+          { integration_id: 'dir-2', external_user_id: 'dt-user-2' },
+        ],
+        rowCount: 2,
+      }),
+    })
+    await expect(ambiguous.send(base)).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: 'dingtalk_recipient_ambiguous',
+    })
+  })
+
+  it('real DingTalk channel classifies config, network, and DingTalk business failures', async () => {
+    const base = {
+      id: 'delivery-1',
+      orgId: 'default',
+      sourceType: 'comp_time_expiry_reminder',
+      sourceId: 'balance-1',
+      sourceKey: 'balance-1:recipient:u1',
+      recipientUserId: 'u1',
+      recipientRole: 'subject',
+      channel: 'dingtalk_work_notification',
+      payload: {},
+    }
+    const query: AttendanceNotificationDeliveryQuery = async () => ({
+      rows: [{ integration_id: 'dir-1', external_user_id: 'dt-user-1' }],
+      rowCount: 1,
+    })
+    const config: DingTalkMessageConfig = { appKey: 'k', appSecret: 's', agentId: '1' }
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => { throw new Error('DINGTALK_AGENT_ID is not configured') },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: expect.stringContaining('dingtalk_work_notification_config_unavailable'),
+    })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => { throw new DingTalkRequestError('upstream down', 503, null) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: true,
+      error: expect.stringContaining('dingtalk_request_503'),
+    })
+
+    await expect(new DingTalkAttendanceDeliveryChannel({
+      query,
+      readConfig: async () => config,
+      fetchAccessToken: async () => 'access-token',
+      sendWorkNotification: async () => { throw new DingTalkBusinessError('invalid userid', { errcode: 40001 }) },
+    }).send(base)).resolves.toEqual({
+      ok: false,
+      retryable: false,
+      error: expect.stringContaining('dingtalk_business_error'),
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add the C5-3 real `dingtalk_work_notification` delivery channel behind `ATTENDANCE_NOTIFICATION_DINGTALK_WORK_NOTIFICATION_ENABLED=true`
- reuse existing DingTalk work-notification runtime: directory binding lookup, `readDingTalkMessageConfigFromRuntime`, `fetchDingTalkAppAccessToken`, and `sendDingTalkWorkNotification`
- keep fake channel available for C5-5a, but prefer real DingTalk if both env gates are accidentally enabled
- update the tracker: C5-2 is landed (#2504), C5-3 is this PR, C5 overall remains pending real staging closeout

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-scheduler.test.ts --reporter=dot` → 20/20
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-notification-deliveries.test.ts --reporter=dot` → 4/4
- C5-adjacent DB subset (`attendance-expiry-service`, `attendance-unscheduled-reminder`, `attendance-notification-deliveries`, `attendance-comp-time-expiry-reminder`) → 4 files / 7 tests
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `git diff --check`

## Notes
- Tests inject the sender seam; this PR does not call real DingTalk/network in CI.
- Missing config/binding is fail-visible; DingTalk 5xx/429 and unexpected send failures remain retryable via the delivery worker.
- No DB migration, OpenAPI, frontend, or real staging-smoke closeout in this slice.
