### PR TITLE
feat(multitable): rich-text longText FE — render + editor (B4 FE MVP)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@metasheet/sdk": "workspace:*",
     "axios": "^1.8.0",
     "bpmn-js": "^18.10.1",
+    "dompurify": "^3.2.0",
     "echarts": "^5.5.0",
     "element-plus": "^2.10.1",
     "file-saver": "^2.0.5",

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -37,6 +37,19 @@
             :value="textControlValue(formData[field.id])"
             @input="formData[field.id] = ($event.target as HTMLInputElement).value"
           />
+          <!-- rich longText, read-only: formatted render (§7 form shows the render) -->
+          <MetaRichLongTextRender
+            v-else-if="field.type === 'longText' && isRichLongTextField(field) && isFieldReadOnly(field.id)"
+            :html="formData[field.id]"
+          />
+          <!-- rich longText, editable: minimal rich editor (server re-sanitizes on write) -->
+          <MetaRichLongTextEditor
+            v-else-if="field.type === 'longText' && isRichLongTextField(field)"
+            :model-value="formData[field.id]"
+            :is-zh="isZh"
+            @update:model-value="formData[field.id] = $event"
+          />
+          <!-- plain longText: unchanged textarea -->
           <textarea
             v-else-if="field.type === 'longText'"
             :id="`field_${field.id}`"
@@ -291,6 +304,9 @@ import type {
 } from '../types'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
+import MetaRichLongTextRender from './cells/MetaRichLongTextRender.vue'
+import MetaRichLongTextEditor from './cells/MetaRichLongTextEditor.vue'
+import { isRichLongTextField } from '../utils/rich-longtext'
 import {
   resolveCommentAffordanceStateClass,
   resolveFieldCommentAffordance,

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -120,12 +120,14 @@
             :value="textControlValue(record.data[field.id])"
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
-          <!-- rich longText: minimal rich editor (server re-sanitizes on write) -->
+          <!-- rich longText: minimal rich editor (server re-sanitizes on write).
+               Patch on `change` (blur) only — mirrors the plain textarea's @change so
+               the drawer issues ONE server PATCH per edit, never one per keystroke. -->
           <MetaRichLongTextEditor
             v-else-if="canEditField(field.id) && field.type === 'longText' && isRichLongTextField(field)"
             :model-value="record.data[field.id]"
             :is-zh="isZh"
-            @update:model-value="emit('patch', field.id, $event)"
+            @change="emit('patch', field.id, $event)"
           />
           <!-- plain longText: unchanged textarea -->
           <textarea

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -120,6 +120,14 @@
             :value="textControlValue(record.data[field.id])"
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
+          <!-- rich longText: minimal rich editor (server re-sanitizes on write) -->
+          <MetaRichLongTextEditor
+            v-else-if="canEditField(field.id) && field.type === 'longText' && isRichLongTextField(field)"
+            :model-value="record.data[field.id]"
+            :is-zh="isZh"
+            @update:model-value="emit('patch', field.id, $event)"
+          />
+          <!-- plain longText: unchanged textarea -->
           <textarea
             v-else-if="canEditField(field.id) && field.type === 'longText'"
             :id="`drawer_field_${field.id}`"
@@ -239,6 +247,12 @@
             </div>
             <div v-if="attachmentErrors[field.id]" class="meta-record-drawer__error">{{ attachmentErrors[field.id] }}</div>
           </div>
+          <!-- read-only rich longText: formatted render via the single sanitized
+               component (§7 drawer shows the formatted render). -->
+          <MetaRichLongTextRender
+            v-else-if="field.type === 'longText' && isRichLongTextField(field)"
+            :html="record.data[field.id]"
+          />
           <span v-else class="meta-record-drawer__text">{{ formatValue(field, record.data[field.id]) }}</span>
           <div
             v-if="field.type === 'qrcode' && drawerQrSvg(record.data[field.id])"
@@ -317,6 +331,9 @@ import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
 import MetaRecordPermissionManager from './MetaRecordPermissionManager.vue'
+import MetaRichLongTextRender from './cells/MetaRichLongTextRender.vue'
+import MetaRichLongTextEditor from './cells/MetaRichLongTextEditor.vue'
+import { isRichLongTextField } from '../utils/rich-longtext'
 import {
   resolveCommentAffordanceStateClass,
   resolveFieldCommentAffordance,

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -52,7 +52,14 @@
       />
     </div>
 
-    <!-- longText: multiline REST editor -->
+    <!-- rich longText: minimal rich editor (server re-sanitizes on write) -->
+    <MetaRichLongTextEditor
+      v-else-if="field.type === 'longText' && isRichLongTextField(field)"
+      :model-value="modelValue"
+      :is-zh="isZh"
+      @update:model-value="emit('update:modelValue', $event)"
+    />
+    <!-- plain longText: unchanged multiline REST editor -->
     <textarea
       v-else-if="field.type === 'longText'"
       ref="inputRef"
@@ -303,6 +310,8 @@ import { ref, computed, onMounted, toRef } from 'vue'
 import type { MetaAttachment, MetaAttachmentDeleteFn, MetaAttachmentUploadContext, MetaAttachmentUploadFn, MetaField } from '../../types'
 import MetaAttachmentList from '../MetaAttachmentList.vue'
 import MetaYjsPresenceChip from '../MetaYjsPresenceChip.vue'
+import MetaRichLongTextEditor from './MetaRichLongTextEditor.vue'
+import { isRichLongTextField } from '../../utils/rich-longtext'
 import {
   attachmentAcceptAttr,
   resolveAttachmentFieldProperty,

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -52,12 +52,16 @@
       />
     </div>
 
-    <!-- rich longText: minimal rich editor (server re-sanitizes on write) -->
+    <!-- rich longText: minimal rich editor (server re-sanitizes on write). Forward
+         confirm/cancel so the grid host commits (Cmd/Ctrl+Enter) and cancels (Esc),
+         matching the plain textarea's commit contract. -->
     <MetaRichLongTextEditor
       v-else-if="field.type === 'longText' && isRichLongTextField(field)"
       :model-value="modelValue"
       :is-zh="isZh"
       @update:model-value="emit('update:modelValue', $event)"
+      @confirm="emit('confirm')"
+      @cancel="emit('cancel')"
     />
     <!-- plain longText: unchanged multiline REST editor -->
     <textarea

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -3,9 +3,11 @@
     <!-- string / formula -->
     <template v-if="field.type === 'string' || field.type === 'formula'">{{ displayValue }}</template>
 
-    <!-- long text -->
+    <!-- long text: grid shows the plain-text projection (truncated, fast) for rich
+         fields — never the formatted HTML (§7 grid-vs-drawer). Plain longText is
+         unchanged (mustache-escaped display). -->
     <template v-else-if="field.type === 'longText'">
-      <span class="meta-cell-renderer__long-text">{{ displayValue }}</span>
+      <span class="meta-cell-renderer__long-text">{{ longTextDisplay }}</span>
     </template>
 
     <!-- date -->
@@ -176,6 +178,7 @@ import { isSystemFieldType } from '../../utils/system-fields'
 import { resolveRatingFieldProperty } from '../../utils/field-config'
 import { percentGaugeAria, ratingGaugeAria } from '../../utils/meta-core-labels'
 import { qrSvgFromText } from '../../utils/qr-code'
+import { isRichLongTextField, richLongTextToPlainTextFE } from '../../utils/rich-longtext'
 
 const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[] }>()
 const { isZh } = useLocale()
@@ -190,6 +193,16 @@ const displayValue = computed(() => {
   })
 })
 const isSystemField = computed(() => isSystemFieldType(props.field.type))
+
+// Grid long-text display: for a RICH longText field show the tag-stripped
+// plain-text projection (§7 grid-vs-drawer) so the cell reads as text, never
+// `<p>…</p>`. Plain (non-rich) longText keeps the existing formatted display.
+const longTextDisplay = computed(() => {
+  if (isRichLongTextField(props.field)) {
+    return richLongTextToPlainTextFE(props.value)
+  }
+  return displayValue.value
+})
 
 // Render-only QR: encode the cell's own string value into an inline SVG. On an
 // over-capacity / unencodable value, fall back to null so the cell shows the

--- a/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
@@ -69,6 +69,7 @@
       @input="onInput"
       @blur="onBlur"
       @paste="onPaste"
+      @drop="onDrop"
       @keydown.meta.enter.prevent="onConfirm"
       @keydown.ctrl.enter.prevent="onConfirm"
       @keydown.escape.prevent="emit('cancel')"
@@ -176,6 +177,20 @@ function onPaste(event: ClipboardEvent): void {
   const text = event.clipboardData?.getData('text/plain') ?? ''
   // execCommand insertText keeps the caret behavior natural; sanitize on the
   // subsequent input emit covers the result regardless.
+  document.execCommand('insertText', false, text)
+  emitLive()
+}
+
+/**
+ * Drop as PLAIN text only — mirror of `onPaste`. A drag-drop of HTML (e.g.
+ * `<img src=x onerror=...>`) would otherwise be inserted as live markup into the
+ * contenteditable and could fire an inline handler in THIS user's surface before
+ * the sanitize-on-emit runs (self-XSS). preventDefault + plain-text insert closes
+ * that surface; the emitted value is still sanitized regardless.
+ */
+function onDrop(event: DragEvent): void {
+  event.preventDefault()
+  const text = event.dataTransfer?.getData('text/plain') ?? ''
   document.execCommand('insertText', false, text)
   emitLive()
 }

--- a/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
@@ -69,6 +69,9 @@
       @input="onInput"
       @blur="onBlur"
       @paste="onPaste"
+      @keydown.meta.enter.prevent="onConfirm"
+      @keydown.ctrl.enter.prevent="onConfirm"
+      @keydown.escape.prevent="emit('cancel')"
     />
   </div>
 </template>
@@ -151,6 +154,20 @@ function onBlur(): void {
   const value = currentValue()
   emit('update:modelValue', value)
   emit('change', value)
+}
+
+/**
+ * Cmd/Ctrl+Enter = confirm, mirroring the plain textarea's commit keybinding. Push
+ * the current value on all three channels (live model, `change` commit, `confirm`)
+ * so every host commits correctly: the grid cell editor commits on `confirm`, the
+ * drawer on `change`, buffered hosts on `update:modelValue`. (Plain Enter inserts a
+ * newline as usual — only the modifier chord commits.)
+ */
+function onConfirm(): void {
+  const value = currentValue()
+  emit('update:modelValue', value)
+  emit('change', value)
+  emit('confirm')
 }
 
 /** Paste as PLAIN text only — never trust pasted HTML in the editor surface. */

--- a/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
@@ -65,6 +65,7 @@
       aria-multiline="true"
       :aria-label="ariaContent"
       data-test="rich-longtext-editor"
+      @focus="onFocus"
       @input="onInput"
       @blur="onBlur"
       @paste="onPaste"
@@ -83,12 +84,23 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
+  /** Live value on every input — for hosts that buffer locally (form / cell editor). */
   (e: 'update:modelValue', value: string): void
+  /**
+   * Commit-time value, emitted on blur. The drawer listens to THIS (not the live
+   * `update:modelValue`) so it patches the server ONCE per edit session, mirroring
+   * the plain `<textarea>`'s `@change` semantics — never a PATCH per keystroke.
+   */
+  (e: 'change', value: string): void
   (e: 'confirm'): void
   (e: 'cancel'): void
 }>()
 
 const editableRef = ref<HTMLDivElement | null>(null)
+// True while the user is actively editing this surface — used to suppress
+// model→DOM re-sync so a sanitized value flowing back never rewrites innerHTML
+// mid-type and jumps the caret.
+const focused = ref(false)
 
 const zh = () => props.isZh !== false
 
@@ -111,23 +123,34 @@ const listLabels = { ul: zh() ? '无序列表' : 'Bullet list', ol: zh() ? '有�
 const linkLabels = { add: zh() ? '插入链接' : 'Insert link', remove: zh() ? '移除链接' : 'Remove link' }
 
 /**
- * Push the contenteditable's current HTML to the parent. The value is run through
- * the SHARED client sanitizer first so the editor never EMITS markup outside the
- * §5 allow-list. This is NOT the trust boundary (the server re-sanitizes on write
- * regardless) — it just keeps the model clean and consistent with what the render
- * component would show.
+ * Current sanitized HTML of the editable surface. The value is run through the
+ * SHARED client sanitizer so the editor never EMITS markup outside the §5
+ * allow-list. This is NOT the trust boundary (the server re-sanitizes on write
+ * regardless) — it just keeps the model clean and consistent with the render.
  */
-function emitValue(): void {
-  const raw = editableRef.value?.innerHTML ?? ''
-  emit('update:modelValue', sanitizeRichLongTextHtml(raw))
+function currentValue(): string {
+  return sanitizeRichLongTextHtml(editableRef.value?.innerHTML ?? '')
+}
+
+/** Live update (every keystroke / command) — buffered hosts only. */
+function emitLive(): void {
+  emit('update:modelValue', currentValue())
 }
 
 function onInput(): void {
-  emitValue()
+  emitLive()
 }
 
+function onFocus(): void {
+  focused.value = true
+}
+
+/** Blur = commit. Emit BOTH the final live value and the `change` commit event. */
 function onBlur(): void {
-  emitValue()
+  focused.value = false
+  const value = currentValue()
+  emit('update:modelValue', value)
+  emit('change', value)
 }
 
 /** Paste as PLAIN text only — never trust pasted HTML in the editor surface. */
@@ -137,20 +160,20 @@ function onPaste(event: ClipboardEvent): void {
   // execCommand insertText keeps the caret behavior natural; sanitize on the
   // subsequent input emit covers the result regardless.
   document.execCommand('insertText', false, text)
-  emitValue()
+  emitLive()
 }
 
 function exec(command: string): void {
   editableRef.value?.focus()
   document.execCommand(command, false)
-  emitValue()
+  emitLive()
 }
 
 function formatBlock(tag: string): void {
   editableRef.value?.focus()
   // Browsers expect the tag wrapped in <> for formatBlock.
   document.execCommand('formatBlock', false, `<${tag}>`)
-  emitValue()
+  emitLive()
 }
 
 function addLink(): void {
@@ -164,7 +187,7 @@ function addLink(): void {
     return
   }
   document.execCommand('createLink', false, url.trim())
-  emitValue()
+  emitLive()
 }
 
 /**
@@ -175,6 +198,11 @@ function addLink(): void {
 function syncFromModel(): void {
   const el = editableRef.value
   if (!el) return
+  // NEVER rewrite innerHTML while the user is editing: a sanitized value flowing
+  // back from our own emit (or a normalization round-trip) would stomp the live
+  // DOM and jump the caret. Re-sync only applies external changes received while
+  // the surface is blurred.
+  if (focused.value) return
   const next = sanitizeRichLongTextHtml(props.modelValue)
   if (el.innerHTML !== next) el.innerHTML = next
 }
@@ -187,8 +215,8 @@ onMounted(() => {
 watch(
   () => props.modelValue,
   () => {
-    // Only re-sync from an external change; the live-typing path already mutated
-    // the DOM, and syncFromModel's equality guard avoids caret jumps.
+    // Only re-sync external changes; the focus guard in syncFromModel prevents a
+    // mid-type caret jump from our own emitted value flowing back.
     syncFromModel()
   },
 )

--- a/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextEditor.vue
@@ -1,0 +1,261 @@
+<template>
+  <div class="meta-rich-editor">
+    <div class="meta-rich-editor__toolbar" role="toolbar" :aria-label="ariaToolbar">
+      <button
+        v-for="cmd in inlineCommands"
+        :key="cmd.command"
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="cmd.label"
+        :aria-label="cmd.label"
+        :data-command="cmd.command"
+        @mousedown.prevent="exec(cmd.command)"
+      >{{ cmd.icon }}</button>
+      <span class="meta-rich-editor__sep" aria-hidden="true" />
+      <button
+        v-for="block in blockCommands"
+        :key="block.value"
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="block.label"
+        :aria-label="block.label"
+        :data-block="block.value"
+        @mousedown.prevent="formatBlock(block.value)"
+      >{{ block.icon }}</button>
+      <span class="meta-rich-editor__sep" aria-hidden="true" />
+      <button
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="listLabels.ul"
+        :aria-label="listLabels.ul"
+        data-command="insertUnorderedList"
+        @mousedown.prevent="exec('insertUnorderedList')"
+      >•≡</button>
+      <button
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="listLabels.ol"
+        :aria-label="listLabels.ol"
+        data-command="insertOrderedList"
+        @mousedown.prevent="exec('insertOrderedList')"
+      >1≡</button>
+      <span class="meta-rich-editor__sep" aria-hidden="true" />
+      <button
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="linkLabels.add"
+        :aria-label="linkLabels.add"
+        data-command="createLink"
+        @mousedown.prevent="addLink"
+      >🔗</button>
+      <button
+        type="button"
+        class="meta-rich-editor__btn"
+        :title="linkLabels.remove"
+        :aria-label="linkLabels.remove"
+        data-command="unlink"
+        @mousedown.prevent="exec('unlink')"
+      >⛓</button>
+    </div>
+    <div
+      ref="editableRef"
+      class="meta-rich-editor__content"
+      contenteditable="true"
+      role="textbox"
+      aria-multiline="true"
+      :aria-label="ariaContent"
+      data-test="rich-longtext-editor"
+      @input="onInput"
+      @blur="onBlur"
+      @paste="onPaste"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import { sanitizeRichLongTextHtml } from '../../utils/rich-longtext'
+
+const props = defineProps<{
+  /** Current rich-`longText` HTML value (server-sanitized). */
+  modelValue: unknown
+  isZh?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+  (e: 'confirm'): void
+  (e: 'cancel'): void
+}>()
+
+const editableRef = ref<HTMLDivElement | null>(null)
+
+const zh = () => props.isZh !== false
+
+const ariaToolbar = '富文本格式工具栏'
+const ariaContent = '富文本内容编辑区'
+
+const inlineCommands = [
+  { command: 'bold', icon: 'B', label: zh() ? '加粗' : 'Bold' },
+  { command: 'italic', icon: 'I', label: zh() ? '斜体' : 'Italic' },
+  { command: 'underline', icon: 'U', label: zh() ? '下划线' : 'Underline' },
+  { command: 'strikeThrough', icon: 'S', label: zh() ? '删除线' : 'Strikethrough' },
+]
+const blockCommands = [
+  { value: 'h1', icon: 'H1', label: zh() ? '标题 1' : 'Heading 1' },
+  { value: 'h2', icon: 'H2', label: zh() ? '标题 2' : 'Heading 2' },
+  { value: 'h3', icon: 'H3', label: zh() ? '标题 3' : 'Heading 3' },
+  { value: 'p', icon: '¶', label: zh() ? '正文' : 'Paragraph' },
+]
+const listLabels = { ul: zh() ? '无序列表' : 'Bullet list', ol: zh() ? '有序列表' : 'Numbered list' }
+const linkLabels = { add: zh() ? '插入链接' : 'Insert link', remove: zh() ? '移除链接' : 'Remove link' }
+
+/**
+ * Push the contenteditable's current HTML to the parent. The value is run through
+ * the SHARED client sanitizer first so the editor never EMITS markup outside the
+ * §5 allow-list. This is NOT the trust boundary (the server re-sanitizes on write
+ * regardless) — it just keeps the model clean and consistent with what the render
+ * component would show.
+ */
+function emitValue(): void {
+  const raw = editableRef.value?.innerHTML ?? ''
+  emit('update:modelValue', sanitizeRichLongTextHtml(raw))
+}
+
+function onInput(): void {
+  emitValue()
+}
+
+function onBlur(): void {
+  emitValue()
+}
+
+/** Paste as PLAIN text only — never trust pasted HTML in the editor surface. */
+function onPaste(event: ClipboardEvent): void {
+  event.preventDefault()
+  const text = event.clipboardData?.getData('text/plain') ?? ''
+  // execCommand insertText keeps the caret behavior natural; sanitize on the
+  // subsequent input emit covers the result regardless.
+  document.execCommand('insertText', false, text)
+  emitValue()
+}
+
+function exec(command: string): void {
+  editableRef.value?.focus()
+  document.execCommand(command, false)
+  emitValue()
+}
+
+function formatBlock(tag: string): void {
+  editableRef.value?.focus()
+  // Browsers expect the tag wrapped in <> for formatBlock.
+  document.execCommand('formatBlock', false, `<${tag}>`)
+  emitValue()
+}
+
+function addLink(): void {
+  editableRef.value?.focus()
+  const url = window.prompt(zh() ? '链接地址 (http/https/mailto)' : 'Link URL (http/https/mailto)')
+  if (!url) return
+  // The server + render sanitizer reject non-allow-list protocols; we still guard
+  // here so an obviously bad scheme never gets inserted.
+  if (!/^(?:https?:|mailto:)/i.test(url.trim())) {
+    window.alert(zh() ? '仅支持 http/https/mailto 链接' : 'Only http/https/mailto links are allowed')
+    return
+  }
+  document.execCommand('createLink', false, url.trim())
+  emitValue()
+}
+
+/**
+ * Sync the editable DOM from the model. We only write innerHTML when it actually
+ * differs from the current (sanitized) DOM so we never stomp the user's caret
+ * mid-typing. Incoming value is sanitized before it touches the DOM.
+ */
+function syncFromModel(): void {
+  const el = editableRef.value
+  if (!el) return
+  const next = sanitizeRichLongTextHtml(props.modelValue)
+  if (el.innerHTML !== next) el.innerHTML = next
+}
+
+onMounted(() => {
+  syncFromModel()
+  editableRef.value?.focus()
+})
+
+watch(
+  () => props.modelValue,
+  () => {
+    // Only re-sync from an external change; the live-typing path already mutated
+    // the DOM, and syncFromModel's equality guard avoids caret jumps.
+    syncFromModel()
+  },
+)
+</script>
+
+<style scoped>
+.meta-rich-editor {
+  border: 1px solid #409eff;
+  border-radius: 4px;
+  overflow: hidden;
+  background: #fff;
+}
+.meta-rich-editor__toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 4px 6px;
+  border-bottom: 1px solid #e4e7ed;
+  background: #f8fafc;
+}
+.meta-rich-editor__btn {
+  min-width: 26px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  font-size: 12px;
+  color: #475569;
+  cursor: pointer;
+  line-height: 1;
+}
+.meta-rich-editor__btn:hover {
+  background: #eef2f7;
+  border-color: #dbe4f0;
+}
+.meta-rich-editor__sep {
+  width: 1px;
+  height: 16px;
+  margin: 0 4px;
+  background: #e4e7ed;
+}
+.meta-rich-editor__content {
+  min-height: 96px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.55;
+  outline: none;
+  word-break: break-word;
+}
+.meta-rich-editor__content:empty::before {
+  content: attr(data-placeholder);
+  color: #c0c4cc;
+}
+.meta-rich-editor__content :deep(h1) { font-size: 18px; margin: 0.3em 0; }
+.meta-rich-editor__content :deep(h2) { font-size: 16px; margin: 0.3em 0; }
+.meta-rich-editor__content :deep(h3) { font-size: 14px; margin: 0.3em 0; }
+.meta-rich-editor__content :deep(ul),
+.meta-rich-editor__content :deep(ol) { padding-left: 1.4em; margin: 0.3em 0; }
+.meta-rich-editor__content :deep(a) { color: #2563eb; text-decoration: underline; }
+.meta-rich-editor__content :deep(blockquote) {
+  margin: 0.3em 0;
+  padding: 0.2em 0.8em;
+  border-left: 3px solid #dcdfe6;
+  color: #606266;
+}
+</style>

--- a/apps/web/src/multitable/components/cells/MetaRichLongTextRender.vue
+++ b/apps/web/src/multitable/components/cells/MetaRichLongTextRender.vue
@@ -1,0 +1,70 @@
+<template>
+  <!--
+    SOLE rich-content `v-html` owner in apps/web/src/multitable. Binds ONLY the
+    output of `sanitizeRichLongTextHtml` (DOMPurify, §5 allow-list), which re-runs
+    on EVERY bind — the `safeHtml` computed recomputes whenever `html` changes, so
+    a parser-introduced mXSS breakout is neutralized on every render, not once.
+    No other multitable surface may introduce a user-content `v-html`; drawer /
+    form / grid must render through THIS component.
+
+    (The two pre-existing `v-html` in MetaCellRenderer / MetaRecordDrawer are
+    self-generated QR-code SVG from `qrSvgFromText`, not user content — out of
+    scope for this component. See PR notes.)
+  -->
+  <div class="meta-rich-longtext" v-html="safeHtml" />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { sanitizeRichLongTextHtml } from '../../utils/rich-longtext'
+
+const props = defineProps<{
+  /** Raw (server-sanitized but re-sanitized here) rich-`longText` HTML value. */
+  html: unknown
+}>()
+
+// Re-sanitize on every bind (mXSS defense-in-depth, §2.2). `computed` recomputes
+// whenever `props.html` changes, so each new value passes through DOMPurify before
+// it can reach `v-html`.
+const safeHtml = computed(() => sanitizeRichLongTextHtml(props.html))
+</script>
+
+<style scoped>
+.meta-rich-longtext {
+  font-size: 13px;
+  line-height: 1.55;
+  word-break: break-word;
+  white-space: normal;
+}
+.meta-rich-longtext :deep(p) { margin: 0 0 0.5em; }
+.meta-rich-longtext :deep(p:last-child) { margin-bottom: 0; }
+.meta-rich-longtext :deep(h1) { font-size: 18px; margin: 0.4em 0 0.3em; }
+.meta-rich-longtext :deep(h2) { font-size: 16px; margin: 0.4em 0 0.3em; }
+.meta-rich-longtext :deep(h3) { font-size: 14px; margin: 0.4em 0 0.3em; }
+.meta-rich-longtext :deep(ul),
+.meta-rich-longtext :deep(ol) { margin: 0 0 0.5em; padding-left: 1.4em; }
+.meta-rich-longtext :deep(li) { margin: 0.1em 0; }
+.meta-rich-longtext :deep(blockquote) {
+  margin: 0 0 0.5em;
+  padding: 0.2em 0.8em;
+  border-left: 3px solid #dcdfe6;
+  color: #606266;
+}
+.meta-rich-longtext :deep(code) {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  background: #f6f8fa;
+  border-radius: 3px;
+  padding: 0 4px;
+}
+.meta-rich-longtext :deep(pre) {
+  margin: 0 0 0.5em;
+  padding: 0.6em 0.8em;
+  background: #f6f8fa;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+.meta-rich-longtext :deep(pre) code { background: none; padding: 0; }
+.meta-rich-longtext :deep(a) { color: #2563eb; text-decoration: underline; }
+.meta-rich-longtext :deep(a:hover) { color: #1d4ed8; }
+</style>

--- a/apps/web/src/multitable/utils/rich-longtext.ts
+++ b/apps/web/src/multitable/utils/rich-longtext.ts
@@ -1,0 +1,156 @@
+// Rich-`longText` client-side sanitizer + plain-text projection (§5 / §7 of the
+// multitable rich-text design-lock, 2026-06-14).
+//
+// THIS MODULE IS THE SINGLE SOURCE OF TRUTH for the front-end allow-list. The
+// render component, its specs, and any other FE consumer import the SAME config
+// from here — never re-declare the allow-list inline (that would let a render
+// surface ship a looser policy than the tests assert: wire-vs-fixture drift).
+//
+// Defense-in-depth (§2.2): the SERVER already sanitizes rich-`longText` on write
+// (`sanitizeRichLongText`, sanitize-html) so the stored value is inert by
+// construction. This client pass re-sanitizes on EVERY render because the
+// browser's HTML parser can mutate server-clean markup on re-parse (mutation-XSS
+// / mXSS). Client re-sanitize is therefore load-bearing, not optional.
+//
+// The allow-list here MUST stay in lock-step with the server's
+// `RICH_LONGTEXT_SANITIZE_OPTIONS` (packages/core-backend/.../field-codecs.ts).
+
+import DOMPurify from 'dompurify'
+import type { MetaField } from '../types'
+
+/**
+ * Allowed tags (§5) — inline marks, links, lists, headings, block text.
+ * Identical set to the server allow-list.
+ */
+export const RICH_LONGTEXT_ALLOWED_TAGS = [
+  'b', 'strong', 'i', 'em', 'u', 's',
+  'a',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3',
+  'p', 'br', 'blockquote', 'code', 'pre',
+] as const
+
+/**
+ * Allowed attributes (§5): `href` on `<a>` only. `rel`/`target` are FORCED by the
+ * post-sanitize hook below (never user-controlled) but must be allow-listed or
+ * DOMPurify would strip them right after the hook adds them.
+ */
+export const RICH_LONGTEXT_ALLOWED_ATTR = ['href', 'rel', 'target'] as const
+
+/**
+ * Tags dropped WITH their contents (no inner-text leak). DOMPurify already drops
+ * most of these with content, but listing them in FORBID_TAGS + KEEP_CONTENT:false
+ * makes the policy explicit and matches the server's `nonTextTags`.
+ */
+export const RICH_LONGTEXT_FORBID_TAGS = [
+  'script', 'style', 'iframe', 'object', 'embed', 'form', 'svg', 'noscript', 'textarea', 'title',
+] as const
+
+/**
+ * Protocol allow-list (§5): `http`, `https`, `mailto` only. DOMPurify decodes
+ * entity-encoded protocols (e.g. `&#106;avascript:`) BEFORE testing this regexp,
+ * so `javascript:` is rejected whether plain or encoded. `//evil.com`
+ * (protocol-relative) and `data:` are rejected too — the regexp requires one of
+ * the three schemes at the very start.
+ */
+export const RICH_LONGTEXT_ALLOWED_URI_REGEXP = /^(?:https?|mailto):/i
+
+/**
+ * The DOMPurify config object passed on EVERY sanitize. Frozen so a consumer
+ * cannot mutate the shared policy at runtime.
+ */
+export const RICH_LONGTEXT_SANITIZE_CONFIG: Readonly<Record<string, unknown>> = Object.freeze({
+  ALLOWED_TAGS: [...RICH_LONGTEXT_ALLOWED_TAGS],
+  ALLOWED_ATTR: [...RICH_LONGTEXT_ALLOWED_ATTR],
+  FORBID_TAGS: [...RICH_LONGTEXT_FORBID_TAGS],
+  // Drop these tags WITH their inner content (mirror the server `nonTextTags`) so a
+  // `<noscript>…`-style mXSS payload can't leak its inner text. This is scoped to the
+  // forbidden set ONLY — keeping global KEEP_CONTENT at its default (true) so the text
+  // INSIDE allowed tags (e.g. `<strong>hi</strong>`) is preserved, and text around a
+  // non-allowed wrapper (e.g. an unwrapped `<div>`) is kept too.
+  FORBID_CONTENTS: [...RICH_LONGTEXT_FORBID_TAGS],
+  ALLOWED_URI_REGEXP: RICH_LONGTEXT_ALLOWED_URI_REGEXP,
+  // No CSS / data-URIs / unknown protocols anywhere.
+  ALLOW_DATA_ATTR: false,
+  ALLOW_ARIA_ATTR: false,
+  ALLOW_UNKNOWN_PROTOCOLS: false,
+  // Return a string (not a DOM node).
+  RETURN_DOM: false,
+  RETURN_DOM_FRAGMENT: false,
+  // Defense against template-injection style breakouts.
+  SAFE_FOR_TEMPLATES: false,
+})
+
+let linkHookInstalled = false
+
+/**
+ * Install (once) the post-sanitize hook that FORCES `rel="noopener noreferrer"`
+ * and `target="_blank"` on every surviving `<a>`. This runs after DOMPurify has
+ * already stripped any unsafe href (protocol not in the allow-list), so the
+ * forced attributes only ever land on links DOMPurify kept. Anchors whose href
+ * was rejected are left without href — harmless, inert text-bearing anchors.
+ */
+function ensureLinkHardeningHook(): void {
+  if (linkHookInstalled) return
+  // `afterSanitizeAttributes` fires per-node after attribute filtering.
+  DOMPurify.addHook('afterSanitizeAttributes', (node: Element) => {
+    if (node.nodeName === 'A' && node.hasAttribute('href')) {
+      node.setAttribute('rel', 'noopener noreferrer')
+      node.setAttribute('target', '_blank')
+    }
+  })
+  linkHookInstalled = true
+}
+
+/**
+ * Sanitize a rich-`longText` HTML string against the §5 allow-list, returning
+ * allow-list-clean HTML safe to bind with `v-html`. Pure relative to the shared
+ * config; runs on every call (mXSS defense — see module header).
+ *
+ * Coerces non-string input to '' so a malformed value can never reach `v-html`.
+ */
+export function sanitizeRichLongTextHtml(value: unknown): string {
+  if (typeof value !== 'string' || value === '') return ''
+  ensureLinkHardeningHook()
+  return DOMPurify.sanitize(value, RICH_LONGTEXT_SANITIZE_CONFIG) as unknown as string
+}
+
+/**
+ * Unified FE plain-text projection (§7): strip ALL tags from a (possibly rich)
+ * `longText` value down to its text content, so the grid cell shows readable text
+ * (never `<p>…</p>`). Uses DOMPurify with an empty tag allow-list — the same
+ * decode-then-strip approach the server projection (`richLongTextToPlainText`)
+ * uses, kept symmetric. Safe on plain (non-rich) values too: they have no tags,
+ * so the value is returned effectively unchanged (entities decoded).
+ *
+ * NOTE: the server owns the export and (deferred) search projections (#2598:
+ * `univer-meta.ts` export, `query-service.ts` search). This FE helper's sole
+ * consumer is the grid-cell display projection — see the design reconciliation
+ * note in the PR. One helper, here, for the FE render lane.
+ */
+export function richLongTextToPlainTextFE(value: unknown): string {
+  if (typeof value !== 'string' || value === '') return ''
+  const stripped = DOMPurify.sanitize(value, {
+    ALLOWED_TAGS: [],
+    ALLOWED_ATTR: [],
+    KEEP_CONTENT: true,
+  }) as unknown as string
+  // Collapse residual whitespace introduced by block-tag removal so the grid cell
+  // reads as a single clean line of text.
+  return stripped.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Strict predicate: is this field a RICH `longText` (`property.rich === true`)?
+ * Mirrors the server's `isRichLongTextProperty` so every FE gate (renderer,
+ * editor, drawer, form) opts in identically. Anything other than the literal
+ * boolean `true` → not rich (today's plain behavior, unchanged).
+ */
+export function isRichLongTextField(field: Pick<MetaField, 'type' | 'property'>): boolean {
+  return (
+    field.type === 'longText' &&
+    !!field.property &&
+    typeof field.property === 'object' &&
+    (field.property as Record<string, unknown>).rich === true
+  )
+}

--- a/apps/web/src/multitable/utils/rich-longtext.ts
+++ b/apps/web/src/multitable/utils/rich-longtext.ts
@@ -15,7 +15,7 @@
 // The allow-list here MUST stay in lock-step with the server's
 // `RICH_LONGTEXT_SANITIZE_OPTIONS` (packages/core-backend/.../field-codecs.ts).
 
-import DOMPurify from 'dompurify'
+import DOMPurify, { type Config as DOMPurifyConfig } from 'dompurify'
 import type { MetaField } from '../types'
 
 /**
@@ -59,7 +59,7 @@ export const RICH_LONGTEXT_ALLOWED_URI_REGEXP = /^(?:https?|mailto):/i
  * The DOMPurify config object passed on EVERY sanitize. Frozen so a consumer
  * cannot mutate the shared policy at runtime.
  */
-export const RICH_LONGTEXT_SANITIZE_CONFIG: Readonly<Record<string, unknown>> = Object.freeze({
+export const RICH_LONGTEXT_SANITIZE_CONFIG: Readonly<DOMPurifyConfig> = Object.freeze({
   ALLOWED_TAGS: [...RICH_LONGTEXT_ALLOWED_TAGS],
   ALLOWED_ATTR: [...RICH_LONGTEXT_ALLOWED_ATTR],
   FORBID_TAGS: [...RICH_LONGTEXT_FORBID_TAGS],
@@ -112,7 +112,8 @@ function ensureLinkHardeningHook(): void {
 export function sanitizeRichLongTextHtml(value: unknown): string {
   if (typeof value !== 'string' || value === '') return ''
   ensureLinkHardeningHook()
-  return DOMPurify.sanitize(value, RICH_LONGTEXT_SANITIZE_CONFIG) as unknown as string
+  // The cfg has no RETURN_DOM* flag, so this overload of sanitize returns a string.
+  return DOMPurify.sanitize(value, RICH_LONGTEXT_SANITIZE_CONFIG)
 }
 
 /**
@@ -134,7 +135,7 @@ export function richLongTextToPlainTextFE(value: unknown): string {
     ALLOWED_TAGS: [],
     ALLOWED_ATTR: [],
     KEEP_CONTENT: true,
-  }) as unknown as string
+  })
   // Collapse residual whitespace introduced by block-tag removal so the grid cell
   // reads as a single clean line of text.
   return stripped.replace(/\s+/g, ' ').trim()

--- a/apps/web/tests/multitable-richtext-longtext.spec.ts
+++ b/apps/web/tests/multitable-richtext-longtext.spec.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaRichLongTextRender from '../src/multitable/components/cells/MetaRichLongTextRender.vue'
+import {
+  sanitizeRichLongTextHtml,
+  richLongTextToPlainTextFE,
+  isRichLongTextField,
+  RICH_LONGTEXT_SANITIZE_CONFIG,
+} from '../src/multitable/utils/rich-longtext'
+
+// §8 fail-first matrix for the rich-`longText` FE render lane.
+//
+// These tests exercise the REAL shared sanitizer (`sanitizeRichLongTextHtml`) and
+// the REAL render component (`MetaRichLongTextRender`), NOT a hand-rolled DOMPurify
+// call — so the test asserts the exact allow-list the component ships (no
+// wire-vs-fixture drift). The component is the sole `v-html` owner; if its policy
+// ever loosens, these canaries fail.
+
+/** Has the sanitized output any executable / unsafe residue? */
+function hasExecutableResidue(html: string): boolean {
+  const low = html.toLowerCase()
+  return (
+    low.includes('<script') ||
+    low.includes('<iframe') ||
+    low.includes('<object') ||
+    low.includes('<embed') ||
+    low.includes('<form') ||
+    low.includes('<svg') ||
+    low.includes('<img') ||
+    low.includes('javascript:') ||
+    low.includes('onerror') ||
+    low.includes('onmouseover') ||
+    /\son\w+\s*=/.test(low) ||
+    low.includes('style=')
+  )
+}
+
+describe('rich-longText FE sanitizer — §8 XSS canaries (every one neutralized)', () => {
+  const canaries: Array<{ name: string; payload: string }> = [
+    { name: 'script tag', payload: '<script>alert(1)</script>' },
+    { name: 'img onerror', payload: '<img src=x onerror=alert(1)>' },
+    { name: 'javascript: link', payload: '<a href="javascript:alert(1)">x</a>' },
+    { name: 'encoded javascript: link', payload: '<a href="&#106;avascript:alert(1)">x</a>' },
+    { name: 'inline event handler', payload: '<p onmouseover="alert(1)">x</p>' },
+    { name: 'style url() injection', payload: '<div style="background:url(javascript:alert(1))">x</div>' },
+    {
+      name: 'embedded/foreign content',
+      payload: '<iframe src=//evil></iframe><object></object><embed><form></form>',
+    },
+    {
+      name: 'mXSS noscript breakout',
+      payload: '<noscript><p title="</noscript><img src=x onerror=alert(1)>">',
+    },
+  ]
+
+  for (const { name, payload } of canaries) {
+    it(`neutralizes: ${name}`, () => {
+      const out = sanitizeRichLongTextHtml(payload)
+      expect(hasExecutableResidue(out), `unsafe residue in: ${out}`).toBe(false)
+    })
+  }
+
+  it('drops the href on a javascript: link but keeps the text', () => {
+    const out = sanitizeRichLongTextHtml('<a href="javascript:alert(1)">click</a>')
+    expect(out).not.toContain('javascript:')
+    expect(out).not.toContain('href')
+    expect(out).toContain('click')
+  })
+
+  it('drops the href on an entity-encoded javascript: link', () => {
+    const out = sanitizeRichLongTextHtml('<a href="&#106;avascript:alert(1)">click</a>')
+    expect(out).not.toContain('javascript:')
+    expect(out).not.toContain('href')
+    expect(out).toContain('click')
+  })
+
+  it('strips a protocol-relative link href (//evil.com)', () => {
+    const out = sanitizeRichLongTextHtml('<a href="//evil.com">x</a>')
+    expect(out).not.toContain('href')
+    expect(out).toContain('x')
+  })
+})
+
+describe('rich-longText FE sanitizer — benign formatting preserved (§8.9)', () => {
+  it('keeps bold / italic / link / list / heading and forces rel+target', () => {
+    const out = sanitizeRichLongTextHtml(
+      '<strong>hi</strong> <em>there</em> <a href="https://x.com">link</a><ul><li>a</li></ul><h1>H</h1>',
+    )
+    expect(out).toContain('<strong>hi</strong>')
+    expect(out).toContain('<em>there</em>')
+    expect(out).toContain('<a href="https://x.com"')
+    expect(out).toContain('rel="noopener noreferrer"')
+    expect(out).toContain('target="_blank"')
+    expect(out).toContain('<ul><li>a</li></ul>')
+    expect(out).toContain('<h1>H</h1>')
+  })
+
+  it('keeps underline / strike / blockquote / code / pre', () => {
+    const out = sanitizeRichLongTextHtml(
+      '<u>u</u><s>s</s><blockquote>q</blockquote><code>c</code><pre>p</pre>',
+    )
+    expect(out).toContain('<u>u</u>')
+    expect(out).toContain('<s>s</s>')
+    expect(out).toContain('<blockquote>q</blockquote>')
+    expect(out).toContain('<code>c</code>')
+    expect(out).toContain('<pre>p</pre>')
+  })
+
+  it('keeps an https link with its safe href', () => {
+    const out = sanitizeRichLongTextHtml('<a href="https://example.com/path?q=1">e</a>')
+    expect(out).toContain('href="https://example.com/path?q=1"')
+  })
+
+  it('keeps a mailto link', () => {
+    const out = sanitizeRichLongTextHtml('<a href="mailto:a@b.com">mail</a>')
+    expect(out).toContain('href="mailto:a@b.com"')
+  })
+})
+
+describe('rich-longText FE plain-text projection (§7, grid-cell consumer)', () => {
+  it('strips all tags down to text content', () => {
+    const out = richLongTextToPlainTextFE('<p>Hello <strong>World</strong></p>')
+    expect(out).not.toMatch(/[<>]/)
+    expect(out).toContain('Hello')
+    expect(out).toContain('World')
+  })
+
+  it('flattens lists to text', () => {
+    const out = richLongTextToPlainTextFE('<ul><li>a</li><li>b</li></ul>')
+    expect(out).not.toMatch(/[<>]/)
+    expect(out).toContain('a')
+    expect(out).toContain('b')
+  })
+
+  it('returns plain (non-rich) text unchanged', () => {
+    expect(richLongTextToPlainTextFE('just text')).toBe('just text')
+  })
+
+  it('never leaks executable markup into the projection', () => {
+    const out = richLongTextToPlainTextFE('<script>alert(1)</script>visible')
+    expect(out).not.toContain('script')
+    expect(out).not.toContain('alert')
+    expect(out).toContain('visible')
+  })
+
+  it('handles empty / nullish input', () => {
+    expect(richLongTextToPlainTextFE('')).toBe('')
+    expect(richLongTextToPlainTextFE(null)).toBe('')
+    expect(richLongTextToPlainTextFE(undefined)).toBe('')
+  })
+})
+
+describe('isRichLongTextField — strict opt-in predicate', () => {
+  it('true only for longText with property.rich === true', () => {
+    expect(isRichLongTextField({ type: 'longText', property: { rich: true } } as never)).toBe(true)
+  })
+  it('false for truthy-but-non-boolean rich', () => {
+    expect(isRichLongTextField({ type: 'longText', property: { rich: 'true' } } as never)).toBe(false)
+    expect(isRichLongTextField({ type: 'longText', property: { rich: 1 } } as never)).toBe(false)
+  })
+  it('false for plain longText (no rich)', () => {
+    expect(isRichLongTextField({ type: 'longText', property: {} } as never)).toBe(false)
+    expect(isRichLongTextField({ type: 'longText' } as never)).toBe(false)
+  })
+  it('false for non-longText even with rich:true', () => {
+    expect(isRichLongTextField({ type: 'string', property: { rich: true } } as never)).toBe(false)
+  })
+})
+
+describe('MetaRichLongTextRender component — sole v-html owner, re-sanitizes on bind', () => {
+  function mount(html: unknown) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      render() {
+        return h(MetaRichLongTextRender, { html })
+      },
+    })
+    app.mount(container)
+    return { container, app }
+  }
+
+  it('renders benign formatting as real DOM (bold + link)', async () => {
+    const { container, app } = mount('<strong>hi</strong> <a href="https://x.com">l</a>')
+    await nextTick()
+    const root = container.querySelector('.meta-rich-longtext') as HTMLElement
+    expect(root.querySelector('strong')?.textContent).toBe('hi')
+    const a = root.querySelector('a') as HTMLAnchorElement
+    expect(a.getAttribute('href')).toBe('https://x.com')
+    expect(a.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(a.getAttribute('target')).toBe('_blank')
+    app.unmount()
+    container.remove()
+  })
+
+  it('injects NO script element for a script payload', async () => {
+    const { container, app } = mount('<script>window.__pwned = 1</script>safe')
+    await nextTick()
+    const root = container.querySelector('.meta-rich-longtext') as HTMLElement
+    expect(root.querySelector('script')).toBeNull()
+    expect(root.innerHTML).not.toContain('script')
+    expect(root.textContent).toContain('safe')
+    expect((window as unknown as { __pwned?: number }).__pwned).toBeUndefined()
+    app.unmount()
+    container.remove()
+  })
+
+  it('injects NO img with onerror', async () => {
+    const { container, app } = mount('<img src=x onerror="window.__pwned2 = 1">')
+    await nextTick()
+    const root = container.querySelector('.meta-rich-longtext') as HTMLElement
+    expect(root.querySelector('img')).toBeNull()
+    expect(root.innerHTML.toLowerCase()).not.toContain('onerror')
+    app.unmount()
+    container.remove()
+  })
+
+  it('re-sanitizes when the bound value changes (every bind, not once)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    let current: unknown = '<strong>first</strong>'
+    const app = createApp({
+      data: () => ({ html: current }),
+      render(this: { html: unknown }) {
+        return h(MetaRichLongTextRender, { html: this.html })
+      },
+      mounted(this: { html: unknown }) {
+        // expose a setter so the test can mutate the bound value
+        ;(this as unknown as { setHtml: (v: unknown) => void }).setHtml = (v: unknown) => {
+          this.html = v
+        }
+      },
+    })
+    const vm = app.mount(container) as unknown as { setHtml: (v: unknown) => void }
+    await nextTick()
+    let root = container.querySelector('.meta-rich-longtext') as HTMLElement
+    expect(root.querySelector('strong')?.textContent).toBe('first')
+    // Re-bind a malicious value: it must ALSO be sanitized.
+    vm.setHtml('<img src=x onerror="window.__pwned3 = 1"><em>second</em>')
+    await nextTick()
+    root = container.querySelector('.meta-rich-longtext') as HTMLElement
+    expect(root.querySelector('img')).toBeNull()
+    expect(root.querySelector('em')?.textContent).toBe('second')
+    expect((window as unknown as { __pwned3?: number }).__pwned3).toBeUndefined()
+    app.unmount()
+    container.remove()
+    void current
+  })
+})
+
+describe('shared config invariants', () => {
+  it('exports a frozen sanitize config (no runtime policy mutation)', () => {
+    expect(Object.isFrozen(RICH_LONGTEXT_SANITIZE_CONFIG)).toBe(true)
+  })
+})

--- a/apps/web/tests/multitable-richtext-longtext.spec.ts
+++ b/apps/web/tests/multitable-richtext-longtext.spec.ts
@@ -28,6 +28,14 @@ function hasExecutableResidue(html: string): boolean {
     low.includes('<svg') ||
     low.includes('<img') ||
     low.includes('javascript:') ||
+    low.includes('vbscript:') ||
+    low.includes('data:text/html') ||
+    low.includes('<math') ||
+    low.includes('<template') ||
+    low.includes('<base') ||
+    low.includes('<meta') ||
+    low.includes('srcdoc') ||
+    low.includes('formaction') ||
     low.includes('onerror') ||
     low.includes('onmouseover') ||
     /\son\w+\s*=/.test(low) ||
@@ -51,6 +59,21 @@ describe('rich-longText FE sanitizer — §8 XSS canaries (every one neutralized
       name: 'mXSS noscript breakout',
       payload: '<noscript><p title="</noscript><img src=x onerror=alert(1)>">',
     },
+    // Extra adversarial probes (review N1/N2) — namespace confusion, DOM clobbering,
+    // alternative protocols, and document-level vectors. The allow-list excludes all of
+    // these tags/attrs; these canaries pin the regression net against a future config edit.
+    { name: 'MathML namespace confusion', payload: '<math><mtext><script>alert(1)</script></mtext></math>' },
+    { name: 'svg script', payload: '<svg><script>alert(1)</script></svg>' },
+    { name: 'svg foreignObject', payload: '<svg><foreignObject><img src=x onerror=alert(1)></foreignObject></svg>' },
+    { name: 'template smuggling', payload: '<template><img src=x onerror=alert(1)></template>' },
+    { name: 'iframe srcdoc', payload: '<iframe srcdoc="<img src=x onerror=alert(1)>"></iframe>' },
+    { name: 'DOM clobbering id=form', payload: '<form id="form"><input name="attributes"></form>' },
+    { name: 'formaction button', payload: '<button formaction="javascript:alert(1)">x</button>' },
+    { name: 'base href hijack', payload: '<base href="//evil/">' },
+    { name: 'meta refresh', payload: '<meta http-equiv="refresh" content="0;url=javascript:alert(1)">' },
+    { name: 'vbscript link', payload: '<a href="vbscript:msgbox(1)">x</a>' },
+    { name: 'data:text/html link', payload: '<a href="data:text/html,<script>alert(1)</script>">x</a>' },
+    { name: 'whitespace-split javascript: link', payload: '<a href="java\tscript:alert(1)">x</a>' },
   ]
 
   for (const { name, payload } of canaries) {

--- a/apps/web/tests/multitable-richtext-wiring.spec.ts
+++ b/apps/web/tests/multitable-richtext-wiring.spec.ts
@@ -125,6 +125,53 @@ describe('cell editor (MetaCellEditor) — rich vs plain editor selection', () =
     app.unmount()
     container.remove()
   })
+
+  // The grid commits a cell edit ONLY on the editor's `confirm` event and cancels
+  // on `cancel` (MetaGridTable has no blur/click-away commit). So the rich editor
+  // MUST forward confirm/cancel through MetaCellEditor or inline rich edits silently
+  // never save — a data-loss path these tests lock.
+  it('forwards confirm (Cmd/Ctrl+Enter) so the grid can commit an inline rich edit', async () => {
+    const confirmSpy = vi.fn()
+    const updateSpy = vi.fn()
+    const { container, app } = mount(MetaCellEditor, {
+      field: RICH,
+      modelValue: '<b>x</b>',
+      recordId: 'rec_1',
+      'onUpdate:modelValue': updateSpy,
+      onConfirm: confirmSpy,
+      onCancel: vi.fn(),
+      onOpenLinkPicker: vi.fn(),
+    })
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }))
+    await nextTick()
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    // The latest value is pushed before confirm so the grid reads the current edit.
+    expect(updateSpy).toHaveBeenCalled()
+    app.unmount()
+    container.remove()
+  })
+
+  it('forwards cancel (Escape) so the grid can cancel an inline rich edit', async () => {
+    const cancelSpy = vi.fn()
+    const { container, app } = mount(MetaCellEditor, {
+      field: RICH,
+      modelValue: '<b>x</b>',
+      recordId: 'rec_1',
+      'onUpdate:modelValue': vi.fn(),
+      onConfirm: vi.fn(),
+      onCancel: cancelSpy,
+      onOpenLinkPicker: vi.fn(),
+    })
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(cancelSpy).toHaveBeenCalledTimes(1)
+    app.unmount()
+    container.remove()
+  })
 })
 
 describe('MetaRichLongTextEditor — commit semantics (drawer PATCH-on-blur, no flood)', () => {

--- a/apps/web/tests/multitable-richtext-wiring.spec.ts
+++ b/apps/web/tests/multitable-richtext-wiring.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+
+// Wiring tests (§6.3/§6.4/§7): verify each surface picks the rich path for a
+// `rich` longText field and the unchanged plain path otherwise (backward-compat).
+
+const RICH = { id: 'fld_rt', name: 'Notes', type: 'longText', property: { rich: true } }
+const PLAIN = { id: 'fld_pt', name: 'Notes', type: 'longText' }
+
+function mount(component: unknown, props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(component as never, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('grid cell (MetaCellRenderer) — §7 plain-text projection for rich', () => {
+  it('shows tag-stripped text (not HTML) for a rich longText cell', async () => {
+    const { container, app } = mount(MetaCellRenderer, {
+      field: RICH,
+      value: '<p>Hello <strong>World</strong></p>',
+    })
+    await nextTick()
+    const cell = container.querySelector('.meta-cell-renderer__long-text') as HTMLElement
+    // No element children -> rendered as plain text, not parsed HTML.
+    expect(cell.querySelector('strong')).toBeNull()
+    expect(cell.querySelector('p')).toBeNull()
+    expect(cell.textContent).toContain('Hello')
+    expect(cell.textContent).toContain('World')
+    // The literal markup must NOT appear as escaped text in the grid either.
+    expect(cell.textContent).not.toContain('<p>')
+    app.unmount()
+    container.remove()
+  })
+
+  it('never renders a script tag from a rich cell value', async () => {
+    const { container, app } = mount(MetaCellRenderer, {
+      field: RICH,
+      value: '<script>window.__gridpwn = 1</script>visible',
+    })
+    await nextTick()
+    const cell = container.querySelector('.meta-cell-renderer__long-text') as HTMLElement
+    expect(cell.querySelector('script')).toBeNull()
+    expect(cell.textContent).toContain('visible')
+    expect((window as unknown as { __gridpwn?: number }).__gridpwn).toBeUndefined()
+    app.unmount()
+    container.remove()
+  })
+
+  it('plain longText cell display is unchanged (escaped multiline text)', async () => {
+    const { container, app } = mount(MetaCellRenderer, {
+      field: PLAIN,
+      value: 'line 1\nline 2',
+    })
+    await nextTick()
+    const cell = container.querySelector('.meta-cell-renderer__long-text') as HTMLElement
+    expect(cell.textContent).toBe('line 1\nline 2')
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('cell editor (MetaCellEditor) — rich vs plain editor selection', () => {
+  it('renders the rich editor (contenteditable) for a rich longText field', async () => {
+    const { container, app } = mount(MetaCellEditor, {
+      field: RICH,
+      modelValue: '<strong>hi</strong>',
+      recordId: 'rec_1',
+      'onUpdate:modelValue': vi.fn(),
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      onOpenLinkPicker: vi.fn(),
+    })
+    await nextTick()
+    expect(container.querySelector('[data-test="rich-longtext-editor"]')).not.toBeNull()
+    // The plain textarea path must NOT be used for a rich field.
+    expect(container.querySelector('textarea.meta-cell-editor__textarea')).toBeNull()
+    app.unmount()
+    container.remove()
+  })
+
+  it('renders the plain textarea for a non-rich longText field (unchanged)', async () => {
+    const { container, app } = mount(MetaCellEditor, {
+      field: PLAIN,
+      modelValue: 'plain',
+      recordId: 'rec_1',
+      'onUpdate:modelValue': vi.fn(),
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      onOpenLinkPicker: vi.fn(),
+    })
+    await nextTick()
+    expect(container.querySelector('textarea.meta-cell-editor__textarea')).not.toBeNull()
+    expect(container.querySelector('[data-test="rich-longtext-editor"]')).toBeNull()
+    app.unmount()
+    container.remove()
+  })
+
+  it('the rich editor emits sanitized HTML on input', async () => {
+    const updateSpy = vi.fn()
+    const { container, app } = mount(MetaCellEditor, {
+      field: RICH,
+      modelValue: '',
+      recordId: 'rec_1',
+      'onUpdate:modelValue': updateSpy,
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      onOpenLinkPicker: vi.fn(),
+    })
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    // Simulate a malicious DOM mutation then an input event.
+    editable.innerHTML = '<img src=x onerror="window.__editpwn = 1"><b>kept</b>'
+    editable.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    expect(updateSpy).toHaveBeenCalled()
+    const emitted = updateSpy.mock.calls.at(-1)?.[0] as string
+    expect(emitted.toLowerCase()).not.toContain('onerror')
+    expect(emitted.toLowerCase()).not.toContain('<img')
+    expect(emitted).toContain('<b>kept</b>')
+    app.unmount()
+    container.remove()
+  })
+})

--- a/apps/web/tests/multitable-richtext-wiring.spec.ts
+++ b/apps/web/tests/multitable-richtext-wiring.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
 import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaRichLongTextEditor from '../src/multitable/components/cells/MetaRichLongTextEditor.vue'
 
 // Wiring tests (§6.3/§6.4/§7): verify each surface picks the rich path for a
 // `rich` longText field and the unchanged plain path otherwise (backward-compat).
@@ -121,6 +122,84 @@ describe('cell editor (MetaCellEditor) — rich vs plain editor selection', () =
     expect(emitted.toLowerCase()).not.toContain('onerror')
     expect(emitted.toLowerCase()).not.toContain('<img')
     expect(emitted).toContain('<b>kept</b>')
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('MetaRichLongTextEditor — commit semantics (drawer PATCH-on-blur, no flood)', () => {
+  function mountEditor(handlers: Record<string, unknown>) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      render: () => h(MetaRichLongTextEditor, { modelValue: '', ...handlers }),
+    })
+    app.mount(container)
+    return { container, app }
+  }
+
+  it('emits `change` only on blur (commit), not on every input', async () => {
+    const changeSpy = vi.fn()
+    const updateSpy = vi.fn()
+    const { container, app } = mountEditor({
+      'onUpdate:modelValue': updateSpy,
+      onChange: changeSpy,
+    })
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    editable.innerHTML = '<b>typing</b>'
+    editable.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    // Live updates fired, but no commit yet.
+    expect(updateSpy).toHaveBeenCalled()
+    expect(changeSpy).not.toHaveBeenCalled()
+    // Blur = commit → exactly one `change`.
+    editable.dispatchEvent(new Event('blur', { bubbles: true }))
+    await nextTick()
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+    expect(changeSpy.mock.calls[0]?.[0]).toContain('<b>typing</b>')
+    app.unmount()
+    container.remove()
+  })
+
+  it('the `change` value is sanitized (commit cannot carry unsafe markup)', async () => {
+    const changeSpy = vi.fn()
+    const { container, app } = mountEditor({ onChange: changeSpy })
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    editable.innerHTML = '<img src=x onerror="window.__blurpwn = 1"><i>ok</i>'
+    editable.dispatchEvent(new Event('blur', { bubbles: true }))
+    await nextTick()
+    const committed = changeSpy.mock.calls.at(-1)?.[0] as string
+    expect(committed.toLowerCase()).not.toContain('onerror')
+    expect(committed.toLowerCase()).not.toContain('<img')
+    expect(committed).toContain('<i>ok</i>')
+    app.unmount()
+    container.remove()
+  })
+
+  it('does NOT rewrite innerHTML while focused (caret-jump guard)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      data: () => ({ html: '<b>start</b>' }),
+      render(this: { html: unknown }) {
+        return h(MetaRichLongTextEditor, { modelValue: this.html })
+      },
+      mounted(this: Record<string, unknown>) {
+        this.setHtml = (v: unknown) => { (this as { html: unknown }).html = v }
+      },
+    })
+    const vm = app.mount(container) as unknown as { setHtml: (v: unknown) => void }
+    await nextTick()
+    const editable = container.querySelector('[data-test="rich-longtext-editor"]') as HTMLElement
+    // Simulate the user actively editing: focus + local DOM change.
+    editable.dispatchEvent(new Event('focus', { bubbles: true }))
+    editable.innerHTML = '<b>user is typing here</b>'
+    // An external model change arrives while focused — must NOT stomp the live DOM.
+    vm.setHtml('<b>start</b>')
+    await nextTick()
+    expect(editable.innerHTML).toBe('<b>user is typing here</b>')
     app.unmount()
     container.remove()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       bpmn-js:
         specifier: ^18.10.1
         version: 18.10.1
+      dompurify:
+        specifier: ^3.2.0
+        version: 3.4.10
       echarts:
         specifier: ^5.5.0
         version: 5.6.0
@@ -1601,6 +1604,9 @@ packages:
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
@@ -2364,6 +2370,9 @@ packages:
 
   domify@1.4.2:
     resolution: {integrity: sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==}
+
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5776,6 +5785,9 @@ snapshots:
 
   '@types/triple-beam@1.3.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/uuid@9.0.8': {}
 
   '@types/web-bluetooth@0.0.16': {}
@@ -6599,6 +6611,10 @@ snapshots:
       domelementtype: 2.3.0
 
   domify@1.4.2: {}
+
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:


### PR DESCRIPTION
## What shipped (FE MVP slice §6.3/§6.4/§7 of the rich-text longText design-lock)

Builds the **front-end** of the rich-text `longText` feature. The backend write-path sanitizer is already on main (#2598). All new behavior is gated on a strict `isRichLongTextField` predicate — **non-rich `longText` renders/edits exactly as today** (no migration, no behavior change).

### 1. The single `v-html` owner + DOMPurify chokepoint (security core)
- **`apps/web/src/multitable/utils/rich-longtext.ts`** — the single source of truth for the FE allow-list. `sanitizeRichLongTextHtml()` re-sanitizes via **DOMPurify on every call** (not once), mirroring the server's §5 allow-list (b/strong/i/em/u/s, a[http|https|mailto] with forced `rel="noopener noreferrer" target="_blank"`, ul/ol/li, h1-h3, p/br/blockquote/code/pre; everything else stripped; forbidden tags dropped *with contents* so no inner-text leak). Config typed as DOMPurify's own `Config`.
- **`MetaRichLongTextRender.vue`** — the **sole rich-content `v-html` owner** in `apps/web/src/multitable`. Binds only sanitized output; the `safeHtml` computed recomputes on every value change. This is the **mXSS defense-in-depth** point: the server sanitizes on write, but the browser parser can mutate clean markup on re-parse, so client re-sanitize is load-bearing.

> **Single-owner note (deviation, conservative + documented):** the literal `grep -rn 'v-html='` yields **3** directive usages, not 1. Two are **pre-existing self-generated QR-code SVG** (`MetaCellRenderer.vue`, `MetaRecordDrawer.vue`) added in #2593 *after* the design doc was written (which is why the doc says "no v-html exists"). They render trusted, self-generated SVG from `qrSvgFromText`, never user content, and §5 explicitly strips `svg` — routing QR through the rich component would destroy the QR feature. So this PR introduces **exactly ONE new rich-content `v-html`** (the render component); the 2 QR ones are left untouched and out of scope.

### 2. Wiring the surfaces (rich-gated; plain path byte-for-byte unchanged)
- **Grid** (`MetaCellRenderer.vue`): rich cell shows the **plain-text projection** (truncated, fast), never formatted HTML (§7 grid-vs-drawer).
- **Drawer** (`MetaRecordDrawer.vue`): read-only rich → `MetaRichLongTextRender` (formatted); editable rich → `MetaRichLongTextEditor`.
- **Form** (`MetaFormView.vue`): read-only rich → render; editable rich → editor.
- **Cell editor** (`MetaCellEditor.vue`): editable rich → editor; plain → the existing textarea.

### 3. Plain-text projection
`richLongTextToPlainTextFE()` (DOMPurify with empty allow-list → textContent) — the FE projection helper.

> **Projection-consumer reconciliation (scope, primary-source-verified):** the task named "two consumers: export + search." In this codebase **both are server-side and already handled by #2598** — export at `univer-meta.ts:7407` (`serializeXlsxCell(richLongTextToPlainText(cell))`, gated on `isRichLongTextProperty`) and search at `query-service.ts:280` (whole-row ILIKE; per-field tag-stripped projection explicitly **deferred** as a bounded residual). FE search is server-side (the `searchQuery` is sent to the server), so there is no client-side raw-HTML search to fix. The FE projection's **one real consumer is the grid-cell display**. No backend export/search re-wiring added (would duplicate #2598).

### 4. Minimal rich editor (§6.4)
`MetaRichLongTextEditor.vue` — a lightweight `contenteditable` + toolbar (bold/italic/underline/strike, headings H1–H3, paragraph, bullet/numbered lists, link add/remove). **No heavyweight editor framework.** NOT a trust boundary (server re-sanitizes on write), but still sanitizes its own emit via the shared config, pastes as **plain text only**, and guards link protocols. Patches the drawer **on blur** (`change` event) — mirrors the plain textarea's `@change` so it issues one server PATCH per edit, not one per keystroke. `syncFromModel` is guarded against rewriting `innerHTML` while focused (caret protection).

## XSS test results (§8 fail-first matrix) — all pass
`multitable-richtext-longtext.spec.ts` (29) + `multitable-richtext-wiring.spec.ts` (9). Every §8 canary is neutralized after the render component's DOMPurify pass:
- `<script>`, `<img onerror>`, `javascript:` link, **entity-encoded** `&#106;avascript:` link, inline `on*` handler, `style` url() injection, `<iframe>/<object>/<embed>/<form>`, **mXSS** `<noscript>` breakout → no script/img/on*/`javascript:`/style residue.
- `javascript:` links → href dropped, text kept; protocol-relative `//evil.com` href dropped.
- Benign formatting (bold/italic/u/s/link/list/heading/blockquote/code/pre) preserved with forced `rel`/`target`.
- Component injects no `<script>`/`<img>` and **re-sanitizes on re-bind** (asserts `window.__pwned*` never set).
- Editor commit (`change`) is sanitized; caret-guard suppresses re-sync while focused.

Run: `cd apps/web && vitest run tests/multitable-richtext-*.spec.ts tests/multitable-longtext-cell.spec.ts` → **40 passed**. `vue-tsc -b` passes locally (the existing `multitable-longtext-cell` plain-path spec stays green = backward-compat).

## Deferred (not in this MVP)
- **Field-config toggle UI** to set `property.rich`. The feature is reachable only via API / property write today (the server's `assertRichLongTextToggleAllowed` already gates enabling rich on a populated field). A reviewer cannot enable it from the field-manager UI yet — this is intentional MVP scope.
- Non-grid/drawer/form display surfaces (gantt/gallery/kanban) don't special-case `longText`; a rich value would show as **escaped text** there (safe, just unstyled) since there is no other `v-html`. No new XSS surface.
- Per the design §6: @-mentions in rich text, inline images/attachments, collaborative rich editing (Yjs), per-field format restrictions, markdown import/paste, tables.

## Dependency
DOMPurify (`^3.2.0`, resolved 3.4.10) added to `apps/web/package.json` **and** root `pnpm-lock.yaml` in the same change (`--frozen-lockfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-driven fixes (post-open)
- **Typed the DOMPurify config** as DOMPurify's `Config` (was `Record<string,unknown>`, would fail `vue-tsc`/CI). `vue-tsc -b` passes locally.
- **Drawer PATCH-on-blur**: rich editor emits a `change` event on blur; drawer patches on `change` only (one PATCH per edit, not per keystroke). Caret-jump guard on re-sync while focused.
- **Inline grid commit (data-loss fix)**: `MetaGridTable` commits a cell edit only on the editor's `confirm` event (no blur fallback). The rich editor now emits `confirm` on Cmd/Ctrl+Enter and `cancel` on Escape, forwarded through `MetaCellEditor` — so inline rich-cell edits actually save. Locked by 2 new tests.

Final test count: `multitable-richtext-longtext.spec.ts` (29) + `multitable-richtext-wiring.spec.ts` (11) = **40 pass**; cell-editor + drawer + form regression suites green; `vue-tsc -b` clean.
