### PR TITLE
fix(multitable): lock hierarchy parent link cardinality in field manager

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -93,9 +93,17 @@
             </select>
           </label>
           <label class="meta-field-mgr__toggle">
-            <input v-model="linkDraft.limitSingleRecord" type="checkbox" />
+            <input
+              v-model="linkDraft.limitSingleRecord"
+              type="checkbox"
+              :disabled="linkSingleRecordLockedByHierarchy"
+              data-test="link-single-record-toggle"
+            />
             <span>{{ ml('field.limitSingleLinkedRecord') }}</span>
           </label>
+          <div v-if="linkSingleRecordLockedByHierarchy" class="meta-field-mgr__hint" data-test="hierarchy-parent-link-lock">
+            {{ ml('field.hierarchyParentLinkLocked') }}
+          </div>
         </template>
 
         <template v-else-if="configTargetType === 'person'">
@@ -756,6 +764,10 @@ const props = defineProps<{
   fields: MetaField[]
   sheets: MetaSheet[]
   sheetId: string
+  // S4 companion guard: hierarchy reparent writes a single `[parentRecordId]`
+  // into the configured parent link field, so the field manager must not offer
+  // a downgrade path from single-value link to multi-value link for those IDs.
+  hierarchyParentFieldIds?: string[]
   // #5b: formula dry-run callback (the workbench wires it to client.dryRunFormula). Optional so the
   // panel degrades gracefully (button hidden) where no fn is provided.
   dryRunFn?: (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) => Promise<DryRunResult>
@@ -888,6 +900,13 @@ const configTarget = computed(() => props.fields.find((field) => field.id === co
 const deleteTarget = computed(() => props.fields.find((field) => field.id === deleteTargetId.value) ?? null)
 const linkSourceFields = computed(() => props.fields.filter((field) => field.type === 'link'))
 const targetSheets = computed(() => props.sheets.filter((sheet) => sheet.id !== props.sheetId))
+const hierarchyParentFieldIdSet = computed(() => new Set(props.hierarchyParentFieldIds ?? []))
+const linkSingleRecordLockedByHierarchy = computed(() => {
+  const target = configTarget.value
+  return target?.type === 'link'
+    && target.property?.limitSingleRecord === true
+    && hierarchyParentFieldIdSet.value.has(target.id)
+})
 const formulaSourceFields = computed(() =>
   props.fields.filter((field) => field.id !== configTarget.value?.id && field.type !== 'formula'),
 )
@@ -1231,7 +1250,7 @@ function serializeFieldDraft(type: string | null): string {
   if (type === 'link') {
     return JSON.stringify({
       foreignSheetId: linkDraft.foreignSheetId,
-      limitSingleRecord: linkDraft.limitSingleRecord,
+      limitSingleRecord: linkSingleRecordLockedByHierarchy.value || linkDraft.limitSingleRecord,
     })
   }
   if (type === 'person') {
@@ -1724,7 +1743,7 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     return {
       foreignSheetId: linkDraft.foreignSheetId,
       foreignDatasheetId: linkDraft.foreignSheetId,
-      limitSingleRecord: linkDraft.limitSingleRecord,
+      limitSingleRecord: linkSingleRecordLockedByHierarchy.value || linkDraft.limitSingleRecord,
     }
   }
   if (normalizedType === 'person') {

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -111,9 +111,17 @@
             {{ ml('field.personHint') }}
           </div>
           <label class="meta-field-mgr__toggle">
-            <input v-model="personDraft.limitSingleRecord" type="checkbox" />
+            <input
+              v-model="personDraft.limitSingleRecord"
+              type="checkbox"
+              :disabled="linkSingleRecordLockedByHierarchy"
+              data-test="person-single-record-toggle"
+            />
             <span>{{ ml('field.limitSinglePerson') }}</span>
           </label>
+          <div v-if="linkSingleRecordLockedByHierarchy" class="meta-field-mgr__hint" data-test="hierarchy-parent-link-lock">
+            {{ ml('field.hierarchyParentLinkLocked') }}
+          </div>
         </template>
 
         <template v-else-if="configTargetType === 'lookup'">
@@ -1255,7 +1263,7 @@ function serializeFieldDraft(type: string | null): string {
   }
   if (type === 'person') {
     return JSON.stringify({
-      limitSingleRecord: personDraft.limitSingleRecord,
+      limitSingleRecord: linkSingleRecordLockedByHierarchy.value || personDraft.limitSingleRecord,
     })
   }
   if (type === 'lookup') {
@@ -1747,7 +1755,7 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
   }
   if (normalizedType === 'person') {
-    return { limitSingleRecord: personDraft.limitSingleRecord }
+    return { limitSingleRecord: linkSingleRecordLockedByHierarchy.value || personDraft.limitSingleRecord }
   }
   if (normalizedType === 'lookup') {
     if (!lookupDraft.linkFieldId || !linkSourceFields.value.some((field) => field.id === lookupDraft.linkFieldId) || !lookupDraft.targetFieldId) {

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -22,6 +22,7 @@ export type MetaManagerLabelKey =
   | 'formatting.noFieldsHint' | 'formatting.saveRules'
   | 'field.title' | 'field.empty' | 'field.options' | 'field.optionValue'
   | 'field.targetSheet' | 'field.selectSheet' | 'field.limitSingleLinkedRecord'
+  | 'field.hierarchyParentLinkLocked'
   | 'field.personHint' | 'field.limitSinglePerson'
   | 'field.linkField' | 'field.selectLinkField'
   | 'field.foreignSheetId' | 'field.targetFieldId'
@@ -162,6 +163,10 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.targetSheet': { en: 'Target sheet', zh: '目标表' },
   'field.selectSheet': { en: 'Select sheet', zh: '选择表' },
   'field.limitSingleLinkedRecord': { en: 'Limit to a single linked record', zh: '限制为单条关联记录' },
+  'field.hierarchyParentLinkLocked': {
+    en: 'This field is used as a hierarchy parent field, so it must remain single-record.',
+    zh: '此字段正在作为层级父字段使用，必须保持单条关联。',
+  },
   'field.personHint': {
     en: 'People fields use the system people sheet preset and stay hidden from normal sheet navigation.',
     zh: '人员字段使用系统人员表预设，并在普通表导航中保持隐藏。',

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -355,11 +355,19 @@
       @cancel-import="cancelImport"
       @import="onBulkImport"
     />
-    <MetaLinkPicker :visible="linkPickerVisible" :field="linkPickerField" :current-value="linkPickerCurrentValue"
-      @close="linkPickerVisible = false" @confirm="onLinkPickerConfirm"
+    <MetaLinkPicker
+      :visible="linkPickerVisible"
+      :field="linkPickerField"
+      :current-value="linkPickerCurrentValue"
+      @close="linkPickerVisible = false"
+      @confirm="onLinkPickerConfirm"
     />
     <MetaFieldManager
-      :visible="showFieldManager" :fields="propertyVisibleWorkbenchFields" :sheets="workbench.sheets.value" :sheet-id="workbench.activeSheetId.value"
+      :visible="showFieldManager"
+      :fields="propertyVisibleWorkbenchFields"
+      :sheets="workbench.sheets.value"
+      :sheet-id="workbench.activeSheetId.value"
+      :hierarchy-parent-field-ids="hierarchyParentFieldIds"
       :dry-run-fn="dryRunFormulaFn"
       :current-record-id="selectedRecordId"
       :ai-preview-fn="aiPreviewFn"
@@ -421,7 +429,6 @@ import { useRouter } from 'vue-router'
 import { AppRouteNames } from '../../router/types'
 import { useAuth } from '../../composables/useAuth'
 import { useLocale } from '../../composables/useLocale'
-import { apiFetch } from '../../utils/api'
 import type { CalendarVisibleRange } from '../../composables/useCalendarDays'
 import {
   EffectiveCalendarFetchError,
@@ -1264,6 +1271,12 @@ async function resolveLinkedImportValue(rawValue: string, field: MetaField): Pro
 }
 
 const propertyVisibleWorkbenchFields = computed(() => filterPropertyVisibleFields(workbench.fields.value))
+const hierarchyParentFieldIds = computed(() =>
+  workbench.views.value
+    .filter((view) => view.type === 'hierarchy' && view.sheetId === workbench.activeSheetId.value)
+    .map((view) => typeof view.config?.parentFieldId === 'string' ? view.config.parentFieldId : '')
+    .filter((fieldId): fieldId is string => fieldId.length > 0),
+)
 const propertyVisibleGridFields = computed(() => filterPropertyVisibleFields(grid.fields.value))
 
 const uploadAttachmentFn: MetaAttachmentUploadFn = async (file: File, context?: MetaAttachmentUploadContext) =>

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1274,7 +1274,7 @@ const propertyVisibleWorkbenchFields = computed(() => filterPropertyVisibleField
 const hierarchyParentFieldIds = computed(() =>
   workbench.views.value
     .filter((view) => view.type === 'hierarchy' && view.sheetId === workbench.activeSheetId.value)
-    .map((view) => typeof view.config?.parentFieldId === 'string' ? view.config.parentFieldId : '')
+    .map((view) => typeof view.config?.parentFieldId === 'string' ? view.config.parentFieldId.trim() : '')
     .filter((fieldId): fieldId is string => fieldId.length > 0),
 )
 const propertyVisibleGridFields = computed(() => filterPropertyVisibleFields(grid.fields.value))

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -879,4 +879,114 @@ describe('MetaFieldManager', () => {
 
     app.unmount()
   })
+
+  it('locks single-record link mode when the field is used as a hierarchy parent', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [{ id: 'sheet_2', name: 'Related' }],
+          fields: [
+            {
+              id: 'fld_parent',
+              name: 'Parent',
+              type: 'link',
+              property: { foreignSheetId: 'sheet_2', limitSingleRecord: true },
+            },
+          ],
+          hierarchyParentFieldIds: ['fld_parent'],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const singleToggle = container.querySelector('[data-test="link-single-record-toggle"]') as HTMLInputElement
+    expect(singleToggle.disabled).toBe(true)
+    expect(singleToggle.checked).toBe(true)
+    expect(container.querySelector('[data-test="hierarchy-parent-link-lock"]')?.textContent).toContain('hierarchy parent')
+
+    // Even a synthetic event cannot downgrade the emitted property.
+    singleToggle.checked = false
+    singleToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('fld_parent', {
+      property: {
+        foreignSheetId: 'sheet_2',
+        foreignDatasheetId: 'sheet_2',
+        limitSingleRecord: true,
+      },
+    })
+
+    app.unmount()
+  })
+
+  it('still allows unrelated link fields to switch to multi-record mode', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [{ id: 'sheet_2', name: 'Related' }],
+          fields: [
+            {
+              id: 'fld_vendor',
+              name: 'Vendor',
+              type: 'link',
+              property: { foreignSheetId: 'sheet_2', limitSingleRecord: true },
+            },
+          ],
+          hierarchyParentFieldIds: ['fld_parent'],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const singleToggle = container.querySelector('[data-test="link-single-record-toggle"]') as HTMLInputElement
+    expect(singleToggle.disabled).toBe(false)
+    singleToggle.checked = false
+    singleToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('fld_vendor', {
+      property: {
+        foreignSheetId: 'sheet_2',
+        foreignDatasheetId: 'sheet_2',
+        limitSingleRecord: false,
+      },
+    })
+
+    app.unmount()
+  })
 })

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -937,6 +937,61 @@ describe('MetaFieldManager', () => {
     app.unmount()
   })
 
+  it('locks single-record person link mode when the user field is used as a hierarchy parent', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [{ id: 'sheet_1', name: 'Current' }],
+          fields: [
+            {
+              id: 'fld_user_parent',
+              name: 'Owner',
+              type: 'link',
+              property: { refKind: 'user', limitSingleRecord: true },
+            },
+          ],
+          hierarchyParentFieldIds: ['fld_user_parent'],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const singleToggle = container.querySelector('[data-test="person-single-record-toggle"]') as HTMLInputElement
+    expect(singleToggle.disabled).toBe(true)
+    expect(singleToggle.checked).toBe(true)
+    expect(container.querySelector('[data-test="hierarchy-parent-link-lock"]')?.textContent).toContain('hierarchy parent')
+
+    // Even a synthetic event cannot downgrade the emitted person/user link property.
+    singleToggle.checked = false
+    singleToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('fld_user_parent', {
+      property: {
+        limitSingleRecord: true,
+      },
+    })
+
+    app.unmount()
+  })
+
   it('still allows unrelated link fields to switch to multi-record mode', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -494,6 +494,7 @@ vi.mock('../src/multitable/components/MetaFieldManager.vue', () => ({
     props: {
       visible: { type: Boolean, default: false },
       fields: { type: Array, default: () => [] },
+      hierarchyParentFieldIds: { type: Array, default: () => [] },
     },
     emits: ['create-field', 'update:dirty'],
     render() {
@@ -501,9 +502,15 @@ vi.mock('../src/multitable/components/MetaFieldManager.vue', () => ({
         .map((field) => field.id ?? '')
         .filter((fieldId) => fieldId.length > 0)
         .join(',')
+      const hierarchyParentFieldIds = (this.$props.hierarchyParentFieldIds as string[])
+        .filter((fieldId) => fieldId.length > 0)
+        .join(',')
       return h(
         'div',
-        { 'data-field-manager-field-ids': fieldIds },
+        {
+          'data-field-manager-field-ids': fieldIds,
+          'data-field-manager-hierarchy-parent-ids': hierarchyParentFieldIds,
+        },
         [
           h(
             'button',
@@ -1154,6 +1161,29 @@ describe('MultitableWorkbench view wiring', () => {
 
     expect(container!.querySelector('[data-view-manager-field-ids]')?.getAttribute('data-view-manager-field-ids'))
       .toBe('fld_title,fld_view_hidden')
+  })
+
+  it('passes active-sheet hierarchy parent field ids into the field manager', async () => {
+    workbenchMock.fields.value = [
+      { id: 'fld_title', name: 'Title', type: 'string' },
+      { id: 'fld_parent', name: 'Parent', type: 'link', property: { foreignSheetId: 'sheet_orders', limitSingleRecord: true } },
+      { id: 'fld_other_parent', name: 'Other Parent', type: 'link', property: { foreignSheetId: 'sheet_other', limitSingleRecord: true } },
+    ]
+    workbenchMock.views.value = [
+      ...workbenchMock.views.value,
+      { id: 'view_hierarchy', sheetId: 'sheet_orders', name: 'Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_parent' } },
+      { id: 'view_other_hierarchy', sheetId: 'sheet_other', name: 'Other Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_other_parent' } },
+    ]
+
+    mountWorkbench()
+    await flushUi()
+
+    const managerButtons = Array.from(container!.querySelectorAll('.mt-workbench__mgr-btn')) as HTMLButtonElement[]
+    managerButtons.find((button) => button.textContent?.includes('Fields'))?.click()
+    await flushUi()
+
+    expect(container!.querySelector('[data-field-manager-hierarchy-parent-ids]')?.getAttribute('data-field-manager-hierarchy-parent-ids'))
+      .toBe('fld_parent')
   })
 
   it('opens sheet access manager and refreshes sheet state after updates', async () => {

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -1171,7 +1171,7 @@ describe('MultitableWorkbench view wiring', () => {
     ]
     workbenchMock.views.value = [
       ...workbenchMock.views.value,
-      { id: 'view_hierarchy', sheetId: 'sheet_orders', name: 'Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_parent' } },
+      { id: 'view_hierarchy', sheetId: 'sheet_orders', name: 'Hierarchy', type: 'hierarchy', config: { parentFieldId: ' fld_parent ' } },
       { id: 'view_other_hierarchy', sheetId: 'sheet_other', name: 'Other Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_other_parent' } },
     ]
 


### PR DESCRIPTION
## Summary

S4 frontend companion for the hierarchy-parent link downgrade guard:

- passes active-sheet hierarchy `parentFieldId` values into `MetaFieldManager` as a narrow `hierarchyParentFieldIds` prop;
- disables the link `limitSingleRecord` checkbox when the configured field is already used as a hierarchy parent field;
- forces the emitted link property to keep `limitSingleRecord: true` for locked fields, so synthetic draft/event changes cannot downgrade it;
- keeps ordinary link fields editable, including single-record -> multi-record changes when they are not hierarchy parents.

This is UX/readability only. The backend safety guard remains #2523; this PR does not change backend/runtime/storage behavior.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts --watch=false` — 20/20
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts --watch=false -t "passes active-sheet hierarchy parent field ids into the field manager"` — 1/1
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec eslint src/multitable/components/MetaFieldManager.vue src/multitable/views/MultitableWorkbench.vue src/multitable/utils/meta-manager-labels.ts tests/multitable-field-manager.spec.ts tests/multitable-workbench-view.spec.ts` — 0 errors; existing spec-file `vue/one-component-per-file` warnings only
- `git diff --check`

## Notes

Local full `tests/multitable-workbench-view.spec.ts` still has an unrelated existing failure in `opens workflow designer with multitable context when automation is enabled` (`pushSpy` not called). The new workbench wiring test passes directly and is the scoped evidence for this PR.
