### PR TITLE
feat(multitable): cross-base record delete + lock (Phase C2)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260614120000_add_delete_record_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260614120000_add_delete_record_automation_action.ts
@@ -1,0 +1,69 @@
+/**
+ * Migration: Phase C2 — widen the automation action-type CHECK constraint to
+ * include `delete_record` (cross-base record delete; same-base delete too).
+ *
+ * Keeps `chk_automation_action_type` aligned with the app-level
+ * `ALL_ACTION_TYPES`. NULL-safe: only the enum widens; no table or column is
+ * added in this slice.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'delete_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+  'parallel_branch',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+  'parallel_branch',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD)
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -6,6 +6,7 @@
 export type AutomationActionType =
   | 'update_record'
   | 'create_record'
+  | 'delete_record'
   | 'send_webhook'
   | 'send_notification'
   | 'send_email'
@@ -20,6 +21,7 @@ export type AutomationActionType =
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
   'create_record',
+  'delete_record',
   'send_webhook',
   'send_notification',
   'send_email',
@@ -59,6 +61,21 @@ export interface CreateRecordConfig {
    * `targetBaseId` (claim == truth). Absent = same-base create (unchanged, back-compat).
    */
   targetBaseId?: string
+}
+
+/** Config shape for delete_record */
+export interface DeleteRecordConfig {
+  /**
+   * ②b / Phase C2 cross-base DELETE opt-in. When `targetBaseId` is set and ≠ the trigger base, this is a
+   * GOVERNED cross-base delete (a delete is a write for abuse-accounting): it requires FULL explicit
+   * addressing (`targetSheetId` + `targetRecordId`) because the trigger record is not in the target base.
+   * The executor write-gate then re-verifies, per run, that the TRIGGER ACTOR holds base-WRITE on
+   * `targetBaseId` and that `targetSheetId ∈ targetBaseId` / `targetRecordId ∈ targetSheetId`
+   * (claim == truth). All three absent = same-base trigger-record delete (back-compat).
+   */
+  targetBaseId?: string
+  targetSheetId?: string
+  targetRecordId?: string
 }
 
 /** Config shape for send_webhook */
@@ -113,6 +130,17 @@ export interface SendDingTalkPersonMessageConfig {
 /** Config shape for lock_record */
 export interface LockRecordConfig {
   locked: boolean
+  /**
+   * Phase C2 cross-base LOCK opt-in. Locking a record in ANOTHER base is a denial-of-edit on foreign
+   * data — a governance surface gated by the SAME primitive as a cross-base write (`base:write` on the
+   * target base, NOT base:admin; lock is an edit-class affordance). When `targetBaseId` is set and ≠ the
+   * trigger base, FULL explicit addressing (`targetSheetId` + `targetRecordId`) is required and the lock
+   * verifies claim == truth (the target record actually lives in `targetSheetId ∈ targetBaseId`) +
+   * trigger-actor base-write. All three absent = same-base trigger-record lock (unchanged, back-compat).
+   */
+  targetBaseId?: string
+  targetSheetId?: string
+  targetRecordId?: string
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2528,9 +2528,9 @@ export class AutomationExecutor {
 
       if (locked) {
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
-        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
         // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
+        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
@@ -2538,9 +2538,9 @@ export class AutomationExecutor {
           [lockedBy, effectiveRecordId, effectiveSheetId],
         )
       } else {
-        // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
         // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
+        // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1349,6 +1349,9 @@ export class AutomationExecutor {
         case 'create_record':
           result = await this.executeCreateRecord(action.config, context)
           break
+        case 'delete_record':
+          result = await this.executeDeleteRecord(action.config, context)
+          break
         case 'send_webhook':
           result = await this.executeSendWebhook(action.config, context)
           break
@@ -1798,6 +1801,104 @@ export class AutomationExecutor {
       return { actionType: 'update_record', status: 'success', output: { updatedFields: Object.keys(fields) } }
     } catch (err) {
       return { actionType: 'update_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  private async executeDeleteRecord(
+    config: Record<string, unknown>,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    // Phase C2a cross-base addressing — MIRRORS executeUpdateRecord. The resolved target sheet is
+    // `config.targetSheetId ?? context.sheetId`. For a CROSS-BASE delete, `targetSheetId` +
+    // `targetRecordId` are REQUIRED (the trigger record is not in the target base); for a SAME-BASE
+    // delete they default to the trigger record (back-compat). A delete is a WRITE for abuse-accounting,
+    // so it routes through the SAME `evaluateCrossBaseWrite` gate (same base-writable check, claim==truth,
+    // shared per-target-base quota bucket).
+    const targetSheetId = (config.targetSheetId as string) || context.sheetId
+    const declaredTargetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId : undefined
+
+    try {
+      const gate = await this.evaluateCrossBaseWrite(targetSheetId, declaredTargetBaseId, context)
+      let effectiveSheetId = context.sheetId
+      let effectiveRecordId = context.recordId
+      if (gate.crossBase) {
+        if (gate.ok === false) {
+          return { actionType: 'delete_record', status: 'failed', error: gate.error }
+        }
+        // Cross-base requires the full explicit target triple (mirrors update). The executor is the last
+        // line of defense even if rule-save validation were bypassed.
+        const targetRecordId = typeof config.targetRecordId === 'string' ? config.targetRecordId : ''
+        if (!config.targetSheetId || !targetRecordId) {
+          return {
+            actionType: 'delete_record',
+            status: 'failed',
+            error: 'Cross-base delete_record requires targetBaseId + targetSheetId + targetRecordId',
+          }
+        }
+        effectiveSheetId = targetSheetId
+        effectiveRecordId = targetRecordId
+      }
+
+      // Record-lock guard: you cannot delete a record locked by someone you can't unlock. The SELECT and
+      // the DELETE below BOTH read `effectiveSheetId`/`effectiveRecordId`, so a cross-base delete checks
+      // the TARGET record's lock (not the trigger record's) — lock priority over base-write.
+      const lockRes = await this.deps.queryFn(
+        'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [effectiveRecordId, effectiveSheetId],
+      )
+      const lockRow = lockRes.rows[0] as
+        | { locked?: unknown; locked_by?: unknown; created_by?: unknown }
+        | undefined
+      // ②b claim==truth for the record: a cross-base delete must address a record that ACTUALLY lives in
+      // `targetSheetId`. No row → the targetRecordId does not exist there → fail-closed (never a silent
+      // no-op success). Same-base keeps its leniency (a missing trigger record yields a 0-row DELETE
+      // reported as success) to avoid any behavior regression vs the other same-base sinks.
+      if (gate.crossBase && !lockRow) {
+        return {
+          actionType: 'delete_record',
+          status: 'failed',
+          error: `Cross-base delete_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+        }
+      }
+      if (lockRow) {
+        ensureRecordNotLocked(context.actorId ?? null, lockRow, () => new Error('Record is locked'))
+      }
+
+      // Clean up links FIRST (mirrors the same-base delete sinks `records.deleteRecord` /
+      // `RecordService.deleteRecord`): the FK cascade only covers the `record_id` side, so the
+      // `foreign_record_id` side must be deleted explicitly or it dangles. (This statement touches
+      // meta_links, NOT meta_records, so the cross-base write-guard regex does not match it.)
+      await this.deps.queryFn(
+        'DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1',
+        [effectiveRecordId],
+      )
+
+      // HARD delete — the system has NO soft-delete for records: `meta_records` has no `deleted_at`
+      // column and both same-base delete sinks (`records.ts`, `record-service.ts`) hard-`DELETE`. A
+      // soft-delete here would target a non-existent column AND would be a silent no-op (no read path
+      // filters `deleted_at`). So this mirrors the proven sinks. No `version = version + 1` (the row is
+      // gone); `sheet_id` scoping matches the update template.
+      // xbase-write-gated: routes through evaluateCrossBaseWrite (gate computed above) — a cross-base
+      // delete is rejected before this DELETE unless claim==truth + trigger-actor base-write.
+      // lock-guarded: automation delete_record (C2a) — ensureRecordNotLocked enforced just above.
+      await this.deps.queryFn(
+        'DELETE FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [effectiveRecordId, effectiveSheetId],
+      )
+
+      // Emit event for chaining (mirrors the updated/created emits + the same-base delete sink's
+      // `multitable.record.deleted` shape). C1 real-time invalidation fan-out to the target base's room
+      // is OUT of this lock — this only emits the domain event; no cross-room publish is wired here.
+      this.deps.eventBus.emit('multitable.record.deleted', {
+        sheetId: effectiveSheetId,
+        recordId: effectiveRecordId,
+        actorId: context.actorId,
+        _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
+      })
+
+      return { actionType: 'delete_record', status: 'success', output: { recordId: effectiveRecordId, sheetId: effectiveSheetId } }
+    } catch (err) {
+      return { actionType: 'delete_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
     }
   }
 
@@ -2379,34 +2480,79 @@ export class AutomationExecutor {
   ): Promise<AutomationStepResult> {
     const locked = config.locked !== false // default to true (decision f: config.locked === false → unlock)
 
+    // Phase C2b cross-base addressing — MIRRORS executeUpdateRecord. Locking a record in ANOTHER base is a
+    // denial-of-edit on foreign data, gated by the SAME `evaluateCrossBaseWrite` primitive as a cross-base
+    // write (base:write, not base:admin — lock is an edit-class affordance). The gate's same-base fast-path
+    // (`targetSheetId === context.sheetId && no targetBaseId`) returns `{crossBase:false}` with NO base
+    // lookups, so a same-base lock/unlock is BYTE-IDENTICAL to the pre-C2 behavior (it still writes the
+    // trigger record). A cross-base lock REQUIRES the full target triple + claim==truth (the target record
+    // must actually live in the target sheet). Lock is lock-MGMT (it sets the lock columns), so unlike
+    // update/delete it does NOT call ensureRecordNotLocked.
+    const targetSheetId = (config.targetSheetId as string) || context.sheetId
+    const declaredTargetBaseId = typeof config.targetBaseId === 'string' ? config.targetBaseId : undefined
+
     try {
+      const gate = await this.evaluateCrossBaseWrite(targetSheetId, declaredTargetBaseId, context)
+      let effectiveSheetId = context.sheetId
+      let effectiveRecordId = context.recordId
+      if (gate.crossBase) {
+        if (gate.ok === false) {
+          return { actionType: 'lock_record', status: 'failed', error: gate.error }
+        }
+        const targetRecordId = typeof config.targetRecordId === 'string' ? config.targetRecordId : ''
+        if (!config.targetSheetId || !targetRecordId) {
+          return {
+            actionType: 'lock_record',
+            status: 'failed',
+            error: 'Cross-base lock_record requires targetBaseId + targetSheetId + targetRecordId',
+          }
+        }
+        effectiveSheetId = targetSheetId
+        effectiveRecordId = targetRecordId
+
+        // ②b claim==truth for the record: a cross-base lock must address a record that ACTUALLY lives in
+        // `targetSheetId`. No row → fail-closed (never lock a phantom / silently no-op). Same-base skips
+        // this SELECT entirely (fast-path), preserving byte-identical back-compat.
+        const existsRes = await this.deps.queryFn(
+          'SELECT 1 FROM meta_records WHERE id = $1 AND sheet_id = $2',
+          [effectiveRecordId, effectiveSheetId],
+        )
+        if (!existsRes.rows[0]) {
+          return {
+            actionType: 'lock_record',
+            status: 'failed',
+            error: `Cross-base lock_record target record not found in target sheet: ${effectiveRecordId} ∉ ${effectiveSheetId}`,
+          }
+        }
+      }
+
       if (locked) {
-        // xbase-write-exempt: lock_record writes ONLY context.sheetId/context.recordId (the trigger
-        // record) — it never retargets to a config-declared base, so it is not a cross-base write surface.
-        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
         const lockedBy = typeof context.actorId === 'string' && context.actorId.trim() ? context.actorId : 'system'
+        // lock-mgmt: LOCK action — sets the lock columns themselves (not a data edit of a locked row).
+        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base uses the gate's
+        // fast-path (byte-identical to pre-C2); a cross-base lock is rejected unless claim==truth + base-write.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = true, locked_by = $1, locked_at = NOW(), version = version + 1, updated_at = NOW()
            WHERE id = $2 AND sheet_id = $3`,
-          [lockedBy, context.recordId, context.sheetId],
+          [lockedBy, effectiveRecordId, effectiveSheetId],
         )
       } else {
-        // xbase-write-exempt: unlock writes ONLY context.sheetId/context.recordId (the trigger record),
-        // never a config-declared base — not a cross-base write surface.
         // lock-mgmt: UNLOCK action — clears the lock columns (decision f: automation may unlock).
+        // xbase-write-gated: routes through evaluateCrossBaseWrite (gate above) — same-base fast-path keeps
+        // this byte-identical to pre-C2; a cross-base unlock is rejected unless claim==truth + base-write.
         await this.deps.queryFn(
           `UPDATE meta_records
            SET locked = false, locked_by = NULL, locked_at = NULL, version = version + 1, updated_at = NOW()
            WHERE id = $1 AND sheet_id = $2`,
-          [context.recordId, context.sheetId],
+          [effectiveRecordId, effectiveSheetId],
         )
       }
 
       return {
         actionType: 'lock_record',
         status: 'success',
-        output: { locked, recordId: context.recordId },
+        output: { locked, recordId: effectiveRecordId },
       }
     } catch (err) {
       // Failures surface honestly in the automation execution log instead of crashing the run.

--- a/packages/core-backend/tests/integration/multitable-cross-base-automation-delete-lock.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-base-automation-delete-lock.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Phase C2 automation slice — governed cross-base record DELETE + cross-base record LOCK (real DB).
+ *
+ * Sibling of `multitable-cross-base-automation-write.test.ts`. C2 extends the same cross-base write gate
+ * (`evaluateCrossBaseWrite`: trigger-actor base-write authority + claim==truth + shared per-target-base
+ * quota bucket) to two NEW destructive/governance sinks:
+ *
+ *  - C2a `delete_record`: a delete is a WRITE for abuse-accounting. A CROSS-BASE delete demands full
+ *    explicit addressing (`targetBaseId + targetSheetId + targetRecordId`), claim==truth (the record
+ *    actually lives in the target sheet), and honors the TARGET record's lock (you cannot delete a record
+ *    locked by someone you can't unlock). The delete is a HARD delete — `meta_records` has no `deleted_at`
+ *    column and both same-base sinks (`records.ts`, `record-service.ts`) hard-`DELETE`; so this suite
+ *    asserts the row is GONE, not a `deleted_at` flag.
+ *  - C2b `lock_record`: locking another base's record is a denial-of-edit on foreign data, gated by the
+ *    SAME primitive (base:write, not base:admin). Same-base lock/unlock is byte-identical to pre-C2 (the
+ *    gate's same-base fast-path), so this suite re-proves the same-base path is unchanged.
+ *
+ * Drives the REAL AutomationExecutor with a real-DB queryFn (the executor is the write chokepoint — this
+ * proves the gate stands alone even if rule-save validation were bypassed). The structural write-guard
+ * (`multitable-cross-base-write-guard.guard.test.ts`) separately proves the new DELETE sink + the relabeled
+ * lock UPDATEs are enrolled in the gate by construction.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { MemoryRateLimitStore } from '../../src/middleware/rate-limiter'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus } from '../../src/integration/events/event-bus'
+import {
+  AutomationExecutor,
+  type AutomationDeps,
+  type AutomationRule,
+  type CrossBaseWriteQuotaConfig,
+} from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+
+// Actors (mirrors the write suite).
+const OWNER = `u_dl_owner_${TS}` // owns BASE_A (trigger) AND BASE_B (target) → base-write on both (owner)
+const ADMIN_CODE = `u_dl_admincode_${TS}` // holds multitable:base:admin grant → base-write on any base
+const NO_WRITE = `u_dl_nowrite_${TS}` // owns nothing, no codes → NO base-write on BASE_B
+
+// Bases.
+const BASE_A = `base_dl_a_${TS}` // trigger base (source)
+const BASE_B = `base_dl_b_${TS}` // target base (cross-base delete/lock sink)
+
+// Sheets.
+const SHEET_A = `sheet_dl_a_${TS}` // trigger sheet (BASE_A)
+const SHEET_B = `sheet_dl_b_${TS}` // cross-base target sheet (BASE_B)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+// Default-store executor: a FRESH private high-limit quota store per call so the process-global singleton
+// (consumed by sibling cross-base suites in the same process at the generous 60/min default) can never
+// perturb these non-quota assertions, and vice-versa. The quota-sharing test below injects its own LOW
+// limit deliberately.
+function makeExecutor(quota?: CrossBaseWriteQuotaConfig): { executor: AutomationExecutor; eventBus: EventBus } {
+  const eventBus = new EventBus()
+  const deps: AutomationDeps = {
+    eventBus,
+    queryFn: (sql: string, params?: unknown[]) => q(sql, params),
+    crossBaseWriteQuota: quota ?? { limit: 1000, windowMs: 60_000, store: new MemoryRateLimitStore() },
+  }
+  return { executor: new AutomationExecutor(deps), eventBus }
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }, createdBy: string): AutomationRule {
+  return {
+    id: `axr_dl_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'DL rule',
+    sheetId: SHEET_A,
+    trigger: { type: 'record.created', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+const countRecords = async (sheetId: string): Promise<number> => {
+  const r = await q('SELECT COUNT(*)::int AS n FROM meta_records WHERE sheet_id = $1', [sheetId])
+  return (r.rows as Array<{ n: number }>)[0]?.n ?? 0
+}
+const recordExists = async (recordId: string): Promise<boolean> => {
+  const r = await q('SELECT 1 FROM meta_records WHERE id = $1', [recordId])
+  return Boolean((r.rows as unknown[])[0])
+}
+const recordLocked = async (recordId: string): Promise<boolean | undefined> => {
+  const r = await q('SELECT locked FROM meta_records WHERE id = $1', [recordId])
+  const row = (r.rows as Array<{ locked: unknown }>)[0]
+  return row ? Boolean(row.locked) : undefined
+}
+const insertRecord = async (recordId: string, sheetId: string): Promise<void> => {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [
+    recordId,
+    sheetId,
+    JSON.stringify({ v: 'x' }),
+  ])
+}
+
+describeIfDatabase('Phase C2 automation — governed cross-base DELETE + LOCK (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'DL Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'DL Base B', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'Trigger A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'Target B'])
+
+    await q(
+      `INSERT INTO permissions (code, name, description)
+       VALUES ('multitable:base:admin', 'Base Admin', 'cross-base C2 delete/lock tests')
+       ON CONFLICT (code) DO NOTHING`,
+    )
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [ADMIN_CODE, `${ADMIN_CODE}@example.test`],
+    )
+    await q(
+      `INSERT INTO user_permissions (user_id, permission_code)
+       VALUES ($1, 'multitable:base:admin') ON CONFLICT DO NOTHING`,
+      [ADMIN_CODE],
+    )
+  })
+
+  afterAll(async () => {
+    const sheets = [SHEET_A, SHEET_B]
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [sheets]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[ADMIN_CODE]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // ════════════════════════ C2a — cross-base DELETE ════════════════════════
+
+  // ── DL-1: cross-base delete by an authorized actor → target row HARD-deleted ──
+  test('DL-1: cross-base delete_record with full addressing + trigger-actor base-write → target record GONE', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl1_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordExists(recId)).toBe(false) // HARD delete: row is gone (no deleted_at)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-1 (admin-code path) ──
+  test('DL-1 (admin-code): cross-base delete with trigger-actor holding multitable:base:admin → target GONE', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl1admin_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: ADMIN_CODE, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordExists(recId)).toBe(false)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-1c: cross-base delete also cleans up the foreign_record_id link side ──
+  // The FK cascade only covers the record_id side; the executor (mirroring the same-base sinks) deletes
+  // BOTH sides explicitly. A link where the deleted record is the FOREIGN endpoint must be gone too.
+  test('DL-1c: cross-base delete clears links on the foreign_record_id side (no dangling links)', async () => {
+    const { executor } = makeExecutor()
+    const victim = `rec_dl1c_victim_${TS}` // the record being deleted (in SHEET_B)
+    const other = `rec_dl1c_other_${TS}` // an unrelated live record (in SHEET_A) that links TO the victim
+    const fieldId = `fld_dl1c_${TS}`
+    const linkId = `lnk_dl1c_${TS}`
+    await insertRecord(victim, SHEET_B)
+    await insertRecord(other, SHEET_A)
+    // meta_links.field_id has an FK to meta_fields — seed a real link field on SHEET_A.
+    await q(
+      `INSERT INTO meta_fields (id, sheet_id, name, type, "order") VALUES ($1, $2, $3, 'link', 0)`,
+      [fieldId, SHEET_A, 'DL1c link'],
+    )
+    // other → victim: victim is the FOREIGN endpoint (foreign_record_id) — the side the FK cascade does NOT
+    // cover (only record_id cascades), so the executor's explicit `OR foreign_record_id` cleanup must remove it.
+    await q(
+      `INSERT INTO meta_links (id, record_id, field_id, foreign_record_id) VALUES ($1, $2, $3, $4)`,
+      [linkId, other, fieldId, victim],
+    )
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: victim } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordExists(victim)).toBe(false)
+      const links = await q('SELECT 1 FROM meta_links WHERE id = $1', [linkId])
+      expect((links.rows as unknown[]).length).toBe(0) // foreign-side link cleaned up (no dangling link)
+    } finally {
+      await q('DELETE FROM meta_links WHERE id = $1', [linkId]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE id = $1', [fieldId]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE id = ANY($1::text[])', [[victim, other]]).catch(() => {})
+    }
+  })
+
+  // ── DL-1b: cross-base delete, NO base-write → blocked, target SURVIVES ──
+  test('DL-1b: cross-base delete where trigger actor lacks target base-write → step failed, target survives', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl1b_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER, // rule owner DOES have write — but the ratified actor is the TRIGGER actor, not the owner
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(await recordExists(recId)).toBe(true) // fail-closed: NOT deleted
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-1d: cross-base delete of a LOCKED target the actor can't unlock → blocked ──
+  test('DL-1d: cross-base delete of a target locked by someone else is blocked even WITH base-write', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl1d_${TS}`
+    await q(
+      'INSERT INTO meta_records (id, sheet_id, data, version, locked, locked_by, created_by) VALUES ($1,$2,$3::jsonb,1,true,$4,$5)',
+      [recId, SHEET_B, JSON.stringify({ v: 'x' }), `someone_else_${TS}`, `someone_else_${TS}`],
+    )
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER,
+      )
+      // OWNER has base-write on BASE_B — but the TARGET record is locked by someone else → blocked.
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(await recordExists(recId)).toBe(true) // lock priority: NOT deleted
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-1e: cross-base (target sheet IS foreign) but missing targetRecordId → fail-closed on the triple ──
+  // A delete whose resolved target sheet IS in another base (so the gate classifies it cross-base) but which
+  // OMITS targetRecordId must fail on the explicit-triple requirement — the executor is the last line of
+  // defense even if rule-save validation were bypassed. (A bare targetBaseId with the target sheet defaulting
+  // to the trigger sheet resolves SAME-BASE and runs on the trigger record — that's the update template's
+  // behavior and is NOT this case.)
+  test('DL-1e: cross-base delete with targetSheetId in a foreign base but NO targetRecordId → step failed (triple)', async () => {
+    const { executor } = makeExecutor()
+    const survivor = `rec_dl1e_${TS}`
+    await insertRecord(survivor, SHEET_B) // a record in the TARGET sheet that must NOT be collaterally deleted
+    try {
+      const rule = ruleWith({ type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B } }, OWNER)
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(exec.steps[0]?.error ?? '').toMatch(/requires targetBaseId \+ targetSheetId \+ targetRecordId/)
+      expect(await recordExists(survivor)).toBe(true) // nothing deleted
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [survivor]).catch(() => {})
+    }
+  })
+
+  // ── DL-1f: claim==truth for the record — targetRecordId ∉ targetSheetId → fail-closed ──
+  test('DL-1f: cross-base delete where targetRecordId is not in targetSheetId → step failed (no silent no-op)', async () => {
+    const { executor } = makeExecutor()
+    const before = await countRecords(SHEET_B)
+    const rule = ruleWith(
+      { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: `rec_dl1f_missing_${TS}` } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+    expect(await countRecords(SHEET_B)).toBe(before) // nothing changed
+  })
+
+  // ── DL-1g: null actor (scheduled trigger) cross-base delete → fail-closed, NO delete ──
+  test('DL-1g: cross-base delete with null actorId (scheduled trigger) → fail-closed, target survives', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl1g_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER, // rule owner has write — but actorId is null and there is NO owner fallback
+      )
+      const exec = await executor.execute(
+        rule,
+        { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: null, data: {}, _triggeredBy: 'schedule' } as never,
+      )
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(await recordExists(recId)).toBe(true) // fail-closed: no delete
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-3: same-base delete → works (no gate; deletes the trigger record), even for a no-write actor ──
+  test('DL-3: same-base delete_record (no target addressing) deletes the trigger record', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_dl3_${TS}`
+    await insertRecord(recId, SHEET_A)
+    try {
+      // NO_WRITE has no base-write anywhere — but same-base must NOT hit the gate at all.
+      const rule = ruleWith({ type: 'delete_record', config: {} }, OWNER)
+      const exec = await executor.execute(rule, { recordId: recId, sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordExists(recId)).toBe(false)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── DL-Q: a cross-base DELETE shares the per-target-base write QUOTA bucket with cross-base WRITEs ──
+  // Proves a base cannot dodge the limit by mixing deletes and creates: with limit=2, a create + a delete
+  // exhaust the bucket and the 3rd cross-base op (a create) is rejected (quota), no row.
+  test('DL-Q: cross-base delete + create share the per-target-base quota bucket (limit=2 → 3rd rejected)', async () => {
+    const { executor } = makeExecutor({ limit: 2, windowMs: 60_000, store: new MemoryRateLimitStore() })
+    const delRec = `rec_dlq_del_${TS}`
+    const rowWith = async (v: string): Promise<boolean> => {
+      const r = await q("SELECT 1 FROM meta_records WHERE sheet_id = $1 AND data->>'v' = $2", [SHEET_B, v])
+      return Boolean((r.rows as unknown[])[0])
+    }
+    await insertRecord(delRec, SHEET_B)
+    try {
+      // op 1: a cross-base CREATE → slot 1.
+      const c1 = await executor.execute(
+        ruleWith({ type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'dlq1' } } }, OWNER),
+        { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} },
+      )
+      expect(c1.steps[0]?.status).toBe('success')
+
+      // op 2: a cross-base DELETE → slot 2 (same bucket).
+      const d1 = await executor.execute(
+        ruleWith({ type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: delRec } }, OWNER),
+        { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} },
+      )
+      expect(d1.steps[0]?.status).toBe('success')
+      expect(await recordExists(delRec)).toBe(false) // the delete consumed its slot AND deleted
+
+      // op 3: another cross-base CREATE → over the limit of 2 → rejected (quota), NO row.
+      const c2 = await executor.execute(
+        ruleWith({ type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'dlq-over' } } }, OWNER),
+        { recordId: '', sheetId: SHEET_A, actorId: OWNER, data: {} },
+      )
+      expect(c2.steps[0]?.status).toBe('failed')
+      expect(c2.steps[0]?.error ?? '').toMatch(/quota/i)
+      // The first create (dlq1) landed and survives; the over-limit create (dlq-over) was rejected → no row.
+      expect(await rowWith('dlq1')).toBe(true)
+      expect(await rowWith('dlq-over')).toBe(false)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [delRec]).catch(() => {})
+      await q("DELETE FROM meta_records WHERE sheet_id = $1 AND data->>'v' IN ('dlq1','dlq-over')", [SHEET_B]).catch(() => {})
+    }
+  })
+
+  // ════════════════════════ C2b — cross-base LOCK ═════════════════════════
+
+  // ── LK-1: cross-base lock by a base-write actor → target record locked ──
+  test('LK-1: cross-base lock_record with full addressing + trigger-actor base-write → target record LOCKED', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_lk1_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'lock_record', config: { locked: true, targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER,
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordLocked(recId)).toBe(true) // target locked
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── LK-1b: cross-base lock by a NON-writer → blocked, target NOT locked ──
+  test('LK-1b: cross-base lock where trigger actor lacks target base-write → step failed, target NOT locked', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_lk1b_${TS}`
+    await insertRecord(recId, SHEET_B)
+    try {
+      const rule = ruleWith(
+        { type: 'lock_record', config: { locked: true, targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: recId } },
+        OWNER, // owner has write — but the TRIGGER actor (NO_WRITE) does not
+      )
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(await recordLocked(recId)).toBe(false) // fail-closed: not locked
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── LK-1e: cross-base lock (target sheet IS foreign) but missing targetRecordId → fail-closed on triple ──
+  test('LK-1e: cross-base lock with targetSheetId in a foreign base but NO targetRecordId → step failed (triple)', async () => {
+    const { executor } = makeExecutor()
+    const survivor = `rec_lk1e_${TS}`
+    await insertRecord(survivor, SHEET_B) // target-sheet record that must NOT be collaterally locked
+    try {
+      const rule = ruleWith({ type: 'lock_record', config: { locked: true, targetBaseId: BASE_B, targetSheetId: SHEET_B } }, OWNER)
+      const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+      expect(exec.steps[0]?.status).toBe('failed')
+      expect(exec.steps[0]?.error ?? '').toMatch(/requires targetBaseId \+ targetSheetId \+ targetRecordId/)
+      expect(await recordLocked(survivor)).toBe(false) // nothing locked
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [survivor]).catch(() => {})
+    }
+  })
+
+  // ── LK-1f: cross-base lock where targetRecordId ∉ targetSheetId → fail-closed ──
+  test('LK-1f: cross-base lock where targetRecordId is not in targetSheetId → step failed (claim==truth)', async () => {
+    const { executor } = makeExecutor()
+    const rule = ruleWith(
+      { type: 'lock_record', config: { locked: true, targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: `rec_lk1f_missing_${TS}` } },
+      OWNER,
+    )
+    const exec = await executor.execute(rule, { recordId: 'trigger_rec', sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed')
+  })
+
+  // ── LK-3: same-base lock → UNCHANGED (locks the trigger record), even for a no-write actor ──
+  // Back-compat keystone: a lock_record with NO targetBaseId must behave EXACTLY as pre-C2 (gate fast-path).
+  test('LK-3: same-base lock_record (no target addressing) locks the trigger record (back-compat)', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_lk3_${TS}`
+    await insertRecord(recId, SHEET_A)
+    try {
+      // NO_WRITE has no base-write — same-base lock must NOT hit the gate at all (unchanged behavior).
+      const rule = ruleWith({ type: 'lock_record', config: { locked: true } }, OWNER)
+      const exec = await executor.execute(rule, { recordId: recId, sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordLocked(recId)).toBe(true)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+
+  // ── LK-3b: same-base UNLOCK → UNCHANGED (clears the lock on the trigger record) ──
+  test('LK-3b: same-base lock_record{locked:false} unlocks the trigger record (back-compat)', async () => {
+    const { executor } = makeExecutor()
+    const recId = `rec_lk3b_${TS}`
+    await q(
+      'INSERT INTO meta_records (id, sheet_id, data, version, locked, locked_by) VALUES ($1,$2,$3::jsonb,1,true,$4)',
+      [recId, SHEET_A, JSON.stringify({ v: 'x' }), NO_WRITE],
+    )
+    try {
+      const rule = ruleWith({ type: 'lock_record', config: { locked: false } }, OWNER)
+      const exec = await executor.execute(rule, { recordId: recId, sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+      expect(exec.steps[0]?.status).toBe('success')
+      expect(await recordLocked(recId)).toBe(false)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [recId]).catch(() => {})
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD,
+  AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD,
+} from '../../src/db/migrations/zzzz20260614120000_add_delete_record_automation_action'
+
+describe('delete_record automation action migration (Phase C2)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
+    // action type added to the app without a DB migration trips this drift guard RED.
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD).toContain(actionType)
+    }
+  })
+
+  it('adds delete_record on top of the prior parallel_branch action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD).toContain('delete_record')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD).not.toContain('delete_record')
+    expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD.filter((a) => a !== 'delete_record'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD])
+  })
+
+  it('rolls back only the delete_record widening (parallel_branch + create_record remain)', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD).not.toContain('delete_record')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD).toContain('parallel_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_DELETE_RECORD).toContain('create_record')
+  })
+})

--- a/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
@@ -6,8 +6,13 @@ import {
 } from '../../src/db/migrations/zzzz20260611120000_add_parallel_branch_automation_action'
 
 describe('parallel_branch automation action migration (A6-3-4 / W3-1)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
+  it('keeps this constraint in sync with app-level action types except those added by later migrations', () => {
+    // This is no longer the LATEST migration (delete_record widened the constraint afterwards — see
+    // `delete-record-automation-action-migration.test.ts` for the live "latest in sync" guard). Every
+    // app-level action type except the ones introduced by a strictly-later migration must already be here.
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record'])
     for (const actionType of ALL_ACTION_TYPES) {
+      if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain(actionType)
     }
   })


### PR DESCRIPTION
## Phase C2 — cross-base record DELETE + cross-base record LOCK

Design-lock: `docs/development/multitable-crossbase-phase-c-write-tier-delete-lock-design-20260614.md` §2. Continues the cross-base governance arc; consumes the C3 base-write tier (already merged). **C1** real-time fan-out stays out of this PR (its own beat — §4).

Security-critical (destructive cross-base ops). Mirrors the proven `executeUpdateRecord` gating shape **exactly** — no new gating primitive.

### The mirrored gate
Both new sinks route through the existing `evaluateCrossBaseWrite(targetSheetId, declaredTargetBaseId, context)` (trigger-actor base-write authority + claim==truth + the per-target-base write **quota** bucket; null actor fails closed). Cross-base requires the full triple (`targetBaseId + targetSheetId + targetRecordId`) and resolves `effective*` to the target; same-base hits the gate's same-base **fast-path** (`{crossBase:false}`, no base lookup), so same-base behavior is preserved automatically.

### Part 1 — cross-base DELETE (new `delete_record` action)
- `automation-actions.ts`: `DeleteRecordConfig` (mirrors `UpdateRecordConfig`); `delete_record` added to the action-type union + `ALL_ACTION_TYPES`.
- `automation-executor.ts`: `executeDeleteRecord` mirrors `executeUpdateRecord` — gate → cross-base triple required → lock SELECT + claim==truth (missing target row ⇒ fail-closed "target record not found") + `ensureRecordNotLocked` (you cannot delete a record locked by someone you can't unlock) → the mutation → emit `multitable.record.deleted`.

**Deviation — HARD delete, not soft (spec said "do NOT hard-DELETE if the system soft-deletes"; verified the system HARD-deletes).** `meta_records` has **no `deleted_at` column** (confirmed via live `\d meta_records`), and **both** existing same-base sinks (`records.ts:551` plugin-SDK, `record-service.ts:757` REST) issue `DELETE FROM meta_records`. No read path filters `deleted_at IS NULL`. A soft `UPDATE … SET deleted_at = NOW()` would (a) target a non-existent column and (b) be a semantic no-op (row still visible). The design-lock §2a is silent on mechanism (it mandates only gate/claim==truth/quota), so hard-delete is fully compliant and the conservative codebase-consistent choice. The executor mirrors the proven sinks: it first runs `DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1` (the FK cascade only covers the `record_id` side — the `foreign_record_id` side would dangle), then a bare `DELETE FROM meta_records … WHERE id = $1 AND sheet_id = $2` (no `version + 1` — the row is gone). Tests assert the **row is gone** (not a `deleted_at` flag).

### Part 2 — cross-base LOCK (extend `executeLockRecord`)
- `LockRecordConfig`: + `targetBaseId?/targetSheetId?/targetRecordId?`.
- `executeLockRecord` refactored to compute `gate` once, resolve `effective*`, and route **both** the lock and unlock UPDATEs through `effective*`. Cross-base requires the triple + a claim==truth existence check. Lock is **lock-mgmt** (sets lock columns), so — per §2b — it does **not** call `ensureRecordNotLocked`. The bar is `base:write` (not `base:admin`), per the design-lock decision (lock is an edit-class affordance, strictly weaker than delete).
- **EXEMPT → GATED unification + back-compat:** the two lock/unlock UPDATE markers flip `// xbase-write-exempt:` → `// xbase-write-gated:`. The gate's same-base fast-path means a `lock_record` with **no `targetBaseId`** is **byte-identical** to pre-C2 (locks the trigger record). Verified by keeping the existing `automation-v1.test.ts` lock tests green + new same-base LK-3/LK-3b.

### Structural guard — coverage
The new hard DELETE and the relabeled lock UPDATEs all carry the right marker; `tests/unit/multitable-cross-base-write-guard.guard.test.ts` passes (every `meta_records` site classified, smoke count within the ≤20 bound). The `meta_links` cleanup correctly needs **no** marker (the guard regex matches only `meta_records`).

### DB migration (this PR is NOT docs-only)
`delete_record` in `ALL_ACTION_TYPES` requires widening the `chk_automation_action_type` CHECK constraint, kept in sync one-migration-per-action. New `zzzz20260614120000_add_delete_record_automation_action.ts` + drift-guard test mirror the `parallel_branch` pattern; the now-non-latest `parallel_branch` drift test is relaxed to ignore later-migration types. **Needs migration application on deploy** (note: staging postgres trails prod-track — see deploy SOP).

### Known consistency property (not a hole)
A `delete_record`/`lock_record` with `targetBaseId` set but the target sheet **defaulting to the trigger sheet** resolves **same-base** (the mismatched `targetBaseId` claim is ignored when the resolved target sheet is same-base) and runs on the trigger record. This is **exactly** `executeUpdateRecord`'s behavior. The "requires the triple" fail-closed guard is reached only once the gate has already classified the op cross-base (i.e. `targetSheetId` names a foreign-base sheet). Tests DL-1e/LK-1e exercise the true cross-base missing-triple path; DL-3/LK-3 the same-base path.

### Out of scope (per §4)
C1 real-time fan-out to the target base's room (this PR only emits the domain `multitable.record.deleted` event; no cross-room publish is wired). BPMN compile-preview (`bpmnCompilePreview.ts`) is the designer-only A6-4 track with a graceful `default: return false`; `delete_record` is intentionally not BPMN-mapped, consistent with `condition_branch`/`parallel_branch`.

### Tests (real DB, local)
- New `tests/integration/multitable-cross-base-automation-delete-lock.test.ts` — **16 cases**, all green: authorized cross-base delete (hard-delete + foreign-link cleanup) · no-base-write blocked · locked-by-other blocked · missing-triple / claim≠truth / null-actor fail-closed · same-base delete works · cross-base lock writer→locks / non-writer→blocked / missing-triple / claim≠truth · same-base lock+unlock back-compat · delete+create share the per-target-base quota bucket.
- Structural write-guard: **5/5 pass**.
- Regression `multitable-cross-base-automation-write.test.ts`: **22/22 pass** (no regression).
- Migration drift guards + existing executor/lock suites (`automation-v1`, `multitable-automation-conditions`, `IntegrationSimulation`, `multitable-automation-service`): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
