### PR TITLE
docs(multitable): scope A6-4 BPMN compile preview

### DIFF
--- a/docs/development/multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md
+++ b/docs/development/multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md
@@ -1,0 +1,226 @@
+# Multitable Automation A6-4 BPMN Compile/Preview Scope Gate - 2026-06-12
+
+Status: docs-only scope gate
+
+Grounded on: `origin/main@52ce8279d`
+
+Scope: A6-4 / W8 only - BPMN as a compile/preview and gap-report input for the
+existing automation + approval substrate.
+
+Runtime: not started
+
+## Verdict
+
+A6-4 may open only as a side-effect-free compile/preview adapter.
+
+The adapter may parse existing Workflow Designer visual definitions or BPMN XML
+drafts and return:
+
+- an automation preview;
+- an approval preview;
+- a deterministic gap report;
+- supported mapping evidence.
+
+It must not deploy, start, execute, persist, publish, or mutate anything. BPMN is
+a modeling language in this line, not a fourth production runtime.
+
+## Grounding
+
+Current main already has enough substrate for a useful constrained preview:
+
+- A6-1 persistent `WorkflowJob` runtime is production reachable through
+  rule-level `execution_mode`.
+- A6-2 `wait_for_callback` suspend/resume is admin-gated and complete.
+- A6-3 has both `condition_branch` exclusive branching and `parallel_branch`
+  `joinMode: 'all'` fan-out/fan-in.
+- W6-1 `start_approval` can start one approval instance from automation and
+  resume or fail from W5 terminal completion events.
+- Approval remains source-of-truth for approval templates, published runtime
+  graphs, assignments, permissions, and task state.
+
+Current main also has older Workflow Designer / BPMN surfaces:
+
+- `WorkflowDesigner` supports visual node types such as start/end events,
+  user/service/script tasks, exclusive/parallel gateways, and intermediate catch
+  events.
+- `POST /api/workflow-designer/workflows/:id/deploy` can deploy BPMN XML through
+  `BPMNWorkflowEngine`.
+- `POST /api/workflow/deploy` and `POST /api/workflow/start/:key` are live BPMN
+  engine routes.
+- `POST /api/workflow-designer/workflows/:id/test` writes a synthetic completed
+  draft execution and is not a proof of automation/approval execution.
+
+Those existing live BPMN routes are not the A6-4 target. A6-4 must not extend
+them into the convergence engine v1 path.
+
+## Scope Decision
+
+### In Scope
+
+1. Add a pure compile-preview module and, if needed, a read-only authenticated
+   preview route.
+2. Accept one of these inputs:
+   - a Workflow Designer visual definition; or
+   - a BPMN XML draft loaded from the existing designer draft.
+3. Return a preview payload with:
+   - `automationPreview`: proposed automation actions / graph shape;
+   - `approvalPreview`: proposed approval-template or approval-runtime shape;
+   - `gapReport`: unsupported nodes, unsupported mappings, and why;
+   - `mappingReport`: which BPMN elements mapped to existing A6/W5/W6
+     primitives;
+   - `warnings`: non-blocking fidelity or authoring warnings.
+4. Reuse existing automation and approval vocabulary:
+   - automation actions: `condition_branch`, `parallel_branch`,
+     `wait_for_callback`, `start_approval`, and the already-supported simple
+     side-effect actions where explicitly configured;
+   - C1 status and job vocabulary only in explanatory preview metadata, never a
+     new status model;
+   - approval source vocabulary and published-graph concepts only as preview.
+5. Produce deterministic output: same input, same preview and same gap ordering.
+6. Redact secret-shaped values from preview output before returning it.
+
+### Out of Scope / Hard No
+
+- No call to `BPMNWorkflowEngine.deployProcess()` or
+  `BPMNWorkflowEngine.startProcess()`.
+- No use of the old live `/api/workflow/deploy` or `/api/workflow/start/:key`
+  paths as the A6-4 implementation path.
+- No writes to `bpmn_*`, `workflow_definitions`, automation rule tables,
+  approval template tables, automation execution tables, or automation job
+  tables.
+- No creation, update, publish, deploy, start, retry, resume, or backwrite.
+- No live BPMN execution route.
+- No second run store, audit store, job table, or status vocabulary.
+- No generic JavaScript / SQL / HTTP code node.
+- No branch-local `wait_for_callback` or nested branch mapping until A6-3-3 is
+  explicitly unlocked.
+- No `join_any` / cancellation mapping until A6-3-5 is explicitly unlocked.
+- No result backwrite mapping until W7 runtime is explicitly unlocked.
+- No public webhook/token emitter.
+
+## Mapping Contract
+
+The first implementation must be conservative. If a mapping is not fully
+grounded in landed automation or approval contracts, it goes to the gap report
+instead of being silently dropped or approximated.
+
+| BPMN / designer element | Preview behavior |
+|---|---|
+| Start event | Structural only. It may identify the trigger boundary, but must not invent a new trigger binding. |
+| End event | Structural only. It may close the preview graph. |
+| Service task | Maps only when the node explicitly names a supported automation action and provides the required config shape. Otherwise gap. |
+| User task | Maps to an approval preview only when it can express a supported approval assignee source and form shape. Otherwise gap. |
+| Exclusive gateway | Maps to `condition_branch` preview when outgoing conditions and a default path can be expressed in the existing condition model. Otherwise gap. |
+| Parallel gateway split + matching join | Maps to `parallel_branch` with `joinMode: 'all'` only when the split/join pair is well-formed. Otherwise gap. |
+| Intermediate catch event, message/signal | Gap until public webhook/token emitter is explicitly scoped. |
+| Intermediate catch event, timer | Gap until delay/timer resume and durable scheduler semantics are explicitly scoped. |
+| Script task | Gap. Generic code execution is out of scope. |
+| Inclusive gateway, event gateway, boundary event, subprocess, call activity | Gap in v1. |
+
+## Shape of the Preview Response
+
+The exact TypeScript shape belongs in the implementation PR, but the first slice
+should expose this structure:
+
+```ts
+type BpmnCompilePreview = {
+  source: {
+    workflowId?: string
+    mode: 'visual' | 'bpmn_xml'
+    sourceVersion?: number
+  }
+  supported: boolean
+  automationPreview?: {
+    actions: unknown[]
+    requiresExecutionMode: 'workflow_job_v1'
+  }
+  approvalPreview?: {
+    formSchema?: unknown
+    approvalGraph?: unknown
+    runtimeGraphPreview?: unknown
+  }
+  mappingReport: Array<{
+    bpmnElementId: string
+    bpmnElementType: string
+    target: 'automation' | 'approval' | 'structural'
+    targetKind: string
+  }>
+  gapReport: Array<{
+    bpmnElementId: string
+    bpmnElementType: string
+    reason: string
+    requiredRung?: 'A6-3-3' | 'A6-3-5' | 'W7' | 'public-webhook' | 'unsupported'
+  }>
+  warnings: string[]
+}
+```
+
+`supported` means "all required runtime mappings are supported by existing,
+landed contracts." It must not mean "safe to deploy as BPMN."
+
+## Implementation Entry Point
+
+The first implementation PR should start with a pure module and route only if the
+module is already deterministic:
+
+1. Build a pure compiler function that accepts normalized designer/BPMN input.
+2. Add unit tests for supported and unsupported mappings.
+3. Add a read-only preview route only after the pure module is stable.
+4. Add route tests proving no persistence and no live BPMN engine calls.
+5. Add frontend only after the response contract is stable.
+
+Recommended route shape if a route is added:
+
+```text
+POST /api/workflow-designer/workflows/:id/compile-preview
+```
+
+That route name is intentionally different from `deploy`, `test`, `start`, or
+`publish`.
+
+## Required Tests
+
+The implementation PR must include focused tests before merge:
+
+1. **Side-effect free:** preview does not call deploy/start/publish/create/update
+   services and performs no DB writes except ordinary read queries needed to load
+   the draft.
+2. **No live BPMN engine:** spies or dependency injection prove the preview route
+   does not call `BPMNWorkflowEngine.deployProcess()` or `startProcess()`.
+3. **Exclusive gateway mapping:** a valid exclusive gateway maps to
+   `condition_branch`; missing default or unrepresentable condition goes to
+   `gapReport`.
+4. **Parallel gateway mapping:** a well-formed split/join maps to
+   `parallel_branch` with `joinMode: 'all'`; mixed split/join or unmatched join
+   goes to `gapReport`.
+5. **Unsupported node report:** script task, inclusive gateway, event gateway,
+   subprocess, boundary event, and call activity produce deterministic gaps.
+6. **Timer/message gap:** intermediate catch timer/message/signal events are
+   reported as gated, not silently compiled.
+7. **Redaction:** secret-shaped values in node config are redacted in
+   `automationPreview`, `approvalPreview`, and gap/warning text.
+8. **Stable output:** equivalent input produces stable, sorted mapping/gap
+   output.
+9. **No new runtime route:** route inventory or tests prove no new live
+   `/start`, `/deploy`, or execution route was added.
+
+## Re-entry Signal
+
+The owner unlock phrase for runtime implementation should be explicit, for
+example:
+
+> Start A6-4 BPMN compile-preview adapter only: side-effect-free preview +
+> deterministic gap report, no deploy/start/live BPMN runtime, no persistence,
+> gateway mappings to existing A6-3 condition/parallel primitives.
+
+"Continue workflow automation" is not enough for A6-4 runtime implementation.
+
+## Exit Criteria for This Scope Gate
+
+This docs-only scope gate is complete when:
+
+- the A6 execution plan points to this file for A6-4 detail;
+- the run-governance TODO distinguishes "A6-4 scope-gate recorded" from
+  "A6-4 implementation not started";
+- the workflow/automation completion ledger lists W8 as scoped but not built;
+- no runtime files, migrations, routes, or tests change in this PR.

--- a/docs/development/multitable-automation-a6-convergence-scout-20260529.md
+++ b/docs/development/multitable-automation-a6-convergence-scout-20260529.md
@@ -1,43 +1,45 @@
 # Multitable Automation A6 Convergence Scout / Scope Gate — 2026-05-29
 
-Status: docs-only scout / scope gate
+Status: historical docs-only scout / scope gate; current rung status lives in
+`multitable-automation-run-governance-todo-20260527.md`
 Scope: A6 capability-half planning only
-Runtime: not started
+Runtime at A6-0 time: not started. Later A6 runtime slices have landed by
+explicit opt-in; see the decomposition table below.
 Companions:
 - `docs/development/run-governance-forward-plan-20260528.md`
 - `docs/development/multitable-automation-run-governance-todo-20260527.md`
 - `docs/development/multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`
+- `docs/development/multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`
 - `docs/research/approval-automation-convergence-rfc-20260526.md`
 
 ## Verdict
 
-A6 can be opened only as a docs-only scout / scope-gate slice right now. A6
-runtime remains frozen and demand-gated.
+At A6-0 time, A6 could be opened only as a docs-only scout / scope-gate slice.
+Later runtime slices landed only after separate owner opt-ins. Remaining A6
+rungs are still demand-gated.
 
-The next runtime step is not "build the workflow engine". The A6-1 persistent
-`WorkflowJob` runtime scout is now recorded in
-`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`; runtime
-still requires a separate implementation unlock with a feature flag /
-compatibility gate and no default behavior change for existing automation rules.
+The next runtime step is still not "build the workflow engine". Current status
+has moved past A6-1/A6-2 and the first A6-3 graph slices; remaining rungs still
+require separate implementation unlocks with narrow compatibility gates.
 
 This document records the sequence, boundaries, risks, and future test surface so
 the next runtime unlock starts from a smaller, auditable shape.
 
 ## Grounding
 
-Current `origin/main` already has the governance substrate:
+Current `origin/main` already has the governance substrate and several landed
+A6 runtime slices:
 
 - C1 `WorkflowJob` contract exists in
   `packages/core-backend/src/multitable/workflow-job-contract.ts`. It defines
   `queued/running/suspended/resolved/failed/skipped/rejected/errored`, suspend
   reasons, strict normalizers, and legacy status bridges.
-- The automation runs API consumes C1 only at the read boundary:
-  `packages/core-backend/src/routes/automation.ts` maps persisted steps with
-  `toWorkflowJobView()` and accepts future statuses as legal empty filters.
-- The automation executor is still linear and fail-stop:
-  `packages/core-backend/src/multitable/automation-executor.ts` builds one
-  `AutomationExecution`, runs `executeActions()` sequentially, and stops after
-  the first failed action.
+- The automation runs API consumes C1 at the read boundary and now also renders
+  persisted A6 job lineage from the `multitable_automation_jobs` plane.
+- The automation executor has moved beyond the original linear-only state:
+  A6-2 `wait_for_callback`, A6-3 `condition_branch`, and A6-3 parallel
+  `joinMode: 'all'` are landed, while branch-local waits and join-any remain
+  gated.
 - A5 retry is whole-execution replay only:
   `packages/core-backend/src/multitable/automation-service.ts` re-runs the
   current enabled rule with the stored trigger event and stamps
@@ -77,12 +79,14 @@ The dependency order is fixed, but it is not a schedule.
 | Step | Name | First deliverable after opt-in | Gate |
 |---|---|---|---|
 | A6-0 | Scout / scope gate | This docs-only document | done by this slice |
-| A6-1 | Persistent WorkflowJob runtime | ✅ LANDED #2130 (dormant; enable path deferred) | done (dormant) |
-| A6-1e | Enable-writer (API/UI sets `execution_mode`) | makes A6-1 live in production | named demand |
-| A6-2 | Suspend/resume | external-event/webhook resume before delay/timer resume | named demand |
-| A6-3 | Branch/parallel DAG | condition/parallel nodes with upstream/downstream graph fields | named demand |
-| A6-4 | BPMN adapter | compile/preview + gap report only; no live BPMN runtime | named demand |
-| A6-5 | Approval-as-job | `start_approval` + completion-event contract, then bridge | double-gated |
+| A6-1 | Persistent WorkflowJob runtime | Landed and enabled end-to-end (#2130/#2191/#2193) | done |
+| A6-2 | Suspend/resume | Landed end-to-end (#2237/#2245/#2257); delay/timer still deferred | done for admin-gated v1 |
+| A6-3 | Branch/parallel DAG | `condition_branch` and `parallel_branch` `joinMode: all` landed; branch-local waits and join-any still gated | partially done |
+| A6-4 | BPMN adapter | Scope gate recorded in `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`; implementation not started | named demand |
+| A6-5 | Approval-as-job | First `start_approval` bridge slice landed (#2469); result backwrite / follow-ups still gated | partially done |
+
+The sections below retain the original design rationale for each rung. The table
+above and the TODO checklist are the current status sources.
 
 ### A6-1 — Persistent WorkflowJob Runtime
 
@@ -147,6 +151,11 @@ This is also the real landing zone for BPMN gateways. Without A6-3,
 gap report.
 
 ### A6-4 — BPMN Compile/Preview Adapter
+
+The detailed A6-4 scope gate is now recorded in
+`multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`.
+That document is the current contract for any implementation; this section is
+kept as the original A6-0 positioning.
 
 Goal: use BPMN as a modeling/preview language, not as a runtime.
 
@@ -265,7 +274,10 @@ A6 must not:
 
 ## Current Recommendation
 
-Stop after the A6-1 scout unless a named A6 runtime demand is provided.
+After A6-3 `condition_branch` + parallel `join_all`, the next A6 runtime work
+still requires a named demand. A6-4 is now scoped as compile-preview only, but
+implementation should not start without explicit owner opt-in using the re-entry
+signal in `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`.
 
 The healthiest next technical action, when demand appears, is a small A6-1
 runtime PR: feature-flagged persistent job runtime for linear automation, with

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -32,8 +32,9 @@ treatment **on purpose**:
   the A6-3-2 frontend/readability slice **landed via #2339 + #2348**; the
   A6-3-4/W3 parallel fan-out + join-all slice **landed via #2496 + #2500 + #2501**.
   A6-3-3 branch-local wait/nesting and A6-3-5 join-any stay deferred. A6-5's first `start_approval` bridge slice **landed via #2469**
-  as a named cross-surface carve-out on top of A6-2 + W5 completion events. A6-4 remains
-  plan-level only.
+  as a named cross-surface carve-out on top of A6-2 + W5 completion events. A6-4 now has
+  a docs-only scope gate (`multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`);
+  implementation remains not started.
 
 The original ladder was:
 **A6-1 enable-writer → A6-2 suspend/resume → A6-3 branch/parallel DAG → A6-4 BPMN
@@ -210,18 +211,24 @@ rung.
   independent, join-all waits, join-any cancels with explicit audit, branch failures
   isolated).
 
-## 4. A6-4 BPMN compile/preview adapter — PLAN-LEVEL (design deferred to its scout)
+## 4. A6-4 BPMN compile/preview adapter — SCOPED (implementation not started)
+
+Scope gate:
+`multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`.
 
 - **Adds:** parse a constrained BPMN subset, compile-**preview** into automation/approval
   definitions, and return a gap report for unsupported nodes.
 - **Must not — permanent positioning:** never execute BPMN, never a second status model,
   never a separate audit/log store, no side-effecting preview. BPMN is a modeling/preview
   input, never a fourth runtime.
-- **Depends on:** A6-3 (gateways map onto branch/parallel; without it, gateways can only be
-  reported as unsupported).
-- **Gate:** a named modeling/preview demand.
-- **Test surface:** see A6-0 scout "→ A6-4" (preview side-effect-free, deterministic gap
-  report, gateway mappings backed by A6-3 tests, no live BPMN route).
+- **Depends on:** landed A6-3 `condition_branch` and `parallel_branch` `joinMode: 'all'`
+  mappings. Branch-local waits, join-any, public webhook/token emitters, and result backwrite
+  remain gaps unless their own rungs are explicitly unlocked.
+- **Gate:** a named modeling/preview demand. "Continue automation" is not enough.
+- **Test surface:** preview side-effect-free, deterministic gap report, gateway mappings backed
+  by A6-3 tests, no live BPMN route, no `BPMNWorkflowEngine.deployProcess()` /
+  `startProcess()` call, and no writes to BPMN, workflow, automation, approval, execution, or
+  job tables.
 
 ## 5. A6-5 approval-as-job — LANDED first slice (#2469); W7 backwrite still separate
 

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-4/W3 parallel join-all LANDED end-to-end (#2496 runtime `b161080b8`, #2500 editor `4408239d0`, #2501 admin-runs readability `88f5f538a`, 2026-06-12); A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / join-any cancellation semantics still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated.
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-4/W3 parallel join-all LANDED end-to-end (#2496 runtime `b161080b8`, #2500 editor `4408239d0`, #2501 admin-runs readability `88f5f538a`, 2026-06-12); A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-4 BPMN compile/preview scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / join-any cancellation semantics and public webhook/token emitter remain demand-gated.
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -30,7 +30,8 @@ A6-1 and A6-2 are complete end-to-end; A6-3-1 `condition_branch` exclusive-branc
 landed (#2321), A6-3-2 frontend/runs readability landed (#2339 + #2348), and
 A6-3-4/W3 parallel `join_all` landed end-to-end (#2496 + #2500 + #2501). A6-3-3
 branch-local wait/nesting and A6-3-5 join-any remain gated; A6-5/W6-1
-`start_approval` later landed separately in #2469; A6-4 remains a separate future unlock. Later trial
+`start_approval` later landed separately in #2469; A6-4 now has a docs-only compile/preview
+scope-gate but remains a separate future implementation unlock. Later trial
 evidence (#2367/#2371) confirmed the A6-3 v1 surface is enough for the tested
 condition-branch flow and did not produce a branch-local wait/nesting demand.
 
@@ -78,7 +79,7 @@ W7-1 runtime remains gated.
   (explicit opt-in; not "read-only so no review needed").
 - A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
   idempotency keys, and re-fetch-current-record context remain future opt-ins.
-- A6: A6-0/A6-3 design-locks are docs-only; A6-1/A6-2 + A6-3-1 `condition_branch` runtime
+- A6: A6-0/A6-3/A6-4 design-locks are docs-only; A6-1/A6-2 + A6-3-1 `condition_branch` runtime
   + A6-3-2 frontend/readability + A6-3-4/W3 parallel `join_all` + A6-5/W6-1
   `start_approval` bridge landed by explicit opt-in; A6-3-3 + join-any, A6-4 BPMN,
   public webhook/token emitter, and W7 result
@@ -310,7 +311,8 @@ complete.
 - [x] A6-3-4 / W3-1 parallel fan-out + join-all runtime — LANDED #2496 `b161080b8` (2026-06-11): canonical `parallel_branch` action, `joinMode: all`, service/executor fail-closed validation, C1 parent/branch-child fan-out/fan-in lineage, fail/skip aggregation, and real-DB seam tests.
 - [x] A6-3-4 frontend and admin-runs readability — LANDED #2500 `4408239d0` + #2501 `88f5f538a` (2026-06-12): editor authoring for `parallel_branch` with workflow-job auto-lock and admin runs detail showing branch labels/child jobs. **A6-3-4/W3 join-all closed end-to-end.**
 - [ ] A6-3-5 join-any / cancellation semantics — gated after join-all runtime.
-- [ ] A6-4 BPMN compile/preview adapter — not started.
+- [x] A6-4 / W8 BPMN compile/preview scope-gate — `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`: side-effect-free preview + deterministic gap report only; no live BPMN runtime, no deploy/start, no persistence.
+- [ ] A6-4 BPMN compile/preview adapter implementation — not started; requires explicit modeling/preview opt-in.
 - [x] A6-5 / W6-1 `start_approval` approval-as-job bridge — LANDED #2469: creates one approval instance from a published template, persists the bridge row, writes suspended / terminal C1 jobs, resumes/fails from W5 completion events, and guards A5 retry duplicates.
 - [x] W7-0 approval result backwrite scope-gate — `automation-approval-result-backwrite-scope-gate-20260611.md`: explicit mapping only; durable idempotent attempt state; permission/field guards; no approval form/comment/profile leakage; runtime remains gated.
 - [ ] W7-1 approval result backwrite runtime — not started; waits for W6 operator smoke (#2480) or named runtime unlock.

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -3,7 +3,7 @@
 > 类型：**前向开发安排（forward plan）**，非开工清单。
 > **2026-05-29 update（historical; superseded below）**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；当时 A6 runtime 仍 frozen / demand-gated。
 > **2026-05-30 update（historical; superseded below）**：A6-1 persistent `WorkflowJob` runtime scout（`…-a6-1-workflowjob-runtime-scout-20260530.md`）+ **runtime 已落地（#2130，verification `…-a6-1-workflowjob-runtime-verification-20260530.md`）**：opt-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed、A1 redaction 复用、A2 detail prefer-jobs）。当时 **DORMANT** —— API/UI enable 路径 deferred（createRule/updateRule 不接 `execution_mode`），现有规则零影响。该 dormant 状态已由 #2191/#2193 关闭。
-> **2026-06-12 update**：A6-1 已 end-to-end 完成（runtime #2130 + enable-writer #2191 + admin UI toggle #2193）；A6-2 suspend/resume 已 end-to-end 完成（design #2236 + runtime #2237 + frontend #2245 + UAT #2257）。A6-3 branch/parallel DAG 已分段落地：exclusive `condition_branch` #2321/#2339/#2348，parallel `join_all` #2496/#2500/#2501。A6-3-3 branch-local wait/nesting、A6-3-5 join-any、A6-4、A6-5/W7 follow-ups 仍 demand-gated。
+> **2026-06-12 update**：A6-1 已 end-to-end 完成（runtime #2130 + enable-writer #2191 + admin UI toggle #2193）；A6-2 suspend/resume 已 end-to-end 完成（design #2236 + runtime #2237 + frontend #2245 + UAT #2257）。A6-3 branch/parallel DAG 已分段落地：exclusive `condition_branch` #2321/#2339/#2348，parallel `join_all` #2496/#2500/#2501。A6-4 BPMN compile/preview scope-gate 已记录在 `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`，implementation 未启动。A6-3-3 branch-local wait/nesting、A6-3-5 join-any、A6-4 implementation、A6-5/W7 follow-ups 仍 demand-gated。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -18,9 +18,9 @@
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
 | **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
-| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 + A6-2 已完成**；A6-3 exclusive branch + parallel `join_all` 已落地；A6-3-3 / join-any / A6-4 / W7 follow-ups 未启动 | 否 —— **剩余 A6 rungs 仍需具名 opt-in；A6-4/A6-5 follow-ups 受需求闸** |
+| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 + A6-2 已完成**；A6-3 exclusive branch + parallel `join_all` 已落地；A6-4 scope-gate 已记录、implementation 未启动；A6-3-3 / join-any / W7 follow-ups 未启动 | 否 —— **剩余 A6 rungs 仍需具名 opt-in；A6-4/A6-5 follow-ups 受需求闸** |
 
-> **grounded 2026-06-12**：`/retry` 路由实现 A5 whole-execution retry；A6-1 persist-job runtime 已生产可达（#2130/#2191/#2193）；A6-2 suspend/resume 已生产可达（#2237/#2245，admin-gated v1，operator UAT #2257）；A6-3 has `condition_branch` and parallel `join_all` runtime/editor/runs-readability (#2321/#2339/#2348/#2496/#2500/#2501)。C1 契约现被 A2 读边界、A6-1 job 持久化、A6-2 suspended job/resume、A6-3 branch/parallel job lineage 使用。**仍无** A6-3-3 branch-local wait/nesting、join-any、BPMN adapter、W7 result backwrite runtime, or public webhook/token emitter.
+> **grounded 2026-06-12**：`/retry` 路由实现 A5 whole-execution retry；A6-1 persist-job runtime 已生产可达（#2130/#2191/#2193）；A6-2 suspend/resume 已生产可达（#2237/#2245，admin-gated v1，operator UAT #2257）；A6-3 has `condition_branch` and parallel `join_all` runtime/editor/runs-readability (#2321/#2339/#2348/#2496/#2500/#2501)。C1 契约现被 A2 读边界、A6-1 job 持久化、A6-2 suspended job/resume、A6-3 branch/parallel job lineage 使用。A6-4/W8 BPMN compile-preview has a docs-only scope gate; **仍无** A6-3-3 branch-local wait/nesting、join-any、BPMN adapter implementation、W7 result backwrite runtime, or public webhook/token emitter.
 
 **所以"接下去的开发安排" = 触发条件账本 + 不自动推进纪律，不是任务队列。**
 
@@ -72,11 +72,12 @@
 - **✅ A6-1 COMPLETE end-to-end（2026-06，不再 dormant）**：runtime **#2130**（`multitable_automation_jobs` 表 + rule-level `execution_mode` + inline linear job persistence fail-closed + A1 redaction 复用 + A2 detail prefer-jobs/legacy-fallback）+ **enable-writer #2191**（createRule/updateRule 接 `execution_mode`，service 层 enum 严格校验）+ **admin UI toggle #2193**（规则编辑器复选框，默认关）。净效果：管理员勾选规则 → 该规则每个动作持久化为 C1 WorkflowJob，A2/A3 可见。验收 runbook：`multitable-automation-a6-1-acceptance-runbook-20260602.md`。状态以 `…-todo-20260527.md` 为准。
 - **✅ A6-2 COMPLETE end-to-end（2026-06）**：design-lock #2236 + backend runtime #2237 + frontend #2245 + operator UAT #2257。Admin-gated v1，`wait_for_callback` + single-use token resume；delay/timer/public emitter 仍 deferred。
 - **A6-3 landed in two useful graph slices**：`condition_branch` / exclusive branch v1 (#2321/#2339/#2348) and parallel fan-out + `join_all` (#2496/#2500/#2501)。Both reuse the existing C1 job plane and admin runs detail.
-- **剩余依赖序（未建，各需具名 opt-in）**：**A6-3-3 branch-local wait/nesting**（让 `wait_for_callback`/nested branches live inside graph branches）→ **A6-3-5 join-any/cancellation** → **A6-4 BPMN compile/preview** → **W7 result backwrite / A6-5 follow-ups**。触发须点名具体用例（"分支内需要等待外部回调" / "需要先完成任一并行分支即继续" / "BPMN 只做 compile-preview" / "审批结果需要写回记录字段"），"继续自动化"不够。
+- **A6-4 scope-gate**：`multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md` pins BPMN as side-effect-free compile-preview + deterministic gap report only; no deploy/start/live BPMN runtime.
+- **剩余依赖序（未建，各需具名 opt-in）**：**A6-3-3 branch-local wait/nesting**（让 `wait_for_callback`/nested branches live inside graph branches）→ **A6-3-5 join-any/cancellation** → **A6-4 BPMN compile/preview implementation** → **W7 result backwrite / A6-5 follow-ups**。触发须点名具体用例（"分支内需要等待外部回调" / "需要先完成任一并行分支即继续" / "BPMN 只做 compile-preview" / "审批结果需要写回记录字段"），"继续自动化"不够。
 - **触发信号**：某个**集成/DF 流水线真的需要 human-in-the-loop**（"导入→清洗→**等人工审批**→导出"= suspend + approval-as-job）或按记录分支；**且本就在 K3 GATE 下游**。
 - **治理继承硬契约**：A6 任一能力落地必须**复用本线的 run/job/status/provenance/redaction 底座**，不得新建二等可观测层。
-- **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 定义），**永不自己执行**（否则第四套状态孤岛）。
-- **锁姿态**：A6-3 已落地的 exclusive branch + join-all slices closed；A6-3-3、join-any、A6-4、W7 result backwrite、public webhook/token emitter 仍 frozen / demand-gated。
+- **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 预览 + gap report），**永不自己执行**（否则第四套状态孤岛）。
+- **锁姿态**：A6-3 已落地的 exclusive branch + join-all slices closed；A6-4 scope-gate recorded but implementation not started；A6-3-3、join-any、A6-4 implementation、W7 result backwrite、public webhook/token emitter 仍 frozen / demand-gated。
 
 ---
 
@@ -120,4 +121,4 @@
 
 ## 8. 一句话排期
 
-**治理半已完成、A5 whole-execution retry v1 已完成、A6-1/A6-2 已 end-to-end 落地，A6-3 已覆盖 exclusive branch + parallel join-all。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5/A6-2/A6-3 的运行效果用于判断是否需要 branch-local wait / join-any / BPMN / result backwrite；剩余 A6/W7 仍按具名需求推进。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。
+**治理半已完成、A5 whole-execution retry v1 已完成、A6-1/A6-2 已 end-to-end 落地，A6-3 已覆盖 exclusive branch + parallel join-all，A6-4 已有 compile-preview scope-gate。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5/A6-2/A6-3 的运行效果用于判断是否需要 branch-local wait / join-any / BPMN implementation / result backwrite；剩余 A6/W7 仍按具名需求推进。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-09
 
-Grounded on: `origin/main@88f5f538a`
+Grounded on: `origin/main@52ce8279d`
 
 Scope: MetaSheet2 workflow, approval, and multitable automation as one product
 target. This is a completion definition and execution ledger, not a sprint
@@ -66,7 +66,7 @@ but it is not yet the unified workflow automation authoring layer.
 | BPMN draft API | Existing draft save/load/update/deploy support. |
 | Designer hub/catalog | Existing list/template/team-view/hub improvements. |
 | Runtime positioning | Must stay modeling/preview first. v1 must not route production execution through a separate BPMN runtime. |
-| Still missing | Compile/preview adapter into automation/approval definitions, deterministic gap report, no-live-runtime guard. |
+| Still missing | Compile/preview adapter implementation into automation/approval definitions. A6-4/W8 scope is now locked in `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`: deterministic gap report, side-effect-free preview, no-live-runtime guard. |
 
 ## 2. Definition of Complete v1
 
@@ -125,7 +125,7 @@ operate a practical business workflow using existing product surfaces:
 | W6-1 | Automation `start_approval` runtime | Landed #2469 | Starts one approval instance from a published template, persists the approval bridge, creates a suspended C1 job, resumes/fails from W5 terminal completion events, and guards retry duplicates. |
 | W7-0 | Approval result backwrite scope-gate | Scope-gate document added; runtime not started | `automation-approval-result-backwrite-scope-gate-20260611.md` locks explicit mapping, idempotency, permission/field guards, redaction, and tests. |
 | W7-1 | Approval result backwrite runtime | Not started; after W6 operator smoke or named runtime unlock | Explicit mapping writes approved/rejected/revoked/cancelled outcomes to multitable record fields with audit and permission checks; `return` transition backwrite needs a separate named scope if required. |
-| W8 | BPMN compile/preview adapter | Not started; after W3 minimum | Constrained BPMN subset compiles into automation/approval preview plus gap report; no live execution route. |
+| W8 | BPMN compile/preview adapter | Scope-gate recorded; implementation not started | `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md` locks the constrained subset, side-effect-free preview, gap report, and hard no-live-runtime boundary. Runtime implementation still needs explicit opt-in. |
 | W9 | Public webhook resume token emitter | Not started; use-case gated | External consumer can receive a token/callback URL safely; auth, expiry, replay, and redaction are locked before public route. |
 | W10 | Field-visibility / richer approval authoring | Optional follow-up | Existing `visibilityRule` data can be authored, not only preserved; unsupported graph constructs remain fail-closed. |
 
@@ -146,8 +146,10 @@ Why:
 The next cross-surface candidate is **W7 approval result backwrite**. W7-0 now
 has a scope-gate document, but W7-1 runtime remains gated because it writes
 business data and changes record state. W3-1 has now landed the minimum
-parallel `join_all` semantics that BPMN parallel-gateway preview can map to,
-but BPMN still needs its own compile/preview scout and must remain non-runtime.
+parallel `join_all` semantics that BPMN parallel-gateway preview can map to.
+W8/A6-4 now has its own compile/preview scope gate, and remains non-runtime:
+implementation may only produce side-effect-free preview plus gap report unless
+separately unlocked.
 
 ## 5. Non-goals for v1
 
@@ -176,6 +178,8 @@ needed, one verification/runbook:
   `automation-approval-result-backwrite-scope-gate-20260611.md`.
 - A6-3-4 / W3 parallel join-all scope:
   `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`.
+- A6-4 / W8 BPMN compile-preview scope:
+  `multitable-automation-a6-4-bpmn-compile-preview-scope-gate-20260612.md`.
 
 If code lands but the tracker still says "not started", the tracker is wrong
 and should be corrected before starting a new rung.


### PR DESCRIPTION
## Summary

- add the A6-4 / W8 BPMN compile-preview scope gate
- pin BPMN as side-effect-free preview + deterministic gap report, not live runtime
- update the A6/TODO/forward-plan/completion trackers so A6-4 is scoped but implementation remains not started
- re-ground the historical A6 convergence scout to avoid stale A6-1/A6-3 status wording

## Boundaries

- docs-only
- no runtime, routes, migrations, tests, or UI changes
- no deploy/start/live BPMN path
- no persistence, no BPMN engine execution, no new status/audit store

## Verification

- `git diff --check`
- scanned tracker wording for stale A6-4 / runtime-unlocked phrasing
