### PR TITLE
docs(multitable): reconcile AI M4 TODO closeout

### DIFF
--- a/docs/development/multitable-ai-field-staged-arc-todo-20260610.md
+++ b/docs/development/multitable-ai-field-staged-arc-todo-20260610.md
@@ -3,9 +3,11 @@
 > Date: 2026-06-10 · 配套计划:`multitable-ai-field-staged-arc-development-plan-20260610.md`
 > 标记:✅ done · ⬜ todo(opt-in 后可动手)· 🔒 gated(被前置环/决策阻塞)
 > 纪律:主线每环独立 opt-in;副线各项独立小 PR;AI 一律 fail-closed + 脱敏。
+> 回填 2026-06-11:M4 公式 AI 辅助已按设计锁定 #2518 → 实现 #2520 → 会话验证 #2521 闭合;主线 M0→M4 全闭。
 
 ## 0. 依据(2026-06-10 完成度审计,5-agent 条目级核验)
 
+- 注:本节保留 2026-06-10 审计快照原貌;其中 AI 未建判断已被 2026-06-11 回填的 M0→M4 合并事实取代。
 - 总纲 §9 八步:①D2 🟡(10k ✅/50k-100k 阻塞)②虚拟化 ✅决策关闭 ③D3 ✅ ④BI polish ✅ ⑤dry-run ✅ ⑥**AI ❌未建** ⑦模板 🟡(中心+install ✅/preview-onboarding ❌)⑧cross-base ❌(前提已齐)。
 - RC 100%(69 项核验为真)· Phase2 功能 100% · Phase3 硬化门 ✅ + AI lanes 真实未建 · 多系列图表已由 BI v2-d(#2297→#2354)落地(open-items 标记 stale)。
 - 审计工件:`/tmp/multitable-feishu-completion-audit-20260610.md`。
@@ -17,7 +19,7 @@
 - [x] ✅ **M1b A1 实现**(#2486 MERGED `6a91b22c4` 2026-06-10):resolver + internal admin 路由 + tsx 门脚本;18 单元/路由 + 5 门测试 fail-first;审查泄漏狩猎 7 对抗场景零泄漏,APPROVE-WITH-NITS 全修后合并。**M1 整环闭合。**
 - [x] ✅ **M2 A2 shortcut 后端**(#2490 MERGED `1e677208` 2026-06-11):design #2489 + 实现(preview/run、createRecordWriteHelpers 工厂(/patch 同源)、provider 客户端 fetchFn DI + E-12 双确认、台账 migration、**reserve-then-settle 配额**);审查 F1 major(跨 IO 持锁)→ 重构 → delta 复审 FIX-VERIFIED + NF-1 中文估算修复。**T1 + T6 关闭。**
 - [x] ✅ **M3 A3 前端**(#2494 MERGED `a5809db11` 2026-06-11):配置区(双腿 clobber 防护)+ 抽屉/单元格触发(busy 三面统一)+ run 适配器(自回声豁免)+ usage-summary;审查 F3/F4 合并前修。**T3 关闭 → 主线 M0→M3 全闭。**
-- [ ] 🔒 **M4 B2 公式 AI 辅助**(gated on M1-M3 验证 + 独立 opt-in)。
+- [x] ✅ **M4 B2 公式 AI 辅助**(#2520 MERGED `62460217f` 2026-06-11):design #2518 + 实现(NL→formula suggest、`canManageFields` 产品路径、单候选同步、A2 reserve-then-settle 台账/配额复用、formula dry-run 校验、前端候选接受写回 textarea);record values 构造上不入 prompt,审查零发现。**主线 M0→M4 全闭。**
 
 ## 2. 副线 — parity 清尾(已获 owner 总 opt-in 2026-06-10,可并行)
 
@@ -29,7 +31,8 @@
 
 ## 3. 收官
 
-- [x] ✅ **验证 MD**(本 PR):`multitable-ai-field-staged-arc-verification-20260611.md` — 14 PR 全弧证据链 + 终态。
+- [x] ✅ **AI staged 主线验证 MD**:`multitable-ai-field-staged-arc-verification-20260611.md` — M0→M3 证据链 + 终态。
+- [x] ✅ **会话执行验证 MD**(#2521 `f9a663eb9`):`multitable-benchmark-arc-session-verification-20260611.md` — M4 公式 AI 辅助与 2026-06-11 阶梯执行收敛 checkpoint。
 
 ## 4. 明确不做(各既有 gate)
 

--- a/docs/development/multitable-ai-field-staged-arc-verification-20260611.md
+++ b/docs/development/multitable-ai-field-staged-arc-verification-20260611.md
@@ -2,6 +2,7 @@
 
 > Status: **VERIFICATION(收官文档)** · 计划/TODO:`multitable-ai-field-staged-arc-{development-plan,todo}-20260610.md`(#2474)
 > 方法:每环 = 勘察(file:line)→ 设计锁定(多 agent 事实核验)→ fail-first → 实现 → 独立对抗审查 → 发现修复(major 加 delta 复审)→ CI → admin-squash。审查工件存 `/tmp/*-review-claude-2026061*.md`。
+> 回填 2026-06-11:本文原始收口点为 M0→M3;M4 公式 AI 辅助随后已通过 #2518(设计)→#2520(`62460217f`,实现)→#2521(`f9a663eb9`,会话验证)闭合。当前 AI staged 主线状态以 `multitable-ai-field-staged-arc-todo-20260610.md` 的 M0→M4 回填为准。
 
 ## 0. 总览
 
@@ -31,8 +32,8 @@
 
 ## 2. 已知边缘与 follow-up 池(全部已登记)
 
-scatter 后端 x/y 维度 · gauge 非加性聚合文案 · 异步 chunk 加载失败兜底 · 图表持久化 type 校验(F4 既有)· API-authored aiShortcut canonicalization · all-sources-deleted 阻塞保存恢复 UX · stripUrlUserinfo 首-@ 边角 · 台账 aging(NiFi 对标既有 GAP)· S4 残留(field-PATCH 翻转/provisioning 旁路)· main 上烂掉的 multitable-view-config.api.test.ts(4/7 红,CI 不跑)· M4 公式 AI 辅助(deferred-eval 门)· C1 PM 门(G-4 样例数据/G-6 T7 回滚/onboarding)。
+scatter 后端 x/y 维度 · gauge 非加性聚合文案 · 异步 chunk 加载失败兜底 · 图表持久化 type 校验(F4 既有)· API-authored aiShortcut canonicalization · all-sources-deleted 阻塞保存恢复 UX · stripUrlUserinfo 首-@ 边角 · 台账 aging(NiFi 对标既有 GAP)· S4 残留(field-PATCH 翻转/provisioning 旁路)· main 上烂掉的 multitable-view-config.api.test.ts(4/7 红,CI 不跑)· 公式 AI 后续优化(deferred-eval/多候选等,独立 opt-in)· C1 PM 门(G-4 样例数据/G-6 T7 回滚/onboarding)。
 
 ## 3. TODO 终态
 
-主线 M0→M3 **全闭**(7 PR:#2476/#2478/#2481/#2486/#2489/#2490/#2491/#2494),T1/T3/T6 关闭;副线 S1/S2/S3/S4/S5a **全闭**(#2475/#2503/#2492/#2488/#2497)。仍门控:M4(deferred-eval + 独立 opt-in)· S5b(staging 实跑,operator-gated)· C1 PM 件(G-4/T7/onboarding)· §2 follow-up 池。**本 arc 共 14 个 PR、6 轮多 agent 设计核验、9 轮独立对抗审查(2 个 major 实弹:M2 跨 IO 持锁、A-full 前传 F1 同级)、全程零真实 provider 调用。**后续总目标见 benchmark-surpass goal(滚动 refresh → 阶梯 → staged arc)。
+原始收口时主线 M0→M3 **全闭**(7 PR:#2476/#2478/#2481/#2486/#2489/#2490/#2491/#2494),T1/T3/T6 关闭;副线 S1/S2/S3/S4/S5a **全闭**(#2475/#2503/#2492/#2488/#2497)。2026-06-11 回填后,M4 公式 AI 辅助也已闭合(#2518/#2520/#2521),所以当前 AI staged 主线为 **M0→M4 全闭**。仍门控:S5b(staging 实跑,operator-gated)· C1 PM 件(G-4/T7/onboarding)· §2 follow-up 池。**本 arc 原始收口共 14 个 PR、6 轮多 agent 设计核验、9 轮独立对抗审查(2 个 major 实弹:M2 跨 IO 持锁、A-full 前传 F1 同级)、全程零真实 provider 调用。**后续总目标见 benchmark-surpass goal(滚动 refresh → 阶梯 → staged arc)。

--- a/docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
@@ -16,6 +16,15 @@ Date: 2026-05-14
 
 ## Status
 
+> 2026-06-11 status backfill: this 2026-05-14 plan is a historical
+> activation snapshot. The AI shortcut / formula-assist lanes were later
+> re-scoped and delivered through the AI staged arc: M1 #2486, M2 #2490,
+> M3 #2494, M4 design #2518, M4 implementation #2520, and session
+> verification #2521. Do not use the deferred Lane A / Lane B tables below as
+> current AI status; use `multitable-ai-field-staged-arc-todo-20260610.md` and
+> `multitable-benchmark-arc-session-verification-20260611.md` for current
+> routing.
+
 This document starts the next multitable Feishu-parity phase after the signed RC and Phase 2 closeout.
 
 Current repository evidence shows the core multitable product line is no longer blocked by the original Feishu parity gaps:

--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -13,6 +13,16 @@ Date: 2026-05-14
 
 ## Status
 
+> 2026-06-11 status backfill: this 2026-05-14 TODO is a historical
+> activation snapshot. The AI shortcut / formula-assist lanes were later
+> re-scoped and delivered through the AI staged arc: M1 #2486, M2 #2490,
+> M3 #2494, M4 design #2518, M4 implementation #2520, and session
+> verification #2521. Do not use the deferred Lane A / Lane B checklist below
+> as current AI status; use
+> `multitable-ai-field-staged-arc-todo-20260610.md` and
+> `multitable-benchmark-arc-session-verification-20260611.md` for current
+> routing.
+
 - Baseline: `origin/main` after Phase 2 and RC closeout.
 - Goal: continue Feishu parity toward AI-assisted authoring and customer-trial hardening.
 - Rule: each completed implementation item must include PR, merge commit, development MD, verification MD, and verification summary.


### PR DESCRIPTION
## Summary

Docs-only TODO reconcile after the M4 formula AI assist line landed.

- Marks M4 B2 formula AI assist as closed via design #2518 and implementation #2520.
- Points the closeout evidence to the #2521 session verification checkpoint.
- Keeps remaining gates unchanged: cross-base, FOL follow-ups, AI rings, automation actions, and other deferred work remain separate opt-ins.

## Verification

- `git diff --check`

No runtime, route, schema, frontend, provider, or test code changed.
