### PR TITLE
feat(multitable): formula AI assist (NL→formula suggest) — M4 (final main-line AI stage)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -201,6 +201,7 @@ jobs:
             tests/integration/multitable-webhook-retry-tick.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \
             tests/integration/multitable-ai-ledger-retention.test.ts \
+            tests/integration/multitable-ai-suggest-formula.test.ts \
             --reporter=dot
 
       - name: Start core backend (background)

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -861,6 +861,17 @@ export interface AiShortcutRunData {
   model: string | null
 }
 
+export interface AiSuggestFormulaData {
+  status: 'succeeded'
+  action: 'suggest'
+  /** The proposed formula expression — the client runs it through the existing dry-run + Test flow. */
+  candidate: string
+  usage: AiShortcutUsage | null
+  estimatedCostUsd: number
+  provider: string | null
+  model: string | null
+}
+
 export interface AiUsageSummary {
   callerDayTokens: number
   callerWeekTokens: number
@@ -1216,6 +1227,19 @@ export class MultitableApiClient {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ recordId: input.recordId, fieldId: input.fieldId }),
+    })
+    return this.parseJson(res)
+  }
+
+  // NL→formula suggest (M4 / Lane B2). Field-authoring (canManageFields) gate;
+  // the prompt context is the sheet field NAMES + TYPES only (no record values
+  // server-side). Returns ONE candidate expression for the caller to validate
+  // through the existing dry-run + Test flow (no auto-persist).
+  async aiSuggestFormula(sheetId: string, input: { instruction: string }): Promise<AiSuggestFormulaData> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/suggest-formula`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instruction: input.instruction }),
     })
     return this.parseJson(res)
   }

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -173,6 +173,47 @@
               {{ diagnostic.message }}
             </div>
           </div>
+          <!-- M4 / Lane B2: NL→formula suggest. Describe → generate ONE candidate →
+               accept (copies into the expression textarea) → Test validates. -->
+          <div v-if="formulaSuggestFn" class="meta-field-mgr__field meta-field-mgr__formula-suggest" data-test="formula-suggest">
+            <span>{{ ml('field.formulaSuggest.heading') }}</span>
+            <textarea
+              v-model="formulaSuggestInstruction"
+              class="meta-field-mgr__textarea"
+              :maxlength="FORMULA_SUGGEST_MAX_INSTRUCTION_LENGTH"
+              :placeholder="ml('field.formulaSuggest.placeholder')"
+              data-test="formula-suggest-instruction"
+            ></textarea>
+            <span class="meta-field-mgr__hint">{{ ml('field.formulaSuggest.hint') }}</span>
+            <button
+              type="button"
+              class="meta-field-mgr__dryrun-btn"
+              :disabled="!formulaSuggestCanRun"
+              data-test="formula-suggest-generate"
+              @click="runFormulaSuggest"
+            >
+              {{ formulaSuggestRunning ? ml('field.formulaSuggest.generating') : ml('field.formulaSuggest.generate') }}
+            </button>
+            <div v-if="formulaSuggestError" class="meta-field-mgr__formula-diagnostic meta-field-mgr__formula-diagnostic--error" data-test="formula-suggest-error">{{ formulaSuggestError }}</div>
+            <div v-else-if="formulaSuggestCandidate" class="meta-field-mgr__dryrun-result" data-test="formula-suggest-candidate">
+              <div class="meta-field-mgr__dryrun-result-head">
+                <strong>{{ ml('field.formulaSuggest.candidateHeading') }}</strong>
+              </div>
+              <code class="meta-field-mgr__dryrun-value meta-field-mgr__formula-suggest-code" data-test="formula-suggest-candidate-code">{{ formulaSuggestCandidate }}</code>
+              <div class="meta-field-mgr__formula-suggest-actions">
+                <button type="button" class="meta-field-mgr__dryrun-btn" data-test="formula-suggest-accept" @click="acceptFormulaSuggest">
+                  {{ ml('field.formulaSuggest.accept') }}
+                </button>
+                <button type="button" class="meta-field-mgr__dryrun-btn" data-test="formula-suggest-reject" @click="rejectFormulaSuggest">
+                  {{ ml('field.formulaSuggest.reject') }}
+                </button>
+                <button type="button" class="meta-field-mgr__dryrun-btn" :disabled="!formulaSuggestCanRun" data-test="formula-suggest-regenerate" @click="runFormulaSuggest">
+                  {{ ml('field.formulaSuggest.regenerate') }}
+                </button>
+              </div>
+            </div>
+            <div v-if="formulaSuggestAccepted" class="meta-field-mgr__hint" data-test="formula-suggest-accepted">{{ ml('field.formulaSuggest.acceptedHint') }}</div>
+          </div>
           <!-- #5b dry-run: evaluate the UNSAVED expression against sample data (server response only) -->
           <div v-if="dryRunFn" class="meta-field-mgr__field meta-field-mgr__dryrun">
             <div v-if="dryRunReferencedFields.length" class="meta-field-mgr__dryrun-samples">
@@ -603,6 +644,7 @@ import {
   AI_SHORTCUT_MAX_SOURCE_FIELDS,
   AI_SHORTCUT_MAX_TARGET_LANG_LENGTH,
   fetchAiUsageSummaryWithProbeCache,
+  type AiFormulaSuggestOutcome,
   type AiShortcutPreviewOutcome,
 } from '../composables/useAiShortcut'
 import type { AiShortcutConfigInput, AiShortcutKind, AiShortcutPreviewData, AiUsageSummary } from '../api/client'
@@ -731,6 +773,11 @@ const props = defineProps<{
   aiPreviewBusy?: boolean
   // A3 §2.4: admin usage summary (403 probe is session-cached by the helper).
   aiUsageSummaryFn?: () => Promise<AiUsageSummary>
+  // M4 / Lane B2: NL→formula suggest over the inline instruction. The
+  // workbench wires this to useAiShortcut.suggestFormula so the unified
+  // in-flight guard + countdown cover this entry point too. null outcome =
+  // guarded no-op (another AI request is in flight / countdown active).
+  formulaSuggestFn?: (params: { instruction: string }) => Promise<AiFormulaSuggestOutcome | null>
 }>()
 
 const emit = defineEmits<{
@@ -966,6 +1013,79 @@ watch(() => formulaDraft.expression, () => {
   dryRunRunning.value = false
   dryRunSeq++
 })
+
+// ---- M4 / Lane B2: NL→formula suggest (describe → candidate → accept) ----
+const FORMULA_SUGGEST_MAX_INSTRUCTION_LENGTH = 500
+const formulaSuggestInstruction = ref('')
+const formulaSuggestCandidate = ref('')
+const formulaSuggestError = ref('')
+const formulaSuggestRunning = ref(false)
+// The expression value we last copied via Accept. The "accepted, run Test" hint
+// shows only while the textarea still holds exactly that — a manual edit (or a
+// reset) makes it stale automatically (no watcher-ordering hazard).
+const formulaSuggestAcceptedExpression = ref<string | null>(null)
+const formulaSuggestAccepted = computed(
+  () => formulaSuggestAcceptedExpression.value !== null && formulaDraft.expression === formulaSuggestAcceptedExpression.value,
+)
+let formulaSuggestSeq = 0
+
+const formulaSuggestCanRun = computed(() =>
+  Boolean(props.formulaSuggestFn) &&
+  formulaSuggestInstruction.value.trim().length > 0 &&
+  !formulaSuggestRunning.value &&
+  // Review F3: countdown / cross-surface in-flight → disable, like the AI preview.
+  !props.aiPreviewBusy,
+)
+
+async function runFormulaSuggest() {
+  if (!props.formulaSuggestFn || !formulaSuggestCanRun.value) return
+  const seq = ++formulaSuggestSeq
+  formulaSuggestRunning.value = true
+  formulaSuggestError.value = ''
+  formulaSuggestCandidate.value = ''
+  formulaSuggestAcceptedExpression.value = null
+  try {
+    const outcome = await props.formulaSuggestFn({ instruction: formulaSuggestInstruction.value.trim() })
+    if (seq !== formulaSuggestSeq) return
+    if (!outcome) return // unified in-flight guard refused (another AI request active)
+    if ('error' in outcome) {
+      // AI-state errors use the §2.3 copy (fall back to the raw message for unknown codes).
+      formulaSuggestError.value = aiShortcutErrorMessage(outcome.error.code, isZh.value) ?? outcome.error.message
+      return
+    }
+    formulaSuggestCandidate.value = outcome.data.candidate
+  } finally {
+    if (seq === formulaSuggestSeq) formulaSuggestRunning.value = false
+  }
+}
+
+// Accept = copy the candidate into the expression textarea (no auto-persist —
+// the user still runs Test/dry-run + Save). The expression watch clears the
+// candidate, so re-show the "accepted" hint explicitly.
+function acceptFormulaSuggest() {
+  if (!formulaSuggestCandidate.value) return
+  const accepted = formulaSuggestCandidate.value
+  formulaDraft.expression = accepted
+  formulaSuggestCandidate.value = ''
+  formulaSuggestError.value = ''
+  formulaSuggestAcceptedExpression.value = accepted
+}
+
+function rejectFormulaSuggest() {
+  formulaSuggestCandidate.value = ''
+  formulaSuggestError.value = ''
+  formulaSuggestAcceptedExpression.value = null
+}
+
+function resetFormulaSuggestState() {
+  formulaSuggestInstruction.value = ''
+  formulaSuggestCandidate.value = ''
+  formulaSuggestError.value = ''
+  formulaSuggestRunning.value = false
+  formulaSuggestAcceptedExpression.value = null
+  formulaSuggestSeq++
+}
+
 const fieldConfigSchemaChanged = computed(() =>
   Boolean(configTarget.value && configDraftType.value && displayFieldType(configTarget.value) !== configDraftType.value),
 )
@@ -1076,6 +1196,7 @@ function resetDrafts() {
   formulaFunctionSearch.value = ''
   formulaFunctionCategory.value = 'all'
   resetDryRunState()
+  resetFormulaSuggestState()
   attachmentDraft.maxFiles = 1
   attachmentDraft.acceptedMimeTypesText = ''
   currencyDraft.code = 'CNY'

--- a/apps/web/src/multitable/composables/useAiShortcut.ts
+++ b/apps/web/src/multitable/composables/useAiShortcut.ts
@@ -40,6 +40,7 @@ import type {
   AiShortcutPreviewData,
   AiShortcutRunData,
   AiShortcutUsage,
+  AiSuggestFormulaData,
   AiUsageSummary,
 } from '../api/client'
 import type { PatchResult } from '../types'
@@ -105,12 +106,18 @@ export type AiShortcutPreviewOutcome =
   | { data: AiShortcutPreviewData }
   | { error: AiShortcutUiError }
 
+/** M4 / Lane B2: NL→formula suggest outcome (mirrors the preview outcome shape). */
+export type AiFormulaSuggestOutcome =
+  | { data: AiSuggestFormulaData }
+  | { error: AiShortcutUiError }
+
 interface AiShortcutClientLike {
   aiShortcutPreview(
     sheetId: string,
     input: { recordId: string; fieldId?: string; config?: AiShortcutConfigInput },
   ): Promise<AiShortcutPreviewData>
   aiShortcutRun(sheetId: string, input: { recordId: string; fieldId: string }): Promise<AiShortcutRunData>
+  aiSuggestFormula(sheetId: string, input: { instruction: string }): Promise<AiSuggestFormulaData>
 }
 
 export interface UseAiShortcutOptions {
@@ -284,6 +291,33 @@ export function useAiShortcut(opts: UseAiShortcutOptions) {
     }
   }
 
+  /**
+   * Field-manager path (M4 / Lane B2): NL→formula suggest over the inline
+   * instruction (real call, consumes quota — sheet-scoped, no record). Outcome
+   * is returned inline so the manager renders the candidate/errors next to the
+   * description; the shared pending guard + countdown still apply. null =
+   * guarded no-op. Reuses the 'preview' kind for the unified in-flight guard
+   * (suggest has no record/field of its own).
+   */
+  async function suggestFormula(
+    sheetId: string,
+    instruction: string,
+  ): Promise<AiFormulaSuggestOutcome | null> {
+    if (!begin('preview', '', null)) return null
+    try {
+      const data = await opts.client.aiSuggestFormula(sheetId, { instruction })
+      return { data }
+    } catch (err) {
+      const mapped = mapAiShortcutError(err)
+      if (mapped.code === 'RATE_LIMITED' && typeof mapped.retryAfterMs === 'number' && mapped.retryAfterMs > 0) {
+        startCountdown(mapped.retryAfterMs)
+      }
+      return { error: mapped }
+    } finally {
+      state.pending = null
+    }
+  }
+
   /** Run the persisted config and merge the echo through applyPatchResult. */
   async function run(recordId: string, fieldId: string): Promise<void> {
     if (!begin('run', recordId, fieldId)) return
@@ -339,5 +373,5 @@ export function useAiShortcut(opts: UseAiShortcutOptions) {
     })
   }
 
-  return { state, busy, preview, previewWithConfig, run, clear }
+  return { state, busy, preview, previewWithConfig, suggestFormula, run, clear }
 }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -31,6 +31,12 @@ export type MetaManagerLabelKey =
   | 'field.formulaDryRun.test' | 'field.formulaDryRun.testWithRecord' | 'field.formulaDryRun.recordHint' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
   | 'field.formulaDryRun.resultHeading' | 'field.formulaDryRun.errorHeading' | 'field.formulaDryRun.invalidNumber'
   | 'field.formulaDryRun.forbidden' | 'field.formulaDryRun.tooLarge' | 'field.formulaDryRun.requestFailed'
+  // --- M4 / Lane B2: NL→formula AI suggest ---
+  | 'field.formulaSuggest.heading' | 'field.formulaSuggest.hint'
+  | 'field.formulaSuggest.placeholder' | 'field.formulaSuggest.generate'
+  | 'field.formulaSuggest.generating' | 'field.formulaSuggest.candidateHeading'
+  | 'field.formulaSuggest.accept' | 'field.formulaSuggest.reject'
+  | 'field.formulaSuggest.regenerate' | 'field.formulaSuggest.acceptedHint'
   | 'field.allCategories' | 'field.noMatchingFunctions'
   | 'field.maxFiles' | 'field.acceptedMimeTypes'
   | 'field.decimals' | 'field.preserve' | 'field.unit'
@@ -184,6 +190,18 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.formulaDryRun.forbidden': { en: 'You cannot manage fields on this sheet', zh: '你没有管理该表字段的权限' },
   'field.formulaDryRun.tooLarge': { en: 'Expression is too large or complex to test', zh: '表达式过大或过于复杂，无法试算' },
   'field.formulaDryRun.requestFailed': { en: 'Dry-run request failed', zh: '试算请求失败' },
+  // M4 / Lane B2: describe a formula in words → AI proposes ONE candidate you
+  // accept manually (then Test/dry-run validates it). No auto-persist.
+  'field.formulaSuggest.heading': { en: 'Describe the formula (AI)', zh: '用自然语言描述公式（AI）' },
+  'field.formulaSuggest.hint': { en: 'A real AI request consuming quota; the proposal is validated with Test before you keep it.', zh: '这是会消耗配额的真实 AI 请求；接受后请用“试算”校验再保存。' },
+  'field.formulaSuggest.placeholder': { en: 'e.g. unit price times one plus tax rate', zh: '例如：单价乘以（1 加税率）' },
+  'field.formulaSuggest.generate': { en: 'Generate formula', zh: '生成公式' },
+  'field.formulaSuggest.generating': { en: 'Generating…', zh: '生成中…' },
+  'field.formulaSuggest.candidateHeading': { en: 'Suggested expression', zh: '建议表达式' },
+  'field.formulaSuggest.accept': { en: 'Accept', zh: '接受' },
+  'field.formulaSuggest.reject': { en: 'Reject', zh: '拒绝' },
+  'field.formulaSuggest.regenerate': { en: 'Regenerate', zh: '重新生成' },
+  'field.formulaSuggest.acceptedHint': { en: 'Copied to the expression above — run Test to validate it.', zh: '已填入上方表达式——请运行“试算”校验。' },
   'field.formulaSearchPlaceholder': { en: 'Search SUM, IF, %, ^, &...', zh: '搜索 SUM、IF、%、^、&...' },
   'field.allCategories': { en: 'All categories', zh: '全部分类' },
   'field.noMatchingFunctions': { en: 'No matching functions.', zh: '没有匹配的函数。' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -363,6 +363,7 @@
       :ai-preview-fn="aiPreviewFn"
       :ai-preview-busy="aiShortcutBusy"
       :ai-usage-summary-fn="aiUsageSummaryFn"
+      :formula-suggest-fn="formulaSuggestFn"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -609,6 +610,10 @@ function onGridAiRun(recordId: string, field: MetaField) {
 const aiPreviewFn = (params: { recordId: string; config: AiShortcutConfigInput }) =>
   aiShortcut.previewWithConfig(params.recordId, params.config)
 const aiUsageSummaryFn = () => workbench.client.aiUsageSummary()
+// M4 / Lane B2: NL→formula suggest routes through the SAME composable guard
+// (sheet-scoped; the unified pending/countdown covers this entry point too).
+const formulaSuggestFn = (params: { instruction: string }) =>
+  aiShortcut.suggestFormula(workbench.activeSheetId.value, params.instruction)
 
 const showComments = ref(false)
 const selectedCommentFieldId = ref<string | null>(null)

--- a/apps/web/tests/multitable-formula-suggest-field-manager.spec.ts
+++ b/apps/web/tests/multitable-formula-suggest-field-manager.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * M4 / Lane B2 — MetaFieldManager NL→formula suggest section (matrix leg
+ * M4-T9): describe → generate → candidate → accept fills the expression
+ * textarea → Test (dry-run) validates; blocked/quota state UX.
+ *
+ * The suggest fn is injected as a prop (dryRunFn/aiPreviewFn precedent); the
+ * spec asserts the wire shape and the accept→textarea copy, never a real call.
+ */
+import { createApp, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import type { AiFormulaSuggestOutcome } from '../src/multitable/composables/useAiShortcut'
+import type { DryRunResult } from '../src/multitable/api/client'
+
+type SuggestFn = (params: { instruction: string }) => Promise<AiFormulaSuggestOutcome | null>
+
+function candidate(text: string): AiFormulaSuggestOutcome {
+  return {
+    data: {
+      status: 'succeeded',
+      action: 'suggest',
+      candidate: text,
+      usage: { promptTokens: 14, completionTokens: 9 },
+      estimatedCostUsd: 0.0005,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    },
+  }
+}
+
+async function mountFormulaConfig(opts: {
+  formulaSuggestFn?: SuggestFn
+  dryRunFn?: (p: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) => Promise<DryRunResult>
+  aiPreviewBusy?: boolean
+} = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaFieldManager, {
+        visible: true,
+        sheetId: 'sheet_1',
+        sheets: [],
+        // formula field kept LAST so the last Configure button always targets it
+        fields: [
+          { id: 'fld_price', name: 'Unit Price', type: 'number' },
+          { id: 'fld_tax', name: 'Tax Rate', type: 'percent' },
+          { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '' } },
+        ],
+        ...(opts.formulaSuggestFn ? { formulaSuggestFn: opts.formulaSuggestFn } : {}),
+        ...(opts.dryRunFn ? { dryRunFn: opts.dryRunFn } : {}),
+        ...(opts.aiPreviewBusy !== undefined ? { aiPreviewBusy: opts.aiPreviewBusy } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  await nextTick()
+  const configs = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+  configs[configs.length - 1]?.click() // the formula field
+  await nextTick()
+  return { container, app }
+}
+
+const q = <T extends HTMLElement = HTMLElement>(c: HTMLElement, sel: string) => c.querySelector(sel) as T | null
+function setInstruction(c: HTMLElement, value: string) {
+  const ta = q<HTMLTextAreaElement>(c, '[data-test="formula-suggest-instruction"]')!
+  ta.value = value
+  ta.dispatchEvent(new Event('input'))
+}
+async function flush() { for (let i = 0; i < 6; i++) { await Promise.resolve(); await nextTick() } }
+
+afterEach(() => { useLocale().setLocale('en'); document.body.innerHTML = ''; vi.restoreAllMocks() })
+
+describe('MetaFieldManager NL→formula suggest (M4)', () => {
+  it('the section renders only when a formulaSuggestFn is wired', async () => {
+    const { container: without } = await mountFormulaConfig()
+    expect(q(without, '[data-test="formula-suggest"]')).toBeNull()
+
+    const { container: withFn } = await mountFormulaConfig({ formulaSuggestFn: vi.fn() })
+    expect(q(withFn, '[data-test="formula-suggest"]')).not.toBeNull()
+  })
+
+  it('M4-T9: describe → generate → candidate → accept fills the expression textarea', async () => {
+    const suggestFn = vi.fn<Parameters<SuggestFn>, ReturnType<SuggestFn>>(async () => candidate('={fld_price}*(1+{fld_tax})'))
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: suggestFn })
+
+    // Generate is disabled with an empty instruction.
+    const generate = q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!
+    expect(generate.disabled).toBe(true)
+
+    setInstruction(container, 'unit price times one plus tax')
+    await nextTick()
+    expect(generate.disabled).toBe(false)
+    generate.click()
+    await flush()
+
+    // The fn was called with the trimmed instruction (and NOTHING else — no
+    // record id, no values: data minimization is server-side, the wire is just
+    // the instruction).
+    expect(suggestFn).toHaveBeenCalledTimes(1)
+    expect(suggestFn.mock.calls[0][0]).toEqual({ instruction: 'unit price times one plus tax' })
+
+    const code = q(container, '[data-test="formula-suggest-candidate-code"]')!
+    expect(code.textContent).toBe('={fld_price}*(1+{fld_tax})')
+
+    // Accept copies the candidate into the expression textarea (no auto-persist).
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-accept"]')!.click()
+    await nextTick()
+    const expression = q<HTMLTextAreaElement>(container, '.meta-field-mgr__textarea')!
+    expect(expression.value).toBe('={fld_price}*(1+{fld_tax})')
+    // Candidate block is gone; the "run Test" hint appears.
+    expect(q(container, '[data-test="formula-suggest-candidate"]')).toBeNull()
+    expect(q(container, '[data-test="formula-suggest-accepted"]')).not.toBeNull()
+  })
+
+  it('M4-T9: an accepted candidate validates through the existing Test (dry-run) flow', async () => {
+    const suggestFn = vi.fn<Parameters<SuggestFn>, ReturnType<SuggestFn>>(async () => candidate('={fld_price}*2'))
+    const dryRunFn = vi.fn(async () => ({
+      success: true, result: 84, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [],
+    } satisfies DryRunResult))
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: suggestFn, dryRunFn })
+
+    setInstruction(container, 'price doubled')
+    await nextTick()
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!.click()
+    await flush()
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-accept"]')!.click()
+    await nextTick()
+
+    // The accepted expression flows into the dry-run/Test button — click it.
+    const testBtn = q<HTMLButtonElement>(container, '.meta-field-mgr__dryrun-btn')
+    // first dryrun button in the dry-run block: re-query within the dryrun zone
+    const dryrunZone = q(container, '.meta-field-mgr__dryrun')!
+    ;(dryrunZone.querySelector('.meta-field-mgr__dryrun-btn') as HTMLButtonElement).click()
+    await flush()
+
+    expect(dryRunFn).toHaveBeenCalledTimes(1)
+    expect(dryRunFn.mock.calls[0][0].expression).toBe('={fld_price}*2')
+    expect(testBtn).not.toBeNull()
+  })
+
+  it('M4-T9: reject clears the candidate without touching the expression', async () => {
+    const suggestFn = vi.fn<Parameters<SuggestFn>, ReturnType<SuggestFn>>(async () => candidate('=BAD()'))
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: suggestFn })
+    setInstruction(container, 'something')
+    await nextTick()
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!.click()
+    await flush()
+    expect(q(container, '[data-test="formula-suggest-candidate"]')).not.toBeNull()
+
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-reject"]')!.click()
+    await nextTick()
+    expect(q(container, '[data-test="formula-suggest-candidate"]')).toBeNull()
+    expect(q<HTMLTextAreaElement>(container, '.meta-field-mgr__textarea')!.value).toBe('')
+  })
+
+  it('M4-T9: an AI-state error (blocked/quota) renders localized copy, never the raw code', async () => {
+    const suggestFn = vi.fn<Parameters<SuggestFn>, ReturnType<SuggestFn>>(async () => ({
+      error: { code: 'AI_QUOTA_EXHAUSTED', message: 'AI usage quota exhausted (user_daily_tokens).' },
+    }))
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: suggestFn })
+    setInstruction(container, 'price times tax')
+    await nextTick()
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!.click()
+    await flush()
+
+    const err = q(container, '[data-test="formula-suggest-error"]')!
+    expect(err).not.toBeNull()
+    expect(err.textContent).not.toContain('AI_QUOTA_EXHAUSTED') // localized, not the raw code
+    expect(err.textContent?.length).toBeGreaterThan(0)
+    expect(q(container, '[data-test="formula-suggest-candidate"]')).toBeNull()
+  })
+
+  it('M4-T9: a null outcome (unified in-flight guard refused) is a no-op, not an error', async () => {
+    const suggestFn = vi.fn<Parameters<SuggestFn>, ReturnType<SuggestFn>>(async () => null)
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: suggestFn })
+    setInstruction(container, 'price times tax')
+    await nextTick()
+    q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!.click()
+    await flush()
+
+    expect(suggestFn).toHaveBeenCalledTimes(1)
+    expect(q(container, '[data-test="formula-suggest-error"]')).toBeNull()
+    expect(q(container, '[data-test="formula-suggest-candidate"]')).toBeNull()
+  })
+
+  it('M4-T9: aiPreviewBusy (cross-surface in-flight / countdown) disables Generate', async () => {
+    const { container } = await mountFormulaConfig({ formulaSuggestFn: vi.fn(), aiPreviewBusy: true })
+    setInstruction(container, 'price times tax')
+    await nextTick()
+    expect(q<HTMLButtonElement>(container, '[data-test="formula-suggest-generate"]')!.disabled).toBe(true)
+  })
+})

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -50,7 +50,8 @@ import { normalizeJson } from '../multitable/field-codecs'
 import { poolManager } from '../integration/db/connection-pool'
 import { eventBus } from '../integration/events/event-bus'
 import { createRateLimiter } from '../middleware/rate-limiter'
-import { ensureRecordWriteAllowed } from '../multitable/permission-service'
+import { ensureRecordWriteAllowed, resolveSheetCapabilities } from '../multitable/permission-service'
+import { loadFieldsForSheet } from '../multitable/loaders'
 
 /**
  * Multitable AI routes — A1 readiness (M1b) + A2 shortcut preview/run (M2).
@@ -103,7 +104,8 @@ type PoolLike = ConnectionPool & { query: QueryFn }
 interface ShortcutRequestContext {
   pool: PoolLike
   sheetId: string
-  recordId: string
+  /** null for sheet-scoped attempts (M4 suggest: NL→formula is field-authoring, not a record read). */
+  recordId: string | null
   fieldId: string | null
   action: AiUsageAction
   userId: string
@@ -639,7 +641,112 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
     }
   })
 
+  /**
+   * M4 / Lane B2 — NL→formula suggest (INTERNAL, not in OpenAPI). The user
+   * describes a formula in natural language; the model proposes ONE candidate
+   * expression which the client then validates through the EXISTING zero-cost
+   * `POST /formula/dry-run` + Test flow (no auto-persist — the user accepts
+   * manually). Design lock:
+   * docs/development/multitable-ai-formula-assist-m4-design-20260611.md.
+   *
+   * RBAC (§1.4, 修正二): `canManageFields` — formula authoring is a SHEET-LEVEL
+   * field operation, NOT record-level (so NOT requireRecordReadable/
+   * canEditRecord). Posture matches A2: per-route guard, not in OpenAPI.
+   *
+   * Data minimization (§1.2): the prompt context is the sheet field list as
+   * NAMES + TYPES ONLY — record values NEVER enter the prompt (no data[]). The
+   * assembled prompt still passes the SAME A2 unsafe_input redactString gate
+   * (secret-shaped field names / instruction → 422), and the attempt rides the
+   * SHARED reserve-then-settle pipeline (sheet-scoped: record_id/field_id NULL,
+   * action=suggest). Status mapping reuses A2 (blocked/rate_limited/
+   * quota_exhausted/unsafe_input/provider_error).
+   */
+  router.post('/sheets/:sheetId/ai/suggest-formula', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const schema = z.object({
+      instruction: z.string().min(1).max(SUGGEST_FORMULA_MAX_INSTRUCTION_LENGTH),
+    })
+    const parsed = schema.safeParse(req.body)
+    if (!sheetId || !parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: !sheetId ? 'sheetId is required' : parsed.error?.message } })
+    }
+    const instruction = parsed.data.instruction.trim()
+    if (!instruction) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'instruction is required' } })
+    }
+
+    try {
+      const pool = poolManager.get() as unknown as PoolLike
+      const query = pool.query.bind(pool) as QueryFn
+
+      // Field-authoring gate (sheet-scoped): resolveSheetCapabilities yields the
+      // SAME canManageFields primitive the formula field write/dry-run paths use.
+      const { access, capabilities } = await resolveSheetCapabilities(req, query, sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } })
+      }
+      if (!capabilities.canManageFields) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'You cannot manage fields on this sheet' } })
+      }
+
+      // Schema metadata only — NAMES + TYPES, no record `data[]` (§1.2). Same
+      // {id,type}-style column-metadata posture as the dry-run engine.
+      const fields = await loadFieldsForSheet(query as AiUsageQueryFn, sheetId)
+      const prompt = buildFormulaSuggestPrompt(instruction, fields)
+
+      await executeShortcut(
+        req,
+        res,
+        { pool, sheetId, recordId: null, fieldId: null, action: 'suggest', userId: access.userId },
+        prompt,
+        // The reservation is already settled to 'succeeded' with actual usage;
+        // suggest only ships the candidate (no write, no auto-persist — the
+        // client runs it through the existing /formula/dry-run + Test flow).
+        async (result) => {
+          res.json({
+            ok: true,
+            data: {
+              status: 'succeeded',
+              action: 'suggest',
+              candidate: result.text ?? '',
+              usage: result.usage,
+              estimatedCostUsd: result.estimatedCostUsd,
+              provider: result.provider,
+              model: result.model,
+            },
+          })
+        },
+      )
+    } catch (err) {
+      console.error('[multitable-ai] suggest-formula failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to suggest formula' } })
+    }
+  })
+
   return router
+}
+
+/** M4 §1.2: NL description length cap (mirrors the A2 instruction cap surface). */
+export const SUGGEST_FORMULA_MAX_INSTRUCTION_LENGTH = 500
+
+/**
+ * Assemble the NL→formula suggest prompt from the sheet schema (M4 §1.2). The
+ * context is the field list as NAME + TYPE ONLY — record values are NEVER
+ * included (no `data[]`), so no per-record read happens on this path. The
+ * `{fldId}`-reference convention is surfaced so the model proposes an
+ * expression the existing dry-run engine can parse.
+ */
+export function buildFormulaSuggestPrompt(instruction: string, fields: { id: string; name: string; type: string }[]): string {
+  const fieldLines = fields.map((field) => `- ${field.name} (id: ${field.id}, type: ${field.type})`).join('\n')
+  return [
+    'You are a formula assistant for a multidimensional table. Propose ONE formula expression that fulfils the user request.',
+    'Reference fields by their id wrapped in braces, e.g. {fld_price}. Return ONLY the formula expression, no prose, no code fences.',
+    '',
+    'Available fields (name, id, type — no values are provided):',
+    fieldLines || '- (no fields)',
+    '',
+    `User request: ${instruction}`,
+  ].join('\n')
 }
 
 function resolvePersistedShortcutConfig(

--- a/packages/core-backend/src/services/ai-usage-ledger.ts
+++ b/packages/core-backend/src/services/ai-usage-ledger.ts
@@ -43,7 +43,13 @@ export const AI_USAGE_LEDGER_TABLE = 'multitable_ai_usage_ledger'
 /** Q-4 (instance daily USD) aggregation/lock subject. */
 export const AI_USAGE_INSTANCE_SUBJECT_KEY = '__instance__'
 
-export type AiUsageAction = 'preview' | 'run'
+/**
+ * `suggest` (M4 / Lane B2): NL→formula suggestion. Type-only addition — a
+ * suggest row is SHEET-SCOPED (record_id/field_id NULL, both already nullable
+ * per migration zzzz20260611090000); reserve/settle/quota SUM never filter by
+ * scope so the windows are byte-identical to preview/run accounting.
+ */
+export type AiUsageAction = 'preview' | 'run' | 'suggest'
 
 export type AiUsageLedgerStatus =
   | 'succeeded'

--- a/packages/core-backend/tests/integration/multitable-ai-suggest-formula.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-suggest-formula.test.ts
@@ -1,0 +1,218 @@
+/**
+ * M4 / Lane B2 — NL→formula suggest, REAL-DB suite (design §3: M4-T3 ledger
+ * round-trip, M4-T8 quota non-interference,
+ * docs/development/multitable-ai-formula-assist-m4-design-20260611.md).
+ *
+ * The ledger insert/settle path is NOT mocked: a suggest attempt must land a
+ * SHEET-SCOPED row (record_id/field_id NULL, action=suggest) and that row must
+ * count in the SAME quota SUM as preview/run — i.e. it neither escapes the
+ * window nor corrupts the existing accounting. Provider HTTP is NEVER real —
+ * fetchFn is injected at router construction (the production seam).
+ *
+ * Wired into .github/workflows/plugin-tests.yml multitable real-DB explicit list.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { createMultitableAiRoutes } from '../../src/routes/multitable-ai'
+import { AI_USAGE_LEDGER_TABLE, sumAiUsageWindows, type AiUsageQueryFn } from '../../src/services/ai-usage-ledger'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_m4_${TS}`
+const SHEET_ID = `sheet_m4_${TS}`
+const FLD_PRICE = `fld_m4_price_${TS}`
+const FLD_TAX = `fld_m4_tax_${TS}`
+
+const USER_SUGGEST = `u_m4_suggest_${TS}`
+const USER_QUOTA = `u_m4_quota_${TS}`
+
+const API_KEY_SENTINEL = `sk-${'m4realdbleak'.repeat(2)}`
+const RECORD_VALUE_SENTINEL = `record-value-must-not-leak-${TS}`
+
+const AI_ENV_KEYS = [
+  'MULTITABLE_AI_ENABLED',
+  'MULTITABLE_AI_PROVIDER',
+  'MULTITABLE_AI_API_KEY',
+  'MULTITABLE_AI_BASE_URL',
+  'MULTITABLE_AI_MODEL',
+  'MULTITABLE_AI_REQUEST_TIMEOUT_MS',
+  'MULTITABLE_AI_MAX_OUTPUT_TOKENS',
+  'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_BURST_RPM',
+  'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP',
+  'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS',
+] as const
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = { id: USER_SUGGEST, roles: ['member'], perms: ['multitable:write'] }
+let stubUsage = { input_tokens: 18, output_tokens: 7 }
+let lastOutboundBody = ''
+let fetchCallCount = 0
+const savedEnv = new Map<string, string | undefined>()
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const fetchStub = (async (_url: unknown, init?: { body?: unknown }) => {
+  fetchCallCount += 1
+  lastOutboundBody = String(init?.body ?? '')
+  return new Response(
+    JSON.stringify({ content: [{ type: 'text', text: '={fld_price}*(1+{fld_tax})' }], usage: { ...stubUsage } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  )
+}) as typeof fetch
+
+const suggestReq = (instruction: string) =>
+  request(app).post(`/api/multitable/sheets/${SHEET_ID}/ai/suggest-formula`).send({ instruction })
+
+const ledgerRows = async (userId: string) => {
+  const res = await q(
+    `SELECT action, status, field_id, record_id, prompt_tokens, completion_tokens FROM ${AI_USAGE_LEDGER_TABLE} WHERE user_id = $1 ORDER BY occurred_at ASC`,
+    [userId],
+  )
+  return res.rows as Array<{ action: string; status: string; field_id: string | null; record_id: string | null; prompt_tokens: number; completion_tokens: number }>
+}
+
+describeIfDatabase('M4 suggest-formula (real DB)', () => {
+  beforeAll(async () => {
+    for (const key of AI_ENV_KEYS) {
+      savedEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    process.env.MULTITABLE_AI_ENABLED = '1'
+    process.env.MULTITABLE_AI_PROVIDER = 'anthropic'
+    process.env.MULTITABLE_AI_API_KEY = API_KEY_SENTINEL
+    process.env.MULTITABLE_AI_MODEL = 'claude-sonnet-4-6'
+    process.env.MULTITABLE_AI_CONFIRM_LIVE_REQUESTS = '1'
+
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = currentUser
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+    app.use('/api/multitable', createMultitableAiRoutes({ fetchFn: fetchStub }))
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'M4 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'M4 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_PRICE, SHEET_ID, 'Unit Price', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_TAX, SHEET_ID, 'Tax Rate', 'percent', '{}', 2])
+    // A record exists on the sheet with a sentinel value — proves the suggest
+    // path never reads records (no value can reach the prompt).
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+      `rec_m4_${TS}`,
+      SHEET_ID,
+      JSON.stringify({ [FLD_PRICE]: RECORD_VALUE_SENTINEL }),
+    ])
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM ${AI_USAGE_LEDGER_TABLE} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    for (const key of AI_ENV_KEYS) {
+      const value = savedEnv.get(key)
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('M4-T3: suggest lands a sheet-scoped ledger row (action=suggest, record/field NULL); prompt has names+types, no record values', async () => {
+    currentUser = { id: USER_SUGGEST, roles: ['member'], perms: ['multitable:write'] }
+    stubUsage = { input_tokens: 18, output_tokens: 7 }
+
+    const res = await suggestReq('unit price times one plus tax')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.status).toBe('succeeded')
+    expect(res.body.data.action).toBe('suggest')
+    expect(res.body.data.candidate).toBe('={fld_price}*(1+{fld_tax})')
+    expect(res.body.data.usage).toEqual({ promptTokens: 18, completionTokens: 7 })
+    expect(JSON.stringify(res.body)).not.toContain(API_KEY_SENTINEL)
+
+    // Prompt = field NAMES + TYPES only; record VALUES never enter it.
+    expect(lastOutboundBody).toContain('Unit Price')
+    expect(lastOutboundBody).toContain('Tax Rate')
+    expect(lastOutboundBody).toContain('number')
+    expect(lastOutboundBody).not.toContain(RECORD_VALUE_SENTINEL)
+
+    const rows = await ledgerRows(USER_SUGGEST)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].action).toBe('suggest')
+    expect(rows[0].status).toBe('succeeded')
+    expect(rows[0].field_id).toBeNull() // sheet-scoped
+    expect(rows[0].record_id).toBeNull()
+    expect(Number(rows[0].prompt_tokens)).toBe(18)
+    expect(Number(rows[0].completion_tokens)).toBe(7)
+  })
+
+  test('M4-T8: a suggest (NULL-scope) row counts in the SAME quota SUM as preview/run — no escape, no corruption', async () => {
+    currentUser = { id: USER_QUOTA, roles: ['member'], perms: ['multitable:write'] }
+    const query = poolManager.get().query.bind(poolManager.get()) as AiUsageQueryFn
+
+    const before = await sumAiUsageWindows(query, USER_QUOTA)
+    expect(before.userDailyTokens).toBe(0)
+    expect(before.userWeeklyTokens).toBe(0)
+
+    stubUsage = { input_tokens: 40, output_tokens: 10 }
+    const res = await suggestReq('grand total across the sheet')
+    expect(res.status).toBe(200)
+
+    // The NULL-scope suggest row is aggregated into the user's daily/weekly
+    // token windows EXACTLY like a preview/run row would be (SUM is not scope-filtered).
+    const after = await sumAiUsageWindows(query, USER_QUOTA)
+    expect(after.userDailyTokens).toBe(before.userDailyTokens + 50)
+    expect(after.userWeeklyTokens).toBe(before.userWeeklyTokens + 50)
+
+    // And the row really is the suggest, NULL-scope row.
+    const rows = await ledgerRows(USER_QUOTA)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].action).toBe('suggest')
+    expect(rows[0].field_id).toBeNull()
+    expect(rows[0].record_id).toBeNull()
+  })
+
+  test('M4-T8: a daily token cap reached via a suggest row blocks the NEXT suggest (quota interference works both ways)', async () => {
+    // Fresh subject so the window starts empty. The readiness resolver floors
+    // the daily cap at 1000 (min), so the first suggest consumes EXACTLY 1000.
+    const capUser = `u_m4_cap_${TS}`
+    currentUser = { id: capUser, roles: ['member'], perms: ['multitable:write'] }
+    process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = '1000'
+    stubUsage = { input_tokens: 600, output_tokens: 400 } // exactly the cap
+
+    const first = await suggestReq('first formula')
+    expect(first.status).toBe(200)
+    const callsAfterFirst = fetchCallCount
+
+    // The suggest row (NULL scope) is counted in the daily SUM → the next
+    // suggest reserve sees the window exhausted and refuses BEFORE any call.
+    const second = await suggestReq('another formula please')
+    expect(second.status).toBe(429)
+    expect(second.body.status).toBe('quota_exhausted')
+    expect(fetchCallCount).toBe(callsAfterFirst) // never reached the provider
+
+    const rows = await ledgerRows(capUser)
+    expect(rows.map((row) => row.status)).toEqual(['succeeded', 'quota_exhausted'])
+    expect(rows.every((row) => row.action === 'suggest')).toBe(true)
+
+    delete process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP
+  })
+
+  test('M4-T2: canManageFields gate — a read-only actor is 403', async () => {
+    currentUser = { id: `u_m4_reader_${TS}`, roles: ['member'], perms: ['multitable:read'] }
+    const res = await suggestReq('price times tax')
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/core-backend/tests/unit/ai-usage-ledger.test.ts
+++ b/packages/core-backend/tests/unit/ai-usage-ledger.test.ts
@@ -75,6 +75,27 @@ describe('insertAiUsageLedgerEntry', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0].params).toContain('blocked')
   })
+
+  it('M4-T10: a sheet-scoped suggest row inserts action=suggest with NULL field_id/record_id', async () => {
+    const { calls, query } = captureQuery()
+    await insertAiUsageLedgerEntry(query, {
+      subjectKey: 'user-1',
+      userId: 'user-1',
+      sheetId: 'sheet-1',
+      // No fieldId/recordId — the NL→formula suggest is sheet-scoped (§1.1).
+      action: 'suggest',
+      promptTokens: 14,
+      completionTokens: 9,
+      estimatedCostUsd: 0.0005,
+      status: 'succeeded',
+    })
+    expect(calls).toHaveLength(1)
+    // INSERT param order: (id,subject_key,user_id,sheet_id,field_id,record_id,action,…)
+    const params = calls[0].params
+    expect(params[4]).toBeNull() // field_id NULL
+    expect(params[5]).toBeNull() // record_id NULL
+    expect(params[6]).toBe('suggest') // action
+  })
 })
 
 describe('checkAiUsageQuota', () => {

--- a/packages/core-backend/tests/unit/multitable-ai-suggest-formula-routes.test.ts
+++ b/packages/core-backend/tests/unit/multitable-ai-suggest-formula-routes.test.ts
@@ -1,0 +1,311 @@
+/**
+ * M4 / Lane B2 — NL→formula suggest route matrix legs with the REAL router and
+ * a mock pool (design §3: M4-T1 / T2 / T3 / T5 / T6 / T7 / T10). The real-DB
+ * ledger row + quota non-interference (M4-T8) live in
+ * tests/integration/multitable-ai-suggest-formula.test.ts.
+ *
+ * HARD RULES exercised here:
+ *   - fetchFn is injected at CONSTRUCTION — blocked/unsafe/rate-limited requests
+ *     make ZERO outbound provider calls.
+ *   - RECORD VALUES NEVER enter the prompt (M4-T7 leak sentinel): the spy
+ *     captures the outbound request body and asserts it carries field
+ *     names+types but NO record data values.
+ *   - canManageFields gate (NOT requireRecordReadable/canEditRecord).
+ *   - suggest rows are SHEET-SCOPED — record_id/field_id NULL, action=suggest.
+ *   - the API key never appears in responses or ledger params.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+
+const SHEET_ID = 'sheet_ai_suggest'
+const FLD_PRICE = 'fld_price'
+const FLD_TAX = 'fld_tax'
+const FLD_NAME = 'fld_name'
+
+const API_KEY_SENTINEL = `sk-${'suggestleak1'.repeat(3)}`
+const RECORD_VALUE_SENTINEL = 'do-not-leak-record-value-9173'
+const UNSAFE_INSTRUCTION = `use Bearer ${'b'.repeat(24)} to fetch the total`
+
+const AI_ENV_KEYS = [
+  'MULTITABLE_AI_ENABLED',
+  'MULTITABLE_AI_PROVIDER',
+  'MULTITABLE_AI_API_KEY',
+  'MULTITABLE_AI_BASE_URL',
+  'MULTITABLE_AI_MODEL',
+  'MULTITABLE_AI_REQUEST_TIMEOUT_MS',
+  'MULTITABLE_AI_MAX_OUTPUT_TOKENS',
+  'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_BURST_RPM',
+  'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP',
+  'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS',
+] as const
+
+type QueryResult = { rows: any[]; rowCount?: number }
+
+// Records that DO exist on the sheet — used only to prove their VALUES never
+// reach the prompt (the suggest path must not read any record).
+const FIELDS = [
+  { id: FLD_PRICE, name: 'Unit Price', type: 'number', property: {}, order: 1 },
+  { id: FLD_TAX, name: 'Tax Rate', type: 'percent', property: {}, order: 2 },
+  { id: FLD_NAME, name: 'Product', type: 'string', property: {}, order: 3 },
+]
+
+let currentUser: { id: string; roles: string[]; perms: string[] } | undefined
+let ledgerInserts: unknown[][]
+let ledgerSettles: unknown[][]
+let metaRecordsQueried: boolean
+
+function createMockPool() {
+  const query = vi.fn(async (sql: string, params?: unknown[]): Promise<QueryResult> => {
+    if (sql.includes('INSERT INTO multitable_ai_usage_ledger')) {
+      ledgerInserts.push(params ?? [])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('UPDATE multitable_ai_usage_ledger')) {
+      if (sql.includes(`'in_flight'`)) return { rows: [], rowCount: 0 }
+      ledgerSettles.push(params ?? [])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('FROM multitable_ai_usage_ledger')) {
+      return { rows: [{ user_daily_tokens: '0', user_weekly_tokens: '0', instance_daily_usd: '0' }] }
+    }
+    if (sql.includes('pg_advisory_xact_lock')) {
+      return { rows: [] }
+    }
+    if (sql.includes('FROM meta_records')) {
+      // The suggest path must NEVER read records — this is a leak tripwire.
+      metaRecordsQueried = true
+      return { rows: [{ id: 'rec_x', sheet_id: SHEET_ID, data: { [FLD_PRICE]: RECORD_VALUE_SENTINEL } }] }
+    }
+    if (sql.includes('FROM meta_fields WHERE sheet_id')) {
+      return { rows: FIELDS.map((f) => ({ ...f })) }
+    }
+    if (sql.includes('FROM meta_sheets WHERE id = $1')) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    // sheet_permissions / record_permissions / anything else → empty
+    return { rows: [], rowCount: 0 }
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+let app: Express
+
+function anthropicSuccess(text = '={fld_price}*(1+{fld_tax})'): Response {
+  return new Response(
+    JSON.stringify({
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: 14, output_tokens: 9 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  )
+}
+
+async function buildApp() {
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { createMultitableAiRoutes } = await import('../../src/routes/multitable-ai')
+  vi.spyOn(poolManager, 'get').mockReturnValue(createMockPool() as any)
+
+  const built = express()
+  built.use(express.json())
+  built.use((req, _res, next) => {
+    if (currentUser) (req as any).user = currentUser
+    next()
+  })
+  built.use('/api/multitable', createMultitableAiRoutes({ fetchFn: fetchSpy as unknown as typeof fetch }))
+  return built
+}
+
+const savedEnv = new Map<string, string | undefined>()
+const suggestUrl = `/api/multitable/sheets/${SHEET_ID}/ai/suggest-formula`
+
+describe('M4 suggest-formula routes (mock pool)', () => {
+  beforeEach(async () => {
+    for (const key of AI_ENV_KEYS) {
+      savedEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    process.env.MULTITABLE_AI_ENABLED = '1'
+    process.env.MULTITABLE_AI_PROVIDER = 'anthropic'
+    process.env.MULTITABLE_AI_API_KEY = API_KEY_SENTINEL
+    process.env.MULTITABLE_AI_MODEL = 'claude-sonnet-4-6'
+    process.env.MULTITABLE_AI_CONFIRM_LIVE_REQUESTS = '1'
+
+    currentUser = { id: 'u_ai_author', roles: ['member'], perms: ['multitable:write'] }
+    ledgerInserts = []
+    ledgerSettles = []
+    metaRecordsQueried = false
+    fetchSpy = vi.fn(async () => anthropicSuccess())
+    app = await buildApp()
+  })
+
+  afterEach(() => {
+    for (const key of AI_ENV_KEYS) {
+      const value = savedEnv.get(key)
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('M4-T1: readiness ≠ ready → blocked, zero outbound, zero-token suggest ledger row (record/field NULL)', async () => {
+    delete process.env.MULTITABLE_AI_API_KEY // breaks readiness → blocked
+
+    const res = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(res.status).toBe(503)
+    expect(res.body.status).toBe('blocked')
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(ledgerInserts).toHaveLength(1)
+    const params = ledgerInserts[0] as unknown[]
+    expect(JSON.stringify(params)).toContain('blocked')
+    expect(JSON.stringify(params)).toContain('suggest') // action=suggest
+    expect(params).toContain(0) // zero-token row
+    // record_id ($6) and field_id ($5) are NULL (sheet-scoped). The INSERT param
+    // order is (id,subject_key,user_id,sheet_id,field_id,record_id,action,…).
+    expect(params[4]).toBeNull() // field_id
+    expect(params[5]).toBeNull() // record_id
+  })
+
+  it('M4-T1: E-12 unset → blocked, zero outbound', async () => {
+    delete process.env.MULTITABLE_AI_CONFIRM_LIVE_REQUESTS
+
+    const res = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(res.status).toBe(503)
+    expect(res.body.status).toBe('blocked')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('M4-T2: no canManageFields → 403; unauthenticated → 401; zero outbound', async () => {
+    currentUser = { id: 'u_ai_reader', roles: ['member'], perms: ['multitable:read'] }
+    const reader = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(reader.status).toBe(403)
+
+    currentUser = undefined
+    const anon = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(anon.status).toBe(401)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(ledgerInserts).toHaveLength(0)
+  })
+
+  it('M4-T3: success path — returns candidate + usage; settled suggest row tokens>0; no record read', async () => {
+    const res = await request(app).post(suggestUrl).send({ instruction: 'unit price times one plus tax' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.status).toBe('succeeded')
+    expect(res.body.data.action).toBe('suggest')
+    expect(res.body.data.candidate).toBe('={fld_price}*(1+{fld_tax})')
+    expect(res.body.data.usage).toEqual({ promptTokens: 14, completionTokens: 9 })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    // The suggest path must NOT read any record — field-authoring only.
+    expect(metaRecordsQueried).toBe(false)
+
+    // reserve-then-settle: in_flight INSERT then a settle UPDATE to actual usage.
+    expect(ledgerInserts).toHaveLength(1)
+    expect(JSON.stringify(ledgerInserts[0])).toContain('in_flight')
+    expect(ledgerInserts[0]).toContain('suggest')
+    expect(ledgerSettles).toHaveLength(1)
+    expect(JSON.stringify(ledgerSettles[0])).toContain('succeeded')
+  })
+
+  it('M4-T7: leak sentinel — prompt carries field names+types, NEVER record values', async () => {
+    const res = await request(app).post(suggestUrl).send({ instruction: 'compute the grand total' })
+    expect(res.status).toBe(200)
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit]
+    const outbound = String(init.body)
+    // Field NAMES + TYPES present (positive control)…
+    expect(outbound).toContain('Unit Price')
+    expect(outbound).toContain('Tax Rate')
+    expect(outbound).toContain('number')
+    expect(outbound).toContain('percent')
+    // …but NO record VALUE ever enters the prompt.
+    expect(outbound).not.toContain(RECORD_VALUE_SENTINEL)
+    // And the suggest path read no records to begin with.
+    expect(metaRecordsQueried).toBe(false)
+  })
+
+  it('M4-T6: unsafe_input — secret-shaped instruction → 422, refused before any outbound call', async () => {
+    const res = await request(app).post(suggestUrl).send({ instruction: UNSAFE_INSTRUCTION })
+    expect(res.status).toBe(422)
+    expect(res.body.status).toBe('unsafe_input')
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    expect(ledgerInserts).toHaveLength(1)
+    expect(JSON.stringify(ledgerInserts[0])).toContain('unsafe_input')
+    expect(JSON.stringify(ledgerInserts[0])).not.toContain('bbbbbbbb')
+  })
+
+  it('M4-T5: burst rate limit → 429 rate_limited and NO ledger row', async () => {
+    process.env.MULTITABLE_AI_TENANT_BURST_RPM = '1'
+    app = await buildApp() // limiter caps resolve at router construction
+
+    const first = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(first.status).toBe(200)
+    const ledgerAfterFirst = ledgerInserts.length
+
+    const second = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(second.status).toBe(429)
+    expect(second.body.status).toBe('rate_limited')
+    expect(ledgerInserts.length).toBe(ledgerAfterFirst) // rate_limited never inserts
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('M4-T5: quota exhausted → 429 quota_exhausted, zero outbound', async () => {
+    // Force the window SUM over the cap so the reserve refuses.
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    const pool = createMockPool()
+    pool.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM multitable_ai_usage_ledger')) {
+        return { rows: [{ user_daily_tokens: '999999', user_weekly_tokens: '999999', instance_daily_usd: '0' }] }
+      }
+      if (sql.includes('INSERT INTO multitable_ai_usage_ledger')) {
+        ledgerInserts.push(params ?? [])
+        return { rows: [], rowCount: 1 }
+      }
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+      if (sql.includes('UPDATE multitable_ai_usage_ledger')) return { rows: [], rowCount: 0 }
+      if (sql.includes('FROM meta_fields WHERE sheet_id')) return { rows: FIELDS.map((f) => ({ ...f })) }
+      if (sql.includes('FROM meta_sheets WHERE id = $1')) return { rows: [{ id: SHEET_ID }] }
+      return { rows: [], rowCount: 0 }
+    })
+    vi.spyOn(poolManager, 'get').mockReturnValue(pool as any)
+
+    const res = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(res.status).toBe(429)
+    expect(res.body.status).toBe('quota_exhausted')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('M4-T6: validation — empty instruction → 400; over-cap instruction → 400; no outbound', async () => {
+    const empty = await request(app).post(suggestUrl).send({ instruction: '   ' })
+    expect(empty.status).toBe(400)
+
+    const tooLong = await request(app).post(suggestUrl).send({ instruction: 'x'.repeat(501) })
+    expect(tooLong.status).toBe(400)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('M4-T10: the API key never appears in any response or ledger params', async () => {
+    const ok = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(ok.status).toBe(200)
+    expect(JSON.stringify(ok.body)).not.toContain(API_KEY_SENTINEL)
+
+    fetchSpy.mockImplementation(async () => {
+      throw new Error(`socket reset, key was ${API_KEY_SENTINEL}`)
+    })
+    const failed = await request(app).post(suggestUrl).send({ instruction: 'price times tax' })
+    expect(failed.status).toBe(502)
+    expect(JSON.stringify(failed.body)).not.toContain(API_KEY_SENTINEL)
+    expect(JSON.stringify(ledgerInserts)).not.toContain(API_KEY_SENTINEL)
+    expect(JSON.stringify(ledgerSettles)).not.toContain(API_KEY_SENTINEL)
+  })
+})


### PR DESCRIPTION
## Summary

**M4 — the final main-line stage of the AI arc.** NL→formula suggest: a user describes a formula in words → AI proposes one candidate expression → the existing dry-run validates it → the user manually accepts (no auto-persist). Per design-lock #2518, after rank-9 set the ledger retention contract.

- **Ledger**: `AiUsageAction` += `suggest` (type-only — no migration; the table's record_id/field_id are already nullable; suggest rows are sheet-scoped with NULL record/field; the scope-unfiltered quota SUM aggregates them identically to preview/run).
- **Endpoint** `POST /sheets/:sheetId/ai/suggest-formula` (per-route guard, internal posture): gate = **canManageFields** (field-authoring, sheet-scoped — not `requireRecordReadable`/`canEditRecord`). The prompt is assembled from the sheet field list as **NAMES + TYPES ONLY** — `loadFieldsForSheet` (meta_fields only); the route **never reads meta_records**, so no record value can reach the prompt by construction. The full prompt passes the A2 `redactString` unsafe_input gate (secret-shaped field name / instruction → reject). Then A2 reserve-then-settle (action=suggest) → provider call (fetchFn DI, double-confirm ready+E-12) → returns `{ candidate }` (no auto-persist).
- **Frontend**: MetaFieldManager formula config gains an NL input + Generate → candidate Accept/Reject/regenerate; Accept copies into the expression textarea, then the existing **Test (dry-run)** validates. Reuses `useAiShortcut` (unified pending/countdown/busy guard, error.code status mapping) — no duplicated state machine. i18n `field.formulaSuggest.*` (EN+zh).

## Tests (fail-first)

Backend route suite (10, fail-first proven via route-disable → 10/10 404) + ledger suggest-scope leg; real-DB integration (5: NULL-scope ledger row + **leak sentinel** [request body has names+types, zero meta_records reads], quota non-interference both directions, canManageFields 403) — wired into plugin-tests.yml. FE spec 7 + affected FE 69; full backend test:unit 243 files / 3091; tsc + vue-tsc -b clean. **Zero real provider calls** (fetchFn spy).

## Review

Adversarial review (`/tmp/m4-formula-review-claude-20260611.md`): **APPROVE** (zero findings). Independently reproduced the headline privacy guarantee (prompt has only field name/id/type + the user request, no `data[]`; route never reads meta_records), the unsafe_input gate on secret-shaped names, canManageFields RBAC, type-only ledger + quota non-interference (proven both ways on real DB), and no-auto-persist.

**Arc milestone: M0→M4 complete** — provider readiness → shortcut backend → frontend → formula assist. T1/T3/T6 closed; the AI-field capability is now full-stack end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)