### PR TITLE
test(multitable): handle §2a.4 guard SELECTs in multitable-context mock

### DIFF
--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -23,6 +23,17 @@ function createMockPool(queryHandler: QueryHandler) {
     if (sql.includes('FROM record_permissions')) {
       return { rows: [], rowCount: 0 }
     }
+    // ②a §2a write-path guards reached before each per-test handler runs (the
+    // sheet/field-create chokepoints): the link-target materialization advisory
+    // lock (#2578) and the retroactive-cross-base link scan (#2576,
+    // validateSheetCreateNoRetroactiveCrossBaseLink). The mock world has no
+    // inbound cross-base link, so both no-op cleanly with empty rows.
+    if (sql.includes('pg_advisory_xact_lock')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('source_base_id')) {
+      return { rows: [], rowCount: 0 }
+    }
     return queryHandler(sql, params)
   })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))


### PR DESCRIPTION
## What

CI-invisible debt cleanup. `packages/core-backend/tests/integration/multitable-context.api.test.ts` is **quarantined** — it's in the `exclude` array of `packages/core-backend/vitest.config.ts`, so it does **not** run in CI. This PR removes the "Unhandled SQL" the §2a write-path guards introduced into its hand-rolled SQL mock. Quarantine status is **unchanged** (still excluded).

## The two unhandled guard SELECTs

The §2a write-path guards now run two SELECTs at the sheet/field-create chokepoints, *before* each per-test `queryHandler` is reached:

1. `SELECT pg_advisory_xact_lock(hashtext($1))` — link-target materialization advisory lock (**#2578**, "serialize link target materialization").
2. `SELECT mf.id AS field_id, s.base_id AS source_base_id FROM meta_fields mf JOIN meta_sheets s ... WHERE mf.type = 'link' ...` — the retroactive-cross-base link scan in `validateSheetCreateNoRetroactiveCrossBaseLink` (**#2576**, §2a.4 sheet-create TOCTOU guard).

Fix: two global no-op handlers in `createMockPool` returning `{ rows: [] }` (the mock world has no inbound cross-base link, so the guards no-op cleanly), matching the existing permission-SELECT no-op style. Matched on distinctive substrings (`pg_advisory_xact_lock`, `source_base_id`) — verified collision-free against all per-test handlers.

## Count: 5 failures fixed at the SQL layer, not 3 (and why)

The task framed this as "3 failures from the §2a.4 (#2576) guard SELECTs." That estimate predates **#2578** (the advisory lock), which **is already on this branch's base** (`origin/main` = `7fe7d6c16`) and inserts `pg_advisory_xact_lock` *before* the link-scan in every write path. So on current `main`:

- **Before:** 5 failed / 17 passed — all 5 threw the same `Unhandled SQL: SELECT pg_advisory_xact_lock(hashtext($1))` (3 × POST /sheets, 2 × person-field create/update).
- **After:** 2 failed / 20 passed — zero "Unhandled SQL".

The 3 POST /sheets tests (the §2a.4 subject) are green: they surfaced the #2576 link-scan once #2578's lock was handled.

## The 2 remaining failures are pre-existing and unrelated (proven)

The 2 remaining failures (`creates native person field...`, `updates native person field...`) are **not** caused by the §2a.4 guard SELECTs. They originate in **#2574** (the §2a.2 cross-base wall): `validateLinkFieldConfig` calls `loadSheetRow(foreignSheetId)` with the *provisioned people-sheet id*, hitting a per-test handler whose strict `expect(params).toEqual(['sheet_ops'])` was never written to expect a foreign-sheet lookup. (Quarantined → CI never caught the drift when #2574 landed.)

Proof: reverting `univer-meta.ts` + `loaders.ts` to **#2574** (`78f7d2acd`, where neither #2576's link-scan nor #2578's lock exists) reproduces the **identical** assertion — `loadSheetRow` → `validateLinkFieldConfig` → `expected [ <people-sheet-id> ] to deeply equal [ 'sheet_ops' ]`. They predate the §2a.4 guard and are out of scope for this cleanup.

## Verification

- Run in isolation (excluded from default config): `DATABASE_URL="" pnpm --filter @metasheet/core-backend exec vitest run --config vitest.integration.config.ts tests/integration/multitable-context.api.test.ts` → **20 passed / 2 failed (pre-existing #2574)**, zero "Unhandled SQL".
- `tsc --noEmit` clean (exit 0).
- Diff is the test file only (+11); `vitest.config.ts` exclude untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)