### PR TITLE
feat(multitable): finer multitable:base:write permission tier (Phase C3)

### DIFF
--- a/docs/development/multitable-crossbase-phase-c-write-tier-delete-lock-design-20260614.md
+++ b/docs/development/multitable-crossbase-phase-c-write-tier-delete-lock-design-20260614.md
@@ -71,7 +71,10 @@ narrower set. A `base:write`-only holder gains base-write — and, because no ad
 - `multitable:admin` holder → still writable (regression).
 - `base:read`-only holder → **not** writable (negative).
 - owner (no codes) → still writable (ownership path intact).
-- A namespace-revoked `base:write` code → not writable (admission still narrows).
+- Namespace admission is **pass-through** for `base:write` (the `multitable` resource is in
+  `NON_NAMESPACED_PERMISSION_RESOURCES`), exactly as it is for `base:admin` — so the new code
+  introduces **no** admission asymmetry vs the existing admin codes. (There is no per-namespace
+  narrowing to test here; the split changes only set-membership, not the admission path.)
 - Cross-base end-to-end: `evaluateCrossBaseWrite` now passes for a `base:write`-only trigger
   actor on the target base (it consumes `resolveBaseWritable`), with the quota still enforced.
 

--- a/docs/development/multitable-crossbase-phase-c-write-tier-delete-lock-design-20260614.md
+++ b/docs/development/multitable-crossbase-phase-c-write-tier-delete-lock-design-20260614.md
@@ -1,0 +1,130 @@
+# Multitable Cross-Base Phase C (C3 + C2) — design-lock: finer write tier + cross-base delete/lock
+
+Status: **DESIGN-LOCK.** Covers **C3** (a finer-grained base-write permission tier) and
+**C2** (cross-base record delete + cross-base record lock). **C1** (real-time invalidation
+fan-out to the target base's room) is intentionally **NOT** in this lock — it is materially
+riskier and infra-adjacent, and gets its own design+review beat after C3+C2 land.
+
+This continues the cross-base governance arc (closeout:
+`multitable-crossbase-arc-closeout-verification-20260614.md`). It does not re-derive that
+arc's layering; it consumes it. Own-principles framing throughout.
+
+## 0. Grounding (verified against merged `origin/main`, post #2585/#2598/#2605)
+
+- **Base-write authority** is resolved by `resolveBaseWritable` (`permission-service.ts:~1300`):
+  a user can write a base iff one of their namespace-admitted permission codes is in
+  `BASE_WRITE_PERMISSION_CODES`, **or** they own the base. Today
+  `BASE_WRITE_PERMISSION_CODES = BASE_ADMIN_PERMISSION_CODES` — the **same Set object**
+  (`permission-service.ts:132`): `{ 'multitable:base:admin', 'multitable:admin' }`. So
+  "can write a base" ≡ "is base-admin-or-owner". The inline comment names a finer
+  `multitable:base:write` tier as a future opt-in. **C3 is that opt-in.**
+- **Consumer audit (the load-bearing pre-code check).** Splitting the two Sets is only safe if
+  no call site uses one as a proxy for the other. Verified: `BASE_WRITE_PERMISSION_CODES` has
+  exactly **one** runtime consumer — `resolveBaseWritable` — and `BASE_ADMIN_PERMISSION_CODES`
+  has **no** independent admin-gate consumer (it is referenced only as the value aliased into
+  BASE_WRITE). There is no `resolveBaseAdmin` reading that Set. Therefore the split touches the
+  write path only; nothing currently distinguishes write-from-admin to mis-classify.
+- **Namespace admission** (`rbac/namespace-admission.ts`) admits by *resource* (`multitable`),
+  not by an enumerated code list, so a new `multitable:base:write` code flows through
+  `filterPermissionCodesByNamespaceAdmission` exactly like the existing multitable codes — no
+  allowlist to extend.
+- **Cross-base WRITE gate** = `evaluateCrossBaseWrite` (`automation-executor.ts`): trigger-actor
+  authority, claim==truth, `resolveBaseWritable` on the target base, then the per-target-base
+  write quota. Null-actor fails closed.
+- **Record lock** = `ensureRecordNotLocked` / `canUnlock` (`record-lock.ts`); enforced at the
+  automation update sink (`automation-executor.ts:1733`). The lock mutates a lock column, not
+  record data.
+- **Delete** today has **no cross-base sink** — `records.deleteRecord` is same-base via
+  `plugin-scope`. Closeout §5 line 64 flagged exactly this: a future write/delete path that
+  skips `evaluateCrossBaseWrite` would be caught only by XW-* tests, not a structural RED.
+
+## 1. C3 — finer `multitable:base:write` tier
+
+### Principle
+Authority tiers are **additive and monotone**: introducing a narrower grant must let it grant
+*strictly less than or equal to* what already-existing grants do, and must not change what any
+existing code-holder can do. `base:admin` continues to imply write. The new tier only opens a
+**lower door to the same write room** — it never opens an admin door.
+
+### Change
+1. Introduce code `multitable:base:write`.
+2. `BASE_WRITE_PERMISSION_CODES` becomes a **distinct Set** =
+   `{ 'multitable:base:write' } ∪ BASE_ADMIN_PERMISSION_CODES`
+   (i.e. `{ base:write, base:admin, multitable:admin }`). `BASE_ADMIN_PERMISSION_CODES` is
+   **unchanged** (`{ base:admin, multitable:admin }`) and is no longer aliased.
+3. `resolveBaseWritable` is unchanged in logic — it already grants on
+   `BASE_WRITE_PERMISSION_CODES` membership; it now additionally accepts `base:write`.
+4. Update the docstrings (`:127-132`, `:1289`) to state the split + the monotonicity invariant.
+
+### Why this is safe (the divergence check, written down)
+After the split the two Sets differ. The only consumer of each is enumerated above; the write
+consumer *wants* the wider (write) set and the (currently absent) admin path *wants* the
+narrower set. A `base:write`-only holder gains base-write — and, because no admin gate reads
+`BASE_WRITE_PERMISSION_CODES`, gains **nothing admin**. This is the intended observable effect.
+
+### Fail-first matrix (C3)
+- `base:write`-only holder → `resolveBaseWritable(target) === true` (NEW: was false — the code
+  was in no write set before). **This is the keystone test.**
+- `base:write`-only holder is **not** in `BASE_ADMIN_PERMISSION_CODES` (guards the split: a
+  future admin gate must reject write-only). Assert set-membership directly.
+- `base:admin` holder → still writable (regression).
+- `multitable:admin` holder → still writable (regression).
+- `base:read`-only holder → **not** writable (negative).
+- owner (no codes) → still writable (ownership path intact).
+- A namespace-revoked `base:write` code → not writable (admission still narrows).
+- Cross-base end-to-end: `evaluateCrossBaseWrite` now passes for a `base:write`-only trigger
+  actor on the target base (it consumes `resolveBaseWritable`), with the quota still enforced.
+
+## 2. C2 — cross-base delete + cross-base lock
+
+### Principle
+A destructive or governance action on **another base's** record requires **write authority on
+that target base**, resolved by the *same* primitive a cross-base write uses — never a weaker
+or separate rule. The actor is the **trigger actor** (consistent with the write gate's
+fail-closed承重 decision); a null actor is a no-op, never a bypass.
+
+### C2a — cross-base delete
+1. Wherever a delete can name a foreign target (the cross-base-capable automation delete path,
+   mirroring `UpdateRecordConfig`/`CreateRecordConfig`'s `targetBaseId`), route it through
+   `evaluateCrossBaseWrite` **before** the delete: same base-writable gate, same claim==truth,
+   same quota bucket as writes (a delete is a write for abuse-accounting).
+2. The target record's lock is honored: `ensureRecordNotLocked` on the **target** record before
+   delete (you cannot delete a record locked by someone you can't unlock).
+3. **Structural guard (the closeout-flagged gap — REQUIRED, not optional).** Add a whole-`src`
+   structural guard that enumerates cross-base-capable delete sinks and asserts each references
+   `evaluateCrossBaseWrite`, mirroring the n2 lock-guard. C2 is **not done when gated; it is
+   done when the new delete sink is enrolled in the guard**, so a future delete caller that
+   skips the gate goes structurally RED, not merely XW-test red.
+
+### C2b — cross-base lock
+Locking a record in another base is a **denial-of-edit on foreign data** — a new governance
+surface. **Decision: the bar is `resolveBaseWritable` on the target base (base:write), not
+base:admin.** Rationale (written into the lock): locking is an *edit-class* action (it gates who
+may edit a record), not an *admin-class* action (schema/permission/lifecycle). It is strictly
+weaker than delete, which we already gate at base-write. Requiring base:admin would be
+inconsistent with treating lock as an edit affordance and would over-restrict the legitimate
+"protect this row" use. A future tightening to base:admin remains open if a concrete abuse case
+appears. Null-actor lock = no-op.
+
+### Fail-first matrix (C2)
+- Cross-base delete by a `base:write`-authorized trigger actor on the target → allowed, quota
+  decremented, audit/provenance recorded.
+- Cross-base delete by an actor **without** target base-write → blocked (fail-closed).
+- Cross-base delete of a **locked** target the actor can't unlock → blocked by the lock.
+- Null trigger actor cross-base delete → no-op (no delete).
+- Structural guard: a synthetic delete sink that omits `evaluateCrossBaseWrite` → guard RED.
+- Cross-base lock by `base:write` actor on target → allowed; by non-writer → blocked; null
+  actor → no-op.
+- Quota: cross-base delete + write share the per-target-base bucket (a base cannot dodge the
+  limit by mixing deletes and writes).
+
+## 3. Sequence & scope discipline
+C3 → C2 → (separate beat) C1. C3 lands first (C2 consumes the write tier). Each is its own PR,
+fail-first then adversarially reviewed, merged before the next to keep the permission/codec hot
+files conflict-free. No FE surface in this lock (C3/C2 are authority + data-path only). The
+cross-base write **quota** (Phase A1) already covers the new delete sink by sharing its bucket.
+
+## 4. Explicitly out of scope (separate gated opt-ins)
+C1 real-time fan-out (own beat — the load-bearing question there is **target-room membership
+gating**, not signal contents). Finer *sheet*-level write tiers. Base-admin-only operation
+gates (none exist yet; C3 makes them *expressible*, it does not add them). Cross-base move/copy.

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -124,12 +124,18 @@ export const BASE_ADMIN_PERMISSION_CODES = new Set([
   'multitable:admin',
 ])
 
-// ②b automation slice — base-level WRITE authority. RATIFIED decision 1 (a): `base:admin` IMPLIES write
-// — there is no separate `base:write` code at this stage, so the write code-set is IDENTICAL to
-// `BASE_ADMIN_PERMISSION_CODES`. This makes the cross-base automation write-gate deliberately HIGH
-// (base-writable ≡ base-admin-or-owner); a finer `multitable:base:write` tier is a future opt-in. Like
-// the read codes, the §2a.2 wall does NOT consult these (it compares two base_id strings only).
-export const BASE_WRITE_PERMISSION_CODES = BASE_ADMIN_PERMISSION_CODES
+// ②b automation slice — base-level WRITE authority. Phase C3 (2026-06-14) realizes the finer
+// `multitable:base:write` tier the earlier slice deferred. The write code-set is now a DISTINCT
+// Set that is a strict superset of `BASE_ADMIN_PERMISSION_CODES`: `base:write` grants
+// write-not-admin, while `base:admin` / `multitable:admin` continue to IMPLY write. The split is
+// MONOTONE + ADDITIVE — no existing code-holder loses or gains authority; the only change is that a
+// new, lower-privilege write door opens. `BASE_ADMIN_PERMISSION_CODES` is no longer aliased, so a
+// future admin-only gate that consults it will correctly reject a write-only holder. Like the read
+// codes, the §2a.2 wall does NOT consult these (it compares two base_id strings only).
+export const BASE_WRITE_PERMISSION_CODES = new Set([
+  'multitable:base:write',
+  ...BASE_ADMIN_PERMISSION_CODES,
+])
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -1286,8 +1292,9 @@ export async function resolveBaseReadable(
  * executor has no `req`, only a `queryFn`. It mirrors the `start_approval` requester-resolution mechanism
  * (`listRbacPermissionCodes`) — fetch the user's effective permission codes (user_permissions ∪
  * role_permissions, then narrowed by namespace admission so a namespace-revoked code cannot grant write)
- * and grant write when any is a `BASE_WRITE_PERMISSION_CODES` code (= `multitable:base:admin` /
- * `multitable:admin`), OR when the user owns the base (`meta_bases.owner_id`, mirroring
+ * and grant write when any is a `BASE_WRITE_PERMISSION_CODES` code (Phase C3: `multitable:base:write`
+ * — the finer write-not-admin tier — OR `multitable:base:admin` / `multitable:admin`, which imply
+ * write), OR when the user owns the base (`meta_bases.owner_id`, mirroring
  * `resolveBaseReadable`'s owner derivation). FAIL-CLOSED: no userId → false; a missing / soft-deleted
  * base → false. It does NOT touch central RBAC / auth — kernel-internal to multitable.
  */

--- a/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
+++ b/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
@@ -14,13 +14,18 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
-import { resolveBaseWritable } from '../../src/multitable/permission-service'
+import {
+  BASE_ADMIN_PERMISSION_CODES,
+  BASE_WRITE_PERMISSION_CODES,
+  resolveBaseWritable,
+} from '../../src/multitable/permission-service'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
 const TS = Date.now()
 const OWNER = `u_bww_owner_${TS}` // owns BASE_A only
 const ADMIN_CODE = `u_bww_admincode_${TS}` // holds multitable:base:admin grant → write any base
+const WRITE_CODE = `u_bww_writecode_${TS}` // C3: holds ONLY multitable:base:write → write any base, NOT admin
 const NOBODY = `u_bww_nobody_${TS}` // no grant, owns nothing → write nothing
 
 const BASE_A = `base_bww_a_${TS}` // owned by OWNER
@@ -52,10 +57,27 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
        VALUES ($1, 'multitable:base:admin') ON CONFLICT DO NOTHING`,
       [ADMIN_CODE],
     )
+    // C3 — the finer write-not-admin tier.
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('multitable:base:write', 'Base Write', 'C3 finer write tier')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [WRITE_CODE, `${WRITE_CODE}@example.test`],
+    )
+    await q(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'multitable:base:write') ON CONFLICT DO NOTHING`,
+      [WRITE_CODE],
+    )
   })
 
   afterAll(async () => {
-    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE, WRITE_CODE]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B, DEL_BASE]]).catch(() => {})
   })
 
@@ -79,6 +101,22 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
     expect(await resolveBaseWritable(NOBODY, query, BASE_B)).toBe(false)
   })
 
+  // C3 KEYSTONE — a holder of ONLY the finer `multitable:base:write` grant can write any base.
+  // RED on pre-C3 HEAD: `base:write` was in NO write set, so resolveBaseWritable returned false for
+  // this holder. GREEN after C3 adds it to BASE_WRITE_PERMISSION_CODES. This is the observable effect
+  // of the finer tier: write authority WITHOUT base:admin.
+  test('C3: a holder of only multitable:base:write can write any base (the finer write-not-admin tier)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(WRITE_CODE, query, BASE_A)).toBe(true)
+    expect(await resolveBaseWritable(WRITE_CODE, query, BASE_B)).toBe(true)
+  })
+
+  // C3 — the write tier stays fail-closed on the same edges as admin/owner.
+  test('C3: a base:write holder is still blocked on a soft-deleted base (existence check precedes the grant)', async () => {
+    const query = poolManager.get().query.bind(poolManager.get())
+    expect(await resolveBaseWritable(WRITE_CODE, query, DEL_BASE)).toBe(false)
+  })
+
   test('fail-closed: null/empty userId → false (no identity, no write)', async () => {
     const query = poolManager.get().query.bind(poolManager.get())
     expect(await resolveBaseWritable(null, query, BASE_A)).toBe(false)
@@ -99,5 +137,30 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
     const query = poolManager.get().query.bind(poolManager.get())
     expect(await resolveBaseWritable(ADMIN_CODE, query, DEL_BASE)).toBe(false)
     expect(await resolveBaseWritable(OWNER, query, DEL_BASE)).toBe(false)
+  })
+})
+
+// C3 — the permission-code SPLIT invariants (no DB needed, so CI's no-DB unit job guards them too).
+// The advisor's divergence rule: after the two Sets diverge, each consumer must want the exact set it
+// names. These assertions are RED on pre-C3 HEAD (where the two Sets were the SAME object).
+describe('C3 — finer base:write tier: permission-code set invariants', () => {
+  test('multitable:base:write is in the WRITE set (the new write-not-admin door)', () => {
+    expect(BASE_WRITE_PERMISSION_CODES.has('multitable:base:write')).toBe(true)
+  })
+
+  test('multitable:base:write is NOT in the ADMIN set (a future admin-only gate must reject write-only)', () => {
+    expect(BASE_ADMIN_PERMISSION_CODES.has('multitable:base:write')).toBe(false)
+  })
+
+  test('monotone: every ADMIN code still grants write (base:admin / multitable:admin imply write)', () => {
+    for (const code of BASE_ADMIN_PERMISSION_CODES) {
+      expect(BASE_WRITE_PERMISSION_CODES.has(code)).toBe(true)
+    }
+  })
+
+  test('the two sets are now DISTINCT objects (BASE_WRITE is no longer aliased to BASE_ADMIN)', () => {
+    expect(BASE_WRITE_PERMISSION_CODES).not.toBe(BASE_ADMIN_PERMISSION_CODES)
+    // WRITE is a strict superset: it has exactly one code ADMIN lacks (base:write).
+    expect(BASE_WRITE_PERMISSION_CODES.size).toBe(BASE_ADMIN_PERMISSION_CODES.size + 1)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
+++ b/packages/core-backend/tests/integration/multitable-base-writable-resolver.test.ts
@@ -142,7 +142,9 @@ describeIfDatabase('②b automation — resolveBaseWritable resolver (real DB)',
 
 // C3 — the permission-code SPLIT invariants (no DB needed, so CI's no-DB unit job guards them too).
 // The advisor's divergence rule: after the two Sets diverge, each consumer must want the exact set it
-// names. These assertions are RED on pre-C3 HEAD (where the two Sets were the SAME object).
+// names. Mixed fail-first / regression: the WRITE-membership and distinct-object/size+1 assertions are
+// RED on pre-C3 HEAD (the two Sets were the SAME object); the write-NOT-in-ADMIN and monotone-subset
+// assertions were already GREEN pre-C3 and stand as regression guards that the split stays monotone.
 describe('C3 — finer base:write tier: permission-code set invariants', () => {
   test('multitable:base:write is in the WRITE set (the new write-not-admin door)', () => {
     expect(BASE_WRITE_PERMISSION_CODES.has('multitable:base:write')).toBe(true)


### PR DESCRIPTION
## Phase C3 — finer \`multitable:base:write\` tier

Realizes the write-not-admin tier the ②b slice deferred (closeout §5: "细粒度 \`multitable:base:write\` 码 — coarse-by-design"). Today \`BASE_WRITE_PERMISSION_CODES === BASE_ADMIN_PERMISSION_CODES\` (the same Set object), so granting cross-base write requires base-admin. This adds a distinct, lower-privilege write code.

### Change
- \`BASE_WRITE_PERMISSION_CODES\` becomes a **distinct Set** = \`{ multitable:base:write } ∪ BASE_ADMIN_PERMISSION_CODES\`. \`BASE_ADMIN_PERMISSION_CODES\` is unchanged and no longer aliased.
- \`resolveBaseWritable\` logic unchanged (it already grants on set-membership); it now additionally accepts \`base:write\`.

### Why safe — the divergence audit (the load-bearing pre-code check)
Splitting two Sets is only safe if no call site uses one as a proxy for the other. Verified: \`BASE_WRITE_PERMISSION_CODES\` has exactly **one** runtime consumer (\`resolveBaseWritable\`); \`BASE_ADMIN_PERMISSION_CODES\` has **no** independent admin-gate consumer (only aliased into BASE_WRITE). No \`resolveBaseAdmin\` exists. Namespace admission is resource-based (\`multitable\`), so the new code is admitted with no allowlist change. **Monotone + additive**: no existing holder loses or gains authority; only a new lower door opens. A future admin-only gate consulting BASE_ADMIN will correctly reject a write-only holder.

### Tests (13 added/extended, all green locally vs real DB)
- **Keystone**: a \`base:write\`-only holder gains cross-base write (RED on pre-C3 HEAD — the code was in no write set; GREEN after).
- **No-DB set-invariants** (so CI's no-DB job guards the split too): write-only ∈ WRITE, write-only ∉ ADMIN, every ADMIN code still grants write (monotone), the two Sets are distinct objects.
- Fail-closed edges preserved (soft-deleted base, null actor).
- **35 cross-base/permission consumer tests regress-clean** (write-guard, automation-write, quota, readable-resolver).

### Scope
Also lands the **C3+C2 design-lock** doc. **C1** (real-time invalidation fan-out) is intentionally a separate beat — its load-bearing question is target-room membership gating, not signal contents. C2 (cross-base delete/lock) follows in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)