### PR TITLE
feat(attendance): finalize shift-swap approvals

### DIFF
--- a/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
+++ b/packages/core-backend/tests/integration/attendance-shift-swap.test.ts
@@ -87,6 +87,8 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
   }
 
   async function seedSwapPair(prefix: string, options: {
+    requesterDate?: string
+    counterpartyDate?: string
     requesterEndDate?: string
     requesterPublishStatus?: string
     requesterProducerType?: string | null
@@ -98,6 +100,8 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
     const shiftB = randomUUID()
     const assignmentA = randomUUID()
     const assignmentB = randomUUID()
+    const requesterDate = options.requesterDate ?? '2049-06-14'
+    const counterpartyDate = options.counterpartyDate ?? '2049-06-15'
     await pool.query(
       `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
        VALUES ($1, $2, $3, '09:00', '13:00'), ($4, $2, $5, '14:00', '18:00')`,
@@ -111,14 +115,15 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
        (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind,
         producer_type, producer_ref_id, producer_key, producer_run_id)
        VALUES
-       ($1, $2, $3, $4, 0, '2049-06-14', $5, true, $6, $7, $8, $9, $10, $11),
-       ($12, $2, $13, $14, 0, '2049-06-15', '2049-06-15', true, 'published', 'regular', NULL, NULL, NULL, NULL)`,
+       ($1, $2, $3, $4, 0, $5, $6, true, $7, $8, $9, $10, $11, $12),
+       ($13, $2, $14, $15, 0, $16, $16, true, 'published', 'regular', NULL, NULL, NULL, NULL)`,
       [
         assignmentA,
         ORG,
         requester,
         shiftA,
-        options.requesterEndDate ?? '2049-06-14',
+        requesterDate,
+        options.requesterEndDate ?? requesterDate,
         options.requesterPublishStatus ?? 'published',
         options.requesterAssignmentKind ?? 'regular',
         options.requesterProducerType ?? null,
@@ -128,9 +133,10 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
         assignmentB,
         counterparty,
         shiftB,
+        counterpartyDate,
       ],
     )
-    return { requester, counterparty, shiftA, shiftB, assignmentA, assignmentB }
+    return { requester, counterparty, shiftA, shiftB, assignmentA, assignmentB, requesterDate, counterpartyDate }
   }
 
   async function seedExtraSource(prefix: string, userSuffix = 'c') {
@@ -159,6 +165,66 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
       [id, ORG, `${prefix}-flow-${requestType}-${isActive ? 'active' : 'inactive'}`, requestType, isActive],
     )
     return id
+  }
+
+  function dateKey(offsetDays: number) {
+    const date = new Date()
+    date.setUTCDate(date.getUTCDate() + offsetDays)
+    return date.toISOString().slice(0, 10)
+  }
+
+  async function getAttendanceSettings(token: string): Promise<Record<string, unknown>> {
+    const res = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: authHeaders(token) })
+    expect(res.status, res.raw).toBe(200)
+    return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+  }
+
+  async function saveAttendanceSettings(token: string, body: Record<string, unknown>) {
+    const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+      method: 'PUT',
+      headers: authHeaders(token),
+      body: JSON.stringify(body),
+    })
+    expect(res.status, res.raw).toBe(200)
+    return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+  }
+
+  async function restoreScheduleGuardSettings(token: string, originalSettings: Record<string, unknown>) {
+    await saveAttendanceSettings(token, {
+      shiftCompliance: originalSettings.shiftCompliance ?? {
+        enforcement: 'block',
+        dailyMaxMinutes: null,
+        weeklyMaxMinutes: null,
+        monthlyMaxMinutes: null,
+      },
+      shiftEditPolicy: originalSettings.shiftEditPolicy ?? { mode: 'unrestricted', windowDays: 0 },
+    })
+  }
+
+  async function createShiftSwap(pair: { assignmentA: string; assignmentB: string }, requesterToken: string, body: Record<string, unknown> = {}) {
+    const res = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests`, {
+      method: 'POST',
+      headers: authHeaders(requesterToken),
+      body: JSON.stringify({
+        requesterAssignmentId: pair.assignmentA,
+        counterpartyAssignmentId: pair.assignmentB,
+        ...body,
+      }),
+    })
+    expect(res.status, res.raw).toBe(201)
+    const requestId = (res.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+    expect(requestId).toBeTruthy()
+    return String(requestId)
+  }
+
+  async function acceptShiftSwap(requestId: string, counterpartyToken: string) {
+    const res = await requestJson(`${baseUrl}/api/attendance/shift-swap-requests/${requestId}/accept`, {
+      method: 'POST',
+      headers: authHeaders(counterpartyToken),
+      body: '{}',
+    })
+    expect(res.status, res.raw).toBe(200)
+    return res
   }
 
   beforeAll(async () => {
@@ -300,7 +366,7 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
     }
   })
 
-  it('creates a dedicated shift-swap request, records counterparty consent, and keeps final approval deferred', async () => {
+  it('creates a dedicated shift-swap request, accepts consent, and final approval writes replacement assignments once', async () => {
     const prefix = `swap-api-${Date.now().toString(36)}`
     try {
       const pair = await seedSwapPair(prefix)
@@ -358,26 +424,381 @@ describeDb('shift-swap envelope and dedicated routes (real DB, route-level)', ()
       expect(accept.status).toBe(200)
       expect((accept.body as { data?: { shiftSwap?: { counterpartyStatus?: string } } } | undefined)?.data?.shiftSwap?.counterpartyStatus).toBe('accepted')
 
+      const eventCountBefore = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_events
+          WHERE org_id = $1 AND user_id LIKE $2`,
+        [ORG, `${prefix}%`],
+      )).rows[0].n)
+      const recordCountBefore = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_records
+          WHERE org_id = $1 AND user_id LIKE $2`,
+        [ORG, `${prefix}%`],
+      )).rows[0].n)
       const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
         method: 'POST',
         headers: authHeaders(requesterToken),
-        body: JSON.stringify({ comment: 'not yet' }),
+        body: JSON.stringify({ comment: 'approved swap' }),
       })
-      expect(approve.status).toBe(422)
-      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_FINALIZATION_DEFERRED')
+      expect(approve.status, approve.raw).toBe(200)
+      expect((approve.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('approved')
 
       const persisted = (await pool.query(
+        `SELECT r.status, d.counterparty_status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id,
+                d.finalized_at, d.source_key
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(persisted.status).toBe('approved')
+      expect(persisted.counterparty_status).toBe('accepted')
+      expect(persisted.requester_replacement_assignment_id).toBeTruthy()
+      expect(persisted.counterparty_replacement_assignment_id).toBeTruthy()
+      expect(persisted.finalized_at).toBeTruthy()
+      expect(String(persisted.source_key)).not.toContain(':closed:')
+
+      const sourceRows = await pool.query(
+        `SELECT id, is_active
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[])
+          ORDER BY id`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )
+      expect(sourceRows.rows.map(row => row.is_active)).toEqual([false, false])
+
+      const replacementRows = await pool.query(
+        `SELECT id, user_id, shift_id, slot_index, start_date, end_date, is_active,
+                publish_status, published_at, published_by, locked_at,
+                producer_type, producer_ref_id, producer_key, producer_run_id
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[])
+          ORDER BY user_id`,
+        [[persisted.requester_replacement_assignment_id, persisted.counterparty_replacement_assignment_id]],
+      )
+      expect(replacementRows.rows).toHaveLength(2)
+      const requesterReplacement = replacementRows.rows.find(row => row.user_id === pair.requester)
+      const counterpartyReplacement = replacementRows.rows.find(row => row.user_id === pair.counterparty)
+      expect(requesterReplacement).toMatchObject({
+        shift_id: pair.shiftB,
+        slot_index: 0,
+        is_active: true,
+        publish_status: 'published',
+        published_by: pair.requester,
+        producer_type: 'shift_swap',
+        producer_ref_id: requestId,
+        producer_run_id: requestId,
+      })
+      expect(counterpartyReplacement).toMatchObject({
+        shift_id: pair.shiftA,
+        slot_index: 0,
+        is_active: true,
+        publish_status: 'published',
+        published_by: pair.requester,
+        producer_type: 'shift_swap',
+        producer_ref_id: requestId,
+        producer_run_id: requestId,
+      })
+      expect(new Date(requesterReplacement.start_date).toISOString().slice(0, 10)).toBe(pair.counterpartyDate)
+      expect(new Date(requesterReplacement.end_date).toISOString().slice(0, 10)).toBe(pair.counterpartyDate)
+      expect(new Date(counterpartyReplacement.start_date).toISOString().slice(0, 10)).toBe(pair.requesterDate)
+      expect(new Date(counterpartyReplacement.end_date).toISOString().slice(0, 10)).toBe(pair.requesterDate)
+      expect(requesterReplacement.locked_at).toBeTruthy()
+      expect(counterpartyReplacement.locked_at).toBeTruthy()
+      expect(requesterReplacement.producer_key).toBe(`shift_swap:${requestId}:${pair.requester}:${pair.counterpartyDate}:0`)
+      expect(counterpartyReplacement.producer_key).toBe(`shift_swap:${requestId}:${pair.counterparty}:${pair.requesterDate}:0`)
+
+      const eventCountAfter = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_events
+          WHERE org_id = $1 AND user_id LIKE $2`,
+        [ORG, `${prefix}%`],
+      )).rows[0].n)
+      expect(eventCountAfter).toBe(eventCountBefore)
+      const recordCountAfter = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_records
+          WHERE org_id = $1 AND user_id LIKE $2`,
+        [ORG, `${prefix}%`],
+      )).rows[0].n)
+      expect(recordCountAfter).toBe(recordCountBefore)
+
+      const replay = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'again' }),
+      })
+      expect(replay.status).toBe(400)
+      expect((replay.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('INVALID_STATUS')
+      const replacementCount = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE org_id = $1 AND producer_type = 'shift_swap' AND producer_ref_id = $2`,
+        [ORG, requestId],
+      )).rows[0].n)
+      expect(replacementCount).toBe(2)
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('requires counterparty acceptance before final approval can write schedule rows', async () => {
+    const prefix = `swap-consent-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve')
+      const requestId = await createShiftSwap(pair, requesterToken)
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'too early' }),
+      })
+      expect(approve.status).toBe(422)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_COUNTERPARTY_CONSENT_REQUIRED')
+
+      const state = (await pool.query(
         `SELECT r.status, d.counterparty_status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
            FROM attendance_requests r
            JOIN attendance_shift_swap_requests d ON d.request_id = r.id
           WHERE r.id = $1`,
         [requestId],
       )).rows[0]
-      expect(persisted.status).toBe('pending')
-      expect(persisted.counterparty_status).toBe('accepted')
-      expect(persisted.requester_replacement_assignment_id).toBeNull()
-      expect(persisted.counterparty_replacement_assignment_id).toBeNull()
+      expect(state.status).toBe('pending')
+      expect(state.counterparty_status).toBe('pending')
+      expect(state.requester_replacement_assignment_id).toBeNull()
+      expect(state.counterparty_replacement_assignment_id).toBeNull()
+      const activeSources = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[]) AND COALESCE(is_active, true) = true`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )).rows[0].n)
+      expect(activeSources).toBe(2)
     } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('rolls back final approval when a captured source assignment changed after request creation', async () => {
+    const prefix = `swap-drift-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      const requestId = await createShiftSwap(pair, requesterToken)
+      await acceptShiftSwap(requestId, counterpartyToken)
+
+      await pool.query(
+        `UPDATE attendance_shift_assignments
+            SET shift_id = $3, updated_at = now()
+          WHERE org_id = $1 AND id = $2`,
+        [ORG, pair.assignmentA, pair.shiftB],
+      )
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'drift' }),
+      })
+      expect(approve.status).toBe(409)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_SWAP_SOURCE_CHANGED')
+
+      const state = (await pool.query(
+        `SELECT r.status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(state.status).toBe('pending')
+      expect(state.requester_replacement_assignment_id).toBeNull()
+      expect(state.counterparty_replacement_assignment_id).toBeNull()
+      const activeSources = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[]) AND COALESCE(is_active, true) = true`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )).rows[0].n)
+      expect(activeSources).toBe(2)
+      const replacementCount = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE org_id = $1 AND producer_type = 'shift_swap' AND producer_ref_id = $2`,
+        [ORG, requestId],
+      )).rows[0].n)
+      expect(replacementCount).toBe(0)
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('rolls back final approval when the swapped assignment conflicts with an existing assignment', async () => {
+    const prefix = `swap-conflict-${Date.now().toString(36)}`
+    try {
+      const pair = await seedSwapPair(prefix)
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      const requestId = await createShiftSwap(pair, requesterToken)
+      await acceptShiftSwap(requestId, counterpartyToken)
+
+      const conflictShiftId = randomUUID()
+      const conflictAssignmentId = randomUUID()
+      await pool.query(
+        `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
+         VALUES ($1, $2, $3, '15:00', '19:00')`,
+        [conflictShiftId, ORG, `${prefix}-conflict-shift`],
+      )
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status, assignment_kind)
+         VALUES ($1, $2, $3, $4, 0, $5, $5, true, 'published', 'regular')`,
+        [conflictAssignmentId, ORG, pair.requester, conflictShiftId, pair.counterpartyDate],
+      )
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'conflict' }),
+      })
+      expect(approve.status).toBe(409)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+
+      const state = (await pool.query(
+        `SELECT r.status, d.counterparty_status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(state.status).toBe('pending')
+      expect(state.counterparty_status).toBe('accepted')
+      expect(state.requester_replacement_assignment_id).toBeNull()
+      expect(state.counterparty_replacement_assignment_id).toBeNull()
+      const activeSources = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[]) AND COALESCE(is_active, true) = true`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )).rows[0].n)
+      expect(activeSources).toBe(2)
+      const replacementCount = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE org_id = $1 AND producer_type = 'shift_swap' AND producer_ref_id = $2`,
+        [ORG, requestId],
+      )).rows[0].n)
+      expect(replacementCount).toBe(0)
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('rolls back final approval when shift compliance caps reject the swapped load', async () => {
+    const prefix = `swap-cap-${Date.now().toString(36)}`
+    let originalSettings: Record<string, unknown> | null = null
+    try {
+      const pair = await seedSwapPair(prefix, { counterpartyDate: '2049-09-15' })
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve,attendance:admin')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      originalSettings = await getAttendanceSettings(requesterToken)
+      await saveAttendanceSettings(requesterToken, {
+        shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 60, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+        shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+      })
+      const requestId = await createShiftSwap(pair, requesterToken)
+      await acceptShiftSwap(requestId, counterpartyToken)
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'cap' }),
+      })
+      expect(approve.status).toBe(422)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+
+      const state = (await pool.query(
+        `SELECT r.status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(state.status).toBe('pending')
+      expect(state.requester_replacement_assignment_id).toBeNull()
+      expect(state.counterparty_replacement_assignment_id).toBeNull()
+      const activeSources = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[]) AND COALESCE(is_active, true) = true`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )).rows[0].n)
+      expect(activeSources).toBe(2)
+      const replacementCount = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE org_id = $1 AND producer_type = 'shift_swap' AND producer_ref_id = $2`,
+        [ORG, requestId],
+      )).rows[0].n)
+      expect(replacementCount).toBe(0)
+    } finally {
+      if (originalSettings) {
+        const token = await mintToken(`${prefix}-settings-restore`, 'attendance:admin')
+        await restoreScheduleGuardSettings(token, originalSettings).catch(() => undefined)
+      }
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('rolls back final approval when the shift edit window rejects a source or target date', async () => {
+    const prefix = `swap-window-${Date.now().toString(36)}`
+    let originalSettings: Record<string, unknown> | null = null
+    try {
+      const pair = await seedSwapPair(prefix, {
+        requesterDate: dateKey(-3),
+        counterpartyDate: dateKey(-2),
+      })
+      const requesterToken = await mintToken(pair.requester, 'attendance:read,attendance:write,attendance:approve,attendance:admin')
+      const counterpartyToken = await mintToken(pair.counterparty, 'attendance:read,attendance:write')
+      originalSettings = await getAttendanceSettings(requesterToken)
+      await saveAttendanceSettings(requesterToken, {
+        shiftEditPolicy: { mode: 'past_locked', windowDays: 0 },
+        shiftCompliance: { enforcement: 'block', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+      })
+      const requestId = await createShiftSwap(pair, requesterToken)
+      await acceptShiftSwap(requestId, counterpartyToken)
+
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(requesterToken),
+        body: JSON.stringify({ comment: 'window' }),
+      })
+      expect(approve.status).toBe(422)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_EDIT_WINDOW_EXCEEDED')
+
+      const state = (await pool.query(
+        `SELECT r.status, d.requester_replacement_assignment_id, d.counterparty_replacement_assignment_id
+           FROM attendance_requests r
+           JOIN attendance_shift_swap_requests d ON d.request_id = r.id
+          WHERE r.id = $1`,
+        [requestId],
+      )).rows[0]
+      expect(state.status).toBe('pending')
+      expect(state.requester_replacement_assignment_id).toBeNull()
+      expect(state.counterparty_replacement_assignment_id).toBeNull()
+      const activeSources = Number((await pool.query(
+        `SELECT count(*)::int AS n
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[]) AND COALESCE(is_active, true) = true`,
+        [[pair.assignmentA, pair.assignmentB]],
+      )).rows[0].n)
+      expect(activeSources).toBe(2)
+    } finally {
+      if (originalSettings) {
+        const token = await mintToken(`${prefix}-settings-restore`, 'attendance:admin')
+        await restoreScheduleGuardSettings(token, originalSettings).catch(() => undefined)
+      }
       await cleanupPrefix(prefix)
     }
   })

--- a/packages/core-backend/vitest.integration.config.ts
+++ b/packages/core-backend/vitest.integration.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     hookTimeout: 15000,
     setupFiles: ['./tests/setup.integration.ts'],
     reporter: ['verbose'],
+    // Integration specs share one real Postgres and several org-global settings rows.
+    // Run files serially so route-level tests that temporarily change settings cannot
+    // bleed into another file's server process while it is asserting default behavior.
+    fileParallelism: false,
     maxConcurrency: 1,
     globalTeardown: './tests/globalTeardown.ts',
   },

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -22219,6 +22219,249 @@ module.exports = {
       )
     }
 
+    const SHIFT_SWAP_PRODUCER_TYPE = 'shift_swap'
+
+    function buildShiftSwapReplacementProducerKey(requestId, userId, workDate, slotIndex) {
+      return [
+        SHIFT_SWAP_PRODUCER_TYPE,
+        requestId,
+        userId,
+        workDate,
+        normalizeAttendanceScheduleSlotIndex(slotIndex, 0),
+      ].join(':')
+    }
+
+    function assertShiftSwapSourceStillMatches(row, expected, field) {
+      const current = normalizeShiftSwapSourceSnapshot(row, field)
+      const expectedWorkDate = normalizeShiftSwapDetailDate(expected.workDate)
+      const expectedStartDate = normalizeShiftSwapDetailDate(expected.startDate)
+      const expectedEndDate = normalizeShiftSwapDetailDate(expected.endDate)
+      const matches =
+        current.id === expected.assignmentId
+        && current.userId === expected.userId
+        && current.shiftId === expected.shiftId
+        && current.slotIndex === normalizeAttendanceScheduleSlotIndex(expected.slotIndex, 0)
+        && current.workDate === expectedWorkDate
+        && current.startDate === expectedStartDate
+        && current.endDate === expectedEndDate
+        && current.publishStatus === expected.publishStatus
+        && current.producerType === (expected.producerType ?? null)
+        && current.assignmentKind === expected.assignmentKind
+      if (!matches) {
+        throw new HttpError(
+          409,
+          'SHIFT_SWAP_SOURCE_CHANGED',
+          'Shift-swap source assignment changed after the request was created',
+          singleValidationDetail(field, 'Source assignment no longer matches the captured swap snapshot')
+        )
+      }
+      return current
+    }
+
+    function throwAttendanceScheduleAssignmentConflict(conflict) {
+      throw new HttpError(
+        409,
+        'ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT',
+        getAttendanceScheduleAssignmentConflictMessage(conflict),
+        conflict
+      )
+    }
+
+    async function enforceShiftSwapEditWindow(client, dates) {
+      const settings = await getSettings(client)
+      const violation = evaluateShiftEditWindow(settings?.shiftEditPolicy, dates, normalizeDateOnly(new Date()))
+      if (!violation) return
+      throw new HttpError(
+        422,
+        'SHIFT_EDIT_WINDOW_EXCEEDED',
+        `Schedule edit window exceeded: ${violation.earliest} is before the earliest editable date ${violation.boundary}`,
+        {
+          earliestDate: violation.earliest,
+          boundaryDate: violation.boundary,
+          mode: violation.mode,
+        }
+      )
+    }
+
+    async function insertShiftSwapReplacementAssignment(client, {
+      orgId,
+      requestId,
+      actorId,
+      targetUserId,
+      source,
+      multiShiftEnabled,
+      shift,
+    }) {
+      const replacementId = randomUUID()
+      const producerKey = buildShiftSwapReplacementProducerKey(requestId, targetUserId, source.workDate, source.slotIndex)
+      const rows = await client.query(
+        `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active,
+          publish_status, published_at, published_by, locked_at,
+          assignment_kind, producer_type, producer_ref_id, producer_key, producer_run_id)
+         VALUES
+         ($1, $2, $3, $4, $5, $6, $6, true,
+          'published', now(), $7, now(),
+          'regular', $8, $9, $10, $9)
+         RETURNING *`,
+        [
+          replacementId,
+          orgId,
+          targetUserId,
+          source.shiftId,
+          source.slotIndex,
+          source.workDate,
+          actorId,
+          SHIFT_SWAP_PRODUCER_TYPE,
+          requestId,
+          producerKey,
+        ]
+      )
+      const row = rows[0]
+      const conflict = await findAttendanceScheduleAssignmentConflict(client, {
+        kind: 'shift',
+        orgId,
+        userId: targetUserId,
+        startDate: source.workDate,
+        endDate: source.workDate,
+        isActive: true,
+        slotIndex: source.slotIndex,
+        multiShiftEnabled,
+        shift,
+        excludeId: replacementId,
+      })
+      if (conflict) throwAttendanceScheduleAssignmentConflict(conflict)
+      return row
+    }
+
+    async function finalizeShiftSwapRequest(client, { orgId, requestId, actorId }) {
+      const detail = await loadShiftSwapDetail(client, orgId, requestId, { forUpdate: true })
+      if (!detail) {
+        throw new HttpError(404, 'NOT_FOUND', 'Shift-swap request not found')
+      }
+      if (detail.counterparty_status !== 'accepted') {
+        throw new HttpError(422, 'SHIFT_SWAP_COUNTERPARTY_CONSENT_REQUIRED', 'Counterparty must accept before shift-swap approval can finalize')
+      }
+      if (detail.requester_replacement_assignment_id || detail.counterparty_replacement_assignment_id || detail.finalized_at) {
+        throw new HttpError(409, 'SHIFT_SWAP_ALREADY_FINALIZED', 'Shift-swap request is already finalized')
+      }
+
+      const lockIds = [detail.requester_assignment_id, detail.counterparty_assignment_id].sort()
+      const lockedRows = new Map()
+      for (const assignmentId of lockIds) {
+        lockedRows.set(
+          assignmentId,
+          await loadShiftSwapSourceAssignment(client, orgId, assignmentId, { forUpdate: true })
+        )
+      }
+      const requesterSource = assertShiftSwapSourceStillMatches(
+        lockedRows.get(detail.requester_assignment_id),
+        {
+          assignmentId: detail.requester_assignment_id,
+          userId: detail.requester_user_id,
+          shiftId: detail.requester_shift_id,
+          slotIndex: detail.requester_slot_index,
+          workDate: detail.requester_work_date,
+          startDate: detail.requester_start_date,
+          endDate: detail.requester_end_date,
+          publishStatus: detail.requester_publish_status,
+          producerType: detail.requester_producer_type ?? null,
+          assignmentKind: detail.requester_assignment_kind,
+        },
+        'requesterAssignmentId'
+      )
+      const counterpartySource = assertShiftSwapSourceStillMatches(
+        lockedRows.get(detail.counterparty_assignment_id),
+        {
+          assignmentId: detail.counterparty_assignment_id,
+          userId: detail.counterparty_user_id,
+          shiftId: detail.counterparty_shift_id,
+          slotIndex: detail.counterparty_slot_index,
+          workDate: detail.counterparty_work_date,
+          startDate: detail.counterparty_start_date,
+          endDate: detail.counterparty_end_date,
+          publishStatus: detail.counterparty_publish_status,
+          producerType: detail.counterparty_producer_type ?? null,
+          assignmentKind: detail.counterparty_assignment_kind,
+        },
+        'counterpartyAssignmentId'
+      )
+
+      await acquireAttendanceScheduleAssignmentLocks(client, orgId, [requesterSource.userId, counterpartySource.userId])
+      await enforceShiftSwapEditWindow(client, [
+        requesterSource.workDate,
+        counterpartySource.workDate,
+      ])
+
+      const shiftRows = await client.query(
+        `SELECT * FROM attendance_shifts
+          WHERE org_id = $1 AND id = ANY($2::uuid[])`,
+        [orgId, [requesterSource.shiftId, counterpartySource.shiftId]]
+      )
+      const shiftsById = new Map(shiftRows.map(row => [row.id, row]))
+      const requesterShift = shiftsById.get(requesterSource.shiftId)
+      const counterpartyShift = shiftsById.get(counterpartySource.shiftId)
+      if (!requesterShift || !counterpartyShift) {
+        throw new HttpError(409, 'SHIFT_SWAP_SOURCE_CHANGED', 'Shift-swap source shift no longer exists')
+      }
+
+      const settings = await getSettings(client)
+      const multiShiftDay = normalizeMultiShiftDaySetting(settings?.multiShiftDay)
+      await client.query(
+        `UPDATE attendance_shift_assignments
+            SET is_active = false, updated_at = now()
+          WHERE org_id = $1 AND id = ANY($2::uuid[])`,
+        [orgId, [requesterSource.id, counterpartySource.id]]
+      )
+
+      const requesterReplacement = await insertShiftSwapReplacementAssignment(client, {
+        orgId,
+        requestId,
+        actorId,
+        targetUserId: requesterSource.userId,
+        source: counterpartySource,
+        multiShiftEnabled: multiShiftDay.enabled,
+        shift: counterpartyShift,
+      })
+      const counterpartyReplacement = await insertShiftSwapReplacementAssignment(client, {
+        orgId,
+        requestId,
+        actorId,
+        targetUserId: counterpartySource.userId,
+        source: requesterSource,
+        multiShiftEnabled: multiShiftDay.enabled,
+        shift: requesterShift,
+      })
+
+      const affectedDates = Array.from(new Set([requesterSource.workDate, counterpartySource.workDate])).sort()
+      for (const targetUserId of [requesterSource.userId, counterpartySource.userId]) {
+        for (const affectedDate of affectedDates) {
+          await enforceShiftComplianceCap(client, {
+            orgId,
+            userId: targetUserId,
+            fromDate: affectedDate,
+            toDate: affectedDate,
+          })
+        }
+      }
+
+      const updatedRows = await client.query(
+        `UPDATE attendance_shift_swap_requests
+            SET requester_replacement_assignment_id = $3,
+                counterparty_replacement_assignment_id = $4,
+                finalized_at = now(),
+                updated_at = now()
+          WHERE org_id = $1 AND request_id = $2
+          RETURNING *`,
+        [orgId, requestId, requesterReplacement.id, counterpartyReplacement.id]
+      )
+      return {
+        detail: updatedRows[0] ?? detail,
+        requesterReplacement,
+        counterpartyReplacement,
+      }
+    }
+
     async function loadActiveApprovalFlowForRequestType(client, orgId, requestType, flowId) {
       if (flowId) {
         const rows = await client.query(
@@ -23463,9 +23706,6 @@ module.exports = {
           const requestMetadata = normalizeMetadata(requestRow.metadata)
           const orgId = requestRow.org_id ?? DEFAULT_ORG_ID
           const requestType = requestRow.request_type
-          if (action === 'approve' && requestType === 'shift_swap') {
-            throw new HttpError(422, 'SHIFT_SWAP_FINALIZATION_DEFERRED', 'Shift-swap approval finalization is not wired yet')
-          }
           const flowMeta = normalizeMetadata(requestMetadata.approvalFlow)
           const flowSteps = normalizeApprovalSteps(flowMeta.steps)
           const rawStepIndex = Number(flowMeta.currentStep ?? 0)
@@ -23540,6 +23780,19 @@ module.exports = {
           )
 
           const nextMetadata = { ...requestMetadata }
+          let shiftSwapFinalization = null
+          if (action === 'approve' && isFinalApproval && requestType === 'shift_swap') {
+            shiftSwapFinalization = await finalizeShiftSwapRequest(trx, {
+              orgId,
+              requestId,
+              actorId: requesterId,
+            })
+            nextMetadata.shiftSwapFinalization = {
+              requesterReplacementAssignmentId: shiftSwapFinalization.requesterReplacement.id,
+              counterpartyReplacementAssignmentId: shiftSwapFinalization.counterpartyReplacement.id,
+              finalizedAt: new Date().toISOString(),
+            }
+          }
           if (action === 'approve' && isFinalApproval && requestType === 'overtime') {
             const overtimeSegmentation = await maybeBuildOvertimeSegmentationSnapshot(trx, {
               orgId,
@@ -23578,7 +23831,7 @@ module.exports = {
 	               WHERE id = $1`,
 	              [requestId, newStatus, requesterId, resolvedAt, JSON.stringify(nextMetadata)]
 	            )
-	            if (requestType === 'shift_swap') {
+	            if (requestType === 'shift_swap' && action !== 'approve') {
 	              await archiveShiftSwapSourceKey(trx, orgId, requestId)
 	            }
 	          } else {
@@ -23755,8 +24008,9 @@ module.exports = {
             }
 
             // The generic 'adjustment' audit event covers missed/correction/leave/overtime. outdoor_punch
-            // writes its OWN real punch event above, so it must NOT also get an adjustment event.
-            if (requestType !== 'outdoor_punch') {
+            // writes its OWN real punch event above, and shift_swap writes schedule rows only, so neither
+            // must also get an adjustment event.
+            if (requestType !== 'outdoor_punch' && requestType !== 'shift_swap') {
               const eventMeta = {
                 requestId,
                 requestType,
@@ -23808,6 +24062,7 @@ module.exports = {
         })
         res.json({ ok: true, data: result })
       } catch (error) {
+        if (respondShiftComplianceCapExceeded(res, error)) return
         if (error instanceof HttpError) {
           res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
           return


### PR DESCRIPTION
## Summary
- finalize accepted shift-swap requests during final approval by deactivating both source assignments and inserting published/locked replacement assignments with `shift_swap` provenance
- require counterparty consent, snapshot-stable source assignments, conflict-free replacements, edit-window compliance, and shift-compliance cap checks before committing
- keep swap finalization schedule-only: no `attendance_events` / `attendance_records` writes, and no source-key archival on approved swaps
- add real-DB route tests for happy path, consent gate, source drift, conflict rollback, cap rollback, edit-window rollback, and replay idempotency
- serialize core-backend integration test files because attendance specs mutate org-global settings against the same real Postgres database

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- fresh scratch Postgres + `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/ms2_sw3_1781262492 pnpm --filter @metasheet/core-backend migrate`
- fresh scratch Postgres + `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/ms2_sw3_1781262492 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-shift-swap.test.ts --reporter=dot` → 12/12 pass
- fresh scratch Postgres + `DATABASE_URL=postgres://metasheet:metasheet@127.0.0.1:5435/ms2_sw3_1781262492 pnpm --filter @metasheet/core-backend run test:integration:attendance` → 7 files / 147 tests pass

## Review
- Subagent review (Gibbs): no P1/P2/P3 after fixes.
- Closed two review findings before PR: happy path now asserts no `attendance_records`, and final approval now has a source-snapshot-drift reverse test.
- Reviewer also accepted `fileParallelism:false` for the real-DB integration layer because multiple attendance specs mutate org-global settings rows.

## Deferred
- SW4 admin/employee UI for shift swap remains a separate opt-in.
- Staging smoke / tracker closeout remain separate after this backend runtime slice lands.
