### PR TITLE
feat(multitable): UI parity batch (cell comment / progress / person chip / attachment thumbnail)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -51,13 +51,25 @@
       >{{ tag.value }}</span>
     </template>
 
+    <!-- person (dedicated type or user-link field): avatar chip + name -->
+    <template v-else-if="isPersonLink">
+      <span
+        v-for="item in personItems"
+        :key="item.id"
+        class="meta-cell-renderer__person-chip"
+        :title="item.display"
+      >
+        <span class="meta-cell-renderer__person-avatar" aria-hidden="true">{{ item.initial }}</span>
+        <span class="meta-cell-renderer__person-name">{{ item.display }}</span>
+      </span>
+    </template>
+
     <!-- link -->
     <template v-else-if="field.type === 'link'">
       <span
         v-for="item in linkItems"
         :key="item.id"
         class="meta-cell-renderer__link"
-        :class="{ 'meta-cell-renderer__link--person': isPersonLink }"
       >{{ item.display }}</span>
     </template>
 
@@ -66,14 +78,45 @@
       <MetaAttachmentList :attachments="attachmentItems" variant="compact" empty-label="" />
     </template>
 
-    <!-- currency / percent -->
-    <template v-else-if="field.type === 'currency' || field.type === 'percent'">
+    <!-- percent: inline read-only progress gauge + numeric label -->
+    <template v-else-if="field.type === 'percent'">
+      <span
+        v-if="percentGauge !== null"
+        class="meta-cell-renderer__gauge"
+        role="img"
+        :aria-label="percentGaugeAria(displayValue, isZh)"
+      >
+        <span class="meta-cell-renderer__gauge-track" aria-hidden="true">
+          <span class="meta-cell-renderer__gauge-fill" :style="{ width: `${percentGauge}%` }"></span>
+        </span>
+        <span class="meta-cell-renderer__gauge-label">{{ displayValue }}</span>
+      </span>
+      <span v-else class="meta-cell-renderer__numeric">{{ displayValue }}</span>
+    </template>
+
+    <!-- currency -->
+    <template v-else-if="field.type === 'currency'">
       <span class="meta-cell-renderer__numeric">{{ displayValue }}</span>
     </template>
 
-    <!-- rating -->
+    <!-- rating: read-only filled/empty segment display -->
     <template v-else-if="field.type === 'rating'">
-      <span class="meta-cell-renderer__rating" :title="ratingTitle">{{ displayValue }}</span>
+      <span
+        v-if="ratingGauge"
+        class="meta-cell-renderer__rating"
+        role="img"
+        :aria-label="ratingGaugeAria(ratingGauge.filled, ratingGauge.max, isZh)"
+        :title="ratingTitle"
+      >
+        <span
+          v-for="i in ratingGauge.max"
+          :key="i"
+          class="meta-cell-renderer__rating-segment"
+          :class="{ 'meta-cell-renderer__rating-segment--filled': i <= ratingGauge.filled }"
+          aria-hidden="true"
+        >{{ i <= ratingGauge.filled ? '★' : '☆' }}</span>
+      </span>
+      <span v-else class="meta-cell-renderer__rating" :title="ratingTitle">{{ displayValue }}</span>
     </template>
 
     <!-- url -->
@@ -124,6 +167,8 @@ import { useLocale } from '../../../composables/useLocale'
 import { isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
 import { isSystemFieldType } from '../../utils/system-fields'
+import { resolveRatingFieldProperty } from '../../utils/field-config'
+import { percentGaugeAria, ratingGaugeAria } from '../../utils/meta-core-labels'
 
 const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[] }>()
 const { isZh } = useLocale()
@@ -184,6 +229,47 @@ const linkItems = computed(() => {
   return [{ id: '__link_summary__', display: fallbackLabel }]
 })
 const isPersonLink = computed(() => isPersonField(props.field))
+
+function personInitial(display: string): string {
+  const trimmed = display.trim()
+  if (!trimmed) return '?'
+  return [...trimmed][0]!.toUpperCase()
+}
+
+const personItems = computed(() =>
+  linkItems.value.map((item) => ({
+    id: item.id,
+    display: item.display,
+    initial: personInitial(item.display),
+  })),
+)
+
+// percentGauge: bar fill width 0..100 for the read-only progress gauge.
+// Percent values are stored as the percent number itself (e.g. 65 → "65%"),
+// so the fill clamps the value into [0, 100]. Returns null for non-numeric
+// values so the template falls back to the plain numeric label.
+const percentGauge = computed<number | null>(() => {
+  if (props.field.type !== 'percent') return null
+  const v = props.value
+  if (v === null || v === undefined || v === '') return null
+  const num = typeof v === 'number' ? v : Number(v)
+  if (!Number.isFinite(num)) return null
+  return Math.max(0, Math.min(100, num))
+})
+
+// ratingGauge: filled-segment count and segment max for the read-only rating
+// display. Returns null for non-numeric values so the template falls back to
+// the plain star string.
+const ratingGauge = computed<{ filled: number; max: number } | null>(() => {
+  if (props.field.type !== 'rating') return null
+  const v = props.value
+  if (v === null || v === undefined || v === '') return null
+  const num = typeof v === 'number' ? v : Number(v)
+  if (!Number.isFinite(num)) return null
+  const { max } = resolveRatingFieldProperty(props.field.property)
+  const filled = Math.max(0, Math.min(max, Math.round(num)))
+  return { filled, max }
+})
 
 const attachmentIds = computed(() => {
   const v = props.value
@@ -254,10 +340,6 @@ const conditionalClass = computed(() => {
   display: inline-block; padding: 1px 6px; background: #ecf5ff;
   color: #409eff; border-radius: 3px; font-size: 11px; margin-right: 4px;
 }
-.meta-cell-renderer__link--person {
-  background: #eefbf3;
-  color: #227447;
-}
 .meta-cell-renderer__date { color: #606266; }
 .meta-cell-renderer__date-time {
   color: #475569;
@@ -279,6 +361,72 @@ const conditionalClass = computed(() => {
 .meta-cell-renderer__rating {
   color: #f5a623;
   letter-spacing: 1px;
+}
+.meta-cell-renderer__rating-segment { color: #d8dee9; }
+.meta-cell-renderer__rating-segment--filled { color: #f5a623; }
+.meta-cell-renderer__gauge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+.meta-cell-renderer__gauge-track {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 36px;
+  max-width: 96px;
+  height: 6px;
+  border-radius: 999px;
+  background: #eceff4;
+  overflow: hidden;
+}
+.meta-cell-renderer__gauge-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: #409eff;
+  transition: width 0.15s ease;
+}
+.meta-cell-renderer__gauge-label {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: #475569;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum';
+}
+.meta-cell-renderer__person-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 8px 1px 2px;
+  margin-right: 4px;
+  background: #eefbf3;
+  color: #227447;
+  border-radius: 999px;
+  font-size: 11px;
+  max-width: 100%;
+  min-width: 0;
+}
+.meta-cell-renderer__person-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #227447;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.meta-cell-renderer__person-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 .meta-cell-renderer__barcode {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -252,6 +252,19 @@ export function groupNoValue(isZh: boolean): string {
   return isZh ? '(无值)' : '(No value)'
 }
 
+// percentGaugeAria: accessible label for the read-only percent progress bar
+// in MetaCellRenderer (r13 UI parity). `text` is the already-formatted percent
+// string (e.g. "65%") — user-facing data, interpolated raw.
+export function percentGaugeAria(text: string, isZh: boolean): string {
+  return isZh ? `进度 ${text}` : `Progress ${text}`
+}
+
+// ratingGaugeAria: accessible label for the read-only rating segment display
+// in MetaCellRenderer (r13 UI parity). Both numbers are UI-derived counts.
+export function ratingGaugeAria(filled: number, max: number, isZh: boolean): string {
+  return isZh ? `评分 ${filled} / ${max}` : `Rating ${filled} of ${max}`
+}
+
 // fieldTypeLabel: stable field-type display labels. F2 — used by BOTH the
 // filter panel and the group panel so the two stay consistent (before T3A1
 // the group panel showed the raw `f.type`; reusing this helper there also

--- a/apps/web/tests/multitable-cell-visual-display.spec.ts
+++ b/apps/web/tests/multitable-cell-visual-display.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaCellRenderer, props)
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaCellRenderer percent gauge', () => {
+  it('renders an inline progress bar whose fill width tracks the percent value', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_pct', name: 'Progress', type: 'percent' },
+      value: 65,
+    })
+    await nextTick()
+
+    const fill = container.querySelector('.meta-cell-renderer__gauge-fill') as HTMLElement | null
+    expect(fill).not.toBeNull()
+    expect(fill?.style.width).toBe('65%')
+    // numeric label is preserved alongside the bar (default 1-decimal percent format)
+    expect(container.textContent).toContain('65.0%')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('clamps the bar fill width to 0..100 for out-of-range percent values', async () => {
+    const over = mount({
+      field: { id: 'fld_pct', name: 'Progress', type: 'percent' },
+      value: 140,
+    })
+    await nextTick()
+    const overFill = over.container.querySelector('.meta-cell-renderer__gauge-fill') as HTMLElement | null
+    expect(overFill?.style.width).toBe('100%')
+    over.app.unmount()
+    over.container.remove()
+
+    const under = mount({
+      field: { id: 'fld_pct', name: 'Progress', type: 'percent' },
+      value: -20,
+    })
+    await nextTick()
+    const underFill = under.container.querySelector('.meta-cell-renderer__gauge-fill') as HTMLElement | null
+    expect(underFill?.style.width).toBe('0%')
+    under.app.unmount()
+    under.container.remove()
+  })
+
+  it('does not render a gauge fill for a non-numeric percent value', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_pct', name: 'Progress', type: 'percent' },
+      value: '',
+    })
+    await nextTick()
+    expect(container.querySelector('.meta-cell-renderer__gauge-fill')).toBeNull()
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('MetaCellRenderer rating segments', () => {
+  it('renders filled and empty rating segments tracking the value and max', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_rate', name: 'Quality', type: 'rating', property: { max: 5 } },
+      value: 3,
+    })
+    await nextTick()
+
+    const segments = container.querySelectorAll('.meta-cell-renderer__rating-segment')
+    expect(segments.length).toBe(5)
+    const filled = container.querySelectorAll('.meta-cell-renderer__rating-segment--filled')
+    expect(filled.length).toBe(3)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('honors a custom rating max', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_rate', name: 'Quality', type: 'rating', property: { max: 8 } },
+      value: 6,
+    })
+    await nextTick()
+    expect(container.querySelectorAll('.meta-cell-renderer__rating-segment').length).toBe(8)
+    expect(container.querySelectorAll('.meta-cell-renderer__rating-segment--filled').length).toBe(6)
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('MetaCellRenderer person avatar chip', () => {
+  it('renders an avatar chip with an initial and name for a person-type field', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_assignee', name: 'Assignee', type: 'person' },
+      value: ['user_1'],
+      linkSummaries: [{ id: 'user_1', display: 'Jamie Park' }],
+    })
+    await nextTick()
+
+    const chip = container.querySelector('.meta-cell-renderer__person-chip') as HTMLElement | null
+    expect(chip).not.toBeNull()
+    const avatar = container.querySelector('.meta-cell-renderer__person-avatar') as HTMLElement | null
+    expect(avatar?.textContent?.trim()).toBe('J')
+    expect(container.textContent).toContain('Jamie Park')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('renders an avatar chip for a user link field (refKind=user)', async () => {
+    const { container, app } = mount({
+      field: {
+        id: 'fld_owner',
+        name: 'Owner',
+        type: 'link',
+        property: { refKind: 'user', limitSingleRecord: true },
+      },
+      value: ['user_2'],
+      linkSummaries: [{ id: 'user_2', display: 'Sofia' }],
+    })
+    await nextTick()
+
+    const avatar = container.querySelector('.meta-cell-renderer__person-avatar') as HTMLElement | null
+    expect(avatar?.textContent?.trim()).toBe('S')
+    expect(container.textContent).toContain('Sofia')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('keeps a plain link chip (no avatar) for non-person link fields', async () => {
+    const { container, app } = mount({
+      field: { id: 'fld_vendor', name: 'Vendor', type: 'link' },
+      value: ['rec_1'],
+      linkSummaries: [{ id: 'rec_1', display: 'Acme Supply' }],
+    })
+    await nextTick()
+    expect(container.querySelector('.meta-cell-renderer__person-avatar')).toBeNull()
+    expect(container.querySelector('.meta-cell-renderer__link')).not.toBeNull()
+    expect(container.textContent).toContain('Acme Supply')
+    app.unmount()
+    container.remove()
+  })
+})

--- a/apps/web/tests/multitable-grid-link-renderer.spec.ts
+++ b/apps/web/tests/multitable-grid-link-renderer.spec.ts
@@ -37,7 +37,7 @@ describe('MetaCellRenderer link rendering', () => {
     container.remove()
   })
 
-  it('uses the people style for user link fields', async () => {
+  it('renders a person avatar chip for user link fields', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
 
@@ -64,8 +64,9 @@ describe('MetaCellRenderer link rendering', () => {
     app.mount(container)
     await nextTick()
 
-    const chip = container.querySelector('.meta-cell-renderer__link') as HTMLElement | null
-    expect(chip?.classList.contains('meta-cell-renderer__link--person')).toBe(true)
+    const chip = container.querySelector('.meta-cell-renderer__person-chip') as HTMLElement | null
+    expect(chip).not.toBeNull()
+    expect(container.querySelector('.meta-cell-renderer__person-avatar')?.textContent?.trim()).toBe('J')
     expect(container.textContent).toContain('Jamie')
 
     app.unmount()


### PR DESCRIPTION
## Summary

Ladder rank-13 (trimmed to the 4 decision-free UI-only parity items; QR field + export selection split out — they carry sub-decisions). Each item was verified against current code first.

- **Per-cell comment trigger** — **already present** (MetaGridTable both grid variants emit `open-field-comments` wrapping MetaCommentAffordance; covered by existing specs). No change.
- **Progress / linear-gauge for percent & rating** — **done**: percent cells render an inline progress bar (width = clamped 0..100) + numeric label; rating cells render filled/empty star segments (tracking value + `resolveRatingFieldProperty` max). Read-only display only; empty/null/non-numeric falls back to the plain label (empty ≠ 0% — display safety). aria-labels via 2 new EN+ZH helpers.
- **Person avatar chip** — **done**: person-type cells + user link refs render a circular initial avatar + name (reusing the existing green person palette); removed the now-dead `--person` text-chip CSS. Display-only (initial from display name — `LinkedRecordSummary` carries no avatarUrl, no img lib added).
- **Attachment image thumbnail** — **already present** (MetaAttachmentList thumbnails image mimetypes via `isPreviewableImage`; non-image keeps icon+filename). No change.

## Tests (fail-first)

New `multitable-cell-visual-display.spec.ts` 8 tests written fail-first (6/8 red against origin/main — gauge fill/clamp, rating segments, person chip; 2 negative controls invariant), now 8/8. Touched-component + regression sweep: 87 + 79 + 30 green; vue-tsc -b clean. **No new dependency** (package.json + lockfile unchanged).

## Review

Adversarial review (`/tmp/r13-parity-review-claude-20260611.md`): **APPROVE** (zero findings). Independently verified: display-only gate (MetaCellRenderer is props-only, no emit/v-model in new branches), already-present claims true, component reuse (no dup), image-mimetype-gated, i18n discipline, no new dep, fail-first reproduced (6/8 red).

Ladder: rank 13 trimmed (decision-free, advanced while rank-8/§2a.3 owner decisions pend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)