### PR TITLE
fix(multitable): serialize link target materialization

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1030,6 +1030,19 @@ export function baseIdsAreCrossBase(a: string | null, b: string | null): boolean
   return a !== b
 }
 
+function linkTargetMaterializationLockKey(sheetId: string): string {
+  return `multitable:link-target:${sheetId}`
+}
+
+async function acquireLinkTargetMaterializationLock(query: QueryFn, sheetId: string): Promise<void> {
+  await query('SELECT pg_advisory_xact_lock(hashtext($1))', [linkTargetMaterializationLockKey(sheetId)])
+}
+
+function getLinkTargetSheetIdForMaterializationLock(type: UniverMetaField['type'], property: unknown): string | null {
+  if (type !== 'link') return null
+  return parseLinkFieldConfig(property)?.foreignSheetId ?? null
+}
+
 /**
  * ②a §2a.2 — the cross-base WALL. A `link` field may not silently span two bases: the foreign sheet's
  * `base_id` must equal the source sheet's `base_id`. This closes the STRUCTURAL hole — today the
@@ -3891,6 +3904,7 @@ async function createSeededSheet(args: { sheetId: string; name: string; descript
     const existing = await query('SELECT id FROM meta_sheets WHERE id = $1', [args.sheetId])
     const isGenuinelyNew = (existing.rows as unknown[]).length === 0
     if (isGenuinelyNew) {
+      await acquireLinkTargetMaterializationLock(query as unknown as QueryFn, args.sheetId)
       const retroactiveCrossBase = await validateSheetCreateNoRetroactiveCrossBaseLink(query, args.sheetId, baseId)
       if (retroactiveCrossBase) {
         throw new CrossBaseLinkError(retroactiveCrossBase)
@@ -5585,6 +5599,10 @@ export function univerMetaRouter(): Router {
         // ②a §2a.2 — cross-base WALL (create). Fire only when the payload explicitly carries a link
         // foreign-sheet key (any alias), mirroring the aiShortcut/expression presence gates.
         if (linkForeignKeyInPayload(parsed.data.property)) {
+          const lockTargetSheetId = getLinkTargetSheetIdForMaterializationLock(type, property)
+          if (lockTargetSheetId) {
+            await acquireLinkTargetMaterializationLock(query as unknown as QueryFn, lockTargetSheetId)
+          }
           const linkBaseError = await validateLinkFieldConfig(req, query, sheetId, type, property)
           if (linkBaseError) {
             throw new ValidationError(linkBaseError)
@@ -5908,6 +5926,10 @@ export function univerMetaRouter(): Router {
         // conversion we MUST validate the effective `nextProperty`. (link→link rename keeps currentType
         // 'link' so this clause stays false → GA-T4b compat preserved.)
         if (linkForeignKeyInPayload(parsed.data.property) || (nextType === 'link' && currentType !== 'link')) {
+          const lockTargetSheetId = getLinkTargetSheetIdForMaterializationLock(nextType, nextProperty)
+          if (lockTargetSheetId) {
+            await acquireLinkTargetMaterializationLock(query as unknown as QueryFn, lockTargetSheetId)
+          }
           const linkBaseError = await validateLinkFieldConfig(req, query, sheetId, nextType, nextProperty)
           if (linkBaseError) {
             throw new ValidationError(linkBaseError)
@@ -6816,6 +6838,7 @@ export function univerMetaRouter(): Router {
         // ②a §2a.4-c TOCTOU close: reject if creating this sheet (with this resolved baseId) would
         // retroactively make an EXISTING link field cross-base (a link previously pointed at this
         // not-yet-existent sheet id from a source sheet in a different base). Mirrors the §2a.2 wall.
+        await acquireLinkTargetMaterializationLock(query as unknown as QueryFn, sheetId)
         const retroactiveCrossBase = await validateSheetCreateNoRetroactiveCrossBaseLink(
           query as unknown as QueryFn,
           sheetId,

--- a/packages/core-backend/tests/integration/multitable-cross-base-sheet-create-toctou.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-sheet-create-toctou.test.ts
@@ -45,12 +45,16 @@ const FUTURE_SAME = `sheet_toctou_future_same_${TS}` // will be created in BASE_
 const FUTURE_NULL = `sheet_toctou_future_null_${TS}` // created with null base → cross-base vs set-base source
 const FUTURE_ALIAS = `sheet_toctou_future_alias_${TS}` // referenced via the datasheetId alias
 const FUTURE_SEED_SAME = `sheet_toctou_future_seed_same_${TS}` // POST /sheets + seed:true, SAME base as source
+const FUTURE_LOCKED_CROSS = `sheet_toctou_future_locked_cross_${TS}` // used by the advisory-lock serialization test
+const FUTURE_LOCKED_FIELD = `sheet_toctou_future_locked_field_${TS}` // route-created link points here while lock is held
 
 const FLD_CROSS = `fld_toctou_cross_${TS}`
 const FLD_SAME = `fld_toctou_same_${TS}`
 const FLD_NULL = `fld_toctou_null_${TS}`
 const FLD_ALIAS = `fld_toctou_alias_${TS}`
 const FLD_SEED_SAME = `fld_toctou_seed_same_${TS}`
+const FLD_LOCKED_CROSS = `fld_toctou_locked_cross_${TS}`
+const FLD_LOCKED_CREATE = `fld_toctou_locked_create_${TS}`
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
@@ -76,6 +80,38 @@ const sheetExists = async (sheetId: string): Promise<boolean> => {
   return (r.rows as unknown[]).length > 0
 }
 
+const linkTargetMaterializationLockKey = (sheetId: string): string => `multitable:link-target:${sheetId}`
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function runWhileAdvisoryLockHeld<T>(sheetId: string, start: () => Promise<T>): Promise<T> {
+  const client = await poolManager.get().getInternalPool().connect()
+  const lockKey = linkTargetMaterializationLockKey(sheetId)
+  await client.query('SELECT pg_advisory_lock(hashtext($1))', [lockKey])
+  let settled = false
+  const requestPromise = start().then(
+    (value) => {
+      settled = true
+      return value
+    },
+    (error) => {
+      settled = true
+      throw error
+    },
+  )
+  try {
+    await sleep(100)
+    const settledWhileLocked = settled
+    await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey])
+    const result = await requestPromise
+    expect(settledWhileLocked).toBe(false)
+    return result
+  } finally {
+    await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey]).catch(() => {})
+    client.release()
+  }
+}
+
 describeIfDatabase('②a wall — sheet-create TOCTOU close (§2a.4-c, real DB)', () => {
   beforeAll(async () => {
     await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_A, 'TOCTOU Base A'])
@@ -95,10 +131,21 @@ describeIfDatabase('②a wall — sheet-create TOCTOU close (§2a.4-c, real DB)'
       [FLD_ALIAS, SHEET_A, 'Link Future Alias', 'link', JSON.stringify({ datasheetId: FUTURE_ALIAS }), 4])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_SEED_SAME, SHEET_A, 'Link Future Seed Same', 'link', JSON.stringify({ foreignSheetId: FUTURE_SEED_SAME }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LOCKED_CROSS, SHEET_A, 'Link Future Locked Cross', 'link', JSON.stringify({ foreignSheetId: FUTURE_LOCKED_CROSS }), 6])
   })
 
   afterAll(async () => {
-    const allSheets = [SHEET_A, FUTURE_CROSS, FUTURE_SAME, FUTURE_NULL, FUTURE_ALIAS, FUTURE_SEED_SAME]
+    const allSheets = [
+      SHEET_A,
+      FUTURE_CROSS,
+      FUTURE_SAME,
+      FUTURE_NULL,
+      FUTURE_ALIAS,
+      FUTURE_SEED_SAME,
+      FUTURE_LOCKED_CROSS,
+      FUTURE_LOCKED_FIELD,
+    ]
     await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [allSheets]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [allSheets]).catch(() => {})
     await q('DELETE FROM meta_views WHERE sheet_id = ANY($1::text[])', [allSheets]).catch(() => {})
@@ -188,5 +235,50 @@ describeIfDatabase('②a wall — sheet-create TOCTOU close (§2a.4-c, real DB)'
     const rows = r.rows as Array<{ base_id: string | null }>
     expect(rows).toHaveLength(1)
     expect(rows[0].base_id).toBe(BASE_A)
+  })
+
+  // §2a.4-d (concurrency): POST /sheets must take the same per-target advisory lock used by link field
+  // writes before it scans for existing link fields. Holding the session-level version of that lock makes
+  // the real HTTP route wait; if this regresses, the request settles while the lock is still held.
+  test('TOCTOU concurrency: sheet create waits on the target materialization advisory lock before validating retroactive links', async () => {
+    const res = await runWhileAdvisoryLockHeld(FUTURE_LOCKED_CROSS, () =>
+      request(buildApp(USER))
+        .post('/api/multitable/sheets')
+        .send({
+          id: FUTURE_LOCKED_CROSS,
+          baseId: BASE_B,
+          name: 'Locked Retroactive Cross Target',
+        })
+        .timeout({ deadline: 5000 }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await sheetExists(FUTURE_LOCKED_CROSS)).toBe(false)
+  })
+
+  // §2a.4-d (concurrency): POST /fields must take the same per-target advisory lock before validating or
+  // inserting a link to a not-yet-existent target. This is the symmetric half of the materialization race:
+  // link writes and target-sheet creation now serialize on `multitable:link-target:<sheetId>`.
+  test('TOCTOU concurrency: link field create waits on the target materialization advisory lock', async () => {
+    const res = await runWhileAdvisoryLockHeld(FUTURE_LOCKED_FIELD, () =>
+      request(buildApp(USER))
+        .post('/api/multitable/fields')
+        .send({
+          id: FLD_LOCKED_CREATE,
+          sheetId: SHEET_A,
+          name: 'Locked Future Link',
+          type: 'link',
+          property: { foreignSheetId: FUTURE_LOCKED_FIELD },
+        })
+        .timeout({ deadline: 5000 }),
+    )
+
+    expect(res.status).toBe(201)
+    expect(res.body.ok).toBe(true)
+    const fieldRes = await q('SELECT property FROM meta_fields WHERE id = $1', [FLD_LOCKED_CREATE])
+    expect((fieldRes.rows as Array<{ property: { foreignSheetId?: string } }>)[0]?.property?.foreignSheetId).toBe(
+      FUTURE_LOCKED_FIELD,
+    )
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #2576. Closes the remaining P1 materialization race by making link-field writes and target-sheet creation contend on the same transaction-scoped advisory lock:

- `POST /fields` link create/update locks `multitable:link-target:<foreignSheetId>` before validation/insert/update.
- `POST /sheets` and the seeded-sheet centralized path lock `multitable:link-target:<sheetId>` before retroactive cross-base validation/materialization.
- Adds real HTTP route tests that hold the session-level advisory lock and assert the request waits while locked, proving the wire path uses the lock rather than a fixture-only helper.

## Verification

- `pnpm --filter @metasheet/core-backend run build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-cross-base-sheet-create-toctou.test.ts --watch=false` *(local machine has no DATABASE_URL, so the DB integration file is collected and skipped; CI should execute it with the DB matrix)*

## Boundaries

- Multitable-only.
- No permission/RBAC/auth changes.
- No frontend changes.
- No broad schema or sweep changes beyond serializing the already-locked #2576 chokepoints.