### PR TITLE
feat(multitable): scatter chart (per-record x/y projection)

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -76,7 +76,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import * as echarts from 'echarts/core'
-import { BarChart, LineChart, PieChart, FunnelChart, GaugeChart } from 'echarts/charts'
+import { BarChart, LineChart, PieChart, FunnelChart, GaugeChart, ScatterChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
 import type { AggregationFunction, ChartData, ChartDisplayConfig } from '../types'
@@ -84,10 +84,10 @@ import { buildChartOption, CHART_COLORS, ECHARTS_CHART_TYPES } from '../utils/bu
 import { useLocale } from '../../composables/useLocale'
 import { viewRenderLabel } from '../utils/meta-view-render-labels'
 
-// Tree-shakeable: only the chart types + components actually used (S3 adds funnel/gauge; the
-// 'area' type reuses LineChart). Legend/title are HTML chrome (not ECharts components), so
-// LegendComponent/TitleComponent are deliberately absent.
-echarts.use([BarChart, LineChart, PieChart, FunnelChart, GaugeChart, GridComponent, TooltipComponent, CanvasRenderer])
+// Tree-shakeable: only the chart types + components actually used (S3 adds funnel/gauge; r12 adds
+// scatter; the 'area' type reuses LineChart). Legend/title are HTML chrome (not ECharts components),
+// so LegendComponent/TitleComponent are deliberately absent.
+echarts.use([BarChart, LineChart, PieChart, FunnelChart, GaugeChart, ScatterChart, GridComponent, TooltipComponent, CanvasRenderer])
 
 const props = defineProps<{
   chartData: ChartData

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -162,6 +162,7 @@
               <option value="pie">pie</option>
               <option value="funnel">funnel</option>
               <option value="gauge">gauge</option>
+              <option value="scatter">scatter</option>
               <option value="number">number</option>
               <option value="table">table</option>
             </select>
@@ -175,7 +176,7 @@
               <option v-if="chartDraft.chartType === 'line'" value="area">{{ viewRenderLabel('dashboard.variantArea', isZh) }}</option>
             </select>
           </label>
-          <label class="meta-dashboard__field">
+          <label v-if="!isScatter" class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.groupBy', isZh) }}</span>
             <select
               v-model="chartDraft.groupByFieldId"
@@ -193,7 +194,7 @@
             </small>
             <small v-else-if="!groupableFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noGroupableFields', isZh) }}</small>
           </label>
-          <label class="meta-dashboard__field">
+          <label v-if="!isScatter" class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.aggregation', isZh) }}</span>
             <select v-model="chartDraft.aggregation" class="meta-dashboard__select" data-field="chart-aggregation">
               <option value="count">count</option>
@@ -213,6 +214,48 @@
             </select>
             <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
           </label>
+          <!-- r12 scatter: per-record x/y projection — x + y are required numeric fields; color/size are
+               optional. Shown ONLY for scatter (groupBy/aggregation/value/series/bar-mode are hidden above). -->
+          <template v-if="isScatter">
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.xField', isZh) }}</span>
+              <select v-model="chartDraft.xFieldId" class="meta-dashboard__select" data-field="chart-x-field">
+                <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+                <option v-for="field in numericFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+            </label>
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.yField', isZh) }}</span>
+              <select v-model="chartDraft.yFieldId" class="meta-dashboard__select" data-field="chart-y-field">
+                <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+                <option v-for="field in numericFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+              <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
+            </label>
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.colorField', isZh) }}</span>
+              <select v-model="chartDraft.colorFieldId" class="meta-dashboard__select" data-field="chart-color-field">
+                <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
+                <option v-for="field in groupableFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+            </label>
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.sizeField', isZh) }}</span>
+              <select v-model="chartDraft.sizeFieldId" class="meta-dashboard__select" data-field="chart-size-field">
+                <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
+                <option v-for="field in numericFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+              <small class="meta-dashboard__hint" data-hint="scatter-fields">{{ viewRenderLabel('dashboard.scatterFieldHint', isZh) }}</small>
+            </label>
+          </template>
           <!-- v2-d: series split — for any bar chart (grouped or stacked); needs a primary groupBy. -->
           <label v-if="seriesByAllowed" class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.seriesBy', isZh) }}</span>
@@ -362,6 +405,12 @@ const chartDraft = ref({
   seriesByFieldId: '',
   // v2-d-b1: bar series layout — 'stacked' (default) or 'grouped' (side-by-side, allows non-additive).
   barMode: 'stacked' as 'stacked' | 'grouped',
+  // r12 scatter (only meaningful for chartType === 'scatter'): x/y are required numeric fields;
+  // color sets the per-point category, size the per-point bubble size.
+  xFieldId: '',
+  yFieldId: '',
+  colorFieldId: '',
+  sizeFieldId: '',
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
@@ -371,7 +420,10 @@ const editingDateGrouped = computed(() => Boolean(editingChart.value?.dataSource
 const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? []))
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
 const numericFields = computed(() => chartFields.value.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
-const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chartDraft.value.aggregation))
+// r12: scatter is the one non-grouped chart type — it hides groupBy/aggregation/value/series/bar-mode
+// and shows x/y/color/size pickers instead.
+const isScatter = computed(() => chartDraft.value.chartType === 'scatter')
+const requiresValueField = computed(() => !isScatter.value && AGGREGATIONS_REQUIRING_VALUE.has(chartDraft.value.aggregation))
 // v2-d / v2-d-b1: the series-split picker is offered for any bar chart with a non-date-grouped
 // primary axis (grouped layout accepts any aggregation). Whether STACKED is a legal layout depends
 // on the aggregation being additive (sum/count) — see `stackedAllowed` + the producer/validator.
@@ -404,6 +456,10 @@ watch(
 const createChartDisabled = computed(() => {
   if (!activeDashboard.value) return true
   if (!chartDraft.value.name.trim()) return true
+  // r12 scatter: requires BOTH x and y fields; it has no groupBy/aggregation to validate.
+  if (isScatter.value) {
+    return !chartDraft.value.xFieldId || !chartDraft.value.yFieldId
+  }
   if (!editingDateGrouped.value && !chartDraft.value.groupByFieldId) return true
   if (requiresValueField.value && !chartDraft.value.valueFieldId) return true
   return false
@@ -429,6 +485,10 @@ function resetChartDraft() {
     variant: '',
     seriesByFieldId: '',
     barMode: 'stacked',
+    xFieldId: '',
+    yFieldId: '',
+    colorFieldId: '',
+    sizeFieldId: '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -454,6 +514,10 @@ function openEditChart(chartId: string) {
     variant: cfg.displayConfig?.variant ?? '',
     seriesByFieldId: cfg.dataSource.seriesByFieldId ?? '',
     barMode: cfg.displayConfig?.barMode ?? 'stacked',
+    xFieldId: cfg.dataSource.xFieldId ?? '',
+    yFieldId: cfg.dataSource.yFieldId ?? '',
+    colorFieldId: cfg.dataSource.colorFieldId ?? '',
+    sizeFieldId: cfg.dataSource.sizeFieldId ?? '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -553,6 +617,29 @@ async function addPanelForChart(chartId: string) {
 // chart keeps its date-grouping — full grouping-mode editing is a later slice.)
 function buildChartInput(base?: ChartConfig): ChartCreateInput {
   const name = chartDraft.value.name.trim()
+  // r12 scatter: a per-record x/y projection — emit x/y (+ optional color/size) and DROP the grouped
+  // dataSource fields (groupBy/series/date). `aggregation` stays present (the contract requires it) but
+  // the backend scatter branch ignores it. Built explicitly off `base` so groupBy/series carried by an
+  // edited config are cleared when switching INTO scatter.
+  if (isScatter.value) {
+    const scatterSource: ChartDataSource = {
+      sheetId: props.sheetId,
+      aggregation: { function: chartDraft.value.aggregation },
+      xFieldId: chartDraft.value.xFieldId,
+      yFieldId: chartDraft.value.yFieldId,
+      ...(chartDraft.value.colorFieldId ? { colorFieldId: chartDraft.value.colorFieldId } : {}),
+      ...(chartDraft.value.sizeFieldId ? { sizeFieldId: chartDraft.value.sizeFieldId } : {}),
+    }
+    return {
+      name,
+      chartType: 'scatter',
+      dataSource: scatterSource,
+      displayConfig: {
+        ...(base?.displayConfig ?? {}),
+        title: name,
+      },
+    }
+  }
   const dataSource: ChartDataSource = {
     ...(base?.dataSource ?? {}),
     sheetId: props.sheetId,
@@ -561,6 +648,11 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
       ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
     },
   }
+  // r12: a base config switching OUT of scatter must not leak its x/y/color/size fields.
+  delete dataSource.xFieldId
+  delete dataSource.yFieldId
+  delete dataSource.colorFieldId
+  delete dataSource.sizeFieldId
   if (!editingDateGrouped.value) {
     dataSource.groupByFieldId = chartDraft.value.groupByFieldId
   }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -952,7 +952,9 @@ export interface AutomationStats {
 // --- Charts ---
 // S3: area / funnel / gauge are render-layer additions — the backend aggregates them through the
 // same grouped {label,value} pipeline as bar/line/pie (no per-type aggregation math).
-export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table' | 'area' | 'funnel' | 'gauge'
+// r12: scatter is the one NON-grouped type — a per-record x/y projection (xValue/yValue per dataPoint),
+// not a grouped aggregation. It uses x/y/color/sizeFieldId on the dataSource (ignores groupBy/aggregation).
+export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table' | 'area' | 'funnel' | 'gauge' | 'scatter'
 
 export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
 
@@ -971,6 +973,13 @@ export interface ChartDataSource {
   dateFieldId?: string
   dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
   aggregation: ChartAggregation
+  // r12 scatter (discriminant — meaningful only when chartType === 'scatter'). x/y are both required
+  // numeric fields; color sets the per-point category (label); size sets the per-point bubble size.
+  // Scatter ignores groupByFieldId / aggregation / seriesByFieldId / dateFieldId.
+  xFieldId?: string
+  yFieldId?: string
+  colorFieldId?: string
+  sizeFieldId?: string
 }
 
 export interface ChartDisplayConfig {
@@ -1011,6 +1020,11 @@ export interface ChartDataPoint {
   label: string
   value: number
   color?: string
+  // r12 scatter: a per-record point carries its own x/y (+ optional size). Optional so grouped types
+  // stay unchanged; only scatter dataPoints populate them. `label` then holds the optional color category.
+  xValue?: number
+  yValue?: number
+  size?: number
 }
 
 // v2-d: a bar series (grouped or stacked). `data` is dense + aligned positionally to ChartData.dataPoints.

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -15,8 +15,11 @@ export const CHART_COLORS = [
  * renderer — single source so the renderer's canvas gate and this mapper's guard never drift.
  */
 export const ECHARTS_CHART_TYPES: ReadonlySet<ChartData['chartType']> = new Set<ChartData['chartType']>([
-  'bar', 'line', 'pie', 'area', 'funnel', 'gauge',
+  'bar', 'line', 'pie', 'area', 'funnel', 'gauge', 'scatter',
 ])
+
+// r12 scatter: default symbol size when no per-point `size` is supplied.
+const SCATTER_DEFAULT_SYMBOL_SIZE = 10
 
 /**
  * Map a ChartData (+ optional display config) to an ECharts option for the
@@ -114,6 +117,51 @@ export function buildChartOption(
           max: Math.max(chartData.total ?? 0, value, 1),
           progress: { show: true },
           data: [{ name: point?.label ?? '', value }],
+        },
+      ],
+    }
+  }
+
+  // r12 scatter: a per-record x/y projection. BOTH axes are type:'value' (numeric, not category) — the
+  // defining difference from bar/line. Each dataPoint maps to an [xValue, yValue] pair; symbolSize comes
+  // from the point's `size` (falling back to a default), and the tooltip shows the (x, y) coordinate.
+  if (chartType === 'scatter') {
+    // Color-by (review M1): `label` carries the optional color-category from colorFieldId.
+    // Assign each distinct category a stable palette color here (the palette lives frontend-side)
+    // so the Color-by picker has a visible effect; the category is also named in the tooltip.
+    const scatterCategories = [...new Set(dataPoints.map((p) => p.label).filter((l) => l !== ''))]
+    const colorForCategory = (label: string): string | undefined =>
+      label === '' ? undefined : CHART_COLORS[scatterCategories.indexOf(label) % CHART_COLORS.length]
+    return {
+      ...base,
+      tooltip: {
+        trigger: 'item',
+        formatter: (params: unknown) => {
+          const data = (params as { data?: { value?: unknown; category?: string } })?.data
+          const value = data?.value
+          const [x, y] = Array.isArray(value) ? value : [undefined, undefined]
+          return data?.category ? `${data.category}\n(${x}, ${y})` : `(${x}, ${y})`
+        },
+      },
+      grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
+      xAxis: { type: 'value' },
+      yAxis: { type: 'value' },
+      series: [
+        {
+          type: 'scatter',
+          symbolSize: (rawValue: unknown, params: unknown) => {
+            const size = (params as { data?: { size?: number } })?.data?.size
+            return typeof size === 'number' && Number.isFinite(size) ? size : SCATTER_DEFAULT_SYMBOL_SIZE
+          },
+          data: dataPoints.map((p) => {
+            const color = p.color ?? colorForCategory(p.label)
+            return {
+              value: [p.xValue ?? 0, p.yValue ?? 0],
+              ...(p.label !== '' ? { category: p.label } : {}),
+              ...(p.size !== undefined ? { size: p.size } : {}),
+              ...(color ? { itemStyle: { color } } : {}),
+            }
+          }),
         },
       ],
     }

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -111,6 +111,11 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.barModeGrouped'
   | 'dashboard.barModeAdditiveOnly'
   | 'dashboard.noNumericFields'
+  | 'dashboard.xField'
+  | 'dashboard.yField'
+  | 'dashboard.colorField'
+  | 'dashboard.sizeField'
+  | 'dashboard.scatterFieldHint'
   | 'dashboard.livePreview'
   | 'dashboard.previewFillRequired'
   | 'dashboard.loadingPreview'
@@ -232,6 +237,11 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.barModeGrouped',
   'dashboard.barModeAdditiveOnly',
   'dashboard.noNumericFields',
+  'dashboard.xField',
+  'dashboard.yField',
+  'dashboard.colorField',
+  'dashboard.sizeField',
+  'dashboard.scatterFieldHint',
   'dashboard.livePreview',
   'dashboard.previewFillRequired',
   'dashboard.loadingPreview',
@@ -360,6 +370,11 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.barModeGrouped': { en: 'Grouped (side by side)', zh: '并排分组' },
   'dashboard.barModeAdditiveOnly': { en: 'Stacked needs a sum or count aggregation; using grouped.', zh: '堆叠需要求和或计数聚合；已改用并排分组。' },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
+  'dashboard.xField': { en: 'X axis (numeric)', zh: 'X 轴（数值）' },
+  'dashboard.yField': { en: 'Y axis (numeric)', zh: 'Y 轴（数值）' },
+  'dashboard.colorField': { en: 'Color by (optional)', zh: '颜色分类（可选）' },
+  'dashboard.sizeField': { en: 'Size by (optional, numeric)', zh: '气泡大小（可选，数值）' },
+  'dashboard.scatterFieldHint': { en: 'Each record is one point at (X, Y); no grouping or aggregation.', zh: '每条记录是一个 (X, Y) 坐标点，不分组也不聚合。' },
   'dashboard.livePreview': { en: 'Live preview', zh: '实时预览' },
   'dashboard.previewFillRequired': { en: 'Complete the chart fields to preview.', zh: '填写完整图表字段后可预览。' },
   'dashboard.loadingPreview': { en: 'Loading preview...', zh: '正在加载预览...' },

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -326,4 +326,66 @@ describe('buildChartOption', () => {
     expect(buildChartOption(chart('number', [{ label: 'x', value: 1 }]))).toBeNull()
     expect(buildChartOption(chart('table', [{ label: 'x', value: 1 }]))).toBeNull()
   })
+
+  // --- r12 scatter: per-record x/y projection ---
+  const scatterData = (
+    points: Array<{ label?: string; xValue: number; yValue: number; size?: number; color?: string }>,
+  ): ChartData => ({
+    chartType: 'scatter',
+    dataPoints: points.map((p) => ({ label: p.label ?? '', value: p.yValue, xValue: p.xValue, yValue: p.yValue, ...(p.size !== undefined ? { size: p.size } : {}), ...(p.color ? { color: p.color } : {}) })),
+  })
+
+  it('r12 scatter: BOTH axes are type "value" (numeric, not category) and series type is scatter', () => {
+    const o = opt(buildChartOption(scatterData([{ xValue: 1, yValue: 10 }, { xValue: 2, yValue: 20 }])))
+    expect(o.xAxis.type).toBe('value')
+    expect(o.yAxis.type).toBe('value')
+    expect(o.xAxis.data).toBeUndefined() // no category labels
+    expect(o.series[0].type).toBe('scatter')
+  })
+
+  it('r12 scatter: maps each dataPoint to an [xValue, yValue] pair', () => {
+    const o = opt(buildChartOption(scatterData([{ xValue: 1, yValue: 10 }, { xValue: 3.5, yValue: 7 }])))
+    expect(o.series[0].data.map((d: any) => d.value)).toEqual([[1, 10], [3.5, 7]])
+  })
+
+  it('r12 scatter: symbolSize uses the point size, falling back to the default', () => {
+    const o = opt(buildChartOption(scatterData([{ xValue: 1, yValue: 1, size: 25 }, { xValue: 2, yValue: 2 }])))
+    const sizeFn = o.series[0].symbolSize
+    expect(typeof sizeFn).toBe('function')
+    expect(sizeFn(undefined, { data: { size: 25 } })).toBe(25)
+    expect(sizeFn(undefined, { data: {} })).toBe(10) // default
+  })
+
+  it('r12 scatter: honors per-point color via itemStyle', () => {
+    const o = opt(buildChartOption(scatterData([{ xValue: 1, yValue: 1, color: '#abcdef' }])))
+    expect(o.series[0].data[0].itemStyle.color).toBe('#abcdef')
+  })
+
+  it('r12 scatter M1: color-by category assigns a stable palette color per distinct label', () => {
+    const o = opt(buildChartOption(scatterData([
+      { label: 'A', xValue: 1, yValue: 1 },
+      { label: 'B', xValue: 2, yValue: 2 },
+      { label: 'A', xValue: 3, yValue: 3 },
+    ])))
+    const colors = o.series[0].data.map((d: any) => d.itemStyle.color)
+    expect(colors[0]).toBe(colors[2]) // same category → same color
+    expect(colors[0]).not.toBe(colors[1]) // distinct categories → distinct colors
+    expect(o.series[0].data[0].category).toBe('A')
+  })
+
+  it('r12 scatter M1: tooltip names the category when present', () => {
+    const o = opt(buildChartOption(scatterData([{ label: 'North', xValue: 4, yValue: 9 }])))
+    expect(o.tooltip.formatter({ data: { value: [4, 9], category: 'North' } })).toBe('North\n(4, 9)')
+  })
+
+  it('r12 scatter: item tooltip formats the (x, y) coordinate (no category)', () => {
+    const o = opt(buildChartOption(scatterData([{ xValue: 4, yValue: 9 }])))
+    expect(o.tooltip.trigger).toBe('item')
+    expect(o.tooltip.formatter({ data: { value: [4, 9] } })).toBe('(4, 9)')
+  })
+
+  it('r12 scatter: does not crash on empty dataPoints', () => {
+    const o = opt(buildChartOption(scatterData([])))
+    expect(o.series[0].data).toEqual([])
+  })
 })

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => {
   return { setOption, resize, dispose, init, instance }
 })
 vi.mock('echarts/core', () => ({ init: mocks.init, use: vi.fn() }))
-vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {} }))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {}, ScatterChart: {} }))
 vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }))
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 
@@ -107,6 +107,14 @@ const gaugeData: ChartData = {
     { label: 'closed', value: 70 },
   ],
   total: 100,
+}
+
+const scatterData: ChartData = {
+  chartType: 'scatter',
+  dataPoints: [
+    { label: '', value: 10, xValue: 1, yValue: 10 },
+    { label: '', value: 20, xValue: 2, yValue: 20 },
+  ],
 }
 
 describe('MetaChartRenderer', () => {
@@ -309,6 +317,29 @@ describe('MetaChartRenderer', () => {
     await flushPromises()
     const note = container.querySelector('[data-gauge-agg-note]')
     expect(note?.textContent || '').toContain('占比')
+  })
+
+  it('r12: renders scatter via ECharts canvas (init once + setOption) with NO HTML legend', async () => {
+    const { container } = mount({ chartData: scatterData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart-type="scatter"]')).toBeTruthy()
+    expect(container.querySelector('[data-chart-canvas]')).toBeTruthy()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.setOption).toHaveBeenCalledTimes(1)
+    // The scatter option carries function props (symbolSize / tooltip.formatter) so a whole-option
+    // deepEqual is brittle (fresh fn instances) — assert the structural bits the renderer must pass.
+    const passed = mocks.setOption.mock.calls[0][0] as {
+      series: { type: string; data: { value: number[] }[] }[]
+      xAxis: { type: string }
+      yAxis: { type: string }
+    }
+    expect(passed.series[0].type).toBe('scatter')
+    expect(passed.xAxis.type).toBe('value')
+    expect(passed.yAxis.type).toBe('value')
+    expect(passed.series[0].data.map((d) => d.value)).toEqual([[1, 10], [2, 20]])
+    // scatter is neither a point-legend (pie/funnel) nor a series-legend (bar/line) type
+    expect(container.querySelector('[data-legend]')).toBeNull()
   })
 
   it('S3: disposes the canvas when switching funnel → number (new types share the lifecycle)', async () => {

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -17,7 +17,7 @@ vi.mock('echarts/core', () => ({
   init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() })),
   use: vi.fn(),
 }))
-vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {} }))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {}, ScatterChart: {} }))
 vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }))
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 
@@ -282,6 +282,74 @@ describe('MetaDashboardView', () => {
     ])
     const dataLoads = fetchFn.mock.calls.filter(([url]: [string]) => url.includes('/charts/chart_new/data'))
     expect(dataLoads.length).toBe(1)
+  })
+
+  it('r12 scatter: shows x/y/color/size pickers + hides grouped pickers, and gates save on x && y', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client, fetchFn } = mockClient([dashboard], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    // grouped pickers are shown for the default (bar) type
+    expect(container.querySelector('[data-field="chart-group-by"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="chart-aggregation"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="chart-x-field"]')).toBeNull()
+
+    const typeSelect = container.querySelector('[data-field="chart-type"]') as HTMLSelectElement
+    typeSelect.value = 'scatter'
+    typeSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // scatter HIDES groupBy/aggregation/series/bar-mode and SHOWS x/y/color/size
+    expect(container.querySelector('[data-field="chart-group-by"]')).toBeNull()
+    expect(container.querySelector('[data-field="chart-aggregation"]')).toBeNull()
+    expect(container.querySelector('[data-field="chart-series-by"]')).toBeNull()
+    expect(container.querySelector('[data-field="chart-x-field"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="chart-y-field"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="chart-color-field"]')).toBeTruthy()
+    expect(container.querySelector('[data-field="chart-size-field"]')).toBeTruthy()
+
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Amount vs Amount'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const submit = container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement
+    // x and y both required — disabled with neither, then only x, then enabled with both
+    expect(submit.disabled).toBe(true)
+
+    const xSelect = container.querySelector('[data-field="chart-x-field"]') as HTMLSelectElement
+    xSelect.value = 'fld_amount'
+    xSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(submit.disabled).toBe(true) // still missing y
+
+    const ySelect = container.querySelector('[data-field="chart-y-field"]') as HTMLSelectElement
+    ySelect.value = 'fld_amount'
+    ySelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(submit.disabled).toBe(false)
+
+    submit.click()
+    await flushPromises()
+
+    const chartPosts = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/charts') && init?.method === 'POST',
+    )
+    expect(chartPosts.length).toBe(1)
+    const chartBody = JSON.parse(chartPosts[0][1].body as string)
+    // the client maps chartType -> type and dataSource/displayConfig -> dataSource/display on the wire
+    expect(chartBody).toMatchObject({
+      name: 'Amount vs Amount',
+      type: 'scatter',
+      dataSource: { sheetId: 'sheet_1', xFieldId: 'fld_amount', yFieldId: 'fld_amount' },
+    })
+    // scatter payload carries NO grouped fields
+    expect(chartBody.dataSource.groupByFieldId).toBeUndefined()
+    expect(chartBody.dataSource.seriesByFieldId).toBeUndefined()
   })
 
   it('loads a debounced live preview without gating chart save', async () => {
@@ -1052,14 +1120,14 @@ describe('MetaDashboardView', () => {
 
   // ---- S3: chart-type completion (area / funnel / gauge) + S1-9 async renderer ----
 
-  it('S3: the chart-type select offers area / funnel / gauge alongside the original five', async () => {
+  it('S3 + r12: the chart-type select offers area / funnel / gauge / scatter alongside the originals', async () => {
     const { client } = mockClient([fakeDashboard({ panels: [] })], [])
     const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
     await flushPromises()
     await openCreateForm(container)
 
     const options = Array.from(typeSelectOf(container).options).map((o) => o.value)
-    expect(options).toEqual(['bar', 'line', 'area', 'pie', 'funnel', 'gauge', 'number', 'table'])
+    expect(options).toEqual(['bar', 'line', 'area', 'pie', 'funnel', 'gauge', 'scatter', 'number', 'table'])
   })
 
   it('S3: variant + series pickers stay hidden for area/funnel/gauge (no inapplicable controls)', async () => {

--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -13,6 +13,12 @@ export interface ChartDataPoint {
   label: string
   value: number
   color?: string
+  // r12 scatter: a per-record point carries its own x/y (and optional size) instead of an aggregated
+  // `value`. These stay OPTIONAL so the grouped {label,value} types are byte-unchanged; only scatter
+  // dataPoints populate them. `label` then holds the optional color category (empty when unset).
+  xValue?: number
+  yValue?: number
+  size?: number
 }
 
 /**
@@ -117,6 +123,12 @@ export class ChartAggregationService {
       }
     }
 
+    // r12 scatter: a PER-RECORD x/y projection — NOT a grouped aggregation. Branch out BEFORE the
+    // grouped pipeline so that path stays byte-identical; scatter has no groupBy/aggregation/series.
+    if (chart.type === 'scatter') {
+      return this.computeScatterData(chart, filtered)
+    }
+
     // Group records
     let groups: Map<string, RecordRow[]>
 
@@ -207,6 +219,46 @@ export class ChartAggregationService {
         ...(series ? { seriesByField: seriesByFieldId } : {}),
         aggregationFunction: aggFn,
         recordCount: filtered.length,
+      },
+    }
+  }
+
+  /**
+   * r12 scatter: one dataPoint PER RECORD (no grouping/aggregation/sort). A record is included only
+   * when BOTH x and y parse to finite numbers (a scatter point with a missing axis is meaningless);
+   * `label` carries the optional color category (`colorFieldId`, stringified — '' when unset), and
+   * `size` the optional bubble size (`sizeFieldId`, finite-numeric or omitted). `limit` caps the point
+   * count (records are taken in encounter order — scatter has no value to sort by). `total` is omitted
+   * (a sum of scattered y-values is meaningless); `metadata.recordCount` reports the matched records.
+   */
+  private computeScatterData(chart: ChartConfig, records: RecordRow[]): ChartData {
+    const { xFieldId, yFieldId, colorFieldId, sizeFieldId, limit } = chart.dataSource
+    const dataPoints: ChartDataPoint[] = []
+    for (const record of records) {
+      const xRaw = record.data[xFieldId ?? '']
+      const yRaw = record.data[yFieldId ?? '']
+      // Review M2: an empty string coerces to a misleading 0 — a phantom point at the axis edge.
+      // For a scatter coordinate, treat '' as absent like null.
+      const x = xRaw === '' ? null : toNumber(xRaw)
+      const y = yRaw === '' ? null : toNumber(yRaw)
+      if (x === null || y === null) continue // skip a record missing/non-numeric on either axis
+      const colorRaw = colorFieldId ? record.data[colorFieldId] : undefined
+      const size = sizeFieldId ? toNumber(record.data[sizeFieldId]) : null
+      dataPoints.push({
+        label: colorRaw != null ? String(colorRaw) : '',
+        value: y, // keep `value` populated (= y) so generic {label,value} consumers degrade gracefully
+        xValue: x,
+        yValue: y,
+        ...(size !== null ? { size } : {}),
+      })
+      if (limit && limit > 0 && dataPoints.length >= limit) break
+    }
+    return {
+      chartId: chart.id,
+      chartType: chart.type,
+      dataPoints,
+      metadata: {
+        recordCount: dataPoints.length,
       },
     }
   }

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -5,7 +5,10 @@
 // S3: area / funnel / gauge are RENDER-LAYER types — the aggregation service computes them through
 // the same grouped {label,value} pipeline as bar/line/pie (no per-type math; series split stays
 // bar/line-only). The frontend maps area→line+areaStyle, funnel→stages, gauge→first-point/total dial.
-export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table' | 'area' | 'funnel' | 'gauge'
+// r12: scatter is the ONE non-grouped type — a PER-RECORD x/y projection (no groupBy / aggregation /
+// seriesBy / dateField). It branches early in the producer and carries xValue/yValue (+ optional size)
+// per dataPoint; `label` is its optional color category. See `ChartDataSource` x/y/color/sizeFieldId.
+export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table' | 'area' | 'funnel' | 'gauge' | 'scatter'
 
 export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
 
@@ -42,6 +45,18 @@ export interface ChartDataSource {
   /** For line charts: time field for X axis */
   dateFieldId?: string
   dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
+
+  /**
+   * r12 scatter (a discriminant — meaningful ONLY when `type === 'scatter'`). Scatter is a per-record
+   * x/y projection, so it ignores `groupByFieldId` / `aggregation` / `seriesByFieldId` / `dateFieldId`.
+   * `xFieldId` + `yFieldId` are both required (numeric fields). `colorFieldId` sets the per-point
+   * `label` (color category); `sizeFieldId` sets the per-point `size`. `limit` caps the number of
+   * points (no sort — scatter has no value to sort by).
+   */
+  xFieldId?: string
+  yFieldId?: string
+  colorFieldId?: string
+  sizeFieldId?: string
 
   /** Limit number of groups/slices */
   limit?: number
@@ -129,5 +144,17 @@ export function assertSeriesConstraints(
   // additive aggregation. (v2-d-b1 = grouped relaxation; v2-d-b2 = line; v2-d-b3 = date axis.)
   if (type === 'bar' && barMode !== 'grouped' && !ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
     throw new Error('stacked series require a sum or count aggregation (use barMode "grouped" for others)')
+  }
+}
+
+/**
+ * A scatter chart is a per-record x/y projection — it requires both axis fields (review M3: the
+ * persisted POST/PATCH path must enforce this, not just the preview path + config UI, or a direct
+ * API write of a scatter chart with no x/y would persist and later render an empty plot).
+ */
+export function assertScatterFields(dataSource: ChartDataSource | undefined, type: ChartType): void {
+  if (type !== 'scatter') return
+  if (!dataSource?.xFieldId || !dataSource?.yFieldId) {
+    throw new Error('scatter requires xFieldId and yFieldId')
   }
 }

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -31,7 +31,7 @@ import { randomUUID } from 'crypto'
 import { poolManager } from '../integration/db/connection-pool'
 import type { MultitableCapabilities } from '../multitable/access'
 import type { AggregationFunction, ChartConfig, ChartCreateInput, ChartType } from '../multitable/charts'
-import { assertSeriesConstraints } from '../multitable/charts'
+import { assertScatterFields, assertSeriesConstraints } from '../multitable/charts'
 import type { ChartData } from '../multitable/chart-aggregation-service'
 import { DashboardService } from '../multitable/dashboard-service'
 import type { MultitableField } from '../multitable/field-codecs'
@@ -45,7 +45,7 @@ import {
 } from '../multitable/permission-service'
 
 const dashboardService = new DashboardService()
-const CHART_TYPES = new Set<ChartType>(['bar', 'line', 'pie', 'number', 'table', 'area', 'funnel', 'gauge'])
+const CHART_TYPES = new Set<ChartType>(['bar', 'line', 'pie', 'number', 'table', 'area', 'funnel', 'gauge', 'scatter'])
 const AGGREGATION_FUNCTIONS = new Set<AggregationFunction>(['count', 'sum', 'avg', 'min', 'max', 'count_distinct'])
 const AGGREGATIONS_REQUIRING_FIELD = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max', 'count_distinct'])
 const DATE_GROUPINGS = new Set(['day', 'week', 'month', 'quarter', 'year'])
@@ -149,11 +149,16 @@ async function loadAllowedFieldIds(
 function chartReferencedFieldIds(chart: ChartConfig): string[] {
   const source = chart.dataSource
   const ids = [
-    source.aggregation.fieldId,
+    source.aggregation?.fieldId,
     source.groupByFieldId,
     source.seriesByFieldId, // v2-d: a denied series field must restrict, not leak its values as series names
     source.dateFieldId,
     source.filterFieldId,
+    // r12 scatter: a denied x/y/color/size field must restrict too (its values feed point coords/category).
+    source.xFieldId,
+    source.yFieldId,
+    source.colorFieldId,
+    source.sizeFieldId,
   ]
   return ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
@@ -199,6 +204,28 @@ function buildPreviewChart(sheetId: string, userId: string, body: unknown): Char
   const source = input.dataSource
   if (!source || typeof source !== 'object') {
     throw new Error('dataSource is required')
+  }
+  // r12 scatter: a per-record x/y projection — NOT a grouped aggregation. It requires xFieldId +
+  // yFieldId and IGNORES aggregation / groupBy / date / series (so the grouped-path requirements below
+  // do not apply). Branch out early once the type+source are valid.
+  if (chartType === 'scatter') {
+    const xFieldId = readString((source as ChartConfig['dataSource']).xFieldId)
+    const yFieldId = readString((source as ChartConfig['dataSource']).yFieldId)
+    if (!xFieldId || !yFieldId) {
+      throw new Error('scatter requires xFieldId and yFieldId')
+    }
+    const now = new Date().toISOString()
+    return {
+      id: `chart_preview_${randomUUID()}`,
+      name: readString(input.name) ?? 'Preview chart',
+      type: chartType as ChartType,
+      sheetId,
+      viewId: readString(input.viewId),
+      dataSource: source as ChartConfig['dataSource'],
+      display: (input.display ?? input.displayConfig ?? {}) as ChartConfig['display'],
+      createdBy: userId,
+      createdAt: now,
+    }
   }
   const aggregation = (source as ChartConfig['dataSource']).aggregation
   if (!aggregation || typeof aggregation !== 'object') {
@@ -267,6 +294,8 @@ export function dashboardRouter() {
       }
       // v2-d: validate series constraints on the persisted path too — the UI is never the sole guard.
       assertSeriesConstraints(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType, readBarMode(req.body?.display))
+      // r12 M3: scatter requires x/y on the persisted path too (not just preview + config UI).
+      assertScatterFields(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType)
       const chart = await dashboardService.createChart(req.params.sheetId, {
         ...req.body,
         createdBy: auth.userId,
@@ -340,6 +369,8 @@ export function dashboardRouter() {
         effectiveType,
         readBarMode(req.body?.display ?? chart.display),
       )
+      // r12 M3: scatter requires x/y on the effective (merged) config.
+      assertScatterFields((req.body?.dataSource ?? chart.dataSource) as ChartConfig['dataSource'], effectiveType)
       const updated = await dashboardService.updateChart(req.params.id, req.body)
       res.json(updated)
     } catch (err: unknown) {

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -566,6 +566,112 @@ describe('ChartAggregationService', () => {
       expect(result.metadata?.recordCount).toBe(5)
     })
   })
+
+  // -- r12 scatter: PER-RECORD x/y projection (no grouping/aggregation) ------
+  describe('scatter (per-record x/y projection)', () => {
+    function scatterChart(overrides: Partial<ChartConfig['dataSource']> = {}): ChartConfig {
+      return makeChart({
+        type: 'scatter',
+        dataSource: { aggregation: { function: 'count' }, xFieldId: 'x', yFieldId: 'y', ...overrides },
+      })
+    }
+
+    it('emits ONE dataPoint per record (N records → N points, no grouping)', async () => {
+      const records = makeRecords([
+        { x: 1, y: 10 },
+        { x: 2, y: 20 },
+        { x: 1, y: 30 }, // same x as the first record — NOT merged (no grouping)
+      ])
+      const result = await service.computeChartData(scatterChart(), records)
+      expect(result.dataPoints).toHaveLength(3)
+      expect(result.dataPoints.map((p) => [p.xValue, p.yValue])).toEqual([
+        [1, 10],
+        [2, 20],
+        [1, 30],
+      ])
+    })
+
+    it('parses numeric strings for x/y', async () => {
+      const records = makeRecords([{ x: '3.5', y: '7' }])
+      const result = await service.computeChartData(scatterChart(), records)
+      expect(result.dataPoints).toEqual([
+        expect.objectContaining({ xValue: 3.5, yValue: 7, value: 7 }),
+      ])
+    })
+
+    it('SKIPS records missing or non-numeric on either axis', async () => {
+      const records = makeRecords([
+        { x: 1, y: 10 }, // ok
+        { x: null, y: 20 }, // missing x → skip
+        { x: 3 }, // missing y → skip
+        { x: 'abc', y: 40 }, // non-numeric x → skip
+        { x: 5, y: 'xyz' }, // non-numeric y → skip
+        { x: '', y: 50 }, // empty-string x → skip (M2: not a phantom 0 point)
+        { x: 7, y: '' }, // empty-string y → skip
+        { x: 6, y: 60 }, // ok
+      ])
+      const result = await service.computeChartData(scatterChart(), records)
+      expect(result.dataPoints).toHaveLength(2)
+      expect(result.dataPoints.map((p) => p.xValue)).toEqual([1, 6])
+      expect(result.metadata?.recordCount).toBe(2) // matched records, not input length
+    })
+
+    it('sets label from colorFieldId and size from sizeFieldId (both optional)', async () => {
+      const records = makeRecords([{ x: 1, y: 2, cat: 'A', mag: 18 }])
+      const result = await service.computeChartData(
+        scatterChart({ colorFieldId: 'cat', sizeFieldId: 'mag' }),
+        records,
+      )
+      expect(result.dataPoints[0]).toEqual(
+        expect.objectContaining({ label: 'A', xValue: 1, yValue: 2, size: 18 }),
+      )
+    })
+
+    it('leaves label empty and omits size when color/size fields are unset', async () => {
+      const records = makeRecords([{ x: 1, y: 2 }])
+      const result = await service.computeChartData(scatterChart(), records)
+      expect(result.dataPoints[0].label).toBe('')
+      expect(result.dataPoints[0].size).toBeUndefined()
+    })
+
+    it('honors the optional limit (caps points, no value-sort)', async () => {
+      const records = makeRecords([
+        { x: 1, y: 1 },
+        { x: 2, y: 2 },
+        { x: 3, y: 3 },
+      ])
+      const result = await service.computeChartData(scatterChart({ limit: 2 }), records)
+      expect(result.dataPoints).toHaveLength(2)
+      expect(result.dataPoints.map((p) => p.xValue)).toEqual([1, 2]) // encounter order, NOT sorted
+    })
+
+    it('does NOT emit grouped series/total/groupByField metadata', async () => {
+      const records = makeRecords([{ x: 1, y: 1 }])
+      const result = await service.computeChartData(scatterChart(), records)
+      expect(result.series).toBeUndefined()
+      expect(result.total).toBeUndefined()
+      expect(result.metadata?.groupByField).toBeUndefined()
+      expect(result.metadata?.aggregationFunction).toBeUndefined()
+    })
+  })
+
+  // -- r12 NON-REGRESSION: the grouped pipeline is unchanged by the scatter branch --
+  describe('grouped non-regression (scatter branch must not alter grouped charts)', () => {
+    it('a bar chart still groups + aggregates per category (no x/y leak)', async () => {
+      const chart = makeChart({
+        type: 'bar',
+        dataSource: { groupByFieldId: 'status', aggregation: { function: 'sum', fieldId: 'amount' } },
+      })
+      const result = await service.computeChartData(chart, sampleRecords)
+      const open = result.dataPoints.find((dp) => dp.label === 'open')
+      const closed = result.dataPoints.find((dp) => dp.label === 'closed')
+      expect(open?.value).toBe(80) // 10 + 20 + 50
+      expect(closed?.value).toBe(70) // 30 + 40
+      // grouped points carry NO scatter fields
+      expect(result.dataPoints.every((dp) => dp.xValue === undefined && dp.yValue === undefined)).toBe(true)
+      expect(result.metadata?.groupByField).toBe('status')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
@@ -194,8 +194,8 @@ describe('dashboardRouter HTTP mounting', () => {
     }
   })
 
-  it('POST /charts/preview-data still rejects unknown chart types (scatter stays out — no numeric x/y in the data contract)', async () => {
-    for (const type of ['scatter', 'radar', 'nope']) {
+  it('POST /charts/preview-data still rejects unknown chart types (radar/nope — scatter is now a real type, see scatter tests below)', async () => {
+    for (const type of ['radar', 'nope']) {
       const res = await request(buildApp())
         .post('/api/multitable/sheets/sheet-a/charts/preview-data')
         .send({ type, dataSource: { groupByFieldId: 'fld_x', aggregation: { function: 'count' } } })
@@ -204,12 +204,36 @@ describe('dashboardRouter HTTP mounting', () => {
     }
   })
 
+  // r12 scatter: a per-record x/y projection — the preview-data type gate must ADMIT it. With the
+  // loaders mocked to zero fields the referenced x/y fields are "not allowed" → the route answers the
+  // restricted ChartData shape (200), which is enough to prove the type passed validation.
+  it('POST /charts/preview-data accepts scatter when xFieldId + yFieldId are present', async () => {
+    const res = await request(buildApp())
+      .post('/api/multitable/sheets/sheet-a/charts/preview-data')
+      .send({ type: 'scatter', dataSource: { xFieldId: 'fld_x', yFieldId: 'fld_y', aggregation: { function: 'count' } } })
+    expect(res.status).toBe(200)
+    expect(res.body.chartType).toBe('scatter')
+  })
+
+  it('POST /charts/preview-data rejects scatter MISSING xFieldId or yFieldId with 400', async () => {
+    for (const dataSource of [
+      { yFieldId: 'fld_y', aggregation: { function: 'count' } }, // no x
+      { xFieldId: 'fld_x', aggregation: { function: 'count' } }, // no y
+    ]) {
+      const res = await request(buildApp())
+        .post('/api/multitable/sheets/sheet-a/charts/preview-data')
+        .send({ type: 'scatter', dataSource })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('scatter requires xFieldId and yFieldId')
+    }
+  })
+
   // F4: the PERSISTED write paths (POST/PATCH /charts) must reject an unknown `type` too —
   // the `type` column is TEXT NOT NULL with no CHECK, and only preview-data validated
   // it before. An unknown type must 400 BEFORE the service is touched.
   it('POST /charts rejects an unknown chart type with 400 (never persists)', async () => {
     const createChart = vi.spyOn(service, 'createChart')
-    for (const type of ['scatter', 'radar', 'nope']) {
+    for (const type of ['radar', 'nope']) {
       const res = await request(buildApp())
         .post('/api/multitable/sheets/sheet-a/charts')
         .send({ name: 'X', type, dataSource: { aggregation: { function: 'count' } } })
@@ -229,6 +253,26 @@ describe('dashboardRouter HTTP mounting', () => {
       .expect(201)
   })
 
+  it('M3: POST /charts rejects a scatter chart missing x/y on the PERSISTED path (never persists)', async () => {
+    const createChart = vi.spyOn(service, 'createChart')
+    const res = await request(buildApp())
+      .post('/api/multitable/sheets/sheet-a/charts')
+      .send({ name: 'S', type: 'scatter', dataSource: { xFieldId: 'fld_x' } }) // y missing
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('scatter requires xFieldId and yFieldId')
+    expect(createChart).not.toHaveBeenCalled()
+  })
+
+  it('M3: POST /charts accepts a scatter chart with x/y', async () => {
+    vi.spyOn(service, 'createChart').mockResolvedValue({
+      id: 'c', sheetId: 'sheet-a', name: 'S', type: 'scatter',
+    } as any)
+    await request(buildApp())
+      .post('/api/multitable/sheets/sheet-a/charts')
+      .send({ name: 'S', type: 'scatter', dataSource: { xFieldId: 'fld_x', yFieldId: 'fld_y' } })
+      .expect(201)
+  })
+
   it('PATCH /charts/:id rejects an unknown chart type with 400 (never updates)', async () => {
     vi.spyOn(service, 'getChart').mockResolvedValue({
       id: 'chart-1', sheetId: 'sheet-a', name: 'c', type: 'bar',
@@ -237,7 +281,7 @@ describe('dashboardRouter HTTP mounting', () => {
     const updateChart = vi.spyOn(service, 'updateChart')
     const res = await request(buildApp())
       .patch('/api/multitable/sheets/sheet-a/charts/chart-1')
-      .send({ type: 'scatter' })
+      .send({ type: 'radar' })
     expect(res.status).toBe(400)
     expect(res.body.error).toBe('Invalid chart type')
     expect(updateChart).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Ladder rank-12 — the last missing chart of the Feishu S1-10 parity set (#2492 deferred scatter because the `{label,value}` contract had no x/y pair). Scatter is a **per-record projection**, not grouped aggregation.

- **Data contract** (engineering decision): `ChartDataPoint` gains optional `xValue`/`yValue`/`size` on both shapes (`value` stays for grouped types — scatter sets value=y so generic consumers degrade gracefully); `ChartDataSource` gains scatter-only `xFieldId`/`yFieldId`/`colorFieldId`/`sizeFieldId`. Single `dataPoints` array, no parallel shape.
- **Aggregation**: `computeChartData` early-branches to `computeScatterData` **before** the grouped pipeline — the grouped path stays byte-identical (proven by unchanged grouped tests + an explicit non-regression assertion). Per-record projection skips records with missing/non-numeric x or y.
- **Renderer**: `ScatterChart` registered (tree-shaken; rides the existing async echarts chunk — build-verified), both axes `type:value`, `[x,y]` pairs, size-driven symbolSize.
- **Enum** added to all 4 sites (FE/BE types, CHART_TYPES gate, type select); not in OpenAPI (S3 verified). Config UI shows x/y/color/size pickers for scatter, hides grouped controls, validates x+y required. Field-permission restriction extended to x/y/color/size.

## Review findings fixed pre-merge

Adversarial review (`/tmp/r12-scatter-review-claude-20260611.md`): **APPROVE-WITH-NITS**, all fixed:
- **M1 (major) — Color-by was a dead control**: it persisted but never rendered (no color, no legend). Now the buildOption scatter branch assigns each distinct category a stable palette color (palette is frontend-side) **and** names the category in the tooltip — the picker has a visible effect. (Per-category legend = follow-up.)
- **M2 (minor)**: empty-string x/y coerced to a misleading `0` phantom point — now treated as absent (skipped), with a test.
- **M3 (nit)**: the persisted POST/PATCH `/charts` path didn't validate scatter x/y (only preview + UI did) — extracted `assertScatterFields` and called it on both write routes; a direct API write of a scatter chart with no x/y now 400s.

## Tests

Backend chart suites 98, FE buildChartOption 46 (+ M1/M2/M3 cases), renderer + dashboard-view specs green; grouped non-regression asserted; backend tsc + vue-tsc -b clean; scatter rode the async chunk (no new eager echarts).

Ladder: rank 12 (decision-free, advanced while the rank-8/§2a.3 owner decisions are pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)