### PR TITLE
fix(data-factory): resolve PLM BOM fields case-insensitively

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
@@ -140,6 +140,52 @@ async function testNoHit() {
   assert.deepEqual(result.summary.actions, { add: 0, update: 0, skip: 0, inactive: 0, manualConfirm: 0 })
 }
 
+async function testSourceRowsResolveCaseVariantFieldKeys() {
+  {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_OrderHeadInfo: [{ obj_id: 'ORDER-1', path_id: 'PATH-1' }],
+    }))
+    const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001' })
+
+    assert.equal(result.valid, true)
+    assert.equal(result.status, 'expanded')
+    assert.ok(
+      !result.rowErrors.some((error) => error.type === 'missing_order_id'),
+      'case-variant order id must not fail as missing_order_id',
+    )
+    assert.equal(result.rows.length, 2)
+  }
+
+  {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_OrderHeadInfo: [{ OBJ_ID: 'ORDER-1', obj_id: 'SHOULD_NOT_WIN', path_id: 'PATH-1' }],
+    }))
+    const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001' })
+
+    assert.equal(result.valid, true)
+    assert.equal(result.status, 'expanded')
+    assert.equal(
+      result.rows.length,
+      2,
+      'exact field key wins over a case-variant sibling; fallback must not retarget to SHOULD_NOT_WIN',
+    )
+  }
+
+  {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_OrderHeadInfo: [{ obj_id: 'ORDER-1', Obj_Id: 'ORDER-ALT', path_id: 'PATH-1' }],
+    }))
+    const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001' })
+
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.rowErrors.some((error) => error.type === 'missing_order_id'),
+      'ambiguous case-variant field keys fail closed instead of picking the first value',
+    )
+    assert.equal(result.rows.length, 0)
+  }
+}
+
 async function testSameComponentUnderDifferentParentsStaysDistinct() {
   const data = baseData({
     DN_PDM_OrderDetailInfo: [
@@ -366,6 +412,7 @@ async function main() {
   await testSuccessfulExpansion()
   await testReadFailureDiagnosticsAreValuesFree()
   await testNoHit()
+  await testSourceRowsResolveCaseVariantFieldKeys()
   await testSameComponentUnderDifferentParentsStaysDistinct()
   await testFailClosedGuards()
   await testScaleLimitsRemainDiagnosableAndValuesFree()

--- a/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
@@ -352,7 +352,12 @@ async function readAll(adapter, object, filters, options, readStats) {
 
 function readField(row, field) {
   if (!isPlainObject(row) || field === undefined) return undefined
-  return row[field]
+  if (Object.prototype.hasOwnProperty.call(row, field)) return row[field]
+  if (typeof field !== 'string' || field.trim() === '') return undefined
+  const normalized = field.toLowerCase()
+  const matchingKeys = Object.keys(row).filter((key) => key.toLowerCase() === normalized)
+  if (matchingKeys.length !== 1) return undefined
+  return row[matchingKeys[0]]
 }
 
 function matchesByField(rows, field, value) {


### PR DESCRIPTION
## Summary

- Fixes the #2425 `missing_order_id` rerun blocker where the bound SQL/source path returned the order-head id field under a different key casing.
- Keeps exact-key lookup first, then falls back to a case-insensitive row key match only when there is exactly one match.
- Ambiguous case variants fail closed as missing field instead of pick-first.

## Why

The refreshed `f587cf122` entity-machine package cleared the previous `where` forwarding blocker, but the Large-BOM run still stopped before plan/apply:

- binding stayed green;
- public source-select could traverse to a usable shape;
- `orderHead.idField.exactKeyRows=0` but `caseInsensitiveKeyRows=1`;
- expansion is exact-key-only and reported `missing_order_id`.

This patch keeps the normalization local to the stock-preparation BOM expansion read path instead of changing global data-source adapter casing.

## Verification

- `node plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs` -> pass
- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs` -> pass
- `node plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs` -> pass
- `git diff --check` -> pass
- Subagent review: APPROVE, no findings

## Scope

Read/expansion helper only. No checkpoint apply, no target write, no external DB write, no K3, no raw SQL, no auth/RBAC change.

After merge, cut a refreshed on-prem package and rerun #2425 values-free run / plan / checkpoint apply / re-pull idempotence.
