### PR TITLE
feat(multitable): record locking storage + write-path enforcement + re-expose (rank 8)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -190,6 +190,7 @@ jobs:
             tests/integration/multitable-dashboard-preview-data.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \
+            tests/integration/multitable-record-lock.test.ts \
             tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-view.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-export.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -191,6 +191,7 @@ jobs:
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \
             tests/integration/multitable-record-lock.test.ts \
+            tests/integration/multitable-record-lock-bypass.test.ts \
             tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-view.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-export.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1321,6 +1321,20 @@ export class MultitableApiClient {
     return this.parseJson(res)
   }
 
+  // Record locking (design #2278 follow-up): { locked: true } locks, { locked: false } unlocks.
+  async setRecordLock(
+    recordId: string,
+    locked: boolean,
+    params?: { sheetId?: string; viewId?: string },
+  ): Promise<{ recordId: string; locked: boolean; lockedBy: string | null; lockedAt: string | null }> {
+    const res = await this.fetch(`/api/multitable/records/${recordId}/lock`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locked, ...params }),
+    })
+    return this.parseJson(res)
+  }
+
   async patchRecords(input: PatchRecordsInput): Promise<PatchResult> {
     const res = await this.fetch('/api/multitable/patch', {
       method: 'POST',

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1264,6 +1264,10 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'wait_for_callback',
   'condition_branch',
   'parallel_branch',
+  // lock_record is now a complete contract (record-locking storage + write-path enforcement, rank 8),
+  // so it is a first-class selectable action — both for new rules and to keep existing lock_record rules
+  // editable (it must appear in SUPPORTED so an existing rule's option isn't dropped to empty).
+  'lock_record',
 ]
 
 // A6-3-2a: BRANCH_AUTHORABLE_ACTION_TYPES (the v1 in-branch action subset) is imported from

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1269,7 +1269,9 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
 // A6-3-2a: BRANCH_AUTHORABLE_ACTION_TYPES (the v1 in-branch action subset) is imported from
 // ../utils/conditionBranchAuthoring — the single source of truth shared with the seam + tests.
 
-const UNSUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = ['lock_record']
+// lock_record is now a complete contract (record-locking storage + write-path enforcement), so it is
+// re-exposed in the rule-editor dropdown (reversing the #2278 stop-gap that hid the then-broken action).
+const UNSUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = []
 
 function isUnsupportedSelectableActionType(type: AutomationActionType): boolean {
   return UNSUPPORTED_SELECTABLE_ACTION_TYPES.includes(type)

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -157,6 +157,22 @@
               <td class="meta-grid__row-num" :style="{ left: `${rowNumLeft}px` }">
                 <button class="meta-grid__expand-btn" :class="{ 'meta-grid__expand-btn--open': expandedRowIds.has(row.id) }" :aria-label="expandedRowIds.has(row.id) ? l('grid.collapseRow') : l('grid.expandRow')" @click.stop="toggleRowExpand(row.id)">&#x25B6;</button>
                 <span>{{ startIndex + ri + 1 }}</span>
+                <span
+                  v-if="isRowLocked(row.id)"
+                  class="meta-grid__lock-indicator"
+                  :title="l('grid.lockedIndicator')"
+                  :aria-label="l('grid.lockedIndicator')"
+                  data-test="row-lock-indicator"
+                >&#x1F512;</span>
+                <button
+                  v-if="canShowLockAction(row.id)"
+                  type="button"
+                  class="meta-grid__lock-action"
+                  :aria-label="isRowLocked(row.id) ? l('grid.unlockRow') : l('grid.lockRow')"
+                  :title="isRowLocked(row.id) ? l('grid.unlockRow') : l('grid.lockRow')"
+                  data-test="row-lock-action"
+                  @click.stop="emit('toggle-lock', { recordId: row.id, locked: !isRowLocked(row.id) })"
+                >{{ isRowLocked(row.id) ? '🔓' : '🔒' }}</button>
                 <button
                   v-if="resolveRowActions(row.id).canComment"
                   type="button"
@@ -390,6 +406,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'select-record', recordId: string): void
   (e: 'open-comments', recordId: string): void
+  (e: 'toggle-lock', payload: { recordId: string; locked: boolean }): void
   (e: 'open-field-comments', payload: { recordId: string; fieldId: string }): void
   (e: 'toggle-sort', fieldId: string): void
   (e: 'patch-cell', recordId: string, fieldId: string, value: unknown, version: number): void
@@ -548,7 +565,23 @@ function resolveRowActions(recordId: string): MetaRowActions {
     canComment: props.canComment !== false,
   }
 }
+// Record-locking (design #2278 follow-up): index rows so the lock indicator + lock/unlock action +
+// read-only-while-locked visual can resolve a row's lock state by id without scanning.
+const recordById = computed(() => {
+  const map = new Map<string, MetaRecord>()
+  for (const row of props.rows) map.set(row.id, row)
+  return map
+})
+const isRowLocked = (recordId: string): boolean => recordById.value.get(recordId)?.locked === true
+const canUnlockRow = (recordId: string): boolean => recordById.value.get(recordId)?.canUnlock === true
+// Show the lock/unlock affordance per `canUnlock` (decision b): a LOCKED row shows "unlock" only to an
+// actor the server says can unlock it; an UNLOCKED row shows "lock" to anyone who can edit the row.
+function canShowLockAction(recordId: string): boolean {
+  return isRowLocked(recordId) ? canUnlockRow(recordId) : resolveRowActions(recordId).canEdit
+}
+
 const isEditable = (recordId: string, f: MetaField) =>
+  !isRowLocked(recordId) &&
   resolveRowActions(recordId).canEdit && EDITABLE.has(f.type) && !isSystemField(f) && !props.fieldReadOnlyIds?.includes(f.id)
 const isEditing = (rid: string, fid: string) => editCell.value?.recordId === rid && editCell.value?.fieldId === fid
 

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -55,6 +55,19 @@
         >{{ l('record.history') }}</button>
       </div>
       <div v-if="subscriptionError" class="meta-record-drawer__watch-error">{{ subscriptionError }}</div>
+      <div v-if="record?.locked" class="meta-record-drawer__lock-banner" data-test="record-lock-banner">
+        <span class="meta-record-drawer__lock-icon" aria-hidden="true">&#x1F512;</span>
+        <span class="meta-record-drawer__lock-status">{{ l('record.locked') }}</span>
+        <span v-if="record.lockedBy" class="meta-record-drawer__lock-meta">{{ l('record.lockedBy') }}: {{ record.lockedBy }}</span>
+        <span v-if="record.lockedAt" class="meta-record-drawer__lock-meta">{{ l('record.lockedAt') }}: {{ record.lockedAt }}</span>
+        <button
+          v-if="record.canUnlock"
+          type="button"
+          class="meta-record-drawer__btn meta-record-drawer__lock-unlock"
+          data-test="record-unlock-action"
+          @click="emit('toggle-lock', { recordId: record.id, locked: false })"
+        >{{ l('record.unlock') }}</button>
+      </div>
       <div v-if="activeTab === 'details'" class="meta-record-drawer__fields">
       <div v-for="field in visibleFields" :key="field.id" class="meta-record-drawer__field">
         <div class="meta-record-drawer__field-header">
@@ -350,6 +363,7 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'delete'): void
   (e: 'patch', fieldId: string, value: unknown): void
+  (e: 'toggle-lock', payload: { recordId: string; locked: boolean }): void
   (e: 'toggle-comments'): void
   (e: 'comment-field', field: MetaField): void
   (e: 'open-automation'): void

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -120,6 +120,12 @@ export interface MetaRecord {
   id: string
   version: number
   data: Record<string, unknown>
+  // Record-locking metadata (top-level, NOT a data field). `canUnlock` is the server-authoritative
+  // per-row gate for showing the unlock action; only meaningful when `locked` is true.
+  locked?: boolean
+  lockedBy?: string | null
+  lockedAt?: string | null
+  canUnlock?: boolean
 }
 
 // --- Pagination ---

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -57,6 +57,9 @@ export type MetaCoreLabelKey =
   | 'grid.aggregateTooLarge'
   | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
   | 'grid.collapseRow' | 'grid.expandRow'
+  // --- Record locking (design #2278 follow-up) ---
+  | 'grid.lockRow' | 'grid.unlockRow' | 'grid.lockedIndicator'
+  | 'grid.errorLockRow' | 'grid.errorUnlockRow'
   | 'grid.prev' | 'grid.next' | 'grid.loading'
   | 'grid.errorLoadViewData'
   | 'grid.errorEditRowBlocked' | 'grid.errorDeleteRowBlocked'
@@ -160,6 +163,11 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.noMatchingHint': { en: 'Try a different search term', zh: '试试其他搜索词' },
   'grid.collapseRow': { en: 'Collapse row', zh: '收起行' },
   'grid.expandRow': { en: 'Expand row', zh: '展开行' },
+  'grid.lockRow': { en: 'Lock row', zh: '锁定此行' },
+  'grid.unlockRow': { en: 'Unlock row', zh: '解锁此行' },
+  'grid.lockedIndicator': { en: 'Row is locked', zh: '该行已锁定' },
+  'grid.errorLockRow': { en: 'Failed to lock row', zh: '锁定行失败' },
+  'grid.errorUnlockRow': { en: 'Failed to unlock row', zh: '解锁行失败' },
   'grid.prev': { en: 'Prev', zh: '上一页' },
   'grid.next': { en: 'Next', zh: '下一页' },
   'grid.loading': { en: 'Loading data', zh: '正在加载数据' },

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -30,6 +30,9 @@ export type MetaRecordLabelKey =
   | 'record.comments'
   | 'record.workflow' | 'record.workflowTitle'
   | 'record.permissions' | 'record.permissionsTitle'
+  // --- Record locking (design #2278 follow-up) ---
+  | 'record.locked' | 'record.lockedBy' | 'record.lockedAt'
+  | 'record.lock' | 'record.unlock'
   | 'record.delete' | 'record.close'
   | 'record.tabsAria'
   | 'record.details' | 'record.history'
@@ -61,6 +64,11 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.workflowTitle': { en: 'Open workflow designer', zh: '打开工作流设计器' },
   'record.permissions': { en: 'Permissions', zh: '权限' },
   'record.permissionsTitle': { en: 'Record Permissions', zh: '记录权限' },
+  'record.locked': { en: 'This record is locked', zh: '该记录已锁定' },
+  'record.lockedBy': { en: 'Locked by', zh: '锁定人' },
+  'record.lockedAt': { en: 'Locked at', zh: '锁定时间' },
+  'record.lock': { en: 'Lock', zh: '锁定' },
+  'record.unlock': { en: 'Unlock', zh: '解锁' },
   'record.delete': { en: 'Delete', zh: '删除' },
   'record.close': { en: 'Close record drawer', zh: '关闭记录抽屉' },
   'record.tabsAria': { en: 'Record drawer sections', zh: '记录抽屉分区' },

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -29,6 +29,7 @@ export type WorkbenchLabelKey =
   // §3.5 static (non-interpolated) toast subset
   | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
   | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted'
+  | 'toast.recordLocked' | 'toast.recordUnlocked' | 'toast.recordLockFailed'
   | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
   | 'toast.commentUpdated' | 'toast.commentAdded'
   | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
@@ -122,6 +123,9 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.datesUpdated': { en: 'Dates updated', zh: '日期已更新' },
   'toast.hierarchyUpdated': { en: 'Hierarchy updated', zh: '层级已更新' },
   'toast.recordDeleted': { en: 'Record deleted', zh: '记录已删除' },
+  'toast.recordLocked': { en: 'Record locked', zh: '记录已锁定' },
+  'toast.recordUnlocked': { en: 'Record unlocked', zh: '记录已解锁' },
+  'toast.recordLockFailed': { en: 'Failed to update record lock', zh: '更新锁定状态失败' },
   'toast.loadedLatest': { en: 'Loaded the latest row state', zh: '已加载最新行状态' },
   'toast.changeReapplied': { en: 'Change reapplied', zh: '修改已重新应用' },
   'toast.recordUpdated': { en: 'Record updated', zh: '记录已更新' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -269,6 +269,7 @@
           @set-aggregation="onSetAggregation"
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
+          @toggle-lock="onToggleRecordLock"
           @ai-run="onGridAiRun"
         />
       </div>
@@ -287,6 +288,7 @@
         :ai-shortcut="aiShortcut.state"
         @close="onCloseDrawer" @delete="onDeleteRecord" @patch="onDrawerPatch"
         @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker"
+        @toggle-lock="onToggleRecordLock"
         @navigate="onDrawerNavigate"
         @ai-preview="onAiPreviewField" @ai-run="onAiRunField"
       />
@@ -1510,6 +1512,19 @@ async function onDeleteRecord() {
     return
   }
   if (grid.error.value) showError(grid.error.value)
+}
+
+async function onToggleRecordLock(payload: { recordId: string; locked: boolean }) {
+  try {
+    await workbench.client.setRecordLock(payload.recordId, payload.locked, {
+      sheetId: workbench.activeSheetId.value || undefined,
+      viewId: workbench.activeViewId.value || undefined,
+    })
+    showSuccess(wb(payload.locked ? 'toast.recordLocked' : 'toast.recordUnlocked', isZh.value))
+    await grid.loadViewData(grid.page.value.offset)
+  } catch (error) {
+    showError((error as Error)?.message ?? wb('toast.recordLockFailed', isZh.value))
+  }
 }
 
 async function onReloadConflict() {

--- a/apps/web/tests/meta-grid-table-record-lock.spec.ts
+++ b/apps/web/tests/meta-grid-table-record-lock.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * LR-T9 — record-lock indicator + action visibility in MetaGridTable (design #2278 follow-up).
+ *
+ * Asserts:
+ *  - a locked row renders the lock indicator (read-only visual)
+ *  - the lock/unlock action visibility follows the server-authoritative `canUnlock` per row:
+ *      · locked row + canUnlock=true  → unlock action shown
+ *      · locked row + canUnlock=false → no unlock action
+ *      · unlocked row + canEdit       → lock action shown
+ *  - toggling the action emits `toggle-lock` with the inverse locked state
+ *  - a locked row's cells are not editable (no edit cell on dblclick)
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+let emitted: Array<{ recordId: string; locked: boolean }> = []
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  emitted = []
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 'title', name: 'Title', type: 'string' }
+
+function mountGrid(rows: MetaRecord[], props: Record<string, unknown> = {}) {
+  // Tear down any prior mount so a test that mounts twice (e.g. canUnlock true vs false) does not leak
+  // a stale container that pollutes the next querySelector.
+  app?.unmount()
+  container?.remove()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  emitted = []
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows,
+        visibleFields: [TITLE_FIELD],
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        canDelete: true,
+        canBulkEdit: true,
+        enableMultiSelect: true,
+        searchText: '',
+        rowDensity: 'normal',
+        canComment: true,
+        'onToggle-lock': (payload: { recordId: string; locked: boolean }) => emitted.push(payload),
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaGridTable record locking (LR-T9)', () => {
+  it('renders a lock indicator on a locked row', () => {
+    const rows: MetaRecord[] = [{ id: 'r1', version: 1, data: { title: 'Locked' }, locked: true, lockedBy: 'u1', canUnlock: false }]
+    const root = mountGrid(rows)
+    expect(root.querySelector('[data-test="row-lock-indicator"]')).toBeTruthy()
+  })
+
+  it('does NOT render a lock indicator on an unlocked row', () => {
+    const rows: MetaRecord[] = [{ id: 'r1', version: 1, data: { title: 'Open' } }]
+    const root = mountGrid(rows)
+    expect(root.querySelector('[data-test="row-lock-indicator"]')).toBeNull()
+  })
+
+  it('shows the unlock action only when canUnlock is true on a locked row', () => {
+    const canUnlock = mountGrid([
+      { id: 'r1', version: 1, data: { title: 'L' }, locked: true, lockedBy: 'me', canUnlock: true },
+    ])
+    expect(canUnlock.querySelector('[data-test="row-lock-action"]')).toBeTruthy()
+
+    const cannotUnlock = mountGrid([
+      { id: 'r1', version: 1, data: { title: 'L' }, locked: true, lockedBy: 'other', canUnlock: false },
+    ])
+    expect(cannotUnlock.querySelector('[data-test="row-lock-action"]')).toBeNull()
+  })
+
+  it('shows the lock action on an unlocked editable row', () => {
+    const root = mountGrid([{ id: 'r1', version: 1, data: { title: 'Open' } }])
+    expect(root.querySelector('[data-test="row-lock-action"]')).toBeTruthy()
+  })
+
+  it('emits toggle-lock with the inverse locked state when clicked', async () => {
+    const root = mountGrid([{ id: 'r1', version: 1, data: { title: 'L' }, locked: true, canUnlock: true }])
+    const btn = root.querySelector('[data-test="row-lock-action"]') as HTMLButtonElement | null
+    expect(btn).toBeTruthy()
+    btn!.click()
+    await nextTick()
+    expect(emitted).toEqual([{ recordId: 'r1', locked: false }])
+  })
+
+  it('does not start a cell edit on a locked row (read-only visual)', async () => {
+    const root = mountGrid([{ id: 'r1', version: 1, data: { title: 'L' }, locked: true, canUnlock: false }])
+    const cell = root.querySelector('tbody tr .meta-grid__cell') as HTMLElement | null
+    expect(cell).toBeTruthy()
+    cell!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    await nextTick()
+    // no editor mounted → the read-only class stays and no <input>/editor appears in the cell
+    expect(cell!.querySelector('.meta-grid__cell--editing')).toBeNull()
+    expect(cell!.classList.contains('meta-grid__cell--readonly')).toBe(true)
+  })
+})

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -308,7 +308,7 @@ describe('MetaAutomationRuleEditor', () => {
       .toBe('记录 {{recordId}} 已变更。状态：{{record.status}}')
   })
 
-  it('does not offer unsupported lock_record actions for new automation rules', async () => {
+  it('offers lock_record as a first-class action for new automation rules', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flushPromises()
 
@@ -322,10 +322,13 @@ describe('MetaAutomationRuleEditor', () => {
     expect(actionValues).toContain('send_dingtalk_group_message')
     expect(actionValues).toContain('send_dingtalk_person_message')
     expect(actionValues).toContain('wait_for_callback')
-    expect(actionValues).not.toContain('lock_record')
+    // rank 8: lock_record is now a complete contract → re-exposed as a selectable, enabled action.
+    expect(actionValues).toContain('lock_record')
+    const lockOption = Array.from(actionSelect.options).find((option) => option.value === 'lock_record')
+    expect(lockOption?.disabled).toBe(false)
   })
 
-  it('keeps existing lock_record actions visible but disabled for compatibility', async () => {
+  it('keeps existing lock_record actions selectable and enabled', async () => {
     const { container } = mount({
       visible: true,
       sheetId: 'sheet_1',
@@ -342,7 +345,9 @@ describe('MetaAutomationRuleEditor', () => {
     const lockOption = Array.from(actionSelect.options).find((option) => option.value === 'lock_record')
     expect(actionSelect.value).toBe('lock_record')
     expect(lockOption).toBeTruthy()
-    expect(lockOption?.disabled).toBe(true)
+    // rank 8: lock_record is a complete contract → the existing rule's option stays selectable & enabled
+    // (previously hidden behind the #2278 stop-gap that disabled the then-broken action).
+    expect(lockOption?.disabled).toBe(false)
   })
 
   it('localizes test-run warning and confirm text while leaving runtime status messages raw', async () => {

--- a/packages/core-backend/src/db/migrations/zzzz20260612140000_add_meta_record_locked.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260612140000_add_meta_record_locked.ts
@@ -1,0 +1,34 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * Record locking storage (design #2278 follow-up — lock_record storage contract).
+ *
+ * `executeLockRecord` historically UPDATEd a non-existent `meta_records.locked` column,
+ * so the automation crashed at runtime (#2278 only hid the action from the rule-editor
+ * dropdown). This adds the three backing columns so the action — plus the manual
+ * lock/unlock write-path guard — has a real store.
+ *
+ * Decision a = whole-record lock (no per-field granularity).
+ * Decision c = ONE shared column set for both manual and automation locks.
+ * Existing rows default to `locked = false` (NOT NULL DEFAULT false).
+ *
+ * `locked_by` carries the locking actor id (or 'system' for an actor-less automation run)
+ * and is indexed mirroring the `modified_by` precedent
+ * (zzzz20260430163000_add_meta_record_modified_by.ts).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS locked boolean NOT NULL DEFAULT false`.execute(db)
+  await sql`ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS locked_by text`.execute(db)
+  await sql`ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS locked_at timestamptz`.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_locked_by
+    ON meta_records(locked_by)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_records_locked_by`.execute(db)
+  await sql`ALTER TABLE meta_records DROP COLUMN IF EXISTS locked_at`.execute(db)
+  await sql`ALTER TABLE meta_records DROP COLUMN IF EXISTS locked_by`.execute(db)
+  await sql`ALTER TABLE meta_records DROP COLUMN IF EXISTS locked`.execute(db)
+}

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -96,6 +96,7 @@ export async function backfillAutoNumberField(
   // row-level locks atomically as it executes, so no separate
   // SELECT ... FOR UPDATE is required.
   const overwrite = opts?.overwrite === true
+  // lock-exempt: system auto-number backfill — system-derived sequence value, no user actor.
   const updated = await query(
     `UPDATE meta_records mr
      SET data = jsonb_set(

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
 import { redactString } from './automation-log-redact'
+import { ensureRecordNotLocked } from './record-lock'
 import {
   DingTalkBusinessError,
   DingTalkRequestError,
@@ -1462,6 +1463,22 @@ export class AutomationExecutor {
     const patch = Object.fromEntries(Object.entries(fields))
 
     try {
+      // Record-lock guard (rank-8 review B1; decisions d/e/f). An automation acting on behalf of its
+      // actor is NOT implicitly the locker/owner — overwriting a locked record is blocked. To write
+      // through a lock the rule must first run a `lock_record{locked:false}` action (decision f). The
+      // step fails honestly so it surfaces in the execution log.
+      const lockRes = await this.deps.queryFn(
+        'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [context.recordId, context.sheetId],
+      )
+      const lockRow = lockRes.rows[0] as
+        | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
+        | undefined
+      if (lockRow) {
+        ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
+      }
+
+      // lock-guarded: automation update_record (B1) — ensureRecordNotLocked enforced just above.
       await this.deps.queryFn(
         `UPDATE meta_records
          SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb,
@@ -2047,7 +2064,7 @@ export class AutomationExecutor {
 
     try {
       if (locked) {
-        // LOCK: stamp the locker (rule actor id, or 'system' for an actor-less run) + lock time.
+        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
         await this.deps.queryFn(
           `UPDATE meta_records
@@ -2056,7 +2073,7 @@ export class AutomationExecutor {
           [lockedBy, context.recordId, context.sheetId],
         )
       } else {
-        // UNLOCK: clear lock state.
+        // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2043,14 +2043,27 @@ export class AutomationExecutor {
     config: Record<string, unknown>,
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
-    const locked = config.locked !== false // default to true
+    const locked = config.locked !== false // default to true (decision f: config.locked === false → unlock)
 
     try {
-      await this.deps.queryFn(
-        `UPDATE meta_records SET locked = $1, version = version + 1, updated_at = NOW()
-         WHERE id = $2 AND sheet_id = $3`,
-        [locked, context.recordId, context.sheetId],
-      )
+      if (locked) {
+        // LOCK: stamp the locker (rule actor id, or 'system' for an actor-less run) + lock time.
+        const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
+        await this.deps.queryFn(
+          `UPDATE meta_records
+           SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
+           WHERE id = $2 AND sheet_id = $3`,
+          [lockedBy, context.recordId, context.sheetId],
+        )
+      } else {
+        // UNLOCK: clear lock state.
+        await this.deps.queryFn(
+          `UPDATE meta_records
+           SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
+           WHERE id = $1 AND sheet_id = $2`,
+          [context.recordId, context.sheetId],
+        )
+      }
 
       return {
         actionType: 'lock_record',
@@ -2058,6 +2071,7 @@ export class AutomationExecutor {
         output: { locked, recordId: context.recordId },
       }
     } catch (err) {
+      // Failures surface honestly in the automation execution log instead of crashing the run.
       return { actionType: 'lock_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
     }
   }

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -339,6 +339,7 @@ export class MultitableFormulaEngine {
       // Merge only the computed formula keys (`data || $patch`) so a concurrent
       // write to other fields between this SELECT and UPDATE is not clobbered. No
       // version bump: formula values are derived, not an authoritative user edit.
+      // lock-exempt: system formula materialization — derived value, no user actor (lock = read-only to USERS).
       await query(
         `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
         [JSON.stringify(updates), recordId, sheetId],

--- a/packages/core-backend/src/multitable/query-service.ts
+++ b/packages/core-backend/src/multitable/query-service.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
 import type { MultitableField } from './field-codecs'
+import { mapRecordLockState } from './record-lock'
 
 export type MultitableRecordsQueryFn = (
   sql: string,
@@ -42,6 +43,11 @@ export type LoadedMultitableRecord = {
   modifiedBy?: string | null
   createdAt?: string | null
   updatedAt?: string | null
+  // Record-locking metadata (design #2278 follow-up). TOP-LEVEL — NOT a `data` field, so it is never
+  // swept by the §2a.3 record-data masking.
+  locked: boolean
+  lockedBy: string | null
+  lockedAt: string | null
 }
 
 export type CursorPaginatedResult<T> = {
@@ -230,6 +236,7 @@ function mapRecordRow(row: any, fields: MultitableField[]): LoadedMultitableReco
     ...(modifiedBy !== null ? { modifiedBy } : {}),
     ...(createdAt !== null ? { createdAt } : {}),
     ...(updatedAt !== null ? { updatedAt } : {}),
+    ...mapRecordLockState(row),
   }
 }
 
@@ -290,7 +297,7 @@ export async function queryRecords(
   const offsetParamIndex = offset !== undefined ? params.length : null
 
   const sqlParts = [
-    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by FROM meta_records',
+    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by, locked, locked_by, locked_at FROM meta_records',
     `WHERE ${where.join(' AND ')}`,
     orderSql,
   ]
@@ -361,7 +368,7 @@ export async function queryRecordsWithCursor(
     : `ORDER BY id ${direction}`
 
   const sql = [
-    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by FROM meta_records',
+    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by, locked, locked_by, locked_at FROM meta_records',
     `WHERE ${where.join(' AND ')}`,
     orderSql,
     `LIMIT $${fetchLimitIndex}`,

--- a/packages/core-backend/src/multitable/record-errors.ts
+++ b/packages/core-backend/src/multitable/record-errors.ts
@@ -5,3 +5,12 @@ export class MultitableRecordValidationError extends Error {
 export class MultitableRecordNotFoundError extends Error {
   code = 'NOT_FOUND'
 }
+
+/**
+ * Thrown by the plugin-SDK record API (records.ts) when a caller tries to edit or delete a record that
+ * is locked. The plugin path carries no per-record actor identity, so a locked record is hard read-only
+ * to it (decision d/e) — the lock can only be lifted via the explicit unlock action.
+ */
+export class MultitableRecordLockedError extends Error {
+  code = 'FORBIDDEN'
+}

--- a/packages/core-backend/src/multitable/record-lock.ts
+++ b/packages/core-backend/src/multitable/record-lock.ts
@@ -58,6 +58,48 @@ export function canEditWhileLocked(actorId: string | null, record: LockableRecor
   return false
 }
 
+/** The subset of a persisted record row this guard reads to decide whether a mutation is locked-out. */
+export interface LockGuardRow {
+  locked?: unknown
+  locked_by?: unknown
+  created_by?: unknown
+}
+
+/** Normalize a raw `meta_records` row's lock-relevant columns into a `LockableRecord`. */
+export function lockableFromRow(row: LockGuardRow): LockableRecord {
+  return {
+    lockedBy: typeof row.locked_by === 'string' ? row.locked_by : null,
+    createdBy: typeof row.created_by === 'string' ? row.created_by : null,
+  }
+}
+
+/**
+ * THE ONE record-lock mutation gate (decision d/e/f — centralized after the rank-8 review found the lock
+ * was advisory on three un-enumerated write paths + the plugin SDK). EVERY path that edits or deletes an
+ * existing `meta_records` row by user/rule/plugin intent MUST route through this helper instead of
+ * re-deriving the `locked && !canEditWhileLocked(...)` check inline. A future mutation path that forgets
+ * it trips the durable structural guard (`multitable-record-lock-guard.guard.test.ts`).
+ *
+ *  - `actorId` is the EFFECTIVE actor of the mutation: the request user, the automation's actor, etc.
+ *    A trusted system recompute (formula/auto-number/lookup materialization) is lock-EXEMPT by design
+ *    (the lock means "read-only to USERS"); those paths deliberately do NOT call this.
+ *  - An ACTOR-LESS caller (e.g. the plugin SDK, which carries no per-record actor identity) passes
+ *    `actorId = null`; `canEditWhileLocked(null, …)` is always false, so a locked record is hard
+ *    read-only to it — the lock can only be lifted via the explicit unlock action.
+ *
+ * Throws the error produced by `makeError()` (so each surface keeps its native error type / HTTP shape)
+ * when the row is locked and the actor is not the locker or owner. No-ops otherwise.
+ */
+export function ensureRecordNotLocked(
+  actorId: string | null,
+  row: LockGuardRow,
+  makeError: () => Error,
+): void {
+  if (row.locked !== true) return
+  if (canEditWhileLocked(actorId, lockableFromRow(row))) return
+  throw makeError()
+}
+
 /** Normalize raw DB row lock columns into the wire-facing metadata shape. */
 export function mapRecordLockState(row: {
   locked?: unknown

--- a/packages/core-backend/src/multitable/record-lock.ts
+++ b/packages/core-backend/src/multitable/record-lock.ts
@@ -1,0 +1,79 @@
+import type { MultitableCapabilities } from './sheet-capabilities'
+
+/**
+ * Record locking (design #2278 follow-up — lock_record storage contract).
+ *
+ * A locked record is whole-record read-only: edits and deletes are rejected unless the
+ * actor `canUnlock` it. Comments are a separate path and stay allowed (decision d).
+ *
+ * The three columns round-trip as RECORD-LEVEL METADATA (top-level on the wire), never as
+ * `data` fields — so they are NOT subject to the §2a.3 `filterRecordDataByFieldIds` masking.
+ */
+export interface RecordLockState {
+  locked: boolean
+  lockedBy: string | null
+  lockedAt: string | null
+}
+
+/** The subset of a persisted record row needed to evaluate `canUnlock`. */
+export interface LockableRecord {
+  lockedBy: string | null
+  createdBy: string | null
+}
+
+/**
+ * Decision b: an actor may perform the explicit UNLOCK action when they are any one of:
+ *  - the locker            (`lockedBy === actorId`)
+ *  - the record owner      (`createdBy === actorId`)
+ *  - a sheet admin         (`capabilities.canManageSheetAccess`)
+ *
+ * This gates the unlock ACTION and its frontend visibility — NOT the per-mutation edit-while-locked
+ * bypass. Built purely from existing capability/system fields — zero new primitives.
+ */
+export function canUnlock(
+  actorId: string | null,
+  record: LockableRecord,
+  capabilities: Pick<MultitableCapabilities, 'canManageSheetAccess'>,
+): boolean {
+  if (capabilities.canManageSheetAccess) return true
+  if (!actorId) return false
+  if (record.lockedBy === actorId) return true
+  if (record.createdBy === actorId) return true
+  return false
+}
+
+/**
+ * Decision e — NO silent admin bypass on the WRITE/DELETE path. While a record is locked, only the
+ * locker or the record owner may edit/delete it WITHOUT first unlocking. An admin (sheet-admin) is a
+ * `canUnlock` layer but must explicitly unlock first — they do NOT get an implicit edit-while-locked
+ * pass. This keeps the mutation path free of per-mutation admin-bypass logic (the unlock is the one
+ * explicit place admin authority applies).
+ *
+ * Write/delete guards reject when `locked && !canEditWhileLocked(...)`.
+ */
+export function canEditWhileLocked(actorId: string | null, record: LockableRecord): boolean {
+  if (!actorId) return false
+  if (record.lockedBy === actorId) return true
+  if (record.createdBy === actorId) return true
+  return false
+}
+
+/** Normalize raw DB row lock columns into the wire-facing metadata shape. */
+export function mapRecordLockState(row: {
+  locked?: unknown
+  locked_by?: unknown
+  locked_at?: unknown
+}): RecordLockState {
+  return {
+    locked: row.locked === true,
+    lockedBy: typeof row.locked_by === 'string' ? row.locked_by : null,
+    lockedAt: toIsoLockTimestamp(row.locked_at),
+  }
+}
+
+function toIsoLockTimestamp(value: unknown): string | null {
+  if (value == null) return null
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string') return value
+  return null
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -44,7 +44,7 @@ import {
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
-import { canEditWhileLocked } from './record-lock'
+import { ensureRecordNotLocked } from './record-lock'
 
 export type QueryFn = (
   sql: string,
@@ -689,13 +689,9 @@ export class RecordService {
     }
 
     // Record-lock guard (decision d/e): a locked record cannot be deleted unless the actor is the
-    // locker or owner. No silent admin bypass — an admin must explicitly unlock first.
-    if (recordRow.locked === true && !canEditWhileLocked(actorId, {
-      lockedBy: typeof recordRow.locked_by === 'string' ? recordRow.locked_by : null,
-      createdBy,
-    })) {
-      throw new RecordPermissionError('Record is locked')
-    }
+    // locker or owner. No silent admin bypass — an admin must explicitly unlock first. Routed through
+    // the ONE shared rule (`ensureRecordNotLocked`) so every mutation path enforces it identically.
+    ensureRecordNotLocked(actorId, recordRow, () => new RecordPermissionError('Record is locked'))
 
     await this.pool.transaction(async ({ query }) => {
       const lockedRecordRes = await query(
@@ -734,6 +730,7 @@ export class RecordService {
         snapshot,
       })
 
+      // lock-guarded: single DELETE — ensureRecordNotLocked enforced above (rejects before this txn).
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
     })
 
@@ -935,16 +932,9 @@ export class RecordService {
         throw new RecordPermissionError('Record editing is not allowed for this row')
       }
       // Record-lock guard (decision d/e): a locked record is read-only unless the actor is the locker
-      // or owner. No silent admin bypass — an admin must explicitly unlock first.
-      if (currentRow.locked === true && !canEditWhileLocked(
-        patchActorId,
-        {
-          lockedBy: typeof currentRow.locked_by === 'string' ? currentRow.locked_by : null,
-          createdBy: typeof currentRow.created_by === 'string' ? currentRow.created_by : null,
-        },
-      )) {
-        throw new RecordPermissionError('Record is locked')
-      }
+      // or owner. No silent admin bypass — an admin must explicitly unlock first. Routed through the
+      // ONE shared rule (`ensureRecordNotLocked`) so every mutation path enforces it identically.
+      ensureRecordNotLocked(patchActorId, currentRow, () => new RecordPermissionError('Record is locked'))
 
       const serverVersion = Number(currentRow.version ?? 1)
       if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
@@ -975,6 +965,7 @@ export class RecordService {
       }
 
       if (Object.keys(patch).length > 0) {
+        // lock-guarded: single PATCH — ensureRecordNotLocked enforced above in this txn.
         const updateRes = await query(
           `UPDATE meta_records
            SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -44,6 +44,7 @@ import {
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
+import { canEditWhileLocked } from './record-lock'
 
 export type QueryFn = (
   sql: string,
@@ -667,7 +668,7 @@ export class RecordService {
     const { recordId, expectedVersion, actorId, access, resolveSheetAccess } = input
 
     const recordRes = await this.pool.query(
-      'SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1',
+      'SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1',
       [recordId],
     )
     if (recordRes.rows.length === 0) {
@@ -685,6 +686,15 @@ export class RecordService {
 
     if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) {
       throw new RecordPermissionError('Record deletion is not allowed for this row')
+    }
+
+    // Record-lock guard (decision d/e): a locked record cannot be deleted unless the actor is the
+    // locker or owner. No silent admin bypass — an admin must explicitly unlock first.
+    if (recordRow.locked === true && !canEditWhileLocked(actorId, {
+      lockedBy: typeof recordRow.locked_by === 'string' ? recordRow.locked_by : null,
+      createdBy,
+    })) {
+      throw new RecordPermissionError('Record is locked')
     }
 
     await this.pool.transaction(async ({ query }) => {
@@ -908,7 +918,7 @@ export class RecordService {
     let pendingSubscriberNotification: NotifyRecordSubscribersInput | null = null
     await this.pool.transaction(async ({ query }) => {
       const currentRes = await query(
-        'SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
+        'SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
         [recordId, sheetId],
       )
       if (currentRes.rows.length === 0) {
@@ -923,6 +933,17 @@ export class RecordService {
         'edit',
       )) {
         throw new RecordPermissionError('Record editing is not allowed for this row')
+      }
+      // Record-lock guard (decision d/e): a locked record is read-only unless the actor is the locker
+      // or owner. No silent admin bypass — an admin must explicitly unlock first.
+      if (currentRow.locked === true && !canEditWhileLocked(
+        patchActorId,
+        {
+          lockedBy: typeof currentRow.locked_by === 'string' ? currentRow.locked_by : null,
+          createdBy: typeof currentRow.created_by === 'string' ? currentRow.created_by : null,
+        },
+      )) {
+        throw new RecordPermissionError('Record is locked')
       }
 
       const serverVersion = Number(currentRow.version ?? 1)

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -35,7 +35,7 @@ import {
   notifyRecordSubscribersBestEffort,
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
-import { canEditWhileLocked } from './record-lock'
+import { ensureRecordNotLocked } from './record-lock'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -584,15 +584,14 @@ export class RecordWriteService {
         }
 
         // Record-lock guard (decision d/e): a locked record is read-only unless the actor is the
-        // locker or owner. No silent admin bypass — an admin must explicitly unlock first.
-        if (
-          recordRow?.locked === true &&
-          !canEditWhileLocked(actorId, {
-            lockedBy: typeof recordRow?.locked_by === 'string' ? recordRow.locked_by : null,
-            createdBy: typeof recordRow?.created_by === 'string' ? recordRow.created_by : null,
-          })
-        ) {
-          throw new RecordValidationError(`Record is locked: ${recordId}`, 'FORBIDDEN')
+        // locker or owner. No silent admin bypass — an admin must explicitly unlock first. Routed
+        // through the ONE shared rule (`ensureRecordNotLocked`) so every mutation path matches.
+        if (recordRow) {
+          ensureRecordNotLocked(
+            actorId,
+            recordRow,
+            () => new RecordValidationError(`Record is locked: ${recordId}`, 'FORBIDDEN'),
+          )
         }
 
         const serverVersion = Number(recordRow?.version ?? 1)
@@ -695,7 +694,7 @@ export class RecordWriteService {
           }
         }
 
-        // Apply patch
+        // lock-guarded: bulk/multi-record PATCH — ensureRecordNotLocked enforced per record above.
         const updateRes = await query(
           `UPDATE meta_records
            SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -35,6 +35,7 @@ import {
   notifyRecordSubscribersBestEffort,
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
+import { canEditWhileLocked } from './record-lock'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -562,7 +563,7 @@ export class RecordWriteService {
         )[0]
 
         const recordRes = await query(
-          'SELECT id, version, data, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
+          'SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
           [sheetId, recordId],
         )
         if ((recordRes.rows as any[]).length === 0) {
@@ -580,6 +581,18 @@ export class RecordWriteService {
           )
         ) {
           throw new RecordValidationError(`Record editing is not allowed for ${recordId}`)
+        }
+
+        // Record-lock guard (decision d/e): a locked record is read-only unless the actor is the
+        // locker or owner. No silent admin bypass — an admin must explicitly unlock first.
+        if (
+          recordRow?.locked === true &&
+          !canEditWhileLocked(actorId, {
+            lockedBy: typeof recordRow?.locked_by === 'string' ? recordRow.locked_by : null,
+            createdBy: typeof recordRow?.created_by === 'string' ? recordRow.created_by : null,
+          })
+        ) {
+          throw new RecordValidationError(`Record is locked: ${recordId}`, 'FORBIDDEN')
         }
 
         const serverVersion = Number(recordRow?.version ?? 1)

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -7,6 +7,7 @@ import {
 import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+import { mapRecordLockState } from './record-lock'
 import {
   listRecords as listRecordsViaQueryService,
   queryRecords as queryRecordsViaQueryService,
@@ -392,7 +393,7 @@ export async function getRecord(
   input: GetMultitableRecordInput,
 ): Promise<LoadedMultitableRecord> {
   const recordRes = await input.query(
-    'SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+    'SELECT id, sheet_id, version, data, locked, locked_by, locked_at FROM meta_records WHERE id = $1 AND sheet_id = $2',
     [input.recordId, input.sheetId],
   )
   const row = (recordRes.rows as any[])[0]
@@ -404,6 +405,7 @@ export async function getRecord(
     sheetId: String(row.sheet_id),
     version: Number(row.version ?? 1),
     data: normalizeRecordData(row.data),
+    ...mapRecordLockState(row),
   }
 }
 
@@ -460,6 +462,9 @@ export async function patchRecord(
     sheetId: existing.sheetId,
     version: Number.isFinite(version) ? version : existing.version + 1,
     data: nextData,
+    locked: existing.locked,
+    lockedBy: existing.lockedBy,
+    lockedAt: existing.lockedAt,
   }
 }
 

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -6,8 +6,8 @@ import {
 } from './auto-number-service'
 import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
-import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
-import { mapRecordLockState } from './record-lock'
+import { MultitableRecordLockedError, MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+import { ensureRecordNotLocked, mapRecordLockState } from './record-lock'
 import {
   listRecords as listRecordsViaQueryService,
   queryRecords as queryRecordsViaQueryService,
@@ -427,6 +427,26 @@ export async function queryRecordsWithCursor(
   return queryRecordsWithCursorViaQueryService(input)
 }
 
+/**
+ * Plugin-SDK record-lock chokepoint (rank-8 review M1). The plugin path is actor-less — it carries no
+ * per-record actor — so `ensureRecordNotLocked(null, …)` rejects ANY edit/delete of a locked record
+ * (`canEditWhileLocked(null, …)` is always false). The lock can only be lifted via the explicit unlock
+ * action. Reads the lock columns through the same `query` so it participates in the caller's transaction.
+ */
+async function guardRecordNotLockedForPlugin(
+  query: MultitableRecordsQueryFn,
+  sheetId: string,
+  recordId: string,
+): Promise<void> {
+  const res = await query(
+    'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+    [recordId, sheetId],
+  )
+  const row = res.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
+  if (!row) return // not found — surfaced later by the caller's own missing-row handling
+  ensureRecordNotLocked(null, row, () => new MultitableRecordLockedError('Record is locked'))
+}
+
 export async function patchRecord(
   input: PatchMultitableRecordInput,
 ): Promise<LoadedMultitableRecord> {
@@ -438,12 +458,16 @@ export async function patchRecord(
     sheetId: input.sheetId,
     recordId: input.recordId,
   })
+  // Record-lock guard (rank-8 review M1; decision d/e). The plugin SDK carries no per-record actor
+  // identity → `ensureRecordNotLocked(null, …)` makes a locked record hard read-only to plugins.
+  await guardRecordNotLockedForPlugin(query, input.sheetId, input.recordId)
   const { patch, linkUpdates } = await buildNormalizedPatch(query, fields, input.changes)
   const nextData = {
     ...existing.data,
     ...patch,
   }
 
+  // lock-guarded: plugin-SDK patchRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
   const updated = await query(
     `UPDATE meta_records
      SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -509,8 +533,13 @@ export async function deleteRecord(
   const query = input.query
   await loadSheetAndFields(query, input.sheetId)
 
+  // Record-lock guard (rank-8 review M1; decision d). Actor-less plugin path → a locked record cannot
+  // be deleted via the SDK (it must be unlocked first through the explicit unlock action).
+  await guardRecordNotLockedForPlugin(query, input.sheetId, input.recordId)
+
   await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [input.recordId])
 
+  // lock-guarded: plugin-SDK deleteRecord (M1) — guardRecordNotLockedForPlugin(actor=null) rejected above.
   const deleted = await query(
     `DELETE FROM meta_records
      WHERE id = $1 AND sheet_id = $2

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -141,6 +141,7 @@ import {
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
+import { canUnlock, mapRecordLockState } from '../multitable/record-lock'
 import {
   acquireAutoNumberSheetWriteLock,
   allocateAutoNumberValues,
@@ -297,6 +298,14 @@ type UniverMetaRecord = {
   version: number
   data: Record<string, unknown>
   createdBy?: string | null
+  // Record-locking metadata (design #2278 follow-up). TOP-LEVEL on the wire — NOT a `data` field, so it
+  // is never swept by the §2a.3 `filterRecordDataByFieldIds` / `maskStoredRecordFieldIds` masking.
+  locked?: boolean
+  lockedBy?: string | null
+  lockedAt?: string | null
+  // Server-authoritative per-row unlock gate (decision b) so the grid/drawer can show the unlock
+  // action without exposing `created_by` to the client. Only meaningful when `locked` is true.
+  canUnlock?: boolean
 }
 
 type UniverMetaView = {
@@ -7281,7 +7290,7 @@ export function univerMetaRouter(): Router {
             const limitParamIndex = firstFieldParamIndex + searchableFieldIds.length
             const offsetParamIndex = limitParamIndex + 1
             const recordRes = await pool.query(
-              `SELECT id, version, data, COUNT(*) OVER()::int AS total
+              `SELECT id, version, data, locked, locked_by, locked_at, COUNT(*) OVER()::int AS total
                FROM meta_records
                WHERE sheet_id = $1 AND (${predicate})
                ORDER BY created_at ASC, id ASC
@@ -7293,6 +7302,7 @@ export function univerMetaRouter(): Router {
               id: String(r.id),
               version: Number(r.version ?? 1),
               data: normalizeJson(r.data),
+              ...mapRecordLockState(r),
             }))
 
             let total = Number((recordRes.rows[0] as any)?.total ?? 0)
@@ -7308,7 +7318,7 @@ export function univerMetaRouter(): Router {
             page = { offset, limit, total, hasMore: offset + rows.length < total }
           } else {
             const recordRes = await pool.query(
-              `SELECT id, version, data
+              `SELECT id, version, data, locked, locked_by, locked_at
                FROM meta_records
                WHERE sheet_id = $1 AND (${predicate})
                ORDER BY created_at ASC, id ASC`,
@@ -7319,12 +7329,13 @@ export function univerMetaRouter(): Router {
               id: String(r.id),
               version: Number(r.version ?? 1),
               data: normalizeJson(r.data),
+              ...mapRecordLockState(r),
             }))
           }
         }
       } else if (hasInMemoryProcessing) {
         const recordRes = await pool.query(
-          'SELECT id, version, data, created_at FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC',
+          'SELECT id, version, data, created_at, locked, locked_by, locked_at FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC',
           [sheetId],
         )
 
@@ -7333,6 +7344,7 @@ export function univerMetaRouter(): Router {
           version: Number(r.version ?? 1),
           data: normalizeJson(r.data),
           createdAt: (r as any).created_at as unknown,
+          lock: mapRecordLockState(r),
         }))
 
         const needsComputedFilterSort =
@@ -7399,12 +7411,12 @@ export function univerMetaRouter(): Router {
 
         const total = sorted.length
         const paged = limit ? sorted.slice(offset, offset + limit) : sorted
-        rows = paged.map((r) => ({ id: r.id, version: r.version, data: r.data }))
+        rows = paged.map((r) => ({ id: r.id, version: r.version, data: r.data, ...r.lock }))
         if (limit) page = { offset, limit, total, hasMore: offset + rows.length < total }
       } else {
         if (limit) {
           const recordRes = await pool.query(
-            `SELECT id, version, data, COUNT(*) OVER()::int AS total
+            `SELECT id, version, data, locked, locked_by, locked_at, COUNT(*) OVER()::int AS total
              FROM meta_records
              WHERE sheet_id = $1
              ORDER BY created_at ASC, id ASC
@@ -7416,6 +7428,7 @@ export function univerMetaRouter(): Router {
             id: String(r.id),
             version: Number(r.version ?? 1),
             data: normalizeJson(r.data),
+            ...mapRecordLockState(r),
           }))
 
           let total = Number((recordRes.rows[0] as any)?.total ?? 0)
@@ -7426,7 +7439,7 @@ export function univerMetaRouter(): Router {
           page = { offset, limit, total, hasMore: offset + rows.length < total }
         } else {
           const recordRes = await pool.query(
-            'SELECT id, version, data FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC',
+            'SELECT id, version, data, locked, locked_by, locked_at FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC',
             [sheetId],
           )
 
@@ -7434,6 +7447,7 @@ export function univerMetaRouter(): Router {
             id: String(r.id),
             version: Number(r.version ?? 1),
             data: normalizeJson(r.data),
+            ...mapRecordLockState(r),
           }))
         }
       }
@@ -7529,6 +7543,25 @@ export function univerMetaRouter(): Router {
         sheetScope,
         access,
       )
+      // Per-row unlock gate (decision b): compute `canUnlock` server-side for the LOCKED rows so the
+      // grid/drawer can show the unlock action without the client ever seeing `created_by`. The owner
+      // layer needs each locked row's creator, so load a creator map scoped to just the locked ids.
+      const lockedRowIds = rows.filter((row) => row.locked).map((row) => row.id)
+      if (lockedRowIds.length > 0) {
+        const lockedCreatorMap = await loadRecordCreatorMap(pool.query.bind(pool), sheetId, lockedRowIds)
+        for (const row of rows) {
+          if (!row.locked) continue
+          row.canUnlock = canUnlock(
+            access.userId ?? null,
+            {
+              lockedBy: row.lockedBy ?? null,
+              createdBy: lockedCreatorMap.get(row.id) ?? null,
+            },
+            capabilities,
+          )
+        }
+      }
+
       const viewScopeMap = (access.userId && viewConfig) ? await loadViewPermissionScopeMap(pool.query.bind(pool), [viewConfig.id], access.userId) : new Map()
       const permissions: MultitableScopedPermissions = {
         fieldPermissions: deriveFieldPermissions(fields, capabilities, {
@@ -8288,7 +8321,7 @@ export function univerMetaRouter(): Router {
       const nextVersion = patchResult.version
 
       const recordRes = await pool.query(
-        'SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        'SELECT id, version, data, locked, locked_by, locked_at FROM meta_records WHERE id = $1 AND sheet_id = $2',
         [recordId, sheetId],
       )
       const row: any = recordRes.rows[0]
@@ -8300,6 +8333,7 @@ export function univerMetaRouter(): Router {
         id: String(row.id),
         version: Number(row.version ?? nextVersion),
         data: normalizeJson(row.data),
+        ...mapRecordLockState(row),
       }
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
       // F3 (#2106 §3 F3): the write already happened above; this set gates ONLY the read-back echo, so it must
@@ -8512,7 +8546,15 @@ export function univerMetaRouter(): Router {
       const body = {
         ok: true,
         data: {
-          records: items.map((r) => ({ id: r.id, version: r.version, data: filterRecordDataByFieldIds(r.data, allowedFieldIds) })),
+          records: items.map((r) => ({
+            id: r.id,
+            version: r.version,
+            data: filterRecordDataByFieldIds(r.data, allowedFieldIds),
+            // Lock metadata is TOP-LEVEL (never inside data) — not subject to the §2a.3 data mask.
+            locked: r.locked,
+            lockedBy: r.lockedBy,
+            lockedAt: r.lockedAt,
+          })),
           nextCursor: result.nextCursor,
           hasMore: result.hasMore,
         },
@@ -8555,11 +8597,11 @@ export function univerMetaRouter(): Router {
 
       const recordRes = sheetId
         ? await pool.query(
-          'SELECT id, sheet_id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+          'SELECT id, sheet_id, version, data, created_by, locked, locked_by, locked_at FROM meta_records WHERE id = $1 AND sheet_id = $2',
           [recordId, sheetId],
         )
         : await pool.query(
-          'SELECT id, sheet_id, version, data, created_by FROM meta_records WHERE id = $1',
+          'SELECT id, sheet_id, version, data, created_by, locked, locked_by, locked_at FROM meta_records WHERE id = $1',
           [recordId],
         )
       const row: any = recordRes.rows[0]
@@ -8582,6 +8624,7 @@ export function univerMetaRouter(): Router {
         version: Number(row.version ?? 1),
         data: normalizeJson(row.data),
         createdBy: typeof row.created_by === 'string' ? row.created_by : null,
+        ...mapRecordLockState(row),
       }
 
       const relationalLinkFields = fields
@@ -8642,6 +8685,15 @@ export function univerMetaRouter(): Router {
       })
       const viewPermissions = viewConfig ? deriveViewPermissions([viewConfig], capabilities, viewScopeMap) : {}
       const rowActions = deriveRecordRowActions(capabilities, sheetScope, access, record.createdBy)
+      // Per-row unlock gate (decision b) for the drawer's lock/unlock action. `created_by` is already
+      // resolved on `record` here, so no extra read is needed. Only meaningful while locked.
+      if (record.locked) {
+        record.canUnlock = canUnlock(
+          access.userId ?? null,
+          { lockedBy: record.lockedBy ?? null, createdBy: record.createdBy ?? null },
+          capabilities,
+        )
+      }
 
       return res.json({
         ok: true,
@@ -9297,6 +9349,95 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] delete record failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete record' } })
+    }
+  })
+
+  // Manual record lock / unlock (design #2278 follow-up). `{ locked: true }` LOCKS, `{ locked: false }`
+  // UNLOCKS. Locking requires edit rights on the row (you may protect a row you can edit). Unlocking
+  // requires `canUnlock` (decision b: locker ∨ owner ∨ sheet-admin) — decision e's explicit unlock gate.
+  router.post('/records/:recordId/lock', async (req: Request, res: Response) => {
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
+    }
+    const schema = z.object({
+      locked: z.boolean(),
+      sheetId: z.string().min(1).optional(),
+      viewId: z.string().min(1).optional(),
+    })
+    const parsed = schema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      let sheetId = parsed.data.sheetId
+      if (parsed.data.sheetId || parsed.data.viewId) {
+        const resolved = await resolveMetaSheetId(pool as unknown as { query: QueryFn }, {
+          sheetId: parsed.data.sheetId,
+          viewId: parsed.data.viewId,
+        })
+        sheetId = resolved.sheetId
+      }
+
+      const lookup = sheetId
+        ? await pool.query('SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+        : await pool.query('SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1', [recordId])
+      const recordRow: any = lookup.rows[0]
+      if (!recordRow) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+      sheetId = String(recordRow.sheet_id)
+      const createdBy = typeof recordRow.created_by === 'string' ? recordRow.created_by : null
+
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      const actorId = getRequestActorId(req)
+
+      if (parsed.data.locked) {
+        // LOCK: must be allowed to edit this row.
+        if (!capabilities.canEditRecord || !ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'edit')) {
+          return sendForbidden(res, 'Record editing is not allowed for this row')
+        }
+        const lockedBy = actorId ?? access.userId
+        await pool.query(
+          `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
+           WHERE id = $1 AND sheet_id = $3`,
+          [recordId, lockedBy, sheetId],
+        )
+      } else {
+        // UNLOCK: must pass canUnlock (locker ∨ owner ∨ sheet-admin).
+        if (!canUnlock(actorId ?? access.userId ?? null, {
+          lockedBy: typeof recordRow.locked_by === 'string' ? recordRow.locked_by : null,
+          createdBy,
+        }, capabilities)) {
+          return sendForbidden(res, 'Not allowed to unlock this record')
+        }
+        await pool.query(
+          `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
+           WHERE id = $1 AND sheet_id = $2`,
+          [recordId, sheetId],
+        )
+      }
+
+      const after = await pool.query('SELECT locked, locked_by, locked_at FROM meta_records WHERE id = $1', [recordId])
+      publishMultitableSheetRealtime({
+        spreadsheetId: sheetId,
+        actorId,
+        source: 'multitable',
+        kind: 'record-updated',
+        recordIds: [recordId],
+        fieldIds: [],
+      })
+      return res.json({ ok: true, data: { recordId, ...mapRecordLockState(after.rows[0] as any) } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] lock record failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update record lock state' } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -141,7 +141,7 @@ import {
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
-import { canUnlock, mapRecordLockState } from '../multitable/record-lock'
+import { canUnlock, ensureRecordNotLocked, mapRecordLockState } from '../multitable/record-lock'
 import {
   acquireAutoNumberSheetWriteLock,
   allocateAutoNumberValues,
@@ -3328,6 +3328,7 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
         existing.data[avatarFieldId] !== nextData[avatarFieldId]
 
       if (changed) {
+        // lock-exempt: internal people-directory sync — system sheet, not a user-facing record edit path.
         await query(
           `UPDATE meta_records
            SET data = $1::jsonb, version = version + 1, updated_at = now()
@@ -3822,6 +3823,14 @@ class ValidationError extends Error {
   constructor(public message: string) {
     super(message)
     this.name = 'ValidationError'
+  }
+}
+
+/** Thrown by `ensureRecordNotLocked` on a throw-based route path (form-submit edit) → 403. */
+class RecordLockedError extends Error {
+  constructor(message = 'Record is locked') {
+    super(message)
+    this.name = 'RecordLockedError'
   }
 }
 
@@ -5876,6 +5885,7 @@ export function univerMetaRouter(): Router {
           if (!isUndefinedTableError(err, 'meta_links')) throw err
         }
 
+        // lock-exempt: field-delete schema op — drops the deleted field's key sheet-wide; not a per-record user edit.
         await query('UPDATE meta_records SET data = data - $1 WHERE sheet_id = $2', [fieldId, sheetId])
         await query('UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2', [sheetId, order])
 
@@ -8014,7 +8024,7 @@ export function univerMetaRouter(): Router {
 
         if (recordId) {
           const currentRes = await query(
-            'SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
+            'SELECT id, version, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
             [recordId, view.sheetId],
           )
           if ((currentRes as any).rows.length === 0) {
@@ -8024,12 +8034,16 @@ export function univerMetaRouter(): Router {
           if (!ensureRecordWriteAllowed(effectiveCapabilities, effectiveSheetScope, effectiveAccess, typeof currentRow?.created_by === 'string' ? currentRow.created_by : null, 'edit')) {
             throw new ValidationError('Record editing is not allowed for this row')
           }
+          // Record-lock guard (rank-8 review B2; decision d/e). The form-submit EDIT branch is reachable
+          // only by an authenticated member with edit rights — exactly the non-locker the lock must stop.
+          ensureRecordNotLocked(getRequestActorId(req), currentRow, () => new RecordLockedError())
           const serverVersion = Number(currentRow?.version ?? 1)
           if (typeof parsed.data.expectedVersion === 'number' && parsed.data.expectedVersion !== serverVersion) {
             throw new VersionConflictError(recordId, serverVersion)
           }
 
           if (Object.keys(patch).length > 0) {
+            // lock-guarded: form-submit EDIT (B2) — ensureRecordNotLocked enforced just above.
             const updateRes = await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -8245,6 +8259,9 @@ export function univerMetaRouter(): Router {
       }
       if (err instanceof NotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      if (err instanceof RecordLockedError) {
+        return sendForbidden(res, err.message)
       }
       if (err instanceof ValidationError) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
@@ -9123,6 +9140,23 @@ export function univerMetaRouter(): Router {
           creatorMap.get(attachmentRow.recordId),
           'edit',
         )) return sendForbidden(res, 'Record editing is not allowed for this row')
+        // Record-lock guard (rank-8 review B3; decision d/e). Removing an attachment mutates the
+        // record's `data`, so it is an EDIT — blocked on a locked record for a non-locker/owner.
+        const lockRes = await pool.query(
+          'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+          [attachmentRow.recordId, attachmentRow.sheetId],
+        )
+        const lockRow = lockRes.rows[0] as
+          | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
+          | undefined
+        if (lockRow) {
+          try {
+            ensureRecordNotLocked(getRequestActorId(req), lockRow, () => new RecordLockedError())
+          } catch (lockErr) {
+            if (lockErr instanceof RecordLockedError) return sendForbidden(res, lockErr.message)
+            throw lockErr
+          }
+        }
       } else if (!ensureRecordWriteAllowed(
         sheetCapabilities.capabilities,
         sheetCapabilities.sheetScope,
@@ -9149,6 +9183,7 @@ export function univerMetaRouter(): Router {
             const currentIds = normalizeAttachmentIds(data[fieldId])
             const nextIds = currentIds.filter((id) => id !== attachmentId)
             if (nextIds.length !== currentIds.length) {
+              // lock-guarded: attachment-delete record edit (B3) — ensureRecordNotLocked enforced before this txn.
               const updateRes = await query(
                 `UPDATE meta_records
                  SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -9403,6 +9438,7 @@ export function univerMetaRouter(): Router {
           return sendForbidden(res, 'Record editing is not allowed for this row')
         }
         const lockedBy = actorId ?? access.userId
+        // lock-mgmt: LOCK action — sets the lock columns (own canEditRecord authority above).
         await pool.query(
           `UPDATE meta_records SET locked = true, locked_by = $2, locked_at = NOW(), version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $3`,
@@ -9416,6 +9452,7 @@ export function univerMetaRouter(): Router {
         }, capabilities)) {
           return sendForbidden(res, 'Not allowed to unlock this record')
         }
+        // lock-mgmt: UNLOCK action — clears the lock columns (own canUnlock authority above).
         await pool.query(
           `UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $2`,

--- a/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
@@ -100,7 +100,7 @@ describe('Multitable record and form context API', () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:read', 'comments:write'],
       queryHandler: async (sql, params) => {
-        if (sql.includes('SELECT id, sheet_id, version, data, created_by FROM meta_records WHERE id = $1')) {
+        if (sql.includes('SELECT id, sheet_id, version, data, created_by, locked, locked_by, locked_at FROM meta_records WHERE id = $1')) {
           expect(params).toEqual(['rec_1'])
           return {
             rows: [{
@@ -566,7 +566,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
-        if (sql.includes('SELECT id, sheet_id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+        if (sql.includes('SELECT id, sheet_id, version, data, created_by, locked, locked_by, locked_at FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           expect(params).toEqual(['rec_perm_1', 'sheet_ops'])
           return {
             rows: [{
@@ -602,7 +602,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
-        if (sql.includes('SELECT id, sheet_id, version, data, created_by FROM meta_records WHERE id = $1')) {
+        if (sql.includes('SELECT id, sheet_id, version, data, created_by, locked, locked_by, locked_at FROM meta_records WHERE id = $1')) {
           expect(params).toEqual(['rec_perm_1'])
           return {
             rows: [{
@@ -740,7 +740,7 @@ describe('Multitable record and form context API', () => {
             }
           }
         }
-        if (sql.includes('SELECT id, version, data FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC')) {
+        if (sql.includes('SELECT id, version, data, locked, locked_by, locked_at FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC')) {
           expect(params).toEqual(['sheet_orders'])
           return {
             rows: [
@@ -801,6 +801,10 @@ describe('Multitable record and form context API', () => {
           fld_vendor_link: ['vendor_1'],
           fld_files: ['att_view_1'],
         },
+        // Record-locking metadata now rides top-level on every row (unlocked → false/null).
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
     ])
     expect(response.body.data.linkSummaries).toEqual({
@@ -856,7 +860,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
-        if (sql.includes('SELECT id, version, data, COUNT(*) OVER()::int AS total') && sql.includes('WHERE sheet_id = $1 AND (')) {
+        if (sql.includes('SELECT id, version, data, locked, locked_by, locked_at, COUNT(*) OVER()::int AS total') && sql.includes('WHERE sheet_id = $1 AND (')) {
           expect(params).toEqual(['sheet_orders', '%120%', 'fld_name', 'fld_amount', 1, 0])
           return {
             rows: [
@@ -887,6 +891,9 @@ describe('Multitable record and form context API', () => {
           fld_name: 'Beta rollout',
           fld_amount: 1200,
         },
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
     ])
     expect(response.body.data.page).toEqual({
@@ -1135,7 +1142,7 @@ describe('Multitable record and form context API', () => {
       queryHandler: async (sql, params) => {
         if (
           sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1')
-          || sql.includes('SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1')
+          || sql.includes('SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1')
         ) {
           expect(params).toEqual(['rec_existing'])
           return { rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops' }] }

--- a/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
@@ -1035,9 +1035,9 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual(['sheet_vendors', ['vendor_1']])
           return { rows: [{ id: 'vendor_1' }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_existing', 'sheet_ops'])
-          return { rows: [{ id: 'rec_existing', version: 5 }] }
+          return { rows: [{ id: 'rec_existing', version: 5, created_by: null, locked: false, locked_by: null }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           expect(params).toEqual([JSON.stringify({ fld_title: 'Updated title', fld_vendor_link: ['vendor_1'] }), 'rec_existing', 'sheet_ops'])
@@ -1171,9 +1171,9 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual(['sheet_vendors', ['vendor_1']])
           return { rows: [{ id: 'vendor_1' }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_existing', 'sheet_ops'])
-          return { rows: [{ id: 'rec_existing', version: 3 }] }
+          return { rows: [{ id: 'rec_existing', version: 3, created_by: null, locked: false, locked_by: null }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           expect(params).toEqual([JSON.stringify({ fld_title: 'Patched title', fld_vendor_link: ['vendor_1'] }), 'rec_existing', 'sheet_ops'])

--- a/packages/core-backend/tests/integration/multitable-record-lock-bypass.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-lock-bypass.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Real-DB regression canaries for the rank-8 review — record locking must hold across EVERY mutation
+ * path, not just the three named ones (single PATCH / bulk PATCH / single DELETE, covered by
+ * `multitable-record-lock.test.ts`). The adversarial review found four advisory-only paths:
+ *
+ *  - LRX-B1  automation `update_record` overwrote a locked record (automation-executor.ts)
+ *  - LRX-B2  authenticated form-submit EDIT mode overwrote a locked record (POST /views/:id/submit)
+ *  - LRX-B3  DELETE /attachments/:id removed an attachment from a locked record (an edit of its data)
+ *  - LRX-M1  plugin-SDK bare patchRecord / deleteRecord (records.ts) — actor-less, must be hard read-only
+ *
+ * Each canary seeds a record LOCKED BY THE OWNER, then attempts the mutation as a non-`canEditWhileLocked`
+ * actor (a plain `multitable:write` STRANGER — not locker, owner, or admin) and asserts the mutation is
+ * REJECTED and the row is byte-for-byte unchanged. These FAIL-FIRST on HEAD (the paths bypassed the lock)
+ * and pass once every path routes through `ensureRecordNotLocked`.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { AutomationExecutor } from '../../src/multitable/automation-executor'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { patchRecord, deleteRecord } from '../../src/multitable/records'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_lrx_${TS}`
+const SHEET_ID = `sheet_lrx_${TS}`
+const VIEW_ID = `view_lrx_${TS}`
+const FLD_NAME = `fld_lrx_name_${TS}` // string
+const FLD_ATT = `fld_lrx_att_${TS}` // attachment
+const OWNER_ID = `u_lrx_owner_${TS}` // record creator + locker
+const STRANGER_ID = `u_lrx_stranger_${TS}` // plain write member — not locker/owner/admin → canUnlock=false
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const queryFn = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: STRANGER_ID,
+  roles: ['member'],
+  perms: ['multitable:write'],
+}
+
+const asUser = (id: string, perms: string[], roles: string[] = ['member']) => {
+  currentUser = { id, roles, perms }
+}
+
+const seedLockedRecord = async (recordId: string, name: string, extra: Record<string, unknown> = {}) => {
+  await q(
+    'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
+    [recordId, SHEET_ID, JSON.stringify({ [FLD_NAME]: name, ...extra }), OWNER_ID],
+  )
+  await q(
+    'UPDATE meta_records SET locked = true, locked_by = $2, locked_at = now() WHERE id = $1',
+    [recordId, OWNER_ID], // locked by the OWNER, not the stranger
+  )
+}
+
+const readData = async (recordId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  return (r.rows[0]?.data as Record<string, unknown> | undefined) ?? undefined
+}
+
+describeIfDatabase('record lock — every-mutation-path bypass canaries (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as { user?: unknown }).user = currentUser
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'LRX Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'LRX Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_NAME, SHEET_ID, 'Name', 'string', '{}', 1],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_ATT, SHEET_ID, 'Files', 'attachment', '{}', 2],
+    )
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)',
+      [VIEW_ID, SHEET_ID, 'LRX Form', 'form', '{}'],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM multitable_attachments WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID])
+  })
+
+  test('LRX-B1: automation update_record cannot overwrite a record locked by another actor', async () => {
+    const recId = `rec_lrx_b1_${TS}`
+    await seedLockedRecord(recId, 'before')
+
+    const executor = new AutomationExecutor({ eventBus: new EventBus(), queryFn })
+    const rule = {
+      id: `rule_lrx_b1_${TS}`,
+      name: 'Overwrite rule',
+      sheetId: SHEET_ID,
+      trigger: { type: 'record.updated' as const, config: {} },
+      enabled: true,
+      createdBy: STRANGER_ID,
+      createdAt: '2026-01-01T00:00:00Z',
+      actions: [{ type: 'update_record', config: { fields: { [FLD_NAME]: 'AUTOMATION-OVERWROTE' } } }],
+    }
+    // actorId = the stranger — NOT the locker/owner → must be blocked (decision f: author unlocks first).
+    const triggerEvent = { recordId: recId, sheetId: SHEET_ID, actorId: STRANGER_ID, data: {} }
+
+    const exec = await executor.execute(rule, triggerEvent)
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(String(exec.steps[0]?.error ?? '')).toMatch(/lock/i)
+
+    expect((await readData(recId))?.[FLD_NAME]).toBe('before') // unchanged
+  })
+
+  test('LRX-B2: authenticated form-submit EDIT cannot overwrite a locked record', async () => {
+    const recId = `rec_lrx_b2_${TS}`
+    await seedLockedRecord(recId, 'before')
+    asUser(STRANGER_ID, ['multitable:write'])
+
+    const res = await request(app)
+      .post(`/api/multitable/views/${VIEW_ID}/submit`)
+      .send({ recordId: recId, data: { [FLD_NAME]: 'FORM-OVERWROTE' } })
+    expect(res.status).toBe(403)
+
+    expect((await readData(recId))?.[FLD_NAME]).toBe('before') // unchanged
+  })
+
+  test('LRX-B3: DELETE /attachments cannot remove an attachment from a locked record', async () => {
+    const recId = `rec_lrx_b3_${TS}`
+    const attId = `att_lrx_b3_${TS}`
+    await seedLockedRecord(recId, 'before', { [FLD_ATT]: [attId] })
+    await q(
+      `INSERT INTO multitable_attachments
+         (id, sheet_id, record_id, field_id, storage_file_id, filename, original_name, mime_type, size, storage_path, storage_provider, metadata, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13)`,
+      [attId, SHEET_ID, recId, FLD_ATT, `sf_${attId}`, 'f.txt', 'f.txt', 'text/plain', 3, `/tmp/${attId}`, 'local', '{}', OWNER_ID],
+    )
+    asUser(STRANGER_ID, ['multitable:write'])
+
+    const res = await request(app).delete(`/api/multitable/attachments/${attId}`)
+    expect(res.status).toBe(403)
+
+    // the attachment id is still in the locked record's data AND the row not soft-deleted
+    expect((await readData(recId))?.[FLD_ATT]).toEqual([attId])
+    const att = await q('SELECT deleted_at FROM multitable_attachments WHERE id = $1', [attId])
+    expect((att.rows[0] as { deleted_at: unknown } | undefined)?.deleted_at).toBeNull()
+  })
+
+  test('LRX-M1a: plugin-SDK patchRecord cannot edit a locked record (actor-less → hard read-only)', async () => {
+    const recId = `rec_lrx_m1a_${TS}`
+    await seedLockedRecord(recId, 'before')
+
+    await expect(
+      patchRecord({ query: queryFn, sheetId: SHEET_ID, recordId: recId, changes: { [FLD_NAME]: 'PLUGIN-OVERWROTE' } }),
+    ).rejects.toThrow(/lock/i)
+
+    expect((await readData(recId))?.[FLD_NAME]).toBe('before') // unchanged
+  })
+
+  test('LRX-M1b: plugin-SDK deleteRecord cannot delete a locked record', async () => {
+    const recId = `rec_lrx_m1b_${TS}`
+    await seedLockedRecord(recId, 'keep')
+
+    await expect(
+      deleteRecord({ query: queryFn, sheetId: SHEET_ID, recordId: recId }),
+    ).rejects.toThrow(/lock/i)
+
+    const r = await q('SELECT id FROM meta_records WHERE id = $1', [recId])
+    expect(r.rows.length).toBe(1) // still present
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-record-lock.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-lock.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Real-DB integration test for record locking (design #2278 follow-up — lock_record storage contract).
+ *
+ * The lock_record automation action historically UPDATEd a non-existent `meta_records.locked` column
+ * (crash at runtime; #2278 only hid it from the rule-editor dropdown). This suite is the FAIL-FIRST
+ * canary set for the full storage contract:
+ *  - LR-T1  a locked record rejects an EDIT by a canUnlock=false actor
+ *  - LR-T2  a locked record rejects a DELETE by a canUnlock=false actor
+ *  - LR-T3  comments are a SEPARATE path — a locked record still accepts a comment
+ *  - LR-T4  canUnlock's three layers each individually permit (locker / owner / sheet-admin)
+ *  - LR-T5  executeLockRecord truly writes the lock columns, then truly clears them on unlock
+ *  - LR-T6  an admin is NOT silently bypassed — admin edit on a locked record is rejected until unlock
+ *  - LR-T7  pre-existing rows behave as locked=false (regression)
+ *  - LR-T10 wire-vs-fixture — locked/locked_by round-trip through the REAL records wire (/view + /records)
+ *
+ * (LR-T8 migration up/down lives in the unit suite; LR-T9 frontend lives in apps/web jsdom.)
+ *
+ * The lock columns ride as RECORD-LEVEL METADATA (top-level on the wire), NOT inside `data`, so they
+ * are never swept by §2a.3's `filterRecordDataByFieldIds` masking — LR-T10 asserts that round-trip.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { AutomationExecutor } from '../../src/multitable/automation-executor'
+import { canUnlock } from '../../src/multitable/record-lock'
+import { EventBus } from '../../src/integration/events/event-bus'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_lr_${TS}`
+const SHEET_ID = `sheet_lr_${TS}`
+const FLD_NAME = `fld_lr_name_${TS}` // string
+const OWNER_ID = `u_lr_owner_${TS}` // record creator (created_by)
+const STRANGER_ID = `u_lr_stranger_${TS}` // not locker, not owner, not admin → canUnlock=false
+const ADMIN_ID = `u_lr_admin_${TS}` // sheet admin (multitable:admin)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: STRANGER_ID,
+  roles: ['member'],
+  perms: ['multitable:write'],
+}
+
+const asUser = (id: string, perms: string[], roles: string[] = ['member']) => {
+  currentUser = { id, roles, perms }
+}
+
+const seedRecord = async (recordId: string, createdBy: string | null, name: string) => {
+  await q(
+    'INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)',
+    [recordId, SHEET_ID, JSON.stringify({ [FLD_NAME]: name }), createdBy],
+  )
+}
+
+const lockRow = async (recordId: string, lockedBy: string) => {
+  await q(
+    'UPDATE meta_records SET locked = true, locked_by = $2, locked_at = now() WHERE id = $1',
+    [recordId, lockedBy],
+  )
+}
+
+const patchReq = (recordId: string, body: Record<string, unknown>) =>
+  request(app).patch(`/api/multitable/records/${recordId}`).send(body)
+const deleteReq = (recordId: string) =>
+  request(app).delete(`/api/multitable/records/${recordId}`)
+const viewReq = () =>
+  request(app).get('/api/multitable/view').query({ sheetId: SHEET_ID })
+const listReq = () =>
+  request(app).get('/api/multitable/records').query({ sheetId: SHEET_ID })
+
+const dbLock = async (recordId: string) => {
+  const r = await q('SELECT locked, locked_by, locked_at FROM meta_records WHERE id = $1', [recordId])
+  return r.rows[0] as { locked: boolean; locked_by: string | null; locked_at: unknown } | undefined
+}
+
+describeIfDatabase('record locking (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = currentUser
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'LR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'LR Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_NAME, SHEET_ID, 'Name', 'string', '{}', 1],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID])
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID])
+  })
+
+  test('LR-T1: a locked record rejects an EDIT by a canUnlock=false actor', async () => {
+    const recId = `rec_lr_t1_${TS}`
+    await seedRecord(recId, OWNER_ID, 'before')
+    await lockRow(recId, OWNER_ID) // locked by the owner, NOT the stranger
+    asUser(STRANGER_ID, ['multitable:write'])
+
+    const res = await patchReq(recId, { data: { [FLD_NAME]: 'after' } })
+    expect(res.status).toBe(403)
+
+    // and the value must NOT have changed
+    const r = await q('SELECT data FROM meta_records WHERE id = $1', [recId])
+    expect((r.rows[0]?.data as Record<string, unknown>)?.[FLD_NAME]).toBe('before')
+  })
+
+  test('LR-T2: a locked record rejects a DELETE by a canUnlock=false actor', async () => {
+    const recId = `rec_lr_t2_${TS}`
+    await seedRecord(recId, OWNER_ID, 'keep')
+    await lockRow(recId, OWNER_ID)
+    asUser(STRANGER_ID, ['multitable:write'])
+
+    const res = await deleteReq(recId)
+    expect(res.status).toBe(403)
+
+    const r = await q('SELECT id FROM meta_records WHERE id = $1', [recId])
+    expect(r.rows.length).toBe(1) // still present
+  })
+
+  test('LR-T3: comments are a separate path — a locked record still accepts a comment', async () => {
+    const recId = `rec_lr_t3_${TS}`
+    await seedRecord(recId, OWNER_ID, 'commentable')
+    await lockRow(recId, OWNER_ID)
+
+    // The comment store has no lock awareness and no FK to meta_records: a comment on a locked
+    // record persists exactly as on an unlocked one (decision d — comments bypass the lock guard).
+    const commentId = `cmt_lr_t3_${TS}`
+    await q(
+      `INSERT INTO meta_comments (id, spreadsheet_id, row_id, target_id, container_id, content, author_id)
+       VALUES ($1,$2,$3,$3,$2,$4,$5)`,
+      [commentId, SHEET_ID, recId, 'a comment on a locked record', STRANGER_ID],
+    )
+    const r = await q('SELECT id FROM meta_comments WHERE id = $1', [commentId])
+    expect(r.rows.length).toBe(1)
+  })
+
+  test('LR-T4: canUnlock three layers each individually permit', () => {
+    const caps = { canManageSheetAccess: false }
+    const adminCaps = { canManageSheetAccess: true }
+    const record = { lockedBy: OWNER_ID, createdBy: OWNER_ID }
+
+    // locker
+    expect(canUnlock(OWNER_ID, { lockedBy: OWNER_ID, createdBy: 'someone-else' }, caps)).toBe(true)
+    // owner (locked by a third party)
+    expect(canUnlock(OWNER_ID, { lockedBy: 'someone-else', createdBy: OWNER_ID }, caps)).toBe(true)
+    // sheet admin (neither locker nor owner)
+    expect(canUnlock(ADMIN_ID, { lockedBy: 'x', createdBy: 'y' }, adminCaps)).toBe(true)
+    // none of the three → denied
+    expect(canUnlock(STRANGER_ID, record, caps)).toBe(false)
+  })
+
+  test('LR-T5: executeLockRecord writes the lock columns, then clears them on unlock', async () => {
+    const recId = `rec_lr_t5_${TS}`
+    await seedRecord(recId, OWNER_ID, 'automate-me')
+
+    const executor = new AutomationExecutor({
+      eventBus: new EventBus(),
+      queryFn: (sql: string, params?: unknown[]) => poolManager.get().query(sql, params),
+    })
+
+    const baseRule = {
+      id: `rule_lr_${TS}`,
+      name: 'Lock rule',
+      sheetId: SHEET_ID,
+      trigger: { type: 'record.updated' as const, config: {} },
+      enabled: true,
+      createdBy: ADMIN_ID,
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    const triggerEvent = { recordId: recId, sheetId: SHEET_ID, actorId: ADMIN_ID, data: {} }
+
+    // LOCK
+    const lockExec = await executor.execute(
+      { ...baseRule, actions: [{ type: 'lock_record', config: { locked: true } }] },
+      triggerEvent,
+    )
+    expect(lockExec.steps[0]?.status).toBe('success')
+    const afterLock = await dbLock(recId)
+    expect(afterLock?.locked).toBe(true)
+    expect(afterLock?.locked_by).toBe(ADMIN_ID)
+    expect(afterLock?.locked_at).not.toBeNull()
+
+    // UNLOCK (config.locked === false)
+    const unlockExec = await executor.execute(
+      { ...baseRule, actions: [{ type: 'lock_record', config: { locked: false } }] },
+      triggerEvent,
+    )
+    expect(unlockExec.steps[0]?.status).toBe('success')
+    const afterUnlock = await dbLock(recId)
+    expect(afterUnlock?.locked).toBe(false)
+    expect(afterUnlock?.locked_by).toBeNull()
+    expect(afterUnlock?.locked_at).toBeNull()
+  })
+
+  test('LR-T6: an admin is NOT silently bypassed — admin edit on a locked record is rejected until unlock', async () => {
+    const recId = `rec_lr_t6_${TS}`
+    await seedRecord(recId, OWNER_ID, 'admin-cannot-edit-blindly')
+    await lockRow(recId, OWNER_ID)
+
+    // NOTE: decision e — even an admin must explicitly unlock first. But the admin IS a canUnlock
+    // layer (canManageSheetAccess), so for decision e to be testable the guard must reject a DIRECT
+    // edit when the record is still locked. To isolate "no silent bypass" from "admin can unlock",
+    // this asserts the admin's edit is rejected while locked, then succeeds after an explicit unlock.
+    asUser(ADMIN_ID, ['multitable:admin', 'multitable:write'], ['admin'])
+
+    const blocked = await patchReq(recId, { data: { [FLD_NAME]: 'sneaky' } })
+    expect(blocked.status).toBe(403)
+
+    // explicit unlock (admin clears the lock), then the edit succeeds
+    await q('UPDATE meta_records SET locked = false, locked_by = NULL, locked_at = NULL WHERE id = $1', [recId])
+    const ok = await patchReq(recId, { data: { [FLD_NAME]: 'after-unlock' } })
+    expect(ok.status).toBe(200)
+  })
+
+  test('LR-T7: pre-existing rows behave as locked=false (regression)', async () => {
+    const recId = `rec_lr_t7_${TS}`
+    await seedRecord(recId, STRANGER_ID, 'never-locked')
+    asUser(STRANGER_ID, ['multitable:write'])
+
+    const dbRow = await dbLock(recId)
+    expect(dbRow?.locked).toBe(false)
+
+    // an unlocked record edits freely
+    const res = await patchReq(recId, { data: { [FLD_NAME]: 'edited' } })
+    expect(res.status).toBe(200)
+  })
+
+  test('LR-T10: locked/locked_by round-trip through the real records wire (/view + /records)', async () => {
+    const recId = `rec_lr_t10_${TS}`
+    await seedRecord(recId, OWNER_ID, 'wire-roundtrip')
+    await lockRow(recId, OWNER_ID)
+    asUser(ADMIN_ID, ['multitable:admin', 'multitable:write'], ['admin'])
+
+    // (a) GET /view (primary grid loader)
+    const viewRes = await viewReq()
+    expect(viewRes.status).toBe(200)
+    const viewRow = (viewRes.body.data.rows as Array<Record<string, unknown>>).find((r) => r.id === recId)
+    expect(viewRow).toBeDefined()
+    expect(viewRow?.locked).toBe(true)
+    expect(viewRow?.lockedBy).toBe(OWNER_ID)
+    expect(typeof viewRow?.lockedAt).toBe('string')
+    // lock metadata is TOP-LEVEL, never inside data
+    expect((viewRow?.data as Record<string, unknown>)?.locked).toBeUndefined()
+
+    // (b) GET /records (cursor list)
+    const listRes = await listReq()
+    expect(listRes.status).toBe(200)
+    const listRow = (listRes.body.data.records as Array<Record<string, unknown>>).find((r) => r.id === recId)
+    expect(listRow).toBeDefined()
+    expect(listRow?.locked).toBe(true)
+    expect(listRow?.lockedBy).toBe(OWNER_ID)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -107,10 +107,10 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
           return {
-            rows: [{ id: 'rec_1', version: 7, data: { fld_title: 'Original title' }, created_by: 'user_patch_1' }],
+            rows: [{ id: 'rec_1', version: 7, data: { fld_title: 'Original title' }, created_by: 'user_patch_1', locked: false, locked_by: null }],
           }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
@@ -272,7 +272,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           return { rows: [{ id: 'rec_1', version: 11, data: { fld_title: 'Current' }, created_by: 'user_patch_1' }] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
@@ -325,7 +325,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
           expect(params).toEqual(['sheet_customer', ['rec_c2', 'rec_c3']])
           return { rows: [{ id: 'rec_c2' }, { id: 'rec_c3' }] }
         }
-        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           return {
             rows: [{ id: 'rec_1', version: 2, data: { fld_customer: ['rec_c1', 'rec_c2'] }, created_by: 'user_patch_1' }],
           }
@@ -438,7 +438,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('FROM multitable_attachments') && sql.includes('id = ANY')) {
           return { rows: [{ id: 'att_new_1', field_id: 'fld_files' }] }
         }
-        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           return {
             rows: [{
               id: 'rec_1',

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -238,9 +238,9 @@ describe('Multitable sheet realtime events', () => {
         if (sql.includes('FROM field_permissions')) {
           return { rows: [] }
         }
-        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
           expect(params).toEqual(['sheet_ops', 'rec_1'])
-          return { rows: [{ id: 'rec_1', version: 2, data: { fld_title: 'Original title' }, created_by: 'user_realtime_1' }] }
+          return { rows: [{ id: 'rec_1', version: 2, data: { fld_title: 'Original title' }, created_by: 'user_realtime_1', locked: false, locked_by: null }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('WHERE sheet_id = $2 AND id = $3')) {
           expect(params).toEqual([

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -164,9 +164,9 @@ describe('Multitable sheet realtime events', () => {
         if (sql.includes('SELECT pg_advisory_xact_lock')) {
           return { rows: [] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
-          return { rows: [{ id: 'rec_1', version: 4, created_by: 'user_realtime_1' }] }
+          return { rows: [{ id: 'rec_1', version: 4, created_by: 'user_realtime_1', locked: false, locked_by: null }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           expect(params).toEqual([

--- a/packages/core-backend/tests/unit/meta-record-locked-migration.test.ts
+++ b/packages/core-backend/tests/unit/meta-record-locked-migration.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * LR-T8 — migration up/down clean for the record-locking storage columns
+ * (design #2278 follow-up). Mirrors the modified_by precedent
+ * (zzzz20260430163000_add_meta_record_modified_by.ts): additive columns, indexed
+ * locker, and a `down()` that removes EVERY artifact `up()` created.
+ */
+const MIGRATION = resolve(
+  __dirname,
+  '../../src/db/migrations/zzzz20260612140000_add_meta_record_locked.ts',
+)
+const src = readFileSync(MIGRATION, 'utf8')
+
+describe('meta_records locking columns migration', () => {
+  it('adds locked / locked_by / locked_at to meta_records with the right shapes', () => {
+    expect(src).toMatch(/ADD COLUMN IF NOT EXISTS locked boolean NOT NULL DEFAULT false/)
+    expect(src).toMatch(/ADD COLUMN IF NOT EXISTS locked_by text/)
+    expect(src).toMatch(/ADD COLUMN IF NOT EXISTS locked_at timestamptz/)
+  })
+
+  it('indexes locked_by mirroring the modified_by precedent', () => {
+    expect(src).toMatch(/CREATE INDEX IF NOT EXISTS idx_meta_records_locked_by[\s\S]*ON meta_records\(locked_by\)/)
+  })
+
+  it('down() removes every artifact up() created (clean rollback)', () => {
+    expect(src).toContain('DROP INDEX IF EXISTS idx_meta_records_locked_by')
+    expect(src).toContain('DROP COLUMN IF EXISTS locked_at')
+    expect(src).toContain('DROP COLUMN IF EXISTS locked_by')
+    expect(src).toMatch(/DROP COLUMN IF EXISTS locked\b/)
+    // index dropped before columns, columns dropped in reverse-add order
+    expect(src).toMatch(/down[\s\S]*DROP INDEX[\s\S]*DROP COLUMN IF EXISTS locked_at[\s\S]*DROP COLUMN IF EXISTS locked_by[\s\S]*DROP COLUMN IF EXISTS locked\b/)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-query-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-query-service.test.ts
@@ -48,7 +48,7 @@ describe('multitable query-service', () => {
     ])
 
     await expect(listRecords({ query, sheetId: 'sheet_1' })).resolves.toEqual([
-      { id: 'rec_1', sheetId: 'sheet_1', version: 3, data: { title: 'A' } },
+      { id: 'rec_1', sheetId: 'sheet_1', version: 3, data: { title: 'A' }, locked: false, lockedBy: null, lockedAt: null },
     ])
   })
 
@@ -102,6 +102,9 @@ describe('multitable query-service', () => {
           created_by_sys: 'user_creator',
           modified_by_sys: 'user_editor',
         },
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
     ])
 
@@ -141,7 +144,7 @@ describe('multitable query-service', () => {
 
     const result = await queryRecordsWithCursor({ query, sheetId: 'sheet_1', limit: 1 })
     expect(result.items).toEqual([
-      { id: 'rec_1', sheetId: 'sheet_1', version: 1, data: { title: 'A' } },
+      { id: 'rec_1', sheetId: 'sheet_1', version: 1, data: { title: 'A' }, locked: false, lockedBy: null, lockedAt: null },
     ])
     expect(result.hasMore).toBe(true)
     expect(result.nextCursor).toBe(encodeRecordCursor('rec_1', 'rec_1'))

--- a/packages/core-backend/tests/unit/multitable-record-lock-guard.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-record-lock-guard.guard.test.ts
@@ -1,0 +1,150 @@
+/**
+ * RANK-8 DURABLE STRUCTURAL GUARD — "every record mutation/delete path must enforce the record lock, or
+ * declare itself lock-exempt, by construction".
+ *
+ * The rank-8 review found the record lock was advisory on three un-enumerated write paths
+ * (automation `update_record`, form-submit EDIT, attachment-delete) + the plugin SDK — the named
+ * patch/bulk/delete guards were correct but the lock check had been bolted on one sink at a time, and
+ * new sinks silently bypassed it. The fix centralized the rule into ONE helper (`ensureRecordNotLocked`
+ * in `record-lock.ts`) and routed every path through it. This guard prevents the whack-a-mole from
+ * regressing.
+ *
+ * HOW IT WORKS: it enumerates EVERY `UPDATE meta_records` / `DELETE FROM meta_records` statement across
+ * the audited runtime source files (migrations + tests excluded) and requires each site to carry, on
+ * the line immediately above the SQL, exactly one explicit disposition marker comment:
+ *
+ *   • `// lock-guarded:<reason>`  → GUARDED       — the site routes through the ONE shared lock rule
+ *                                                   (`ensureRecordNotLocked` in record-lock.ts). The
+ *                                                   marker is local so a refactor that moves the guard
+ *                                                   call away from the SQL still keeps the site labelled.
+ *   • `// lock-exempt:<reason>`   → SYSTEM-EXEMPT  — a trusted system recompute / schema op with no user
+ *                                                   actor (formula/auto-number/field-drop/people-sync).
+ *                                                   Lock = "read-only to USERS"; these are not user edits.
+ *   • `// lock-mgmt:<reason>`     → LOCK-MGMT      — the lock/unlock action itself (it carries its own
+ *                                                   canEditRecord / canUnlock authority).
+ *
+ * A NEW or MOVED mutation site with NO marker on the line above its SQL FAILS this test until the
+ * contributor consciously classifies it — forcing them to read this rule and either route through
+ * `ensureRecordNotLocked` (and label it GUARDED) or document why the path is exempt. A future
+ * edit/delete path that forgets the lock guard therefore trips RED by construction, exactly as the
+ * §2a.3 taint chokepoint guard does. A GUARDED label without a real guard call elsewhere is separately
+ * anchored by the cross-check below + the real-DB canaries (`multitable-record-lock-bypass.test.ts`).
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const SRC = join(__dirname, '../../src')
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
+
+/** The audited runtime source files that mutate `meta_records` by id (migrations + tests are excluded:
+ *  migrations are one-shot schema/backfill ops, never a live user/plugin mutation surface). */
+const AUDITED_FILES = [
+  'multitable/records.ts',
+  'multitable/record-service.ts',
+  'multitable/record-write-service.ts',
+  'multitable/automation-executor.ts',
+  'multitable/formula-engine.ts',
+  'multitable/auto-number-service.ts',
+  'routes/univer-meta.ts',
+] as const
+
+/** How many physical lines ABOVE the SQL line the disposition marker may sit (allow a blank/`SET` line). */
+const MARKER_WINDOW = 3
+
+type Disposition = 'GUARDED' | 'SYSTEM-EXEMPT' | 'LOCK-MGMT'
+
+interface Site {
+  file: string
+  line: number // 1-based
+  sql: string
+  disposition: Disposition | null
+}
+
+const MUTATION_RE = /\b(?:UPDATE meta_records|DELETE FROM meta_records)\b/
+
+function classify(window: string): Disposition | null {
+  if (/\/\/\s*lock-guarded:/.test(window)) return 'GUARDED'
+  if (/\/\/\s*lock-exempt:/.test(window)) return 'SYSTEM-EXEMPT'
+  if (/\/\/\s*lock-mgmt:/.test(window)) return 'LOCK-MGMT'
+  return null
+}
+
+function enumerateSites(file: string, src: string): Site[] {
+  const lines = src.split('\n')
+  const sites: Site[] = []
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (!MUTATION_RE.test(line)) continue
+    // skip comments / JSDoc that merely mention the statement
+    const trimmed = line.trimStart()
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+    const windowStart = Math.max(0, i - MARKER_WINDOW)
+    const window = lines.slice(windowStart, i + 1).join('\n')
+    sites.push({ file, line: i + 1, sql: line.trim(), disposition: classify(window) })
+  }
+  return sites
+}
+
+describe('rank-8 record-lock mutation-path guard — durable structural guard', () => {
+  const allSites = AUDITED_FILES.flatMap((file) => enumerateSites(file, read(file)))
+
+  test('the enumeration finds the expected mutation surface (smoke — not zero, not exploded)', () => {
+    // 16 known sites at authoring time (3 services + 1 plugin × 2 + automation update + 2 lock-mgmt ×2
+    // surfaces + univer-meta form/attachment/people/field-drop/lock/unlock + formula + auto-number).
+    // A count change is FINE — it just means you added/removed a mutation site; the per-site assertion
+    // below is the real gate. This bound only flags an extractor that silently matched nothing.
+    expect(allSites.length).toBeGreaterThanOrEqual(14)
+    expect(allSites.length).toBeLessThanOrEqual(40)
+  })
+
+  test('EVERY meta_records UPDATE/DELETE site carries a lock disposition (GUARDED / SYSTEM-EXEMPT / LOCK-MGMT)', () => {
+    const unclassified = allSites.filter((s) => s.disposition === null)
+    expect(
+      unclassified,
+      `RANK-8 LOCK GUARD: ${unclassified.length} meta_records mutation site(s) with NO lock disposition:\n` +
+        unclassified.map((s) => `  - ${s.file}:${s.line}  ${s.sql}`).join('\n') +
+        `\n\nYou added or moved a record mutation/delete path. Within ${MARKER_WINDOW} lines above the SQL, ` +
+        `EITHER route it through ensureRecordNotLocked(...) (GUARDED — the one shared lock rule in ` +
+        `record-lock.ts), OR add a "// lock-exempt:<reason>" marker (trusted system recompute / schema op ` +
+        `with no user actor) OR a "// lock-mgmt:<reason>" marker (the lock/unlock action itself). ` +
+        `A silent unguarded edit/delete of a locked record is exactly the bypass this PR closed.`,
+    ).toEqual([])
+  })
+
+  test('every GUARDED-labelled file actually calls the shared rule (a label cannot fake a guard)', () => {
+    // A `// lock-guarded:` marker must be backed by a real `ensureRecordNotLocked(` call in the SAME file
+    // (directly, or via that file's own local wrapper which itself calls it). This stops a site from
+    // wearing the GUARDED label without enforcing anything. The by-VALUE proof (that the guard truly
+    // rejects a locked-record mutation as a non-locker) lives in the real-DB canaries.
+    const guardedFiles = new Set(
+      allSites.filter((s) => s.disposition === 'GUARDED').map((s) => s.file),
+    )
+    // the four named paths + the two new BLOCKER fixes must be present as GUARDED files
+    for (const f of [
+      'multitable/record-service.ts', // single PATCH + single DELETE
+      'multitable/record-write-service.ts', // bulk PATCH
+      'multitable/records.ts', // plugin SDK (M1)
+      'multitable/automation-executor.ts', // B1 update_record
+      'routes/univer-meta.ts', // B2 form-submit + B3 attachment-delete
+    ]) {
+      expect(guardedFiles.has(f), `${f} should have at least one GUARDED mutation site`).toBe(true)
+    }
+    for (const f of guardedFiles) {
+      expect(
+        read(f).includes('ensureRecordNotLocked('),
+        `${f} is labelled lock-guarded but never calls ensureRecordNotLocked(`,
+      ).toBe(true)
+    }
+  })
+
+  test('ensureRecordNotLocked is the single rule, defined once, used only with explicit error factories', () => {
+    const lockSrc = read('multitable/record-lock.ts')
+    expect(lockSrc).toContain('export function ensureRecordNotLocked(')
+    // exactly one definition
+    expect([...lockSrc.matchAll(/function ensureRecordNotLocked\(/g)].length).toBe(1)
+    // the rule itself is `locked && !canEditWhileLocked` — assert it routes through canEditWhileLocked
+    expect(lockSrc).toMatch(/ensureRecordNotLocked[\s\S]{0,400}canEditWhileLocked\(/)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-records.test.ts
+++ b/packages/core-backend/tests/unit/multitable-records.test.ts
@@ -504,6 +504,9 @@ describe('multitable records helper', () => {
         title: 'Broken compressor',
         priority: 'urgent',
       },
+      locked: false,
+      lockedBy: null,
+      lockedAt: null,
     })
   })
 
@@ -537,6 +540,9 @@ describe('multitable records helper', () => {
         priority: 'urgent',
         refundAmount: 88.5,
       },
+      locked: false,
+      lockedBy: null,
+      lockedAt: null,
     })
   })
 
@@ -571,6 +577,9 @@ describe('multitable records helper', () => {
         priority: 'urgent',
         scheduledAt: null,
       },
+      locked: false,
+      lockedBy: null,
+      lockedAt: null,
     })
   })
 
@@ -658,6 +667,9 @@ describe('multitable records helper', () => {
           title: 'A compressor',
           priority: 'urgent',
         },
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
       {
         id: 'rec_b',
@@ -668,6 +680,9 @@ describe('multitable records helper', () => {
           title: 'B compressor',
           priority: 'normal',
         },
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
     ])
   })
@@ -730,6 +745,9 @@ describe('multitable records helper', () => {
           title: 'Broken compressor',
           priority: 'urgent',
         },
+        locked: false,
+        lockedBy: null,
+        lockedAt: null,
       },
     ])
   })

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -85,9 +85,9 @@ function createMockPool(
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
     }
-    if (sql.includes('SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1')) {
+    if (sql.includes('SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1')) {
       return responses.SELECT_DELETE_RECORD ?? {
-        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1' }],
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1', locked: false, locked_by: null }],
       }
     }
     if (sql.includes('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE')) {
@@ -95,9 +95,9 @@ function createMockPool(
         rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4, data: { fld_title: 'Before' } }],
       }
     }
-    if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+    if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
       return responses.SELECT_PATCH_FOR_UPDATE ?? {
-        rows: [{ id: 'rec_existing', version: 4, data: { fld_title: 'Before' }, created_by: 'user_1' }],
+        rows: [{ id: 'rec_existing', version: 4, data: { fld_title: 'Before' }, created_by: 'user_1', locked: false, locked_by: null }],
       }
     }
     if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -67,8 +67,8 @@ function createMockPool(queryResponses: Record<string, { rows: unknown[] }> = {}
 
   const queryFn = vi.fn(async (sql: string, _params?: unknown[]) => {
     // Match SQL patterns to return the correct responses
-    if (sql.includes('SELECT id, version, data, created_by FROM meta_records') && sql.includes('FOR UPDATE')) {
-      return queryResponses['SELECT_FOR_UPDATE'] ?? { rows: [{ id: 'rec1', version: 1, data: { fld_name: 'Before' }, created_by: 'user1' }] }
+    if (sql.includes('SELECT id, version, data, created_by, locked, locked_by FROM meta_records') && sql.includes('FOR UPDATE')) {
+      return queryResponses['SELECT_FOR_UPDATE'] ?? { rows: [{ id: 'rec1', version: 1, data: { fld_name: 'Before' }, created_by: 'user1', locked: false, locked_by: null }] }
     }
     if (sql.includes('UPDATE meta_records')) {
       return queryResponses['UPDATE'] ?? { rows: [{ version: 2 }] }

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2226,6 +2226,24 @@ components:
         data:
           type: object
           additionalProperties: true
+        locked:
+          type: boolean
+          description: >-
+            Whole-record lock flag (record-locking storage contract). Top-level
+            metadata, never a data field.
+        lockedBy:
+          type: string
+          nullable: true
+          description: User id (or 'system') that locked the record.
+        lockedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp when the record was locked.
+        canUnlock:
+          type: boolean
+          description: >-
+            Server-authoritative per-row unlock gate (locker / owner /
+            sheet-admin). Only meaningful when locked.
     MultitableRecordSubscription:
       type: object
       properties:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3108,6 +3108,24 @@
           "data": {
             "type": "object",
             "additionalProperties": true
+          },
+          "locked": {
+            "type": "boolean",
+            "description": "Whole-record lock flag (record-locking storage contract). Top-level metadata, never a data field."
+          },
+          "lockedBy": {
+            "type": "string",
+            "nullable": true,
+            "description": "User id (or 'system') that locked the record."
+          },
+          "lockedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp when the record was locked."
+          },
+          "canUnlock": {
+            "type": "boolean",
+            "description": "Server-authoritative per-row unlock gate (locker / owner / sheet-admin). Only meaningful when locked."
           }
         }
       },

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2226,6 +2226,24 @@ components:
         data:
           type: object
           additionalProperties: true
+        locked:
+          type: boolean
+          description: >-
+            Whole-record lock flag (record-locking storage contract). Top-level
+            metadata, never a data field.
+        lockedBy:
+          type: string
+          nullable: true
+          description: User id (or 'system') that locked the record.
+        lockedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp when the record was locked.
+        canUnlock:
+          type: boolean
+          description: >-
+            Server-authoritative per-row unlock gate (locker / owner /
+            sheet-admin). Only meaningful when locked.
     MultitableRecordSubscription:
       type: object
       properties:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2059,6 +2059,20 @@ components:
         data:
           type: object
           additionalProperties: true
+        locked:
+          type: boolean
+          description: Whole-record lock flag (record-locking storage contract). Top-level metadata, never a data field.
+        lockedBy:
+          type: string
+          nullable: true
+          description: User id (or 'system') that locked the record.
+        lockedAt:
+          type: string
+          nullable: true
+          description: ISO timestamp when the record was locked.
+        canUnlock:
+          type: boolean
+          description: Server-authoritative per-row unlock gate (locker / owner / sheet-admin). Only meaningful when locked.
     MultitableRecordSubscription:
       type: object
       properties:


### PR DESCRIPTION
Implements the full **lock_record storage contract** (design-lock `docs/development/multitable-lock-record-storage-contract-design-20260611.md`), completing the action that #2278 only hid from the rule-editor dropdown. Today `executeLockRecord` UPDATEs a non-existent `meta_records.locked` column → runtime crash; this builds the real store, the write-path enforcement, the wire round-trip, and re-exposes the action in the UI.

## The 6 design decisions, as-built (owner ratified "按推荐")
| # | Decision | As-built |
|---|---|---|
| a | Lock granularity | **Whole record** |
| b | Unlock permission (`canUnlock`) | **locker ∨ owner ∨ sheet-admin** — gates the unlock *action* + frontend action visibility |
| c | Manual vs automation lock | **Single shared column set** (`locked`/`locked_by`/`locked_at`) |
| d | Lock scope | **Block edits AND deletes; comments still allowed** (comments are a separate path — they never go through `patchRecords`/`deleteRecord`) |
| e | Admin bypass | **No silent bypass** — the write/delete guards reject even an admin's edit while locked; admin must explicitly unlock first |
| f | Unlock trigger | **Manual action + automation unlock** (`config.locked === false`) |

### Reconciling decision e with §2.2's `!canUnlock` prose
§2.2 literally writes the guard as `recordRow.locked && !canUnlock(actor)`, but `canUnlock` includes admin, while decision e + LR-T6 require an admin's edit to be **rejected** while locked. Resolution: a focused **`canEditWhileLocked(actorId, record)` = locker ∨ owner** (no admin) gates the per-mutation write/delete path, while `canUnlock` (locker ∨ owner ∨ admin) gates the explicit unlock action and the frontend action visibility. This keeps the mutation path free of per-mutation admin-bypass logic (decision e's intent) and makes LR-T6 pass.

## Migration / tier
`packages/core-backend/src/db/migrations/zzzz20260612140000_add_meta_record_locked.ts` — **zzzz tier**, sorts strictly after the current highest (`zzzz20260612130000_*`). Adds `locked boolean NOT NULL DEFAULT false`, `locked_by text NULL`, `locked_at timestamptz NULL`, and `idx_meta_records_locked_by`, mirroring the `modified_by` precedent. Clean `down()` (verified live: down→0 cols, up→3 cols, in a rolled-back txn). Existing rows default `locked=false`.

## Wire round-trip (the wire-vs-fixture trap)
Lock state rides as **TOP-LEVEL record metadata, NOT inside `data`** → it is never swept by §2a.3's `filterRecordDataByFieldIds` / `maskStoredRecordFieldIds` masking. Threaded through:
- `GET /view` (the grid loader) — **all 5 SELECT branches** + the `UniverMetaRecord` type
- `GET /records` (cursor list) — `query-service` `mapRecordRow` + `LoadedMultitableRecord` + route serialization
- `GET /records/:recordId` (drawer single-read)
- the **PATCH echo**
A server-authoritative per-row **`canUnlock` boolean** is computed for locked rows (via a creator-map scoped to locked ids) so the client never receives `created_by`. New **`POST /records/:recordId/lock`** route performs manual lock/unlock (lock requires edit rights; unlock requires `canUnlock`).

`LR-T10` proves the columns round-trip through the **real** wire (write→lock→re-read on `/view` + `/records`), and asserts the lock fields are top-level (not in `data`). The §2a.3 mask suites stay green (36 tests) — confirming lock columns don't perturb masking.

## `canUnlock` implementation
`packages/core-backend/src/multitable/record-lock.ts` — pure, zero new primitives: `canUnlock` returns true for `canManageSheetAccess`, else locker (`lockedBy===actor`) ∨ owner (`createdBy===actor`); `canEditWhileLocked` is the same minus the admin layer; `mapRecordLockState` normalizes DB columns → `{locked, lockedBy, lockedAt}` wire shape.

## Frontend (reverse #2278)
- Rule editor: `UNSUPPORTED_SELECTABLE_ACTION_TYPES` now empty → `lock_record` selectable again.
- Grid (`MetaGridTable.vue`): lock indicator (🔒) on locked rows, lock/unlock action shown per `canUnlock`/edit, locked rows made non-editable (`isEditable` returns false). Emits `toggle-lock`.
- Drawer (`MetaRecordDrawer.vue`): lock status banner + locker/time + unlock button (per `canUnlock`).
- `MultitableWorkbench.vue` wires both surfaces to `client.setRecordLock` + reload.
- i18n via existing label modules (`meta-core-labels`, `meta-record-labels`, `workbench-labels`) — no new module.

## Tests — LR-T1..T10, fail-first, RED→GREEN
RED proven first (7 backend failed / 1 passed: missing columns + `executeLockRecord` crash), then GREEN:
- **Backend (real DB, `describeIfDatabase`)** `multitable-record-lock.test.ts`: T1 edit-reject (403), T2 delete-reject (403), T3 comment-still-allowed, T4 canUnlock three layers, T5 automation lock→unlock writes/clears columns, T6 admin not silently bypassed, T7 pre-existing rows = locked false, T10 wire round-trip. **8/8 green.**
- **Migration unit** `meta-record-locked-migration.test.ts` (T8): column shapes + index + clean down(). **3/3 green.**
- **Frontend (jsdom)** `meta-grid-table-record-lock.spec.ts` (T9): indicator + action visibility follows canUnlock + locked-row read-only. **6/6 green.**

## Neighbor suites
§2a.3 mask suites (write-echo / create-echo / cross-sheet / lookup-foreign-mask ×7 / read-field-mask / search-filter-mask), FOL-1 invalidation, records-list-authz — **all green**. `record-service` + `record-write-service` + `automation-v1` unit (249), `multitable-record-patch.api`, `multitable-sheet-realtime.api` — green after updating the mock-string SELECT matchers for the added columns. `tsc --noEmit` (backend) + `vue-tsc -b` (web) clean. OpenAPI `MultitableRecord` schema gains `locked`/`lockedBy`/`lockedAt`/`canUnlock`; `verify:multitable-openapi:parity` green.

## CI wiring
Added `tests/integration/multitable-record-lock.test.ts` to the **enumerated DB-gated list** in `.github/workflows/plugin-tests.yml` (not a glob), so the locking canaries run on the real-DB lane.

## Residual for the reviewer
- `multitable-record-form.api.test.ts` has **8 pre-existing failures on the base commit** (`pg_advisory_xact_lock` / `SELECT id, sheet_id FROM meta_records` mock gaps from prior PRs) — unrelated to this change. My delta touched only the 2 `/view` tests in that file (mock SELECT + the `toEqual` rows expectation now include the top-level lock metadata); verified the failing-test set is **identical to base** (no new regressions).
- `MultitableWorkbench.vue` has a **pre-existing** ESLint error (`'apiFetch' is defined but never used`) on base — left untouched to avoid scope creep.
- The new `POST /records/:recordId/lock` route is not yet in the OpenAPI path list (the response *schema* is covered via `MultitableRecord`); flag if you want the path documented too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)