### PR TITLE
test(multitable): repair + CI-wire view-config api regression net (rank 7)

### DIFF
--- a/packages/core-backend/tests/integration/multitable-view-config.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-view-config.api.test.ts
@@ -2,12 +2,83 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+// ---------------------------------------------------------------------------
+// MOCK-POOL CONTRACT (read before editing — this is a hand-rolled SQL matcher).
+//
+// POST /views and PATCH /views/:viewId each fan out to a fixed set of queries.
+// Every query the handler issues MUST have a matching `if (sql.includes(...))`
+// branch in the test's queryHandler, or the route's try/catch swallows the
+// "Unhandled SQL in test" throw and returns 500 (silent regression — see #2052
+// / #2068 redaction wiring that this net guards). The branches a handler needs:
+//
+//   POST /views (create):
+//     1. SELECT sp.sheet_id, sp.perm_code, sp.subject_type ...   (sheet ACL → capabilities)
+//     2. SELECT id FROM meta_sheets WHERE id = $1 ...            (sheet existence)
+//     3. SELECT id, name, type, property, "order" FROM meta_fields
+//          WHERE sheet_id = $1 AND id = $2                       (gantt/hierarchy dep field, gantt/hierarchy only)
+//     4. SELECT id, name, type, property, "order" FROM meta_fields
+//          WHERE sheet_id = $1 ORDER BY ...                      (loadFieldsForSheet — #2052 allowed-field set)
+//     5. SELECT fp.field_id, fp.visible, fp.read_only FROM field_permissions fp
+//          WHERE fp.sheet_id = $2 ...                            (loadFieldPermissionScopeMap — #2052)
+//     6. INSERT INTO meta_views ...
+//
+//   PATCH /views/:viewId (update):
+//     1. SELECT sp.sheet_id, sp.perm_code, sp.subject_type ...   (sheet ACL → capabilities)
+//     2. SELECT id, sheet_id, name, type, filter_info, ... FROM meta_views WHERE id = $1  (current row)
+//     3. + 4. the same two loadAllowedFieldIds queries as POST (4 & 5 above) — run UP FRONT,
+//             before validateGanttDependencyConfig, so a malformed mock 500s before the 400.
+//     5. SELECT id, name, type, property, "order" FROM meta_fields
+//          WHERE sheet_id = $1 AND id = $2                       (gantt/hierarchy dep field, gantt/hierarchy only)
+//     6. UPDATE meta_views ...
+//
+// `matchAllowedFieldQueries` below satisfies branches (4) & (5); callers supply
+// the sheet's field rows so the redaction path genuinely runs over a real field
+// set. field_permissions returns [] (no per-field denials) → all fields allowed
+// → redactViewConfigFilterLiterals is a no-op (none of these configs carry
+// filterInfo.conditions literals), so assertions stay exact.
+// ---------------------------------------------------------------------------
+
 type QueryResult = {
   rows: any[]
   rowCount?: number
 }
 
 type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+type FieldRow = {
+  id: string
+  name: string
+  type: string
+  property: Record<string, unknown>
+  order: number
+}
+
+// Satisfies the #2052 loadAllowedFieldIds query pair (loadFieldsForSheet +
+// loadFieldPermissionScopeMap). Returns the matching QueryResult, or null when
+// `sql` is some other query the caller must handle itself.
+function matchAllowedFieldQueries(
+  sql: string,
+  params: unknown[] | undefined,
+  fieldsBySheet: Record<string, FieldRow[]>,
+): QueryResult | null {
+  // loadFieldsForSheet — full field list, ORDER BY (distinct from the gantt
+  // single-field lookup which has `AND id = $2`).
+  if (sql.includes('FROM meta_fields') && sql.includes('ORDER BY') && !sql.includes('AND id = $2')) {
+    const sheetId = String((params ?? [])[0] ?? '')
+    return { rows: fieldsBySheet[sheetId] ?? [] }
+  }
+  // loadFieldPermissionScopeMap — no per-field denials → empty set → all fields allowed.
+  if (sql.includes('FROM field_permissions fp')) {
+    return { rows: [] }
+  }
+  return null
+}
+
+const SHEET_OPS_FIELDS: FieldRow[] = [
+  { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0 },
+  { id: 'fld_owner', name: 'Owner', type: 'string', property: {}, order: 1 },
+  { id: 'fld_status', name: 'Status', type: 'singleSelect', property: {}, order: 2 },
+]
 
 function createMockPool(queryHandler: QueryHandler) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => queryHandler(sql, params))
@@ -75,6 +146,8 @@ describe('Multitable view config API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
         }
+        const allowed = matchAllowedFieldQueries(sql, params, { sheet_ops: SHEET_OPS_FIELDS })
+        if (allowed) return allowed
         if (sql.includes('INSERT INTO meta_views')) {
           insertParams = params
           return { rows: [], rowCount: 1 }
@@ -120,10 +193,15 @@ describe('Multitable view config API', () => {
 
   test('updates view config and groupInfo through PATCH /views/:viewId', async () => {
     let updateParams: unknown[] | undefined
+    // NIT-1: positively assert the #2052/#2068 redaction wiring actually runs on
+    // this path — a future refactor that deletes the loadAllowedFieldIds call would
+    // otherwise leave the mock branch unused and these tests silently green.
+    let sawFieldPermissionQuery = false
 
     const { app } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
+        if (sql.includes('FROM field_permissions fp')) sawFieldPermissionQuery = true
         if (sql.includes('SELECT sp.sheet_id, sp.perm_code, sp.subject_type')) {
           expect(params).toEqual(['user_multitable_1', ['sheet_ops']])
           return { rows: [] }
@@ -144,6 +222,8 @@ describe('Multitable view config API', () => {
             }],
           }
         }
+        const allowed = matchAllowedFieldQueries(sql, params, { sheet_ops: SHEET_OPS_FIELDS })
+        if (allowed) return allowed
         if (sql.includes('UPDATE meta_views')) {
           updateParams = params
           return { rows: [], rowCount: 1 }
@@ -176,6 +256,8 @@ describe('Multitable view config API', () => {
     })
     expect(updateParams?.[0]).toBe('view_kanban')
     expect(updateParams?.[5]).toBe(JSON.stringify({ fieldId: 'fld_status' }))
+    // The redaction wiring (loadAllowedFieldIds → loadFieldPermissionScopeMap) ran.
+    expect(sawFieldPermissionQuery).toBe(true)
     expect(updateParams?.[7]).toBe(JSON.stringify({
       groupFieldId: 'fld_status',
       cardFieldIds: ['fld_title', 'fld_owner'],
@@ -206,6 +288,8 @@ describe('Multitable view config API', () => {
             }],
           }
         }
+        const allowed = matchAllowedFieldQueries(sql, params, { sheet_ops: SHEET_OPS_FIELDS })
+        if (allowed) return allowed
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
           expect(params).toEqual(['sheet_ops', 'fld_cross_sheet'])
           return {
@@ -270,6 +354,8 @@ describe('Multitable view config API', () => {
             }],
           }
         }
+        const allowed = matchAllowedFieldQueries(sql, params, { sheet_ops: SHEET_OPS_FIELDS })
+        if (allowed) return allowed
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
           expect(params).toEqual(['sheet_ops', 'fld_deps'])
           return {

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -34,7 +34,10 @@ export default defineConfig({
       'tests/integration/multitable-record-form.api.test.ts',
       'tests/integration/multitable-sheet-permissions.api.test.ts',
       'tests/integration/multitable-sheet-realtime.api.test.ts',
-      'tests/integration/multitable-view-config.api.test.ts',
+      // multitable-view-config.api.test.ts uses an in-file MOCK pool (no live DB) and
+      // self-contains its RBAC mocking — it runs under the default config + setup.ts, so
+      // it stays IN the standard `test` job (runs on every PR, Node 18 + 20). Excluding it
+      // here hid a #2052/#2068 redaction-wiring regression (4/7 RED) that no CI job caught.
       'tests/integration/plugin-failures.test.ts',
       'tests/integration/rooms.basic.test.ts',
       'tests/integration/snapshot-protection.test.ts',


### PR DESCRIPTION
## Summary

Ladder rank-7: `multitable-view-config.api.test.ts` was **4/7 red on main and run by no CI job** — a live instance of the repo's skip-when-unreachable blind spot, sitting over POST/PATCH `/views` that ranks 10/13/15 will lean on.

**Root cause (precise)**: the in-file mock pool didn't handle the `loadAllowedFieldIds` query pair that #2052/#2068 added to the view-write routes — `loadFieldsForSheet` (`loaders.ts:69`, the field-list SELECT, distinct from the gantt single-field lookup) + `loadFieldPermissionScopeMap` (`permission-service.ts:781`, the `field_permissions fp` SELECT), run in parallel at `univer-meta.ts:5701` (POST, after INSERT) and `:5748` (PATCH, **before** gantt validation). Unmatched → `throw Unhandled SQL` → route 500. That's why PATCH gantt-reject expected 400 but got 500 (redaction runs before validation), while POST gantt-reject stayed green (validation precedes loadAllowedFieldIds there).

**Repair (no green-by-deletion)**: purely additive — a `matchAllowedFieldQueries()` helper supplying the two query branches with correct-shaped rows + a header comment documenting the contract the hand-rolled SQL matcher must satisfy. **No assertion weakened or removed** (reviewer diff-confirmed the removed-lines side is empty). No src/route change — this was test rot, not a masked route bug.

**CI-wire**: removed the file from `vitest.config.ts`'s default-config `exclude` (it was mislabeled as needing a live DB; it's a self-contained mock-pool test). It now runs in the standard backend `test` job on **every PR, Node 18.x + 20.x**.

**NIT-1 closed**: added a positive `expect(sawFieldPermissionQuery).toBe(true)` on the PATCH path so a future deletion of the redaction wiring fails the test (the net was asymmetric — caught "query added, mock missing → 500" but not "call deleted → silent green").

## Tests

Repaired file 7/7, deterministic ×3, green under both default + integration config. Full CI-faithful default suite 303 files / 3924 passed (the repaired file now collected). Backend tsc clean; test:unit 240 files / 3045.

## Review

Adversarial review (`/tmp/r7-viewconfig-review-claude-20260611.md`): **APPROVE-WITH-NITS** — green-by-deletion check PASS (empty removed-side diff), root cause reproduced + confirmed, CI wiring traced to the `test` job. NIT-1 fixed; NIT-2 (mock-pool SQL-substring fragility) mitigated by the header comment + centralized helper, real-DB rewrite noted as a follow-up.

Ladder: rank 7 (after rank 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)