### PR TITLE
feat(workflow): expose BPMN compile preview route

### DIFF
--- a/packages/core-backend/src/routes/workflow-designer.ts
+++ b/packages/core-backend/src/routes/workflow-designer.ts
@@ -7,6 +7,7 @@ import type { Request, Response } from 'express';
 import { Router } from 'express'
 import { WorkflowDesigner, type WorkflowDefinition } from '../workflow/WorkflowDesigner'
 import { BPMNWorkflowEngine } from '../workflow/BPMNWorkflowEngine'
+import { compileBpmnPreview } from '../workflow/bpmnCompilePreview'
 import {
   appendWorkflowDraftExecution,
   canDeployWorkflowDraft,
@@ -600,6 +601,7 @@ router.post(
               : [],
             bpmnXml: workflowDefinition.bpmnXml,
             createdBy: userId,
+            sourceMode: 'bpmn_xml',
           })
         : await (async () => {
             const visualDefinition = workflowDefinition as unknown as WorkflowDefinition
@@ -830,6 +832,7 @@ router.put(
           bpmnXml: updates.bpmnXml,
           createdBy: workflow.createdBy,
           status: workflow.status,
+          sourceMode: 'bpmn_xml',
         })
       } else {
         const currentDefinition = await designer.loadWorkflow(id)
@@ -922,6 +925,7 @@ router.post(
         shares: [],
         executions: [],
         visual: workflow.visual,
+        sourceMode: workflow.sourceMode,
       })
 
       await recordWorkflowAnalytics({
@@ -1119,6 +1123,85 @@ router.post(
       })
     }
   }
+)
+
+/**
+ * POST /api/workflow-designer/workflows/:id/compile-preview
+ * Compile a side-effect-free BPMN/visual preview from the saved draft
+ */
+router.post(
+  '/workflows/:id/compile-preview',
+  authenticate,
+  param('id').isString(),
+  validate,
+  async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params
+      const userId = req.user?.id?.toString()
+
+      const workflow = await designer.loadWorkflowDraft(id)
+      if (!workflow) {
+        return res.status(404).json({
+          success: false,
+          error: 'Workflow not found',
+        })
+      }
+
+      if (!hasWorkflowDraftAccess(workflow, userId)) {
+        return res.status(403).json({
+          success: false,
+          error: 'Access denied',
+        })
+      }
+
+      if (workflow.bpmnXml && workflow.sourceMode === 'bpmn_xml') {
+        return res.json({
+          success: true,
+          data: compileBpmnPreview({
+            mode: 'bpmn_xml',
+            workflowId: workflow.id,
+            sourceVersion: workflow.version,
+            bpmnXml: workflow.bpmnXml,
+          }),
+        })
+      }
+
+      if (workflow.visual) {
+        return res.json({
+          success: true,
+          data: compileBpmnPreview({
+            mode: 'visual',
+            workflowId: workflow.id,
+            sourceVersion: workflow.version,
+            visual: workflow.visual,
+          }),
+        })
+      }
+
+      if (workflow.bpmnXml) {
+        return res.json({
+          success: true,
+          data: compileBpmnPreview({
+            mode: 'bpmn_xml',
+            workflowId: workflow.id,
+            sourceVersion: workflow.version,
+            bpmnXml: workflow.bpmnXml,
+          }),
+        })
+      }
+
+      return res.status(400).json({
+        success: false,
+        error: 'Workflow draft has no visual definition or BPMN XML to preview',
+      })
+    } catch (error: unknown) {
+      logger.error('Failed to compile workflow preview:', error as Error)
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to compile workflow preview',
+      })
+    }
+  },
 )
 
 /**

--- a/packages/core-backend/src/workflow/WorkflowDesigner.ts
+++ b/packages/core-backend/src/workflow/WorkflowDesigner.ts
@@ -124,6 +124,23 @@ export interface BpmnWorkflowDraftInput {
   shares?: WorkflowDraftRecord['shares']
   executions?: WorkflowDraftRecord['executions']
   visual?: WorkflowDefinition | null
+  sourceMode?: 'visual' | 'bpmn_xml'
+}
+
+function normalizeBpmnForSourceModeCompare(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function inferWorkflowDraftSourceMode(
+  visual: WorkflowDefinition | null | undefined,
+  bpmnXml: string | undefined,
+  convertVisualToBpmn: (visual: WorkflowDefinition) => string,
+): 'visual' | 'bpmn_xml' | undefined {
+  if (!bpmnXml) return visual ? 'visual' : undefined
+  if (!visual) return 'bpmn_xml'
+  return normalizeBpmnForSourceModeCompare(bpmnXml) === normalizeBpmnForSourceModeCompare(convertVisualToBpmn(visual))
+    ? 'visual'
+    : 'bpmn_xml'
 }
 
 export class WorkflowDesigner extends EventEmitter {
@@ -430,6 +447,7 @@ export class WorkflowDesigner extends EventEmitter {
         tags: definition.tags || existing?.tags || [],
         shares: existing?.shares || [],
         executions: existing?.executions || [],
+        sourceMode: 'visual',
       })
 
       // Save to database using workflow_definitions table
@@ -503,8 +521,12 @@ export class WorkflowDesigner extends EventEmitter {
       }
 
       const record = toWorkflowDraftRecord(workflow)
+      if (!record.sourceMode) {
+        record.sourceMode = inferWorkflowDraftSourceMode(record.visual, record.bpmnXml, (visual) => this.convertToBPMN(visual))
+      }
       if (!record.bpmnXml && record.visual) {
         record.bpmnXml = this.convertToBPMN(record.visual)
+        record.sourceMode = record.sourceMode ?? 'visual'
       }
       return record
     } catch (error) {
@@ -526,6 +548,7 @@ export class WorkflowDesigner extends EventEmitter {
         tags: input.tags || existing?.tags || [],
         shares: input.shares || existing?.shares || [],
         executions: input.executions || existing?.executions || [],
+        sourceMode: input.sourceMode ?? existing?.sourceMode ?? (input.visual ? 'visual' : 'bpmn_xml'),
       })
 
       await db

--- a/packages/core-backend/src/workflow/workflowDesignerDrafts.ts
+++ b/packages/core-backend/src/workflow/workflowDesignerDrafts.ts
@@ -3,6 +3,7 @@ import type { WorkflowDefinition } from './WorkflowDesigner'
 export interface StoredWorkflowDefinitionEnvelope {
   visual?: WorkflowDefinition | null
   bpmn?: string | null
+  sourceMode?: 'visual' | 'bpmn_xml'
   description?: string
   category?: string
   tags?: string[]
@@ -57,6 +58,7 @@ export interface WorkflowDraftRecord {
   category?: string
   tags: string[]
   bpmnXml?: string
+  sourceMode?: 'visual' | 'bpmn_xml'
   visual?: WorkflowDefinition | null
   shares: WorkflowDraftShare[]
   executions: WorkflowDraftExecution[]
@@ -122,6 +124,7 @@ export function parseStoredWorkflowDefinition(definition: unknown): StoredWorkfl
   return {
     visual,
     bpmn: typeof parsed.bpmn === 'string' ? parsed.bpmn : null,
+    sourceMode: parsed.sourceMode === 'bpmn_xml' ? 'bpmn_xml' : parsed.sourceMode === 'visual' ? 'visual' : undefined,
     description: typeof parsed.description === 'string' ? parsed.description : undefined,
     category: typeof parsed.category === 'string' ? parsed.category : undefined,
     tags: Array.isArray(parsed.tags) ? parsed.tags.filter((tag): tag is string => typeof tag === 'string') : [],
@@ -139,10 +142,12 @@ export function buildStoredWorkflowDefinition(input: {
   tags?: string[]
   shares?: WorkflowDraftShare[]
   executions?: WorkflowDraftExecution[]
+  sourceMode?: 'visual' | 'bpmn_xml'
 }): StoredWorkflowDefinitionEnvelope {
   return {
     visual: input.visual ?? null,
     bpmn: input.bpmnXml,
+    sourceMode: input.sourceMode ?? (input.visual ? 'visual' : 'bpmn_xml'),
     description: input.description,
     category: input.category,
     tags: input.tags ?? [],
@@ -167,6 +172,7 @@ export function toWorkflowDraftRecord(row: WorkflowDefinitionRowLike): WorkflowD
     category: stored.category,
     tags: stored.tags ?? [],
     bpmnXml: stored.bpmn ?? undefined,
+    sourceMode: stored.sourceMode,
     visual: stored.visual ?? null,
     shares: stored.shares ?? [],
     executions: stored.executions ?? [],

--- a/packages/core-backend/tests/unit/workflow-designer-compile-preview-route.test.ts
+++ b/packages/core-backend/tests/unit/workflow-designer-compile-preview-route.test.ts
@@ -1,0 +1,283 @@
+import { readFileSync } from 'node:fs'
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeState = vi.hoisted(() => ({
+  user: { id: 'owner-1' } as Record<string, unknown> | null,
+  loadWorkflowDraft: vi.fn(),
+  saveBpmnDraft: vi.fn(),
+  initializeWorkflowEngine: vi.fn(),
+  deployProcess: vi.fn(),
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!routeState.user) {
+      res.status(401).json({ success: false, error: 'Unauthorized' })
+      return
+    }
+    req.user = routeState.user as never
+    next()
+  },
+}))
+
+vi.mock('../../src/db/db', () => ({
+  db: {
+    insertInto: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    selectFrom: vi.fn(),
+    updateTable: vi.fn(),
+    deleteFrom: vi.fn(),
+  },
+}))
+
+vi.mock('../../src/workflow/WorkflowDesigner', () => ({
+  WorkflowDesigner: vi.fn().mockImplementation(() => ({
+    loadWorkflowDraft: routeState.loadWorkflowDraft,
+    loadWorkflow: vi.fn(),
+    saveWorkflow: vi.fn(),
+    saveBpmnDraft: routeState.saveBpmnDraft,
+    validateWorkflow: vi.fn(),
+    deployWorkflow: vi.fn(),
+  })),
+}))
+
+vi.mock('../../src/workflow/BPMNWorkflowEngine', () => ({
+  BPMNWorkflowEngine: vi.fn().mockImplementation(() => ({
+    initialize: routeState.initializeWorkflowEngine,
+    deployProcess: routeState.deployProcess,
+  })),
+}))
+
+function visualWorkflow() {
+  return {
+    id: 'wf_1',
+    name: 'Preview workflow',
+    version: 4,
+    nodes: [
+      {
+        id: 'start',
+        type: 'startEvent',
+        name: 'Start',
+        position: { x: 0, y: 0 },
+        data: {},
+      },
+      {
+        id: 'task_update',
+        type: 'serviceTask',
+        name: 'Update record',
+        position: { x: 120, y: 0 },
+        data: {
+          properties: {
+            actionType: 'update_record',
+            config: { fields: { status: 'done' } },
+          },
+        },
+      },
+      {
+        id: 'end',
+        type: 'endEvent',
+        name: 'End',
+        position: { x: 240, y: 0 },
+        data: {},
+      },
+    ],
+    edges: [
+      { id: 'flow_start_task', source: 'start', target: 'task_update' },
+      { id: 'flow_task_end', source: 'task_update', target: 'end' },
+    ],
+  }
+}
+
+function draft(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf_1',
+    name: 'Preview workflow',
+    description: '',
+    version: 4,
+    status: 'draft',
+    createdBy: 'owner-1',
+    createdAt: new Date('2026-06-13T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-13T00:00:00.000Z'),
+    category: 'automation',
+    tags: [],
+    bpmnXml: undefined,
+    sourceMode: 'visual',
+    visual: visualWorkflow(),
+    shares: [],
+    executions: [],
+    ...overrides,
+  }
+}
+
+async function buildApp() {
+  vi.resetModules()
+  const router = (await import('../../src/routes/workflow-designer')).default
+  const app = express()
+  app.use(express.json())
+  app.use('/api/workflow-designer', router)
+  return app
+}
+
+describe('workflow-designer compile-preview route - A6-4b', () => {
+  beforeEach(() => {
+    routeState.user = { id: 'owner-1' }
+    routeState.loadWorkflowDraft.mockReset()
+    routeState.saveBpmnDraft.mockReset()
+    routeState.initializeWorkflowEngine.mockReset()
+    routeState.deployProcess.mockReset()
+  })
+
+  it('compiles an accessible visual draft without touching the live BPMN engine', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft())
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/compile-preview')
+      .send({})
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.source).toEqual({
+      mode: 'visual',
+      workflowId: 'wf_1',
+      sourceVersion: 4,
+    })
+    expect(res.body.data.automationPreview.actions).toEqual([
+      { type: 'update_record', config: { fields: { status: 'done' } } },
+    ])
+    expect(routeState.initializeWorkflowEngine).not.toHaveBeenCalled()
+    expect(routeState.deployProcess).not.toHaveBeenCalled()
+  })
+
+  it('compiles a BPMN-only draft when no visual definition is stored', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft({
+      visual: null,
+      bpmnXml: [
+        '<definitions>',
+        '<process id="p1">',
+        '<startEvent id="start" />',
+        '<sequenceFlow id="flow_start_end" sourceRef="start" targetRef="end" />',
+        '<endEvent id="end" />',
+        '</process>',
+        '</definitions>',
+      ].join(''),
+    }))
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/compile-preview')
+      .send({})
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.source).toEqual({
+      mode: 'bpmn_xml',
+      workflowId: 'wf_1',
+      sourceVersion: 4,
+    })
+    expect(res.body.data.automationPreview.actions).toEqual([])
+    expect(routeState.initializeWorkflowEngine).not.toHaveBeenCalled()
+    expect(routeState.deployProcess).not.toHaveBeenCalled()
+  })
+
+  it('prefers explicitly saved BPMN XML over a preserved stale visual definition', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft({
+      sourceMode: 'bpmn_xml',
+      bpmnXml: [
+        '<definitions>',
+        '<process id="p1">',
+        '<startEvent id="start" />',
+        '<sequenceFlow id="flow_start_end" sourceRef="start" targetRef="end" />',
+        '<endEvent id="end" />',
+        '</process>',
+        '</definitions>',
+      ].join(''),
+    }))
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/compile-preview')
+      .send({})
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.source).toEqual({
+      mode: 'bpmn_xml',
+      workflowId: 'wf_1',
+      sourceVersion: 4,
+    })
+    expect(res.body.data.automationPreview.actions).toEqual([])
+  })
+
+  it('preserves sourceMode when duplicating a mixed visual and BPMN draft', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft({
+      sourceMode: 'bpmn_xml',
+      bpmnXml: '<definitions><process id="p1" /></definitions>',
+    }))
+    routeState.saveBpmnDraft.mockResolvedValue('wf_copy')
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/duplicate')
+      .send({ name: 'Copy' })
+
+    expect(res.status).toBe(201)
+    expect(routeState.saveBpmnDraft).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Copy',
+      bpmnXml: '<definitions><process id="p1" /></definitions>',
+      visual: visualWorkflow(),
+      sourceMode: 'bpmn_xml',
+    }))
+  })
+
+  it('uses ordinary draft access and rejects users who cannot view the draft', async () => {
+    routeState.user = { id: 'other-user' }
+    routeState.loadWorkflowDraft.mockResolvedValue(draft())
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/compile-preview')
+      .send({})
+
+    expect(res.status).toBe(403)
+    expect(res.body).toMatchObject({ success: false, error: 'Access denied' })
+  })
+
+  it('returns 400 for drafts without visual or BPMN source', async () => {
+    routeState.loadWorkflowDraft.mockResolvedValue(draft({ visual: null, bpmnXml: undefined }))
+    const app = await buildApp()
+
+    const res = await request(app)
+      .post('/api/workflow-designer/workflows/wf_1/compile-preview')
+      .send({})
+
+    expect(res.status).toBe(400)
+    expect(res.body).toMatchObject({
+      success: false,
+      error: 'Workflow draft has no visual definition or BPMN XML to preview',
+    })
+    expect(routeState.initializeWorkflowEngine).not.toHaveBeenCalled()
+    expect(routeState.deployProcess).not.toHaveBeenCalled()
+  })
+
+  it('does not wire deploy, test-run, or persistence calls into the compile-preview route block', () => {
+    const source = readFileSync(new URL('../../src/routes/workflow-designer.ts', import.meta.url), 'utf8')
+    const start = source.indexOf("'/workflows/:id/compile-preview'")
+    const end = source.indexOf("'/workflows/:id/deploy'", start)
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+
+    const routeSource = source.slice(start, end)
+    expect(routeSource).toContain('compileBpmnPreview')
+    expect(routeSource).toContain('hasWorkflowDraftAccess')
+    expect(routeSource).not.toMatch(/ensureWorkflowEngineReady|workflowEngine|deployProcess|startProcess/)
+    expect(routeSource).not.toMatch(/appendWorkflowDraftExecution|recordWorkflowAnalytics/)
+    expect(routeSource).not.toMatch(/saveBpmnDraft|saveWorkflow|deployWorkflow/)
+    expect(routeSource).not.toMatch(/insertInto|updateTable|deleteFrom/)
+  })
+})

--- a/packages/core-backend/tests/unit/workflow-designer-drafts.test.ts
+++ b/packages/core-backend/tests/unit/workflow-designer-drafts.test.ts
@@ -30,6 +30,7 @@ describe('workflowDesignerDrafts helpers', () => {
       shares: [],
       executions: [],
       format: 'bpmn-only',
+      sourceMode: 'bpmn_xml',
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/workflow-designer/workflows/:id/compile-preview` as the A6-4b read-only compile-preview route.
- Loads the saved workflow-designer draft, checks ordinary draft access with `hasWorkflowDraftAccess`, then calls the existing pure `compileBpmnPreview` compiler.
- Tracks draft `sourceMode` so visual drafts compile from visual definitions, while drafts explicitly saved through BPMN XML compile from the saved XML even when older visual metadata is preserved.

## Scope / Non-goals

- No persistence, migrations, frontend, deploy, start, test execution, or live BPMN runtime.
- Does not call `ensureWorkflowEngineReady`, `BPMNWorkflowEngine.deployProcess`, `appendWorkflowDraftExecution`, or analytics/write paths.
- A6-5 approval-as-job and live BPMN runtime remain gated.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/bpmn-compile-preview.test.ts tests/unit/workflow-designer-compile-preview-route.test.ts tests/unit/workflow-designer-drafts.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Review response

- Subagent P1: original source selection could prefer stale preserved visual metadata after a BPMN XML save. Fixed by persisting/inferring `sourceMode` and adding a mixed visual+BPMN regression test that must compile the explicitly saved BPMN XML.
- Subagent P2: duplicate could drop `sourceMode` for mixed drafts and recreate the same stale-preview hazard. Fixed by preserving `workflow.sourceMode` on duplicate and adding a route regression test.
- Subagent final re-review: APPROVE, no remaining blockers.

## Notes

`pnpm install --frozen-lockfile` was required in the temporary worktree to restore local test dependencies; generated node_modules churn was reverted before commit.
