### PR TITLE
feat(multitable): cross-base write quota guardrail

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -209,6 +209,7 @@ jobs:
             tests/integration/multitable-cross-base-link-optin.test.ts \
             tests/integration/multitable-cross-base-automation-write.test.ts \
             tests/integration/multitable-cross-base-automation-write-rule.test.ts \
+            tests/integration/multitable-cross-base-write-quota.test.ts \
             tests/integration/multitable-sheet-realtime.api.test.ts \
             tests/integration/rooms.basic.test.ts \
             tests/integration/multitable-automation-retry.test.ts \

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -8,6 +8,7 @@ import { Logger } from '../core/logger'
 import { redactString } from './automation-log-redact'
 import { ensureRecordNotLocked } from './record-lock'
 import { resolveBaseWritable } from './permission-service'
+import { MemoryRateLimitStore, type RateLimitStore } from '../middleware/rate-limiter'
 import {
   DingTalkBusinessError,
   DingTalkRequestError,
@@ -674,16 +675,66 @@ export interface ExecutionContext {
 
 // ── Dependencies interface for action executors ───────────────────────────
 
+/**
+ * Cross-base write QUOTA configuration. Caps the RATE of AUTHORIZED cross-base automation writes per
+ * TARGET base inside a rolling window. Optional on AutomationDeps: when omitted the executor uses a
+ * process-global default (env-configurable, see CROSS_BASE_WRITE_QUOTA_*). Same-base writes are never
+ * counted (the gate short-circuits same-base before the quota), so this is zero-regression.
+ */
+export interface CrossBaseWriteQuotaConfig {
+  /** Max authorized cross-base writes allowed per target base within `windowMs`. */
+  limit: number
+  /** Rolling window length in milliseconds. */
+  windowMs: number
+  /**
+   * Counter store. Reuses the rate-limiter `RateLimitStore` (increment-then-check) primitive. Inject a
+   * private `MemoryRateLimitStore` in tests so a low limit cannot perturb the process-global default.
+   * Omit to share the executor's default singleton store.
+   */
+  store?: RateLimitStore
+}
+
+// ── Cross-base write quota defaults (process-global; env-configurable) ─────
+// Defensible generous default: 60 authorized cross-base writes per target base per 60s. Tuned to protect
+// a target base from an automation storm while never tripping legitimate human-paced or modest-fan-out
+// automation. CAVEAT: the default store is IN-PROCESS, so under N replicas the effective ceiling is
+// ~limit×N. The shared Redis-backed RateLimitStore exists (rate-limiter.ts) if a cluster-wide cap is ever
+// required; that is out of scope for v1.
+const DEFAULT_CROSS_BASE_WRITE_QUOTA_LIMIT = 60
+const DEFAULT_CROSS_BASE_WRITE_QUOTA_WINDOW_MS = 60_000
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw.trim() === '') return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback
+}
+
+/** Resolve the process-global default quota from env once (re-read per call is cheap and test-friendly). */
+function defaultCrossBaseWriteQuota(): { limit: number; windowMs: number } {
+  return {
+    limit: readPositiveIntEnv('CROSS_BASE_WRITE_QUOTA_LIMIT', DEFAULT_CROSS_BASE_WRITE_QUOTA_LIMIT),
+    windowMs: readPositiveIntEnv('CROSS_BASE_WRITE_QUOTA_WINDOW_MS', DEFAULT_CROSS_BASE_WRITE_QUOTA_WINDOW_MS),
+  }
+}
+
+// Module-level default counter store. A SINGLETON so cross-base write accounting is independent of how
+// many AutomationExecutor instances exist (a per-instance Map would reset on every re-construction and
+// silently defeat the guardrail). `unref`'d cleanup timer prunes expired windows.
+const defaultCrossBaseWriteQuotaStore = new MemoryRateLimitStore(DEFAULT_CROSS_BASE_WRITE_QUOTA_WINDOW_MS)
+
 export interface AutomationDeps {
   eventBus: EventBus
   queryFn: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
   fetchFn?: typeof fetch
   notificationService?: Pick<NotificationService, 'send'>
+  /** Optional cross-base write quota override (limit/window/store). Omit → process-global default. */
+  crossBaseWriteQuota?: CrossBaseWriteQuotaConfig
 }
 
 // ②b cross-base write-gate verdict. `crossBase: false` → same-base, no gate (zero regression).
 // `crossBase: true` → cross-base; `ok` discriminates allowed vs the fail-closed rejection (with reason).
-type CrossBaseWriteGate =
+export type CrossBaseWriteGate =
   | { crossBase: false }
   | { crossBase: true; ok: true }
   | { crossBase: true; ok: false; error: string }
@@ -692,9 +743,19 @@ type CrossBaseWriteGate =
 
 export class AutomationExecutor {
   private deps: AutomationDeps
+  /** Resolved cross-base write quota (injected override or process-global default). */
+  private readonly crossBaseQuotaLimit: number
+  private readonly crossBaseQuotaWindowMs: number
+  private readonly crossBaseQuotaStore: RateLimitStore
 
   constructor(deps: AutomationDeps) {
     this.deps = deps
+    const override = deps.crossBaseWriteQuota
+    const def = defaultCrossBaseWriteQuota()
+    this.crossBaseQuotaLimit = override?.limit ?? def.limit
+    this.crossBaseQuotaWindowMs = override?.windowMs ?? def.windowMs
+    // Injected store wins (test isolation); else the module-level singleton default.
+    this.crossBaseQuotaStore = override?.store ?? defaultCrossBaseWriteQuotaStore
   }
 
   /**
@@ -1551,7 +1612,54 @@ export class AutomationExecutor {
         error: `Cross-base write denied: trigger actor lacks base-write on ${targetBaseId}`,
       }
     }
+
+    // Per-target-base write QUOTA — the LAST gate before an authorized cross-base write. Caps the RATE of
+    // authorized cross-base writes per target base within a rolling window to protect a target base from
+    // an automation storm. Same-base writes never reach here (the early returns above short-circuit
+    // same-base), so this is zero-regression. Increment-then-check: limit N → N writes allowed, the N+1th
+    // rejected fail-closed (step `failed`, NO row), mirroring the rejections above. The counter is keyed
+    // by the resolved TARGET base, so each base has an isolated budget. NOTE: for update_record the
+    // lock/addressing checks run AFTER this point, so a blocked-by-lock or not-found update still consumes
+    // a slot — intentional: this throttles authorized cross-base WRITE ATTEMPTS, the right unit for DB
+    // protection.
+    const quotaReject = await this.checkCrossBaseWriteQuota(targetBaseId)
+    if (quotaReject) return quotaReject
+
     return { crossBase: true, ok: true }
+  }
+
+  /**
+   * Increment-and-check the per-target-base cross-base write quota. Returns a fail-closed
+   * `CrossBaseWriteGate` rejection when the target base has exceeded its limit within the window, else
+   * `null` (allowed). Reuses the rate-limiter `RateLimitStore` (memory/Redis) increment primitive.
+   */
+  private async checkCrossBaseWriteQuota(
+    targetBaseId: string,
+  ): Promise<Extract<CrossBaseWriteGate, { ok: false }> | null> {
+    const key = `crossbase-write-quota:${targetBaseId}`
+    let count: number
+    try {
+      const res = await this.crossBaseQuotaStore.increment(key, this.crossBaseQuotaWindowMs)
+      count = res.count
+    } catch (err) {
+      // A counter-store failure must NOT silently disable the guardrail (fail-open) nor wrongly block a
+      // legitimate write. The memory store cannot throw; a Redis store could. Log and ALLOW this single
+      // write (the store, not the actor, failed) — consistent with the rate-limiter middleware, which
+      // falls back rather than 429-ing on store error.
+      logger.warn('Cross-base write quota store error; allowing this write', {
+        targetBaseId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return null
+    }
+    if (count > this.crossBaseQuotaLimit) {
+      return {
+        crossBase: true,
+        ok: false,
+        error: `Cross-base write quota exceeded for target base ${targetBaseId}: limit ${this.crossBaseQuotaLimit} per ${this.crossBaseQuotaWindowMs}ms`,
+      }
+    }
+    return null
   }
 
   // ── Individual action executors ─────────────────────────────────────────

--- a/packages/core-backend/tests/integration/multitable-cross-base-write-quota.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-write-quota.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Cross-base write QUOTA guardrail — per-target-base sliding/tumbling-window rate limit (real DB).
+ *
+ * The cross-base automation write path (executeCreateRecord / executeUpdateRecord, gated by
+ * evaluateCrossBaseWrite) is the last governance chokepoint before an automation writes into ANOTHER
+ * base. This guardrail caps the RATE of authorized cross-base writes per TARGET base inside a rolling
+ * window: an allowed cross-base write increments a per-target-base counter; once the counter exceeds the
+ * configured limit, further cross-base writes to that base are rejected fail-closed (step `failed`, NO
+ * row), mirroring evaluateCrossBaseWrite's other rejections.
+ *
+ * Contract under test:
+ *  - under-limit cross-base writes succeed and increment the counter;
+ *  - the over-limit cross-base write → step `failed` (quota), NO row written;
+ *  - SAME-BASE writes are NEVER counted (the gate short-circuits same-base before the quota) → no regression;
+ *  - per-target-base ISOLATION: filling BASE_B to its limit does NOT block a write to BASE_C;
+ *  - the limit is CONFIGURABLE — this suite injects a low limit + a private store via AutomationDeps so it
+ *    cannot perturb the process-global default (which the sibling cross-base-automation-write suite uses).
+ *
+ * Drives the REAL AutomationExecutor with a real-DB queryFn (the executor is the write chokepoint). A
+ * SINGLE executor instance is reused for the accumulating writes so the injected per-instance store
+ * accumulates across calls (matches production: one long-lived executor per AutomationService).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { MemoryRateLimitStore } from '../../src/middleware/rate-limiter'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+  type CrossBaseWriteQuotaConfig,
+} from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+
+// Actor: owns every test base → base-write everywhere via ownership (so the ONLY gate that can fail in
+// these canaries is the quota, not the base-write authority).
+const OWNER = `u_q_owner_${TS}`
+
+// Bases. BASE_A = trigger (source). BASE_B / BASE_C = distinct cross-base targets (isolation proof).
+// BASE_D = exercised through the process-global DEFAULT singleton store (no injected store) by TWO
+// executor instances → proves the counter survives re-construction (singleton, not per-instance Map).
+const BASE_A = `base_q_a_${TS}`
+const BASE_B = `base_q_b_${TS}`
+const BASE_C = `base_q_c_${TS}`
+const BASE_D = `base_q_d_${TS}`
+
+// Sheets.
+const SHEET_A = `sheet_q_a_${TS}` // trigger sheet (BASE_A)
+const SHEET_B = `sheet_q_b_${TS}` // cross-base target sheet (BASE_B)
+const SHEET_C = `sheet_q_c_${TS}` // cross-base target sheet (BASE_C)
+const SHEET_D = `sheet_q_d_${TS}` // cross-base target sheet (BASE_D — default-singleton path)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+// Build an executor with an INJECTED low-limit quota using a PRIVATE store, so this suite never touches
+// the process-global default singleton (which sibling suites rely on at the generous default).
+function makeExecutor(quota: CrossBaseWriteQuotaConfig): { executor: AutomationExecutor; eventBus: EventBus } {
+  const eventBus = new EventBus()
+  const deps: AutomationDeps = {
+    eventBus,
+    queryFn: (sql: string, params?: unknown[]) => q(sql, params),
+    crossBaseWriteQuota: quota,
+  }
+  return { executor: new AutomationExecutor(deps), eventBus }
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }, createdBy: string): AutomationRule {
+  return {
+    id: `axr_q_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'Quota rule',
+    sheetId: SHEET_A,
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+const countRecords = async (sheetId: string): Promise<number> => {
+  const r = await q('SELECT COUNT(*)::int AS n FROM meta_records WHERE sheet_id = $1', [sheetId])
+  return (r.rows as Array<{ n: number }>)[0]?.n ?? 0
+}
+
+// A cross-base create into the given target sheet/base, run by OWNER.
+function crossBaseCreate(targetSheet: string, targetBase: string, v: string): AutomationRule {
+  return ruleWith({ type: 'create_record', config: { sheetId: targetSheet, targetBaseId: targetBase, data: { v } } }, OWNER)
+}
+const trigger = { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} }
+
+describeIfDatabase('cross-base write QUOTA guardrail (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'Quota Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'Quota Base B', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_C, 'Quota Base C', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_D, 'Quota Base D', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'Quota Trigger A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'Quota Target B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_C, BASE_C, 'Quota Target C'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_D, BASE_D, 'Quota Target D'])
+  })
+
+  afterAll(async () => {
+    const sheets = [SHEET_A, SHEET_B, SHEET_C, SHEET_D]
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, BASE_C, BASE_D]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ── Q-1: under-limit cross-base writes all succeed; the over-limit write → failed (quota), NO row ──
+  test('Q-1: with limit=3, the first 3 cross-base creates succeed; the 4th is rejected (quota), NO row', async () => {
+    // Private store + low limit → isolated from the global default and from BASE_C below.
+    const { executor } = makeExecutor({ limit: 3, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    const before = await countRecords(SHEET_B)
+
+    for (let i = 1; i <= 3; i++) {
+      const exec = await executor.execute(crossBaseCreate(SHEET_B, BASE_B, `q1-${i}`), trigger)
+      expect(exec.steps[0]?.status).toBe('success')
+    }
+    expect(await countRecords(SHEET_B)).toBe(before + 3)
+
+    // 4th exceeds the limit → fail-closed, no row.
+    const over = await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q1-over'), trigger)
+    expect(over.steps[0]?.status).toBe('failed')
+    expect(over.steps[0]?.error ?? '').toMatch(/quota/i)
+    expect(await countRecords(SHEET_B)).toBe(before + 3) // no extra row written
+  })
+
+  // ── Q-2: SAME-BASE writes are NEVER counted (no regression) ─────────────────────────────────────
+  // With limit=1, a single cross-base write to BASE_B exhausts the BASE_B budget. Same-base writes to
+  // BASE_A must remain unlimited — the gate short-circuits same-base before the quota even runs.
+  test('Q-2: same-base writes are never quota-limited (limit=1; many same-base creates all succeed)', async () => {
+    const { executor } = makeExecutor({ limit: 1, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    const beforeA = await countRecords(SHEET_A)
+
+    // Exhaust the BASE_B budget (1 allowed).
+    const xb = await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q2-xb'), trigger)
+    expect(xb.steps[0]?.status).toBe('success')
+    const xb2 = await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q2-xb2'), trigger)
+    expect(xb2.steps[0]?.status).toBe('failed') // BASE_B now over-limit
+
+    // Same-base creates into SHEET_A (no targetBaseId) must NOT be counted → all succeed.
+    for (let i = 0; i < 5; i++) {
+      const same = await executor.execute(ruleWith({ type: 'create_record', config: { sheetId: SHEET_A, data: { v: `q2-same-${i}` } }, }, OWNER), trigger)
+      expect(same.steps[0]?.status).toBe('success')
+    }
+    expect(await countRecords(SHEET_A)).toBe(beforeA + 5)
+  })
+
+  // ── Q-3: per-target-base ISOLATION — BASE_B at its limit does NOT block BASE_C ───────────────────
+  test('Q-3: filling BASE_B to its limit does not block a cross-base write to BASE_C (per-base counters)', async () => {
+    const { executor } = makeExecutor({ limit: 1, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    const beforeC = await countRecords(SHEET_C)
+
+    // Saturate BASE_B (limit=1): 1 success then 1 quota-failure.
+    expect((await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q3-b'), trigger)).steps[0]?.status).toBe('success')
+    expect((await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q3-b2'), trigger)).steps[0]?.status).toBe('failed')
+
+    // BASE_C has its own counter → a write to BASE_C still succeeds despite BASE_B being saturated.
+    const cWrite = await executor.execute(crossBaseCreate(SHEET_C, BASE_C, 'q3-c'), trigger)
+    expect(cWrite.steps[0]?.status).toBe('success')
+    expect(await countRecords(SHEET_C)).toBe(beforeC + 1)
+  })
+
+  // ── Q-4: the limit is CONFIGURABLE — a higher injected limit allows more writes before rejecting ──
+  test('Q-4: limit is configurable (limit=5 → 5 succeed, 6th rejected)', async () => {
+    const { executor } = makeExecutor({ limit: 5, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    const before = await countRecords(SHEET_B)
+    for (let i = 1; i <= 5; i++) {
+      expect((await executor.execute(crossBaseCreate(SHEET_B, BASE_B, `q4-${i}`), trigger)).steps[0]?.status).toBe('success')
+    }
+    const over = await executor.execute(crossBaseCreate(SHEET_B, BASE_B, 'q4-over'), trigger)
+    expect(over.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before + 5)
+  })
+
+  // ── Q-5: DEFAULT (process-global singleton) store — construction-INDEPENDENT counting ───────────
+  // The previous canaries inject a PRIVATE store. This one omits `store` so the executor routes through
+  // the module-level DEFAULT singleton at a low limit (limit override only). Two SEPARATE executor
+  // instances share that counter: 2 writes via executor A succeed, then a 3rd write via a FRESHLY
+  // constructed executor B is rejected. If the counter were a per-instance Map it would reset on B's
+  // construction and the 3rd write would wrongly succeed → this proves the guardrail is not silently
+  // defeated by re-construction (the exact prod failure mode the singleton design prevents). BASE_D is
+  // touched by NO other test, so the shared singleton's per-process persistence is harmless here.
+  test('Q-5: the default singleton store counts across distinct executor instances (construction-independent)', async () => {
+    const cfg = { limit: 2, windowMs: 60_000 } // NO `store` → process-global default singleton
+    const before = await countRecords(SHEET_D)
+
+    const a = makeExecutor(cfg).executor
+    expect((await a.execute(crossBaseCreate(SHEET_D, BASE_D, 'q5-a1'), trigger)).steps[0]?.status).toBe('success')
+    expect((await a.execute(crossBaseCreate(SHEET_D, BASE_D, 'q5-a2'), trigger)).steps[0]?.status).toBe('success')
+
+    // A brand-new executor instance — a per-instance Map would reset here. The singleton must NOT.
+    const b = makeExecutor(cfg).executor
+    const over = await b.execute(crossBaseCreate(SHEET_D, BASE_D, 'q5-b1'), trigger)
+    expect(over.steps[0]?.status).toBe('failed')
+    expect(over.steps[0]?.error ?? '').toMatch(/quota/i)
+    expect(await countRecords(SHEET_D)).toBe(before + 2) // only the 2 under-limit writes landed
+  })
+})


### PR DESCRIPTION
## What

Adds a **per-target-base write quota** as the last governance gate before an *authorized* cross-base automation write, closing the rate-protection gap on the cross-base write path opened by the ②b automation slice (#2585).

The check lives **inside `evaluateCrossBaseWrite`**, immediately before its final `return { crossBase: true, ok: true }` — the single cross-base chokepoint shared by `executeCreateRecord` and `executeUpdateRecord`. By sitting after the same-base early-returns and after the existing claim==truth / base-write / soft-delete rejections, it naturally counts **only authorized cross-base writes** and excludes same-base writes for free.

## Design as built

| Aspect | Decision |
|---|---|
| **Scope** | Per **TARGET base** counter, keyed `crossbase-write-quota:<targetBaseId>` → each base has an isolated budget. |
| **Limit** | Default **60** authorized cross-base writes / target-base / window. Generous: protects a target base from an automation storm without tripping human-paced or modest-fan-out automation. |
| **Window** | Default **60s** rolling window. |
| **Config** | Env `CROSS_BASE_WRITE_QUOTA_LIMIT` / `CROSS_BASE_WRITE_QUOTA_WINDOW_MS` (positive-int, else fallback) for the process-global default; per-executor override via `AutomationDeps.crossBaseWriteQuota` (`{ limit, windowMs, store? }`). |
| **Exceed** | Increment-then-check (`count > limit`): limit N → N writes allowed, the N+1th **rejected fail-closed** — step recorded `failed` in the execution log (mirrors `evaluateCrossBaseWrite`'s other `ok:false` rejections), **no row written**. |
| **Store** | Reuses the existing `RateLimitStore` primitive from `middleware/rate-limiter.ts` (`MemoryRateLimitStore`, `increment(key, windowMs)`). Default is a **module-level SINGLETON** so accounting is construction-independent. |
| **Same-base** | Never counted (the gate short-circuits same-base before reaching the quota) → **zero regression**. |

## Reviewer notes (pre-empting likely flags)

1. **Module-level singleton store, deliberately.** `AutomationExecutor` can be (re)constructed; a per-instance `Map` would reset on every construction and silently defeat the guardrail in prod while a single-instance test still passes. The default store is therefore a module-level singleton; an injected store (tests) wins for isolation. **Q-5 proves this**: two separate executor instances share the default counter (2 writes via executor A succeed, a 3rd via a *freshly constructed* executor B is rejected) — a per-instance Map would have let B's write through.
2. **Store-error → fail-open for that single write, by design.** A counter-store failure (only possible with a future Redis store; `MemoryRateLimitStore` cannot throw) logs a warning and **allows** that one write — consistent with the rate-limiter middleware, which falls back rather than 429-ing on store error. The store failing is not the actor misbehaving; we don't wrongly block a legitimate write, and the next write re-checks.
3. **`update_record` consumes a slot before its lock/addressing checks.** Those checks run *after* `evaluateCrossBaseWrite`, so a cross-base update that's then blocked-by-lock or target-not-found still consumes a quota slot. Intentional — this throttles authorized cross-base **write attempts**, the correct unit for DB protection.
4. **Fixed/tumbling window, not true sliding.** `MemoryRateLimitStore` resets the bucket at window expiry (documented). True sliding is unnecessary for storm protection at v1.
5. **In-process default → effective ceiling ~`limit × replicas`.** Documented caveat. The shared **Redis-backed `RateLimitStore`** exists if a cluster-wide cap is ever required; out of scope for v1.

6. **No automatic retry re-enters the gate.** Verified: `executeActions` runs steps once (a failed cross-base step is recorded `failed`, no per-action auto-retry of create/update); `send_webhook`'s internal retry loop is unrelated to `evaluateCrossBaseWrite`. The only re-entry is `retryExecution` — an **admin-initiated whole-execution re-run** (A5, explicitly "no auto-retry"). Each such admin retry is a distinct authorized write attempt, so consuming a quota slot is the correct semantics, not an accidental slot burn. The documented 60/60s ceiling therefore holds under the actual retry model.

Tests exercise `create_record`; the quota lives in the shared `evaluateCrossBaseWrite`, so `update_record` is covered structurally (not directly asserted).

> Lint note: `tsc --noEmit` is clean; `eslint` could not run in this local symlinked-`node_modules` worktree (binary shim unresolvable in the pnpm store), but the enforced rules hold by inspection (inline `type` import qualifier, no `any`, no unused identifiers) and CI runs lint in a clean environment.

## Tests — RED → GREEN

New real-DB canaries `tests/integration/multitable-cross-base-write-quota.test.ts` (wired into `plugin-tests.yml` DB list). Type/config surface added first with **no enforcement** → over-limit writes succeeded (meaningful RED, 4/4 assertion failures + sentinel pass) → enforcement added → **6/6 GREEN**:

- **Q-1** limit=3: first 3 cross-base creates succeed, 4th → `failed` (quota), no row.
- **Q-2** same-base writes never quota-limited (limit=1; BASE_B exhausted, 5 same-base creates all succeed).
- **Q-3** per-base isolation: BASE_B saturated does not block a BASE_C write.
- **Q-4** configurable: limit=5 → 5 succeed, 6th rejected.
- **Q-5** default singleton counts across distinct executor instances (construction-independence).

Each suite injects a private store + low limit so it cannot perturb the process-global default that sibling suites rely on.

## Verification

- New suite: **6/6 pass** (real DB).
- Neighbors green: `multitable-cross-base-automation-write` (17), `-write-rule` (6), `base-writable-resolver` (7), `record-lock` (8), `record-lock-bypass` (5), `cross-sheet-related-echo-mask` (4) — **47 pass**.
- `tsc --noEmit` clean (exit 0).

## Residuals / out of scope

- Cluster-wide (Redis-backed) quota — primitive exists, not wired for v1.
- Direct `update_record` quota assertion (covered structurally via the shared gate).
- True sliding window (tumbling is sufficient for storm protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
