### PR TITLE
fix(multitable): close ②b cross-base echo gaps

### DIFF
--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -206,6 +206,7 @@ export function sanitizeFieldProperty(
   }
 
   if (type === 'link') {
+    const { foreignBaseId: _omitForeignBaseId, ...cleanObj } = obj
     const foreignSheetId =
       typeof (obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId) === 'string'
         ? String(obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId).trim()
@@ -218,9 +219,9 @@ export function sanitizeFieldProperty(
         ? obj.foreignBaseId.trim()
         : ''
     return {
-      ...obj,
+      ...cleanObj,
       ...(foreignSheetId ? { foreignSheetId, foreignDatasheetId: foreignSheetId } : {}),
-      ...(foreignBaseId ? { foreignBaseId } : {}),
+      ...(foreignSheetId && foreignBaseId ? { foreignBaseId } : {}),
       limitSingleRecord: obj.limitSingleRecord === true,
       ...(typeof obj.refKind === 'string' && obj.refKind.trim().length > 0
         ? { refKind: obj.refKind.trim() }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1121,6 +1121,9 @@ async function validateLinkFieldConfig(
   // the opt-in declaration carried in the link property (null when absent).
   const actualForeignBaseId = foreignSheet.baseId ?? null
   const claimed = linkCfg.foreignBaseId ?? null
+  if (claimed !== null && claimed !== actualForeignBaseId) {
+    return `链接字段 foreignBaseId 需与外表实际 base 一致：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} 实际 base=${actualForeignBaseId ?? 'null'}，声明=${claimed ?? 'null'}`
+  }
   if (baseIdsAreCrossBase(sourceBaseId, actualForeignBaseId)) {
     // ②b opt-in short-circuit — a cross-base link is allowed IFF it carries an EXPLICIT foreignBaseId
     // EQUAL to the foreign sheet's real base (claim == truth; you can't declare a wrong base). A
@@ -1128,7 +1131,7 @@ async function validateLinkFieldConfig(
     // (claimed===null falls through to reject; a non-null claim !== null actual also rejects). This is a
     // pure consistency gate — the foreign READ-permission check is §3 (base-read) + §2a.3 (field mask),
     // NOT here (adding a perm check in this structural wall would over-reach).
-    if (claimed !== null && claimed === actualForeignBaseId) {
+    if (claimed !== null) {
       return null
     }
     return `链接字段跨 base 需显式 foreignBaseId 且与外表实际 base 一致：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} 实际 base=${actualForeignBaseId ?? 'null'}，声明=${claimed ?? 'null'}`
@@ -1556,6 +1559,7 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
   }
 
   if (type === 'link') {
+    const { foreignBaseId: _omitForeignBaseId, ...cleanObj } = obj
     const foreignSheetId = typeof (obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId) === 'string'
       ? String(obj.foreignSheetId ?? obj.foreignDatasheetId ?? obj.datasheetId).trim()
       : ''
@@ -1566,9 +1570,9 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
       ? obj.foreignBaseId.trim()
       : ''
     return {
-      ...obj,
+      ...cleanObj,
       ...(foreignSheetId ? { foreignSheetId, foreignDatasheetId: foreignSheetId } : {}),
-      ...(foreignBaseId ? { foreignBaseId } : {}),
+      ...(foreignSheetId && foreignBaseId ? { foreignBaseId } : {}),
       limitSingleRecord: obj.limitSingleRecord === true,
       ...(typeof obj.refKind === 'string' && obj.refKind.trim().length > 0 ? { refKind: obj.refKind.trim() } : {}),
     }
@@ -2538,7 +2542,18 @@ async function computeDependentLookupRollupRecords(
   }
 
   const allowedFieldIdsBySheet = new Map<string, Set<string>>()
+  // ②b arc closeout — related-record write echoes are another cross-base read sink. Sheet-read
+  // alone is not enough: mirror the link-summary base-read gate so PATCH and the A2 AI-shortcut
+  // path cannot echo related ids or computed values from a base the caller cannot read.
+  const sourceSheet = await loadSheetRowShared(query, sourceSheetId)
+  const sourceBaseId = sourceSheet?.baseId ?? null
   for (const sheetId of rowsBySheet.keys()) {
+    const relatedSheet = await loadSheetRowShared(query, sheetId)
+    const relatedBaseId = relatedSheet?.baseId ?? null
+    if (baseIdsAreCrossBase(sourceBaseId, relatedBaseId)) {
+      const baseReadable = relatedBaseId != null && (await resolveBaseReadable(req, query, relatedBaseId))
+      if (!baseReadable) continue
+    }
     const fields = fieldsBySheet.get(sheetId) ?? []
     if (fields.length === 0) continue
     const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
@@ -6037,6 +6052,9 @@ export function univerMetaRouter(): Router {
         // a `foreignBaseId` to falsely claim cross-base) and means the wall's claim==truth check, once
         // passed at create, can never be retroactively desynced.
         if (foreignBaseIdInPayload(parsed.data.property)) {
+          if (!linkForeignKeyInPayload(parsed.data.property)) {
+            throw new ValidationError('foreignBaseId PATCH 必须同时携带 foreignSheetId')
+          }
           const storedForeignBaseId = extractForeignBaseId(row.property)
           const payloadForeignBaseId = extractForeignBaseId(parsed.data.property)
           if (payloadForeignBaseId !== storedForeignBaseId) {

--- a/packages/core-backend/tests/integration/multitable-cross-base-link-optin.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-link-optin.test.ts
@@ -291,6 +291,80 @@ describeIfDatabase('②b slice 1 — cross-base link foreignBaseId opt-in + base
     expect(await fieldExists(fieldId)).toBe(true)
   })
 
+  test('XB-3b: CREATE same-base link with truthful own-base foreignBaseId succeeds', async () => {
+    const fieldId = `fld_xbo_t3b_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'Same Base Truthful Claim',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2, foreignBaseId: BASE_A },
+    })
+
+    expect(res.status).toBe(201)
+    expect((await fieldProperty(fieldId))?.foreignBaseId).toBe(BASE_A)
+  })
+
+  test('XB-3c: CREATE same-base link with a stale external foreignBaseId is rejected', async () => {
+    const fieldId = `fld_xbo_t3c_${TS}`
+    const res = await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'Same Base Stale External Claim',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2, foreignBaseId: BASE_B },
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await fieldExists(fieldId)).toBe(false)
+  })
+
+  test('XB-3d: CREATE same-base link drops empty and non-string foreignBaseId claims', async () => {
+    const emptyFieldId = `fld_xbo_t3d_empty_${TS}`
+    const nonStringFieldId = `fld_xbo_t3d_num_${TS}`
+
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: emptyFieldId,
+      name: 'Same Base Empty Claim',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2, foreignBaseId: '   ' },
+    }).expect(201)
+
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: nonStringFieldId,
+      name: 'Same Base Non String Claim',
+      type: 'link',
+      property: { foreignSheetId: SHEET_A2, foreignBaseId: 42 },
+    }).expect(201)
+
+    expect((await fieldProperty(emptyFieldId))?.foreignBaseId).toBeUndefined()
+    expect((await fieldProperty(nonStringFieldId))?.foreignBaseId).toBeUndefined()
+  })
+
+  test('XB-immut-orphan: PATCH re-sending only the stored foreignBaseId is rejected', async () => {
+    const fieldId = `fld_xbo_immutorphan_${TS}`
+    await request(buildApp(OWNER, WRITE)).post('/api/multitable/fields').send({
+      sheetId: SHEET_A,
+      id: fieldId,
+      name: 'XB Immut Orphan',
+      type: 'link',
+      property: { foreignSheetId: SHEET_B, foreignBaseId: BASE_B },
+    }).expect(201)
+
+    const res = await request(buildApp(OWNER, WRITE))
+      .patch(`/api/multitable/fields/${fieldId}`)
+      .send({ property: { foreignBaseId: BASE_B } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    const property = await fieldProperty(fieldId)
+    expect(property?.foreignSheetId).toBe(SHEET_B)
+    expect(property?.foreignBaseId).toBe(BASE_B)
+  })
+
   // ── XB-6 (TOCTOU): an opted-in link does NOT block the legit late sheet-create ─
   test('XB-6: a pre-seeded foreignBaseId-matching link does NOT block creating its target sheet; a non-opted-in link still blocks', async () => {
     // Pre-seed a cross-base link from SHEET_A (BASE_A) targeting the not-yet-existent SHEET_LATE,

--- a/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
@@ -17,9 +17,11 @@ const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
 const TS = Date.now()
 const BASE_ID = `base_xrel_${TS}`
+const BASE_FOREIGN = `base_xrel_foreign_${TS}`
 const SHEET_A = `sheet_xrel_a_${TS}`
 const SHEET_B = `sheet_xrel_b_${TS}`
 const SHEET_C = `sheet_xrel_c_${TS}`
+const SHEET_D = `sheet_xrel_d_${TS}`
 
 const A_EDIT = `fld_xrel_a_edit_${TS}`
 const A_VISIBLE = `fld_xrel_a_visible_${TS}`
@@ -35,13 +37,18 @@ const B_LOOKUP_HIDDEN = `fld_xrel_b_lookup_hidden_${TS}`
 const C_LINK = `fld_xrel_c_link_${TS}`
 const C_LOOKUP_VISIBLE = `fld_xrel_c_lookup_visible_${TS}`
 
+const D_LINK = `fld_xrel_d_link_${TS}`
+const D_LOOKUP_VISIBLE = `fld_xrel_d_lookup_visible_${TS}`
+
 const A_REC = `rec_xrel_a_${TS}`
 const A_DEP = `rec_xrel_a_dep_${TS}`
 const B_REC = `rec_xrel_b_${TS}`
 const C_REC = `rec_xrel_c_${TS}`
+const D_REC = `rec_xrel_d_${TS}`
 
 const USER_DENIED = `u_xrel_denied_${TS}`
 const USER_SHEET_A_ONLY = `u_xrel_a_only_${TS}`
+const USER_BASE_READ = `u_xrel_base_read_${TS}`
 const USER_GRANTED = `u_xrel_granted_${TS}` // no deny row → per-subject positive control
 
 const VISIBLE_CANARY = `visible-cross-related-${TS}`
@@ -75,9 +82,11 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
     app.use('/api/multitable', univerMetaRouter())
 
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Cross Related Base'])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_FOREIGN, 'Cross Related Foreign Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE_ID, 'Source'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE_ID, 'Dependent B'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_C, BASE_ID, 'Dependent C'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_D, BASE_FOREIGN, 'Dependent D Foreign Base'])
 
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_EDIT, SHEET_A, 'Edit', 'string', '{}', 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_VISIBLE, SHEET_A, 'Visible', 'string', '{}', 2])
@@ -93,14 +102,19 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [C_LINK, SHEET_C, 'Source Link', 'link', JSON.stringify({ foreignSheetId: SHEET_A }), 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [C_LOOKUP_VISIBLE, SHEET_C, 'Visible Lookup', 'lookup', JSON.stringify({ linkFieldId: C_LINK, targetFieldId: A_VISIBLE, foreignSheetId: SHEET_A }), 2])
 
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [D_LINK, SHEET_D, 'Source Link', 'link', JSON.stringify({ foreignSheetId: SHEET_A, foreignBaseId: BASE_ID }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [D_LOOKUP_VISIBLE, SHEET_D, 'Visible Lookup', 'lookup', JSON.stringify({ linkFieldId: D_LINK, targetFieldId: A_VISIBLE, foreignSheetId: SHEET_A }), 2])
+
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [A_REC, SHEET_A, JSON.stringify({ [A_EDIT]: 'initial', [A_VISIBLE]: VISIBLE_CANARY, [A_SECRET]: SECRET_CANARY }), USER_DENIED])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [A_DEP, SHEET_A, '{}', USER_DENIED])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [B_REC, SHEET_B, '{}', USER_DENIED])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [C_REC, SHEET_C, '{}', USER_DENIED])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [D_REC, SHEET_D, '{}', USER_DENIED])
 
     await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [A_SELF_LINK, A_DEP, A_REC])
     await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [B_LINK, B_REC, A_REC])
     await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [C_LINK, C_REC, A_REC])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [D_LINK, D_REC, A_REC])
 
     // Deny solely at layer-3: B_LOOKUP_SECRET.property.hidden is unset.
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_B, B_LOOKUP_SECRET, 'user', USER_DENIED, false, false])
@@ -109,13 +123,13 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
   })
 
   afterAll(async () => {
-    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[A_SELF_LINK, B_LINK, C_LINK]]).catch(() => {})
-    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
-    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
-    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
-    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
-    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
-    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[A_SELF_LINK, B_LINK, C_LINK, D_LINK]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C, SHEET_D]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C, SHEET_D]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C, SHEET_D]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C, SHEET_D]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C, SHEET_D]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_ID, BASE_FOREIGN]]).catch(() => {})
   })
 
   test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
@@ -136,6 +150,8 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
     expect(c).toBeDefined()
     expect(c.data[C_LOOKUP_VISIBLE]).toEqual([VISIBLE_CANARY]) // R4: independent per-related-sheet allow set
 
+    expect(related(res.body, SHEET_D, D_REC)).toBeUndefined() // R7: cross-base related sheet requires base-read
+
     const same = sameSheetRecord(res.body, A_DEP)
     expect(same).toBeDefined()
     expect(same.data[A_SELF_LOOKUP]).toEqual([VISIBLE_CANARY]) // R6: same-sheet related echo regression guard
@@ -148,6 +164,16 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
     expect(related(res.body, SHEET_B, B_REC)).toBeUndefined()
     expect(related(res.body, SHEET_C, C_REC)).toBeUndefined()
     expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R7 positive control: cross-base related echo is delivered when the caller has base-read', async () => {
+    currentUser = { id: USER_BASE_READ, roles: ['member'], perms: ['multitable:write', 'multitable:base:read'] }
+    const res = await batchPatch(`edit-${TS}-base-read`)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    const d = related(res.body, SHEET_D, D_REC)
+    expect(d).toBeDefined()
+    expect(d.data[D_LOOKUP_VISIBLE]).toEqual([VISIBLE_CANARY])
   })
 
   test('per-subject: a user WITHOUT the deny row receives B_LOOKUP_SECRET — the mask is subject-scoped, not global', async () => {

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -207,6 +207,30 @@ describe('sanitizeFieldProperty — url / email / phone / barcode / location', (
   })
 })
 
+describe('sanitizeFieldProperty — link foreignBaseId claim', () => {
+  it('normalizes a valid claim only when a foreign target is present', () => {
+    expect(sanitizeFieldProperty('link', {
+      foreignSheetId: ' sheet_b ',
+      foreignBaseId: ' base_b ',
+    })).toMatchObject({
+      foreignSheetId: 'sheet_b',
+      foreignDatasheetId: 'sheet_b',
+      foreignBaseId: 'base_b',
+    })
+
+    expect(sanitizeFieldProperty('link', { foreignBaseId: ' base_b ' })).not.toHaveProperty('foreignBaseId')
+  })
+
+  it('drops empty and non-string claims instead of preserving them through passthrough', () => {
+    for (const foreignBaseId of ['', '   ', null, 42, { id: 'base_b' }]) {
+      expect(sanitizeFieldProperty('link', {
+        foreignSheetId: 'sheet_b',
+        foreignBaseId,
+      })).not.toHaveProperty('foreignBaseId')
+    }
+  })
+})
+
 describe('sanitizeFieldProperty — dateTime', () => {
   it('round-trips a valid IANA timezone', () => {
     expect(sanitizeFieldProperty('dateTime', { timezone: 'Asia/Shanghai' })).toEqual({


### PR DESCRIPTION
## Summary
- gate cross-base related-record write echoes on foreign base-read, matching the existing link-summary sink
- tighten the foreignBaseId claim invariant so same-base stale claims are rejected and claim-only PATCHes cannot create orphan link config
- strip empty/non-string foreignBaseId values from link property sanitizers instead of preserving passthrough dirt

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-cross-base-link-optin.test.ts tests/integration/multitable-cross-sheet-related-echo-mask.test.ts --reporter=dot (local DATABASE_URL unset, integration suites skipped)
- pnpm --filter @metasheet/core-backend build
- git diff --check
- subagent review x2: runtime/security no findings; test/contract coverage no findings

## Notes
- The real-DB integration suites are expected to execute in CI where DATABASE_URL is configured.
- Scope is P0 ②b arc closeout only; no data-source C2/C3/C6 runtime changes.