### PR TITLE
feat(multitable): cross-base real-time invalidation fan-out (Phase C1)

### DIFF
--- a/docs/development/multitable-crossbase-phase-c1-realtime-fanout-design-20260614.md
+++ b/docs/development/multitable-crossbase-phase-c1-realtime-fanout-design-20260614.md
@@ -1,0 +1,92 @@
+# Multitable Cross-Base Phase C1 — real-time invalidation fan-out — design-lock
+
+Status: **DESIGN-LOCK.** Closes the closeout §5 deferred item "Yjs 跨 base fan-out — 实时层失效
+信号扇出到 target base 房间" (real-time invalidation fan-out to the target base's room). Own
+beat, separate from C3/C2 per the riskiness of the real-time surface. Own-principles framing.
+
+## 0. Empirical trace (done before designing — this is what the live path actually is)
+
+The real-time client-delivery path for a multitable write is:
+`publishMultitableSheetRealtime(payload)` (`realtime-publish.ts`) → invalidates the sheet's
+records cache **and** publishes the shared-eventBus event `spreadsheet.cell.updated` with an
+**ids-only** broadcast payload (`Omit<…,'recordPatches'>` — no row data) → `CollabService`
+(`CollabService.ts:49`) is subscribed and emits `sheet:op` to the Socket.IO room
+`sheet:${spreadsheetId}`.
+
+- **The `sheet:${sheetId}` room join is auth-gated** by `sheetRoomAuthChecker`
+  (`CollabService.ts:223`, wired `index.ts:2161`; fail-closed default `async () => false`). Only
+  authorized users are in a sheet's room.
+- **REST writes** (`univer-meta.ts`) call `publishMultitableSheetRealtime`, so a sheet's room
+  already receives that sheet's invalidations.
+- **The gap (缺席):** the **automation executor never calls** `publishMultitableSheetRealtime`.
+  So automation-driven writes — including the new cross-base writes/deletes (②b / C2) — are
+  **invisible to the real-time layer**; a base-A automation that writes a record in base B does
+  not tell base-B's subscribers their data changed. The domain events the executor *does* emit
+  (`multitable.record.updated/created/deleted`) are consumed only by automation-trigger chaining
+  and the webhook bridge — **not** the client fan-out path.
+
+(Correcting an earlier mis-grounding: this is NOT a base-read membership problem. A *direct*
+record read in REST is gated by **sheet** capability, not base-read — `resolveBaseReadable`
+applies only to cross-base *link/foreign-field* projection. So the room's existing sheet-scoped
+gate is the right and sufficient boundary; there is no membership gap to close.)
+
+## 1. Principle — relative invariance, not an absolute claim
+
+C1 must deliver the cross-base invalidation **to the same target, gated identically** as the
+already-established fan-out for that sheet. The target of a write to sheet `T` (base `B`) is the
+room `sheet:T`; that room's audience is fixed by `sheetRoomAuthChecker(T, user)` and **does not
+depend on where the write originated**. So routing an automation write's invalidation to
+`sheet:${effectiveSheetId}` **adds no audience and changes no gate** — a cross-base write to `T`
+reaches exactly the audience a REST write to `T` already reaches. Any property of that gate
+(e.g. it returns raw sheet `canRead`) is pre-existing and out of scope. We deliberately do **not**
+assert "room membership == full read authority" (the Yjs/sheet gate is sheet-scoped and does not
+re-apply the record-scope map REST uses — a pre-existing property, not C1's concern).
+
+## 2. The change (minimal)
+
+In the automation executor's three record-write methods — `executeUpdateRecord`,
+`executeCreateRecord`, `executeDeleteRecord` — after the successful mutation (and alongside the
+existing domain-event emit), call `publishMultitableSheetRealtime` for the **effective** sheet:
+
+```
+publishMultitableSheetRealtime({
+  spreadsheetId: effectiveSheetId,           // target sheet for cross-base; trigger sheet for same-base
+  source: 'multitable',
+  kind: 'record-updated' | 'record-created' | 'record-deleted',
+  recordId: effectiveRecordId,
+  actorId: gate.crossBase ? undefined : (context.actorId ?? undefined),
+})
+```
+
+This closes the gap uniformly (same-base automation writes also gain the live invalidation REST
+writes already have); the cross-base case is the named demand. `effectiveSheetId`/
+`effectiveRecordId` are the values the gate already resolved (target for cross-base, trigger for
+same-base), so the fan-out targets exactly the row that changed.
+
+## 3. The one genuinely-new datum: `actorId`
+
+The ids the invalidation carries (recordId; the payload omits row data) name a row in `T` that
+`sheet:T` subscribers can already read — nothing new. The one new datum a **cross-base** fan-out
+would put in base-B's room is the **trigger `actorId`** — a base-A actor's id surfacing to base-B
+subscribers. **Decision: omit `actorId` for cross-base** (pass it only for same-base, where the
+actor belongs to the same base). Rationale: the actor hint is a same-base UI affordance ("changed
+by X" / self-echo suppression); a base-B subscriber has no need for a base-A actor identity, and
+omitting it avoids surfacing a cross-base principal. `fieldIds` are intentionally not added by
+these call sites; the target record's own fields are not §2a.3-masked to its own sheet's
+subscribers, so this is not about the cross-base mask — it is simply the minimal payload.
+
+## 4. Fail-first tests
+- A **cross-base** `update_record` fan-out publishes `spreadsheet.cell.updated` with
+  `spreadsheetId === targetSheetId`, `recordId === targetRecordId`, and **no `actorId`** (RED
+  before C1 — the executor published nothing).
+- A **same-base** `update_record` publishes with `spreadsheetId === triggerSheetId` and the
+  `actorId` present (the uniform gap-close).
+- `create_record` / `delete_record` publish the matching `kind` for the effective sheet.
+- A blocked cross-base write (gate `ok:false`) publishes **nothing** (no fan-out on a write that
+  did not happen).
+
+## 5. Out of scope (not gold-plating the real-time layer)
+No change to `sheetRoomAuthChecker` or the Yjs per-record auth gate (pre-existing, correct for
+their scope). No live CRDT cross-base co-editing (the fan-out is an invalidation, subscribers
+re-fetch through the normal gated+masked REST path). No per-field real-time masking (the re-fetch
+path applies §2a.3). No new socket channel.

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -9,6 +9,7 @@ import { redactString } from './automation-log-redact'
 import { isRichLongTextProperty, sanitizeRichLongText } from './field-codecs'
 import { ensureRecordNotLocked } from './record-lock'
 import { resolveBaseWritable } from './permission-service'
+import { publishMultitableSheetRealtime } from './realtime-publish'
 import { MemoryRateLimitStore, type RateLimitStore } from '../middleware/rate-limiter'
 import {
   DingTalkBusinessError,
@@ -1703,6 +1704,34 @@ export class AutomationExecutor {
     return payload
   }
 
+  /**
+   * C1 — publish a real-time invalidation for an automation record write to the EFFECTIVE sheet's
+   * room (target sheet for cross-base, trigger sheet for same-base). Same gated audience as a REST
+   * write to that sheet already reaches (relative invariance — origin base does not change who is in
+   * the target room). For a CROSS-BASE write the trigger `actorId` is omitted so a trigger-base
+   * principal is not surfaced to the target base's subscribers; same-base passes it through (the
+   * UI "who changed" / self-echo hint). Best-effort: never fails the authorized write.
+   */
+  private publishRecordRealtime(
+    kind: 'record-updated' | 'record-created' | 'record-deleted',
+    sheetId: string,
+    recordId: string,
+    crossBase: boolean,
+    context: ExecutionContext,
+  ): void {
+    try {
+      publishMultitableSheetRealtime({
+        spreadsheetId: sheetId,
+        source: 'multitable',
+        kind,
+        recordId,
+        actorId: crossBase ? undefined : (context.actorId ?? undefined),
+      })
+    } catch {
+      // publishMultitableSheetRealtime already swallows its own errors; this is belt-and-suspenders.
+    }
+  }
+
   private async executeUpdateRecord(
     config: Record<string, unknown>,
     context: ExecutionContext,
@@ -1797,6 +1826,13 @@ export class AutomationExecutor {
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
       })
+
+      // C1 real-time fan-out: invalidate the EFFECTIVE sheet's room (target for cross-base, trigger for
+      // same-base) so its gated subscribers see the change live — automation writes were previously
+      // invisible to the real-time layer (closeout §5). Same audience/gate as a REST write to that sheet
+      // (relative invariance). actorId is omitted for cross-base so a trigger-base actor id is not
+      // surfaced to the target base's subscribers.
+      this.publishRecordRealtime('record-updated', effectiveSheetId, effectiveRecordId, gate.crossBase, context)
 
       return { actionType: 'update_record', status: 'success', output: { updatedFields: Object.keys(fields) } }
     } catch (err) {
@@ -1896,6 +1932,9 @@ export class AutomationExecutor {
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
       })
 
+      // C1 real-time fan-out (see executeUpdateRecord) — invalidate the effective sheet's room.
+      this.publishRecordRealtime('record-deleted', effectiveSheetId, effectiveRecordId, gate.crossBase, context)
+
       return { actionType: 'delete_record', status: 'success', output: { recordId: effectiveRecordId, sheetId: effectiveSheetId } }
     } catch (err) {
       return { actionType: 'delete_record', status: 'failed', error: err instanceof Error ? err.message : String(err) }
@@ -1942,6 +1981,9 @@ export class AutomationExecutor {
         actorId: context.actorId,
         _automationDepth: ((context.triggerEvent as Record<string, unknown>)?._automationDepth as number ?? 0) + 1,
       })
+
+      // C1 real-time fan-out (see executeUpdateRecord) — invalidate the target sheet's room.
+      this.publishRecordRealtime('record-created', targetSheetId, recordId, gate.crossBase, context)
 
       return { actionType: 'create_record', status: 'success', output: { recordId, sheetId: targetSheetId } }
     } catch (err) {

--- a/packages/core-backend/tests/integration/multitable-crossbase-realtime-fanout.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-realtime-fanout.test.ts
@@ -1,0 +1,153 @@
+/**
+ * C1 — automation record writes fan out a real-time invalidation to the EFFECTIVE sheet's room.
+ *
+ * Before C1 the automation executor never called `publishMultitableSheetRealtime`, so automation
+ * writes — including the new cross-base writes/deletes — were invisible to the real-time layer
+ * (closeout §5: "Yjs 跨 base fan-out 缺席"). C1 wires each of executeUpdate/Create/DeleteRecord to
+ * publish for the effective sheet (target for cross-base, trigger for same-base). The fan-out lands
+ * on the shared-singleton eventBus topic `spreadsheet.cell.updated` — the SAME topic CollabService
+ * subscribes to and emits to the gated `sheet:${id}` room. So this suite captures that singleton
+ * topic (NOT the executor's injected deps.eventBus, which carries only chaining events).
+ *
+ * Security framing = relative invariance: routing to `sheet:${effectiveSheetId}` reaches exactly the
+ * audience a REST write to that sheet already reaches; origin base does not change the target room's
+ * membership. The one new datum a cross-base fan-out would add is the trigger actorId — which C1
+ * OMITS for cross-base (asserted below) so a trigger-base principal is not surfaced to the target
+ * base's subscribers.
+ *
+ * Real DB (describeIfDatabase) — drives the real AutomationExecutor end-to-end.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { EventBus, eventBus as sharedEventBus } from '../../src/integration/events/event-bus'
+import { AutomationExecutor, type AutomationDeps, type AutomationRule } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const OWNER = `u_rt_owner_${TS}` // owns BASE_A (trigger) AND BASE_B (target) → base-write on both
+const NO_WRITE = `u_rt_nowrite_${TS}` // owns nothing, no codes → NO base-write on BASE_B
+
+const BASE_A = `base_rt_a_${TS}` // trigger base
+const BASE_B = `base_rt_b_${TS}` // cross-base target base
+const SHEET_A = `sheet_rt_a_${TS}` // trigger sheet (BASE_A)
+const SHEET_B = `sheet_rt_b_${TS}` // cross-base target sheet (BASE_B)
+const TRIG_REC = `rec_rt_trig_${TS}` // a record in SHEET_A (same-base update target)
+const TGT_REC = `rec_rt_tgt_${TS}` // a record in SHEET_B (cross-base update/delete target)
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function makeExecutor(): AutomationExecutor {
+  const deps = {
+    eventBus: new EventBus(),
+    queryFn: (sql: string, params?: unknown[]) => q(sql, params),
+  } as unknown as AutomationDeps
+  return new AutomationExecutor(deps)
+}
+
+function ruleWith(action: { type: string; config: Record<string, unknown> }, createdBy: string): AutomationRule {
+  return {
+    id: `axr_rt_${TS}_${Math.random().toString(36).slice(2, 8)}`,
+    name: 'RT rule',
+    sheetId: SHEET_A,
+    trigger: { type: 'record.updated', config: {} },
+    actions: [action as never],
+    enabled: true,
+    createdBy,
+    createdAt: new Date().toISOString(),
+  } as unknown as AutomationRule
+}
+
+// Capture the shared-singleton realtime topic (what CollabService consumes).
+type Fanout = { spreadsheetId?: string; recordId?: string; kind?: string; actorId?: unknown; source?: string }
+let captured: Fanout[] = []
+const onFanout = (payload: unknown) => { captured.push(payload as Fanout) }
+
+describeIfDatabase('C1 — automation real-time fan-out to the effective sheet room (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_A, 'RT Base A', OWNER])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3)', [BASE_B, 'RT Base B', OWNER])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_A, BASE_A, 'Trigger A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_B, BASE_B, 'Target B'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)', [TRIG_REC, SHEET_A, JSON.stringify({ v: 'trig' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)', [TGT_REC, SHEET_B, JSON.stringify({ v: 'tgt' })])
+    sharedEventBus.subscribe('spreadsheet.cell.updated', onFanout)
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+  })
+
+  beforeEach(() => { captured = [] })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  // C1-1 KEYSTONE: a CROSS-BASE update fans out to the TARGET sheet's room, with NO actorId.
+  // RED before C1 — the executor published nothing to the realtime topic.
+  test('C1-1: cross-base update_record fans out to the target sheet (no actorId surfaced)', async () => {
+    const rule = ruleWith(
+      { type: 'update_record', config: { fields: { v: 'rt1' }, targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: TGT_REC } },
+      OWNER,
+    )
+    const exec = await makeExecutor().execute(rule, { recordId: TRIG_REC, sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    const fan = captured.find((c) => c.recordId === TGT_REC)
+    expect(fan, 'cross-base update must fan out to the target sheet room').toBeTruthy()
+    expect(fan?.spreadsheetId).toBe(SHEET_B)
+    expect(fan?.kind).toBe('record-updated')
+    expect(fan?.actorId).toBeUndefined() // OMITTED for cross-base (no base-A principal in base-B's room)
+  })
+
+  // C1-2: a SAME-BASE update fans out to the trigger sheet, WITH actorId (the uniform gap-close).
+  test('C1-2: same-base update_record fans out to the trigger sheet, actorId present', async () => {
+    const rule = ruleWith({ type: 'update_record', config: { fields: { v: 'rt2' } } }, OWNER)
+    const exec = await makeExecutor().execute(rule, { recordId: TRIG_REC, sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    const fan = captured.find((c) => c.recordId === TRIG_REC)
+    expect(fan?.spreadsheetId).toBe(SHEET_A)
+    expect(fan?.kind).toBe('record-updated')
+    expect(fan?.actorId).toBe(OWNER) // same-base: actor belongs to the same base, pass it through
+  })
+
+  // C1-3: cross-base create fans out kind 'record-created' to the target sheet.
+  test('C1-3: cross-base create_record fans out record-created to the target sheet', async () => {
+    const rule = ruleWith({ type: 'create_record', config: { sheetId: SHEET_B, targetBaseId: BASE_B, data: { v: 'rt3' } } }, OWNER)
+    const exec = await makeExecutor().execute(rule, { recordId: TRIG_REC, sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    const fan = captured.find((c) => c.spreadsheetId === SHEET_B && c.kind === 'record-created')
+    expect(fan, 'cross-base create must fan out record-created').toBeTruthy()
+    expect(fan?.actorId).toBeUndefined()
+  })
+
+  // C1-4: cross-base delete fans out kind 'record-deleted' to the target sheet.
+  test('C1-4: cross-base delete_record fans out record-deleted to the target sheet', async () => {
+    // dedicated victim so the suite stays order-independent
+    const victim = `rec_rt_victim_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1, $2, $3::jsonb, 1)', [victim, SHEET_B, JSON.stringify({ v: 'victim' })])
+    const rule = ruleWith(
+      { type: 'delete_record', config: { targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: victim } },
+      OWNER,
+    )
+    const exec = await makeExecutor().execute(rule, { recordId: TRIG_REC, sheetId: SHEET_A, actorId: OWNER, data: {} })
+    expect(exec.steps[0]?.status).toBe('success')
+    const fan = captured.find((c) => c.recordId === victim && c.kind === 'record-deleted')
+    expect(fan, 'cross-base delete must fan out record-deleted').toBeTruthy()
+    expect(fan?.spreadsheetId).toBe(SHEET_B)
+    expect(fan?.actorId).toBeUndefined()
+  })
+
+  // C1-5: a BLOCKED cross-base write (actor lacks target base-write) fans out NOTHING — no fan-out
+  // for a write that did not happen.
+  test('C1-5: a blocked cross-base write (no base-write) fans out nothing', async () => {
+    const rule = ruleWith(
+      { type: 'update_record', config: { fields: { v: 'rt5' }, targetBaseId: BASE_B, targetSheetId: SHEET_B, targetRecordId: TGT_REC } },
+      NO_WRITE,
+    )
+    const exec = await makeExecutor().execute(rule, { recordId: TRIG_REC, sheetId: SHEET_A, actorId: NO_WRITE, data: {} })
+    expect(exec.steps[0]?.status).toBe('failed') // gate denies (no base-write on BASE_B)
+    expect(captured.find((c) => c.recordId === TGT_REC), 'a denied write must not fan out').toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Phase C1 — cross-base real-time fan-out

Closes closeout §5 "Yjs 跨 base fan-out — 缺席". Automation record writes (update/create/delete) now publish a real-time invalidation to the **effective** sheet's room.

### Trace (the live path, established before designing)
`publishMultitableSheetRealtime` → eventBus `spreadsheet.cell.updated` (ids-only; row data omitted) → `CollabService` → Socket.IO room `sheet:${spreadsheetId}` (join gated by `sheetRoomAuthChecker`, fail-closed). REST writes already use this; **the automation executor never did** → automation writes (incl. the new cross-base writes/deletes) were invisible to subscribers.

### Change (minimal)
`executeUpdate/Create/DeleteRecord` call a shared `publishRecordRealtime(kind, effectiveSheetId, effectiveRecordId, gate.crossBase, context)` after the successful mutation. `effective*` is what the gate already resolved (target for cross-base, trigger for same-base).

### Safety = relative invariance (not an absolute claim)
Routing to `sheet:${effectiveSheetId}` reaches exactly the audience a REST write to that sheet already reaches; **origin base does not change the target room's membership**, so C1 adds no audience and changes no gate. We deliberately do NOT assert "membership == full read authority" (the sheet/Yjs gate is sheet-scoped and doesn't re-apply REST's record-scope map — pre-existing, out of scope). *Correction of an earlier mis-framing:* this is not a base-read membership gap — REST **direct** record read is sheet-capability-gated, not base-read (`resolveBaseReadable` applies only to cross-base link projection). **No authChecker change.**

### The one new datum: `actorId`
A cross-base fan-out would put the trigger (base-A) `actorId` into base-B's room. **Omitted for cross-base**; passed for same-base (the actor belongs to the same base). The ids it does carry name a row the target room's subscribers can already read.

### Tests (5, real DB) + verification
C1-1 keystone (cross-base update → target sheet, **no actorId**; RED before C1) · C1-2 same-base → trigger sheet **with actorId** · C1-3 create · C1-4 delete · C1-5 a blocked write fans out **nothing**. Both structural guards green (the publish calls aren't `meta_records` mutations); tsc clean; 212 regression tests pass.

### Scope
No `sheetRoomAuthChecker` / Yjs-auth change; no live CRDT cross-base co-editing; no per-field real-time masking (re-fetch applies §2a.3); no new channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)