### PR TITLE
feat(multitable): wire webhook outbound pipeline (bridge + retry tick)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + realtime invalidation + automation retry provenance + AI shortcut run)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + realtime invalidation + automation retry provenance + webhook outbound chain + AI shortcut run)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -197,6 +197,8 @@ jobs:
             tests/integration/multitable-automation-jobs.test.ts \
             tests/integration/multitable-automation-suspend-resume.test.ts \
             tests/integration/multitable-automation-start-approval.test.ts \
+            tests/integration/multitable-webhook-event-bridge.test.ts \
+            tests/integration/multitable-webhook-retry-tick.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -100,6 +100,13 @@ import {
   startAttendanceScheduler,
   stopAttendanceScheduler,
 } from './services/AttendanceScheduler'
+import {
+  resolveWebhookRetrySchedulerIntervalMs,
+  resolveWebhookRetrySchedulerLeaderOptions,
+  startWebhookRetryScheduler,
+  stopWebhookRetryScheduler,
+} from './services/WebhookRetryScheduler'
+import { initWebhookEventBridge } from './multitable/webhook-event-bridge'
 import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
 import {
   createApprovalBreachChannelsFromEnv,
@@ -1861,6 +1868,14 @@ export class MetaSheetServer {
       }
     })())
 
+    shutdownTasks.push((async () => {
+      try {
+        stopWebhookRetryScheduler()
+      } catch (err) {
+        this.logger.warn(`Webhook retry scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources (only if one was constructed during start()).
     shutdownTasks.push((async () => {
       try {
@@ -2051,6 +2066,38 @@ export class MetaSheetServer {
       this.logger.info(scheduler ? 'Attendance scheduler initialized' : 'Attendance scheduler disabled (ATTENDANCE_SCHEDULER_ENABLED!=true)')
     } catch (e) {
       this.logger.error('Attendance scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // Webhook outbound pipeline. Two independent halves wired here:
+    //   (1) the event bridge — subscribes the multitable record/comment topics on the
+    //       module-singleton integration eventBus (the SAME bus the record-write path
+    //       emits on; independent of core/EventBusService.initialize() above) and
+    //       forwards them to WebhookService.deliverEvent. Webhooks are DB-row-driven,
+    //       not env-gated, so this is wired unconditionally; the bridge keeps its own
+    //       initialized idempotency guard, so a duplicate call is a no-op.
+    //   (2) the retry tick — a periodic scan that re-attempts `pending` deliveries past
+    //       their next_retry_at, mirroring the SLA scheduler's leader-elected interval.
+    //       Enabled by default (opt out via WEBHOOK_RETRY_SCHEDULER_DISABLED=1).
+    try {
+      initWebhookEventBridge()
+      this.logger.info('Webhook event bridge initialized')
+    } catch (e) {
+      this.logger.error('Webhook event bridge initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    try {
+      const webhookRetryLeaderOptions = await resolveWebhookRetrySchedulerLeaderOptions()
+      const webhookRetryScheduler = startWebhookRetryScheduler({
+        leaderOptions: webhookRetryLeaderOptions,
+        intervalMs: resolveWebhookRetrySchedulerIntervalMs(),
+      })
+      this.logger.info(
+        webhookRetryScheduler
+          ? 'Webhook retry scheduler initialized'
+          : 'Webhook retry scheduler disabled (WEBHOOK_RETRY_SCHEDULER_DISABLED=1)',
+      )
+    } catch (e) {
+      this.logger.error('Webhook retry scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/multitable/webhook-event-bridge.ts
+++ b/packages/core-backend/src/multitable/webhook-event-bridge.ts
@@ -2,11 +2,26 @@
  * Webhook Event Bridge
  * Wires internal EventBus events to the WebhookService delivery pipeline.
  *
- * This module subscribes to multitable EventBus topics and forwards them
- * as webhook deliveries, keeping the publish sites untouched.
+ * This module subscribes to multitable EventBus topics and forwards them as
+ * webhook deliveries, keeping the publish sites untouched.
+ *
+ * IMPORTANT — bus identity: the multitable record write path
+ * (record-write-service.ts / record-service.ts) and the AutomationService both
+ * emit/subscribe on the `integration/events/event-bus` singleton (the `EventBus`
+ * class with `.subscribe()`), NOT the `core/EventBusService` instance. The bridge
+ * MUST subscribe to that SAME bus or it never fires. We therefore default to the
+ * integration eventBus and mirror AutomationService.init()'s subscription shape.
+ *
+ * Posture (at-least-once, fire-and-forget): `deliverEvent` persists a durable
+ * delivery row BEFORE the HTTP attempt and only then fires the request without
+ * awaiting it, so a crash mid-flight leaves a `pending` row the retry tick picks
+ * up. The bridge subscription itself is fire-and-forget (errors are logged, never
+ * propagated back to the emitting write). A full transactional outbox (emit inside
+ * the write transaction) is out of scope — see the rank-5 wiring deliverable.
  */
 
-import { eventBus } from '../core/EventBusService'
+import { eventBus as integrationEventBus } from '../integration/events/event-bus'
+import type { EventBus } from '../integration/events/event-bus'
 import { Logger } from '../core/logger'
 import { WebhookService } from './webhook-service'
 import { db } from '../db/db'
@@ -24,24 +39,62 @@ const EVENT_MAP: Record<string, WebhookEventType> = {
   'multitable.comment.created': 'comment.created',
 }
 
+export interface WebhookEventBridgeOptions {
+  /**
+   * The bus to subscribe on. Defaults to the integration eventBus — the SAME
+   * singleton the record write path emits on. Tests inject their own instance.
+   */
+  eventBus?: EventBus
+  /**
+   * The delivery service. Defaults to a WebhookService bound to the shared
+   * runtime `db` (same pool the rest of the app uses). Tests inject one with a
+   * mock fetch + scoped db.
+   */
+  webhookService?: WebhookService
+  logger?: Logger
+}
+
 let initialized = false
-const webhookService = new WebhookService(db)
+const subscriptionIds: string[] = []
 
 /**
  * Call once at application startup to bridge EventBus -> WebhookService.
+ * Idempotent: a second call is a no-op until {@link resetWebhookEventBridgeForTests}.
  */
-export function initWebhookEventBridge(): void {
+export function initWebhookEventBridge(options: WebhookEventBridgeOptions = {}): void {
   if (initialized) return
   initialized = true
 
+  const bus = options.eventBus ?? integrationEventBus
+  // Construct the service lazily at init time (not module load) so the bridge
+  // binds to the shared runtime db rather than a stray import-time instance.
+  const webhookService = options.webhookService ?? new WebhookService(db)
+  const log = options.logger ?? logger
+
   for (const [busEvent, webhookEvent] of Object.entries(EVENT_MAP)) {
-    eventBus.on(busEvent, (payload: unknown) => {
+    const id = bus.subscribe(busEvent, (payload: unknown) => {
+      // Fire-and-forget: deliverEvent persists a durable row before the HTTP
+      // attempt, so an error here never blocks or fails the emitting write.
       webhookService.deliverEvent(webhookEvent, payload).catch((err) => {
-        logger.error(
+        log.error(
           `Failed to deliver webhook for ${webhookEvent}: ${err instanceof Error ? err.message : String(err)}`,
         )
       })
     })
-    logger.info(`Bridged EventBus "${busEvent}" -> Webhook "${webhookEvent}"`)
+    subscriptionIds.push(id)
+    log.info(`Bridged EventBus "${busEvent}" -> Webhook "${webhookEvent}"`)
   }
+}
+
+/** Test-only: tear down subscriptions and clear the idempotency guard. */
+export function resetWebhookEventBridgeForTests(bus: EventBus = integrationEventBus): void {
+  for (const id of subscriptionIds) {
+    try {
+      bus.unsubscribe(id)
+    } catch {
+      // best-effort
+    }
+  }
+  subscriptionIds.length = 0
+  initialized = false
 }

--- a/packages/core-backend/src/multitable/webhook-service.ts
+++ b/packages/core-backend/src/multitable/webhook-service.ts
@@ -23,6 +23,10 @@ const logger = new Logger('WebhookService')
 const DELIVERY_TIMEOUT_MS = 5_000
 const MAX_CONSECUTIVE_FAILURES = 10
 const BASE_RETRY_DELAY_MS = 1_000
+// Lease window a retry tick holds a claimed delivery for (review MINOR-1):
+// long enough to out-live the HTTP attempt + backoff recompute so a concurrent
+// replica's tick skips it; short enough that a crashed tick's row is retried soon.
+const RETRY_CLAIM_LEASE_MS = DELIVERY_TIMEOUT_MS * 4
 
 function generateId(): string {
   return randomBytes(16).toString('hex')
@@ -404,20 +408,42 @@ export class WebhookService {
    * Retry all failed deliveries that are due for retry.
    */
   async retryFailedDeliveries(): Promise<number> {
-    const rows = await this.db
-      .selectFrom('multitable_webhook_deliveries')
-      .selectAll()
-      .where('status', '=', 'pending')
-      .execute()
-
+    // Cross-replica safety (review MINOR-1): claim due rows under
+    // FOR UPDATE SKIP LOCKED in a short transaction and lease them forward by
+    // bumping next_retry_at, so a concurrent tick on another replica skips
+    // them — then deliver OUTSIDE the transaction (no DB lock held across the
+    // HTTP attempt, mirroring the M2 reserve-then-settle posture). If this
+    // tick crashes mid-delivery the lease expires and the row is retried.
     const now = Date.now()
+    const leaseUntil = new Date(now + RETRY_CLAIM_LEASE_MS)
+    const claimed = await this.db.transaction().execute(async (trx) => {
+      const due = await trx
+        .selectFrom('multitable_webhook_deliveries')
+        .selectAll()
+        .where('status', '=', 'pending')
+        .where('next_retry_at', 'is not', null)
+        .where('next_retry_at', '<=', new Date(now))
+        .forUpdate()
+        .skipLocked()
+        .execute()
+      if (due.length > 0) {
+        await trx
+          .updateTable('multitable_webhook_deliveries')
+          .set({ next_retry_at: leaseUntil })
+          .where(
+            'id',
+            'in',
+            due.map((r) => String((r as { id: string }).id)),
+          )
+          .execute()
+      }
+      return due
+    })
+
     let retried = 0
 
-    for (const row of rows) {
+    for (const row of claimed) {
       const delivery = rowToDelivery(row as Parameters<typeof rowToDelivery>[0])
-
-      if (!delivery.nextRetryAt) continue
-      if (new Date(delivery.nextRetryAt).getTime() > now) continue
 
       const wh = await this.getWebhookById(delivery.webhookId)
       if (!wh || !wh.active) {

--- a/packages/core-backend/src/services/WebhookRetryScheduler.ts
+++ b/packages/core-backend/src/services/WebhookRetryScheduler.ts
@@ -1,0 +1,302 @@
+/**
+ * Webhook retry scheduler.
+ *
+ * Runs a periodic tick that calls WebhookService.retryFailedDeliveries() — picking
+ * up `pending` delivery rows whose `next_retry_at` has elapsed and re-attempting
+ * delivery with the existing exponential-backoff bookkeeping. This is the missing
+ * half of the webhook outbound pipeline: without it, a delivery that fails its first
+ * attempt is parked `pending` forever.
+ *
+ * Mirrors ApprovalSlaScheduler exactly: a single-process interval with a one-run
+ * guard; multi-instance fleets can opt into a Redis leader lock via
+ * ENABLE_WEBHOOK_RETRY_LEADER_LOCK=true. retryFailedDeliveries() is itself
+ * concurrency-tolerant (each attempt re-reads webhook state and the delivery's
+ * attempt_count guards termination), so the leader lock is a LOAD optimisation only,
+ * never load-bearing for correctness — at-least-once is the accepted posture.
+ *
+ * Enabled by default (webhooks are DB-row-driven, not env-gated); disable with
+ * WEBHOOK_RETRY_SCHEDULER_DISABLED=1. Interval defaults to 60s
+ * (WEBHOOK_RETRY_SCHEDULER_INTERVAL_MS), clamped to a 5s floor.
+ */
+
+import { randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
+import { WebhookService } from '../multitable/webhook-service'
+import { db } from '../db/db'
+
+const DEFAULT_INTERVAL_MS = 60 * 1000
+const MIN_INTERVAL_MS = 5000
+const DEFAULT_LOCK_TTL_MS = 30_000
+
+export interface WebhookRetryService {
+  retryFailedDeliveries(): Promise<number>
+}
+
+export interface WebhookRetrySchedulerLeaderOptions {
+  leaderLock: RedisLeaderLock
+  lockKey?: string
+  ownerId: string
+  ttlMs?: number
+  renewIntervalMs?: number
+  retryIntervalMs?: number
+}
+
+export interface WebhookRetrySchedulerLeaderGauge {
+  labels(labels: { state: 'leader' | 'follower' | 'relinquished' }): { set(value: number): void }
+}
+
+export interface WebhookRetrySchedulerRuntimeOptions {
+  leaderStateGauge?: WebhookRetrySchedulerLeaderGauge
+}
+
+export interface WebhookRetrySchedulerOptions {
+  service?: WebhookRetryService
+  intervalMs?: number
+  leaderOptions?: WebhookRetrySchedulerLeaderOptions | null
+  runtime?: WebhookRetrySchedulerRuntimeOptions
+  logger?: Logger
+}
+
+export class WebhookRetryScheduler {
+  private readonly logger: Logger
+  private readonly service: WebhookRetryService
+  private readonly intervalMs: number
+  private readonly leaderOptions: WebhookRetrySchedulerLeaderOptions | null
+  private readonly lockKey: string
+  private readonly ttlMs: number
+  private readonly renewIntervalMs: number
+  private readonly retryIntervalMs: number
+  private readonly leaderStateGauge: WebhookRetrySchedulerLeaderGauge | null
+  private timer: NodeJS.Timeout | null = null
+  private renewalTimer: NodeJS.Timeout | null = null
+  private acquisitionTimer: NodeJS.Timeout | null = null
+  private running = false
+  private started = false
+  private isLeader = false
+  public readonly ready: Promise<void>
+
+  constructor(options: WebhookRetrySchedulerOptions = {}) {
+    this.service = options.service ?? new WebhookService(db)
+    this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+    this.leaderOptions = options.leaderOptions ?? null
+    this.lockKey = this.leaderOptions?.lockKey ?? 'webhook-retry-scheduler:leader'
+    this.ttlMs = this.leaderOptions?.ttlMs ?? DEFAULT_LOCK_TTL_MS
+    this.renewIntervalMs = this.leaderOptions?.renewIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
+    this.logger = options.logger ?? new Logger('WebhookRetryScheduler')
+    if (this.leaderOptions) {
+      this.setLeaderGauge('follower')
+      this.ready = this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Webhook retry leader-lock acquisition failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    } else {
+      this.isLeader = true
+      this.setLeaderGauge('leader')
+      this.ready = Promise.resolve()
+    }
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.ready.then(() => {
+      if (!this.started) return
+      if (this.isLeader) {
+        this.startTickLoop()
+      } else {
+        this.startAcquisitionRetryLoop()
+      }
+    }).catch((error) => {
+      this.logger.warn(`Webhook retry scheduler start skipped after leader-lock error: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
+
+  stop(): void {
+    this.started = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.acquisitionTimer) {
+      clearInterval(this.acquisitionTimer)
+      this.acquisitionTimer = null
+    }
+    if (this.leaderOptions && this.isLeader) {
+      const { leaderLock, ownerId } = this.leaderOptions
+      leaderLock.release(this.lockKey, ownerId).catch(() => {})
+      this.isLeader = false
+    }
+    this.setLeaderGauge('relinquished')
+    this.logger.info('Webhook retry scheduler stopped')
+  }
+
+  /**
+   * Run one retry pass. Returns the number of deliveries re-attempted. The one-run
+   * guard (`running`) prevents overlapping passes when a tick runs long.
+   */
+  async tick(): Promise<number> {
+    if (!this.isLeader) return 0
+    if (this.running) return 0
+    this.running = true
+    try {
+      const retried = await this.service.retryFailedDeliveries()
+      if (retried > 0) {
+        this.logger.info(`Webhook deliveries retried: ${retried}`)
+      }
+      return retried
+    } catch (error) {
+      this.logger.error(`Webhook retry tick failed: ${error instanceof Error ? error.message : String(error)}`)
+      return 0
+    } finally {
+      this.running = false
+    }
+  }
+
+  get leader(): boolean {
+    return this.isLeader
+  }
+
+  private async attemptLeadership(): Promise<void> {
+    if (!this.leaderOptions) return
+    const { leaderLock, ownerId } = this.leaderOptions
+    const won = await leaderLock.acquire(this.lockKey, ownerId, this.ttlMs)
+    this.isLeader = won
+    if (won) {
+      this.logger.info(`Acquired webhook retry scheduler leader lock ${this.lockKey} (owner=${ownerId}, ttl=${this.ttlMs}ms)`)
+      this.setLeaderGauge('leader')
+      this.stopAcquisitionRetryLoop()
+      this.startRenewalLoop()
+      if (this.started) this.startTickLoop()
+    } else {
+      this.logger.info(`Did not acquire webhook retry scheduler leader lock ${this.lockKey}; operating as non-leader (owner=${ownerId})`)
+      this.setLeaderGauge('follower')
+    }
+  }
+
+  private setLeaderGauge(state: 'leader' | 'follower' | 'relinquished'): void {
+    if (!this.leaderStateGauge) return
+    try {
+      for (const candidate of ['leader', 'follower', 'relinquished'] as const) {
+        this.leaderStateGauge.labels({ state: candidate }).set(candidate === state ? 1 : 0)
+      }
+    } catch {
+      // Metrics failures must not break the scheduler.
+    }
+  }
+
+  private startTickLoop(): void {
+    if (!this.started || !this.isLeader || this.timer) return
+    this.logger.info(`Webhook retry scheduler starting with interval ${this.intervalMs}ms`)
+    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+    if (typeof this.timer.unref === 'function') this.timer.unref()
+  }
+
+  private startAcquisitionRetryLoop(): void {
+    if (!this.leaderOptions || this.acquisitionTimer || this.isLeader) return
+    this.acquisitionTimer = setInterval(() => {
+      this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Webhook retry leader-lock retry failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, this.retryIntervalMs)
+    if (typeof this.acquisitionTimer.unref === 'function') this.acquisitionTimer.unref()
+  }
+
+  private stopAcquisitionRetryLoop(): void {
+    if (!this.acquisitionTimer) return
+    clearInterval(this.acquisitionTimer)
+    this.acquisitionTimer = null
+  }
+
+  private startRenewalLoop(): void {
+    if (!this.leaderOptions) return
+    if (this.renewalTimer) clearInterval(this.renewalTimer)
+    const { leaderLock, ownerId } = this.leaderOptions
+    this.renewalTimer = setInterval(() => {
+      leaderLock.renew(this.lockKey, ownerId, this.ttlMs).then(
+        (ok) => {
+          if (!ok) this.relinquishLeadership('renewal rejected')
+        },
+        (error) => {
+          this.logger.warn(`Webhook retry leader renewal error for ${this.lockKey}: ${error instanceof Error ? error.message : String(error)}`)
+          this.relinquishLeadership('renewal error')
+        },
+      )
+    }, this.renewIntervalMs)
+    if (typeof this.renewalTimer.unref === 'function') this.renewalTimer.unref()
+  }
+
+  private relinquishLeadership(reason: string): void {
+    if (!this.isLeader) return
+    this.logger.warn(`Relinquishing webhook retry scheduler leadership (${reason})`)
+    this.isLeader = false
+    this.setLeaderGauge('relinquished')
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.started) this.startAcquisitionRetryLoop()
+  }
+}
+
+let sharedScheduler: WebhookRetryScheduler | null = null
+
+/**
+ * Enabled by default; opt OUT with WEBHOOK_RETRY_SCHEDULER_DISABLED=1. Returns null
+ * when disabled or already started.
+ */
+export function startWebhookRetryScheduler(options: WebhookRetrySchedulerOptions = {}): WebhookRetryScheduler | null {
+  if (process.env.WEBHOOK_RETRY_SCHEDULER_DISABLED === '1') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new WebhookRetryScheduler(options)
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function getSharedWebhookRetryScheduler(): WebhookRetryScheduler | null {
+  return sharedScheduler
+}
+
+export function stopWebhookRetryScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}
+
+export function resolveWebhookRetrySchedulerIntervalMs(): number | undefined {
+  const raw = Number(process.env.WEBHOOK_RETRY_SCHEDULER_INTERVAL_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : undefined
+}
+
+export async function resolveWebhookRetrySchedulerLeaderOptions(): Promise<WebhookRetrySchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_WEBHOOK_RETRY_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.WEBHOOK_RETRY_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.WEBHOOK_RETRY_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.WEBHOOK_RETRY_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.WEBHOOK_RETRY_LEADER_LOCK_RETRY_MS)
+    : undefined
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `webhook-retry:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
+    retryIntervalMs,
+  }
+}

--- a/packages/core-backend/tests/integration/multitable-webhook-event-bridge.test.ts
+++ b/packages/core-backend/tests/integration/multitable-webhook-event-bridge.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Real-event-chain integration test for the webhook outbound pipeline (rank-5 wiring).
+ *
+ * THE GAP this closes: the webhook surface (CRUD, HMAC signing, durable delivery
+ * rows, retry/backoff) was fully built but COMPLETELY DISCONNECTED —
+ * initWebhookEventBridge() was never called at startup AND it subscribed to the
+ * `core/EventBusService` instance while the record-write path emits on the
+ * `integration/events/event-bus` singleton (two different objects). So a record
+ * write never produced a delivery. This test exercises the REAL chain end to end:
+ *
+ *   PATCH /records/:id  →  RecordWriteService.patchRecords (real route, real pool)
+ *     →  eventBus.emit('multitable.record.updated')  (integration bus)
+ *       →  bridge subscription  →  WebhookService.deliverEvent('record.updated')
+ *         →  durable row in multitable_webhook_deliveries + HMAC X-Webhook-Signature.
+ *
+ * FAIL-FIRST: on origin/main the bridge is unwired and bound to the wrong bus, so the
+ * PATCH produces NO delivery row → the positive assertion fails. After the wiring fix
+ * the row lands. A NEGATIVE control (a webhook subscribed only to comment.created)
+ * proves the event filter — it must get no delivery.
+ *
+ * No real external calls: WebhookService is injected with a loopback fetch that
+ * records the request (URL + headers + body) instead of hitting the network.
+ *
+ * Runs only with DATABASE_URL (plugin-tests.yml multitable real-DB job).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { WebhookService } from '../../src/multitable/webhook-service'
+import {
+  initWebhookEventBridge,
+  resetWebhookEventBridgeForTests,
+} from '../../src/multitable/webhook-event-bridge'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_whk_${TS}`
+const SHEET_ID = `sheet_whk_${TS}`
+const FLD_VALUE = `fld_whk_value_${TS}`
+const REC_ID = `rec_whk_${TS}`
+const USER_ID = `u_whk_${TS}`
+const WH_SUBSCRIBED = `whk_sub_${TS}` // subscribed to record.updated — must receive a delivery
+const WH_UNSUBSCRIBED = `whk_unsub_${TS}` // subscribed only to comment.created — must NOT
+const WH_SECRET = `whk-secret-${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+interface CapturedRequest {
+  url: string
+  headers: Record<string, string>
+  body: string
+}
+
+let app: Express
+let captured: CapturedRequest[] = []
+
+/** Loopback fetch: records the request and returns 200; never touches the network. */
+const loopbackFetch = (async (url: unknown, init?: { headers?: Record<string, string>; body?: string }) => {
+  captured.push({
+    url: String(url),
+    headers: { ...(init?.headers ?? {}) },
+    body: init?.body ?? '',
+  })
+  return {
+    ok: true,
+    status: 200,
+    text: async () => 'ok',
+  } as Response
+}) as unknown as typeof fetch
+
+async function deliveriesFor(webhookId: string): Promise<Array<Record<string, unknown>>> {
+  const r = await q('SELECT * FROM multitable_webhook_deliveries WHERE webhook_id = $1', [webhookId])
+  return r.rows as Array<Record<string, unknown>>
+}
+
+async function waitForDelivery(webhookId: string, timeoutMs = 5000): Promise<Array<Record<string, unknown>>> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const rows = await deliveriesFor(webhookId)
+    if (rows.length > 0) return rows
+    if (Date.now() > deadline) return rows
+    await new Promise((r) => setTimeout(r, 50))
+  }
+}
+
+describeIfDatabase('webhook event bridge real chain (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { user: unknown }).user = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Webhook Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Webhook Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUE, SHEET_ID, 'Value', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VALUE]: 1 })])
+
+    const now = new Date().toISOString()
+    // Subscribed webhook: record.updated, with a secret (so the HMAC header is computed).
+    await q(
+      'INSERT INTO multitable_webhooks (id, name, url, secret, events, active, created_by, created_at, failure_count, max_retries) VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,$10)',
+      [WH_SUBSCRIBED, 'Subscribed', 'https://sink.test/subscribed', WH_SECRET, JSON.stringify(['record.updated']), true, USER_ID, now, 0, 3],
+    )
+    // Unsubscribed webhook (negative control): only comment.created.
+    await q(
+      'INSERT INTO multitable_webhooks (id, name, url, secret, events, active, created_by, created_at, failure_count, max_retries) VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,$10)',
+      [WH_UNSUBSCRIBED, 'Unsubscribed', 'https://sink.test/unsubscribed', null, JSON.stringify(['comment.created']), true, USER_ID, now, 0, 3],
+    )
+
+    // Wire the bridge onto the SAME integration bus the PATCH route emits on, with a
+    // WebhookService bound to the shared runtime db + the loopback fetch.
+    resetWebhookEventBridgeForTests(integrationEventBus)
+    initWebhookEventBridge({
+      eventBus: integrationEventBus,
+      webhookService: new WebhookService(db, loopbackFetch),
+    })
+  })
+
+  afterAll(async () => {
+    resetWebhookEventBridgeForTests(integrationEventBus)
+    await q('DELETE FROM multitable_webhook_deliveries WHERE webhook_id = ANY($1)', [[WH_SUBSCRIBED, WH_UNSUBSCRIBED]]).catch(() => {})
+    await q('DELETE FROM multitable_webhooks WHERE id = ANY($1)', [[WH_SUBSCRIBED, WH_UNSUBSCRIBED]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(() => {
+    captured = []
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('a real PATCH emits record.updated → bridge → durable delivery row + HMAC header (FAIL-FIRST keystone)', async () => {
+    const res = await request(app)
+      .patch(`/api/multitable/records/${REC_ID}`)
+      .send({ sheetId: SHEET_ID, data: { [FLD_VALUE]: 42 } })
+    expect(res.status).toBe(200)
+
+    // The bridge subscription fires synchronously on emit, but deliverEvent is
+    // fire-and-forget; poll for the durable row it persists.
+    const rows = await waitForDelivery(WH_SUBSCRIBED)
+    expect(rows.length).toBeGreaterThanOrEqual(1)
+    const delivery = rows[0]
+    expect(delivery.event).toBe('record.updated')
+    // The delivery row carries the actual emitted payload (recordId + changes).
+    const payload = typeof delivery.payload === 'string' ? JSON.parse(delivery.payload) : delivery.payload
+    expect((payload as { recordId?: string }).recordId).toBe(REC_ID)
+
+    // The loopback sink received the POST with the HMAC X-Webhook-Signature header
+    // computed over the body with the webhook secret.
+    expect(captured.length).toBeGreaterThanOrEqual(1)
+    const sentToSubscribed = captured.find((c) => c.url === 'https://sink.test/subscribed')
+    expect(sentToSubscribed).toBeDefined()
+    expect(sentToSubscribed!.headers['X-Webhook-Id']).toBe(WH_SUBSCRIBED)
+    expect(sentToSubscribed!.headers['X-Webhook-Event']).toBe('record.updated')
+    const expectedSig = WebhookService.signPayload(sentToSubscribed!.body, WH_SECRET)
+    expect(sentToSubscribed!.headers['X-Webhook-Signature']).toBe(expectedSig)
+  })
+
+  test('negative: an unsubscribed webhook (comment.created only) receives no delivery for record.updated', async () => {
+    const rows = await deliveriesFor(WH_UNSUBSCRIBED)
+    expect(rows.length).toBe(0)
+    // ...and the loopback sink was never POSTed for that URL across the suite.
+    expect(captured.some((c) => c.url === 'https://sink.test/unsubscribed')).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
+++ b/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Real-DB integration test for the webhook retry tick (rank-5 wiring).
+ *
+ * The retry half of the outbound pipeline: retryFailedDeliveries() picks up `pending`
+ * delivery rows whose next_retry_at has elapsed and re-attempts delivery. This proves
+ * the SCHEDULED path — a WebhookRetryScheduler.tick() (the leader-elected periodic
+ * entry the app schedules) drives that pickup through the real Postgres wire, not just
+ * a direct service call against a mock db.
+ *
+ * Seed a webhook + a `pending` delivery row with next_retry_at in the PAST, then run
+ * one scheduler tick with a WebhookService bound to the real db + a loopback fetch
+ * (no external calls). Assert the tick reports the row retried, the loopback sink got
+ * the POST, and the row transitions out of the due-pending state.
+ *
+ * Runs only with DATABASE_URL (plugin-tests.yml multitable real-DB job).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { db } from '../../src/db/db'
+import { WebhookService } from '../../src/multitable/webhook-service'
+import { WebhookRetryScheduler } from '../../src/services/WebhookRetryScheduler'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const WH_ID = `whk_retry_${TS}`
+const DEL_DUE = `del_retry_due_${TS}` // pending, next_retry_at in the past — must be picked up
+const DEL_FUTURE = `del_retry_future_${TS}` // pending, next_retry_at in the future — must be skipped
+const USER_ID = `u_whk_retry_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let captured: string[] = []
+
+const loopbackFetch = (async (url: unknown) => {
+  captured.push(String(url))
+  return { ok: true, status: 200, text: async () => 'ok' } as Response
+}) as unknown as typeof fetch
+
+describeIfDatabase('webhook retry tick (real DB)', () => {
+  beforeAll(async () => {
+    const now = new Date().toISOString()
+    await q(
+      'INSERT INTO multitable_webhooks (id, name, url, secret, events, active, created_by, created_at, failure_count, max_retries) VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,$10)',
+      [WH_ID, 'Retry', 'https://sink.test/retry', null, JSON.stringify(['record.updated']), true, USER_ID, now, 1, 3],
+    )
+    const past = new Date(Date.now() - 60_000).toISOString()
+    const future = new Date(Date.now() + 600_000).toISOString()
+    // Due pending delivery (attempt_count 1 < max_retries 3) → eligible for retry.
+    await q(
+      'INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, next_retry_at) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8)',
+      [DEL_DUE, WH_ID, 'record.updated', JSON.stringify({ recordId: 'r1' }), 'pending', 1, now, past],
+    )
+    // Not-yet-due pending delivery → must be skipped by the same pass.
+    await q(
+      'INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, next_retry_at) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8)',
+      [DEL_FUTURE, WH_ID, 'record.updated', JSON.stringify({ recordId: 'r2' }), 'pending', 1, now, future],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM multitable_webhook_deliveries WHERE webhook_id = $1', [WH_ID]).catch(() => {})
+    await q('DELETE FROM multitable_webhooks WHERE id = $1', [WH_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('a pending delivery past next_retry_at is picked up by the scheduled tick path', async () => {
+    captured = []
+    // No leaderOptions → the scheduler is leader immediately (single-process). We call
+    // tick() directly (the same entry the interval drives) so the test is deterministic
+    // and does not depend on wall-clock interval timing.
+    const scheduler = new WebhookRetryScheduler({
+      service: new WebhookService(db, loopbackFetch),
+    })
+    expect(scheduler.leader).toBe(true)
+
+    const retried = await scheduler.tick()
+    expect(retried).toBe(1) // exactly the due row; the future row is skipped
+
+    // The loopback sink received the re-attempt POST for the due delivery's webhook.
+    expect(captured).toContain('https://sink.test/retry')
+
+    // The due delivery transitioned out of the due-pending state (success on the
+    // loopback 200), while the future delivery is untouched.
+    const due = await q('SELECT status FROM multitable_webhook_deliveries WHERE id = $1', [DEL_DUE])
+    expect(due.rows[0].status).toBe('success')
+    const future = await q('SELECT status, next_retry_at FROM multitable_webhook_deliveries WHERE id = $1', [DEL_FUTURE])
+    expect(future.rows[0].status).toBe('pending')
+
+    scheduler.stop()
+  })
+
+  test('a second tick does no work once the due delivery is resolved', async () => {
+    captured = []
+    const scheduler = new WebhookRetryScheduler({
+      service: new WebhookService(db, loopbackFetch),
+    })
+    const retried = await scheduler.tick()
+    expect(retried).toBe(0)
+    expect(captured).not.toContain('https://sink.test/retry')
+    scheduler.stop()
+  })
+
+  test('MINOR-1: two concurrent retry passes claim the due row exactly once (no double-delivery)', async () => {
+    // Re-arm the due row to pending+due, then run two retryFailedDeliveries() passes
+    // concurrently (simulating two replicas ticking at once). FOR UPDATE SKIP LOCKED +
+    // the next_retry_at lease must let exactly one pass claim+deliver it.
+    captured = []
+    await q(
+      "UPDATE multitable_webhook_deliveries SET status = 'pending', attempt_count = 0, next_retry_at = now() - interval '1 minute' WHERE id = $1",
+      [DEL_DUE],
+    )
+    const svcA = new WebhookService(db, loopbackFetch)
+    const svcB = new WebhookService(db, loopbackFetch)
+    const [a, b] = await Promise.all([svcA.retryFailedDeliveries(), svcB.retryFailedDeliveries()])
+    expect(a + b).toBe(1) // exactly one pass did the work
+    expect(captured.filter((u) => u === 'https://sink.test/retry')).toHaveLength(1) // delivered once
+  })
+})

--- a/packages/core-backend/tests/unit/api-token-webhook.test.ts
+++ b/packages/core-backend/tests/unit/api-token-webhook.test.ts
@@ -28,7 +28,7 @@ function makeChain(): Record<string, unknown> {
     'limit', 'offset', 'groupBy', 'insertInto', 'values',
     'onConflict', 'columns', 'doUpdateSet',
     'updateTable', 'set', 'deleteFrom', 'returningAll',
-    'leftJoin',
+    'leftJoin', 'forUpdate', 'skipLocked',
   ]
   for (const m of methods) {
     self[m] = vi.fn(chainFn)

--- a/packages/core-backend/tests/unit/webhook-retry-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/webhook-retry-scheduler.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  WebhookRetryScheduler,
+  resolveWebhookRetrySchedulerIntervalMs,
+  startWebhookRetryScheduler,
+  stopWebhookRetryScheduler,
+} from '../../src/services/WebhookRetryScheduler'
+import { MemoryLeaderLockClient, RedisLeaderLock } from '../../src/multitable/redis-leader-lock'
+
+describe('WebhookRetryScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    stopWebhookRetryScheduler()
+    delete process.env.WEBHOOK_RETRY_SCHEDULER_DISABLED
+    delete process.env.WEBHOOK_RETRY_SCHEDULER_INTERVAL_MS
+  })
+
+  it('tick() delegates to retryFailedDeliveries and returns its count', async () => {
+    const retryFailedDeliveries = vi.fn<() => Promise<number>>().mockResolvedValue(3)
+    const scheduler = new WebhookRetryScheduler({ service: { retryFailedDeliveries } })
+    expect(await scheduler.tick()).toBe(3)
+    expect(retryFailedDeliveries).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows retry errors and returns 0', async () => {
+    const retryFailedDeliveries = vi.fn().mockRejectedValue(new Error('db down'))
+    const scheduler = new WebhookRetryScheduler({ service: { retryFailedDeliveries } })
+    expect(await scheduler.tick()).toBe(0)
+  })
+
+  it('prevents reentrant ticks from overlapping', async () => {
+    let resolveFirst: ((v: number) => void) | null = null
+    const retryFailedDeliveries = vi.fn()
+      .mockImplementationOnce(() => new Promise<number>((resolve) => { resolveFirst = resolve }))
+      .mockResolvedValue(0)
+    const scheduler = new WebhookRetryScheduler({ service: { retryFailedDeliveries } })
+
+    const firstPromise = scheduler.tick()
+    const second = await scheduler.tick()
+    expect(second).toBe(0)
+    expect(retryFailedDeliveries).toHaveBeenCalledTimes(1) // second was blocked by the one-run guard
+
+    resolveFirst?.(0)
+    await firstPromise
+  })
+
+  it('runs ticks only on the process that acquired the leader lock', async () => {
+    const store = new Map()
+    const lockA = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const lockB = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const leaderRetry = vi.fn().mockResolvedValue(1)
+    const followerRetry = vi.fn().mockResolvedValue(1)
+
+    const leader = new WebhookRetryScheduler({
+      service: { retryFailedDeliveries: leaderRetry },
+      leaderOptions: { leaderLock: lockA, ownerId: 'node-a', ttlMs: 30_000 },
+    })
+    const follower = new WebhookRetryScheduler({
+      service: { retryFailedDeliveries: followerRetry },
+      leaderOptions: { leaderLock: lockB, ownerId: 'node-b', ttlMs: 30_000 },
+    })
+    await Promise.all([leader.ready, follower.ready])
+
+    expect(leader.leader).toBe(true)
+    expect(follower.leader).toBe(false)
+    expect(await leader.tick()).toBe(1)
+    expect(await follower.tick()).toBe(0)
+    expect(leaderRetry).toHaveBeenCalledTimes(1)
+    expect(followerRetry).not.toHaveBeenCalled()
+  })
+
+  it('startWebhookRetryScheduler returns null when WEBHOOK_RETRY_SCHEDULER_DISABLED=1', () => {
+    process.env.WEBHOOK_RETRY_SCHEDULER_DISABLED = '1'
+    const scheduler = startWebhookRetryScheduler({ service: { retryFailedDeliveries: vi.fn().mockResolvedValue(0) } })
+    expect(scheduler).toBeNull()
+  })
+
+  it('startWebhookRetryScheduler is enabled by default (no env)', () => {
+    const scheduler = startWebhookRetryScheduler({ service: { retryFailedDeliveries: vi.fn().mockResolvedValue(0) } })
+    expect(scheduler).not.toBeNull()
+  })
+
+  it('resolveWebhookRetrySchedulerIntervalMs reads a positive override, else undefined', () => {
+    expect(resolveWebhookRetrySchedulerIntervalMs()).toBeUndefined()
+    process.env.WEBHOOK_RETRY_SCHEDULER_INTERVAL_MS = '15000'
+    expect(resolveWebhookRetrySchedulerIntervalMs()).toBe(15000)
+    process.env.WEBHOOK_RETRY_SCHEDULER_INTERVAL_MS = '-5'
+    expect(resolveWebhookRetrySchedulerIntervalMs()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Ladder rank-5 (benchmark §8-1): the webhook surface is fully built (CRUD, HMAC `X-Webhook-Signature`, `meta_webhook_deliveries`, exponential-backoff retry, auto-disable) but was **completely disconnected** — users created webhooks that never fired. Recon + fail-first found the gap was **deeper than "uncalled init"**: the bridge also subscribed to the WRONG bus (`core/EventBusService`) while the record-write path emits on the `integration/events/event-bus` singleton — so even calling `initWebhookEventBridge()` delivered nothing.

- **Bridge wired** in `index.ts start()` on the correct integration eventBus singleton (the same one `RecordWriteService.patchRecords` emits `multitable.record.updated` on; mirrors `AutomationService.init()`), using the runtime pool (`db/db.ts` → `poolManager.get()`, no second DB), idempotent via the existing `initialized` guard.
- **Retry scheduler** `WebhookRetryScheduler` — a faithful clone of `ApprovalSlaScheduler` (same `RedisLeaderLock`, one-run guard, env interval/enable), reusing the existing leader-election primitive, not a parallel mechanism. Enabled by default (webhooks are DB-row-driven); opt-out `WEBHOOK_RETRY_SCHEDULER_DISABLED=1`.
- **Cross-replica safety (review MINOR-1)**: `retryFailedDeliveries()` now claims due rows under `FOR UPDATE SKIP LOCKED` in a short transaction and leases them forward (`next_retry_at` bump) before delivering **outside** the transaction — the M2 reserve-then-settle posture; two concurrent ticks claim each row exactly once (no double-delivery), proven by a new concurrency test.

## Tests (fail-first)

- **Real-event-chain keystone** (`multitable-webhook-event-bridge.test.ts`, real DB): PATCH → eventBus → bridge → durable delivery row + HMAC header, plus a negative (unsubscribed webhook = no delivery). **Independently proven to FAIL on origin/main's unwired/wrong-bus state (0 delivery rows).**
- `multitable-webhook-retry-tick.test.ts`: due row delivered, future row skipped, idempotent second tick, **+ MINOR-1 concurrency** (two passes → claimed once).
- `WebhookRetryScheduler` unit 7/7; full backend `test:unit` 237 files / 3023 (incl. server-lifecycle boot with the new wiring — start() doesn't throw); tsc clean. Wired into plugin-tests.yml real-DB list.

## Documented follow-ups (out of scope)

- **MINOR-2**: `comment.created` webhooks still won't fire — `CommentService` broadcasts via `collabService`, not the integration eventBus, so `EVENT_MAP`'s `multitable.comment.created` has no emitter. Separate subsystem; record.* is the keystone.
- NIT-2 (bus `unsubscribe` removes all listeners for an event name — pre-existing), NIT-3 (bridge not torn down on stop — harmless, `initialized` guard prevents double-subscribe).

## Review

Adversarial review (`/tmp/r5-webhook-review-claude-20260611.md`): **APPROVE-WITH-NITS** — MINOR-1 fixed (SKIP-LOCKED lease claim + concurrency test), NIT-1 comment corrected; MINOR-2/NIT-2/NIT-3 documented above.

Ladder: rank 5 (after rank 1/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)