### PR TITLE
docs(workflow): sync completion ledger grounding

### DIFF
--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -64,7 +64,7 @@
 - **健壮性闭合**：`/test` 与 retry 的 HTTP serialization invariant 已闭合；log-read failure uses safe fallback, not 500.
 - **锁姿态**：本 A5 v1 closed。后续 retry UI / idempotency / live-record-context 都是新 opt-in，不属于本 closed slice。
 
-### A6 — 收敛引擎（已落 A6-1/A6-2；剩余需求驱动）
+### A6 — 收敛引擎（已落 A6-1/A6-2/A6-3；剩余需求驱动）
 依赖序：**持久 WorkflowJob runtime → suspend/resume（先 webhook 后 delay）→ branch/parallel（DAG）→ BPMN compile/preview adapter → approval-as-job**。
 - **执行细节（per-rung 最小改动集 / 测试面 / gate）**：见 `multitable-automation-a6-execution-plan-20260601.md` 的历史分解；A6-1/A6-2/A6-3 的已落状态、A6-4 的 scope-gate + A6-4a plan、以及仍冻结的后续项，以下方 bullets 和 `…-todo-20260527.md` 清单为准。
 - **A6-0 scout**：`multitable-automation-a6-convergence-scout-20260529.md` 只记录边界/顺序/测试面；它不是 runtime unlock。

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-09
 
-Grounded on: `origin/main@34b0327cf`
+Grounded on: `origin/main@79bda929`
 
 Scope: MetaSheet2 workflow, approval, and multitable automation as one product
 target. This is a completion definition and execution ledger, not a sprint


### PR DESCRIPTION
## Summary
- update the workflow completion plan grounding pointer to origin/main@79bda929 after the W6/W7 gate sync
- update the run-governance A6 heading to include A6-3 as landed
- keep A6-4 and W7 implementation gates unchanged

## Verification
- git diff --check
- docs-only path guard
- rg "Grounded on:|A6 — 收敛引擎" docs/development/workflow-automation-completion-plan-20260609.md docs/development/run-governance-forward-plan-20260528.md

Docs-only. No runtime, routes, schema, tests, or behavior changes.