### PR TITLE
feat(data-source): add C3 keyset watermark reads

### DIFF
--- a/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
+++ b/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
@@ -180,13 +180,19 @@ argument is the same wire-vs-fixture class of bug.)
   `where` pass-through to `DataSourceManager.select`; parameterized-only; writable-source still rejected.
   Facade unit test covers pass-through, malformed `orderBy` fail-closed, uppercase direction normalization,
   and the existing no-fallback / writable-source guard. Landed in #2609 / squash `1586c3841`.
-- 🔒 **C3-2a — structured `where` logical groups:** widen adapter structured reads to express the
+- ✅ **C3-2a — structured `where` logical groups:** widen adapter structured reads to express the
   `updated_at` composite keyset predicate as `field > last OR (field = last AND tiebreaker > lastTie)`;
   keep all values parameterized; reject malformed logical groups and unknown `$` operators fail-closed;
   add MySQL operator parity with Postgres/MSSQL. This is a prerequisite only — no watermark predicate is
-  generated yet, and the offset/full path stays unchanged.
-- 🔒 **C3-2 — adapter watermark mode (plugin):** type-conditional keyset (Seam B) + cursor model (Seam C);
-  unit tests incl. the **no-miss** and **no-stall** negative controls and offset/full coexistence.
+  generated yet, and the offset/full path stays unchanged. Landed in #2625 / squash `c2c59994c`.
+- 🔒 **C3-2 — adapter watermark mode (plugin):** type-conditional keyset (Seam B) + cursor model (Seam C).
+  Current implementation slice wires `data-source:sql-readonly.read()` so `watermark + watermarkConfig`
+  generates structured `where/orderBy`, with `updated_at` first-page `>=` store-floor seeding and
+  subsequent in-run `(field,tiebreaker)` composite cursors, plus `monotonic_id` strict `>`.
+  SQL BIGINT monotonic values are preserved as integer strings, not coerced through JS `Number`.
+  Offset/full coexistence and wrong-mode cursor fail-closed behavior are unit-locked. Runtime run details
+  redact watermark cursors (they contain source values), and max-page truncation is partial/no-watermark-advance
+  rather than a silent succeeded run. C3-5 remains the real-DB acceptance gate.
 - ✅ **C3-3a — watermark-config plumbing (runner → read request):** extend `pipeline.options.watermark` to
   `{ type, field, tiebreaker? }`, pass the resolved config into `read()` (Seam D), and require
   `updated_at` configs to declare a tiebreaker for the `data-source:sql-readonly` bridge. Landed in #2619
@@ -204,7 +210,7 @@ argument is the same wire-vs-fixture class of bug.)
   facade→`DataSourceManager`→real-adapter→DB keyset path — this real-DB test is the acceptance keystone.
 
 **All remaining C3-2..C3-5 work stays 🔒** until both a real volume/perf signal **and** a separate opt-in.
-Build order from the current mainline: C3-2a (structured `where` groups) → C3-2 (adapter mode + cursor)
+Build order from the current mainline: C3-2 (adapter mode + cursor)
 → C3-4 (filter+watermark composition) → C3-5 (real-DB lock).
 
 ## Acceptance checklist (the locks — for the impl slices)
@@ -212,6 +218,8 @@ Build order from the current mainline: C3-2a (structured `where` groups) → C3-
 - ⬜ `monotonic_id`: strict `>`, single-key order, progress guaranteed.
 - ⬜ `updated_at`: composite keyset `(field, tiebreaker)` — **no-miss** across a same-timestamp page boundary.
 - ⬜ `updated_at`: a same-timestamp batch larger than `limit` **still advances** (no stall).
+- ⬜ Watermark cursors remain internal: raw cursor values are not persisted in run details / evidence.
+- ⬜ Source page-cap truncation (`maxPagesReached`) is partial and blocks watermark advance.
 - ⬜ Across-run resume: first page seeds from the store floor (`>` mono / `>=`+dedup `updated_at`); subsequent
   pages use the in-run composite cursor; no `watermarkStore` schema change.
 - ⬜ Mode coexistence: no watermark ⇒ the C1 offset/full path is byte-for-byte unchanged.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -126,14 +126,25 @@ TODO:
   - #2619 / squash `7f61709ea`.
   - 目标: adapter 后续实现 keyset 时读取同一个 runner-resolved config，不再自己猜 `type/field/tiebreaker`。
   - 边界: 不生成 watermark `where/orderBy`，不改变 offset cursor，不打开 C3-2/C3-3 runtime。
-- [ ] C3-2a structured `where` 逻辑分组 + MySQL operator parity。
+- [x] C3-2a structured `where` 逻辑分组 + MySQL operator parity。
+  - #2625 / squash `c2c59994c`.
   - 目标: 先让 Postgres/MSSQL/MySQL 的 structured read 能表达
     `field > last OR (field = last AND tiebreaker > lastTie)`，为 `updated_at + id`
     复合 keyset 铺底。
   - 边界: 不生成 watermark predicate，不解析/推进 cursor，不改变 offset full-read 行为，不新增写能力。
-- [ ] C3-2 adapter 实现 in-run mode-tagged cursor；跨 run 仍复用现有 watermark store，不改 store schema。
-- [ ] C3-3 `updated_at + id` 复合游标实现和测试。
-- [ ] C3-4 `monotonic_id` 游标实现和测试。
+- [ ] C3-2 adapter 实现 watermark keyset runtime + in-run mode-tagged cursor；跨 run 仍复用现有
+  watermark store，不改 store schema。
+  - 当前实现 slice: `data-source:sql-readonly.read()` 在有 `watermark + watermarkConfig` 时生成
+    type-conditional structured `where/orderBy`。
+  - `updated_at`: 第一页从 store floor 用 `>=` bounded re-read，后续页用 `(field,tiebreaker)` composite cursor。
+  - `monotonic_id`: 严格 `field > last` 单键 cursor；SQL BIGINT 值按 integer string 传递，避免 JS Number
+    精度丢失。
+  - offset/full-read 无 watermark 时保持原路径；wrong-mode cursor fail-closed；watermark cursor 不原样写入 run
+    details，只存 values-free redacted marker。
+  - 若读到 `maxPages` cap 仍未完成，run 标记 partial 且不推进 watermark，避免跳过未读行。
+- [ ] C3-4 filter + watermark composition lock。
+  - 当前实现 slice 已在 plugin adapter unit 层覆盖 equality `filters` 与 watermark predicate 的 structured `$and`
+    组合；C3-5 仍需真实 DB wire-vs-fixture 验证。
 - [ ] C3-5 实体机 real-DB smoke: 跨页同 timestamp 不漏读、不卡住、可 resume。
 
 完成条件:

--- a/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
@@ -16,6 +16,13 @@ const {
 } = require('../lib/adapters/data-source-sql-readonly-source-adapter.cjs')
 
 const SYSTEM = { kind: ADAPTER_KIND, config: { dataSourceId: 'pg-1' } }
+const WATERMARK_CURSOR_PREFIX = 'dswm1:'
+
+function decodeWatermarkCursor(cursor) {
+  assert.equal(typeof cursor, 'string')
+  assert.ok(cursor.startsWith(WATERMARK_CURSOR_PREFIX), 'cursor must be an opaque watermark cursor')
+  return JSON.parse(Buffer.from(cursor.slice(WATERMARK_CURSOR_PREFIX.length), 'base64url').toString('utf8'))
+}
 
 // A fake host facade that records calls and returns canned data.
 function fakeFacade(overrides = {}) {
@@ -163,6 +170,242 @@ async function main() {
     const res = await adapterWith(f).read({ object: 'items', limit: 2, cursor: '4' })
     assert.equal(res.done, false, 'full page => not done')
     assert.equal(res.nextCursor, '6', 'full page => nextCursor = offset + count')
+  }
+
+  // 7b. C3 updated_at watermark: the first page seeds from the store timestamp with >=,
+  //     orders by (field,tiebreaker), and emits a mode-tagged composite cursor.
+  {
+    const timestamp = '2026-06-01T01:00:00.000Z'
+    const f = fakeFacade({
+      select: () => ({
+        data: [
+          { id: 'A-001', updatedAt: timestamp },
+          { id: 'A-002', updatedAt: timestamp },
+        ],
+        metadata: {},
+      }),
+    })
+    const res = await adapterWith(f).read({
+      object: 'items',
+      limit: 2,
+      watermark: { updatedAt: timestamp },
+      watermarkConfig: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
+    })
+    assert.deepEqual(f.calls.select[0].options, {
+      limit: 2,
+      where: { updatedAt: { $gte: timestamp } },
+      orderBy: [
+        { column: 'updatedAt', direction: 'asc' },
+        { column: 'id', direction: 'asc' },
+      ],
+    })
+    assert.equal(res.done, false)
+    const cursor = decodeWatermarkCursor(res.nextCursor)
+    assert.equal(cursor.mode, 'wm-composite')
+    assert.equal(cursor.field, 'updatedAt')
+    assert.equal(cursor.tiebreaker, 'id')
+    assert.equal(cursor.value, timestamp)
+    assert.equal(cursor.tiebreakerValue, 'A-002')
+    assert.equal(res.metadata.mode, 'wm-composite')
+  }
+
+  // 7c. C3 updated_at watermark: subsequent pages use the in-run composite cursor, so a
+  //     same-timestamp batch larger than the page limit advances instead of stalling.
+  {
+    const timestamp = '2026-06-01T01:00:00.000Z'
+    const f = fakeFacade({
+      select: (options) => {
+        if (!options.where.$or) {
+          return {
+            data: [
+              { id: 'A-001', updatedAt: timestamp },
+              { id: 'A-002', updatedAt: timestamp },
+            ],
+            metadata: {},
+          }
+        }
+        return {
+          data: [
+            { id: 'A-003', updatedAt: timestamp },
+            { id: 'A-004', updatedAt: timestamp },
+          ],
+          metadata: {},
+        }
+      },
+    })
+    const a = adapterWith(f)
+    const first = await a.read({
+      object: 'items',
+      limit: 2,
+      watermark: { updatedAt: timestamp },
+      watermarkConfig: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
+    })
+    const second = await a.read({
+      object: 'items',
+      limit: 2,
+      cursor: first.nextCursor,
+      watermark: { updatedAt: timestamp },
+      watermarkConfig: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
+    })
+    assert.deepEqual(f.calls.select[1].options.where, {
+      $or: [
+        { updatedAt: { $gt: timestamp } },
+        { updatedAt: timestamp, id: { $gt: 'A-002' } },
+      ],
+    })
+    assert.equal(decodeWatermarkCursor(second.nextCursor).tiebreakerValue, 'A-004')
+  }
+
+  // 7d. C3 monotonic_id watermark: strict > plus single-key ordering and cursor progress.
+  {
+    const floor = '9007199254740992'
+    const lastId = '9007199254740994'
+    const f = fakeFacade({
+      select: () => ({
+        data: [{ id: '9007199254740993' }, { id: lastId }],
+        metadata: {},
+      }),
+    })
+    const res = await adapterWith(f).read({
+      object: 'items',
+      limit: 2,
+      // The runner's watermark store persists values as strings; the adapter normalizes
+      // monotonic ids as integer strings, preserving SQL BIGINT precision beyond JS safe ints.
+      watermark: { id: floor },
+      watermarkConfig: { type: 'monotonic_id', field: 'id' },
+    })
+    assert.deepEqual(f.calls.select[0].options, {
+      limit: 2,
+      where: { id: { $gt: floor } },
+      orderBy: [{ column: 'id', direction: 'asc' }],
+    })
+    const cursor = decodeWatermarkCursor(res.nextCursor)
+    assert.equal(cursor.mode, 'wm-mono')
+    assert.equal(cursor.value, lastId)
+  }
+
+  // 7d.1. Unsafe numeric monotonic ids fail closed instead of losing SQL BIGINT precision.
+  {
+    const f = fakeFacade()
+    await assert.rejects(
+      () => adapterWith(f).read({
+        object: 'items',
+        limit: 2,
+        watermark: { id: Number.MAX_SAFE_INTEGER + 1 },
+        watermarkConfig: { type: 'monotonic_id', field: 'id' },
+      }),
+      /safe integer or integer string/,
+      'unsafe JS number monotonic ids are rejected before rounding',
+    )
+    assert.equal(f.calls.select.length, 0)
+  }
+
+  // 7e. Filters compose with watermark under one structured AND, so C2 equality filters are
+  //     not silently dropped when C3 incremental mode is active.
+  {
+    const f = fakeFacade({
+      select: () => ({ data: [{ id: 11, tenant: 'north' }], metadata: {} }),
+    })
+    await adapterWith(f).read({
+      object: 'items',
+      limit: 1,
+      filters: { tenant: 'north' },
+      watermark: { id: 10 },
+      watermarkConfig: { type: 'monotonic_id', field: 'id' },
+    })
+    assert.deepEqual(f.calls.select[0].options.where, {
+      $and: [
+        { tenant: 'north' },
+        { id: { $gt: '10' } },
+      ],
+    })
+  }
+
+  // 7e.1. The same filter composition also holds for updated_at's composite shape.
+  {
+    const timestamp = '2026-06-01T01:00:00.000Z'
+    const f = fakeFacade({
+      select: () => ({ data: [{ id: 'A-001', updatedAt: timestamp, tenant: 'north' }], metadata: {} }),
+    })
+    await adapterWith(f).read({
+      object: 'items',
+      limit: 10,
+      filters: { tenant: 'north' },
+      watermark: { updatedAt: timestamp },
+      watermarkConfig: { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
+    })
+    assert.deepEqual(f.calls.select[0].options.where, {
+      $and: [
+        { tenant: 'north' },
+        { updatedAt: { $gte: timestamp } },
+      ],
+    })
+  }
+
+  // 7f. Cursor mode tagging is fail-closed: offset cursors cannot drive watermark reads,
+  //     and watermark cursors cannot drive offset reads.
+  {
+    const f = fakeFacade()
+    const a = adapterWith(f)
+    await assert.rejects(
+      () => a.read({
+        object: 'items',
+        limit: 2,
+        cursor: '6',
+        watermark: { id: 10 },
+        watermarkConfig: { type: 'monotonic_id', field: 'id' },
+      }),
+      /watermark cursor/,
+      'offset cursor is rejected in watermark mode',
+    )
+    const wmCursor = `${WATERMARK_CURSOR_PREFIX}${Buffer.from(JSON.stringify({
+      v: 1,
+      mode: 'wm-mono',
+      type: 'monotonic_id',
+      field: 'id',
+      value: 12,
+    }), 'utf8').toString('base64url')}`
+    await assert.rejects(
+      () => a.read({ object: 'items', limit: 2, cursor: wmCursor }),
+      /watermark cursor cannot be used for offset reads/,
+      'watermark cursor is rejected in offset mode',
+    )
+    assert.equal(f.calls.select.length, 0, 'cursor mode mismatch fails before any facade read')
+  }
+
+  // 7g. updated_at mode requires the runner-resolved tiebreaker; otherwise it would either
+  //     strict-> miss ties or >= stall on a same-timestamp page.
+  {
+    const f = fakeFacade()
+    await assert.rejects(
+      () => adapterWith(f).read({
+        object: 'items',
+        limit: 2,
+        watermark: { updatedAt: '2026-06-01T01:00:00.000Z' },
+        watermarkConfig: { type: 'updated_at', field: 'updatedAt' },
+      }),
+      /watermarkConfig\.tiebreaker/,
+      'updated_at watermark mode requires a tiebreaker',
+    )
+    assert.equal(f.calls.select.length, 0)
+  }
+
+  // 7h. A full incremental page must expose the ordered cursor key on the last record, otherwise
+  //     the adapter cannot advance safely and must fail instead of looping.
+  {
+    const f = fakeFacade({
+      select: () => ({ data: [{ id: 11 }, { noId: true }], metadata: {} }),
+    })
+    await assert.rejects(
+      () => adapterWith(f).read({
+        object: 'items',
+        limit: 2,
+        watermark: { id: 10 },
+        watermarkConfig: { type: 'monotonic_id', field: 'id' },
+      }),
+      /record\.id/,
+      'missing cursor key on a full page fails closed',
+    )
   }
 
   // 8. read surfaces a facade select error (fail-closed; never a silent empty page).

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -9,6 +9,12 @@ const { createWatermarkStore } = require(path.join(__dirname, '..', 'lib', 'wate
 const { createRunLogger } = require(path.join(__dirname, '..', 'lib', 'run-log.cjs'))
 const { createDataSourceSqlReadonlySourceAdapterFactory } = require(path.join(__dirname, '..', 'lib', 'adapters', 'data-source-sql-readonly-source-adapter.cjs'))
 
+const WATERMARK_CURSOR_PREFIX = 'dswm1:'
+
+function encodeWatermarkCursor(payload) {
+  return `${WATERMARK_CURSOR_PREFIX}${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')}`
+}
+
 function createMockDb() {
   const tables = new Map([
     ['integration_dead_letters', []],
@@ -1535,6 +1541,12 @@ async function main() {
       'maxPagesReached=true when source has more data and page cap is hit')
     assert.equal(cappedResult.run.details.pagesProcessed, 2,
       'pagesProcessed reflects the number of pages read')
+    assert.equal(cappedResult.run.status, 'partial',
+      'a capped source read is incomplete and must not be marked succeeded')
+    assert.equal(cappedResult.run.details.watermarkAdvanced, false,
+      'a capped source read must not advance the watermark and skip unread rows')
+    assert.equal(await cappedHarness.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' }), null,
+      'maxPagesReached blocks watermark persistence')
     assert.equal(cappedPage, 2, 'source read called exactly maxPages times')
 
     // Source returns 1 page (done=true) → maxPagesReached=false, exited normally
@@ -1560,6 +1572,51 @@ async function main() {
       'maxPagesReached=false when source signals done before cap')
     assert.equal(normalResult.run.details.pagesProcessed, 1,
       'pagesProcessed=1 when single page completes the run')
+    assert.equal(normalResult.run.details.nextCursor, null,
+      'normal terminal reads do not persist a stale previous cursor')
+  }
+
+  // --- 20b. Watermark cursors are internal and values-free in persisted run details.
+  {
+    const secretTiebreaker = 'PART-SECRET-001'
+    const sensitiveCursor = encodeWatermarkCursor({
+      v: 1,
+      mode: 'wm-composite',
+      type: 'updated_at',
+      field: 'updatedAt',
+      value: '2026-04-24T01:00:00.000Z',
+      tiebreaker: 'code',
+      tiebreakerValue: secretTiebreaker,
+    })
+    let page = 0
+    const cursorHarness = createRunnerHarness({
+      sourceRecords: [],
+      pipelineOverrides: { options: { batchSize: 1, maxPages: 1 } },
+      sourceRead: async () => {
+        page += 1
+        return createReadResult({
+          records: [
+            { code: secretTiebreaker, revision: 'r1', qty: '1', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+          ],
+          nextCursor: sensitiveCursor,
+          done: false,
+        })
+      },
+    })
+    const result = await cursorHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(page, 1)
+    assert.equal(result.run.status, 'partial')
+    assert.equal(result.run.details.nextCursor, null)
+    assert.equal(result.run.details.nextCursorRedacted, true)
+    assert.equal(result.run.details.nextCursorKind, 'watermark')
+    assert.equal(result.run.details.watermarkAdvanced, false)
+    assert.equal(await cursorHarness.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' }), null,
+      'redacted incomplete watermark cursor does not advance the store')
+    const serializedDetails = JSON.stringify(result.run.details)
+    assert.ok(!serializedDetails.includes(secretTiebreaker), 'run details must not leak cursor tiebreaker source values')
+    assert.ok(!serializedDetails.includes(sensitiveCursor), 'run details must not persist the raw watermark cursor')
   }
 
   // --- 21. invalid source record (null/array/scalar) → dead letter, run continues

--- a/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
@@ -7,6 +7,7 @@ const {
   computeRecordIdempotencyKey,
 } = require(path.join(__dirname, '..', 'lib', 'idempotency.cjs'))
 const {
+  compareWatermarkValues,
   createWatermarkStore,
   deriveNextWatermark,
   normalizeWatermarkConfig,
@@ -202,6 +203,19 @@ async function main() {
     deriveNextWatermark([{ id: 7 }, { id: '42' }, { id: 13 }], { type: 'monotonic_id' }),
     { type: 'monotonic_id', value: '42' },
   )
+  assert.equal(
+    compareWatermarkValues('monotonic_id', '9007199254740993', '9007199254740992'),
+    1,
+    'monotonic_id comparison preserves SQL BIGINT precision beyond JS safe integers',
+  )
+  assert.deepEqual(
+    deriveNextWatermark(
+      [{ id: '9007199254740992' }, { id: '9007199254740993' }],
+      { type: 'monotonic_id' },
+    ),
+    { type: 'monotonic_id', value: '9007199254740993' },
+    'deriveNextWatermark picks the later SQL BIGINT id without Number rounding',
+  )
   assert.deepEqual(
     normalizeWatermarkConfig(
       { type: 'updated_at', field: 'updatedAt', tiebreaker: 'id' },
@@ -261,6 +275,19 @@ async function main() {
   assert.equal(updatedWatermark.value, '42')
   const notRegressed = await watermarks.advanceWatermark({ pipelineId: 'pipe_1', type: 'monotonic_id', value: '7' })
   assert.equal(notRegressed.value, '42', 'advanceWatermark does not move monotonic watermarks backwards')
+  const bigIntWatermark = await watermarks.advanceWatermark({
+    pipelineId: 'pipe_bigint',
+    type: 'monotonic_id',
+    value: '9007199254740992',
+  })
+  assert.equal(bigIntWatermark.value, '9007199254740992')
+  const biggerBigIntWatermark = await watermarks.advanceWatermark({
+    pipelineId: 'pipe_bigint',
+    type: 'monotonic_id',
+    value: '9007199254740993',
+  })
+  assert.equal(biggerBigIntWatermark.value, '9007199254740993',
+    'advanceWatermark advances adjacent SQL BIGINT values without precision collapse')
   await assert.rejects(() => watermarks.setWatermark({
     pipelineId: 'pipe_bad_ts',
     type: 'updated_at',
@@ -275,6 +302,11 @@ async function main() {
     pipelineId: 'pipe_1',
     type: 'monotonic_id',
     value: Number.POSITIVE_INFINITY,
+  }), WatermarkError)
+  await assert.rejects(() => watermarks.advanceWatermark({
+    pipelineId: 'pipe_1',
+    type: 'monotonic_id',
+    value: Number.MAX_SAFE_INTEGER + 1,
   }), WatermarkError)
   assert.equal(
     await db.selectOne('integration_watermarks', { pipeline_id: 'pipe_bad_ts' }),

--- a/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
@@ -17,8 +17,11 @@ const {
   createReadResult,
   unsupportedAdapterOperation,
 } = require('../contracts.cjs')
+const { getPath, isBlank } = require('../transform-engine.cjs')
 
 const ADAPTER_KIND = 'data-source:sql-readonly'
+const WATERMARK_CURSOR_PREFIX = 'dswm1:'
+const WATERMARK_TYPES = new Set(['updated_at', 'monotonic_id'])
 
 // `requiredString` / `optionalString` are kept local (contracts.cjs only exposes them under
 // `__internals`); mirrors the staging adapter's approach.
@@ -44,6 +47,12 @@ function isPlainObject(value) {
 
 function hasOwnKeys(value) {
   return isPlainObject(value) && Object.keys(value).length > 0
+}
+
+function isScalarQueryValue(value) {
+  return value === null ||
+    value instanceof Date ||
+    ['string', 'number', 'boolean'].includes(typeof value)
 }
 
 function normalizeEqualityFilters(filters = {}) {
@@ -86,11 +95,199 @@ function getDataSourcesApi(context) {
 
 function parseOffsetCursor(cursor) {
   if (cursor === null || cursor === undefined || cursor === '') return 0
+  if (typeof cursor === 'string' && cursor.startsWith(WATERMARK_CURSOR_PREFIX)) {
+    throw new AdapterValidationError('watermark cursor cannot be used for offset reads', { field: 'cursor' })
+  }
   const numeric = Number(cursor)
   if (!Number.isInteger(numeric) || numeric < 0) {
     throw new AdapterValidationError('cursor must be a non-negative offset', { field: 'cursor' })
   }
   return numeric
+}
+
+function encodeWatermarkCursor(payload) {
+  return `${WATERMARK_CURSOR_PREFIX}${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')}`
+}
+
+function decodeWatermarkCursor(cursor) {
+  if (typeof cursor !== 'string' || !cursor.startsWith(WATERMARK_CURSOR_PREFIX)) {
+    throw new AdapterValidationError('watermark reads require a watermark cursor', { field: 'cursor' })
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor.slice(WATERMARK_CURSOR_PREFIX.length), 'base64url').toString('utf8'))
+    if (!isPlainObject(decoded) || decoded.v !== 1 || typeof decoded.mode !== 'string') {
+      throw new Error('invalid cursor payload')
+    }
+    return decoded
+  } catch {
+    throw new AdapterValidationError('invalid watermark cursor', { field: 'cursor' })
+  }
+}
+
+function normalizeWatermarkField(value, field) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AdapterValidationError(`${field} must be a non-empty string`, { field })
+  }
+  return value.trim()
+}
+
+function normalizeWatermarkConfigForRead(config = {}) {
+  if (!hasOwnKeys(config)) {
+    throw new AdapterValidationError('watermarkConfig is required for watermark reads', { field: 'watermarkConfig' })
+  }
+  const type = config.type || config.watermarkType
+  if (!WATERMARK_TYPES.has(type)) {
+    throw new AdapterValidationError('watermarkConfig.type must be updated_at or monotonic_id', {
+      field: 'watermarkConfig.type',
+    })
+  }
+  const field = normalizeWatermarkField(config.field || config.watermarkField, 'watermarkConfig.field')
+  const normalized = { type, field }
+  if (type === 'updated_at') {
+    const tiebreaker = config.tiebreaker || config.tieBreaker || config.tiebreakerField || config.watermarkTiebreaker
+    normalized.tiebreaker = normalizeWatermarkField(tiebreaker, 'watermarkConfig.tiebreaker')
+    if (normalized.tiebreaker === normalized.field) {
+      throw new AdapterValidationError('watermarkConfig.tiebreaker must be different from field', {
+        field: 'watermarkConfig.tiebreaker',
+      })
+    }
+  }
+  return normalized
+}
+
+function normalizeWatermarkValue(type, value, field) {
+  if (isBlank(value)) {
+    throw new AdapterValidationError(`${field} is required for watermark reads`, { field })
+  }
+  if (type === 'updated_at') {
+    const candidate = value instanceof Date ? value.toISOString() : String(value)
+    if (Number.isNaN(Date.parse(candidate))) {
+      throw new AdapterValidationError(`${field} must be a valid timestamp`, { field })
+    }
+    return candidate
+  }
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw new AdapterValidationError(`${field} must be a safe integer or integer string`, { field })
+    }
+    return String(value)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (/^-?\d+$/.test(trimmed)) return trimmed
+  }
+  throw new AdapterValidationError(`${field} must be an integer`, { field })
+}
+
+function normalizeTiebreakerValue(value, field) {
+  if (!isScalarQueryValue(value) || isBlank(value)) {
+    throw new AdapterValidationError(`${field} must be a non-empty scalar`, { field })
+  }
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function readRecordValue(record, field) {
+  if (isPlainObject(record) && Object.prototype.hasOwnProperty.call(record, field)) {
+    return record[field]
+  }
+  return getPath(record, field)
+}
+
+function modeForWatermarkConfig(config) {
+  return config.type === 'monotonic_id' ? 'wm-mono' : 'wm-composite'
+}
+
+function assertCursorMatchesConfig(cursor, mode, config) {
+  if (cursor.mode !== mode || cursor.type !== config.type || cursor.field !== config.field) {
+    throw new AdapterValidationError('watermark cursor mode does not match the read request', { field: 'cursor' })
+  }
+  if (config.type === 'updated_at' && cursor.tiebreaker !== config.tiebreaker) {
+    throw new AdapterValidationError('watermark cursor tiebreaker does not match the read request', { field: 'cursor' })
+  }
+}
+
+function combineWhereClauses(baseWhere, watermarkWhere) {
+  if (baseWhere && watermarkWhere) return { $and: [baseWhere, watermarkWhere] }
+  return watermarkWhere || baseWhere
+}
+
+function buildWatermarkReadPlan(request) {
+  if (!hasOwnKeys(request.watermark)) return null
+  const config = normalizeWatermarkConfigForRead(request.watermarkConfig)
+  const watermarkValue = normalizeWatermarkValue(
+    config.type,
+    request.watermark[config.field],
+    `watermark.${config.field}`
+  )
+  const mode = modeForWatermarkConfig(config)
+  const orderBy = [{ column: config.field, direction: 'asc' }]
+  let cursor = null
+  if (request.cursor) {
+    cursor = decodeWatermarkCursor(request.cursor)
+    assertCursorMatchesConfig(cursor, mode, config)
+  }
+
+  if (config.type === 'monotonic_id') {
+    const cursorValue = cursor
+      ? normalizeWatermarkValue(config.type, cursor.value, 'cursor.value')
+      : watermarkValue
+    return {
+      mode,
+      config,
+      where: { [config.field]: { $gt: cursorValue } },
+      orderBy,
+    }
+  }
+
+  orderBy.push({ column: config.tiebreaker, direction: 'asc' })
+  if (!cursor) {
+    return {
+      mode,
+      config,
+      // Across-run store has only the timestamp, so the first page re-reads that timestamp floor
+      // and lets downstream idempotency absorb already-seen rows. In-run pages use the composite cursor.
+      where: { [config.field]: { $gte: watermarkValue } },
+      orderBy,
+    }
+  }
+  const cursorValue = normalizeWatermarkValue(config.type, cursor.value, 'cursor.value')
+  const cursorTiebreaker = normalizeTiebreakerValue(cursor.tiebreakerValue, 'cursor.tiebreakerValue')
+  return {
+    mode,
+    config,
+    where: {
+      $or: [
+        { [config.field]: { $gt: cursorValue } },
+        { [config.field]: cursorValue, [config.tiebreaker]: { $gt: cursorTiebreaker } },
+      ],
+    },
+    orderBy,
+  }
+}
+
+function buildNextWatermarkCursor({ mode, config, records }) {
+  if (!records.length) return null
+  const last = records[records.length - 1]
+  const value = normalizeWatermarkValue(
+    config.type,
+    readRecordValue(last, config.field),
+    `record.${config.field}`
+  )
+  const payload = {
+    v: 1,
+    mode,
+    type: config.type,
+    field: config.field,
+    value,
+  }
+  if (config.type === 'updated_at') {
+    payload.tiebreaker = config.tiebreaker
+    payload.tiebreakerValue = normalizeTiebreakerValue(
+      readRecordValue(last, config.tiebreaker),
+      `record.${config.tiebreaker}`
+    )
+  }
+  return encodeWatermarkCursor(payload)
 }
 
 // getSchema/getTableInfo want a BARE table name + a SEPARATE schema, but listObjects emits (and
@@ -176,10 +373,14 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
     async read(input = {}) {
       const request = normalizeReadRequest(input)
       const api = getDataSourcesApi(context)
-      const offset = parseOffsetCursor(request.cursor)
-      const selectOptions = { limit: request.limit, offset }
+      const watermarkPlan = buildWatermarkReadPlan(request)
+      const offset = watermarkPlan ? null : parseOffsetCursor(request.cursor)
+      const selectOptions = { limit: request.limit }
+      if (offset !== null) selectOptions.offset = offset
       const where = normalizeEqualityFilters(request.filters)
-      if (where) selectOptions.where = where
+      const effectiveWhere = combineWhereClauses(where, watermarkPlan && watermarkPlan.where)
+      if (effectiveWhere) selectOptions.where = effectiveWhere
+      if (watermarkPlan) selectOptions.orderBy = watermarkPlan.orderBy
       const result = await api.select(
         dataSourceId,
         request.object,
@@ -191,16 +392,24 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
       }
       const rows = Array.isArray(result && result.data) ? result.data : []
       const records = rows.map((row) => (isPlainObject(row) ? { ...row } : row))
-      const nextOffset = offset + records.length
+      const fullPage = records.length >= request.limit
+      const nextCursor = watermarkPlan && fullPage
+        ? buildNextWatermarkCursor({ mode: watermarkPlan.mode, config: watermarkPlan.config, records })
+        : (!watermarkPlan && fullPage ? String(offset + records.length) : null)
       return createReadResult({
         records,
-        // Offset paging: a full page implies "maybe more"; a short page is terminal (done).
-        nextCursor: records.length >= request.limit ? String(nextOffset) : null,
-        done: records.length < request.limit,
+        // Full page implies "maybe more"; a short page is terminal. In incremental mode the
+        // next cursor is an opaque mode-tagged keyset cursor, never an offset.
+        nextCursor,
+        done: !fullPage,
         metadata: {
           object: request.object,
           dataSourceId,
-          offset,
+          ...(watermarkPlan ? {
+            mode: watermarkPlan.mode,
+            watermarkType: watermarkPlan.config.type,
+            watermarkField: watermarkPlan.config.field,
+          } : { offset }),
           count: records.length,
         },
       })

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -27,6 +27,7 @@ const MAX_BATCH_SIZE = 10000
 const DEFAULT_MAX_PAGES = 100
 const MAX_RUN_PAGES = 10000
 const DATA_SOURCE_SQL_READONLY_KIND = 'data-source:sql-readonly'
+const SENSITIVE_WATERMARK_CURSOR_PREFIX = 'dswm1:'
 // DF-N2-2b: per-run cap on appended provenance events. Keeps the
 // integration_runs.provenance_events JSONB column bounded (~300 bytes/event →
 // ~150KB) so a large run cannot bloat the row. Overflow is surfaced as a counter
@@ -63,6 +64,17 @@ function normalizePositiveIntegerOption(value, { defaultValue, max }) {
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function buildCursorRunDetails(cursor) {
+  if (typeof cursor === 'string' && cursor.startsWith(SENSITIVE_WATERMARK_CURSOR_PREFIX)) {
+    return {
+      nextCursor: null,
+      nextCursorRedacted: true,
+      nextCursorKind: 'watermark',
+    }
+  }
+  return { nextCursor: cursor }
 }
 
 function resolveTargetOptions(pipeline = {}) {
@@ -712,14 +724,16 @@ function createPipelineRunner(deps = {}) {
           break
         }
         if (readResult.done || !readResult.nextCursor) {
+          cursor = null
           exitedNormally = true
           break
         }
         cursor = readResult.nextCursor
       }
       const maxPagesReached = !exitedNormally && page >= maxPages
+      const watermarkMayAdvance = !dryRun && metrics.rowsFailed === 0 && !maxPagesReached
 
-      if (!dryRun && metrics.rowsFailed === 0 && lastSuccessfulWatermark) {
+      if (watermarkMayAdvance && lastSuccessfulWatermark) {
         const advance = typeof watermarkStore.advanceWatermark === 'function'
           ? watermarkStore.advanceWatermark.bind(watermarkStore)
           : watermarkStore.setWatermark.bind(watermarkStore)
@@ -731,15 +745,15 @@ function createPipelineRunner(deps = {}) {
       }
 
       metrics.durationMs = Math.max(0, clock() - started)
-      const status = metrics.rowsFailed > 0 ? 'partial' : 'succeeded'
+      const status = metrics.rowsFailed > 0 || maxPagesReached ? 'partial' : 'succeeded'
       let finishRunWarning = null
       try {
         run = await runLogger.finishRun(run, metrics, status, {
           provenanceEvents,
           details: {
             dryRun,
-            watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
-            nextCursor: cursor,
+            watermarkAdvanced: watermarkMayAdvance && Boolean(lastSuccessfulWatermark),
+            ...buildCursorRunDetails(cursor),
             erpFeedback,
             ...(targetWriteSummaries.length > 0 && {
               targetWriteSummaries,

--- a/plugins/plugin-integration-core/lib/watermark.cjs
+++ b/plugins/plugin-integration-core/lib/watermark.cjs
@@ -69,17 +69,30 @@ function parseWatermarkValue(type, value) {
     }
     return parsed
   }
-  const numeric = Number(value)
-  if (!Number.isFinite(numeric)) {
-    throw new WatermarkError('monotonic_id watermark value must be numeric', { value })
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw new WatermarkError('monotonic_id watermark value must be a safe integer or integer string', { value })
+    }
+    return BigInt(value)
   }
-  return numeric
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (/^-?\d+$/.test(trimmed)) return BigInt(trimmed)
+  }
+  throw new WatermarkError('monotonic_id watermark value must be an integer', { value })
 }
 
 function compareWatermarkValues(type, left, right) {
   if (isBlank(left)) return -1
   if (isBlank(right)) return 1
-  return parseWatermarkValue(type, left) - parseWatermarkValue(type, right)
+  const parsedLeft = parseWatermarkValue(type, left)
+  const parsedRight = parseWatermarkValue(type, right)
+  if (type === 'monotonic_id') {
+    if (parsedLeft > parsedRight) return 1
+    if (parsedLeft < parsedRight) return -1
+    return 0
+  }
+  return parsedLeft - parsedRight
 }
 
 function valueToString(value) {


### PR DESCRIPTION
## Summary\n- implement C3-2 keyset watermark reads for data-source:sql-readonly: updated_at composite cursor and monotonic_id strict cursor\n- preserve offset/full-read mode, compose equality filters with watermark predicates, and fail closed on cursor mode mismatch\n- keep SQL BIGINT monotonic ids as integer strings, redact raw watermark cursors from run details, and block watermark advance when maxPages truncates a source read\n- update C3 TODO/design docs while keeping C3-5 real-DB validation pending\n\n## Verification\n- pnpm --filter plugin-integration-core test\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-plugin-facade.test.ts tests/unit/data-source-readonly.test.ts tests/unit/postgres-adapter.test.ts tests/unit/mssql-adapter.test.ts tests/unit/data-source-mysql-schema.test.ts --watch=false\n- pnpm exec eslint src/data-adapters/BaseAdapter.ts src/data-adapters/DataSourceManager.ts src/data-adapters/MSSQLAdapter.ts src/data-adapters/MongoDBAdapter.ts src/data-adapters/MySQLAdapter.ts src/data-adapters/PostgresAdapter.ts (from packages/core-backend)\n- git diff --check\n\n## Review\n- Subagent review found and rechecked fixes for BIGINT precision, run-details cursor redaction, and maxPages watermark safety. Final re-review: no findings.\n\n## Boundaries\n- read-only only; no C6 external write\n- no K3/RBAC/auth changes\n- no UI\n- C3-5 real-DB wire-vs-fixture smoke remains gated/pending