### PR TITLE
feat(multitable): export column/row picker (A2)

### DIFF
--- a/apps/web/src/multitable/components/MetaExportDialog.vue
+++ b/apps/web/src/multitable/components/MetaExportDialog.vue
@@ -1,0 +1,193 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="meta-export-overlay" @click.self="onCancel">
+      <div class="meta-export-modal" role="dialog" :aria-label="l('export.title')">
+        <div class="meta-export__header">
+          <strong>{{ l('export.title') }}</strong>
+          <button class="meta-export__close" :aria-label="l('export.close')" @click="onCancel">&times;</button>
+        </div>
+
+        <div class="meta-export__body">
+          <!-- Columns -->
+          <div class="meta-export__row">
+            <div class="meta-export__row-head">
+              <span class="meta-export__label">{{ l('export.columns') }}</span>
+              <span class="meta-export__bulk">
+                <button type="button" class="meta-export__link" @click="selectAll">{{ l('export.selectAll') }}</button>
+                <button type="button" class="meta-export__link" @click="clearAll">{{ l('export.clearAll') }}</button>
+              </span>
+            </div>
+            <ul class="meta-export__cols" role="group" :aria-label="l('export.columns')">
+              <li v-for="field in fields" :key="field.id" class="meta-export__col">
+                <label class="meta-export__col-label">
+                  <input
+                    type="checkbox"
+                    :checked="checked.has(field.id)"
+                    @change="toggle(field.id)"
+                  />
+                  <span class="meta-export__col-name">{{ field.name }}</span>
+                </label>
+              </li>
+            </ul>
+            <p v-if="!canExport" class="meta-export__hint meta-export__hint--warn" role="alert">{{ l('export.noColumns') }}</p>
+          </div>
+
+          <!-- Row scope -->
+          <div class="meta-export__row">
+            <span class="meta-export__label">{{ l('export.rowScope') }}</span>
+            <label class="meta-export__opt">
+              <input type="radio" value="all" :checked="rowScope === 'all'" @change="rowScope = 'all'" />
+              <span>{{ l('export.allRows') }}</span>
+            </label>
+            <label class="meta-export__opt" :class="{ 'meta-export__opt--disabled': selectedRowCount === 0 }">
+              <input
+                type="radio"
+                value="selected"
+                :checked="rowScope === 'selected'"
+                :disabled="selectedRowCount === 0"
+                @change="rowScope = 'selected'"
+              />
+              <span>{{ l('export.selectedRows') }}</span>
+              <span v-if="selectedRowCount > 0" class="meta-export__count">{{ selectedCount(selectedRowCount, isZh) }}</span>
+            </label>
+          </div>
+
+          <!-- Format -->
+          <div class="meta-export__row">
+            <span class="meta-export__label">{{ l('export.format') }}</span>
+            <label class="meta-export__opt">
+              <input type="radio" value="xlsx" :checked="format === 'xlsx'" @change="format = 'xlsx'" />
+              <span>{{ l('export.formatXlsx') }}</span>
+            </label>
+            <label class="meta-export__opt">
+              <input type="radio" value="csv" :checked="format === 'csv'" @change="format = 'csv'" />
+              <span>{{ l('export.formatCsv') }}</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="meta-export__actions">
+          <button class="meta-export__btn" @click="onCancel">{{ l('export.cancel') }}</button>
+          <button
+            class="meta-export__btn meta-export__btn--primary"
+            :disabled="!canExport"
+            @click="onConfirm"
+          >
+            {{ l('export.confirm') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel, selectedCount, type MetaCoreLabelKey } from '../utils/meta-core-labels'
+
+export interface ExportColumn {
+  id: string
+  name: string
+}
+
+export interface ExportConfirmPayload {
+  fieldIds: string[]
+  rowScope: 'all' | 'selected'
+  format: 'csv' | 'xlsx'
+}
+
+const props = defineProps<{
+  visible: boolean
+  fields: ExportColumn[]
+  /** Number of currently-selected rows; 0 disables the "selected rows only" scope. */
+  selectedRowCount: number
+  /** Format to preselect when the dialog opens (the toolbar's CSV vs XLSX button). */
+  initialFormat?: 'csv' | 'xlsx'
+}>()
+
+const emit = defineEmits<{
+  (e: 'confirm', payload: ExportConfirmPayload): void
+  (e: 'cancel'): void
+}>()
+
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+
+const checked = ref<Set<string>>(new Set())
+const rowScope = ref<'all' | 'selected'>('all')
+const format = ref<'csv' | 'xlsx'>('xlsx')
+
+// Reset to a clean default state every time the dialog opens (all columns
+// checked, all rows, xlsx). Preserves field ORDER via the emit below (the Set
+// is membership only; order comes from props.fields at confirm time).
+watch(
+  () => props.visible,
+  (open) => {
+    if (!open) return
+    checked.value = new Set(props.fields.map((f) => f.id))
+    rowScope.value = 'all'
+    format.value = props.initialFormat ?? 'xlsx'
+  },
+  { immediate: true },
+)
+
+const canExport = computed(() => checked.value.size > 0)
+
+function toggle(fieldId: string) {
+  const next = new Set(checked.value)
+  if (next.has(fieldId)) next.delete(fieldId)
+  else next.add(fieldId)
+  checked.value = next
+}
+
+function selectAll() {
+  checked.value = new Set(props.fields.map((f) => f.id))
+}
+
+function clearAll() {
+  checked.value = new Set()
+}
+
+function onConfirm() {
+  if (!canExport.value) return
+  // Preserve the on-screen column order: filter props.fields by membership
+  // rather than emitting the Set's insertion order.
+  const fieldIds = props.fields.filter((f) => checked.value.has(f.id)).map((f) => f.id)
+  emit('confirm', { fieldIds, rowScope: rowScope.value, format: format.value })
+}
+
+function onCancel() {
+  emit('cancel')
+}
+</script>
+
+<style scoped>
+.meta-export-overlay { position: fixed; inset: 0; z-index: 110; background: rgba(0,0,0,.3); display: flex; align-items: center; justify-content: center; }
+.meta-export-modal { background: #fff; border-radius: 6px; min-width: 420px; max-width: 540px; box-shadow: 0 10px 40px rgba(0,0,0,.18); display: flex; flex-direction: column; max-height: 80vh; }
+.meta-export__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #ebedf0; }
+.meta-export__close { background: transparent; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #909399; }
+.meta-export__close:hover { color: #303133; }
+.meta-export__body { padding: 16px; display: flex; flex-direction: column; gap: 16px; overflow-y: auto; }
+.meta-export__row { display: flex; flex-direction: column; gap: 6px; }
+.meta-export__row-head { display: flex; align-items: center; justify-content: space-between; }
+.meta-export__label { font-size: 12px; color: #909399; }
+.meta-export__bulk { display: flex; gap: 12px; }
+.meta-export__link { background: none; border: none; padding: 0; color: #409eff; font-size: 12px; cursor: pointer; }
+.meta-export__link:hover { text-decoration: underline; }
+.meta-export__cols { list-style: none; margin: 0; padding: 4px; border: 1px solid #dcdfe6; border-radius: 4px; max-height: 220px; overflow-y: auto; display: flex; flex-direction: column; gap: 2px; }
+.meta-export__col-label { display: flex; align-items: center; gap: 8px; padding: 4px 6px; cursor: pointer; font-size: 14px; border-radius: 3px; }
+.meta-export__col-label:hover { background: #f5f7fa; }
+.meta-export__col-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-export__opt { display: flex; align-items: center; gap: 8px; font-size: 14px; cursor: pointer; }
+.meta-export__opt--disabled { color: #c0c4cc; cursor: not-allowed; }
+.meta-export__count { color: #909399; font-size: 12px; }
+.meta-export__hint { font-size: 13px; margin: 0; }
+.meta-export__hint--warn { color: #e6a23c; }
+.meta-export__actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid #ebedf0; }
+.meta-export__btn { background: #fff; border: 1px solid #dcdfe6; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-size: 14px; }
+.meta-export__btn:hover:not(:disabled) { border-color: #c0c4cc; }
+.meta-export__btn:disabled { opacity: .55; cursor: not-allowed; }
+.meta-export__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
+.meta-export__btn--primary:hover:not(:disabled) { background: #66b1ff; border-color: #66b1ff; }
+</style>

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -42,6 +42,11 @@ export type MetaCoreLabelKey =
   | 'toolbar.importRecords' | 'toolbar.import'
   | 'toolbar.exportCsv' | 'toolbar.exportExcel' | 'toolbar.exportExcelXlsx' | 'toolbar.exportXlsx'
   | 'toolbar.newRecord'
+  // --- Export options dialog (A2: column/row selection) ---
+  | 'export.title' | 'export.close' | 'export.columns' | 'export.selectAll' | 'export.clearAll'
+  | 'export.rowScope' | 'export.allRows' | 'export.selectedRows'
+  | 'export.format' | 'export.formatCsv' | 'export.formatXlsx'
+  | 'export.noColumns' | 'export.cancel' | 'export.confirm' | 'export.openAria'
   // --- Row density ---
   | 'density.compact' | 'density.normal' | 'density.expanded'
   // --- MetaGridTable static ---
@@ -134,6 +139,21 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'toolbar.exportExcel': { en: 'Export Excel', zh: '导出 Excel' },
   'toolbar.exportExcelXlsx': { en: 'Export Excel (.xlsx)', zh: '导出 Excel (.xlsx)' },
   'toolbar.exportXlsx': { en: 'Export XLSX', zh: '导出 XLSX' },
+  'export.title': { en: 'Export options', zh: '导出选项' },
+  'export.close': { en: 'Close', zh: '关闭' },
+  'export.columns': { en: 'Columns', zh: '列' },
+  'export.selectAll': { en: 'Select all', zh: '全选' },
+  'export.clearAll': { en: 'Clear all', zh: '清空' },
+  'export.rowScope': { en: 'Rows', zh: '行' },
+  'export.allRows': { en: 'All loaded rows', zh: '全部已加载行' },
+  'export.selectedRows': { en: 'Selected rows only', zh: '仅选中行' },
+  'export.format': { en: 'Format', zh: '格式' },
+  'export.formatCsv': { en: 'CSV', zh: 'CSV' },
+  'export.formatXlsx': { en: 'Excel (.xlsx)', zh: 'Excel (.xlsx)' },
+  'export.noColumns': { en: 'Select at least one column to export.', zh: '请至少选择一列导出。' },
+  'export.cancel': { en: 'Cancel', zh: '取消' },
+  'export.confirm': { en: 'Export', zh: '导出' },
+  'export.openAria': { en: 'Export options', zh: '导出选项' },
   'toolbar.newRecord': { en: '+ New Record', zh: '+ 新建记录' },
 
   'density.compact': { en: 'Compact', zh: '紧凑' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -272,6 +272,7 @@
           @open-field-comments="onOpenGridFieldComments"
           @toggle-lock="onToggleRecordLock"
           @ai-run="onGridAiRun"
+          @selection-change="onGridSelectionChange"
         />
       </div>
       <MetaRecordDrawer
@@ -355,6 +356,14 @@
       @close="closeImportModal"
       @cancel-import="cancelImport"
       @import="onBulkImport"
+    />
+    <MetaExportDialog
+      :visible="exportDialogVisible"
+      :fields="scopedGridFields"
+      :selected-row-count="exportSelectedRecordIds.size"
+      :initial-format="exportInitialFormat"
+      @confirm="onExportDialogConfirm"
+      @cancel="exportDialogVisible = false"
     />
     <MetaLinkPicker
       :visible="linkPickerVisible"
@@ -501,6 +510,7 @@ import { subscribeToMultitableCommentSheetRealtime } from '../realtime/comments-
 import MetaViewTabBar from '../components/MetaViewTabBar.vue'
 import MetaToolbar from '../components/MetaToolbar.vue'
 import MetaGridTable from '../components/MetaGridTable.vue'
+import MetaExportDialog, { type ExportConfirmPayload } from '../components/MetaExportDialog.vue'
 import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaCommentsDrawer from '../components/MetaCommentsDrawer.vue'
@@ -2535,12 +2545,58 @@ function closeImportModal() {
 }
 
 // --- CSV export ---
-function onExportCsv() {
-  const visibleFields = scopedGridFields.value
-  if (!visibleFields.length) return
-  const header = visibleFields.map((f) => csvEscape(f.name)).join(',')
-  const rows = grid.rows.value.map((row) =>
-    visibleFields.map((f) => {
+// --- Export dialog state (A2) ---
+const exportDialogVisible = ref(false)
+const exportInitialFormat = ref<'csv' | 'xlsx'>('xlsx')
+// Selected row ids surfaced from the grid's existing multi-select (selection-change).
+const exportSelectedRecordIds = ref<Set<string>>(new Set())
+function onGridSelectionChange(recordIds: string[]) {
+  exportSelectedRecordIds.value = new Set(recordIds)
+}
+
+// --- Export (A2: column/row selection via MetaExportDialog) ---
+// The toolbar's CSV/XLSX buttons now open the export-options dialog (column
+// checklist + row scope + format) instead of exporting immediately. Export
+// stays fully client-side over grid.rows — already permission-masked at read
+// time — so filtering already-authorized columns/rows adds no auth surface.
+type GridExportField = (typeof scopedGridFields)['value'][number]
+type GridExportRow = (typeof grid.rows)['value'][number]
+
+function onExportCsv() { openExportDialog('csv') }
+async function onExportXlsx() { openExportDialog('xlsx') }
+
+function openExportDialog(initialFormat: 'csv' | 'xlsx') {
+  if (!scopedGridFields.value.length) return
+  exportInitialFormat.value = initialFormat
+  exportDialogVisible.value = true
+}
+
+function onExportDialogConfirm(payload: ExportConfirmPayload) {
+  exportDialogVisible.value = false
+  const selectedFieldIds = new Set(payload.fieldIds)
+  // Preserve the on-screen column order; ignore unknown ids defensively.
+  const fields = scopedGridFields.value.filter((f) => selectedFieldIds.has(f.id))
+  if (!fields.length) return
+  const rows = payload.rowScope === 'selected'
+    ? grid.rows.value.filter((r) => exportSelectedRecordIds.value.has(r.id))
+    : grid.rows.value
+  if (payload.format === 'csv') doExportCsv(fields, rows)
+  else void doExportXlsx(fields, rows)
+}
+
+function triggerDownload(blob: Blob, extension: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${workbench.activeSheetId.value || 'export'}.${extension}`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function doExportCsv(fields: GridExportField[], rowList: GridExportRow[]) {
+  const header = fields.map((f) => csvEscape(f.name)).join(',')
+  const rows = rowList.map((row) =>
+    fields.map((f) => {
       const v = row.data[f.id]
       if (v === null || v === undefined) return ''
       if (typeof v === 'boolean') return v ? 'true' : 'false'
@@ -2549,13 +2605,7 @@ function onExportCsv() {
     }).join(','),
   )
   const csv = [header, ...rows].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `${workbench.activeSheetId.value || 'export'}.csv`
-  a.click()
-  URL.revokeObjectURL(url)
+  triggerDownload(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), 'csv')
 }
 
 function csvEscape(val: string): string {
@@ -2563,15 +2613,12 @@ function csvEscape(val: string): string {
   return val
 }
 
-// --- XLSX export ---
-async function onExportXlsx() {
-  const visibleFields = scopedGridFields.value
-  if (!visibleFields.length) return
+async function doExportXlsx(fields: GridExportField[], rowList: GridExportRow[]) {
   try {
     const xlsxModule = (await import('xlsx')) as unknown as Parameters<typeof buildXlsxBuffer>[0]
-    const headers = visibleFields.map((f) => f.name)
-    const rows = grid.rows.value.map((row) =>
-      visibleFields.map((f) => {
+    const headers = fields.map((f) => f.name)
+    const rows = rowList.map((row) =>
+      fields.map((f) => {
         const v = row.data[f.id]
         if (v === null || v === undefined) return ''
         if (typeof v === 'boolean') return v
@@ -2583,13 +2630,7 @@ async function onExportXlsx() {
     )
     const sheetName = (workbench.activeSheetId.value || 'export').slice(0, 31)
     const buffer = buildXlsxBuffer(xlsxModule, { sheetName, headers, rows })
-    const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${workbench.activeSheetId.value || 'export'}.xlsx`
-    a.click()
-    URL.revokeObjectURL(url)
+    triggerDownload(new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), 'xlsx')
   } catch (err: any) {
     showError(err?.message ?? wb('toast.excelExportFailed', isZh.value))
   }

--- a/apps/web/tests/multitable-export-dialog.spec.ts
+++ b/apps/web/tests/multitable-export-dialog.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import MetaExportDialog, { type ExportColumn, type ExportConfirmPayload } from '../src/multitable/components/MetaExportDialog.vue'
+
+const baseFields: ExportColumn[] = [
+  { id: 'fld_name', name: 'Name' },
+  { id: 'fld_amount', name: 'Amount' },
+  { id: 'fld_status', name: 'Status' },
+]
+
+function mountDialog(propsOverride: Partial<{
+  visible: boolean
+  fields: ExportColumn[]
+  selectedRowCount: number
+  initialFormat: 'csv' | 'xlsx'
+  onConfirm: (p: ExportConfirmPayload) => void
+  onCancel: () => void
+}> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const props = {
+    visible: true,
+    fields: baseFields,
+    selectedRowCount: 0,
+    initialFormat: 'xlsx' as const,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    ...propsOverride,
+  }
+  const app = createApp({ render() { return h(MetaExportDialog, props) } })
+  app.mount(container)
+  return { app, props, root: document.body }
+}
+
+function colCheckboxes(root: HTMLElement): HTMLInputElement[] {
+  return Array.from(root.querySelectorAll('.meta-export__cols input[type="checkbox"]'))
+}
+
+describe('MetaExportDialog', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    useLocale().setLocale('en')
+    vi.restoreAllMocks()
+  })
+
+  it('defaults to all columns checked and emits them in on-screen order with all-rows + initial format', async () => {
+    const onConfirm = vi.fn()
+    const { app, root } = mountDialog({ onConfirm, initialFormat: 'xlsx' })
+    await nextTick()
+
+    expect(colCheckboxes(root).every((cb) => cb.checked)).toBe(true)
+    ;(root.querySelector('.meta-export__btn--primary') as HTMLButtonElement).click()
+    await nextTick()
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onConfirm.mock.calls[0][0]).toEqual({
+      fieldIds: ['fld_name', 'fld_amount', 'fld_status'],
+      rowScope: 'all',
+      format: 'xlsx',
+    })
+    app.unmount()
+  })
+
+  it('excludes an unchecked column and preserves on-screen order', async () => {
+    const onConfirm = vi.fn()
+    const { app, root } = mountDialog({ onConfirm })
+    await nextTick()
+
+    // Uncheck the middle column (Amount).
+    const amount = colCheckboxes(root)[1]
+    amount.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(root.querySelector('.meta-export__btn--primary') as HTMLButtonElement).click()
+    await nextTick()
+    expect(onConfirm.mock.calls[0][0].fieldIds).toEqual(['fld_name', 'fld_status'])
+    app.unmount()
+  })
+
+  it('blocks export with zero columns: button disabled, warning shown, no emit', async () => {
+    const onConfirm = vi.fn()
+    const { app, root } = mountDialog({ onConfirm })
+    await nextTick()
+
+    ;(root.querySelector('.meta-export__link:last-child') as HTMLButtonElement).click() // Clear all
+    await nextTick()
+
+    const btn = root.querySelector('.meta-export__btn--primary') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(root.querySelector('.meta-export__hint--warn')).not.toBeNull()
+    btn.click()
+    await nextTick()
+    expect(onConfirm).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('disables "selected rows only" when nothing is selected', async () => {
+    const { app, root } = mountDialog({ selectedRowCount: 0 })
+    await nextTick()
+    const selected = root.querySelector('input[type="radio"][value="selected"]') as HTMLInputElement
+    expect(selected.disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('emits rowScope "selected" when selection exists and the option is chosen', async () => {
+    const onConfirm = vi.fn()
+    const { app, root } = mountDialog({ onConfirm, selectedRowCount: 2 })
+    await nextTick()
+
+    const selected = root.querySelector('input[type="radio"][value="selected"]') as HTMLInputElement
+    expect(selected.disabled).toBe(false)
+    selected.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(root.querySelector('.meta-export__btn--primary') as HTMLButtonElement).click()
+    await nextTick()
+    expect(onConfirm.mock.calls[0][0].rowScope).toBe('selected')
+    app.unmount()
+  })
+
+  it('preselects the initial format (csv) and emits it', async () => {
+    const onConfirm = vi.fn()
+    const { app, root } = mountDialog({ onConfirm, initialFormat: 'csv' })
+    await nextTick()
+
+    const csv = root.querySelector('input[type="radio"][value="csv"]') as HTMLInputElement
+    expect(csv.checked).toBe(true)
+    ;(root.querySelector('.meta-export__btn--primary') as HTMLButtonElement).click()
+    await nextTick()
+    expect(onConfirm.mock.calls[0][0].format).toBe('csv')
+    app.unmount()
+  })
+
+  it('renders zh-CN chrome while preserving raw column names', async () => {
+    useLocale().setLocale('zh-CN')
+    const { app, root } = mountDialog({})
+    await nextTick()
+    expect(root.querySelector('.meta-export__header strong')?.textContent).toBe('导出选项')
+    expect(root.textContent).toContain('全部已加载行')
+    expect(root.textContent).toContain('Name') // raw field name unchanged
+    app.unmount()
+  })
+
+  it('emits cancel on close', async () => {
+    const onCancel = vi.fn()
+    const { app, root } = mountDialog({ onCancel })
+    await nextTick()
+    ;(root.querySelector('.meta-export__close') as HTMLButtonElement).click()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -1453,6 +1453,13 @@ describe('MultitableWorkbench view wiring', () => {
       container!.querySelector<HTMLButtonElement>('[data-export-csv="true"]')!.click()
       await flushUi()
 
+      // A2: export buttons now open the export-options dialog (column/row picker);
+      // confirm it (defaults = all scoped columns, all rows) to fire the export.
+      const confirmBtn = document.body.querySelector<HTMLButtonElement>('.meta-export__btn--primary')
+      expect(confirmBtn).not.toBeNull()
+      confirmBtn!.click()
+      await flushUi()
+
       expect(createObjectURLMock).toHaveBeenCalledTimes(1)
       const csv = exportedBlob
         ? await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary

Closes the 飞书-parity gap (audit ladder A2) where export dumped **all** visible columns + **all** loaded rows with no selection UX. The toolbar CSV/XLSX buttons now open an **export-options dialog**:

- **Column checklist** — default all checked, ≥1 required (export disabled + warning otherwise), select-all / clear-all.
- **Row scope** — all loaded rows / **selected rows only** (the latter enabled from the grid's *existing* multi-select; shows the count).
- **Format** — CSV / XLSX; the clicked toolbar button preselects it.

Export stays **fully client-side** over `grid.rows`, which is already permission-masked at read time — so filtering already-authorized columns/rows adds **no auth surface** and needs no server round-trip. Column order follows the on-screen order at confirm time.

**Out of scope (separate later slice):** server-side export of the full dataset beyond the loaded page via the `#2591` masked route.

## Changes

- New `MetaExportDialog.vue` (Teleport modal, mirrors `MetaBulkEditDialog`) + **8 component tests** (default-all, column exclude + order preservation, ≥1-column guard, selected-rows enable/emit, format preselect, zh-CN chrome, cancel).
- `MultitableWorkbench.vue`: capture the grid's existing `@selection-change`; refactor export into `doExportCsv`/`doExportXlsx(fields, rows)`; the dialog drives both.
- i18n: `export.*` keys (en/zh) in `meta-core-labels.ts` (strict-zero discipline).
- Updated the existing `exports only scoped visible grid fields` test to drive the new confirm step (the column-masking assertion is preserved).

## Verification

Local (Node 25): new dialog suite **8/8**, `multitable-workbench-view` export test green. `vue-tsc -b` can't run on the local Node 25 (internal crash) — **CI Node 20 is the authoritative type gate**. Two pre-existing local-env failures (`workflow-designer`, `manager-flow`) fail on clean `origin/main` too (unrelated `auth.getToken` env issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)