### PR TITLE
fix(attendance): guard dispatch finalization over generated rows

### DIFF
--- a/packages/core-backend/tests/integration/attendance-schedule-dispatch.test.ts
+++ b/packages/core-backend/tests/integration/attendance-schedule-dispatch.test.ts
@@ -514,6 +514,60 @@ describeDb('schedule-dispatch D1 contract (real DB, route-level)', () => {
     }
   })
 
+  it('reuses an existing target membership as the finalized schedule-dispatch context', async () => {
+    const prefix = `dispatch-membership-reuse-${Date.now().toString(36)}`
+    const token = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const { scheduleGroupId, shiftId } = await seedDispatchTargets(prefix)
+    const approvalFlowId = await seedDispatchFlow(prefix)
+    const userId = `${prefix}-user`
+    const existingMembershipId = randomUUID()
+    const payload = {
+      userId,
+      targetScheduleGroupId: scheduleGroupId,
+      targetShiftId: shiftId,
+      startDate: '2049-08-05',
+      endDate: '2049-08-05',
+      approvalFlowId,
+    }
+    try {
+      await pool.query(
+        `INSERT INTO attendance_schedule_group_members
+         (id, org_id, schedule_group_id, user_id, effective_from, effective_to, role, source)
+         VALUES ($1, $2, $3, $4, '2049-08-01', '2049-08-31', 'member', 'manual')`,
+        [existingMembershipId, ORG, scheduleGroupId, userId],
+      )
+
+      const requestId = await createScheduleDispatchRequest(token, payload)
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(token),
+        body: JSON.stringify({ comment: `${prefix} approve` }),
+      })
+      expect(approve.status, approve.raw).toBe(200)
+
+      const rows = await pool.query(
+        `SELECT d.membership_id,
+                r.metadata -> 'scheduleDispatchFinalization' AS finalization,
+                (SELECT count(*)::int FROM attendance_schedule_group_members
+                  WHERE org_id = $1 AND user_id = $3 AND schedule_group_id = $4) AS membership_count,
+                (SELECT count(*)::int FROM attendance_schedule_group_members
+                  WHERE org_id = $1 AND user_id = $3 AND source = 'schedule_dispatch') AS dispatch_membership_count
+           FROM attendance_schedule_dispatch_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE d.request_id = $2`,
+        [ORG, requestId, userId, scheduleGroupId],
+      )
+      expect(rows.rows[0]).toMatchObject({
+        membership_id: existingMembershipId,
+        membership_count: 1,
+        dispatch_membership_count: 0,
+      })
+      expect(rows.rows[0].finalization).toMatchObject({ membershipId: existingMembershipId })
+    } finally {
+      await cleanupPrefix(prefix)
+    }
+  })
+
   it('closes schedule-dispatch detail rows on reject and cancel without materializing assignments', async () => {
     const prefix = `dispatch-close-${Date.now().toString(36)}`
     const token = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
@@ -1009,6 +1063,72 @@ describeDb('schedule-dispatch D1 contract (real DB, route-level)', () => {
         [ORG, slotOneRequestId],
       )).rows[0]
       expect(slotOneAssignment?.slot_index).toBe(1)
+    } finally {
+      await saveAttendanceSettings(token, { multiShiftDay: { enabled: false, maxSlots: 3 } }).catch(() => undefined)
+      await cleanupPrefix(prefix)
+    }
+  })
+
+  it('blocks final schedule-dispatch approval over protected generated rows even when multi-shift slots do not conflict', async () => {
+    const prefix = `dispatch-protected-row-${Date.now().toString(36)}`
+    const token = await mintToken(`${prefix}-admin`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const { scheduleGroupId, shiftId } = await seedDispatchTargets(prefix)
+    const approvalFlowId = await seedDispatchFlow(prefix)
+    const userId = `${prefix}-user`
+    const protectedShiftId = randomUUID()
+    const protectedAssignmentId = randomUUID()
+    const protectedProducerRunId = randomUUID()
+    try {
+      await saveAttendanceSettings(token, { multiShiftDay: { enabled: true, maxSlots: 2 } })
+      await pool.query(
+        `INSERT INTO attendance_shifts (id, org_id, name, work_start_time, work_end_time)
+         VALUES ($1, $2, $3, '00:00', '01:00')`,
+        [protectedShiftId, ORG, `${prefix}-protected-shift`],
+      )
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+         (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active,
+          publish_status, assignment_kind, producer_type, producer_ref_id, producer_key, producer_run_id)
+         VALUES
+         ($1, $2, $3, $4, 1, '2049-08-26', '2049-08-26', true,
+          'published', 'regular', 'auto_shift_match', $5, $6, $5)`,
+        [protectedAssignmentId, ORG, userId, protectedShiftId, protectedProducerRunId, `${prefix}:auto-shift`],
+      )
+
+      const requestId = await createScheduleDispatchRequest(token, {
+        userId,
+        targetScheduleGroupId: scheduleGroupId,
+        targetShiftId: shiftId,
+        startDate: '2049-08-26',
+        endDate: '2049-08-26',
+        slotIndex: 0,
+        approvalFlowId,
+      })
+      const approve = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/approve`, {
+        method: 'POST',
+        headers: authHeaders(token),
+        body: JSON.stringify({ comment: `${prefix} protected row` }),
+      })
+      expect(approve.status, approve.raw).toBe(409)
+      expect((approve.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULE_DISPATCH_PROTECTED_ASSIGNMENT_CONFLICT')
+
+      const rows = await pool.query(
+        `SELECT r.status AS request_status, d.publish_status,
+                (SELECT count(*)::int FROM attendance_shift_assignments
+                  WHERE org_id = $1 AND producer_type = 'schedule_dispatch' AND producer_ref_id = $2::uuid) AS assignment_count,
+                (SELECT count(*)::int FROM attendance_schedule_group_members
+                  WHERE org_id = $1 AND user_id = $3 AND source = 'schedule_dispatch') AS membership_count
+           FROM attendance_schedule_dispatch_requests d
+           JOIN attendance_requests r ON r.id = d.request_id
+          WHERE d.request_id = $2`,
+        [ORG, requestId, userId],
+      )
+      expect(rows.rows[0]).toMatchObject({
+        request_status: 'pending',
+        publish_status: 'pending',
+        assignment_count: 0,
+        membership_count: 0,
+      })
     } finally {
       await saveAttendanceSettings(token, { multiShiftDay: { enabled: false, maxSlots: 3 } }).catch(() => undefined)
       await cleanupPrefix(prefix)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -22284,6 +22284,7 @@ module.exports = {
     }
 
     const SHIFT_SWAP_PRODUCER_TYPE = 'shift_swap'
+    const SCHEDULE_DISPATCH_PROTECTED_PRODUCER_TYPES = [SHIFT_SWAP_PRODUCER_TYPE, AUTO_SHIFT_MATCH_PRODUCER_TYPE]
 
     function buildShiftSwapReplacementProducerKey(requestId, userId, workDate, slotIndex) {
       return [
@@ -22328,6 +22329,48 @@ module.exports = {
         'ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT',
         getAttendanceScheduleAssignmentConflictMessage(conflict),
         conflict
+      )
+    }
+
+    async function assertScheduleDispatchProtectedRowsAbsent(client, { orgId, detail }) {
+      const rows = await client.query(
+        `SELECT id, assignment_kind, producer_type, slot_index, start_date, end_date
+           FROM attendance_shift_assignments
+          WHERE org_id = $1
+            AND user_id = $2
+            AND COALESCE(is_active, true) = true
+            AND COALESCE(publish_status, 'published') = 'published'
+            AND start_date <= COALESCE($4::date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}')
+            AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+            AND (
+              assignment_kind = 'temporary'
+              OR producer_type = ANY($5::text[])
+            )
+          ORDER BY start_date DESC, created_at DESC, id
+          LIMIT 1`,
+        [
+          orgId,
+          detail.user_id,
+          detail.start_date,
+          detail.end_date,
+          SCHEDULE_DISPATCH_PROTECTED_PRODUCER_TYPES,
+        ]
+      )
+      const row = rows[0]
+      if (!row) return
+      throw new HttpError(
+        409,
+        'SCHEDULE_DISPATCH_PROTECTED_ASSIGNMENT_CONFLICT',
+        'Schedule dispatch cannot be finalized over a protected generated assignment',
+        {
+          conflictType: 'protected_generated_assignment',
+          assignmentId: row.id,
+          assignmentKind: row.assignment_kind ?? 'regular',
+          producerType: row.producer_type ?? null,
+          slotIndex: normalizeAttendanceScheduleSlotIndex(row.slot_index, 0),
+          startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
+          endDate: normalizeAttendanceScheduleAssignmentEndDate(row.end_date),
+        }
       )
     }
 
@@ -22762,17 +22805,18 @@ module.exports = {
     }) {
       await acquireAttendanceScheduleGroupMemberLock(client, orgId, targetGroup.id, detail.user_id)
       const existingRows = await client.query(
-        `SELECT id
+        `SELECT *
            FROM attendance_schedule_group_members
           WHERE org_id = $1
             AND schedule_group_id = $2
             AND user_id = $3
             AND COALESCE(effective_from, DATE '0001-01-01') <= COALESCE($5::date, DATE '9999-12-31')
             AND COALESCE(effective_to, DATE '9999-12-31') >= COALESCE($4::date, DATE '0001-01-01')
+          ORDER BY effective_from NULLS FIRST, effective_to NULLS LAST, id
           LIMIT 1`,
         [orgId, targetGroup.id, detail.user_id, detail.start_date, detail.end_date]
       )
-      if (existingRows.length) return null
+      if (existingRows.length) return existingRows[0]
       const rows = await client.query(
         `INSERT INTO attendance_schedule_group_members (
            org_id, schedule_group_id, user_id, effective_from, effective_to, role,
@@ -22829,6 +22873,7 @@ module.exports = {
       await acquireScheduleDispatchWindowLock(client, orgId, detail.user_id, targetGroup.id, slotResolution.slotIndex)
       await acquireAttendanceScheduleAssignmentLocks(client, orgId, [detail.user_id])
       await enforceScheduleDispatchEditWindow(client, [detail.start_date, detail.end_date])
+      await assertScheduleDispatchProtectedRowsAbsent(client, { orgId, detail })
 
       const draft = {
         kind: 'shift',


### PR DESCRIPTION
## Summary\n- follow-up hardening after #2569: final schedule-dispatch approval now fails closed over protected generated rows\n- blocks active published overlapping rows with assignment_kind='temporary' or producer_type in {shift_swap, auto_shift_match} before materializing the schedule_dispatch assignment\n- records reused target schedule-group membership ids instead of leaving membership_id null when a membership already exists\n\n## Verification\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-schedule-dispatch.test.ts --watch=false --reporter=dot (loads the dedicated spec; skipped locally because no DATABASE_URL)\n- git diff --check origin/main...HEAD\n\n## Notes\n- Scope stays D3 writer hardening only: no UI, no staging smoke, no D4/D5 unlock.\n- Real-DB proof is expected from CI's attendance integration matrix.