### PR TITLE
feat(attendance): annual-leave L0 — latent config + deductLeaveBalance extraction

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7455,6 +7455,65 @@ attendanceIntegrationDescribe(
     expect(emptyTemplateBody.error?.message).toContain('required')
   })
 
+  it('④/年假 L0 — config integrity: enabling requires a timezone (422), and a broken tiers ladder falls back to the preset', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const userId = `attendance-annual-l0-guard-${Date.now().toString(36)}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    const readAnnual = async () => {
+      const r = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })
+      return (r.body as { data?: { annualLeavePolicy?: { timezone?: string | null; tiers?: Array<{ minYears: number; maxYears: number | null; days: number }> } } } | undefined)?.data?.annualLeavePolicy
+    }
+    const putAnnual = (annualLeavePolicy: Record<string, unknown>) =>
+      requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ annualLeavePolicy }) })
+    const statutoryPreset = [
+      { minYears: 1, maxYears: 10, days: 5 },
+      { minYears: 10, maxYears: 20, days: 10 },
+      { minYears: 20, maxYears: null, days: 15 },
+    ]
+    try {
+      // (1) enabled=true without a timezone → 422 ANNUAL_LEAVE_TIMEZONE_REQUIRED (no silent UTC fallback).
+      const noTz = await putAnnual({ enabled: true })
+      expect(noTz.status).toBe(422)
+      expect((noTz.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ANNUAL_LEAVE_TIMEZONE_REQUIRED')
+
+      // (2) enabled=false without a timezone → allowed (the guard only fires when enabling).
+      expect((await putAnnual({ enabled: false })).status).toBe(200)
+
+      // (3) enabled=true + explicit timezone but an OVERLAPPING ladder (1–10 and 5–20 overlap) → saved, but
+      //     the malformed ladder falls back to the statutory preset (a broken ladder is never persisted).
+      const overlap = await putAnnual({
+        enabled: true,
+        timezone: 'Asia/Shanghai',
+        tiers: [{ minYears: 1, maxYears: 10, days: 5 }, { minYears: 5, maxYears: 20, days: 10 }],
+      })
+      expect(overlap.status, JSON.stringify(overlap.body)).toBe(200)
+      const afterOverlap = await readAnnual()
+      expect(afterOverlap?.timezone).toBe('Asia/Shanghai')
+      expect(afterOverlap?.tiers).toEqual(statutoryPreset)
+
+      // (4) a contiguous custom ladder (single trailing open-ended band) is preserved — proves the fallback
+      //     is targeted, not a blanket overwrite.
+      const okLadder = await putAnnual({
+        enabled: true,
+        timezone: 'Asia/Shanghai',
+        tiers: [{ minYears: 0, maxYears: 3, days: 4 }, { minYears: 3, maxYears: null, days: 9 }],
+      })
+      expect(okLadder.status, JSON.stringify(okLadder.body)).toBe(200)
+      expect((await readAnnual())?.tiers).toEqual([{ minYears: 0, maxYears: 3, days: 4 }, { minYears: 3, maxYears: null, days: 9 }])
+    } finally {
+      // restore default-OFF so the shared local DB doesn't leak enabled=true into later tests.
+      await putAnnual({ enabled: false, timezone: null }).catch(() => undefined)
+    }
+  })
+
   it('rejects future punches and still allows immediate check-out after check-in when min interval is enabled', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7508,6 +7508,16 @@ attendanceIntegrationDescribe(
       })
       expect(okLadder.status, JSON.stringify(okLadder.body)).toBe(200)
       expect((await readAnnual())?.tiers).toEqual([{ minYears: 0, maxYears: 3, days: 4 }, { minYears: 3, maxYears: null, days: 9 }])
+
+      // (5) a non-empty ladder with a CLOSED last band (no open-ended tail) leaves the most-senior
+      //     employees with no matching tier → malformed → falls back to the statutory preset.
+      const closedTail = await putAnnual({
+        enabled: true,
+        timezone: 'Asia/Shanghai',
+        tiers: [{ minYears: 1, maxYears: 10, days: 5 }],
+      })
+      expect(closedTail.status, JSON.stringify(closedTail.body)).toBe(200)
+      expect((await readAnnual())?.tiers).toEqual(statutoryPreset)
     } finally {
       // restore default-OFF so the shared local DB doesn't leak enabled=true into later tests.
       await putAnnual({ enabled: false, timezone: null }).catch(() => undefined)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7493,6 +7493,14 @@ attendanceIntegrationDescribe(
           },
           multiShiftDay: { enabled: true, maxSlots: 3 },
           compTimeFromOvertime: { enabled: true, expiresInDays: 45 },
+          annualLeavePolicy: {
+            enabled: true,
+            tenureMode: 'company_tenure',
+            standardDayMinutes: 600,
+            tiers: [{ minYears: 0, maxYears: 5, days: 3 }, { minYears: 5, maxYears: null, days: 8 }],
+            carryover: { enabled: true },
+            timezone: 'Asia/Shanghai',
+          },
           overtimeSegmentation: { enabled: true },
           autoShiftMatching: {
             enabled: true,
@@ -7524,6 +7532,7 @@ attendanceIntegrationDescribe(
           shiftCompliance?: Record<string, unknown>
           multiShiftDay?: Record<string, unknown>
           compTimeFromOvertime?: Record<string, unknown>
+          annualLeavePolicy?: Record<string, unknown>
           overtimeSegmentation?: Record<string, unknown>
           autoShiftMatching?: Record<string, unknown>
         }
@@ -7537,6 +7546,17 @@ attendanceIntegrationDescribe(
       })
       expect(reloaded?.multiShiftDay).toEqual({ enabled: true, maxSlots: 3 })
       expect(reloaded?.compTimeFromOvertime).toEqual({ enabled: true, expiresInDays: 45 })
+      // 年假/法定假 L0 latent config — round-trips through the PUT zod schema + persist + normalize
+      // (incl. a custom tiers ladder and an org timezone), proving the new sub-shape isn't silently
+      // stripped (the save-path drift class). Nothing reads it yet; L2 accrual consumes it.
+      expect(reloaded?.annualLeavePolicy).toEqual({
+        enabled: true,
+        tenureMode: 'company_tenure',
+        standardDayMinutes: 600,
+        tiers: [{ minYears: 0, maxYears: 5, days: 3 }, { minYears: 5, maxYears: null, days: 8 }],
+        carryover: { enabled: true },
+        timezone: 'Asia/Shanghai',
+      })
       expect(reloaded?.overtimeSegmentation).toEqual({ enabled: true })
       expect(reloaded?.autoShiftMatching).toEqual({
         enabled: true,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11781,6 +11781,15 @@ function normalizeAnnualLeaveTiers(raw, fallbackTiers) {
     if (maxYears !== null && (!Number.isFinite(maxYears) || maxYears <= minYears)) return clone()
     tiers.push({ minYears, maxYears, days })
   }
+  // Ladder integrity (#2622 P2): the parsed tiers must form a contiguous, ascending, non-overlapping
+  // ladder with at most ONE trailing open-ended (maxYears=null) band — no gaps, no overlaps, no
+  // out-of-order, and no open-ended band followed by another tier. Any violation falls the WHOLE list
+  // back to the statutory preset (a broken ladder is never persisted). Gaps count as malformed: a
+  // statutory ladder is contiguous, so a gap is almost always a mistake rather than "this band gets none".
+  for (let i = 1; i < tiers.length; i++) {
+    if (tiers[i - 1].maxYears === null) return clone()
+    if (tiers[i].minYears !== tiers[i - 1].maxYears) return clone()
+  }
   return tiers
 }
 
@@ -37345,6 +37354,15 @@ module.exports = {
         try {
           const current = await getSettings(db)
           const merged = mergeSettings(current, parsed.data)
+          // 年假/法定假 L0 config-integrity guard (#2622 timezone lock): enabling the engine requires a
+          // resolvable timezone — carryover/expiry boundaries are calendar-year-end in org time, so an
+          // unset timezone would silently fall back to UTC (forbidden). L0 requires an EXPLICIT timezone;
+          // inherited-timezone resolution (attendance default rule / org) is an L2/L4 extension. A disabled
+          // policy persists freely.
+          if (merged.annualLeavePolicy?.enabled === true && !merged.annualLeavePolicy?.timezone) {
+            res.status(422).json({ ok: false, error: { code: 'ANNUAL_LEAVE_TIMEZONE_REQUIRED', message: 'annualLeavePolicy.timezone is required when annualLeavePolicy.enabled is true' } })
+            return
+          }
           const saved = await saveSettings(db, merged)
           scheduleAutoAbsence({ db, logger, emit: emitEvent })
           scheduleHolidaySync({ db, logger, emit: emitEvent })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -159,6 +159,22 @@ const DEFAULT_SETTINGS = {
     enabled: false,
     expiresInDays: null,
   },
+  // 年假/法定假余额引擎 (annual/statutory leave-balance engine) — L0 latent config
+  // (design-lock attendance-annual-leave-balance-engine-design-lock-20260615, #2622).
+  // Default OFF; nothing reads this yet (L2 accrual engine consumes it). tiers = the statutory
+  // preset by 累计工作时间 (1–10y=5d / 10–20y=10d / ≥20y=15d), org-configurable.
+  annualLeavePolicy: {
+    enabled: false,
+    tenureMode: 'cumulative_service',
+    standardDayMinutes: 480,
+    tiers: [
+      { minYears: 1, maxYears: 10, days: 5 },
+      { minYears: 10, maxYears: 20, days: 10 },
+      { minYears: 20, maxYears: null, days: 15 },
+    ],
+    carryover: { enabled: false },
+    timezone: null,
+  },
   // 加班三段引擎 (overtime segmentation) — O2 runtime switch. Default OFF means
   // overtime requests keep today's single total-minute metadata until an org opts in.
   overtimeSegmentation: {
@@ -11649,6 +11665,7 @@ function normalizeSettings(raw) {
     },
     comprehensiveHours: normalizeAttendanceComprehensiveHoursSettings(raw.comprehensiveHours),
     compTimeFromOvertime: normalizeCompTimeFromOvertimeSetting(raw.compTimeFromOvertime),
+    annualLeavePolicy: normalizeAnnualLeavePolicySetting(raw.annualLeavePolicy),
     overtimeSegmentation: normalizeOvertimeSegmentationSetting(raw.overtimeSegmentation),
     autoShiftMatching: normalizeAutoShiftMatchingSetting(raw.autoShiftMatching),
   }
@@ -11718,6 +11735,53 @@ function normalizeCompTimeFromOvertimeSetting(raw) {
     enabled: typeof config.enabled === 'boolean' ? config.enabled : DEFAULT_SETTINGS.compTimeFromOvertime.enabled,
     expiresInDays,
   }
+}
+
+// 年假/法定假余额引擎 — L0 latent normalize (design-lock #2622). Fills defaults + validates the
+// org-configurable shape; enforces nothing (no accrual/deduction wiring lands until L2/L3).
+function normalizeAnnualLeavePolicySetting(raw) {
+  const config = raw && typeof raw === 'object' ? raw : {}
+  const fallback = DEFAULT_SETTINGS.annualLeavePolicy
+  const tenureModeRaw = typeof config.tenureMode === 'string' ? config.tenureMode.trim() : ''
+  const tenureMode = ['cumulative_service', 'company_tenure'].includes(tenureModeRaw)
+    ? tenureModeRaw
+    : fallback.tenureMode
+  const standardDayMinutesRaw = Number(config.standardDayMinutes)
+  const standardDayMinutes = Number.isInteger(standardDayMinutesRaw) && standardDayMinutesRaw > 0
+    ? standardDayMinutesRaw
+    : fallback.standardDayMinutes
+  const carryoverRaw = config.carryover && typeof config.carryover === 'object' ? config.carryover : {}
+  const timezoneRaw = typeof config.timezone === 'string' ? config.timezone.trim() : ''
+  return {
+    enabled: typeof config.enabled === 'boolean' ? config.enabled : fallback.enabled,
+    tenureMode,
+    standardDayMinutes,
+    tiers: normalizeAnnualLeaveTiers(config.tiers, fallback.tiers),
+    carryover: {
+      enabled: typeof carryoverRaw.enabled === 'boolean' ? carryoverRaw.enabled : fallback.carryover.enabled,
+    },
+    timezone: timezoneRaw.length > 0 ? timezoneRaw : null,
+  }
+}
+
+// A tier = { minYears >= 0, maxYears > minYears or null = open-ended, days >= 0 }. Any malformed
+// entry falls the whole list back to the statutory preset, so a bad PUT can never silently persist
+// a broken accrual ladder. A well-formed empty list is allowed (org explicitly disables tiers).
+function normalizeAnnualLeaveTiers(raw, fallbackTiers) {
+  const clone = () => fallbackTiers.map((tier) => ({ ...tier }))
+  if (!Array.isArray(raw)) return clone()
+  const tiers = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') return clone()
+    const minYears = Number(entry.minYears)
+    const days = Number(entry.days)
+    const maxYears = entry.maxYears === null || entry.maxYears === undefined ? null : Number(entry.maxYears)
+    if (!Number.isFinite(minYears) || minYears < 0) return clone()
+    if (!Number.isFinite(days) || days < 0) return clone()
+    if (maxYears !== null && (!Number.isFinite(maxYears) || maxYears <= minYears)) return clone()
+    tiers.push({ minYears, maxYears, days })
+  }
+  return tiers
 }
 
 function normalizeOvertimeSegmentationSetting(raw) {
@@ -11864,6 +11928,16 @@ function mergeSettings(base, update) {
     compTimeFromOvertime: {
       ...(base?.compTimeFromOvertime || {}),
       ...(update?.compTimeFromOvertime || {}),
+    },
+    annualLeavePolicy: {
+      ...(base?.annualLeavePolicy || {}),
+      ...(update?.annualLeavePolicy || {}),
+      // deep-merge carryover so a partial update (e.g. only { enabled }) keeps siblings; tiers is an
+      // array → replaced wholesale when an update provides it (partial tier merges are meaningless).
+      carryover: {
+        ...(base?.annualLeavePolicy?.carryover || {}),
+        ...(update?.annualLeavePolicy?.carryover || {}),
+      },
     },
     overtimeSegmentation: {
       ...(base?.overtimeSegmentation || {}),
@@ -15245,33 +15319,29 @@ function respondShiftComplianceCapExceeded(res, error) {
   return true
 }
 
-// ④ C3 (#2230 design-lock): deduct comp-time (调休) balance on a comp_time leave's final approval.
-// FIFO by soonest expiry then oldest grant, over active lots with remaining_minutes > 0. Runs entirely
-// inside the caller's approval txn: lots are SELECT … FOR UPDATE (no concurrent double-spend), each
-// touched lot's remaining_minutes is reduced (status → 'exhausted' at zero) and a 'deduct' event is
-// written (delta < 0, back-linked to the leave request for reconciliation). When the active balance is
-// short of the requested minutes the whole call throws → the approval txn rolls back → 422
-// COMP_TIME_BALANCE_INSUFFICIENT (no partial approval in v1). Idempotency comes from the pending→approved
-// transition guard: resolveRequest locks the request row FOR UPDATE and rejects re-approve before reaching
-// here, so a repeated approve never double-deducts.
-async function deductCompTimeBalance(trx, { orgId, userId, requestId, minutes }) {
-  const deductMinutes = Math.floor(Number(minutes) || 0)
+// Generalized FIFO leave-balance deduction engine (④ C3 extracted for the 年假/法定假 L0, #2622).
+// Draws `amountMinutes` from the given leave-type's active lots, expiring/oldest first, writing one
+// deduct event per touched lot. Insufficient active balance → HttpError(422, insufficientCode) → the
+// caller's approval txn rolls back. The CALLER owns amount semantics (deductionBasis): comp_time
+// passes actual minutes; 年假 L3 will pass standard-day minutes (requestedDays × standardDayMinutes).
+async function deductLeaveBalance(trx, { orgId, userId, leaveTypeCode, amountMinutes, sourceType, insufficientCode, insufficientLabel, sourceId }) {
+  const deductMinutes = Math.floor(Number(amountMinutes) || 0)
   if (deductMinutes <= 0) return { deducted: 0, lots: 0 }
   const lots = (await trx.query(
     `SELECT id, remaining_minutes, status
        FROM attendance_leave_balances
-      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = 'comp_time'
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3
         AND status = 'active' AND remaining_minutes > 0
       ORDER BY expires_at ASC NULLS LAST, granted_at ASC
       FOR UPDATE`,
-    [orgId, userId]
+    [orgId, userId, leaveTypeCode]
   )).map((row) => ({ id: row.id, remaining: Number(row.remaining_minutes), status: row.status }))
   const available = lots.reduce((sum, lot) => sum + lot.remaining, 0)
   if (available < deductMinutes) {
     throw new HttpError(
       422,
-      'COMP_TIME_BALANCE_INSUFFICIENT',
-      `Comp-time balance insufficient: requested ${deductMinutes} min, available ${available} min`
+      insufficientCode,
+      `${insufficientLabel} balance insufficient: requested ${deductMinutes} min, available ${available} min`
     )
   }
   let remaining = deductMinutes
@@ -15289,13 +15359,33 @@ async function deductCompTimeBalance(trx, { orgId, userId, requestId, minutes })
     await trx.query(
       `INSERT INTO attendance_leave_balance_events
          (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
-       VALUES ($1, $2, $3, 'deduct', $4, 'comp_time_leave', $5)`,
-      [orgId, userId, lot.id, -take, requestId]
+       VALUES ($1, $2, $3, 'deduct', $4, $5, $6)`,
+      [orgId, userId, lot.id, -take, sourceType, sourceId]
     )
     remaining -= take
     touched += 1
   }
   return { deducted: deductMinutes, lots: touched }
+}
+
+// ④ C3 (#2230 design-lock): comp_time (调休) balance deduction on a comp_time leave's final approval —
+// a thin wrapper over the generalized engine so the call site and comp_time behavior stay byte-identical
+// (leave_type_code='comp_time', source_type='comp_time_leave', the same COMP_TIME_BALANCE_INSUFFICIENT
+// code/message, the same floor(minutes)/<=0 short-circuit). No partial approval in v1: a short balance
+// throws → the approval txn rolls back. Idempotency is the pending→approved transition guard —
+// resolveRequest locks the request row FOR UPDATE and rejects re-approve before reaching here, so a
+// repeated approve never double-deducts.
+async function deductCompTimeBalance(trx, { orgId, userId, requestId, minutes }) {
+  return deductLeaveBalance(trx, {
+    orgId,
+    userId,
+    leaveTypeCode: 'comp_time',
+    amountMinutes: minutes,
+    sourceType: 'comp_time_leave',
+    insufficientCode: 'COMP_TIME_BALANCE_INSUFFICIENT',
+    insufficientLabel: 'Comp-time',
+    sourceId: requestId,
+  })
 }
 
 async function loadAttendanceComprehensiveActualMinutesByUser(db, orgId, userIds, period) {
@@ -18533,6 +18623,22 @@ module.exports = {
       compTimeFromOvertime: z.object({
         enabled: z.boolean().optional(),
         expiresInDays: z.number().int().positive().nullable().optional(),
+      }).optional(),
+      // 年假/法定假余额引擎 — L0 latent config (design-lock #2622). Round-trips through PUT/GET; no
+      // runtime reads it until L2 (accrual). tiers = org-configurable statutory bands.
+      annualLeavePolicy: z.object({
+        enabled: z.boolean().optional(),
+        tenureMode: z.enum(['cumulative_service', 'company_tenure']).optional(),
+        standardDayMinutes: z.number().int().positive().optional(),
+        tiers: z.array(z.object({
+          minYears: z.number().min(0),
+          maxYears: z.number().positive().nullable(),
+          days: z.number().min(0),
+        })).optional(),
+        carryover: z.object({
+          enabled: z.boolean().optional(),
+        }).optional(),
+        timezone: z.string().nullable().optional(),
       }).optional(),
       // 加班三段引擎 O2: request metadata snapshot switch. Default false preserves
       // today's total-only overtime metadata; later slices consume the snapshot.

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11781,15 +11781,18 @@ function normalizeAnnualLeaveTiers(raw, fallbackTiers) {
     if (maxYears !== null && (!Number.isFinite(maxYears) || maxYears <= minYears)) return clone()
     tiers.push({ minYears, maxYears, days })
   }
-  // Ladder integrity (#2622 P2): the parsed tiers must form a contiguous, ascending, non-overlapping
-  // ladder with at most ONE trailing open-ended (maxYears=null) band — no gaps, no overlaps, no
-  // out-of-order, and no open-ended band followed by another tier. Any violation falls the WHOLE list
-  // back to the statutory preset (a broken ladder is never persisted). Gaps count as malformed: a
-  // statutory ladder is contiguous, so a gap is almost always a mistake rather than "this band gets none".
+  // Ladder integrity (#2622 P2): a non-empty tiers list must form a contiguous, ascending,
+  // non-overlapping ladder that ENDS in exactly one open-ended (maxYears=null) band — no gaps,
+  // overlaps, out-of-order, an open-ended band mid-list, or a closed last band (which would leave the
+  // most-senior employees with no matching tier). Any violation falls the WHOLE list back to the
+  // statutory preset (a broken ladder is never persisted). Gaps and a closed tail both count as
+  // malformed: statutory bands are contiguous and cover all eligible tenure. An empty list is allowed
+  // (an org explicitly configuring no accrual bands).
   for (let i = 1; i < tiers.length; i++) {
     if (tiers[i - 1].maxYears === null) return clone()
     if (tiers[i].minYears !== tiers[i - 1].maxYears) return clone()
   }
+  if (tiers.length > 0 && tiers[tiers.length - 1].maxYears !== null) return clone()
   return tiers
 }
 


### PR DESCRIPTION
## What (L0 of the annual/statutory leave-balance engine — design-lock #2622, tracker §0.4)

Two **no-behavior-change** changes. Implementation gated; nothing accrues/deducts for annual until L2/L3.

**(a) Latent `annualLeavePolicy` org-settings config (default OFF)** — `enabled` / `tenureMode` / `standardDayMinutes` / statutory `tiers` preset (累计工作时间 1–10y=5d / 10–20y=10d / ≥20y=15d) / `carryover.enabled` / `timezone`, wired through `DEFAULT_SETTINGS` + normalize + `mergeSettings` + the PUT/GET zod schema. **Nothing reads it yet** (L2 accrual consumes it). Defensive `normalizeAnnualLeaveTiers` falls a malformed ladder back to the preset (never silently persists a broken ladder).

**(b) Extracted `deductCompTimeBalance` → generalized `deductLeaveBalance`** (`leaveTypeCode, amountMinutes, sourceType, insufficientCode, insufficientLabel, sourceId`); `deductCompTimeBalance` is now a thin comp_time wrapper → **call site unchanged, comp_time byte-identical**.

## Validation (local, real DB)

- `node --check` ✓
- **④ C3 comp_time deduct test passes unchanged** through the generalized helper — the design-lock §8 L0 byte-identical lock. ✓
- New `annualLeavePolicy` round-trip assertion (custom tiers ladder + timezone) survives PUT→persist→GET. ✓
- Full `attendance-plugin.test.ts`: my two target tests pass; the only failures are **pre-existing auto-shift local-pollution flakes** (proven identical on clean origin/main via stash — `deductLeaveBalance` count=0). CI's fresh DB won't hit them.

## One judgment call for your review

The design-lock §5 listed a `deductionBasis` param on the engine. **L0 omits it**: the *caller* owns amount semantics (comp_time passes actual minutes; 年假 L3 will pass `requestedDays × standardDayMinutes`), so including it in L0 with no annual caller would be a dead param (PR-hardening: no dead params). The "annual must not pull actual shift minutes" guardrail moves to **L3**, where the annual approval computes the standard-day amount. Flagging in case you'd rather pin it in the signature now.

Per connected-run A: opening for your merge; on merge I immediately start **L1** (expiry `source_type` generalization, comp_time no-regress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)