### PR TITLE
feat(attendance): add shift-swap request envelope

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -261,6 +261,7 @@ jobs:
             tests/integration/attendance-outdoor-punch.test.ts \
             tests/integration/attendance-notification-deliveries.test.ts \
             tests/integration/attendance-comp-time-expiry-reminder.test.ts \
+            tests/integration/attendance-shift-swap.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -26,7 +26,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
-    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts --reporter=dot",
+    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts tests/integration/attendance-shift-swap.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",

--- a/packages/core-backend/src/db/migrations/zzzz20260612120000_create_attendance_shift_swap_requests.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260612120000_create_attendance_shift_swap_requests.ts
@@ -1,0 +1,107 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const TABLE = 'attendance_shift_swap_requests'
+
+const REQUEST_TYPES = [
+  'missed_check_in',
+  'missed_check_out',
+  'time_correction',
+  'leave',
+  'overtime',
+  'outdoor_punch',
+  'shift_swap',
+]
+
+const PRIOR_REQUEST_TYPES = [
+  'missed_check_in',
+  'missed_check_out',
+  'time_correction',
+  'leave',
+  'overtime',
+  'outdoor_punch',
+]
+
+async function setRequestTypeCheck(db: Kysely<unknown>, types: string[]): Promise<void> {
+  const list = types.map(type => `'${type}'`).join(', ')
+  await sql`ALTER TABLE attendance_requests DROP CONSTRAINT IF EXISTS attendance_requests_type_check`.execute(db)
+  await sql`
+    ALTER TABLE attendance_requests ADD CONSTRAINT attendance_requests_type_check
+    CHECK (request_type IN (${sql.raw(list)}))
+  `.execute(db)
+}
+
+// Shift-swap SW1 (design-lock attendance-shift-swap-design-lock-20260612).
+// Latent schema only: the generic requests API still rejects shift_swap, and no
+// final-approval schedule writer is wired in this slice.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const requestsExists = await checkTableExists(db, 'attendance_requests')
+  const assignmentsExists = await checkTableExists(db, 'attendance_shift_assignments')
+  if (!requestsExists || !assignmentsExists) return
+
+  await setRequestTypeCheck(db, REQUEST_TYPES)
+
+  const exists = await checkTableExists(db, TABLE)
+  if (!exists) {
+    await db.schema
+      .createTable(TABLE)
+      .ifNotExists()
+      .addColumn('request_id', 'uuid', col => col.primaryKey().references('attendance_requests.id').onDelete('cascade'))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('requester_user_id', 'text', col => col.notNull())
+      .addColumn('counterparty_user_id', 'text', col => col.notNull())
+      .addColumn('counterparty_status', 'text', col => col.notNull().defaultTo('pending'))
+      .addColumn('requester_assignment_id', 'uuid', col => col.notNull().references('attendance_shift_assignments.id'))
+      .addColumn('counterparty_assignment_id', 'uuid', col => col.notNull().references('attendance_shift_assignments.id'))
+      .addColumn('requester_replacement_assignment_id', 'uuid', col => col.references('attendance_shift_assignments.id'))
+      .addColumn('counterparty_replacement_assignment_id', 'uuid', col => col.references('attendance_shift_assignments.id'))
+      .addColumn('requester_work_date', 'date', col => col.notNull())
+      .addColumn('counterparty_work_date', 'date', col => col.notNull())
+      .addColumn('requester_shift_id', 'uuid', col => col.notNull())
+      .addColumn('counterparty_shift_id', 'uuid', col => col.notNull())
+      .addColumn('requester_slot_index', 'smallint', col => col.notNull().defaultTo(0))
+      .addColumn('counterparty_slot_index', 'smallint', col => col.notNull().defaultTo(0))
+      .addColumn('requester_start_date', 'date', col => col.notNull())
+      .addColumn('requester_end_date', 'date', col => col.notNull())
+      .addColumn('counterparty_start_date', 'date', col => col.notNull())
+      .addColumn('counterparty_end_date', 'date', col => col.notNull())
+      .addColumn('requester_publish_status', 'text', col => col.notNull())
+      .addColumn('counterparty_publish_status', 'text', col => col.notNull())
+      .addColumn('requester_producer_type', 'text')
+      .addColumn('counterparty_producer_type', 'text')
+      .addColumn('requester_assignment_kind', 'text', col => col.notNull())
+      .addColumn('counterparty_assignment_kind', 'text', col => col.notNull())
+      .addColumn('source_key', 'text', col => col.notNull())
+      .addColumn('counterparty_responded_at', 'timestamptz')
+      .addColumn('finalized_at', 'timestamptz')
+      .addColumn('created_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addCheckConstraint('chk_attendance_shift_swap_counterparty_status', sql`counterparty_status IN ('pending', 'accepted', 'rejected')`)
+      .addCheckConstraint('chk_attendance_shift_swap_two_users', sql`requester_user_id <> counterparty_user_id`)
+      .addCheckConstraint('chk_attendance_shift_swap_two_assignments', sql`requester_assignment_id <> counterparty_assignment_id`)
+      .addCheckConstraint('chk_attendance_shift_swap_slot_index', sql`requester_slot_index BETWEEN 0 AND 2 AND counterparty_slot_index BETWEEN 0 AND 2`)
+      .addCheckConstraint(
+        'chk_attendance_shift_swap_single_day',
+        sql`requester_start_date = requester_end_date AND requester_work_date = requester_start_date AND counterparty_start_date = counterparty_end_date AND counterparty_work_date = counterparty_start_date`,
+      )
+      .addCheckConstraint('chk_attendance_shift_swap_published', sql`requester_publish_status = 'published' AND counterparty_publish_status = 'published'`)
+      .addCheckConstraint('chk_attendance_shift_swap_regular', sql`requester_assignment_kind = 'regular' AND counterparty_assignment_kind = 'regular'`)
+      .addCheckConstraint('chk_attendance_shift_swap_manual', sql`requester_producer_type IS NULL AND counterparty_producer_type IS NULL`)
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'uq_attendance_shift_swap_requests_source_key', TABLE, ['org_id', 'source_key'], { unique: true })
+  await createIndexIfNotExists(db, 'idx_attendance_shift_swap_requests_requester', TABLE, ['org_id', 'requester_user_id'])
+  await createIndexIfNotExists(db, 'idx_attendance_shift_swap_requests_counterparty', TABLE, ['org_id', 'counterparty_user_id', 'counterparty_status'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).ifExists().execute()
+  if (await checkTableExists(db, 'attendance_requests')) {
+    await setRequestTypeCheck(db, PRIOR_REQUEST_TYPES)
+  }
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -85,6 +85,7 @@ export interface Database {
   attendance_events: AttendanceEventsTable
   attendance_records: AttendanceRecordsTable
   attendance_requests: AttendanceRequestsTable
+  attendance_shift_swap_requests: AttendanceShiftSwapRequestsTable
   attendance_rules: AttendanceRulesTable
   attendance_shifts: AttendanceShiftsTable
   attendance_shift_assignments: AttendanceShiftAssignmentsTable
@@ -1061,7 +1062,7 @@ export interface AttendanceRequestsTable {
   user_id: string
   org_id: string
   work_date: ColumnType<string, string | undefined, string>
-  request_type: 'missed_check_in' | 'missed_check_out' | 'time_correction' | 'leave' | 'overtime' | 'outdoor_punch'
+  request_type: 'missed_check_in' | 'missed_check_out' | 'time_correction' | 'leave' | 'overtime' | 'outdoor_punch' | 'shift_swap'
   requested_in_at: NullableTimestamp
   requested_out_at: NullableTimestamp
   reason: string | null
@@ -1070,6 +1071,39 @@ export interface AttendanceRequestsTable {
   resolved_by: string | null
   resolved_at: NullableTimestamp
   metadata: JSONColumnType<Record<string, unknown> | null>
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface AttendanceShiftSwapRequestsTable {
+  request_id: string
+  org_id: string
+  requester_user_id: string
+  counterparty_user_id: string
+  counterparty_status: 'pending' | 'accepted' | 'rejected'
+  requester_assignment_id: string
+  counterparty_assignment_id: string
+  requester_replacement_assignment_id: string | null
+  counterparty_replacement_assignment_id: string | null
+  requester_work_date: ColumnType<string, string | undefined, string>
+  counterparty_work_date: ColumnType<string, string | undefined, string>
+  requester_shift_id: string
+  counterparty_shift_id: string
+  requester_slot_index: number
+  counterparty_slot_index: number
+  requester_start_date: ColumnType<string, string | undefined, string>
+  requester_end_date: ColumnType<string, string | undefined, string>
+  counterparty_start_date: ColumnType<string, string | undefined, string>
+  counterparty_end_date: ColumnType<string, string | undefined, string>
+  requester_publish_status: string
+  counterparty_publish_status: string
+  requester_producer_type: string | null
+  counterparty_producer_type: string | null
+  requester_assignment_kind: string
+  counterparty_assignment_kind: string
+  source_key: string
+  counterparty_responded_at: NullableTimestamp
+  finalized_at: NullableTimestamp
   created_at: CreatedAt
   updated_at: UpdatedAt
 }

--- a/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+
+type HttpResponse = { status: number; body?: unknown; raw: string }
+
+function requestJson(url: string, options: { method?: string; headers?: Record<string, string>; body?: string } = {}): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+const ORG = 'default'
+
+describeDb('shift-swap SW1 envelope (real DB, route-level)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let pool: Pool
+
+  const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' })
+
+  async function mintToken(userId: string, perms: string): Promise<string> {
+    const res = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent(perms)}`)
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+
+  async function cleanupPrefix(prefix: string) {
+    const userPattern = `${prefix}%`
+    await pool.query(
+      `DELETE FROM approval_instances
+       WHERE business_key IN (
+         SELECT 'attendance-request:' || id FROM attendance_requests
+         WHERE org_id = $1 AND (user_id LIKE $2 OR id IN (
+           SELECT request_id FROM attendance_shift_swap_requests
+           WHERE org_id = $1 AND (requester_user_id LIKE $2 OR counterparty_user_id LIKE $2)
+         ))
+       )`,
+      [ORG, userPattern],
+    ).catch(() => undefined)
+    await pool.query(
+      `DELETE FROM attendance_requests
+       WHERE org_id = $1 AND (user_id LIKE $2 OR id IN (
+         SELECT request_id FROM attendance_shift_swap_requests
+         WHERE org_id = $1 AND (requester_user_id LIKE $2 OR counterparty_user_id LIKE $2)
+       ))`,
+      [ORG, userPattern],
+    ).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_shift_assignments WHERE org_id = $1 AND user_id LIKE $2`, [ORG, userPattern]).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1 AND name LIKE $2`, [ORG, userPattern]).catch(() => undefined)
+  }
+
+  async function expectPgReject(promise: Promise<unknown>, code: string) {
+    try {
+      await promise
+      throw new Error(`expected postgres error ${code}`)
+    } catch (error) {
+      expect((error as { code?: string }).code).toBe(code)
+    }
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('shift-swap integration needs a loopback port + DATABASE_URL')
+
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    const repoRoot = path.join(__dirname, '../../../../')
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')] })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+  })
+
+  afterAll(async () => {
+    await cleanupPrefix('swap-').catch(() => undefined)
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) await (server as unknown as { stop: () => Promise<void> }).stop()
+    await pool?.end().catch(() => undefined)
+  })
+
+  it('generic /requests API cannot create or update shift_swap', async () => {
+    const userId = `swap-route-${Date.now().toString(36)}`
+    const workDate = '2049-06-12'
+    const token = await mintToken(userId, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    try {
+      const create = await requestJson(`${baseUrl}/api/attendance/requests`, {
+        method: 'POST',
+        headers: authHeaders(token),
+        body: JSON.stringify({ workDate, requestType: 'shift_swap', reason: 'blocked generic create' }),
+      })
+      expect(create.status).toBe(422)
+      expect((create.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_DEDICATED_ROUTE_ONLY')
+      const createdCount = Number((await pool.query(
+        `SELECT count(*)::int AS n FROM attendance_requests WHERE org_id = $1 AND request_type = 'shift_swap' AND work_date = $2`,
+        [ORG, workDate],
+      )).rows[0].n)
+      expect(createdCount).toBe(0)
+
+      const normal = await requestJson(`${baseUrl}/api/attendance/requests`, {
+        method: 'POST',
+        headers: authHeaders(token),
+        body: JSON.stringify({
+          workDate: '2049-06-13',
+          requestType: 'missed_check_in',
+          requestedInAt: '2049-06-13T09:00:00.000Z',
+          reason: userId,
+        }),
+      })
+      expect(normal.status).toBe(201)
+      const requestId = (normal.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+      expect(requestId).toBeTruthy()
+
+      const update = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}`, {
+        method: 'PUT',
+        headers: authHeaders(token),
+        body: JSON.stringify({ requestType: 'shift_swap' }),
+      })
+      expect(update.status).toBe(422)
+      expect((update.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_DEDICATED_ROUTE_ONLY')
+      const unchanged = (await pool.query(`SELECT request_type FROM attendance_requests WHERE id = $1`, [requestId])).rows[0]
+      expect(unchanged.request_type).toBe('missed_check_in')
+    } finally {
+      await cleanupPrefix('swap-route-')
+    }
+  })
+
+  it('persists structured single-day swap details and rejects duplicate or multi-day shapes', async () => {
+    const prefix = `swap-db-${Date.now().toString(36)}`
+    const requester = `${prefix}-a`
+    const counterparty = `${prefix}-b`
+    const requestId = randomUUID()
+    const duplicateRequestId = randomUUID()
+    const multiDayRequestId = randomUUID()
+    const shiftA = randomUUID()
+    const shiftB = randomUUID()
+    const assignmentA = randomUUID()
+    const assignmentB = randomUUID()
+    try {
+      await pool.query(
+        `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
+         VALUES ($1, $2, $3, '09:00', '13:00'), ($4, $2, $5, '14:00', '18:00')`,
+        [shiftA, ORG, `${prefix}-shift-a`, shiftB, `${prefix}-shift-b`],
+      )
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+         VALUES
+         ($1, $2, $3, $4, 0, '2049-06-14', '2049-06-14', true, 'published', 'regular'),
+         ($5, $2, $6, $7, 0, '2049-06-15', '2049-06-15', true, 'published', 'regular')`,
+        [assignmentA, ORG, requester, shiftA, assignmentB, counterparty, shiftB],
+      )
+      await pool.query(
+        `INSERT INTO attendance_requests (id, user_id, org_id, work_date, request_type, status, metadata)
+         VALUES ($1, $2, $3, '2049-06-14', 'shift_swap', 'pending', '{}'::jsonb),
+                ($4, $2, $3, '2049-06-14', 'shift_swap', 'pending', '{}'::jsonb),
+                ($5, $2, $3, '2049-06-14', 'shift_swap', 'pending', '{}'::jsonb)`,
+        [requestId, requester, ORG, duplicateRequestId, multiDayRequestId],
+      )
+
+      const insertDetail = (id: string, sourceKey: string, requesterEndDate = '2049-06-14') => pool.query(
+        `INSERT INTO attendance_shift_swap_requests
+         (request_id, org_id, requester_user_id, counterparty_user_id, requester_assignment_id, counterparty_assignment_id,
+          requester_work_date, counterparty_work_date, requester_shift_id, counterparty_shift_id,
+          requester_slot_index, counterparty_slot_index, requester_start_date, requester_end_date,
+          counterparty_start_date, counterparty_end_date, requester_publish_status, counterparty_publish_status,
+          requester_assignment_kind, counterparty_assignment_kind, source_key)
+         VALUES
+         ($1, $2, $3, $4, $5, $6,
+          '2049-06-14', '2049-06-15', $7, $8,
+          0, 0, '2049-06-14', $9,
+          '2049-06-15', '2049-06-15', 'published', 'published',
+          'regular', 'regular', $10)`,
+        [id, ORG, requester, counterparty, assignmentA, assignmentB, shiftA, shiftB, requesterEndDate, sourceKey],
+      )
+
+      await insertDetail(requestId, `${prefix}:source`)
+      const detail = (await pool.query(
+        `SELECT counterparty_status, requester_work_date, counterparty_work_date
+         FROM attendance_shift_swap_requests WHERE request_id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(detail.counterparty_status).toBe('pending')
+      expect(new Date(detail.requester_work_date).toISOString().slice(0, 10)).toBe('2049-06-14')
+      expect(new Date(detail.counterparty_work_date).toISOString().slice(0, 10)).toBe('2049-06-15')
+
+      await expectPgReject(insertDetail(duplicateRequestId, `${prefix}:source`), '23505')
+      await expectPgReject(insertDetail(multiDayRequestId, `${prefix}:multi`, '2049-06-16'), '23514')
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'tests/integration/attendance-notification-deliveries.test.ts',
       'tests/integration/attendance-outdoor-punch.test.ts',
       'tests/integration/attendance-plugin.test.ts',
+      'tests/integration/attendance-shift-swap.test.ts',
       'tests/integration/attendance-unscheduled-reminder.test.ts',
       'tests/integration/comments.api.test.ts',
       'tests/integration/events-api.test.ts',

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -13318,7 +13318,7 @@ export interface components {
             /** Format: date */
             work_date?: string;
             /** @enum {string} */
-            request_type?: "missed_check_in" | "missed_check_out" | "time_correction" | "leave" | "overtime";
+            request_type?: "missed_check_in" | "missed_check_out" | "time_correction" | "leave" | "overtime" | "outdoor_punch" | "shift_swap";
             /** Format: date-time */
             requested_in_at?: string | null;
             /** Format: date-time */

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -504,6 +504,8 @@ components:
             - time_correction
             - leave
             - overtime
+            - outdoor_punch
+            - shift_swap
         requested_in_at:
           type: string
           format: date-time

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -711,7 +711,9 @@
               "missed_check_out",
               "time_correction",
               "leave",
-              "overtime"
+              "overtime",
+              "outdoor_punch",
+              "shift_swap"
             ]
           },
           "requested_in_at": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -504,6 +504,8 @@ components:
             - time_correction
             - leave
             - overtime
+            - outdoor_punch
+            - shift_swap
         requested_in_at:
           type: string
           format: date-time

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -466,7 +466,7 @@ components:
           format: date
         request_type:
           type: string
-          enum: [missed_check_in, missed_check_out, time_correction, leave, overtime]
+          enum: [missed_check_in, missed_check_out, time_correction, leave, overtime, outdoor_punch, shift_swap]
         requested_in_at:
           type: string
           format: date-time

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -44,6 +44,9 @@ const REQUEST_TYPES = [
   'overtime',
   // ② S3 外勤审批 (#2304): outdoor field-work punch that needs approval before it counts.
   'outdoor_punch',
+  // OPTIONAL shift-swap SW1 (#2538 design-lock): approval envelope type only; generic /requests
+  // must not create it because swap needs structured assignment snapshots + counterparty consent.
+  'shift_swap',
 ]
 const OUTDOOR_APPROVAL_EVENT_SOURCE = 'outdoor_approval'
 // ② S2-0 (#2325 design-lock): event sources that ONLY a trusted internal writer may set — never accepted
@@ -22049,6 +22052,14 @@ module.exports = {
           'OUTDOOR_PUNCH_VIA_PUNCH_ONLY',
           'outdoor_punch requests are created by the attendance punch route, not the requests API',
           singleValidationDetail('requestType', 'outdoor_punch is not creatable via the requests API')
+        )
+      }
+      if (requestType === 'shift_swap') {
+        throw new HttpError(
+          422,
+          'SHIFT_SWAP_DEDICATED_ROUTE_ONLY',
+          'shift_swap requests are created by the attendance shift-swap route, not the requests API',
+          singleValidationDetail('requestType', 'shift_swap is not creatable via the requests API')
         )
       }
 

--- a/scripts/ops/attendance-regression-local.sh
+++ b/scripts/ops/attendance-regression-local.sh
@@ -53,7 +53,7 @@ fi
 
 run_check \
   "backend-attendance-integration" \
-  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts"
+  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts tests/integration/attendance-shift-swap.test.ts"
 
 run_check \
   "web-unit-tests" \


### PR DESCRIPTION
## Summary
- add the SW1 `attendance_shift_swap_requests` schema plus DB request-type support for `shift_swap`
- keep generic `/api/attendance/requests` create/update blocked with `SHIFT_SWAP_DEDICATED_ROUTE_ONLY` so swap requests must use the future dedicated route
- update backend DB types and AttendanceRequest output contract, without exposing `shift_swap` in generic request input enums
- add a real-DB integration spec and wire it into the DB-having attendance CI step / local regression script while excluding it from default Vitest

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `bash -n scripts/ops/attendance-regression-local.sh`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `DATABASE_URL=postgresql://chouhua@localhost:5432/ms2_sw1_1781258550 pnpm --filter @metasheet/core-backend migrate` on a fresh local DB
- `DATABASE_URL=postgresql://chouhua@localhost:5432/ms2_sw1_1781258550 ATTENDANCE_TEST_DATABASE_URL=postgresql://chouhua@localhost:5432/ms2_sw1_1781258550 pnpm --filter @metasheet/core-backend test:integration:attendance` → 7 files / 137 tests passed

## Review
- subagent review: APPROVE (no blocking findings)

## Scope boundary
SW1 is latent schema/envelope only. It does not implement the dedicated shift-swap create route, counterparty consent runtime, final approval schedule mutation, or admin UI; those remain later gated slices from the SW0 design-lock.