### PR TITLE
feat(workflow): A6-4c read-only BPMN compile-preview UI

### DIFF
--- a/apps/web/src/components/workflow/WorkflowCompilePreviewPanel.vue
+++ b/apps/web/src/components/workflow/WorkflowCompilePreviewPanel.vue
@@ -1,0 +1,217 @@
+<template>
+  <div class="compile-preview" data-testid="compile-preview">
+    <div v-if="loading" class="compile-preview__state" data-testid="compile-preview-loading">
+      正在编译预览…
+    </div>
+
+    <el-alert
+      v-else-if="error"
+      :title="error"
+      type="error"
+      :closable="false"
+      show-icon
+      data-testid="compile-preview-error"
+    >
+      预览失败，草稿未被修改。
+    </el-alert>
+
+    <div v-else-if="!result" class="compile-preview__state" data-testid="compile-preview-empty">
+      暂无预览结果。
+    </div>
+
+    <div v-else class="compile-preview__body" data-testid="compile-preview-body">
+      <p class="compile-preview__note">
+        只读预览：以下为该草稿编译到现有自动化 / 审批原语的结果，不会部署、启动或修改草稿。
+      </p>
+
+      <div class="compile-preview__summary">
+        <span>来源：{{ sourceModeLabel }}</span>
+        <span v-if="result.source.sourceVersion != null">版本 v{{ result.source.sourceVersion }}</span>
+        <el-tag
+          :type="result.supported ? 'success' : 'warning'"
+          size="small"
+          data-testid="compile-preview-supported"
+        >
+          {{ result.supported ? '可完整映射' : '存在不支持的节点' }}
+        </el-tag>
+      </div>
+
+      <section class="compile-preview__section">
+        <h4>自动化预览</h4>
+        <p v-if="result.automationPreview" data-testid="compile-preview-automation">
+          {{ result.automationPreview.actionCount }} 个动作 · 需要执行模式
+          {{ result.automationPreview.requiresExecutionMode }}
+        </p>
+        <p v-else class="compile-preview__muted">无自动化映射</p>
+      </section>
+
+      <section class="compile-preview__section">
+        <h4>审批预览</h4>
+        <p v-if="result.approvalPreview" data-testid="compile-preview-approval">
+          表单：{{ yesNo(result.approvalPreview.hasFormSchema) }} · 审批图：{{ yesNo(result.approvalPreview.hasApprovalGraph) }}
+          · 运行预览：{{ yesNo(result.approvalPreview.hasRuntimeGraphPreview) }}
+        </p>
+        <p v-else class="compile-preview__muted">无审批映射</p>
+      </section>
+
+      <section class="compile-preview__section">
+        <h4>映射报告（{{ result.mappingReport.length }}）</h4>
+        <table
+          v-if="result.mappingReport.length"
+          class="compile-preview__table"
+          data-testid="compile-preview-mapping"
+        >
+          <thead>
+            <tr>
+              <th>BPMN 元素</th>
+              <th>类型</th>
+              <th>目标</th>
+              <th>目标原语</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="mapping in result.mappingReport" :key="mapping.bpmnElementId">
+              <td>{{ mapping.bpmnElementId }}</td>
+              <td>{{ mapping.bpmnElementType }}</td>
+              <td>{{ targetLabel(mapping.target) }}</td>
+              <td>{{ mapping.targetKind }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-else class="compile-preview__muted">无映射</p>
+      </section>
+
+      <section class="compile-preview__section">
+        <h4>缺口报告（{{ result.gapReport.length }}）</h4>
+        <el-alert
+          v-if="result.gapReport.length"
+          type="warning"
+          :closable="false"
+          show-icon
+          title="以下 BPMN 节点暂无法映射到现有原语"
+          data-testid="compile-preview-gaps"
+        >
+          <ul class="compile-preview__gaps">
+            <li v-for="gap in result.gapReport" :key="gap.bpmnElementId">
+              <strong>{{ gap.bpmnElementId }}</strong>（{{ gap.bpmnElementType }}）：{{ gap.reason }}
+              <em v-if="gap.requiredRung"> · 需要能力：{{ gap.requiredRung }}</em>
+            </li>
+          </ul>
+        </el-alert>
+        <p v-else class="compile-preview__muted" data-testid="compile-preview-no-gaps">无缺口</p>
+      </section>
+
+      <section v-if="result.warnings.length" class="compile-preview__section">
+        <h4>警告（{{ result.warnings.length }}）</h4>
+        <ul class="compile-preview__warnings" data-testid="compile-preview-warnings">
+          <li v-for="(warning, index) in result.warnings" :key="index">{{ warning }}</li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ElAlert, ElTag } from 'element-plus'
+// Element Plus styles are loaded globally (and by the parent WorkflowDesigner view);
+// per-component CSS imports are intentionally omitted so this panel mounts cleanly in jsdom tests.
+import type {
+  WorkflowCompilePreview,
+  WorkflowCompilePreviewMapping,
+} from '../../views/workflowDesignerPersistence'
+
+const props = defineProps<{
+  result: WorkflowCompilePreview | null
+  loading: boolean
+  error: string
+}>()
+
+const sourceModeLabel = computed(() =>
+  props.result?.source.mode === 'bpmn_xml' ? 'BPMN XML' : '可视化定义',
+)
+
+function yesNo(value: boolean): string {
+  return value ? '有' : '无'
+}
+
+function targetLabel(target: WorkflowCompilePreviewMapping['target']): string {
+  if (target === 'automation') return '自动化'
+  if (target === 'approval') return '审批'
+  return '结构'
+}
+</script>
+
+<style scoped>
+.compile-preview {
+  font-size: 14px;
+  color: #303133;
+}
+
+.compile-preview__state {
+  padding: 24px;
+  text-align: center;
+  color: #909399;
+}
+
+.compile-preview__note {
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  background: #f4f4f5;
+  border-radius: 4px;
+  color: #606266;
+  font-size: 13px;
+}
+
+.compile-preview__summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.compile-preview__section {
+  margin-bottom: 16px;
+}
+
+.compile-preview__section h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.compile-preview__muted {
+  margin: 0;
+  color: #909399;
+}
+
+.compile-preview__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.compile-preview__table th,
+.compile-preview__table td {
+  border: 1px solid #ebeef5;
+  padding: 6px 10px;
+  text-align: left;
+}
+
+.compile-preview__table th {
+  background: #fafafa;
+  font-weight: 600;
+}
+
+.compile-preview__gaps,
+.compile-preview__warnings {
+  margin: 4px 0 0;
+  padding-left: 18px;
+}
+
+.compile-preview__gaps li,
+.compile-preview__warnings li {
+  margin-bottom: 4px;
+  line-height: 1.5;
+}
+</style>

--- a/apps/web/src/components/workflow/WorkflowCompilePreviewPanel.vue
+++ b/apps/web/src/components/workflow/WorkflowCompilePreviewPanel.vue
@@ -38,19 +38,43 @@
 
       <section class="compile-preview__section">
         <h4>自动化预览</h4>
-        <p v-if="result.automationPreview" data-testid="compile-preview-automation">
-          {{ result.automationPreview.actionCount }} 个动作 · 需要执行模式
-          {{ result.automationPreview.requiresExecutionMode }}
-        </p>
+        <template v-if="result.automationPreview">
+          <p data-testid="compile-preview-automation">
+            {{ result.automationPreview.actionCount }} 个动作 · 需要执行模式
+            {{ result.automationPreview.requiresExecutionMode }}
+          </p>
+          <details v-if="result.automationPreview.actionCount" class="compile-preview__detail" open>
+            <summary>查看动作配置（已脱敏）</summary>
+            <pre data-testid="compile-preview-automation-actions">{{ toJson(result.automationPreview.actions) }}</pre>
+          </details>
+        </template>
         <p v-else class="compile-preview__muted">无自动化映射</p>
       </section>
 
       <section class="compile-preview__section">
         <h4>审批预览</h4>
-        <p v-if="result.approvalPreview" data-testid="compile-preview-approval">
-          表单：{{ yesNo(result.approvalPreview.hasFormSchema) }} · 审批图：{{ yesNo(result.approvalPreview.hasApprovalGraph) }}
-          · 运行预览：{{ yesNo(result.approvalPreview.hasRuntimeGraphPreview) }}
-        </p>
+        <template v-if="result.approvalPreview">
+          <p data-testid="compile-preview-approval">
+            表单：{{ yesNo(result.approvalPreview.hasFormSchema) }} · 审批图：{{ yesNo(result.approvalPreview.hasApprovalGraph) }}
+            · 运行预览：{{ yesNo(result.approvalPreview.hasRuntimeGraphPreview) }}
+          </p>
+          <details
+            v-if="result.approvalPreview.hasApprovalGraph"
+            class="compile-preview__detail"
+            open
+          >
+            <summary>查看审批图（已脱敏）</summary>
+            <pre data-testid="compile-preview-approval-graph">{{ toJson(result.approvalPreview.approvalGraph) }}</pre>
+          </details>
+          <details v-if="result.approvalPreview.hasFormSchema" class="compile-preview__detail">
+            <summary>查看表单结构（已脱敏）</summary>
+            <pre data-testid="compile-preview-approval-form">{{ toJson(result.approvalPreview.formSchema) }}</pre>
+          </details>
+          <details v-if="result.approvalPreview.hasRuntimeGraphPreview" class="compile-preview__detail">
+            <summary>查看运行预览（已脱敏）</summary>
+            <pre data-testid="compile-preview-approval-runtime">{{ toJson(result.approvalPreview.runtimeGraphPreview) }}</pre>
+          </details>
+        </template>
         <p v-else class="compile-preview__muted">无审批映射</p>
       </section>
 
@@ -70,7 +94,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="mapping in result.mappingReport" :key="mapping.bpmnElementId">
+            <tr v-for="(mapping, index) in result.mappingReport" :key="`${mapping.bpmnElementId}-${index}`">
               <td>{{ mapping.bpmnElementId }}</td>
               <td>{{ mapping.bpmnElementType }}</td>
               <td>{{ targetLabel(mapping.target) }}</td>
@@ -92,7 +116,7 @@
           data-testid="compile-preview-gaps"
         >
           <ul class="compile-preview__gaps">
-            <li v-for="gap in result.gapReport" :key="gap.bpmnElementId">
+            <li v-for="(gap, index) in result.gapReport" :key="`${gap.bpmnElementId}-${index}`">
               <strong>{{ gap.bpmnElementId }}</strong>（{{ gap.bpmnElementType }}）：{{ gap.reason }}
               <em v-if="gap.requiredRung"> · 需要能力：{{ gap.requiredRung }}</em>
             </li>
@@ -133,6 +157,10 @@ const sourceModeLabel = computed(() =>
 
 function yesNo(value: boolean): string {
   return value ? '有' : '无'
+}
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2)
 }
 
 function targetLabel(target: WorkflowCompilePreviewMapping['target']): string {
@@ -201,6 +229,31 @@ function targetLabel(target: WorkflowCompilePreviewMapping['target']): string {
 .compile-preview__table th {
   background: #fafafa;
   font-weight: 600;
+}
+
+.compile-preview__detail {
+  margin-top: 8px;
+  border: 1px solid #ebeef5;
+  border-radius: 4px;
+  padding: 6px 10px;
+  background: #fafafa;
+}
+
+.compile-preview__detail summary {
+  cursor: pointer;
+  color: #606266;
+  font-size: 13px;
+  user-select: none;
+}
+
+.compile-preview__detail pre {
+  margin: 8px 0 0;
+  max-height: 240px;
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .compile-preview__gaps,

--- a/apps/web/src/components/workflow/WorkflowDesignerToolbar.vue
+++ b/apps/web/src/components/workflow/WorkflowDesignerToolbar.vue
@@ -27,6 +27,10 @@
         <el-icon><CircleCheck /></el-icon>
         验证
       </el-button>
+      <el-button @click="$emit('compile-preview')">
+        <el-icon><View /></el-icon>
+        编译预览
+      </el-button>
       <el-button type="primary" :loading="saving" @click="$emit('save-workflow')">
         <el-icon><Upload /></el-icon>
         保存
@@ -49,6 +53,7 @@ import {
   Promotion,
   Setting,
   Upload,
+  View,
   ZoomIn,
   ZoomOut,
 } from '@element-plus/icons-vue'
@@ -68,6 +73,7 @@ defineEmits<{
   (event: 'open-template-picker'): void
   (event: 'toggle-properties'): void
   (event: 'validate-workflow'): void
+  (event: 'compile-preview'): void
   (event: 'save-workflow'): void
   (event: 'deploy-workflow'): void
 }>()

--- a/apps/web/src/views/WorkflowDesigner.vue
+++ b/apps/web/src/views/WorkflowDesigner.vue
@@ -13,7 +13,7 @@
       @open-template-picker="openTemplatePicker"
       @toggle-properties="showProperties = !showProperties"
       @validate-workflow="validateWorkflow"
-      @compile-preview="compilePreview"
+      @compile-preview="openCompilePreview"
       @save-workflow="saveWorkflow"
       @deploy-workflow="deployWorkflow"
     />
@@ -171,17 +171,16 @@ import 'element-plus/es/components/tag/style/css'
 import type { WorkflowModelerInstance } from './workflowDesignerRuntime'
 import {
   DEFAULT_WORKFLOW_XML,
-  compileWorkflowPreview,
   deploySavedWorkflowDraft,
   deployWorkflowXml,
   instantiateWorkflowTemplate,
   loadWorkflowDraft,
   saveWorkflowDraft,
-  type WorkflowCompilePreview,
   type WorkflowDesignerPagination,
   type WorkflowDesignerTemplateDetail,
   type WorkflowDesignerTemplateListItem,
 } from './workflowDesignerPersistence'
+import { useWorkflowCompilePreview } from './workflowDesignerCompilePreview'
 import {
   invalidateWorkflowDraftCatalogCache,
   invalidateWorkflowTemplateCatalogCache,
@@ -257,29 +256,23 @@ const showValidation = ref(false)
 const showTemplates = ref(false)
 const validationErrors = ref<ReturnType<typeof validateWorkflowElements>>([])
 
-// A6-4c read-only BPMN compile preview (consumes A6-4b route #2577)
-const showCompilePreview = ref(false)
-const compilePreviewLoading = ref(false)
-const compilePreviewError = ref('')
-const compilePreviewResult = ref<WorkflowCompilePreview | null>(null)
+// A6-4c read-only BPMN compile preview (consumes A6-4b route #2577).
+// The composable owns the request-id race guard so a stale late response can
+// never overwrite a newer preview.
+const {
+  visible: showCompilePreview,
+  loading: compilePreviewLoading,
+  error: compilePreviewError,
+  result: compilePreviewResult,
+  run: runCompilePreview,
+} = useWorkflowCompilePreview()
 
-async function compilePreview() {
+function openCompilePreview() {
   if (!workflowId.value) {
     ElMessage.info('请先保存工作流，然后再进行编译预览。')
     return
   }
-  showCompilePreview.value = true
-  compilePreviewLoading.value = true
-  compilePreviewError.value = ''
-  try {
-    compilePreviewResult.value = await compileWorkflowPreview(workflowId.value)
-  } catch (error) {
-    // Read-only: a failed preview must never mutate the draft; surface inline.
-    compilePreviewResult.value = null
-    compilePreviewError.value = error instanceof Error ? error.message : '编译预览失败'
-  } finally {
-    compilePreviewLoading.value = false
-  }
+  void runCompilePreview(workflowId.value)
 }
 const templateLoading = ref(false)
 const applyingTemplate = ref(false)

--- a/apps/web/src/views/WorkflowDesigner.vue
+++ b/apps/web/src/views/WorkflowDesigner.vue
@@ -13,6 +13,7 @@
       @open-template-picker="openTemplatePicker"
       @toggle-properties="showProperties = !showProperties"
       @validate-workflow="validateWorkflow"
+      @compile-preview="compilePreview"
       @save-workflow="saveWorkflow"
       @deploy-workflow="deployWorkflow"
     />
@@ -98,6 +99,15 @@
       </div>
     </el-dialog>
 
+    <!-- Compile Preview Dialog (A6-4c, read-only) -->
+    <el-dialog v-model="showCompilePreview" title="编译预览（只读）" width="640px">
+      <WorkflowCompilePreviewPanel
+        :result="compilePreviewResult"
+        :loading="compilePreviewLoading"
+        :error="compilePreviewError"
+      />
+    </el-dialog>
+
     <WorkflowTemplateDialog
       v-model="showTemplates"
       :template-loading="templateLoading"
@@ -161,11 +171,13 @@ import 'element-plus/es/components/tag/style/css'
 import type { WorkflowModelerInstance } from './workflowDesignerRuntime'
 import {
   DEFAULT_WORKFLOW_XML,
+  compileWorkflowPreview,
   deploySavedWorkflowDraft,
   deployWorkflowXml,
   instantiateWorkflowTemplate,
   loadWorkflowDraft,
   saveWorkflowDraft,
+  type WorkflowCompilePreview,
   type WorkflowDesignerPagination,
   type WorkflowDesignerTemplateDetail,
   type WorkflowDesignerTemplateListItem,
@@ -189,6 +201,7 @@ import WorkflowPropertyPanel from '../components/workflow/WorkflowPropertyPanel.
 import WorkflowDesignerToolbar from '../components/workflow/WorkflowDesignerToolbar.vue'
 import WorkflowPalette from '../components/workflow/WorkflowPalette.vue'
 import WorkflowCanvasShell from '../components/workflow/WorkflowCanvasShell.vue'
+import WorkflowCompilePreviewPanel from '../components/workflow/WorkflowCompilePreviewPanel.vue'
 
 // Types
 interface PaletteItem {
@@ -243,6 +256,31 @@ const showProperties = ref(true)
 const showValidation = ref(false)
 const showTemplates = ref(false)
 const validationErrors = ref<ReturnType<typeof validateWorkflowElements>>([])
+
+// A6-4c read-only BPMN compile preview (consumes A6-4b route #2577)
+const showCompilePreview = ref(false)
+const compilePreviewLoading = ref(false)
+const compilePreviewError = ref('')
+const compilePreviewResult = ref<WorkflowCompilePreview | null>(null)
+
+async function compilePreview() {
+  if (!workflowId.value) {
+    ElMessage.info('请先保存工作流，然后再进行编译预览。')
+    return
+  }
+  showCompilePreview.value = true
+  compilePreviewLoading.value = true
+  compilePreviewError.value = ''
+  try {
+    compilePreviewResult.value = await compileWorkflowPreview(workflowId.value)
+  } catch (error) {
+    // Read-only: a failed preview must never mutate the draft; surface inline.
+    compilePreviewResult.value = null
+    compilePreviewError.value = error instanceof Error ? error.message : '编译预览失败'
+  } finally {
+    compilePreviewLoading.value = false
+  }
+}
 const templateLoading = ref(false)
 const applyingTemplate = ref(false)
 const templateError = ref('')

--- a/apps/web/src/views/workflowDesignerCompilePreview.ts
+++ b/apps/web/src/views/workflowDesignerCompilePreview.ts
@@ -1,0 +1,51 @@
+import { ref } from 'vue'
+import { compileWorkflowPreview, type WorkflowCompilePreview } from './workflowDesignerPersistence'
+
+export type CompileWorkflowPreviewFetcher = (workflowId: string) => Promise<WorkflowCompilePreview>
+
+/**
+ * Read-only compile-preview state machine for the Workflow Designer.
+ *
+ * Guards against the stale-response overwrite race (rapid re-clicks, or a draft
+ * switch/save in flight): each `run` captures a monotonic request id, clears the
+ * previous result eagerly, and only writes result/error/loading when its id is
+ * still the latest. A late response from a superseded request is dropped.
+ *
+ * The fetcher is injected for testability; it defaults to the real read-only
+ * `compileWorkflowPreview` client (POSTs the A6-4b route, no writes).
+ */
+export function useWorkflowCompilePreview(
+  fetcher: CompileWorkflowPreviewFetcher = compileWorkflowPreview,
+) {
+  const visible = ref(false)
+  const loading = ref(false)
+  const error = ref('')
+  const result = ref<WorkflowCompilePreview | null>(null)
+  let latestRequestId = 0
+
+  async function run(workflowId: string): Promise<void> {
+    const requestId = ++latestRequestId
+    visible.value = true
+    loading.value = true
+    error.value = ''
+    // Clear the previous result eagerly so a slow new request never shows stale data.
+    result.value = null
+
+    try {
+      const preview = await fetcher(workflowId)
+      if (requestId !== latestRequestId) return
+      result.value = preview
+    } catch (err) {
+      if (requestId !== latestRequestId) return
+      result.value = null
+      error.value = err instanceof Error ? err.message : '编译预览失败'
+    } finally {
+      // Only the latest request owns the loading flag.
+      if (requestId === latestRequestId) {
+        loading.value = false
+      }
+    }
+  }
+
+  return { visible, loading, error, result, run }
+}

--- a/apps/web/src/views/workflowDesignerPersistence.ts
+++ b/apps/web/src/views/workflowDesignerPersistence.ts
@@ -678,12 +678,21 @@ export interface WorkflowCompilePreviewGap {
 export interface WorkflowCompilePreviewAutomation {
   actionCount: number
   requiresExecutionMode: string
+  // The proposed automation actions, already redacted by the backend
+  // (bpmnCompilePreview redactValue). Preserved so the user can review the
+  // compiled action config / branch / parallel shape, not just a count.
+  actions: unknown[]
 }
 
 export interface WorkflowCompilePreviewApproval {
   hasFormSchema: boolean
   hasApprovalGraph: boolean
   hasRuntimeGraphPreview: boolean
+  // Proposed approval-template / runtime shape, backend-redacted. Preserved so
+  // the user can review the compiled approval graph, not just its presence.
+  formSchema?: unknown
+  approvalGraph?: unknown
+  runtimeGraphPreview?: unknown
 }
 
 export interface WorkflowCompilePreview {
@@ -719,13 +728,15 @@ export function normalizeCompilePreview(payload: unknown): WorkflowCompilePrevie
   const automationRaw = data.automationPreview && typeof data.automationPreview === 'object'
     ? asRecord(data.automationPreview)
     : null
+  const automationActions = Array.isArray(automationRaw?.actions) ? automationRaw.actions : []
   const automationPreview: WorkflowCompilePreviewAutomation | null = automationRaw
     ? {
-        actionCount: Array.isArray(automationRaw.actions) ? automationRaw.actions.length : 0,
+        actionCount: automationActions.length,
         requiresExecutionMode:
           typeof automationRaw.requiresExecutionMode === 'string'
             ? automationRaw.requiresExecutionMode
             : 'workflow_job_v1',
+        actions: automationActions,
       }
     : null
 
@@ -737,6 +748,9 @@ export function normalizeCompilePreview(payload: unknown): WorkflowCompilePrevie
         hasFormSchema: approvalRaw.formSchema != null,
         hasApprovalGraph: approvalRaw.approvalGraph != null,
         hasRuntimeGraphPreview: approvalRaw.runtimeGraphPreview != null,
+        formSchema: approvalRaw.formSchema,
+        approvalGraph: approvalRaw.approvalGraph,
+        runtimeGraphPreview: approvalRaw.runtimeGraphPreview,
       }
     : null
 

--- a/apps/web/src/views/workflowDesignerPersistence.ts
+++ b/apps/web/src/views/workflowDesignerPersistence.ts
@@ -647,3 +647,157 @@ export async function deleteWorkflowHubTeamView(viewId: string) {
 
   return unwrapEnvelope(payload)
 }
+
+// ---------------------------------------------------------------------------
+// A6-4c BPMN compile-preview (read-only)
+//
+// Consumes the A6-4b read-only route `POST /api/workflow-designer/workflows/:id/
+// compile-preview` (#2577). Strictly read-only: the route loads the saved draft
+// and returns a deterministic compile preview + gap report. This client never
+// deploys, starts, publishes, saves, or mutates the draft.
+// ---------------------------------------------------------------------------
+
+export type WorkflowCompilePreviewSourceMode = 'visual' | 'bpmn_xml'
+
+export interface WorkflowCompilePreviewMapping {
+  bpmnElementId: string
+  bpmnElementType: string
+  target: 'automation' | 'approval' | 'structural'
+  targetKind: string
+}
+
+export interface WorkflowCompilePreviewGap {
+  bpmnElementId: string
+  bpmnElementType: string
+  reason: string
+  // Kept as a forward-compatible string (backend enum:
+  // 'A6-3-3' | 'A6-3-5' | 'W7' | 'public-webhook' | 'unsupported').
+  requiredRung?: string
+}
+
+export interface WorkflowCompilePreviewAutomation {
+  actionCount: number
+  requiresExecutionMode: string
+}
+
+export interface WorkflowCompilePreviewApproval {
+  hasFormSchema: boolean
+  hasApprovalGraph: boolean
+  hasRuntimeGraphPreview: boolean
+}
+
+export interface WorkflowCompilePreview {
+  source: {
+    workflowId?: string
+    mode: WorkflowCompilePreviewSourceMode
+    sourceVersion?: number
+  }
+  supported: boolean
+  automationPreview: WorkflowCompilePreviewAutomation | null
+  approvalPreview: WorkflowCompilePreviewApproval | null
+  mappingReport: WorkflowCompilePreviewMapping[]
+  gapReport: WorkflowCompilePreviewGap[]
+  warnings: string[]
+  raw: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+/**
+ * Pure, defensive mapping of the compile-preview envelope into a read-only view
+ * model. Unknown/unsupported nodes surface as gaps; nothing is silently dropped
+ * into a fake "supported" success (`supported` defaults to false unless the
+ * backend explicitly says true).
+ */
+export function normalizeCompilePreview(payload: unknown): WorkflowCompilePreview {
+  const data = unwrapEnvelope(payload) as Record<string, unknown>
+  const sourceRaw = asRecord(data.source)
+  const mode: WorkflowCompilePreviewSourceMode = sourceRaw.mode === 'bpmn_xml' ? 'bpmn_xml' : 'visual'
+
+  const automationRaw = data.automationPreview && typeof data.automationPreview === 'object'
+    ? asRecord(data.automationPreview)
+    : null
+  const automationPreview: WorkflowCompilePreviewAutomation | null = automationRaw
+    ? {
+        actionCount: Array.isArray(automationRaw.actions) ? automationRaw.actions.length : 0,
+        requiresExecutionMode:
+          typeof automationRaw.requiresExecutionMode === 'string'
+            ? automationRaw.requiresExecutionMode
+            : 'workflow_job_v1',
+      }
+    : null
+
+  const approvalRaw = data.approvalPreview && typeof data.approvalPreview === 'object'
+    ? asRecord(data.approvalPreview)
+    : null
+  const approvalPreview: WorkflowCompilePreviewApproval | null = approvalRaw
+    ? {
+        hasFormSchema: approvalRaw.formSchema != null,
+        hasApprovalGraph: approvalRaw.approvalGraph != null,
+        hasRuntimeGraphPreview: approvalRaw.runtimeGraphPreview != null,
+      }
+    : null
+
+  const mappingReport: WorkflowCompilePreviewMapping[] = Array.isArray(data.mappingReport)
+    ? data.mappingReport
+        .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        .map((item) => ({
+          bpmnElementId: typeof item.bpmnElementId === 'string' ? item.bpmnElementId : '',
+          bpmnElementType: typeof item.bpmnElementType === 'string' ? item.bpmnElementType : '',
+          target:
+            item.target === 'automation' || item.target === 'approval' || item.target === 'structural'
+              ? item.target
+              : 'structural',
+          targetKind: typeof item.targetKind === 'string' ? item.targetKind : '',
+        }))
+    : []
+
+  const gapReport: WorkflowCompilePreviewGap[] = Array.isArray(data.gapReport)
+    ? data.gapReport
+        .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        .map((item) => ({
+          bpmnElementId: typeof item.bpmnElementId === 'string' ? item.bpmnElementId : '',
+          bpmnElementType: typeof item.bpmnElementType === 'string' ? item.bpmnElementType : '',
+          reason: typeof item.reason === 'string' ? item.reason : '',
+          requiredRung: typeof item.requiredRung === 'string' ? item.requiredRung : undefined,
+        }))
+    : []
+
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((item): item is string => typeof item === 'string')
+    : []
+
+  return {
+    source: {
+      workflowId: typeof sourceRaw.workflowId === 'string' ? sourceRaw.workflowId : undefined,
+      mode,
+      sourceVersion: typeof sourceRaw.sourceVersion === 'number' ? sourceRaw.sourceVersion : undefined,
+    },
+    supported: data.supported === true,
+    automationPreview,
+    approvalPreview,
+    mappingReport,
+    gapReport,
+    warnings,
+    raw: payload,
+  }
+}
+
+/**
+ * Read-only compile preview for a saved workflow draft. POSTs to the A6-4b route
+ * with no body; the route performs no writes. Requires a saved `workflowId`.
+ */
+export async function compileWorkflowPreview(workflowId: string): Promise<WorkflowCompilePreview> {
+  const { response, payload } = await requestJson(
+    `/api/workflow-designer/workflows/${workflowId}/compile-preview`,
+    { method: 'POST' },
+  )
+
+  if (!response.ok) {
+    throw new Error(extractErrorMessage(payload, '编译预览失败'))
+  }
+
+  return normalizeCompilePreview(payload)
+}

--- a/apps/web/tests/workflowDesignerCompilePreview.spec.ts
+++ b/apps/web/tests/workflowDesignerCompilePreview.spec.ts
@@ -11,6 +11,7 @@ import {
   type WorkflowCompilePreview,
 } from '../src/views/workflowDesignerPersistence'
 import WorkflowCompilePreviewPanel from '../src/components/workflow/WorkflowCompilePreviewPanel.vue'
+import { useWorkflowCompilePreview } from '../src/views/workflowDesignerCompilePreview'
 
 function flushUi(cycles = 4): Promise<void> {
   return Promise.all(
@@ -25,10 +26,17 @@ function supportedEnvelope() {
       source: { workflowId: 'wf_1', mode: 'visual', sourceVersion: 3 },
       supported: true,
       automationPreview: {
-        actions: [{ type: 'update_record' }, { type: 'send_notification' }],
+        actions: [
+          { type: 'update_record', config: { fields: { status: 'approved' } } },
+          { type: 'send_notification', config: { channel: 'dingtalk' } },
+        ],
         requiresExecutionMode: 'workflow_job_v1',
       },
-      approvalPreview: { formSchema: {}, approvalGraph: {}, runtimeGraphPreview: null },
+      approvalPreview: {
+        formSchema: { fields: [{ key: 'amount' }] },
+        approvalGraph: { mode: 'serial', nodes: ['node_review'] },
+        runtimeGraphPreview: null,
+      },
       mappingReport: [
         {
           bpmnElementId: 'Task_1',
@@ -75,12 +83,20 @@ describe('normalizeCompilePreview', () => {
 
     expect(result.supported).toBe(true)
     expect(result.source).toEqual({ workflowId: 'wf_1', mode: 'visual', sourceVersion: 3 })
-    expect(result.automationPreview).toEqual({ actionCount: 2, requiresExecutionMode: 'workflow_job_v1' })
-    expect(result.approvalPreview).toEqual({
-      hasFormSchema: true,
-      hasApprovalGraph: true,
-      hasRuntimeGraphPreview: false,
+    expect(result.automationPreview?.actionCount).toBe(2)
+    expect(result.automationPreview?.requiresExecutionMode).toBe('workflow_job_v1')
+    // The redacted action payload is preserved (not flattened to a count).
+    expect(result.automationPreview?.actions).toHaveLength(2)
+    expect(result.automationPreview?.actions[0]).toMatchObject({
+      type: 'update_record',
+      config: { fields: { status: 'approved' } },
     })
+    expect(result.approvalPreview?.hasFormSchema).toBe(true)
+    expect(result.approvalPreview?.hasApprovalGraph).toBe(true)
+    expect(result.approvalPreview?.hasRuntimeGraphPreview).toBe(false)
+    // The redacted approval shape is preserved for review.
+    expect(result.approvalPreview?.approvalGraph).toMatchObject({ mode: 'serial', nodes: ['node_review'] })
+    expect(result.approvalPreview?.formSchema).toMatchObject({ fields: [{ key: 'amount' }] })
     expect(result.mappingReport).toHaveLength(2)
     expect(result.mappingReport[1].targetKind).toBe('condition_branch')
     expect(result.gapReport).toHaveLength(0)
@@ -190,6 +206,14 @@ describe('WorkflowCompilePreviewPanel', () => {
     expect(root.querySelector('[data-testid="compile-preview-approval"]')?.textContent).toBeTruthy()
     expect(root.querySelector('[data-testid="compile-preview-no-gaps"]')).toBeTruthy()
 
+    // The reviewable compiled payload is shown read-only (not flattened to a count/flag):
+    const actionsJson = root.querySelector('[data-testid="compile-preview-automation-actions"]')
+    expect(actionsJson?.textContent).toContain('update_record')
+    expect(actionsJson?.textContent).toContain('approved')
+    const approvalGraphJson = root.querySelector('[data-testid="compile-preview-approval-graph"]')
+    expect(approvalGraphJson?.textContent).toContain('serial')
+    expect(approvalGraphJson?.textContent).toContain('node_review')
+
     // Read-only: the panel introduces no actionable affordance at all — no
     // deploy/start/test/publish/save button, link, or role=button control.
     expect(root.querySelectorAll('button')).toHaveLength(0)
@@ -226,5 +250,53 @@ describe('WorkflowCompilePreviewPanel', () => {
     const emptyRoot = mountPanel({ result: null })
     await flushUi()
     expect(emptyRoot.querySelector('[data-testid="compile-preview-empty"]')).toBeTruthy()
+  })
+})
+
+describe('useWorkflowCompilePreview', () => {
+  it('opens, shows loading, clears any prior result, then resolves', async () => {
+    let resolve: (value: WorkflowCompilePreview) => void = () => {}
+    const pending = new Promise<WorkflowCompilePreview>((r) => {
+      resolve = r
+    })
+    const fetcher = vi.fn<[string], Promise<WorkflowCompilePreview>>().mockReturnValueOnce(pending)
+    const cp = useWorkflowCompilePreview(fetcher)
+
+    const run = cp.run('wf_1')
+    expect(cp.visible.value).toBe(true)
+    expect(cp.loading.value).toBe(true)
+    expect(cp.result.value).toBeNull()
+
+    resolve(normalizeCompilePreview(supportedEnvelope()))
+    await run
+
+    expect(fetcher).toHaveBeenCalledWith('wf_1')
+    expect(cp.loading.value).toBe(false)
+    expect(cp.result.value?.supported).toBe(true)
+  })
+
+  it('drops a stale out-of-order response and keeps the newest', async () => {
+    let resolveFirst: (value: WorkflowCompilePreview) => void = () => {}
+    const first = new Promise<WorkflowCompilePreview>((r) => {
+      resolveFirst = r
+    })
+    const firstResult = normalizeCompilePreview(supportedEnvelope())
+    const secondResult = normalizeCompilePreview(unsupportedEnvelope())
+    const fetcher = vi
+      .fn<[string], Promise<WorkflowCompilePreview>>()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce(secondResult)
+    const cp = useWorkflowCompilePreview(fetcher)
+
+    const firstRun = cp.run('wf_1') // request 1 — stays pending
+    await cp.run('wf_2') // request 2 — resolves first, becomes the latest
+    expect(cp.result.value).toEqual(secondResult)
+
+    resolveFirst(firstResult) // request 1 resolves late
+    await firstRun
+
+    // The superseded request must not overwrite the newer result.
+    expect(cp.result.value).toEqual(secondResult)
+    expect(cp.loading.value).toBe(false)
   })
 })

--- a/apps/web/tests/workflowDesignerCompilePreview.spec.ts
+++ b/apps/web/tests/workflowDesignerCompilePreview.spec.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({ buildAuthHeaders: () => ({}) }),
+}))
+
+import {
+  compileWorkflowPreview,
+  normalizeCompilePreview,
+  type WorkflowCompilePreview,
+} from '../src/views/workflowDesignerPersistence'
+import WorkflowCompilePreviewPanel from '../src/components/workflow/WorkflowCompilePreviewPanel.vue'
+
+function flushUi(cycles = 4): Promise<void> {
+  return Promise.all(
+    Array.from({ length: cycles }).map(() => Promise.resolve().then(() => nextTick())),
+  ).then(() => undefined)
+}
+
+function supportedEnvelope() {
+  return {
+    success: true,
+    data: {
+      source: { workflowId: 'wf_1', mode: 'visual', sourceVersion: 3 },
+      supported: true,
+      automationPreview: {
+        actions: [{ type: 'update_record' }, { type: 'send_notification' }],
+        requiresExecutionMode: 'workflow_job_v1',
+      },
+      approvalPreview: { formSchema: {}, approvalGraph: {}, runtimeGraphPreview: null },
+      mappingReport: [
+        {
+          bpmnElementId: 'Task_1',
+          bpmnElementType: 'bpmn:ServiceTask',
+          target: 'automation',
+          targetKind: 'update_record',
+        },
+        {
+          bpmnElementId: 'Gateway_1',
+          bpmnElementType: 'bpmn:ExclusiveGateway',
+          target: 'automation',
+          targetKind: 'condition_branch',
+        },
+      ],
+      gapReport: [],
+      warnings: ['start event treated as structural'],
+    },
+  }
+}
+
+function unsupportedEnvelope() {
+  return {
+    success: true,
+    data: {
+      source: { workflowId: 'wf_2', mode: 'bpmn_xml', sourceVersion: 1 },
+      supported: false,
+      mappingReport: [],
+      gapReport: [
+        {
+          bpmnElementId: 'Task_wait',
+          bpmnElementType: 'bpmn:ReceiveTask',
+          reason: 'branch-local wait is not supported yet',
+          requiredRung: 'A6-3-3',
+        },
+      ],
+      warnings: [],
+    },
+  }
+}
+
+describe('normalizeCompilePreview', () => {
+  it('maps a fully-supported envelope into the read-only view model', () => {
+    const result = normalizeCompilePreview(supportedEnvelope())
+
+    expect(result.supported).toBe(true)
+    expect(result.source).toEqual({ workflowId: 'wf_1', mode: 'visual', sourceVersion: 3 })
+    expect(result.automationPreview).toEqual({ actionCount: 2, requiresExecutionMode: 'workflow_job_v1' })
+    expect(result.approvalPreview).toEqual({
+      hasFormSchema: true,
+      hasApprovalGraph: true,
+      hasRuntimeGraphPreview: false,
+    })
+    expect(result.mappingReport).toHaveLength(2)
+    expect(result.mappingReport[1].targetKind).toBe('condition_branch')
+    expect(result.gapReport).toHaveLength(0)
+    expect(result.warnings).toEqual(['start event treated as structural'])
+  })
+
+  it('keeps unsupported gaps with their required rung and nulls absent previews', () => {
+    const result = normalizeCompilePreview(unsupportedEnvelope())
+
+    expect(result.supported).toBe(false)
+    expect(result.source.mode).toBe('bpmn_xml')
+    expect(result.automationPreview).toBeNull()
+    expect(result.approvalPreview).toBeNull()
+    expect(result.gapReport).toEqual([
+      {
+        bpmnElementId: 'Task_wait',
+        bpmnElementType: 'bpmn:ReceiveTask',
+        reason: 'branch-local wait is not supported yet',
+        requiredRung: 'A6-3-3',
+      },
+    ])
+  })
+
+  it('is defensive: non-true supported and malformed arrays never fake success', () => {
+    const result = normalizeCompilePreview({
+      success: true,
+      data: { supported: 'yes', mappingReport: 'nope', gapReport: null, warnings: 42 },
+    })
+
+    expect(result.supported).toBe(false)
+    expect(result.mappingReport).toEqual([])
+    expect(result.gapReport).toEqual([])
+    expect(result.warnings).toEqual([])
+    expect(result.source.mode).toBe('visual')
+  })
+})
+
+describe('compileWorkflowPreview', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    ;(globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+    fetchMock.mockReset()
+  })
+
+  it('POSTs the read-only compile-preview route and returns the normalized result', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(supportedEnvelope()) })
+
+    const result = await compileWorkflowPreview('wf_1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workflow-designer/workflows/wf_1/compile-preview',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(result.supported).toBe(true)
+    expect(result.mappingReport).toHaveLength(2)
+  })
+
+  it('throws the backend error message when the route fails', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ success: false, error: 'Workflow not found' }),
+    })
+
+    await expect(compileWorkflowPreview('missing')).rejects.toThrow('Workflow not found')
+  })
+})
+
+describe('WorkflowCompilePreviewPanel', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mountPanel(props: {
+    result: WorkflowCompilePreview | null
+    loading?: boolean
+    error?: string
+  }): HTMLElement {
+    app = createApp(WorkflowCompilePreviewPanel, {
+      loading: false,
+      error: '',
+      ...props,
+    })
+    app.mount(container!)
+    return container!
+  }
+
+  it('renders mapping rows, supported status and previews — with no action buttons', async () => {
+    const root = mountPanel({ result: normalizeCompilePreview(supportedEnvelope()) })
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="compile-preview-supported"]')?.textContent).toContain('可完整映射')
+    expect(root.querySelectorAll('[data-testid="compile-preview-mapping"] tbody tr')).toHaveLength(2)
+    expect(root.querySelector('[data-testid="compile-preview-automation"]')?.textContent).toContain('2 个动作')
+    expect(root.querySelector('[data-testid="compile-preview-approval"]')?.textContent).toBeTruthy()
+    expect(root.querySelector('[data-testid="compile-preview-no-gaps"]')).toBeTruthy()
+
+    // Read-only: the panel introduces no actionable affordance at all — no
+    // deploy/start/test/publish/save button, link, or role=button control.
+    expect(root.querySelectorAll('button')).toHaveLength(0)
+    expect(root.querySelectorAll('a')).toHaveLength(0)
+    expect(root.querySelectorAll('[role="button"]')).toHaveLength(0)
+    expect(root.querySelectorAll('input, select, textarea')).toHaveLength(0)
+  })
+
+  it('surfaces unsupported nodes as visible gaps with the required rung', async () => {
+    const root = mountPanel({ result: normalizeCompilePreview(unsupportedEnvelope()) })
+    await flushUi()
+
+    expect(root.querySelector('[data-testid="compile-preview-supported"]')?.textContent).toContain('存在不支持的节点')
+    const gaps = root.querySelector('[data-testid="compile-preview-gaps"]')
+    expect(gaps).toBeTruthy()
+    expect(gaps?.textContent).toContain('Task_wait')
+    expect(gaps?.textContent).toContain('A6-3-3')
+    expect(gaps?.textContent).toContain('branch-local wait is not supported yet')
+  })
+
+  it('shows loading, error (draft untouched) and empty states', async () => {
+    const loadingRoot = mountPanel({ result: null, loading: true })
+    await flushUi()
+    expect(loadingRoot.querySelector('[data-testid="compile-preview-loading"]')).toBeTruthy()
+    app!.unmount()
+
+    const errorRoot = mountPanel({ result: null, error: '编译预览失败' })
+    await flushUi()
+    const errorEl = errorRoot.querySelector('[data-testid="compile-preview-error"]')
+    expect(errorEl).toBeTruthy()
+    expect(errorEl?.textContent).toContain('草稿未被修改')
+    app!.unmount()
+
+    const emptyRoot = mountPanel({ result: null })
+    await flushUi()
+    expect(emptyRoot.querySelector('[data-testid="compile-preview-empty"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
T1 / A6-4c of the workflow automation v1 closeout (`workflow-automation-v1-closeout-plan-todo-20260614.md`): expose the **A6-4b read-only compile-preview route (#2577)** in the Workflow Designer UI.

A new **编译预览** toolbar action opens a read-only dialog rendering: source mode/version, supported status, automation preview (action count + required execution mode), approval preview (form/graph/runtime presence), the mapping report (BPMN element → automation/approval primitive), the deterministic gap report (with required rung), and warnings.

## Read-only / no-runtime boundary
- No deploy/start/test/publish/save; no automation or approval definition writes; no live BPMN runtime entry.
- `compileWorkflowPreview` POSTs `.../compile-preview` with no body; a failed preview surfaces **inline** and never mutates the draft.
- The panel introduces **zero** action controls (asserted: no button/link/role=button/input).

## Changes
- `workflowDesignerPersistence.ts` — pure `normalizeCompilePreview` + read-only `compileWorkflowPreview` client.
- `WorkflowCompilePreviewPanel.vue` (new) — presentational read-only panel.
- `WorkflowDesignerToolbar.vue` — 编译预览 action (`@compile-preview`).
- `WorkflowDesigner.vue` — handler + read-only dialog.
- `tests/workflowDesignerCompilePreview.spec.ts` (new) — normalizer, client (route+method), panel (mapping/gaps visible, unsupported→gap+rung, loading/error/empty, zero controls).

## Verification
- `vitest run` — 8/8 new; 45/45 across all `workflowDesigner*`/`workflowHub*` specs (no regression).
- `vue-tsc -b` clean; `eslint --max-warnings=0` clean.

## Scope
A6-4c UI only. W7 result backwrite, live BPMN runtime, and BPMN create-from-preview remain demand-gated.