### PR TITLE
feat(workflow): A6-3-3a branch-local wait runtime (WIP)

### DIFF
--- a/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
+++ b/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
@@ -26,6 +26,7 @@ result backwrite; no BPMN live runtime.
 | 3.5 — resume-cursor fail-closed gate | `c2854f79d` | `automation-service.ts` `resumeExecution()` dispatches on the parsed cursor: `invalid` → `409 SUSPENSION_CURSOR_INVALID` (never a top-level fallback). |
 | 4 — branch-aware resume orchestration | `199fdcffb` | `resumeExecution` adds the branch fingerprint drift guard BEFORE the token claim, then routes a `condition_branch` cursor to `continueBranchExecution`. `continueBranchExecution` settles the branch wait → runs the branch tail → settles the parent → runs the top-level tail (scope-gate §4.3). |
 | 4.x — skipped-job fix | `e29199da6` | On a resumed branch-tail failure, `continueBranchExecution` writes `skipped` C1 jobs for the REMAINING branch children AND the REMAINING top-level actions (mirrors the initial `executeConditionBranch` / `executeActions` fail-stop) so the job plane is complete instead of leaving downstream work invisible. |
+| 4.y — pre-claim cursor-binding guard | `98ef122a5` | `resumeExecution` also requires (pre-claim) that the cursor points at a `wait_for_callback` AND carries the deterministic ids (`stepKey` / `parentJobId` / `branchJobId` / `upstreamJobId`) for its branch position — a structurally-valid cursor at a non-wait action with tampered-consistent ids would otherwise claim the token and settle a non-wait action as the wait. → `409 SUSPENSION_CURSOR_INVALID`. |
 | 5a — `listByExecution` stepKey hydration | `bd3e472dc` | `automation-job-service.ts` `listByExecution()` now hydrates the C1 suspend descriptor by job `step_key`, not top-level `step_index`. See §2. |
 | 5b — real-DB high-amount E2E | `8c2242fc9` | `tests/integration/multitable-automation-branch-local-wait.test.ts` — the un-draft gate. See §4. |
 | 5c — this verification doc | (this commit) | Records the runtime + the exact verification evidence. |
@@ -87,7 +88,8 @@ invalid-cursor case to the `resumeExecution` → 409 path and does not call
   (notify) `resolved`, branch wait child `suspended`, downstream branch + top
   level absent.
 - §4.3 resume semantics — slices 4/4.x: load by token → validate `pending` →
-  current rule + enabled → top-level fingerprint → branch fingerprint + cursor
+  current rule + enabled → top-level fingerprint → branch fingerprint → cursor
+  binding (points at a `wait_for_callback` + deterministic stepKey/job ids)
   → re-fetch record → read execution before claim → single-use claim → settle
   branch wait → branch tail → settle parent → top-level tail.
 
@@ -99,6 +101,7 @@ invalid-cursor case to the `resumeExecution` → 409 path and does not call
 | top-level action fingerprint changed | `409 RULE_CHANGED`, token kept | resumeExecution (shared; suspend-resume T8) |
 | selected branch path changed / key removed | `409 RULE_CHANGED`, token kept | E2E `drift guard before claim` |
 | corrupt non-null resume cursor | `409 SUSPENSION_CURSOR_INVALID`, token kept | E2E `invalid cursor` |
+| structurally-valid cursor at a non-wait action / inconsistent derived ids | `409 SUSPENSION_CURSOR_INVALID`, token kept, no job settles | E2E `semantic-corrupt cursor` |
 | record deleted while waiting | `404 RECORD_GONE`, token kept | resumeExecution (shared; suspend-resume T9) |
 | second resume | `409 ALREADY_RESUMED` | E2E `second resume` |
 | post-claim branch-tail failure | execution terminal `failed`; remaining branch + top-level jobs `skipped` | E2E `branch-tail failure on resume` |
@@ -170,7 +173,7 @@ pnpm --filter @metasheet/core-backend exec vitest \
   tests/integration/multitable-automation-branch-local-wait.test.ts
 ```
 
-Result: **10 passed (10)** — the `describeIfDatabase` sentinel test confirms
+Result: **11 passed (11)** — the `describeIfDatabase` sentinel test confirms
 `DATABASE_URL` is set, so the suite actually RAN (not skipped). Each assertion
 shape:
 
@@ -183,6 +186,7 @@ shape:
 | HAPPY-high resume | §4.3 / §6.7 | PASS | resume returns `execution`, `success`, `initiatedBy=admin_resume`; jobs `0`/`0.branch.high_amount.0..2`/`1` all `resolved`; record `status=approved_after_review`; suspension `resumed` |
 | drift guard before claim | §5 branch drift | PASS | mutate SELECTED branch actions only (top-level fingerprint stays equal) → `409 RULE_CHANGED`; suspension still `pending` |
 | invalid cursor | §5 fail-closed | PASS | corrupt `resume_cursor` to `{kind:'top_level'}` → `409 SUSPENSION_CURSOR_INVALID`; suspension still `pending` (token NOT claimed) |
+| semantic-corrupt cursor | §5 cursor binding | PASS | valid-shaped cursor re-pointed at index 0 (send_notification) + consistent ids + unchanged branch fingerprint → `409 SUSPENSION_CURSOR_INVALID`; suspension `pending`; branch wait child `0.branch.high_amount.1` stays `suspended` (no settle) |
 | second resume | §5 single-use | PASS | first resume succeeds; second → `409 ALREADY_RESUMED` |
 | branch-tail failure on resume | §5 + slice-4 | PASS | post-wait `send_webhook` returns 500 → execution terminal `failed`; `0.branch.high_amount.2`=`failed`; remaining branch child `0.branch.high_amount.3`=`skipped`; parent `0`=`failed`; remaining top-level `1`=`skipped`; record never `should_not_run` |
 
@@ -207,7 +211,7 @@ disambiguation test is what discriminates the fix.)
 
 `vitest --config vitest.integration.config.ts run` over the new E2E +
 `multitable-automation-suspend-resume.test.ts` + `multitable-automation-jobs.test.ts`
-(all share `listByExecution`) → **29 passed (29)** (10 + 11 + 8).
+(all share `listByExecution`) → **30 passed (30)** (11 + 11 + 8).
 
 ## Out-of-scope (still rejected, by design)
 

--- a/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
+++ b/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
@@ -125,8 +125,9 @@ resumes to `approved_after_review`. Matches §6 steps 1–7.
   `start_approval` branch rejections are unit-asserted in
   `tests/unit/automation-v1.test.ts` (`cannot contain parallel_branch ...`,
   `cannot contain start_approval until A6-3-3`); the nested `condition_branch`
-  rejection is enforced by the validator (lines 261/289) and the executor branch
-  loop. 203 unit tests green.
+  rejection is now also unit-asserted (`cannot contain nested condition_branch`),
+  alongside the validator (lines 261/289) + the executor branch loop. 204 unit
+  tests green.
 - executor suspends a selected branch-local wait and does not run later branch
   actions before resume — E2E `HAPPY-high suspends`.
 - resume continues the selected branch tail then the top-level tail — E2E
@@ -158,7 +159,7 @@ output. Clean (with both slice 5a source and the slice 5b test present).
 ### Unit tests
 
 `vitest run tests/unit/automation-v1.test.ts tests/unit/automation-runs-api.test.ts`
-→ **203 passed** (2 files; automation-v1 = 179, automation-runs-api = 24). The
+→ **204 passed** (2 files; automation-v1 = 180, automation-runs-api = 24). The
 `error: ... jsonb insert failed` log line is an intentional error-path fixture,
 not a failure.
 

--- a/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
+++ b/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
@@ -27,7 +27,7 @@ result backwrite; no BPMN live runtime.
 | 4 — branch-aware resume orchestration | `199fdcffb` | `resumeExecution` adds the branch fingerprint drift guard BEFORE the token claim, then routes a `condition_branch` cursor to `continueBranchExecution`. `continueBranchExecution` settles the branch wait → runs the branch tail → settles the parent → runs the top-level tail (scope-gate §4.3). |
 | 4.x — skipped-job fix | `e29199da6` | On a resumed branch-tail failure, `continueBranchExecution` writes `skipped` C1 jobs for the REMAINING branch children AND the REMAINING top-level actions (mirrors the initial `executeConditionBranch` / `executeActions` fail-stop) so the job plane is complete instead of leaving downstream work invisible. |
 | 5a — `listByExecution` stepKey hydration | `bd3e472dc` | `automation-job-service.ts` `listByExecution()` now hydrates the C1 suspend descriptor by job `step_key`, not top-level `step_index`. See §2. |
-| 5b — real-DB high-amount E2E | `7ef67ece2` | `tests/integration/multitable-automation-branch-local-wait.test.ts` — the un-draft gate. See §4. |
+| 5b — real-DB high-amount E2E | `8c2242fc9` | `tests/integration/multitable-automation-branch-local-wait.test.ts` — the un-draft gate. See §4. |
 | 5c — this verification doc | (this commit) | Records the runtime + the exact verification evidence. |
 
 ## 2. Slice 5a — the stepKey hydration fix (③)

--- a/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
+++ b/docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
@@ -1,0 +1,227 @@
+# Multitable Automation A6-3-3a Branch-Local Wait — Runtime + Verification (2026-06-15)
+
+Status: backend runtime COMPLETE; verified against real Postgres. PR #2626 (draft).
+Branch: `runtime/a6-3-3a-runtime-20260615`.
+
+Scope gate (acceptance source):
+`docs/development/multitable-automation-a6-3-3-branch-local-wait-scope-gate-20260615.md`.
+
+A6-3-3a allows exactly one new nested shape — a `wait_for_callback` inside the
+SELECTED `condition_branch` path — so that only that branch suspends while
+ordinary branches finish without waiting. It is built strictly on top of the
+landed A6-2 suspend/resume and A6-3-1 `condition_branch` runtime. Out-of-scope
+shapes stay rejected: nested `condition_branch`, `parallel_branch`, and
+branch-local `start_approval` inside a branch; no public webhook/callback
+endpoint or token emitter; no delay/timer resume; no `join_any`; no W7 approval
+result backwrite; no BPMN live runtime.
+
+## 1. Runtime, slice by slice
+
+| Slice | Commit | What it does |
+|---|---|---|
+| 1 — resume-cursor parser | `ca73f0b69` | New `automation-resume-cursor.ts`: `ConditionBranchResumeCursor` + `parseResumeCursor`. Discriminated result `top_level` / `condition_branch` / `invalid`. NULL/absent → `top_level`; a valid cursor → use it. |
+| 1.x — parser fail-open close | `0c6cd4bfd` | A non-null cursor OBJECT is NEVER the top-level path. A corrupt `{kind:'top_level'}`, an array, or any unknown kind → `invalid` (fail closed) — so a corrupted branch suspension can never silently resume at the top-level `step_index`. |
+| 2 — suspension/job persistence | `4031b95b3` | `automation-suspension-service.ts` `createBranchLocal()` writes the suspension row WITH `resume_cursor` + a suspended branch-child job, atomically; `mapRow` parses the cursor into `SuspensionRow.resumeCursor`. `automation-job-service.ts` `writeSuspendedBranchJob()` writes the wait job by `cursor.stepKey` / `cursor.branchJobId` (inside the condition_branch lineage, not the top-level index). Migration `zzzz20260615120000_add_automation_suspension_resume_cursor.ts` adds the nullable `resume_cursor jsonb` column. |
+| 3 — executor suspend + validator relax | `7213c3893` | `automation-executor.ts` `executeConditionBranch` suspends on a branch-local `wait_for_callback`: builds the cursor (parent index + branch key + branch action index + step key + parent/branch/upstream job ids + `branchActionFingerprint`) and calls `onSuspendBranch`. `validateConditionBranchConfig` now ALLOWS branch-local `wait_for_callback` (condition_branch already forces `workflow_job_v1`) while still rejecting nested `condition_branch`, `parallel_branch`, and `start_approval` inside a branch. |
+| 3.5 — resume-cursor fail-closed gate | `c2854f79d` | `automation-service.ts` `resumeExecution()` dispatches on the parsed cursor: `invalid` → `409 SUSPENSION_CURSOR_INVALID` (never a top-level fallback). |
+| 4 — branch-aware resume orchestration | `199fdcffb` | `resumeExecution` adds the branch fingerprint drift guard BEFORE the token claim, then routes a `condition_branch` cursor to `continueBranchExecution`. `continueBranchExecution` settles the branch wait → runs the branch tail → settles the parent → runs the top-level tail (scope-gate §4.3). |
+| 4.x — skipped-job fix | `e29199da6` | On a resumed branch-tail failure, `continueBranchExecution` writes `skipped` C1 jobs for the REMAINING branch children AND the REMAINING top-level actions (mirrors the initial `executeConditionBranch` / `executeActions` fail-stop) so the job plane is complete instead of leaving downstream work invisible. |
+| 5a — `listByExecution` stepKey hydration | `bd3e472dc` | `automation-job-service.ts` `listByExecution()` now hydrates the C1 suspend descriptor by job `step_key`, not top-level `step_index`. See §2. |
+| 5b — real-DB high-amount E2E | `7ef67ece2` | `tests/integration/multitable-automation-branch-local-wait.test.ts` — the un-draft gate. See §4. |
+| 5c — this verification doc | (this commit) | Records the runtime + the exact verification evidence. |
+
+## 2. Slice 5a — the stepKey hydration fix (③)
+
+### 2.1 The bug it closes
+
+A branch-local suspension stores, on the suspension row, `step_index =
+parentStepIndex` (so the existing top-level locators keep working) AND a
+non-null `resume_cursor` whose `stepKey` (e.g. `2.branch.high_amount.1`)
+identifies the suspended branch CHILD job. The top-level `condition_branch`
+PARENT job shares that same `step_index` (its key is `String(parentStepIndex)`,
+e.g. `"2"`, and it stays `running` while suspended).
+
+The pre-5a `listByExecution` built a `Map<number, descriptor>` keyed by
+`step_index` and attached the descriptor to any `suspended` row by `step_index`.
+Two problems:
+
+1. Keying by `step_index` could attach a branch descriptor to the wrong job at
+   the same index. (In the in-scope happy path the parent is `running`, not
+   `suspended`, so it is incidentally safe — but the keying is wrong in
+   principle and §7 requires keying by `stepKey`.)
+2. With two `suspended` rows at the same `step_index` and distinct `stepKey`,
+   `Map` overwrite means every suspended sibling collapses to the LAST token.
+
+### 2.2 The fix
+
+One map keyed by the job `step_key` string:
+
+- Select `resume_cursor` alongside `step_index, reason, resume_token`, run it
+  through the existing `parseResumeCursor` (same string-or-object normalization
+  as `mapRow`), and key by
+  `parsed.kind === 'condition_branch' ? parsed.cursor.stepKey : String(step_index)`.
+- Key approval-bridge entries by `String(bridge.step_index)` (`start_approval`
+  is always top-level → its job's `step_key` is `String(stepIndex)`).
+- In `rows.map`, look up `suspendByStepKey.get(row.step_key)` under the same
+  `status === 'suspended'` guard.
+
+This is correct for all three job families at once: a top-level suspended job's
+`step_key` is `String(step_index)`; a branch child's is `cursor.stepKey`; the
+parent's `"2"` is never a branch suspension key, so the descriptor can never
+land on the parent `condition_branch` job. A corrupt non-null cursor parses to
+`invalid` and falls back to `String(step_index)` — the real suspended branch
+child then stays descriptor-less (fail-closed); the verification keeps the
+invalid-cursor case to the `resumeExecution` → 409 path and does not call
+`listByExecution` on it.
+
+## 3. How it satisfies the scope gate
+
+### §4 Runtime shape
+
+- §4.1 suspension cursor — slices 1/1.x/2: the nullable structured cursor
+  (`parentStepIndex` / `branchKey` / `branchActionIndex` / `stepKey` /
+  `parentJobId` / `branchJobId` / `upstreamJobId` / `branchActionFingerprint`),
+  NULL = legacy top-level, non-null-but-malformed = invalid.
+- §4.2 job state while suspended — verified by the HAPPY-high E2E: execution
+  `running`, parent `condition_branch` job `running`, prior branch child
+  (notify) `resolved`, branch wait child `suspended`, downstream branch + top
+  level absent.
+- §4.3 resume semantics — slices 4/4.x: load by token → validate `pending` →
+  current rule + enabled → top-level fingerprint → branch fingerprint + cursor
+  → re-fetch record → read execution before claim → single-use claim → settle
+  branch wait → branch tail → settle parent → top-level tail.
+
+### §5 Failure matrix
+
+| Case | Expected | Where verified |
+|---|---|---|
+| current rule missing/disabled | `409 RULE_MISSING_OR_DISABLED`, token kept | resumeExecution (shared A6-2 path; covered by suspend-resume T7) |
+| top-level action fingerprint changed | `409 RULE_CHANGED`, token kept | resumeExecution (shared; suspend-resume T8) |
+| selected branch path changed / key removed | `409 RULE_CHANGED`, token kept | E2E `drift guard before claim` |
+| corrupt non-null resume cursor | `409 SUSPENSION_CURSOR_INVALID`, token kept | E2E `invalid cursor` |
+| record deleted while waiting | `404 RECORD_GONE`, token kept | resumeExecution (shared; suspend-resume T9) |
+| second resume | `409 ALREADY_RESUMED` | E2E `second resume` |
+| post-claim branch-tail failure | execution terminal `failed`; remaining branch + top-level jobs `skipped` | E2E `branch-tail failure on resume` |
+| non-selected branch contains wait | no suspension | covered by A6-3-1 selection semantics (only the selected branch runs) |
+
+### §6 Acceptance scenario
+
+The E2E uses a real-DB rule with one `condition_branch` (low `amount ≤ 100000`
+→ `update_record status=auto_approved`; high `amount > 100000` →
+`send_notification`, `wait_for_callback`, `update_record
+status=approved_after_review`) plus a top-level `update_record` tail. LOW
+finishes (auto_approved, no suspension); HIGH suspends at the branch wait and
+resumes to `approved_after_review`. Matches §6 steps 1–7.
+
+### §7 Required tests (backend runtime PR)
+
+- service validation accepts branch-local `wait_for_callback` only in
+  `workflow_job_v1` rules (condition_branch forces `workflow_job_v1`), and
+  `validateConditionBranchConfig` still rejects nested `condition_branch` /
+  `parallel_branch` / branch-local `start_approval`. `parallel_branch` and
+  `start_approval` branch rejections are unit-asserted in
+  `tests/unit/automation-v1.test.ts` (`cannot contain parallel_branch ...`,
+  `cannot contain start_approval until A6-3-3`); the nested `condition_branch`
+  rejection is enforced by the validator (lines 261/289) and the executor branch
+  loop. 203 unit tests green.
+- executor suspends a selected branch-local wait and does not run later branch
+  actions before resume — E2E `HAPPY-high suspends`.
+- resume continues the selected branch tail then the top-level tail — E2E
+  `HAPPY-high resume`.
+- stale top-level fingerprint fails closed; stale selected branch fingerprint
+  fails closed; second resume already-resumed; record-gone 404 — §5 table.
+- **`listByExecution()` hydrates the suspend descriptor by branch `stepKey` and
+  never attaches it to the parent branch job by top-level `step_index`** — E2E
+  `descriptor-on-stepKey` (placement) + `stepKey disambiguation` (the
+  discriminating proof, §VERIFICATION).
+
+## VERIFICATION (exact evidence, 2026-06-15)
+
+Environment: local Postgres `metasheet_test`, OS-user owner, trust TCP.
+`DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test`.
+
+### Migrations
+
+`pnpm --filter @metasheet/core-backend migrate` (with the DATABASE_URL above) →
+`migration "zzzz20260615120000_add_automation_suspension_resume_cursor" was
+executed successfully`. Confirmed the `resume_cursor jsonb` (nullable) column
+exists on `multitable_automation_suspensions`.
+
+### Type-check
+
+`pnpm exec tsc --noEmit -p packages/core-backend/tsconfig.json` → exit 0, no
+output. Clean (with both slice 5a source and the slice 5b test present).
+
+### Unit tests
+
+`vitest run tests/unit/automation-v1.test.ts tests/unit/automation-runs-api.test.ts`
+→ **203 passed** (2 files; automation-v1 = 179, automation-runs-api = 24). The
+`error: ... jsonb insert failed` log line is an intentional error-path fixture,
+not a failure.
+
+### Real-DB E2E (the un-draft gate)
+
+Command:
+
+```
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test \
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/multitable-automation-branch-local-wait.test.ts
+```
+
+Result: **10 passed (10)** — the `describeIfDatabase` sentinel test confirms
+`DATABASE_URL` is set, so the suite actually RAN (not skipped). Each assertion
+shape:
+
+| # | Test | Result | Key assertions |
+|---|---|---|---|
+| HAPPY-low | low branch, no suspension | PASS | execution `success`; 0 suspension rows; 0 suspended jobs; record `status=auto_approved` |
+| HAPPY-high suspends | selected branch suspends | PASS | execution `running`; suspension `pending`, `step_index=0`, branch cursor `{branchKey:high_amount, branchActionIndex:1, stepKey:0.branch.high_amount.1}`; parent job `0` = `condition_branch`/`running`; `0.branch.high_amount.0` = `send_notification`/`resolved`; `0.branch.high_amount.1` = `wait_for_callback`/`suspended`; `0.branch.high_amount.2` absent; top-level `1` absent; record not yet `approved_after_review` |
+| descriptor-on-stepKey | §7 placement | PASS | `listByExecution`: parent `0` is `running` with NO `suspend` descriptor; branch child `0.branch.high_amount.1` is `suspended` with a valid C1 `suspend.resumeToken` (passes `normalizeWorkflowJob`) |
+| stepKey disambiguation | §7 discriminating proof (③) | PASS | two `suspended` jobs at the SAME `step_index=2` with distinct stepKeys (`2.branch.b1.0`, `2.branch.b2.0`) + distinct tokens → each job keeps ITS OWN token (`tok_b1`, `tok_b2`) |
+| HAPPY-high resume | §4.3 / §6.7 | PASS | resume returns `execution`, `success`, `initiatedBy=admin_resume`; jobs `0`/`0.branch.high_amount.0..2`/`1` all `resolved`; record `status=approved_after_review`; suspension `resumed` |
+| drift guard before claim | §5 branch drift | PASS | mutate SELECTED branch actions only (top-level fingerprint stays equal) → `409 RULE_CHANGED`; suspension still `pending` |
+| invalid cursor | §5 fail-closed | PASS | corrupt `resume_cursor` to `{kind:'top_level'}` → `409 SUSPENSION_CURSOR_INVALID`; suspension still `pending` (token NOT claimed) |
+| second resume | §5 single-use | PASS | first resume succeeds; second → `409 ALREADY_RESUMED` |
+| branch-tail failure on resume | §5 + slice-4 | PASS | post-wait `send_webhook` returns 500 → execution terminal `failed`; `0.branch.high_amount.2`=`failed`; remaining branch child `0.branch.high_amount.3`=`skipped`; parent `0`=`failed`; remaining top-level `1`=`skipped`; record never `should_not_run` |
+
+### Discrimination proof for slice 5a (does the §7 test actually catch the bug?)
+
+To confirm the `stepKey disambiguation` test is non-vacuous, I temporarily
+reverted `listByExecution` keying to the OLD `step_index` form and re-ran only
+that test:
+
+```
+× stepKey disambiguation ...
+  → expected 'tok_b2' to be 'tok_b1' // Object.is equality
+```
+
+Both suspended siblings collapsed to the last-inserted token (`tok_b2`) — the
+exact bug slice 5a fixes. The source was then restored to the stepKey keying and
+the full suite re-run **10/10 green**. (The happy-path `descriptor-on-stepKey`
+test is parent-safe regardless of keying because the parent stays `running`; the
+disambiguation test is what discriminates the fix.)
+
+### No regression (shared `listByExecution`)
+
+`vitest --config vitest.integration.config.ts run` over the new E2E +
+`multitable-automation-suspend-resume.test.ts` + `multitable-automation-jobs.test.ts`
+(all share `listByExecution`) → **29 passed (29)** (10 + 11 + 8).
+
+## Out-of-scope (still rejected, by design)
+
+- nested `condition_branch` inside a branch → rejected at rule save and in the
+  executor branch loop;
+- `parallel_branch` inside a branch → rejected at rule save;
+- branch-local `start_approval` → rejected at rule save;
+- no public webhook/callback endpoint, no token emitter (the resume token's only
+  read surface remains the admin-gated execution detail);
+- no delay/timer resume, no `join_any`, no W7 approval result backwrite, no BPMN
+  live runtime.
+
+## Re-entry
+
+A6-3-3b (editor support + admin-runs readability tests) is a separate explicit
+opt-in PR after this backend runtime lands. The PR (#2626) stays draft until the
+owner reviews this verification.

--- a/packages/core-backend/src/db/migrations/zzzz20260615120000_add_automation_suspension_resume_cursor.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260615120000_add_automation_suspension_resume_cursor.ts
@@ -1,0 +1,22 @@
+import { sql, type Kysely } from 'kysely'
+
+/**
+ * A6-3-3 branch-local wait: store a structured resume cursor on a suspension row.
+ *
+ * A6-2 top-level waits resume by `step_index` alone. A6-3-3 branch-local waits
+ * need a structured cursor (parent step index + selected branch key + branch
+ * action index + step key + job ids + branch action fingerprint) so an admin
+ * resume re-enters the SELECTED `condition_branch` at the right position.
+ *
+ * Nullable, no default: every existing A6-2 suspension keeps the legacy top-level
+ * meaning (`parseResumeCursor`: NULL -> top_level). A non-null but malformed value
+ * fails closed at resume (never a silent top-level `step_index` fallback). The
+ * cursor is non-secret (types/ids only), so it is stored unredacted.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_automation_suspensions ADD COLUMN IF NOT EXISTS resume_cursor jsonb`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE multitable_automation_suspensions DROP COLUMN IF EXISTS resume_cursor`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1366,6 +1366,8 @@ export interface MultitableAutomationSuspensionsTable {
   reason: string
   action_fingerprint: JsonValueColumn
   trigger_event: JsonValueColumn
+  // A6-3-3 branch-local resume cursor (nullable + insert-optional; NULL = legacy A6-2 top-level path).
+  resume_cursor: ColumnType<unknown | null, unknown | null | undefined, unknown | null>
   status: string
   created_at: CreatedAt
   resumed_at: Date | string | null

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -975,6 +975,7 @@ export class AutomationExecutor {
       let branchFailed = false
       let branchError: string | undefined
       let branchSuspendedAgain = false
+      let failedAtBranchIndex = -1
       for (let i = cursor.branchActionIndex + 1; i < branchActions.length; i++) {
         const branchAction = branchActions[i]
         const stepKey = `${cursor.parentStepIndex}.branch.${cursor.branchKey}.${i}`
@@ -985,6 +986,7 @@ export class AutomationExecutor {
           if (!jobLifecycle.onSuspendBranch) {
             branchFailed = true
             branchError = 'branch-local wait_for_callback requires execution_mode workflow_job_v1'
+            failedAtBranchIndex = i
             break
           }
           await jobLifecycle.onSuspendBranch(
@@ -1011,6 +1013,7 @@ export class AutomationExecutor {
         ) {
           branchFailed = true
           branchError = `${branchAction.type} is not supported inside a condition_branch`
+          failedAtBranchIndex = i
           break
         }
 
@@ -1021,6 +1024,7 @@ export class AutomationExecutor {
         if (branchActionResult.status === 'failed') {
           branchFailed = true
           branchError = branchActionResult.error ?? `Branch action ${i} failed`
+          failedAtBranchIndex = i
           break
         }
       }
@@ -1028,6 +1032,22 @@ export class AutomationExecutor {
       if (branchSuspendedAgain) {
         execution.duration = (execution.duration ?? 0) + (Date.now() - startTime)
         return execution
+      }
+
+      // On branch-tail failure, fail-stop the REMAINING selected-branch actions as `skipped` C1
+      // jobs (branch keys), mirroring the initial executeConditionBranch — keeps the branch job
+      // plane complete instead of leaving downstream branch work invisible.
+      if (branchFailed && failedAtBranchIndex >= 0) {
+        for (let j = failedAtBranchIndex + 1; j < branchActions.length; j++) {
+          const skippedStepKey = `${cursor.parentStepIndex}.branch.${cursor.branchKey}.${j}`
+          const skippedJobId = `${context.executionId}:job:${cursor.parentStepIndex}:branch:${cursor.branchKey}:${j}`
+          await jobLifecycle.onSkipped(cursor.parentStepIndex, branchActions[j], {
+            stepKey: skippedStepKey,
+            jobId: skippedJobId,
+            upstreamJobId,
+          })
+          upstreamJobId = skippedJobId
+        }
       }
 
       // 3. Settle the parent condition_branch job + push its step result.
@@ -1051,7 +1071,8 @@ export class AutomationExecutor {
         stepKey: String(cursor.parentStepIndex),
       })
 
-      // 4. Continue the top-level tail after the parent (only when the branch succeeded).
+      // 4. Top-level tail: continue on success; on failure, fail-stop the remaining top-level
+      // actions as `skipped` (job plane + legacy steps), mirroring executeActions' parent-failure skip.
       if (!branchFailed) {
         const { suspended } = await this.executeActions(
           rule.actions, context, execution.steps, jobLifecycle, cursor.parentStepIndex + 1,
@@ -1059,6 +1080,11 @@ export class AutomationExecutor {
         if (suspended) {
           execution.duration = (execution.duration ?? 0) + (Date.now() - startTime)
           return execution
+        }
+      } else {
+        for (let k = cursor.parentStepIndex + 1; k < rule.actions.length; k++) {
+          await jobLifecycle.onSkipped(k, rule.actions[k])
+          execution.steps.push({ actionType: rule.actions[k].type, status: 'skipped', durationMs: 0 })
         }
       }
 

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -6,6 +6,8 @@
 import { randomUUID } from 'crypto'
 import { Logger } from '../core/logger'
 import { redactString } from './automation-log-redact'
+import { computeActionFingerprint } from './automation-suspension-service'
+import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
 import { isRichLongTextProperty, sanitizeRichLongText } from './field-codecs'
 import { ensureRecordNotLocked } from './record-lock'
 import { resolveBaseWritable } from './permission-service'
@@ -604,6 +606,13 @@ export interface ActionJobLifecycle {
    */
   onSuspend?(stepIndex: number, action: AutomationAction): Promise<void>
   /**
+   * A6-3-3: a `wait_for_callback` inside the SELECTED `condition_branch` — persist the
+   * branch suspension row + a `suspended` branch-child C1 job (via the resume cursor),
+   * then the executor STOPS. The branch tail + top-level tail run on admin resume.
+   * Optional: absent → branch-local wait fails closed.
+   */
+  onSuspendBranch?(cursor: ConditionBranchResumeCursor, action: AutomationAction): Promise<void>
+  /**
    * W6-1: `start_approval` in an opted-in rule — create one approval, persist the
    * approval bridge + a `suspended` C1 job, then STOP. Completion resumes from W5.
    */
@@ -998,10 +1007,20 @@ export class AutomationExecutor {
 
         await jobLifecycle.onStart(index, action, topLevelMeta)
         const branchResult = await this.executeConditionBranch(index, action, context, jobLifecycle)
-        results.push(branchResult.result)
-        await jobLifecycle.onSettled(index, action, branchResult.result)
+        if (branchResult.suspended) {
+          // A6-3-3 branch-local wait: the branch persisted its suspended child + the
+          // suspension row. The parent condition_branch job stays `running`; admin resume
+          // settles it after the branch tail. Stop the execution here.
+          return { suspended: true }
+        }
+        const branchStepResult = branchResult.result
+        if (!branchStepResult) {
+          throw new Error('condition_branch returned neither a suspension nor a result')
+        }
+        results.push(branchStepResult)
+        await jobLifecycle.onSettled(index, action, branchStepResult)
 
-        if (branchResult.result.status === 'failed') {
+        if (branchStepResult.status === 'failed') {
           for (let i = index + 1; i < actions.length; i++) {
             await jobLifecycle.onSkipped(i, actions[i])
             results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
@@ -1184,7 +1203,15 @@ export class AutomationExecutor {
     action: AutomationAction,
     context: ExecutionContext,
     jobLifecycle: ActionJobLifecycle,
-  ): Promise<{ result: AutomationStepResult; lastJobId: string }> {
+  ): Promise<{
+    // A6-3-3: `suspended` is set when a branch-local `wait_for_callback` suspended the
+    // execution mid-branch; `cursor` then carries the resume position. Otherwise `result`
+    // is the settled condition_branch step result (one is always present).
+    suspended?: boolean
+    result?: AutomationStepResult
+    lastJobId: string
+    cursor?: ConditionBranchResumeCursor
+  }> {
     const startMs = Date.now()
     const parentJobId = `${context.executionId}:job:${stepIndex}`
     const config = action.config as {
@@ -1271,14 +1298,35 @@ export class AutomationExecutor {
       const meta = { stepKey, jobId, upstreamJobId }
 
       if (branchAction.type === 'wait_for_callback') {
-        const failed: AutomationStepResult = {
-          actionType: 'condition_branch',
-          status: 'failed',
-          error: 'wait_for_callback inside condition_branch is deferred to A6-3-3',
-          output,
-          durationMs: Date.now() - startMs,
+        // A6-3-3 branch-local suspend. Fail closed if no resume capability (shouldn't happen:
+        // condition_branch already requires workflow_job_v1, which supplies onSuspendBranch).
+        if (!jobLifecycle.onSuspendBranch) {
+          return {
+            lastJobId,
+            result: {
+              actionType: 'condition_branch',
+              status: 'failed',
+              error: 'branch-local wait_for_callback requires execution_mode workflow_job_v1',
+              output,
+              durationMs: Date.now() - startMs,
+            },
+          }
         }
-        return { result: failed, lastJobId }
+        const cursor: ConditionBranchResumeCursor = {
+          kind: 'condition_branch',
+          parentStepIndex: stepIndex,
+          branchKey: selectedBranchKey,
+          branchActionIndex: actionIndex,
+          stepKey,
+          parentJobId,
+          branchJobId: jobId,
+          upstreamJobId,
+          branchActionFingerprint: computeActionFingerprint(branchActions),
+        }
+        // Persists the branch suspension row + a `suspended` branch-child C1 job, then STOP.
+        // The parent condition_branch job stays `running`; resume settles it (scope-gate §4.3).
+        await jobLifecycle.onSuspendBranch(cursor, branchAction)
+        return { suspended: true, cursor, lastJobId }
       }
 
       if (branchAction.type === 'condition_branch') {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -918,6 +918,167 @@ export class AutomationExecutor {
   }
 
   /**
+   * A6-3-3 branch-local resume. The caller (resumeExecution) has claimed the single-use token,
+   * re-loaded the CURRENT rule, verified BOTH the top-level fingerprint AND the selected-branch
+   * fingerprint (drift guard, before the claim), and re-derived `context`. Order (scope-gate §4.3):
+   *   1. settle the suspended branch wait child job → resolved (by branch step_key);
+   *   2. run the branch tail (`branchActions[branchActionIndex+1..]`) under branch job keys;
+   *   3. settle the parent condition_branch job + push its step result;
+   *   4. continue the top-level tail after the parent.
+   * A second wait inside the branch tail re-suspends (execution stays `running`, new suspension
+   * row). Any failure or thrown settle leaves the execution terminal `failed` (B3; no 500 with the
+   * token consumed and the tail unrun).
+   */
+  async continueBranchExecution(
+    execution: AutomationExecution,
+    rule: AutomationRule,
+    context: ExecutionContext,
+    cursor: ConditionBranchResumeCursor,
+    jobLifecycle: ActionJobLifecycle,
+  ): Promise<AutomationExecution> {
+    const startTime = Date.now()
+    execution.status = 'running'
+
+    try {
+      const parentAction = rule.actions[cursor.parentStepIndex]
+      const config = (parentAction?.config ?? {}) as {
+        branches?: Array<{ key?: unknown; actions?: AutomationAction[] }>
+        defaultBranch?: { key?: unknown; actions?: AutomationAction[] } | null
+      }
+      const candidates = [
+        ...(Array.isArray(config.branches) ? config.branches : []),
+        ...(config.defaultBranch ? [config.defaultBranch] : []),
+      ]
+      const branch = candidates.find((candidate) => candidate.key === cursor.branchKey)
+      // Guarded upstream by the branch fingerprint check; defensive fail-closed if it drifted.
+      if (!parentAction || parentAction.type !== 'condition_branch' || !branch || !Array.isArray(branch.actions)) {
+        throw new Error('A6-3-3 resume: selected branch is no longer present in the current rule')
+      }
+      const branchActions = branch.actions
+      const waitAction = branchActions[cursor.branchActionIndex]
+
+      // 1. Settle the suspended branch wait child job → resolved (keeps the C1 branch lineage clean).
+      const waitResult: AutomationStepResult = {
+        actionType: waitAction?.type ?? 'wait_for_callback',
+        status: 'success',
+        durationMs: 0,
+      }
+      await jobLifecycle.onSettled(
+        cursor.parentStepIndex,
+        waitAction ?? parentAction,
+        waitResult,
+        { stepKey: cursor.stepKey, jobId: cursor.branchJobId, upstreamJobId: cursor.upstreamJobId },
+      )
+
+      // 2. Run the branch tail under branch job keys.
+      let upstreamJobId: string | null = cursor.branchJobId
+      let branchFailed = false
+      let branchError: string | undefined
+      let branchSuspendedAgain = false
+      for (let i = cursor.branchActionIndex + 1; i < branchActions.length; i++) {
+        const branchAction = branchActions[i]
+        const stepKey = `${cursor.parentStepIndex}.branch.${cursor.branchKey}.${i}`
+        const jobId = `${context.executionId}:job:${cursor.parentStepIndex}:branch:${cursor.branchKey}:${i}`
+        const meta = { stepKey, jobId, upstreamJobId }
+
+        if (branchAction.type === 'wait_for_callback') {
+          if (!jobLifecycle.onSuspendBranch) {
+            branchFailed = true
+            branchError = 'branch-local wait_for_callback requires execution_mode workflow_job_v1'
+            break
+          }
+          await jobLifecycle.onSuspendBranch(
+            {
+              kind: 'condition_branch',
+              parentStepIndex: cursor.parentStepIndex,
+              branchKey: cursor.branchKey,
+              branchActionIndex: i,
+              stepKey,
+              parentJobId: cursor.parentJobId,
+              branchJobId: jobId,
+              upstreamJobId,
+              branchActionFingerprint: cursor.branchActionFingerprint,
+            },
+            branchAction,
+          )
+          branchSuspendedAgain = true
+          break
+        }
+        if (
+          branchAction.type === 'condition_branch' ||
+          branchAction.type === 'parallel_branch' ||
+          branchAction.type === 'start_approval'
+        ) {
+          branchFailed = true
+          branchError = `${branchAction.type} is not supported inside a condition_branch`
+          break
+        }
+
+        await jobLifecycle.onStart(cursor.parentStepIndex, branchAction, meta)
+        const branchActionResult = await this.executeSingleAction(branchAction, context)
+        await jobLifecycle.onSettled(cursor.parentStepIndex, branchAction, branchActionResult, meta)
+        upstreamJobId = jobId
+        if (branchActionResult.status === 'failed') {
+          branchFailed = true
+          branchError = branchActionResult.error ?? `Branch action ${i} failed`
+          break
+        }
+      }
+
+      if (branchSuspendedAgain) {
+        execution.duration = (execution.duration ?? 0) + (Date.now() - startTime)
+        return execution
+      }
+
+      // 3. Settle the parent condition_branch job + push its step result.
+      const parentStepResult: AutomationStepResult = branchFailed
+        ? {
+            actionType: 'condition_branch',
+            status: 'failed',
+            error: branchError ?? 'Branch tail failed',
+            output: { selectedBranchKey: cursor.branchKey },
+            durationMs: 0,
+          }
+        : {
+            actionType: 'condition_branch',
+            status: 'success',
+            output: { selectedBranchKey: cursor.branchKey, matched: true },
+            durationMs: 0,
+          }
+      execution.steps.push(parentStepResult)
+      await jobLifecycle.onSettled(cursor.parentStepIndex, parentAction, parentStepResult, {
+        jobId: cursor.parentJobId,
+        stepKey: String(cursor.parentStepIndex),
+      })
+
+      // 4. Continue the top-level tail after the parent (only when the branch succeeded).
+      if (!branchFailed) {
+        const { suspended } = await this.executeActions(
+          rule.actions, context, execution.steps, jobLifecycle, cursor.parentStepIndex + 1,
+        )
+        if (suspended) {
+          execution.duration = (execution.duration ?? 0) + (Date.now() - startTime)
+          return execution
+        }
+      }
+
+      const hasFailed = execution.steps.some((step) => step.status === 'failed')
+      const allSkipped = execution.steps.length > 0 && execution.steps.every((step) => step.status === 'skipped')
+      execution.status = hasFailed ? 'failed' : allSkipped ? 'skipped' : 'success'
+      if (hasFailed) {
+        execution.error = execution.steps.find((step) => step.status === 'failed')?.error ?? 'Action failed'
+      }
+    } catch (err) {
+      execution.status = 'failed'
+      execution.error = err instanceof Error ? err.message : String(err)
+    }
+
+    execution.duration = (execution.duration ?? 0) + (Date.now() - startTime)
+    execution.finishedAt = new Date().toISOString()
+    return execution
+  }
+
+  /**
    * Execute actions in sequence. Stop on first failure.
    */
   private async executeActions(

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -20,6 +20,7 @@ import { toJsonValue } from '../db/type-helpers'
 import { legacyAutomationStatusToJobStatus, normalizeWorkflowJobStatus, type WorkflowJobStatus, type WorkflowJobSuspendReason } from './workflow-job-contract'
 import type { ActionJobLifecycle, ActionJobLifecycleMeta } from './automation-executor'
 import type { AutomationAction } from './automation-actions'
+import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
 import { redactString, redactValue } from './automation-log-redact'
 
 const JOB_SCHEMA_VERSION = 1
@@ -140,6 +141,42 @@ export class AutomationJobService {
         action_type: action.type,
         status: 'suspended', // C1 'suspended' (non-terminal); excluded from TERMINAL_JOB_STATUSES
         upstream_job_id: stepIndex > 0 ? `${executionId}:job:${stepIndex - 1}` : null,
+        result: null,
+        error: null,
+        started_at: now,
+        finished_at: null,
+        duration_ms: null,
+        schema_version: JOB_SCHEMA_VERSION,
+      })
+      .execute()
+  }
+
+  /**
+   * A6-3-3: write the SELECTED branch's suspended wait job as `suspended`, keyed by the
+   * BRANCH step_key / job_id (not the top-level step_index). Mirrors writeSuspendedJob but
+   * positions the C1 job inside the condition_branch lineage so listByExecution hydrates
+   * the suspend descriptor onto the branch child, never onto the top-level parent.
+   */
+  async writeSuspendedBranchJob(
+    executionId: string,
+    rule: { id: string; sheetId?: string },
+    cursor: ConditionBranchResumeCursor,
+    action: AutomationAction,
+    executor: typeof db = db,
+  ): Promise<void> {
+    const now = new Date().toISOString()
+    await executor
+      .insertInto('multitable_automation_jobs')
+      .values({
+        id: cursor.branchJobId,
+        execution_id: executionId,
+        rule_id: rule.id,
+        sheet_id: rule.sheetId ?? null,
+        step_index: cursor.parentStepIndex,
+        step_key: cursor.stepKey,
+        action_type: action.type,
+        status: 'suspended',
+        upstream_job_id: cursor.upstreamJobId,
         result: null,
         error: null,
         started_at: now,

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -20,7 +20,7 @@ import { toJsonValue } from '../db/type-helpers'
 import { legacyAutomationStatusToJobStatus, normalizeWorkflowJobStatus, type WorkflowJobStatus, type WorkflowJobSuspendReason } from './workflow-job-contract'
 import type { ActionJobLifecycle, ActionJobLifecycleMeta } from './automation-executor'
 import type { AutomationAction } from './automation-actions'
-import type { ConditionBranchResumeCursor } from './automation-resume-cursor'
+import { parseResumeCursor, type ConditionBranchResumeCursor } from './automation-resume-cursor'
 import { redactString, redactValue } from './automation-log-redact'
 
 const JOB_SCHEMA_VERSION = 1
@@ -246,24 +246,43 @@ export class AutomationJobService {
 
     // B1: a `suspended` job MUST carry its C1 suspend descriptor — the contract enforces
     // `suspended ⇔ { reason, resumeToken }` (normalizeWorkflowJob throws otherwise). Hydrate it from
-    // the suspension table (single source of truth) by step — **regardless of suspension status**:
-    // resume claims the token (suspension `pending`→`resumed`) BEFORE it settles the wait job, so a
-    // still-`suspended` job can coexist with an already-`resumed` suspension — briefly (the post-claim
+    // the suspension table (single source of truth) — **regardless of suspension status**: resume
+    // claims the token (suspension `pending`→`resumed`) BEFORE it settles the wait job, so a still-
+    // `suspended` job can coexist with an already-`resumed` suspension — briefly (the post-claim
     // window) or durably (a wait-settle failure leaves job=suspended). A `pending`-only lookup would
-    // then return a descriptor-less suspended job again. Matching by step (any status) closes that.
+    // then return a descriptor-less suspended job again. Matching any status closes that.
     // (The token in this admin-gated read is also the v1 token surface — how an admin obtains it to
     // resume; there is no external emitter. Detail-only — the list route uses legacy steps.)
+    //
+    // A6-3-3 KEY-BY-STEP_KEY (not top-level step_index): a branch-local suspension stores
+    // `step_index = parentStepIndex` AND a non-null `resume_cursor` whose `stepKey` (e.g.
+    // `2.branch.high.1`) identifies the suspended BRANCH CHILD. The top-level `condition_branch`
+    // PARENT job shares that same `step_index` (its key is `String(parentStepIndex)`, e.g. `"2"`).
+    // Keying by `step_index` could therefore mis-attach the descriptor to the parent — or, with a
+    // sequential same-index double-suspend, give every suspended sibling the LAST token. We key the
+    // map by the job `step_key` string instead: top-level/start_approval suspensions store
+    // `String(step_index)`; branch-local suspensions store `cursor.stepKey`. A corrupt non-null
+    // cursor parses to `invalid` and falls to `String(step_index)` — the branch child then gets no
+    // descriptor (fail-closed), never the parent. The parent's `"2"` key is never a branch suspension
+    // key, so the descriptor can never land on the parent `condition_branch` job.
     const hasSuspended = rows.some((r) => r.status === 'suspended')
-    const suspendByStep = new Map<number, { reason: WorkflowJobSuspendReason; resumeToken: string }>()
+    const suspendByStepKey = new Map<string, { reason: WorkflowJobSuspendReason; resumeToken: string }>()
     if (hasSuspended) {
       const susps = await db
         .selectFrom('multitable_automation_suspensions')
-        .select(['step_index', 'reason', 'resume_token'])
+        .select(['step_index', 'reason', 'resume_token', 'resume_cursor'])
         .where('execution_id', '=', executionId)
-        .orderBy('created_at', 'asc') // latest suspension per step wins (defensive; v1 has one per step)
+        .orderBy('created_at', 'asc') // latest suspension per step_key wins (defensive; v1 has one per key)
         .execute()
       for (const s of susps) {
-        suspendByStep.set(Number(s.step_index), {
+        // NULL cursor → top_level (key by String(step_index)); a valid branch cursor → key by its
+        // stepKey; a corrupt non-null cursor → invalid → fall back to String(step_index) (the real
+        // suspended branch child stays descriptor-less = fail-closed, never mis-attached to the parent).
+        const parsed = parseResumeCursor(
+          typeof s.resume_cursor === 'string' ? s.resume_cursor : (s.resume_cursor ?? null),
+        )
+        const key = parsed.kind === 'condition_branch' ? parsed.cursor.stepKey : String(s.step_index)
+        suspendByStepKey.set(key, {
           reason: s.reason as WorkflowJobSuspendReason,
           resumeToken: s.resume_token as string,
         })
@@ -276,7 +295,8 @@ export class AutomationJobService {
         .orderBy('created_at', 'asc')
         .execute()
       for (const bridge of approvalBridges) {
-        suspendByStep.set(Number(bridge.step_index), {
+        // start_approval is always top-level → its suspended job's step_key is String(step_index).
+        suspendByStepKey.set(String(bridge.step_index), {
           reason: 'manual_task',
           resumeToken: bridge.approval_instance_id as string,
         })
@@ -288,7 +308,7 @@ export class AutomationJobService {
       // suspended via writeSuspendedJob) — normalize (fail-loud on a corrupt status) so the read
       // boundary stays enum-strict.
       const status = normalizeWorkflowJobStatus(row.status)
-      const descriptor = status === 'suspended' ? suspendByStep.get(Number(row.step_index)) : undefined
+      const descriptor = status === 'suspended' ? suspendByStepKey.get(row.step_key as string) : undefined
       return {
         id: row.id as string,
         executionId: row.execution_id as string,

--- a/packages/core-backend/src/multitable/automation-resume-cursor.ts
+++ b/packages/core-backend/src/multitable/automation-resume-cursor.ts
@@ -42,7 +42,10 @@ export interface ConditionBranchResumeCursor {
   branchActionFingerprint: ActionFingerprint
 }
 
-export type AutomationResumeCursor = { kind: 'top_level' } | ConditionBranchResumeCursor
+// A STORED cursor is always a branch cursor — a top-level suspension stores NULL, not a
+// cursor object. The `top_level` discriminator lives only on ParsedResumeCursor (the
+// in-memory parse RESULT), never on a persisted value.
+export type AutomationResumeCursor = ConditionBranchResumeCursor
 
 export type ParsedResumeCursor =
   | { kind: 'top_level' }
@@ -86,10 +89,13 @@ export function parseResumeCursor(raw: unknown): ParsedResumeCursor {
   }
 
   if (typeof raw !== 'object') return { kind: 'invalid', reason: 'not_an_object' }
-  // Arrays have typeof 'object' but no `kind` → fall through to unknown_kind below.
+  // A non-null cursor OBJECT is NEVER the top-level path. Only SQL NULL / absent (or a
+  // JSON `null`) means "no cursor / legacy A6-2 top-level". A stored object — including a
+  // corrupt `{ kind: 'top_level' }`, an array (no `kind`), or any unknown kind — fails
+  // closed as invalid, so a corrupted branch suspension can never resume at the top-level
+  // step_index. We never persist a top-level cursor object (top-level rows store NULL).
   const cursor = raw as Record<string, unknown>
 
-  if (cursor.kind === 'top_level') return { kind: 'top_level' }
   if (cursor.kind !== 'condition_branch') return { kind: 'invalid', reason: 'unknown_kind' }
 
   if (!isNonNegativeInt(cursor.parentStepIndex)) return { kind: 'invalid', reason: 'bad_parentStepIndex' }

--- a/packages/core-backend/src/multitable/automation-resume-cursor.ts
+++ b/packages/core-backend/src/multitable/automation-resume-cursor.ts
@@ -1,0 +1,123 @@
+/**
+ * A6-3-3 resume cursor — the position an admin resume re-enters an execution from.
+ *
+ * A6-2 top-level waits resume from a numeric top-level step index. A6-3-3
+ * branch-local waits need a richer cursor that locates the suspended wait INSIDE
+ * a selected `condition_branch`. This module owns the cursor type plus a
+ * fail-closed parser.
+ *
+ * Safety invariant (the whole point of the A6-3-3 scope gate). A stored
+ * `resume_cursor` value is interpreted as exactly one of:
+ *   - NULL / absent        → legacy A6-2 top-level path (resume by `step_index`);
+ *   - a valid cursor       → use it;
+ *   - present-but-invalid  → FAIL CLOSED.
+ *
+ * A non-null but malformed / unknown-kind cursor must NEVER silently fall back to
+ * the top-level `step_index` path: a corrupted branch-local suspension resumed as
+ * top-level would re-enter at the wrong position (the `condition_branch` parent
+ * index), re-running or skipping actions. The caller maps `invalid` to a
+ * fail-closed `409` and never to a top-level resume.
+ */
+
+/** Non-secret action-sequence fingerprint (types only), matching the A6-2 guard. */
+export interface ActionFingerprint {
+  count: number
+  hash: string
+}
+
+export interface ConditionBranchResumeCursor {
+  kind: 'condition_branch'
+  /** Top-level index of the `condition_branch` action that owns the selected branch. */
+  parentStepIndex: number
+  /** Selected branch key. */
+  branchKey: string
+  /** Index of the suspended `wait_for_callback` inside the selected branch. */
+  branchActionIndex: number
+  /** C1 job step key of the suspended branch child (`${parentStepIndex}.branch.${branchKey}.${branchActionIndex}`). */
+  stepKey: string
+  parentJobId: string
+  branchJobId: string
+  upstreamJobId: string | null
+  /** Fingerprint of the SELECTED branch's action types — detects branch drift the top-level fingerprint cannot. */
+  branchActionFingerprint: ActionFingerprint
+}
+
+export type AutomationResumeCursor = { kind: 'top_level' } | ConditionBranchResumeCursor
+
+export type ParsedResumeCursor =
+  | { kind: 'top_level' }
+  | { kind: 'condition_branch'; cursor: ConditionBranchResumeCursor }
+  | { kind: 'invalid'; reason: string }
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isFingerprint(value: unknown): value is ActionFingerprint {
+  if (!value || typeof value !== 'object') return false
+  const fp = value as Record<string, unknown>
+  return isNonNegativeInt(fp.count) && typeof fp.hash === 'string'
+}
+
+/**
+ * Parse a stored `resume_cursor` value into a discriminated result.
+ *
+ * Only `null` / `undefined` yields `top_level`. Any non-null value that is not a
+ * fully valid cursor yields `invalid` (the caller MUST fail closed) — never a
+ * silent top-level fallback.
+ */
+export function parseResumeCursor(raw: unknown): ParsedResumeCursor {
+  if (raw == null) return { kind: 'top_level' }
+
+  // Tolerate a JSON-encoded column value, but a non-null unparseable string is invalid, not top-level.
+  if (typeof raw === 'string') {
+    let decoded: unknown
+    try {
+      decoded = JSON.parse(raw)
+    } catch {
+      return { kind: 'invalid', reason: 'unparseable_json' }
+    }
+    // A JSON `null` string round-trips to the top-level path; anything else re-validates.
+    return parseResumeCursor(decoded)
+  }
+
+  if (typeof raw !== 'object') return { kind: 'invalid', reason: 'not_an_object' }
+  // Arrays have typeof 'object' but no `kind` → fall through to unknown_kind below.
+  const cursor = raw as Record<string, unknown>
+
+  if (cursor.kind === 'top_level') return { kind: 'top_level' }
+  if (cursor.kind !== 'condition_branch') return { kind: 'invalid', reason: 'unknown_kind' }
+
+  if (!isNonNegativeInt(cursor.parentStepIndex)) return { kind: 'invalid', reason: 'bad_parentStepIndex' }
+  if (!isNonEmptyString(cursor.branchKey)) return { kind: 'invalid', reason: 'bad_branchKey' }
+  if (!isNonNegativeInt(cursor.branchActionIndex)) return { kind: 'invalid', reason: 'bad_branchActionIndex' }
+  if (!isNonEmptyString(cursor.stepKey)) return { kind: 'invalid', reason: 'bad_stepKey' }
+  if (!isNonEmptyString(cursor.parentJobId)) return { kind: 'invalid', reason: 'bad_parentJobId' }
+  if (!isNonEmptyString(cursor.branchJobId)) return { kind: 'invalid', reason: 'bad_branchJobId' }
+  if (!(cursor.upstreamJobId === null || isNonEmptyString(cursor.upstreamJobId))) {
+    return { kind: 'invalid', reason: 'bad_upstreamJobId' }
+  }
+  if (!isFingerprint(cursor.branchActionFingerprint)) return { kind: 'invalid', reason: 'bad_branchActionFingerprint' }
+
+  return {
+    kind: 'condition_branch',
+    cursor: {
+      kind: 'condition_branch',
+      parentStepIndex: cursor.parentStepIndex,
+      branchKey: cursor.branchKey,
+      branchActionIndex: cursor.branchActionIndex,
+      stepKey: cursor.stepKey,
+      parentJobId: cursor.parentJobId,
+      branchJobId: cursor.branchJobId,
+      upstreamJobId: cursor.upstreamJobId === null ? null : (cursor.upstreamJobId as string),
+      branchActionFingerprint: {
+        count: (cursor.branchActionFingerprint as ActionFingerprint).count,
+        hash: (cursor.branchActionFingerprint as ActionFingerprint).hash,
+      },
+    },
+  }
+}

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1195,9 +1195,7 @@ export class AutomationService {
     if (suspension.resumeCursor.kind === 'invalid') {
       return { status: 409, code: 'SUSPENSION_CURSOR_INVALID', message: 'Suspension resume cursor is invalid; cannot resume safely' }
     }
-    if (suspension.resumeCursor.kind === 'condition_branch') {
-      return { status: 409, code: 'BRANCH_RESUME_UNAVAILABLE', message: 'Branch-local resume is not yet available for this suspension' }
-    }
+    const resumeCursor = suspension.resumeCursor // top_level | { condition_branch, cursor }
     // Re-load the CURRENT rule (D4); fail closed if missing/disabled (T7).
     const rule = await this.getRule(suspension.ruleId)
     if (!rule || !rule.enabled) {
@@ -1208,6 +1206,31 @@ export class AutomationService {
     const currentFp = computeActionFingerprint(execRule.actions)
     if (currentFp.count !== suspension.actionFingerprint.count || currentFp.hash !== suspension.actionFingerprint.hash) {
       return { status: 409, code: 'RULE_CHANGED', message: 'Rule actions changed since suspend; cannot resume safely' }
+    }
+    // A6-3-3 branch drift guard (still BEFORE the claim): the selected branch must still exist and
+    // its action sequence must match the suspend-time fingerprint, else resume could re-enter the
+    // wrong branch position. The top-level fingerprint above only covers top-level action types.
+    if (resumeCursor.kind === 'condition_branch') {
+      const branchCursor = resumeCursor.cursor
+      const parentAction = execRule.actions[branchCursor.parentStepIndex]
+      const parentConfig = (parentAction?.config ?? {}) as {
+        branches?: Array<{ key?: unknown; actions?: AutomationAction[] }>
+        defaultBranch?: { key?: unknown; actions?: AutomationAction[] } | null
+      }
+      const branch = [
+        ...(Array.isArray(parentConfig.branches) ? parentConfig.branches : []),
+        ...(parentConfig.defaultBranch ? [parentConfig.defaultBranch] : []),
+      ].find((candidate) => candidate.key === branchCursor.branchKey)
+      if (!parentAction || parentAction.type !== 'condition_branch' || !branch || !Array.isArray(branch.actions)) {
+        return { status: 409, code: 'RULE_CHANGED', message: 'Selected branch no longer exists; cannot resume safely' }
+      }
+      const branchFp = computeActionFingerprint(branch.actions)
+      if (
+        branchFp.count !== branchCursor.branchActionFingerprint.count ||
+        branchFp.hash !== branchCursor.branchActionFingerprint.hash
+      ) {
+        return { status: 409, code: 'RULE_CHANGED', message: 'Selected branch actions changed since suspend; cannot resume safely' }
+      }
     }
     // Re-fetch the live record (D4); fail closed if it was deleted during the wait (T9).
     let recordData: Record<string, unknown> = {}
@@ -1251,7 +1274,9 @@ export class AutomationService {
     const lineageIds = await this.collectExecutionLineageIds(execution)
     const rootExecutionId = lineageIds.at(-1) ?? execution.id
     const jobLifecycle = this.buildJobLifecycle(execution.id, execRule, triggerEvent, rootExecutionId)
-    const continued = await this.executor.continueExecution(execution, execRule, context, suspension.stepIndex, jobLifecycle)
+    const continued = resumeCursor.kind === 'condition_branch'
+      ? await this.executor.continueBranchExecution(execution, execRule, context, resumeCursor.cursor, jobLifecycle)
+      : await this.executor.continueExecution(execution, execRule, context, suspension.stepIndex, jobLifecycle)
     try {
       await this.logService.updateRecordedExecution(continued)
     } catch (err) {

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1187,6 +1187,17 @@ export class AutomationService {
     if (suspension.status !== 'pending') {
       return { status: 409, code: 'ALREADY_RESUMED', message: `Suspension is ${suspension.status}, not resumable` }
     }
+    // A6-3-3 resume-cursor gate — fail closed BEFORE any token claim:
+    // - `invalid`: a non-null but malformed / unknown cursor must NEVER fall back to the
+    //   top-level step_index path (that is the corrupt-branch-cursor fail-open we close).
+    // - `condition_branch`: branch-aware resume lands in the next slice; until then fail
+    //   closed rather than mis-resume a branch suspension via the top-level path.
+    if (suspension.resumeCursor.kind === 'invalid') {
+      return { status: 409, code: 'SUSPENSION_CURSOR_INVALID', message: 'Suspension resume cursor is invalid; cannot resume safely' }
+    }
+    if (suspension.resumeCursor.kind === 'condition_branch') {
+      return { status: 409, code: 'BRANCH_RESUME_UNAVAILABLE', message: 'Branch-local resume is not yet available for this suspension' }
+    }
     // Re-load the CURRENT rule (D4); fail closed if missing/disabled (T7).
     const rule = await this.getRule(suspension.ruleId)
     if (!rule || !rule.enabled) {

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1231,6 +1231,30 @@ export class AutomationService {
       ) {
         return { status: 409, code: 'RULE_CHANGED', message: 'Selected branch actions changed since suspend; cannot resume safely' }
       }
+      // Semantic-corruption guard (still BEFORE the claim). The branch fingerprint only hashes branch
+      // action TYPES, so a structurally-valid cursor whose branchActionIndex points at a NON-wait action
+      // (with tampered ids) would otherwise pass and let continueBranchExecution settle that non-wait
+      // action as the suspended wait. The cursor must (a) point at a branch-local wait_for_callback, and
+      // (b) carry the deterministic ids for this execution + branch position (stepKey / parentJobId /
+      // branchJobId / upstreamJobId are pure functions of executionId + parentStepIndex + branchKey +
+      // branchActionIndex). Any mismatch fails closed.
+      if (branch.actions[branchCursor.branchActionIndex]?.type !== 'wait_for_callback') {
+        return { status: 409, code: 'SUSPENSION_CURSOR_INVALID', message: 'Resume cursor does not point at a branch-local wait; cannot resume safely' }
+      }
+      const expectedStepKey = `${branchCursor.parentStepIndex}.branch.${branchCursor.branchKey}.${branchCursor.branchActionIndex}`
+      const expectedParentJobId = `${suspension.executionId}:job:${branchCursor.parentStepIndex}`
+      const expectedBranchJobId = `${suspension.executionId}:job:${branchCursor.parentStepIndex}:branch:${branchCursor.branchKey}:${branchCursor.branchActionIndex}`
+      const expectedUpstreamJobId = branchCursor.branchActionIndex === 0
+        ? expectedParentJobId
+        : `${suspension.executionId}:job:${branchCursor.parentStepIndex}:branch:${branchCursor.branchKey}:${branchCursor.branchActionIndex - 1}`
+      if (
+        branchCursor.stepKey !== expectedStepKey ||
+        branchCursor.parentJobId !== expectedParentJobId ||
+        branchCursor.branchJobId !== expectedBranchJobId ||
+        branchCursor.upstreamJobId !== expectedUpstreamJobId
+      ) {
+        return { status: 409, code: 'SUSPENSION_CURSOR_INVALID', message: 'Resume cursor ids are inconsistent with the branch position; cannot resume safely' }
+      }
     }
     // Re-fetch the live record (D4); fail closed if it was deleted during the wait (T9).
     let recordData: Record<string, unknown> = {}

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -263,9 +263,8 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'parallel_branch') {
         throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain parallel_branch until a later nested-DAG slice`)
       }
-      if (nested.type === 'wait_for_callback') {
-        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain wait_for_callback until A6-3-3`)
-      }
+      // A6-3-3: branch-local wait_for_callback is allowed — condition_branch already forces
+      // workflow_job_v1 at the rule level, so the wait is only reachable in an opted-in rule.
       if (nested.type === 'start_approval') {
         throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain start_approval until A6-3-3`)
       }
@@ -292,9 +291,7 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'parallel_branch') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain parallel_branch until a later nested-DAG slice`)
       }
-      if (nested.type === 'wait_for_callback') {
-        throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain wait_for_callback until A6-3-3`)
-      }
+      // A6-3-3: branch-local wait_for_callback is allowed (see branches loop above).
       if (nested.type === 'start_approval') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain start_approval until A6-3-3`)
       }
@@ -1069,6 +1066,19 @@ export class AutomationService {
             recordId: ((triggerEvent as Record<string, unknown>)?.recordId as string) ?? '',
             triggerEvent,
             stepIndex,
+            action,
+          })
+          .then(() => undefined),
+      // A6-3-3: a branch-local wait_for_callback persists the branch suspension (with cursor)
+      // + a suspended branch-child job, then the executor stops; resume continues the branch tail.
+      onSuspendBranch: (cursor, action: AutomationAction): Promise<void> =>
+        this.suspensionService
+          .createBranchLocal({
+            executionId,
+            rule: { id: rule.id, sheetId: rule.sheetId, actions: rule.actions },
+            recordId: ((triggerEvent as Record<string, unknown>)?.recordId as string) ?? '',
+            triggerEvent,
+            cursor,
             action,
           })
           .then(() => undefined),

--- a/packages/core-backend/src/multitable/automation-suspension-service.ts
+++ b/packages/core-backend/src/multitable/automation-suspension-service.ts
@@ -24,6 +24,11 @@ import { toJsonValue } from '../db/type-helpers'
 import { redactValue } from './automation-log-redact'
 import { AutomationJobService } from './automation-job-service'
 import type { AutomationAction } from './automation-actions'
+import {
+  parseResumeCursor,
+  type ConditionBranchResumeCursor,
+  type ParsedResumeCursor,
+} from './automation-resume-cursor'
 
 /** Suspend-time action sequence fingerprint (D4b rule-drift guard) — non-secret (types only). */
 export interface ActionFingerprint {
@@ -42,6 +47,8 @@ export interface SuspensionRow {
   reason: string
   actionFingerprint: ActionFingerprint
   triggerEvent: unknown
+  /** A6-3-3 branch-local resume cursor, parsed + validated; top_level for legacy A6-2 rows. */
+  resumeCursor: ParsedResumeCursor
   status: string
 }
 
@@ -108,6 +115,54 @@ export class AutomationSuspensionService {
     return resumeToken
   }
 
+  /**
+   * A6-3-3 branch-local suspend: persist the suspension row WITH the structured
+   * resume cursor + the suspended branch-child C1 job (step_key, not top-level
+   * index), atomically. `step_index` stores the parent `condition_branch` index
+   * so the existing top-level locators still work; the cursor carries the branch
+   * detail. The top-level action fingerprint guards the parent position; the
+   * cursor's `branchActionFingerprint` guards the selected branch path.
+   */
+  async createBranchLocal(input: {
+    executionId: string
+    rule: { id: string; sheetId?: string; actions: ReadonlyArray<AutomationAction> }
+    recordId: string
+    triggerEvent: unknown
+    cursor: ConditionBranchResumeCursor
+    action: AutomationAction
+  }): Promise<string> {
+    const resumeToken = randomUUID()
+    const fingerprint = computeActionFingerprint(input.rule.actions)
+    await db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto('multitable_automation_suspensions')
+        .values({
+          id: `asp_${randomUUID()}`,
+          execution_id: input.executionId,
+          rule_id: input.rule.id,
+          sheet_id: input.rule.sheetId ?? null,
+          record_id: input.recordId || null,
+          step_index: input.cursor.parentStepIndex,
+          resume_token: resumeToken,
+          reason: 'external_event',
+          action_fingerprint: toJsonValue(fingerprint) as never,
+          trigger_event: input.triggerEvent == null ? null : (toJsonValue(redactValue(input.triggerEvent)) as never),
+          // Non-secret (ids + types only); stored unredacted so resume re-derives the branch position.
+          resume_cursor: toJsonValue(input.cursor) as never,
+          status: 'pending',
+        })
+        .execute()
+      await this.jobService.writeSuspendedBranchJob(
+        input.executionId,
+        { id: input.rule.id, sheetId: input.rule.sheetId },
+        input.cursor,
+        input.action,
+        trx,
+      )
+    })
+    return resumeToken
+  }
+
   /** Look up a suspension by its resume token (null if unknown → route 404). */
   async findByToken(resumeToken: string): Promise<SuspensionRow | null> {
     const row = await db
@@ -150,6 +205,10 @@ export class AutomationSuspensionService {
       reason: row.reason as string,
       actionFingerprint: { count: Number(fp.count ?? 0), hash: String(fp.hash ?? '') },
       triggerEvent: typeof row.trigger_event === 'string' ? JSON.parse(row.trigger_event) : (row.trigger_event ?? null),
+      // NULL → top_level (A6-2 legacy); non-null-but-malformed → invalid (resume fails closed).
+      resumeCursor: parseResumeCursor(
+        typeof row.resume_cursor === 'string' ? row.resume_cursor : (row.resume_cursor ?? null),
+      ),
       status: row.status as string,
     }
   }

--- a/packages/core-backend/tests/integration/multitable-automation-branch-local-wait.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-branch-local-wait.test.ts
@@ -396,6 +396,49 @@ describeIfDatabase('multitable automation branch-local wait (A6-3-3a, real DB)',
     expect(susp.rows[0].status).toBe('pending') // token NOT claimed
   })
 
+  // §5 (cursor binding) — a STRUCTURALLY-VALID cursor whose branchActionIndex points at a NON-wait
+  // action must fail closed pre-claim. The branch fingerprint only hashes action TYPES, so without the
+  // wait-type + deterministic-id guard this cursor would pass, claim the token, and settle a non-wait
+  // action as if it were the suspended wait.
+  test('semantic-corrupt cursor: valid-shaped cursor at a non-wait branch action → 409, token NOT claimed, no job settles', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'semantic', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_semantic_${TS}`
+    await seedRecord(recId, { amount: 700000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 700000 })
+    const token = await tokenFor(exec.id)
+
+    // Read the real cursor (correct branch fingerprint), then re-point branchActionIndex at index 0
+    // (send_notification, a NON-wait) with the deterministic ids for index 0 — so the branch fingerprint
+    // guard still passes and ONLY the new wait-type / id-binding check can catch it.
+    const before = await q('SELECT resume_cursor FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    const real = typeof before.rows[0].resume_cursor === 'string'
+      ? JSON.parse(before.rows[0].resume_cursor)
+      : before.rows[0].resume_cursor
+    const semanticCorrupt = {
+      kind: 'condition_branch',
+      parentStepIndex: 0,
+      branchKey: 'high_amount',
+      branchActionIndex: 0, // send_notification — NOT the wait at index 1
+      stepKey: '0.branch.high_amount.0',
+      parentJobId: `${exec.id}:job:0`,
+      branchJobId: `${exec.id}:job:0:branch:high_amount:0`,
+      upstreamJobId: `${exec.id}:job:0`,
+      branchActionFingerprint: real.branchActionFingerprint, // unchanged → fingerprint guard passes
+    }
+    await q(
+      'UPDATE multitable_automation_suspensions SET resume_cursor = $1::jsonb WHERE execution_id = $2',
+      [JSON.stringify(semanticCorrupt), exec.id],
+    )
+
+    expect(await svc.resumeExecution(token, 'admin_semantic')).toMatchObject({ status: 409, code: 'SUSPENSION_CURSOR_INVALID' })
+    // Pre-claim → token stays pending, and the suspended branch wait child was NOT settled.
+    const after = await q('SELECT status FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    expect(after.rows[0].status).toBe('pending')
+    const waitJob = await q('SELECT status FROM multitable_automation_jobs WHERE id = $1', [`${exec.id}:job:0:branch:high_amount:1`])
+    expect(waitJob.rows[0].status).toBe('suspended') // no settle happened
+  })
+
   // §5 — single-use token: the second resume is rejected.
   test('second resume → 409 ALREADY_RESUMED (single-use token, §5)', async () => {
     const svc = makeService(okFetch)

--- a/packages/core-backend/tests/integration/multitable-automation-branch-local-wait.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-branch-local-wait.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Real-DB branch-local wait suspend/resume for the A6-3-3a runtime (admin-gated v1).
+ *
+ * Drives AutomationService.executeRule (suspend mid-branch) + resumeExecution (branch-aware
+ * resume) against REAL Postgres — proving the wire that mock-db unit tests cannot for a
+ * `wait_for_callback` INSIDE a selected `condition_branch`:
+ *   - only the selected high-risk branch suspends; the ordinary low branch finishes (scope-gate §6);
+ *   - the SUSPENDED job is the branch CHILD (step_key `N.branch.<key>.M`), the parent
+ *     `condition_branch` job stays `running` (§4.2), and the suspend descriptor (resume token)
+ *     hydrates onto the branch child, never the parent (§7 listByExecution stepKey hydration);
+ *   - branch resume settles the wait child, runs the branch tail, settles the parent, then the
+ *     top-level tail (§4.3);
+ *   - the failure matrix (§5): branch-fingerprint drift → 409 RULE_CHANGED (pre-claim, token kept),
+ *     a corrupt non-null resume cursor → 409 SUSPENSION_CURSOR_INVALID (pre-claim, token kept),
+ *     a second resume → 409 ALREADY_RESUMED, and a post-resume branch-tail failure writes `skipped`
+ *     C1 jobs for the REMAINING branch children AND the REMAINING top-level actions (slice-4 finding),
+ *     execution terminal `failed`.
+ *
+ * Runs only with DATABASE_URL (plugin-tests.yml real-DB job).
+ *
+ * See docs/development/multitable-automation-a6-3-3-branch-local-wait-scope-gate-20260615.md
+ *  and docs/development/multitable-automation-a6-3-3a-branch-local-wait-verification-20260615.md
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { AutomationJobService } from '../../src/multitable/automation-job-service'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
+import { db } from '../../src/db/db'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const SHEET = `sheet_blw_${TS}`
+const BASE = `base_blw_${TS}`
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const jobsRead = new AutomationJobService()
+const execIds: string[] = []
+
+/**
+ * Real queryFn so update_record actually writes + resumeExecution re-fetches the live record.
+ * fetchFn is injected per-scenario: an OK responder for the happy path, a 500 responder for the
+ * branch-tail-failure scenario. failFetch returns 500 on EVERY attempt, so send_webhook settles
+ * `failed` after its default retries regardless of AUTOMATION_WEBHOOK_MAX_RETRIES — no global env
+ * mutation (which would leak into sibling integration files in a shared vitest worker).
+ */
+function makeService(fetchFn?: typeof fetch): AutomationService {
+  return new AutomationService(new EventBus(), db as never, q as never, fetchFn as never)
+}
+
+const okFetch = (async () => new Response('OK', { status: 200 })) as unknown as typeof fetch
+const failFetch = (async () => new Response('boom', { status: 500 })) as unknown as typeof fetch
+
+// HAPPY rule: one condition_branch (low ≤100000 → auto_approved; high >100000 → notify, WAIT,
+// approved_after_review), then a top-level update_record so resume settles the top-level tail too.
+const LOW_BRANCH_HAPPY = {
+  key: 'low_amount',
+  label: 'Low',
+  conditions: { logic: 'and', conditions: [{ fieldId: 'amount', operator: 'less_or_equal', value: 100000 }] },
+  actions: [{ type: 'update_record', config: { fields: { status: 'auto_approved' } } }],
+}
+const HIGH_BRANCH_HAPPY = {
+  key: 'high_amount',
+  label: 'High',
+  conditions: { logic: 'and', conditions: [{ fieldId: 'amount', operator: 'greater_than', value: 100000 }] },
+  actions: [
+    { type: 'send_notification', config: { userIds: ['owner-1'], message: 'High amount needs review' } },
+    { type: 'wait_for_callback', config: {} },
+    { type: 'update_record', config: { fields: { status: 'approved_after_review' } } },
+  ],
+}
+const HAPPY_BRANCH_ACTION = {
+  type: 'condition_branch',
+  config: { branches: [LOW_BRANCH_HAPPY, HIGH_BRANCH_HAPPY] },
+} as const
+const HAPPY_RULE_ACTIONS = [
+  HAPPY_BRANCH_ACTION,
+  { type: 'update_record', config: { fields: { final_step: 'done' } } },
+] as const
+
+// TAIL-FAILURE rule: the high branch's post-wait tail has a failing send_webhook that is NOT the
+// last branch action, AND there is a top-level action after the condition_branch — so a tail
+// failure must skip BOTH the remaining branch child (index 3) AND the remaining top-level (index 1).
+const HIGH_BRANCH_FAIL = {
+  key: 'high_amount',
+  label: 'High',
+  conditions: { logic: 'and', conditions: [{ fieldId: 'amount', operator: 'greater_than', value: 100000 }] },
+  actions: [
+    { type: 'send_notification', config: { userIds: ['owner-1'], message: 'review' } },
+    { type: 'wait_for_callback', config: {} },
+    { type: 'send_webhook', config: { url: 'https://example.test/fail' } },
+    { type: 'update_record', config: { fields: { status: 'should_not_run' } } },
+  ],
+}
+const FAIL_BRANCH_ACTION = {
+  type: 'condition_branch',
+  config: { branches: [LOW_BRANCH_HAPPY, HIGH_BRANCH_FAIL] },
+} as const
+const FAIL_RULE_ACTIONS = [
+  FAIL_BRANCH_ACTION,
+  { type: 'update_record', config: { fields: { final_step: 'should_not_run' } } },
+] as const
+
+async function createRule(
+  svc: AutomationService,
+  suffix: string,
+  actions: ReadonlyArray<unknown>,
+  branchConfig: unknown,
+): Promise<string> {
+  const created = await svc.createRule(SHEET, {
+    name: `a6-3-3a ${suffix}`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'condition_branch',
+    actionConfig: branchConfig as never,
+    actions: actions as never,
+    executionMode: 'workflow_job_v1',
+    createdBy: 'u1',
+  })
+  return created.id
+}
+
+function execRuleOf(ruleId: string, actions: ReadonlyArray<unknown>, mode: string | undefined = 'workflow_job_v1') {
+  return {
+    id: ruleId, name: 'a6-3-3a', sheetId: SHEET,
+    trigger: { type: 'record.created', config: {} },
+    actions, enabled: true, createdBy: 'u1',
+    createdAt: new Date(TS).toISOString(), executionMode: mode,
+  }
+}
+
+/** Insert a real meta_records row so resume's record re-fetch succeeds + update_record writes land. */
+async function seedRecord(recordId: string, data: Record<string, unknown>): Promise<void> {
+  await q(
+    `INSERT INTO meta_records (id, sheet_id, data) VALUES ($1, $2, $3::jsonb)
+       ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data`,
+    [recordId, SHEET, JSON.stringify(data)],
+  )
+}
+
+async function run(
+  svc: AutomationService,
+  ruleId: string,
+  actions: ReadonlyArray<unknown>,
+  recordId: string,
+  data: Record<string, unknown>,
+) {
+  const exec = await svc.executeRule(execRuleOf(ruleId, actions) as never, { sheetId: SHEET, recordId, data })
+  execIds.push(exec.id)
+  return exec
+}
+
+async function tokenFor(executionId: string): Promise<string> {
+  const r = await q('SELECT resume_token FROM multitable_automation_suspensions WHERE execution_id = $1', [executionId])
+  return r.rows[0]?.resume_token as string
+}
+
+async function jobRows(executionId: string): Promise<Array<{ step_index: number; step_key: string; action_type: string; status: string }>> {
+  const r = await q(
+    `SELECT step_index, step_key, action_type, status
+       FROM multitable_automation_jobs WHERE execution_id = $1
+       ORDER BY step_index ASC, created_at ASC, step_key ASC`,
+    [executionId],
+  )
+  return r.rows as Array<{ step_index: number; step_key: string; action_type: string; status: string }>
+}
+
+async function recordStatus(recordId: string): Promise<string | undefined> {
+  const r = await q(`SELECT data->>'status' AS status FROM meta_records WHERE id = $1 AND sheet_id = $2`, [recordId, SHEET])
+  return r.rows[0]?.status as string | undefined
+}
+
+describeIfDatabase('multitable automation branch-local wait (A6-3-3a, real DB)', () => {
+  beforeAll(async () => {
+    // meta_records.sheet_id → meta_sheets(id) → meta_bases(id): seed the base + sheet so resume's
+    // record re-fetch and update_record writes land (the A6-2 suspend-resume test sidesteps this
+    // with recordId='', but the branch happy/tail-failure paths need a real record).
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING', [BASE, 'BLW Base', 'u1'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING', [SHEET, BASE, 'BLW Sheet'])
+    await q('DELETE FROM multitable_automation_jobs WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM multitable_automation_suspensions WHERE sheet_id = $1', [SHEET])
+  })
+  afterAll(async () => {
+    for (const id of execIds) {
+      await q('DELETE FROM multitable_automation_executions WHERE id = $1', [id])
+    }
+    await q('DELETE FROM multitable_automation_suspensions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM multitable_automation_jobs WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM automation_rules WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // §6 step 5 — LOW branch never suspends.
+  test('HAPPY-low: amount ≤ 100000 → low branch runs, NO suspension, status auto_approved (§6.5)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'happy-low', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_low_${TS}`
+    await seedRecord(recId, { amount: 50000 })
+
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 50000 })
+
+    expect(exec.status).toBe('success')
+    const susp = await q('SELECT count(*)::int AS n FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    expect(susp.rows[0].n).toBe(0)
+    const suspendedJobs = (await jobRows(exec.id)).filter((j) => j.status === 'suspended')
+    expect(suspendedJobs).toHaveLength(0)
+    expect(await recordStatus(recId)).toBe('auto_approved')
+  })
+
+  // §6 step 6 — HIGH branch suspends; only the branch child is suspended, the parent stays running.
+  test('HAPPY-high suspends: execution running, parent condition_branch RUNNING, branch wait child SUSPENDED, record not yet approved (§4.2/§6.6)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'happy-high', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_high_${TS}`
+    await seedRecord(recId, { amount: 250000 })
+
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 250000 })
+
+    // D2: execution stays `running` (suspended state is out-of-band).
+    expect(exec.status).toBe('running')
+
+    const susp = await q(
+      'SELECT status, step_index, reason, resume_cursor FROM multitable_automation_suspensions WHERE execution_id = $1',
+      [exec.id],
+    )
+    expect(susp.rows).toHaveLength(1)
+    expect(susp.rows[0].status).toBe('pending')
+    expect(Number(susp.rows[0].step_index)).toBe(0) // parent condition_branch index
+    expect(susp.rows[0].reason).toBe('external_event')
+    // Branch-local cursor persisted (non-null) → resume re-enters the SELECTED branch.
+    const cursor = typeof susp.rows[0].resume_cursor === 'string' ? JSON.parse(susp.rows[0].resume_cursor) : susp.rows[0].resume_cursor
+    expect(cursor).toMatchObject({ kind: 'condition_branch', branchKey: 'high_amount', branchActionIndex: 1, stepKey: '0.branch.high_amount.1' })
+
+    // §4.2 job state: parent condition_branch RUNNING; prior branch child (notify) resolved;
+    // branch wait child SUSPENDED; later branch action + top-level tail not yet present.
+    const rows = await jobRows(exec.id)
+    const byKey = new Map(rows.map((r) => [r.step_key, r]))
+    expect(byKey.get('0')).toMatchObject({ action_type: 'condition_branch', status: 'running' })
+    expect(byKey.get('0.branch.high_amount.0')).toMatchObject({ action_type: 'send_notification', status: 'resolved' })
+    expect(byKey.get('0.branch.high_amount.1')).toMatchObject({ action_type: 'wait_for_callback', status: 'suspended' })
+    expect(byKey.has('0.branch.high_amount.2')).toBe(false) // later branch action not run yet
+    expect(byKey.has('1')).toBe(false) // top-level tail not run yet
+    expect(await recordStatus(recId)).not.toBe('approved_after_review') // post-wait update not run yet
+  })
+
+  // §7 — descriptor hydrates onto the branch CHILD (stepKey), NEVER the parent condition_branch job.
+  test('descriptor-on-stepKey: listByExecution attaches the resume token to the branch child (step_key 0.branch.high_amount.1), never the parent (§7)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'desc-stepkey', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_desc_${TS}`
+    await seedRecord(recId, { amount: 300000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 300000 })
+
+    const views = await jobsRead.listByExecution(exec.id)
+    const parent = views.find((v) => v.stepKey === '0')
+    const waitChild = views.find((v) => v.stepKey === '0.branch.high_amount.1')
+
+    // Parent condition_branch job is `running` and carries NO suspend descriptor.
+    expect(parent).toMatchObject({ status: 'running' })
+    expect((parent as { suspend?: unknown }).suspend).toBeUndefined()
+
+    // Branch wait child is `suspended` and carries a VALID C1 descriptor (passes normalizeWorkflowJob).
+    expect(waitChild).toMatchObject({ status: 'suspended', suspend: { reason: 'external_event' } })
+    expect((waitChild as { suspend?: { resumeToken?: string } }).suspend?.resumeToken).toBeTruthy()
+    expect(() => normalizeWorkflowJob(waitChild)).not.toThrow()
+  })
+
+  // The focused disambiguation that actually DISCRIMINATES step_key keying from step_index keying:
+  // two `suspended` rows at the SAME step_index with DISTINCT stepKey + token. step_index keying would
+  // give both the LAST token; step_key keying gives each its own. (The happy-path placement is
+  // vacuously parent-safe because the parent is `running`; this case is the real proof of ③.)
+  test('stepKey disambiguation: two suspended jobs at the same step_index get their OWN tokens by step_key (not the last token) (③)', async () => {
+    const execId = `axe_blw_disamb_${TS}`
+    execIds.push(execId)
+    const ruleId = `atr_blw_disamb_${TS}`
+    const mk = (stepKey: string, jobId: string) =>
+      q(
+        `INSERT INTO multitable_automation_jobs
+           (id, execution_id, rule_id, sheet_id, step_index, step_key, action_type, status, schema_version, started_at)
+         VALUES ($1, $2, $3, $4, 2, $5, 'wait_for_callback', 'suspended', 1, NOW())`,
+        [jobId, execId, ruleId, SHEET, stepKey],
+      )
+    // Two suspended branch-child jobs, same step_index = 2, different branch step_keys.
+    await mk('2.branch.b1.0', `${execId}:job:2:branch:b1:0`)
+    await mk('2.branch.b2.0', `${execId}:job:2:branch:b2:0`)
+
+    const mkSusp = (token: string, cursorStepKey: string) =>
+      q(
+        `INSERT INTO multitable_automation_suspensions
+           (id, execution_id, rule_id, sheet_id, step_index, resume_token, reason, action_fingerprint, status, resume_cursor)
+         VALUES ($1, $2, $3, $4, 2, $5, 'external_event', '{"count":1,"hash":"h"}'::jsonb, 'pending', $6::jsonb)`,
+        [
+          `asp_${token}`, execId, ruleId, SHEET, token,
+          JSON.stringify({
+            kind: 'condition_branch', parentStepIndex: 2, branchKey: cursorStepKey.split('.')[2],
+            branchActionIndex: 0, stepKey: cursorStepKey,
+            parentJobId: `${execId}:job:2`, branchJobId: `${execId}:job:2:branch:${cursorStepKey.split('.')[2]}:0`,
+            upstreamJobId: null, branchActionFingerprint: { count: 1, hash: 'h' },
+          }),
+        ],
+      )
+    await mkSusp('tok_b1', '2.branch.b1.0')
+    await mkSusp('tok_b2', '2.branch.b2.0')
+
+    const views = await jobsRead.listByExecution(execId)
+    const v1 = views.find((v) => v.stepKey === '2.branch.b1.0') as { suspend?: { resumeToken?: string } } | undefined
+    const v2 = views.find((v) => v.stepKey === '2.branch.b2.0') as { suspend?: { resumeToken?: string } } | undefined
+    // Each suspended job keeps ITS OWN token (step_key keying). With step_index keying both would
+    // collapse to the last-inserted token (tok_b2) — this assertion fails on the unfixed code.
+    expect(v1?.suspend?.resumeToken).toBe('tok_b1')
+    expect(v2?.suspend?.resumeToken).toBe('tok_b2')
+  })
+
+  // §6 step 7 — branch resume: wait child resolves, branch tail runs, parent settles, top-level tail runs.
+  test('HAPPY-high resume: branch wait resolves → branch update runs → parent resolved → top-level tail → success, status approved_after_review (§4.3/§6.7)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'happy-resume', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_resume_${TS}`
+    await seedRecord(recId, { amount: 400000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 400000 })
+
+    const result = await svc.resumeExecution(await tokenFor(exec.id), 'admin_resume')
+    expect('execution' in result).toBe(true)
+    if ('execution' in result) {
+      expect(result.execution.status).toBe('success')
+      expect(result.execution.initiatedBy).toBe('admin_resume')
+    }
+
+    const rows = await jobRows(exec.id)
+    const byKey = new Map(rows.map((r) => [r.step_key, r.status]))
+    expect(byKey.get('0')).toBe('resolved') // parent condition_branch settled
+    expect(byKey.get('0.branch.high_amount.0')).toBe('resolved') // notify
+    expect(byKey.get('0.branch.high_amount.1')).toBe('resolved') // wait settled
+    expect(byKey.get('0.branch.high_amount.2')).toBe('resolved') // post-wait branch update ran
+    expect(byKey.get('1')).toBe('resolved') // top-level tail ran
+
+    expect(await recordStatus(recId)).toBe('approved_after_review')
+    const susp = await q('SELECT status FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    expect(susp.rows[0].status).toBe('resumed')
+  })
+
+  // §5 — selected branch path changed before resume → 409 RULE_CHANGED (branch fingerprint), pre-claim.
+  test('drift guard before claim: mutating the SELECTED branch actions → 409 RULE_CHANGED, token NOT claimed (§5)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'drift', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_drift_${TS}`
+    await seedRecord(recId, { amount: 500000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 500000 })
+    const token = await tokenFor(exec.id)
+
+    // Re-sequence the SELECTED branch's actions only (append one) so the BRANCH fingerprint trips
+    // while the top-level fingerprint (['condition_branch','update_record']) stays equal → the branch
+    // drift guard (not the top-level guard) is what fires. Persist via the rule jsonb.
+    const driftedHigh = {
+      ...HIGH_BRANCH_HAPPY,
+      actions: [...HIGH_BRANCH_HAPPY.actions, { type: 'update_record', config: { fields: { extra: 1 } } }],
+    }
+    const driftedActions = JSON.stringify([
+      { type: 'condition_branch', config: { branches: [LOW_BRANCH_HAPPY, driftedHigh] } },
+      { type: 'update_record', config: { fields: { final_step: 'done' } } },
+    ])
+    await q('UPDATE automation_rules SET actions = $1::jsonb WHERE id = $2', [driftedActions, ruleId])
+
+    expect(await svc.resumeExecution(token, 'admin_drift')).toMatchObject({ status: 409, code: 'RULE_CHANGED' })
+    // Pre-claim guard → token stays pending (recoverable).
+    const susp = await q('SELECT status FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    expect(susp.rows[0].status).toBe('pending')
+  })
+
+  // §5 — a corrupt non-null resume cursor must fail closed (never a silent top-level fallback), pre-claim.
+  test('invalid cursor: a corrupt non-null resume_cursor → 409 SUSPENSION_CURSOR_INVALID, token NOT claimed (§5)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'invalid', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_invalid_${TS}`
+    await seedRecord(recId, { amount: 600000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 600000 })
+    const token = await tokenFor(exec.id)
+
+    // Corrupt the persisted cursor to a non-null but malformed object (unknown kind) → parseResumeCursor
+    // yields `invalid` → resume must 409 fail-closed, NOT fall back to the top-level step_index path.
+    await q(
+      `UPDATE multitable_automation_suspensions SET resume_cursor = '{"kind":"top_level"}'::jsonb WHERE execution_id = $1`,
+      [exec.id],
+    )
+
+    expect(await svc.resumeExecution(token, 'admin_invalid')).toMatchObject({ status: 409, code: 'SUSPENSION_CURSOR_INVALID' })
+    const susp = await q('SELECT status FROM multitable_automation_suspensions WHERE execution_id = $1', [exec.id])
+    expect(susp.rows[0].status).toBe('pending') // token NOT claimed
+  })
+
+  // §5 — single-use token: the second resume is rejected.
+  test('second resume → 409 ALREADY_RESUMED (single-use token, §5)', async () => {
+    const svc = makeService(okFetch)
+    const ruleId = await createRule(svc, 'second', HAPPY_RULE_ACTIONS, HAPPY_BRANCH_ACTION.config)
+    const recId = `rec_second_${TS}`
+    await seedRecord(recId, { amount: 700000 })
+    const exec = await run(svc, ruleId, HAPPY_RULE_ACTIONS, recId, { amount: 700000 })
+    const token = await tokenFor(exec.id)
+
+    expect('execution' in (await svc.resumeExecution(token, 'admin_second_1'))).toBe(true)
+    expect(await svc.resumeExecution(token, 'admin_second_2')).toMatchObject({ status: 409, code: 'ALREADY_RESUMED' })
+  })
+
+  // §5 / slice-4 finding — a post-resume branch-tail failure fail-stops BOTH the remaining branch
+  // children AND the remaining top-level actions as `skipped`; execution terminal `failed`.
+  test('branch-tail failure on resume: remaining branch children AND remaining top-level jobs are skipped, execution failed (§5 + slice-4)', async () => {
+    const svc = makeService(failFetch) // the post-wait send_webhook returns 500 → terminal branch-tail failure
+    const ruleId = await createRule(svc, 'tail-fail', FAIL_RULE_ACTIONS, FAIL_BRANCH_ACTION.config)
+    const recId = `rec_tailfail_${TS}`
+    await seedRecord(recId, { amount: 800000 })
+    const exec = await run(svc, ruleId, FAIL_RULE_ACTIONS, recId, { amount: 800000 })
+    expect(exec.status).toBe('running') // suspended at the branch wait first
+
+    const result = await svc.resumeExecution(await tokenFor(exec.id), 'admin_tailfail')
+    expect('execution' in result).toBe(true)
+    if ('execution' in result) {
+      expect(result.execution.status).toBe('failed') // terminal; no auto-retry (D8)
+    }
+
+    const rows = await jobRows(exec.id)
+    const byKey = new Map(rows.map((r) => [r.step_key, r.status]))
+    expect(byKey.get('0.branch.high_amount.0')).toBe('resolved') // notify
+    expect(byKey.get('0.branch.high_amount.1')).toBe('resolved') // wait settled on resume
+    expect(byKey.get('0.branch.high_amount.2')).toBe('failed')   // send_webhook (500) failed
+    // Remaining BRANCH child after the failed action → skipped (slice-4 finding).
+    expect(byKey.get('0.branch.high_amount.3')).toBe('skipped')
+    expect(byKey.get('0')).toBe('failed') // parent condition_branch settled failed
+    // Remaining TOP-LEVEL action after the condition_branch → skipped (slice-4 finding).
+    expect(byKey.get('1')).toBe('skipped')
+
+    // The post-failure branch update must NOT have written the record.
+    expect(await recordStatus(recId)).not.toBe('should_not_run')
+  })
+})

--- a/packages/core-backend/tests/unit/automation-resume-cursor.test.ts
+++ b/packages/core-backend/tests/unit/automation-resume-cursor.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseResumeCursor,
+  type ConditionBranchResumeCursor,
+} from '../../src/multitable/automation-resume-cursor'
+
+function validBranchCursor(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: 'condition_branch',
+    parentStepIndex: 2,
+    branchKey: 'high_amount',
+    branchActionIndex: 1,
+    stepKey: '2.branch.high_amount.1',
+    parentJobId: 'exec_1:job:2',
+    branchJobId: 'exec_1:job:2:branch:high_amount:1',
+    upstreamJobId: null,
+    branchActionFingerprint: { count: 3, hash: 'abc123' },
+    ...overrides,
+  }
+}
+
+describe('parseResumeCursor — A6-3-3 fail-closed safety invariant', () => {
+  it('treats only NULL / undefined as the top-level (A6-2 legacy) path', () => {
+    expect(parseResumeCursor(null)).toEqual({ kind: 'top_level' })
+    expect(parseResumeCursor(undefined)).toEqual({ kind: 'top_level' })
+    expect(parseResumeCursor('null')).toEqual({ kind: 'top_level' }) // JSON-encoded null column
+    expect(parseResumeCursor({ kind: 'top_level' })).toEqual({ kind: 'top_level' })
+  })
+
+  it('parses a valid condition_branch cursor (object or JSON string)', () => {
+    const parsed = parseResumeCursor(validBranchCursor())
+    expect(parsed.kind).toBe('condition_branch')
+    const cursor = (parsed as { kind: 'condition_branch'; cursor: ConditionBranchResumeCursor }).cursor
+    expect(cursor).toMatchObject({
+      parentStepIndex: 2,
+      branchKey: 'high_amount',
+      branchActionIndex: 1,
+      stepKey: '2.branch.high_amount.1',
+      upstreamJobId: null,
+      branchActionFingerprint: { count: 3, hash: 'abc123' },
+    })
+    // JSON-encoded column value parses identically.
+    expect(parseResumeCursor(JSON.stringify(validBranchCursor()))).toEqual(parsed)
+  })
+
+  // The crux: a non-null but malformed / unknown cursor must NEVER become top_level.
+  it('fails closed (invalid) on any non-null malformed value — never top-level fallback', () => {
+    const cases: Array<[unknown, string]> = [
+      [{}, 'empty object (no kind)'],
+      [{ kind: 'unknown' }, 'unknown kind'],
+      [{ kind: 'condition_branch' }, 'missing all branch fields'],
+      [validBranchCursor({ branchKey: '' }), 'empty branchKey'],
+      [validBranchCursor({ parentStepIndex: -1 }), 'negative parentStepIndex'],
+      [validBranchCursor({ parentStepIndex: 1.5 }), 'non-integer parentStepIndex'],
+      [validBranchCursor({ branchActionIndex: 'x' }), 'non-number branchActionIndex'],
+      [validBranchCursor({ stepKey: 123 }), 'non-string stepKey'],
+      [validBranchCursor({ upstreamJobId: 42 }), 'bad upstreamJobId'],
+      [validBranchCursor({ branchActionFingerprint: { count: -1, hash: 'h' } }), 'bad fingerprint count'],
+      [validBranchCursor({ branchActionFingerprint: null }), 'missing fingerprint'],
+      ['not json at all', 'unparseable string'],
+      [42, 'number'],
+      [true, 'boolean'],
+      [['condition_branch'], 'array'],
+    ]
+    for (const [input, label] of cases) {
+      const result = parseResumeCursor(input)
+      expect(result.kind, `expected invalid for: ${label}`).toBe('invalid')
+      expect(result.kind, `must NOT be top_level for: ${label}`).not.toBe('top_level')
+    }
+  })
+
+  it('reports a reason for invalid cursors (operator-debuggable, non-secret)', () => {
+    expect(parseResumeCursor({}).kind).toBe('invalid')
+    const r1 = parseResumeCursor({}) as { kind: 'invalid'; reason: string }
+    expect(r1.reason).toBe('unknown_kind')
+    const r2 = parseResumeCursor(validBranchCursor({ stepKey: '' })) as { kind: 'invalid'; reason: string }
+    expect(r2.reason).toBe('bad_stepKey')
+    const r3 = parseResumeCursor('not json') as { kind: 'invalid'; reason: string }
+    expect(r3.reason).toBe('unparseable_json')
+  })
+})

--- a/packages/core-backend/tests/unit/automation-resume-cursor.test.ts
+++ b/packages/core-backend/tests/unit/automation-resume-cursor.test.ts
@@ -20,11 +20,16 @@ function validBranchCursor(overrides: Record<string, unknown> = {}): Record<stri
 }
 
 describe('parseResumeCursor — A6-3-3 fail-closed safety invariant', () => {
-  it('treats only NULL / undefined as the top-level (A6-2 legacy) path', () => {
+  it('treats only NULL / undefined (or a JSON null) as the top-level (A6-2 legacy) path', () => {
     expect(parseResumeCursor(null)).toEqual({ kind: 'top_level' })
     expect(parseResumeCursor(undefined)).toEqual({ kind: 'top_level' })
-    expect(parseResumeCursor('null')).toEqual({ kind: 'top_level' }) // JSON-encoded null column
-    expect(parseResumeCursor({ kind: 'top_level' })).toEqual({ kind: 'top_level' })
+    expect(parseResumeCursor('null')).toEqual({ kind: 'top_level' }) // JSON-encoded SQL NULL only
+  })
+
+  it('rejects a non-null { kind: "top_level" } OBJECT (corruption, not the legacy path)', () => {
+    // The fail-open we are closing: a stored object must never force top-level resume.
+    expect(parseResumeCursor({ kind: 'top_level' })).toEqual({ kind: 'invalid', reason: 'unknown_kind' })
+    expect(parseResumeCursor('{"kind":"top_level"}')).toEqual({ kind: 'invalid', reason: 'unknown_kind' })
   })
 
   it('parses a valid condition_branch cursor (object or JSON string)', () => {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2445,6 +2445,43 @@ describe('AutomationService — Rule CRUD', () => {
     expect(dbExecuteResults).toHaveLength(0)
   })
 
+  it('A6-3-3: createRule still rejects nested condition_branch inside a branch (out of scope)', async () => {
+    // Well-formed inner condition_branch so ONLY the nesting rule can fire (not a malformed-config error).
+    const innerBranch = {
+      type: 'condition_branch',
+      config: {
+        branches: [{
+          key: 'inner',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'x' }] },
+          actions: [{ type: 'update_record', config: { fields: {} } }],
+        }],
+      },
+    }
+    const outer = {
+      type: 'condition_branch',
+      config: {
+        branches: [{
+          key: 'outer',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+          actions: [innerBranch],
+        }],
+      },
+    }
+    const promise = service.createRule('sheet_1', {
+      name: 'Nested branch',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: outer.config,
+      actions: [outer],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toThrow('cannot contain nested condition_branch')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('A6-3-1: createRule rejects parallel_branch inside a condition_branch branch', async () => {
     const nestedParallel = {
       type: 'parallel_branch',

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2382,9 +2382,10 @@ describe('AutomationService — Rule CRUD', () => {
     await expect(promise).rejects.toThrow('requires execution_mode workflow_job_v1')
   })
 
-  it('A6-3-1: createRule rejects wait_for_callback inside a condition_branch branch', async () => {
-    const promise = service.createRule('sheet_1', {
-      name: 'Nested wait branch',
+  it('A6-3-3: createRule ACCEPTS branch-local wait_for_callback in a workflow_job_v1 rule', async () => {
+    dbExecuteResults.push([]) // for insertInto().execute()
+    const rule = await service.createRule('sheet_1', {
+      name: 'Branch-local wait',
       triggerType: 'record.created',
       triggerConfig: {},
       actionType: 'condition_branch',
@@ -2409,7 +2410,38 @@ describe('AutomationService — Rule CRUD', () => {
       createdBy: 'user_1',
     })
 
-    await expect(promise).rejects.toThrow('cannot contain wait_for_callback until A6-3-3')
+    // A6-3-3: branch-local wait is no longer rejected; the rule persists.
+    expect(rule).toBeTruthy()
+  })
+
+  it('A6-3-3: createRule still rejects branch-local start_approval (out of scope)', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Nested approval branch',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: {
+        branches: [{
+          key: 'needs_approval',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+          actions: [{ type: 'start_approval', config: {} }],
+        }],
+      },
+      actions: [{
+        type: 'condition_branch',
+        config: {
+          branches: [{
+            key: 'needs_approval',
+            conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+            actions: [{ type: 'start_approval', config: {} }],
+          }],
+        },
+      }],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toThrow('cannot contain start_approval until A6-3-3')
     expect(dbExecuteResults).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Status: DRAFT / WIP — slice 1 of the A6-3-3a runtime.

Implements the A6-3-3 branch-local wait scope-gate (`multitable-automation-a6-3-3-branch-local-wait-scope-gate-20260615.md`, merged #2621). Building in verified slices.

### Slice 1 (this commit): resume-cursor parser — fail-closed
The safety-critical piece. `parseResumeCursor` distinguishes:
- `resume_cursor` NULL/absent → `top_level` (A6-2 legacy);
- valid `condition_branch` cursor → `condition_branch`;
- **non-null but malformed / unknown-kind → `invalid` (caller fails closed)** — never a silent top-level `step_index` fallback. A corrupted branch-local suspension resumed as top-level would re-enter at the wrong index; this closes that hole.

Pure module + 4/4 unit tests (only `null`→top_level; 14 malformed inputs incl. empty object → invalid). vitest green, tsc clean.

### Remaining (separate commits, then un-draft)
- `resume_cursor` column + migration on `multitable_automation_suspensions`;
- suspension-service cursor write + mapRow parse;
- executor: branch-local wait suspend + `writeSuspendedBranchJob` (step_key);
- `listByExecution()` hydrate suspend descriptor by branch `stepKey`;
- `validateConditionBranchConfig` relax (branch-local `wait_for_callback` only, `workflow_job_v1`-gated);
- `resumeExecution` branch-aware 12-step resume + branch fingerprint drift guard;
- real-DB high-amount scenario test (§6) + the malformed-cursor fail-closed route test;
- scope-gate §5/§7 cursor-fail-closed rows (folded here since #2621 already merged).

Nested branch/parallel/start_approval, join-any, public webhook, W7, live BPMN remain out of scope per the gate.