### PR TITLE
feat(data-source): thread C3 watermark config

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -121,6 +121,10 @@ TODO:
 - [x] C3-1 facade 支持 `orderBy` 并保留 `where`/equality `filters` passthrough。
   - #2609 / squash `1586c3841`.
   - 仍是 host-side seam；未打开 watermark runtime、未改变 adapter cursor、未新增写能力。
+- [ ] C3-3a runner 透传 resolved `watermarkConfig`，并对 `data-source:sql-readonly`
+  的 `updated_at` 增量配置强制声明 tiebreaker。
+  - 目标: adapter 后续实现 keyset 时读取同一个 runner-resolved config，不再自己猜 `type/field/tiebreaker`。
+  - 边界: 不生成 watermark `where/orderBy`，不改变 offset cursor，不打开 C3-2/C3-3 runtime。
 - [ ] C3-2 adapter 实现 in-run mode-tagged cursor；跨 run 仍复用现有 watermark store，不改 store schema。
 - [ ] C3-3 `updated_at + id` 复合游标实现和测试。
 - [ ] C3-4 `monotonic_id` 游标实现和测试。

--- a/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
@@ -80,11 +80,17 @@ async function main() {
     cursor: 'c1',
     filters: { status: 'approved' },
     watermark: { updated_at: '2026-04-24T00:00:00Z' },
+    watermarkConfig: { type: 'updated_at', field: 'updated_at', tiebreaker: 'id' },
   })
   assert.equal(read.object, 'materials')
   assert.equal(read.limit, 10000, 'read limit is capped')
   assert.equal(read.cursor, 'c1')
   assert.deepEqual(read.filters, { status: 'approved' })
+  assert.deepEqual(
+    read.watermarkConfig,
+    { type: 'updated_at', field: 'updated_at', tiebreaker: 'id' },
+    'read normalizer preserves the resolved watermarkConfig payload for C3 adapters',
+  )
 
   const upsert = normalizeUpsertRequest({
     object: 'materials',

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -126,9 +126,9 @@ function createPipelineRegistry(pipeline, db) {
   }
 }
 
-function createExternalSystemRegistry() {
+function createExternalSystemRegistry({ sourceSystemKind = 'mock-source' } = {}) {
   const systems = new Map([
-    ['source_1', { id: 'source_1', name: 'PLM mock', kind: 'mock-source', role: 'source', config: {} }],
+    ['source_1', { id: 'source_1', name: 'PLM mock', kind: sourceSystemKind, role: 'source', config: {} }],
     ['target_1', { id: 'target_1', name: 'ERP mock', kind: 'mock-target', role: 'target', config: {} }],
   ])
   return {
@@ -142,10 +142,14 @@ function createExternalSystemRegistry() {
   }
 }
 
-function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead, targetUpsert, erpFeedbackWriter } = {}) {
+function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead, sourceSystemKind = 'mock-source', targetUpsert, erpFeedbackWriter } = {}) {
   const db = createMockDb()
   const targetRows = new Map()
   const adapterSystems = []
+  const defaultOptions = {
+    batchSize: 100,
+    watermark: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'code' },
+  }
   const pipeline = {
     id: 'pipe_1',
     tenantId: 'tenant_1',
@@ -158,19 +162,20 @@ function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead
     mode: 'incremental',
     status: 'active',
     idempotencyKeyFields: ['code', 'revision'],
-    options: {
-      batchSize: 100,
-      watermark: { type: 'updated_at', field: 'updatedAt' },
-    },
+    options: defaultOptions,
     fieldMappings: [
       { sourceField: 'code', targetField: 'FNumber', transform: ['trim', 'upper'], validation: [{ type: 'required' }] },
       { sourceField: 'qty', targetField: 'FQty', transform: { fn: 'toNumber' }, validation: [{ type: 'min', value: 1 }] },
       { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }] },
     ],
     ...pipelineOverrides,
+    options: {
+      ...defaultOptions,
+      ...(pipelineOverrides.options || {}),
+    },
   }
   const adapterRegistry = createAdapterRegistry()
-    .registerAdapter('mock-source', ({ system }) => ({
+    .registerAdapter(sourceSystemKind, ({ system }) => ({
       system,
       async testConnection() { return { ok: true } },
       async listObjects() { return [{ name: 'materials' }] },
@@ -217,7 +222,7 @@ function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead
   const pipelineRegistry = createPipelineRegistry(pipeline, db)
   const runner = createPipelineRunner({
     pipelineRegistry,
-    externalSystemRegistry: createExternalSystemRegistry(),
+    externalSystemRegistry: createExternalSystemRegistry({ sourceSystemKind }),
     adapterRegistry,
     deadLetterStore: createDeadLetterStore({ db, idGenerator: () => `dl_${db.tables.get('integration_dead_letters').length + 1}` }),
     watermarkStore: createWatermarkStore({ db }),
@@ -460,6 +465,133 @@ async function main() {
   assert.equal(incRun2.metrics.rowsRead, 1)
   assert.equal(incRun2.metrics.rowsWritten, 1)
   assert.equal((await incremental.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' })).watermark_value, '2026-04-24T02:00:00.000Z')
+
+  // --- 3b. Incremental reads receive the resolved watermarkConfig ----------
+  {
+    const readInputs = []
+    const configHarness = createRunnerHarness({
+      sourceRecords: [],
+      sourceRead: async (input) => {
+        readInputs.push(input)
+        return createReadResult({
+          records: [
+            { code: 'cfg-01', revision: 'r1', qty: '1', name: 'Config', updatedAt: '2026-04-24T03:00:00.000Z' },
+          ],
+        })
+      },
+      pipelineOverrides: {
+        options: {
+          batchSize: 100,
+          watermark: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'code' },
+        },
+      },
+    })
+    await configHarness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+    })
+    assert.deepEqual(readInputs[0].watermarkConfig, {
+      type: 'updated_at',
+      field: 'updatedAt',
+      tiebreaker: 'code',
+    }, 'runner passes the resolved C3 watermark config to sourceAdapter.read')
+  }
+
+  // --- 3c. SQL bridge updated_at incremental mode requires a tiebreaker ----
+  {
+    let sourceReadCalls = 0
+    const invalidConfig = createRunnerHarness({
+      sourceRecords: [],
+      sourceSystemKind: 'data-source:sql-readonly',
+      sourceRead: async () => {
+        sourceReadCalls += 1
+        return createReadResult({ records: [] })
+      },
+      pipelineOverrides: {
+        options: {
+          batchSize: 100,
+          watermark: { type: 'updated_at', field: 'updatedAt' },
+        },
+      },
+    })
+    await assert.rejects(
+      () => invalidConfig.runner.runPipeline({
+        tenantId: 'tenant_1',
+        pipelineId: 'pipe_1',
+        mode: 'incremental',
+        triggeredBy: 'manual',
+      }),
+      (error) => error && error.details && /updated_at watermark config requires a tiebreaker/.test(error.details.cause),
+      'incremental updated_at without tiebreaker fails closed',
+    )
+    assert.equal(sourceReadCalls, 0, 'invalid watermark config fails before any source read')
+  }
+
+  // --- 3d. Non-bridge incremental sources keep the legacy optional-tiebreaker path.
+  {
+    const readInputs = []
+    const legacySource = createRunnerHarness({
+      sourceRecords: [],
+      sourceRead: async (input) => {
+        readInputs.push(input)
+        return createReadResult({
+          records: [
+            { code: 'legacy-01', revision: 'r1', qty: '1', name: 'Legacy', updatedAt: '2026-04-24T03:30:00.000Z' },
+          ],
+        })
+      },
+      pipelineOverrides: {
+        options: {
+          batchSize: 100,
+          watermark: { type: 'updated_at', field: 'updatedAt' },
+        },
+      },
+    })
+    await legacySource.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+    })
+    assert.deepEqual(readInputs[0].watermarkConfig, {
+      type: 'updated_at',
+      field: 'updatedAt',
+    }, 'non-bridge adapters are not forced onto the SQL bridge tiebreaker contract')
+  }
+
+  // --- 3e. monotonic_id incremental mode does not require a tiebreaker -----
+  {
+    const readInputs = []
+    const monotonic = createRunnerHarness({
+      sourceRecords: [],
+      sourceRead: async (input) => {
+        readInputs.push(input)
+        return createReadResult({
+          records: [
+            { code: 'mono-01', revision: 'r1', qty: '1', name: 'Mono', id: 10 },
+          ],
+        })
+      },
+      pipelineOverrides: {
+        options: {
+          batchSize: 100,
+          watermark: { type: 'monotonic_id', field: 'id' },
+        },
+      },
+    })
+    await monotonic.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+    })
+    assert.deepEqual(readInputs[0].watermarkConfig, {
+      type: 'monotonic_id',
+      field: 'id',
+    }, 'monotonic_id config is passed without requiring a tiebreaker')
+  }
 
   // --- 4. Dry-run previews records without target/dead-letter/watermark --
   const dryRun = createRunnerHarness({

--- a/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
@@ -9,6 +9,7 @@ const {
 const {
   createWatermarkStore,
   deriveNextWatermark,
+  normalizeWatermarkConfig,
   WatermarkError,
 } = require(path.join(__dirname, '..', 'lib', 'watermark.cjs'))
 const { createDeadLetterStore } = require(path.join(__dirname, '..', 'lib', 'dead-letter.cjs'))
@@ -200,6 +201,38 @@ async function main() {
   assert.deepEqual(
     deriveNextWatermark([{ id: 7 }, { id: '42' }, { id: 13 }], { type: 'monotonic_id' }),
     { type: 'monotonic_id', value: '42' },
+  )
+  assert.deepEqual(
+    normalizeWatermarkConfig(
+      { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
+      { requireTiebreaker: true },
+    ),
+    {
+      type: 'updated_at',
+      field: 'updatedAt',
+      tiebreaker: 'id',
+      fallbackFields: ['updated_at', 'updatedAt'],
+    },
+    'updated_at configs carry the declared tiebreaker for C3 keyset config plumbing',
+  )
+  assert.deepEqual(
+    normalizeWatermarkConfig({ type: 'monotonic_id', field: 'id' }, { requireTiebreaker: true }),
+    {
+      type: 'monotonic_id',
+      field: 'id',
+      fallbackFields: ['id'],
+    },
+    'monotonic_id does not require a tiebreaker',
+  )
+  assert.throws(
+    () => normalizeWatermarkConfig({ type: 'updated_at', field: 'updatedAt' }, { requireTiebreaker: true }),
+    WatermarkError,
+    'incremental updated_at configs fail closed without a tiebreaker',
+  )
+  assert.throws(
+    () => normalizeWatermarkConfig({ type: 'updated_at', field: 'updatedAt', tiebreaker: 'updatedAt' }, { requireTiebreaker: true }),
+    WatermarkError,
+    'updated_at tiebreaker cannot be the watermark field itself',
   )
 
   const db = createMockDb()

--- a/plugins/plugin-integration-core/lib/contracts.cjs
+++ b/plugins/plugin-integration-core/lib/contracts.cjs
@@ -98,6 +98,7 @@ function normalizeReadRequest(input = {}) {
     cursor: optionalString(input.cursor, 'cursor'),
     filters: objectOrEmpty(input.filters, 'filters'),
     watermark: objectOrEmpty(input.watermark, 'watermark'),
+    watermarkConfig: objectOrEmpty(input.watermarkConfig, 'watermarkConfig'),
     options: objectOrEmpty(input.options, 'options'),
   }
 }

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -3,7 +3,7 @@
 const { transformRecord } = require('./transform-engine.cjs')
 const { validateRecord } = require('./validator.cjs')
 const { computeRecordIdempotencyKey } = require('./idempotency.cjs')
-const { deriveNextWatermark } = require('./watermark.cjs')
+const { deriveNextWatermark, normalizeWatermarkConfig } = require('./watermark.cjs')
 const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
 
 class PipelineRunnerError extends Error {
@@ -26,6 +26,7 @@ const DEFAULT_BATCH_SIZE = 1000
 const MAX_BATCH_SIZE = 10000
 const DEFAULT_MAX_PAGES = 100
 const MAX_RUN_PAGES = 10000
+const DATA_SOURCE_SQL_READONLY_KIND = 'data-source:sql-readonly'
 // DF-N2-2b: per-run cap on appended provenance events. Keeps the
 // integration_runs.provenance_events JSONB column bounded (~300 bytes/event →
 // ~150KB) so a large run cannot bloat the row. Overflow is surfaced as a counter
@@ -196,12 +197,27 @@ function isTruncatedReplayPayload(value) {
   return Boolean(value && typeof value === 'object' && value.payloadTruncated === true)
 }
 
-function resolveWatermarkConfig(pipeline) {
-  const options = pipeline.options || {}
-  return options.watermark || {
+function resolveWatermarkConfig(pipeline, options = {}) {
+  const pipelineOptions = pipeline.options || {}
+  return normalizeWatermarkConfig(pipelineOptions.watermark || {
     type: 'updated_at',
     field: 'updatedAt',
+  }, {
+    requireTiebreaker: options.requireTiebreaker === true,
+  })
+}
+
+function createReadWatermarkConfig(config) {
+  const out = {
+    type: config.type,
+    field: config.field,
   }
+  if (config.tiebreaker) out.tiebreaker = config.tiebreaker
+  return out
+}
+
+function shouldRequireWatermarkTiebreaker(context, mode) {
+  return mode === 'incremental' && context.sourceSystem && context.sourceSystem.kind === DATA_SOURCE_SQL_READONLY_KIND
 }
 
 function assertActiveSystem(system, field) {
@@ -542,7 +558,10 @@ function createPipelineRunner(deps = {}) {
     })
 
     try {
-      const watermarkConfig = resolveWatermarkConfig(context.pipeline)
+      const watermarkConfig = resolveWatermarkConfig(context.pipeline, {
+        requireTiebreaker: shouldRequireWatermarkTiebreaker(context, mode),
+      })
+      const readWatermarkConfig = mode === 'incremental' ? createReadWatermarkConfig(watermarkConfig) : {}
       const currentWatermark = mode === 'incremental'
         ? await watermarkStore.getWatermark(context.pipeline.id)
         : null
@@ -581,6 +600,7 @@ function createPipelineRunner(deps = {}) {
               limit: effectiveBatchSize,
               cursor,
               watermark: currentWatermark ? { [watermarkConfig.field]: currentWatermark.value } : {},
+              watermarkConfig: readWatermarkConfig,
               filters: sourceReadOptions.filters,
               options: sourceReadOptions.options,
             })

--- a/plugins/plugin-integration-core/lib/watermark.cjs
+++ b/plugins/plugin-integration-core/lib/watermark.cjs
@@ -13,7 +13,7 @@ class WatermarkError extends Error {
   }
 }
 
-function normalizeWatermarkConfig(config = {}) {
+function normalizeWatermarkConfig(config = {}, options = {}) {
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
     throw new WatermarkError('watermark config must be an object')
   }
@@ -21,12 +21,40 @@ function normalizeWatermarkConfig(config = {}) {
   if (!VALID_TYPES.has(type)) {
     throw new WatermarkError(`unsupported watermark type: ${type}`, { type })
   }
-  const field = config.field || config.watermarkField || (type === 'updated_at' ? 'updated_at' : 'id')
-  return {
+  const field = normalizeWatermarkFieldName(
+    config.field || config.watermarkField || (type === 'updated_at' ? 'updated_at' : 'id'),
+    'watermark.field'
+  )
+  const normalized = {
     type,
     field,
     fallbackFields: type === 'updated_at' ? ['updated_at', 'updatedAt'] : ['id'],
   }
+  if (type === 'updated_at') {
+    const tiebreaker = config.tiebreaker || config.tieBreaker || config.tiebreakerField || config.watermarkTiebreaker
+    if (isBlank(tiebreaker)) {
+      if (options.requireTiebreaker === true) {
+        throw new WatermarkError('updated_at watermark config requires a tiebreaker', {
+          field: 'watermark.tiebreaker',
+        })
+      }
+      return normalized
+    }
+    normalized.tiebreaker = normalizeWatermarkFieldName(tiebreaker, 'watermark.tiebreaker')
+    if (normalized.tiebreaker === normalized.field) {
+      throw new WatermarkError('updated_at watermark tiebreaker must be different from field', {
+        field: 'watermark.tiebreaker',
+      })
+    }
+  }
+  return normalized
+}
+
+function normalizeWatermarkFieldName(value, field) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new WatermarkError(`${field} must be a non-empty string`, { field })
+  }
+  return value.trim()
 }
 
 function parseWatermarkValue(type, value) {


### PR DESCRIPTION
## Summary

C3-3a for the read-only SQL data-source bridge: thread the runner-resolved watermark config into source reads, without opening keyset runtime yet.

- normalize `pipeline.options.watermark` through the shared watermark helper and preserve `{ type, field, tiebreaker? }` in the read contract
- pass the resolved config as `watermarkConfig` to `sourceAdapter.read()` so the upcoming SQL bridge keyset adapter does not guess type/field/tiebreaker
- fail closed for `data-source:sql-readonly` incremental `updated_at` configs that omit a tiebreaker
- keep non-bridge sources, including K3, on the existing optional-tiebreaker path
- update the delivery TODO to mark this as C3-3a plumbing only; C3-2/C3-3 keyset runtime remains gated

## Boundaries

- no adapter keyset implementation yet
- no watermark `where/orderBy` generation yet
- no cursor-mode change
- no K3 change
- no write path / RBAC / auth change

## Verification

- `node plugins/plugin-integration-core/__tests__/runner-support.test.cjs`
- `node plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs`
- `node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs`
- `node plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs`
- `node plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs`
- `node plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs`
- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

## Review

Subagent Hooke reviewed the diff: no P0/P1/P2 findings; one wording NIT was fixed before opening this PR.