### PR TITLE
docs(multitable): close out A6-3 parallel join-all

### DIFF
--- a/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
+++ b/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
@@ -1,8 +1,8 @@
 # Multitable Automation A6-3 Branch / Parallel DAG Design-Lock (2026-06-05)
 
-Status: **A6-3 design-lock / scope gate; A6-3-1 + A6-3-2 landed**
+Status: **A6-3 design-lock / scope gate; A6-3-1 + A6-3-2 + A6-3-4 join-all landed**
 
-Runtime: **A6-3-1 `condition_branch` exclusive runtime landed; A6-3-2 frontend/readability landed; A6-3-3 and parallel/join still gated**
+Runtime: **A6-3-1 `condition_branch` exclusive runtime landed; A6-3-2 frontend/readability landed; A6-3-4 `parallel_branch` join-all landed; A6-3-3 and join-any still gated**
 
 Grounded on: `origin/main@83801c668`
 Companions:
@@ -15,15 +15,16 @@ Companions:
 
 ## 0. Verdict
 
-> **2026-06-09 status refresh**: this design-lock originally froze the shape
+> **2026-06-12 status refresh**: this design-lock originally froze the shape
 > before runtime. Since then, A6-3-1 landed via #2321, A6-3-2a editor landed
-> via #2339, and A6-3-2b runs readability landed via #2348. The remaining
-> design-lock boundaries still apply to A6-3-3 and parallel/join.
+> via #2339, A6-3-2b runs readability landed via #2348, and A6-3-4
+> parallel fan-out + `join_all` landed via #2496/#2500/#2501. The remaining
+> design-lock boundaries still apply to A6-3-3 and join-any.
 
 A6-3 was opened as the next automation-only capability rung, but **only through
-this docs-only design-lock first**. A6-3-1 and A6-3-2 later landed by explicit
-opt-in; the remaining A6-3-3 and parallel/join work still requires a separate
-explicit opt-in.
+this docs-only design-lock first**. A6-3-1, A6-3-2, and A6-3-4 later landed by
+explicit opt-in; the remaining A6-3-3 and join-any work still requires a
+separate explicit opt-in.
 
 The first runtime slice must be **A6-3-1 `condition_branch` / exclusive branch
 v1**, not full parallel DAG. Parallel fan-out and join semantics are important,
@@ -99,7 +100,8 @@ branch v1 does not smuggle in a suspension schema change.
 ### A6-3-4 — Parallel fan-out + `join_all`
 
 Run multiple branches independently and continue only after all selected
-branches finish. This is a separate runtime opt-in after exclusive branch v1.
+branches finish. This landed as the first parallel runtime/frontend/readability
+slice via #2496/#2500/#2501.
 
 ### A6-3-5 — `join_any` / cancellation semantics
 
@@ -225,7 +227,8 @@ list remains the source:
 
 ## 5. Parallel Shape (A6-3-4, Not A6-3-1)
 
-Parallel fan-out is deferred. When opened, it should add a separate action type:
+Parallel fan-out was deferred from A6-3-1 and later landed as A6-3-4. It adds a
+separate action type:
 
 ```ts
 parallel_branch
@@ -354,7 +357,8 @@ First acceptable frontend slice:
 - Creates this A6-3 design-lock.
 - Updates tracker pointers only.
 - No runtime, migration, route, UI, OpenAPI, or test changes.
-- States that A6-3 runtime still requires a separate explicit owner opt-in.
+- States that A6-3 runtime requires separate explicit owner opt-in per sub-rung.
+  That happened for A6-3-1/A6-3-2/A6-3-4; A6-3-3 and A6-3-5 still require it.
 
 ## 12. Recommended Next Opt-In Phrase
 

--- a/docs/development/multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md
+++ b/docs/development/multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md
@@ -4,6 +4,12 @@ Type: **A6-3-4 docs-only scope-gate**.
 
 Grounded on: `origin/main@699a1b15`.
 
+Status refresh (2026-06-12): **runtime/editor/runs-readability landed** via
+#2496 (`b161080b8`), #2500 (`4408239d0`), and #2501 (`88f5f538a`). This document
+now serves as the historical contract for that slice; `join_any`, branch-local
+waits, nested branches, BPMN, approval coupling, and public webhook emitters
+remain out of scope / demand-gated.
+
 Companion:
 
 - `docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md`
@@ -17,9 +23,8 @@ Companion:
 
 ## 0. Verdict
 
-A6-3-4 may be scoped as the next automation graph rung, but runtime remains
-gated. This document locks the first parallel slice as **fan-out + join-all
-only**.
+A6-3-4 was scoped as the next automation graph rung and later landed as
+**fan-out + join-all only**.
 
 The runtime PR may add a `parallel_branch` action that runs all configured
 branches, records branch child jobs in the existing C1 job plane, and continues
@@ -304,15 +309,14 @@ A6-3-4 must not:
 
 W3-0 is complete when this docs-only scope gate is merged.
 
-A6-3-4/W3-1 runtime is complete only when:
+A6-3-4/W3-1 runtime is complete because:
 
-1. A runtime PR lands `parallel_branch` with `joinMode: 'all'` under this
+1. Runtime PR #2496 landed `parallel_branch` with `joinMode: 'all'` under this
    contract.
 2. Real-DB tests prove fan-out/fan-in C1 job shape and fail/skip behavior.
-3. Admin runs can explain parent/child jobs without leaking sensitive data.
+3. Admin runs can explain parent/child jobs without leaking sensitive data via
+   #2501; editor authoring landed via #2500.
 4. `workflow-automation-completion-plan-20260609.md`,
    `multitable-automation-run-governance-todo-20260527.md`, and
-   `multitable-automation-a6-execution-plan-20260601.md` are updated to mark
-   W3-1 runtime landed.
-
-Until then, A6-3-4 remains scoped but not implemented.
+   `multitable-automation-a6-execution-plan-20260601.md` now mark W3-1 runtime
+   landed.

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -29,16 +29,20 @@ treatment **on purpose**:
 - **A6-3 … A6-5 ADD capability** (branch/parallel graph execution, modeling import,
   approval coupling). Their *shape* is undefined until a concrete use-case names it.
   A6-3's first runtime slice (A6-3-1 `condition_branch` / exclusive branch v1) **landed via #2321**;
-  the A6-3-2 frontend/readability slice **landed via #2339 + #2348**; parallel/join +
-  A6-3-3 stay deferred. A6-5's first `start_approval` bridge slice **landed via #2469**
+  the A6-3-2 frontend/readability slice **landed via #2339 + #2348**; the
+  A6-3-4/W3 parallel fan-out + join-all slice **landed via #2496 + #2500 + #2501**.
+  A6-3-3 branch-local wait/nesting and A6-3-5 join-any stay deferred. A6-5's first `start_approval` bridge slice **landed via #2469**
   as a named cross-surface carve-out on top of A6-2 + W5 completion events. A6-4 remains
   plan-level only.
 
 The original ladder was:
 **A6-1 enable-writer → A6-2 suspend/resume → A6-3 branch/parallel DAG → A6-4 BPMN
-compile/preview adapter → A6-5 approval-as-job.** #2469 intentionally lands only the
+compile/preview adapter → A6-5 approval-as-job.** #2496/#2500/#2501 intentionally land only
+the `join_all` parallel fan-out slice, without `join_any`, branch-local waits, nested branches,
+BPMN, or approval coupling. #2469 intentionally lands only the
 minimal W6-1 `start_approval` bridge slice of A6-5 before A6-4, without unlocking BPMN
-compile/preview, public webhook/token emitters, branch-local wait/nesting, or parallel/join.
+compile/preview, public webhook/token emitters, branch-local wait/nesting, or join-any /
+parallel follow-ups beyond the separately landed `join_all` slice.
 W7 result backwrite remains a separate rung.
 
 ---
@@ -158,7 +162,7 @@ only missing link.
   duplicate-resume idempotent/rejected, resume-after-completion rejected, invalid/expired
   token rejected without leak, later: survives process restart).
 
-## 3. A6-3 branch/parallel DAG — A6-3-1 runtime + A6-3-2 frontend/readability ✅ LANDED (#2321/#2339/#2348); rest deferred
+## 3. A6-3 branch/parallel DAG — condition branches + join-all parallel ✅ LANDED (#2321/#2339/#2348/#2496/#2500/#2501); rest deferred
 
 Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
 
@@ -176,23 +180,32 @@ Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
 > conditions, `update_record` / `send_notification` branch action subset, default branch, read-only
 > never-flatten guard for richer loaded shapes, `workflow_job_v1` auto-lock), and the admin runs detail
 > shows selected branch `label (key)` plus branch child jobs. **Still deferred, each its own opt-in:**
-> A6-3-3 `wait_for_callback` / nested-`condition_branch` inside branches; A6-3 parallel fan-out /
-> join-all runtime / join-any. A6-3-4/W3-0 now has a docs-only scope gate:
+> A6-3-3 `wait_for_callback` / nested-`condition_branch` inside branches; A6-3 join-any / cancellation
+> semantics. A6-3-4/W3-0 has a docs-only scope gate:
 > `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`.
+>
+> **✅ A6-3-4/W3 parallel fan-out + join-all LANDED 2026-06-11/12 — #2496 (squash
+> `b161080b8`) + #2500 (squash `4408239d0`) + #2501 (squash `88f5f538a`)**: the backend
+> can run `parallel_branch` with `joinMode: 'all'`, persist C1 parent/branch-child fan-out/fan-in
+> lineage, and aggregate fail/skip semantics; the editor can author the constrained `parallel_branch`
+> shape with `workflow_job_v1` auto-lock; admin runs detail can explain branch labels and child
+> jobs. **Still deferred:** A6-3-3 branch-local wait/nesting, A6-3-5 join-any/cancellation, A6-4
+> BPMN compile/preview, public webhook/token emitter, and W7 result backwrite runtime.
 > Design-lock detail below retained for the record.
 
-The design-lock pins the first runtime slice as **A6-3-1 `condition_branch` /
-exclusive branch v1**, not full parallel DAG. Parallel fan-out, join-all, and
-join-any stay separate follow rungs. The first parallel follow rung is scoped as
-A6-3-4/W3-0 (`join_all` only); runtime remains gated.
+The design-lock pinned the first runtime slice as **A6-3-1 `condition_branch` /
+exclusive branch v1**, not full parallel DAG. The first parallel follow rung
+A6-3-4/W3 (`join_all` only) has now landed. `join_any` remains a separate follow
+rung.
 
 - **Adds:** graph fields (upstream/downstream edges, branch discriminator, join mode,
   branch result aggregation) and generalizes the linear executor into a DAG. This is the
   **largest single engine change** on the ladder.
 - **Must not (this rung):** no BPMN import; no approval coupling.
 - **Depends on:** A6-2 (job persistence + resume stable before fan-out/join).
-- **Gate:** A6-3-4/W3-0 docs-only scope gate exists; runtime still needs a named
-  parallel/join-all opt-in.
+- **Gate:** A6-3-4/W3 `join_all` landed after named opt-in (#2496/#2500/#2501).
+  `join_any`, branch-local waits/nesting, BPMN, and approval coupling still need
+  separate named opt-ins.
 - **Test surface:** see A6-0 scout "→ A6-3" (branch picks exactly one, parallel fan-out
   independent, join-all waits, join-any cancels with explicit audit, branch failures
   isolated).
@@ -226,7 +239,7 @@ A6-3-4/W3-0 (`join_all` only); runtime remains gated.
   graphs, assignments, permissions, and version freezing; automation stores only the
   waiting job, bridge lineage, and terminal outcome needed to continue the job plane.
 - **Still separate:** W7 approval result backwrite runtime, approval trigger bindings,
-  public webhook/token emitters, branch-local wait/nesting, parallel/join, and BPMN
+  public webhook/token emitters, branch-local wait/nesting, join-any / parallel follow-ups, and BPMN
   compile/preview all require separate named gates. W7-0 now has a docs-only scope
   gate (`automation-approval-result-backwrite-scope-gate-20260611.md`); W7-1 runtime
   remains gated.
@@ -254,7 +267,8 @@ A6-3-4/W3-0 (`join_all` only); runtime remains gated.
   A6-0/A6-1 scouts for test surface and runtime rationale.
 - A6-1 enable-writer **landed** (#2130/#2191/#2193) and A6-2 suspend/resume **landed**
   2026-06-03 (#2236 design-lock + #2237 impl, admin-gated v1); A6-3 exclusive branch
-  v1 **landed** (#2321/#2339/#2348); A6-5 `start_approval` bridge **landed** (#2469).
-  A6-3-3, A6-3-4/W3-1 parallel join-all runtime, A6-3-5 join-any, A6-4 BPMN
+  v1 **landed** (#2321/#2339/#2348); A6-3-4/W3 parallel join-all **landed**
+  (#2496/#2500/#2501); A6-5 `start_approval` bridge **landed** (#2469).
+  A6-3-3, A6-3-5 join-any, A6-4 BPMN
   compile/preview, public webhook/token emitter, and W7 result backwrite
   runtime remain demand-gated.

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-4/W3-0 parallel join-all scope-gate added (runtime not started); A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / parallel join-all runtime / join-any still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated.
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-4/W3 parallel join-all LANDED end-to-end (#2496 runtime `b161080b8`, #2500 editor `4408239d0`, #2501 admin-runs readability `88f5f538a`, 2026-06-12); A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / join-any cancellation semantics still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated.
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -27,9 +27,10 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 
 This closeout did NOT mark the convergence engine complete at the time. Current status:
 A6-1 and A6-2 are complete end-to-end; A6-3-1 `condition_branch` exclusive-branch runtime
-landed (#2321), and A6-3-2 frontend/runs readability landed (#2339 + #2348). A6-3-3 /
-parallel-join remain gated; A6-5/W6-1 `start_approval` later landed separately in #2469;
-A6-4 remains a separate future unlock. Later trial
+landed (#2321), A6-3-2 frontend/runs readability landed (#2339 + #2348), and
+A6-3-4/W3 parallel `join_all` landed end-to-end (#2496 + #2500 + #2501). A6-3-3
+branch-local wait/nesting and A6-3-5 join-any remain gated; A6-5/W6-1
+`start_approval` later landed separately in #2469; A6-4 remains a separate future unlock. Later trial
 evidence (#2367/#2371) confirmed the A6-3 v1 surface is enough for the tested
 condition-branch flow and did not produce a branch-local wait/nesting demand.
 
@@ -78,8 +79,9 @@ W7-1 runtime remains gated.
 - A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
   idempotency keys, and re-fetch-current-record context remain future opt-ins.
 - A6: A6-0/A6-3 design-locks are docs-only; A6-1/A6-2 + A6-3-1 `condition_branch` runtime
-  + A6-3-2 frontend/readability + A6-5/W6-1 `start_approval` bridge landed by explicit
-  opt-in; A6-3-3 + parallel-join, A6-4 BPMN, public webhook/token emitter, and W7 result
+  + A6-3-2 frontend/readability + A6-3-4/W3 parallel `join_all` + A6-5/W6-1
+  `start_approval` bridge landed by explicit opt-in; A6-3-3 + join-any, A6-4 BPMN,
+  public webhook/token emitter, and W7 result
   backwrite runtime remain demand-gated.
 
 ## Current Baseline
@@ -125,11 +127,14 @@ Landed (capability half) — A6-1 COMPLETE, end-to-end & reachable in production
 - A6-2b suspend/resume FRONTEND (admin Resume UI on suspended steps + `wait_for_callback` editor that
   auto-locks `workflow_job_v1`; token admin-detail-only, never rendered) — LANDED #2245 cee99c8e4
   (2026-06-04). **A6-2 now closed end-to-end.**
+- A6-3 exclusive condition branch + parallel join-all — LANDED through #2321/#2339/#2348 and
+  #2496/#2500/#2501. **A6-3 now covers first-match/default branching plus fan-out/fan-in
+  `join_all`; branch-local waits and join-any remain separate.**
 
 Deferred (capability half — A6, frozen/demand-gated):
 - A6-2 delay/timer resume (v1 was webhook/external only; delay/timer later forces a durable
   scheduler/worker/leader)
-- A6-3-3 branch-local wait/nesting; A6-3-4/W3-1 parallel join-all runtime; A6-3-5 join-any;
+- A6-3-3 branch-local wait/nesting; A6-3-5 join-any;
   A6-4 BPMN compile/preview adapter; public webhook/token emitter; W7 approval result backwrite
 
 ## Milestones
@@ -302,7 +307,8 @@ complete.
 - [x] A6-3 v1 operator/API/UI trial — PASS #2367/#2371; no A6-3-3 demand surfaced.
 - [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1); open only for a named branch-local wait/nesting scenario.
 - [x] A6-3-4 / W3-0 parallel fan-out + join-all scope-gate — `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`: `parallel_branch`, `joinMode: all` only, C1 fan-out/fan-in graph, fail/skip semantics, and no BPMN/approval/webhook expansion.
-- [ ] A6-3-4 / W3-1 parallel fan-out + join-all runtime — not started; named opt-in required.
+- [x] A6-3-4 / W3-1 parallel fan-out + join-all runtime — LANDED #2496 `b161080b8` (2026-06-11): canonical `parallel_branch` action, `joinMode: all`, service/executor fail-closed validation, C1 parent/branch-child fan-out/fan-in lineage, fail/skip aggregation, and real-DB seam tests.
+- [x] A6-3-4 frontend and admin-runs readability — LANDED #2500 `4408239d0` + #2501 `88f5f538a` (2026-06-12): editor authoring for `parallel_branch` with workflow-job auto-lock and admin runs detail showing branch labels/child jobs. **A6-3-4/W3 join-all closed end-to-end.**
 - [ ] A6-3-5 join-any / cancellation semantics — gated after join-all runtime.
 - [ ] A6-4 BPMN compile/preview adapter — not started.
 - [x] A6-5 / W6-1 `start_approval` approval-as-job bridge — LANDED #2469: creates one approval instance from a published template, persists the bridge row, writes suspended / terminal C1 jobs, resumes/fails from W5 completion events, and guards A5 retry duplicates.

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -3,7 +3,7 @@
 > 类型：**前向开发安排（forward plan）**，非开工清单。
 > **2026-05-29 update（historical; superseded below）**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；当时 A6 runtime 仍 frozen / demand-gated。
 > **2026-05-30 update（historical; superseded below）**：A6-1 persistent `WorkflowJob` runtime scout（`…-a6-1-workflowjob-runtime-scout-20260530.md`）+ **runtime 已落地（#2130，verification `…-a6-1-workflowjob-runtime-verification-20260530.md`）**：opt-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed、A1 redaction 复用、A2 detail prefer-jobs）。当时 **DORMANT** —— API/UI enable 路径 deferred（createRule/updateRule 不接 `execution_mode`），现有规则零影响。该 dormant 状态已由 #2191/#2193 关闭。
-> **2026-06-05 update**：A6-1 已 end-to-end 完成（runtime #2130 + enable-writer #2191 + admin UI toggle #2193）；A6-2 suspend/resume 已 end-to-end 完成（design #2236 + runtime #2237 + frontend #2245 + UAT #2257）。A6-3 branch/parallel DAG 现只打开 docs-only design-lock（`multitable-automation-a6-3-branch-parallel-design-20260605.md`）；A6-3 runtime、A6-4、A6-5 仍 demand-gated。
+> **2026-06-12 update**：A6-1 已 end-to-end 完成（runtime #2130 + enable-writer #2191 + admin UI toggle #2193）；A6-2 suspend/resume 已 end-to-end 完成（design #2236 + runtime #2237 + frontend #2245 + UAT #2257）。A6-3 branch/parallel DAG 已分段落地：exclusive `condition_branch` #2321/#2339/#2348，parallel `join_all` #2496/#2500/#2501。A6-3-3 branch-local wait/nesting、A6-3-5 join-any、A6-4、A6-5/W7 follow-ups 仍 demand-gated。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -18,9 +18,9 @@
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
 | **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
-| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 + A6-2 已完成**；A6-3 branch/parallel DAG 只打开 design-lock，runtime 未启动；A6-4/A6-5 未启动 | 否 —— **A6-3 runtime 仍需具名 opt-in；A6-4/A6-5 受需求闸** |
+| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 + A6-2 已完成**；A6-3 exclusive branch + parallel `join_all` 已落地；A6-3-3 / join-any / A6-4 / W7 follow-ups 未启动 | 否 —— **剩余 A6 rungs 仍需具名 opt-in；A6-4/A6-5 follow-ups 受需求闸** |
 
-> **grounded 2026-06-05**：`/retry` 路由实现 A5 whole-execution retry；A6-1 persist-job runtime 已生产可达（#2130/#2191/#2193）；A6-2 suspend/resume 已生产可达（#2237/#2245，admin-gated v1，operator UAT #2257）。C1 契约现被 A2 读边界、A6-1 job 持久化、A6-2 suspended job/resume 使用。**仍无** branch/parallel runtime、BPMN adapter、approval-as-job bridge。
+> **grounded 2026-06-12**：`/retry` 路由实现 A5 whole-execution retry；A6-1 persist-job runtime 已生产可达（#2130/#2191/#2193）；A6-2 suspend/resume 已生产可达（#2237/#2245，admin-gated v1，operator UAT #2257）；A6-3 has `condition_branch` and parallel `join_all` runtime/editor/runs-readability (#2321/#2339/#2348/#2496/#2500/#2501)。C1 契约现被 A2 读边界、A6-1 job 持久化、A6-2 suspended job/resume、A6-3 branch/parallel job lineage 使用。**仍无** A6-3-3 branch-local wait/nesting、join-any、BPMN adapter、W7 result backwrite runtime, or public webhook/token emitter.
 
 **所以"接下去的开发安排" = 触发条件账本 + 不自动推进纪律，不是任务队列。**
 
@@ -71,12 +71,12 @@
 - **A6-1 scout**：`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md` 已回答第一片 runtime 的七个设计问题。
 - **✅ A6-1 COMPLETE end-to-end（2026-06，不再 dormant）**：runtime **#2130**（`multitable_automation_jobs` 表 + rule-level `execution_mode` + inline linear job persistence fail-closed + A1 redaction 复用 + A2 detail prefer-jobs/legacy-fallback）+ **enable-writer #2191**（createRule/updateRule 接 `execution_mode`，service 层 enum 严格校验）+ **admin UI toggle #2193**（规则编辑器复选框，默认关）。净效果：管理员勾选规则 → 该规则每个动作持久化为 C1 WorkflowJob，A2/A3 可见。验收 runbook：`multitable-automation-a6-1-acceptance-runbook-20260602.md`。状态以 `…-todo-20260527.md` 为准。
 - **✅ A6-2 COMPLETE end-to-end（2026-06）**：design-lock #2236 + backend runtime #2237 + frontend #2245 + operator UAT #2257。Admin-gated v1，`wait_for_callback` + single-use token resume；delay/timer/public emitter 仍 deferred。
-- **A6-3 design-lock opened（2026-06-05）**：`multitable-automation-a6-3-branch-parallel-design-20260605.md`。First runtime slice is `condition_branch` / exclusive branch v1 only; runtime not started.
-- **剩余依赖序（未建，各需具名 opt-in）**：**A6-3 runtime**（先 exclusive branch，不是 parallel）→ **A6-4 BPMN compile/preview** → **A6-5 approval-as-job**。触发须点名具体用例（"按记录字段走不同动作分支" / "需要并行 fan-out + join" / "BPMN 只做 compile-preview" / "approval-as-job 需要审批完成事件桥"），"继续自动化"不够。
+- **A6-3 landed in two useful graph slices**：`condition_branch` / exclusive branch v1 (#2321/#2339/#2348) and parallel fan-out + `join_all` (#2496/#2500/#2501)。Both reuse the existing C1 job plane and admin runs detail.
+- **剩余依赖序（未建，各需具名 opt-in）**：**A6-3-3 branch-local wait/nesting**（让 `wait_for_callback`/nested branches live inside graph branches）→ **A6-3-5 join-any/cancellation** → **A6-4 BPMN compile/preview** → **W7 result backwrite / A6-5 follow-ups**。触发须点名具体用例（"分支内需要等待外部回调" / "需要先完成任一并行分支即继续" / "BPMN 只做 compile-preview" / "审批结果需要写回记录字段"），"继续自动化"不够。
 - **触发信号**：某个**集成/DF 流水线真的需要 human-in-the-loop**（"导入→清洗→**等人工审批**→导出"= suspend + approval-as-job）或按记录分支；**且本就在 K3 GATE 下游**。
 - **治理继承硬契约**：A6 任一能力落地必须**复用本线的 run/job/status/provenance/redaction 底座**，不得新建二等可观测层。
 - **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 定义），**永不自己执行**（否则第四套状态孤岛）。
-- **锁姿态**：A6-3 runtime、A6-4、A6-5 仍 frozen / demand-gated。approval-as-job 排最后（最高价值+最高风险，completion-event-contract 先行）。
+- **锁姿态**：A6-3 已落地的 exclusive branch + join-all slices closed；A6-3-3、join-any、A6-4、W7 result backwrite、public webhook/token emitter 仍 frozen / demand-gated。
 
 ---
 
@@ -120,4 +120,4 @@
 
 ## 8. 一句话排期
 
-**治理半已完成、A5 whole-execution retry v1 已完成、A6-1/A6-2 已 end-to-end 落地；A6-3 runtime、A6-4、A6-5 仍 demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5/A6-2 的运行效果用于判断是否需要 branch/parallel / BPMN / approval-as-job；A6 仍排在成熟 DF/automation 编排需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。
+**治理半已完成、A5 whole-execution retry v1 已完成、A6-1/A6-2 已 end-to-end 落地，A6-3 已覆盖 exclusive branch + parallel join-all。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5/A6-2/A6-3 的运行效果用于判断是否需要 branch-local wait / join-any / BPMN / result backwrite；剩余 A6/W7 仍按具名需求推进。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-09
 
-Grounded on: `origin/main@275644e81`
+Grounded on: `origin/main@88f5f538a`
 
 Scope: MetaSheet2 workflow, approval, and multitable automation as one product
 target. This is a completion definition and execution ledger, not a sprint
@@ -38,7 +38,8 @@ Current main already contains the governance and first convergence slices:
 | A6-2 suspend/resume | Landed end-to-end: `wait_for_callback`, `multitable_automation_suspensions`, admin resume route, editor config, admin runs resume UI, UAT recorded. |
 | A6-3-1 condition branch runtime | Landed: `condition_branch`, exclusive first-match/default branch, C1 parent/child/downstream lineage. |
 | A6-3-2 frontend and runs readability | Landed in code: editor builder in `MetaAutomationRuleEditor.vue` and `conditionBranchAuthoring.ts`; runs readability in `AutomationExecutionsView.vue`. |
-| Still missing | Branch-local wait/nesting, parallel join-all runtime, join-any/cancellation, BPMN compile/preview mapping, public webhook token emitter. |
+| A6-3-4 parallel join-all | Landed end-to-end: backend `parallel_branch` / `joinMode: all` runtime (#2496), editor authoring (#2500), and admin runs readability (#2501). |
+| Still missing | Branch-local wait/nesting, join-any/cancellation, BPMN compile/preview mapping, public webhook token emitter. |
 
 ### 1.2 Approval
 
@@ -115,8 +116,8 @@ operate a practical business workflow using existing product surfaces:
 | W0 | Re-ground status docs against current main | Landed #2411/#2412 | Existing TODOs no longer say A6-3-2 is not started after #2339/#2348. |
 | W1 | Approval authoring deployed-browser smoke | Done | #2318 PASS accepted: UI-created template published, `/approvals/new/:templateId` started, submitted user field resolved to expected assignee, unsupported rich template was read-only/save-disabled. #2375/#2371 reconfirmed current deployment. |
 | W2 | Automation A6-3-3 branch-local wait/nesting | Not started; demand-gated; no current unlock | `wait_for_callback` can live inside selected branch with stable nested step cursor, rule-drift guard, resume tests, and no silent flattening in editor. #2367 trial found A6-3 v1 sufficient for the tested flow, so do not start W2 without a new named scenario. |
-| W3-0 | Automation parallel fan-out + join-all scope-gate | Scope-gate document added; runtime not started | `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md` locks fan-out/fan-in C1 graph shape, `join_all` only, fail/skip semantics, redaction, and tests. |
-| W3-1 | Automation parallel fan-out + join-all runtime | Not started; named opt-in required | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited. |
+| W3-0 | Automation parallel fan-out + join-all scope-gate | Landed before W3-1 | `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md` locks fan-out/fan-in C1 graph shape, `join_all` only, fail/skip semantics, redaction, and tests. |
+| W3-1 | Automation parallel fan-out + join-all runtime | Landed #2496/#2500/#2501 | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited; editor and admin runs detail expose the constrained shape. |
 | W4 | Automation join-any / cancellation semantics | Not started; demand-gated after W3 | First completed branch continues; ignored/cancelled siblings are explicit in C1 jobs and audit. |
 | W5-0 | Approval completion event contract scope-gate | Landed #2413 | Defines terminal approval event taxonomy, redacted payload, idempotency key, post-commit emission boundary, and test matrix without adding automation behavior. |
 | W5-1 | Approval completion event contract implementation | Landed #2414 (`184f2293c`) | `approval.approved/rejected/revoked/cancelled` payload is versioned, redacted, idempotent, emitted post-commit, and tested without adding automation action yet. `return` remains a non-terminal rework transition. |
@@ -144,10 +145,9 @@ Why:
 
 The next cross-surface candidate is **W7 approval result backwrite**. W7-0 now
 has a scope-gate document, but W7-1 runtime remains gated because it writes
-business data and changes record state. Do not jump straight to BPMN before the
-remaining graph prerequisites are named. W3-0 now scopes the `join_all` slice,
-but W3-1 runtime remains gated. BPMN gateway preview still needs
-branch/parallel semantics to map to.
+business data and changes record state. W3-1 has now landed the minimum
+parallel `join_all` semantics that BPMN parallel-gateway preview can map to,
+but BPMN still needs its own compile/preview scout and must remain non-runtime.
 
 ## 5. Non-goals for v1
 


### PR DESCRIPTION
## Summary\n- mark A6-3-4 / W3 parallel join-all as landed end-to-end after #2496, #2500, and #2501\n- refresh run-governance, A6 execution, completion-plan, and A6-3 design/scope docs\n- keep A6-3-3 branch-local wait/nesting, join-any, A6-4 BPMN, W7 result backwrite, and public webhook/token emitter demand-gated\n\n## Verification\n- git diff --check\n- rg stale-status checks for parallel join-all not-started/gated wording across the changed canonical docs\n\n## Notes\nDocs-only closeout; no runtime, routes, migrations, tests, or UI changes.