### PR TITLE
test(multitable): wire context.api integration test into CI (C3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -176,6 +176,7 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
             tests/integration/multitable-permission-golden-d3d1.test.ts \
             tests/integration/multitable-permission-golden-d3d2.test.ts \
+            tests/integration/multitable-context.api.test.ts \
             tests/integration/multitable-view-aggregate.test.ts \
             tests/integration/multitable-typed-query-numeric-view.test.ts \
             tests/integration/multitable-formula-over-lookup-view.test.ts \

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
       'tests/integration/comments.api.test.ts',
       'tests/integration/events-api.test.ts',
       'tests/integration/multitable-attachments.api.test.ts',
+      // multitable-context.api.test.ts needs setup.integration.ts + a live DB (its template
+      // catalog/install routes go through rbacGuard, which 403s under the default setup). It
+      // stays excluded HERE but is now wired INTO the `Run multitable real-DB integration`
+      // job (plugin-tests.yml), where it is green — so it is CI-covered, not invisible debt.
       'tests/integration/multitable-context.api.test.ts',
       'tests/integration/multitable-record-form.api.test.ts',
       'tests/integration/multitable-sheet-permissions.api.test.ts',


### PR DESCRIPTION
## Summary

Closes the audit's **C3** debt: `multitable-context.api.test.ts` was **CI-invisible** — excluded from the default vitest config (its template catalog/install routes go through `rbacGuard`, which 403s under `setup.ts`) **and** absent from the real-DB integration job list. So no CI ran it. (#2588 fixed its two native-person mock tests but the file stayed quarantined behind 4 template-route failures that only reproduce under the default setup.)

The file is green under `setup.integration.ts` + a live DB (the config it was written for). This wires it into the **`Run multitable real-DB integration`** job where it belongs, and documents in `vitest.config.ts` why it stays excluded from the default job but is now CI-covered.

## Changes

- `plugin-tests.yml`: add `multitable-context.api.test.ts` to the real-DB integration run.
- `vitest.config.ts`: comment explaining the exclude is intentional (needs integration setup + DB) and the file is now covered by the integration job.

## Verification

Real Postgres: **22/22** in isolation; **40/40** in CI order alongside its list neighbors (`d3d1`/`d3d2`) on a fresh DB (no shared-DB contamination). No trigger/path-filter change (only adds a file to an existing job's run command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)