### PR TITLE
feat(multitable): configurable webhook retry policy + send_webhook hardening

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -124,6 +124,57 @@
             </div>
             <label class="meta-api-mgr__label">{{ a('webhook.secretOptional') }}</label>
             <input v-model="webhookDraft.secret" class="meta-api-mgr__input" type="text" :placeholder="a('webhook.secretPlaceholder')" data-webhook-secret="true" />
+
+            <!-- Retry policy (optional; blank = backend default) -->
+            <div class="meta-api-mgr__label" data-webhook-retry-section="true">{{ a('webhook.retry.section') }}</div>
+            <label class="meta-api-mgr__label">{{ a('webhook.retry.maxRetries') }}</label>
+            <input
+              v-model="webhookDraft.maxRetries"
+              class="meta-api-mgr__input"
+              type="number"
+              :min="WEBHOOK_RETRY_BOUNDS.maxRetries.min"
+              :max="WEBHOOK_RETRY_BOUNDS.maxRetries.max"
+              :placeholder="a('webhook.retry.maxRetriesHint')"
+              data-webhook-max-retries="true"
+            />
+            <p
+              v-if="!webhookRetryPolicy.maxRetries.ok"
+              class="meta-api-mgr__error"
+              data-webhook-max-retries-error="true"
+            >{{ a('webhook.retry.rangeError') }}</p>
+
+            <label class="meta-api-mgr__label">{{ a('webhook.retry.baseDelay') }}</label>
+            <input
+              v-model="webhookDraft.retryBaseDelayMs"
+              class="meta-api-mgr__input"
+              type="number"
+              :min="WEBHOOK_RETRY_BOUNDS.baseDelayMs.min"
+              :max="WEBHOOK_RETRY_BOUNDS.baseDelayMs.max"
+              :placeholder="a('webhook.retry.baseDelayHint')"
+              data-webhook-base-delay="true"
+            />
+            <p
+              v-if="!webhookRetryPolicy.retryBaseDelayMs.ok"
+              class="meta-api-mgr__error"
+              data-webhook-base-delay-error="true"
+            >{{ a('webhook.retry.rangeError') }}</p>
+
+            <label class="meta-api-mgr__label">{{ a('webhook.retry.maxDelay') }}</label>
+            <input
+              v-model="webhookDraft.retryMaxDelayMs"
+              class="meta-api-mgr__input"
+              type="number"
+              :min="WEBHOOK_RETRY_BOUNDS.maxDelayMs.min"
+              :max="WEBHOOK_RETRY_BOUNDS.maxDelayMs.max"
+              :placeholder="a('webhook.retry.maxDelayHint')"
+              data-webhook-max-delay="true"
+            />
+            <p
+              v-if="!webhookRetryPolicy.retryMaxDelayMs.ok"
+              class="meta-api-mgr__error"
+              data-webhook-max-delay-error="true"
+            >{{ a('webhook.retry.rangeError') }}</p>
+
             <div class="meta-api-mgr__form-actions">
               <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!canSaveWebhook || busy" data-webhook-save="true" @click="onSaveWebhook">
                 {{ editingWebhookId ? a('webhook.action.update') : a('webhook.action.create') }}
@@ -440,8 +491,24 @@ const availableScopes = ['read', 'write', 'admin']
 const webhooks = ref<Webhook[]>([])
 const webhooksLoading = ref(false)
 const showWebhookForm = ref(false)
+// Retry-policy bounds — mirror the backend webhook schema (webhooks.ts).
+const WEBHOOK_RETRY_BOUNDS = {
+  maxRetries: { min: 0, max: 10 },
+  baseDelayMs: { min: 100, max: 60_000 },
+  maxDelayMs: { min: 1_000, max: 3_600_000 },
+} as const
+
 const editingWebhookId = ref<string | null>(null)
-const webhookDraft = ref({ name: '', url: '', events: [] as string[], secret: '' })
+// Retry-policy fields are kept as raw strings ('' = unset → backend default).
+const webhookDraft = ref({
+  name: '',
+  url: '',
+  events: [] as string[],
+  secret: '',
+  maxRetries: '',
+  retryBaseDelayMs: '',
+  retryMaxDelayMs: '',
+})
 const availableEvents = ['record.created', 'record.updated', 'record.deleted', 'field.changed']
 const deliveriesWebhookId = ref<string | null>(null)
 const deliveries = ref<WebhookDelivery[]>([])
@@ -467,8 +534,43 @@ const dingTalkGroupDraft = ref({
 const canManageDingTalkGroups = computed(() => props.canManageAutomation !== false)
 const managerTitle = computed(() => apiManagerTitle(canManageDingTalkGroups.value, isZh.value))
 
+/**
+ * Parse an optional bounded integer from a raw input string.
+ * Returns `{ ok: true, value: undefined }` for blank (use backend default),
+ * `{ ok: true, value: n }` when in range, and `{ ok: false }` otherwise.
+ */
+function parseBoundedInt(
+  raw: string | number,
+  bounds: { min: number; max: number },
+): { ok: boolean; value?: number } {
+  // `v-model` on <input type="number"> can hand back a number; normalize to a
+  // trimmed string first so the empty-input case stays detectable.
+  const trimmed = String(raw ?? '').trim()
+  if (trimmed === '') return { ok: true, value: undefined }
+  if (!/^-?\d+$/.test(trimmed)) return { ok: false }
+  const n = Number(trimmed)
+  if (n < bounds.min || n > bounds.max) return { ok: false }
+  return { ok: true, value: n }
+}
+
+const webhookRetryPolicy = computed(() => ({
+  maxRetries: parseBoundedInt(webhookDraft.value.maxRetries, WEBHOOK_RETRY_BOUNDS.maxRetries),
+  retryBaseDelayMs: parseBoundedInt(webhookDraft.value.retryBaseDelayMs, WEBHOOK_RETRY_BOUNDS.baseDelayMs),
+  retryMaxDelayMs: parseBoundedInt(webhookDraft.value.retryMaxDelayMs, WEBHOOK_RETRY_BOUNDS.maxDelayMs),
+}))
+
+const webhookRetryPolicyValid = computed(() => {
+  const p = webhookRetryPolicy.value
+  return p.maxRetries.ok && p.retryBaseDelayMs.ok && p.retryMaxDelayMs.ok
+})
+
 const canSaveWebhook = computed(() => {
-  return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
+  return (
+    !!webhookDraft.value.name.trim() &&
+    webhookDraft.value.url.startsWith('https://') &&
+    webhookDraft.value.events.length > 0 &&
+    webhookRetryPolicyValid.value
+  )
 })
 
 const dingTalkGroupWebhookChanged = computed(() => {
@@ -665,7 +767,15 @@ async function loadWebhooks() {
 
 function openWebhookForm() {
   editingWebhookId.value = null
-  webhookDraft.value = { name: '', url: '', events: [], secret: '' }
+  webhookDraft.value = {
+    name: '',
+    url: '',
+    events: [],
+    secret: '',
+    maxRetries: '',
+    retryBaseDelayMs: '',
+    retryMaxDelayMs: '',
+  }
   showWebhookForm.value = true
 }
 
@@ -676,6 +786,9 @@ function openEditWebhook(wh: Webhook) {
     url: wh.url,
     events: [...wh.events],
     secret: wh.secret ?? '',
+    maxRetries: wh.maxRetries != null ? String(wh.maxRetries) : '',
+    retryBaseDelayMs: wh.retryBaseDelayMs != null ? String(wh.retryBaseDelayMs) : '',
+    retryMaxDelayMs: wh.retryMaxDelayMs != null ? String(wh.retryMaxDelayMs) : '',
   }
   showWebhookForm.value = true
 }
@@ -699,11 +812,15 @@ async function onSaveWebhook() {
   busy.value = true
   error.value = null
   try {
+    const policy = webhookRetryPolicy.value
     const input = {
       name: webhookDraft.value.name.trim(),
       url: webhookDraft.value.url.trim(),
       events: webhookDraft.value.events,
       secret: webhookDraft.value.secret || undefined,
+      maxRetries: policy.maxRetries.value,
+      retryBaseDelayMs: policy.retryBaseDelayMs.value,
+      retryMaxDelayMs: policy.retryMaxDelayMs.value,
     }
     if (editingWebhookId.value) {
       await props.client.updateWebhook(editingWebhookId.value, input)

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1097,6 +1097,9 @@ export interface Webhook {
   active: boolean
   secret: string | null
   failureCount: number
+  maxRetries?: number
+  retryBaseDelayMs?: number
+  retryMaxDelayMs?: number
   createdAt: string
   updatedAt: string
 }
@@ -1107,6 +1110,9 @@ export interface WebhookCreateInput {
   events: string[]
   secret?: string
   active?: boolean
+  maxRetries?: number
+  retryBaseDelayMs?: number
+  retryMaxDelayMs?: number
 }
 
 export interface WebhookDelivery {

--- a/apps/web/src/multitable/utils/meta-api-token-labels.ts
+++ b/apps/web/src/multitable/utils/meta-api-token-labels.ts
@@ -26,6 +26,10 @@ export type MetaApiTokenLabelKey =
   | 'webhook.action.enable' | 'webhook.action.disable' | 'webhook.action.deliveries'
   | 'webhook.delivery.recent' | 'webhook.delivery.ok' | 'webhook.delivery.fail'
   | 'webhook.delivery.retries'
+  | 'webhook.retry.section' | 'webhook.retry.maxRetries'
+  | 'webhook.retry.maxRetriesHint' | 'webhook.retry.baseDelay'
+  | 'webhook.retry.baseDelayHint' | 'webhook.retry.maxDelay'
+  | 'webhook.retry.maxDelayHint' | 'webhook.retry.rangeError'
   | 'webhook.event.recordCreated' | 'webhook.event.recordUpdated'
   | 'webhook.event.recordDeleted' | 'webhook.event.fieldChanged'
   | 'dingtalk.scopeNote.title' | 'dingtalk.scopeNote.bound'
@@ -123,6 +127,14 @@ const LABELS: Record<MetaApiTokenLabelKey, { en: string; zh: string }> = {
   'webhook.delivery.ok': { en: 'OK', zh: '成功' },
   'webhook.delivery.fail': { en: 'FAIL', zh: '失败' },
   'webhook.delivery.retries': { en: 'Retries', zh: '重试次数' },
+  'webhook.retry.section': { en: 'Retry policy (optional)', zh: '重试策略（可选）' },
+  'webhook.retry.maxRetries': { en: 'Max retries', zh: '最大重试次数' },
+  'webhook.retry.maxRetriesHint': { en: '0–10 (default 3)', zh: '0–10（默认 3）' },
+  'webhook.retry.baseDelay': { en: 'Base delay (ms)', zh: '基础延迟（毫秒）' },
+  'webhook.retry.baseDelayHint': { en: '100–60000 (default 1000)', zh: '100–60000（默认 1000）' },
+  'webhook.retry.maxDelay': { en: 'Max delay (ms)', zh: '最大延迟（毫秒）' },
+  'webhook.retry.maxDelayHint': { en: '1000–3600000 (optional)', zh: '1000–3600000（可选）' },
+  'webhook.retry.rangeError': { en: 'Value is out of the allowed range.', zh: '取值超出允许范围。' },
   'webhook.event.recordCreated': { en: 'record.created', zh: '记录已创建' },
   'webhook.event.recordUpdated': { en: 'record.updated', zh: '记录已更新' },
   'webhook.event.recordDeleted': { en: 'record.deleted', zh: '记录已删除' },

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -372,6 +372,128 @@ describe('MetaApiTokenManager', () => {
     expect(createCalls.length).toBe(1)
   })
 
+  async function openWebhookCreateForm() {
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+    const newBtn = document.querySelector('[data-webhook-new]') as HTMLButtonElement
+    newBtn.click()
+    await flushPromises()
+
+    const nameInput = document.querySelector('[data-webhook-name]') as HTMLInputElement
+    nameInput.value = 'Policy hook'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const urlInput = document.querySelector('[data-webhook-url]') as HTMLInputElement
+    urlInput.value = 'https://example.com/hook'
+    urlInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const eventCheckbox = document.querySelector('[data-webhook-event="record.created"]') as HTMLInputElement
+    eventCheckbox.click()
+    await flushPromises()
+  }
+
+  function setNumberField(selector: string, value: string) {
+    const input = document.querySelector(selector) as HTMLInputElement
+    input.value = value
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  it('rejects an out-of-bounds maxRetries (save disabled + error shown)', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+    await openWebhookCreateForm()
+
+    setNumberField('[data-webhook-max-retries]', '11') // > 10
+    await flushPromises()
+
+    expect(document.querySelector('[data-webhook-max-retries-error]')).toBeTruthy()
+    const saveBtn = document.querySelector('[data-webhook-save]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+
+    saveBtn.click()
+    await flushPromises()
+    const createCalls = fetchFn.mock.calls.filter(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/webhooks'),
+    )
+    expect(createCalls.length).toBe(0)
+  })
+
+  it('rejects a below-min base delay', async () => {
+    const { client } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+    await openWebhookCreateForm()
+
+    setNumberField('[data-webhook-base-delay]', '50') // < 100
+    await flushPromises()
+
+    expect(document.querySelector('[data-webhook-base-delay-error]')).toBeTruthy()
+    expect((document.querySelector('[data-webhook-save]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('sends in-bounds retry policy in the create payload', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+    await openWebhookCreateForm()
+
+    setNumberField('[data-webhook-max-retries]', '5')
+    setNumberField('[data-webhook-base-delay]', '2000')
+    setNumberField('[data-webhook-max-delay]', '30000')
+    await flushPromises()
+
+    expect(document.querySelector('[data-webhook-max-retries-error]')).toBeFalsy()
+    const saveBtn = document.querySelector('[data-webhook-save]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const createCall = fetchFn.mock.calls.find(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/webhooks'),
+    )
+    expect(createCall).toBeTruthy()
+    const body = JSON.parse(createCall![1]!.body as string)
+    expect(body.maxRetries).toBe(5)
+    expect(body.retryBaseDelayMs).toBe(2000)
+    expect(body.retryMaxDelayMs).toBe(30000)
+  })
+
+  it('omits retry policy fields when blank (backend default)', async () => {
+    const { client, fetchFn } = mockClient()
+    mount({ visible: true, client })
+    await flushPromises()
+    await openWebhookCreateForm()
+
+    const saveBtn = document.querySelector('[data-webhook-save]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const createCall = fetchFn.mock.calls.find(
+      (c: [string, RequestInit?]) => c[1]?.method === 'POST' && c[0].includes('/webhooks'),
+    )
+    const body = JSON.parse(createCall![1]!.body as string)
+    expect(body.maxRetries).toBeUndefined()
+    expect(body.retryBaseDelayMs).toBeUndefined()
+    expect(body.retryMaxDelayMs).toBeUndefined()
+  })
+
+  it('prefills retry policy when editing an existing webhook', async () => {
+    const { client } = mockClient([], [fakeWebhook({ maxRetries: 7, retryBaseDelayMs: 3000 })])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+    const editBtn = document.querySelector('[data-webhook-edit]') as HTMLButtonElement
+    editBtn.click()
+    await flushPromises()
+
+    expect((document.querySelector('[data-webhook-max-retries]') as HTMLInputElement).value).toBe('7')
+    expect((document.querySelector('[data-webhook-base-delay]') as HTMLInputElement).value).toBe('3000')
+  })
+
   it('deletes a webhook', async () => {
     const { client, fetchFn } = mockClient([], [fakeWebhook()])
     mount({ visible: true, client })

--- a/packages/core-backend/src/db/migrations/zzzz20260611130000_add_webhook_retry_policy.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260611130000_add_webhook_retry_policy.ts
@@ -1,0 +1,26 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Webhook configurable retry policy (ladder rank-6).
+ *
+ * `max_retries` already exists (default 3). Add two NULLABLE backoff columns so
+ * existing rows are unchanged — NULL means "use the service default" (1s base,
+ * uncapped exponential), exactly today's behavior. A per-webhook policy is
+ * stored only when the caller opts in.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE multitable_webhooks
+      ADD COLUMN IF NOT EXISTS retry_base_delay_ms integer,
+      ADD COLUMN IF NOT EXISTS retry_max_delay_ms integer
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE multitable_webhooks
+      DROP COLUMN IF EXISTS retry_max_delay_ms,
+      DROP COLUMN IF EXISTS retry_base_delay_ms
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1413,6 +1413,8 @@ export interface MultitableWebhooksTable {
   last_delivered_at: NullableTimestamp
   failure_count: number
   max_retries: number
+  retry_base_delay_ms: number | null
+  retry_max_delay_ms: number | null
 }
 
 export interface MultitableWebhookDeliveriesTable {

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -47,6 +47,8 @@ export interface SendWebhookConfig {
   method?: string
   headers?: Record<string, string>
   body?: unknown
+  /** Optional HMAC-SHA256 signing secret (X-Webhook-Signature header). */
+  secret?: string
 }
 
 /** Config shape for send_notification */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -32,11 +32,39 @@ import type { ConditionGroup } from './automation-conditions'
 import { evaluateConditions } from './automation-conditions'
 import type { AutomationTrigger } from './automation-triggers'
 import type { NotificationService } from '../types/plugin'
+import { WebhookService } from './webhook-service'
 
 const logger = new Logger('AutomationExecutor')
 
-const WEBHOOK_TIMEOUT_MS = 5_000
-const MAX_WEBHOOK_RETRIES = 2
+const DEFAULT_WEBHOOK_TIMEOUT_MS = 5_000
+const DEFAULT_MAX_WEBHOOK_RETRIES = 2
+// DingTalk group/person dispatch keeps its fixed timeout (unchanged by rank-6).
+const WEBHOOK_TIMEOUT_MS = DEFAULT_WEBHOOK_TIMEOUT_MS
+
+/**
+ * send_webhook timeout, env-overridable via AUTOMATION_WEBHOOK_TIMEOUT_MS.
+ * Bounded [1s, 30s]; a bad value falls back to the default (mirrors the
+ * webhook-service delivery timeout posture).
+ */
+function webhookTimeoutMs(): number {
+  const raw = process.env.AUTOMATION_WEBHOOK_TIMEOUT_MS
+  if (raw === undefined) return DEFAULT_WEBHOOK_TIMEOUT_MS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_WEBHOOK_TIMEOUT_MS
+  return Math.min(Math.max(parsed, 1_000), 30_000)
+}
+
+/**
+ * send_webhook bounded retry count, env-overridable via
+ * AUTOMATION_WEBHOOK_MAX_RETRIES. Bounded [0, 5]; bad value → default.
+ */
+function maxWebhookRetries(): number {
+  const raw = process.env.AUTOMATION_WEBHOOK_MAX_RETRIES
+  if (raw === undefined) return DEFAULT_MAX_WEBHOOK_RETRIES
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MAX_WEBHOOK_RETRIES
+  return Math.min(parsed, 5)
+}
 const DINGTALK_PERSON_BATCH_SIZE = 100
 const DINGTALK_FAILURE_ALERT_CONTENT_LIMIT = 1_000
 
@@ -1281,7 +1309,7 @@ export class AutomationExecutor {
     }
 
     const method = (config.method as string) ?? 'POST'
-    const headers = (config.headers as Record<string, string>) ?? {}
+    const headers = { ...((config.headers as Record<string, string>) ?? {}) }
     if (!headers['Content-Type']) {
       headers['Content-Type'] = 'application/json'
     }
@@ -1292,19 +1320,34 @@ export class AutomationExecutor {
       data: context.recordData,
       triggeredAt: new Date().toISOString(),
     }
+    // Serialize once so the signature is computed over exactly the bytes sent.
+    const bodyStr = JSON.stringify(body)
+
+    // Share the webhook-service security posture: HMAC-SHA256 sign the body and
+    // stamp a timestamp when a secret is configured, using the same header names
+    // and algorithm so a single receiver verifier works for both dispatch paths.
+    const secret = typeof config.secret === 'string' ? config.secret : undefined
+    if (secret) {
+      headers['X-Webhook-Signature'] = WebhookService.signPayload(bodyStr, secret)
+      if (!headers['X-Webhook-Timestamp']) {
+        headers['X-Webhook-Timestamp'] = new Date().toISOString()
+      }
+    }
 
     const fetchFn = this.deps.fetchFn ?? globalThis.fetch
+    const timeoutMs = webhookTimeoutMs()
+    const retries = maxWebhookRetries()
 
     let lastError: string | undefined
-    for (let attempt = 0; attempt <= MAX_WEBHOOK_RETRIES; attempt++) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
       try {
         const controller = new AbortController()
-        const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS)
+        const timeout = setTimeout(() => controller.abort(), timeoutMs)
 
         const response = await fetchFn(url, {
           method,
           headers,
-          body: JSON.stringify(body),
+          body: bodyStr,
           signal: controller.signal,
         })
         clearTimeout(timeout)
@@ -1323,12 +1366,21 @@ export class AutomationExecutor {
       }
 
       // Wait before retry (simple exponential backoff)
-      if (attempt < MAX_WEBHOOK_RETRIES) {
+      if (attempt < retries) {
         await new Promise((resolve) => setTimeout(resolve, 100 * (attempt + 1)))
       }
     }
 
-    return { actionType: 'send_webhook', status: 'failed', error: `Webhook failed after ${MAX_WEBHOOK_RETRIES + 1} attempts: ${lastError}` }
+    // Surface the failure in the step result (never silent) — the executor lifts
+    // a failed step into the execution log + marks the run failed.
+    logger.warn(
+      `send_webhook to ${redactString(url)} failed after ${retries + 1} attempts: ${lastError}`,
+    )
+    return {
+      actionType: 'send_webhook',
+      status: 'failed',
+      error: `Webhook failed after ${retries + 1} attempts: ${lastError}`,
+    }
   }
 
   private async executeSendNotification(

--- a/packages/core-backend/src/multitable/webhook-service.ts
+++ b/packages/core-backend/src/multitable/webhook-service.ts
@@ -16,13 +16,17 @@ import type {
   WebhookEventType,
   WebhookUpdateInput,
 } from './webhooks'
-import { ALL_WEBHOOK_EVENT_TYPES } from './webhooks'
+import {
+  ALL_WEBHOOK_EVENT_TYPES,
+  WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS,
+  WEBHOOK_DEFAULT_MAX_RETRIES,
+} from './webhooks'
 
 const logger = new Logger('WebhookService')
 
 const DELIVERY_TIMEOUT_MS = 5_000
-const MAX_CONSECUTIVE_FAILURES = 10
-const BASE_RETRY_DELAY_MS = 1_000
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 10
+const BASE_RETRY_DELAY_MS = WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS
 // Lease window a retry tick holds a claimed delivery for (review MINOR-1):
 // long enough to out-live the HTTP attempt + backoff recompute so a concurrent
 // replica's tick skips it; short enough that a crashed tick's row is retried soon.
@@ -46,6 +50,8 @@ function rowToWebhook(row: {
   last_delivered_at?: string | Date | null
   failure_count: number
   max_retries: number
+  retry_base_delay_ms?: number | null
+  retry_max_delay_ms?: number | null
 }): Webhook {
   const events =
     typeof row.events === 'string'
@@ -75,6 +81,8 @@ function rowToWebhook(row: {
       : undefined,
     failureCount: row.failure_count,
     maxRetries: row.max_retries,
+    retryBaseDelayMs: row.retry_base_delay_ms ?? undefined,
+    retryMaxDelayMs: row.retry_max_delay_ms ?? undefined,
   }
 }
 
@@ -164,6 +172,10 @@ export class WebhookService {
     const id = generateId()
     const now = new Date().toISOString()
 
+    const maxRetries = input.maxRetries ?? WEBHOOK_DEFAULT_MAX_RETRIES
+    const retryBaseDelayMs = input.retryBaseDelayMs ?? null
+    const retryMaxDelayMs = input.retryMaxDelayMs ?? null
+
     await this.db
       .insertInto('multitable_webhooks')
       .values({
@@ -176,7 +188,9 @@ export class WebhookService {
         created_by: userId,
         created_at: now,
         failure_count: 0,
-        max_retries: 3,
+        max_retries: maxRetries,
+        retry_base_delay_ms: retryBaseDelayMs,
+        retry_max_delay_ms: retryMaxDelayMs,
       })
       .execute()
 
@@ -190,7 +204,9 @@ export class WebhookService {
       createdBy: userId,
       createdAt: now,
       failureCount: 0,
-      maxRetries: 3,
+      maxRetries,
+      retryBaseDelayMs: retryBaseDelayMs ?? undefined,
+      retryMaxDelayMs: retryMaxDelayMs ?? undefined,
     }
 
     logger.info(`Webhook created: ${id} by user ${userId}`)
@@ -238,6 +254,11 @@ export class WebhookService {
     if (input.events !== undefined)
       updates.events = toJsonValue([...input.events])
     if (input.active !== undefined) updates.active = input.active
+    if (input.maxRetries !== undefined) updates.max_retries = input.maxRetries
+    if (input.retryBaseDelayMs !== undefined)
+      updates.retry_base_delay_ms = input.retryBaseDelayMs
+    if (input.retryMaxDelayMs !== undefined)
+      updates.retry_max_delay_ms = input.retryMaxDelayMs
 
     await this.db
       .updateTable('multitable_webhooks')
@@ -530,8 +551,9 @@ export class WebhookService {
     wh: Webhook,
   ): Promise<void> {
     const newFailureCount = wh.failureCount + 1
+    const maxConsecutiveFailures = WebhookService.maxConsecutiveFailures()
 
-    if (newFailureCount >= MAX_CONSECUTIVE_FAILURES) {
+    if (newFailureCount >= maxConsecutiveFailures) {
       await this.db
         .updateTable('multitable_webhooks')
         .set({ active: false, failure_count: newFailureCount })
@@ -551,7 +573,7 @@ export class WebhookService {
 
       delivery.status = 'failed'
       logger.warn(
-        `Webhook ${wh.id} auto-disabled after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`,
+        `Webhook ${wh.id} auto-disabled after ${maxConsecutiveFailures} consecutive failures`,
       )
       return
     }
@@ -578,8 +600,13 @@ export class WebhookService {
       return
     }
 
-    // Exponential backoff
-    const delay = BASE_RETRY_DELAY_MS * Math.pow(2, delivery.attemptCount - 1)
+    // Exponential backoff, driven by the webhook's stored retry policy (or the
+    // module defaults when the row predates the policy columns / leaves them NULL).
+    const delay = WebhookService.computeBackoffMs(
+      delivery.attemptCount,
+      wh.retryBaseDelayMs,
+      wh.retryMaxDelayMs,
+    )
     const nextRetry = new Date(Date.now() + delay).toISOString()
     delivery.nextRetryAt = nextRetry
     delivery.status = 'pending'
@@ -602,5 +629,39 @@ export class WebhookService {
    */
   static signPayload(body: string, secret: string): string {
     return createHmac('sha256', secret).update(body).digest('hex')
+  }
+
+  /**
+   * Exponential backoff for the Nth attempt (1-based): base * 2^(attempt-1),
+   * optionally capped at maxMs. Absent base/cap fall back to the module
+   * default (1s base, uncapped) so legacy webhooks keep today's behavior.
+   */
+  static computeBackoffMs(
+    attemptCount: number,
+    baseMs?: number,
+    maxMs?: number,
+  ): number {
+    const base = baseMs ?? BASE_RETRY_DELAY_MS
+    const exp = Math.max(0, attemptCount - 1)
+    const delay = base * Math.pow(2, exp)
+    if (maxMs === undefined) return delay
+    // Cross-field guard (review NIT-1): a cap below the base delay would shorten
+    // the very first retry below `base`, which is never intended — floor the cap
+    // at the base so "cap wins" can only ever lengthen the wait, not invert it.
+    return Math.min(delay, Math.max(maxMs, base))
+  }
+
+  /**
+   * Consecutive-failure count that auto-disables a webhook. Env-configurable via
+   * WEBHOOK_MAX_CONSECUTIVE_FAILURES (default 10); a non-positive / non-numeric
+   * value falls back to the default rather than disabling immediately.
+   */
+  static maxConsecutiveFailures(): number {
+    const raw = process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES
+    if (raw === undefined) return DEFAULT_MAX_CONSECUTIVE_FAILURES
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_MAX_CONSECUTIVE_FAILURES
   }
 }

--- a/packages/core-backend/src/multitable/webhooks.ts
+++ b/packages/core-backend/src/multitable/webhooks.ts
@@ -3,6 +3,8 @@
  * Type definitions for the multitable webhook delivery system.
  */
 
+import { z } from 'zod'
+
 export interface Webhook {
   id: string
   name: string
@@ -15,8 +17,24 @@ export interface Webhook {
   updatedAt?: string
   lastDeliveredAt?: string
   failureCount: number     // consecutive failures
-  maxRetries: number       // default 3
+  maxRetries: number       // default 3 (WEBHOOK_DEFAULT_MAX_RETRIES)
+  // Backoff policy for the retry scheduler. Both NULL/undefined on existing rows
+  // → fall back to the module defaults so legacy webhooks keep today's behavior.
+  retryBaseDelayMs?: number // first-retry delay; exponential 2^n from here
+  retryMaxDelayMs?: number  // cap on the computed backoff (undefined = uncapped)
 }
+
+// ─── Retry-policy bounds (shared by route schema + service) ────────────────
+export const WEBHOOK_DEFAULT_MAX_RETRIES = 3
+export const WEBHOOK_MIN_MAX_RETRIES = 0
+export const WEBHOOK_MAX_MAX_RETRIES = 10
+
+export const WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS = 1_000
+export const WEBHOOK_MIN_BASE_RETRY_DELAY_MS = 100
+export const WEBHOOK_MAX_BASE_RETRY_DELAY_MS = 60_000 // 1 min
+
+export const WEBHOOK_MIN_MAX_RETRY_DELAY_MS = 1_000
+export const WEBHOOK_MAX_MAX_RETRY_DELAY_MS = 3_600_000 // 1 hour
 
 export type WebhookEventType =
   | 'record.created'
@@ -50,6 +68,9 @@ export interface WebhookCreateInput {
   url: string
   secret?: string
   events: WebhookEventType[]
+  maxRetries?: number
+  retryBaseDelayMs?: number
+  retryMaxDelayMs?: number
 }
 
 export interface WebhookUpdateInput {
@@ -58,4 +79,58 @@ export interface WebhookUpdateInput {
   secret?: string
   events?: WebhookEventType[]
   active?: boolean
+  maxRetries?: number
+  retryBaseDelayMs?: number
+  retryMaxDelayMs?: number
 }
+
+// ─── Route validation schemas ──────────────────────────────────────────────
+// Bounds-checked at the route layer; out-of-range values are rejected (not
+// silently clamped) so callers learn their config is invalid.
+
+const maxRetriesSchema = z
+  .number()
+  .int()
+  .min(WEBHOOK_MIN_MAX_RETRIES)
+  .max(WEBHOOK_MAX_MAX_RETRIES)
+
+const retryBaseDelayMsSchema = z
+  .number()
+  .int()
+  .min(WEBHOOK_MIN_BASE_RETRY_DELAY_MS)
+  .max(WEBHOOK_MAX_BASE_RETRY_DELAY_MS)
+
+const retryMaxDelayMsSchema = z
+  .number()
+  .int()
+  .min(WEBHOOK_MIN_MAX_RETRY_DELAY_MS)
+  .max(WEBHOOK_MAX_MAX_RETRY_DELAY_MS)
+
+export const CreateWebhookSchema = z.object({
+  name: z.string().min(1).max(100),
+  url: z.string().url(),
+  secret: z.string().optional(),
+  events: z
+    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
+    .min(1),
+  maxRetries: maxRetriesSchema.optional(),
+  retryBaseDelayMs: retryBaseDelayMsSchema.optional(),
+  retryMaxDelayMs: retryMaxDelayMsSchema.optional(),
+})
+
+export const UpdateWebhookSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  url: z.string().url().optional(),
+  secret: z.string().optional(),
+  events: z
+    .array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]]))
+    .min(1)
+    .optional(),
+  active: z.boolean().optional(),
+  maxRetries: maxRetriesSchema.optional(),
+  retryBaseDelayMs: retryBaseDelayMsSchema.optional(),
+  retryMaxDelayMs: retryMaxDelayMsSchema.optional(),
+})
+
+export type CreateWebhookBody = z.infer<typeof CreateWebhookSchema>
+export type UpdateWebhookBody = z.infer<typeof UpdateWebhookSchema>

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -15,7 +15,10 @@ import { DingTalkGroupDestinationService } from '../multitable/dingtalk-group-de
 import { toDingTalkGroupDestinationResponse } from '../multitable/dingtalk-group-destination-response'
 import { resolveSheetCapabilitiesForUser } from '../multitable/sheet-capabilities'
 import { WebhookService } from '../multitable/webhook-service'
-import { ALL_WEBHOOK_EVENT_TYPES } from '../multitable/webhooks'
+import {
+  CreateWebhookSchema,
+  UpdateWebhookSchema,
+} from '../multitable/webhooks'
 
 const logger = new Logger('ApiTokenRoutes')
 
@@ -38,21 +41,6 @@ const CreateTokenSchema = z.object({
   name: z.string().min(1).max(100),
   scopes: z.array(z.enum(ALL_API_TOKEN_SCOPES as [string, ...string[]])).min(1),
   expiresAt: z.string().datetime().optional(),
-})
-
-const CreateWebhookSchema = z.object({
-  name: z.string().min(1).max(100),
-  url: z.string().url(),
-  secret: z.string().optional(),
-  events: z.array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]])).min(1),
-})
-
-const UpdateWebhookSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  url: z.string().url().optional(),
-  secret: z.string().optional(),
-  events: z.array(z.enum(ALL_WEBHOOK_EVENT_TYPES as [string, ...string[]])).min(1).optional(),
-  active: z.boolean().optional(),
 })
 
 const CreateDingTalkGroupSchema = z.object({
@@ -327,6 +315,9 @@ export function apiTokensRouter(): Router {
         url: input.url,
         secret: input.secret,
         events: input.events as import('../multitable/webhooks').WebhookEventType[],
+        maxRetries: input.maxRetries,
+        retryBaseDelayMs: input.retryBaseDelayMs,
+        retryMaxDelayMs: input.retryMaxDelayMs,
       })
       res.status(201).json({ ok: true, data: webhook })
     } catch (err) {
@@ -353,6 +344,9 @@ export function apiTokensRouter(): Router {
         secret: input.secret,
         events: input.events as import('../multitable/webhooks').WebhookEventType[] | undefined,
         active: input.active,
+        maxRetries: input.maxRetries,
+        retryBaseDelayMs: input.retryBaseDelayMs,
+        retryMaxDelayMs: input.retryMaxDelayMs,
       })
       res.json({ ok: true, data: webhook })
     } catch (err) {

--- a/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
+++ b/packages/core-backend/tests/integration/multitable-webhook-retry-tick.test.ts
@@ -105,6 +105,43 @@ describeIfDatabase('webhook retry tick (real DB)', () => {
     scheduler.stop()
   })
 
+  test('stored retry policy drives the backoff: a custom base delay reschedules next_retry_at accordingly', async () => {
+    // Seed a webhook with a large custom base delay + a due pending delivery that
+    // will FAIL on retry (loopback 500). After the tick, the row is rescheduled
+    // and its next_retry_at must reflect the stored base delay (computeBackoffMs
+    // with attemptCount=2 → base * 2), not the 1s module default.
+    const POLICY_WH = `whk_policy_${TS}`
+    const POLICY_DEL = `del_policy_${TS}`
+    const BASE_MS = 50_000 // attempt 1→failure already done, this retry is attempt 2 → 100s ahead
+    const now = new Date().toISOString()
+    await q(
+      'INSERT INTO multitable_webhooks (id, name, url, secret, events, active, created_by, created_at, failure_count, max_retries, retry_base_delay_ms) VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,$10,$11)',
+      [POLICY_WH, 'Policy', 'https://sink.test/policy', null, JSON.stringify(['record.updated']), true, USER_ID, now, 0, 5, BASE_MS],
+    )
+    await q(
+      'INSERT INTO multitable_webhook_deliveries (id, webhook_id, event, payload, status, attempt_count, created_at, next_retry_at) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8)',
+      [POLICY_DEL, POLICY_WH, 'record.updated', JSON.stringify({ recordId: 'rp' }), 'pending', 1, now, new Date(Date.now() - 60_000).toISOString()],
+    )
+
+    const failFetch = (async () => ({ ok: false, status: 500, text: async () => 'boom' }) as Response) as unknown as typeof fetch
+    const svc = new WebhookService(db, failFetch)
+    const before = Date.now()
+    const retried = await svc.retryFailedDeliveries()
+    expect(retried).toBe(1)
+
+    const row = await q('SELECT status, attempt_count, next_retry_at FROM multitable_webhook_deliveries WHERE id = $1', [POLICY_DEL])
+    expect(row.rows[0].status).toBe('pending') // failed but still under max_retries → rescheduled
+    expect(Number(row.rows[0].attempt_count)).toBe(2)
+    // attempt_count is now 2 → computeBackoffMs(2, 50000) = 100000ms ahead.
+    const nextRetry = new Date(row.rows[0].next_retry_at).getTime()
+    const aheadMs = nextRetry - before
+    expect(aheadMs).toBeGreaterThan(90_000) // well above the 2s the default policy would give
+    expect(aheadMs).toBeLessThan(130_000)
+
+    await q('DELETE FROM multitable_webhook_deliveries WHERE webhook_id = $1', [POLICY_WH]).catch(() => {})
+    await q('DELETE FROM multitable_webhooks WHERE id = $1', [POLICY_WH]).catch(() => {})
+  })
+
   test('MINOR-1: two concurrent retry passes claim the due row exactly once (no double-delivery)', async () => {
     // Re-arm the due row to pending+due, then run two retryFailedDeliveries() passes
     // concurrently (simulating two replicas ticking at once). FOR UPDATE SKIP LOCKED +

--- a/packages/core-backend/tests/unit/send-webhook-action-hardening.test.ts
+++ b/packages/core-backend/tests/unit/send-webhook-action-hardening.test.ts
@@ -1,0 +1,89 @@
+/**
+ * send_webhook automation-action hardening.
+ *
+ * The send_webhook action is a distinct dispatch path from webhook-service
+ * deliveries, but it should share the same security/timeout posture:
+ *  - HMAC-SHA256 signing when a `secret` is configured (same X-Webhook-Signature
+ *    header + algorithm as WebhookService.signPayload)
+ *  - no signature header when no secret
+ *  - bounded retries with the failure surfaced in the step result (not silent)
+ */
+import { describe, test, expect, vi } from 'vitest'
+import { createHmac } from 'crypto'
+import { AutomationExecutor, type AutomationDeps } from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+function deps(fetchFn: typeof fetch): AutomationDeps {
+  return {
+    eventBus: new EventBus(),
+    queryFn: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    fetchFn,
+  }
+}
+
+function rule(config: Record<string, unknown>) {
+  return {
+    id: 'rule_1',
+    name: 'Webhook rule',
+    sheetId: 'sheet_1',
+    trigger: { type: 'record.created' as const, config: {} },
+    actions: [{ type: 'send_webhook' as const, config }],
+    enabled: true,
+    createdBy: 'user_1',
+    createdAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('send_webhook HMAC signing', () => {
+  test('signs the body with HMAC-SHA256 when a secret is configured', async () => {
+    const fetchFn = vi.fn(async () => new Response('OK', { status: 200 })) as unknown as typeof fetch
+    const executor = new AutomationExecutor(deps(fetchFn))
+    const body = { hello: 'world' }
+
+    const result = await executor.execute(
+      rule({ url: 'https://example.com/hook', secret: 's3cr3t', body }),
+      { recordId: 'r1', data: {}, sheetId: 'sheet_1' },
+    )
+
+    expect(result.status).toBe('success')
+    const callArgs = (fetchFn as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    const headers = callArgs[1].headers as Record<string, string>
+    const sentBody = callArgs[1].body as string
+    const expected = createHmac('sha256', 's3cr3t').update(sentBody).digest('hex')
+    expect(headers['X-Webhook-Signature']).toBe(expected)
+    expect(headers['X-Webhook-Timestamp']).toBeDefined()
+  })
+
+  test('omits the signature header when no secret', async () => {
+    const fetchFn = vi.fn(async () => new Response('OK', { status: 200 })) as unknown as typeof fetch
+    const executor = new AutomationExecutor(deps(fetchFn))
+
+    await executor.execute(rule({ url: 'https://example.com/hook' }), {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    })
+
+    const callArgs = (fetchFn as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0]
+    const headers = callArgs[1].headers as Record<string, string>
+    expect(headers['X-Webhook-Signature']).toBeUndefined()
+  })
+})
+
+describe('send_webhook failure surfacing', () => {
+  test('exhausted retries surface as a failed step with an error message', async () => {
+    const fetchFn = vi.fn(async () => new Response('boom', { status: 500 })) as unknown as typeof fetch
+    const executor = new AutomationExecutor(deps(fetchFn))
+
+    const result = await executor.execute(rule({ url: 'https://example.com/hook' }), {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].actionType).toBe('send_webhook')
+    expect(result.steps[0].status).toBe('failed')
+    expect(result.steps[0].error).toMatch(/Webhook failed after/)
+  })
+})

--- a/packages/core-backend/tests/unit/webhook-retry-policy-schema.test.ts
+++ b/packages/core-backend/tests/unit/webhook-retry-policy-schema.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Webhook retry-policy route schema — accepts in-bounds policy, rejects
+ * out-of-bounds. Mirrors the bounds the FE validation enforces.
+ */
+import { describe, expect, test } from 'vitest'
+import {
+  CreateWebhookSchema,
+  UpdateWebhookSchema,
+  WEBHOOK_MAX_MAX_RETRIES,
+  WEBHOOK_MAX_BASE_RETRY_DELAY_MS,
+} from '../../src/multitable/webhooks'
+
+const baseCreate = {
+  name: 'Hook',
+  url: 'https://example.com/hook',
+  events: ['record.created'],
+}
+
+describe('CreateWebhookSchema retry policy', () => {
+  test('accepts a webhook with no retry policy (defaults applied downstream)', () => {
+    const parsed = CreateWebhookSchema.parse(baseCreate)
+    expect(parsed.maxRetries).toBeUndefined()
+    expect(parsed.retryBaseDelayMs).toBeUndefined()
+    expect(parsed.retryMaxDelayMs).toBeUndefined()
+  })
+
+  test('accepts in-bounds maxRetries + backoff', () => {
+    const parsed = CreateWebhookSchema.parse({
+      ...baseCreate,
+      maxRetries: 5,
+      retryBaseDelayMs: 2_000,
+      retryMaxDelayMs: 30_000,
+    })
+    expect(parsed.maxRetries).toBe(5)
+    expect(parsed.retryBaseDelayMs).toBe(2_000)
+    expect(parsed.retryMaxDelayMs).toBe(30_000)
+  })
+
+  test('accepts the lower bound maxRetries = 0', () => {
+    expect(CreateWebhookSchema.parse({ ...baseCreate, maxRetries: 0 }).maxRetries).toBe(0)
+  })
+
+  test('rejects maxRetries above the max', () => {
+    expect(() =>
+      CreateWebhookSchema.parse({ ...baseCreate, maxRetries: WEBHOOK_MAX_MAX_RETRIES + 1 }),
+    ).toThrow()
+  })
+
+  test('rejects negative maxRetries', () => {
+    expect(() => CreateWebhookSchema.parse({ ...baseCreate, maxRetries: -1 })).toThrow()
+  })
+
+  test('rejects non-integer maxRetries', () => {
+    expect(() => CreateWebhookSchema.parse({ ...baseCreate, maxRetries: 2.5 })).toThrow()
+  })
+
+  test('rejects retryBaseDelayMs above the max', () => {
+    expect(() =>
+      CreateWebhookSchema.parse({
+        ...baseCreate,
+        retryBaseDelayMs: WEBHOOK_MAX_BASE_RETRY_DELAY_MS + 1,
+      }),
+    ).toThrow()
+  })
+
+  test('rejects retryBaseDelayMs below the min', () => {
+    expect(() =>
+      CreateWebhookSchema.parse({ ...baseCreate, retryBaseDelayMs: 1 }),
+    ).toThrow()
+  })
+})
+
+describe('UpdateWebhookSchema retry policy', () => {
+  test('accepts a partial update of maxRetries only', () => {
+    expect(UpdateWebhookSchema.parse({ maxRetries: 7 }).maxRetries).toBe(7)
+  })
+
+  test('rejects out-of-bounds maxRetries on update', () => {
+    expect(() => UpdateWebhookSchema.parse({ maxRetries: 99 })).toThrow()
+  })
+})

--- a/packages/core-backend/tests/unit/webhook-retry-policy-service.test.ts
+++ b/packages/core-backend/tests/unit/webhook-retry-policy-service.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Webhook retry-policy service wiring.
+ *
+ * 1) computeBackoffMs is the pure backoff function the stored policy drives:
+ *    base * 2^(attempt-1), capped at maxMs, defaulting to today's behavior
+ *    (1s base, uncapped) when the policy is absent.
+ * 2) createWebhook persists the stored policy columns.
+ * 3) the auto-disable threshold is env-configurable, defaulting to 10.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WebhookService } from '../../src/multitable/webhook-service'
+import { WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS } from '../../src/multitable/webhooks'
+import type { Kysely } from 'kysely'
+import type { Database } from '../../src/db/types'
+
+// ── Minimal mock db capturing insert values ───────────────────────────────
+function makeChain(captured: { insertValues?: Record<string, unknown> }): Record<string, unknown> {
+  const self: Record<string, unknown> = {}
+  const chainFn = () => self
+  for (const m of [
+    'selectFrom', 'selectAll', 'select', 'where', 'orderBy', 'limit',
+    'insertInto', 'updateTable', 'set', 'deleteFrom', 'forUpdate', 'skipLocked',
+  ]) {
+    self[m] = vi.fn(chainFn)
+  }
+  self.values = vi.fn((v: Record<string, unknown>) => {
+    captured.insertValues = v
+    return self
+  })
+  self.execute = vi.fn(async () => [])
+  self.executeTakeFirst = vi.fn(async () => undefined)
+  self.executeTakeFirstOrThrow = vi.fn(async () => {
+    throw new Error('no rows')
+  })
+  return self
+}
+
+function createMockDb(captured: { insertValues?: Record<string, unknown> }): Kysely<Database> {
+  const root: Record<string, unknown> = {}
+  for (const m of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
+    root[m] = vi.fn(() => makeChain(captured))
+  }
+  return root as unknown as Kysely<Database>
+}
+
+describe('WebhookService.computeBackoffMs', () => {
+  test('default (no policy) reproduces today behavior: 1s base, exponential, uncapped', () => {
+    expect(WebhookService.computeBackoffMs(1)).toBe(WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS)
+    expect(WebhookService.computeBackoffMs(2)).toBe(WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS * 2)
+    expect(WebhookService.computeBackoffMs(3)).toBe(WEBHOOK_DEFAULT_BASE_RETRY_DELAY_MS * 4)
+  })
+
+  test('honors a custom base delay', () => {
+    expect(WebhookService.computeBackoffMs(1, 5_000)).toBe(5_000)
+    expect(WebhookService.computeBackoffMs(2, 5_000)).toBe(10_000)
+  })
+
+  test('caps the computed backoff at maxMs', () => {
+    // 1000 * 2^4 = 16000, but capped at 8000
+    expect(WebhookService.computeBackoffMs(5, 1_000, 8_000)).toBe(8_000)
+  })
+
+  test('uncapped when maxMs is undefined', () => {
+    expect(WebhookService.computeBackoffMs(6, 1_000)).toBe(1_000 * 2 ** 5)
+  })
+})
+
+describe('WebhookService.createWebhook persists retry policy', () => {
+  let captured: { insertValues?: Record<string, unknown> }
+  let svc: WebhookService
+
+  beforeEach(() => {
+    captured = {}
+    svc = new WebhookService(createMockDb(captured))
+  })
+
+  test('stores maxRetries + backoff columns when provided', async () => {
+    await svc.createWebhook('u1', {
+      name: 'Policy',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+      maxRetries: 7,
+      retryBaseDelayMs: 2_000,
+      retryMaxDelayMs: 30_000,
+    })
+    expect(captured.insertValues?.max_retries).toBe(7)
+    expect(captured.insertValues?.retry_base_delay_ms).toBe(2_000)
+    expect(captured.insertValues?.retry_max_delay_ms).toBe(30_000)
+  })
+
+  test('defaults max_retries to 3 and leaves backoff NULL when omitted', async () => {
+    await svc.createWebhook('u1', {
+      name: 'No policy',
+      url: 'https://example.com/hook',
+      events: ['record.created'],
+    })
+    expect(captured.insertValues?.max_retries).toBe(3)
+    expect(captured.insertValues?.retry_base_delay_ms ?? null).toBeNull()
+    expect(captured.insertValues?.retry_max_delay_ms ?? null).toBeNull()
+  })
+})
+
+describe('WebhookService auto-disable threshold', () => {
+  const ORIG = process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES
+
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES
+    else process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES = ORIG
+  })
+
+  test('defaults to 10', () => {
+    delete process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES
+    expect(WebhookService.maxConsecutiveFailures()).toBe(10)
+  })
+
+  test('reads an env override', () => {
+    process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES = '25'
+    expect(WebhookService.maxConsecutiveFailures()).toBe(25)
+  })
+
+  test('ignores a non-numeric env value (falls back to 10)', () => {
+    process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES = 'oops'
+    expect(WebhookService.maxConsecutiveFailures()).toBe(10)
+  })
+})


### PR DESCRIPTION
## Summary

Ladder rank-6 (after #2511 wired the pipeline). Makes the previously-hardcoded webhook retry knobs configurable, defaults preserving today's behavior exactly.

- **Per-webhook retry policy**: `maxRetries` (0–10, was hardcoded 3) + optional `retryBaseDelayMs` / `retryMaxDelayMs` stored as two NULLABLE columns (migration `zzzz20260611130000`, highest tier; NULL = default so existing rows are byte-identical). The stored policy drives `computeBackoffMs` + the max-retries check in `retryFailedDeliveries` — proven through the **real Postgres wire** (extended rank-5 integration test: custom 50s base → ~100s reschedule at attempt 2, not the 2s default), per wire-vs-fixture discipline.
- **Auto-disable threshold**: env-configurable `WEBHOOK_MAX_CONSECUTIVE_FAILURES` (default 10; non-positive falls back, never disables immediately).
- **send_webhook automation hardening**: adds HMAC-SHA256 `X-Webhook-Signature` + `X-Webhook-Timestamp` when a secret is set (reusing `WebhookService.signPayload`), bounded env-overridable retries (`AUTOMATION_WEBHOOK_MAX_RETRIES` 0–5, default 2) + timeout (`AUTOMATION_WEBHOOK_TIMEOUT_MS` 1s–30s, default 5s), redacted failure warn log. Defaults reproduce today's behavior; the action stays a separate dispatch path from webhook-service rows (documented).
- **Frontend**: retry-policy fields in the webhook config UI with bounds mirroring the backend (handled the `<input type=number>` v-model number-coercion gotcha — `parseBoundedInt` String()-normalizes first, caught fail-first).

## Tests (fail-first)

4 backend unit files / 63 tests (schema bounds, service backoff+policy persistence, send_webhook HMAC hardening) + real-DB retry-tick 5/5 (stored-policy backoff) + FE 31/31 (5 new validation). Full backend `test:unit` 240 files / 3045; tsc + vue-tsc -b clean; OpenAPI parity green (webhooks not in spec). Migration up/down verified directly against the DB (the `pnpm migrate` CLI hiccup is a pre-existing cross-branch **local test-DB ledger** drift, not a defect — main has no 130000 collision; up/down SQL applies clean).

## Review

Adversarial review (`/tmp/r6-webhook-config-review-claude-20260611.md`): **APPROVE-WITH-NITS** — NIT-1 (max-delay-below-base cross-field guard) **fixed** (`computeBackoffMs` floors the cap at base); NIT-2 (pre-existing MetaApiTokenManager eslint), OBS-1 (local-DB ledger drift) documented.

Ladder: rank 6 (after rank 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)