### PR TITLE
fix(multitable): mask denied rollup counts as null

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2281,6 +2281,8 @@ async function applyLookupRollup(
   ): { values: unknown[]; masked: boolean } => {
     const foreignSheetId = cfg.foreignSheetId ?? linkConfigById.get(cfg.linkFieldId)?.foreignSheetId
     if (!foreignSheetId) return { values: [], masked: false }
+    const linkIds = getLinkIds(record, cfg.linkFieldId)
+    if (linkIds.length === 0) return { values: [], masked: false }
     if (!readableForeignSheetIds.has(foreignSheetId)) return { values: [], masked: true }
     // §2a.3: fail-closed foreign-FIELD mask — if the actor can't read the foreign target field,
     // mask it (cross-base unconditional / same-base default unless opt-out). Same gate for
@@ -2288,8 +2290,6 @@ async function applyLookupRollup(
     if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cfg.targetFieldId, cfg.skipForeignFieldMasking)) {
       return { values: [], masked: true }
     }
-    const linkIds = getLinkIds(record, cfg.linkFieldId)
-    if (linkIds.length === 0) return { values: [], masked: false }
     const foreignMap = foreignRecordsBySheet.get(foreignSheetId)
     if (!foreignMap) return { values: [], masked: true }
     const values: unknown[] = []

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2275,20 +2275,23 @@ async function applyLookupRollup(
     foreignRecordsBySheet.set(foreignSheetId, recordMap)
   }
 
-  const resolveLookupValues = (record: UniverMetaRecord, cfg: LookupFieldConfig | RollupFieldConfig): unknown[] => {
+  const resolveLookupValues = (
+    record: UniverMetaRecord,
+    cfg: LookupFieldConfig | RollupFieldConfig,
+  ): { values: unknown[]; masked: boolean } => {
     const foreignSheetId = cfg.foreignSheetId ?? linkConfigById.get(cfg.linkFieldId)?.foreignSheetId
-    if (!foreignSheetId) return []
-    if (!readableForeignSheetIds.has(foreignSheetId)) return []
+    if (!foreignSheetId) return { values: [], masked: false }
+    if (!readableForeignSheetIds.has(foreignSheetId)) return { values: [], masked: true }
     // §2a.3: fail-closed foreign-FIELD mask — if the actor can't read the foreign target field,
     // mask it (cross-base unconditional / same-base default unless opt-out). Same gate for
     // lookup AND rollup (both read data[targetFieldId]).
     if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cfg.targetFieldId, cfg.skipForeignFieldMasking)) {
-      return []
+      return { values: [], masked: true }
     }
     const linkIds = getLinkIds(record, cfg.linkFieldId)
-    if (linkIds.length === 0) return []
+    if (linkIds.length === 0) return { values: [], masked: false }
     const foreignMap = foreignRecordsBySheet.get(foreignSheetId)
-    if (!foreignMap) return []
+    if (!foreignMap) return { values: [], masked: true }
     const values: unknown[] = []
     for (const id of linkIds) {
       const data = foreignMap.get(id)
@@ -2297,7 +2300,7 @@ async function applyLookupRollup(
       if (value === null || value === undefined) continue
       values.push(value)
     }
-    return values
+    return { values, masked: false }
   }
 
   const aggregateRollup = (values: unknown[], aggregation: RollupAggregation): number | null => {
@@ -2319,7 +2322,7 @@ async function applyLookupRollup(
         row.data[fieldId] = []
         continue
       }
-      row.data[fieldId] = resolveLookupValues(row, cfg)
+      row.data[fieldId] = resolveLookupValues(row, cfg).values
     }
 
     for (const [fieldId, cfg] of rollupConfigs.entries()) {
@@ -2327,8 +2330,8 @@ async function applyLookupRollup(
         row.data[fieldId] = null
         continue
       }
-      const values = resolveLookupValues(row, cfg)
-      row.data[fieldId] = aggregateRollup(values, cfg.aggregation)
+      const { values, masked } = resolveLookupValues(row, cfg)
+      row.data[fieldId] = masked ? null : aggregateRollup(values, cfg.aggregation)
     }
   }
 }

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
@@ -70,11 +70,13 @@ const readRowData = async (): Promise<Record<string, unknown>> => {
 }
 
 const readEmptyRowData = async (): Promise<Record<string, unknown>> => {
-  const res = await request(app).get('/api/multitable/view').query({ sheetId: MS })
+  // Read only the empty-link row so another row in the same response cannot prime the foreign-sheet
+  // readability set. A readable count rollup with no links must still be a concrete 0.
+  const res = await request(app).get(`/api/multitable/records/${REC_M_EMPTY}`).query({ sheetId: MS })
   expect(res.status).toBe(200)
-  const rows = res.body?.data?.rows as Array<{ id: string; data: Record<string, unknown> }>
-  const row = rows.find((r) => r.id === REC_M_EMPTY)
+  const row = res.body?.data?.record as { id: string; data: Record<string, unknown> } | undefined
   expect(row).toBeDefined()
+  expect(row!.id).toBe(REC_M_EMPTY)
   return row!.data
 }
 

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
@@ -55,6 +55,7 @@ const FLD_ROLL_OK_COUNT = `fld_ffm_rok_${TS}` // count rollup over readable same
 const REC_FX = `rec_ffm_fx_${TS}` // cross-base foreign record (XTARGET = 7)
 const REC_FS = `rec_ffm_fs_${TS}` // same-base foreign record (STARGET = 11, SOK = 13)
 const REC_M = `rec_ffm_m_${TS}` // main record linking to both
+const REC_M_EMPTY = `rec_ffm_me_${TS}` // main record with no links; readable count rollup must be 0
 
 let app: Express
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
@@ -64,6 +65,15 @@ const readRowData = async (): Promise<Record<string, unknown>> => {
   expect(res.status).toBe(200)
   const rows = res.body?.data?.rows as Array<{ id: string; data: Record<string, unknown> }>
   const row = rows.find((r) => r.id === REC_M)
+  expect(row).toBeDefined()
+  return row!.data
+}
+
+const readEmptyRowData = async (): Promise<Record<string, unknown>> => {
+  const res = await request(app).get('/api/multitable/view').query({ sheetId: MS })
+  expect(res.status).toBe(200)
+  const rows = res.body?.data?.rows as Array<{ id: string; data: Record<string, unknown> }>
+  const row = rows.find((r) => r.id === REC_M_EMPTY)
   expect(row).toBeDefined()
   return row!.data
 }
@@ -124,6 +134,8 @@ describeIfDatabase('multitable lookup foreign-field mask — read/JSON (GA-T2a, 
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC_M, MS, JSON.stringify({ [FLD_LINK_X]: [REC_FX], [FLD_LINK_S]: [REC_FS] })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_M_EMPTY, MS, JSON.stringify({})])
     await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
       [`lnk_x_${TS}`, FLD_LINK_X, REC_M, REC_FX])
     await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
@@ -186,5 +198,10 @@ describeIfDatabase('multitable lookup foreign-field mask — read/JSON (GA-T2a, 
   test('count rollup over a READABLE foreign field still returns a concrete count', async () => {
     const data = await readRowData()
     expect(data[FLD_ROLL_OK_COUNT]).toBe(1)
+  })
+
+  test('count rollup over a READABLE foreign field with no links returns concrete zero', async () => {
+    const data = await readEmptyRowData()
+    expect(data[FLD_ROLL_OK_COUNT]).toBe(0)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-view.test.ts
@@ -49,6 +49,8 @@ const FLD_LU_X = `fld_ffm_lux_${TS}` // lookup over cross-base denied target
 const FLD_LU_S_DEFAULT = `fld_ffm_lusd_${TS}` // lookup over same-base denied target (default → mask)
 const FLD_LU_S_OPTOUT = `fld_ffm_luso_${TS}` // lookup over same-base denied target WITH opt-out
 const FLD_LU_OK = `fld_ffm_luok_${TS}` // lookup over readable same-base target (must stay present)
+const FLD_ROLL_X_COUNT = `fld_ffm_rxc_${TS}` // count rollup over cross-base denied target
+const FLD_ROLL_OK_COUNT = `fld_ffm_rok_${TS}` // count rollup over readable same-base target
 
 const REC_FX = `rec_ffm_fx_${TS}` // cross-base foreign record (XTARGET = 7)
 const REC_FS = `rec_ffm_fs_${TS}` // same-base foreign record (STARGET = 11, SOK = 13)
@@ -113,6 +115,12 @@ describeIfDatabase('multitable lookup foreign-field mask — read/JSON (GA-T2a, 
     // same-base lookup over a READABLE target → value present (no regression)
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_LU_OK, MS, 'LookupOk', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK_S, targetFieldId: FLD_SOK, foreignSheetId: FS_S }), 6])
+    // count rollup over a denied target must not emit a concrete 0: null means masked/no visible value.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_ROLL_X_COUNT, MS, 'RollupXCount', 'rollup', JSON.stringify({ linkFieldId: FLD_LINK_X, targetFieldId: FLD_XTARGET, foreignSheetId: FS_X, aggregation: 'count' }), 7])
+    // count rollup over a readable target remains a concrete count.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_ROLL_OK_COUNT, MS, 'RollupOkCount', 'rollup', JSON.stringify({ linkFieldId: FLD_LINK_S, targetFieldId: FLD_SOK, foreignSheetId: FS_S, aggregation: 'count' }), 8])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC_M, MS, JSON.stringify({ [FLD_LINK_X]: [REC_FX], [FLD_LINK_S]: [REC_FS] })])
@@ -168,5 +176,15 @@ describeIfDatabase('multitable lookup foreign-field mask — read/JSON (GA-T2a, 
   test('lookup of a READABLE foreign field is unaffected (no regression)', async () => {
     const data = await readRowData()
     expect(data[FLD_LU_OK]).toEqual([13])
+  })
+
+  test('count rollup over a DENIED foreign field is masked as null, not a concrete zero', async () => {
+    const data = await readRowData()
+    expect(data[FLD_ROLL_X_COUNT]).toBeNull()
+  })
+
+  test('count rollup over a READABLE foreign field still returns a concrete count', async () => {
+    const data = await readRowData()
+    expect(data[FLD_ROLL_OK_COUNT]).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- distinguish permission-masked lookup/rollup reads from genuine empty values inside applyLookupRollup
- keep lookup masking as an empty array, but return null for rollups whose foreign sheet/field is masked so count rollups do not emit a misleading concrete 0
- add a real-DB /view regression covering denied count rollup -> null and readable count rollup -> 1

## Verification
- git diff --check
- pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-lookup-foreign-field-mask-view.test.ts --watch=false (skipped locally because DATABASE_URL is not set; CI should exercise the real DB path)

Follow-up to #2549 review P2; #2549 current head already covered the formula taint/read-sink P1 on current main.