### PR TITLE
feat(data-source): expose readonly orderBy facade

### DIFF
--- a/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
+++ b/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
@@ -32,7 +32,7 @@ export interface DataSourceReadOnlyFacade {
   select(
     dataSourceId: string,
     table: string,
-    options: Pick<QueryOptions, 'limit' | 'offset' | 'where'>,
+    options: Pick<QueryOptions, 'limit' | 'offset' | 'where' | 'orderBy'>,
     principal: string | undefined
   ): Promise<QueryResult<Record<string, DbValue>>>
 }
@@ -41,6 +41,7 @@ export const MISSING_PRINCIPAL_MESSAGE = 'data source read requires an owner pri
 export const DATA_SOURCE_PRINCIPAL_REQUIRED_CODE = 'DATA_SOURCE_PRINCIPAL_REQUIRED'
 export const DATA_SOURCE_NOT_FOUND_CODE = 'DATA_SOURCE_NOT_FOUND'
 export const DATA_SOURCE_NOT_READ_ONLY_CODE = 'DATA_SOURCE_NOT_READ_ONLY'
+export const DATA_SOURCE_QUERY_INVALID_CODE = 'DATA_SOURCE_QUERY_INVALID'
 
 export function writableSourceMessage(dataSourceId: string): string {
   return `data source '${dataSourceId}' is writable; the read-only bridge refuses a writable binding`
@@ -91,6 +92,46 @@ function requirePrincipal(principal: string | undefined): string {
     )
   }
   return principal
+}
+
+function normalizeOrderBy(orderBy: QueryOptions['orderBy'] | undefined): QueryOptions['orderBy'] | undefined {
+  if (orderBy === undefined) return undefined
+  if (!Array.isArray(orderBy)) {
+    throw new DataSourceBridgeConfigError(
+      DATA_SOURCE_QUERY_INVALID_CODE,
+      'data source read orderBy must be an array',
+      'DataSourceQueryInvalidError'
+    )
+  }
+  if (orderBy.length === 0) return undefined
+
+  return orderBy.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new DataSourceBridgeConfigError(
+        DATA_SOURCE_QUERY_INVALID_CODE,
+        `data source read orderBy[${index}] must be an object`,
+        'DataSourceQueryInvalidError'
+      )
+    }
+    const column = (entry as { column?: unknown }).column
+    const rawDirection = (entry as { direction?: unknown }).direction
+    const direction = typeof rawDirection === 'string' ? rawDirection.toLowerCase() : ''
+    if (typeof column !== 'string' || column.trim() === '') {
+      throw new DataSourceBridgeConfigError(
+        DATA_SOURCE_QUERY_INVALID_CODE,
+        `data source read orderBy[${index}].column must be a non-empty string`,
+        'DataSourceQueryInvalidError'
+      )
+    }
+    if (direction !== 'asc' && direction !== 'desc') {
+      throw new DataSourceBridgeConfigError(
+        DATA_SOURCE_QUERY_INVALID_CODE,
+        `data source read orderBy[${index}].direction must be asc or desc`,
+        'DataSourceQueryInvalidError'
+      )
+    }
+    return { column, direction }
+  })
 }
 
 /**
@@ -158,6 +199,10 @@ export function createDataSourcePluginFacade(
       }
       if (options.where && Object.keys(options.where).length > 0) {
         queryOptions.where = options.where
+      }
+      const orderBy = normalizeOrderBy(options.orderBy)
+      if (orderBy) {
+        queryOptions.orderBy = orderBy
       }
       return manager.select<Record<string, DbValue>>(dataSourceId, table, queryOptions)
     },

--- a/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
+++ b/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
@@ -5,6 +5,7 @@ import {
   DATA_SOURCE_NOT_FOUND_CODE,
   DATA_SOURCE_NOT_READ_ONLY_CODE,
   DATA_SOURCE_PRINCIPAL_REQUIRED_CODE,
+  DATA_SOURCE_QUERY_INVALID_CODE,
   DataSourceUnavailableError,
   MISSING_PRINCIPAL_MESSAGE,
   writableSourceMessage,
@@ -141,6 +142,59 @@ describe('createDataSourcePluginFacade', () => {
       limit: 100,
       offset: 0,
       where,
+    })
+  })
+
+  it('select forwards orderBy with where for C3 keyset reads without opening a query/write surface', async () => {
+    const m = managerStub()
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    const where = { status: 'active' }
+    const orderBy = [
+      { column: 'updated_at', direction: 'asc' as const },
+      { column: 'id', direction: 'asc' as const },
+    ]
+    await facade.select('pg', 'public.items', { limit: 100, offset: 0, where, orderBy }, 'owner-1')
+    expect(m.stub.assertAccess).toHaveBeenCalledWith('pg', 'owner-1')
+    expect(m.stub.select).toHaveBeenCalledWith('pg', 'public.items', {
+      limit: 100,
+      offset: 0,
+      where,
+      orderBy,
+    })
+  })
+
+  it('select rejects malformed orderBy before DataSourceManager.select (direction allowlist)', async () => {
+    const m = managerStub()
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    await expect(
+      facade.select(
+        'pg',
+        'public.items',
+        { limit: 100, offset: 0, orderBy: [{ column: 'id', direction: 'asc;DROP' }] as never },
+        'owner-1'
+      )
+    ).rejects.toMatchObject({
+      status: 422,
+      code: DATA_SOURCE_QUERY_INVALID_CODE,
+      message: 'data source read orderBy[0].direction must be asc or desc',
+    })
+    expect(m.stub.assertAccess).toHaveBeenCalledWith('pg', 'owner-1')
+    expect(m.stub.select).not.toHaveBeenCalled()
+  })
+
+  it('select normalizes uppercase orderBy directions to lowercase before forwarding', async () => {
+    const m = managerStub()
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    await facade.select(
+      'pg',
+      'public.items',
+      { limit: 50, orderBy: [{ column: 'updated_at', direction: 'DESC' }] as never },
+      'owner-1'
+    )
+    expect(m.stub.select).toHaveBeenCalledWith('pg', 'public.items', {
+      limit: 50,
+      offset: undefined,
+      orderBy: [{ column: 'updated_at', direction: 'desc' }],
     })
   })
 


### PR DESCRIPTION
## Summary

C3-1 host-side seam for the read-only SQL data-source bridge.

What changed:
- `DataSourceReadOnlyFacade.select` now accepts structured `orderBy` and forwards it to `DataSourceManager.select` together with existing `limit` / `offset` / `where`.
- Added runtime validation/normalization for `orderBy` before the manager call:
  - must be an array of objects;
  - `column` must be a non-empty string;
  - `direction` must be `asc` / `desc` (case-insensitive, normalized to lowercase);
  - malformed directions fail closed with 422 before any read reaches `DataSourceManager.select`.
- Keeps the read-only/principal/writable-source gates unchanged.

This is **not** watermark runtime. It only opens the safe host-side `orderBy` pass-through required for later C3 keyset slices.

## Verification

Local:
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-plugin-facade.test.ts --reporter=dot` — 13/13 pass
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

Subagent review:
- Runtime/security: APPROVE — no write/query/credential/raw-SQL surface opened; principal and writable-source guards intact.
- Test/contract: APPROVE after P2 fix — pass-through, malicious direction rejection, uppercase normalization, no-fallback principal, and writable-source coverage all locked.

## Boundaries

- Read-only only.
- No raw SQL authoring.
- No C3 watermark/keyset runtime yet.
- No C6 external write.
- No K3 Save/Submit/Audit/BOM.
