### PR TITLE
feat(attendance): add schedule group admin cockpit

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6243,6 +6243,211 @@
                 {{ tr('No planning signals in the current range.', '当前区间暂无排班信号。') }}
               </div>
 
+              <div class="attendance__admin-subsection" data-attendance-small-org-cockpit>
+                <div class="attendance__admin-section-header">
+                  <div>
+                    <h5>{{ tr('Small scheduling organizations', '小组织排班') }}</h5>
+                    <small class="attendance__field-hint">
+                      {{ tr('Schedule groups are operational grouping and responsibility boundaries. Shifts, rotations, and fixed schedules still create the schedule facts.', '排班组是排班工作台里的分组与负责人边界；班次、轮班和固定排班仍负责产生排班事实。') }}
+                    </small>
+                  </div>
+                  <button class="attendance__btn" :disabled="scheduleGroupAdminLoading" @click="loadScheduleGroupAdminCockpit">
+                    {{ scheduleGroupAdminLoading ? tr('Loading...', '加载中...') : tr('Reload groups', '重载排班组') }}
+                  </button>
+                </div>
+
+                <p v-if="scheduleGroupAdminTruncationWarning" class="attendance__field-hint attendance__field-hint--warn" data-attendance-small-org-groups-cap>
+                  {{ scheduleGroupAdminTruncationWarning }}
+                </p>
+
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field" for="attendance-small-org-name">
+                    <span>{{ tr('Name', '名称') }}</span>
+                    <input id="attendance-small-org-name" v-model="scheduleGroupForm.name" type="text" />
+                  </label>
+                  <label class="attendance__field" for="attendance-small-org-code">
+                    <span>{{ tr('Code', '编码') }}</span>
+                    <input id="attendance-small-org-code" v-model="scheduleGroupForm.code" type="text" :placeholder="tr('optional', '可选')" />
+                  </label>
+                  <label class="attendance__field" for="attendance-small-org-parent">
+                    <span>{{ tr('Parent schedule group', '上级排班组') }}</span>
+                    <select id="attendance-small-org-parent" v-model="scheduleGroupForm.parentId">
+                      <option value="">{{ tr('Top level', '顶层') }}</option>
+                      <option v-for="group in scheduleGroupParentOptions" :key="group.id" :value="group.id">
+                        {{ scheduleGroupTreeLabel(group) }}
+                      </option>
+                    </select>
+                  </label>
+                  <label class="attendance__field" for="attendance-small-org-attendance-group">
+                    <span>{{ tr('Linked attendance group', '关联考勤组') }}</span>
+                    <select id="attendance-small-org-attendance-group" v-model="scheduleGroupForm.attendanceGroupId">
+                      <option value="">{{ tr('None', '无') }}</option>
+                      <option v-for="group in attendanceGroups" :key="group.id" :value="group.id">
+                        {{ group.name }}
+                      </option>
+                    </select>
+                  </label>
+                  <label class="attendance__field" for="attendance-small-org-department">
+                    <span>{{ tr('Department reference', '部门引用') }}</span>
+                    <input id="attendance-small-org-department" v-model="scheduleGroupForm.departmentRef" type="text" :placeholder="tr('preserve synced department id', '保留同步部门 ID')" />
+                  </label>
+                  <label class="attendance__field attendance__field--full" for="attendance-small-org-description">
+                    <span>{{ tr('Description', '说明') }}</span>
+                    <input id="attendance-small-org-description" v-model="scheduleGroupForm.description" type="text" />
+                  </label>
+                  <label class="attendance__field attendance__checkbox-field" for="attendance-small-org-active">
+                    <input id="attendance-small-org-active" v-model="scheduleGroupForm.isActive" type="checkbox" />
+                    <span>{{ tr('Active', '启用') }}</span>
+                  </label>
+                </div>
+                <div class="attendance__admin-actions">
+                  <button
+                    class="attendance__btn attendance__btn--primary"
+                    :disabled="scheduleGroupSaving"
+                    data-attendance-small-org-save
+                    @click="saveScheduleGroup"
+                  >
+                    {{ scheduleGroupSaving ? tr('Saving...', '保存中...') : scheduleGroupEditingId ? tr('Update schedule group', '更新排班组') : tr('Create schedule group', '创建排班组') }}
+                  </button>
+                  <button class="attendance__btn" :disabled="scheduleGroupSaving" data-attendance-small-org-new @click="startCreateScheduleGroup">
+                    {{ tr('New group', '新建排班组') }}
+                  </button>
+                </div>
+
+                <div v-if="scheduleGroupAdminRows.length === 0" class="attendance__empty" data-attendance-small-org-empty>
+                  {{ tr('No schedule groups loaded.', '暂无已加载排班组。') }}
+                </div>
+                <div v-else class="attendance__table-wrapper">
+                  <table class="attendance__table" data-attendance-small-org-groups>
+                    <thead>
+                      <tr>
+                        <th>{{ tr('Schedule group', '排班组') }}</th>
+                        <th>{{ tr('Parent', '上级') }}</th>
+                        <th>{{ tr('Linked attendance group', '关联考勤组') }}</th>
+                        <th>{{ tr('Department', '部门') }}</th>
+                        <th>{{ tr('Members', '成员') }}</th>
+                        <th>{{ tr('Assignments', '排班') }}</th>
+                        <th>{{ tr('Source', '来源') }}</th>
+                        <th>{{ tr('State', '状态') }}</th>
+                        <th>{{ tr('Actions', '操作') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="row in scheduleGroupAdminRows" :key="row.group.id" data-attendance-small-org-row>
+                        <td>
+                          <strong>{{ scheduleGroupTreeIndent(row.depth) }}{{ row.group.name }}</strong>
+                          <div class="attendance__field-hint">{{ row.group.code || row.group.id }}</div>
+                        </td>
+                        <td>{{ scheduleGroupParentName(row.group) }}</td>
+                        <td>{{ scheduleGroupAttendanceGroupName(row.group.attendanceGroupId) }}</td>
+                        <td>{{ row.group.departmentRef || '-' }}</td>
+                        <td>{{ row.group.memberCount ?? 0 }}</td>
+                        <td>{{ scheduleGroupAssignmentCount(row.group) }}</td>
+                        <td>{{ row.group.source || 'manual' }}</td>
+                        <td>
+                          <span class="attendance__status-chip" :class="row.group.isActive === false ? 'attendance__status-chip--inactive' : 'attendance__status-chip--ok'">
+                            {{ row.group.isActive === false ? tr('Inactive', '停用') : tr('Active', '启用') }}
+                          </span>
+                        </td>
+                        <td class="attendance__table-actions">
+                          <button class="attendance__btn" type="button" data-attendance-small-org-edit @click="editScheduleGroup(row.group)">
+                            {{ tr('Edit', '编辑') }}
+                          </button>
+                          <button class="attendance__btn" type="button" data-attendance-small-org-members @click="openScheduleGroupMembers(row.group)">
+                            {{ tr('Members', '成员') }}
+                          </button>
+                          <button
+                            class="attendance__btn attendance__btn--danger"
+                            type="button"
+                            data-attendance-small-org-deactivate
+                            :disabled="scheduleGroupDeletingId === row.group.id || row.group.isActive === false"
+                            @click="deactivateScheduleGroup(row.group)"
+                          >
+                            {{ tr('Deactivate', '停用') }}
+                          </button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <div v-if="selectedScheduleGroupForMembers" class="attendance__admin-subsection" data-attendance-small-org-members-panel>
+                  <div class="attendance__admin-section-header">
+                    <div>
+                      <h6 class="attendance__subheading">{{ tr('Schedule group members', '排班组成员') }}</h6>
+                      <small class="attendance__field-hint">{{ selectedScheduleGroupForMembers.name }}</small>
+                    </div>
+                    <button class="attendance__btn" :disabled="scheduleGroupMemberLoading" @click="loadScheduleGroupMembers">
+                      {{ scheduleGroupMemberLoading ? tr('Loading...', '加载中...') : tr('Reload members', '重载成员') }}
+                    </button>
+                  </div>
+                  <p v-if="scheduleGroupMemberTruncationWarning" class="attendance__field-hint attendance__field-hint--warn" data-attendance-small-org-members-cap>
+                    {{ scheduleGroupMemberTruncationWarning }}
+                  </p>
+                  <div class="attendance__admin-grid">
+                    <label class="attendance__field attendance__field--full" for="attendance-small-org-member-user-ids">
+                      <span>{{ tr('User IDs', '员工 ID') }}</span>
+                      <textarea id="attendance-small-org-member-user-ids" v-model="scheduleGroupMemberForm.userIds" rows="2" :placeholder="tr('Comma or newline separated', '逗号或换行分隔')" />
+                    </label>
+                    <label class="attendance__field" for="attendance-small-org-member-role">
+                      <span>{{ tr('Role', '角色') }}</span>
+                      <select id="attendance-small-org-member-role" v-model="scheduleGroupMemberForm.role">
+                        <option value="member">{{ tr('Member', '成员') }}</option>
+                        <option value="lead">{{ tr('Lead', '负责人') }}</option>
+                        <option value="backup">{{ tr('Backup', '备份') }}</option>
+                      </select>
+                    </label>
+                    <label class="attendance__field" for="attendance-small-org-member-from">
+                      <span>{{ tr('Effective from', '生效开始') }}</span>
+                      <input id="attendance-small-org-member-from" v-model="scheduleGroupMemberForm.effectiveFrom" type="date" />
+                    </label>
+                    <label class="attendance__field" for="attendance-small-org-member-to">
+                      <span>{{ tr('Effective to', '生效结束') }}</span>
+                      <input id="attendance-small-org-member-to" v-model="scheduleGroupMemberForm.effectiveTo" type="date" />
+                    </label>
+                  </div>
+                  <div class="attendance__admin-actions">
+                    <button
+                      class="attendance__btn attendance__btn--primary"
+                      :disabled="scheduleGroupMemberSaving"
+                      data-attendance-small-org-member-add
+                      @click="addScheduleGroupMembers"
+                    >
+                      {{ scheduleGroupMemberSaving ? tr('Saving...', '保存中...') : tr('Add members', '添加成员') }}
+                    </button>
+                  </div>
+                  <div v-if="scheduleGroupMembers.length === 0" class="attendance__empty">
+                    {{ tr('No members in this schedule group.', '该排班组暂无成员。') }}
+                  </div>
+                  <div v-else class="attendance__table-wrapper">
+                    <table class="attendance__table" data-attendance-small-org-members>
+                      <thead>
+                        <tr>
+                          <th>{{ tr('User', '员工') }}</th>
+                          <th>{{ tr('Role', '角色') }}</th>
+                          <th>{{ tr('Effective window', '生效窗口') }}</th>
+                          <th>{{ tr('Source', '来源') }}</th>
+                          <th>{{ tr('Actions', '操作') }}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr v-for="member in scheduleGroupMembers" :key="member.id" data-attendance-small-org-member-row>
+                          <td>{{ member.userId }}</td>
+                          <td>{{ scheduleGroupMemberRoleLabel(member.role) }}</td>
+                          <td>{{ scheduleGroupMemberWindowLabel(member) }}</td>
+                          <td>{{ member.source || 'manual' }}</td>
+                          <td class="attendance__table-actions">
+                            <button class="attendance__btn attendance__btn--danger" type="button" data-attendance-small-org-member-remove @click="removeScheduleGroupMember(member)">
+                              {{ tr('Remove', '移除') }}
+                            </button>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
               <div v-if="advancedSchedulingWorkbenchGroups.length === 0" class="attendance__empty">
                 {{ tr('No active schedule groups yet.', '暂无启用的排班组。') }}
               </div>
@@ -8762,6 +8967,33 @@ interface AttendanceAdvancedSchedulingGroupItem {
   isActive?: boolean
 }
 
+interface AttendanceScheduleGroupAdminItem {
+  id: string
+  orgId?: string
+  name: string
+  code?: string | null
+  description?: string | null
+  attendanceGroupId?: string | null
+  parentId?: string | null
+  departmentRef?: string | null
+  source?: string | null
+  isActive?: boolean
+  memberCount?: number | null
+  assignedUserCount?: number | null
+  shiftAssignmentCount?: number | null
+  rotationAssignmentCount?: number | null
+}
+
+interface AttendanceScheduleGroupMemberItem {
+  id: string
+  scheduleGroupId?: string | null
+  userId: string
+  effectiveFrom?: string | null
+  effectiveTo?: string | null
+  role?: 'member' | 'lead' | 'backup' | string | null
+  source?: string | null
+}
+
 interface AttendanceAdvancedSchedulingWorkbench {
   range?: {
     from: string | null
@@ -9364,6 +9596,166 @@ const advancedSchedulingWorkbenchMetricItems = computed(() => {
 const advancedSchedulingWorkbenchGroups = computed(() =>
   advancedSchedulingWorkbench.value?.scheduleGroups?.items ?? []
 )
+
+const scheduleGroupAdminTruncationWarning = computed(() => {
+  if (scheduleGroupAdminTotal.value <= scheduleGroupAdminItems.value.length) return ''
+  return tr(
+    `Showing first ${scheduleGroupAdminItems.value.length} of ${scheduleGroupAdminTotal.value} schedule groups.`,
+    `仅显示前 ${scheduleGroupAdminItems.value.length}/${scheduleGroupAdminTotal.value} 个排班组。`,
+  )
+})
+
+const scheduleGroupMemberTruncationWarning = computed(() => {
+  if (scheduleGroupMembersTotal.value <= scheduleGroupMembers.value.length) return ''
+  return tr(
+    `Showing first ${scheduleGroupMembers.value.length} of ${scheduleGroupMembersTotal.value} members.`,
+    `仅显示前 ${scheduleGroupMembers.value.length}/${scheduleGroupMembersTotal.value} 名成员。`,
+  )
+})
+
+const scheduleGroupById = computed(() => {
+  const map = new Map<string, AttendanceScheduleGroupAdminItem>()
+  for (const group of scheduleGroupAdminItems.value) map.set(group.id, group)
+  return map
+})
+
+const scheduleGroupAdminRows = computed<Array<{ group: AttendanceScheduleGroupAdminItem; depth: number }>>(() => {
+  const children = new Map<string, AttendanceScheduleGroupAdminItem[]>()
+  const roots: AttendanceScheduleGroupAdminItem[] = []
+  const sorted = [...scheduleGroupAdminItems.value].sort((left, right) => {
+    if ((left.isActive === false) !== (right.isActive === false)) return left.isActive === false ? 1 : -1
+    return (left.name || '').localeCompare(right.name || '') || (left.code || '').localeCompare(right.code || '')
+  })
+  for (const group of sorted) {
+    const parentId = group.parentId || ''
+    if (!parentId || !scheduleGroupById.value.has(parentId)) {
+      roots.push(group)
+      continue
+    }
+    const list = children.get(parentId) ?? []
+    list.push(group)
+    children.set(parentId, list)
+  }
+  const rows: Array<{ group: AttendanceScheduleGroupAdminItem; depth: number }> = []
+  const seen = new Set<string>()
+  const visit = (group: AttendanceScheduleGroupAdminItem, depth: number) => {
+    if (seen.has(group.id)) return
+    seen.add(group.id)
+    rows.push({ group, depth })
+    for (const child of children.get(group.id) ?? []) visit(child, depth + 1)
+  }
+  for (const group of roots) visit(group, 0)
+  for (const group of sorted) visit(group, 0)
+  return rows
+})
+
+const scheduleGroupParentOptions = computed(() =>
+  scheduleGroupAdminRows.value
+    .map(row => row.group)
+    .filter(group => group.id !== scheduleGroupEditingId.value && group.isActive !== false)
+)
+
+const selectedScheduleGroupForMembers = computed(() =>
+  scheduleGroupAdminItems.value.find(group => group.id === scheduleGroupMemberGroupId.value) ?? null
+)
+
+function scheduleGroupWorkbenchCounts(groupId: string): Partial<AttendanceScheduleGroupAdminItem> {
+  const item = advancedSchedulingWorkbenchGroups.value.find(group => group.id === groupId)
+  if (!item) return {}
+  return {
+    memberCount: item.memberCount,
+    assignedUserCount: item.assignedUserCount,
+    shiftAssignmentCount: item.shiftAssignmentCount,
+    rotationAssignmentCount: item.rotationAssignmentCount,
+  }
+}
+
+function normalizeScheduleGroupAdminItem(value: any): AttendanceScheduleGroupAdminItem | null {
+  if (!value || typeof value !== 'object') return null
+  const id = String(value.id || '').trim()
+  const name = String(value.name || '').trim()
+  if (!id || !name) return null
+  return {
+    id,
+    orgId: value.orgId ?? value.org_id,
+    name,
+    code: value.code ?? null,
+    description: value.description ?? null,
+    attendanceGroupId: value.attendanceGroupId ?? value.attendance_group_id ?? null,
+    parentId: value.parentId ?? value.parent_id ?? null,
+    departmentRef: value.departmentRef ?? value.department_ref ?? null,
+    source: value.source ?? 'manual',
+    isActive: value.isActive ?? value.is_active ?? true,
+    memberCount: value.memberCount ?? value.member_count ?? null,
+    assignedUserCount: value.assignedUserCount ?? value.assigned_user_count ?? null,
+    shiftAssignmentCount: value.shiftAssignmentCount ?? value.shift_assignment_count ?? null,
+    rotationAssignmentCount: value.rotationAssignmentCount ?? value.rotation_assignment_count ?? null,
+    ...scheduleGroupWorkbenchCounts(id),
+  }
+}
+
+function normalizeScheduleGroupMemberItem(value: any): AttendanceScheduleGroupMemberItem | null {
+  if (!value || typeof value !== 'object') return null
+  const id = String(value.id || '').trim()
+  const userId = String(value.userId ?? value.user_id ?? '').trim()
+  if (!id || !userId) return null
+  return {
+    id,
+    scheduleGroupId: value.scheduleGroupId ?? value.schedule_group_id ?? null,
+    userId,
+    effectiveFrom: value.effectiveFrom ?? value.effective_from ?? null,
+    effectiveTo: value.effectiveTo ?? value.effective_to ?? null,
+    role: value.role ?? 'member',
+    source: value.source ?? 'manual',
+  }
+}
+
+function scheduleGroupDepth(groupId: string): number {
+  let depth = 0
+  const seen = new Set<string>()
+  let current = scheduleGroupById.value.get(groupId)
+  while (current?.parentId && scheduleGroupById.value.has(current.parentId) && !seen.has(current.parentId)) {
+    seen.add(current.parentId)
+    depth += 1
+    current = scheduleGroupById.value.get(current.parentId)
+  }
+  return depth
+}
+
+function scheduleGroupTreeIndent(depth: number): string {
+  return depth > 0 ? `${'— '.repeat(Math.min(depth, 6))}` : ''
+}
+
+function scheduleGroupTreeLabel(group: AttendanceScheduleGroupAdminItem): string {
+  const prefix = scheduleGroupTreeIndent(scheduleGroupDepth(group.id))
+  return `${prefix}${group.name}`
+}
+
+function scheduleGroupParentName(group: AttendanceScheduleGroupAdminItem): string {
+  if (!group.parentId) return tr('Top level', '顶层')
+  return scheduleGroupById.value.get(group.parentId)?.name ?? group.parentId
+}
+
+function scheduleGroupAttendanceGroupName(groupId?: string | null): string {
+  if (!groupId) return '-'
+  return attendanceGroups.value.find(group => group.id === groupId)?.name ?? groupId
+}
+
+function scheduleGroupAssignmentCount(group: AttendanceScheduleGroupAdminItem): number {
+  return Number(group.shiftAssignmentCount ?? 0) + Number(group.rotationAssignmentCount ?? 0)
+}
+
+function scheduleGroupMemberRoleLabel(role?: string | null): string {
+  if (role === 'lead') return tr('Lead', '负责人')
+  if (role === 'backup') return tr('Backup', '备份')
+  return tr('Member', '成员')
+}
+
+function scheduleGroupMemberWindowLabel(member: AttendanceScheduleGroupMemberItem): string {
+  const from = member.effectiveFrom || tr('Any start', '不限开始')
+  const to = member.effectiveTo || tr('Any end', '不限结束')
+  return `${from} - ${to}`
+}
 
 const advancedSchedulingWorkbenchDiagnostics = computed(() =>
   advancedSchedulingWorkbench.value?.diagnostics ?? []
@@ -10196,6 +10588,10 @@ const approvalFlows = ref<AttendanceApprovalFlow[]>([])
 const rotationRules = ref<AttendanceRotationRule[]>([])
 const rotationAssignments = ref<AttendanceRotationAssignmentItem[]>([])
 const advancedSchedulingWorkbench = ref<AttendanceAdvancedSchedulingWorkbench | null>(null)
+const scheduleGroupAdminItems = ref<AttendanceScheduleGroupAdminItem[]>([])
+const scheduleGroupAdminTotal = ref(0)
+const scheduleGroupMembers = ref<AttendanceScheduleGroupMemberItem[]>([])
+const scheduleGroupMembersTotal = ref(0)
 const comprehensiveHoursPreview = ref<AttendanceComprehensiveHoursPreviewResult | null>(null)
 const ruleSets = ref<AttendanceRuleSet[]>([])
 const ruleTemplateSystemText = ref('[]')
@@ -10284,6 +10680,13 @@ const assignmentEditingPublishStatus = ref<AttendanceSchedulePublishStatus | nul
 const assignmentPublishStatusFilter = ref<AttendanceSchedulePublishStatusFilter>('all')
 const selectedDraftAssignmentIds = ref<string[]>([])
 const advancedSchedulingWorkbenchLoading = ref(false)
+const scheduleGroupAdminLoading = ref(false)
+const scheduleGroupSaving = ref(false)
+const scheduleGroupDeletingId = ref<string | null>(null)
+const scheduleGroupEditingId = ref<string | null>(null)
+const scheduleGroupMemberGroupId = ref('')
+const scheduleGroupMemberLoading = ref(false)
+const scheduleGroupMemberSaving = ref(false)
 const comprehensiveHoursPreviewLoading = ref(false)
 const comprehensiveHoursPreviewStatus = ref<{ kind: 'info' | 'warn' | 'error'; message: string }>({
   kind: 'info',
@@ -12326,6 +12729,23 @@ const attendanceGroupForm = reactive({
   ruleSetId: '',
   attendanceType: 'fixed_shift' as AttendanceGroupType,
   description: '',
+})
+
+const scheduleGroupForm = reactive({
+  name: '',
+  code: '',
+  parentId: '',
+  attendanceGroupId: '',
+  departmentRef: '',
+  description: '',
+  isActive: true,
+})
+
+const scheduleGroupMemberForm = reactive({
+  userIds: '',
+  role: 'member' as 'member' | 'lead' | 'backup',
+  effectiveFrom: '',
+  effectiveTo: '',
 })
 
 const payrollTemplateForm = reactive({
@@ -18700,6 +19120,283 @@ async function loadAdvancedSchedulingWorkbench() {
   }
 }
 
+function resetScheduleGroupForm() {
+  scheduleGroupEditingId.value = null
+  scheduleGroupForm.name = ''
+  scheduleGroupForm.code = ''
+  scheduleGroupForm.parentId = ''
+  scheduleGroupForm.attendanceGroupId = ''
+  scheduleGroupForm.departmentRef = ''
+  scheduleGroupForm.description = ''
+  scheduleGroupForm.isActive = true
+}
+
+function startCreateScheduleGroup() {
+  resetScheduleGroupForm()
+}
+
+function editScheduleGroup(item: AttendanceScheduleGroupAdminItem) {
+  scheduleGroupEditingId.value = item.id
+  scheduleGroupForm.name = item.name
+  scheduleGroupForm.code = item.code ?? ''
+  scheduleGroupForm.parentId = item.parentId ?? ''
+  scheduleGroupForm.attendanceGroupId = item.attendanceGroupId ?? ''
+  scheduleGroupForm.departmentRef = item.departmentRef ?? ''
+  scheduleGroupForm.description = item.description ?? ''
+  scheduleGroupForm.isActive = item.isActive !== false
+}
+
+async function loadScheduleGroupAdminCockpit() {
+  scheduleGroupAdminLoading.value = true
+  try {
+    const query = buildQuery({
+      orgId: normalizedOrgId(),
+      page: '1',
+      pageSize: '200',
+      includeInactive: 'true',
+    })
+    const response = await apiFetch(`/api/attendance/schedule-groups?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load schedule groups', '加载排班组失败')))
+    }
+    adminForbidden.value = false
+    const items = Array.isArray(data.data?.items)
+      ? data.data.items.map(normalizeScheduleGroupAdminItem).filter(Boolean) as AttendanceScheduleGroupAdminItem[]
+      : []
+    scheduleGroupAdminItems.value = items
+    scheduleGroupAdminTotal.value = Number(data.data?.total ?? items.length) || items.length
+    if (scheduleGroupMemberGroupId.value && !items.some(group => group.id === scheduleGroupMemberGroupId.value)) {
+      scheduleGroupMemberGroupId.value = ''
+      scheduleGroupMembers.value = []
+      scheduleGroupMembersTotal.value = 0
+    }
+    if (scheduleGroupEditingId.value) {
+      const edited = items.find(group => group.id === scheduleGroupEditingId.value)
+      if (edited) editScheduleGroup(edited)
+    }
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to load schedule groups', '加载排班组失败')), 'error')
+  } finally {
+    scheduleGroupAdminLoading.value = false
+  }
+}
+
+function buildScheduleGroupPayload(): Record<string, unknown> {
+  return {
+    name: scheduleGroupForm.name.trim(),
+    code: scheduleGroupForm.code.trim() || null,
+    description: scheduleGroupForm.description.trim() || null,
+    attendanceGroupId: scheduleGroupForm.attendanceGroupId || null,
+    parentId: scheduleGroupForm.parentId || null,
+    departmentRef: scheduleGroupForm.departmentRef.trim() || null,
+    isActive: scheduleGroupForm.isActive,
+  }
+}
+
+async function saveScheduleGroup() {
+  scheduleGroupSaving.value = true
+  try {
+    const payload = buildScheduleGroupPayload()
+    if (!String(payload.name || '').trim()) {
+      throw new Error(tr('Schedule group name is required', '排班组名称为必填项'))
+    }
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const suffix = query.toString()
+    const path = scheduleGroupEditingId.value
+      ? `/api/attendance/schedule-groups/${encodeURIComponent(scheduleGroupEditingId.value)}${suffix ? `?${suffix}` : ''}`
+      : `/api/attendance/schedule-groups${suffix ? `?${suffix}` : ''}`
+    const response = await apiFetch(path, {
+      method: scheduleGroupEditingId.value ? 'PUT' : 'POST',
+      body: JSON.stringify(payload),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to save schedule group', '保存排班组失败')))
+    }
+    adminForbidden.value = false
+    const saved = normalizeScheduleGroupAdminItem(data.data)
+    await loadAdvancedSchedulingWorkbench()
+    await loadScheduleGroupAdminCockpit()
+    if (saved?.id) {
+      const fresh = scheduleGroupAdminItems.value.find(group => group.id === saved.id) ?? saved
+      editScheduleGroup(fresh)
+    }
+    setStatus(tr('Schedule group saved.', '排班组已保存。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to save schedule group', '保存排班组失败')), 'error')
+  } finally {
+    scheduleGroupSaving.value = false
+  }
+}
+
+async function deactivateScheduleGroup(item: AttendanceScheduleGroupAdminItem) {
+  if (!window.confirm(tr('Deactivate this schedule group?', '确认停用该排班组吗？'))) return
+  scheduleGroupDeletingId.value = item.id
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const suffix = query.toString()
+    const response = await apiFetch(`/api/attendance/schedule-groups/${encodeURIComponent(item.id)}${suffix ? `?${suffix}` : ''}`, {
+      method: 'DELETE',
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to deactivate schedule group', '停用排班组失败')))
+    }
+    adminForbidden.value = false
+    await loadAdvancedSchedulingWorkbench()
+    await loadScheduleGroupAdminCockpit()
+    if (scheduleGroupEditingId.value === item.id) resetScheduleGroupForm()
+    if (scheduleGroupMemberGroupId.value === item.id) {
+      scheduleGroupMemberGroupId.value = ''
+      scheduleGroupMembers.value = []
+      scheduleGroupMembersTotal.value = 0
+    }
+    setStatus(tr('Schedule group deactivated.', '排班组已停用。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to deactivate schedule group', '停用排班组失败')), 'error')
+  } finally {
+    scheduleGroupDeletingId.value = null
+  }
+}
+
+function resetScheduleGroupMemberForm() {
+  scheduleGroupMemberForm.userIds = ''
+  scheduleGroupMemberForm.role = 'member'
+  scheduleGroupMemberForm.effectiveFrom = ''
+  scheduleGroupMemberForm.effectiveTo = ''
+}
+
+async function openScheduleGroupMembers(item: AttendanceScheduleGroupAdminItem) {
+  scheduleGroupMemberGroupId.value = item.id
+  resetScheduleGroupMemberForm()
+  await loadScheduleGroupMembers()
+}
+
+async function loadScheduleGroupMembers() {
+  const groupId = scheduleGroupMemberGroupId.value
+  if (!groupId) {
+    scheduleGroupMembers.value = []
+    scheduleGroupMembersTotal.value = 0
+    return
+  }
+  scheduleGroupMemberLoading.value = true
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId(), page: '1', pageSize: '200' })
+    const response = await apiFetch(`/api/attendance/schedule-groups/${encodeURIComponent(groupId)}/members?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load schedule group members', '加载排班组成员失败')))
+    }
+    adminForbidden.value = false
+    const items = Array.isArray(data.data?.items)
+      ? data.data.items.map(normalizeScheduleGroupMemberItem).filter(Boolean) as AttendanceScheduleGroupMemberItem[]
+      : []
+    scheduleGroupMembers.value = items
+    scheduleGroupMembersTotal.value = Number(data.data?.total ?? items.length) || items.length
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to load schedule group members', '加载排班组成员失败')), 'error')
+  } finally {
+    scheduleGroupMemberLoading.value = false
+  }
+}
+
+function buildScheduleGroupMemberPayload(): Record<string, unknown> {
+  return {
+    userIds: parseUserIdList(scheduleGroupMemberForm.userIds),
+    role: scheduleGroupMemberForm.role,
+    effectiveFrom: scheduleGroupMemberForm.effectiveFrom || null,
+    effectiveTo: scheduleGroupMemberForm.effectiveTo || null,
+    source: 'manual',
+  }
+}
+
+async function addScheduleGroupMembers() {
+  const groupId = scheduleGroupMemberGroupId.value
+  if (!groupId) {
+    setStatus(tr('Select a schedule group first.', '请先选择排班组。'), 'error')
+    return
+  }
+  const payload = buildScheduleGroupMemberPayload()
+  if (!Array.isArray(payload.userIds) || payload.userIds.length === 0) {
+    setStatus(tr('Enter at least one user ID.', '请至少输入一个员工 ID。'), 'error')
+    return
+  }
+  scheduleGroupMemberSaving.value = true
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const suffix = query.toString()
+    const response = await apiFetch(`/api/attendance/schedule-groups/${encodeURIComponent(groupId)}/members${suffix ? `?${suffix}` : ''}`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to add schedule group members', '添加排班组成员失败')))
+    }
+    adminForbidden.value = false
+    resetScheduleGroupMemberForm()
+    await loadScheduleGroupMembers()
+    await loadAdvancedSchedulingWorkbench()
+    await loadScheduleGroupAdminCockpit()
+    setStatus(tr('Schedule group members added.', '排班组成员已添加。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to add schedule group members', '添加排班组成员失败')), 'error')
+  } finally {
+    scheduleGroupMemberSaving.value = false
+  }
+}
+
+async function removeScheduleGroupMember(member: AttendanceScheduleGroupMemberItem) {
+  const groupId = scheduleGroupMemberGroupId.value
+  if (!groupId || !member.id) return
+  scheduleGroupMemberSaving.value = true
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const suffix = query.toString()
+    const response = await apiFetch(`/api/attendance/schedule-groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(member.id)}${suffix ? `?${suffix}` : ''}`, {
+      method: 'DELETE',
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to remove schedule group member', '移除排班组成员失败')))
+    }
+    adminForbidden.value = false
+    await loadScheduleGroupMembers()
+    await loadAdvancedSchedulingWorkbench()
+    await loadScheduleGroupAdminCockpit()
+    setStatus(tr('Schedule group member removed.', '排班组成员已移除。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to remove schedule group member', '移除排班组成员失败')), 'error')
+  } finally {
+    scheduleGroupMemberSaving.value = false
+  }
+}
+
 async function previewComprehensiveHours() {
   const userIds = comprehensiveHoursUserIds()
   if (userIds.length === 0) {
@@ -21467,6 +22164,7 @@ async function loadAdminData() {
       loadOvertimeRules(),
       loadApprovalFlows(),
       loadAdvancedSchedulingWorkbench(),
+      loadScheduleGroupAdminCockpit(),
       loadRotationRules(),
       loadShifts(),
       loadAssignments(),

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -116,6 +116,7 @@ describe('Attendance admin regressions', () => {
   let attendanceSettingsSaveData: Record<string, unknown> | null = null
   let attendanceApprovalFlowsData: unknown[] | null = null
   let attendanceGroupsData: unknown[] | null = null
+  let scheduleGroupsData: unknown[] | null = null
   let autoShiftPreviewStatus = 200
   let autoShiftPreviewData: Record<string, unknown> | null = null
   let autoShiftApplyStatus = 200
@@ -130,6 +131,7 @@ describe('Attendance admin regressions', () => {
     attendanceSettingsSaveData = null
     attendanceApprovalFlowsData = null
     attendanceGroupsData = null
+    scheduleGroupsData = null
     autoShiftPreviewStatus = 200
     autoShiftPreviewData = null
     autoShiftApplyStatus = 200
@@ -288,6 +290,17 @@ describe('Attendance admin regressions', () => {
               },
             ],
             total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/schedule-groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: scheduleGroupsData ?? [],
+            total: scheduleGroupsData?.length ?? 0,
+            page: 1,
+            pageSize: 200,
           },
         })
       }
@@ -4027,7 +4040,19 @@ describe('Attendance admin regressions', () => {
     expect(window.getComputedStyle(actionCell!).display).toBe('table-cell')
   })
 
-  it('renders the read-only advanced scheduling workbench without write controls', async () => {
+  it('renders the advanced scheduling snapshot with the small-organization cockpit', async () => {
+    scheduleGroupsData = [
+      {
+        id: 'sg-1',
+        name: 'Line A',
+        code: 'line-a',
+        parentId: null,
+        departmentRef: 'dept-line-a',
+        attendanceGroupId: 'group-a',
+        source: 'manual',
+        isActive: true,
+      },
+    ]
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
     await flushUi()
@@ -4047,11 +4072,398 @@ describe('Attendance admin regressions', () => {
     expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="assignments"]')?.textContent).toContain('10')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-diagnostic="assignment_without_schedule_group"]')?.textContent).toContain('1')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-groups]')?.textContent).toContain('Line A')
+    expect(section!.querySelector('[data-attendance-small-org-cockpit]')?.textContent).toContain('Small scheduling organizations')
+    expect(section!.querySelector('[data-attendance-small-org-groups]')?.textContent).toContain('dept-line-a')
+    expect(section!.querySelector('[data-attendance-small-org-groups]')?.textContent).toContain('manual')
     const buttons = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).map(button => button.textContent || '')
     expect(buttons.join(' ')).toContain('Reload workbench')
-    expect(buttons.join(' ')).not.toContain('Create')
-    expect(buttons.join(' ')).not.toContain('Edit')
-    expect(buttons.join(' ')).not.toContain('Delete')
+    expect(buttons.join(' ')).toContain('Create schedule group')
+    expect(buttons.join(' ')).toContain('Edit')
+    expect(buttons.join(' ')).toContain('Deactivate')
+  })
+
+  it('saves and deactivates schedule groups with exact strict bodies and no silent caps', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const posts: Array<Record<string, unknown>> = []
+    const puts: Array<Record<string, unknown>> = []
+    const deletes: Array<{ url: string; body?: unknown }> = []
+    const groupGets: string[] = []
+    let groups = [
+      {
+        id: 'sg-root',
+        name: 'Line A Root',
+        code: 'line-a-root',
+        parentId: null,
+        attendanceGroupId: null,
+        departmentRef: 'dept-root',
+        description: null,
+        source: 'manual',
+        isActive: true,
+      },
+      {
+        id: 'sg-child',
+        name: 'Line A Child',
+        code: 'line-a-child',
+        parentId: 'sg-root',
+        attendanceGroupId: 'group-a',
+        departmentRef: 'dept-child',
+        description: 'Child team',
+        source: 'manual',
+        isActive: true,
+      },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'group-a', name: 'Ops Team', code: 'ops-team', timezone: 'Asia/Shanghai', attendanceType: 'scheduled_shift', memberCount: 1 },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            summary: {
+              scheduleGroups: groups.length,
+              scheduleGroupMembers: 2,
+              schedulerScopes: 0,
+              shifts: 0,
+              rotationRules: 0,
+              shiftAssignments: 1,
+              rotationAssignments: 1,
+              assignedUsers: 1,
+              diagnostics: 0,
+              groupsWithoutMembers: 0,
+              assignmentUsersWithoutScheduleGroup: 0,
+              usersWithMultipleScheduleGroups: 0,
+              usersWithBothAssignmentKinds: 0,
+            },
+            scheduleGroups: {
+              items: groups.map(group => ({
+                ...group,
+                memberCount: group.id === 'sg-child' ? 2 : 0,
+                assignedUserCount: group.id === 'sg-child' ? 1 : 0,
+                shiftAssignmentCount: group.id === 'sg-child' ? 1 : 0,
+                rotationAssignmentCount: group.id === 'sg-child' ? 1 : 0,
+              })),
+              total: groups.length,
+            },
+            diagnostics: [],
+            metadata: { readOnly: true },
+          },
+        })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child') && method === 'PUT') {
+        const body = JSON.parse(String((init as { body?: string } | undefined)?.body || '{}'))
+        puts.push(body)
+        groups = groups.map(group => group.id === 'sg-child' ? { ...group, ...body } : group)
+        return jsonResponse(200, { ok: true, data: groups.find(group => group.id === 'sg-child') })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child') && method === 'DELETE') {
+        deletes.push({ url, body: (init as { body?: unknown } | undefined)?.body })
+        groups = groups.map(group => group.id === 'sg-child' ? { ...group, isActive: false } : group)
+        return jsonResponse(200, { ok: true, data: groups.find(group => group.id === 'sg-child') })
+      }
+      if (url.includes('/api/attendance/schedule-groups') && method === 'POST') {
+        const body = JSON.parse(String((init as { body?: string } | undefined)?.body || '{}'))
+        posts.push(body)
+        const created = { id: 'sg-new', source: 'manual', ...body }
+        groups = [...groups, created]
+        return jsonResponse(200, { ok: true, data: created })
+      }
+      if (url.includes('/api/attendance/schedule-groups') && method === 'GET') {
+        groupGets.push(url)
+        return jsonResponse(200, { ok: true, data: { items: groups, total: 250, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'admin' })
+      app.mount(container!)
+      await flushUi(8)
+      container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-advanced-scheduling-workbench"]')!.click()
+      await flushUi(4)
+
+      const section = container!.querySelector<HTMLElement>('[data-attendance-small-org-cockpit]')!
+      expect(section).toBeTruthy()
+      expect(groupGets.some(url => url.includes('pageSize=200') && url.includes('includeInactive=true'))).toBe(true)
+      expect(section.querySelector('[data-attendance-small-org-groups-cap]')?.textContent).toContain('Showing first 2 of 250')
+
+      const childRow = Array.from(section.querySelectorAll<HTMLElement>('[data-attendance-small-org-row]'))
+        .find(row => row.textContent?.includes('Line A Child'))
+      expect(childRow).toBeTruthy()
+      childRow!.querySelector<HTMLButtonElement>('[data-attendance-small-org-edit]')!.click()
+      await flushUi(2)
+      setInput(section, '#attendance-small-org-name', 'Line A Child Prime')
+      setInput(section, '#attendance-small-org-code', 'line-a-child-prime')
+      setInput(section, '#attendance-small-org-department', 'dept-child-prime')
+      setInput(section, '#attendance-small-org-description', 'Prime child team')
+      section.querySelector<HTMLButtonElement>('[data-attendance-small-org-save]')!.click()
+      await flushUi(12)
+
+      expect(puts).toHaveLength(1)
+      expect(puts[0]).toEqual({
+        name: 'Line A Child Prime',
+        code: 'line-a-child-prime',
+        description: 'Prime child team',
+        attendanceGroupId: 'group-a',
+        parentId: 'sg-root',
+        departmentRef: 'dept-child-prime',
+        isActive: true,
+      })
+
+      section.querySelector<HTMLButtonElement>('[data-attendance-small-org-new]')!.click()
+      await flushUi(2)
+      setInput(section, '#attendance-small-org-name', 'Line B')
+      setInput(section, '#attendance-small-org-code', 'line-b')
+      setInput(section, '#attendance-small-org-department', 'dept-line-b')
+      const parent = section.querySelector<HTMLSelectElement>('#attendance-small-org-parent')!
+      parent.value = 'sg-root'
+      parent.dispatchEvent(new Event('change', { bubbles: true }))
+      const attendanceGroup = section.querySelector<HTMLSelectElement>('#attendance-small-org-attendance-group')!
+      attendanceGroup.value = 'group-a'
+      attendanceGroup.dispatchEvent(new Event('change', { bubbles: true }))
+      section.querySelector<HTMLButtonElement>('[data-attendance-small-org-save]')!.click()
+      await flushUi(12)
+
+      expect(posts).toHaveLength(1)
+      expect(posts[0]).toEqual({
+        name: 'Line B',
+        code: 'line-b',
+        description: null,
+        attendanceGroupId: 'group-a',
+        parentId: 'sg-root',
+        departmentRef: 'dept-line-b',
+        isActive: true,
+      })
+
+      const updatedChildRow = Array.from(section.querySelectorAll<HTMLElement>('[data-attendance-small-org-row]'))
+        .find(row => row.textContent?.includes('Line A Child Prime'))
+      expect(updatedChildRow).toBeTruthy()
+      updatedChildRow!.querySelector<HTMLButtonElement>('[data-attendance-small-org-deactivate]')!.click()
+      await flushUi(12)
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(deletes).toHaveLength(1)
+      expect(deletes[0].url).toContain('/api/attendance/schedule-groups/sg-child')
+      expect(deletes[0].body).toBeUndefined()
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it('manages date-aware schedule group members with exact POST and DELETE requests', async () => {
+    const memberGets: string[] = []
+    const posts: Array<Record<string, unknown>> = []
+    const deletes: Array<{ url: string; body?: unknown }> = []
+    let members = [
+      {
+        id: 'member-1',
+        scheduleGroupId: 'sg-child',
+        userId: 'user-1',
+        role: 'lead',
+        effectiveFrom: '2026-06-01',
+        effectiveTo: null,
+        source: 'manual',
+      },
+    ]
+    const groups = [
+      {
+        id: 'sg-child',
+        name: 'Line A Child',
+        code: 'line-a-child',
+        parentId: null,
+        attendanceGroupId: null,
+        departmentRef: 'dept-child',
+        source: 'manual',
+        isActive: true,
+      },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            summary: {
+              scheduleGroups: 1,
+              scheduleGroupMembers: members.length,
+              schedulerScopes: 0,
+              shifts: 0,
+              rotationRules: 0,
+              shiftAssignments: 0,
+              rotationAssignments: 0,
+              assignedUsers: 0,
+              diagnostics: 0,
+              groupsWithoutMembers: 0,
+              assignmentUsersWithoutScheduleGroup: 0,
+              usersWithMultipleScheduleGroups: 0,
+              usersWithBothAssignmentKinds: 0,
+            },
+            scheduleGroups: {
+              items: groups.map(group => ({ ...group, memberCount: members.length, assignedUserCount: 0, shiftAssignmentCount: 0, rotationAssignmentCount: 0 })),
+              total: groups.length,
+            },
+            diagnostics: [],
+            metadata: { readOnly: true },
+          },
+        })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child/members/member-1') && method === 'DELETE') {
+        deletes.push({ url, body: (init as { body?: unknown } | undefined)?.body })
+        members = members.filter(member => member.id !== 'member-1')
+        return jsonResponse(200, { ok: true, data: { id: 'member-1' } })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child/members') && method === 'POST') {
+        const body = JSON.parse(String((init as { body?: string } | undefined)?.body || '{}'))
+        posts.push(body)
+        members = [
+          ...members,
+          ...((body.userIds as string[]) || []).map((userId, index) => ({
+            id: `created-${index}`,
+            scheduleGroupId: 'sg-child',
+            userId,
+            role: body.role,
+            effectiveFrom: body.effectiveFrom,
+            effectiveTo: body.effectiveTo,
+            source: 'manual',
+          })),
+        ]
+        return jsonResponse(200, { ok: true, data: { items: members.slice(1) } })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child/members') && method === 'GET') {
+        memberGets.push(url)
+        return jsonResponse(200, { ok: true, data: { items: members, total: 250, page: 1, pageSize: 200 } })
+      }
+      if (url.includes('/api/attendance/schedule-groups') && method === 'GET') {
+        return jsonResponse(200, { ok: true, data: { items: groups, total: groups.length, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-advanced-scheduling-workbench"]')!.click()
+    await flushUi(4)
+
+    const section = container!.querySelector<HTMLElement>('[data-attendance-small-org-cockpit]')!
+    const row = section.querySelector<HTMLElement>('[data-attendance-small-org-row]')!
+    row.querySelector<HTMLButtonElement>('[data-attendance-small-org-members]')!.click()
+    await flushUi(4)
+    const panel = section.querySelector<HTMLElement>('[data-attendance-small-org-members-panel]')!
+    expect(panel).toBeTruthy()
+    expect(memberGets.some(url => url.includes('pageSize=200'))).toBe(true)
+    expect(panel.querySelector('[data-attendance-small-org-members-cap]')?.textContent).toContain('Showing first 1 of 250')
+
+    setInput(panel, '#attendance-small-org-member-user-ids', 'user-2\nuser-3')
+    const role = panel.querySelector<HTMLSelectElement>('#attendance-small-org-member-role')!
+    role.value = 'backup'
+    role.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(panel, '#attendance-small-org-member-from', '2026-06-10')
+    setInput(panel, '#attendance-small-org-member-to', '2026-06-30')
+    panel.querySelector<HTMLButtonElement>('[data-attendance-small-org-member-add]')!.click()
+    await flushUi(6)
+
+    expect(posts).toHaveLength(1)
+    expect(posts[0]).toEqual({
+      userIds: ['user-2', 'user-3'],
+      role: 'backup',
+      effectiveFrom: '2026-06-10',
+      effectiveTo: '2026-06-30',
+      source: 'manual',
+    })
+
+    panel.querySelector<HTMLButtonElement>('[data-attendance-small-org-member-remove]')!.click()
+    await flushUi(6)
+
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0].url).toContain('/api/attendance/schedule-groups/sg-child/members/member-1')
+    expect(deletes[0].body).toBeUndefined()
+  })
+
+  it('does not deactivate a schedule group when confirmation is dismissed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const deletes: string[] = []
+    const groups = [
+      {
+        id: 'sg-child',
+        name: 'Line A Child',
+        code: 'line-a-child',
+        parentId: null,
+        departmentRef: 'dept-child',
+        source: 'manual',
+        isActive: true,
+      },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            summary: {
+              scheduleGroups: 1,
+              scheduleGroupMembers: 0,
+              schedulerScopes: 0,
+              shifts: 0,
+              rotationRules: 0,
+              shiftAssignments: 0,
+              rotationAssignments: 0,
+              assignedUsers: 0,
+              diagnostics: 0,
+              groupsWithoutMembers: 0,
+              assignmentUsersWithoutScheduleGroup: 0,
+              usersWithMultipleScheduleGroups: 0,
+              usersWithBothAssignmentKinds: 0,
+            },
+            scheduleGroups: {
+              items: groups.map(group => ({ ...group, memberCount: 0, assignedUserCount: 0, shiftAssignmentCount: 0, rotationAssignmentCount: 0 })),
+              total: groups.length,
+            },
+            diagnostics: [],
+            metadata: { readOnly: true },
+          },
+        })
+      }
+      if (url.includes('/api/attendance/schedule-groups/sg-child') && method === 'DELETE') {
+        deletes.push(url)
+        return jsonResponse(200, { ok: true, data: { ...groups[0], isActive: false } })
+      }
+      if (url.includes('/api/attendance/schedule-groups') && method === 'GET') {
+        return jsonResponse(200, { ok: true, data: { items: groups, total: groups.length, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'admin' })
+      app.mount(container!)
+      await flushUi(8)
+      container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-advanced-scheduling-workbench"]')!.click()
+      await flushUi(4)
+
+      const section = container!.querySelector<HTMLElement>('[data-attendance-small-org-cockpit]')!
+      const row = section.querySelector<HTMLElement>('[data-attendance-small-org-row]')!
+      row.querySelector<HTMLButtonElement>('[data-attendance-small-org-deactivate]')!.click()
+      await flushUi(4)
+
+      expect(confirmSpy).toHaveBeenCalled()
+      expect(deletes).toEqual([])
+      expect(row.textContent).toContain('Active')
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 
   it('runs the read-only comprehensive hours preview without write controls', async () => {


### PR DESCRIPTION
## Summary
- add the SO1 small-organization schedule-group admin cockpit under Advanced scheduling
- load schedule groups via `/api/attendance/schedule-groups?page=1&pageSize=200&includeInactive=true` with no-silent-caps warning
- support create/update/deactivate schedule groups plus date-aware member add/remove over existing schedule-group routes
- keep copy scoped to schedule groups / small scheduling organizations; no HR-org/payroll-department/auto-dispatch claims

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --reporter=dot` (107 passed)
- `pnpm --filter @metasheet/web exec vue-tsc -b --pretty false`
- `git diff --check`

## Review
- Subagent Archimedes reviewed the SO1 diff, raised two findings, and approved after fixes:
  - member POST body now includes `source: 'manual'` and the exact-body test locks it
  - deactivate cancel path now proves no DELETE is sent

## Scope / Deferred
- Frontend-only over existing SO0-hardened backend routes.
- No backend runtime, no DDL, no OpenAPI/dist changes.
- SO2 scoped actor smoke and SO3 staging closeout remain separate gated slices before `小组织挂部门` can flip ✅.
