### PR TITLE
feat(multitable): cross-base link foreignBaseId opt-in + base-read gating (②b slice 1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -205,6 +205,7 @@ jobs:
             tests/integration/multitable-cross-base-seed-view-toctou.test.ts \
             tests/integration/multitable-dangling-link-sweep.test.ts \
             tests/integration/multitable-base-readable-resolver.test.ts \
+            tests/integration/multitable-cross-base-link-optin.test.ts \
             tests/integration/multitable-sheet-realtime.api.test.ts \
             tests/integration/rooms.basic.test.ts \
             tests/integration/multitable-automation-retry.test.ts \

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -208,9 +208,17 @@ export function sanitizeFieldProperty(
       typeof (obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId) === 'string'
         ? String(obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId).trim()
         : ''
+    // ②b slice 1 — promote foreignBaseId (the cross-base opt-in claim) to an EXPLICIT normalized key
+    // (trim; empty → omitted), mirroring univer-meta.ts's sanitizeFieldProperty so the claim is
+    // contractual, not incidental `...obj` passthrough (wire-vs-fixture).
+    const foreignBaseId =
+      typeof obj.foreignBaseId === 'string' && obj.foreignBaseId.trim().length > 0
+        ? obj.foreignBaseId.trim()
+        : ''
     return {
       ...obj,
       ...(foreignSheetId ? { foreignSheetId, foreignDatasheetId: foreignSheetId } : {}),
+      ...(foreignBaseId ? { foreignBaseId } : {}),
       limitSingleRecord: obj.limitSingleRecord === true,
       ...(typeof obj.refKind === 'string' && obj.refKind.trim().length > 0
         ? { refKind: obj.refKind.trim() }

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -325,6 +325,10 @@ export interface RecordWriteHelpers {
   ) => Promise<Map<string, Map<string, string[]>>>
   buildLinkSummaries: (
     query: QueryFn,
+    // ②b — the SOURCE sheet id, required so buildLinkSummaries can resolve the source base and apply
+    // the cross-base base-read gate (Sink B-1). Positional + required so every caller is forced to pass
+    // it (a missing arg would silently re-open the cross-base summary leak).
+    sourceSheetId: string,
     rows: UniverMetaRecord[],
     relationalLinkFields: RelationalLinkField[],
     linkValuesByRecord: Map<string, Map<string, string[]>>,
@@ -994,6 +998,7 @@ export class RecordWriteService {
             h.serializeLinkSummaryMap(
               await h.buildLinkSummaries(
                 this.pool.query.bind(this.pool),
+                sheetId,
                 updates.map((update) => ({ id: update.recordId, version: 0, data: {} })),
                 relationalLinkFields,
                 await h.loadLinkValuesByRecord(

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -49,6 +49,7 @@ import {
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
   requiresOwnWriteRowPolicy,
+  resolveBaseReadable,
   resolveReadableSheetIds,
   resolveSheetCapabilities,
   resolveSheetReadableCapabilities,
@@ -869,6 +870,11 @@ function filterVisibleSheetRows<T extends { description?: unknown }>(rows: T[]):
 type LinkFieldConfig = {
   foreignSheetId: string
   limitSingleRecord: boolean
+  // ②b slice 1 — explicit cross-base opt-in claim. Present only when the link declares a foreign base;
+  // a same-base link omits it (back-compat). The §2a.2 wall allows the cross-base link IFF this equals
+  // the foreign sheet's actual base_id (claim == truth). Extracted explicitly (not via incidental
+  // spread) so it round-trips the real wire — see the wire-vs-fixture rule.
+  foreignBaseId?: string
 }
 
 type LookupFieldConfig = {
@@ -896,9 +902,14 @@ function parseLinkFieldConfig(property: unknown): LinkFieldConfig | null {
   const foreign = obj.foreignDatasheetId ?? obj.foreignSheetId ?? obj.datasheetId
   if (typeof foreign !== 'string' || foreign.trim().length === 0) return null
 
+  // ②b slice 1 — the explicit cross-base opt-in claim (trim; empty → omitted).
+  const claimedBase = typeof obj.foreignBaseId === 'string' && obj.foreignBaseId.trim().length > 0
+    ? obj.foreignBaseId.trim()
+    : undefined
   return {
     foreignSheetId: foreign.trim(),
     limitSingleRecord: obj.limitSingleRecord === true,
+    ...(claimedBase ? { foreignBaseId: claimedBase } : {}),
   }
 }
 
@@ -913,6 +924,25 @@ const LINK_FOREIGN_KEYS = ['foreignSheetId', 'foreignDatasheetId', 'datasheetId'
 function linkForeignKeyInPayload(payloadProperty: unknown): boolean {
   if (typeof payloadProperty === 'undefined' || payloadProperty === null) return false
   return LINK_FOREIGN_KEYS.some((key) => Object.prototype.hasOwnProperty.call(payloadProperty, key))
+}
+
+/**
+ * ②b §2.5(b) / decision (c) — does the RAW PATCH payload explicitly carry a `foreignBaseId` key?
+ * Mirrors `linkForeignKeyInPayload`: immutability is enforced only when the caller is actually
+ * (re)writing the claim, so a rename-only / unrelated PATCH (no `foreignBaseId` key) leaves the stored
+ * claim untouched (and the explicit codec keeps it from being dropped).
+ */
+function foreignBaseIdInPayload(payloadProperty: unknown): boolean {
+  if (typeof payloadProperty === 'undefined' || payloadProperty === null) return false
+  return Object.prototype.hasOwnProperty.call(payloadProperty, 'foreignBaseId')
+}
+
+/** ②b — normalized cross-base opt-in claim (trim; empty/absent → null) from a (possibly stored) property. */
+function extractForeignBaseId(property: unknown): string | null {
+  const obj = normalizeJson(property)
+  return typeof obj.foreignBaseId === 'string' && obj.foreignBaseId.trim().length > 0
+    ? obj.foreignBaseId.trim()
+    : null
 }
 
 function parseLookupFieldConfig(property: unknown): LookupFieldConfig | null {
@@ -1085,9 +1115,21 @@ async function validateLinkFieldConfig(
   if (!foreignSheet) return null
 
   const sourceBaseId = sourceSheet?.baseId ?? null
-  const foreignBaseId = foreignSheet.baseId ?? null
-  if (baseIdsAreCrossBase(sourceBaseId, foreignBaseId)) {
-    return `链接字段不能跨 base：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} base=${foreignBaseId ?? 'null'}`
+  // ②b §2: disambiguated names. `actualForeignBaseId` = the foreign sheet's real base; `claimed` =
+  // the opt-in declaration carried in the link property (null when absent).
+  const actualForeignBaseId = foreignSheet.baseId ?? null
+  const claimed = linkCfg.foreignBaseId ?? null
+  if (baseIdsAreCrossBase(sourceBaseId, actualForeignBaseId)) {
+    // ②b opt-in short-circuit — a cross-base link is allowed IFF it carries an EXPLICIT foreignBaseId
+    // EQUAL to the foreign sheet's real base (claim == truth; you can't declare a wrong base). A
+    // degenerate null/legacy-base foreign sheet has no concrete base to claim, so it can never opt in
+    // (claimed===null falls through to reject; a non-null claim !== null actual also rejects). This is a
+    // pure consistency gate — the foreign READ-permission check is §3 (base-read) + §2a.3 (field mask),
+    // NOT here (adding a perm check in this structural wall would over-reach).
+    if (claimed !== null && claimed === actualForeignBaseId) {
+      return null
+    }
+    return `链接字段跨 base 需显式 foreignBaseId 且与外表实际 base 一致：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} 实际 base=${actualForeignBaseId ?? 'null'}，声明=${claimed ?? 'null'}`
   }
 
   return null
@@ -1115,7 +1157,8 @@ async function validateSheetCreateNoRetroactiveCrossBaseLink(
   // Existing link fields whose effective foreign target (alias-aware) is this new sheet id, joined to
   // their source sheet's base_id. NULLIF('') drops empty-string aliases so they don't match a real id.
   const res = await query(
-    `SELECT mf.id AS field_id, s.base_id AS source_base_id
+    `SELECT mf.id AS field_id, s.base_id AS source_base_id,
+            NULLIF(trim(mf.property ->> 'foreignBaseId'), '') AS claimed_foreign_base
        FROM meta_fields mf
        JOIN meta_sheets s ON s.id = mf.sheet_id
       WHERE mf.type = 'link'
@@ -1126,9 +1169,17 @@ async function validateSheetCreateNoRetroactiveCrossBaseLink(
             ) = $1`,
     [newSheetId],
   )
-  const rows = (res as { rows: Array<{ field_id: unknown; source_base_id: unknown }> }).rows
+  const rows = (res as { rows: Array<{ field_id: unknown; source_base_id: unknown; claimed_foreign_base: unknown }> }).rows
   for (const row of rows) {
     const sourceBaseId = typeof row.source_base_id === 'string' ? row.source_base_id : null
+    const claimedForeignBase = typeof row.claimed_foreign_base === 'string' ? row.claimed_foreign_base : null
+    // ②b §2.4 — an EXISTING link that already opted into the base this new sheet is being created in
+    // (claim == new sheet's base) is a LEGITIMATE cross-base link; the TOCTOU guard must NOT retroactively
+    // reject it. The wall (§2) will accept it at write-time because its claim equals the foreign sheet's
+    // (now-materialized) real base. A non-opted-in (or wrong-claim) link still blocks.
+    if (claimedForeignBase !== null && claimedForeignBase === newSheetBaseId) {
+      continue
+    }
     if (baseIdsAreCrossBase(sourceBaseId, newSheetBaseId)) {
       const fieldId = String(row.field_id)
       return `创建该 sheet 会使现有链接字段跨 base：字段 ${fieldId} 的源表 base=${sourceBaseId ?? 'null'}，新 sheet ${newSheetId} base=${newSheetBaseId ?? 'null'}`
@@ -1484,9 +1535,16 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
     const foreignSheetId = typeof (obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId) === 'string'
       ? String(obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId).trim()
       : ''
+    // ②b slice 1 — promote foreignBaseId (the cross-base opt-in claim) to an EXPLICIT normalized key
+    // (trim; empty → omitted) so it survives even if the `...obj` passthrough is later tightened
+    // (wire-vs-fixture: the claim is contractual, not incidental).
+    const foreignBaseId = typeof obj.foreignBaseId === 'string' && obj.foreignBaseId.trim().length > 0
+      ? obj.foreignBaseId.trim()
+      : ''
     return {
       ...obj,
       ...(foreignSheetId ? { foreignSheetId, foreignDatasheetId: foreignSheetId } : {}),
+      ...(foreignBaseId ? { foreignBaseId } : {}),
       limitSingleRecord: obj.limitSingleRecord === true,
       ...(typeof obj.refKind === 'string' && obj.refKind.trim().length > 0 ? { refKind: obj.refKind.trim() } : {}),
     }
@@ -1961,10 +2019,23 @@ async function resolveForeignFieldReadability(
       resolveSheetReadableCapabilities(req, query, foreignSheetId).then((r) => r.capabilities),
       access.userId ? loadFieldPermissionScopeMap(query, foreignSheetId, access.userId) : Promise.resolve(new Map<string, FieldPermissionScope>()),
     ])
-    const readableFieldIds = computeAllowedFieldIds(foreignFields as UniverMetaField[], capabilities, fieldScopeMap)
+    let readableFieldIds = computeAllowedFieldIds(foreignFields as UniverMetaField[], capabilities, fieldScopeMap)
     // null vs non-null ⇒ cross-base (mask); equal (incl. both null) ⇒ same-base.
     const foreignBaseId = foreignSheet?.baseId ?? null
     const crossBase = foreignBaseId !== sourceBaseId
+    // ②b §3.2 Sink A — base-read COARSE gate, ONLY for cross-base foreign sheets. A reader lacking
+    // base-read on the foreign base sees the WHOLE foreign sheet's readable-field set emptied (→
+    // shouldMaskForeignField :1988 never short-circuits → every foreign field masked → lookup/rollup
+    // hydration AND formula-taint both drop it). This is a strict ADD on top of the §2a.3 field mask
+    // (it only REDUCES visibility, never widens it — §6.2.2). Same-base is never touched (XB-3). A null
+    // foreign base is unreadable by definition (can't opt in / can't grant) → mask (also crash-safe:
+    // resolveBaseReadable would throw on null).
+    if (crossBase) {
+      const baseReadable = foreignBaseId != null && (await resolveBaseReadable(req, query, foreignBaseId))
+      if (!baseReadable) {
+        readableFieldIds = new Set<string>()
+      }
+    }
     out.set(foreignSheetId, { readableFieldIds, crossBase })
   }
   return out
@@ -2922,7 +2993,7 @@ export function createRecordWriteHelpers(req: Request, _pool?: { query: QueryFn 
     recalculateFormulaFields: (q, sid, f, ids, changed, hydrated) =>
       recalculateFormulaFields(req, q, sid, f, ids, changed, hydrated),
     loadLinkValuesByRecord,
-    buildLinkSummaries: (q, rows, rl, lv) => buildLinkSummaries(req, q, rows, rl, lv),
+    buildLinkSummaries: (q, sourceSheetId, rows, rl, lv) => buildLinkSummaries(req, q, sourceSheetId, rows, rl, lv),
     buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
     ensureAttachmentIdsExist,
   }
@@ -3531,6 +3602,7 @@ async function ensureAttachmentIdsExist(
 async function buildLinkSummaries(
   req: Request,
   query: QueryFn,
+  sourceSheetId: string,
   rows: UniverMetaRecord[],
   relationalLinkFields: RelationalLinkField[],
   linkValuesByRecord: Map<string, Map<string, string[]>>,
@@ -3555,6 +3627,24 @@ async function buildLinkSummaries(
   }
 
   const readableSheetIds = await resolveReadableSheetIds(req, query, idsBySheet.keys())
+
+  // ②b §3.2 Sink B-1 — base-read COARSE gate on the inline link summaries. resolveReadableSheetIds
+  // only checks SHEET-level read, so a sheet-readable-but-base-unreadable actor could enumerate a
+  // cross-base foreign sheet's records (id + display) via every summary consumer (/view, single-record
+  // read, write-echo). For each CROSS-BASE foreign sheet (foreign base ≠ source base), require
+  // resolveBaseReadable; failure DROPS it from readableSheetIds, so the existing :3611 gate masks the
+  // summary AND the display-field load + foreign-record load below skip it (one gate, all consumers,
+  // no wasted loads). Same-base is untouched; a null foreign base is unreadable (mask) and crash-safe.
+  // Decision (d): silent mask here (omit summaries) — the explicit pull endpoint 403s separately.
+  const sourceSheet = await loadSheetRowShared(query, sourceSheetId)
+  const sourceBaseId = sourceSheet?.baseId ?? null
+  for (const foreignSheetId of Array.from(readableSheetIds)) {
+    const foreignSheet = await loadSheetRowShared(query, foreignSheetId)
+    const foreignBaseId = foreignSheet?.baseId ?? null
+    if (!baseIdsAreCrossBase(sourceBaseId, foreignBaseId)) continue
+    const baseReadable = foreignBaseId != null && (await resolveBaseReadable(req, query, foreignBaseId))
+    if (!baseReadable) readableSheetIds.delete(foreignSheetId)
+  }
 
   // F5-followup (#2106): the foreign-record `display` echoed in link summaries is the value of the foreign
   // sheet's default display field. resolveReadableSheetIds gates SHEET-level read, but the display field
@@ -5912,6 +6002,22 @@ export function univerMetaRouter(): Router {
         if (configError) {
           throw new ValidationError(configError)
         }
+        // ②b decision (c) — foreignBaseId is IMMUTABLE after create. A PATCH that explicitly carries a
+        // `foreignBaseId` DIFFERENT from the stored field's claim is rejected (not silently ignored).
+        // Gating on the RAW payload (not nextProperty) is load-bearing: nextProperty falls back to the
+        // stored property, so re-asserting nothing must not 400 (GA-T4b parity). Re-sending the SAME
+        // claim is allowed (no-op). This blocks the two-step bypass (create a same-base link, then PATCH
+        // a `foreignBaseId` to falsely claim cross-base) and means the wall's claim==truth check, once
+        // passed at create, can never be retroactively desynced.
+        if (foreignBaseIdInPayload(parsed.data.property)) {
+          const storedForeignBaseId = extractForeignBaseId(row.property)
+          const payloadForeignBaseId = extractForeignBaseId(parsed.data.property)
+          if (payloadForeignBaseId !== storedForeignBaseId) {
+            throw new ValidationError(
+              `foreignBaseId 建后不可变：当前=${storedForeignBaseId ?? 'null'}，请求=${payloadForeignBaseId ?? 'null'}`,
+            )
+          }
+        }
         // ②a §2a.2 — cross-base WALL (update). Lazy/on-edit, exactly like the expression/aiShortcut
         // re-validation below: `nextProperty` falls back to the STORED `row.property`, so gating on the
         // RAW payload carrying a foreign-sheet key is load-bearing — a rename-only PATCH on a
@@ -7718,6 +7824,7 @@ export function univerMetaRouter(): Router {
               await buildLinkSummaries(
                 req,
                 pool.query.bind(pool),
+                sheetId,
                 rows,
                 relationalLinkFields,
                 linkValuesByRecord,
@@ -8896,7 +9003,7 @@ export function univerMetaRouter(): Router {
       record.data = filterRecordDataByFieldIds(record.data, allowedFieldIds)
       const linkSummaries = filterSingleRecordFieldSummaryMap(
         Object.fromEntries(
-          Array.from((await buildLinkSummaries(req, pool.query.bind(pool), [record], relationalLinkFields, linkValuesByRecord)).get(record.id)?.entries() ?? []),
+          Array.from((await buildLinkSummaries(req, pool.query.bind(pool), sheetId, [record], relationalLinkFields, linkValuesByRecord)).get(record.id)?.entries() ?? []),
         ),
         allowedFieldIds,
       )
@@ -9105,6 +9212,20 @@ export function univerMetaRouter(): Router {
       const { access: foreignAccess, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), linkConfig.foreignSheetId)
       if (!capabilities.canRead) return sendForbidden(res)
 
+      // ②b §3.2 Sink B-2 / decision (d) — the EXPLICIT cross-base candidate pull. Unlike the inline
+      // summary sinks (silent mask), this endpoint deliberately enumerates the foreign sheet's records,
+      // so a sheet-readable-but-base-unreadable actor would leak them. For a CROSS-BASE foreign sheet
+      // (source base ≠ foreign base) require base-read; failure → 403 (explicit, matching the existing
+      // sendForbidden semantics). Placed BEFORE the `selected` summaries and the candidate pull so it
+      // short-circuits both. Same-base is untouched (200 as before); a null foreign base is unreadable.
+      const sourceSheetRow = await loadSheetRow(pool.query.bind(pool), String(fieldRow.sheet_id))
+      const sourceBaseId = sourceSheetRow?.baseId ?? null
+      const foreignBaseId = targetSheet.baseId ?? null
+      if (baseIdsAreCrossBase(sourceBaseId, foreignBaseId)) {
+        const baseReadable = foreignBaseId != null && (await resolveBaseReadable(req, pool.query.bind(pool), foreignBaseId))
+        if (!baseReadable) return sendForbidden(res)
+      }
+
       let selected: LinkedRecordSummary[] = []
       if (recordId) {
         const sourceRecordRes = await pool.query(
@@ -9123,6 +9244,7 @@ export function univerMetaRouter(): Router {
         const linkSummaries = await buildLinkSummaries(
           req,
           pool.query.bind(pool),
+          String(fieldRow.sheet_id),
           [{ id: recordId, version: 0, data: {} }],
           [{ fieldId, cfg: linkConfig }],
           linkValuesByRecord,

--- a/packages/core-backend/tests/integration/multitable-cross-base-link-optin.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-link-optin.test.ts
@@ -1,0 +1,419 @@
+/**
+ * ②b slice 1 — cross-base link `foreignBaseId` opt-in + base-read gating (real DB).
+ *
+ * Opens the §2a.2 wall for an EXPLICIT, CONSISTENT cross-base opt-in: a `link` field may span two
+ * bases IFF it carries `foreignBaseId` EQUAL to the foreign sheet's actual `base_id` (claim == truth).
+ * No flag, or a mismatched one → still rejected (the wall's current behavior). `foreignBaseId` is
+ * IMMUTABLE after create (decision c). Cross-base READ derives from `resolveBaseReadable` (decision a):
+ * a reader lacking foreign-base-read gets foreign data SILENTLY MASKED on hydration/summaries
+ * (decision d) but a 403 on the explicit `GET /fields/:fieldId/link-options` pull (decision d).
+ *
+ * Drives the real POST/PATCH /fields + GET /view + GET /fields/:id/link-options wires (wire-vs-fixture
+ * rule). Real DB (describeIfDatabase) — the field-permission + base-readability resolvers hit real
+ * tables (meta_bases, field_permissions, user_roles, ...).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+
+// Actors.
+const OWNER = `u_xbo_owner_${TS}` // owns BASE_A AND BASE_B → base-read on both (owner derivation)
+const READER_BASE = `u_xbo_rbase_${TS}` // member + multitable:base:read grant → base-read on any base
+const READER_NOBASE = `u_xbo_rnobase_${TS}` // member + multitable:read only, owns nothing → NO base-read
+
+// Bases.
+const BASE_A = `base_xbo_a_${TS}` // source base
+const BASE_B = `base_xbo_b_${TS}` // foreign base
+const BASE_NULL_OWNER = `base_xbo_b2_${TS}` // alt foreign base (no special owner) for mismatch tests
+
+// Sheets.
+const SHEET_A = `sheet_xbo_a_${TS}` // source sheet (BASE_A)
+const SHEET_A2 = `sheet_xbo_a2_${TS}` // same-base foreign target (BASE_A)
+const SHEET_B = `sheet_xbo_b_${TS}` // cross-base foreign target (BASE_B)
+const SHEET_NULL = `sheet_xbo_null_${TS}` // null base_id (legacy) foreign target
+const SHEET_LATE = `sheet_xbo_late_${TS}` // TOCTOU: created late, targeted by a pre-seeded link
+
+// Foreign fields on SHEET_B (the cross-base target).
+const FLD_B_OK = `fld_xbo_bok_${TS}` // readable foreign field (value 41)
+const FLD_B_DENIED = `fld_xbo_bden_${TS}` // field-permission denied for READER_BASE (value 43)
+
+// Foreign records.
+const REC_B = `rec_xbo_b_${TS}`
+const REC_A = `rec_xbo_a_${TS}` // source record linking to REC_B
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string, permissions: string[]): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as { user?: unknown }).user = {
+      id: userId,
+      roles: ['member'],
+      perms: permissions,
+      permissions,
+    }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+
+// Common permission sets.
+const WRITE = ['multitable:read', 'multitable:write']
+const READ_ONLY = ['multitable:read']
+const READ_PLUS_BASE = ['multitable:read', 'multitable:base:read']
+
+const fieldExists = async (fieldId: string): Promise<boolean> => {
+  const r = await q('SELECT id FROM meta_fields WHERE id = $1', [fieldId])
+  return (r.rows as unknown[]).length > 0
+}
+const fieldProperty = async (fieldId: string): Promise<Record<string, unknown> | undefined> => {
+  const r = await q('SELECT property FROM meta_fields WHERE id = $1', [fieldId])
+  const p = (r.rows as Array<{ property: unknown }>)[0]?.property
+  if (p == null) return undefined
+  return (typeof p === 'string' ? JSON.parse(p) : p) as Record<string, unknown>
+}
+
+describeIfDatabase('②b slice 1 — cross-base link foreignBaseId opt-in + base-read gating (real DB)', () => {
+  beforeAll(async () => {
+    // OWNER owns BASE_A and BASE_B; BASE_NULL_OWNER has no owner.
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'XBO Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'XBO Base B', OWNER])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_NULL_OWNER, 'XBO Base B2'])
+
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'Source A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A2, BASE_A, 'Foreign A2'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'Foreign B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, NULL, $2)', [SHEET_NULL, 'Foreign Null'])
+
+    // Foreign target fields on SHEET_B.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_B_OK, SHEET_B, 'BOk', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_B_DENIED, SHEET_B, 'BDenied', 'number', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_B, SHEET_B, JSON.stringify({ [FLD_B_OK]: 41, [FLD_B_DENIED]: 43 })])
+
+    // READER_BASE is field-DENIED on FLD_B_DENIED (to prove the §2a.3 layering under an open base gate).
+    await q(
+      'INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [SHEET_B, FLD_B_DENIED, 'user', READER_BASE, false, false],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id IN (SELECT id FROM meta_fields WHERE sheet_id = ANY($1::text[]))', [[SHEET_A]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_A2, SHEET_B, SHEET_NULL, SHEET_LATE]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_A2, SHEET_B, SHEET_NULL, SHEET_LATE]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_A2, SHEET_B, SHEET_NULL, SHEET_LATE]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, BASE_NULL_OWNER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── XB-1: opt-in allow ────────────────────────────────────────────────────
+  // CREATE a cross-base link with foreignBaseId == foreign sheet's real base → ALLOWED (was rejected).
+  test('XB-1: CREATE cross-base link with correct foreignBaseId is ALLOWED (201) and persists', async () => {
+    const fieldId = `fld_xbo_t1_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Opt-in Link',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B },
+    })
+
+    expect(res.status).toBe(201)
+    expect(await fieldExists(fieldId)).toBe(true)
+    // XB-4 (wire round-trip): foreignBaseId must persist (not dropped by sanitizer/codec).
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBe(BASE_B)
+  })
+
+  // ── XB-1b: mismatch reject ────────────────────────────────────────────────
+  test('XB-1b: CREATE cross-base link with WRONG foreignBaseId is rejected (4xx); field not created', async () => {
+    const fieldId = `fld_xbo_t1b_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Wrong Claim',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_A }, // claims source base, not SHEET_B's
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await fieldExists(fieldId)).toBe(false)
+  })
+
+  // ── XB-1c: no-flag reject (regression — the wall's current behavior) ───────
+  test('XB-1c: CREATE cross-base link WITHOUT foreignBaseId is still rejected (4xx)', async () => {
+    const fieldId = `fld_xbo_t1c_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Bare Cross',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B },
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await fieldExists(fieldId)).toBe(false)
+  })
+
+  // ── XB-1d (degenerate): null/legacy-base foreign sheet cannot be opted into ─
+  test('XB-1d: CREATE cross-base link to a null-base foreign sheet with any foreignBaseId is rejected (4xx)', async () => {
+    const fieldId = `fld_xbo_t1d_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Null Foreign',
+      type: 'link',
+      property: { foreignSheetId: SHEET_NULL, foreignBaseId: BASE_B }, // null actual ≠ any claim
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await fieldExists(fieldId)).toBe(false)
+  })
+
+  // ── XB-immut: foreignBaseId is IMMUTABLE after create (decision c) ─────────
+  test('XB-immut: PATCH changing a stored foreignBaseId is rejected (4xx); stored value unchanged', async () => {
+    const fieldId = `fld_xbo_immut_${TS}`
+    // Create a valid cross-base opt-in.
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Immut Link',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B },
+    }).expect(201)
+
+    // Attempt to change foreignBaseId to a different value → must be rejected.
+    const res = await request(buildApp(OWNER, WRITE))
+      .patch(`/api/multitable/fields/${fieldId}`)
+      .send({ property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_A } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBe(BASE_B)
+  })
+
+  // ── XB-immut-noop: a PATCH that does NOT touch foreignBaseId preserves it (wire-vs-fixture) ─
+  test('XB-immut-noop: a rename-only PATCH preserves the stored foreignBaseId', async () => {
+    const fieldId = `fld_xbo_immutnoop_${TS}`
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Immut Noop',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B },
+    }).expect(201)
+
+    const res = await request(buildApp(OWNER, WRITE))
+      .patch(`/api/multitable/fields/${fieldId}`)
+      .send({ name: 'XB Immut Noop Renamed' })
+
+    expect(res.status).toBe(200)
+    // foreignBaseId must SURVIVE an unrelated PATCH (not dropped by explicit codec handling).
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBe(BASE_B)
+  })
+
+  // ── XB-immut-add: the named two-step bypass — same-base link, then PATCH ADDS foreignBaseId ──
+  // §2.5(b)'s reason-for-being: create a same-base link (no foreignBaseId), then PATCH ONLY a
+  // `foreignBaseId` (NO foreign-sheet key) to falsely claim cross-base. The immutability gate must fire
+  // INDEPENDENTLY of the wall's foreign-key presence gate (the PATCH carries no foreign-sheet key, so
+  // the wall would not re-run) — stored is null, payload claims X, X !== null → reject. This canary
+  // locks that the two gates are independent; aligning immutability with the wall's gate would silently
+  // reopen the bypass.
+  test('XB-immut-add: same-base link → PATCH adding ONLY foreignBaseId (no foreign key) is rejected (4xx)', async () => {
+    const fieldId = `fld_xbo_immutadd_${TS}`
+    // Same-base link, no foreignBaseId.
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Immut Add',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2 },
+    }).expect(201)
+
+    // PATCH adds ONLY foreignBaseId (no foreignSheetId/datasheetId) → must be rejected (claim != stored null).
+    const res = await request(buildApp(OWNER, WRITE))
+      .patch(`/api/multitable/fields/${fieldId}`)
+      .send({ property: { foreignBaseId: BASE_B } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    // The stored config must NOT have gained a foreignBaseId.
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBeUndefined()
+  })
+
+  // ── XB-immut-same: re-asserting the SAME foreignBaseId on PATCH is allowed ──
+  test('XB-immut-same: PATCH re-sending the identical foreignBaseId is allowed (200)', async () => {
+    const fieldId = `fld_xbo_immutsame_${TS}`
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Immut Same',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B },
+    }).expect(201)
+
+    const res = await request(buildApp(OWNER, WRITE))
+      .patch(`/api/multitable/fields/${fieldId}`)
+      .send({ name: 'XB Immut Same Renamed', property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B } })
+
+    expect(res.status).toBe(200)
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBe(BASE_B)
+  })
+
+  // ── XB-3: same-base link unaffected (zero regression) ─────────────────────
+  test('XB-3: CREATE same-base link (no foreignBaseId) still succeeds (201)', async () => {
+    const fieldId = `fld_xbo_t3_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'Same Base Link',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2 },
+    })
+
+    expect(res.status).toBe(201)
+    expect(await fieldExists(fieldId)).toBe(true)
+  })
+
+  // ── XB-6 (TOCTOU): an opted-in link does NOT block the legit late sheet-create ─
+  test('XB-6: a pre-seeded foreignBaseId-matching link does NOT block creating its target sheet; a non-opted-in link still blocks', async () => {
+    // Pre-seed a cross-base link from SHEET_A (BASE_A) targeting the not-yet-existent SHEET_LATE,
+    // claiming foreignBaseId = BASE_B (the base the late sheet will be created in) → opted in.
+    const fldOptIn = `fld_xbo_t6_optin_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [fldOptIn, SHEET_A, 'Late OptIn Link', 'link', JSON.stringify({ foreignSheetId: SHEET_LATE, foreignBaseId: BASE_B }), 90])
+
+    // Creating SHEET_LATE in BASE_B must be ALLOWED (the link legitimately opted into BASE_B).
+    // POST /sheets returns 200 on success (res.json default), unlike POST /fields (201).
+    const okRes = await request(buildApp(OWNER, WRITE)).post('/api/multitable/sheets').send({
+      id: SHEET_LATE,
+      baseId: BASE_B,
+      name: 'Late Target',
+    })
+    expect(okRes.status).toBe(200)
+
+    // Now a SECOND pre-seeded link claiming a DIFFERENT base (BASE_A) targeting a fresh late sheet must
+    // still block that sheet's creation in BASE_B (claim ≠ new base → not opted in).
+    const lateMismatch = `sheet_xbo_late2_${TS}`
+    const fldMismatch = `fld_xbo_t6_mismatch_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [fldMismatch, SHEET_A, 'Late Mismatch Link', 'link', JSON.stringify({ foreignSheetId: lateMismatch, foreignBaseId: BASE_A }), 91])
+    const blockRes = await request(buildApp(OWNER, WRITE)).post('/api/multitable/sheets').send({
+      id: lateMismatch,
+      baseId: BASE_B,
+      name: 'Late Mismatch Target',
+    })
+    expect(blockRes.status).toBe(400)
+    expect(await q('SELECT id FROM meta_sheets WHERE id = $1', [lateMismatch]).then((r) => (r.rows as unknown[]).length)).toBe(0)
+
+    // cleanup the extra fields
+    await q('DELETE FROM meta_fields WHERE id = ANY($1::text[])', [[fldOptIn, fldMismatch]]).catch(() => {})
+  })
+
+  // ── XB-2 / XB-2b: base-read gating on the READ sinks ──────────────────────
+  // We seed one stable opted-in cross-base link + lookup on SHEET_A pointing at SHEET_B, then read
+  // through /view (Sink A hydration + Sink B summaries) and /link-options (Sink B-2 endpoint) as
+  // three actors.
+  describe('read-sink base gating (Sink A + Sink B)', () => {
+    const FLD_LINK = `fld_xbo_link_${TS}`
+    const FLD_LU_OK = `fld_xbo_luok_${TS}` // lookup over readable foreign field
+    const FLD_LU_DEN = `fld_xbo_luden_${TS}` // lookup over field-denied foreign field
+
+    beforeAll(async () => {
+      // Opted-in cross-base link (seeded directly with a VALID foreignBaseId claim).
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [FLD_LINK, SHEET_A, 'XLink', 'link', JSON.stringify({ foreignSheetId: SHEET_B, foreignBaseId: BASE_B }), 50])
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [FLD_LU_OK, SHEET_A, 'XLookupOk', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_B_OK, foreignSheetId: SHEET_B }), 51])
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [FLD_LU_DEN, SHEET_A, 'XLookupDen', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_B_DENIED, foreignSheetId: SHEET_B }), 52])
+
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [REC_A, SHEET_A, JSON.stringify({ [FLD_LINK]: [REC_B] })])
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
+        [`lnk_xbo_${TS}`, FLD_LINK, REC_A, REC_B])
+    })
+
+    const readViewRow = async (app: Express): Promise<Record<string, unknown>> => {
+      const res = await request(app).get('/api/multitable/view').query({ sheetId: SHEET_A })
+      expect(res.status).toBe(200)
+      const rows = res.body?.data?.rows as Array<{ id: string; data: Record<string, unknown> }>
+      const row = rows.find((r) => r.id === REC_A)
+      expect(row).toBeDefined()
+      return row!.data
+    }
+    // Link summaries are emitted by /view ONLY when includeLinkSummaries=true, at data.linkSummaries
+    // (recordId → fieldId → summaries[]). Fetch with the flag and read REC_A's FLD_LINK summary ids.
+    const fetchLinkSummaryIds = async (app: Express): Promise<string[]> => {
+      const res = await request(app)
+        .get('/api/multitable/view')
+        .query({ sheetId: SHEET_A, includeLinkSummaries: 'true' })
+      expect(res.status).toBe(200)
+      const linkSummaries = (res.body?.data?.linkSummaries ?? {}) as Record<string, Record<string, Array<{ id: string }>>>
+      return (linkSummaries[REC_A]?.[FLD_LINK] ?? []).map((s) => s.id)
+    }
+
+    // XB-2: reader WITHOUT foreign-base-read → Sink A hydration empty + Sink B summary empty + endpoint 403.
+    test('XB-2 (no base-read): lookup hydration MASKED, link summary EMPTY, /link-options 403', async () => {
+      const app = buildApp(READER_NOBASE, READ_ONLY)
+      const data = await readViewRow(app)
+      // Sink A: both cross-base lookups masked (foreign sheet base unreadable).
+      const ok = data[FLD_LU_OK]
+      const den = data[FLD_LU_DEN]
+      expect(Array.isArray(ok) ? ok : [ok].filter((x) => x != null)).toEqual([])
+      expect(Array.isArray(den) ? den : [den].filter((x) => x != null)).toEqual([])
+      // Sink B-1: the cross-base link summary must be empty (omitted).
+      expect(await fetchLinkSummaryIds(app)).toEqual([])
+      // Sink B-2: explicit pull → 403.
+      const lo = await request(app).get(`/api/multitable/fields/${FLD_LINK}/link-options`).query({ recordId: REC_A })
+      expect(lo.status).toBe(403)
+    })
+
+    // XB-2b: reader WITH foreign-base-read (grant code) → base gate passes; readable field visible,
+    // field-DENIED foreign field STILL masked by §2a.3 (double layer); /link-options 200.
+    test('XB-2b (base-read granted): base gate passes; readable field visible, denied field still §2a.3-masked; /link-options 200', async () => {
+      const app = buildApp(READER_BASE, READ_PLUS_BASE)
+      const data = await readViewRow(app)
+      // readable foreign field flows.
+      expect(data[FLD_LU_OK]).toEqual([41])
+      // field-permission-denied foreign field STILL masked even with base-read (layering).
+      const den = data[FLD_LU_DEN]
+      expect(Array.isArray(den) ? den : [den].filter((x) => x != null)).toEqual([])
+      // Sink B-1: summary visible (base gate open).
+      expect(await fetchLinkSummaryIds(app)).toEqual([REC_B])
+      // Sink B-2: explicit pull → 200 with candidate records.
+      const lo = await request(app).get(`/api/multitable/fields/${FLD_LINK}/link-options`).query({ recordId: REC_A })
+      expect(lo.status).toBe(200)
+    })
+
+    // base-read via OWNERSHIP (OWNER owns BASE_B) → same visibility as grant-code reader.
+    test('XB-2c (base-read via ownership): owner of foreign base sees cross-base summary + /link-options 200', async () => {
+      const app = buildApp(OWNER, WRITE)
+      expect(await fetchLinkSummaryIds(app)).toEqual([REC_B])
+      const lo = await request(app).get(`/api/multitable/fields/${FLD_LINK}/link-options`).query({ recordId: REC_A })
+      expect(lo.status).toBe(200)
+    })
+
+    afterAll(async () => {
+      await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE id = $1', [REC_A]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE id = ANY($1::text[])', [[FLD_LINK, FLD_LU_OK, FLD_LU_DEN]]).catch(() => {})
+    })
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts
@@ -50,7 +50,11 @@ function buildApp(userId: string): Express {
   const a = express()
   a.use(express.json())
   a.use((req, _res, next) => {
-    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read'], permissions: ['multitable:read'] }
+    // ②b: this suite's foreign sheet is cross-base; grant `multitable:base:read` so the actor clears
+    // the new §3.2 coarse base-read gate and these tests keep isolating FIELD-level masking (the DENY
+    // cases stay masked by the field gate, non-vacuously). The base-gate axis is covered by the
+    // dedicated XB-2* canaries in multitable-cross-base-link-optin.test.ts.
+    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read', 'multitable:base:read'], permissions: ['multitable:read', 'multitable:base:read'] }
     next()
   })
   a.use('/api/multitable', univerMetaRouter())

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-convergence.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-convergence.test.ts
@@ -58,8 +58,11 @@ function buildApp(userId: string): Express {
     ;(req as any).user = {
       id: userId,
       roles: ['member'],
-      perms: ['multitable:read', 'multitable:write'],
-      permissions: ['multitable:read', 'multitable:write'],
+      // ②b: foreign sheet is cross-base; grant `multitable:base:read` so the actor clears the new §3.2
+      // coarse base-read gate and this suite keeps isolating FIELD-level masking (DENY cases stay masked
+      // by the field gate). Base-gate axis covered by XB-2* in multitable-cross-base-link-optin.test.ts.
+      perms: ['multitable:read', 'multitable:write', 'multitable:base:read'],
+      permissions: ['multitable:read', 'multitable:write', 'multitable:base:read'],
     }
     next()
   })

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-create.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-create.test.ts
@@ -61,8 +61,11 @@ function buildApp(userId: string | null): Express {
       ;(req as any).user = {
         id: userId,
         roles: ['member'],
-        perms: ['multitable:read', 'multitable:write'],
-        permissions: ['multitable:read', 'multitable:write'],
+        // ②b: foreign sheet is cross-base; grant `multitable:base:read` so the actor clears the new
+        // §3.2 coarse base-read gate and this suite keeps isolating FIELD-level masking (DENY cases stay
+        // masked by the field gate). Base-gate axis covered by XB-2* in the cross-base-link-optin suite.
+        perms: ['multitable:read', 'multitable:write', 'multitable:base:read'],
+        permissions: ['multitable:read', 'multitable:write', 'multitable:base:read'],
       }
     }
     next()

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-export.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-export.test.ts
@@ -49,7 +49,11 @@ function buildApp(userId: string): Express {
   const a = express()
   a.use(express.json())
   a.use((req, _res, next) => {
-    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read'], permissions: ['multitable:read'] }
+    // ②b: this suite's foreign sheet is cross-base; grant `multitable:base:read` so the actor clears
+    // the new §3.2 coarse base-read gate and these tests keep isolating FIELD-level masking (the DENY
+    // cases stay masked by the field gate, non-vacuously). The base-gate axis is covered by the
+    // dedicated XB-2* canaries in multitable-cross-base-link-optin.test.ts.
+    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read', 'multitable:base:read'], permissions: ['multitable:read', 'multitable:base:read'] }
     next()
   })
   a.use('/api/multitable', univerMetaRouter())

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts
@@ -60,8 +60,11 @@ function buildApp(userId: string): Express {
     ;(req as any).user = {
       id: userId,
       roles: ['member'],
-      perms: ['multitable:read', 'multitable:write'],
-      permissions: ['multitable:read', 'multitable:write'],
+      // ②b: foreign sheet is cross-base; grant `multitable:base:read` so the actor clears the new §3.2
+      // coarse base-read gate and this suite keeps isolating FIELD-level masking (DENY cases stay masked
+      // by the field gate). Base-gate axis covered by XB-2* in multitable-cross-base-link-optin.test.ts.
+      perms: ['multitable:read', 'multitable:write', 'multitable:base:read'],
+      permissions: ['multitable:read', 'multitable:write', 'multitable:base:read'],
     }
     next()
   })

--- a/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-write.test.ts
+++ b/packages/core-backend/tests/integration/multitable-lookup-foreign-field-mask-write.test.ts
@@ -52,8 +52,11 @@ function buildApp(userId: string): Express {
     ;(req as any).user = {
       id: userId,
       roles: ['member'],
-      perms: ['multitable:read', 'multitable:write'],
-      permissions: ['multitable:read', 'multitable:write'],
+      // ②b: foreign sheet is cross-base; grant `multitable:base:read` so the actor clears the new §3.2
+      // coarse base-read gate and this suite keeps isolating FIELD-level masking (DENY cases stay masked
+      // by the field gate). Base-gate axis covered by XB-2* in multitable-cross-base-link-optin.test.ts.
+      perms: ['multitable:read', 'multitable:write', 'multitable:base:read'],
+      permissions: ['multitable:read', 'multitable:write', 'multitable:base:read'],
     }
     next()
   })

--- a/packages/core-backend/tests/integration/multitable-permission-golden-d3d1.test.ts
+++ b/packages/core-backend/tests/integration/multitable-permission-golden-d3d1.test.ts
@@ -48,6 +48,21 @@ const FIELDS = [
 const SECRET_FIELD = FIELDS[2].id
 const RECORD_ID = `rec_d3d1_${TS}`
 
+// ②b cross-base dimension — a SECOND base + a cross-base foreign sheet + a link/lookup/formula on
+// SHEET_ID, so the export golden can assert the new §3.2 base-read coarse gate ON TOP of the existing
+// FIELD × VIEW dimensions. The export path serializes only MATERIALIZED data, so (mirroring the proven
+// multitable-lookup-foreign-field-mask-export pattern) the value surfaced is a FORMULA over the lookup:
+// when Sink A masks the lookup, §2a.3 taints the formula → its column is dropped; otherwise it exports.
+const XBASE_ID = `base_d3d1_xb_${TS}` // foreign base (no owner → base-read only via grant code)
+const XFOREIGN_SHEET = `sheet_d3d1_xf_${TS}` // cross-base foreign sheet (in XBASE_ID)
+const XFOREIGN_FIELD = `fld_d3d1_xf_${TS}` // foreign numeric field surfaced by the lookup
+const XLINK_FIELD = `fld_d3d1_xlink_${TS}` // opted-in cross-base link on SHEET_ID
+const XLOOKUP_FIELD = `fld_d3d1_xlu_${TS}` // lookup over the foreign field (Sink A consumer)
+const XFORMULA_FIELD = `fld_d3d1_xf2_${TS}` // formula over the lookup (the materialized export carrier)
+const XFOREIGN_RECORD = `rec_d3d1_xf_${TS}`
+const XFOREIGN_NUM = 91 // the foreign numeric value (denied target)
+const XFORMULA_VALUE = '92' // materialized = lookup(91)+1, asserted in the export CELLS (flat)
+
 // Mutable so a single app can test both the authorized non-admin user and the no-read user.
 let currentUser: { id: string; roles: string[]; perms: string[] } = {
   id: USER_ID,
@@ -108,6 +123,30 @@ describeIfDatabase('multitable permission golden matrix — D3d-1 (field tri-sta
     await q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids) VALUES ($1, $2, $3, $4, $5::jsonb)', [
       VIEW_HIDDEN, SHEET_ID, 'Hidden', 'grid', JSON.stringify([SECRET_FIELD]),
     ])
+
+    // ②b cross-base dimension seed: a foreign base + cross-base foreign sheet with a numeric field, an
+    // opted-in cross-base link (foreignBaseId == XBASE_ID), a lookup over the foreign field, and a
+    // formula over the lookup on SHEET_ID. The formula value is MATERIALIZED (as the write path would
+    // persist) = lookup(91)+1 = 92; the export reads it RAW, but §2a.3 taint drops it whenever the
+    // lookup is masked (Sink A base gate OR field gate). The dependency edge is the taint edge.
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [XBASE_ID, 'D3d1 Cross Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [XFOREIGN_SHEET, XBASE_ID, 'D3d1 Cross Foreign'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [XFOREIGN_FIELD, XFOREIGN_SHEET, 'XForeign', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [XFOREIGN_RECORD, XFOREIGN_SHEET, JSON.stringify({ [XFOREIGN_FIELD]: XFOREIGN_NUM })])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [XLINK_FIELD, SHEET_ID, 'XLink', 'link', JSON.stringify({ foreignSheetId: XFOREIGN_SHEET, foreignBaseId: XBASE_ID }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [XLOOKUP_FIELD, SHEET_ID, 'XLookup', 'lookup', JSON.stringify({ linkFieldId: XLINK_FIELD, targetFieldId: XFOREIGN_FIELD, foreignSheetId: XFOREIGN_SHEET }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [XFORMULA_FIELD, SHEET_ID, 'XFormula', 'formula', JSON.stringify({ expression: `={${XLOOKUP_FIELD}}+1` }), 6])
+    await q('UPDATE meta_records SET data = data || $2::jsonb WHERE id = $1',
+      [RECORD_ID, JSON.stringify({ [XLINK_FIELD]: [XFOREIGN_RECORD], [XFORMULA_FIELD]: Number(XFORMULA_VALUE) })])
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
+      [`lnk_d3d1_xb_${TS}`, XLINK_FIELD, RECORD_ID, XFOREIGN_RECORD])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [SHEET_ID, XFORMULA_FIELD, XLOOKUP_FIELD, SHEET_ID])
   })
 
   afterEach(async () => {
@@ -118,6 +157,12 @@ describeIfDatabase('multitable permission golden matrix — D3d-1 (field tri-sta
 
   afterAll(async () => {
     // best-effort cleanup (FK cascade from sheet covers fields/records)
+    // ②b cross-base dimension teardown first (links + deps + field_permissions + foreign sheet/base).
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [XLINK_FIELD]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [XFOREIGN_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [XFOREIGN_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [XBASE_ID]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
@@ -188,5 +233,43 @@ describeIfDatabase('multitable permission golden matrix — D3d-1 (field tri-sta
     currentUser = { id: USER_ID, roles: ['member'], perms: [] } // no multitable:read
     const { status } = await exportHeaderAndCells()
     expect(status).toBe(403)
+  })
+
+  // ── ②b CROSS-BASE dimension (NEW) — base-read coarse gate × field mask, layered on FIELD × VIEW ──
+  // Asserts §3.4's three rows on the EXPORT cell (Sink A path, via the §2a.3 formula-taint that the
+  // export sink reads). The Sink B summary + the /link-options 403 legs of §3.4's "denied" row are
+  // locked separately by XB-2/2b/2c in multitable-cross-base-link-optin.test.ts (export only does Sink A).
+  describe('cross-base × base-read (§3.4)', () => {
+    test('cross-base + base-read GRANTED + foreign field readable → formula-over-lookup value EXPORTED', async () => {
+      currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:read', 'multitable:base:read'] }
+      const { status, header, flat } = await exportHeaderAndCells()
+      expect(status).toBe(200)
+      expect(header).toContain('XFormula')
+      expect(flat).toContain(XFORMULA_VALUE)
+    })
+
+    test('cross-base + base-read DENIED → foreign sheet masked (Sink A) → formula tainted, value ABSENT', async () => {
+      currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:read'] } // no base-read, not owner
+      const { status, header, flat } = await exportHeaderAndCells()
+      expect(status).toBe(200)
+      expect(header).not.toContain('XFormula') // whole formula column dropped, fail-closed
+      expect(flat).not.toContain(XFORMULA_VALUE)
+    })
+
+    test('cross-base + base-read GRANTED + foreign field FIELD-permission denied → still masked (double layer)', async () => {
+      currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:read', 'multitable:base:read'] }
+      // deny the foreign field at field level for this actor; base gate is open but §2a.3 still masks
+      // (cross-base unconditional field mask → lookup masked → formula tainted).
+      await q(
+        'INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1, $2, $3, $4, $5, $6)',
+        [XFOREIGN_SHEET, XFOREIGN_FIELD, 'user', USER_ID, false, false],
+      )
+      const { status, header, flat } = await exportHeaderAndCells()
+      expect(status).toBe(200)
+      expect(header).not.toContain('XFormula')
+      expect(flat).not.toContain(XFORMULA_VALUE)
+      // teardown this extra grant (afterEach only clears SHEET_ID's field_permissions, not the foreign sheet's).
+      await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2 AND subject_id = $3', [XFOREIGN_SHEET, XFOREIGN_FIELD, USER_ID])
+    })
   })
 })

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2284,6 +2284,18 @@ components:
         property:
           type: object
           additionalProperties: true
+          properties:
+            foreignBaseId:
+              type: string
+              description: >-
+                Cross-base opt-in claim for a `link` field (②b). When present,
+                the link is permitted to target a foreign sheet in a DIFFERENT
+                base IFF this value equals the foreign sheet's actual base_id
+                (claim == truth); a mismatched or absent value keeps the
+                cross-base link rejected. Immutable after create. Cross-base
+                READ additionally requires foreign-base read permission; a
+                reader lacking it sees foreign data masked (and a 403 on the
+                explicit link-options pull). Omitted for same-base links.
         options:
           type: array
           items:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3185,7 +3185,13 @@
           },
           "property": {
             "type": "object",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "properties": {
+              "foreignBaseId": {
+                "type": "string",
+                "description": "Cross-base opt-in claim for a `link` field (②b). When present, the link is permitted to target a foreign sheet in a DIFFERENT base IFF this value equals the foreign sheet's actual base_id (claim == truth); a mismatched or absent value keeps the cross-base link rejected. Immutable after create. Cross-base READ additionally requires foreign-base read permission; a reader lacking it sees foreign data masked (and a 403 on the explicit link-options pull). Omitted for same-base links."
+              }
+            }
           },
           "options": {
             "type": "array",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2284,6 +2284,18 @@ components:
         property:
           type: object
           additionalProperties: true
+          properties:
+            foreignBaseId:
+              type: string
+              description: >-
+                Cross-base opt-in claim for a `link` field (②b). When present,
+                the link is permitted to target a foreign sheet in a DIFFERENT
+                base IFF this value equals the foreign sheet's actual base_id
+                (claim == truth); a mismatched or absent value keeps the
+                cross-base link rejected. Immutable after create. Cross-base
+                READ additionally requires foreign-base read permission; a
+                reader lacking it sees foreign data masked (and a 403 on the
+                explicit link-options pull). Omitted for same-base links.
         options:
           type: array
           items:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2101,6 +2101,16 @@ components:
         property:
           type: object
           additionalProperties: true
+          properties:
+            foreignBaseId:
+              type: string
+              description: >-
+                Cross-base opt-in claim for a `link` field (②b). When present, the link is permitted to
+                target a foreign sheet in a DIFFERENT base IFF this value equals the foreign sheet's actual
+                base_id (claim == truth); a mismatched or absent value keeps the cross-base link rejected.
+                Immutable after create. Cross-base READ additionally requires foreign-base read permission;
+                a reader lacking it sees foreign data masked (and a 403 on the explicit link-options pull).
+                Omitted for same-base links.
         options:
           type: array
           items:


### PR DESCRIPTION
②b slice 1 — opens the merged ②a cross-base wall for a **GOVERNED** cross-base link, built ON the wall (not around it). Security-critical: every base-comparison/read site learns the opt-in, and the two cross-base READ leak paths are closed in this same slice. Design-lock: `docs/development/multitable-crossbase-2b-capability-design-refresh-20260613.md`. **No migration** (`foreignBaseId` rides the link property JSON).

## The opt-in contract (ratified — "按建议执行", all 4 decisions 按推荐)
A `link` field with an explicit `foreignBaseId` is allowed to be cross-base **IFF `foreignBaseId` == the foreign sheet's actual `base_id`** (consistency / claim==truth). No flag, or a mismatched one → still rejected (the wall's pre-slice behavior).

| # | Decision | As-built |
|---|---|---|
| a | cross-base READ perm | derives from `resolveBaseReadable` (owner / grant-code / admin); **no second mechanism** |
| b | cross-base AUTOMATION | **OFF** — not this slice (no `targetBaseId`) |
| c | `foreignBaseId` after create | **IMMUTABLE** — a `foreignBaseId`-bearing PATCH whose claim differs from stored is rejected |
| d | base-read DENIED posture | **silent mask** on hydration/summaries; **403** on the explicit `GET /fields/:id/link-options` pull |

## Multi-sink table (every base-comparison/read site touched)
| Site | file:line (post-change) | What changed | Sink |
|---|---|---|---|
| Wall `validateLinkFieldConfig` | `univer-meta.ts:~1095` | cross-base branch: `claimed!==null && claimed===actualForeignBaseId` → allow; else reject (disambiguated `actual` vs `claimed`) | write |
| TOCTOU `validateSheetCreateNoRetroactiveCrossBaseLink` | `univer-meta.ts:~1145` (SQL) | SELECT adds `foreignBaseId` claim; an opted-in link (claim == new sheet base) no longer retroactively blocks the legit late create | write (SQL) |
| PATCH immutability | `univer-meta.ts:~5960` | reject when raw payload carries `foreignBaseId` ≠ stored (fires **independently** of the wall's foreign-key gate) | write |
| **Sink A** `resolveForeignFieldReadability` | `univer-meta.ts:~1967` | cross-base + `!resolveBaseReadable` → empty readable-field set. One wire covers **lookup/rollup hydration AND formula-taint**. §2a.3 field mask untouched (gate sits in front). | read |
| **Sink B-1** `buildLinkSummaries` (now takes `sourceSheetId`) | `univer-meta.ts:~3628` | cross-base + `!resolveBaseReadable` drops the foreign sheet from `readableSheetIds` → summary omitted (silent mask). One gate covers display-field load + foreign-record load + emit. | read |
| **Sink B-2** `GET /fields/:id/link-options` | `univer-meta.ts:~9214` | cross-base + `!resolveBaseReadable` → **403** (before `selected` + candidate pull) | read |
| Codecs | `parseLinkFieldConfig` + both `sanitizeFieldProperty` link branches + `field-codecs.ts` link codec | explicit `foreignBaseId` normalized key (wire-vs-fixture — contractual, not `...obj`) | wire |
| OpenAPI | `base.yml` + rebuilt `dist/*` | `foreignBaseId` documented under `MultitableField.property`; parity green | spec |
| D3 golden | `multitable-permission-golden-d3d1.test.ts` | NEW cross-base × base-read dimension (3 rows) via export Sink A | test |

Unchanged on purpose (the §6 invariant): `baseIdsAreCrossBase` ("is cross-base" ≠ "is allowed") and the §2a.3 masking logic (`crossBase`/`shouldMaskForeignField`/`maskStoredRecordFieldIds`) — the base gate is an **additive coarse gate that only reduces visibility**, never a bypass.

## `resolveBaseReadable` wiring — both sinks, the 403-vs-silent-mask split
- **Sink A** (hydration/taint) and **Sink B-1** (inline summaries): base-read failure → foreign data masked **silently** (decision d — no leak of existence, same posture as §2a.3).
- **Sink B-2** (`/link-options`, an explicit candidate enumeration): base-read failure → **403** (decision d — matches the existing `sendForbidden` semantics).
- Null foreign base is treated as **unreadable** at all three (can't opt in / can't grant) — also crash-safe (`resolveBaseReadable` trims `baseId`).
- Same-base paths **never** call `resolveBaseReadable` (zero-regression).

## The closed leak (Sink B), proven
Pre-slice, a sheet-readable-but-base-unreadable actor (`multitable:read`, not base owner) could enumerate a cross-base foreign sheet's records: `/link-options` returned **200** with `records:[{id, display:"secret-foreign"}]` and `/view` summaries leaked the same. Post-slice: summary omitted + `/link-options` 403. (Captured via a throwaway probe; locked by XB-2.)

## Immutability — precise semantics
"Immutable" = a `foreignBaseId`-bearing PATCH cannot **add or change** the claim to a different value (incl. the named `null→X` two-step bypass: same-base link → PATCH adds only `foreignBaseId`, no foreign-sheet key → 400). Re-sending the **same** value is a no-op (200). A PATCH that **omits** `foreignBaseId` while repointing `foreignSheetId` to a same-base target legitimately drops it (the still-cross-base variant is rejected by the wall, so no corruption) — intended, not a hole.

## Fail-first — 14 real-DB canaries (RED→GREEN)
`multitable-cross-base-link-optin.test.ts`. RED proven + evidence saved before impl; load-bearing REDs: XB-1 (create was rejected→allowed), XB-2 (Sink A lookup leaked `[41]` + Sink B summary/200 leaked→masked/[]/403), XB-6 (TOCTOU blocked the legit opt-in late-create 400→200). Plus mismatch/no-flag/null-degenerate rejects, immutability trio + the `null→X` bypass, base-read via grant-code AND ownership, field-mask layering under an open base gate, wire round-trip, same-base zero-regression.

## Neighbors green (additive, no regression)
`§2a.2 wall` + `§2a.4 TOCTOU` (seed-view + sheet-create) + **full §2a.3 mask suite (17 files)** + both **D3 goldens** + base-readable resolver + structural/egress GOLDEN guards (incl. egress-coverage) + `record-write-service` unit. **157 integration + 235 unit green; tsc clean; OpenAPI parity green.**

⚠️ **Modified pre-existing security tests (surfaced for review):** 6 §2a.3 mask fixtures (`multitable-lookup-foreign-field-mask-{aggregate,export,write,create,convergence,sibling-reads}.test.ts`) gained `multitable:base:read` on their shared actor. Reason: their foreign sheet is cross-base and their "ALLOW/AUTHORIZED" control actor was never granted base-read (base-read didn't exist when they were written). Under the new §3.2 coarse gate those controls would lose their cross-base value — the intended §6.2.2 reduction. Granting base-read keeps these suites isolating the **FIELD** axis (DENY cases still masked by the field gate, non-vacuously); the **base** axis is covered head-on by the new XB-2/2b/2c canaries + the d3d1 cross-base dimension. **No assertion weakened, no gate weakened.**

## Deferred (each a separate gated opt-in — staged lineage, do NOT auto-start)
cross-base **automation** (`targetBaseId`) · **Yjs** cross-base fan-out · base-level **quota/rate-limit** · **frontend** (cross-base picker column + base switcher). No migration in this slice.

## Residual for the reviewer
- crossSheetRelated write-echo: not a new cross-base emitter in this slice (a cross-base link couldn't exist pre-slice; foreign records reached via summaries are Sink-B-gated; field-level data goes through the §2a.3 chokepoint). Flagged as the one spot worth a second look.
- `buildLinkSummaries` now takes a **required** `sourceSheetId` (4 direct sites + the `RecordWriteHelpers` factory closure/type/service call site) — required-positional by design so a future caller can't silently re-open the summary leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)