### PR TITLE
fix(multitable): cross-base closeout follow-ups — read-resolver symmetry + write structural guard

### DIFF
--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1625,6 +1625,8 @@ export class AutomationExecutor {
         ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
       }
 
+      // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
+      // update is rejected before this UPDATE unless claim==truth + trigger-actor base-write.
       // lock-guarded: automation update_record (B1) — ensureRecordNotLocked enforced just above.
       await this.deps.queryFn(
         `UPDATE meta_records
@@ -1670,6 +1672,9 @@ export class AutomationExecutor {
         return { actionType: 'create_record', status: 'failed', error: gate.error }
       }
 
+      // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
+      // create is rejected before this INSERT unless claim==truth + trigger-actor base-write. This is
+      // the §1.3 create-to-another-base vector the gate closes.
       await this.deps.queryFn(
         `INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)`,
         [recordId, targetSheetId, JSON.stringify(data)],
@@ -2222,6 +2227,8 @@ export class AutomationExecutor {
 
     try {
       if (locked) {
+        // xbase-write-exempt: lock_record writes ONLY context.sheetId/context.recordId (the trigger
+        // record) — it never retargets to a config-declared base, so it is not a cross-base write surface.
         // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
         await this.deps.queryFn(
@@ -2231,6 +2238,8 @@ export class AutomationExecutor {
           [lockedBy, context.recordId, context.sheetId],
         )
       } else {
+        // xbase-write-exempt: unlock writes ONLY context.sheetId/context.recordId (the trigger record),
+        // never a config-declared base — not a cross-base write surface.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         await this.deps.queryFn(
           `UPDATE meta_records

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1258,15 +1258,23 @@ export async function resolveBaseReadable(
   if (!normalizedBaseId) return false
 
   const access = await resolveRequestAccess(req)
-  if (access.isAdminRole) return true
-  if (access.permissions.some((code) => BASE_READ_PERMISSION_CODES.has(code))) return true
 
+  // Symmetry with `resolveBaseWritable`'s NIT-1: resolve target-base EXISTENCE FIRST. A missing /
+  // soft-deleted base is NOT readable by ANYONE — including an admin / base-read-grant holder — which is
+  // what the docstring promises; previously the admin/grant short-circuits returned `true` ahead of this
+  // check, leaving "a missing/soft-deleted base → false" as dead code for those authorities. The owner
+  // derivation below reuses this same row. (Soft-delete is runtime-unreachable today; this hardens
+  // against a future base soft-delete feature and keeps the two base resolvers consistent.)
   const res = await query(
     'SELECT owner_id FROM meta_bases WHERE id = $1 AND deleted_at IS NULL',
     [normalizedBaseId],
   )
   const row = (res.rows as Array<{ owner_id: unknown }>)[0]
-  if (!row) return false
+  if (!row) return false // missing / soft-deleted base → not readable, even for admin / grant
+
+  if (access.isAdminRole) return true
+  if (access.permissions.some((code) => BASE_READ_PERMISSION_CODES.has(code))) return true
+
   const ownerId = typeof row.owner_id === 'string' ? row.owner_id.trim() : ''
   return Boolean(ownerId) && Boolean(access.userId) && ownerId === access.userId
 }

--- a/packages/core-backend/tests/integration/multitable-base-readable-resolver.test.ts
+++ b/packages/core-backend/tests/integration/multitable-base-readable-resolver.test.ts
@@ -29,6 +29,7 @@ const ADMIN = `u_brr_admin_${TS}`
 
 const BASE_A = `base_brr_a_${TS}` // owned by OWNER
 const BASE_B = `base_brr_b_${TS}` // owned by someone else
+const DEL_BASE = `base_brr_del_${TS}` // SOFT-DELETED (deleted_at set), owned by OWNER
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 
@@ -49,10 +50,13 @@ describeIfDatabase('②a 2a.1 — resolveBaseReadable scaffold (real DB)', () =>
   beforeAll(async () => {
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'BRR Base A', OWNER])
     await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'BRR Base B', OTHER])
+    // A soft-deleted base owned by OWNER — seed `deleted_at` directly; no runtime path produces this
+    // state today, so it must be SQL-injected to exercise the resolver's `deleted_at IS NULL` filter.
+    await q('INSERT INTO meta_bases (id, name, owner_id, deleted_at) VALUES ($1, $2, $3, NOW())', [DEL_BASE, 'BRR Soft-Deleted Base', OWNER])
   })
 
   afterAll(async () => {
-    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, DEL_BASE]]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
@@ -85,5 +89,19 @@ describeIfDatabase('②a 2a.1 — resolveBaseReadable scaffold (real DB)', () =>
   test('a missing / soft-deleted base is not readable (no null-deref)', async () => {
     const query = poolManager.get().query.bind(poolManager.get())
     expect(await resolveBaseReadable(reqAs(OWNER), query, `base_brr_missing_${TS}`)).toBe(false)
+  })
+
+  // NIT-1 (symmetry with resolveBaseWritable): the target-base existence SELECT (`deleted_at IS NULL`)
+  // must run BEFORE the admin / base-read-grant short-circuit, so a soft-deleted base is NOT readable for
+  // ANYONE — including an admin OR a global multitable:base:read grant holder. Under the OLD ordering both
+  // short-circuited to `true` ahead of the SELECT (this canary is RED on that ordering: admin + grant flip
+  // true→false here). OWNER returns false under either ordering (its derivation also needs the now-missing
+  // row), so the discriminating flips are the admin and grant assertions.
+  test('NIT-1: a SOFT-DELETED base is not readable even for an admin OR a base-read-grant holder (nor its owner)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    const grantee = `u_brr_delgrant_${TS}`
+    expect(await resolveBaseReadable(reqAs(ADMIN, { admin: true }), query, DEL_BASE)).toBe(false)
+    expect(await resolveBaseReadable(reqAs(grantee, { perms: ['multitable:base:read'] }), query, DEL_BASE)).toBe(false)
+    expect(await resolveBaseReadable(reqAs(OWNER), query, DEL_BASE)).toBe(false)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -1135,8 +1135,15 @@ describe('Multitable context API', () => {
           return { rows: [{ id: 'sheet_ops' }] }
         }
         if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
-          expect(params).toEqual(['sheet_ops'])
-          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+          // loadSheetRow is hit TWICE here: once for the source sheet (sheet_ops) and once by the §2a.2
+          // cross-base wall (`validateLinkFieldConfig`) for the FOREIGN sheet — which, for a native person
+          // field, is the freshly-provisioned people sheet (`peopleSheetId`), since the person
+          // normalization overwrites the spoofed foreignSheetId. Echo a SAME-BASE (base_ops) row keyed by
+          // the requested id so source-base == foreign-base → the wall sees a same-base link and passes.
+          // A fixed ['sheet_ops'] assertion mis-fires on the peopleSheetId lookup.
+          const requestedSheetId = String(params?.[0] ?? '')
+          expect([requestedSheetId === 'sheet_ops', requestedSheetId === peopleSheetId]).toContain(true)
+          return { rows: [{ id: requestedSheetId, base_id: 'base_ops', name: 'Orders', description: null }] }
         }
         if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
           expect(params).toEqual(['base_ops'])
@@ -1268,8 +1275,12 @@ describe('Multitable context API', () => {
           }
         }
         if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
-          expect(params).toEqual(['sheet_ops'])
-          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+          // Same as the create-field test: loadSheetRow serves both the source sheet (sheet_ops) and the
+          // §2a.2 wall's FOREIGN-sheet lookup (the provisioned people sheet, peopleSheetId). Echo a
+          // SAME-BASE (base_ops) row keyed by the requested id so the wall sees a same-base link and passes.
+          const requestedSheetId = String(params?.[0] ?? '')
+          expect([requestedSheetId === 'sheet_ops', requestedSheetId === peopleSheetId]).toContain(true)
+          return { rows: [{ id: requestedSheetId, base_id: 'base_ops', name: 'Orders', description: null }] }
         }
         if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
           expect(params).toEqual(['base_ops'])

--- a/packages/core-backend/tests/unit/multitable-cross-base-write-guard.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-cross-base-write-guard.guard.test.ts
@@ -1,0 +1,188 @@
+/**
+ * DURABLE STRUCTURAL GUARD — "every record-mutating write site in the automation executor that can be
+ * RETARGETED to a config-declared base must route through the cross-base write gate
+ * (`evaluateCrossBaseWrite`), or declare itself cross-base-exempt, by construction".
+ *
+ * Sibling-in-spirit to `multitable-record-lock-guard.guard.test.ts`. That guard answers a DIFFERENT
+ * invariant (every `meta_records` mutation anywhere in `src/` checks the record lock) and so walks the
+ * WHOLE backend tree. This guard answers the cross-base-write invariant, which is structurally CONFINED
+ * to the automation executor: `evaluateCrossBaseWrite` is a PRIVATE method on `AutomationActionExecutor`,
+ * and only the executor's write actions accept a config-/input-declared target (`targetSheetId` /
+ * `config.sheetId` + `targetBaseId`) that can point at ANOTHER base's sheet (the §1.3
+ * create-to-another-base vector + the §2.x cross-base update). The regular CRUD / plugin-SDK / form-submit
+ * write paths mutate the single sheet the actor is already sheet-permission-gated for — they have no
+ * cross-base retargeting surface, so forcing `xbase-write-exempt` markers on them would be ~14 meaningless
+ * annotations and would conflate two distinct invariants. Hence this guard is single-file ON PURPOSE.
+ *
+ * To answer the fixed-list blind-spot lesson the lock-guard's "n2 hardening" records (a guard keyed to a
+ * narrow surface can miss a mutation introduced elsewhere), the confinement itself is asserted: a test
+ * below proves `evaluateCrossBaseWrite` is defined ONLY in `automation-executor.ts`. If a SECOND cross-base
+ * write gate ever sprouts in another file, that test trips RED — re-validating that the single-file scan
+ * still covers the whole cross-base-write surface.
+ *
+ * HOW IT WORKS: it enumerates EVERY `meta_records` row-mutation statement in `automation-executor.ts`
+ * (INSERT / UPDATE / DELETE — note INSERT is INCLUDED here, unlike the lock-guard, because
+ * create-to-another-base is itself a cross-base vector) and requires each site to carry, within
+ * `MARKER_WINDOW` lines immediately above the SQL, exactly one explicit disposition marker comment:
+ *
+ *   • `// xbase-write-gated:<reason>`  → GATED   — the site routes through `evaluateCrossBaseWrite(...)`
+ *                                                  (the one shared cross-base write gate); a cross-base
+ *                                                  target is rejected before the SQL unless claim==truth +
+ *                                                  trigger-actor base-write authority.
+ *   • `// xbase-write-exempt:<reason>` → EXEMPT  — the site writes ONLY the trigger record
+ *                                                  (`context.sheetId`/`context.recordId`) and never
+ *                                                  retargets to a config-declared base (e.g. lock/unlock),
+ *                                                  so it is not a cross-base write surface.
+ *
+ * A NEW or MOVED mutation site in the executor with NO marker FAILS this test until the contributor
+ * consciously classifies it — forcing them to either route the write through `evaluateCrossBaseWrite`
+ * (and label it GATED) or document why the path can never be cross-base (EXEMPT). A future automation
+ * write site that forgets the cross-base gate therefore trips RED by construction. A GATED label without a
+ * real `evaluateCrossBaseWrite(` call in the file is separately anchored by the cross-check below.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const SRC = join(__dirname, '../../src')
+const EXECUTOR_REL = 'multitable/automation-executor.ts'
+const read = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
+
+/**
+ * Recursively list every runtime `.ts` file under `src/` (paths RELATIVE to `src/`, `/`-separated),
+ * excluding the migration tree / tests / build output / node_modules. Used by the confinement test to scan
+ * the WHOLE backend for the cross-base gate DEFINITION, so a second gate sprouting in any other file trips
+ * RED — re-validating that the single-file enumeration above still covers the whole cross-base surface.
+ */
+function listRuntimeTsFiles(): string[] {
+  const out: string[] = []
+  const walk = (absDir: string): void => {
+    for (const entry of readdirSync(absDir, { withFileTypes: true })) {
+      const abs = join(absDir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'migrations') continue
+        walk(abs)
+        continue
+      }
+      if (!entry.name.endsWith('.ts')) continue
+      if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue
+      out.push(relative(SRC, abs).split(sep).join('/'))
+    }
+  }
+  walk(SRC)
+  return out.sort()
+}
+
+/**
+ * How many physical lines ABOVE the SQL line the disposition marker may sit. Wider than the lock-guard's
+ * window (3) ON PURPOSE: a gated site STACKS this marker above the EXISTING `// lock-guarded:` /
+ * `// lock-mgmt:` comment (inserting above the lock marker, never between it and its SQL, so the
+ * lock-guard's own window is preserved), which pushes the cross-base marker an extra line or two up.
+ */
+const MARKER_WINDOW = 5
+
+type Disposition = 'GATED' | 'EXEMPT'
+
+interface Site {
+  line: number // 1-based
+  sql: string
+  disposition: Disposition | null
+}
+
+/**
+ * Every form a `meta_records` row-mutation can take in this executor. INSERT is INCLUDED (the lock-guard
+ * deliberately omits it — a fresh row has no lock — but a create INTO ANOTHER BASE is a cross-base write,
+ * so it MUST be gated here). Kysely builder forms are matched pre-emptively so a future builder-style
+ * mutation is also caught. `SELECT ... FROM meta_records` row reads do NOT match (token before is `FROM`,
+ * not a mutation verb).
+ */
+const MUTATION_RE =
+  /\b(?:INSERT INTO meta_records|UPDATE meta_records|DELETE FROM meta_records)\b|(?:insertInto|updateTable|deleteFrom)\(\s*['"`]meta_records['"`]/
+
+function classify(window: string): Disposition | null {
+  if (/\/\/\s*xbase-write-gated:/.test(window)) return 'GATED'
+  if (/\/\/\s*xbase-write-exempt:/.test(window)) return 'EXEMPT'
+  return null
+}
+
+function enumerateSites(src: string): Site[] {
+  const lines = src.split('\n')
+  const sites: Site[] = []
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (!MUTATION_RE.test(line)) continue
+    // skip comments / JSDoc that merely mention the statement
+    const trimmed = line.trimStart()
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue
+    const windowStart = Math.max(0, i - MARKER_WINDOW)
+    const window = lines.slice(windowStart, i + 1).join('\n')
+    sites.push({ line: i + 1, sql: line.trim(), disposition: classify(window) })
+  }
+  return sites
+}
+
+describe('cross-base write-gate guard — durable structural guard (automation executor)', () => {
+  const executorSrc = read(EXECUTOR_REL)
+  const sites = enumerateSites(executorSrc)
+
+  test('the enumeration finds the expected mutation surface (smoke — not zero, not exploded)', () => {
+    // 4 known sites at authoring time: executeUpdateRecord UPDATE (GATED) + executeCreateRecord INSERT
+    // (GATED) + executeLockRecord lock/unlock UPDATE ×2 (EXEMPT — trigger-record-only). A count change is
+    // FINE — it just means you added/removed an executor write site; the per-site assertion below is the
+    // real gate. This bound only flags an extractor that matched nothing (regex broke) or exploded.
+    expect(sites.length).toBeGreaterThanOrEqual(3)
+    expect(sites.length).toBeLessThanOrEqual(20)
+  })
+
+  test('EVERY executor meta_records write site carries a cross-base disposition (GATED / EXEMPT)', () => {
+    const unclassified = sites.filter((s) => s.disposition === null)
+    expect(
+      unclassified,
+      `CROSS-BASE WRITE GUARD: ${unclassified.length} automation-executor meta_records write site(s) ` +
+        `with NO cross-base disposition:\n` +
+        unclassified.map((s) => `  - ${EXECUTOR_REL}:${s.line}  ${s.sql}`).join('\n') +
+        `\n\nYou added or moved a record write in the automation executor. Within ${MARKER_WINDOW} lines ` +
+        `above the SQL, EITHER route it through evaluateCrossBaseWrite(...) (GATED — the one shared ` +
+        `cross-base write gate) and add a "// xbase-write-gated:<reason>" marker, OR add a ` +
+        `"// xbase-write-exempt:<reason>" marker (the site writes only the trigger record and can never ` +
+        `retarget to a config-declared base, e.g. lock/unlock). A silent ungated cross-base create/update ` +
+        `is exactly the §1.3 hole the cross-base write gate closed.`,
+    ).toEqual([])
+  })
+
+  test('every GATED site is backed by a real evaluateCrossBaseWrite call (a label cannot fake the gate)', () => {
+    const hasGated = sites.some((s) => s.disposition === 'GATED')
+    expect(hasGated, 'expected at least one GATED cross-base write site in the executor').toBe(true)
+    // A `// xbase-write-gated:` marker must be backed by a real `evaluateCrossBaseWrite(` call in the SAME
+    // file. The by-VALUE proof (that the gate truly rejects a cross-base create/update without claim==truth
+    // / base-write) lives in the cross-base wall + automation integration suites.
+    expect(
+      executorSrc.includes('evaluateCrossBaseWrite('),
+      `${EXECUTOR_REL} has GATED write sites but never calls evaluateCrossBaseWrite(`,
+    ).toBe(true)
+  })
+
+  test('both cross-base-capable executors (create + update) are GATED, not exempt', () => {
+    // Anchor the two known cross-base vectors so a future refactor can't silently flip them to EXEMPT:
+    // the INSERT (create-to-another-base, §1.3) and the data-merge UPDATE (cross-base update) must be GATED.
+    const insertSite = sites.find((s) => /INSERT INTO meta_records/.test(s.sql))
+    const updateMergeSite = sites.find((s) => /UPDATE meta_records/.test(s.sql) && executorSrc.split('\n')[s.line]?.includes("|| $1::jsonb") )
+    expect(insertSite?.disposition, 'executeCreateRecord INSERT must be GATED (create-to-another-base vector)').toBe('GATED')
+    expect(updateMergeSite?.disposition, 'executeUpdateRecord data-merge UPDATE must be GATED (cross-base update)').toBe('GATED')
+  })
+
+  test('confinement: the cross-base write gate is defined in EXACTLY ONE src file = the executor (single-file scan stays complete)', () => {
+    // Scan the WHOLE backend `src/` tree for the gate DEFINITION (`private async evaluateCrossBaseWrite(`).
+    // It must live in exactly one file, and that file must be the executor this guard scans. If a SECOND
+    // cross-base write gate sprouts in any other file, this trips RED — and the contributor must either
+    // fold it into the executor or extend THIS guard to cover the new file. This re-validates the
+    // single-file enumeration above stays complete (answering the lock-guard "fixed-list blind spot"
+    // lesson), without forcing whole-`src` markers on the ~14 single-sheet write sites elsewhere.
+    const DEF_RE = /private\s+async\s+evaluateCrossBaseWrite\s*\(/
+    const definingFiles = listRuntimeTsFiles().filter((f) => DEF_RE.test(read(f)))
+    expect(definingFiles).toEqual([EXECUTOR_REL])
+    // and exactly one definition within that file (no overload / duplicate gate)
+    expect([...executorSrc.matchAll(DEF_RE.source ? new RegExp(DEF_RE.source, 'g') : DEF_RE)].length).toBe(1)
+  })
+})


### PR DESCRIPTION
Small 3-part backend follow-up closing out the cross-base capability arc. No runtime behavior change for live data; hardens the read-resolver against a future soft-delete feature, adds a durable structural guard against ungated automation writes, and fixes a CI-excluded mock.

## (a) `resolveBaseReadable` NIT-1 symmetry (`permission-service.ts`)
The target-base existence SELECT (`deleted_at IS NULL`) now runs **before** the admin / base-read-grant short-circuit — mirroring `resolveBaseWritable`'s NIT-1. A missing / soft-deleted base is therefore not readable for **anyone**, admin or grant holder included (previously the short-circuits returned `true` ahead of the check, leaving "soft-deleted → false" as dead code for those authorities). Soft-delete is runtime-unreachable today; this keeps the two base resolvers consistent and hardens against a future base soft-delete feature.

Added a real-DB canary to `multitable-base-readable-resolver.test.ts` (SQL-seeded soft-deleted base) asserting `false` for admin + grant + owner. **RED** on the old ordering (admin/grant flip `true→false`), **GREEN** after the reorder. Existing resolver tests (admin/grant can read live bases) stay green — no over-rejection.

## (b) cross-base-WRITE structural guard (new `multitable-cross-base-write-guard.guard.test.ts`)
No-DB static scan, sibling-in-spirit to `multitable-record-lock-guard.guard.test.ts`. Enumerates every `meta_records` write site in the automation executor and requires each to carry an explicit disposition marker:
- `// xbase-write-gated:` — routes through `evaluateCrossBaseWrite` (the cross-base write gate)
- `// xbase-write-exempt:` — writes only the trigger record (e.g. lock/unlock), no cross-base retargeting surface

Goes **RED** if a new automation write site skips the gate (proven by temporarily adding an unmarked `INSERT INTO meta_records` → guard RED → removed). Single-file ON PURPOSE (the cross-base gate is structurally confined to the executor); a confinement test scans all of `src` to prove `evaluateCrossBaseWrite` is defined only there, so a second gate sprouting elsewhere trips RED.

## (c) §2a.2 wall mock fix (`multitable-context.api.test.ts`, CI-excluded)
The cross-base wall (`validateLinkFieldConfig`) calls `loadSheetRow(foreignSheetId)` for native person fields — the foreign sheet is the provisioned people sheet (`peopleSheetId`), so the hand-rolled mock's fixed `['sheet_ops']` assertion mis-fired and 500'd the two native-person tests. The handler now echoes a same-base (`base_ops`) row keyed by the requested id → both tests pass (16→18). The remaining 4 failures in this file are a separate template-catalog RBAC-mock drift family, left as quarantined CI-invisible debt.

## Verification
- (a) canary RED (old ordering) → GREEN (new) — admin/grant assertions flip
- (b) guard RED proof (unmarked INSERT) → GREEN after removal; all sites correctly classified
- Neighbors green: both base resolvers, cross-base automation-write (incl. soft-deleted-base XW-6a/6b/6d), cross-base link wall/opt-in, all 8 structural guards (72 tests across 9 suites)
- `tsc --noEmit` clean (exit 0)
- (a)'s test already wired in `plugin-tests.yml`; (b) is no-DB in the default `test` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)