### PR TITLE
feat(attendance): annual-leave L1 — generalize expiry source_type by leave_type_code

### DIFF
--- a/packages/core-backend/src/services/AttendanceExpiryService.ts
+++ b/packages/core-backend/src/services/AttendanceExpiryService.ts
@@ -22,6 +22,11 @@ interface ExpiredCompTimeBalanceRow {
 export class AttendanceExpiryService {
   constructor(private readonly query: AttendanceExpiryQuery = defaultQuery as AttendanceExpiryQuery) {}
 
+  // Expires every aged lot across ALL leave types (#2622 §5: the scan has no leave-type filter). The
+  // expire event's source_type is derived per leave_type_code (comp_time → comp_time_expiry, annual →
+  // annual_leave_expiry, else {type}_expiry) inside the single atomic statement, preserving the #2267
+  // claim (events bound to the UPDATE RETURNING → a dup/leader-failed tick writes 0 events). The
+  // comp_time-era method/type names are kept so the ④ C4-1 no-regress test re-runs verbatim.
   async expireCompTimeBalances(): Promise<ExpiredCompTimeBalance[]> {
     const result = await this.query<ExpiredCompTimeBalanceRow>(
       `WITH candidates AS (
@@ -44,12 +49,17 @@ export class AttendanceExpiryService {
             AND b.remaining_minutes > 0
             AND b.expires_at IS NOT NULL
             AND b.expires_at <= now()
-          RETURNING b.org_id, b.user_id, b.id AS balance_id, c.remaining_minutes AS expired_minutes
+          RETURNING b.org_id, b.user_id, b.id AS balance_id, c.remaining_minutes AS expired_minutes, b.leave_type_code
        ),
        inserted_events AS (
          INSERT INTO attendance_leave_balance_events
            (org_id, user_id, balance_id, event_type, delta_minutes, source_type)
-         SELECT org_id, user_id, balance_id, 'expire', -expired_minutes, 'comp_time_expiry'
+         SELECT org_id, user_id, balance_id, 'expire', -expired_minutes,
+                CASE leave_type_code
+                  WHEN 'comp_time' THEN 'comp_time_expiry'
+                  WHEN 'annual' THEN 'annual_leave_expiry'
+                  ELSE leave_type_code || '_expiry'
+                END
            FROM expired
          RETURNING balance_id
        )

--- a/packages/core-backend/tests/integration/attendance-expiry-service.test.ts
+++ b/packages/core-backend/tests/integration/attendance-expiry-service.test.ts
@@ -131,4 +131,55 @@ describeWithDb('AttendanceExpiryService (④ C4-1)', () => {
       await pool.end().catch(() => undefined)
     }
   })
+
+  it('derives the expire event source_type per leave_type_code (年假 L1, #2622): annual -> annual_leave_expiry, others -> {type}_expiry', async () => {
+    const pool = new Pool({ connectionString: dbUrl })
+    const service = new AttendanceExpiryService(async <T = unknown>(sql, params = []) => {
+      const result = await pool.query<T>(sql, params)
+      return { rows: result.rows, rowCount: result.rowCount }
+    })
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-l1-expiry-source-${runSuffix}`
+    const lotIds: Record<string, string> = {}
+    const insertLot = async (tag: string, leaveTypeCode: string): Promise<string> => {
+      const inserted = await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_balances
+           (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, expires_at)
+         VALUES ('default', $1, $2, 480, 480, 'manual_grant', $3, 'active', '2000-01-01T00:00:00Z')
+         RETURNING id`,
+        [userId, leaveTypeCode, `l1-expiry:${runSuffix}:${tag}`],
+      )
+      return inserted.rows[0].id
+    }
+
+    try {
+      await requireTable(pool, 'attendance_leave_balances')
+      await requireTable(pool, 'attendance_leave_balance_events')
+
+      lotIds.annual = await insertLot('annual', 'annual')
+      lotIds.compTime = await insertLot('comp', 'comp_time')
+      lotIds.sick = await insertLot('sick', 'sick')
+
+      const expired = await service.expireCompTimeBalances()
+      expect(expired.map(row => row.balanceId).sort()).toEqual([lotIds.annual, lotIds.compTime, lotIds.sick].sort())
+
+      const events = await pool.query<{ balance_id: string; source_type: string | null; delta_minutes: number; event_type: string }>(
+        `SELECT balance_id, source_type, delta_minutes, event_type
+           FROM attendance_leave_balance_events
+          WHERE user_id = $1`,
+        [userId],
+      )
+      const sourceByLot = new Map(events.rows.map(row => [row.balance_id, row.source_type]))
+      // comp_time stays comp_time_expiry (no-regress); annual derives annual_leave_expiry; any other
+      // leave type derives {leave_type_code}_expiry (the CASE ELSE branch).
+      expect(sourceByLot.get(lotIds.compTime)).toBe('comp_time_expiry')
+      expect(sourceByLot.get(lotIds.annual)).toBe('annual_leave_expiry')
+      expect(sourceByLot.get(lotIds.sick)).toBe('sick_expiry')
+      expect(events.rows.every(row => row.event_type === 'expire' && Number(row.delta_minutes) === -480)).toBe(true)
+    } finally {
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
 })


### PR DESCRIPTION
## What (L1 of the annual/statutory leave-balance engine — design-lock #2622, tracker §0.4)

The `AttendanceExpiryService` scan already expires **every** aged lot regardless of leave type (#2622 §5: "scan already generic") — only the expire event's `source_type` was hardcoded `'comp_time_expiry'`. L1 generalizes just that label.

**Change** (entirely inside the single atomic CTE statement → preserves #2267's events-bound-to-`RETURNING` idempotency): the `expired` CTE now `RETURNING ... b.leave_type_code`, and the events `INSERT...SELECT` derives `source_type` via:
```sql
CASE leave_type_code
  WHEN 'comp_time' THEN 'comp_time_expiry'
  WHEN 'annual'    THEN 'annual_leave_expiry'
  ELSE leave_type_code || '_expiry'
END
```

**Method/type names kept comp_time-era** (comp_time is the only type with `expires_at` today; a rename is out of L1 scope) so the **④ C4-1 expiry test re-runs verbatim** as the comp_time no-regress lock.

## Validation (local, real DB)

- `attendance-expiry-service.test.ts`: **C4-1 no-regress unchanged** + a **new derivation test** seeding annual / comp_time / sick lots → `annual_leave_expiry` / `comp_time_expiry` / `sick_expiry`. ✓
- `④ C4` plugin test (scheduler tick → expiry service): green. ✓
- `tsc` clean (the change is SQL-string + comment only; `ExpiredCompTimeBalanceRow` unchanged).

No annual lots get `expires_at` until L4 — this is forward-ready and harmless today.

Per connected-run A: opening for your merge. **Heads-up:** the next slice is **L2** (accrual snapshot engine), which has the genuine design fork you flagged — `cumulativeServiceStartDate` storage (user/HR column vs HR attribute = the engine's first real DDL). Per our rule I'll **pause and bring you that decision** rather than auto-build L2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)