### PR TITLE
chore(attendance): clarify C5 DingTalk preflight blockers

### DIFF
--- a/docs/development/attendance-c5-delivery-c5-5-staging-runbook-20260611.md
+++ b/docs/development/attendance-c5-delivery-c5-5-staging-runbook-20260611.md
@@ -145,6 +145,24 @@ Before running the real smoke, provide:
 - a test recipient via `DINGTALK_SMOKE_EXTERNAL_USER_ID` or the three role-specific recipient ids;
 - a staging admin token via `SMOKE_TOKEN`/`TOKEN`, or the deploy-host token fallback.
 
+### 2026-06-14 preflight refresh
+
+After dispatch D5 closeout, staging was on deploy `9179c65bb4a6d0014801896645f6108e94466a79`. The C5 preflight was
+rerun from the deployed backend container with a deploy-host minted temporary admin token. Current result:
+
+```text
+overallStatus=blocked
+missingCheckIds=dingtalk-config,recipient
+tables=pass
+auth-token=pass
+due-deliveries=pass (0 due rows)
+directory-state=0 active DingTalk integrations, 0 accounts, 0 links
+```
+
+The container/host env has `DINGTALK_CLIENT_ID` and `DINGTALK_CLIENT_SECRET`, but still lacks the work-notification
+agent id (`DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID`). Before running the real smoke, provide that agent id and
+a test recipient external user id. The auth-token requirement can be satisfied by the existing deploy-host fallback.
+
 ```bash
 BASE_URL=http://127.0.0.1:8082 \
 DATABASE_URL=postgresql://USER@127.0.0.1:5432/metasheet \

--- a/scripts/ops/attendance-c5-real-dingtalk-preflight.mjs
+++ b/scripts/ops/attendance-c5-real-dingtalk-preflight.mjs
@@ -204,6 +204,33 @@ function addCheck(checks, status, id, message, details = {}) {
   checks.push({ id, status, message, details })
 }
 
+function missingEnvConfigInputs(selected) {
+  const missing = []
+  if (!selected.appKey.present) missing.push('DINGTALK_APP_KEY/DINGTALK_CLIENT_ID')
+  if (!selected.appSecret.present) missing.push('DINGTALK_APP_SECRET/DINGTALK_CLIENT_SECRET')
+  if (!selected.agentId.present) missing.push('DINGTALK_AGENT_ID/DINGTALK_NOTIFY_AGENT_ID')
+  return missing
+}
+
+function dingtalkConfigMessage({ envConfigReady, requestedIntegration, requestedIntegrationId, configuredIntegrations, missingEnvInputs }) {
+  if (envConfigReady) {
+    return 'DingTalk app key, app secret, and work-notification agent id are present in env/process'
+  }
+  if (requestedIntegration) {
+    return 'requested DINGTALK_SMOKE_CONFIG_INTEGRATION_ID has complete stored work-notification config'
+  }
+  if (requestedIntegrationId) {
+    return 'requested DINGTALK_SMOKE_CONFIG_INTEGRATION_ID is missing or incomplete'
+  }
+  if (configuredIntegrations.length > 0) {
+    return 'stored DingTalk config exists; set DINGTALK_SMOKE_CONFIG_INTEGRATION_ID to one configured integration id'
+  }
+  if (missingEnvInputs.length > 0 && missingEnvInputs.length < 3) {
+    return `incomplete env DingTalk work-notification config; missing ${missingEnvInputs.join(', ')}`
+  }
+  return 'missing DingTalk work-notification config; provide env config or DINGTALK_SMOKE_CONFIG_INTEGRATION_ID'
+}
+
 export function buildSummary({ env, dbFacts }) {
   const checks = []
   const selected = {
@@ -212,6 +239,7 @@ export function buildSummary({ env, dbFacts }) {
     agentId: pickEnv(env.values, ENV_GROUPS.agentId),
   }
   const envConfigReady = selected.appKey.present && selected.appSecret.present && selected.agentId.present
+  const missingEnvInputs = missingEnvConfigInputs(selected)
 
   const tableStatuses = REQUIRED_TABLES.map(table => ({
     table,
@@ -239,21 +267,20 @@ export function buildSummary({ env, dbFacts }) {
     checks,
     configReady ? 'pass' : 'block',
     'dingtalk-config',
-    envConfigReady
-      ? 'DingTalk app key, app secret, and work-notification agent id are present in env/process'
-      : requestedIntegration
-        ? 'requested DINGTALK_SMOKE_CONFIG_INTEGRATION_ID has complete stored work-notification config'
-        : requestedIntegrationId
-          ? 'requested DINGTALK_SMOKE_CONFIG_INTEGRATION_ID is missing or incomplete'
-          : configuredIntegrations.length > 0
-            ? 'stored DingTalk config exists; set DINGTALK_SMOKE_CONFIG_INTEGRATION_ID to one configured integration id'
-            : 'missing DingTalk work-notification config; provide env config or DINGTALK_SMOKE_CONFIG_INTEGRATION_ID',
+    dingtalkConfigMessage({
+      envConfigReady,
+      requestedIntegration,
+      requestedIntegrationId,
+      configuredIntegrations,
+      missingEnvInputs,
+    }),
     {
       envKeys: {
         appKey: selected.appKey.selectedKey,
         appSecret: selected.appSecret.selectedKey,
         agentId: selected.agentId.selectedKey,
       },
+      missingEnvInputs,
       requestedIntegrationId: requestedIntegrationId || null,
       configuredIntegrationIds: configuredIntegrations.map(item => item.integrationId),
       activeDingTalkIntegrationCount: storedIntegrations.length,

--- a/scripts/ops/attendance-c5-real-dingtalk-preflight.test.mjs
+++ b/scripts/ops/attendance-c5-real-dingtalk-preflight.test.mjs
@@ -110,8 +110,11 @@ test('attendance C5 real DingTalk preflight blocks missing real-mode prerequisit
     assert.equal(summary.overallStatus, 'blocked')
     assert.deepEqual(summary.missingCheckIds.sort(), ['auth-token', 'dingtalk-config', 'recipient'].sort())
     assert.equal(summary.checks.find((check) => check.id === 'tables').status, 'pass')
-    assert.equal(summary.checks.find((check) => check.id === 'dingtalk-config').details.envKeys.appKey, 'DINGTALK_APP_KEY')
-    assert.equal(summary.checks.find((check) => check.id === 'dingtalk-config').details.envKeys.appSecret, 'DINGTALK_APP_SECRET')
+    const configCheck = summary.checks.find((check) => check.id === 'dingtalk-config')
+    assert.match(configCheck.message, /missing DINGTALK_AGENT_ID\/DINGTALK_NOTIFY_AGENT_ID/)
+    assert.equal(configCheck.details.envKeys.appKey, 'DINGTALK_APP_KEY')
+    assert.equal(configCheck.details.envKeys.appSecret, 'DINGTALK_APP_SECRET')
+    assert.deepEqual(configCheck.details.missingEnvInputs, ['DINGTALK_AGENT_ID/DINGTALK_NOTIFY_AGENT_ID'])
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
@@ -136,6 +139,7 @@ test('attendance C5 real DingTalk preflight passes with complete env config, rec
     assert.deepEqual(summary.missingCheckIds, [])
     assert.equal(summary.selectedConfigSource, 'env')
     assert.equal(summary.checks.find((check) => check.id === 'dingtalk-config').details.envKeys.appKey, 'DINGTALK_CLIENT_ID')
+    assert.deepEqual(summary.checks.find((check) => check.id === 'dingtalk-config').details.missingEnvInputs, [])
     assert.equal(summary.checks.find((check) => check.id === 'recipient').status, 'pass')
     assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /unit-client-secret|header\.payload\.signature/)
   } finally {


### PR DESCRIPTION
## Summary
- make the C5 real DingTalk preflight report partial env config precisely, including the missing work-notification agent id key group
- keep secret values out of stdout, JSON, and Markdown; output only key names and presence facts
- add a 2026-06-14 preflight refresh to the C5-5 runbook: token fallback now passes, tables/due rows pass, remaining blockers are dingtalk-config + recipient

## Verification
- node --test scripts/ops/attendance-c5-real-dingtalk-preflight.test.mjs
- node --check scripts/ops/attendance-c5-real-dingtalk-preflight.mjs
- git diff --check origin/main...HEAD
- staging read-only preflight with deploy-host token: blocked only on dingtalk-config + recipient
- subagent review: APPROVE; no secret leak and C5 remains blocked/preflight-only