### PR TITLE
feat(multitable): cross-base link field picker (B1 MVP)

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -92,7 +92,7 @@
             <input
               v-model="linkDraft.crossBase"
               type="checkbox"
-              :disabled="linkBaseAxisLocked"
+              :disabled="linkCrossBaseToggleLocked"
               data-test="link-cross-base-toggle"
               @change="onCrossBaseToggle"
             />
@@ -1009,11 +1009,18 @@ const linkSingleRecordLockedByHierarchy = computed(() => {
 })
 // --- Cross-base link picker (design 2026-06-14) ---
 // True when editing an EXISTING field that already stores a foreignBaseId:
-// foreignBaseId is immutable, so the cross-base toggle AND the base <select>
-// are read-only (only the foreign sheet within the locked base may change).
+// foreignBaseId is immutable, so the base <select> is read-only (only the
+// foreign sheet within the locked base may change).
 const linkBaseAxisLocked = computed(() =>
   Boolean(configTarget.value) && resolveLinkFieldProperty(configTarget.value?.property).foreignBaseId !== null,
 )
+// The cross-base TOGGLE is locked for ANY existing field — not just one that is
+// already cross-base. Same-base↔cross-base re-targeting after create is a
+// DEFERRED capability (design §7) AND unsafe: an existing same-base link's
+// values are record IDs in the CURRENT base, so flipping it to a foreign base
+// would silently break every linked value. So toggling is a create-only
+// affordance; existing fields keep their stored cross-base-ness, read-only.
+const linkCrossBaseToggleLocked = computed(() => Boolean(configTarget.value))
 // The active base id, inferred from the current sheet (props carries no baseId).
 // Used only to exclude the current sheet from the foreign-sheet list when the
 // picked foreign base IS the active base (you can't link a sheet to itself).
@@ -1084,10 +1091,17 @@ function resetCrossBaseState() {
 
 // Toggle handler — clears the OTHER mode's selection so a stale sheet id can
 // never leak into an emit. Off->on loads the base list; on->off restores the
-// same-base path. Disabled in edit mode (immutability), so this only fires for
-// new fields.
+// same-base path. The handler guard (not just `:disabled`) is the real
+// enforcement: jsdom can dispatch `change` on a disabled checkbox, so a
+// synthetic event must not be able to flip an existing field's cross-base-ness
+// (mirrors the hierarchy single-record lock's defense-in-depth).
 function onCrossBaseToggle() {
-  if (linkBaseAxisLocked.value) return
+  if (configTarget.value) {
+    // Existing field: re-targeting is forbidden. Snap the toggle back to the
+    // stored cross-base-ness regardless of the synthetic event.
+    linkDraft.crossBase = resolveLinkFieldProperty(configTarget.value.property).foreignBaseId !== null
+    return
+  }
   linkDraft.foreignSheetId = ''
   linkDraft.foreignBaseId = ''
   resetCrossBaseState()
@@ -1946,7 +1960,15 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     return { options, ...validationProperty }
   }
   if (normalizedType === 'link') {
-    if (linkDraft.crossBase) {
+    // Defense-in-depth (mirrors the hierarchy single-record lock): cross-base-ness
+    // is immutable after create. When editing a field whose STORED foreignBaseId
+    // was null, never emit a cross-base property even if the toggle was somehow
+    // flipped — same-base↔cross-base re-targeting is deferred + unsafe (existing
+    // values are IDs in the current base). The toggle :disabled + handler guard
+    // already prevent this in the UI; this guarantees the emit too.
+    const editingSameBaseLink = Boolean(configTarget.value)
+      && resolveLinkFieldProperty(configTarget.value?.property).foreignBaseId === null
+    if (linkDraft.crossBase && !editingSameBaseLink) {
       // Cross-base: validate the foreign sheet against the FETCHED foreign-base
       // list (not same-base targetSheets), and require a foreignBaseId. A 403 /
       // transport error on the foreign base blocks the save (fail-closed) — it

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -85,7 +85,71 @@
         </template>
 
         <template v-else-if="configTargetType === 'link'">
-          <label class="meta-field-mgr__field">
+          <!-- Cross-base opt-in (design 2026-06-14). OFF (default) = unchanged
+               same-base path, no extra click. Disabled in edit mode because
+               foreignBaseId is immutable. -->
+          <label v-if="listBasesFn" class="meta-field-mgr__toggle">
+            <input
+              v-model="linkDraft.crossBase"
+              type="checkbox"
+              :disabled="linkBaseAxisLocked"
+              data-test="link-cross-base-toggle"
+              @change="onCrossBaseToggle"
+            />
+            <span>{{ ml('field.linkToAnotherBase') }}</span>
+          </label>
+
+          <template v-if="linkDraft.crossBase">
+            <label class="meta-field-mgr__field">
+              <span>{{ ml('field.targetBase') }}</span>
+              <!-- Edit mode: base axis is locked → a single disabled option
+                   showing the stored base name (raw id fallback). -->
+              <select
+                v-if="linkBaseAxisLocked"
+                class="meta-field-mgr__select"
+                disabled
+                data-test="link-cross-base-select"
+              >
+                <option :value="linkDraft.foreignBaseId">{{ lockedForeignBaseLabel }}</option>
+              </select>
+              <select
+                v-else
+                v-model="linkDraft.foreignBaseId"
+                class="meta-field-mgr__select"
+                data-test="link-cross-base-select"
+                @change="onCrossBaseBasePick"
+              >
+                <option value="">{{ ml('field.selectBase') }}</option>
+                <option v-for="base in crossBaseBases" :key="base.id" :value="base.id">{{ base.name }}</option>
+              </select>
+            </label>
+            <div v-if="linkBaseAxisLocked" class="meta-field-mgr__hint" data-test="link-cross-base-locked">
+              {{ ml('field.crossBaseBaseLocked') }}
+            </div>
+
+            <!-- Foreign-sheet axis: loading / 403-gated / empty / list. The
+                 403-gated state fails closed (save blocked via the guard). -->
+            <div v-if="crossBaseSheetsLoading" class="meta-field-mgr__hint" data-test="link-cross-base-loading">
+              {{ ml('field.crossBaseLoadingSheets') }}
+            </div>
+            <div v-else-if="crossBaseSheetsError" class="meta-field-mgr__hint meta-field-mgr__hint--error" data-test="link-cross-base-unreadable">
+              {{ ml('field.crossBaseUnreadable') }}
+            </div>
+            <template v-else-if="linkDraft.foreignBaseId">
+              <label v-if="crossBaseSheetOptions.length" class="meta-field-mgr__field">
+                <span>{{ ml('field.targetSheet') }}</span>
+                <select v-model="linkDraft.foreignSheetId" class="meta-field-mgr__select" data-test="link-cross-base-sheet-select">
+                  <option value="">{{ ml('field.selectSheet') }}</option>
+                  <option v-for="sheet in crossBaseSheetOptions" :key="sheet.id" :value="sheet.id">{{ sheet.name }}</option>
+                </select>
+              </label>
+              <div v-else class="meta-field-mgr__hint" data-test="link-cross-base-empty">
+                {{ ml('field.crossBaseNoSheets') }}
+              </div>
+            </template>
+          </template>
+
+          <label v-else class="meta-field-mgr__field">
             <span>{{ ml('field.targetSheet') }}</span>
             <select v-model="linkDraft.foreignSheetId" class="meta-field-mgr__select">
               <option value="">{{ ml('field.selectSheet') }}</option>
@@ -605,7 +669,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
-import type { FieldValidationRule, MetaField, MetaFieldCreateType, MetaSheet } from '../types'
+import type { FieldValidationRule, MetaBase, MetaField, MetaFieldCreateType, MetaSheet } from '../types'
 import {
   buildFormulaFieldTokenInsertion,
   buildFormulaFunctionInsertion,
@@ -798,6 +862,16 @@ const props = defineProps<{
   // in-flight guard + countdown cover this entry point too. null outcome =
   // guarded no-op (another AI request is in flight / countdown active).
   formulaSuggestFn?: (params: { instruction: string }) => Promise<AiFormulaSuggestOutcome | null>
+  // Cross-base link picker (design 2026-06-14). The base-read gate is the FE's
+  // source of truth: these fns are the ONLY way the picker learns what bases /
+  // foreign sheets exist, and both are backend base-read-gated (listBases returns
+  // only bases with a readable sheet; loadContext({baseId}).sheets is read-gated).
+  // The picker NEVER computes its own readability. Optional so the panel degrades
+  // to same-base-only where no fn is wired. The workbench MUST resolve
+  // listForeignSheetsFn from the BARE client.loadContext, never the workbench's
+  // switchBase/loadBaseContext mutators (those would yank the user's active base).
+  listBasesFn?: () => Promise<MetaBase[]>
+  listForeignSheetsFn?: (baseId: string) => Promise<MetaSheet[]>
 }>()
 
 const emit = defineEmits<{
@@ -829,10 +903,28 @@ const aiSourceAllDeletedBlocked = ref(false)
 const selectDraft = reactive<{ options: Array<{ value: string; color: string }> }>({
   options: [{ value: '', color: '' }],
 })
-const linkDraft = reactive<{ foreignSheetId: string; limitSingleRecord: boolean }>({
+// `foreignBaseId`/`crossBase` are the cross-base opt-in (design 2026-06-14).
+// crossBase OFF = today's same-base path (foreignSheetId over same-base
+// targetSheets); ON = foreignBaseId + foreignSheetId picked from the gated
+// listBasesFn / listForeignSheetsFn. The two modes keep separate state so a
+// stale id never leaks across a toggle.
+const linkDraft = reactive<{ foreignSheetId: string; crossBase: boolean; foreignBaseId: string; limitSingleRecord: boolean }>({
   foreignSheetId: '',
+  crossBase: false,
+  foreignBaseId: '',
   limitSingleRecord: false,
 })
+// Cross-base picker fetched state. The base list + foreign-sheet list come ONLY
+// from the gated fns — never recomputed locally. `crossBaseSheetsError` true =>
+// the foreign-base read failed (403 or transport); fail-closed (the save is
+// blocked and a gated notice renders), never a silent same-base save.
+const crossBaseBases = ref<MetaBase[]>([])
+const crossBaseSheets = ref<MetaSheet[]>([])
+const crossBaseSheetsLoading = ref(false)
+const crossBaseSheetsError = ref(false)
+// Monotonic guard: a slow stale foreign-sheet response must not overwrite a
+// newer base pick (mirrors the dryRun/aggregate seq precedent).
+let crossBaseFetchSeq = 0
 const personDraft = reactive<{ limitSingleRecord: boolean }>({
   limitSingleRecord: true,
 })
@@ -915,6 +1007,101 @@ const linkSingleRecordLockedByHierarchy = computed(() => {
     && target.property?.limitSingleRecord === true
     && hierarchyParentFieldIdSet.value.has(target.id)
 })
+// --- Cross-base link picker (design 2026-06-14) ---
+// True when editing an EXISTING field that already stores a foreignBaseId:
+// foreignBaseId is immutable, so the cross-base toggle AND the base <select>
+// are read-only (only the foreign sheet within the locked base may change).
+const linkBaseAxisLocked = computed(() =>
+  Boolean(configTarget.value) && resolveLinkFieldProperty(configTarget.value?.property).foreignBaseId !== null,
+)
+// The active base id, inferred from the current sheet (props carries no baseId).
+// Used only to exclude the current sheet from the foreign-sheet list when the
+// picked foreign base IS the active base (you can't link a sheet to itself).
+const activeBaseId = computed(() =>
+  props.sheets.find((sheet) => sheet.id === props.sheetId)?.baseId ?? null,
+)
+const crossBaseSheetOptions = computed(() => {
+  const sameAsActive = !!linkDraft.foreignBaseId && linkDraft.foreignBaseId === activeBaseId.value
+  return sameAsActive
+    ? crossBaseSheets.value.filter((sheet) => sheet.id !== props.sheetId)
+    : crossBaseSheets.value
+})
+// Resolve the stored foreign-base display name in edit mode (single locked
+// option). Falls back to the raw id if listBasesFn hasn't resolved it — the
+// locked select never depends on the full base list loading.
+const lockedForeignBaseLabel = computed(() => {
+  const id = linkDraft.foreignBaseId
+  if (!id) return ''
+  return crossBaseBases.value.find((base) => base.id === id)?.name ?? id
+})
+
+async function loadCrossBaseBases() {
+  const fn = props.listBasesFn
+  if (!fn) return
+  try {
+    crossBaseBases.value = await fn()
+  } catch {
+    // Read failure on the base list is non-fatal: the user simply has no bases
+    // to pick (the gated save still blocks). Never throw out of config load.
+    crossBaseBases.value = []
+  }
+}
+
+// Fetch the foreign base's readable sheets via the gated fn. Fail-closed: any
+// rejection (403 / transport) sets crossBaseSheetsError so the UI renders the
+// gated notice and the save is blocked — it must NEVER fall through to a
+// same-base property.
+async function fetchCrossBaseSheets(baseId: string) {
+  const fn = props.listForeignSheetsFn
+  const seq = ++crossBaseFetchSeq
+  crossBaseSheetsError.value = false
+  if (!fn || !baseId) {
+    crossBaseSheets.value = []
+    crossBaseSheetsLoading.value = false
+    return
+  }
+  crossBaseSheetsLoading.value = true
+  try {
+    const sheets = await fn(baseId)
+    if (seq !== crossBaseFetchSeq) return
+    crossBaseSheets.value = sheets
+  } catch {
+    if (seq !== crossBaseFetchSeq) return
+    crossBaseSheets.value = []
+    crossBaseSheetsError.value = true
+  } finally {
+    if (seq === crossBaseFetchSeq) crossBaseSheetsLoading.value = false
+  }
+}
+
+function resetCrossBaseState() {
+  crossBaseFetchSeq++
+  crossBaseBases.value = []
+  crossBaseSheets.value = []
+  crossBaseSheetsLoading.value = false
+  crossBaseSheetsError.value = false
+}
+
+// Toggle handler — clears the OTHER mode's selection so a stale sheet id can
+// never leak into an emit. Off->on loads the base list; on->off restores the
+// same-base path. Disabled in edit mode (immutability), so this only fires for
+// new fields.
+function onCrossBaseToggle() {
+  if (linkBaseAxisLocked.value) return
+  linkDraft.foreignSheetId = ''
+  linkDraft.foreignBaseId = ''
+  resetCrossBaseState()
+  if (linkDraft.crossBase) void loadCrossBaseBases()
+}
+
+// Base pick — clears the prior foreign sheet (it belonged to the old base) and
+// fetches the new base's sheets. Disabled in edit mode.
+function onCrossBaseBasePick() {
+  if (linkBaseAxisLocked.value) return
+  linkDraft.foreignSheetId = ''
+  void fetchCrossBaseSheets(linkDraft.foreignBaseId)
+}
+
 const formulaSourceFields = computed(() =>
   props.fields.filter((field) => field.id !== configTarget.value?.id && field.type !== 'formula'),
 )
@@ -1210,7 +1397,10 @@ function resetDrafts() {
   resetAiDraft()
   selectDraft.options = [{ value: '', color: '' }]
   linkDraft.foreignSheetId = ''
+  linkDraft.crossBase = false
+  linkDraft.foreignBaseId = ''
   linkDraft.limitSingleRecord = false
+  resetCrossBaseState()
   personDraft.limitSingleRecord = true
   lookupDraft.linkFieldId = ''
   lookupDraft.targetFieldId = ''
@@ -1258,6 +1448,9 @@ function serializeFieldDraft(type: string | null): string {
   if (type === 'link') {
     return JSON.stringify({
       foreignSheetId: linkDraft.foreignSheetId,
+      // Cross-base keys only when toggled on, so a same-base field's signature
+      // is byte-for-byte what it was before this feature (no spurious dirty).
+      ...(linkDraft.crossBase ? { crossBase: true, foreignBaseId: linkDraft.foreignBaseId } : {}),
       limitSingleRecord: linkSingleRecordLockedByHierarchy.value || linkDraft.limitSingleRecord,
     })
   }
@@ -1375,6 +1568,15 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     const property = resolveLinkFieldProperty(field.property)
     linkDraft.foreignSheetId = property.foreignSheetId ?? ''
     linkDraft.limitSingleRecord = property.limitSingleRecord
+    // Cross-base existing field: reflect the stored base (axis locked), resolve
+    // its name for the locked select, and fetch its sheets so the foreign sheet
+    // shows selected. A foreign-base 403 surfaces as the gated state (not blank).
+    if (property.foreignBaseId) {
+      linkDraft.crossBase = true
+      linkDraft.foreignBaseId = property.foreignBaseId
+      void loadCrossBaseBases()
+      void fetchCrossBaseSheets(property.foreignBaseId)
+    }
   } else if (fieldType === 'person') {
     const property = resolveLinkFieldProperty(field.property)
     personDraft.limitSingleRecord = property.limitSingleRecord || property.limitSingleRecord !== false
@@ -1744,10 +1946,34 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     return { options, ...validationProperty }
   }
   if (normalizedType === 'link') {
+    if (linkDraft.crossBase) {
+      // Cross-base: validate the foreign sheet against the FETCHED foreign-base
+      // list (not same-base targetSheets), and require a foreignBaseId. A 403 /
+      // transport error on the foreign base blocks the save (fail-closed) — it
+      // must NEVER fall through to a same-base property.
+      if (
+        crossBaseSheetsError.value
+        || !linkDraft.foreignBaseId
+        || !linkDraft.foreignSheetId
+        || !crossBaseSheetOptions.value.some((sheet) => sheet.id === linkDraft.foreignSheetId)
+      ) {
+        fieldConfigError.value = ml('field.error.linkNeedsCrossBaseTarget')
+        return undefined
+      }
+      // foreignBaseId emitted ONLY when cross-base AND both ids present —
+      // mirrors the codec's both-present rule (field-codecs.ts:235).
+      return {
+        foreignSheetId: linkDraft.foreignSheetId,
+        foreignDatasheetId: linkDraft.foreignSheetId,
+        foreignBaseId: linkDraft.foreignBaseId,
+        limitSingleRecord: linkSingleRecordLockedByHierarchy.value || linkDraft.limitSingleRecord,
+      }
+    }
     if (!linkDraft.foreignSheetId || !targetSheets.value.some((sheet) => sheet.id === linkDraft.foreignSheetId)) {
       fieldConfigError.value = ml('field.error.linkNeedsTargetSheet')
       return undefined
     }
+    // Same-base: unchanged, no foreignBaseId key (backward compatible).
     return {
       foreignSheetId: linkDraft.foreignSheetId,
       foreignDatasheetId: linkDraft.foreignSheetId,
@@ -2099,6 +2325,7 @@ onBeforeUnmount(() => {
 .meta-field-mgr__field { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #666; }
 .meta-field-mgr__toggle { display: flex; gap: 8px; align-items: center; font-size: 12px; color: #444; }
 .meta-field-mgr__hint { padding: 8px 10px; border: 1px solid #d9ecff; border-radius: 6px; background: #ecf5ff; color: #4a6785; font-size: 12px; }
+.meta-field-mgr__hint--error { border-color: #fbc4c4; background: #fef0f0; color: #a8323f; }
 .meta-field-mgr__warning { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 10px; border: 1px solid #f3d19e; border-radius: 6px; background: #fff7e6; color: #8a5a00; font-size: 12px; }
 .meta-field-mgr__refresh { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 10px; border: 1px solid #bfd6ff; border-radius: 6px; background: #eef5ff; color: #1d4ed8; font-size: 12px; }
 .meta-field-mgr__chips { display: flex; flex-wrap: wrap; gap: 6px; }

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -7,6 +7,13 @@ export type NormalizedSelectOption = {
 
 export type NormalizedLinkFieldProperty = {
   foreignSheetId: string | null
+  // Cross-base opt-in (design 2026-06-14). Mirrors the backend codec
+  // (`field-codecs.ts:208-239`): present only when a cross-base link is
+  // authored; same-base links resolve this to `null`. Without carrying it
+  // through here the picker would emit the field but read-back would drop it
+  // and the link would silently revert to same-base on reload (the #1781
+  // wire-vs-fixture trap).
+  foreignBaseId: string | null
   limitSingleRecord: boolean
   refKind: string | null
 }
@@ -95,6 +102,7 @@ export function resolveLinkFieldProperty(value: unknown): NormalizedLinkFieldPro
   const property = asRecord(value)
   return {
     foreignSheetId: stringOrNull(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId),
+    foreignBaseId: stringOrNull(property.foreignBaseId),
     limitSingleRecord: property.limitSingleRecord === true,
     refKind: stringOrNull(property.refKind),
   }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -23,6 +23,10 @@ export type MetaManagerLabelKey =
   | 'field.title' | 'field.empty' | 'field.options' | 'field.optionValue'
   | 'field.targetSheet' | 'field.selectSheet' | 'field.limitSingleLinkedRecord'
   | 'field.hierarchyParentLinkLocked'
+  // Cross-base link picker (design 2026-06-14)
+  | 'field.linkToAnotherBase' | 'field.targetBase' | 'field.selectBase'
+  | 'field.crossBaseLoadingSheets' | 'field.crossBaseNoSheets'
+  | 'field.crossBaseBaseLocked' | 'field.crossBaseUnreadable'
   | 'field.personHint' | 'field.limitSinglePerson'
   | 'field.linkField' | 'field.selectLinkField'
   | 'field.foreignSheetId' | 'field.targetFieldId'
@@ -49,6 +53,7 @@ export type MetaManagerLabelKey =
   | 'field.latestMetadataLoaded'
   | 'field.discardManagerConfirm'
   | 'field.error.linkNeedsTargetSheet'
+  | 'field.error.linkNeedsCrossBaseTarget'
   | 'field.error.lookupNeedsLinkAndTarget'
   | 'field.error.lookupNeedsValidTargetSheet'
   | 'field.error.rollupNeedsLinkAndTarget'
@@ -167,6 +172,19 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
     en: 'This field is used as a hierarchy parent field, so it must remain single-record.',
     zh: '此字段正在作为层级父字段使用，必须保持单条关联。',
   },
+  'field.linkToAnotherBase': { en: 'Link to another base', zh: '关联到其他多维表' },
+  'field.targetBase': { en: 'Target base', zh: '目标多维表' },
+  'field.selectBase': { en: 'Select base', zh: '选择多维表' },
+  'field.crossBaseLoadingSheets': { en: 'Loading tables…', zh: '正在加载数据表…' },
+  'field.crossBaseNoSheets': { en: 'No readable tables in this base', zh: '该多维表中没有可读取的数据表' },
+  'field.crossBaseBaseLocked': {
+    en: 'The linked base is fixed and cannot be changed after the field is created.',
+    zh: '关联的目标多维表在字段创建后即固定，无法更改。',
+  },
+  'field.crossBaseUnreadable': {
+    en: 'You no longer have access to the linked base, so its tables cannot be loaded.',
+    zh: '你已无权访问关联的目标多维表，无法加载其数据表。',
+  },
   'field.personHint': {
     en: 'People fields use the system people sheet preset and stay hidden from normal sheet navigation.',
     zh: '人员字段使用系统人员表预设，并在普通表导航中保持隐藏。',
@@ -240,6 +258,7 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.latestMetadataLoaded': { en: 'Latest field metadata loaded from the sheet context.', zh: '已从表上下文加载最新字段元数据。' },
   'field.discardManagerConfirm': { en: 'Discard unsaved field manager changes?', zh: '放弃未保存的字段管理更改吗？' },
   'field.error.linkNeedsTargetSheet': { en: 'Choose a target sheet for link fields', zh: '请为关联字段选择目标表' },
+  'field.error.linkNeedsCrossBaseTarget': { en: 'Choose a base and a readable table for the cross-base link', zh: '请为跨多维表关联选择目标多维表和可读取的数据表' },
   'field.error.lookupNeedsLinkAndTarget': { en: 'Lookup fields need a link field and a target field id', zh: '查找字段需要关联字段和目标字段 ID' },
   'field.error.lookupNeedsValidTargetSheet': { en: 'Lookup fields need a valid target sheet', zh: '查找字段需要有效的目标表' },
   'field.error.rollupNeedsLinkAndTarget': { en: 'Rollup fields need a link field and a target field id', zh: '汇总字段需要关联字段和目标字段 ID' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -375,6 +375,8 @@
       :ai-preview-busy="aiShortcutBusy"
       :ai-usage-summary-fn="aiUsageSummaryFn"
       :formula-suggest-fn="formulaSuggestFn"
+      :list-bases-fn="listBasesForFieldFn"
+      :list-foreign-sheets-fn="listForeignSheetsForFieldFn"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -1843,6 +1845,16 @@ const aggregateGroups = ref<import('../api/client').ViewAggregateGroup[]>([]) //
 // #5b: formula dry-run passthrough to the API client (MetaFieldManager is emit-based, so it takes a fn prop)
 const dryRunFormulaFn = (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) =>
   workbench.client.dryRunFormula(params)
+// Cross-base link picker (design 2026-06-14). Both fns hit the BARE client —
+// NEVER workbench.switchBase / loadBaseContext, which run syncContextState and
+// would yank the user's active base/sheet out from under the field config.
+// Both endpoints are backend base-read-gated (the FE never recomputes
+// readability): listBases returns only bases with a readable sheet;
+// loadContext({baseId}).sheets is read-gated and resolves nothing about the
+// user's active base.
+const listBasesForFieldFn = async () => (await workbench.client.listBases()).bases
+const listForeignSheetsForFieldFn = async (baseId: string) =>
+  (await workbench.client.loadContext({ baseId })).sheets
 const activeAggregationConfig = computed<Record<string, string>>(() => {
   const raw = workbench.activeView.value?.config?.aggregations
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}

--- a/apps/web/tests/multitable-crossbase-link-normalizer.spec.ts
+++ b/apps/web/tests/multitable-crossbase-link-normalizer.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLinkFieldProperty } from '../src/multitable/utils/field-config'
+
+// Cross-base FE picker — design-lock 2026-06-14 §3.4 / test-row #1 (wire-vs-fixture).
+//
+// The picker assembles a link property with `foreignBaseId` (cross-base) or just
+// `foreignSheetId` (same-base). The FE normalizer (`resolveLinkFieldProperty`) is the
+// read-back path. If it dropped `foreignBaseId`, the picker would emit a cross-base
+// field that silently reverts to same-base on reload — the #1781 trap. These tests
+// lock the round-trip on the normalizer itself (the wire keystone, no component
+// mounting required).
+describe('resolveLinkFieldProperty — cross-base foreignBaseId round-trip', () => {
+  it('preserves foreignBaseId when both foreignSheetId and foreignBaseId are present (cross-base)', () => {
+    const wireProperty = {
+      foreignSheetId: 'sheet_foreign',
+      foreignDatasheetId: 'sheet_foreign',
+      foreignBaseId: 'base_other',
+      limitSingleRecord: false,
+    }
+
+    const resolved = resolveLinkFieldProperty(wireProperty)
+
+    expect(resolved.foreignSheetId).toBe('sheet_foreign')
+    expect(resolved.foreignBaseId).toBe('base_other')
+  })
+
+  it('resolves foreignBaseId to null for a same-base link (no foreignBaseId key)', () => {
+    const sameBaseProperty = {
+      foreignSheetId: 'sheet_2',
+      foreignDatasheetId: 'sheet_2',
+      limitSingleRecord: true,
+    }
+
+    const resolved = resolveLinkFieldProperty(sameBaseProperty)
+
+    expect(resolved.foreignSheetId).toBe('sheet_2')
+    expect(resolved.foreignBaseId).toBeNull()
+  })
+
+  it('treats a blank/whitespace foreignBaseId as null (mirrors codec trim → omit)', () => {
+    expect(resolveLinkFieldProperty({ foreignSheetId: 's', foreignBaseId: '   ' }).foreignBaseId).toBeNull()
+    expect(resolveLinkFieldProperty({ foreignSheetId: 's', foreignBaseId: '' }).foreignBaseId).toBeNull()
+  })
+})

--- a/apps/web/tests/multitable-crossbase-link-picker.spec.ts
+++ b/apps/web/tests/multitable-crossbase-link-picker.spec.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import { resolveLinkFieldProperty } from '../src/multitable/utils/field-config'
+
+// Cross-base LINK field picker — config-authoring (read side). Design-lock
+// 2026-06-14 §3/§4/§8. Component-level rows #1-7; row #8 (active base unchanged)
+// lives in the workbench-level spec because MetaFieldManager has no switchBase.
+
+async function flush() {
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mountManager(opts: {
+  fields?: unknown[]
+  sheets?: unknown[]
+  sheetId?: string
+  listBasesFn?: () => Promise<unknown[]>
+  listForeignSheetsFn?: (baseId: string) => Promise<unknown[]>
+  onCreateField?: (...args: unknown[]) => void
+  onUpdateField?: (...args: unknown[]) => void
+}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaFieldManager, {
+        visible: true,
+        sheetId: opts.sheetId ?? 'sheet_1',
+        sheets: opts.sheets ?? [{ id: 'sheet_1', baseId: 'base_current', name: 'Current' }, { id: 'sheet_2', baseId: 'base_current', name: 'Related' }],
+        fields: opts.fields ?? [],
+        ...(opts.listBasesFn ? { listBasesFn: opts.listBasesFn } : {}),
+        ...(opts.listForeignSheetsFn ? { listForeignSheetsFn: opts.listForeignSheetsFn } : {}),
+        ...(opts.onCreateField ? { onCreateField: opts.onCreateField } : {}),
+        ...(opts.onUpdateField ? { onUpdateField: opts.onUpdateField } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+function setValue(el: HTMLInputElement | HTMLSelectElement, value: string) {
+  el.value = value
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+  el.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+// Drive the new-field add-row to a configured `link` field with the config open.
+async function openNewLinkConfig(container: HTMLElement, name = 'Vendor') {
+  const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+  const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+  setValue(nameInput, name)
+  setValue(typeSelect, 'link')
+  await flush()
+}
+
+function clickAdd(container: HTMLElement) {
+  ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+    .find((button) => button.textContent?.includes('+ Add'))
+    ?.click()
+}
+
+describe('Cross-base link field picker (MetaFieldManager)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  // Row #1 — round-trip (wire-vs-fixture): the EMITTED property fed back through
+  // resolveLinkFieldProperty must preserve foreignBaseId (no silent revert).
+  it('emits foreignBaseId on a cross-base create and it survives resolve (no silent revert)', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other base' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([{ id: 'sheet_far', baseId: 'base_other', name: 'Far table' }])
+    const createSpy = vi.fn()
+    const { container, app } = mountManager({ listBasesFn, listForeignSheetsFn, onCreateField: createSpy })
+
+    await openNewLinkConfig(container)
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    setValue(toggle, '')
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+    expect(listBasesFn).toHaveBeenCalledTimes(1)
+
+    const baseSelect = container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement
+    setValue(baseSelect, 'base_other')
+    await flush()
+    expect(listForeignSheetsFn).toHaveBeenCalledWith('base_other')
+
+    const sheetSelect = container.querySelector('[data-test="link-cross-base-sheet-select"]') as HTMLSelectElement
+    setValue(sheetSelect, 'sheet_far')
+    await flush()
+
+    clickAdd(container)
+    await flush()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    const payload = createSpy.mock.calls[0][0] as { property: Record<string, unknown> }
+    expect(payload.property.foreignBaseId).toBe('base_other')
+    expect(payload.property.foreignSheetId).toBe('sheet_far')
+
+    // Feed the ACTUAL emitted property back through the FE normalizer.
+    const resolved = resolveLinkFieldProperty(payload.property)
+    expect(resolved.foreignBaseId).toBe('base_other')
+    expect(resolved.foreignSheetId).toBe('sheet_far')
+
+    app.unmount()
+  })
+
+  // Row #2 — same-base default: toggle off => no foreignBaseId key at all.
+  it('does NOT emit foreignBaseId for a same-base link (toggle off)', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([])
+    const createSpy = vi.fn()
+    const { container, app } = mountManager({ listBasesFn, listForeignSheetsFn, onCreateField: createSpy })
+
+    await openNewLinkConfig(container)
+    // Toggle stays off; pick a same-base sheet via the default <select>.
+    const sameBaseSelect = container.querySelector('.meta-field-mgr__config select.meta-field-mgr__select') as HTMLSelectElement
+    setValue(sameBaseSelect, 'sheet_2')
+    await flush()
+
+    clickAdd(container)
+    await flush()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    const payload = createSpy.mock.calls[0][0] as { property: Record<string, unknown> }
+    expect(payload.property.foreignSheetId).toBe('sheet_2')
+    expect(payload.property).not.toHaveProperty('foreignBaseId')
+    expect(listForeignSheetsFn).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  // Row #3 — base list source: toggle calls listBasesFn; base pick calls
+  // listForeignSheetsFn(baseId) and the sheet select shows only those sheets.
+  it('sources bases from listBasesFn and foreign sheets from listForeignSheetsFn(baseId)', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_a', name: 'A' }, { id: 'base_b', name: 'B' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([
+      { id: 'sheet_x', baseId: 'base_b', name: 'X' },
+      { id: 'sheet_y', baseId: 'base_b', name: 'Y' },
+    ])
+    const { container, app } = mountManager({ listBasesFn, listForeignSheetsFn, onCreateField: vi.fn() })
+
+    await openNewLinkConfig(container)
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const baseSelect = container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement
+    const baseOptionValues = Array.from(baseSelect.querySelectorAll('option')).map((o) => o.value)
+    expect(baseOptionValues).toEqual(['', 'base_a', 'base_b'])
+
+    setValue(baseSelect, 'base_b')
+    await flush()
+    expect(listForeignSheetsFn).toHaveBeenCalledWith('base_b')
+
+    const sheetSelect = container.querySelector('[data-test="link-cross-base-sheet-select"]') as HTMLSelectElement
+    const sheetOptionValues = Array.from(sheetSelect.querySelectorAll('option')).map((o) => o.value)
+    expect(sheetOptionValues).toEqual(['', 'sheet_x', 'sheet_y'])
+
+    app.unmount()
+  })
+
+  // Row #4 — cross-base save-guard: a foreignSheetId valid in the FOREIGN base
+  // (not in same-base targetSheets) is accepted with no fieldConfigError.
+  it('accepts a cross-base foreign sheet that is not a same-base target sheet', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other' }])
+    // sheet_far is NOT in props.sheets (the same-base list) — proves the guard
+    // validates against the fetched foreign list, not same-base targetSheets.
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([{ id: 'sheet_far', baseId: 'base_other', name: 'Far' }])
+    const createSpy = vi.fn()
+    const { container, app } = mountManager({ listBasesFn, listForeignSheetsFn, onCreateField: createSpy })
+
+    await openNewLinkConfig(container)
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+    setValue(container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement, 'base_other')
+    await flush()
+    setValue(container.querySelector('[data-test="link-cross-base-sheet-select"]') as HTMLSelectElement, 'sheet_far')
+    await flush()
+
+    clickAdd(container)
+    await flush()
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('.meta-field-mgr__error')).toBeNull()
+
+    app.unmount()
+  })
+
+  // Row #5 — edit immutability: open an existing cross-base field → toggle on,
+  // toggle + base select DISABLED, stored names shown.
+  it('locks the base axis (toggle + base select disabled) when editing an existing cross-base field', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other base' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([{ id: 'sheet_far', baseId: 'base_other', name: 'Far table' }])
+    const { container, app } = mountManager({
+      listBasesFn,
+      listForeignSheetsFn,
+      onUpdateField: vi.fn(),
+      fields: [
+        {
+          id: 'fld_x',
+          name: 'X-link',
+          type: 'link',
+          property: { foreignSheetId: 'sheet_far', foreignBaseId: 'base_other', limitSingleRecord: false },
+        },
+      ],
+    })
+    await flush()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await flush()
+
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+
+    const baseSelect = container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement
+    expect(baseSelect.disabled).toBe(true)
+    expect(baseSelect.value).toBe('base_other')
+    // Locked option resolves the stored base name from listBasesFn.
+    expect(baseSelect.textContent).toContain('Other base')
+    expect(container.querySelector('[data-test="link-cross-base-locked"]')).not.toBeNull()
+
+    app.unmount()
+  })
+
+  // Row #6 — unreadable foreign base: listForeignSheetsFn rejects (403) →
+  // gated state, no crash, and the save is blocked (no silent same-base save).
+  it('renders a gated state and blocks save when the foreign base is unreadable (403)', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other' }])
+    const listForeignSheetsFn = vi.fn().mockRejectedValue(new Error('forbidden'))
+    const createSpy = vi.fn()
+    const { container, app } = mountManager({ listBasesFn, listForeignSheetsFn, onCreateField: createSpy })
+
+    await openNewLinkConfig(container)
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+    setValue(container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement, 'base_other')
+    await flush()
+
+    // Gated notice shown, no sheet select rendered.
+    expect(container.querySelector('[data-test="link-cross-base-unreadable"]')).not.toBeNull()
+    expect(container.querySelector('[data-test="link-cross-base-sheet-select"]')).toBeNull()
+
+    // Attempting to add must NOT emit a (same-base or otherwise) property.
+    clickAdd(container)
+    await flush()
+    expect(createSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  // Row #7 — reset on close/reopen: linkDraft (incl. foreignBaseId) resets so a
+  // new field does not inherit a stale foreign base from a prior edit.
+  it('resets cross-base draft when reopening for a new field after editing a cross-base field', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([{ id: 'sheet_far', baseId: 'base_other', name: 'Far' }])
+    const { container, app } = mountManager({
+      listBasesFn,
+      listForeignSheetsFn,
+      onUpdateField: vi.fn(),
+      onCreateField: vi.fn(),
+      fields: [
+        {
+          id: 'fld_x',
+          name: 'X-link',
+          type: 'link',
+          property: { foreignSheetId: 'sheet_far', foreignBaseId: 'base_other', limitSingleRecord: false },
+        },
+      ],
+    })
+    await flush()
+
+    // Edit the existing cross-base field (loads foreignBaseId into the draft).
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await flush()
+    expect((container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement).checked).toBe(true)
+
+    // Now start a brand-new link field via the add-row.
+    await openNewLinkConfig(container, 'Fresh')
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    // Fresh field defaults to same-base (toggle off), no inherited foreign base.
+    expect(toggle.checked).toBe(false)
+    expect(container.querySelector('[data-test="link-cross-base-select"]')).toBeNull()
+
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-crossbase-link-picker.spec.ts
+++ b/apps/web/tests/multitable-crossbase-link-picker.spec.ts
@@ -262,6 +262,96 @@ describe('Cross-base link field picker (MetaFieldManager)', () => {
     app.unmount()
   })
 
+  // Edit immutability (data-safety): an existing SAME-BASE link must not be
+  // re-targetable to a cross-base — that is deferred (design §7) and would break
+  // the field's existing values (record IDs in the current base). The toggle is
+  // present but DISABLED, and a synthetic change cannot flip it on / emit
+  // foreignBaseId.
+  it('locks (disables) the cross-base toggle when editing an existing same-base link and never emits foreignBaseId', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([{ id: 'base_other', name: 'Other' }])
+    const listForeignSheetsFn = vi.fn().mockResolvedValue([{ id: 'sheet_far', baseId: 'base_other', name: 'Far' }])
+    const updateSpy = vi.fn()
+    const { container, app } = mountManager({
+      listBasesFn,
+      listForeignSheetsFn,
+      onUpdateField: updateSpy,
+      fields: [
+        // Same-base link: foreignSheetId in the current base, NO foreignBaseId.
+        { id: 'fld_same', name: 'Same', type: 'link', property: { foreignSheetId: 'sheet_2', limitSingleRecord: false } },
+      ],
+    })
+    await flush()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await flush()
+
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    expect(toggle).not.toBeNull()
+    expect(toggle.checked).toBe(false)
+    expect(toggle.disabled).toBe(true)
+
+    // Even a synthetic change cannot turn it cross-base. (Like the hierarchy
+    // single-record lock test, the contract is the EMITTED property + that the
+    // cross-base UI never activates — not the disabled checkbox's DOM `.checked`,
+    // which jsdom won't re-sync when the bound ref stays false.)
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+    expect(listBasesFn).not.toHaveBeenCalled()
+    // The cross-base block (base <select>) never renders → toggle stayed off.
+    expect(container.querySelector('[data-test="link-cross-base-select"]')).toBeNull()
+
+    // Saving still emits a SAME-BASE property — no foreignBaseId leaks in.
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await flush()
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    expect(updateSpy.mock.calls[0][1].property).not.toHaveProperty('foreignBaseId')
+
+    app.unmount()
+  })
+
+  // Edit-time 403 (the PRIMARY row-#6 scenario): open an existing CROSS-BASE
+  // field whose foreign base is now unreadable → gated notice + stored ids, no
+  // crash, and a save is blocked (never a silent same-base save).
+  it('renders a gated state and blocks save when an existing cross-base field’s foreign base became unreadable', async () => {
+    const listBasesFn = vi.fn().mockResolvedValue([])
+    const listForeignSheetsFn = vi.fn().mockRejectedValue(new Error('forbidden'))
+    const updateSpy = vi.fn()
+    const { container, app } = mountManager({
+      listBasesFn,
+      listForeignSheetsFn,
+      onUpdateField: updateSpy,
+      fields: [
+        { id: 'fld_x', name: 'X-link', type: 'link', property: { foreignSheetId: 'sheet_far', foreignBaseId: 'base_gone', limitSingleRecord: false } },
+      ],
+    })
+    await flush()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await flush()
+
+    // Toggle on (stored cross-base), base axis locked, gated notice shown, no crash.
+    const toggle = container.querySelector('[data-test="link-cross-base-toggle"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+    expect(container.querySelector('[data-test="link-cross-base-unreadable"]')).not.toBeNull()
+    // Stored base id still shown in the locked select (raw-id fallback, list empty).
+    const baseSelect = container.querySelector('[data-test="link-cross-base-select"]') as HTMLSelectElement
+    expect(baseSelect.value).toBe('base_gone')
+    expect(container.querySelector('[data-test="link-cross-base-sheet-select"]')).toBeNull()
+
+    // Save is blocked — no silent same-base downgrade.
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await flush()
+    expect(updateSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
   // Row #7 — reset on close/reopen: linkDraft (incl. foreignBaseId) resets so a
   // new field does not inherit a stale foreign base from a prior edit.
   it('resets cross-base draft when reopening for a new field after editing a cross-base field', async () => {

--- a/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
+++ b/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
+
+// Cross-base link picker — design-lock 2026-06-14 test-row #8 (active base
+// unchanged) + the "Impl trap" lock. This MUST be a workbench-level test:
+// MetaFieldManager has no switchBase, so a component-level #8 would pass
+// regardless of impl. The bug lives in the workbench wiring — if
+// listForeignSheetsForFieldFn used workbench.switchBase / loadBaseContext
+// (which run syncContextState) instead of the BARE client.loadContext, picking
+// a foreign base would yank the user's active base/sheet. This captures the fn
+// the workbench passes down, invokes it, and asserts the bare client was used
+// and the active base/sheet did NOT move.
+
+const showErrorSpy = vi.fn()
+const showSuccessSpy = vi.fn()
+
+// Capture the props the workbench passes to MetaFieldManager (the stub records
+// them so the test can invoke the wired fns directly).
+let capturedFieldManagerProps: Record<string, unknown> | null = null
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: vi.fn().mockResolvedValue(undefined) }),
+  }
+})
+
+function stubComponent(name: string) {
+  return defineComponent({
+    name,
+    render() {
+      return h('div', { [`data-stub-${name}`]: 'true' })
+    },
+  })
+}
+
+let workbenchMock: any
+let gridMock: any
+
+vi.mock('../src/multitable/composables/useMultitableWorkbench', () => ({
+  useMultitableWorkbench: () => workbenchMock,
+}))
+vi.mock('../src/multitable/composables/useMultitableGrid', () => ({
+  useMultitableGrid: () => gridMock,
+}))
+vi.mock('../src/multitable/composables/useMultitableCapabilities', () => ({
+  useMultitableCapabilities: () => ({
+    canRead: ref(true), canCreateRecord: ref(true), canEditRecord: ref(true), canDeleteRecord: ref(true),
+    canManageFields: ref(true), canManageSheetAccess: ref(true), canManageViews: ref(true), canComment: ref(true),
+    canManageAutomation: ref(false), canExport: ref(true),
+  }),
+}))
+vi.mock('../src/multitable/composables/useMultitableComments', () => ({
+  useMultitableComments: () => ({
+    comments: ref([]), loading: ref(false), submitting: ref(false), resolvingIds: ref<string[]>([]),
+    updatingIds: ref<string[]>([]), deletingIds: ref<string[]>([]), error: ref<string | null>(null),
+    loadComments: vi.fn(), addComment: vi.fn(), updateComment: vi.fn(), deleteComment: vi.fn(), resolveComment: vi.fn(),
+  }),
+}))
+vi.mock('../src/multitable/composables/useMultitableCommentInbox', () => ({
+  useMultitableCommentInbox: () => ({ unreadCount: ref(0), refreshUnreadCount: vi.fn().mockResolvedValue(0) }),
+}))
+vi.mock('../src/multitable/composables/useMultitableCommentRealtime', () => ({ useMultitableCommentRealtime: vi.fn() }))
+vi.mock('../src/multitable/composables/useMultitableSheetRealtime', () => ({ useMultitableSheetRealtime: vi.fn() }))
+vi.mock('../src/multitable/import/bulk-import', () => ({ bulkImportRecords: vi.fn() }))
+
+vi.mock('../src/multitable/components/MetaViewTabBar.vue', () => ({ default: stubComponent('MetaViewTabBar') }))
+vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({ default: stubComponent('MetaToolbar') }))
+vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({ default: stubComponent('MetaGridTable') }))
+vi.mock('../src/multitable/components/MetaFormView.vue', () => ({ default: stubComponent('MetaFormView') }))
+vi.mock('../src/multitable/components/MetaRecordDrawer.vue', () => ({ default: stubComponent('MetaRecordDrawer') }))
+vi.mock('../src/multitable/components/MetaCommentsDrawer.vue', () => ({ default: stubComponent('MetaCommentsDrawer') }))
+vi.mock('../src/multitable/components/MetaLinkPicker.vue', () => ({ default: stubComponent('MetaLinkPicker') }))
+// Capturing stub for the component under wiring test.
+vi.mock('../src/multitable/components/MetaFieldManager.vue', () => ({
+  default: defineComponent({
+    name: 'MetaFieldManager',
+    props: ['listBasesFn', 'listForeignSheetsFn'],
+    setup(props) {
+      capturedFieldManagerProps = props as unknown as Record<string, unknown>
+      return () => h('div', { 'data-stub-MetaFieldManager': 'true' })
+    },
+  }),
+}))
+vi.mock('../src/multitable/components/MetaKanbanView.vue', () => ({ default: stubComponent('MetaKanbanView') }))
+vi.mock('../src/multitable/components/MetaGalleryView.vue', () => ({ default: stubComponent('MetaGalleryView') }))
+vi.mock('../src/multitable/components/MetaCalendarView.vue', () => ({ default: stubComponent('MetaCalendarView') }))
+vi.mock('../src/multitable/components/MetaTimelineView.vue', () => ({ default: stubComponent('MetaTimelineView') }))
+vi.mock('../src/multitable/components/MetaImportModal.vue', () => ({ default: stubComponent('MetaImportModal') }))
+vi.mock('../src/multitable/components/MetaBasePicker.vue', () => ({ default: stubComponent('MetaBasePicker') }))
+vi.mock('../src/multitable/components/MetaToast.vue', () => ({
+  default: defineComponent({
+    name: 'MetaToast',
+    setup(_, { expose }) {
+      expose({ showError: showErrorSpy, showSuccess: showSuccessSpy })
+      return () => h('div', { 'data-toast': 'true' })
+    },
+  }),
+}))
+
+import MultitableWorkbench from '../src/multitable/views/MultitableWorkbench.vue'
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function createWorkbenchMock() {
+  const activeBaseId = ref('base_ops')
+  const activeSheetId = ref('sheet_orders')
+  const activeViewId = ref('view_grid')
+  const views = ref([{ id: 'view_grid', sheetId: 'sheet_orders', name: 'Grid', type: 'grid' }])
+  return {
+    client: {
+      listBases: vi.fn().mockResolvedValue({ bases: [{ id: 'base_ops', name: 'Ops Base' }, { id: 'base_far', name: 'Far Base' }] }),
+      // The bare-client read the wiring MUST use. Returns the foreign base's sheets.
+      loadContext: vi.fn().mockResolvedValue({
+        base: { id: 'base_far', name: 'Far Base' },
+        sheet: null,
+        sheets: [{ id: 'sheet_far', baseId: 'base_far', name: 'Far Table' }],
+        views: [],
+        capabilities: {},
+      }),
+      loadFormContext: vi.fn(), getRecord: vi.fn(), createSheet: vi.fn(), createBase: vi.fn(),
+      createField: vi.fn(), preparePersonField: vi.fn(), updateField: vi.fn(), deleteField: vi.fn(),
+      createView: vi.fn(), deleteView: vi.fn(), patchRecords: vi.fn(), submitForm: vi.fn(), updateView: vi.fn(),
+    },
+    sheets: ref([{ id: 'sheet_orders', baseId: 'base_ops', name: 'Orders', description: null }]),
+    fields: ref([{ id: 'fld_title', name: 'Title', type: 'string' }]),
+    views,
+    activeBaseId,
+    activeSheetId,
+    activeViewId,
+    capabilities: ref({
+      canRead: true, canCreateRecord: true, canEditRecord: true, canDeleteRecord: true, canManageFields: true,
+      canManageSheetAccess: true, canManageViews: true, canComment: true, canManageAutomation: false, canExport: true,
+    }),
+    capabilityOrigin: ref(null),
+    fieldPermissions: ref({}),
+    viewPermissions: ref({}),
+    activeView: computed(() => views.value.find((view) => view.id === activeViewId.value) ?? null),
+    loading: ref(false),
+    error: ref<string | null>(null),
+    loadSheets: vi.fn().mockResolvedValue(true),
+    loadBaseContext: vi.fn().mockResolvedValue(true),
+    loadSheetMeta: vi.fn().mockResolvedValue(true),
+    switchBase: vi.fn().mockResolvedValue(true),
+    syncExternalContext: vi.fn().mockResolvedValue(true),
+    selectBase: vi.fn((baseId: string) => { activeBaseId.value = baseId }),
+    selectSheet: vi.fn((sheetId: string) => { activeSheetId.value = sheetId }),
+    selectView: vi.fn((viewId: string) => { activeViewId.value = viewId }),
+  }
+}
+
+function createGridMock() {
+  return {
+    fields: ref([]), rows: ref([]), loading: ref(false), currentPage: ref(1), totalPages: ref(1),
+    page: ref({ offset: 0, limit: 50, total: 0, hasMore: false }), visibleFields: ref([]), sortRules: ref([]),
+    filterRules: ref([]), filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
+    groupFieldId: ref<string | null>(null), groupField: ref(null), hiddenFieldIds: ref<string[]>([]),
+    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), attachmentSummaries: ref({}),
+    fieldPermissions: ref({}), viewPermission: ref(null), rowActions: ref(null), rowActionOverrides: ref({}),
+    capabilityOrigin: ref(null), conflict: ref(null), error: ref<string | null>(null), sortFilterDirty: ref(false),
+    toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),
+    updateFilterRule: vi.fn(), removeFilterRule: vi.fn(), clearFilters: vi.fn(), applySortFilter: vi.fn(),
+    undo: vi.fn(), redo: vi.fn(), setGroupField: vi.fn(), goToPage: vi.fn(), patchCell: vi.fn(),
+    createRecord: vi.fn(), deleteRecord: vi.fn(), resolveRowActions: vi.fn(() => null),
+    loadViewData: vi.fn().mockResolvedValue(true), reloadCurrentPage: vi.fn(), dismissConflict: vi.fn(),
+    retryConflict: vi.fn(), setColumnWidth: vi.fn(), setSearchQuery: vi.fn(),
+  }
+}
+
+describe('MultitableWorkbench cross-base field-picker wiring', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    workbenchMock = createWorkbenchMock()
+    gridMock = createGridMock()
+    capturedFieldManagerProps = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    showErrorSpy.mockReset()
+    showSuccessSpy.mockReset()
+    vi.clearAllMocks()
+  })
+
+  it('wires listForeignSheetsFn to the bare client.loadContext and never moves the active base (row #8)', async () => {
+    const Host = defineComponent({ setup() { return () => h(MultitableWorkbench as Component) } })
+    app = createApp(Host)
+    app.mount(container!)
+    await flushUi()
+
+    expect(capturedFieldManagerProps).not.toBeNull()
+    const listForeignSheetsFn = capturedFieldManagerProps!.listForeignSheetsFn as (baseId: string) => Promise<unknown[]>
+    const listBasesFn = capturedFieldManagerProps!.listBasesFn as () => Promise<unknown[]>
+    expect(typeof listForeignSheetsFn).toBe('function')
+    expect(typeof listBasesFn).toBe('function')
+
+    const baseBefore = workbenchMock.activeBaseId.value
+    const sheetBefore = workbenchMock.activeSheetId.value
+    // Snapshot mutator call-counts AFTER mount — the workbench's own startup may
+    // legitimately load the ACTIVE base once. We assert the foreign-sheet fetch
+    // adds ZERO further mutator calls (the Impl trap is about not re-syncing on
+    // a foreign-base read, not about mount-time behavior).
+    const switchBaseBefore = workbenchMock.switchBase.mock.calls.length
+    const loadBaseContextBefore = workbenchMock.loadBaseContext.mock.calls.length
+    const selectBaseBefore = workbenchMock.selectBase.mock.calls.length
+    const selectSheetBefore = workbenchMock.selectSheet.mock.calls.length
+
+    // Invoke the wired foreign-sheet fetch for a DIFFERENT base.
+    const sheets = await listForeignSheetsFn('base_far')
+
+    // It resolved via the bare client.loadContext({baseId}) and returned .sheets.
+    expect(workbenchMock.client.loadContext).toHaveBeenCalledWith({ baseId: 'base_far' })
+    expect(sheets).toEqual([{ id: 'sheet_far', baseId: 'base_far', name: 'Far Table' }])
+
+    // The active-base mutators were NOT touched BY THE FETCH (the Impl trap).
+    expect(workbenchMock.switchBase.mock.calls.length).toBe(switchBaseBefore)
+    expect(workbenchMock.loadBaseContext.mock.calls.length).toBe(loadBaseContextBefore)
+    expect(workbenchMock.selectBase.mock.calls.length).toBe(selectBaseBefore)
+    expect(workbenchMock.selectSheet.mock.calls.length).toBe(selectSheetBefore)
+    // No mutator was ever called with the FOREIGN base id.
+    expect(workbenchMock.switchBase).not.toHaveBeenCalledWith('base_far')
+    expect(workbenchMock.loadBaseContext).not.toHaveBeenCalledWith('base_far')
+
+    // And the active base/sheet are unchanged.
+    expect(workbenchMock.activeBaseId.value).toBe(baseBefore)
+    expect(workbenchMock.activeSheetId.value).toBe(sheetBefore)
+
+    // listBasesFn unwraps the gated bases list.
+    const bases = await listBasesFn()
+    expect(workbenchMock.client.listBases).toHaveBeenCalled()
+    expect(bases).toEqual([{ id: 'base_ops', name: 'Ops Base' }, { id: 'base_far', name: 'Far Base' }])
+  })
+})


### PR DESCRIPTION
## Cross-base LINK field picker (B1 MVP)

Implements the MVP slice of the merged design-lock `docs/development/multitable-crossbase-fe-picker-design-20260614.md` (§3 MVP, §4 edit-mode, §5/§8 tests). Makes the already-merged cross-base backend (#2582→#2597) reachable from the frontend: the config-authoring **read-side** picker in `MetaFieldManager`. Backend is unchanged.

### What shipped
- **"Link to another base" checkbox** in the link field config. **Off (default) = today's same-base path, no extra click, fully backward-compatible.**
- When on: a gated base `<select>` (from `client.listBases()`) → a foreign-sheet `<select>` (from `client.loadContext({baseId}).sheets`), with inline **loading / empty / 403-gated** states. The current sheet is excluded only when the picked base IS the active base.
- **Save assembly** emits `foreignBaseId` **only** when cross-base is on AND both ids are present — mirrors the backend codec's both-present rule (`field-codecs.ts:236`). Same-base saves are byte-for-byte unchanged (no `foreignBaseId` key).
- **Cross-base save-guard** validates the foreign sheet against the **fetched foreign-base list** (not same-base `targetSheets`), and **fails closed** on a 403/transport error — never a silent same-base save.
- **Edit-mode immutability**: cross-base-ness is **create-only**. For any existing field the toggle is disabled (handler-guarded, not just `:disabled`) and, for an existing cross-base field, the base axis is locked (only the sheet within the locked base may change). Emit has defense-in-depth so an existing same-base field can never be converted to cross-base (that would break its existing link values — record IDs in the current base).

### The base-read gate is the FE's source of truth
The picker never computes its own readability — it only offers what `listBases()` / `loadContext({baseId}).sheets` return (both backend base-read-gated). Unreadable foreign sheets are simply absent; a foreign base that 403s renders a friendly inline notice. **No new endpoint, no new param** — `link-options` already resolves the foreign sheet+base server-side for an existing field's reads.

### Touch points (7 files)
- `apps/web/src/multitable/utils/field-config.ts` — `foreignBaseId` added to `NormalizedLinkFieldProperty` + `resolveLinkFieldProperty` (the wire keystone).
- `apps/web/src/multitable/components/MetaFieldManager.vue` — checkbox + base/sheet selects + states; `listBasesFn`/`listForeignSheetsFn` fn-props (dryRunFn precedent); save assembly + base-aware guard; edit-mode locks; reset.
- `apps/web/src/multitable/utils/meta-manager-labels.ts` — new en+zh labels.
- `apps/web/src/multitable/views/MultitableWorkbench.vue` — wires both fns from the **bare client** (`listBases` / `loadContext`), **never** `switchBase`/`loadBaseContext` (those run `syncContextState` and would yank the user's active base).

### Tests (13 new, jsdom/Vitest)
- `multitable-crossbase-link-normalizer.spec.ts` (3) — **the wire-vs-fixture round-trip**: `resolveLinkFieldProperty` preserves `foreignBaseId` (cross-base) and resolves it to `null` (same-base / blank). Locks the #1781 trap on the normalizer itself.
- `multitable-crossbase-link-picker.spec.ts` (9) — design rows #1–7 + two added: **row #1 round-trip feeds the ACTUAL emitted `create-field` property back through `resolveLinkFieldProperty`** (not a hand-built fixture); same-base emits no `foreignBaseId`; list sourcing; cross-base guard accepts a foreign-base-only sheet; edit-mode toggle+base lock; create-time 403 blocks save; reset-on-reopen; **existing same-base field → toggle present-but-disabled, no `foreignBaseId` leak**; **edit-time 403 → gated state + save blocked**.
- `multitable-crossbase-workbench-wiring.spec.ts` (1) — **row #8 (active base unchanged)** at the **workbench level** (component-level would be vacuous — `MetaFieldManager` has no `switchBase`): captures the `listForeignSheetsFn` the workbench passes down, asserts it resolves via the **bare `client.loadContext({baseId})`** and adds **zero** active-base mutator calls.

Test command: `pnpm --filter @metasheet/web exec vitest run tests/multitable-crossbase-link-normalizer.spec.ts tests/multitable-crossbase-link-picker.spec.ts tests/multitable-crossbase-workbench-wiring.spec.ts` → **13 passed**. Regression sweep (`multitable-field-manager` + field-config/manager i18n + link-picker specs) green.

### Deferred (per design §7, named with anchors)
- Cross-base **automation** target selectors (`targetBaseId`/`targetSheetId`/`targetRecordId` + informational quota line) in `MetaAutomationRuleEditor.vue`.
- `MetaLinkPicker` friendly-403 copy (record-value picker already works for cross-base reads unchanged — §6).
- Full base-navigation rework; same-base↔cross-base **re-targeting** after create (gated by `foreignBaseId` immutability — now actively enforced here).

### Note for reviewers
`apps/web/tests/multitable-workbench-manager-flow.spec.ts` fails on `origin/main` too (timeline view renders 5 selects, the test expects 4) — verified against baseline source. This PR does **not** touch that file; the red is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
