### PR TITLE
feat(multitable): governed cross-base automation writes + close ungated create hole (②b automation slice)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + webhook outbound chain + AI shortcut run + AI ledger retention sweep)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -205,7 +205,10 @@ jobs:
             tests/integration/multitable-cross-base-seed-view-toctou.test.ts \
             tests/integration/multitable-dangling-link-sweep.test.ts \
             tests/integration/multitable-base-readable-resolver.test.ts \
+            tests/integration/multitable-base-writable-resolver.test.ts \
             tests/integration/multitable-cross-base-link-optin.test.ts \
+            tests/integration/multitable-cross-base-automation-write.test.ts \
+            tests/integration/multitable-cross-base-automation-write-rule.test.ts \
             tests/integration/multitable-sheet-realtime.api.test.ts \
             tests/integration/rooms.basic.test.ts \
             tests/integration/multitable-automation-retry.test.ts \

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -35,12 +35,30 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
 /** Config shape for update_record */
 export interface UpdateRecordConfig {
   fields: Record<string, unknown>
+  /**
+   * ②b cross-base write opt-in. When `targetBaseId` is set and ≠ the trigger base, this is a GOVERNED
+   * cross-base update: it requires FULL explicit addressing (`targetSheetId` + `targetRecordId`) because
+   * the trigger record is not in the target base. The executor write-gate then re-verifies, per run,
+   * that the TRIGGER ACTOR holds base-WRITE on `targetBaseId` and that `targetSheetId ∈ targetBaseId` /
+   * `targetRecordId ∈ targetSheetId` (claim == truth). All three absent = same-base trigger-record
+   * update (unchanged, back-compat).
+   */
+  targetBaseId?: string
+  targetSheetId?: string
+  targetRecordId?: string
 }
 
 /** Config shape for create_record */
 export interface CreateRecordConfig {
   sheetId: string
   data: Record<string, unknown>
+  /**
+   * ②b cross-base write opt-in. When `targetBaseId` is set and ≠ the trigger base, this is a GOVERNED
+   * cross-base create: the executor write-gate re-verifies, per run, that the TRIGGER ACTOR holds
+   * base-WRITE on `targetBaseId` and that the resolved target sheet (`sheetId`) actually lives in
+   * `targetBaseId` (claim == truth). Absent = same-base create (unchanged, back-compat).
+   */
+  targetBaseId?: string
 }
 
 /** Config shape for send_webhook */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1495,6 +1495,19 @@ export class AutomationExecutor {
     declaredTargetBaseId: string | undefined,
     context: ExecutionContext,
   ): Promise<CrossBaseWriteGate> {
+    // Fast-path: a write to the SAME sheet as the trigger, with no explicit cross-base `targetBaseId`,
+    // is DEFINITIONALLY same-base — a sheet cannot exist in two bases — so skip the base lookups
+    // entirely. This keeps a legitimate same-sheet write from fail-closing when the sheet row is
+    // momentarily unresolvable (e.g. an executor whose queryFn doesn't model meta_sheets), while leaving
+    // the cross-base path FULLY gated: a DIFFERENT target sheet (the §1.3 create-to-another-base vector)
+    // OR any explicit `targetBaseId` claim still resolves the bases and enforces the contract below.
+    const declaredBaseClaim = typeof declaredTargetBaseId === 'string' && declaredTargetBaseId.trim()
+      ? declaredTargetBaseId.trim()
+      : null
+    if (targetSheetId === context.sheetId && declaredBaseClaim === null) {
+      return { crossBase: false }
+    }
+
     // NIT-1: check the RAW three-state result of the TARGET sheet lookup BEFORE the `?? null` collapse.
     // `undefined` = the target sheet is missing or SOFT-DELETED (resolveSheetBaseId filters deleted_at) →
     // the write target is unresolvable → fail-closed. This must precede the `?? null` normalization, else
@@ -1519,10 +1532,8 @@ export class AutomationExecutor {
 
     // Cross-base: require an explicit, consistent opt-in (claim == truth). A non-null `targetBaseId`
     // claim that equals the target sheet's ACTUAL base passes; absent or mismatched (incl. a claim vs a
-    // null actual base) rejects.
-    const claimed = typeof declaredTargetBaseId === 'string' && declaredTargetBaseId.trim()
-      ? declaredTargetBaseId.trim()
-      : null
+    // null actual base) rejects. (`declaredBaseClaim` computed at the top, reused here.)
+    const claimed = declaredBaseClaim
     if (claimed === null || claimed !== targetBaseId) {
       return {
         crossBase: true,

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
 import { redactString } from './automation-log-redact'
 import { ensureRecordNotLocked } from './record-lock'
+import { resolveBaseWritable } from './permission-service'
 import {
   DingTalkBusinessError,
   DingTalkRequestError,
@@ -679,6 +680,13 @@ export interface AutomationDeps {
   fetchFn?: typeof fetch
   notificationService?: Pick<NotificationService, 'send'>
 }
+
+// ②b cross-base write-gate verdict. `crossBase: false` → same-base, no gate (zero regression).
+// `crossBase: true` → cross-base; `ok` discriminates allowed vs the fail-closed rejection (with reason).
+type CrossBaseWriteGate =
+  | { crossBase: false }
+  | { crossBase: true; ok: true }
+  | { crossBase: true; ok: false; error: string }
 
 // ── Executor class ────────────────────────────────────────────────────────
 
@@ -1449,6 +1457,73 @@ export class AutomationExecutor {
     }
   }
 
+  // ── ②b cross-base write-gate (shared by create_record + update_record) ────
+
+  /**
+   * Resolve a record sheet's base_id via the executor's queryFn. Returns `undefined` for a missing
+   * sheet (caller treats as null base), `null` for a legacy/null base.
+   */
+  private async resolveSheetBaseId(sheetId: string): Promise<string | null | undefined> {
+    const res = await this.deps.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])
+    const row = (res.rows as Array<{ base_id?: unknown }>)[0]
+    if (!row) return undefined
+    return typeof row.base_id === 'string' ? row.base_id : null
+  }
+
+  /**
+   * ②b write-gate: decide whether a record-mutating action's resolved target sheet is a CROSS-BASE
+   * write, and if so enforce the governed contract. Same-base (target sheet base === trigger base,
+   * null-aware) → `{ crossBase: false }` with NO new gate (zero regression). Cross-base → ALL of:
+   *   1. an explicit `targetBaseId` is provided AND `targetBaseId === target sheet's actual base_id`
+   *      (claim == truth; mirrors the §2a.2 link wall's `claimed === actualForeignBaseId`). A cross-base
+   *      write WITHOUT `targetBaseId`, or with a mismatched one → reject (closes the §1.3 ungated hole).
+   *   2. `resolveBaseWritable(context.actorId, queryFn, targetBaseId)` is true — the EFFECTIVE ACTOR is
+   *      the TRIGGER actor (RATIFIED decision 2); a null actorId (e.g. scheduled trigger) fails this
+   *      because `resolveBaseWritable` is fail-closed on no userId. NO fallback to the rule owner.
+   * Returns a discriminated result; on any rejection the caller records a FAILED step (never a write).
+   *
+   * The trigger base is `context.sheetId`'s base. Note the same-base happy path still issues ONE base
+   * lookup per side; that is read-only and cannot fail the write — a missing trigger sheet base and a
+   * missing target sheet base both normalize to null and (null === null) stays same-base.
+   */
+  private async evaluateCrossBaseWrite(
+    targetSheetId: string,
+    declaredTargetBaseId: string | undefined,
+    context: ExecutionContext,
+  ): Promise<CrossBaseWriteGate> {
+    const triggerBaseId = (await this.resolveSheetBaseId(context.sheetId)) ?? null
+    const targetBaseId = (await this.resolveSheetBaseId(targetSheetId)) ?? null
+
+    // Same-base (null-aware, mirrors `baseIdsAreCrossBase` = strict `!==`): null-vs-null and
+    // same-set are same-base; a null/legacy base vs a set base is cross-base.
+    if (triggerBaseId === targetBaseId) return { crossBase: false }
+
+    // Cross-base: require an explicit, consistent opt-in (claim == truth). A non-null `targetBaseId`
+    // claim that equals the target sheet's ACTUAL base passes; absent or mismatched (incl. a claim vs a
+    // null actual base) rejects.
+    const claimed = typeof declaredTargetBaseId === 'string' && declaredTargetBaseId.trim()
+      ? declaredTargetBaseId.trim()
+      : null
+    if (claimed === null || claimed !== targetBaseId) {
+      return {
+        crossBase: true,
+        ok: false,
+        error: `Cross-base write requires an explicit targetBaseId equal to the target sheet's base: target sheet ${targetSheetId} base=${targetBaseId ?? 'null'}, declared=${claimed ?? 'null'}`,
+      }
+    }
+
+    // Trigger-actor base-write authority (fail-closed: null actor → false).
+    const writable = await resolveBaseWritable(context.actorId ?? null, this.deps.queryFn, targetBaseId)
+    if (!writable) {
+      return {
+        crossBase: true,
+        ok: false,
+        error: `Cross-base write denied: trigger actor lacks base-write on ${targetBaseId}`,
+      }
+    }
+    return { crossBase: true, ok: true }
+  }
+
   // ── Individual action executors ─────────────────────────────────────────
 
   private async executeUpdateRecord(
@@ -1462,18 +1537,60 @@ export class AutomationExecutor {
 
     const patch = Object.fromEntries(Object.entries(fields))
 
+    // ②b cross-base addressing. The resolved target sheet is `config.targetSheetId ?? context.sheetId`.
+    // For a CROSS-BASE update, `targetSheetId` + `targetRecordId` are REQUIRED (the trigger record is not
+    // in the target base) — the lock-check AND the write both retarget to the TARGET record. For a
+    // SAME-BASE update they default to the trigger record (unchanged, back-compat).
+    const targetSheetId = (config.targetSheetId as string) || context.sheetId
+    const declaredTargetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId : undefined
+
     try {
+      const gate = await this.evaluateCrossBaseWrite(targetSheetId, declaredTargetBaseId, context)
+      let effectiveSheetId = context.sheetId
+      let effectiveRecordId = context.recordId
+      if (gate.crossBase) {
+        if (gate.ok === false) {
+          return { actionType: 'update_record', status: 'failed', error: gate.error }
+        }
+        // Cross-base requires the full explicit target triple (§2.4 / decision 5). The executor is the
+        // last line of defense even if rule-save validation were bypassed.
+        const targetRecordId = typeof config.targetRecordId === 'string' ? config.targetRecordId : ''
+        if (!config.targetSheetId || !targetRecordId) {
+          return {
+            actionType: 'update_record',
+            status: 'failed',
+            error: 'Cross-base update_record requires targetBaseId + targetSheetId + targetRecordId',
+          }
+        }
+        effectiveSheetId = targetSheetId
+        effectiveRecordId = targetRecordId
+      }
+
       // Record-lock guard (rank-8 review B1; decisions d/e/f). An automation acting on behalf of its
       // actor is NOT implicitly the locker/owner — overwriting a locked record is blocked. To write
       // through a lock the rule must first run a `lock_record{locked:false}` action (decision f). The
-      // step fails honestly so it surfaces in the execution log.
+      // step fails honestly so it surfaces in the execution log. ②b LOCK-REDIRECT: the SELECT below
+      // and the UPDATE further down BOTH read `effectiveSheetId`/`effectiveRecordId` so a cross-base
+      // update checks the TARGET record's lock (not the trigger record's) — lock priority over base-write.
       const lockRes = await this.deps.queryFn(
         'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
-        [context.recordId, context.sheetId],
+        [effectiveRecordId, effectiveSheetId],
       )
       const lockRow = lockRes.rows[0] as
         | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
         | undefined
+      // ②b claim==truth for the record: a cross-base update must address a record that ACTUALLY lives in
+      // `targetSheetId`. If the lock SELECT found no row, the targetRecordId does not exist in
+      // targetSheetId → fail-closed (decision 4: never a silent no-op success). Same-base keeps its
+      // pre-②b leniency (a missing trigger record yields a 0-row UPDATE reported as success) to avoid
+      // any behavior regression.
+      if (gate.crossBase && !lockRow) {
+        return {
+          actionType: 'update_record',
+          status: 'failed',
+          error: `Cross-base update_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+        }
+      }
       if (lockRow) {
         ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
       }
@@ -1485,13 +1602,13 @@ export class AutomationExecutor {
              version = version + 1,
              updated_at = NOW()
          WHERE id = $2 AND sheet_id = $3`,
-        [JSON.stringify(patch), context.recordId, context.sheetId],
+        [JSON.stringify(patch), effectiveRecordId, effectiveSheetId],
       )
 
       // Emit event for chaining
       this.deps.eventBus.emit('multitable.record.updated', {
-        sheetId: context.sheetId,
-        recordId: context.recordId,
+        sheetId: effectiveSheetId,
+        recordId: effectiveRecordId,
         changes: fields,
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
@@ -1508,10 +1625,21 @@ export class AutomationExecutor {
     context: ExecutionContext,
   ): Promise<AutomationStepResult> {
     const targetSheetId = (config.sheetId as string) || context.sheetId
+    const declaredTargetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId : undefined
     const data = (config.data as Record<string, unknown>) ?? {}
     const recordId = `rec_${randomUUID()}`
 
     try {
+      // ②b write-gate (closes the §1.3 ungated hole). Pre-②b this method did a BARE INSERT to
+      // `config.sheetId ?? context.sheetId` with ZERO permission check, so an automation could create a
+      // record in ANY base's sheet ungated. Now a CROSS-BASE create (target sheet base ≠ trigger base)
+      // demands an explicit consistent `targetBaseId` (claim == truth) + trigger-actor base-write;
+      // a SAME-BASE create is unchanged (no gate).
+      const gate = await this.evaluateCrossBaseWrite(targetSheetId, declaredTargetBaseId, context)
+      if (gate.crossBase && gate.ok === false) {
+        return { actionType: 'create_record', status: 'failed', error: gate.error }
+      }
+
       await this.deps.queryFn(
         `INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)`,
         [recordId, targetSheetId, JSON.stringify(data)],

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1460,11 +1460,15 @@ export class AutomationExecutor {
   // ── ②b cross-base write-gate (shared by create_record + update_record) ────
 
   /**
-   * Resolve a record sheet's base_id via the executor's queryFn. Returns `undefined` for a missing
-   * sheet (caller treats as null base), `null` for a legacy/null base.
+   * Resolve a record sheet's base_id via the executor's queryFn. Returns `undefined` for a missing OR
+   * SOFT-DELETED sheet (caller treats as an unresolvable target → fail-closed), `null` for a legacy/null
+   * base. NIT-1: the `deleted_at IS NULL` filter ensures a soft-deleted target sheet resolves to "no row"
+   * so a cross-base write into a logically-deleted sheet cannot resolve a target base (mirrors the REST
+   * record-create guard at record-service.ts). The state is unreachable today (sheets are hard-deleted)
+   * but this hardens against a future sheet-soft-delete feature.
    */
   private async resolveSheetBaseId(sheetId: string): Promise<string | null | undefined> {
-    const res = await this.deps.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])
+    const res = await this.deps.queryFn('SELECT base_id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL', [sheetId])
     const row = (res.rows as Array<{ base_id?: unknown }>)[0]
     if (!row) return undefined
     return typeof row.base_id === 'string' ? row.base_id : null
@@ -1491,8 +1495,23 @@ export class AutomationExecutor {
     declaredTargetBaseId: string | undefined,
     context: ExecutionContext,
   ): Promise<CrossBaseWriteGate> {
+    // NIT-1: check the RAW three-state result of the TARGET sheet lookup BEFORE the `?? null` collapse.
+    // `undefined` = the target sheet is missing or SOFT-DELETED (resolveSheetBaseId filters deleted_at) →
+    // the write target is unresolvable → fail-closed. This must precede the `?? null` normalization, else
+    // a soft-deleted target (undefined → null) would collapse against a legacy-null trigger base
+    // (null === null → same-base) and silently SKIP the gate. Treating it as a cross-base rejection keeps
+    // legitimate legacy-null-base SAME-BASE writes (both sides null, both rows present) unaffected.
+    const rawTargetBaseId = await this.resolveSheetBaseId(targetSheetId)
+    if (rawTargetBaseId === undefined) {
+      return {
+        crossBase: true,
+        ok: false,
+        error: `Cross-base write target sheet ${targetSheetId} is missing or soft-deleted (no resolvable base)`,
+      }
+    }
+
     const triggerBaseId = (await this.resolveSheetBaseId(context.sheetId)) ?? null
-    const targetBaseId = (await this.resolveSheetBaseId(targetSheetId)) ?? null
+    const targetBaseId = rawTargetBaseId ?? null
 
     // Same-base (null-aware, mirrors `baseIdsAreCrossBase` = strict `!==`): null-vs-null and
     // same-set are same-base; a null/legacy base vs a set base is cross-base.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -177,6 +177,42 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * ②b cross-base write SHAPE validation at rule-save time (fail-closed before any run). This validates
+ * ADDRESSING SHAPE only — the actual base-write AUTHORITY + claim==truth are re-checked per run in the
+ * executor write-gate (`evaluateCrossBaseWrite`). When a record-mutating action declares a non-empty
+ * `targetBaseId` (opting into cross-base):
+ *  - `update_record` MUST also carry a non-empty `targetSheetId` AND `targetRecordId` (the trigger
+ *    record is not in the target base, so the update has no record to address otherwise — §2.4).
+ *  - `create_record` needs nothing more (its `sheetId` is the target sheet).
+ * A malformed cross-base config → rejected at save. (Same-base actions — no `targetBaseId` — pass.)
+ */
+function validateCrossBaseWriteConfig(config: Record<string, unknown>, actionType: string, path: string): string | null {
+  if (actionType !== 'update_record') return null
+  const targetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId.trim() : ''
+  if (!targetBaseId) return null // same-base (or no opt-in) — nothing to validate
+  const targetSheetId = typeof config.targetSheetId === 'string' ? config.targetSheetId.trim() : ''
+  const targetRecordId = typeof config.targetRecordId === 'string' ? config.targetRecordId.trim() : ''
+  if (!targetSheetId || !targetRecordId) {
+    return `${path}: cross-base update_record requires targetSheetId and targetRecordId when targetBaseId is set`
+  }
+  return null
+}
+
+function validateCrossBaseWriteActionConfigs(
+  actionType: string,
+  actionConfig: Record<string, unknown>,
+  actions: AutomationAction[] | null | undefined,
+): string | null {
+  const topLevel = validateCrossBaseWriteConfig(actionConfig, actionType, 'actionConfig')
+  if (topLevel) return topLevel
+  for (const [index, action] of (actions ?? []).entries()) {
+    const error = validateCrossBaseWriteConfig(action.config, action.type, `actions[${index}].config`)
+    if (error) return error
+  }
+  return null
+}
+
 function validateActionObject(action: unknown, path: string): AutomationAction {
   if (!isRecord(action)) {
     throw new AutomationRuleValidationError(`${path} must be an object`)
@@ -646,6 +682,8 @@ export class AutomationService {
     if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
     const startApprovalValidationError = validateStartApprovalActionConfigs(input.actionType, actionConfig, actionsForValidation)
     if (startApprovalValidationError) throw new AutomationRuleValidationError(startApprovalValidationError)
+    const crossBaseWriteValidationError = validateCrossBaseWriteActionConfigs(input.actionType, actionConfig, actionsForValidation)
+    if (crossBaseWriteValidationError) throw new AutomationRuleValidationError(crossBaseWriteValidationError)
     const linkValidationError = await validateDingTalkAutomationLinks(
       this.queryFn,
       sheetId,
@@ -785,6 +823,12 @@ export class AutomationService {
         actionsForValidation,
       )
       if (startApprovalValidationError) throw new AutomationRuleValidationError(startApprovalValidationError)
+      const crossBaseWriteValidationError = validateCrossBaseWriteActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        actionsForValidation,
+      )
+      if (crossBaseWriteValidationError) throw new AutomationRuleValidationError(crossBaseWriteValidationError)
       const linkValidationError = await validateDingTalkAutomationLinks(
         this.queryFn,
         sheetId,

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -43,6 +43,7 @@ import {
   type RecordPermissionScope,
   type ViewPermissionScope,
 } from './permission-derivation'
+import { filterPermissionCodesByNamespaceAdmission } from '../rbac/namespace-admission'
 
 export { deriveRowActions, type MultitableRowActions } from './access'
 
@@ -122,6 +123,13 @@ export const BASE_ADMIN_PERMISSION_CODES = new Set([
   'multitable:base:admin',
   'multitable:admin',
 ])
+
+// ②b automation slice — base-level WRITE authority. RATIFIED decision 1 (a): `base:admin` IMPLIES write
+// — there is no separate `base:write` code at this stage, so the write code-set is IDENTICAL to
+// `BASE_ADMIN_PERMISSION_CODES`. This makes the cross-base automation write-gate deliberately HIGH
+// (base-writable ≡ base-admin-or-owner); a finer `multitable:base:write` tier is a future opt-in. Like
+// the read codes, the §2a.2 wall does NOT consult these (it compares two base_id strings only).
+export const BASE_WRITE_PERMISSION_CODES = BASE_ADMIN_PERMISSION_CODES
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -1261,4 +1269,58 @@ export async function resolveBaseReadable(
   if (!row) return false
   const ownerId = typeof row.owner_id === 'string' ? row.owner_id.trim() : ''
   return Boolean(ownerId) && Boolean(access.userId) && ownerId === access.userId
+}
+
+/**
+ * ②b automation slice — base-level WRITE resolver (the write-side counterpart of `resolveBaseReadable`).
+ *
+ * Unlike `resolveBaseReadable`, this takes an ALREADY-RESOLVED `userId`, NOT a `Request`: the automation
+ * executor has no `req`, only a `queryFn`. It mirrors the `start_approval` requester-resolution mechanism
+ * (`listRbacPermissionCodes`) — fetch the user's effective permission codes (user_permissions ∪
+ * role_permissions, then narrowed by namespace admission so a namespace-revoked code cannot grant write)
+ * and grant write when any is a `BASE_WRITE_PERMISSION_CODES` code (= `multitable:base:admin` /
+ * `multitable:admin`), OR when the user owns the base (`meta_bases.owner_id`, mirroring
+ * `resolveBaseReadable`'s owner derivation). FAIL-CLOSED: no userId → false; a missing / soft-deleted
+ * base → false. It does NOT touch central RBAC / auth — kernel-internal to multitable.
+ */
+export async function resolveBaseWritable(
+  userId: string | null | undefined,
+  query: QueryFn,
+  baseId: string,
+): Promise<boolean> {
+  const normalizedUserId = typeof userId === 'string' ? userId.trim() : ''
+  if (!normalizedUserId) return false // fail-closed: no identity → no write
+  const normalizedBaseId = baseId.trim()
+  if (!normalizedBaseId) return false
+
+  // Effective permission codes (user_permissions ∪ role_permissions), narrowed by namespace admission so
+  // the write gate is never MORE permissive than the codebase's effective-permission resolution.
+  const codesRes = await query(
+    `SELECT DISTINCT permission_code AS code FROM (
+       SELECT up.permission_code
+         FROM user_permissions up
+        WHERE up.user_id = $1
+       UNION ALL
+       SELECT rp.permission_code
+         FROM user_roles ur
+         JOIN role_permissions rp ON rp.role_id = ur.role_id
+        WHERE ur.user_id = $1
+     ) t`,
+    [normalizedUserId],
+  )
+  const rawCodes = (codesRes.rows as Array<{ code: unknown }>)
+    .map((r) => (typeof r.code === 'string' ? r.code : ''))
+    .filter(Boolean)
+  const codes = await filterPermissionCodesByNamespaceAdmission(normalizedUserId, rawCodes)
+  if (codes.some((code) => BASE_WRITE_PERMISSION_CODES.has(code))) return true
+
+  // base ownership (symmetric with resolveBaseReadable).
+  const res = await query(
+    'SELECT owner_id FROM meta_bases WHERE id = $1 AND deleted_at IS NULL',
+    [normalizedBaseId],
+  )
+  const row = (res.rows as Array<{ owner_id: unknown }>)[0]
+  if (!row) return false
+  const ownerId = typeof row.owner_id === 'string' ? row.owner_id.trim() : ''
+  return Boolean(ownerId) && ownerId === normalizedUserId
 }

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1293,6 +1293,18 @@ export async function resolveBaseWritable(
   const normalizedBaseId = baseId.trim()
   if (!normalizedBaseId) return false
 
+  // NIT-1: target-base EXISTENCE first (mirrors the owner SELECT's `deleted_at IS NULL` guard). A
+  // missing / soft-deleted base is NOT writable by ANYONE — including an admin/grant holder. Resolving
+  // existence BEFORE the admin/grant short-circuit closes the latent hole where the short-circuit
+  // returned `true` ahead of this check, so the documented "a missing/soft-deleted base → false"
+  // intent was dead code for admins. The owner derivation below reuses this same row.
+  const baseRes = await query(
+    'SELECT owner_id FROM meta_bases WHERE id = $1 AND deleted_at IS NULL',
+    [normalizedBaseId],
+  )
+  const baseRow = (baseRes.rows as Array<{ owner_id: unknown }>)[0]
+  if (!baseRow) return false // missing / soft-deleted target base → fail-closed (even for an admin)
+
   // Effective permission codes (user_permissions ∪ role_permissions), narrowed by namespace admission so
   // the write gate is never MORE permissive than the codebase's effective-permission resolution.
   const codesRes = await query(
@@ -1314,13 +1326,7 @@ export async function resolveBaseWritable(
   const codes = await filterPermissionCodesByNamespaceAdmission(normalizedUserId, rawCodes)
   if (codes.some((code) => BASE_WRITE_PERMISSION_CODES.has(code))) return true
 
-  // base ownership (symmetric with resolveBaseReadable).
-  const res = await query(
-    'SELECT owner_id FROM meta_bases WHERE id = $1 AND deleted_at IS NULL',
-    [normalizedBaseId],
-  )
-  const row = (res.rows as Array<{ owner_id: unknown }>)[0]
-  if (!row) return false
-  const ownerId = typeof row.owner_id === 'string' ? row.owner_id.trim() : ''
+  // base ownership (symmetric with resolveBaseReadable) — reuses the existence row resolved above.
+  const ownerId = typeof baseRow.owner_id === 'string' ? baseRow.owner_id.trim() : ''
   return Boolean(ownerId) && ownerId === normalizedUserId
 }

--- a/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
+++ b/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
@@ -1,0 +1,91 @@
+/**
+ * ②b automation slice — base-level WRITE resolver `resolveBaseWritable` in isolation (real DB).
+ *
+ * The write-side counterpart of `resolveBaseReadable`. Unlike the read resolver it takes an
+ * already-resolved `userId` (NOT a Request) because the automation executor has no `req` — it derives
+ * write authority from `BASE_WRITE_PERMISSION_CODES` (= `multitable:base:admin` / `multitable:admin`)
+ * via the effective-permission-codes SQL (user_permissions ∪ role_permissions, narrowed by namespace
+ * admission) OR from base ownership (`meta_bases.owner_id`). FAIL-CLOSED: no userId → false; a
+ * missing / soft-deleted base → false.
+ *
+ * Real DB (describeIfDatabase) — the resolver queries user_permissions / role_permissions / user_roles /
+ * meta_bases directly.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { resolveBaseWritable } from '../../src/multitable/permission-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const OWNER = `u_bww_owner_${TS}` // owns BASE_A only
+const ADMIN_CODE = `u_bww_admincode_${TS}` // holds multitable:base:admin grant → write any base
+const NOBODY = `u_bww_nobody_${TS}` // no grant, owns nothing → write nothing
+
+const BASE_A = `base_bww_a_${TS}` // owned by OWNER
+const BASE_B = `base_bww_b_${TS}` // owned by someone else
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'BWW Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'BWW Base B', `u_bww_other_${TS}`])
+
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('multitable:base:admin', 'Base Admin', 'resolveBaseWritable tests')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [ADMIN_CODE, `${ADMIN_CODE}@example.test`],
+    )
+    await q(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'multitable:base:admin') ON CONFLICT DO NOTHING`,
+      [ADMIN_CODE],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('base owner can write its OWN base only (not a base owned by someone else)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(OWNER, query, BASE_A)).toBe(true)
+    expect(await resolveBaseWritable(OWNER, query, BASE_B)).toBe(false)
+  })
+
+  test('a holder of the global multitable:base:admin grant can write any base', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(ADMIN_CODE, query, BASE_A)).toBe(true)
+    expect(await resolveBaseWritable(ADMIN_CODE, query, BASE_B)).toBe(true)
+  })
+
+  test('a non-owner without a base grant cannot write either base', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(NOBODY, query, BASE_A)).toBe(false)
+    expect(await resolveBaseWritable(NOBODY, query, BASE_B)).toBe(false)
+  })
+
+  test('fail-closed: null/empty userId → false (no identity, no write)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(null, query, BASE_A)).toBe(false)
+    expect(await resolveBaseWritable(undefined, query, BASE_A)).toBe(false)
+    expect(await resolveBaseWritable('   ', query, BASE_A)).toBe(false)
+  })
+
+  test('fail-closed: a missing / soft-deleted base is not writable (no null-deref)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    // OWNER owns NO record for this id → owner derivation finds nothing → false.
+    expect(await resolveBaseWritable(OWNER, query, `base_bww_missing_${TS}`)).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
+++ b/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
@@ -25,6 +25,7 @@ const NOBODY = `u_bww_nobody_${TS}` // no grant, owns nothing → write nothing
 
 const BASE_A = `base_bww_a_${TS}` // owned by OWNER
 const BASE_B = `base_bww_b_${TS}` // owned by someone else
+const DEL_BASE = `base_bww_del_${TS}` // SOFT-DELETED (deleted_at set), owned by OWNER
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
@@ -32,6 +33,8 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
   beforeAll(async () => {
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'BWW Base A', OWNER])
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'BWW Base B', `u_bww_other_${TS}`])
+    // A soft-deleted base owned by OWNER — seed `deleted_at` directly (no runtime path produces it).
+    await q('INSERT INTO meta_bases (id, name, owner_id, deleted_at) VALUES ($1, $2, $3, NOW())', [DEL_BASE, 'BWW Soft-Deleted Base', OWNER])
 
     await q(
       `INSERT INTO permissions (code, name, description)
@@ -53,7 +56,7 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
 
   afterAll(async () => {
     await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
-    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, DEL_BASE]]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
@@ -87,5 +90,14 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
     const query = poolManager.get().query.bind(poolManager.get())
     // OWNER owns NO record for this id → owner derivation finds nothing → false.
     expect(await resolveBaseWritable(OWNER, query, `base_bww_missing_${TS}`)).toBe(false)
+  })
+
+  // NIT-1: the existence check must run BEFORE the admin/grant short-circuit, so even an admin/grant
+  // holder is NOT writable on a soft-deleted base (the short-circuit previously returned true first).
+  // RED on pre-fix HEAD (admin short-circuits before the deleted_at SELECT); GREEN after the reorder.
+  test('fail-closed: a SOFT-DELETED base is not writable even for an admin-grant holder OR the owner', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(ADMIN_CODE, query, DEL_BASE)).toBe(false)
+    expect(await resolveBaseWritable(OWNER, query, DEL_BASE)).toBe(false)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-cross-base-automation-write-rule.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-automation-write-rule.test.ts
@@ -1,0 +1,200 @@
+/**
+ * ②b automation slice — rule-save validation + wire round-trip for cross-base writes (real DB).
+ *
+ * Companion to `multitable-cross-base-automation-write.test.ts` (which drives the executor write-gate).
+ * This suite exercises the RULE API altitude:
+ *  - XW-2d: a cross-base `update_record` missing `targetSheetId`/`targetRecordId` → rule-save 400
+ *    (the §2.4 explicit-addressing requirement is enforced at save time, fail-closed before any run).
+ *  - XW-5: `targetBaseId` (+ the update target triple) round-trips through the REAL rule wire
+ *    (createRule → getRule → action config) — the wire-vs-fixture guard this repo bleeds over: a
+ *    field added to a serialized object MUST survive the real persist/read projection.
+ *  - XW-6 (baseline note): the §1.3 hole was that `create_record` could write to ANY sheet ungated.
+ *    Pre-fix that path had no save-time nor run-time gate; post-fix the run-time gate (XW-1b) closes it.
+ *    This suite locks the SAVE-time half: a malformed cross-base update is rejected at save.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { eventBus } from '../../src/integration/events/event-bus'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationService } from '../../src/multitable/automation-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_A = `base_xwr_a_${TS}`
+const BASE_B = `base_xwr_b_${TS}`
+const SHEET_A = `sheet_xwr_a_${TS}`
+const SHEET_B = `sheet_xwr_b_${TS}`
+const OWNER = `u_xwr_owner_${TS}`
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const ruleIds: string[] = []
+
+function makeService(): AutomationService {
+  const svc = new AutomationService(eventBus, db as never, q as never)
+  svc.init()
+  return svc
+}
+
+describeIfDatabase('②b automation — rule-save validation + wire round-trip (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'XWR Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'XWR Base B', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'XWR A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'XWR B'])
+  })
+
+  afterAll(async () => {
+    if (ruleIds.length) {
+      await q('DELETE FROM automation_rules WHERE id = ANY($1::text[])', [ruleIds]).catch(() => {})
+    }
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── XW-2d: cross-base update missing target addressing → rule-save 400 ───────
+  test('XW-2d: createRule with cross-base update_record missing targetSheetId/targetRecordId is rejected at save', async () => {
+    const svc = makeService()
+    try {
+      await expect(
+        svc.createRule(SHEET_A, {
+          name: 'XWR bad update',
+          triggerType: 'record.created',
+          triggerConfig: {},
+          actionType: 'update_record',
+          actionConfig: { targetBaseId: BASE_B, fields: { v: 'x' } }, // missing targetSheetId + targetRecordId
+          createdBy: OWNER,
+        }),
+      ).rejects.toThrow(/cross-base update_record requires targetSheetId and targetRecordId/)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  // ── XW-2d (nested): the same malformed update inside a parallel_branch is rejected ─
+  // parallel_branch ALLOWS update_record as a branch action, so the rejection must come from the
+  // cross-base ADDRESSING validator (not a type-ban). Assert the SPECIFIC error to avoid a false green.
+  test('XW-2d (nested): a cross-base update missing addressing inside parallel_branch is rejected at save with the addressing error', async () => {
+    const svc = makeService()
+    try {
+      await expect(
+        svc.createRule(SHEET_A, {
+          name: 'XWR nested bad update',
+          triggerType: 'record.created',
+          triggerConfig: {},
+          actionType: 'parallel_branch',
+          actionConfig: {
+            joinMode: 'all',
+            branches: [
+              {
+                key: 'b1',
+                actions: [
+                  { type: 'update_record', config: { targetBaseId: BASE_B, fields: { v: 'x' } } },
+                ],
+              },
+            ],
+          },
+          executionMode: 'workflow_job_v1',
+          createdBy: OWNER,
+        } as never),
+      ).rejects.toThrow(/cross-base update_record requires targetSheetId and targetRecordId/)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  // ── XW-2f (nested RUNTIME): a cross-base update nested in parallel_branch is GATED at runtime ──
+  // parallel_branch runs branch actions via `executeSingleAction(branchAction, context)` with the SAME
+  // trigger context, so the executor write-gate must fire on NESTED actions too. Driven through the real
+  // service (workflow_job_v1 supplies the job lifecycle parallel_branch requires) + real DB queryFn.
+  test('XW-2f (nested runtime): cross-base update nested in parallel_branch with NO base-write → not written, execution failed', async () => {
+    const svc = makeService()
+    const NO_WRITE = `u_xwr_nowrite_${TS}`
+    const recId = `rec_xwr_2f_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recId, SHEET_B, JSON.stringify({ v: 'old' })])
+    try {
+      const parallelAction = {
+        type: 'parallel_branch',
+        config: {
+          joinMode: 'all',
+          branches: [
+            {
+              key: 'b1',
+              actions: [
+                { type: 'update_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId, fields: { v: 'new' } } },
+              ],
+            },
+          ],
+        },
+      } as const
+      const exec = await svc.executeRule(
+        {
+          id: `axr_xwr_2f_${TS}`,
+          name: 'XWR nested runtime',
+          sheetId: SHEET_A,
+          trigger: { type: 'record.created', config: {} },
+          actions: [parallelAction],
+          enabled: true,
+          createdBy: OWNER, // rule owner — but the effective actor is the TRIGGER actor (NO_WRITE)
+          createdAt: new Date(TS).toISOString(),
+          executionMode: 'workflow_job_v1',
+        } as never,
+        { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: NO_WRITE, data: {} },
+      )
+      // The nested cross-base update was gated → target unchanged + the execution did not succeed.
+      expect((await q('SELECT data FROM meta_records WHERE id = $1', [recId]).then((r) => (r.rows as Array<{ data: Record<string, unknown> }>)[0]?.data?.v))).toBe('old')
+      expect(exec.status).not.toBe('success')
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+      svc.shutdown()
+    }
+  })
+
+  // ── XW-5: targetBaseId (+ update triple) survive the real rule wire round-trip ─
+  test('XW-5: create_record targetBaseId round-trips through createRule → getRule', async () => {
+    const svc = makeService()
+    try {
+      const created = await svc.createRule(SHEET_A, {
+        name: 'XWR create roundtrip',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'create_record',
+        actionConfig: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'rt' } },
+        createdBy: OWNER,
+      })
+      ruleIds.push(created.id)
+      const fetched = await svc.getRule(created.id)
+      expect(fetched).toBeDefined()
+      const cfg = (fetched as unknown as { action_config: Record<string, unknown> }).action_config
+      expect(cfg.targetBaseId).toBe(BASE_B)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('XW-5b: update_record target addressing triple round-trips through createRule → getRule', async () => {
+    const svc = makeService()
+    try {
+      const recId = `rec_xwr_rt_${TS}`
+      const created = await svc.createRule(SHEET_A, {
+        name: 'XWR update roundtrip',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'update_record',
+        actionConfig: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId, fields: { v: 'rt' } },
+        createdBy: OWNER,
+      })
+      ruleIds.push(created.id)
+      const fetched = await svc.getRule(created.id)
+      const cfg = (fetched as unknown as { action_config: Record<string, unknown> }).action_config
+      expect(cfg.targetBaseId).toBe(BASE_B)
+      expect(cfg.targetSheetId).toBe(SHEET_B)
+      expect(cfg.targetRecordId).toBe(recId)
+    } finally {
+      svc.shutdown()
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-cross-base-automation-write.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-automation-write.test.ts
@@ -42,6 +42,13 @@ const BASE_B = `base_xw_b_${TS}` // target base (cross-base write sink)
 const SHEET_A = `sheet_xw_a_${TS}` // trigger sheet (BASE_A)
 const SHEET_B = `sheet_xw_b_${TS}` // cross-base target sheet (BASE_B)
 
+// NIT-1 soft-delete canary fixtures (dedicated — never mutate the shared BASE_B/SHEET_B which
+// sibling tests reuse live). The soft-deleted state is UNREACHABLE through any runtime path today
+// (sheets are hard-deleted, bases are never deleted), so these seed `deleted_at` directly via SQL.
+const DEL_BASE = `base_xw_del_${TS}` // a SOFT-DELETED base (deleted_at set), owned by OWNER
+const LIVE_SHEET_IN_DEL_BASE = `sheet_xw_indelbase_${TS}` // a LIVE sheet pointing at DEL_BASE
+const DEL_SHEET_IN_LIVE_BASE = `sheet_xw_del_${TS}` // a SOFT-DELETED sheet in the LIVE BASE_B
+
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
 function makeExecutor(): { executor: AutomationExecutor; eventBus: EventBus } {
@@ -102,12 +109,18 @@ describeIfDatabase('②b automation — governed cross-base writes + close §1.3
        VALUES ($1, 'multitable:base:admin') ON CONFLICT DO NOTHING`,
       [ADMIN_CODE],
     )
+
+    // NIT-1 soft-delete canary fixtures — seed `deleted_at` directly (no runtime path produces it).
+    await q('INSERT INTO meta_bases (id, name, owner_id, deleted_at) VALUES ($1, $2, $3, NOW())', [DEL_BASE, 'XW Soft-Deleted Base', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [LIVE_SHEET_IN_DEL_BASE, DEL_BASE, 'Live sheet in soft-deleted base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name, deleted_at) VALUES ($1, $2, $3, NOW())', [DEL_SHEET_IN_LIVE_BASE, BASE_B, 'Soft-deleted sheet in live base'])
   })
 
   afterAll(async () => {
-    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
-    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
-    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    const sheets = [SHEET_A, SHEET_B, LIVE_SHEET_IN_DEL_BASE, DEL_SHEET_IN_LIVE_BASE]
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, DEL_BASE]]).catch(() => {})
     await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
   })
 
@@ -297,5 +310,74 @@ describeIfDatabase('②b automation — governed cross-base writes + close §1.3
     const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: null, data: {}, _triggeredBy: 'schedule' } as never)
     expect(exec.steps[0]?.status).toBe('failed')
     expect(await countRecords(SHEET_B)).toBe(before) // fail-closed: no write
+  })
+
+  // ── XW-6: NIT-1 — soft-deleted / missing target base or sheet → fail-closed ──
+  // The soft-deleted state is UNREACHABLE through any runtime path today (sheets are hard-deleted,
+  // bases are never deleted), so each fixture seeds `deleted_at` directly. The gate must STILL reject
+  // a cross-base write into a logically-deleted target, for an ADMIN *and* a base-OWNER actor, so a
+  // future soft-delete feature cannot silently re-arm a zombie/resurrection write. RED on pre-fix HEAD
+  // (the admin short-circuit / the unfiltered sheet lookup lets the write land); GREEN after.
+
+  test('XW-6a: cross-base create into a LIVE sheet in a SOFT-DELETED base, by an ADMIN actor → step failed, NO write', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(LIVE_SHEET_IN_DEL_BASE)
+    const rule = ruleWith(
+      // claim == truth (DEL_BASE is the live sheet's actual base) — the only thing that should reject
+      // is base existence. ADMIN holds multitable:base:admin, which today short-circuits BEFORE the
+      // deleted_at check → zombie INSERT into a soft-deleted base.
+      { type: 'create_record', config: { sheetId: LIVE_SHEET_IN_DEL_BASE, targetBaseId: DEL_BASE, data: { v: 'xw6a' } } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: ADMIN_CODE, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(LIVE_SHEET_IN_DEL_BASE)).toBe(before) // fail-closed: no write into a soft-deleted base
+  })
+
+  test('XW-6b: cross-base create into a LIVE sheet in a SOFT-DELETED base, by the base OWNER → step failed, NO write', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(LIVE_SHEET_IN_DEL_BASE)
+    // OWNER owns DEL_BASE — the owner path is already deleted_at-guarded, so this should ALSO reject
+    // (mirrors how the owner SELECT requires existence). Locks in symmetry: admin and owner alike.
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: LIVE_SHEET_IN_DEL_BASE, targetBaseId: DEL_BASE, data: { v: 'xw6b' } } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(LIVE_SHEET_IN_DEL_BASE)).toBe(before)
+  })
+
+  test('XW-6c: cross-base create into a SOFT-DELETED sheet (in a live base), by the base OWNER → step failed, NO write', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(DEL_SHEET_IN_LIVE_BASE)
+    // The target sheet is soft-deleted but its base (BASE_B) is LIVE and owned by OWNER. Pre-fix the
+    // sheet→base lookup has no deleted_at filter, so claim==truth passes and the owner is writable on
+    // the live base → an OWNER (non-admin) row lands in a soft-deleted sheet. Post-fix the soft-deleted
+    // sheet resolves to "no row" → target base unresolvable → fail-closed.
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: DEL_SHEET_IN_LIVE_BASE, targetBaseId: BASE_B, data: { v: 'xw6c' } } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(DEL_SHEET_IN_LIVE_BASE)).toBe(before)
+  })
+
+  test('XW-6d: cross-base UPDATE into a LIVE sheet in a SOFT-DELETED base, by an ADMIN actor → step failed, target unchanged', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_xw6d_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recId, LIVE_SHEET_IN_DEL_BASE, JSON.stringify({ v: 'old' })])
+    try {
+      const rule = ruleWith(
+        { type: 'update_record', config: { targetBaseId: DEL_BASE, targetSheetId: LIVE_SHEET_IN_DEL_BASE, targetRecordId: recId, fields: { v: 'mutated' } } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: ADMIN_CODE, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect((await recordData(recId))?.v).toBe('old') // unchanged: no write into a soft-deleted base
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
   })
 })

--- a/packages/core-backend/tests/integration/multitable-cross-base-automation-write.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-automation-write.test.ts
@@ -1,0 +1,301 @@
+/**
+ * ②b automation slice — governed cross-base automation WRITES (real DB).
+ *
+ * Closes a live pre-existing hole AND opens the governed path. Today `executeCreateRecord` does a bare
+ * INSERT to `config.sheetId ?? context.sheetId` with ZERO permission check (design §1.3), so an
+ * automation can create a record in ANOTHER base's sheet ungated. The write-gate added here demands an
+ * explicit, consistent `targetBaseId` (claim == truth) AND that the TRIGGER ACTOR (`context.actorId`,
+ * NOT the rule owner) holds base-WRITE on the target base. Cross-base `update_record` additionally
+ * requires full explicit addressing (`targetBaseId + targetSheetId + targetRecordId`) and retargets the
+ * lock-check + write to the TARGET record.
+ *
+ * RATIFIED contract:
+ *  - effective actor = TRIGGER actor (`context.actorId`); null actor (scheduled trigger) → fail-closed.
+ *  - base-write = `BASE_ADMIN_PERMISSION_CODES` ∪ base-owner (`resolveBaseWritable(userId, query, baseId)`).
+ *  - claim == truth: `targetBaseId === target sheet's actual base_id` (mirrors the link wall).
+ *  - fail-closed: any rejection → step `failed` in the execution log, NO write.
+ *
+ * Drives the REAL AutomationExecutor with a real-DB queryFn (the executor is the write chokepoint — this
+ * proves the gate stands alone even if rule-save validation were bypassed). XW-2d (rule-save 400) and
+ * XW-5 (wire round-trip) live in `multitable-cross-base-automation-write-rule.test.ts` (rule API altitude).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { AutomationExecutor, type AutomationDeps, type AutomationRule } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+
+// Actors.
+const OWNER = `u_xw_owner_${TS}` // owns BASE_A (trigger) AND BASE_B (target) → base-write on both (owner)
+const ADMIN_CODE = `u_xw_admincode_${TS}` // holds multitable:base:admin grant → base-write on any base
+const NO_WRITE = `u_xw_nowrite_${TS}` // owns nothing, no codes → NO base-write on BASE_B
+
+// Bases.
+const BASE_A = `base_xw_a_${TS}` // trigger base (source)
+const BASE_B = `base_xw_b_${TS}` // target base (cross-base write sink)
+
+// Sheets.
+const SHEET_A = `sheet_xw_a_${TS}` // trigger sheet (BASE_A)
+const SHEET_B = `sheet_xw_b_${TS}` // cross-base target sheet (BASE_B)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function makeExecutor(): { executor: AutomationExecutor; eventBus: EventBus } {
+  const eventBus = new EventBus()
+  const deps: AutomationDeps = {
+    eventBus,
+    queryFn: (sql: string, params?: unknown[]) => q(sql, params),
+  }
+  return { executor: new AutomationExecutor(deps), eventBus }
+}
+
+// Build a minimal executor-shaped rule with a single action and run it against a synthetic trigger event.
+function ruleWith(action: { type: string; config: Record<string, unknown> }, createdBy: string): AutomationRule {
+  return {
+    id: `axr_xw_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'XW rule',
+    sheetId: SHEET_A,
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+const countRecords = async (sheetId: string): Promise<number> => {
+  const r = await q('SELECT COUNT(*)::int AS n FROM meta_records WHERE sheet_id = $1', [sheetId])
+  return (r.rows as Array<{ n: number }>)[0]?.n ?? 0
+}
+const recordData = async (recordId: string): Promise<Record<string, unknown> | undefined> => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  const d = (r.rows as Array<{ data: unknown }>)[0]?.data
+  if (d == null) return undefined
+  return (typeof d === 'string' ? JSON.parse(d) : d) as Record<string, unknown>
+}
+
+describeIfDatabase('②b automation — governed cross-base writes + close §1.3 hole (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'XW Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'XW Base B', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'Trigger A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'Target B'])
+
+    // ADMIN_CODE holds the base-admin grant (exercises listRbacPermissionCodes + namespace admission).
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('multitable:base:admin', 'Base Admin', 'cross-base automation write tests')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [ADMIN_CODE, `${ADMIN_CODE}@example.test`],
+    )
+    await q(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'multitable:base:admin') ON CONFLICT DO NOTHING`,
+      [ADMIN_CODE],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── XW-1: cross-base create + base-write (owner) → success ──────────────────
+  test('XW-1: cross-base create_record with correct targetBaseId + trigger-actor base-write → record created in target base', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'xw1' } } },
+      OWNER,
+    )
+    // trigger actor = OWNER, who owns BASE_B → base-write granted via ownership.
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.status).toBe('success')
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(await countRecords(SHEET_B)).toBe(before + 1)
+  })
+
+  // ── XW-1 (admin-code path): cross-base create with base:admin grant → success ─
+  test('XW-1 (admin-code): cross-base create with trigger-actor holding multitable:base:admin → success', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'xw1admin' } } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: ADMIN_CODE, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(await countRecords(SHEET_B)).toBe(before + 1)
+  })
+
+  // ── XW-1b: cross-base create, NO base-write → step failed, NO write ─────────
+  test('XW-1b: cross-base create_record where trigger actor lacks target base-write → step failed, NO record written', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'xw1b' } } },
+      OWNER, // rule owner DOES have write — but ratified actor is the TRIGGER actor, not the owner
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before) // fail-closed: no write
+  })
+
+  // ── XW-1c: claim ≠ truth → step failed (consistency gate, mirrors the wall) ──
+  test('XW-1c: cross-base create where targetBaseId does NOT match target sheet base → step failed, NO write', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      // SHEET_B is in BASE_B, but the rule CLAIMS BASE_A → claim != truth.
+      { type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_A, data: { v: 'xw1c' } } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before)
+  })
+
+  // ── XW-2: cross-base update (full addressing) + base-write → success ─────────
+  test('XW-2: cross-base update_record with full addressing + trigger-actor base-write → target record updated', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_xw2_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recId, SHEET_B, JSON.stringify({ v: 'old' })])
+    try {
+      const rule = ruleWith(
+        {
+          type: 'update_record',
+          config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId, fields: { v: 'new' } },
+        },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect((await recordData(recId))?.v).toBe('new')
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── XW-2b: cross-base update, NO base-write → step failed, NO write ──────────
+  test('XW-2b: cross-base update_record where trigger actor lacks target base-write → step failed, target unchanged', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_xw2b_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recId, SHEET_B, JSON.stringify({ v: 'old' })])
+    try {
+      const rule = ruleWith(
+        { type: 'update_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId, fields: { v: 'new' } } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect((await recordData(recId))?.v).toBe('old') // unchanged
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── XW-2c: target record LOCKED → blocked via TARGET ensureRecordNotLocked ───
+  // Even WITH base-write, a locked target record blocks the write (lock priority + lock-redirect:
+  // the lock-check must SELECT the TARGET record, not the trigger record).
+  test('XW-2c: cross-base update of a LOCKED target record is blocked (step failed) even with base-write', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_xw2c_${TS}`
+    // Locked by someone else; OWNER is not the locker nor the record creator → cannot edit while locked.
+    await q(
+      'INSERT INTO meta_records (id, sheet_id, data, version, locked, locked_by, created_by) VALUES ($1,$2,$3::jsonb,1,true,$4,$5)',
+      [recId, SHEET_B, JSON.stringify({ v: 'old' }), `someone_else_${TS}`, `someone_else_${TS}`],
+    )
+    try {
+      const rule = ruleWith(
+        { type: 'update_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId, fields: { v: 'new' } } },
+        OWNER,
+      )
+      // OWNER has base-write on BASE_B — but the TARGET record is locked → blocked.
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect((await recordData(recId))?.v).toBe('old') // unchanged: lock priority
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── XW-2e: claim==truth for the record — targetRecordId ∉ targetSheetId → failed ──
+  // A cross-base update naming a targetRecordId that does NOT exist in targetSheetId must FAIL
+  // explicitly (decision 4: never a silent no-op success), even with base-write held.
+  test('XW-2e: cross-base update where targetRecordId is not in targetSheetId → step failed (claim==truth)', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      {
+        type: 'update_record',
+        config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: `rec_xw2e_missing_${TS}`, fields: { v: 'new' } },
+      },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before) // no row created/changed
+  })
+
+  // ── XW-3: same-base create/update → unaffected (zero regression, no gate) ────
+  test('XW-3a: same-base create_record (no targetBaseId) is unaffected', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_A)
+    // NO_WRITE has no base-write anywhere — but same-base must NOT hit the gate at all.
+    const rule = ruleWith({ type: 'create_record', config: { sheetId: SHEET_A, data: { v: 'same' } } }, OWNER)
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(await countRecords(SHEET_A)).toBe(before + 1)
+  })
+
+  test('XW-3b: same-base create with targetBaseId == trigger base is unaffected (no gate)', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_A)
+    const rule = ruleWith({ type: 'create_record', config: { sheetId: SHEET_A, targetBaseId: BASE_A, data: { v: 'same2' } } }, OWNER)
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    expect(await countRecords(SHEET_A)).toBe(before + 1)
+  })
+
+  test('XW-3c: same-base update_record (no target addressing) updates the trigger record', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_xw3c_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [recId, SHEET_A, JSON.stringify({ v: 'old' })])
+    try {
+      const rule = ruleWith({ type: 'update_record', config: { fields: { v: 'new' } } }, OWNER)
+      const exec = await executor.execute(rule, { recordId: recId, sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect((await recordData(recId))?.v).toBe('new')
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── XW-4: null actorId (scheduled trigger) + cross-base → fail-closed ────────
+  // The ratified TRIGGER-ACTOR decision: a scheduled trigger has no actorId → no identity to authorize
+  // a cross-base write → fail-closed (step failed, NO write). NO fallback to the rule owner.
+  test('XW-4: cross-base create with null actorId (scheduled trigger) → fail-closed, NO write', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      { type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'xw4' } } },
+      OWNER, // rule owner has write — but actorId is null and there is NO owner fallback
+    )
+    const exec = await executor.execute(rule, { recordId: '', sheetId: SHEET_A, actorId: null, data: {}, _triggeredBy: 'schedule' } as never)
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before) // fail-closed: no write
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -76,7 +76,17 @@ function createMockRule(overrides: Partial<AutomationRule> = {}): AutomationRule
 function createMockDeps(overrides: Partial<AutomationDeps> = {}): AutomationDeps {
   return {
     eventBus: new EventBus(),
-    queryFn: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    // NIT-1: a `meta_sheets` lookup must resolve an EXISTING sheet so the ②b cross-base write-gate can
+    // resolve a base. Empty rows model a MISSING / soft-deleted sheet, which the gate now (correctly)
+    // fail-closes on — that is NOT the same-base intent of these specs. Returning a UNIFORM base for
+    // every sheet keeps trigger and target in the same base → no gate fires (do NOT vary the base, or a
+    // `create_record { sheetId }` to a different sheet becomes cross-base-without-targetBaseId → rejected).
+    queryFn: vi.fn(async (sql: unknown) => {
+      if (typeof sql === 'string' && /FROM meta_sheets/i.test(sql)) {
+        return { rows: [{ base_id: 'base_mock' }], rowCount: 1 }
+      }
+      return { rows: [], rowCount: 0 }
+    }),
     fetchFn: vi.fn(async () => new Response('OK', { status: 200 })) as unknown as typeof fetch,
     ...overrides,
   }


### PR DESCRIPTION
## What

Implements the **②b automation slice** (design-lock `docs/development/multitable-crossbase-2b-automation-design-20260613.md`, landed in #2584): lets a multitable automation write records into **another base, GOVERNED** — and closes a **live pre-existing hole** along the way.

This is **security-critical** (cross-base WRITES). The permission model is airtight + fail-closed; every fail-closed rejection is recorded as a **failed step in the execution log** (never a silent skip).

## The §1.3 hole this closes (the security headline)

Pre-②b, `executeCreateRecord` (`automation-executor.ts`) did a **bare `INSERT` to `config.sheetId ?? context.sheetId` with ZERO permission check**, and rule-save didn't validate `config.sheetId`. So **today** an automation can create a record in **another base's sheet, ungated**. The new write-gate demands an explicit, consistent `targetBaseId` (claim == truth) + trigger-actor base-write — closing it. The fail-first `XW-1b` (post-fix) is the permanent replacement for the pre-fix baseline demonstration.

## Ratified contract (implemented exactly)

- **Trigger-actor authority** (decision 2, overrides the doc's rule-owner recommendation): the cross-base write runs under the **TRIGGERING user's** authority — `resolveBaseWritable(context.actorId, query, targetBaseId)`. A **null `actorId`** (e.g. scheduled trigger) → **fail-closed: step failed, NO write** (NO fallback to rule owner).
- **`resolveBaseWritable(userId, queryFn, baseId)`** (decision 1) — beside `resolveBaseReadable`, but takes a **userId, not a Request** (the executor has no `req`). `BASE_WRITE_PERMISSION_CODES = BASE_ADMIN_PERMISSION_CODES` (`multitable:base:admin` + `multitable:admin`) ∪ base-owner. Reuses the `listRbacPermissionCodes` SQL (user_permissions ∪ role_permissions) **narrowed by namespace admission** (never more permissive than the codebase's effective-permission resolution) + the base-owner SELECT. Fail-closed: no userId → false; missing/soft-deleted base → false.
- **Addressing** (decision 5): `create_record` adds `targetBaseId` (its config already has `sheetId`); cross-base `update_record` requires explicit `targetBaseId + targetSheetId + targetRecordId`.
- **`targetBaseId` mutable** (decision 6) — re-evaluated each run; no immutability gate (automation stores no cross-base data).
- **Cross-base delete/lock NOT in this slice** (decision 3): `lock_record` stays same-base only; no delete sink exists.

## Write-gate logic (as built — the chokepoint)

For `executeCreateRecord` and `executeUpdateRecord`, compute the resolved target sheet (create: `config.sheetId ?? context.sheetId`; update: `config.targetSheetId ?? context.sheetId`) and its actual `base_id`, plus the trigger base (`context.sheetId`'s base):
- **Same-base** (target base === trigger base, null-aware `===` mirroring `baseIdsAreCrossBase`): **no gate** — current behavior, zero regression.
- **Cross-base**: REQUIRE all of —
  1. explicit `targetBaseId` AND `targetBaseId === target sheet's actual base_id` (claim == truth; mirrors the §2a.2 link wall). Absent/mismatched → reject (closes §1.3).
  2. `resolveBaseWritable(context.actorId, query, targetBaseId)` true (else fail-closed: step failed, no write).
  3. update: `targetRecordId` actually resolves to a record in `targetSheetId` (claim == truth) — a missing target record **fails explicitly**, never a silent no-op success.
- **rule-save validation**: when `targetBaseId` is present on `update_record`, `targetSheetId` + `targetRecordId` are required → reject malformed at save (incl. **nested in `parallel_branch`**).

## Lock-redirect (load-bearing)

`executeUpdateRecord` already calls `ensureRecordNotLocked`, but pre-②b the lock SELECT **and** the UPDATE both used the **trigger** record. For a cross-base update, **both retarget** to `targetSheetId`/`targetRecordId`, so the lock-check guards the **target** record (not the trigger record). A **locked target → blocked (step failed, no write)** even with base-write held (lock priority). `XW-2c` locks this.

## Fail-first XW canaries (real DB, RED→GREEN; evidence captured pre/post)

| canary | scenario | expect |
|---|---|---|
| XW-1 / XW-1(admin-code) | cross-base create + base-write (owner / base:admin grant) | success |
| XW-1b | cross-base create, no base-write | step failed, no write (**closes §1.3**) |
| XW-1c | cross-base create, claim ≠ truth | step failed, no write |
| XW-2 | cross-base update full-addressing + base-write | target updated |
| XW-2b | cross-base update, no base-write | step failed, unchanged |
| XW-2c | cross-base update, target LOCKED (+base-write) | blocked via target `ensureRecordNotLocked` |
| XW-2d | cross-base update missing targetSheetId/targetRecordId (top-level + nested in parallel_branch) | rule-save 400 (asserts the specific addressing error) |
| XW-2e | cross-base update, targetRecordId ∉ targetSheetId | step failed, no write |
| XW-2f | cross-base update **nested in parallel_branch**, no base-write | gated at RUNTIME (branch failed, target unchanged) |
| XW-3a/3b/3c | same-base create/update | unaffected (zero regression) |
| XW-4 | null actorId (scheduled) + cross-base | fail-closed, no write |
| XW-5/5b | `targetBaseId` (+ update triple) wire round-trip | preserved through createRule → getRule |

Pre-fix baseline (XW-6 in design): the executor suite ran RED on XW-1b/1c/2b/2c/4 (cross-base writes went through ungated) — the post-fix gate closes them; XW-1b is the permanent replacement. Also added a `resolveBaseWritable` isolated resolver suite (owner / admin-code / no-grant / null-userId / missing-base fail-closed).

## Neighbors green

cross-base link wall/opt-in/TOCTOU, base-readable resolver, **rank-8 record-lock + lock-bypass**, automation jobs/retry/start-approval, **permission goldens d3d1/d3d2**, §2a.3 foreign-field **mask** view/write, and the **structural GOLDEN guards** (record-lock-guard, cross-base-link-wall-guard, egress-coverage, stored-data-taint chokepoint, raw-record-data-projection). `tsc --noEmit` clean. OpenAPI parity gate green.

## CI wiring

Added `multitable-cross-base-automation-write.test.ts`, `multitable-cross-base-automation-write-rule.test.ts`, `multitable-base-writable-resolver.test.ts` to the DB-gated list in `.github/workflows/plugin-tests.yml`.

## Notes / deviations

- **OpenAPI N/A**: automation action configs have **no spec surface** (only `canManageAutomation` capability exists); nothing to extend. The **wire round-trip test** (XW-5) is the real contract guard. Parity gate stays green.
- **Same-base now incurs a base-resolution read** (needed to detect the §1.3 hole regardless of declared config) — XW-3 covers zero behavior regression.
- **Behavior change**: any existing rule relying on the ungated cross-base create now fails unless it adds `targetBaseId` + the trigger actor holds base-write. This is the intended fix.
- **Known mirror**: `resolveBaseWritable` returns true on the admin/grant-code path before the base-existence check (a soft-deleted base + admin actor → true) — faithfully mirrors `resolveBaseReadable`'s posture; claim==truth pins the base to an existing sheet, so not exploitable here.
- **No migration.**

Deferred (each a separate gated opt-in): cross-base rate-limit/quota (Base-A-thrashes-Base-B), Yjs cross-base fan-out, cross-base automation builder UI, cross-base `lock_record`/`delete`, update match-key addressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)