### PR TITLE
fix(multitable): redact database URL userinfo with raw at signs

### DIFF
--- a/apps/web/src/multitable/utils/automation-log-redact.ts
+++ b/apps/web/src/multitable/utils/automation-log-redact.ts
@@ -80,7 +80,7 @@ function redactMalformedDatabaseUrlCredentials(value: string): string {
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
     if (hostPattern.test(rest.slice(index + 1))) return index

--- a/apps/web/src/multitable/utils/automation-log-redact.ts
+++ b/apps/web/src/multitable/utils/automation-log-redact.ts
@@ -13,6 +13,8 @@
 
 type StringReplacement = string | ((substring: string, ...args: unknown[]) => string)
 
+const DATABASE_URL_PATTERN = /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi
+
 const STRING_PATTERNS: Array<[RegExp, StringReplacement]> = [
   // Bearer auth header
   [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>'],
@@ -44,7 +46,7 @@ const STRING_PATTERNS: Array<[RegExp, StringReplacement]> = [
   ],
   // Postgres / MySQL connection URI credentials. Uses URL parsing rather than
   // a first-@ regex so raw `@` characters in username/password do not leak.
-  [/\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi, redactDatabaseUrlCredentials],
+  [DATABASE_URL_PATTERN, redactDatabaseUrlCredentials],
   // Bare email addresses surfaced in free-text fields (error messages,
   // step output strings, audit lines). Runs AFTER env-style and
   // SMTP_*/SMOKE_* patterns so legitimate `KEY=value` assignments are
@@ -62,11 +64,16 @@ function redactDatabaseUrlCredentials(value: string): string {
   try {
     const url = new URL(value)
     if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    if (!url.username && !url.password) return value
-    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
+    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
+    return `${url.protocol}//<redacted>@${url.host}${suffix}`
   } catch {
     return redactMalformedDatabaseUrlCredentials(value)
   }
+}
+
+function redactNestedDatabaseUrls(value: string): string {
+  return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
 function redactMalformedDatabaseUrlCredentials(value: string): string {
@@ -76,7 +83,7 @@ function redactMalformedDatabaseUrlCredentials(value: string): string {
   const rest = match[2]
   const at = findDatabaseAuthoritySeparator(rest)
   if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {

--- a/apps/web/src/multitable/utils/automation-log-redact.ts
+++ b/apps/web/src/multitable/utils/automation-log-redact.ts
@@ -11,7 +11,9 @@
  * browser bundle without leaking secrets into rendered DOM nodes.
  */
 
-const STRING_PATTERNS: Array<[RegExp, string]> = [
+type StringReplacement = string | ((substring: string, ...args: unknown[]) => string)
+
+const STRING_PATTERNS: Array<[RegExp, StringReplacement]> = [
   // Bearer auth header
   [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>'],
   // JWT (eyJ-prefixed)
@@ -40,9 +42,9 @@ const STRING_PATTERNS: Array<[RegExp, string]> = [
     /\b(MULTITABLE_EMAIL_SMOKE_(?:TO|FROM|SUBJECT))(\s*[:=]\s*)("?)([^&\s"'<>]+)\3/g,
     '$1$2$3<redacted>$3',
   ],
-  // Postgres / MySQL connection URI credentials
-  [/\b(postgres(?:ql)?:\/\/)[^@\s"'<>]+@/gi, '$1<redacted>@'],
-  [/\b(mysql:\/\/)[^@\s"'<>]+@/gi, '$1<redacted>@'],
+  // Postgres / MySQL connection URI credentials. Uses URL parsing rather than
+  // a first-@ regex so raw `@` characters in username/password do not leak.
+  [/\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi, redactDatabaseUrlCredentials],
   // Bare email addresses surfaced in free-text fields (error messages,
   // step output strings, audit lines). Runs AFTER env-style and
   // SMTP_*/SMOKE_* patterns so legitimate `KEY=value` assignments are
@@ -55,6 +57,36 @@ const STRING_PATTERNS: Array<[RegExp, string]> = [
     '<email:redacted>',
   ],
 ]
+
+function redactDatabaseUrlCredentials(value: string): string {
+  try {
+    const url = new URL(value)
+    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
+    if (!url.username && !url.password) return value
+    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return redactMalformedDatabaseUrlCredentials(value)
+  }
+}
+
+function redactMalformedDatabaseUrlCredentials(value: string): string {
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+}
+
+function findDatabaseAuthoritySeparator(rest: string): number {
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] !== '@') continue
+    if (hostPattern.test(rest.slice(index + 1))) return index
+  }
+  return -1
+}
 
 /**
  * Object keys whose values are treated as opaque secrets regardless
@@ -110,7 +142,9 @@ export const REDACTION_VERSION = 1
 export function redactString(value: unknown): string {
   let result = String(value ?? '')
   for (const [pattern, replacement] of STRING_PATTERNS) {
-    result = result.replace(pattern, replacement)
+    result = typeof replacement === 'string'
+      ? result.replace(pattern, replacement)
+      : result.replace(pattern, replacement)
   }
   return result
 }

--- a/apps/web/src/multitable/utils/automation-log-redact.ts
+++ b/apps/web/src/multitable/utils/automation-log-redact.ts
@@ -61,38 +61,53 @@ const STRING_PATTERNS: Array<[RegExp, StringReplacement]> = [
 ]
 
 function redactDatabaseUrlCredentials(value: string): string {
-  try {
-    const url = new URL(value)
-    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
-    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
-    return `${url.protocol}//<redacted>@${url.host}${suffix}`
-  } catch {
-    return redactMalformedDatabaseUrlCredentials(value)
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const leadingHost = parseLeadingDatabaseHost(rest)
+  const firstAt = rest.indexOf('@')
+  if (leadingHost && (firstAt < 0 || leadingHost.end < firstAt)) {
+    return `${scheme}://${leadingHost.host}${redactNestedDatabaseUrls(rest.slice(leadingHost.end))}`
   }
+
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function redactNestedDatabaseUrls(value: string): string {
   return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
-function redactMalformedDatabaseUrlCredentials(value: string): string {
-  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
-  if (!match) return value
-  const scheme = match[1]
-  const rest = match[2]
-  const at = findDatabaseAuthoritySeparator(rest)
-  if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
+function parseLeadingDatabaseHost(rest: string): { host: string; end: number } | null {
+  const match = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/.exec(rest)
+  return match ? { host: match[0], end: match[0].length } : null
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
+  let bestIndex = -1
+  let bestScore = -1
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
-    if (hostPattern.test(rest.slice(index + 1))) return index
+    // If another database URL starts before this `@`, this candidate belongs to
+    // a nested URL in the path/query rather than to the outer URL's authority.
+    if (/(?:postgres(?:ql)?|mysql):\/\//i.test(rest.slice(0, index))) continue
+    const host = parseLeadingDatabaseHost(rest.slice(index + 1))
+    if (!host) continue
+    const score = scoreDatabaseHost(host.host)
+    if (score > bestScore) {
+      bestScore = score
+      bestIndex = index
+    }
   }
-  return -1
+  return bestIndex
+}
+
+function scoreDatabaseHost(host: string): number {
+  if (host.startsWith('[') || /:\d+$/.test(host) || /\d+\.\d+\.\d+\.\d+/.test(host)) return 3
+  if (host.includes('.') || host.includes('_')) return 2
+  return 1
 }
 
 /**

--- a/apps/web/tests/automation-log-redact.spec.ts
+++ b/apps/web/tests/automation-log-redact.spec.ts
@@ -98,6 +98,42 @@ describe('redactString', () => {
     expect(b).not.toContain('root:rootpw')
   })
 
+  it('masks database URI credentials containing raw @ characters', () => {
+    const postgres = redactString('postgres://u@ser:p@ss@db.example.com:5432/app')
+    expect(postgres).toBe('postgres://<redacted>@db.example.com:5432/app')
+    expect(postgres).not.toContain('u@ser')
+    expect(postgres).not.toContain('p@ss')
+    expect(postgres).not.toContain('ss@db')
+
+    const mysql = redactString('mysql://root:r@w@10.0.0.5:3306/data')
+    expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+    expect(mysql).not.toContain('r@w')
+    expect(mysql).not.toContain('w@10')
+  })
+
+  it('masks malformed database URI credentials containing reserved delimiters', () => {
+    for (const secret of ['pa#ss', 'pa?ss', 'pa/ss', 'pa)ss', "pa'ss"]) {
+      const out = redactString(`postgres://user:${secret}@db.example.com:5432/app`)
+      expect(out).toBe('postgres://<redacted>@db.example.com:5432/app')
+      expect(out).not.toContain(secret)
+    }
+
+    const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
+    expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+    expect(mysql).not.toContain('r)w')
+  })
+
+  it('preserves the database host when malformed URI query text contains @', () => {
+    const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
+    expect(out).toBe('postgres://<redacted>@db.example.com:5432/app?notify=a@b')
+    expect(out).not.toContain('pa/ss')
+  })
+
+  it('does not mask database URLs without userinfo', () => {
+    expect(redactString('postgres://db.example.com:5432/app')).toBe('postgres://db.example.com:5432/app')
+    expect(redactString('mysql://10.0.0.5:3306/data')).toBe('mysql://10.0.0.5:3306/data')
+  })
+
   it('masks bare email addresses in free text', () => {
     const out = redactString('Notification delivery failed to qa-private@example.com after 3 retries')
     expect(out).toContain('<email:redacted>')

--- a/apps/web/tests/automation-log-redact.spec.ts
+++ b/apps/web/tests/automation-log-redact.spec.ts
@@ -127,6 +127,28 @@ describe('redactString', () => {
     expect(internalHost).not.toContain('pa/ss')
   })
 
+  it('masks malformed database URI credentials mixing raw @ with reserved delimiters', () => {
+    const slash = redactString('postgres://user:pa@ss/word@db.example.com:5432/app')
+    expect(slash).toBe('postgres://<redacted>@db.example.com:5432/app')
+    expect(slash).not.toContain('pa@ss')
+    expect(slash).not.toContain('word@db')
+
+    const query = redactString('postgres://user:pa@ss?word@db.example.com:5432/app')
+    expect(query).toBe('postgres://<redacted>@db.example.com:5432/app')
+    expect(query).not.toContain('pa@ss')
+    expect(query).not.toContain('word@db')
+
+    const hash = redactString('postgres://user:pa@ss#word@db.example.com:5432/app')
+    expect(hash).toBe('postgres://<redacted>@db.example.com:5432/app')
+    expect(hash).not.toContain('pa@ss')
+    expect(hash).not.toContain('word@db')
+
+    const mysql = redactString('mysql://root:r@w/ord@10.0.0.5:3306/data')
+    expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+    expect(mysql).not.toContain('r@w')
+    expect(mysql).not.toContain('ord@10')
+  })
+
   it('preserves the database host when malformed URI query text contains @', () => {
     const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
     expect(out).toBe('postgres://<redacted>@db.example.com:5432/app?notify=a@b')

--- a/apps/web/tests/automation-log-redact.spec.ts
+++ b/apps/web/tests/automation-log-redact.spec.ts
@@ -133,6 +133,22 @@ describe('redactString', () => {
     expect(out).not.toContain('pa/ss')
   })
 
+  it('masks adjacent and nested database URLs', () => {
+    const adjacent = redactString('postgres://u:p@db/app,mysql://root:rootpw@other/db')
+    expect(adjacent).toBe('postgres://<redacted>@db/app,mysql://<redacted>@other/db')
+    expect(adjacent).not.toContain('u:p')
+    expect(adjacent).not.toContain('root:rootpw')
+
+    const nested = redactString('postgres://u:p@db/app?next=mysql://root:rootpw@other/db')
+    expect(nested).toBe('postgres://<redacted>@db/app?next=mysql://<redacted>@other/db')
+    expect(nested).not.toContain('u:p')
+    expect(nested).not.toContain('root:rootpw')
+
+    const nestedOnly = redactString('postgres://db/app?next=mysql://root:rootpw@other/db')
+    expect(nestedOnly).toBe('postgres://db/app?next=mysql://<redacted>@other/db')
+    expect(nestedOnly).not.toContain('root:rootpw')
+  })
+
   it('does not mask database URLs without userinfo', () => {
     expect(redactString('postgres://db.example.com:5432/app')).toBe('postgres://db.example.com:5432/app')
     expect(redactString('mysql://10.0.0.5:3306/data')).toBe('mysql://10.0.0.5:3306/data')

--- a/apps/web/tests/automation-log-redact.spec.ts
+++ b/apps/web/tests/automation-log-redact.spec.ts
@@ -121,6 +121,10 @@ describe('redactString', () => {
     const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
     expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
     expect(mysql).not.toContain('r)w')
+
+    const internalHost = redactString('postgres://user:pa/ss@db_service:5432/app')
+    expect(internalHost).toBe('postgres://<redacted>@db_service:5432/app')
+    expect(internalHost).not.toContain('pa/ss')
   })
 
   it('preserves the database host when malformed URI query text contains @', () => {

--- a/packages/core-backend/src/multitable/automation-log-redact.ts
+++ b/packages/core-backend/src/multitable/automation-log-redact.ts
@@ -23,7 +23,9 @@
 
 export const REDACTION_VERSION = 1
 
-const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+type StringReplacement = string | ((substring: string, ...args: unknown[]) => string)
+
+const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, StringReplacement]> = [
   // DingTalk robot webhook (token-bearing) — must run before the generic
   // `access_token=` rule so the whole URL is masked, not just its token.
   [/https:\/\/oapi\.dingtalk\.com\/robot\/send\?access_token=[A-Za-z0-9._~-]+/gi, '<dingtalk-robot-webhook-redacted>'],
@@ -48,9 +50,43 @@ const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
     /\b(MULTITABLE_EMAIL_SMOKE_(?:TO|FROM|SUBJECT))(\s*[:=]\s*)("?)([^&\s"'<>]+)\3/g,
     '$1$2$3<redacted>$3',
   ],
-  [/\b(postgres(?:ql)?:\/\/)[^@\s"'<>]+@/gi, '$1<redacted>@'],
-  [/\b(mysql:\/\/)[^@\s"'<>]+@/gi, '$1<redacted>@'],
+  [
+    // Use URL parsing rather than a first-@ regex so raw `@` characters in
+    // username/password do not leak into persisted execution snapshots.
+    /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi,
+    redactDatabaseUrlCredentials,
+  ],
 ]
+
+function redactDatabaseUrlCredentials(value: string): string {
+  try {
+    const url = new URL(value)
+    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
+    if (!url.username && !url.password) return value
+    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return redactMalformedDatabaseUrlCredentials(value)
+  }
+}
+
+function redactMalformedDatabaseUrlCredentials(value: string): string {
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+}
+
+function findDatabaseAuthoritySeparator(rest: string): number {
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] !== '@') continue
+    if (hostPattern.test(rest.slice(index + 1))) return index
+  }
+  return -1
+}
 
 /**
  * Key names (NORMALIZED: lowercased, `-`/`_` stripped) whose values are masked
@@ -93,7 +129,9 @@ function normalizeKey(key: string): string {
 export function redactString(value: unknown): string {
   let result = String(value ?? '')
   for (const [pattern, replacement] of STRING_PATTERNS) {
-    result = result.replace(pattern, replacement)
+    result = typeof replacement === 'string'
+      ? result.replace(pattern, replacement)
+      : result.replace(pattern, replacement)
   }
   return result
 }

--- a/packages/core-backend/src/multitable/automation-log-redact.ts
+++ b/packages/core-backend/src/multitable/automation-log-redact.ts
@@ -80,7 +80,7 @@ function redactMalformedDatabaseUrlCredentials(value: string): string {
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
     if (hostPattern.test(rest.slice(index + 1))) return index

--- a/packages/core-backend/src/multitable/automation-log-redact.ts
+++ b/packages/core-backend/src/multitable/automation-log-redact.ts
@@ -61,38 +61,53 @@ const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, StringReplacement]> = [
 ]
 
 function redactDatabaseUrlCredentials(value: string): string {
-  try {
-    const url = new URL(value)
-    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
-    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
-    return `${url.protocol}//<redacted>@${url.host}${suffix}`
-  } catch {
-    return redactMalformedDatabaseUrlCredentials(value)
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const leadingHost = parseLeadingDatabaseHost(rest)
+  const firstAt = rest.indexOf('@')
+  if (leadingHost && (firstAt < 0 || leadingHost.end < firstAt)) {
+    return `${scheme}://${leadingHost.host}${redactNestedDatabaseUrls(rest.slice(leadingHost.end))}`
   }
+
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function redactNestedDatabaseUrls(value: string): string {
   return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
-function redactMalformedDatabaseUrlCredentials(value: string): string {
-  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
-  if (!match) return value
-  const scheme = match[1]
-  const rest = match[2]
-  const at = findDatabaseAuthoritySeparator(rest)
-  if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
+function parseLeadingDatabaseHost(rest: string): { host: string; end: number } | null {
+  const match = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/.exec(rest)
+  return match ? { host: match[0], end: match[0].length } : null
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
+  let bestIndex = -1
+  let bestScore = -1
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
-    if (hostPattern.test(rest.slice(index + 1))) return index
+    // If another database URL starts before this `@`, this candidate belongs to
+    // a nested URL in the path/query rather than to the outer URL's authority.
+    if (/(?:postgres(?:ql)?|mysql):\/\//i.test(rest.slice(0, index))) continue
+    const host = parseLeadingDatabaseHost(rest.slice(index + 1))
+    if (!host) continue
+    const score = scoreDatabaseHost(host.host)
+    if (score > bestScore) {
+      bestScore = score
+      bestIndex = index
+    }
   }
-  return -1
+  return bestIndex
+}
+
+function scoreDatabaseHost(host: string): number {
+  if (host.startsWith('[') || /:\d+$/.test(host) || /\d+\.\d+\.\d+\.\d+/.test(host)) return 3
+  if (host.includes('.') || host.includes('_')) return 2
+  return 1
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-log-redact.ts
+++ b/packages/core-backend/src/multitable/automation-log-redact.ts
@@ -25,6 +25,8 @@ export const REDACTION_VERSION = 1
 
 type StringReplacement = string | ((substring: string, ...args: unknown[]) => string)
 
+const DATABASE_URL_PATTERN = /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi
+
 const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, StringReplacement]> = [
   // DingTalk robot webhook (token-bearing) — must run before the generic
   // `access_token=` rule so the whole URL is masked, not just its token.
@@ -53,7 +55,7 @@ const STRING_PATTERNS: ReadonlyArray<readonly [RegExp, StringReplacement]> = [
   [
     // Use URL parsing rather than a first-@ regex so raw `@` characters in
     // username/password do not leak into persisted execution snapshots.
-    /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi,
+    DATABASE_URL_PATTERN,
     redactDatabaseUrlCredentials,
   ],
 ]
@@ -62,11 +64,16 @@ function redactDatabaseUrlCredentials(value: string): string {
   try {
     const url = new URL(value)
     if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    if (!url.username && !url.password) return value
-    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
+    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
+    return `${url.protocol}//<redacted>@${url.host}${suffix}`
   } catch {
     return redactMalformedDatabaseUrlCredentials(value)
   }
+}
+
+function redactNestedDatabaseUrls(value: string): string {
+  return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
 function redactMalformedDatabaseUrlCredentials(value: string): string {
@@ -76,7 +83,7 @@ function redactMalformedDatabaseUrlCredentials(value: string): string {
   const rest = match[2]
   const at = findDatabaseAuthoritySeparator(rest)
   if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function findDatabaseAuthoritySeparator(rest: string): number {

--- a/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
@@ -40,6 +40,10 @@ describe('automation-log-redact (shared backend redactor)', () => {
       const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
       expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
       expect(mysql).not.toContain('r)w')
+
+      const internalHost = redactString('postgres://user:pa/ss@db_service:5432/app')
+      expect(internalHost).toBe('postgres://<redacted>@db_service:5432/app')
+      expect(internalHost).not.toContain('pa/ss')
     })
 
     it('preserves the database host when malformed URI query text contains @', () => {

--- a/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
@@ -17,6 +17,42 @@ describe('automation-log-redact (shared backend redactor)', () => {
       expect(redactString(`token ${jwt}`)).toContain('<jwt:redacted>')
     })
 
+    it('scrubs database URI credentials containing raw @ characters before persistence', () => {
+      const postgres = redactString('dsn postgres://u@ser:p@ss@db.example.com:5432/app')
+      expect(postgres).toContain('postgres://<redacted>@db.example.com:5432/app')
+      expect(postgres).not.toContain('u@ser')
+      expect(postgres).not.toContain('p@ss')
+      expect(postgres).not.toContain('ss@db')
+
+      const mysql = redactString('mysql://root:r@w@10.0.0.5:3306/data')
+      expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+      expect(mysql).not.toContain('r@w')
+      expect(mysql).not.toContain('w@10')
+    })
+
+    it('scrubs malformed database URI credentials containing reserved delimiters before persistence', () => {
+      for (const secret of ['pa#ss', 'pa?ss', 'pa/ss', 'pa)ss', "pa'ss"]) {
+        const out = redactString(`postgres://user:${secret}@db.example.com:5432/app`)
+        expect(out).toBe('postgres://<redacted>@db.example.com:5432/app')
+        expect(out).not.toContain(secret)
+      }
+
+      const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
+      expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+      expect(mysql).not.toContain('r)w')
+    })
+
+    it('preserves the database host when malformed URI query text contains @', () => {
+      const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
+      expect(out).toBe('postgres://<redacted>@db.example.com:5432/app?notify=a@b')
+      expect(out).not.toContain('pa/ss')
+    })
+
+    it('does not scrub database URLs without userinfo', () => {
+      expect(redactString('postgres://db.example.com:5432/app')).toBe('postgres://db.example.com:5432/app')
+      expect(redactString('mysql://10.0.0.5:3306/data')).toBe('mysql://10.0.0.5:3306/data')
+    })
+
     it('masks the DingTalk robot webhook URL wholesale', () => {
       const url = 'https://oapi.dingtalk.com/robot/send?access_token=abcDEF123._~-'
       expect(redactString(`delivery to ${url}`)).toContain('<dingtalk-robot-webhook-redacted>')

--- a/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
@@ -52,6 +52,22 @@ describe('automation-log-redact (shared backend redactor)', () => {
       expect(out).not.toContain('pa/ss')
     })
 
+    it('scrubs adjacent and nested database URLs before persistence', () => {
+      const adjacent = redactString('postgres://u:p@db/app,mysql://root:rootpw@other/db')
+      expect(adjacent).toBe('postgres://<redacted>@db/app,mysql://<redacted>@other/db')
+      expect(adjacent).not.toContain('u:p')
+      expect(adjacent).not.toContain('root:rootpw')
+
+      const nested = redactString('postgres://u:p@db/app?next=mysql://root:rootpw@other/db')
+      expect(nested).toBe('postgres://<redacted>@db/app?next=mysql://<redacted>@other/db')
+      expect(nested).not.toContain('u:p')
+      expect(nested).not.toContain('root:rootpw')
+
+      const nestedOnly = redactString('postgres://db/app?next=mysql://root:rootpw@other/db')
+      expect(nestedOnly).toBe('postgres://db/app?next=mysql://<redacted>@other/db')
+      expect(nestedOnly).not.toContain('root:rootpw')
+    })
+
     it('does not scrub database URLs without userinfo', () => {
       expect(redactString('postgres://db.example.com:5432/app')).toBe('postgres://db.example.com:5432/app')
       expect(redactString('mysql://10.0.0.5:3306/data')).toBe('mysql://10.0.0.5:3306/data')

--- a/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-log-redact.test.ts
@@ -46,6 +46,28 @@ describe('automation-log-redact (shared backend redactor)', () => {
       expect(internalHost).not.toContain('pa/ss')
     })
 
+    it('scrubs malformed database URI credentials mixing raw @ with reserved delimiters', () => {
+      const slash = redactString('postgres://user:pa@ss/word@db.example.com:5432/app')
+      expect(slash).toBe('postgres://<redacted>@db.example.com:5432/app')
+      expect(slash).not.toContain('pa@ss')
+      expect(slash).not.toContain('word@db')
+
+      const query = redactString('postgres://user:pa@ss?word@db.example.com:5432/app')
+      expect(query).toBe('postgres://<redacted>@db.example.com:5432/app')
+      expect(query).not.toContain('pa@ss')
+      expect(query).not.toContain('word@db')
+
+      const hash = redactString('postgres://user:pa@ss#word@db.example.com:5432/app')
+      expect(hash).toBe('postgres://<redacted>@db.example.com:5432/app')
+      expect(hash).not.toContain('pa@ss')
+      expect(hash).not.toContain('word@db')
+
+      const mysql = redactString('mysql://root:r@w/ord@10.0.0.5:3306/data')
+      expect(mysql).toBe('mysql://<redacted>@10.0.0.5:3306/data')
+      expect(mysql).not.toContain('r@w')
+      expect(mysql).not.toContain('ord@10')
+    })
+
     it('preserves the database host when malformed URI query text contains @', () => {
       const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
       expect(out).toBe('postgres://<redacted>@db.example.com:5432/app?notify=a@b')

--- a/scripts/ops/multitable-phase3-release-gate-redact.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.mjs
@@ -66,7 +66,7 @@ function redactMalformedDatabaseUrlCredentials(value) {
 }
 
 function findDatabaseAuthoritySeparator(rest) {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
     if (hostPattern.test(rest.slice(index + 1))) return index

--- a/scripts/ops/multitable-phase3-release-gate-redact.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.mjs
@@ -10,6 +10,8 @@
 
 export const REDACTION_VERSION = 1
 
+const DATABASE_URL_PATTERN = /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi
+
 const STRING_PATTERNS = [
   [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>'],
   [/\beyJ[A-Za-z0-9._-]{20,}/g, '<jwt:redacted>'],
@@ -39,7 +41,7 @@ const STRING_PATTERNS = [
   [
     // Use URL parsing rather than a first-@ regex so raw `@` characters in
     // username/password do not leak.
-    /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi,
+    DATABASE_URL_PATTERN,
     redactDatabaseUrlCredentials,
   ],
 ]
@@ -48,11 +50,16 @@ function redactDatabaseUrlCredentials(value) {
   try {
     const url = new URL(value)
     if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    if (!url.username && !url.password) return value
-    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
+    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
+    return `${url.protocol}//<redacted>@${url.host}${suffix}`
   } catch {
     return redactMalformedDatabaseUrlCredentials(value)
   }
+}
+
+function redactNestedDatabaseUrls(value) {
+  return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
 function redactMalformedDatabaseUrlCredentials(value) {
@@ -62,7 +69,7 @@ function redactMalformedDatabaseUrlCredentials(value) {
   const rest = match[2]
   const at = findDatabaseAuthoritySeparator(rest)
   if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function findDatabaseAuthoritySeparator(rest) {

--- a/scripts/ops/multitable-phase3-release-gate-redact.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.mjs
@@ -37,14 +37,42 @@ const STRING_PATTERNS = [
     '$1$2$3<redacted>$3',
   ],
   [
-    /\b(postgres(?:ql)?:\/\/)[^@\s"'<>]+@/gi,
-    '$1<redacted>@',
-  ],
-  [
-    /\b(mysql:\/\/)[^@\s"'<>]+@/gi,
-    '$1<redacted>@',
+    // Use URL parsing rather than a first-@ regex so raw `@` characters in
+    // username/password do not leak.
+    /\b(?:postgres(?:ql)?|mysql):\/\/[^\s<>]+/gi,
+    redactDatabaseUrlCredentials,
   ],
 ]
+
+function redactDatabaseUrlCredentials(value) {
+  try {
+    const url = new URL(value)
+    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
+    if (!url.username && !url.password) return value
+    return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return redactMalformedDatabaseUrlCredentials(value)
+  }
+}
+
+function redactMalformedDatabaseUrlCredentials(value) {
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${rest.slice(at + 1)}`
+}
+
+function findDatabaseAuthoritySeparator(rest) {
+  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9][A-Za-z0-9.-]*)(?::\d+)?(?=$|[/?#])/
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] !== '@') continue
+    if (hostPattern.test(rest.slice(index + 1))) return index
+  }
+  return -1
+}
 
 const STRUCTURED_FIELDS = new Set([
   'authToken',

--- a/scripts/ops/multitable-phase3-release-gate-redact.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.mjs
@@ -47,38 +47,53 @@ const STRING_PATTERNS = [
 ]
 
 function redactDatabaseUrlCredentials(value) {
-  try {
-    const url = new URL(value)
-    if (!/^(postgres(?:ql)?|mysql):$/i.test(url.protocol)) return value
-    const suffix = redactNestedDatabaseUrls(`${url.pathname}${url.search}${url.hash}`)
-    if (!url.username && !url.password) return `${url.protocol}//${url.host}${suffix}`
-    return `${url.protocol}//<redacted>@${url.host}${suffix}`
-  } catch {
-    return redactMalformedDatabaseUrlCredentials(value)
+  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
+  if (!match) return value
+  const scheme = match[1]
+  const rest = match[2]
+  const leadingHost = parseLeadingDatabaseHost(rest)
+  const firstAt = rest.indexOf('@')
+  if (leadingHost && (firstAt < 0 || leadingHost.end < firstAt)) {
+    return `${scheme}://${leadingHost.host}${redactNestedDatabaseUrls(rest.slice(leadingHost.end))}`
   }
+
+  const at = findDatabaseAuthoritySeparator(rest)
+  if (at <= 0 || at === rest.length - 1) return value
+  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
 }
 
 function redactNestedDatabaseUrls(value) {
   return value.replace(DATABASE_URL_PATTERN, redactDatabaseUrlCredentials)
 }
 
-function redactMalformedDatabaseUrlCredentials(value) {
-  const match = /^(postgres(?:ql)?|mysql):\/\/(.+)$/i.exec(value)
-  if (!match) return value
-  const scheme = match[1]
-  const rest = match[2]
-  const at = findDatabaseAuthoritySeparator(rest)
-  if (at <= 0 || at === rest.length - 1) return value
-  return `${scheme}://<redacted>@${redactNestedDatabaseUrls(rest.slice(at + 1))}`
+function parseLeadingDatabaseHost(rest) {
+  const match = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/.exec(rest)
+  return match ? { host: match[0], end: match[0].length } : null
 }
 
 function findDatabaseAuthoritySeparator(rest) {
-  const hostPattern = /^(?:\[[^\]\s]+\]|[A-Za-z0-9_][A-Za-z0-9_.-]*)(?::\d+)?(?=$|[/?#])/
+  let bestIndex = -1
+  let bestScore = -1
   for (let index = 0; index < rest.length; index += 1) {
     if (rest[index] !== '@') continue
-    if (hostPattern.test(rest.slice(index + 1))) return index
+    // If another database URL starts before this `@`, this candidate belongs to
+    // a nested URL in the path/query rather than to the outer URL's authority.
+    if (/(?:postgres(?:ql)?|mysql):\/\//i.test(rest.slice(0, index))) continue
+    const host = parseLeadingDatabaseHost(rest.slice(index + 1))
+    if (!host) continue
+    const score = scoreDatabaseHost(host.host)
+    if (score > bestScore) {
+      bestScore = score
+      bestIndex = index
+    }
   }
-  return -1
+  return bestIndex
+}
+
+function scoreDatabaseHost(host) {
+  if (host.startsWith('[') || /:\d+$/.test(host) || /\d+\.\d+\.\d+\.\d+/.test(host)) return 3
+  if (host.includes('.') || host.includes('_')) return 2
+  return 1
 }
 
 const STRUCTURED_FIELDS = new Set([

--- a/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
@@ -121,6 +121,39 @@ test('redactString masks mysql URI credentials', () => {
   assert.doesNotMatch(out, /root:rootpw/)
 })
 
+test('redactString masks database URI credentials containing raw @ characters', () => {
+  const postgres = redactString('postgres://u@ser:p@ss@db.example.com:5432/app')
+  assert.equal(postgres, 'postgres://<redacted>@db.example.com:5432/app')
+  assert.doesNotMatch(postgres, /u@ser|p@ss|ss@db/)
+
+  const mysql = redactString('mysql://root:r@w@10.0.0.5:3306/data')
+  assert.equal(mysql, 'mysql://<redacted>@10.0.0.5:3306/data')
+  assert.doesNotMatch(mysql, /r@w|w@10/)
+})
+
+test('redactString masks malformed database URI credentials containing reserved delimiters', () => {
+  for (const secret of ['pa#ss', 'pa?ss', 'pa/ss', 'pa)ss', "pa'ss"]) {
+    const out = redactString(`postgres://user:${secret}@db.example.com:5432/app`)
+    assert.equal(out, 'postgres://<redacted>@db.example.com:5432/app')
+    assert.doesNotMatch(out, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+
+  const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
+  assert.equal(mysql, 'mysql://<redacted>@10.0.0.5:3306/data')
+  assert.doesNotMatch(mysql, /r\)w/)
+})
+
+test('redactString preserves the database host when malformed URI query text contains @', () => {
+  const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
+  assert.equal(out, 'postgres://<redacted>@db.example.com:5432/app?notify=a@b')
+  assert.doesNotMatch(out, /pa\/ss/)
+})
+
+test('redactString does not mask database URLs without userinfo', () => {
+  assert.equal(redactString('postgres://db.example.com:5432/app'), 'postgres://db.example.com:5432/app')
+  assert.equal(redactString('mysql://10.0.0.5:3306/data'), 'mysql://10.0.0.5:3306/data')
+})
+
 test('redactValue masks structured fields by name', () => {
   const obj = {
     authToken: 'realtokenvalue1234567890',

--- a/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
@@ -141,6 +141,10 @@ test('redactString masks malformed database URI credentials containing reserved 
   const mysql = redactString('mysql://root:r)w@10.0.0.5:3306/data')
   assert.equal(mysql, 'mysql://<redacted>@10.0.0.5:3306/data')
   assert.doesNotMatch(mysql, /r\)w/)
+
+  const internalHost = redactString('postgres://user:pa/ss@db_service:5432/app')
+  assert.equal(internalHost, 'postgres://<redacted>@db_service:5432/app')
+  assert.doesNotMatch(internalHost, /pa\/ss/)
 })
 
 test('redactString preserves the database host when malformed URI query text contains @', () => {

--- a/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
@@ -147,6 +147,24 @@ test('redactString masks malformed database URI credentials containing reserved 
   assert.doesNotMatch(internalHost, /pa\/ss/)
 })
 
+test('redactString masks malformed database URI credentials mixing raw @ with reserved delimiters', () => {
+  const slash = redactString('postgres://user:pa@ss/word@db.example.com:5432/app')
+  assert.equal(slash, 'postgres://<redacted>@db.example.com:5432/app')
+  assert.doesNotMatch(slash, /pa@ss|word@db/)
+
+  const query = redactString('postgres://user:pa@ss?word@db.example.com:5432/app')
+  assert.equal(query, 'postgres://<redacted>@db.example.com:5432/app')
+  assert.doesNotMatch(query, /pa@ss|word@db/)
+
+  const hash = redactString('postgres://user:pa@ss#word@db.example.com:5432/app')
+  assert.equal(hash, 'postgres://<redacted>@db.example.com:5432/app')
+  assert.doesNotMatch(hash, /pa@ss|word@db/)
+
+  const mysql = redactString('mysql://root:r@w/ord@10.0.0.5:3306/data')
+  assert.equal(mysql, 'mysql://<redacted>@10.0.0.5:3306/data')
+  assert.doesNotMatch(mysql, /r@w|ord@10/)
+})
+
 test('redactString preserves the database host when malformed URI query text contains @', () => {
   const out = redactString('postgres://user:pa/ss@db.example.com:5432/app?notify=a@b')
   assert.equal(out, 'postgres://<redacted>@db.example.com:5432/app?notify=a@b')

--- a/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-redact.test.mjs
@@ -153,6 +153,20 @@ test('redactString preserves the database host when malformed URI query text con
   assert.doesNotMatch(out, /pa\/ss/)
 })
 
+test('redactString masks adjacent and nested database URLs', () => {
+  const adjacent = redactString('postgres://u:p@db/app,mysql://root:rootpw@other/db')
+  assert.equal(adjacent, 'postgres://<redacted>@db/app,mysql://<redacted>@other/db')
+  assert.doesNotMatch(adjacent, /u:p|root:rootpw/)
+
+  const nested = redactString('postgres://u:p@db/app?next=mysql://root:rootpw@other/db')
+  assert.equal(nested, 'postgres://<redacted>@db/app?next=mysql://<redacted>@other/db')
+  assert.doesNotMatch(nested, /u:p|root:rootpw/)
+
+  const nestedOnly = redactString('postgres://db/app?next=mysql://root:rootpw@other/db')
+  assert.equal(nestedOnly, 'postgres://db/app?next=mysql://<redacted>@other/db')
+  assert.doesNotMatch(nestedOnly, /root:rootpw/)
+})
+
 test('redactString does not mask database URLs without userinfo', () => {
   assert.equal(redactString('postgres://db.example.com:5432/app'), 'postgres://db.example.com:5432/app')
   assert.equal(redactString('mysql://10.0.0.5:3306/data'), 'mysql://10.0.0.5:3306/data')


### PR DESCRIPTION
## Summary

Closes the rank-2 quality-polish redaction edge where Postgres/MySQL URI credentials were redacted with a first-`@` regex. A credential such as `postgres://u@ser:p@ss@db.example.com/app` could leave tail fragments like `ss@db` in the output.

- replaces the first-`@` database URL credential regex with a URL-parser based replacer
- keeps the browser automation-log redactor and Phase 3 release-gate redactor mirrored
- adds Postgres and MySQL raw-`@` credential tests on both paths

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/automation-log-redact.spec.ts --watch=false`
- `node --test scripts/ops/multitable-phase3-release-gate-redact.test.mjs`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `git diff --check`