### PR TITLE
feat(attendance): add shift-swap create and consent routes

### DIFF
--- a/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
@@ -39,7 +39,7 @@ const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_U
 const describeDb = dbUrl ? describe : describe.skip
 const ORG = 'default'
 
-describeDb('shift-swap SW1 envelope (real DB, route-level)', () => {
+describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
   let pool: Pool
@@ -72,6 +72,7 @@ describeDb('shift-swap SW1 envelope (real DB, route-level)', () => {
        ))`,
       [ORG, userPattern],
     ).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_approval_flows WHERE org_id = $1 AND name LIKE $2`, [ORG, userPattern]).catch(() => undefined)
     await pool.query(`DELETE FROM attendance_shift_assignments WHERE org_id = $1 AND user_id LIKE $2`, [ORG, userPattern]).catch(() => undefined)
     await pool.query(`DELETE FROM attendance_shifts WHERE org_id = $1 AND name LIKE $2`, [ORG, userPattern]).catch(() => undefined)
   }
@@ -83,6 +84,81 @@ describeDb('shift-swap SW1 envelope (real DB, route-level)', () => {
     } catch (error) {
       expect((error as { code?: string }).code).toBe(code)
     }
+  }
+
+  async function seedSwapPair(prefix: string, options: {
+    requesterEndDate?: string
+    requesterPublishStatus?: string
+    requesterProducerType?: string | null
+    requesterAssignmentKind?: string
+  } = {}) {
+    const requester = `${prefix}-a`
+    const counterparty = `${prefix}-b`
+    const shiftA = randomUUID()
+    const shiftB = randomUUID()
+    const assignmentA = randomUUID()
+    const assignmentB = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
+       VALUES ($1, $2, $3, '09:00', '13:00'), ($4, $2, $5, '14:00', '18:00')`,
+      [shiftA, ORG, `${prefix}-shift-a`, shiftB, `${prefix}-shift-b`],
+    )
+    const producerRefId = options.requesterProducerType ? randomUUID() : null
+    const producerRunId = options.requesterProducerType ? randomUUID() : null
+    const producerKey = options.requesterProducerType ? `${prefix}:producer` : null
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+       (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind,
+        producer_type, producer_ref_id, producer_key, producer_run_id)
+       VALUES
+       ($1, $2, $3, $4, 0, '2049-06-14', $5, true, $6, $7, $8, $9, $10, $11),
+       ($12, $2, $13, $14, 0, '2049-06-15', '2049-06-15', true, 'published', 'regular', NULL, NULL, NULL, NULL)`,
+      [
+        assignmentA,
+        ORG,
+        requester,
+        shiftA,
+        options.requesterEndDate ?? '2049-06-14',
+        options.requesterPublishStatus ?? 'published',
+        options.requesterAssignmentKind ?? 'regular',
+        options.requesterProducerType ?? null,
+        producerRefId,
+        producerKey,
+        producerRunId,
+        assignmentB,
+        counterparty,
+        shiftB,
+      ],
+    )
+    return { requester, counterparty, shiftA, shiftB, assignmentA, assignmentB }
+  }
+
+  async function seedExtraSource(prefix: string, userSuffix = 'c') {
+    const user = `${prefix}-${userSuffix}`
+    const shiftId = randomUUID()
+    const assignmentId = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
+       VALUES ($1, $2, $3, '10:00', '14:00')`,
+      [shiftId, ORG, `${prefix}-shift-${userSuffix}`],
+    )
+    await pool.query(
+      `INSERT INTO attendance_shift_assignments
+       (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+       VALUES ($1, $2, $3, $4, 0, '2049-06-16', '2049-06-16', true, 'published', 'regular')`,
+      [assignmentId, ORG, user, shiftId],
+    )
+    return { user, shiftId, assignmentId }
+  }
+
+  async function seedApprovalFlow(prefix: string, requestType: string, isActive = true) {
+    const id = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_approval_flows (id, org_id, name, request_type, steps, is_active)
+       VALUES ($1, $2, $3, $4, '[]'::jsonb, $5)`,
+      [id, ORG, `${prefix}-flow-${requestType}-${isActive ? 'active' : 'inactive'}`, requestType, isActive],
+    )
+    return id
   }
 
   beforeAll(async () => {
@@ -219,6 +295,278 @@ describeDb('shift-swap SW1 envelope (real DB, route-level)', () => {
 
       await expectPgReject(insertDetail(duplicateRequestId, `${prefix}:source`), '23505')
       await expectPgReject(insertDetail(multiDayRequestId, `${prefix}:multi`, '2049-06-16'), '23514')
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('creates a dedicated shift-swap request, records counterparty consent, and keeps final approval deferred', async () => {
+    const prefix = `swap-api-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      const otherToken = await mintToken(`${prefix}-other`, 'attendance:read,attendance:write')
+
+      const create = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({
+          requesterAssignmentId: pair.assignmentA,
+          counterpartyAssignmentId: pair.assignmentB,
+          reason: 'swap api smoke',
+        }),
+      })
+      expect(create.status).toBe(201)
+      const createBody = create.body as {
+        data?: {
+          request?: { id?: string; request_type?: string; status?: string }
+          shiftSwap?: { counterpartyStatus?: string; requesterWorkDate?: string; counterpartyWorkDate?: string }
+        }
+      }
+      const requestId = createBody.data?.request?.id
+      expect(requestId).toBeTruthy()
+      expect(createBody.data?.request?.request_type).toBe('shift_swap')
+      expect(createBody.data?.shiftSwap?.counterpartyStatus).toBe('pending')
+      expect(createBody.data?.shiftSwap?.requesterWorkDate).toBe('2049-06-14')
+      expect(createBody.data?.shiftSwap?.counterpartyWorkDate).toBe('2049-06-15')
+
+      const list = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        headers: authHeaders(requesterToken),
+      })
+      expect(list.status).toBe(200)
+      const listed = (list.body as { data?: { items?: Array<{ requestId?: string }> } } | undefined)?.data?.items ?? []
+      expect(listed.some(item => item.requestId === requestId)).toBe(true)
+
+      const readAsCounterparty = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${requestId}`, {
+        headers: authHeaders(counterpartyToken),
+      })
+      expect(readAsCounterparty.status).toBe(200)
+
+      const otherAccept = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${requestId}/accept`, {
+        method: 'POST',
+        headers: authHeaders(otherToken),
+        body: '{}',
+      })
+      expect(otherAccept.status).toBe(403)
+
+      const accept = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${requestId}/accept`, {
+        method: 'POST',
+        headers: authHeaders(counterpartyToken),
+        body: '{}',
+      })
+      expect(accept.status).toBe(200)
+      expect((accept.body as { data?: { shiftSwap?: { counterpartyStatus?: string } } } | undefined)?.data?.shiftSwap?.counterpartyStatus).toBe('accepted')
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'not yet' }),
+      })
+      expect(approve.status).toBe(422)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_FINALIZATION_DEFERRED')
+
+      const persisted = (await pool.query(
+        `SELECT r.status, d.counterparty_status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(persisted.status).toBe('pending')
+      expect(persisted.counterparty_status).toBe('accepted')
+      expect(persisted.requester_replacement_assignment_id).toBeNull()
+      expect(persisted.counterparty_replacement_assignment_id).toBeNull()
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('hard-blocks a source assignment while a shift-swap request is pending, then releases it after cancel', async () => {
+    const prefix = `swap-dupe-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const third = await seedExtraSource(prefix, 'c')
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write')
+
+      const first = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({
+          requesterAssignmentId: pair.assignmentA,
+          counterpartyAssignmentId: pair.assignmentB,
+        }),
+      })
+      expect(first.status).toBe(201)
+      const firstRequestId = (first.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+      expect(firstRequestId).toBeTruthy()
+
+      const duplicateSource = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({
+          requesterAssignmentId: pair.assignmentA,
+          counterpartyAssignmentId: third.assignmentId,
+        }),
+      })
+      expect(duplicateSource.status).toBe(409)
+      expect((duplicateSource.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('DUPLICATE_SHIFT_SWAP_SOURCE')
+
+      const cancel = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${firstRequestId}/cancel`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: '{}',
+      })
+      expect(cancel.status).toBe(200)
+      expect((cancel.body as { data?: { shiftSwap?: { requestStatus?: string } } } | undefined)?.data?.shiftSwap?.requestStatus).toBe('cancelled')
+
+      const afterCancel = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({
+          requesterAssignmentId: pair.assignmentA,
+          counterpartyAssignmentId: pair.assignmentB,
+        }),
+      })
+      expect(afterCancel.status).toBe(201)
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('requires an explicit approvalFlowId to be an active shift_swap flow', async () => {
+    const prefix = `swap-flow-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write')
+      const leaveFlowId = await seedApprovalFlow(prefix, 'leave', true)
+      const inactiveSwapFlowId = await seedApprovalFlow(prefix, 'shift_swap', false)
+      const activeSwapFlowId = await seedApprovalFlow(prefix, 'shift_swap', true)
+
+      for (const approvalFlowId of [leaveFlowId, inactiveSwapFlowId]) {
+        const invalidFlow = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+          method: 'POST',
+          headers: authHeaders(requesterToken),
+          body: JSON.stringify({
+            requesterAssignmentId: pair.assignmentA,
+            counterpartyAssignmentId: pair.assignmentB,
+            approvalFlowId,
+          }),
+        })
+        expect(invalidFlow.status).toBe(422)
+        expect((invalidFlow.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_APPROVAL_FLOW_REQUIRED')
+      }
+
+      const countBeforeValid = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_requests
+          WHERE org_id = $1 AND user_id = $2 AND request_type = 'shift_swap'`,
+        [ORG, pair.requester],
+      )).rows[0].n)
+      expect(countBeforeValid).toBe(0)
+
+      const validFlow = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({
+          requesterAssignmentId: pair.assignmentA,
+          counterpartyAssignmentId: pair.assignmentB,
+          approvalFlowId: activeSwapFlowId,
+        }),
+      })
+      expect(validFlow.status).toBe(201)
+      const requestId = (validFlow.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+      expect(requestId).toBeTruthy()
+      const metadata = (await pool.query(
+        `SELECT metadata FROM attendance_requests WHERE id = $1`,
+        [requestId],
+      )).rows[0]?.metadata as { approvalFlow?: { id?: string } } | undefined
+      expect(metadata?.approvalFlow?.id).toBe(activeSwapFlowId)
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('rejects unsupported source snapshots before creating a shift-swap envelope', async () => {
+    const multiPrefix = `swap-multiday-${Date.now().toString(36)}`
+    const generatedPrefix = `swap-generated-${Date.now().toString(36)}`
+    try {
+      const multi = await seedSwapPair(multiPrefix, { requesterEndDate: '2049-06-16' })
+      const multiToken = await mintToken(multi.requester, 'attendance:read,attendance:write')
+      const multiRes = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(multiToken),
+        body: JSON.stringify({ requesterAssignmentId: multi.assignmentA, counterpartyAssignmentId: multi.assignmentB }),
+      })
+      expect(multiRes.status).toBe(422)
+      expect((multiRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_SOURCE_NOT_SINGLE_DAY')
+
+      const generated = await seedSwapPair(generatedPrefix, { requesterProducerType: 'fixed_schedule' })
+      const generatedToken = await mintToken(generated.requester, 'attendance:read,attendance:write')
+      const generatedRes = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(generatedToken),
+        body: JSON.stringify({ requesterAssignmentId: generated.assignmentA, counterpartyAssignmentId: generated.assignmentB }),
+      })
+      expect(generatedRes.status).toBe(422)
+      expect((generatedRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_SOURCE_UNSUPPORTED')
+
+      const count = Number((await pool.query(
+        `SELECT count(*)::int AS n FROM attendance_requests
+          WHERE org_id = $1 AND request_type = 'shift_swap' AND user_id LIKE ANY($2::text[])`,
+        [ORG, [`${multiPrefix}%`, `${generatedPrefix}%`]],
+      )).rows[0].n)
+      expect(count).toBe(0)
+    } finally {
+      await cleanupPrefix(multiPrefix)
+      await cleanupPrefix(generatedPrefix)
+    }
+  })
+
+  it('lets the counterparty reject and closes the approval envelope without schedule writes', async () => {
+    const prefix = `swap-reject-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      const create = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ requesterAssignmentId: pair.assignmentA, counterpartyAssignmentId: pair.assignmentB }),
+      })
+      expect(create.status).toBe(201)
+      const requestId = (create.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+      expect(requestId).toBeTruthy()
+
+      const reject = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${requestId}/reject`, {
+        method: 'POST',
+        headers: authHeaders(counterpartyToken),
+        body: '{}',
+      })
+      expect(reject.status).toBe(200)
+      expect((reject.body as { data?: { shiftSwap?: { counterpartyStatus?: string; requestStatus?: string } } } | undefined)?.data?.shiftSwap?.counterpartyStatus).toBe('rejected')
+      expect((reject.body as { data?: { shiftSwap?: { requestStatus?: string } } } | undefined)?.data?.shiftSwap?.requestStatus).toBe('rejected')
+
+      const statusRows = await pool.query(
+        `SELECT r.status AS request_status, ai.status AS approval_status,
+                d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+           LEFT JOIN approval_instances ai ON ai.id = r.approval_instance_id
+          WHERE r.id = $1`,
+        [requestId],
+      )
+      expect(statusRows.rows[0].request_status).toBe('rejected')
+      expect(statusRows.rows[0].approval_status).toBe('rejected')
+      expect(statusRows.rows[0].requester_replacement_assignment_id).toBeNull()
+      expect(statusRows.rows[0].counterparty_replacement_assignment_id).toBeNull()
+
+      const retry = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ requesterAssignmentId: pair.assignmentA, counterpartyAssignmentId: pair.assignmentB }),
+      })
+      expect(retry.status).toBe(201)
     } finally {
       await cleanupPrefix(prefix)
     }

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -542,6 +542,131 @@ components:
         updated_at:
           type: string
           format: date-time
+    AttendanceShiftSwapRequest:
+      type: object
+      properties:
+        requestId:
+          type: string
+        request_id:
+          type: string
+        orgId:
+          type: string
+        org_id:
+          type: string
+        requestStatus:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+            - cancelled
+        request_status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+            - cancelled
+        requesterUserId:
+          type: string
+        requester_user_id:
+          type: string
+        counterpartyUserId:
+          type: string
+        counterparty_user_id:
+          type: string
+        counterpartyStatus:
+          type: string
+          enum:
+            - pending
+            - accepted
+            - rejected
+        counterparty_status:
+          type: string
+          enum:
+            - pending
+            - accepted
+            - rejected
+        requesterAssignmentId:
+          type: string
+        requester_assignment_id:
+          type: string
+        counterpartyAssignmentId:
+          type: string
+        counterparty_assignment_id:
+          type: string
+        requesterReplacementAssignmentId:
+          type: string
+          nullable: true
+        requester_replacement_assignment_id:
+          type: string
+          nullable: true
+        counterpartyReplacementAssignmentId:
+          type: string
+          nullable: true
+        counterparty_replacement_assignment_id:
+          type: string
+          nullable: true
+        requesterWorkDate:
+          type: string
+          format: date
+        requester_work_date:
+          type: string
+          format: date
+        counterpartyWorkDate:
+          type: string
+          format: date
+        counterparty_work_date:
+          type: string
+          format: date
+        requesterShiftId:
+          type: string
+        requester_shift_id:
+          type: string
+        counterpartyShiftId:
+          type: string
+        counterparty_shift_id:
+          type: string
+        requesterSlotIndex:
+          type: integer
+        requester_slot_index:
+          type: integer
+        counterpartySlotIndex:
+          type: integer
+        counterparty_slot_index:
+          type: integer
+        sourceKey:
+          type: string
+        source_key:
+          type: string
+        counterpartyRespondedAt:
+          type: string
+          format: date-time
+          nullable: true
+        counterparty_responded_at:
+          type: string
+          format: date-time
+          nullable: true
+        finalizedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     AttendanceAnomaly:
       type: object
       properties:
@@ -6364,6 +6489,269 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/shift-swap-requests:
+    x-plugin: plugin-attendance
+    post:
+      summary: Create a shift-swap request
+      description: >-
+        Creates the shift-swap approval envelope and counterparty-consent
+        record. Final schedule mutation is handled by a later
+        approval-finalization slice.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requesterAssignmentId:
+                  type: string
+                  description: >-
+                    Published single-day manual assignment owned by the
+                    requester.
+                requester_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for requesterAssignmentId.
+                counterpartyAssignmentId:
+                  type: string
+                  description: >-
+                    Published single-day manual assignment owned by the
+                    counterparty.
+                counterparty_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for counterpartyAssignmentId.
+                reason:
+                  type: string
+                approvalFlowId:
+                  type: string
+                approval_flow_id:
+                  type: string
+                  description: Compatibility snake_case alias for approvalFlowId.
+              required:
+                - requesterAssignmentId
+                - counterpartyAssignmentId
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      request:
+                        $ref: '#/components/schemas/AttendanceRequest'
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+    get:
+      summary: List shift-swap requests visible to the current user
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+          description: >-
+            Optional requester/counterparty filter. Cross-user access requires
+            elevated attendance privileges.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/shift-swap-requests/{id}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get a shift-swap request by id
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/attendance/shift-swap-requests/{id}/accept:
+    x-plugin: plugin-attendance
+    post:
+      summary: Accept counterparty consent for a shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /api/attendance/shift-swap-requests/{id}/reject:
+    x-plugin: plugin-attendance
+    post:
+      summary: Reject counterparty consent for a shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /api/attendance/shift-swap-requests/{id}/cancel:
+    x-plugin: plugin-attendance
+    post:
+      summary: Cancel a pending shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/attendance/rules/default:
     x-plugin: plugin-attendance
     get:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -765,6 +765,179 @@
           }
         }
       },
+      "AttendanceShiftSwapRequest": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "orgId": {
+            "type": "string"
+          },
+          "org_id": {
+            "type": "string"
+          },
+          "requestStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "cancelled"
+            ]
+          },
+          "request_status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "cancelled"
+            ]
+          },
+          "requesterUserId": {
+            "type": "string"
+          },
+          "requester_user_id": {
+            "type": "string"
+          },
+          "counterpartyUserId": {
+            "type": "string"
+          },
+          "counterparty_user_id": {
+            "type": "string"
+          },
+          "counterpartyStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
+            ]
+          },
+          "counterparty_status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
+            ]
+          },
+          "requesterAssignmentId": {
+            "type": "string"
+          },
+          "requester_assignment_id": {
+            "type": "string"
+          },
+          "counterpartyAssignmentId": {
+            "type": "string"
+          },
+          "counterparty_assignment_id": {
+            "type": "string"
+          },
+          "requesterReplacementAssignmentId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requester_replacement_assignment_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "counterpartyReplacementAssignmentId": {
+            "type": "string",
+            "nullable": true
+          },
+          "counterparty_replacement_assignment_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "requesterWorkDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "requester_work_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "counterpartyWorkDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "counterparty_work_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "requesterShiftId": {
+            "type": "string"
+          },
+          "requester_shift_id": {
+            "type": "string"
+          },
+          "counterpartyShiftId": {
+            "type": "string"
+          },
+          "counterparty_shift_id": {
+            "type": "string"
+          },
+          "requesterSlotIndex": {
+            "type": "integer"
+          },
+          "requester_slot_index": {
+            "type": "integer"
+          },
+          "counterpartySlotIndex": {
+            "type": "integer"
+          },
+          "counterparty_slot_index": {
+            "type": "integer"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "source_key": {
+            "type": "string"
+          },
+          "counterpartyRespondedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "counterparty_responded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalizedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalized_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "AttendanceAnomaly": {
         "type": "object",
         "properties": {
@@ -9225,6 +9398,417 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance/shift-swap-requests": {
+      "x-plugin": "plugin-attendance",
+      "post": {
+        "summary": "Create a shift-swap request",
+        "description": "Creates the shift-swap approval envelope and counterparty-consent record. Final schedule mutation is handled by a later approval-finalization slice.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "requesterAssignmentId": {
+                    "type": "string",
+                    "description": "Published single-day manual assignment owned by the requester."
+                  },
+                  "requester_assignment_id": {
+                    "type": "string",
+                    "description": "Compatibility snake_case alias for requesterAssignmentId."
+                  },
+                  "counterpartyAssignmentId": {
+                    "type": "string",
+                    "description": "Published single-day manual assignment owned by the counterparty."
+                  },
+                  "counterparty_assignment_id": {
+                    "type": "string",
+                    "description": "Compatibility snake_case alias for counterpartyAssignmentId."
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "approvalFlowId": {
+                    "type": "string"
+                  },
+                  "approval_flow_id": {
+                    "type": "string",
+                    "description": "Compatibility snake_case alias for approvalFlowId."
+                  }
+                },
+                "required": [
+                  "requesterAssignmentId",
+                  "counterpartyAssignmentId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "request": {
+                          "$ref": "#/components/schemas/AttendanceRequest"
+                        },
+                        "shiftSwap": {
+                          "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      },
+      "get": {
+        "summary": "List shift-swap requests visible to the current user",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "userId",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional requester/counterparty filter. Cross-user access requires elevated attendance privileges."
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/attendance/shift-swap-requests/{id}": {
+      "x-plugin": "plugin-attendance",
+      "get": {
+        "summary": "Get a shift-swap request by id",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "shiftSwap": {
+                          "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/attendance/shift-swap-requests/{id}/accept": {
+      "x-plugin": "plugin-attendance",
+      "post": {
+        "summary": "Accept counterparty consent for a shift-swap request",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "shiftSwap": {
+                          "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/attendance/shift-swap-requests/{id}/reject": {
+      "x-plugin": "plugin-attendance",
+      "post": {
+        "summary": "Reject counterparty consent for a shift-swap request",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "shiftSwap": {
+                          "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/attendance/shift-swap-requests/{id}/cancel": {
+      "x-plugin": "plugin-attendance",
+      "post": {
+        "summary": "Cancel a pending shift-swap request",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "shiftSwap": {
+                          "$ref": "#/components/schemas/AttendanceShiftSwapRequest"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -542,6 +542,131 @@ components:
         updated_at:
           type: string
           format: date-time
+    AttendanceShiftSwapRequest:
+      type: object
+      properties:
+        requestId:
+          type: string
+        request_id:
+          type: string
+        orgId:
+          type: string
+        org_id:
+          type: string
+        requestStatus:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+            - cancelled
+        request_status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - rejected
+            - cancelled
+        requesterUserId:
+          type: string
+        requester_user_id:
+          type: string
+        counterpartyUserId:
+          type: string
+        counterparty_user_id:
+          type: string
+        counterpartyStatus:
+          type: string
+          enum:
+            - pending
+            - accepted
+            - rejected
+        counterparty_status:
+          type: string
+          enum:
+            - pending
+            - accepted
+            - rejected
+        requesterAssignmentId:
+          type: string
+        requester_assignment_id:
+          type: string
+        counterpartyAssignmentId:
+          type: string
+        counterparty_assignment_id:
+          type: string
+        requesterReplacementAssignmentId:
+          type: string
+          nullable: true
+        requester_replacement_assignment_id:
+          type: string
+          nullable: true
+        counterpartyReplacementAssignmentId:
+          type: string
+          nullable: true
+        counterparty_replacement_assignment_id:
+          type: string
+          nullable: true
+        requesterWorkDate:
+          type: string
+          format: date
+        requester_work_date:
+          type: string
+          format: date
+        counterpartyWorkDate:
+          type: string
+          format: date
+        counterparty_work_date:
+          type: string
+          format: date
+        requesterShiftId:
+          type: string
+        requester_shift_id:
+          type: string
+        counterpartyShiftId:
+          type: string
+        counterparty_shift_id:
+          type: string
+        requesterSlotIndex:
+          type: integer
+        requester_slot_index:
+          type: integer
+        counterpartySlotIndex:
+          type: integer
+        counterparty_slot_index:
+          type: integer
+        sourceKey:
+          type: string
+        source_key:
+          type: string
+        counterpartyRespondedAt:
+          type: string
+          format: date-time
+          nullable: true
+        counterparty_responded_at:
+          type: string
+          format: date-time
+          nullable: true
+        finalizedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     AttendanceAnomaly:
       type: object
       properties:
@@ -6364,6 +6489,269 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/attendance/shift-swap-requests:
+    x-plugin: plugin-attendance
+    post:
+      summary: Create a shift-swap request
+      description: >-
+        Creates the shift-swap approval envelope and counterparty-consent
+        record. Final schedule mutation is handled by a later
+        approval-finalization slice.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requesterAssignmentId:
+                  type: string
+                  description: >-
+                    Published single-day manual assignment owned by the
+                    requester.
+                requester_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for requesterAssignmentId.
+                counterpartyAssignmentId:
+                  type: string
+                  description: >-
+                    Published single-day manual assignment owned by the
+                    counterparty.
+                counterparty_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for counterpartyAssignmentId.
+                reason:
+                  type: string
+                approvalFlowId:
+                  type: string
+                approval_flow_id:
+                  type: string
+                  description: Compatibility snake_case alias for approvalFlowId.
+              required:
+                - requesterAssignmentId
+                - counterpartyAssignmentId
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      request:
+                        $ref: '#/components/schemas/AttendanceRequest'
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+    get:
+      summary: List shift-swap requests visible to the current user
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+          description: >-
+            Optional requester/counterparty filter. Cross-user access requires
+            elevated attendance privileges.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/attendance/shift-swap-requests/{id}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get a shift-swap request by id
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/attendance/shift-swap-requests/{id}/accept:
+    x-plugin: plugin-attendance
+    post:
+      summary: Accept counterparty consent for a shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /api/attendance/shift-swap-requests/{id}/reject:
+    x-plugin: plugin-attendance
+    post:
+      summary: Reject counterparty consent for a shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /api/attendance/shift-swap-requests/{id}/cancel:
+    x-plugin: plugin-attendance
+    post:
+      summary: Cancel a pending shift-swap request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap:
+                        $ref: '#/components/schemas/AttendanceShiftSwapRequest'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/attendance/rules/default:
     x-plugin: plugin-attendance
     get:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -500,6 +500,96 @@ components:
           type: string
           format: date-time
 
+    AttendanceShiftSwapRequest:
+      type: object
+      properties:
+        requestId: { type: string }
+        request_id: { type: string }
+        orgId: { type: string }
+        org_id: { type: string }
+        requestStatus:
+          type: string
+          enum: [pending, approved, rejected, cancelled]
+        request_status:
+          type: string
+          enum: [pending, approved, rejected, cancelled]
+        requesterUserId: { type: string }
+        requester_user_id: { type: string }
+        counterpartyUserId: { type: string }
+        counterparty_user_id: { type: string }
+        counterpartyStatus:
+          type: string
+          enum: [pending, accepted, rejected]
+        counterparty_status:
+          type: string
+          enum: [pending, accepted, rejected]
+        requesterAssignmentId: { type: string }
+        requester_assignment_id: { type: string }
+        counterpartyAssignmentId: { type: string }
+        counterparty_assignment_id: { type: string }
+        requesterReplacementAssignmentId:
+          type: string
+          nullable: true
+        requester_replacement_assignment_id:
+          type: string
+          nullable: true
+        counterpartyReplacementAssignmentId:
+          type: string
+          nullable: true
+        counterparty_replacement_assignment_id:
+          type: string
+          nullable: true
+        requesterWorkDate:
+          type: string
+          format: date
+        requester_work_date:
+          type: string
+          format: date
+        counterpartyWorkDate:
+          type: string
+          format: date
+        counterparty_work_date:
+          type: string
+          format: date
+        requesterShiftId: { type: string }
+        requester_shift_id: { type: string }
+        counterpartyShiftId: { type: string }
+        counterparty_shift_id: { type: string }
+        requesterSlotIndex: { type: integer }
+        requester_slot_index: { type: integer }
+        counterpartySlotIndex: { type: integer }
+        counterparty_slot_index: { type: integer }
+        sourceKey: { type: string }
+        source_key: { type: string }
+        counterpartyRespondedAt:
+          type: string
+          format: date-time
+          nullable: true
+        counterparty_responded_at:
+          type: string
+          format: date-time
+          nullable: true
+        finalizedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finalized_at:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
     AttendanceAnomaly:
       type: object
       properties:

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -728,6 +728,201 @@ paths:
                       userId: { type: string }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/attendance/shift-swap-requests:
+    x-plugin: plugin-attendance
+    post:
+      summary: Create a shift-swap request
+      description: Creates the shift-swap approval envelope and counterparty-consent record. Final schedule mutation is handled by a later approval-finalization slice.
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requesterAssignmentId:
+                  type: string
+                  description: Published single-day manual assignment owned by the requester.
+                requester_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for requesterAssignmentId.
+                counterpartyAssignmentId:
+                  type: string
+                  description: Published single-day manual assignment owned by the counterparty.
+                counterparty_assignment_id:
+                  type: string
+                  description: Compatibility snake_case alias for counterpartyAssignmentId.
+                reason:
+                  type: string
+                approvalFlowId:
+                  type: string
+                approval_flow_id:
+                  type: string
+                  description: Compatibility snake_case alias for approvalFlowId.
+              required: [requesterAssignmentId, counterpartyAssignmentId]
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      request: { $ref: '#/components/schemas/AttendanceRequest' }
+                      shiftSwap: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+    get:
+      summary: List shift-swap requests visible to the current user
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: query
+          name: userId
+          schema: { type: string }
+          description: Optional requester/counterparty filter. Cross-user access requires elevated attendance privileges.
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: pageSize
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+                      total: { type: integer }
+                      page: { type: integer }
+                      pageSize: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/attendance/shift-swap-requests/{id}:
+    x-plugin: plugin-attendance
+    get:
+      summary: Get a shift-swap request by id
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/attendance/shift-swap-requests/{id}/accept:
+    x-plugin: plugin-attendance
+    post:
+      summary: Accept counterparty consent for a shift-swap request
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+  /api/attendance/shift-swap-requests/{id}/reject:
+    x-plugin: plugin-attendance
+    post:
+      summary: Reject counterparty consent for a shift-swap request
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+  /api/attendance/shift-swap-requests/{id}/cancel:
+    x-plugin: plugin-attendance
+    post:
+      summary: Cancel a pending shift-swap request
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      shiftSwap: { $ref: '#/components/schemas/AttendanceShiftSwapRequest' }
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
   /api/attendance/rules/default:
     x-plugin: plugin-attendance
     get:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -17136,6 +17136,8 @@ function attendanceRequestTypeLabel(requestType) {
     time_correction: '时间更正',
     leave: '请假',
     overtime: '加班',
+    outdoor_punch: '外勤打卡',
+    shift_swap: '换班',
   }
   return labels[requestType] ?? String(requestType ?? '考勤')
 }
@@ -22008,6 +22010,228 @@ module.exports = {
       }
     }
 
+    const shiftSwapCreateSchema = z.object({
+      requesterAssignmentId: z.string().optional(),
+      requester_assignment_id: z.string().optional(),
+      counterpartyAssignmentId: z.string().optional(),
+      counterparty_assignment_id: z.string().optional(),
+      reason: z.string().optional(),
+      approvalFlowId: z.string().optional(),
+      approval_flow_id: z.string().optional(),
+    })
+
+    function normalizeShiftSwapDetailDate(value) {
+      return normalizeDateOnly(value) ?? (typeof value === 'string' ? value.slice(0, 10) : null)
+    }
+
+    function mapShiftSwapRequestRow(row) {
+      const requesterWorkDate = normalizeShiftSwapDetailDate(row.requester_work_date)
+      const counterpartyWorkDate = normalizeShiftSwapDetailDate(row.counterparty_work_date)
+      const requesterStartDate = normalizeShiftSwapDetailDate(row.requester_start_date)
+      const requesterEndDate = normalizeShiftSwapDetailDate(row.requester_end_date)
+      const counterpartyStartDate = normalizeShiftSwapDetailDate(row.counterparty_start_date)
+      const counterpartyEndDate = normalizeShiftSwapDetailDate(row.counterparty_end_date)
+      return {
+        requestId: row.request_id,
+        request_id: row.request_id,
+        orgId: row.org_id ?? DEFAULT_ORG_ID,
+        org_id: row.org_id ?? DEFAULT_ORG_ID,
+        requestStatus: row.request_status ?? row.status ?? null,
+        request_status: row.request_status ?? row.status ?? null,
+        requesterUserId: row.requester_user_id,
+        requester_user_id: row.requester_user_id,
+        counterpartyUserId: row.counterparty_user_id,
+        counterparty_user_id: row.counterparty_user_id,
+        counterpartyStatus: row.counterparty_status,
+        counterparty_status: row.counterparty_status,
+        requesterAssignmentId: row.requester_assignment_id,
+        requester_assignment_id: row.requester_assignment_id,
+        counterpartyAssignmentId: row.counterparty_assignment_id,
+        counterparty_assignment_id: row.counterparty_assignment_id,
+        requesterReplacementAssignmentId: row.requester_replacement_assignment_id ?? null,
+        requester_replacement_assignment_id: row.requester_replacement_assignment_id ?? null,
+        counterpartyReplacementAssignmentId: row.counterparty_replacement_assignment_id ?? null,
+        counterparty_replacement_assignment_id: row.counterparty_replacement_assignment_id ?? null,
+        requesterWorkDate,
+        requester_work_date: requesterWorkDate,
+        counterpartyWorkDate,
+        counterparty_work_date: counterpartyWorkDate,
+        requesterShiftId: row.requester_shift_id,
+        requester_shift_id: row.requester_shift_id,
+        counterpartyShiftId: row.counterparty_shift_id,
+        counterparty_shift_id: row.counterparty_shift_id,
+        requesterSlotIndex: Number.isFinite(Number(row.requester_slot_index)) ? Number(row.requester_slot_index) : 0,
+        requester_slot_index: Number.isFinite(Number(row.requester_slot_index)) ? Number(row.requester_slot_index) : 0,
+        counterpartySlotIndex: Number.isFinite(Number(row.counterparty_slot_index)) ? Number(row.counterparty_slot_index) : 0,
+        counterparty_slot_index: Number.isFinite(Number(row.counterparty_slot_index)) ? Number(row.counterparty_slot_index) : 0,
+        requesterStartDate,
+        requester_start_date: requesterStartDate,
+        requesterEndDate,
+        requester_end_date: requesterEndDate,
+        counterpartyStartDate,
+        counterparty_start_date: counterpartyStartDate,
+        counterpartyEndDate,
+        counterparty_end_date: counterpartyEndDate,
+        requesterPublishStatus: row.requester_publish_status,
+        requester_publish_status: row.requester_publish_status,
+        counterpartyPublishStatus: row.counterparty_publish_status,
+        counterparty_publish_status: row.counterparty_publish_status,
+        requesterProducerType: row.requester_producer_type ?? null,
+        requester_producer_type: row.requester_producer_type ?? null,
+        counterpartyProducerType: row.counterparty_producer_type ?? null,
+        counterparty_producer_type: row.counterparty_producer_type ?? null,
+        requesterAssignmentKind: row.requester_assignment_kind,
+        requester_assignment_kind: row.requester_assignment_kind,
+        counterpartyAssignmentKind: row.counterparty_assignment_kind,
+        counterparty_assignment_kind: row.counterparty_assignment_kind,
+        sourceKey: row.source_key,
+        source_key: row.source_key,
+        counterpartyRespondedAt: row.counterparty_responded_at ?? null,
+        counterparty_responded_at: row.counterparty_responded_at ?? null,
+        finalizedAt: row.finalized_at ?? null,
+        finalized_at: row.finalized_at ?? null,
+        createdAt: row.created_at ?? null,
+        created_at: row.created_at ?? null,
+        updatedAt: row.updated_at ?? null,
+        updated_at: row.updated_at ?? null,
+      }
+    }
+
+    function buildShiftSwapSourceError(code, message, field) {
+      return new HttpError(422, code, message, singleValidationDetail(field, message))
+    }
+
+    function normalizeShiftSwapSourceSnapshot(row, field) {
+      if (!row) {
+        throw new HttpError(404, 'SHIFT_SWAP_ASSIGNMENT_NOT_FOUND', 'Shift-swap source assignment not found', singleValidationDetail(field, 'Assignment not found'))
+      }
+      const startDate = normalizeDateOnly(row.start_date)
+      const endDate = normalizeDateOnly(row.end_date)
+      if (!startDate || !endDate || startDate !== endDate) {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_NOT_SINGLE_DAY', 'Shift-swap v1 requires a single-day source assignment', field)
+      }
+      if (row.is_active === false) {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_UNSUPPORTED', 'Shift-swap source assignment must be active', field)
+      }
+      const publishStatus = normalizeAttendanceSchedulePublishStatus(row.publish_status)
+      if (publishStatus !== 'published') {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_UNSUPPORTED', 'Shift-swap source assignment must be published', field)
+      }
+      if ((row.assignment_kind ?? 'regular') !== 'regular') {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_UNSUPPORTED', 'Shift-swap source assignment must be a regular assignment', field)
+      }
+      if (row.producer_type) {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_UNSUPPORTED', 'Shift-swap source assignment must be manually managed', field)
+      }
+      if (row.covered_by_temporary === true || row.covered_by_temporary === 't') {
+        throw buildShiftSwapSourceError('SHIFT_SWAP_SOURCE_TEMPORARY_COVERED', 'Shift-swap source assignment is currently covered by a temporary replacement', field)
+      }
+      return {
+        id: row.id,
+        orgId: row.org_id ?? DEFAULT_ORG_ID,
+        userId: row.user_id,
+        shiftId: row.shift_id,
+        slotIndex: normalizeAttendanceScheduleSlotIndex(row.slot_index, 0),
+        startDate,
+        endDate,
+        workDate: startDate,
+        publishStatus,
+        producerType: row.producer_type ?? null,
+        assignmentKind: row.assignment_kind ?? 'regular',
+      }
+    }
+
+    async function loadShiftSwapSourceAssignment(client, orgId, assignmentId, options = {}) {
+      const forUpdate = options.forUpdate === true ? 'FOR UPDATE OF a' : ''
+      const rows = await client.query(
+        `SELECT a.*,
+                EXISTS (
+                  SELECT 1
+                    FROM attendance_shift_assignments t
+                   WHERE t.org_id = a.org_id
+                     AND t.temporary_replaces_assignment_id = a.id
+                     AND COALESCE(t.is_active, true) = true
+                ) AS covered_by_temporary
+           FROM attendance_shift_assignments a
+          WHERE a.id = $1 AND a.org_id = $2
+          ${forUpdate}`,
+        [assignmentId, orgId]
+      )
+      return rows[0] ?? null
+    }
+
+    async function loadShiftSwapDetail(client, orgId, requestId, options = {}) {
+      const lockClause = options.forUpdate === true ? 'FOR UPDATE OF d, r' : ''
+      const rows = await client.query(
+        `SELECT d.*, r.status AS request_status, r.work_date AS request_work_date, r.reason AS request_reason,
+                r.metadata AS request_metadata, r.approval_instance_id AS approval_instance_id
+           FROM attendance_shift_swap_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE d.org_id = $1 AND d.request_id = $2
+          ${lockClause}`,
+        [orgId, requestId]
+      )
+      return rows[0] ?? null
+    }
+
+    async function ensureShiftSwapAccess(row, actorId, actionLabel) {
+      if (row.requester_user_id === actorId || row.counterparty_user_id === actorId) return
+      const allowed = await canAccessOtherUsers(actorId)
+      if (!allowed) {
+        throw new HttpError(403, 'FORBIDDEN', `No access to ${actionLabel}`)
+      }
+    }
+
+    function buildShiftSwapSourceKey(requesterAssignmentId, counterpartyAssignmentId) {
+      return `shift_swap:${[requesterAssignmentId, counterpartyAssignmentId].sort().join(':')}`
+    }
+
+    async function findShiftSwapSourceConflict(client, orgId, assignmentIds) {
+      const ids = Array.from(new Set((assignmentIds ?? []).filter(Boolean)))
+      if (!ids.length) return null
+      const rows = await client.query(
+        `SELECT d.request_id, d.requester_assignment_id, d.counterparty_assignment_id, r.status
+           FROM attendance_shift_swap_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE d.org_id = $1
+            AND r.status IN ('pending', 'approved')
+            AND (
+              d.requester_assignment_id = ANY($2::uuid[])
+              OR d.counterparty_assignment_id = ANY($2::uuid[])
+            )
+          ORDER BY r.created_at DESC
+          LIMIT 1`,
+        [orgId, ids]
+      )
+      return rows[0] ?? null
+    }
+
+    async function archiveShiftSwapSourceKey(client, orgId, requestId) {
+      await client.query(
+        `UPDATE attendance_shift_swap_requests
+            SET source_key = CASE
+                  WHEN source_key LIKE '%' || ':closed:' || request_id::text THEN source_key
+                  ELSE source_key || ':closed:' || request_id::text
+                END,
+                updated_at = now()
+          WHERE org_id = $1 AND request_id = $2`,
+        [orgId, requestId]
+      )
+    }
+
+    async function loadActiveApprovalFlowForRequestType(client, orgId, requestType, flowId) {
+      if (flowId) {
+        const rows = await client.query(
+          `SELECT * FROM attendance_approval_flows
+           WHERE org_id = $1 AND id = $2 AND request_type = $3 AND is_active = true
+           LIMIT 1`,
+          [orgId, flowId, requestType]
+        )
+        return rows.length ? mapApprovalFlowRow(rows[0]) : null
+      }
+      return loadApprovalFlow(client, orgId, { requestType })
+    }
+
     async function resolveAttendanceRequestDraft(parsedData, existingRequest = null) {
       const orgId = existingRequest?.org_id ?? DEFAULT_ORG_ID
       const existingMetadata = normalizeMetadata(existingRequest?.metadata)
@@ -22501,6 +22725,548 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'POST',
+      '/api/attendance/shift-swap-requests',
+      withPermission('attendance:write', async (req, res) => {
+        const parsed = shiftSwapCreateSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json(
+            validationErrorBody(
+              'Invalid shift-swap request payload',
+              formatZodValidationDetails(parsed.error)
+            )
+          )
+          return
+        }
+        const actorUserId = getUserId(req)
+        if (!actorUserId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        let requesterAssignmentId
+        let counterpartyAssignmentId
+        let approvalFlowId
+        try {
+          requesterAssignmentId = normalizeRequestUuidReferenceInput(
+            firstDefinedValue(parsed.data.requesterAssignmentId, parsed.data.requester_assignment_id),
+            null,
+            'requesterAssignmentId'
+          )
+          counterpartyAssignmentId = normalizeRequestUuidReferenceInput(
+            firstDefinedValue(parsed.data.counterpartyAssignmentId, parsed.data.counterparty_assignment_id),
+            null,
+            'counterpartyAssignmentId'
+          )
+          approvalFlowId = normalizeRequestUuidReferenceInput(
+            firstDefinedValue(parsed.data.approvalFlowId, parsed.data.approval_flow_id),
+            null,
+            'approvalFlowId'
+          )
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message, details: error.details } })
+            return
+          }
+          throw error
+        }
+        if (!requesterAssignmentId || !counterpartyAssignmentId) {
+          res.status(400).json(
+            validationErrorBody(
+              'Both requesterAssignmentId and counterpartyAssignmentId are required',
+              [
+                { field: 'requesterAssignmentId', message: 'Required' },
+                { field: 'counterpartyAssignmentId', message: 'Required' },
+              ]
+            )
+          )
+          return
+        }
+        if (requesterAssignmentId === counterpartyAssignmentId) {
+          res.status(422).json({ ok: false, error: { code: 'SHIFT_SWAP_ASSIGNMENTS_MUST_DIFFER', message: 'Shift-swap source assignments must be different' } })
+          return
+        }
+
+        const reason = normalizeOptionalText(parsed.data.reason)
+        const requestId = randomUUID()
+        const approvalId = `apv_${randomUUID()}`
+
+        try {
+          const result = await db.transaction(async (trx) => {
+            const lockedSourceRows = new Map()
+            for (const assignmentId of [requesterAssignmentId, counterpartyAssignmentId].sort()) {
+              lockedSourceRows.set(
+                assignmentId,
+                await loadShiftSwapSourceAssignment(trx, orgId, assignmentId, { forUpdate: true })
+              )
+            }
+            const requesterRow = lockedSourceRows.get(requesterAssignmentId)
+            const counterpartyRow = lockedSourceRows.get(counterpartyAssignmentId)
+            const requesterSource = normalizeShiftSwapSourceSnapshot(requesterRow, 'requesterAssignmentId')
+            const counterpartySource = normalizeShiftSwapSourceSnapshot(counterpartyRow, 'counterpartyAssignmentId')
+
+            if (requesterSource.userId !== actorUserId) {
+              const allowed = await canAccessOtherUsers(actorUserId)
+              if (!allowed) {
+                throw new HttpError(403, 'FORBIDDEN', 'No access to create a shift-swap request for this requester')
+              }
+            }
+            if (requesterSource.userId === counterpartySource.userId) {
+              throw new HttpError(422, 'SHIFT_SWAP_REQUIRES_TWO_USERS', 'Shift-swap requires two different users')
+            }
+
+            const sourceKey = buildShiftSwapSourceKey(requesterAssignmentId, counterpartyAssignmentId)
+            const duplicateRows = await trx.query(
+              `SELECT d.request_id
+                 FROM attendance_shift_swap_requests d
+                 JOIN attendance_requests r ON r.id = d.request_id
+                WHERE d.org_id = $1 AND d.source_key = $2
+                  AND r.status IN ('pending', 'approved')
+                LIMIT 1`,
+              [orgId, sourceKey]
+            )
+            if (duplicateRows.length) {
+              throw new HttpError(409, 'DUPLICATE_SHIFT_SWAP_REQUEST', 'A shift-swap request already exists for these assignments')
+            }
+            const sourceConflict = await findShiftSwapSourceConflict(trx, orgId, [requesterAssignmentId, counterpartyAssignmentId])
+            if (sourceConflict) {
+              throw new HttpError(409, 'DUPLICATE_SHIFT_SWAP_SOURCE', 'A shift-swap request is already pending or approved for one of these source assignments')
+            }
+
+            await acquireAttendanceRequestLock(trx, orgId, requesterSource.userId, requesterSource.workDate, 'shift_swap')
+            const approvalFlow = await loadActiveApprovalFlowForRequestType(trx, orgId, 'shift_swap', approvalFlowId)
+            if (approvalFlowId && !approvalFlow) {
+              throw new HttpError(422, 'SHIFT_SWAP_APPROVAL_FLOW_REQUIRED', 'Shift-swap approval flow does not exist or is inactive', singleValidationDetail('approvalFlowId', 'Provide an active shift_swap approvalFlowId'))
+            }
+            const metadata = {
+              shiftSwap: {
+                requesterAssignmentId,
+                counterpartyAssignmentId,
+                requesterUserId: requesterSource.userId,
+                counterpartyUserId: counterpartySource.userId,
+                requesterWorkDate: requesterSource.workDate,
+                counterpartyWorkDate: counterpartySource.workDate,
+              },
+            }
+            if (approvalFlow) {
+              metadata.approvalFlow = {
+                id: approvalFlow.id,
+                name: approvalFlow.name,
+                steps: approvalFlow.steps,
+                currentStep: 0,
+              }
+            }
+            const draft = {
+              workDate: requesterSource.workDate,
+              requestType: 'shift_swap',
+              requestedInAt: null,
+              requestedOutAt: null,
+              reason,
+              metadata,
+            }
+            const approvalPayload = buildAttendanceApprovalInstancePayload({
+              approvalId,
+              requestId,
+              orgId,
+              userId: requesterSource.userId,
+              requesterName: getUserLabel(req, requesterSource.userId),
+              draft,
+            })
+            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+            await upsertAttendanceApprovalInstance(trx, approvalPayload)
+            await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
+
+            const requestRows = await trx.query(
+              `INSERT INTO attendance_requests
+               (id, user_id, org_id, work_date, request_type, reason, status, approval_instance_id, metadata)
+               VALUES ($1, $2, $3, $4, 'shift_swap', $5, 'pending', $6, $7::jsonb)
+               RETURNING *`,
+              [
+                requestId,
+                requesterSource.userId,
+                orgId,
+                requesterSource.workDate,
+                reason,
+                approvalId,
+                JSON.stringify(metadata),
+              ]
+            )
+
+            await trx.query(
+              `INSERT INTO attendance_shift_swap_requests
+               (request_id, org_id, requester_user_id, counterparty_user_id,
+                requester_assignment_id, counterparty_assignment_id,
+                requester_work_date, counterparty_work_date,
+                requester_shift_id, counterparty_shift_id,
+                requester_slot_index, counterparty_slot_index,
+                requester_start_date, requester_end_date,
+                counterparty_start_date, counterparty_end_date,
+                requester_publish_status, counterparty_publish_status,
+                requester_producer_type, counterparty_producer_type,
+                requester_assignment_kind, counterparty_assignment_kind,
+                source_key)
+               VALUES
+               ($1, $2, $3, $4,
+                $5, $6,
+                $7, $8,
+                $9, $10,
+                $11, $12,
+                $13, $14,
+                $15, $16,
+                $17, $18,
+                $19, $20,
+                $21, $22,
+                $23)`,
+              [
+                requestId,
+                orgId,
+                requesterSource.userId,
+                counterpartySource.userId,
+                requesterSource.id,
+                counterpartySource.id,
+                requesterSource.workDate,
+                counterpartySource.workDate,
+                requesterSource.shiftId,
+                counterpartySource.shiftId,
+                requesterSource.slotIndex,
+                counterpartySource.slotIndex,
+                requesterSource.startDate,
+                requesterSource.endDate,
+                counterpartySource.startDate,
+                counterpartySource.endDate,
+                requesterSource.publishStatus,
+                counterpartySource.publishStatus,
+                requesterSource.producerType,
+                counterpartySource.producerType,
+                requesterSource.assignmentKind,
+                counterpartySource.assignmentKind,
+                sourceKey,
+              ]
+            )
+            const detail = await loadShiftSwapDetail(trx, orgId, requestId)
+            return { request: requestRows[0], detail }
+          })
+
+          emitEvent('attendance.shiftSwap.requested', { orgId, requestId, userId: result.request.user_id })
+          res.status(201).json({
+            ok: true,
+            data: {
+              request: mapAttendanceRequestRow(result.request),
+              shiftSwap: mapShiftSwapRequestRow(result.detail),
+            },
+          })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({
+              ok: false,
+              error: {
+                code: error.code,
+                message: error.message,
+                ...(Array.isArray(error.details) && error.details.length > 0 ? { details: error.details } : {}),
+              },
+            })
+            return
+          }
+          if (error?.code === '23505' && error?.constraint === 'uq_attendance_shift_swap_requests_source_key') {
+            res.status(409).json({ ok: false, error: { code: 'DUPLICATE_SHIFT_SWAP_REQUEST', message: 'A shift-swap request already exists for these assignments' } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance shift-swap tables missing' } })
+            return
+          }
+          logger.error('Attendance shift-swap request creation failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create shift-swap request' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/shift-swap-requests',
+      withPermission('attendance:read', async (req, res) => {
+        const requesterId = getUserId(req)
+        if (!requesterId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const { page, pageSize, offset } = parsePagination(req.query)
+        const targetUserId = typeof req.query.userId === 'string' && req.query.userId.trim() ? req.query.userId.trim() : requesterId
+        if (targetUserId !== requesterId) {
+          const allowed = await canAccessOtherUsers(requesterId)
+          if (!allowed) {
+            res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'No access to other users' } })
+            return
+          }
+        }
+        try {
+          const countRows = await db.query(
+            `SELECT COUNT(*)::int AS total
+               FROM attendance_shift_swap_requests d
+               JOIN attendance_requests r ON r.id = d.request_id
+              WHERE d.org_id = $1
+                AND (d.requester_user_id = $2 OR d.counterparty_user_id = $2)`,
+            [orgId, targetUserId]
+          )
+          const rows = await db.query(
+            `SELECT d.*, r.status AS request_status, r.work_date AS request_work_date, r.reason AS request_reason,
+                    r.metadata AS request_metadata, r.approval_instance_id AS approval_instance_id
+               FROM attendance_shift_swap_requests d
+               JOIN attendance_requests r ON r.id = d.request_id
+              WHERE d.org_id = $1
+                AND (d.requester_user_id = $2 OR d.counterparty_user_id = $2)
+              ORDER BY d.created_at DESC
+              LIMIT $3 OFFSET $4`,
+            [orgId, targetUserId, pageSize, offset]
+          )
+          res.json({ ok: true, data: { items: rows.map(mapShiftSwapRequestRow), total: Number(countRows[0]?.total ?? 0), page, pageSize } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance shift-swap tables missing' } })
+            return
+          }
+          logger.error('Attendance shift-swap request list failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list shift-swap requests' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/shift-swap-requests/:id',
+      withPermission('attendance:read', async (req, res) => {
+        const requesterId = getUserId(req)
+        if (!requesterId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const requestId = normalizeUuidString(req.params.id)
+        if (!requestId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const detail = await loadShiftSwapDetail(db, orgId, requestId)
+          if (!detail) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift-swap request not found' } })
+            return
+          }
+          await ensureShiftSwapAccess(detail, requesterId, 'view shift-swap request')
+          res.json({ ok: true, data: { shiftSwap: mapShiftSwapRequestRow(detail) } })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance shift-swap tables missing' } })
+            return
+          }
+          logger.error('Attendance shift-swap request fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load shift-swap request' } })
+        }
+      })
+    )
+
+    async function respondShiftSwapConsent(req, res, decision) {
+      const requesterId = getUserId(req)
+      if (!requesterId) {
+        res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+        return
+      }
+      const orgId = getOrgId(req)
+      const requestId = normalizeUuidString(req.params.id)
+      if (!requestId) {
+        respondInvalidUuid(res)
+        return
+      }
+      try {
+        const detail = await db.transaction(async (trx) => {
+          const row = await loadShiftSwapDetail(trx, orgId, requestId, { forUpdate: true })
+          if (!row) {
+            throw new HttpError(404, 'NOT_FOUND', 'Shift-swap request not found')
+          }
+          if (row.counterparty_user_id !== requesterId) {
+            throw new HttpError(403, 'FORBIDDEN', 'Only the counterparty can decide shift-swap consent')
+          }
+          if (row.request_status !== 'pending') {
+            throw new HttpError(400, 'INVALID_STATUS', 'Shift-swap request is already resolved')
+          }
+          if (row.counterparty_status !== 'pending') {
+            throw new HttpError(409, 'SHIFT_SWAP_CONSENT_ALREADY_DECIDED', 'Counterparty consent has already been decided')
+          }
+          await trx.query(
+            `UPDATE attendance_shift_swap_requests
+                SET counterparty_status = $3,
+                    counterparty_responded_at = now(),
+                    updated_at = now()
+              WHERE org_id = $1 AND request_id = $2`,
+            [orgId, requestId, decision]
+          )
+          if (decision === 'rejected') {
+            if (row.approval_instance_id) {
+              const approvalRows = await trx.query(
+                'SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE',
+                [row.approval_instance_id]
+              )
+              if (approvalRows.length > 0) {
+                const approval = approvalRows[0]
+                const newVersion = Number(approval.version ?? 0) + 1
+                await trx.query(
+                  'UPDATE approval_instances SET status = $1, version = $2, updated_at = now() WHERE id = $3',
+                  ['rejected', newVersion, row.approval_instance_id]
+                )
+                await deactivateAttendanceApprovalAssignments(trx, row.approval_instance_id)
+                await trx.query(
+                  `INSERT INTO approval_records
+                   (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata, ip_address, user_agent)
+                   VALUES ($1, 'reject', $2, $3, NULL, $4, 'rejected', $5, $6, '{}'::jsonb, $7, $8)`,
+                  [
+                    row.approval_instance_id,
+                    requesterId,
+                    getUserLabel(req, requesterId),
+                    approval.status,
+                    approval.version,
+                    newVersion,
+                    req.ip ?? null,
+                    req.get('user-agent') ?? null,
+                  ]
+                )
+              }
+            }
+	            await trx.query(
+	              `UPDATE attendance_requests
+	                  SET status = 'rejected',
+	                      resolved_by = $3,
+	                      resolved_at = now(),
+	                      updated_at = now()
+	                WHERE id = $1 AND org_id = $2`,
+	              [requestId, orgId, requesterId]
+	            )
+	            await archiveShiftSwapSourceKey(trx, orgId, requestId)
+	          }
+	          return loadShiftSwapDetail(trx, orgId, requestId)
+	        })
+        emitEvent(`attendance.shiftSwap.${decision}`, { orgId, requestId, userId: requesterId })
+        res.json({ ok: true, data: { shiftSwap: mapShiftSwapRequestRow({ ...detail, request_status: decision === 'rejected' ? 'rejected' : detail.request_status }) } })
+      } catch (error) {
+        if (error instanceof HttpError) {
+          res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+          return
+        }
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance shift-swap tables missing' } })
+          return
+        }
+        logger.error('Attendance shift-swap consent update failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update shift-swap consent' } })
+      }
+    }
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/shift-swap-requests/:id/accept',
+      withPermission('attendance:write', async (req, res) => respondShiftSwapConsent(req, res, 'accepted'))
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/shift-swap-requests/:id/reject',
+      withPermission('attendance:write', async (req, res) => respondShiftSwapConsent(req, res, 'rejected'))
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/shift-swap-requests/:id/cancel',
+      withPermission('attendance:write', async (req, res) => {
+        const requesterId = getUserId(req)
+        if (!requesterId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const requestId = normalizeUuidString(req.params.id)
+        if (!requestId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const detail = await db.transaction(async (trx) => {
+            const row = await loadShiftSwapDetail(trx, orgId, requestId, { forUpdate: true })
+            if (!row) {
+              throw new HttpError(404, 'NOT_FOUND', 'Shift-swap request not found')
+            }
+            if (row.requester_user_id !== requesterId) {
+              const allowed = await canAccessOtherUsers(requesterId)
+              if (!allowed) {
+                throw new HttpError(403, 'FORBIDDEN', 'No access to cancel shift-swap request')
+              }
+            }
+            if (row.request_status !== 'pending') {
+              throw new HttpError(400, 'INVALID_STATUS', 'Shift-swap request is already resolved')
+            }
+            if (row.approval_instance_id) {
+              const approvalRows = await trx.query(
+                'SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE',
+                [row.approval_instance_id]
+              )
+              if (approvalRows.length > 0) {
+                const approval = approvalRows[0]
+                const newVersion = Number(approval.version ?? 0) + 1
+                await trx.query(
+                  'UPDATE approval_instances SET status = $1, version = $2, updated_at = now() WHERE id = $3',
+                  ['cancelled', newVersion, row.approval_instance_id]
+                )
+                await deactivateAttendanceApprovalAssignments(trx, row.approval_instance_id)
+                await trx.query(
+                  `INSERT INTO approval_records
+                   (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata, ip_address, user_agent)
+                   VALUES ($1, 'revoke', $2, $3, NULL, $4, 'cancelled', $5, $6, '{}'::jsonb, $7, $8)`,
+                  [
+                    row.approval_instance_id,
+                    requesterId,
+                    getUserLabel(req, requesterId),
+                    approval.status,
+                    approval.version,
+                    newVersion,
+                    req.ip ?? null,
+                    req.get('user-agent') ?? null,
+                  ]
+                )
+              }
+            }
+	            await trx.query(
+	              `UPDATE attendance_requests
+	                  SET status = 'cancelled',
+	                      resolved_by = $3,
+	                      resolved_at = now(),
+	                      updated_at = now()
+	                WHERE id = $1 AND org_id = $2`,
+	              [requestId, orgId, requesterId]
+	            )
+	            await archiveShiftSwapSourceKey(trx, orgId, requestId)
+	            return loadShiftSwapDetail(trx, orgId, requestId)
+	          })
+          emitEvent('attendance.shiftSwap.cancelled', { orgId, requestId, userId: requesterId })
+          res.json({ ok: true, data: { shiftSwap: mapShiftSwapRequestRow({ ...detail, request_status: 'cancelled' }) } })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance shift-swap tables missing' } })
+            return
+          }
+          logger.error('Attendance shift-swap cancel failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to cancel shift-swap request' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
       'PUT',
       '/api/attendance/requests/:id',
       withPermission('attendance:write', async (req, res) => {
@@ -22697,6 +23463,9 @@ module.exports = {
           const requestMetadata = normalizeMetadata(requestRow.metadata)
           const orgId = requestRow.org_id ?? DEFAULT_ORG_ID
           const requestType = requestRow.request_type
+          if (action === 'approve' && requestType === 'shift_swap') {
+            throw new HttpError(422, 'SHIFT_SWAP_FINALIZATION_DEFERRED', 'Shift-swap approval finalization is not wired yet')
+          }
           const flowMeta = normalizeMetadata(requestMetadata.approvalFlow)
           const flowSteps = normalizeApprovalSteps(flowMeta.steps)
           const rawStepIndex = Number(flowMeta.currentStep ?? 0)
@@ -22802,17 +23571,20 @@ module.exports = {
             }
           }
 
-          if (isFinalApproval) {
-            await trx.query(
-              `UPDATE attendance_requests
-               SET status = $2, resolved_by = $3, resolved_at = $4, metadata = $5::jsonb, updated_at = now()
-               WHERE id = $1`,
-              [requestId, newStatus, requesterId, resolvedAt, JSON.stringify(nextMetadata)]
-            )
-          } else {
-            await trx.query(
-              `UPDATE attendance_requests
-               SET metadata = $2::jsonb, updated_at = now()
+	          if (isFinalApproval) {
+	            await trx.query(
+	              `UPDATE attendance_requests
+	               SET status = $2, resolved_by = $3, resolved_at = $4, metadata = $5::jsonb, updated_at = now()
+	               WHERE id = $1`,
+	              [requestId, newStatus, requesterId, resolvedAt, JSON.stringify(nextMetadata)]
+	            )
+	            if (requestType === 'shift_swap') {
+	              await archiveShiftSwapSourceKey(trx, orgId, requestId)
+	            }
+	          } else {
+	            await trx.query(
+	              `UPDATE attendance_requests
+	               SET metadata = $2::jsonb, updated_at = now()
                WHERE id = $1`,
               [requestId, JSON.stringify(nextMetadata)]
             )
@@ -23133,14 +23905,17 @@ module.exports = {
           }
 
           const resolvedAt = new Date()
-          await trx.query(
-            `UPDATE attendance_requests
-             SET status = $2, resolved_by = $3, resolved_at = $4, updated_at = now()
-             WHERE id = $1`,
-            [requestId, 'cancelled', requesterId, resolvedAt]
-          )
+	          await trx.query(
+	            `UPDATE attendance_requests
+	             SET status = $2, resolved_by = $3, resolved_at = $4, updated_at = now()
+	             WHERE id = $1`,
+	            [requestId, 'cancelled', requesterId, resolvedAt]
+	          )
+	          if (requestRow.request_type === 'shift_swap') {
+	            await archiveShiftSwapSourceKey(trx, requestRow.org_id ?? DEFAULT_ORG_ID, requestId)
+	          }
 
-          return {
+	          return {
             requestId,
             status: 'cancelled',
             orgId: requestRow.org_id ?? DEFAULT_ORG_ID,


### PR DESCRIPTION
## Summary

SW2 of the attendance shift-swap line: adds the dedicated create/consent envelope runtime on top of SW1's schema.

- Adds dedicated `/api/attendance/shift-swap-requests` create/list/read plus `/accept`, `/reject`, `/cancel` routes.
- Keeps generic `/api/attendance/requests` unable to create/update `shift_swap`; generic final approve is explicitly deferred with `SHIFT_SWAP_FINALIZATION_DEFERRED` until SW3.
- Validates v1 source assignments before envelope creation: active, published, single-day, manual regular assignments, not temporary-covered, two users/two assignments.
- Locks source rows in sorted assignment-id order; hard-blocks pending/approved source reuse; archives source keys on reject/cancel so cancelled/rejected pairs can be re-requested while active pairs still dedupe.
- Requires explicit approval flow IDs to be active `shift_swap` flows.
- Updates OpenAPI with dedicated shift-swap endpoints/schema while keeping the generic requests input enum restricted to existing request types.

## Review hardening

Subagent review findings fixed before this PR:

- P1: source assignment could be reused in multiple pending envelopes with different counterparties -> fixed with pending/approved source conflict guard.
- P2: reverse pair requests could deadlock by locking source rows in body order -> fixed with sorted source-row locks.
- P2: explicit `approvalFlowId` could reference leave/overtime/inactive flows -> fixed with active `shift_swap` flow validation.
- P2: exact pair stayed blocked after cancel/reject because the SW1 unique source key was lifetime-scoped -> fixed by archiving terminal source keys on dedicated and generic reject/cancel paths.

Final subagent review: APPROVE.

## Verification

Local, fresh DB unless noted:

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `DATABASE_URL=... pnpm --filter @metasheet/core-backend migrate`
- `DATABASE_URL=... ATTENDANCE_TEST_DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-shift-swap.test.ts --reporter=dot` -> 7/7
- `DATABASE_URL=... ATTENDANCE_TEST_DATABASE_URL=... pnpm --filter @metasheet/core-backend test:integration:attendance` -> 7 files / 142 tests passed

## Deferred

- SW3 final approval writer (guarded schedule replacement writes)
- Frontend shift-swap request UX
- Staging smoke / tracker closeout
