### PR TITLE
feat(attendance): add C5 notification delivery observability

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1593,6 +1593,103 @@
               </p>
             </div>
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.notificationDeliveries)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.notificationDeliveries)"
+              data-attendance-notification-deliveries
+            >
+              <div class="attendance__admin-section-header">
+                <h4>{{ tr('Notification delivery status', '通知投递状态') }}</h4>
+                <div class="attendance__admin-actions">
+                  <button class="attendance__btn" :disabled="notificationDeliveriesLoading" data-attendance-notification-deliveries-reload @click="loadAttendanceNotificationDeliveries">
+                    {{ notificationDeliveriesLoading ? tr('Loading...', '加载中...') : tr('Reload deliveries', '刷新投递') }}
+                  </button>
+                </div>
+              </div>
+              <p class="attendance__field-hint" data-attendance-notification-deliveries-readonly>
+                {{ tr('Read-only delivery truth for C5 outbox rows. Manual retry and bulk replay are separate follow-ups.', '这里仅读取 C5 outbox 的投递真实状态；手动重试和批量重放属于后续独立能力。') }}
+              </p>
+              <div class="attendance__group-summary-grid" data-attendance-notification-deliveries-counters>
+                <section
+                  v-for="item in notificationDeliveryCounterItems"
+                  :key="item.status"
+                  class="attendance__group-summary-card"
+                  :data-attendance-notification-deliveries-counter="item.status"
+                >
+                  <span>{{ item.label }}</span>
+                  <strong>{{ item.value }}</strong>
+                </section>
+              </div>
+              <div class="attendance__admin-grid">
+                <label class="attendance__field" for="attendance-notification-delivery-status-filter">
+                  <span>{{ tr('Status filter', '状态筛选') }}</span>
+                  <select
+                    id="attendance-notification-delivery-status-filter"
+                    v-model="notificationDeliveryStatusFilter"
+                    data-attendance-notification-deliveries-status-filter
+                  >
+                    <option value="all">{{ attendanceNotificationDeliveryStatusLabel('all') }}</option>
+                    <option v-for="status in ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES" :key="status" :value="status">
+                      {{ attendanceNotificationDeliveryStatusLabel(status) }}
+                    </option>
+                  </select>
+                </label>
+              </div>
+              <p v-if="notificationDeliveriesError" class="attendance__field-hint attendance__field-hint--error" data-attendance-notification-deliveries-error>
+                {{ notificationDeliveriesError }}
+              </p>
+              <div v-if="!notificationDeliveriesLoading && notificationDeliveries.length === 0" class="attendance__empty" data-attendance-notification-deliveries-empty>
+                {{ tr('No delivery rows match this filter.', '当前筛选下没有通知投递记录。') }}
+              </div>
+              <div v-if="notificationDeliveries.length > 0" class="attendance__table-wrapper">
+                <table class="attendance__table" data-attendance-notification-deliveries-table>
+                  <thead>
+                    <tr>
+                      <th>{{ tr('Status', '状态') }}</th>
+                      <th>{{ tr('Source', '来源') }}</th>
+                      <th>{{ tr('Recipient', '接收人') }}</th>
+                      <th>{{ tr('Channel', '通道') }}</th>
+                      <th>{{ tr('Attempts', '尝试') }}</th>
+                      <th>{{ tr('Last error', '最近错误') }}</th>
+                      <th>{{ tr('Updated', '更新时间') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="delivery in notificationDeliveries" :key="delivery.id" data-attendance-notification-delivery-row>
+                      <td>
+                        <span
+                          class="attendance__status-chip"
+                          :class="`attendance__status-chip--${delivery.status}`"
+                          :data-attendance-notification-delivery-status="delivery.status"
+                        >
+                          {{ attendanceNotificationDeliveryStatusLabel(delivery.status) }}
+                        </span>
+                      </td>
+                      <td>
+                        <strong>{{ attendanceNotificationDeliverySourceLabel(delivery.sourceType) }}</strong>
+                        <small>{{ delivery.sourceId || delivery.sourceKey }}</small>
+                      </td>
+                      <td>
+                        <strong>{{ delivery.recipientUserId }}</strong>
+                        <small>{{ delivery.recipientRole }}</small>
+                      </td>
+                      <td>{{ attendanceNotificationDeliveryChannelLabel(delivery.channel) }}</td>
+                      <td>{{ delivery.attemptCount }}</td>
+                      <td>{{ delivery.lastError || '--' }}</td>
+                      <td>{{ attendanceNotificationDeliveryTimeLabel(delivery.updatedAt || delivery.createdAt) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p
+                v-if="notificationDeliveriesTotal > notificationDeliveries.length"
+                class="attendance__field-hint"
+                data-attendance-notification-deliveries-cap
+              >
+                {{ tr(`Showing first ${notificationDeliveries.length} of ${notificationDeliveriesTotal}`, `仅显示前 ${notificationDeliveries.length}/${notificationDeliveriesTotal} 条`) }}
+              </p>
+            </div>
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.settings)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.settings)"
@@ -8015,6 +8112,29 @@ interface AutoShiftAutoWriteRun {
   skipReasons: Array<{ reason: string; count: number }>
 }
 
+type AttendanceNotificationDeliveryStatus = 'pending' | 'sending' | 'sent' | 'retrying' | 'failed' | 'skipped'
+type AttendanceNotificationDeliveryStatusFilter = AttendanceNotificationDeliveryStatus | 'all'
+
+interface AttendanceNotificationDeliveryItem {
+  id: string
+  sourceType: string
+  sourceId: string | null
+  sourceKey: string
+  recipientUserId: string
+  recipientRole: string
+  channel: string
+  status: AttendanceNotificationDeliveryStatus
+  attemptCount: number
+  nextAttemptAt: string | null
+  lastAttemptAt: string | null
+  deliveredAt: string | null
+  lastError: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+type AttendanceNotificationDeliveryCounters = Record<AttendanceNotificationDeliveryStatus, number>
+
 interface AutoShiftPreviewItem {
   userId: string
   workDate: string
@@ -11884,6 +12004,20 @@ const autoShiftAutoWriteRuns = ref<AutoShiftAutoWriteRun[]>([])
 const autoShiftAutoWriteRunsTotal = ref(0)
 const autoShiftAutoWriteRunsLoading = ref(false)
 const autoShiftAutoWriteRunsError = ref('')
+const ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES: AttendanceNotificationDeliveryStatus[] = ['pending', 'sending', 'sent', 'retrying', 'failed', 'skipped']
+const notificationDeliveryStatusFilter = ref<AttendanceNotificationDeliveryStatusFilter>('all')
+const notificationDeliveries = ref<AttendanceNotificationDeliveryItem[]>([])
+const notificationDeliveriesTotal = ref(0)
+const notificationDeliveriesLoading = ref(false)
+const notificationDeliveriesError = ref('')
+const notificationDeliveryCounters = reactive<AttendanceNotificationDeliveryCounters>({
+  pending: 0,
+  sending: 0,
+  sent: 0,
+  retrying: 0,
+  failed: 0,
+  skipped: 0,
+})
 const autoShiftPreviewForm = reactive({
   from: toDateInput(new Date()),
   to: toDateInput(new Date()),
@@ -17534,6 +17668,81 @@ function normalizeAutoShiftAutoWriteRun(value: any): AutoShiftAutoWriteRun | nul
   }
 }
 
+function normalizeAttendanceNotificationDeliveryStatus(value: unknown): AttendanceNotificationDeliveryStatus {
+  const status = String(value || '').trim().toLowerCase()
+  return ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES.includes(status as AttendanceNotificationDeliveryStatus)
+    ? status as AttendanceNotificationDeliveryStatus
+    : 'pending'
+}
+
+function normalizeAttendanceNotificationDelivery(value: any): AttendanceNotificationDeliveryItem | null {
+  if (!value || typeof value !== 'object') return null
+  const id = String(value.id || '').trim()
+  if (!id) return null
+  return {
+    id,
+    sourceType: String(value.sourceType || value.source_type || ''),
+    sourceId: value.sourceId == null && value.source_id == null ? null : String(value.sourceId ?? value.source_id),
+    sourceKey: String(value.sourceKey || value.source_key || ''),
+    recipientUserId: String(value.recipientUserId || value.recipient_user_id || ''),
+    recipientRole: String(value.recipientRole || value.recipient_role || ''),
+    channel: String(value.channel || ''),
+    status: normalizeAttendanceNotificationDeliveryStatus(value.status),
+    attemptCount: Number(value.attemptCount ?? value.attempt_count ?? 0) || 0,
+    nextAttemptAt: value.nextAttemptAt == null && value.next_attempt_at == null ? null : String(value.nextAttemptAt ?? value.next_attempt_at),
+    lastAttemptAt: value.lastAttemptAt == null && value.last_attempt_at == null ? null : String(value.lastAttemptAt ?? value.last_attempt_at),
+    deliveredAt: value.deliveredAt == null && value.delivered_at == null ? null : String(value.deliveredAt ?? value.delivered_at),
+    lastError: value.lastError == null && value.last_error == null ? null : String(value.lastError ?? value.last_error),
+    createdAt: value.createdAt == null && value.created_at == null ? null : String(value.createdAt ?? value.created_at),
+    updatedAt: value.updatedAt == null && value.updated_at == null ? null : String(value.updatedAt ?? value.updated_at),
+  }
+}
+
+function applyAttendanceNotificationDeliveryCounters(value: any): void {
+  for (const status of ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES) {
+    const count = Number(value?.[status] ?? 0)
+    notificationDeliveryCounters[status] = Number.isFinite(count) && count >= 0 ? count : 0
+  }
+}
+
+function attendanceNotificationDeliveryStatusLabel(status: AttendanceNotificationDeliveryStatus | 'all'): string {
+  if (status === 'all') return tr('All statuses', '全部状态')
+  if (status === 'pending') return tr('Pending', '待发送')
+  if (status === 'sending') return tr('Sending', '发送中')
+  if (status === 'sent') return tr('Sent', '已送达')
+  if (status === 'retrying') return tr('Retrying', '待重试')
+  if (status === 'failed') return tr('Failed', '失败')
+  if (status === 'skipped') return tr('Skipped', '已跳过')
+  return status
+}
+
+function attendanceNotificationDeliverySourceLabel(sourceType: string): string {
+  if (sourceType === 'unscheduled_reminder') return tr('Unscheduled reminder', '未排班提醒')
+  if (sourceType === 'comp_time_expiry_reminder') return tr('Comp-time expiry', '调休到期提醒')
+  return sourceType || '--'
+}
+
+function attendanceNotificationDeliveryChannelLabel(channel: string): string {
+  if (channel === 'dingtalk_work_notification') return tr('DingTalk work notification', '钉钉工作通知')
+  if (channel === 'fake') return tr('Fake channel', '模拟通道')
+  return channel || '--'
+}
+
+function attendanceNotificationDeliveryTimeLabel(value: string | null): string {
+  if (!value) return '--'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+const notificationDeliveryCounterItems = computed(() =>
+  ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES.map(status => ({
+    status,
+    label: attendanceNotificationDeliveryStatusLabel(status),
+    value: notificationDeliveryCounters[status],
+  })),
+)
+
 function formatAutoShiftAutoWriteSkipReasons(run: AutoShiftAutoWriteRun): string {
   if (!run.skipReasons.length) return run.errorMessage || '--'
   return run.skipReasons.map(item => `${item.reason} × ${item.count}`).join(' · ')
@@ -21166,6 +21375,43 @@ async function loadAutoShiftAutoWriteRuns() {
   }
 }
 
+async function loadAttendanceNotificationDeliveries() {
+  notificationDeliveriesLoading.value = true
+  notificationDeliveriesError.value = ''
+  try {
+    const query: Record<string, string> = { orgId: normalizedOrgId() || '', page: '1', pageSize: '50' }
+    if (notificationDeliveryStatusFilter.value !== 'all') query.status = notificationDeliveryStatusFilter.value
+    const params = buildQuery(query)
+    const response = await apiFetch(`/api/attendance/notification-deliveries?${params.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load notification deliveries', '加载通知投递失败')))
+    }
+    adminForbidden.value = false
+    const items = Array.isArray(data.data?.items) ? data.data.items : []
+    notificationDeliveries.value = items
+      .map(normalizeAttendanceNotificationDelivery)
+      .filter((item: AttendanceNotificationDeliveryItem | null): item is AttendanceNotificationDeliveryItem => item !== null)
+    const total = Number(data.data?.total)
+    notificationDeliveriesTotal.value = Number.isFinite(total) && total >= 0 ? total : notificationDeliveries.value.length
+    applyAttendanceNotificationDeliveryCounters(data.data?.counters)
+  } catch (error: unknown) {
+    notificationDeliveriesError.value = readErrorMessage(error, tr('Failed to load notification deliveries', '加载通知投递失败'))
+    setStatus(notificationDeliveriesError.value, 'error')
+  } finally {
+    notificationDeliveriesLoading.value = false
+  }
+}
+
+watch(notificationDeliveryStatusFilter, () => {
+  if (!showAdmin.value) return
+  void loadAttendanceNotificationDeliveries()
+})
+
 function schedulerScopeSubjectLabel(subjectType: string): string {
   if (subjectType === 'user') return tr('Employee', '员工')
   if (subjectType === 'role') return tr('Role', '角色')
@@ -21227,6 +21473,7 @@ async function loadAdminData() {
       loadRotationAssignments(),
       loadSchedulerScopes(),
       loadAutoShiftAutoWriteRuns(),
+      loadAttendanceNotificationDeliveries(),
       loadHolidays(),
     ])
   } catch (error) {

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -14,6 +14,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   userAccess: 'attendance-admin-user-access',
   batchProvisioning: 'attendance-admin-batch-provisioning',
   auditLogs: 'attendance-admin-audit-logs',
+  notificationDeliveries: 'attendance-admin-notification-deliveries',
   holidaySync: 'attendance-admin-holiday-sync',
   defaultRule: 'attendance-admin-default-rule',
   ruleSets: 'attendance-admin-rule-sets',
@@ -163,6 +164,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.userAccess, label: tr('User Access', '用户权限') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.batchProvisioning, label: tr('Batch Provisioning', '批量授权') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.auditLogs, label: tr('Audit Logs', '审计日志') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.notificationDeliveries, label: tr('Notification deliveries', '通知投递') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.holidaySync, label: tr('Holiday Sync', '节假日同步') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.defaultRule, label: tr('Default Rule', '默认规则') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.ruleSets, label: tr('Rule Sets', '规则集') },
@@ -196,6 +198,7 @@ export function useAttendanceAdminRail({
         ATTENDANCE_ADMIN_SECTION_IDS.userAccess,
         ATTENDANCE_ADMIN_SECTION_IDS.batchProvisioning,
         ATTENDANCE_ADMIN_SECTION_IDS.auditLogs,
+        ATTENDANCE_ADMIN_SECTION_IDS.notificationDeliveries,
       ],
     },
     {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,11 +124,12 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
-    expect(labels).toHaveLength(26)
+    expect(labels).toHaveLength(27)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Settings',
         'User Access',
+        'Notification deliveries',
         'Advanced scheduling',
         'Comprehensive hours',
         'Import',
@@ -826,7 +827,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(26)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(27)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -121,6 +121,7 @@ describe('Attendance admin regressions', () => {
   let autoShiftApplyStatus = 200
   let autoShiftApplyData: Record<string, unknown> | null = null
   let autoShiftAutoWriteRunsData: Record<string, unknown> | null = null
+  let attendanceNotificationDeliveriesData: Record<string, unknown> | null = null
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -134,6 +135,7 @@ describe('Attendance admin regressions', () => {
     autoShiftApplyStatus = 200
     autoShiftApplyData = null
     autoShiftAutoWriteRunsData = null
+    attendanceNotificationDeliveriesData = null
     exportReportFieldFingerprint = 'records-unit-test-fingerprint'
     exportReportFieldCodes = 'work_date,employee_name'
     exportReportFieldCount = '2'
@@ -625,6 +627,22 @@ describe('Attendance admin regressions', () => {
           ok: true,
           data: autoShiftAutoWriteRunsData ?? { items: [], total: 0, page: 1, pageSize: 5 },
         })
+      }
+      if (url.includes('/api/attendance/notification-deliveries')) {
+        const parsedUrl = new URL(url, 'http://localhost')
+        const status = parsedUrl.searchParams.get('status')
+        const data = attendanceNotificationDeliveriesData ?? {
+          items: [],
+          total: 0,
+          page: 1,
+          pageSize: 50,
+          counters: { pending: 0, sending: 0, sent: 0, retrying: 0, failed: 0, skipped: 0 },
+        }
+        if (status && status !== 'all' && attendanceNotificationDeliveriesData) {
+          const items = Array.isArray(data.items) ? data.items.filter((item: any) => item.status === status) : []
+          return jsonResponse(200, { ok: true, data: { ...data, items, total: items.length } })
+        }
+        return jsonResponse(200, { ok: true, data })
       }
       if (url.includes('/api/attendance/auto-shift-matching/preview')) {
         if (autoShiftPreviewStatus >= 400) {
@@ -2671,6 +2689,87 @@ describe('Attendance admin regressions', () => {
         && String(url).includes('pageSize=5'),
       ),
     ).toBe(true)
+  })
+
+  it('renders C5 notification delivery counters and read-only delivery rows without retry controls', async () => {
+    attendanceNotificationDeliveriesData = {
+      items: [
+        {
+          id: 'delivery-failed-1',
+          sourceType: 'unscheduled_reminder',
+          sourceId: 'dispatch-1',
+          sourceKey: 'unscheduled:dispatch-1:recipient:owner-1:channel:dingtalk_work_notification',
+          recipientUserId: 'owner-1',
+          recipientRole: 'owner',
+          channel: 'dingtalk_work_notification',
+          status: 'failed',
+          attemptCount: 5,
+          lastError: 'dingtalk_recipient_not_bound',
+          updatedAt: '2026-06-11T09:00:00.000Z',
+        },
+        {
+          id: 'delivery-sent-1',
+          sourceType: 'comp_time_expiry_reminder',
+          sourceId: 'balance-1',
+          sourceKey: 'comp_time_expiry_reminder:balance-1:2026-06-20:recipient:user-1:channel:dingtalk_work_notification',
+          recipientUserId: 'user-1',
+          recipientRole: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'sent',
+          attemptCount: 1,
+          deliveredAt: '2026-06-11T09:01:00.000Z',
+          updatedAt: '2026-06-11T09:01:00.000Z',
+        },
+      ],
+      total: 5,
+      page: 1,
+      pageSize: 50,
+      counters: { pending: 1, sending: 0, sent: 1, retrying: 2, failed: 1, skipped: 0 },
+    }
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const nav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-notification-deliveries"]')
+    expect(nav).toBeTruthy()
+    nav!.click()
+    await flushUi(4)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-notification-deliveries')
+    expect(section).toBeTruthy()
+    expect(window.getComputedStyle(section!).display).not.toBe('none')
+    const text = section!.textContent || ''
+    expect(text).toContain('Read-only delivery truth')
+    expect(text).toContain('Unscheduled reminder')
+    expect(text).toContain('Comp-time expiry')
+    expect(text).toContain('owner-1')
+    expect(text).toContain('dingtalk_recipient_not_bound')
+    expect(text).toContain('Showing first 2 of 5')
+    expect(section!.querySelector('[data-attendance-notification-deliveries-counter="failed"]')?.textContent).toContain('1')
+    expect(section!.querySelector('[data-attendance-notification-deliveries-counter="retrying"]')?.textContent).toContain('2')
+    expect(
+      Array.from(section!.querySelectorAll('button')).map(button => button.textContent || '').filter(label => /retry/i.test(label)),
+    ).toEqual([])
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) =>
+        String(url).includes('/api/attendance/notification-deliveries')
+        && String(url).includes('page=1')
+        && String(url).includes('pageSize=50'),
+      ),
+    ).toBe(true)
+
+    const filter = section!.querySelector<HTMLSelectElement>('[data-attendance-notification-deliveries-status-filter]')
+    expect(filter).toBeTruthy()
+    filter!.value = 'failed'
+    filter!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(8)
+
+    const calls = vi.mocked(apiFetch).mock.calls.map(([url]) => String(url))
+    expect(calls.some(url => url.includes('/api/attendance/notification-deliveries') && url.includes('status=failed'))).toBe(true)
+    const rows = section!.querySelectorAll('[data-attendance-notification-delivery-row]')
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.textContent || '').toContain('dingtalk_recipient_not_bound')
   })
 
   it('loads punchPolicy.outdoor into the card and PUTs ONLY { punchPolicy: { outdoor } } (flow id round-trips)', async () => {

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -82,10 +82,10 @@
 | 4 | **C5-1b comp-time expiry reminder producer** | ✅ #2502 | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；CI real-DB gate 实跑 comp-time expiry reminder producer spec |
 | 5 | **C5-2 delivery worker + fake channel** | ✅ #2504 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；CI real-DB gate 实跑 outbox spec + stale-lease race |
 | 6 | **C5-3 DingTalk work-notification channel** | ✅ #2507 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible；CI real-DB gate 实跑绑定解析 + worker sent 状态流 |
-| 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
+| 7 | **C5-4 admin observability** | 🟡 本 PR | read-only delivery status view/counters；不默认加手动 retry；待合后进入 C5-5 staging closeout |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 #2507 接入真实 DingTalk work-notification channel，复用现有 `readDingTalkMessageConfigFromRuntime` / `fetchDingTalkAppAccessToken` / `sendDingTalkWorkNotification`，缺配置/缺绑定 fail-visible，真实外发仍由 env/store 配置 gate 控制。C5 整体仍保持 🟡，直到 C5-5b 真实 DingTalk staging smoke 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 #2507 接入真实 DingTalk work-notification channel，复用现有 `readDingTalkMessageConfigFromRuntime` / `fetchDingTalkAppAccessToken` / `sendDingTalkWorkNotification`，缺配置/缺绑定 fail-visible，真实外发仍由 env/store 配置 gate 控制。本 PR 推进 C5-4 admin observability：新增只读 delivery status/counters API 与 admin UI，不提供手动 retry。C5 整体仍保持 🟡，直到 C5-5b 真实 DingTalk staging smoke 完整闭环。
 
 ### Out of this target
 

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -82,10 +82,10 @@
 | 4 | **C5-1b comp-time expiry reminder producer** | ✅ #2502 | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；CI real-DB gate 实跑 comp-time expiry reminder producer spec |
 | 5 | **C5-2 delivery worker + fake channel** | ✅ #2504 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖；CI real-DB gate 实跑 outbox spec + stale-lease race |
 | 6 | **C5-3 DingTalk work-notification channel** | ✅ #2507 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible；CI real-DB gate 实跑绑定解析 + worker sent 状态流 |
-| 7 | **C5-4 admin observability** | 🟡 本 PR | read-only delivery status view/counters；不默认加手动 retry；待合后进入 C5-5 staging closeout |
+| 7 | **C5-4 admin observability** | 🟡 #2515 | read-only delivery status view/counters；不默认加手动 retry；待合后进入 C5-5 staging closeout |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 #2507 接入真实 DingTalk work-notification channel，复用现有 `readDingTalkMessageConfigFromRuntime` / `fetchDingTalkAppAccessToken` / `sendDingTalkWorkNotification`，缺配置/缺绑定 fail-visible，真实外发仍由 env/store 配置 gate 控制。本 PR 推进 C5-4 admin observability：新增只读 delivery status/counters API 与 admin UI，不提供手动 retry。C5 整体仍保持 🟡，直到 C5-5b 真实 DingTalk staging smoke 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel）；C5-1b #2502 已接入调休到期提醒 producer；C5-2 #2504 已接入 delivery worker + fake channel（含 stale-lease 防覆盖反向测试）。C5-3 #2507 接入真实 DingTalk work-notification channel，复用现有 `readDingTalkMessageConfigFromRuntime` / `fetchDingTalkAppAccessToken` / `sendDingTalkWorkNotification`，缺配置/缺绑定 fail-visible，真实外发仍由 env/store 配置 gate 控制。C5-4 #2515 推进 admin observability：新增只读 delivery status/counters API 与 admin UI，不提供手动 retry。C5 整体仍保持 🟡，直到 C5-5b 真实 DingTalk staging smoke 完整闭环。
 
 ### Out of this target
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -13407,4 +13407,109 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('C5-4: lists notification deliveries with counters, pagination, filtering, and admin-only access', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const orgId = `c5-observe-${runSuffix}`
+    const adminId = `c5-observe-admin-${runSuffix}`
+    const readOnlyId = `c5-observe-reader-${runSuffix}`
+    const pool = new Pool({ connectionString: dbUrl })
+
+    async function tokenFor(uid: string, role: string, perms: string): Promise<string | null> {
+      const res = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(uid)}&roles=${role}&perms=${perms}`,
+      )
+      return (res.body as { token?: string } | undefined)?.token ?? null
+    }
+
+    const insertDelivery = async (
+      label: string,
+      status: 'pending' | 'sent' | 'failed',
+      overrides: { attemptCount?: number; lastError?: string | null; deliveredAt?: string | null } = {},
+    ) => {
+      await pool.query(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status,
+            attempt_count, last_error, delivered_at, payload)
+         VALUES ($1, $2, $3, $4, $5, $6, 'dingtalk_work_notification', $7, $8, $9, $10::timestamptz, $11::jsonb)`,
+        [
+          orgId,
+          label === 'expiry' ? 'comp_time_expiry_reminder' : 'unscheduled_reminder',
+          randomUUID(),
+          `c5-observe:${runSuffix}:${label}`,
+          `recipient-${label}-${runSuffix}`,
+          label === 'owner' ? 'owner' : 'subject',
+          status,
+          overrides.attemptCount ?? 0,
+          overrides.lastError ?? null,
+          overrides.deliveredAt ?? null,
+          JSON.stringify({ title: `Delivery ${label}`, body: 'C5 observe test' }),
+        ],
+      )
+    }
+
+    try {
+      await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+      await insertDelivery('pending', 'pending')
+      await insertDelivery('owner', 'failed', { attemptCount: 2, lastError: 'recipient_not_bound' })
+      await insertDelivery('expiry', 'sent', { attemptCount: 1, deliveredAt: new Date().toISOString() })
+
+      const adminToken = await tokenFor(adminId, 'admin', 'attendance:read,attendance:admin')
+      const readOnlyToken = await tokenFor(readOnlyId, 'user', 'attendance:read')
+      expect(adminToken).toBeTruthy()
+      expect(readOnlyToken).toBeTruthy()
+      if (!adminToken || !readOnlyToken) return
+
+      const listRes = await requestJson(
+        `${baseUrl}/api/attendance/notification-deliveries?orgId=${encodeURIComponent(orgId)}&page=1&pageSize=2`,
+        { headers: { Authorization: `Bearer ${adminToken}` } },
+      )
+      expect(listRes.status).toBe(200)
+      const listBody = listRes.body as { data?: { items?: any[]; total?: number; counters?: Record<string, number>; pageSize?: number } }
+      expect(listBody.data?.items?.length).toBe(2)
+      expect(listBody.data?.total).toBe(3)
+      expect(listBody.data?.pageSize).toBe(2)
+      expect(listBody.data?.counters).toMatchObject({ pending: 1, failed: 1, sent: 1 })
+      expect(listBody.data?.items?.[0]).toMatchObject({
+        orgId,
+        channel: 'dingtalk_work_notification',
+      })
+
+      const failedRes = await requestJson(
+        `${baseUrl}/api/attendance/notification-deliveries?orgId=${encodeURIComponent(orgId)}&status=failed&pageSize=50`,
+        { headers: { Authorization: `Bearer ${adminToken}` } },
+      )
+      expect(failedRes.status).toBe(200)
+      const failedBody = failedRes.body as { data?: { items?: any[]; total?: number; counters?: Record<string, number> } }
+      expect(failedBody.data?.total).toBe(1)
+      expect(failedBody.data?.items).toHaveLength(1)
+      expect(failedBody.data?.items?.[0]).toMatchObject({
+        status: 'failed',
+        recipientRole: 'owner',
+        attemptCount: 2,
+        lastError: 'recipient_not_bound',
+      })
+      // Counters remain global for the org, not scoped to the current filter.
+      expect(failedBody.data?.counters).toMatchObject({ pending: 1, failed: 1, sent: 1 })
+
+      const invalidRes = await requestJson(
+        `${baseUrl}/api/attendance/notification-deliveries?orgId=${encodeURIComponent(orgId)}&status=bogus`,
+        { headers: { Authorization: `Bearer ${adminToken}` } },
+      )
+      expect(invalidRes.status).toBe(400)
+
+      const forbiddenRes = await requestJson(
+        `${baseUrl}/api/attendance/notification-deliveries?orgId=${encodeURIComponent(orgId)}`,
+        { headers: { Authorization: `Bearer ${readOnlyToken}` } },
+      )
+      expect(forbiddenRes.status).toBe(403)
+    } finally {
+      await pool.query(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [orgId]).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
 })

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -13416,6 +13416,7 @@ attendanceIntegrationDescribe(
     const orgId = `c5-observe-${runSuffix}`
     const adminId = `c5-observe-admin-${runSuffix}`
     const readOnlyId = `c5-observe-reader-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
     const pool = new Pool({ connectionString: dbUrl })
 
     async function tokenFor(uid: string, role: string, perms: string): Promise<string | null> {
@@ -13452,6 +13453,23 @@ attendanceIntegrationDescribe(
     }
 
     try {
+      process.env.RBAC_BYPASS = 'false'
+      await pool.query(
+        `INSERT INTO permissions (code, name, description)
+         VALUES
+           ('attendance:read', 'Attendance Read', 'Read attendance data'),
+           ('attendance:admin', 'Attendance Admin', 'Administer attendance')
+         ON CONFLICT (code) DO NOTHING`,
+      )
+      await pool.query(
+        `INSERT INTO user_permissions (user_id, permission_code)
+         VALUES
+           ($1, 'attendance:read'),
+           ($1, 'attendance:admin'),
+           ($2, 'attendance:read')
+         ON CONFLICT DO NOTHING`,
+        [adminId, readOnlyId],
+      )
       await requireAttendanceTable(pool, 'attendance_notification_deliveries')
       await insertDelivery('pending', 'pending')
       await insertDelivery('owner', 'failed', { attemptCount: 2, lastError: 'recipient_not_bound' })
@@ -13507,6 +13525,8 @@ attendanceIntegrationDescribe(
       )
       expect(forbiddenRes.status).toBe(403)
     } finally {
+      process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[adminId, readOnlyId]]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [orgId]).catch(() => undefined)
       await pool.end()
     }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7773,6 +7773,43 @@ function mapAttendanceSchedulerScopeRow(row) {
   }
 }
 
+const ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES = ['pending', 'sending', 'sent', 'retrying', 'failed', 'skipped']
+
+function normalizeAttendanceNotificationDeliveryStatus(value) {
+  const status = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  return ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES.includes(status) ? status : null
+}
+
+function mapAttendanceNotificationDeliveryRow(row) {
+  const timestamp = (value) => {
+    if (!value) return null
+    const date = value instanceof Date ? value : new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date.toISOString()
+  }
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    sourceType: row.source_type,
+    sourceId: row.source_id ?? null,
+    sourceKey: row.source_key,
+    recipientUserId: row.recipient_user_id,
+    recipientRole: row.recipient_role,
+    channel: row.channel,
+    status: row.status,
+    attemptCount: Number(row.attempt_count ?? 0),
+    nextAttemptAt: timestamp(row.next_attempt_at),
+    lastAttemptAt: timestamp(row.last_attempt_at),
+    claimedAt: timestamp(row.claimed_at),
+    claimExpiresAt: timestamp(row.claim_expires_at),
+    claimWorkerId: row.claim_worker_id ?? null,
+    deliveredAt: timestamp(row.delivered_at),
+    lastError: row.last_error ?? null,
+    payload: normalizeMetadata(row.payload),
+    createdAt: timestamp(row.created_at),
+    updatedAt: timestamp(row.updated_at),
+  }
+}
+
 function scopeListCoversTarget(scopeList, targetList) {
   const allowed = new Set(normalizeStringArray(scopeList))
   const targets = normalizeStringArray(targetList)
@@ -31653,6 +31690,68 @@ module.exports = {
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove schedule group member' } })
         }
       }
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/notification-deliveries',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const { page, pageSize, offset } = parsePagination(req.query, { defaultPageSize: 50, maxPageSize: 200 })
+        const rawStatus = typeof req.query.status === 'string' ? req.query.status.trim() : ''
+        const status = rawStatus && rawStatus !== 'all' ? normalizeAttendanceNotificationDeliveryStatus(rawStatus) : null
+        if (rawStatus && rawStatus !== 'all' && !status) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid delivery status filter' } })
+          return
+        }
+        const filterParams = status ? [orgId, status] : [orgId]
+        const statusClause = status ? 'AND status = $2' : ''
+        try {
+          const countRows = await db.query(
+            `SELECT COUNT(*)::int AS total
+               FROM attendance_notification_deliveries
+              WHERE org_id = $1 ${statusClause}`,
+            filterParams,
+          )
+          const rows = await db.query(
+            `SELECT *
+               FROM attendance_notification_deliveries
+              WHERE org_id = $1 ${statusClause}
+              ORDER BY updated_at DESC, created_at DESC
+              LIMIT $${filterParams.length + 1} OFFSET $${filterParams.length + 2}`,
+            [...filterParams, pageSize, offset],
+          )
+          const counterRows = await db.query(
+            `SELECT status, COUNT(*)::int AS count
+               FROM attendance_notification_deliveries
+              WHERE org_id = $1
+              GROUP BY status`,
+            [orgId],
+          )
+          const counters = Object.fromEntries(ATTENDANCE_NOTIFICATION_DELIVERY_STATUSES.map(item => [item, 0]))
+          for (const row of counterRows) {
+            const normalized = normalizeAttendanceNotificationDeliveryStatus(row.status)
+            if (normalized) counters[normalized] = Number(row.count ?? 0)
+          }
+          res.json({
+            ok: true,
+            data: {
+              items: rows.map(mapAttendanceNotificationDeliveryRow),
+              total: Number(countRows[0]?.total ?? 0),
+              page,
+              pageSize,
+              counters,
+            },
+          })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance notification delivery table missing' } })
+            return
+          }
+          logger.error('Attendance notification deliveries fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load attendance notification deliveries' } })
+        }
+      })
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- add a read-only C5 notification delivery admin API with status filter, pagination, and org-wide counters
- add an Attendance admin "Notification deliveries" section showing counters, recent delivery rows, and no-silent-caps truncation copy
- update the C5 tracker to mark C5-4 as this PR while keeping overall C5 pending C5-5 real DingTalk staging smoke

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav --reporter=dot` (104/104)
- `pnpm --filter @metasheet/web exec vue-tsc -b --pretty false`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` locally skipped all tests because this shell has no `DATABASE_URL` / `ATTENDANCE_TEST_DATABASE_URL`; CI's attendance DB step is expected to run the route test against Postgres.

## Scope notes
- C5-4 is read-only observability only; no manual retry / replay button.
- C5 remains partial until C5-5b real DingTalk work-notification staging smoke proves delivery end to end.
