### PR TITLE
docs(attendance): harden dispatch design scope

### DIFF
--- a/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
+++ b/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
@@ -201,7 +201,7 @@ Already covered by landed D1/D2 (#2551/#2553):
 - approval-flow create/list/select supports `requestType='schedule_dispatch'`; create route rejects missing/ambiguous/inactive flow.
 - parent `attendance_requests` row maps `user_id` to dispatched user and `work_date` to `start_date`.
 - create route with no scope -> 403 for scope-only actor.
-- create route with target schedule group/user dispatch scope -> 201.
+- create route with target schedule group + user + target department dispatch scope -> 201.
 - generic final approve rechecks stored dispatch scope and then fails closed with `SCHEDULE_DISPATCH_FINAL_WRITER_PENDING`; generic reject/cancel closes the detail row and archives `source_key`.
 
 D3 final-writer required tests before assignment/member writes can be called complete:

--- a/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
+++ b/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
@@ -10,7 +10,7 @@
 2. **不做硬件/考勤机绑定**：DingTalk 的考勤机绑定部门属于硬件/原生生态，不进入 metasheet2 v1。多门店归属由 `attendance_schedule_groups.department_ref` / `attendance_group_id` 表达。
 3. **排班事实仍是 `attendance_shift_assignments`**：调度通过后写 `producer_type='schedule_dispatch'` 的 published direct assignments；effective-calendar、planned-minutes、shiftCompliance 和报表继续读既有 assignment resolver，不新增第二套排班真源。
 4. **成员归属是辅助事实**：目标小组织 membership 可以写 `attendance_schedule_group_members.source='schedule_dispatch'` 的有效期 row，供 scoped 管理、查询和后续报表使用；它不单独改变 effective-calendar。
-5. **必须走 dedicated route**：`request_type='schedule_dispatch'` 不允许 generic `/api/attendance/requests` create/update 伪造；创建、审批前校验、最终写入都走专用 API。
+5. **必须走 dedicated route 创建/管理调度申请**：`request_type='schedule_dispatch'` 不允许 generic `/api/attendance/requests` create/update 伪造；create/list/read/cancel 走专用 API。最终审批仍进入 generic approval resolver，但必须执行 dispatch-specific scope/pre-write guards；D3 才打开真正 assignment/member write。
 6. **完成口径**：D1–D5 全部落地并 staging smoke PASS 后，才把「调度」从 ⬜/🟡 翻 ✅。设计锁本身只把状态推进到 🟡。
 
 ## 1. Pre-flight
@@ -27,6 +27,12 @@ D0 review baseline: `88f5f538a`（#2501，#2546 merge-base；已包含 #2545 SO3
   - `attendance_shift_assignments` 已有 `slot_index`、publish lifecycle、`producer_type/ref/key/run_id` provenance。
   - `shift_swap` 已证明 request envelope + dedicated route + final-approval writer + producer assignment 的模式可行。
 
+Current landed status（2026-06-12）:
+
+- D1 contract is landed in #2551.
+- D2 dedicated create/list/read/cancel API is landed in #2553, including generic final-approval/cancel cleanup guards while the final writer is pending.
+- D3 final approval writer is still not landed; the final-approval scope revalidation in this design remains the D3 acceptance lock.
+
 ## 2. Scope
 
 ### In Scope v1
@@ -36,7 +42,7 @@ D0 review baseline: `88f5f538a`（#2501，#2546 merge-base；已包含 #2545 SO3
 - admin 创建按天调度申请：选择调度员工、目标小组织、目标班次、日期区间、slotIndex、原因、approvalFlowId。
 - final approval writer：事务内锁请求和目标用户，写 published direct assignments，写可选小组织 membership window，并回填 detail row。
 - admin/employee UI：管理员在 Advanced scheduling 区域创建/查看调度；员工只读自己的调度状态，不在 v1 自助发起调度。
-- scheduler-scope：scope-only actor 必须拥有 `dispatch` 到目标 user + target schedule group 的权限；中央 admin 保持可达。
+- scheduler-scope：scope-only actor 必须拥有 `dispatch` 到目标 user + target schedule group + target department 的权限；中央 admin 保持可达。
 - real-DB reverse tests + staging smoke。
 
 ### Out of Scope v1
@@ -89,7 +95,7 @@ Indexes:
 schedule_dispatch:{userId}:{targetScheduleGroupId}:{startDate}:{endDate}:{slotIndex}
 ```
 
-Only pending/approved duplicate blocking matters; canceled/rejected rows may archive the key with `:closed:{requestId}` if we need to allow re-apply.
+Only pending/approved duplicate blocking matters; D2 closes canceled/rejected schedule-dispatch rows by archiving the key with `:archived:{requestId}` so the operator can re-apply.
 
 ### `attendance_requests` envelope mapping
 
@@ -188,7 +194,7 @@ Copy must say “按天调度” and avoid claiming hourly support or cost alloc
 
 ## 8. Tests
 
-Required before any runtime PR can be called complete:
+Already covered by landed D1/D2 (#2551/#2553):
 
 - D1 contract: DB check constraint, runtime request-type constants/labels, typed DB union, approval-flow request-type support, OpenAPI source + generated artifacts all include `schedule_dispatch`.
 - generic `/requests` create/update `schedule_dispatch` -> 422, no detail row.
@@ -196,7 +202,11 @@ Required before any runtime PR can be called complete:
 - parent `attendance_requests` row maps `user_id` to dispatched user and `work_date` to `start_date`.
 - create route with no scope -> 403 for scope-only actor.
 - create route with target schedule group/user dispatch scope -> 201.
-- final approve with `attendance:approve` but no matching `dispatch` scope -> 403 and rollback; matching dispatch scope or central admin -> allowed.
+- generic final approve rechecks stored dispatch scope and then fails closed with `SCHEDULE_DISPATCH_FINAL_WRITER_PENDING`; generic reject/cancel closes the detail row and archives `source_key`.
+
+D3 final-writer required tests before assignment/member writes can be called complete:
+
+- final approve with `attendance:approve` but no matching `dispatch` scope -> 403 and rollback before write; matching dispatch scope or central admin may proceed to the D3 writer.
 - final approve writes exactly one `producer_type='schedule_dispatch'` assignment and optional membership row.
 - repeat/replay final approve does not duplicate assignment/membership.
 - conflict guard: existing published assignment same slot/date -> 409/422 and approval rollback.
@@ -209,8 +219,8 @@ Required before any runtime PR can be called complete:
 ## 9. Slice Plan
 
 - D0 design-lock (this PR) — docs only.
-- D1 latent schema + request type enum + runtime constants/labels + typed DB union + approval-flow support + OpenAPI/SDK generated contract + generic `/requests` rejection.
-- D2 dedicated create/list/read/cancel API and route-level tests.
+- D1 latent schema + request type enum + runtime constants/labels + typed DB union + approval-flow support + OpenAPI/SDK generated contract + generic `/requests` rejection — landed #2551.
+- D2 dedicated create/list/read/cancel API and route-level tests — landed #2553.
 - D3 final approval writer + conflict/edit-window/compliance/scope guards.
 - D4 admin/employee UI.
 - D5 staging smoke harness/runbook + staging closeout.

--- a/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
+++ b/docs/development/attendance-dispatch-multisite-design-lock-20260612.md
@@ -15,12 +15,12 @@
 
 ## 1. Pre-flight
 
-Current main: `fe0b4b9f1`（#2545，SO3 closeout）。
+D0 review baseline: `88f5f538a`（#2501，#2546 merge-base；已包含 #2545 SO3 closeout）。
 
 查重结果：
 
 - open PR：没有 attendance/dispatch/multisite 调度 PR。
-- remote branch：`feat/attendance-scheduling` 存在，但与 current `origin/main` **无 merge-base**，且是旧版大分支（`c41904dc9 feat(attendance): add scheduling with shifts, holidays, and off-day support`）。不复用、不 rebase、不把它当当前并行工作。
+- remote branch：`feat/attendance-scheduling` 存在，但与 D0 review baseline **无 merge-base**，且是旧版大分支（`c41904dc9 feat(attendance): add scheduling with shifts, holidays, and off-day support`）。不复用、不 rebase、不把它当当前并行工作。
 - existing substrate:
   - `attendance_schedule_groups` / `attendance_schedule_group_members` 已有 parent/dept、effective window、source、scope guard。
   - `attendance_scheduler_scopes` 已有 `dispatch` action，但它当前是排班写入/自动对班/小组织成员管理权限，不是“人员调度”产品能力。
@@ -127,6 +127,7 @@ Create validates:
 - approvalFlowId, when provided, points to an active `schedule_dispatch` flow; when omitted, exactly one active `schedule_dispatch` flow must exist.
 - dates obey `shiftEditPolicy`.
 - actor has scheduler-scope `dispatch` to `{ userIds:[userId], scheduleGroupIds:[targetScheduleGroupId], departments:[target.department_ref] }`, unless central admin.
+- `target_department_ref` is copied from the reloaded target schedule group, never trusted from client input.
 - target date range does not already have a pending/approved dispatch request with the same source key.
 - generic `/api/attendance/requests` create/update rejects `schedule_dispatch` with `SCHEDULE_DISPATCH_VIA_DEDICATED_ROUTE`.
 
@@ -142,7 +143,7 @@ Inside the approval transaction:
 2. Reject if already `finalized_at` or assignment ids exist.
 3. Lock `attendance_shift_assignments` for the target user via existing per-user assignment lock.
 4. Re-load target group and target shift; reject if inactive/missing.
-5. Re-run scheduler-scope dispatch authorization for the actor if needed.
+5. Re-run scheduler-scope `dispatch` authorization for the final approving actor against the reloaded `{ userId, targetScheduleGroupId, target.department_ref }`, unless central admin. This is mandatory: `attendance:approve` / approval-flow permission alone is not enough to materialize a schedule write outside the actor's dispatch scope.
 6. Re-run `shiftEditPolicy`.
 7. Insert one published direct assignment per date or a single date-range assignment:
    - v1 should prefer **one date-range assignment** if the same shift/slot applies for the full interval, because existing assignment conflict and resolver logic support ranges.
@@ -195,6 +196,7 @@ Required before any runtime PR can be called complete:
 - parent `attendance_requests` row maps `user_id` to dispatched user and `work_date` to `start_date`.
 - create route with no scope -> 403 for scope-only actor.
 - create route with target schedule group/user dispatch scope -> 201.
+- final approve with `attendance:approve` but no matching `dispatch` scope -> 403 and rollback; matching dispatch scope or central admin -> allowed.
 - final approve writes exactly one `producer_type='schedule_dispatch'` assignment and optional membership row.
 - repeat/replay final approve does not duplicate assignment/membership.
 - conflict guard: existing published assignment same slot/date -> 409/422 and approval rollback.


### PR DESCRIPTION
## Summary
- harden the dispatch/multisite design lock after #2546 by making final-approval `dispatch` scope revalidation mandatory
- clarify `target_department_ref` is copied from the reloaded schedule group, not trusted from client input
- replace the stale "current main" pre-flight stamp with the D0 review baseline / merge-base wording
- sync the document with landed D1 (#2551) and D2 (#2553), keeping D3 final approval writer as the still-open acceptance lock

## Verification
- `git diff --check`
- verified D1/D2 landed status against current origin/main
- confirmed this remains docs-only; no runtime opened
