### PR TITLE
fix(multitable): guard hierarchy parent field downgrades

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4335,11 +4335,13 @@ async function validateGanttDependencyConfig(
 // link field via a generic record patch (no dedicated reparent endpoint), so a MULTI-value
 // link used as parent gets silently overwritten on every drag-to-reparent. Reject saving a
 // hierarchy view whose explicit parentFieldId is not a single-value (`limitSingleRecord`)
-// link field. An absent parentFieldId is allowed (runtime auto/first-link fallback unchanged).
-// Documented residuals (accepted): (a) PATCH /fields/:fieldId can later flip limitSingleRecord
-// or the field type without view re-validation — same pre-existing class as gantt's dependency
-// field, follow-up candidate; (b) provisioning ensureView/createView bypass route-layer view
-// validation by design (template library ships no hierarchy views today).
+// same-sheet link field. An absent parentFieldId is allowed (runtime auto/first-link fallback unchanged).
+// PATCH /fields/:fieldId carries the matching reverse guard below: once a hierarchy
+// view explicitly uses a single-value link as its parent field, that field cannot
+// be downgraded to multi-value, non-link, or a different target sheet while the
+// view still points at it.
+// Documented residual (accepted): provisioning ensureView/createView bypasses
+// route-layer view validation by design (template library ships no hierarchy views today).
 async function validateHierarchyParentLinkConfig(
   query: QueryFn,
   sheetId: string,
@@ -4347,7 +4349,7 @@ async function validateHierarchyParentLinkConfig(
   config: Record<string, unknown>,
 ): Promise<string | null> {
   if (viewType !== 'hierarchy') return null
-  const parentFieldId = typeof config.parentFieldId === 'string' ? config.parentFieldId.trim() : ''
+  const parentFieldId = normalizeHierarchyParentFieldId(config.parentFieldId)
   if (!parentFieldId) return null
 
   const fieldRes = await query(
@@ -4360,11 +4362,68 @@ async function validateHierarchyParentLinkConfig(
   }
 
   const field = serializeFieldRow(fieldRow)
-  if (field.type !== 'link' || (field.property ?? {}).limitSingleRecord !== true) {
+  if (!isSameSheetSingleValueHierarchyParentLink(sheetId, field.type, field.property)) {
     return `Hierarchy parent field must be a single-value link field: ${parentFieldId}`
   }
 
   return null
+}
+
+function normalizeHierarchyParentFieldId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeHierarchyViewConfig(
+  viewType: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  if (viewType !== 'hierarchy' || typeof config.parentFieldId !== 'string') return config
+
+  const normalizedParentFieldId = normalizeHierarchyParentFieldId(config.parentFieldId)
+  const nextConfig = { ...config }
+  if (normalizedParentFieldId) {
+    nextConfig.parentFieldId = normalizedParentFieldId
+  } else {
+    delete nextConfig.parentFieldId
+  }
+  return nextConfig
+}
+
+function isSameSheetSingleValueHierarchyParentLink(
+  sheetId: string,
+  type: UniverMetaField['type'],
+  property: Record<string, unknown> | null | undefined,
+): boolean {
+  const obj = property ?? {}
+  const foreignSheetId = stringFromRecord(obj, ['foreignSheetId', 'foreignDatasheetId', 'datasheetId'])
+  return type === 'link' && obj.limitSingleRecord === true && foreignSheetId === sheetId
+}
+
+async function validateHierarchyParentFieldMutation(
+  query: QueryFn,
+  sheetId: string,
+  fieldId: string,
+  currentType: UniverMetaField['type'],
+  currentProperty: Record<string, unknown>,
+  nextType: UniverMetaField['type'],
+  nextProperty: Record<string, unknown>,
+): Promise<string | null> {
+  if (!isSameSheetSingleValueHierarchyParentLink(sheetId, currentType, currentProperty)) return null
+  if (isSameSheetSingleValueHierarchyParentLink(sheetId, nextType, nextProperty)) return null
+
+  const viewRes = await query(
+    `SELECT id, name, config
+     FROM meta_views
+     WHERE sheet_id = $1
+       AND type = $2
+       AND config ? 'parentFieldId'`,
+    [sheetId, 'hierarchy'],
+  )
+  const viewRow = (viewRes.rows as any[]).find((row) =>
+    normalizeHierarchyParentFieldId(normalizeJson(row.config).parentFieldId) === fieldId)
+  if (!viewRow) return null
+
+  return `Cannot change hierarchy parent field ${fieldId}: update or remove the hierarchy view parentFieldId first.`
 }
 
 class PermissionError extends Error {
@@ -6160,6 +6219,7 @@ export function univerMetaRouter(): Router {
         sheetId = String(row.sheet_id)
         const currentOrder = Number(row.order ?? 0)
         const currentType = mapFieldType(String(row.type))
+        const currentProperty = normalizeJson(row.property)
 
         const nextName = typeof parsed.data.name === 'string' ? parsed.data.name.trim() : String(row.name)
         const requestedType = parsed.data.type ?? mapFieldType(String(row.type))
@@ -6264,6 +6324,18 @@ export function univerMetaRouter(): Router {
               `无法将该字段转换为公式：已有公式字段引用它：${referrers.map((id) => `{${id}}`).join('、')}`,
             )
           }
+        }
+        const hierarchyParentMutationError = await validateHierarchyParentFieldMutation(
+          query as unknown as QueryFn,
+          sheetId,
+          fieldId,
+          currentType,
+          currentProperty,
+          nextType,
+          nextProperty,
+        )
+        if (hierarchyParentMutationError) {
+          throw new ValidationError(hierarchyParentMutationError)
         }
 
         if (typeof desiredOrder === 'number' && desiredOrder !== currentOrder) {
@@ -6521,7 +6593,7 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageViews) return sendForbidden(res)
 
-      const incomingConfig: Record<string, unknown> = parsed.data.config ?? {}
+      const incomingConfig: Record<string, unknown> = normalizeHierarchyViewConfig(type, parsed.data.config ?? {})
       const incomingRules = incomingConfig.conditionalFormattingRules
       if (Array.isArray(incomingRules) && incomingRules.length > CONDITIONAL_FORMATTING_RULE_LIMIT) {
         return res.status(400).json({
@@ -6634,7 +6706,10 @@ export function univerMetaRouter(): Router {
       const nextSort = parsed.data.sortInfo ?? normalizeJson(row.sort_info)
       const nextGroup = parsed.data.groupInfo ?? normalizeJson(row.group_info)
       const nextHiddenFieldIds = parsed.data.hiddenFieldIds ?? normalizeJsonArray(row.hidden_field_ids)
-      const nextConfig = parsed.data.config ?? normalizeJson(row.config)
+      const nextConfig = normalizeHierarchyViewConfig(
+        nextType,
+        parsed.data.config ?? normalizeJson(row.config),
+      )
       const incomingRules = (nextConfig as Record<string, unknown>).conditionalFormattingRules
       if (Array.isArray(incomingRules) && incomingRules.length > CONDITIONAL_FORMATTING_RULE_LIMIT) {
         return res.status(400).json({

--- a/packages/core-backend/tests/unit/multitable-hierarchy-parent-link-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-hierarchy-parent-link-guard.test.ts
@@ -17,17 +17,24 @@
  *   2. PATCH accepts a single-value link parent (200, UPDATE persisted).
  *   3. POST rejects a non-link parent field (400, no INSERT).
  *   4. POST rejects a nonexistent parent field (400, no INSERT).
+ *   5. PATCH /fields rejects downgrading a referenced single-value parent link
+ *      to multi-value, non-link, or a different target sheet (400, no field UPDATE).
+ *   6. PATCH /fields treats persisted whitespace around a hierarchy parentFieldId
+ *      as still referencing the active field.
  *
  * Discriminating cases prove we did NOT over-reject:
  *   - POST hierarchy WITHOUT parentFieldId stays allowed (auto/first-link mode).
  *   - POST a non-hierarchy view whose config carries a stray `parentFieldId`
  *     pointing at a multi-value link stays allowed (guard is hierarchy-scoped).
+ *   - PATCH /fields can still rename a referenced parent link while it remains
+ *     single-value, and can still convert unreferenced links to multi-value.
  */
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 
 const SHEET_ID = 'sheet_hier'
+const OTHER_SHEET_ID = 'sheet_other'
 const VIEW_ID = 'view_hier'
 
 type StoredField = {
@@ -37,31 +44,67 @@ type StoredField = {
   property: Record<string, unknown>
   order: number
 }
+type StoredView = {
+  id: string
+  sheetId: string
+  name: string
+  type: string
+  config: Record<string, unknown>
+}
 type QueryResult = { rows: any[]; rowCount?: number }
 
-function createStore(fields: StoredField[]) {
+function createStore(fields: StoredField[], views: StoredView[] = [{
+  id: VIEW_ID,
+  sheetId: SHEET_ID,
+  name: 'Hierarchy',
+  type: 'hierarchy',
+  config: {},
+}]) {
   const fieldById = new Map(fields.map((f) => [f.id, f]))
+  const viewById = new Map(views.map((v) => [v.id, v]))
   const inserts: unknown[][] = []
   const updates: unknown[][] = []
+  const fieldUpdates: unknown[][] = []
 
   const handler = (sql: string, params?: unknown[]): QueryResult => {
     if (sql.includes('FROM meta_sheets WHERE id = $1')) {
       return { rows: [{ id: SHEET_ID }] }
     }
     if (sql.includes('FROM meta_views WHERE id = $1')) {
+      const view = viewById.get(params?.[0] as string)
       return {
-        rows: [{
-          id: VIEW_ID,
-          sheet_id: SHEET_ID,
-          name: 'Hierarchy',
+        rows: view ? [{
+          id: view.id,
+          sheet_id: view.sheetId,
+          name: view.name,
           type: 'hierarchy',
           filter_info: {},
           sort_info: {},
           group_info: {},
           hidden_field_ids: [],
-          config: {},
-        }],
+          config: view.config,
+        }] : [],
       }
+    }
+    if (sql.includes("config ? 'parentFieldId'")) {
+      const sheetId = params?.[0]
+      const viewType = params?.[1]
+      return {
+        rows: views
+          .filter((v) =>
+            v.sheetId === sheetId
+            && v.type === viewType
+            && Object.prototype.hasOwnProperty.call(v.config, 'parentFieldId'))
+          .map((v) => ({ id: v.id, name: v.name, config: v.config })),
+      }
+    }
+    if (sql.includes('SELECT id, sheet_id FROM meta_fields WHERE id = $1')) {
+      const f = fieldById.get(params?.[0] as string)
+      return { rows: f ? [{ id: f.id, sheet_id: SHEET_ID }] : [] }
+    }
+    if (sql.includes('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+      const f = fieldById.get(params?.[0] as string)
+      return { rows: f ? [{ ...f, sheet_id: SHEET_ID }] : [] }
     }
     // S4 guard — single-field lookup for the configured parent field.
     if (sql.includes('FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
@@ -80,10 +123,25 @@ function createStore(fields: StoredField[]) {
       updates.push(params ?? [])
       return { rows: [], rowCount: 1 }
     }
+    if (sql.includes('UPDATE meta_fields') && sql.includes('RETURNING id, name, type, property, "order"')) {
+      fieldUpdates.push(params ?? [])
+      const fieldId = params?.[0] as string
+      const existing = fieldById.get(fieldId)
+      if (!existing) return { rows: [], rowCount: 0 }
+      const next = {
+        ...existing,
+        name: String(params?.[1] ?? existing.name),
+        type: String(params?.[2] ?? existing.type),
+        property: typeof params?.[3] === 'string' ? JSON.parse(params[3] as string) : existing.property,
+        order: Number(params?.[4] ?? existing.order),
+      }
+      fieldById.set(fieldId, next)
+      return { rows: [{ ...next }], rowCount: 1 }
+    }
     return { rows: [], rowCount: 0 }
   }
 
-  return { inserts, updates, handler }
+  return { inserts, updates, fieldUpdates, handler }
 }
 
 function createMockPool(handler: (sql: string, params?: unknown[]) => QueryResult) {
@@ -142,7 +200,24 @@ const SINGLE_LINK = field({
   type: 'link',
   property: { foreignSheetId: SHEET_ID, limitSingleRecord: true },
 })
+const EXTERNAL_SINGLE_LINK = field({
+  id: 'fld_parent_external',
+  type: 'link',
+  property: { foreignSheetId: OTHER_SHEET_ID, limitSingleRecord: true },
+})
+const UNRELATED_SINGLE_LINK = field({
+  id: 'fld_unrelated_single',
+  type: 'link',
+  property: { foreignSheetId: SHEET_ID, limitSingleRecord: true },
+})
 const TEXT_FIELD = field({ id: 'fld_notes', type: 'string' })
+const HIERARCHY_VIEW_USING_SINGLE_PARENT: StoredView = {
+  id: VIEW_ID,
+  sheetId: SHEET_ID,
+  name: 'Hierarchy',
+  type: 'hierarchy',
+  config: { parentFieldId: 'fld_parent_single' },
+}
 
 describe('S4 — hierarchy parent link single-value guard', () => {
   afterEach(() => {
@@ -178,6 +253,55 @@ describe('S4 — hierarchy parent link single-value guard', () => {
     expect(res.body.ok).toBe(true)
     expect(updates).toHaveLength(1)
     expect(updates[0]?.[7]).toBe(JSON.stringify({ parentFieldId: 'fld_parent_single', orphanMode: 'root' }))
+  })
+
+  it('PATCH normalizes a hierarchy parentFieldId before persisting config', async () => {
+    const { updates, handler } = createStore([SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch(`/api/multitable/views/${VIEW_ID}`)
+      .send({ config: { parentFieldId: '\u00A0fld_parent_single\u00A0', orphanMode: 'root' } })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(updates).toHaveLength(1)
+    expect(updates[0]?.[7]).toBe(JSON.stringify({ parentFieldId: 'fld_parent_single', orphanMode: 'root' }))
+  })
+
+  it('POST normalizes a hierarchy parentFieldId before persisting config', async () => {
+    const { inserts, handler } = createStore([SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({
+        sheetId: SHEET_ID,
+        name: 'Tree',
+        type: 'hierarchy',
+        config: { parentFieldId: '\u00A0fld_parent_single\u00A0', orphanMode: 'root' },
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body.ok).toBe(true)
+    expect(inserts).toHaveLength(1)
+    expect(inserts[0]?.[8]).toBe(JSON.stringify({ parentFieldId: 'fld_parent_single', orphanMode: 'root' }))
+  })
+
+  it('POST rejects a hierarchy parentFieldId that resolves to a link targeting another sheet', async () => {
+    const { inserts, handler } = createStore([EXTERNAL_SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({ sheetId: SHEET_ID, name: 'Tree', type: 'hierarchy', config: { parentFieldId: 'fld_parent_external' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Hierarchy parent field must be a single-value link field: fld_parent_external',
+    )
+    expect(inserts).toHaveLength(0)
   })
 
   it('POST rejects a hierarchy parentFieldId that resolves to a non-link field', async () => {
@@ -236,5 +360,216 @@ describe('S4 — hierarchy parent link single-value guard', () => {
     expect(res.status).toBe(201)
     expect(res.body.ok).toBe(true)
     expect(inserts).toHaveLength(1)
+  })
+
+  it('PATCH /fields rejects changing a hierarchy parent link from single-value to multi-value', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects changing a referenced hierarchy parentFieldId even when persisted with whitespace', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [{
+        ...HIERARCHY_VIEW_USING_SINGLE_PARENT,
+        config: { parentFieldId: ' fld_parent_single ' },
+      }],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects changing a referenced hierarchy parentFieldId even when persisted with tabs and newlines', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [{
+        ...HIERARCHY_VIEW_USING_SINGLE_PARENT,
+        config: { parentFieldId: '\tfld_parent_single\n' },
+      }],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects changing a referenced hierarchy parentFieldId even when legacy config persisted Unicode whitespace', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [{
+        ...HIERARCHY_VIEW_USING_SINGLE_PARENT,
+        config: { parentFieldId: '\u00A0fld_parent_single\u00A0' },
+      }],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects changing a hierarchy parent link into a non-link field', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({ type: 'string', property: {} })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects removing the target sheet from a referenced hierarchy parent link', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { limitSingleRecord: true },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields rejects retargeting a referenced hierarchy parent link to another sheet', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: OTHER_SHEET_ID, limitSingleRecord: true },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Cannot change hierarchy parent field fld_parent_single: update or remove the hierarchy view parentFieldId first.',
+    )
+    expect(fieldUpdates).toHaveLength(0)
+  })
+
+  it('PATCH /fields allows renaming a hierarchy parent field while it stays single-value', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({ name: 'Parent link' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(fieldUpdates).toHaveLength(1)
+    expect(fieldUpdates[0]?.[1]).toBe('Parent link')
+    expect(fieldUpdates[0]?.[2]).toBe('link')
+    expect(JSON.parse(fieldUpdates[0]?.[3] as string)).toMatchObject({ limitSingleRecord: true })
+  })
+
+  it('PATCH /fields allows retargeting an unrelated field while a hierarchy view references a different parent link', async () => {
+    const { fieldUpdates, handler } = createStore(
+      [SINGLE_LINK, UNRELATED_SINGLE_LINK],
+      [HIERARCHY_VIEW_USING_SINGLE_PARENT],
+    )
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_unrelated_single')
+      .send({
+        property: { foreignSheetId: OTHER_SHEET_ID, limitSingleRecord: true },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(fieldUpdates).toHaveLength(1)
+    expect(JSON.parse(fieldUpdates[0]?.[3] as string)).toMatchObject({
+      foreignSheetId: OTHER_SHEET_ID,
+      limitSingleRecord: true,
+    })
+  })
+
+  it('PATCH /fields allows multi-value conversion when no hierarchy view references the field', async () => {
+    const { fieldUpdates, handler } = createStore([SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_parent_single')
+      .send({
+        property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(fieldUpdates).toHaveLength(1)
+    expect(JSON.parse(fieldUpdates[0]?.[3] as string)).toMatchObject({ limitSingleRecord: false })
   })
 })


### PR DESCRIPTION
## Summary

Closes the S4 residual where a field already used as a hierarchy `config.parentFieldId` could later be downgraded through `PATCH /fields/:fieldId`.

- adds a reverse guard in the field PATCH path: an explicit hierarchy parent field that is currently a single-value link cannot be changed to a multi-value link or non-link while the hierarchy view still points at it
- keeps the existing boundary: auto/first-link hierarchy mode is unchanged, and unreferenced link fields can still be converted to multi-value
- extends the existing S4 route-level test harness with field PATCH cases

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-hierarchy-parent-link-guard.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

Note: targeted ESLint on `univer-meta.ts` still reports pre-existing lint debt in that large route file (for example old no-useless-escape / no-extra-semi entries outside this patch), so I did not treat that as a new failure for this slice.