### PR TITLE
docs(data-source): reconcile C3 watermark status

### DIFF
--- a/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
+++ b/docs/development/data-factory-sql-data-source-bridge-c3-watermark-incremental-read-design-20260603.md
@@ -1,12 +1,11 @@
 # Data Factory — read-only SQL data-source bridge — C3 incremental / watermark read — design (2026-06-03)
 
-> **Design-first. No runtime in this slice.** Lifts the C0 **Seam-3 deferral** ("incremental + watermark
-> are deferred until a watermark-column convention exists") for the `data-source:sql-readonly` bridge:
-> teach the bridge's `read()` to **honor the watermark argument the pipeline-runner already passes**, as a
-> parameterized **keyset** `WHERE … ORDER BY … LIMIT` over the existing read-only facade. Equality
-> `filters`/`where` support has since landed and must be preserved; the facade `orderBy` seam has
-> landed (C3-1, #2609). **Watermark runtime stays 🔒**
-> — gated on (a) a real volume / slow-full-reread signal, (b) this convention, and (c) a separate opt-in.
+> **Status refresh (2026-06-15):** This document began as design-first. The core runtime has since landed
+> through C3-1 (#2609), C3-2a (#2625), C3-3a (#2619), and C3-2/C3-4(unit) (#2628). It lifts the C0
+> **Seam-3 deferral** ("incremental + watermark are deferred until a watermark-column convention exists")
+> for the `data-source:sql-readonly` bridge: the bridge's `read()` now honors the watermark argument the
+> pipeline-runner already passes as a parameterized **keyset** `WHERE … ORDER BY … LIMIT` over the existing
+> read-only facade. **C3-5 real-DB/entity-machine validation remains 🔒** and is the acceptance gate.
 > Read-only; **no read-contract change**; does **not** touch the K3 channel, central RBAC, or auth.
 
 ## Why — lift C0 Seam-3, don't rebuild what exists
@@ -23,14 +22,15 @@ reads. Two things have since become clear from reading `origin/main`:
    `where` and `orderBy` (`BaseAdapter.ts:56`), and `DataSourceManager.select` passes them straight to the
    adapter. So `WHERE wm > :last ORDER BY wm ASC LIMIT n` is already expressible underneath.
 
-The remaining reason the bridge is full/manual today is that **its `read()` ignores `request.watermark`**
-(does pure offset). Earlier C2-0 hardening already taught the bridge to honor equality `filters` through
-structured `where`, and C3-1 widened the read-only facade to pass `orderBy`; the remaining C3 runtime work
-closes the watermark/keyset half without regressing that filter path.
+Originally, the remaining reason the bridge was full/manual was that **its `read()` ignored
+`request.watermark`** and did pure offset paging. C3-2/C3-4(unit) now close that adapter/runtime gap in
+unit coverage: equality `filters` are preserved through structured `where`, `orderBy` passes through the
+read-only facade, and the bridge composes filters with the watermark keyset predicate. The remaining proof is
+not another helper fixture — it is C3-5: a real DB / entity-machine run proving the full
+facade→`DataSourceManager`→adapter→DB path.
 
-This is **design-ahead**. The prior decision stands — full-table offset paging works, and C3 impl is built
-only on a **real** large-source / full-reread-too-slow signal. This document is the convention so that, when
-that signal appears, the impl is a small, pre-reviewed slice and not a scramble.
+This remains conservative rollout work. Full-table offset paging still exists as fallback, the runtime is
+read-only, and C3 is not delivery-complete until C3-5 passes.
 
 ## Scope boundary (the load-bearing sentence)
 
@@ -46,11 +46,11 @@ and workbench UIs; or add cross-owner grants. Owner-scope and read-only stay exa
 
 ## Grounded current state (verified on `origin/main`)
 
-| Piece | Already exists | The gap C3 fills |
+| Piece | Already exists | Remaining gap after #2628 |
 |---|---|---|
-| Read contract | `read({object,limit,cursor,filters,watermark}) → {records,nextCursor,done}` — `watermark` + `filters` slots present (`normalizeReadRequest`, `contracts.cjs:91`); `nextCursor` is a string (`createReadResult:126`) | bridge `read()` still uses offset paging and **ignores `watermark`**; equality `filters` are already honored through structured `where` |
-| Runner | `mode`, `resolveWatermarkConfig`, `watermarkStore` (get/set/advance), `deriveNextWatermark` (`watermark.cjs`); passes `watermark:{field:value}` into `read()` and advances after success (`pipeline-runner.cjs`) | runner passes **only `{field:value}`**, not the `type` / tiebreaker the keyset needs (see Seam D) |
-| DB layer | `BaseAdapter.QueryOptions` has `where` + `orderBy` (`BaseAdapter.ts:56`); `DataSourceManager.select` passes them through (`:530`) | C3-1 widened the **read-only facade** to pass `orderBy`; remaining runtime work must consume it from the bridge adapter |
+| Read contract | `read({object,limit,cursor,filters,watermark}) → {records,nextCursor,done}` — `watermark` + `filters` slots present (`normalizeReadRequest`, `contracts.cjs:91`); `nextCursor` is a string (`createReadResult:126`) | #2628 makes bridge `read()` honor `watermark + watermarkConfig`; C3-5 must prove the real DB wire path |
+| Runner | `mode`, `resolveWatermarkConfig`, `watermarkStore` (get/set/advance), `deriveNextWatermark` (`watermark.cjs`); passes `watermark:{field:value}` into `read()` and advances after success (`pipeline-runner.cjs`) | #2619 passes the resolved `watermarkConfig`; C3-5 must prove owner-scoped incremental runs preserve it end to end |
+| DB layer | `BaseAdapter.QueryOptions` has `where` + `orderBy` (`BaseAdapter.ts:56`); `DataSourceManager.select` passes them through (`:530`) | #2609/#2625/#2628 unit-lock facade/adapter composition; C3-5 must prove the real adapter/DB behavior |
 | Precedent (do **not** depend on) | `k3-wise-sqlserver-executor.cjs:234` already builds `WHERE wm > v ORDER BY orderBy` (strict `>`, single `orderBy=keyField`, one bounded page per run, `done:true`) | K3 is the **red-line** channel; its strict-`>` is safe only because its `keyField` is **unique/monotonic**. The bridge must **generalize it safely** for the non-unique `updated_at` default — not copy it, not import it |
 
 ## The design — five seams
@@ -185,8 +185,8 @@ argument is the same wire-vs-fixture class of bug.)
   keep all values parameterized; reject malformed logical groups and unknown `$` operators fail-closed;
   add MySQL operator parity with Postgres/MSSQL. This is a prerequisite only — no watermark predicate is
   generated yet, and the offset/full path stays unchanged. Landed in #2625 / squash `c2c59994c`.
-- 🔒 **C3-2 — adapter watermark mode (plugin):** type-conditional keyset (Seam B) + cursor model (Seam C).
-  Current implementation slice wires `data-source:sql-readonly.read()` so `watermark + watermarkConfig`
+- ✅ **C3-2 — adapter watermark mode (plugin):** type-conditional keyset (Seam B) + cursor model (Seam C).
+  Landed in #2628 / squash `f587cf122`: `data-source:sql-readonly.read()` now wires `watermark + watermarkConfig` so it
   generates structured `where/orderBy`, with `updated_at` first-page `>=` store-floor seeding and
   subsequent in-run `(field,tiebreaker)` composite cursors, plus `monotonic_id` strict `>`.
   SQL BIGINT monotonic values are preserved as integer strings, not coerced through JS `Number`.
@@ -200,31 +200,33 @@ argument is the same wire-vs-fixture class of bug.)
   runtime slices.
 - ✅ **C2-0 — honor equality `filters`:** parameterized equality `filters` already pass through as `where`
   before C3 runtime.
-- 🔒 **C3-4 — filter + watermark composition lock:** keep those equality filters AND'd with the watermark
-  predicate; negative control: a filter value cannot inject SQL and cannot be dropped when watermark mode is
-  active.
+- ✅ **C3-4 — filter + watermark composition lock (unit):** landed in #2628 / squash `f587cf122`.
+  Equality filters are AND'd with the watermark predicate in plugin adapter unit coverage; negative controls
+  cover malformed/injectable values and the max-page no-watermark-advance path. C3-5 remains the
+  real-DB wire-vs-fixture proof that the facade -> `DataSourceManager` -> real adapter -> DB path preserves it.
 - 🔒 **C3-5 — real-DB locking test (the keystone, wire-vs-fixture):** against a **real** Postgres (and the
   MSSQL smoke), an incremental run reads **only** rows beyond the stored watermark; same-timestamp
   boundary/stall cases hold; a no-watermark run still does the full re-read; cross-owner is still fail-closed.
   Per the entity-machine lesson (#2205), the committed fake-facade unit tests do **not** prove the
   facade→`DataSourceManager`→real-adapter→DB keyset path — this real-DB test is the acceptance keystone.
 
-**All remaining C3-2..C3-5 work stays 🔒** until both a real volume/perf signal **and** a separate opt-in.
-Build order from the current mainline: C3-2 (adapter mode + cursor)
-→ C3-4 (filter+watermark composition) → C3-5 (real-DB lock).
+**Remaining C3 runtime gate:** C3-5 stays 🔒 until the real DB / entity-machine validation is run.
+The current mainline has unit-locked the adapter/facade/runtime seams, but not the acceptance keystone:
+real Postgres/MSSQL smoke must still prove the complete wire path and boundary behavior.
 
 ## Acceptance checklist (the locks — for the impl slices)
 
-- ⬜ `monotonic_id`: strict `>`, single-key order, progress guaranteed.
-- ⬜ `updated_at`: composite keyset `(field, tiebreaker)` — **no-miss** across a same-timestamp page boundary.
-- ⬜ `updated_at`: a same-timestamp batch larger than `limit` **still advances** (no stall).
-- ⬜ Watermark cursors remain internal: raw cursor values are not persisted in run details / evidence.
-- ⬜ Source page-cap truncation (`maxPagesReached`) is partial and blocks watermark advance.
-- ⬜ Across-run resume: first page seeds from the store floor (`>` mono / `>=`+dedup `updated_at`); subsequent
+- ✅ `monotonic_id`: strict `>`, single-key order, progress guaranteed (unit-locked in #2628).
+- ✅ `updated_at`: composite keyset `(field, tiebreaker)` — **no-miss** across a same-timestamp page boundary
+  (unit-locked in #2628).
+- ✅ `updated_at`: a same-timestamp batch larger than `limit` **still advances** (no stall; unit-locked in #2628).
+- ✅ Watermark cursors remain internal: raw cursor values are not persisted in run details / evidence (#2628).
+- ✅ Source page-cap truncation (`maxPagesReached`) is partial and blocks watermark advance (#2628).
+- ✅ Across-run resume: first page seeds from the store floor (`>` mono / `>=`+dedup `updated_at`); subsequent
   pages use the in-run composite cursor; no `watermarkStore` schema change.
-- ⬜ Mode coexistence: no watermark ⇒ the C1 offset/full path is byte-for-byte unchanged.
-- ⬜ Cursor mode-tagging: a cursor minted in one mode is **rejected fail-closed** under a different mode.
-- ⬜ `filters` honored as parameterized equality predicates; **no raw SQL / no injection**.
+- ✅ Mode coexistence: no watermark ⇒ the C1 offset/full path is unchanged (#2628 unit coverage).
+- ✅ Cursor mode-tagging: a cursor minted in one mode is **rejected fail-closed** under a different mode (#2628).
+- ✅ `filters` honored as parameterized equality predicates; **no raw SQL / no injection** (#2625 + #2628 unit coverage).
 - ✅ Facade widen exposes **no** write/CRUD/credential method; writable binding still rejected (#2609).
 - ⬜ Owner-scope **fail-closed** preserved on the incremental path (`assertAccess` via `pipeline.createdBy`).
 - ⬜ Bind-time **fail-closed**: incremental with no resolvable watermark field / non-orderable column /
@@ -233,8 +235,9 @@ Build order from the current mainline: C3-2 (adapter mode + cursor)
 
 ## Decision log / deferred
 
-- **Design-ahead, impl 🔒.** The prior "offset works, C3 not needed yet" decision stands; impl is built only
-  on a real volume/perf signal + a separate opt-in. This doc removes the design risk, not the gate.
+- **Design-ahead origin; runtime landed, acceptance still gated.** The prior "offset works, C3 not needed yet"
+  decision governed the initial rollout. Runtime slices through #2628 are now merged, but the design risk is
+  only fully retired after C3-5 real-DB/entity-machine validation proves the wire path.
 - **K3 precedent cited, never depended on.** `k3-wise-sqlserver-executor` is the red-line channel; C3
   generalizes its watermark→`where` pattern safely for non-unique watermarks **without** touching or
   importing it.
@@ -244,7 +247,7 @@ Build order from the current mainline: C3-2 (adapter mode + cursor)
 
 ## Gating posture
 
-New integration-core read-only surface → post-GATE **scoped, read-only opt-in** (named, **not** auto-start).
-No K3 surface, no RBAC/auth touch, no write ⇒ low-risk scoped gate. Each C3-N slice above is its own explicit
-opt-in; **none starts** until both a real incremental-read need (volume/perf signal) and that opt-in. This
-track stays **parallel to the K3 line** and blocks nothing on it.
+New integration-core read-only surface → post-GATE **scoped, read-only opt-in**. The runtime slices through
+#2628 have landed; **C3-5 remains a separate explicit validation opt-in** before calling C3 complete. No K3
+surface, no RBAC/auth touch, no write ⇒ low-risk scoped gate. This track stays **parallel to the K3 line**
+and blocks nothing on it.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -8,7 +8,8 @@
 
 - 只读数据库接入 Data Factory 源系统: 已经基本可用。
 - 可交付定义: C6 外部写能力完成并通过实体机验收后，才称为完整交付。
-- 下一步建议: C2-close 已通过实体机 smoke；C3-1 facade `orderBy` seam 已落地；继续 C3 incremental / watermark runtime，但 runtime 仍需单独 opt-in。
+- 下一步建议: C2-close 已通过实体机 smoke；C3-1 / C3-2a / C3-3a / C3-2 / C3-4(unit)
+  已落地；继续 C3-5 real-DB / entity-machine 验证。
 - 不建议: 现在直接开 C6。C6 是最大风险刀，必须等只读链路、增量链路、K3 generic seam 都稳定后再开。
 
 ## 收口顺序
@@ -17,7 +18,7 @@
 | --- | --- | --- | --- | --- |
 | P0 | ②b arc 收口权限/契约修复 | done (#2597) | 已排已合并主线风险 | related-echo 跨 base 泄漏 |
 | C2-close | 只读数据库链路 smoke 收口 | done (#2600) | 证明当前 read-only bridge 可稳定测试 | 实体机配置漂移 |
-| C3 | incremental / watermark runtime | gated; C3-1 done (#2609), C3-3a done (#2619) | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
+| C3 | incremental / watermark runtime | gated; C3-1/#2609, C3-3a/#2619, C3-2a/#2625, C3-2+C3-4(unit)/#2628 done; C3-5 pending | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | gated | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
 | C6 | external write | gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
@@ -132,8 +133,9 @@ TODO:
     `field > last OR (field = last AND tiebreaker > lastTie)`，为 `updated_at + id`
     复合 keyset 铺底。
   - 边界: 不生成 watermark predicate，不解析/推进 cursor，不改变 offset full-read 行为，不新增写能力。
-- [ ] C3-2 adapter 实现 watermark keyset runtime + in-run mode-tagged cursor；跨 run 仍复用现有
+- [x] C3-2 adapter 实现 watermark keyset runtime + in-run mode-tagged cursor；跨 run 仍复用现有
   watermark store，不改 store schema。
+  - #2628 / squash `f587cf122`.
   - 当前实现 slice: `data-source:sql-readonly.read()` 在有 `watermark + watermarkConfig` 时生成
     type-conditional structured `where/orderBy`。
   - `updated_at`: 第一页从 store floor 用 `>=` bounded re-read，后续页用 `(field,tiebreaker)` composite cursor。
@@ -142,9 +144,10 @@ TODO:
   - offset/full-read 无 watermark 时保持原路径；wrong-mode cursor fail-closed；watermark cursor 不原样写入 run
     details，只存 values-free redacted marker。
   - 若读到 `maxPages` cap 仍未完成，run 标记 partial 且不推进 watermark，避免跳过未读行。
-- [ ] C3-4 filter + watermark composition lock。
-  - 当前实现 slice 已在 plugin adapter unit 层覆盖 equality `filters` 与 watermark predicate 的 structured `$and`
-    组合；C3-5 仍需真实 DB wire-vs-fixture 验证。
+- [x] C3-4 filter + watermark composition lock（unit 层）。
+  - #2628 / squash `f587cf122`.
+  - plugin adapter unit 层已覆盖 equality `filters` 与 watermark predicate 的 structured `$and`
+    组合、注入拒绝、以及 maxPages partial/no-watermark-advance；C3-5 仍需真实 DB wire-vs-fixture 验证。
 - [ ] C3-5 实体机 real-DB smoke: 跨页同 timestamp 不漏读、不卡住、可 resume。
 
 完成条件:
@@ -153,6 +156,8 @@ TODO:
 - `>=` 型 stall 和 `>` 型 tie miss 都被测试锁住。
 - offset full-read 仍可作为 fallback，不被破坏。
 - 当前 equality `filters` 不能因 watermark 模式被旁路；C3 测试必须覆盖 filter + watermark 同时存在。
+- watermark cursor 不能原样进入 run details / evidence；只能落 values-free redacted marker。
+- `maxPagesReached` 必须使 run 进入 partial 且不推进 watermark，不能把截断读伪装成成功。
 - watermark 列必须有索引/`EXPLAIN` 验证；否则可能比全量扫描更差。
 - 时间戳精度并列风暴必须进入测试。
 - 迟到提交漏读属于固有限制: 要么记为限制，要么设计安全重扫窗。


### PR DESCRIPTION
## Summary
- mark C3-2 adapter watermark runtime and C3-4 unit composition lock as landed via #2628
- remove stale pre-#2628 wording that said watermark runtime had not started
- keep C3-5 real-DB/entity-machine validation explicitly pending as the acceptance gate

## Verification
- git diff --check
- stale wording scan for pre-#2628 runtime-lock phrases
- subagent review: initial P1 stale design-doc wording fixed; final re-review no findings

Docs-only. No runtime, route, UI, package, or K3 changes.