### PR TITLE
feat(attendance): annual-leave L2a — accrual provenance schema (latent DDL)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260615170000_add_annual_leave_accrual_schema.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260615170000_add_annual_leave_accrual_schema.ts
@@ -1,0 +1,94 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const RUNS = 'attendance_leave_accrual_runs'
+const RUN_ITEMS = 'attendance_leave_accrual_run_items'
+
+// 年假/法定假 L2a (design-lock #2622). LATENT accrual provenance schema — nothing reads or writes these
+// yet (L2b accrual engine + L2c manual adjustment wire the runtime). Three DDL changes:
+//   - users.cumulative_service_start_date : the 累计工龄 anchor for tenureMode='cumulative_service'.
+//       hire_date is本单位入职日 only (insufficient for statutory cumulative service), so a missing value
+//       makes the engine SKIP with a visible reason — it never falls back to hire_date. Parallel to the
+//       existing users HR-profile columns (employee_no/department/position/hire_date).
+//   - attendance_leave_accrual_runs       : one row per accrual execution, snapshotting the policy inputs
+//       actually used (tenure_mode/timezone/standard_day_minutes/tiers/policy_version) so a snapshot-口径
+//       grant stays auditable even as工龄/policy drift later. dry_run marks preview executions.
+//   - attendance_leave_accrual_run_items  : per-user computed entitlement + status/skip_reason. A granted
+//       lot's source_id points HERE (run_item.id) — the audit back-link. UNIQUE(run_id,user_id,leave_type_code)
+//       so one run computes a given user once.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  // (1) users HR anchor for cumulative service (idempotent; parallel to hire_date).
+  const usersExists = await checkTableExists(db, 'users')
+  if (usersExists) {
+    await sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS cumulative_service_start_date DATE`.execute(db)
+  }
+
+  // (2) accrual run header.
+  const runsExists = await checkTableExists(db, RUNS)
+  if (!runsExists) {
+    await db.schema
+      .createTable(RUNS)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('period_key', 'text', col => col.notNull())
+      .addColumn('leave_type_code', 'text', col => col.notNull())
+      .addColumn('policy_version', 'text', col => col.notNull())
+      .addColumn('tenure_mode', 'text', col => col.notNull())
+      .addColumn('timezone', 'text', col => col.notNull())
+      .addColumn('standard_day_minutes', 'integer', col => col.notNull())
+      .addColumn('tiers', 'jsonb', col => col.notNull())
+      .addColumn('triggered_by', 'text', col => col.notNull())
+      .addColumn('dry_run', 'boolean', col => col.notNull().defaultTo(false))
+      .addColumn('occurred_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addCheckConstraint('chk_attendance_leave_accrual_runs_tenure_mode', sql`tenure_mode IN ('cumulative_service', 'company_tenure')`)
+      .addCheckConstraint('chk_attendance_leave_accrual_runs_standard_day', sql`standard_day_minutes > 0`)
+      .addCheckConstraint('chk_attendance_leave_accrual_runs_triggered_by', sql`triggered_by IN ('manual', 'scheduler')`)
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_attendance_leave_accrual_runs_org_period', RUNS, ['org_id', 'period_key'])
+
+  // (3) per-user run items — the provenance a granted lot's source_id points to.
+  const runItemsExists = await checkTableExists(db, RUN_ITEMS)
+  if (!runItemsExists) {
+    await db.schema
+      .createTable(RUN_ITEMS)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('run_id', 'uuid', col => col.notNull().references(`${RUNS}.id`).onDelete('cascade'))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('leave_type_code', 'text', col => col.notNull())
+      .addColumn('tenure_years', 'numeric')
+      .addColumn('tier_days', 'integer')
+      .addColumn('proration_factor', 'numeric')
+      .addColumn('entitlement_minutes', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('status', 'text', col => col.notNull())
+      .addColumn('skip_reason', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      // status enum + the granted⇔no-reason / skipped⇔reason invariant: a row can't claim 'granted' while
+      // carrying a skip reason, nor 'skipped' with no reason — the provenance must always say why it skipped.
+      .addCheckConstraint('chk_attendance_leave_accrual_run_items_status', sql`status IN ('granted', 'skipped')`)
+      .addCheckConstraint('chk_attendance_leave_accrual_run_items_entitlement', sql`entitlement_minutes >= 0`)
+      .addCheckConstraint('chk_attendance_leave_accrual_run_items_reason', sql`(status = 'granted' AND skip_reason IS NULL) OR (status = 'skipped' AND skip_reason IS NOT NULL)`)
+      .execute()
+  }
+  // one computed row per (run, user, leave type) — the engine writes each user once per run.
+  await createIndexIfNotExists(db, 'uq_attendance_leave_accrual_run_items_run_user_type', RUN_ITEMS, ['run_id', 'user_id', 'leave_type_code'], { unique: true })
+  await createIndexIfNotExists(db, 'idx_attendance_leave_accrual_run_items_run', RUN_ITEMS, ['org_id', 'run_id'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // run_items first (FK references runs); then drop the users anchor column.
+  await db.schema.dropTable(RUN_ITEMS).ifExists().execute()
+  await db.schema.dropTable(RUNS).ifExists().execute()
+  const usersExists = await checkTableExists(db, 'users')
+  if (usersExists) {
+    await sql`ALTER TABLE users DROP COLUMN IF EXISTS cumulative_service_start_date`.execute(db)
+  }
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -4822,6 +4822,79 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④/年假 L2a — accrual provenance schema invariants (runs/run_items CHECK·UNIQUE·FK; users service-start column)', async () => {
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = 'default'
+    const userPrefix = `l2a-${runSuffix}`
+    const rejects = async (text: string, params: unknown[], code: string, label: string) => {
+      let err: { code?: string } | null = null
+      try { await pool.query(text, params) } catch (e) { err = e as { code?: string } }
+      expect({ label, code: err?.code }).toEqual({ label, code })
+    }
+    try {
+      // The cumulative-service tenure anchor exists on users (never hire_date for cumulative_service mode).
+      const col = await pool.query(
+        `SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'cumulative_service_start_date'`,
+      )
+      expect(col.rowCount).toBe(1)
+
+      // runs header CHECK invariants (enum + positive standard day).
+      const runInsert = `INSERT INTO attendance_leave_accrual_runs
+        (org_id, period_key, leave_type_code, policy_version, tenure_mode, timezone, standard_day_minutes, tiers, triggered_by)
+        VALUES ($1, $2, 'annual', 'v1', $3, 'Asia/Shanghai', $4, '[]'::jsonb, $5)`
+      await rejects(runInsert, [orgId, `annual:${runSuffix}:a`, 'bogus', 480, 'manual'], '23514', 'tenure_mode must be a valid enum')
+      await rejects(runInsert, [orgId, `annual:${runSuffix}:b`, 'cumulative_service', 0, 'manual'], '23514', 'standard_day_minutes must be > 0')
+      await rejects(runInsert, [orgId, `annual:${runSuffix}:c`, 'cumulative_service', 480, 'bogus'], '23514', 'triggered_by must be a valid enum')
+
+      // a valid run anchors the run_items checks.
+      const run = await pool.query<{ id: string }>(`${runInsert} RETURNING id`, [orgId, `annual:${runSuffix}:ok`, 'cumulative_service', 480, 'manual'])
+      const runId = run.rows[0]?.id
+      expect(runId).toBeTruthy()
+
+      // a granted run item is valid; its id is the provenance back-link a lot's source_id points to.
+      const granted = await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_accrual_run_items
+           (run_id, org_id, user_id, leave_type_code, tenure_years, tier_days, proration_factor, entitlement_minutes, status)
+         VALUES ($1, $2, $3, 'annual', 12, 10, NULL, 4800, 'granted') RETURNING id`,
+        [runId, orgId, `${userPrefix}-g`],
+      )
+      expect(granted.rows[0]?.id).toBeTruthy()
+
+      // (1) one computed row per (run, user, leave type) -> a dup is a 23505 unique violation.
+      await rejects(
+        `INSERT INTO attendance_leave_accrual_run_items (run_id, org_id, user_id, leave_type_code, entitlement_minutes, status)
+         VALUES ($1, $2, $3, 'annual', 999, 'granted')`,
+        [runId, orgId, `${userPrefix}-g`], '23505', 'one computed row per run/user/leave_type',
+      )
+
+      // (2) a dangling run_id -> FK violation (23503).
+      await rejects(
+        `INSERT INTO attendance_leave_accrual_run_items (run_id, org_id, user_id, leave_type_code, entitlement_minutes, status)
+         VALUES ('00000000-0000-4000-8000-000000000000', $1, $2, 'annual', 100, 'granted')`,
+        [orgId, `${userPrefix}-fk`], '23503', 'run_id must reference a run',
+      )
+
+      // (3) CHECK invariants (23514): status enum, entitlement >= 0, and granted<->no-reason / skipped<->reason.
+      const itemInsert = `INSERT INTO attendance_leave_accrual_run_items
+        (run_id, org_id, user_id, leave_type_code, entitlement_minutes, status, skip_reason)
+        VALUES ($1, $2, $3, 'annual', $4, $5, $6)`
+      await rejects(itemInsert, [runId, orgId, `${userPrefix}-s1`, 100, 'bogus', null], '23514', 'status must be a valid enum')
+      await rejects(itemInsert, [runId, orgId, `${userPrefix}-s2`, -1, 'granted', null], '23514', 'entitlement_minutes must be >= 0')
+      await rejects(itemInsert, [runId, orgId, `${userPrefix}-s3`, 100, 'granted', 'SOME_REASON'], '23514', 'granted row must not carry a skip_reason')
+      await rejects(itemInsert, [runId, orgId, `${userPrefix}-s4`, 0, 'skipped', null], '23514', 'skipped row must carry a skip_reason')
+
+      // a skipped row WITH a reason is valid — the provenance always records why it skipped.
+      const skipped = await pool.query(itemInsert, [runId, orgId, `${userPrefix}-ok-skip`, 0, 'skipped', 'NOT_ELIGIBLE_UNDER_ONE_YEAR'])
+      expect(skipped.rowCount).toBe(1)
+    } finally {
+      await pool.query(`DELETE FROM attendance_leave_accrual_runs WHERE period_key LIKE $1`, [`annual:${runSuffix}%`]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('A2 auto-shift auto-write ledger — active-run claim and item invariants are DB-enforced (latent schema)', async () => {
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return


### PR DESCRIPTION
## What (L2a of the annual/statutory leave-balance engine — design-lock #2622, tracker §0.4)

**Latent schema only** — nothing reads/writes these yet (L2b accrual engine + L2c manual-adjust wire the runtime). One migration, three DDL changes:

- **`users.cumulative_service_start_date`** (DATE, nullable) — the 累计工龄 anchor for `tenureMode='cumulative_service'`. `hire_date` is 本单位入职日 only (valid **only** for `company_tenure`); a missing cumulative anchor makes the engine **skip with a visible reason**, never falls back to hire_date. Parallel to the existing users HR-profile columns; idempotent `ADD COLUMN IF NOT EXISTS`.
- **`attendance_leave_accrual_runs`** — one row per accrual execution, snapshotting the policy inputs used (`tenure_mode`/`timezone`/`standard_day_minutes`/`tiers`/`policy_version` + `dry_run`) so a snapshot-口径 grant stays auditable.
- **`attendance_leave_accrual_run_items`** — per-user computed entitlement + `status`/`skip_reason`; the `id` PK is the provenance back-link a granted lot's `source_id` points to (the #2622 P2 fix); `UNIQUE(run_id,user_id,leave_type_code)`.

**DB CHECK invariants** (so a future code bug can't persist a broken row): runs `tenure_mode`/`triggered_by` enums + `standard_day_minutes > 0`; run_items `status` enum + `entitlement_minutes >= 0` + the **granted↔no-reason / skipped↔reason** rule (provenance must always say *why* it skipped).

## Validation

- **Fresh DB migrated clean** (all origin/main migrations + this one), replay-idempotent.
- **Real-DB invariant test** (added to `attendance-plugin.test.ts` — already CI-wired, so it avoids the new-file skip-when-unreachable trap from #2270) asserts every CHECK/UNIQUE/FK fires (`23514`/`23505`/`23503`) + the users column exists.
- `tsc` clean (mirrors the C1 ledger migration). Timestamp `20260615170000` chosen clear of an **unmerged parallel** migration at `120000`.

Per connected-run A: opening for your merge. Next is **L2b** (accrual snapshot engine) — I'll bring its compute design (eligibility 连续/累计, proration floor, idempotency, dry-run semantics) to 拍板 **before** any real-logic code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)