### PR TITLE
feat(data-source): add C3 structured where groups

### DIFF
--- a/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
+++ b/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
@@ -180,11 +180,18 @@ argument is the same wire-vs-fixture class of bug.)
   `where` pass-through to `DataSourceManager.select`; parameterized-only; writable-source still rejected.
   Facade unit test covers pass-through, malformed `orderBy` fail-closed, uppercase direction normalization,
   and the existing no-fallback / writable-source guard. Landed in #2609 / squash `1586c3841`.
+- 🔒 **C3-2a — structured `where` logical groups:** widen adapter structured reads to express the
+  `updated_at` composite keyset predicate as `field > last OR (field = last AND tiebreaker > lastTie)`;
+  keep all values parameterized; reject malformed logical groups and unknown `$` operators fail-closed;
+  add MySQL operator parity with Postgres/MSSQL. This is a prerequisite only — no watermark predicate is
+  generated yet, and the offset/full path stays unchanged.
 - 🔒 **C3-2 — adapter watermark mode (plugin):** type-conditional keyset (Seam B) + cursor model (Seam C);
   unit tests incl. the **no-miss** and **no-stall** negative controls and offset/full coexistence.
-- 🔒 **C3-3 — watermark-config plumbing + bind-time validation:** extend `pipeline.options.watermark` to
-  `{ type, field, tiebreaker? }`, pass the resolved config into `read()` (Seam D); validate column
-  exists/orderable/indexed and `updated_at` has a tiebreaker, else **fail closed** (Seam E bind-time).
+- ✅ **C3-3a — watermark-config plumbing (runner → read request):** extend `pipeline.options.watermark` to
+  `{ type, field, tiebreaker? }`, pass the resolved config into `read()` (Seam D), and require
+  `updated_at` configs to declare a tiebreaker for the `data-source:sql-readonly` bridge. Landed in #2619
+  / squash `7f61709ea`; the remaining column exists/orderable/indexed validation stays gated with the
+  runtime slices.
 - ✅ **C2-0 — honor equality `filters`:** parameterized equality `filters` already pass through as `where`
   before C3 runtime.
 - 🔒 **C3-4 — filter + watermark composition lock:** keep those equality filters AND'd with the watermark
@@ -197,8 +204,8 @@ argument is the same wire-vs-fixture class of bug.)
   facade→`DataSourceManager`→real-adapter→DB keyset path — this real-DB test is the acceptance keystone.
 
 **All remaining C3-2..C3-5 work stays 🔒** until both a real volume/perf signal **and** a separate opt-in.
-Build order: C3-3 (config/validation) → C3-2 (adapter mode) → C3-4
-(filter+watermark composition) → C3-5 (real-DB lock).
+Build order from the current mainline: C3-2a (structured `where` groups) → C3-2 (adapter mode + cursor)
+→ C3-4 (filter+watermark composition) → C3-5 (real-DB lock).
 
 ## Acceptance checklist (the locks — for the impl slices)
 

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -17,7 +17,7 @@
 | --- | --- | --- | --- | --- |
 | P0 | ②b arc 收口权限/契约修复 | done (#2597) | 已排已合并主线风险 | related-echo 跨 base 泄漏 |
 | C2-close | 只读数据库链路 smoke 收口 | done (#2600) | 证明当前 read-only bridge 可稳定测试 | 实体机配置漂移 |
-| C3 | incremental / watermark runtime | gated; C3-1 done (#2609) | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
+| C3 | incremental / watermark runtime | gated; C3-1 done (#2609), C3-3a done (#2619) | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | gated | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
 | C6 | external write | gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
@@ -121,10 +121,16 @@ TODO:
 - [x] C3-1 facade 支持 `orderBy` 并保留 `where`/equality `filters` passthrough。
   - #2609 / squash `1586c3841`.
   - 仍是 host-side seam；未打开 watermark runtime、未改变 adapter cursor、未新增写能力。
-- [ ] C3-3a runner 透传 resolved `watermarkConfig`，并对 `data-source:sql-readonly`
+- [x] C3-3a runner 透传 resolved `watermarkConfig`，并对 `data-source:sql-readonly`
   的 `updated_at` 增量配置强制声明 tiebreaker。
+  - #2619 / squash `7f61709ea`.
   - 目标: adapter 后续实现 keyset 时读取同一个 runner-resolved config，不再自己猜 `type/field/tiebreaker`。
   - 边界: 不生成 watermark `where/orderBy`，不改变 offset cursor，不打开 C3-2/C3-3 runtime。
+- [ ] C3-2a structured `where` 逻辑分组 + MySQL operator parity。
+  - 目标: 先让 Postgres/MSSQL/MySQL 的 structured read 能表达
+    `field > last OR (field = last AND tiebreaker > lastTie)`，为 `updated_at + id`
+    复合 keyset 铺底。
+  - 边界: 不生成 watermark predicate，不解析/推进 cursor，不改变 offset full-read 行为，不新增写能力。
 - [ ] C3-2 adapter 实现 in-run mode-tagged cursor；跨 run 仍复用现有 watermark store，不改 store schema。
 - [ ] C3-3 `updated_at + id` 复合游标实现和测试。
 - [ ] C3-4 `monotonic_id` 游标实现和测试。

--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -37,6 +37,11 @@ export interface WhereOperators {
 
 // Type for where clause values
 export type WhereValue = DbValue | WhereOperators
+export interface WhereClause {
+  [key: string]: WhereValue | WhereClause[] | undefined
+  $or?: WhereClause[]
+  $and?: WhereClause[]
+}
 
 export interface DataSourceConfig {
   id: string
@@ -57,7 +62,7 @@ export interface QueryOptions {
   limit?: number
   offset?: number
   orderBy?: Array<{ column: string; direction: 'asc' | 'desc' }>
-  where?: Record<string, WhereValue>
+  where?: WhereClause
   select?: string[]
   joins?: Array<{
     table: string
@@ -171,7 +176,7 @@ export function isBoolean(value: ConfigValue | undefined): value is boolean {
 }
 
 // Type guard for WhereOperators
-function isWhereOperator(value: WhereValue): value is WhereOperators {
+function isWhereOperator(value: unknown): value is WhereOperators {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     return false
   }
@@ -214,8 +219,8 @@ export abstract class BaseDataAdapter extends EventEmitter {
   abstract query<T = Record<string, DbValue>>(sql: string, params?: DbValue[]): Promise<QueryResult<T>>
   abstract select<T = Record<string, DbValue>>(table: string, options?: QueryOptions): Promise<QueryResult<T>>
   abstract insert<T = Record<string, DbValue>>(table: string, data: Record<string, DbValue> | Record<string, DbValue>[]): Promise<QueryResult<T>>
-  abstract update<T = Record<string, DbValue>>(table: string, data: Record<string, DbValue>, where: Record<string, WhereValue>): Promise<QueryResult<T>>
-  abstract delete<T = Record<string, DbValue>>(table: string, where: Record<string, WhereValue>): Promise<QueryResult<T>>
+  abstract update<T = Record<string, DbValue>>(table: string, data: Record<string, DbValue>, where: WhereClause): Promise<QueryResult<T>>
+  abstract delete<T = Record<string, DbValue>>(table: string, where: WhereClause): Promise<QueryResult<T>>
 
   // Schema operations
   abstract getSchema(schema?: string): Promise<SchemaInfo>
@@ -300,25 +305,74 @@ export abstract class BaseDataAdapter extends EventEmitter {
     return limit
   }
 
-  protected buildWhereClause(where: Record<string, WhereValue>): { sql: string; params: DbValue[] } {
+  protected buildWhereClause(where: WhereClause): { sql: string; params: DbValue[] } {
+    const result = this.buildWhereConditions(where, 1)
+    return {
+      sql: result.conditions.length > 0 ? `WHERE ${result.conditions.join(' AND ')}` : '',
+      params: result.params
+    }
+  }
+
+  private buildWhereConditions(
+    where: WhereClause,
+    startParamIndex: number
+  ): { conditions: string[]; params: DbValue[]; nextParamIndex: number } {
     const conditions: string[] = []
     const params: DbValue[] = []
-    let paramIndex = 1
+    let paramIndex = startParamIndex
 
     for (const [key, value] of Object.entries(where)) {
-      if (value === null) {
+      if (value === undefined) {
+        continue
+      }
+      if (key === '$or' || key === '$and') {
+        if (!Array.isArray(value) || value.length === 0) {
+          throw new Error(`${key} must be a non-empty array of where clauses`)
+        }
+        const nestedParts: string[] = []
+        const clauses = value as WhereClause[]
+        for (const clause of clauses) {
+          if (!clause || typeof clause !== 'object' || Array.isArray(clause)) {
+            throw new Error(`${key} entries must be where clause objects`)
+          }
+          const nested = this.buildWhereConditions(clause, paramIndex)
+          paramIndex = nested.nextParamIndex
+          params.push(...nested.params)
+          if (nested.conditions.length === 0) {
+            throw new Error(`${key} entries must not be empty`)
+          }
+          nestedParts.push(`(${nested.conditions.join(' AND ')})`)
+        }
+        conditions.push(`(${nestedParts.join(key === '$or' ? ' OR ' : ' AND ')})`)
+      } else if (value === null) {
         conditions.push(`${this.sanitizeIdentifier(key)} IS NULL`)
       } else if (Array.isArray(value)) {
-        const placeholders = value.map(() => `$${paramIndex++}`).join(', ')
+        const list = value as DbValue[]
+        const placeholders = list.map(() => `$${paramIndex++}`).join(', ')
         conditions.push(`${this.sanitizeIdentifier(key)} IN (${placeholders})`)
-        params.push(...value)
+        params.push(...list)
       } else if (isWhereOperator(value)) {
         // Handle operators like { $gt: 5, $lt: 10 }
         for (const [op, val] of Object.entries(value)) {
           if (val !== undefined) {
             const operator = this.getOperator(op)
-            conditions.push(`${this.sanitizeIdentifier(key)} ${operator} $${paramIndex++}`)
-            params.push(val)
+            if (op === '$in' || op === '$nin') {
+              if (!Array.isArray(val) || val.length === 0) {
+                throw new Error(`${op} must be a non-empty array`)
+              }
+              const placeholders = val.map(() => `$${paramIndex++}`).join(', ')
+              conditions.push(`${this.sanitizeIdentifier(key)} ${operator} (${placeholders})`)
+              params.push(...val)
+            } else if (op === '$between') {
+              if (!Array.isArray(val) || val.length !== 2) {
+                throw new Error('$between must be a two-value array')
+              }
+              conditions.push(`${this.sanitizeIdentifier(key)} BETWEEN $${paramIndex++} AND $${paramIndex++}`)
+              params.push(...val)
+            } else {
+              conditions.push(`${this.sanitizeIdentifier(key)} ${operator} $${paramIndex++}`)
+              params.push(val)
+            }
           }
         }
       } else if (typeof value === 'object' && value !== null) {
@@ -332,8 +386,9 @@ export abstract class BaseDataAdapter extends EventEmitter {
     }
 
     return {
-      sql: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
-      params
+      conditions,
+      params,
+      nextParamIndex: paramIndex
     }
   }
 
@@ -350,7 +405,11 @@ export abstract class BaseDataAdapter extends EventEmitter {
       $nin: 'NOT IN',
       $between: 'BETWEEN'
     }
-    return operators[op] || '='
+    const operator = operators[op]
+    if (!operator) {
+      throw new Error(`Unsupported where operator: ${op}`)
+    }
+    return operator
   }
 
   // A3: the redacted cause of the most recent connect/test failure (null when healthy).

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'eventemitter3'
 import type { Kysely } from 'kysely'
-import type { BaseDataAdapter, DataSourceConfig, QueryOptions, QueryResult, DbValue, WhereValue, ConnectionConfig, Credentials, AdapterOptions } from './BaseAdapter'
+import type { BaseDataAdapter, DataSourceConfig, QueryOptions, QueryResult, DbValue, WhereClause, ConnectionConfig, Credentials, AdapterOptions } from './BaseAdapter'
 import { PostgresAdapter } from './PostgresAdapter'
 import { HTTPAdapter } from './HTTPAdapter'
 import { MSSQLAdapter } from './MSSQLAdapter'
@@ -562,7 +562,7 @@ export class DataSourceManager extends EventEmitter {
     dataSourceId: string,
     table: string,
     data: Record<string, DbValue>,
-    where: Record<string, WhereValue>
+    where: WhereClause
   ): Promise<QueryResult<T>> {
     const adapter = this.getDataSource(dataSourceId)
     adapter.assertWritable() // defense-in-depth: reject mutations on a read-only source
@@ -577,7 +577,7 @@ export class DataSourceManager extends EventEmitter {
   async delete<T = Record<string, DbValue>>(
     dataSourceId: string,
     table: string,
-    where: Record<string, WhereValue>
+    where: WhereClause
   ): Promise<QueryResult<T>> {
     const adapter = this.getDataSource(dataSourceId)
     adapter.assertWritable() // defense-in-depth: reject mutations on a read-only source
@@ -596,7 +596,7 @@ export class DataSourceManager extends EventEmitter {
     targetId: string,
     targetTable: string,
     options?: {
-      where?: Record<string, WhereValue>
+      where?: WhereClause
       batchSize?: number
       transform?: (row: Record<string, DbValue>) => Record<string, DbValue>
     }

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -15,7 +15,7 @@ import type {
   IndexInfo,
   ForeignKeyInfo,
   DbValue,
-  WhereValue,
+  WhereClause,
   Transaction,
   ConnectionConfig
 } from './BaseAdapter';
@@ -373,7 +373,7 @@ export class MSSQLAdapter extends BaseDataAdapter {
   async update<T = Record<string, DbValue>>(
     table: string,
     data: Record<string, DbValue>,
-    where: Record<string, WhereValue>
+    where: WhereClause
   ): Promise<QueryResult<T>> {
     const setClause: string[] = []
     const values: DbValue[] = []
@@ -397,7 +397,7 @@ export class MSSQLAdapter extends BaseDataAdapter {
 
   async delete<T = Record<string, DbValue>>(
     table: string,
-    where: Record<string, WhereValue>
+    where: WhereClause
   ): Promise<QueryResult<T>> {
     const whereClause = this.buildWhereClause(where)
     const sql = `DELETE FROM ${this.quoteIdent(table)} OUTPUT DELETED.* ${whereClause.sql}`

--- a/packages/core-backend/src/data-adapters/MongoDBAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MongoDBAdapter.ts
@@ -77,7 +77,7 @@ interface MongoDocument extends Record<string, unknown> {
 
 import type {
   DbValue,
-  WhereValue,
+  WhereClause,
   QueryOptions,
   QueryResult,
   SchemaInfo,
@@ -301,7 +301,7 @@ export class MongoDBAdapter extends BaseDataAdapter {
   async update<T = Record<string, DbValue>>(
     collection: string,
     data: Record<string, DbValue>,
-    where: Record<string, WhereValue>
+    where: WhereClause
   ): Promise<QueryResult<T>> {
     if (!this.db) {
       throw new Error('Not connected to database')
@@ -333,7 +333,7 @@ export class MongoDBAdapter extends BaseDataAdapter {
     }
   }
 
-  async delete<T = Record<string, DbValue>>(collection: string, where: Record<string, WhereValue>): Promise<QueryResult<T>> {
+  async delete<T = Record<string, DbValue>>(collection: string, where: WhereClause): Promise<QueryResult<T>> {
     if (!this.db) {
       throw new Error('Not connected to database')
     }
@@ -511,10 +511,16 @@ export class MongoDBAdapter extends BaseDataAdapter {
     return uri
   }
 
-  private buildMongoFilter(where: Record<string, WhereValue>): MongoFilter {
+  private buildMongoFilter(where: WhereClause): MongoFilter {
     const filter: MongoFilter = {}
 
     for (const [key, value] of Object.entries(where)) {
+      if (value === undefined) {
+        continue
+      }
+      if (key === '$or' || key === '$and') {
+        throw new Error(`${key} logical where groups are not supported by the MongoDB adapter`)
+      }
       if (value === null) {
         filter[key] = null
       } else if (Array.isArray(value)) {

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -49,7 +49,8 @@ import type {
   ColumnInfo,
   IndexInfo,
   ForeignKeyInfo,
-  DbValue
+  DbValue,
+  WhereClause
 } from './BaseAdapter';
 import {
   BaseDataAdapter,
@@ -84,6 +85,105 @@ export class MySQLAdapter extends BaseDataAdapter {
     // A2: backtick-quote PER SEGMENT so a schema-qualified name becomes `schema`.`table`. The base
     // sanitizer validates each segment and throws on illegal input.
     return this.sanitizeIdentifier(identifier).split('.').map(seg => `\`${seg}\``).join('.')
+  }
+
+  private getMySQLOperator(op: string): string {
+    const operators: Record<string, string> = {
+      $gt: '>',
+      $gte: '>=',
+      $lt: '<',
+      $lte: '<=',
+      $ne: '!=',
+      $like: 'LIKE',
+      $ilike: 'LIKE',
+      $in: 'IN',
+      $nin: 'NOT IN',
+      $between: 'BETWEEN'
+    }
+    const operator = operators[op]
+    if (!operator) {
+      throw new Error(`Unsupported where operator: ${op}`)
+    }
+    return operator
+  }
+
+  private buildMySQLWhereClause(where: WhereClause): { sql: string; params: DbValue[] } {
+    const result = this.buildMySQLWhereConditions(where)
+    return {
+      sql: result.conditions.length > 0 ? `WHERE ${result.conditions.join(' AND ')}` : '',
+      params: result.params
+    }
+  }
+
+  private buildMySQLWhereConditions(where: WhereClause): { conditions: string[]; params: DbValue[] } {
+    const conditions: string[] = []
+    const params: DbValue[] = []
+
+    for (const [key, value] of Object.entries(where)) {
+      if (value === undefined) {
+        continue
+      }
+      if (key === '$or' || key === '$and') {
+        if (!Array.isArray(value) || value.length === 0) {
+          throw new Error(`${key} must be a non-empty array of where clauses`)
+        }
+        const nestedParts: string[] = []
+        const clauses = value as WhereClause[]
+        for (const clause of clauses) {
+          if (!clause || typeof clause !== 'object' || Array.isArray(clause)) {
+            throw new Error(`${key} entries must be where clause objects`)
+          }
+          const nested = this.buildMySQLWhereConditions(clause)
+          params.push(...nested.params)
+          if (nested.conditions.length === 0) {
+            throw new Error(`${key} entries must not be empty`)
+          }
+          nestedParts.push(`(${nested.conditions.join(' AND ')})`)
+        }
+        conditions.push(`(${nestedParts.join(key === '$or' ? ' OR ' : ' AND ')})`)
+      } else if (value === null) {
+        conditions.push(`${this.sanitizeMySQLIdentifier(key)} IS NULL`)
+      } else if (Array.isArray(value)) {
+        const list = value as DbValue[]
+        const placeholders = list.map(() => '?').join(', ')
+        conditions.push(`${this.sanitizeMySQLIdentifier(key)} IN (${placeholders})`)
+        params.push(...list)
+      } else if (value && typeof value === 'object') {
+        const entries = Object.entries(value)
+        if (entries.length > 0 && entries.some(([op]) => op.startsWith('$'))) {
+          for (const [op, operatorValue] of entries) {
+            if (operatorValue === undefined) continue
+            const operator = this.getMySQLOperator(op)
+            if (op === '$in' || op === '$nin') {
+              if (!Array.isArray(operatorValue) || operatorValue.length === 0) {
+                throw new Error(`${op} must be a non-empty array`)
+              }
+              const values = operatorValue as DbValue[]
+              const placeholders = values.map(() => '?').join(', ')
+              conditions.push(`${this.sanitizeMySQLIdentifier(key)} ${operator} (${placeholders})`)
+              params.push(...values)
+            } else if (op === '$between') {
+              if (!Array.isArray(operatorValue) || operatorValue.length !== 2) {
+                throw new Error('$between must be a two-value array')
+              }
+              conditions.push(`${this.sanitizeMySQLIdentifier(key)} BETWEEN ? AND ?`)
+              params.push(...(operatorValue as [DbValue, DbValue]))
+            } else {
+              conditions.push(`${this.sanitizeMySQLIdentifier(key)} ${operator} ?`)
+              params.push(operatorValue as DbValue)
+            }
+          }
+        } else {
+          conditions.push(`${this.sanitizeMySQLIdentifier(key)} = ?`)
+          params.push(value as DbValue)
+        }
+      } else {
+        conditions.push(`${this.sanitizeMySQLIdentifier(key)} = ?`)
+        params.push(value as DbValue)
+      }
+    }
+
+    return { conditions, params }
   }
 
   async connect(): Promise<void> {
@@ -202,26 +302,10 @@ export class MySQLAdapter extends BaseDataAdapter {
       }
     }
 
-    // Add where clause
     if (options.where && Object.keys(options.where).length > 0) {
-      const conditions: string[] = []
-
-      for (const [key, value] of Object.entries(options.where)) {
-        if (value === null) {
-          conditions.push(`${this.sanitizeMySQLIdentifier(key)} IS NULL`)
-        } else if (Array.isArray(value)) {
-          const placeholders = value.map(() => '?').join(', ')
-          conditions.push(`${this.sanitizeMySQLIdentifier(key)} IN (${placeholders})`)
-          params.push(...value)
-        } else {
-          conditions.push(`${this.sanitizeMySQLIdentifier(key)} = ?`)
-          params.push(value)
-        }
-      }
-
-      if (conditions.length > 0) {
-        sql += ` WHERE ${conditions.join(' AND ')}`
-      }
+      const whereClause = this.buildMySQLWhereClause(options.where)
+      sql += ` ${whereClause.sql}`
+      params.push(...whereClause.params)
     }
 
     // Add order by
@@ -290,7 +374,7 @@ export class MySQLAdapter extends BaseDataAdapter {
     return result
   }
 
-  async update<T = Record<string, unknown>>(table: string, data: Record<string, unknown>, where: Record<string, unknown>): Promise<QueryResult<T>> {
+  async update<T = Record<string, unknown>>(table: string, data: Record<string, unknown>, where: WhereClause): Promise<QueryResult<T>> {
     const setClause: string[] = []
     const values: unknown[] = []
 
@@ -299,44 +383,33 @@ export class MySQLAdapter extends BaseDataAdapter {
       values.push(value)
     }
 
-    const whereConditions: string[] = []
-    for (const [key, value] of Object.entries(where)) {
-      if (value === null) {
-        whereConditions.push(`${this.sanitizeMySQLIdentifier(key)} IS NULL`)
-      } else {
-        whereConditions.push(`${this.sanitizeMySQLIdentifier(key)} = ?`)
-        values.push(value)
-      }
+    const whereClause = this.buildMySQLWhereClause(where)
+    if (!whereClause.sql) {
+      throw new Error('MySQL update requires a non-empty where clause')
     }
+    values.push(...whereClause.params)
 
     const sql = `
       UPDATE ${this.sanitizeMySQLIdentifier(table)}
       SET ${setClause.join(', ')}
-      WHERE ${whereConditions.join(' AND ')}
+      ${whereClause.sql}
     `
 
     return this.query<T>(sql, values)
   }
 
-  async delete<T = Record<string, unknown>>(table: string, where: Record<string, unknown>): Promise<QueryResult<T>> {
-    const conditions: string[] = []
-    const values: unknown[] = []
-
-    for (const [key, value] of Object.entries(where)) {
-      if (value === null) {
-        conditions.push(`${this.sanitizeMySQLIdentifier(key)} IS NULL`)
-      } else {
-        conditions.push(`${this.sanitizeMySQLIdentifier(key)} = ?`)
-        values.push(value)
-      }
+  async delete<T = Record<string, unknown>>(table: string, where: WhereClause): Promise<QueryResult<T>> {
+    const whereClause = this.buildMySQLWhereClause(where)
+    if (!whereClause.sql) {
+      throw new Error('MySQL delete requires a non-empty where clause')
     }
 
     const sql = `
       DELETE FROM ${this.sanitizeMySQLIdentifier(table)}
-      WHERE ${conditions.join(' AND ')}
+      ${whereClause.sql}
     `
 
-    return this.query<T>(sql, values)
+    return this.query<T>(sql, whereClause.params)
   }
 
   async getSchema(schema?: string): Promise<SchemaInfo> {

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -10,7 +10,7 @@ import type {
   IndexInfo,
   ForeignKeyInfo,
   DbValue,
-  WhereValue
+  WhereClause
 } from './BaseAdapter';
 import {
   BaseDataAdapter,
@@ -233,7 +233,7 @@ export class PostgresAdapter extends BaseDataAdapter {
     return this.query<T>(sql, values)
   }
 
-  async update<T = Record<string, DbValue>>(table: string, data: Record<string, DbValue>, where: Record<string, WhereValue>): Promise<QueryResult<T>> {
+  async update<T = Record<string, DbValue>>(table: string, data: Record<string, DbValue>, where: WhereClause): Promise<QueryResult<T>> {
     const setClause: string[] = []
     const values: DbValue[] = []
     let paramIndex = 1
@@ -260,7 +260,7 @@ export class PostgresAdapter extends BaseDataAdapter {
     return this.query<T>(sql, [...values, ...whereClause.params])
   }
 
-  async delete<T = Record<string, DbValue>>(table: string, where: Record<string, WhereValue>): Promise<QueryResult<T>> {
+  async delete<T = Record<string, DbValue>>(table: string, where: WhereClause): Promise<QueryResult<T>> {
     const whereClause = this.buildWhereClause(where)
 
     const sql = `

--- a/packages/core-backend/tests/unit/data-source-mysql-schema.test.ts
+++ b/packages/core-backend/tests/unit/data-source-mysql-schema.test.ts
@@ -56,6 +56,10 @@ class FakeMySQLAdapter extends MySQLAdapter {
   }
 }
 
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
 describe('MySQLAdapter schema metadata', () => {
   it('uses non-reserved metadata aliases and maps returned column fields', async () => {
     const adapter = new FakeMySQLAdapter(cfg)
@@ -93,5 +97,73 @@ describe('MySQLAdapter schema metadata', () => {
         comment: undefined,
       },
     ])
+  })
+})
+
+describe('MySQLAdapter structured read SQL', () => {
+  it('selects with structured OR groups for C3 composite keyset predicates', async () => {
+    const adapter = new FakeMySQLAdapter(cfg)
+
+    await adapter.select('stock_info', {
+      where: {
+        status: 'open',
+        $or: [
+          { updated_at: { $gt: '2026-06-01T00:00:00.000Z' } },
+          {
+            updated_at: '2026-06-01T00:00:00.000Z',
+            id: { $gt: 42 },
+          },
+        ],
+      },
+      orderBy: [
+        { column: 'updated_at', direction: 'asc' },
+        { column: 'id', direction: 'asc' },
+      ],
+      limit: 100,
+    })
+
+    expect(normalizeSql(adapter.queries[0].sql)).toBe(
+      'SELECT * FROM `stock_info` WHERE `status` = ? AND ((`updated_at` > ?) OR (`updated_at` = ? AND `id` > ?)) ORDER BY `updated_at` ASC, `id` ASC LIMIT 100'
+    )
+    expect(adapter.queries[0].params).toEqual([
+      'open',
+      '2026-06-01T00:00:00.000Z',
+      '2026-06-01T00:00:00.000Z',
+      42,
+    ])
+    expect(adapter.queries[0].sql).not.toContain('2026-06-01')
+  })
+
+  it('rejects malformed structured groups before the query is issued', async () => {
+    const adapter = new FakeMySQLAdapter(cfg)
+
+    await expect(adapter.select('stock_info', {
+      where: { $or: [] },
+      limit: 1,
+    })).rejects.toThrow(/\$or must be a non-empty array/)
+
+    expect(adapter.queries).toHaveLength(0)
+  })
+
+  it('rejects unsupported operators before the query is issued', async () => {
+    const adapter = new FakeMySQLAdapter(cfg)
+
+    await expect(adapter.select('stock_info', {
+      where: { updated_at: { $after: '2026-06-01T00:00:00.000Z' } as never },
+      limit: 1,
+    })).rejects.toThrow(/Unsupported where operator/)
+
+    expect(adapter.queries).toHaveLength(0)
+  })
+
+  it('does not turn an empty update/delete where into a full-table write', async () => {
+    const adapter = new FakeMySQLAdapter(cfg)
+
+    await expect(adapter.update('stock_info', { status: 'closed' }, {}))
+      .rejects.toThrow(/requires a non-empty where clause/)
+    await expect(adapter.delete('stock_info', {}))
+      .rejects.toThrow(/requires a non-empty where clause/)
+
+    expect(adapter.queries).toHaveLength(0)
   })
 })

--- a/packages/core-backend/tests/unit/mongodb-adapter.test.ts
+++ b/packages/core-backend/tests/unit/mongodb-adapter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { MongoDBAdapter } from '../../src/data-adapters/MongoDBAdapter'
+import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
+
+const cfg: DataSourceConfig = {
+  id: 'mongo',
+  name: 'mongo',
+  type: 'mongodb',
+  connection: { database: 'ERP' },
+  options: { autoConnect: false },
+}
+
+function adapterWithFakeDb(find = vi.fn()) {
+  const adapter = new MongoDBAdapter(cfg)
+  const collection = vi.fn(() => ({
+    find,
+    countDocuments: vi.fn(async () => 0),
+  }))
+  const internal = adapter as unknown as {
+    db: unknown
+    connected: boolean
+  }
+  internal.db = { collection }
+  internal.connected = true
+  return { adapter, collection, find }
+}
+
+describe('MongoDBAdapter structured where compatibility', () => {
+  it('fails closed on logical where groups instead of misinterpreting them as field IN filters', async () => {
+    const { adapter, collection, find } = adapterWithFakeDb()
+
+    const result = await adapter.select('orders', {
+      where: {
+        $or: [
+          { updated_at: { $gt: '2026-06-01T00:00:00.000Z' } },
+          { updated_at: '2026-06-01T00:00:00.000Z', id: { $gt: 42 } },
+        ],
+      },
+      limit: 1,
+    })
+
+    expect(collection).toHaveBeenCalledWith('orders')
+    expect(find).not.toHaveBeenCalled()
+    expect(result.data).toEqual([])
+    expect(result.error?.message).toMatch(/logical where groups are not supported/)
+  })
+})

--- a/packages/core-backend/tests/unit/mssql-adapter.test.ts
+++ b/packages/core-backend/tests/unit/mssql-adapter.test.ts
@@ -51,6 +51,10 @@ function fakePool(rows: unknown[] = [], rowsAffected: number[] = []) {
   return { pool, calls }
 }
 
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
 function adapterWithFakePool(fp: ReturnType<typeof fakePool>): MSSQLAdapter {
   const a = new MSSQLAdapter({
     id: 's', name: 's', type: 'sqlserver',
@@ -197,6 +201,61 @@ describe('MSSQLAdapter — SQL generation (fake driver)', () => {
     expect(sql).toContain('ORDER BY [id] ASC')
     expect(sql).toContain('OFFSET 20 ROWS')
     expect(sql).toContain('FETCH NEXT 10 ROWS ONLY')
+  })
+
+  it('select: structured OR groups support C3 composite keyset predicates', async () => {
+    const fp = fakePool()
+    await adapterWithFakePool(fp).select('dbo.orders', {
+      where: {
+        status: 'open',
+        $or: [
+          { updated_at: { $gt: '2026-06-01T00:00:00.000Z' } },
+          {
+            updated_at: '2026-06-01T00:00:00.000Z',
+            id: { $gt: 42 },
+          },
+        ],
+      },
+      orderBy: [
+        { column: 'updated_at', direction: 'asc' },
+        { column: 'id', direction: 'asc' },
+      ],
+      limit: 100,
+    })
+
+    const { sql, params } = fp.calls[0]
+    expect(normalizeSql(sql)).toBe(
+      'SELECT TOP (100) * FROM [dbo].[orders] WHERE status = @p0 AND ((updated_at > @p1) OR (updated_at = @p2 AND id > @p3)) ORDER BY [updated_at] ASC, [id] ASC'
+    )
+    expect(params).toEqual({
+      p0: 'open',
+      p1: '2026-06-01T00:00:00.000Z',
+      p2: '2026-06-01T00:00:00.000Z',
+      p3: 42,
+    })
+    expect(sql).not.toContain('2026-06-01')
+  })
+
+  it('select: rejects malformed structured groups before the driver query is issued', async () => {
+    const fp = fakePool()
+
+    await expect(adapterWithFakePool(fp).select('dbo.orders', {
+      where: { $or: [] },
+      limit: 1,
+    })).rejects.toThrow(/\$or must be a non-empty array/)
+
+    expect(fp.calls).toHaveLength(0)
+  })
+
+  it('select: rejects unsupported where operators before the driver query is issued', async () => {
+    const fp = fakePool()
+
+    await expect(adapterWithFakePool(fp).select('dbo.orders', {
+      where: { updated_at: { $after: '2026-06-01T00:00:00.000Z' } as never },
+      limit: 1,
+    })).rejects.toThrow(/Unsupported where operator/)
+
+    expect(fp.calls).toHaveLength(0)
   })
 
   it('insert: OUTPUT INSERTED.* + parameterized values (not concatenated)', async () => {

--- a/packages/core-backend/tests/unit/postgres-adapter.test.ts
+++ b/packages/core-backend/tests/unit/postgres-adapter.test.ts
@@ -115,6 +115,34 @@ describe('PostgresAdapter - structured read SQL', () => {
     expect(fp.calls[0].sql).not.toContain('open')
   })
 
+  it('selects with structured OR groups for C3 composite keyset predicates', async () => {
+    const fp = fakePgPool()
+
+    await adapterWithFakePool(fp).select('public.orders', {
+      where: {
+        status: 'open',
+        $or: [
+          { updated_at: { $gt: '2026-06-01T00:00:00.000Z' } },
+          {
+            updated_at: '2026-06-01T00:00:00.000Z',
+            id: { $gt: 42 },
+          },
+        ],
+      },
+      orderBy: [
+        { column: 'updated_at', direction: 'asc' },
+        { column: 'id', direction: 'asc' },
+      ],
+      limit: 100,
+    })
+
+    expect(normalizeSql(fp.calls[0].sql)).toBe(
+      'SELECT * FROM public.orders WHERE status = $1 AND ((updated_at > $2) OR (updated_at = $3 AND id > $4)) ORDER BY updated_at ASC, id ASC LIMIT 100'
+    )
+    expect(fp.calls[0].params).toEqual(['open', '2026-06-01T00:00:00.000Z', '2026-06-01T00:00:00.000Z', 42])
+    expect(fp.calls[0].sql).not.toContain('2026-06-01')
+  })
+
   it('rejects invalid identifiers before the pool is queried', async () => {
     const badTable = fakePgPool()
     await expect(adapterWithFakePool(badTable).select('bad-table', { limit: 1 }))
@@ -125,6 +153,28 @@ describe('PostgresAdapter - structured read SQL', () => {
     await expect(adapterWithFakePool(badColumn).select('orders', { where: { 'bad-key': 'x' }, limit: 1 }))
       .rejects.toThrow(/Invalid identifier segment/)
     expect(badColumn.calls).toHaveLength(0)
+  })
+
+  it('rejects malformed structured groups before the pool is queried', async () => {
+    const fp = fakePgPool()
+
+    await expect(adapterWithFakePool(fp).select('orders', {
+      where: { $or: [] },
+      limit: 1,
+    })).rejects.toThrow(/\$or must be a non-empty array/)
+
+    expect(fp.calls).toHaveLength(0)
+  })
+
+  it('rejects unsupported where operators before the pool is queried', async () => {
+    const fp = fakePgPool()
+
+    await expect(adapterWithFakePool(fp).select('orders', {
+      where: { updated_at: { $after: '2026-06-01T00:00:00.000Z' } as never },
+      limit: 1,
+    })).rejects.toThrow(/Unsupported where operator/)
+
+    expect(fp.calls).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
## Summary

- Add recursive structured `where` groups (`$or` / `$and`) to the shared SQL adapter where builder so C3 can later express `updated_at > last OR (updated_at = last AND tiebreaker > lastTie)` safely.
- Bring MySQL structured-read operator parity up to Postgres/MSSQL for `$gt/$gte/$lt/$lte/$ne/$like/$ilike/$in/$nin/$between`, with identifier sanitization and parameterized values.
- Keep non-SQL compatibility fail-closed: MongoDB now rejects logical groups instead of misinterpreting `$or` / `$and` as field `IN` filters.
- Refresh C3 docs/TODO: #2619 C3-3a is landed; this PR is C3-2a prerequisite-only and does not generate watermark predicates, cursors, or runtime reads.

## Scope / boundaries

- No watermark runtime.
- No cursor parsing/serialization.
- No K3, RBAC, auth, or credential changes.
- No new write capability. MySQL update/delete now explicitly fail closed on empty where rather than risking a full-table write through the refactored helper.

## Verification

- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-plugin-facade.test.ts tests/unit/data-source-result-boundary.test.ts tests/unit/data-source-readonly.test.ts tests/unit/data-source-identifier-quoting.test.ts tests/unit/data-source-scope.test.ts tests/unit/data-source-test-error-fidelity.test.ts tests/unit/mongodb-adapter.test.ts tests/unit/postgres-adapter.test.ts tests/unit/mssql-adapter.test.ts tests/unit/data-source-mysql-schema.test.ts --watch=false` (10 files / 114 tests)
- `pnpm exec eslint src/data-adapters/BaseAdapter.ts src/data-adapters/DataSourceManager.ts src/data-adapters/MSSQLAdapter.ts src/data-adapters/MongoDBAdapter.ts src/data-adapters/MySQLAdapter.ts src/data-adapters/PostgresAdapter.ts` from `packages/core-backend`
- `git diff --check`

## Review

Subagent review found two issues and both were fixed before opening:

- MongoDB did not implement logical groups despite the shared `WhereClause` type. Fixed by failing closed on `$or` / `$and` and adding a MongoDB adapter regression test.
- MSSQL lacked malformed-group / unsupported-operator negative controls. Added both tests.
