### PR TITLE
fix(multitable): rank-2 quality polish batch (7 shipped-surface defects)

### DIFF
--- a/apps/web/src/multitable/components/MetaChartLoadError.vue
+++ b/apps/web/src/multitable/components/MetaChartLoadError.vue
@@ -1,0 +1,62 @@
+<template>
+  <!-- r2 item 3: error fallback for the lazy MetaChartRenderer chunk. A lazy-chunk network failure
+       (or timeout) would otherwise leave the panel silently empty; this surfaces it + offers retry. -->
+  <div class="meta-chart-load-error" data-chart-load-error="true">
+    <span class="meta-chart-load-error__msg">{{ viewRenderLabel('dashboard.chartLoadFailed', isZh) }}</span>
+    <button
+      type="button"
+      class="meta-chart-load-error__retry"
+      data-action="retry-chart-load"
+      @click="onRetry"
+    >{{ viewRenderLabel('dashboard.retry', isZh) }}</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useLocale } from '../../composables/useLocale'
+import { viewRenderLabel } from '../utils/meta-view-render-labels'
+
+const { isZh } = useLocale()
+
+// Vue's defineAsyncComponent passes the error component a `retry` prop that re-attempts the loader
+// (see the `error` slot contract). Reloading the page is the universal fallback when it is absent
+// (e.g. a stand-alone mount), so retry always does something.
+const props = defineProps<{
+  retry?: () => void
+}>()
+
+function onRetry(): void {
+  if (typeof props.retry === 'function') {
+    props.retry()
+    return
+  }
+  if (typeof window !== 'undefined') {
+    window.location.reload()
+  }
+}
+</script>
+
+<style scoped>
+.meta-chart-load-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 120px;
+  padding: 16px;
+  font-size: 12px;
+  color: #b91c1c;
+  text-align: center;
+}
+
+.meta-chart-load-error__retry {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 4px 12px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 12px;
+  cursor: pointer;
+}
+</style>

--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -11,6 +11,12 @@
     <template v-else-if="isEChartsType">
       <div class="meta-chart__plot" :class="{ 'meta-chart__plot--pie': hasPointLegend }">
         <div ref="chartEl" class="meta-chart__echarts" data-chart-canvas="true"></div>
+        <!-- r2 item 2: caption a gauge whose share-of-total dial is misleading for a non-additive aggregation. -->
+        <p
+          v-if="showGaugeAggNote"
+          class="meta-chart__gauge-note"
+          data-gauge-agg-note="true"
+        >{{ viewRenderLabel('chart.gaugeNonAdditiveNote', isZh) }}</p>
         <!-- S3: funnel shares the pie-style point legend (stages are label-less on the canvas). -->
         <div
           v-if="hasPointLegend && displayConfig?.showLegend !== false"
@@ -73,7 +79,7 @@ import * as echarts from 'echarts/core'
 import { BarChart, LineChart, PieChart, FunnelChart, GaugeChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
-import type { ChartData, ChartDisplayConfig } from '../types'
+import type { AggregationFunction, ChartData, ChartDisplayConfig } from '../types'
 import { buildChartOption, CHART_COLORS, ECHARTS_CHART_TYPES } from '../utils/buildChartOption'
 import { useLocale } from '../../composables/useLocale'
 import { viewRenderLabel } from '../utils/meta-view-render-labels'
@@ -86,8 +92,21 @@ echarts.use([BarChart, LineChart, PieChart, FunnelChart, GaugeChart, GridCompone
 const props = defineProps<{
   chartData: ChartData
   displayConfig?: ChartDisplayConfig
+  // r2 item 2: the chart's aggregation function (from dataSource.aggregation.function). Optional —
+  // the renderer is also mounted in places that have only ChartData. Used solely to caption a gauge
+  // whose share-of-total dial is misleading for a non-additive aggregation (avg/min/max).
+  aggregation?: AggregationFunction
 }>()
 const { isZh } = useLocale()
+
+// Additive aggregations are the only ones whose Σ values is a meaningful whole, so the gauge's
+// share-of-total dial is sound. Mirrors charts.ts ADDITIVE_AGGREGATIONS.
+const ADDITIVE_AGGREGATIONS: ReadonlySet<AggregationFunction> = new Set<AggregationFunction>(['count', 'sum'])
+const showGaugeAggNote = computed(() =>
+  props.chartData.chartType === 'gauge'
+  && props.aggregation !== undefined
+  && !ADDITIVE_AGGREGATIONS.has(props.aggregation),
+)
 
 const isEChartsType = computed(() => ECHARTS_CHART_TYPES.has(props.chartData.chartType))
 // pie + funnel share the HTML "swatch + label + value" point legend (their canvas marks are label-less).
@@ -183,6 +202,14 @@ onBeforeUnmount(teardownChart)
 .meta-chart__plot--pie .meta-chart__echarts { flex: 1; min-width: 0; }
 
 .meta-chart__echarts { width: 100%; height: 250px; }
+
+.meta-chart__gauge-note {
+  margin: 4px 0 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #94a3b8;
+  text-align: center;
+}
 
 .meta-chart__legend { display: flex; flex-direction: column; gap: 4px; }
 .meta-chart__legend--inline { flex-direction: row; flex-wrap: wrap; gap: 12px; margin-top: 8px; }

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -90,6 +90,7 @@
             v-if="chartDataMap[panel.chartId]"
             :chart-data="chartDataMap[panel.chartId]"
             :display-config="chartConfigMap[panel.chartId]?.displayConfig"
+            :aggregation="chartConfigMap[panel.chartId]?.dataSource?.aggregation?.function"
           />
           <div v-else class="meta-dashboard__panel-loading">{{ viewRenderLabel('dashboard.loadingChart', isZh) }}</div>
         </div>
@@ -253,6 +254,7 @@
               <MetaChartRenderer
                 :chart-data="previewChartData"
                 :display-config="previewDisplayConfig"
+                :aggregation="chartDraft.aggregation"
               />
             </div>
             <div v-else class="meta-dashboard__preview-empty" data-chart-preview-empty="true">
@@ -276,12 +278,22 @@
 
 <script lang="ts">
 import { defineAsyncComponent } from 'vue'
+import MetaChartLoadError from './MetaChartLoadError.vue'
 
 // S1-9: the ECharts renderer is the only echarts importer — loading it async puts echarts in its
 // own lazy chunk (≈150KB+ off the workbench bundle); panels keep their loading state meanwhile.
 // MODULE scope (plain <script>), NOT <script setup>: setup-scope would create a fresh loader
 // closure per component instance, losing Vue's resolved-component cache across remounts.
-const MetaChartRenderer = defineAsyncComponent(() => import('./MetaChartRenderer.vue'))
+//
+// r2 item 3: a lazy-chunk network failure (or a slow CDN past `timeout`) previously rendered the
+// panel silently empty. `errorComponent` surfaces a 'chart failed to load' + Retry fallback (Vue
+// passes it a `retry` prop that re-attempts the loader); `timeout` bounds the wait so a stalled
+// fetch eventually trips the error path instead of hanging on the loading state forever.
+const MetaChartRenderer = defineAsyncComponent({
+  loader: () => import('./MetaChartRenderer.vue'),
+  errorComponent: MetaChartLoadError,
+  timeout: 30_000,
+})
 </script>
 
 <script setup lang="ts">

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -399,6 +399,15 @@
                 </label>
               </div>
               <span class="meta-field-mgr__hint">{{ ml('field.ai.sourceHint') }}</span>
+              <!-- r2 item 6: distinct AI-section warning when every persisted source field was deleted.
+                   It is rendered ON the source-fields control so the user sees the AI section is the
+                   blocker (not their unrelated edit). The save stays blocked; no silent auto-disable. -->
+              <p
+                v-if="aiSourceAllDeletedBlocked"
+                class="meta-field-mgr__ai-source-deleted-warning"
+                data-test="ai-source-deleted-warning"
+                role="alert"
+              >{{ ml('field.error.aiSourceAllDeleted') }}</p>
             </div>
             <div v-if="aiDraft.kind === 'classify'" class="meta-field-mgr__field">
               <span>{{ ml('field.ai.options') }}</span>
@@ -745,6 +754,10 @@ const deleteTargetId = ref<string | null>(null)
 const configTargetId = ref<string | null>(null)
 const configDraftType = ref<string | null>(null)
 const fieldConfigError = ref('')
+// r2 item 6: distinct field-level state for "every persisted AI source field was deleted" — drives a
+// warning banner ON the AI config section so the user sees the AI section is the blocker (not their
+// unrelated edit). We still BLOCK the save (no silent auto-disable); this only makes it legible.
+const aiSourceAllDeletedBlocked = ref(false)
 
 const selectDraft = reactive<{ options: Array<{ value: string; color: string }> }>({
   options: [{ value: '', color: '' }],
@@ -1078,6 +1091,7 @@ function resetDrafts() {
   validationDraft.value = []
   validationDraftTouched.value = false
   fieldConfigError.value = ''
+  aiSourceAllDeletedBlocked.value = false
 }
 
 function serializeFieldDraft(type: string | null): string {
@@ -1393,12 +1407,43 @@ function onAiOptionInput(index: number, event: Event) {
  * client-side. ok:false → fieldConfigError is already set. ok:true with no
  * config = the toggle is off (removal-by-key-omission, §2.1 LOCK — never
  * `aiShortcut: null`, which the backend 400s).
+ *
+ * r2 item 5 — INTENTIONAL DRAFT CANONICALIZATION (review F1). Because the
+ * §2.1 clobber guard re-emits this resolved config on EVERY save of a
+ * string/longText field (even a validation-only edit), the returned config is a
+ * canonical form of the persisted aiShortcut, not a verbatim copy. The
+ * transforms applied here, all of them deliberate:
+ *   - self-heal deleted sources: `sourceFieldIds` is filtered to ids that still
+ *     exist as candidates, so a since-deleted source field is dropped rather
+ *     than re-persisted as a dangling reference (see item 6 for the all-deleted
+ *     case, which BLOCKS instead of silently emptying);
+ *   - drop inert non-classify options: `params.options` is emitted only when
+ *     `kind === 'classify'` (options on summarize/translate/custom are inert,
+ *     so they are not round-tripped);
+ *   - drop inert non-translate targetLang likewise (emitted only for
+ *     `kind === 'translate'`);
+ *   - trim + drop empties: options are trimmed and blank ones removed;
+ *     `targetLang` and `instruction` are trimmed (an empty instruction is
+ *     omitted entirely).
+ * Net effect: a validation-only save may rewrite the stored aiShortcut into this
+ * canonical shape. That is acceptable and by design (it cannot enable/disable the
+ * shortcut or change its kind/instruction intent) — flagged here so the rewrite
+ * is not mistaken for an accidental clobber.
  */
 function resolveAiShortcutDraft(): { ok: boolean; config?: AiShortcutConfigInput } {
+  aiSourceAllDeletedBlocked.value = false
   if (!aiDraft.enabled) return { ok: true }
   const candidateIds = new Set(aiSourceFieldCandidates.value.map((field) => field.id))
   const sourceFieldIds = aiDraft.sourceFieldIds.filter((id) => candidateIds.has(id))
   if (sourceFieldIds.length === 0) {
+    // r2 item 6: separate "every configured source was DELETED" (the draft had source ids, but none
+    // survive as candidates) from "none picked yet". The former gets an actionable, AI-section-specific
+    // message + a distinct warning state; we still BLOCK (no silent auto-disable of the shortcut).
+    if (aiDraft.sourceFieldIds.length > 0) {
+      aiSourceAllDeletedBlocked.value = true
+      fieldConfigError.value = ml('field.error.aiSourceAllDeleted')
+      return { ok: false }
+    }
     fieldConfigError.value = ml('field.error.aiSourceRequired')
     return { ok: false }
   }
@@ -1949,6 +1994,16 @@ onBeforeUnmount(() => {
 .meta-field-mgr__ai-header { font-size: 12px; color: #4338ca; }
 .meta-field-mgr__ai-sources { display: flex; flex-wrap: wrap; gap: 6px 12px; }
 .meta-field-mgr__ai-source { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #444; }
+/* r2 item 6: all-sources-deleted needs-attention banner ON the AI section. */
+.meta-field-mgr__ai-source-deleted-warning {
+  margin: 6px 0 0;
+  padding: 6px 8px;
+  border: 1px solid #f0c36d;
+  border-radius: 6px;
+  background: #fdf6ec;
+  color: #b45309;
+  font-size: 12px;
+}
 .meta-field-mgr__ai-preview { display: flex; flex-direction: column; gap: 6px; }
 .meta-field-mgr__ai-preview-output { font-size: 12px; color: #334155; white-space: pre-wrap; word-break: break-word; }
 /* §2.4 admin usage card — automation stats-card styling family

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -63,7 +63,7 @@ export type MetaManagerLabelKey =
   | 'field.ai.previewWithRecord' | 'field.ai.previewNeedsRecord'
   | 'field.ai.previewRealCallHint' | 'field.ai.previewDraftHint'
   | 'field.ai.previewing' | 'field.ai.previewResult'
-  | 'field.error.aiSourceRequired' | 'field.error.aiSourceTooMany'
+  | 'field.error.aiSourceRequired' | 'field.error.aiSourceAllDeleted' | 'field.error.aiSourceTooMany'
   | 'field.error.aiOptionsTooMany' | 'field.error.aiOptionTooLong'
   | 'field.error.aiTargetLangTooLong' | 'field.error.aiInstructionTooLong'
   | 'field.aiUsage.title' | 'field.aiUsage.today' | 'field.aiUsage.week' | 'field.aiUsage.instance'
@@ -252,6 +252,9 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.ai.previewResult': { en: 'Preview result', zh: '预览结果' },
   // Client-side constraint mirrors of the A2 config governance caps.
   'field.error.aiSourceRequired': { en: 'Select at least one source field for the AI shortcut', zh: '请为 AI shortcut 至少选择一个来源字段' },
+  // r2 item 6: ALL persisted AI source fields were deleted. We block (do NOT silently auto-disable the
+  // shortcut), but the message must be actionable + name the AI section as the blocker.
+  'field.error.aiSourceAllDeleted': { en: 'All AI source fields were deleted — pick new sources or turn off the AI shortcut', zh: 'AI 来源字段均已被删除——请重新选择来源字段，或关闭 AI shortcut' },
   'field.error.aiSourceTooMany': { en: 'AI shortcut allows at most 20 source fields', zh: 'AI shortcut 来源字段最多 20 个' },
   'field.error.aiOptionsTooMany': { en: 'AI shortcut allows at most 50 categories', zh: 'AI shortcut 分类选项最多 50 个' },
   'field.error.aiOptionTooLong': { en: 'Each category must be at most 100 characters', zh: '每个分类选项最长 100 字符' },

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -84,6 +84,8 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.loadingDashboard'
   | 'dashboard.empty'
   | 'dashboard.loadingChart'
+  | 'dashboard.chartLoadFailed'
+  | 'dashboard.retry'
   | 'dashboard.addChartPanel'
   | 'dashboard.noCharts'
   | 'dashboard.newChart'
@@ -125,6 +127,7 @@ export type MetaViewRenderLabelKey =
   | 'chart.value'
   | 'chart.restrictedTitle'
   | 'chart.restrictedHint'
+  | 'chart.gaugeNonAdditiveNote'
 
 export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'common.loading',
@@ -202,6 +205,8 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.loadingDashboard',
   'dashboard.empty',
   'dashboard.loadingChart',
+  'dashboard.chartLoadFailed',
+  'dashboard.retry',
   'dashboard.addChartPanel',
   'dashboard.noCharts',
   'dashboard.newChart',
@@ -243,6 +248,7 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'chart.value',
   'chart.restrictedTitle',
   'chart.restrictedHint',
+  'chart.gaugeNonAdditiveNote',
 ]
 
 const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
@@ -324,6 +330,8 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.loadingDashboard': { en: 'Loading dashboard...', zh: '正在加载仪表板...' },
   'dashboard.empty': { en: 'No dashboards yet. Create your first dashboard.', zh: '暂无仪表板。创建你的第一个仪表板。' },
   'dashboard.loadingChart': { en: 'Loading chart...', zh: '正在加载图表...' },
+  'dashboard.chartLoadFailed': { en: 'Chart failed to load.', zh: '图表加载失败。' },
+  'dashboard.retry': { en: 'Retry', zh: '重试' },
   'dashboard.addChartPanel': { en: 'Add Chart Panel', zh: '添加图表面板' },
   'dashboard.noCharts': { en: 'No charts available. Create a chart first.', zh: '暂无可用图表。请先创建一个图表。' },
   'dashboard.newChart': { en: '+ New Chart', zh: '+ 新建图表' },
@@ -370,6 +378,13 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'chart.restrictedHint': {
     en: 'This chart references fields you cannot read.',
     zh: '此图表引用了你无权读取的字段。',
+  },
+  'chart.gaugeNonAdditiveNote': {
+    // r2 item 2: the gauge dials the first value against the sum of all values (share-of-total).
+    // That reading only holds for an additive aggregation (count/sum); for avg/min/max the
+    // sum-of-values denominator is not a meaningful whole, so warn the reader.
+    en: 'Share of total is approximate for this aggregation (avg/min/max do not sum to a whole).',
+    zh: '该聚合方式下的占比仅供参考（平均/最小/最大值之和不构成有意义的总量）。',
   },
 }
 

--- a/apps/web/tests/multitable-ai-shortcut-field-manager.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-field-manager.spec.ts
@@ -196,6 +196,40 @@ describe('MetaFieldManager aiShortcut config section (A3)', () => {
     app.unmount()
   })
 
+  it('r2 item 6: ALL persisted sources deleted → blocks save with an actionable, AI-section-specific message + warning state (no auto-disable)', async () => {
+    const updateSpy = vi.fn()
+    // The target keeps its configured aiShortcut (source = fld_src), but fld_src is GONE from fields.
+    const fieldsMissingSource: MetaField[] = [
+      {
+        id: 'fld_target',
+        name: 'Summary',
+        type: 'string',
+        property: { aiShortcut: structuredClone(AI_CONFIG), validation: [{ type: 'required' }] },
+      } as unknown as MetaField,
+      { id: 'fld_plain', name: 'Plain', type: 'string', property: {} } as unknown as MetaField,
+    ]
+    const { container, app } = mountManager({ fields: fieldsMissingSource, onUpdateField: updateSpy })
+    await openConfigFor(container, 'Summary')
+
+    // The shortcut is still ENABLED (no silent auto-disable on open).
+    expect((container.querySelector('[data-test="ai-shortcut-enable"]') as HTMLInputElement).checked).toBe(true)
+
+    saveButton(container).click()
+    await nextTick()
+
+    // Blocked — no field update is emitted.
+    expect(updateSpy).not.toHaveBeenCalled()
+    // Distinct, actionable message (NOT the generic "select at least one source").
+    const warning = container.querySelector('[data-test="ai-source-deleted-warning"]')
+    expect(warning).toBeTruthy()
+    expect(warning?.textContent || '').toContain('deleted')
+    expect(warning?.textContent || '').toMatch(/turn off the AI shortcut/i)
+    // The inline config error also carries the same actionable copy (not aiSourceRequired).
+    expect(container.querySelector('.meta-field-mgr__error')?.textContent || '').toContain('deleted')
+
+    app.unmount()
+  })
+
   it('A3-T1: enabling with zero source fields blocks the save with an inline error (constraint mirror)', async () => {
     const updateSpy = vi.fn()
     const { container, app } = mountManager({ onUpdateField: updateSpy })

--- a/apps/web/tests/multitable-chart-load-error.spec.ts
+++ b/apps/web/tests/multitable-chart-load-error.spec.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+
+import MetaChartLoadError from '../src/multitable/components/MetaChartLoadError.vue'
+import { useLocale } from '../src/composables/useLocale'
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaChartLoadError, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+// r2 item 3: the lazy MetaChartRenderer chunk previously rendered an EMPTY panel on a network
+// failure. The errorComponent (this) must surface a 'chart failed to load' message + a Retry that
+// re-invokes Vue's loader-retry (or, absent it, reloads the page).
+describe('MetaChartLoadError (async chunk fallback)', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders the failure message and a retry button', async () => {
+    const { container } = mount({})
+    await flushPromises()
+    expect(container.querySelector('[data-chart-load-error]')).toBeTruthy()
+    expect(container.textContent).toContain('Chart failed to load')
+    const retry = container.querySelector('[data-action="retry-chart-load"]')
+    expect(retry).toBeTruthy()
+    expect(retry?.textContent).toContain('Retry')
+  })
+
+  it('calls the Vue-provided retry prop when retry is clicked', async () => {
+    const retry = vi.fn()
+    const { container } = mount({ retry })
+    await flushPromises()
+    ;(container.querySelector('[data-action="retry-chart-load"]') as HTMLButtonElement).click()
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('localizes the message + retry to zh', async () => {
+    useLocale().setLocale('zh')
+    const { container } = mount({})
+    await flushPromises()
+    expect(container.textContent).toContain('图表加载失败')
+    expect(container.textContent).toContain('重试')
+  })
+})
+
+// Wiring leg: a rejected chunk loader must render THIS error component inside a dashboard panel
+// (not an empty panel). Module-isolated so the real ./MetaChartRenderer.vue import is forced to
+// reject before MetaDashboardView's module-scope defineAsyncComponent resolves it.
+describe('MetaDashboardView async chunk failure → error fallback', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('renders the chart-load-error fallback when the renderer chunk fails to import', async () => {
+    vi.resetModules()
+    // Force the lazy chunk import to reject (simulated network/chunk failure).
+    vi.doMock('../src/multitable/components/MetaChartRenderer.vue', () => {
+      throw new Error('Failed to fetch dynamically imported module')
+    })
+    // echarts entrypoints are irrelevant here (renderer never loads) but keep them harmless.
+    vi.doMock('echarts/core', () => ({ init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() })), use: vi.fn() }))
+    vi.doMock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {} }))
+    vi.doMock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }))
+    vi.doMock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
+    const { default: DashboardView } = await import('../src/multitable/components/MetaDashboardView.vue')
+    const { MultitableApiClient } = await import('../src/multitable/api/client')
+
+    const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/dashboards') && !url.includes('/charts')) {
+        return ok({ dashboards: [{ id: 'dash_1', sheetId: 'sheet_1', name: 'D', panels: [{ id: 'p1', chartId: 'chart_1', size: 'medium', order: 0 }] }] })
+      }
+      if (url.includes('/charts') && url.includes('/data')) {
+        return ok({ chartType: 'bar', dataPoints: [{ label: 'A', value: 1 }] })
+      }
+      if (url.includes('/charts')) {
+        return ok({ charts: [{ id: 'chart_1', sheetId: 'sheet_1', name: 'C', chartType: 'bar', dataSource: { sheetId: 'sheet_1', groupByFieldId: 'f', aggregation: { function: 'count' } } }] })
+      }
+      return ok({})
+    })
+    const client = new MultitableApiClient({ fetchFn })
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({ render: () => h(DashboardView, { sheetId: 'sheet_1', client }) })
+    app.mount(container)
+
+    // Let data load + the async-component loader reject + the error component render.
+    const deadline = Date.now() + 5_000
+    while (!container.querySelector('[data-chart-load-error]') && Date.now() < deadline) {
+      await flushPromises()
+    }
+    expect(container.querySelector('[data-chart-load-error]')).toBeTruthy()
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -270,6 +270,47 @@ describe('MetaChartRenderer', () => {
     expect(container.querySelector('[data-legend]')).toBeNull()
   })
 
+  // r2 item 2: gauge dial=first point / max=share-of-total is only meaningful for an ADDITIVE
+  // aggregation (count/sum). For avg/min/max the share-of-total framing misleads → surface an
+  // i18n'd caption. The caption is HTML chrome in the renderer (buildChartOption stays unchanged).
+  it('r2: gauge with a non-additive aggregation (avg) shows the misleading-share caption', async () => {
+    const { container } = mount({ chartData: gaugeData, aggregation: 'avg' })
+    await flushPromises()
+    const note = container.querySelector('[data-gauge-agg-note]')
+    expect(note).toBeTruthy()
+    expect(note?.textContent || '').toMatch(/share of total/i)
+  })
+
+  it('r2: gauge with min / max also shows the caption (all non-additive aggs)', async () => {
+    for (const agg of ['min', 'max'] as const) {
+      const { container } = mount({ chartData: gaugeData, aggregation: agg })
+      await flushPromises()
+      expect(container.querySelector('[data-gauge-agg-note]'), `agg=${agg}`).toBeTruthy()
+    }
+  })
+
+  it('r2: gauge with an additive aggregation (count / sum) shows NO caption', async () => {
+    for (const agg of ['count', 'sum'] as const) {
+      const { container } = mount({ chartData: gaugeData, aggregation: agg })
+      await flushPromises()
+      expect(container.querySelector('[data-gauge-agg-note]'), `agg=${agg}`).toBeNull()
+    }
+  })
+
+  it('r2: a non-gauge chart never shows the gauge caption even with a non-additive agg', async () => {
+    const { container } = mount({ chartData: barData, aggregation: 'avg' })
+    await flushPromises()
+    expect(container.querySelector('[data-gauge-agg-note]')).toBeNull()
+  })
+
+  it('r2: gauge caption localizes to zh', async () => {
+    useLocale().setLocale('zh')
+    const { container } = mount({ chartData: gaugeData, aggregation: 'avg' })
+    await flushPromises()
+    const note = container.querySelector('[data-gauge-agg-note]')
+    expect(note?.textContent || '').toContain('占比')
+  })
+
   it('S3: disposes the canvas when switching funnel → number (new types share the lifecycle)', async () => {
     const { state } = mountReactive({ chartData: funnelData })
     await flushPromises()

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -259,6 +259,12 @@ export function dashboardRouter() {
     try {
       const auth = await requireSheetManageViews(req, res, req.params.sheetId)
       if (!auth) return
+      // F4: validate `type` against CHART_TYPES on the PERSISTED path too — the column is TEXT NOT
+      // NULL with no CHECK, and only preview-data validated it before. Reject an unknown type BEFORE
+      // the service is touched (enum reuse, not a new contract). createChart requires a type.
+      if (!CHART_TYPES.has(req.body?.type as ChartType)) {
+        throw new Error('Invalid chart type')
+      }
       // v2-d: validate series constraints on the persisted path too — the UI is never the sole guard.
       assertSeriesConstraints(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType, readBarMode(req.body?.display))
       const chart = await dashboardService.createChart(req.params.sheetId, {
@@ -320,11 +326,18 @@ export function dashboardRouter() {
         res.status(404).json({ error: 'Chart not found' })
         return
       }
+      // F4: validate the EFFECTIVE `type` against CHART_TYPES (updateChart shallow-merges
+      // `{...existing,...input}`). A patch that introduces a new type is rejected; a patch with no
+      // `type` re-validates the already-stored (always-valid) type, a harmless no-op.
+      const effectiveType = (req.body?.type ?? chart.type) as ChartType
+      if (!CHART_TYPES.has(effectiveType)) {
+        throw new Error('Invalid chart type')
+      }
       // v2-d: validate the EFFECTIVE config (updateChart shallow-merges `{...existing,...input}`),
       // so a patch that introduces a series field or changes type/aggregation is checked.
       assertSeriesConstraints(
         (req.body?.dataSource ?? chart.dataSource) as ChartConfig['dataSource'],
-        (req.body?.type ?? chart.type) as ChartType,
+        effectiveType,
         readBarMode(req.body?.display ?? chart.display),
       )
       const updated = await dashboardService.updateChart(req.params.id, req.body)

--- a/packages/core-backend/src/services/ai-provider-client.ts
+++ b/packages/core-backend/src/services/ai-provider-client.ts
@@ -39,9 +39,17 @@ import {
  * only for postgres/mysql conn-string schemes, so a credentialed
  * MULTITABLE_AI_BASE_URL (e.g. https basic-auth to a proxy) surfacing in a
  * provider error would otherwise leak into the response + ledger `error`.
+ *
+ * NIT-NEW-1: the userinfo run is `[^/\s]*` (greedy, allows '@'), so a password
+ * with an UNENCODED '@' (e.g. `user:p@ss`) is redacted through the LAST '@'
+ * before the host — RFC 3986 puts the authority's userinfo entirely before the
+ * first '/'. A prior `[^@/\s]+` stopped at the FIRST '@' and leaked the tail
+ * (`<redacted>@ss@host`). Stopping at '/' (and whitespace) keeps a bare '@' that
+ * appears only in a path/query (`host/users@me`) untouched, and a string with no
+ * `scheme://…@` before its first '/' never matches (no userinfo → no change).
  */
 export function stripUrlUserinfo(text: string): string {
-  return text.replace(/([a-z][a-z0-9+.-]*:\/\/)[^@/\s]+@/gi, '$1<redacted>@')
+  return text.replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s]*@/gi, '$1<redacted>@')
 }
 
 export interface AiUsage {

--- a/packages/core-backend/tests/unit/ai-provider-client.test.ts
+++ b/packages/core-backend/tests/unit/ai-provider-client.test.ts
@@ -181,6 +181,28 @@ describe('URL userinfo strip (review-fix F2)', () => {
     expect(stripUrlUserinfo('see https://proxy.internal/v1/messages')).toBe('see https://proxy.internal/v1/messages')
   })
 
+  it('redacts through the LAST @ when the password embeds an unencoded @ (multi-@ tail leak)', () => {
+    // NIT-NEW-1: a password with a literal '@' (e.g. user:p@ss) puts a second '@'
+    // BEFORE the host. Stopping at the FIRST '@' leaked the tail ('ss@host').
+    expect(stripUrlUserinfo(`https://user:p${URL_SECRET}@ss@proxy.internal/v1`)).toBe(
+      'https://<redacted>@proxy.internal/v1',
+    )
+    // Three '@' in the userinfo — still redacted through the last one before the host.
+    expect(stripUrlUserinfo(`odbc://sa:a@b@${URL_SECRET}@db.internal;Database=x`)).toBe(
+      'odbc://<redacted>@db.internal;Database=x',
+    )
+    // The secret must not survive anywhere in the output.
+    expect(stripUrlUserinfo(`https://user:p${URL_SECRET}@ss@proxy.internal/v1`)).not.toContain(URL_SECRET)
+  })
+
+  it('does not treat an @ that appears AFTER the path as userinfo', () => {
+    // A bare '@' inside a path/query (no scheme://...@ before the first '/') stays put —
+    // the greedy userinfo run must stop at the first '/'.
+    expect(stripUrlUserinfo('see https://proxy.internal/v1/users@me')).toBe(
+      'see https://proxy.internal/v1/users@me',
+    )
+  })
+
   it('a credentialed MULTITABLE_AI_BASE_URL surfacing in a network error never reaches the provider_error message', async () => {
     const credentialedBase = `https://svc:${URL_SECRET}@proxy.internal`
     const fetchSpy = vi.fn(async (url: unknown) => {

--- a/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
@@ -203,4 +203,58 @@ describe('dashboardRouter HTTP mounting', () => {
       expect(res.body.error).toBe('Invalid chart type')
     }
   })
+
+  // F4: the PERSISTED write paths (POST/PATCH /charts) must reject an unknown `type` too —
+  // the `type` column is TEXT NOT NULL with no CHECK, and only preview-data validated
+  // it before. An unknown type must 400 BEFORE the service is touched.
+  it('POST /charts rejects an unknown chart type with 400 (never persists)', async () => {
+    const createChart = vi.spyOn(service, 'createChart')
+    for (const type of ['scatter', 'radar', 'nope']) {
+      const res = await request(buildApp())
+        .post('/api/multitable/sheets/sheet-a/charts')
+        .send({ name: 'X', type, dataSource: { aggregation: { function: 'count' } } })
+      expect(res.status, `create must reject chart type "${type}"`).toBe(400)
+      expect(res.body.error).toBe('Invalid chart type')
+    }
+    expect(createChart).not.toHaveBeenCalled()
+  })
+
+  it('POST /charts still accepts a known chart type (does not over-reject)', async () => {
+    vi.spyOn(service, 'createChart').mockResolvedValue({
+      id: 'c', sheetId: 'sheet-a', name: 'X', type: 'gauge',
+    } as any)
+    await request(buildApp())
+      .post('/api/multitable/sheets/sheet-a/charts')
+      .send({ name: 'X', type: 'gauge', dataSource: { aggregation: { function: 'count' } } })
+      .expect(201)
+  })
+
+  it('PATCH /charts/:id rejects an unknown chart type with 400 (never updates)', async () => {
+    vi.spyOn(service, 'getChart').mockResolvedValue({
+      id: 'chart-1', sheetId: 'sheet-a', name: 'c', type: 'bar',
+      dataSource: { aggregation: { function: 'count' } },
+    } as any)
+    const updateChart = vi.spyOn(service, 'updateChart')
+    const res = await request(buildApp())
+      .patch('/api/multitable/sheets/sheet-a/charts/chart-1')
+      .send({ type: 'scatter' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('Invalid chart type')
+    expect(updateChart).not.toHaveBeenCalled()
+  })
+
+  it('PATCH /charts/:id leaves an unchanged type alone (patch without type keeps the stored bar)', async () => {
+    vi.spyOn(service, 'getChart').mockResolvedValue({
+      id: 'chart-1', sheetId: 'sheet-a', name: 'c', type: 'bar',
+      dataSource: { aggregation: { function: 'count' } },
+    } as any)
+    const updateChart = vi.spyOn(service, 'updateChart').mockResolvedValue({
+      id: 'chart-1', sheetId: 'sheet-a', name: 'c2', type: 'bar',
+    } as any)
+    await request(buildApp())
+      .patch('/api/multitable/sheets/sheet-a/charts/chart-1')
+      .send({ name: 'c2' })
+      .expect(200)
+    expect(updateChart).toHaveBeenCalled()
+  })
 })

--- a/scripts/ops/multitable-perf-baseline-upload.mjs
+++ b/scripts/ops/multitable-perf-baseline-upload.mjs
@@ -94,7 +94,7 @@ export function formatErrorWithCause(err) {
       current instanceof Error
         ? current.message || String(current)
         : typeof current === 'object'
-          ? JSON.stringify(current)
+          ? safeStringify(current)
           : String(current)
     parts.push(`${message}${code}`)
     current = typeof current === 'object' ? current.cause : undefined
@@ -103,4 +103,36 @@ export function formatErrorWithCause(err) {
     }
   }
   return parts.join(' ← caused by: ')
+}
+
+/**
+ * N1: JSON.stringify throws on a circular plain-object cause (and on BigInt).
+ * The whole point of formatErrorWithCause is to make a FAILURE legible — it must
+ * never throw on the very error it is formatting. Fall back to a readable
+ * placeholder instead of propagating the stringify error.
+ */
+function safeStringify(value) {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return '[unserializable cause]'
+  }
+}
+
+/**
+ * N4: wrap a failed `import('undici')` into an actionable error that ALSO carries
+ * the original as `cause`. The previous wrap spliced `err.message` into the text
+ * but dropped the underlying error object, so a downstream `formatErrorWithCause`
+ * (and any structured logger) lost the real `code`/stack. Building the new Error
+ * with the `{ cause }` option keeps both the operator-facing remediation hint and
+ * the machine-readable cause chain. Lives here (the testable module) so the node
+ * test can assert the cause is attached without importing the network harness.
+ */
+export function wrapUndiciLoadError(err) {
+  // The inner error rides on `cause` (printed by formatErrorWithCause with its
+  // [code=…]); don't splice err.message into the text too, or it prints twice (review N2).
+  return new Error(
+    'Cannot resolve undici package (needed for the seed-upload dispatcher; root devDependency since S5a). Run pnpm install at the repo root.',
+    { cause: err },
+  )
 }

--- a/scripts/ops/multitable-perf-baseline-upload.test.mjs
+++ b/scripts/ops/multitable-perf-baseline-upload.test.mjs
@@ -10,6 +10,7 @@ import {
   formatErrorWithCause,
   resolveSeedUploadTimeoutMs,
   resolveXlsxChunkSize,
+  wrapUndiciLoadError,
 } from './multitable-perf-baseline-upload.mjs'
 
 // ---------------------------------------------------------------------------
@@ -124,4 +125,32 @@ test('formatErrorWithCause terminates on cyclic cause chains', () => {
   b.cause = a
   const out = formatErrorWithCause(a)
   assert.match(out, /cause chain truncated/)
+})
+
+// N1: a non-Error plain-object cause hits JSON.stringify. A CIRCULAR plain object
+// makes JSON.stringify throw — formatErrorWithCause must not itself blow up.
+test('formatErrorWithCause survives a circular plain-object cause (no throw)', () => {
+  const circular = { tag: 'circular-cause' }
+  circular.self = circular
+  const err = new Error('outer', { cause: circular })
+  let out
+  assert.doesNotThrow(() => {
+    out = formatErrorWithCause(err)
+  })
+  assert.match(out, /outer/)
+  // some readable placeholder for the unstringifiable cause (not a crash)
+  assert.match(out, /unserializable|\[object/i)
+})
+
+// N4: the undici-load wrap error must attach the underlying error as `cause`
+// (Error cause option), not just splice its message into the text.
+test('wrapUndiciLoadError attaches the original error as { cause }', () => {
+  const original = new Error('ERR_MODULE_NOT_FOUND: undici')
+  const wrapped = wrapUndiciLoadError(original)
+  assert.ok(wrapped instanceof Error)
+  assert.equal(wrapped.cause, original)
+  assert.match(wrapped.message, /undici/)
+  assert.match(wrapped.message, /pnpm install/)
+  // and it round-trips through the cause formatter
+  assert.match(formatErrorWithCause(wrapped), /ERR_MODULE_NOT_FOUND/)
 })

--- a/scripts/ops/multitable-perf-baseline.mjs
+++ b/scripts/ops/multitable-perf-baseline.mjs
@@ -29,6 +29,7 @@ import {
   formatErrorWithCause,
   resolveSeedUploadTimeoutMs,
   resolveXlsxChunkSize,
+  wrapUndiciLoadError,
 } from './multitable-perf-baseline-upload.mjs'
 
 // --- env config ---
@@ -252,9 +253,9 @@ async function loadUndiciAgent() {
     const mod = await import('undici')
     return mod.Agent
   } catch (err) {
-    throw new Error(
-      `Cannot resolve undici package (needed for the seed-upload dispatcher; root devDependency since S5a). Run pnpm install at the repo root. Error: ${err.message}`,
-    )
+    // N4: wrap with { cause } so the underlying ERR_MODULE_NOT_FOUND (code/stack)
+    // survives for formatErrorWithCause + structured logs.
+    throw wrapUndiciLoadError(err)
   }
 }
 


### PR DESCRIPTION
## Summary

Rank-2 of the benchmark refresh ladder (#2506) — 7 review-verified defects on already-shipped surfaces, security-first order, each fail-first.

1. **stripUrlUserinfo multi-@ leak (SECURITY)** — `ai-provider-client.ts`: redaction stopped at the first `@`, leaking a credential tail when a URL password contained `@`. Now redacts through the last `@` before host; multi-@/3-@/path-@/no-userinfo tests.
2. **gauge non-additive aggregation copy** — `MetaChartRenderer`: share-of-total gauge misleads for avg/min/max; adds an i18n'd caption when the aggregation is non-additive (renderer-level — aggregation isn't in `buildChartOption`'s inputs, so `buildOption` left untouched).
3. **async chunk error fallback** — `MetaDashboardView`: lazy `MetaChartRenderer` chunk failure rendered empty silently; adds `MetaChartLoadError` errorComponent + 30s timeout + retry.
4. **chart persistence type validation (F4)** — `dashboard.ts` POST/PATCH `/charts` now validate `type` against `CHART_TYPES` (was preview-only; column TEXT NOT NULL no CHECK), 400 on unknown. Enum reuse, no OpenAPI change.
5. **aiShortcut canonicalization note** — precise comment documenting the clobber-guard's intentional draft canonicalization (comment-only).
6. **all-sources-deleted UX (owner-decided)** — when every persisted AI source field was deleted, the save is still **blocked** (no silent auto-disable) but with an actionable message + a distinct field-level warning banner on the AI source control.
7. **S5a nits N1/N4** — `formatErrorWithCause` now throw-proof on circular plain-object causes; `wrapUndiciLoadError` attaches `{ cause }`.

## Tests

All behavioral items fail-first (red captured → green). Backend ai-provider-client + dashboard-routes 29 + perf-upload node:test 14 + FE chart/dashboard/field-manager specs 149; full backend unit 236 files / 3016; `tsc` + `vue-tsc -b` clean. Full FE suite's 16 failures are pre-existing (stash-verified, none in touched files).

## Review

Adversarial review (`/tmp/r2-polish-review-claude-20260611.md`): **APPROVE-WITH-NITS** — N1 (test comment column name), N2 (duplicate message in cause chain), N3 (optional-chaining on empty dataSource) all fixed pre-merge.

Ladder: #2506 → rank 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)