### PR TITLE
feat(attendance): harden schedule group parent links

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -353,6 +353,9 @@ attendanceIntegrationDescribe(
       await requireAttendanceTable(pool, 'attendance_rotation_assignments')
       await requireAttendanceTable(pool, 'attendance_groups')
       await requireAttendanceTable(pool, 'attendance_group_members')
+      await requireAttendanceTable(pool, 'attendance_schedule_groups')
+      await requireAttendanceTable(pool, 'attendance_schedule_group_members')
+      await requireAttendanceTable(pool, 'attendance_scheduler_scopes')
       await requireAttendanceTable(pool, 'attendance_rule_template_library')
       await requireAttendanceTable(pool, 'attendance_rule_template_versions')
     } catch (error) {
@@ -5584,6 +5587,156 @@ attendanceIntegrationDescribe(
       }
       if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
       else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.end().catch(() => undefined)
+    }
+  })
+
+  it('hardens schedule group parent links before exposing small-organization editing', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    expect(dbUrl).toBeTruthy()
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-small-org-admin-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    const codePrefix = `so0-${runSuffix}`
+    const pool = new Pool({ connectionString: dbUrl })
+    const createdIds: string[] = []
+    const foreignParentId = randomUuidV4()
+
+    const createGroup = async (body: Record<string, unknown>) => {
+      const response = await requestJson(`${baseUrl}/api/attendance/schedule-groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+      expect(response.status, response.raw).toBe(200)
+      const data = (response.body as { data?: { id?: string } } | undefined)?.data
+      expect(data?.id).toBeTruthy()
+      if (data?.id) createdIds.push(data.id)
+      return data as any
+    }
+
+    const expectRouteError = (response: HttpResponse, status: number, code: string) => {
+      expect(response.status, response.raw).toBe(status)
+      const error = (response.body as { error?: { code?: string } } | undefined)?.error
+      expect(error?.code).toBe(code)
+    }
+
+    try {
+      const root = await createGroup({
+        name: `SO0 Root ${runSuffix}`,
+        code: `${codePrefix}-root`,
+        departmentRef: `dept-root-${runSuffix}`,
+      })
+      const child = await createGroup({
+        name: `SO0 Child ${runSuffix}`,
+        code: `${codePrefix}-child`,
+        parentId: root.id,
+        departmentRef: `dept-child-${runSuffix}`,
+      })
+
+      const childLookup = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${child.id}`, { headers })
+      expect(childLookup.status).toBe(200)
+      const childData = (childLookup.body as { data?: { parentId?: string | null; departmentRef?: string | null } } | undefined)?.data
+      expect(childData?.parentId).toBe(root.id)
+      expect(childData?.departmentRef).toBe(`dept-child-${runSuffix}`)
+
+      const partialUpdate = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${child.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ name: `SO0 Child Renamed ${runSuffix}` }),
+      })
+      expect(partialUpdate.status, partialUpdate.raw).toBe(200)
+      const partialData = (partialUpdate.body as { data?: { parentId?: string | null; departmentRef?: string | null } } | undefined)?.data
+      expect(partialData?.parentId).toBe(root.id)
+      expect(partialData?.departmentRef).toBe(`dept-child-${runSuffix}`)
+
+      const selfParentUpdate = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${root.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ parentId: root.id }),
+      })
+      expectRouteError(selfParentUpdate, 422, 'SCHEDULE_GROUP_PARENT_CYCLE')
+      const rootAfterSelfParent = await pool.query('SELECT parent_id FROM attendance_schedule_groups WHERE id = $1', [root.id])
+      expect(rootAfterSelfParent.rows[0]?.parent_id).toBeNull()
+
+      const inactiveParent = await createGroup({
+        name: `SO0 Inactive Parent ${runSuffix}`,
+        code: `${codePrefix}-inactive`,
+        isActive: false,
+      })
+      const inactiveParentChild = await requestJson(`${baseUrl}/api/attendance/schedule-groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `SO0 Invalid Inactive Child ${runSuffix}`,
+          code: `${codePrefix}-inactive-child`,
+          parentId: inactiveParent.id,
+        }),
+      })
+      expectRouteError(inactiveParentChild, 422, 'SCHEDULE_GROUP_PARENT_INVALID')
+
+      await pool.query(
+        `INSERT INTO attendance_schedule_groups (id, org_id, name, code, is_active)
+         VALUES ($1, $2, $3, $4, true)`,
+        [foreignParentId, 'other-org', `SO0 Foreign Parent ${runSuffix}`, `${codePrefix}-foreign`]
+      )
+      const foreignParentChild = await requestJson(`${baseUrl}/api/attendance/schedule-groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `SO0 Invalid Foreign Child ${runSuffix}`,
+          code: `${codePrefix}-foreign-child`,
+          parentId: foreignParentId,
+        }),
+      })
+      expectRouteError(foreignParentChild, 422, 'SCHEDULE_GROUP_PARENT_INVALID')
+
+      const cycleUpdate = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${root.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ parentId: child.id }),
+      })
+      expectRouteError(cycleUpdate, 422, 'SCHEDULE_GROUP_PARENT_CYCLE')
+      const rootAfterCycle = await pool.query('SELECT parent_id FROM attendance_schedule_groups WHERE id = $1', [root.id])
+      expect(rootAfterCycle.rows[0]?.parent_id).toBeNull()
+
+      const deleteParent = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${root.id}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expectRouteError(deleteParent, 409, 'SCHEDULE_GROUP_HAS_ACTIVE_CHILDREN')
+
+      const deactivateParent = await requestJson(`${baseUrl}/api/attendance/schedule-groups/${root.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ isActive: false }),
+      })
+      expectRouteError(deactivateParent, 409, 'SCHEDULE_GROUP_HAS_ACTIVE_CHILDREN')
+      const rootAfterDeactivate = await pool.query('SELECT is_active FROM attendance_schedule_groups WHERE id = $1', [root.id])
+      expect(rootAfterDeactivate.rows[0]?.is_active).toBe(true)
+    } finally {
+      await pool.query(
+        `DELETE FROM attendance_schedule_group_members
+         WHERE schedule_group_id IN (
+           SELECT id FROM attendance_schedule_groups WHERE code LIKE $1
+         )`,
+        [`${codePrefix}%`]
+      ).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_schedule_groups WHERE code LIKE $1', [`${codePrefix}%`]).catch(() => undefined)
+      if (createdIds.length) {
+        await pool.query('DELETE FROM attendance_schedule_groups WHERE id = ANY($1::uuid[])', [createdIds]).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM attendance_schedule_groups WHERE id = $1', [foreignParentId]).catch(() => undefined)
       await pool.end().catch(() => undefined)
     }
   })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -2374,6 +2374,7 @@ describe('attendance UUID route validation', () => {
       const rbac = rbacQueryResult(sql, params, true)
       if (rbac !== undefined) return rbac
       if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
       if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET name = $3')) {
         return [scheduleGroupRow({ name: 'Line A Prime', updated_by: params[10] })]
       }
@@ -2401,6 +2402,7 @@ describe('attendance UUID route validation', () => {
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
       if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeEditRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
       if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET name = $3')) {
         return [scheduleGroupRow({ name: 'Line A Prime', updated_by: params[10] })]
       }
@@ -2471,6 +2473,8 @@ describe('attendance UUID route validation', () => {
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
       if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeEditRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
+      if (sql.includes('FROM attendance_schedule_groups') && sql.includes('parent_id = $2')) return []
       if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET is_active = false')) {
         return [scheduleGroupRow({ is_active: false, updated_by: params[2] })]
       }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7646,7 +7646,7 @@ function normalizeAttendanceScheduleGroupInput(value, existing = null) {
     ? normalizeOptionalUuidField('parentId', value.parentId)
     : existing?.parent_id ?? existing?.parentId ?? null
   if (parentId && existing?.id && parentId === existing.id) {
-    throw new HttpError(400, 'VALIDATION_ERROR', 'parentId cannot reference the same schedule group')
+    throw new HttpError(422, 'SCHEDULE_GROUP_PARENT_CYCLE', 'Schedule group parent would create a cycle')
   }
   return {
     name,
@@ -7711,6 +7711,13 @@ async function acquireAttendanceScheduleGroupMemberLock(client, orgId, scheduleG
   await client.query(
     'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
     ['attendance-schedule-group-member', buildAttendanceScheduleGroupMemberLockKey(orgId, scheduleGroupId, userId)]
+  )
+}
+
+async function acquireAttendanceScheduleGroupTreeLock(client, orgId) {
+  await client.query(
+    'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+    ['attendance-schedule-group-tree', String(orgId ?? '')]
   )
 }
 
@@ -17880,6 +17887,61 @@ module.exports = {
         target: { scheduleGroupIds: [groupId] },
         actorAccess: access,
       })
+    }
+
+    async function assertAttendanceScheduleGroupParentAllowed(client, { orgId, groupId, parentId }) {
+      if (!parentId) return
+      if (groupId && parentId === groupId) {
+        throw new HttpError(422, 'SCHEDULE_GROUP_PARENT_CYCLE', 'Schedule group parent would create a cycle')
+      }
+
+      const parentRows = await client.query(
+        `SELECT id, parent_id, is_active
+         FROM attendance_schedule_groups
+         WHERE id = $1 AND org_id = $2
+         LIMIT 1`,
+        [parentId, orgId]
+      )
+      if (!parentRows.length || parentRows[0].is_active === false) {
+        throw new HttpError(422, 'SCHEDULE_GROUP_PARENT_INVALID', 'Schedule group parent must be an active group in the same organization')
+      }
+
+      const seen = new Set()
+      if (groupId) seen.add(groupId)
+      let cursor = parentRows[0]
+      while (cursor?.parent_id) {
+        const nextParentId = cursor.parent_id
+        if (seen.has(nextParentId)) {
+          throw new HttpError(422, 'SCHEDULE_GROUP_PARENT_CYCLE', 'Schedule group parent would create a cycle')
+        }
+        seen.add(nextParentId)
+        const nextRows = await client.query(
+          `SELECT id, parent_id, is_active
+           FROM attendance_schedule_groups
+           WHERE id = $1 AND org_id = $2
+           LIMIT 1`,
+          [nextParentId, orgId]
+        )
+        if (!nextRows.length || nextRows[0].is_active === false) {
+          throw new HttpError(422, 'SCHEDULE_GROUP_PARENT_INVALID', 'Schedule group parent chain must stay inside active groups in the same organization')
+        }
+        cursor = nextRows[0]
+      }
+    }
+
+    async function assertAttendanceScheduleGroupCanDeactivate(client, orgId, groupId) {
+      const childRows = await client.query(
+        `SELECT id
+         FROM attendance_schedule_groups
+         WHERE org_id = $1
+           AND parent_id = $2
+           AND is_active = true
+         LIMIT 1`,
+        [orgId, groupId]
+      )
+      if (childRows.length) {
+        throw new HttpError(409, 'SCHEDULE_GROUP_HAS_ACTIVE_CHILDREN', 'Schedule group has active child groups')
+      }
     }
 
     async function assertAttendanceGroupFixedScheduleActionsAllowed(req, res, { groupId, actions, actorAccess } = {}) {
@@ -31314,28 +31376,39 @@ module.exports = {
           throw error
         }
         try {
-          const rows = await db.query(
-            `INSERT INTO attendance_schedule_groups (
-               org_id, name, code, description, attendance_group_id, parent_id, department_ref,
-               source, is_active, created_by, updated_by, created_at, updated_at
-             )
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10, now(), now())
-             RETURNING *`,
-            [
+          const rows = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleGroupTreeLock(trx, orgId)
+            await assertAttendanceScheduleGroupParentAllowed(trx, {
               orgId,
-              input.name,
-              input.code,
-              input.description,
-              input.attendanceGroupId,
-              input.parentId,
-              input.departmentRef,
-              input.source,
-              input.isActive,
-              actorId,
-            ]
-          )
+              parentId: input.parentId,
+            })
+            return trx.query(
+              `INSERT INTO attendance_schedule_groups (
+                 org_id, name, code, description, attendance_group_id, parent_id, department_ref,
+                 source, is_active, created_by, updated_by, created_at, updated_at
+               )
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10, now(), now())
+               RETURNING *`,
+              [
+                orgId,
+                input.name,
+                input.code,
+                input.description,
+                input.attendanceGroupId,
+                input.parentId,
+                input.departmentRef,
+                input.source,
+                input.isActive,
+                actorId,
+              ]
+            )
+          })
           res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
         } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
           if (error?.code === '23505') {
             res.status(409).json({ ok: false, error: { code: 'ALREADY_EXISTS', message: 'Schedule group name or code already exists' } })
             return
@@ -31382,35 +31455,53 @@ module.exports = {
           }
           const access = await assertAttendanceScheduleGroupEditAllowed(req, res, { groupId, actorAccess })
           if (!access) return
-          const input = normalizeAttendanceScheduleGroupInput(parsed.data, existingRows[0])
-          const rows = await db.query(
-            `UPDATE attendance_schedule_groups
-             SET name = $3,
-                 code = $4,
-                 description = $5,
-                 attendance_group_id = $6,
-                 parent_id = $7,
-                 department_ref = $8,
-                 source = $9,
-                 is_active = $10,
-                 updated_by = $11,
-                 updated_at = now()
-             WHERE id = $1 AND org_id = $2
-             RETURNING *`,
-            [
-              groupId,
+          const rows = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleGroupTreeLock(trx, orgId)
+            const lockedRows = await trx.query(
+              'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
+              [groupId, orgId]
+            )
+            if (!lockedRows.length) {
+              throw new HttpError(404, 'NOT_FOUND', 'Schedule group not found')
+            }
+            const input = normalizeAttendanceScheduleGroupInput(parsed.data, lockedRows[0])
+            await assertAttendanceScheduleGroupParentAllowed(trx, {
               orgId,
-              input.name,
-              input.code,
-              input.description,
-              input.attendanceGroupId,
-              input.parentId,
-              input.departmentRef,
-              input.source,
-              input.isActive,
-              access.userId,
-            ]
-          )
+              groupId,
+              parentId: input.parentId,
+            })
+            if (lockedRows[0].is_active !== false && input.isActive === false) {
+              await assertAttendanceScheduleGroupCanDeactivate(trx, orgId, groupId)
+            }
+            return trx.query(
+              `UPDATE attendance_schedule_groups
+               SET name = $3,
+                   code = $4,
+                   description = $5,
+                   attendance_group_id = $6,
+                   parent_id = $7,
+                   department_ref = $8,
+                   source = $9,
+                   is_active = $10,
+                   updated_by = $11,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2
+               RETURNING *`,
+              [
+                groupId,
+                orgId,
+                input.name,
+                input.code,
+                input.description,
+                input.attendanceGroupId,
+                input.parentId,
+                input.departmentRef,
+                input.source,
+                input.isActive,
+                access.userId,
+              ]
+            )
+          })
           res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
         } catch (error) {
           if (error instanceof HttpError) {
@@ -31458,19 +31549,27 @@ module.exports = {
           }
           const access = await assertAttendanceScheduleGroupEditAllowed(req, res, { groupId, actorAccess })
           if (!access) return
-          const rows = await db.query(
-            `UPDATE attendance_schedule_groups
-             SET is_active = false, updated_by = $3, updated_at = now()
-             WHERE id = $1 AND org_id = $2
-             RETURNING *`,
-            [groupId, orgId, access.userId]
-          )
+          const rows = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleGroupTreeLock(trx, orgId)
+            await assertAttendanceScheduleGroupCanDeactivate(trx, orgId, groupId)
+            return trx.query(
+              `UPDATE attendance_schedule_groups
+               SET is_active = false, updated_by = $3, updated_at = now()
+               WHERE id = $1 AND org_id = $2
+               RETURNING *`,
+              [groupId, orgId, access.userId]
+            )
+          })
           if (!rows.length) {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
             return
           }
           res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
         } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
             return


### PR DESCRIPTION
## Summary
- harden attendance schedule-group parent links before the small-organization cockpit UI exposes editing
- require parent groups to be active and in the same org, reject self/ancestor cycles, and block deactivation/deletion while active children exist
- wrap create/update/delete parent-tree checks and writes in an org-level advisory transaction lock
- add a real-route integration test plus unit mock alignment for the new lock/child-check queries

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --reporter=dot` (55 passed)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-advanced-scheduling-workbench.test.ts --reporter=dot` (16 passed)
- `set -a; . packages/core-backend/.env; set +a; pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "hardens schedule group parent links" --reporter=dot` (1 passed, 108 skipped)
- `pnpm --filter @metasheet/core-backend build`

## Review
- Subagent Noether reviewed the patch after fixes and approved with no remaining findings.

## Notes
- Full local `test:integration:attendance` was not used as the merge gate here because this local DB is stale/noisy (missing local enum/migration state such as `outdoor_punch`, `attendance_holidays.origin`, `automation_rules`, plus C5 residue). The new SO0 real-route test passes against the same local DB, and CI's fresh DB should remain authoritative for the full attendance gate.
- Scope is backend runtime + tests only. No UI, no DDL, no OpenAPI/dist changes, no staging/C5 work.
