### PR TITLE
feat(multitable): data-bar conditional formatting — FE mirror + grid render (A5-1b/c)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -329,7 +329,7 @@ import type {
   RowDensity,
 } from '../types'
 import type { SortRule } from '../composables/useMultitableGrid'
-import { composeStyleObject, type EvaluatedFormatting } from '../utils/conditional-formatting'
+import { composeStyleObject, type EvaluatedFormatting, type FieldScaleMap } from '../utils/conditional-formatting'
 
 interface ConditionalFormattingByRecord {
   byRecordId: Map<string, EvaluatedFormatting>
@@ -388,6 +388,7 @@ const props = defineProps<{
   canComment?: boolean
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
   conditionalFormatting?: ConditionalFormattingByRecord
+  conditionalFormattingScale?: FieldScaleMap
   aggregationConfig?: Record<string, string>
   aggregates?: Record<string, { fn: string; value: number }>
   aggregateTooLarge?: boolean
@@ -596,15 +597,26 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   const formatStyle = formatting
     ? composeStyleObject(undefined, formatting.cellStyles[fid])
     : undefined
+  // Data bar (A5-1): render the bar as a left-anchored gradient on the cell.
+  // Per design-lock §2.3 the bar takes the cell background; the operator rule's
+  // textColor still applies, but its backgroundColor is dropped so the two
+  // don't fight. Covers both the grouped and flat render paths (both call this).
+  const scale = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
+  const scaleStyle: Record<string, string> | undefined = scale
+    ? { backgroundImage: `linear-gradient(to right, ${scale.barColor} ${scale.barPct}%, transparent ${scale.barPct}%)` }
+    : undefined
+  const effectiveFormat: Record<string, string> | undefined = scale
+    ? (formatStyle?.color ? { color: formatStyle.color } : undefined)
+    : formatStyle
   // frozen body cell: sticky-left + an OPAQUE bg (occludes scrolled-under content). Preserve any
   // conditional-formatting backgroundColor — only fall back to #fff when formatting set none. (Row
   // hover/selection tint is still not shown on frozen cells — accepted MVP limitation; conditional
-  // formatting is NOT lost.)
+  // formatting is NOT lost.) With a data bar present, the opaque base is #fff so the gradient shows.
   const frozenStyle: Record<string, string> | undefined = frozen
-    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: formatStyle?.backgroundColor ?? '#fff' }
+    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: effectiveFormat?.backgroundColor ?? '#fff' }
     : undefined
-  if (!widthStyle && !formatStyle && !frozenStyle) return undefined
-  return { ...(widthStyle ?? {}), ...(formatStyle ?? {}), ...(frozenStyle ?? {}) }
+  if (!widthStyle && !effectiveFormat && !scaleStyle && !frozenStyle) return undefined
+  return { ...(widthStyle ?? {}), ...(effectiveFormat ?? {}), ...(scaleStyle ?? {}), ...(frozenStyle ?? {}) }
 }
 
 // ── frozen columns (left-prefix) ──────────────────────────────────────────

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -117,6 +117,32 @@ export interface ConditionalFormattingRule {
 
 export const CONDITIONAL_FORMATTING_RULE_LIMIT = 20
 
+// --- Range-based SCALE conditional formatting (A5: data bar / color scale / icon set) ---
+// Distinct from the operator-match rules above: a scale rule applies to EVERY
+// cell of a numeric field, mapping each value against the field's min/max range.
+// A5-1 = data bar. Mirrors backend conditional-formatting-service.ts.
+export type ConditionalFormattingScaleKind = 'dataBar' | 'colorScale' | 'iconSet'
+export interface ConditionalFormattingScaleRange {
+  mode: 'auto' | 'fixed'
+  min?: number
+  max?: number
+}
+export interface ConditionalFormattingDataBarConfig {
+  color: string
+  negativeColor?: string
+  showValue?: boolean
+}
+export interface ConditionalFormattingScaleRule {
+  id: string
+  order: number
+  fieldId: string
+  kind: ConditionalFormattingScaleKind
+  enabled: boolean
+  range: ConditionalFormattingScaleRange
+  dataBar?: ConditionalFormattingDataBarConfig
+}
+export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
+
 // --- Conditional field-visibility (form-conditional-fields MVP) ---
 // A field's `property.visibilityRule` is a single condition on ANOTHER field's
 // value in the same record; the form view shows/hides the field accordingly.

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -5,12 +5,16 @@
 // when extending the rule schema.
 
 import type {
+  ConditionalFormattingDataBarConfig,
   ConditionalFormattingOperator,
   ConditionalFormattingRule,
+  ConditionalFormattingScaleRange,
+  ConditionalFormattingScaleRule,
   ConditionalFormattingStyle,
   MetaField,
   MetaRecord,
 } from '../types'
+import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
 
 const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
 
@@ -368,4 +372,144 @@ export function composeStyleObject(
   if (bg) css.backgroundColor = bg
   if (fg) css.color = fg
   return Object.keys(css).length > 0 ? css : undefined
+}
+
+// ===========================================================================
+// Range-based SCALE formatting (A5-1: data bar) — frontend mirror of
+// packages/core-backend/src/multitable/conditional-formatting-service.ts.
+// Keep the sanitize/range/build semantics in sync with the canonical backend.
+// ===========================================================================
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+export function sanitizeScaleRule(input: unknown): ConditionalFormattingScaleRule | null {
+  if (!isPlainObject(input)) return null
+  const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
+  const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
+  if (!id || !fieldId) return null
+  if (input.kind !== 'dataBar') return null // A5-1: dataBar only (colorScale/iconSet = A5-2/A5-3)
+
+  const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
+  const enabled = input.enabled !== false
+
+  const rangeRaw = isPlainObject(input.range) ? input.range : {}
+  let range: ConditionalFormattingScaleRange
+  if (rangeRaw.mode === 'fixed') {
+    const min = toFiniteNumber(rangeRaw.min)
+    const max = toFiniteNumber(rangeRaw.max)
+    if (min === null || max === null || min === max) return null
+    range = { mode: 'fixed', min: Math.min(min, max), max: Math.max(min, max) }
+  } else {
+    range = { mode: 'auto' }
+  }
+
+  const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
+  const color = sanitizeHex(barRaw.color)
+  if (!color) return null
+  const dataBar: ConditionalFormattingDataBarConfig = { color }
+  const negativeColor = sanitizeHex(barRaw.negativeColor)
+  if (negativeColor) dataBar.negativeColor = negativeColor
+  if (barRaw.showValue === true) dataBar.showValue = true
+
+  return { id, order: Math.floor(orderRaw), fieldId, kind: 'dataBar', enabled, range, dataBar }
+}
+
+export function sanitizeScaleRules(input: unknown): ConditionalFormattingScaleRule[] {
+  if (!Array.isArray(input)) return []
+  const out: ConditionalFormattingScaleRule[] = []
+  for (const item of input) {
+    const rule = sanitizeScaleRule(item)
+    if (rule) out.push(rule)
+    if (out.length >= CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT) break
+  }
+  return out
+    .map((rule, index) => ({ rule, index }))
+    .sort((a, b) => a.rule.order - b.rule.order || a.index - b.index)
+    .map((entry) => entry.rule)
+}
+
+export function extractScaleRulesFromConfig(config: unknown): ConditionalFormattingScaleRule[] {
+  if (!isPlainObject(config)) return []
+  return sanitizeScaleRules(config.conditionalFormattingScaleRules)
+}
+
+export interface FieldScalePresentation {
+  barPct: number
+  barColor: string
+  negative: boolean
+}
+export interface FieldScaleResult {
+  rule: ConditionalFormattingScaleRule
+  min: number
+  max: number
+  byRecordId: Record<string, FieldScalePresentation>
+}
+export interface FieldScaleMap {
+  byField: Record<string, FieldScaleResult>
+}
+
+const EMPTY_SCALE_MAP: FieldScaleMap = Object.freeze({
+  byField: Object.freeze({}) as Record<string, FieldScaleResult>,
+}) as FieldScaleMap
+
+/**
+ * Pre-compute data-bar presentation per (fieldId, recordId). Mirrors the
+ * backend `buildFieldScaleMap`: min/max over the passed records (auto) or the
+ * rule's fixed range; each finite value → 0..100 fill; degenerate range → full
+ * bar; negatives take negativeColor; non-numeric skipped; first rule per field
+ * wins. Caller passes the already-loaded/masked rows (client-side discipline).
+ */
+export function buildFieldScaleMap(
+  rules: ConditionalFormattingScaleRule[],
+  records: ReadonlyArray<MetaRecord | { id?: string; data?: Record<string, unknown> }>,
+): FieldScaleMap {
+  if (!rules.length || !records.length) return EMPTY_SCALE_MAP
+  const byField: Record<string, FieldScaleResult> = {}
+
+  for (const rule of rules) {
+    if (!rule.enabled || rule.kind !== 'dataBar' || !rule.dataBar) continue
+    if (byField[rule.fieldId]) continue
+
+    let min: number
+    let max: number
+    if (rule.range.mode === 'fixed' && typeof rule.range.min === 'number' && typeof rule.range.max === 'number') {
+      min = rule.range.min
+      max = rule.range.max
+    } else {
+      let lo = Infinity
+      let hi = -Infinity
+      for (const record of records) {
+        const v = toComparableNumber(record?.data?.[rule.fieldId])
+        if (v === null) continue
+        if (v < lo) lo = v
+        if (v > hi) hi = v
+      }
+      if (lo === Infinity) continue
+      min = lo
+      max = hi
+    }
+
+    const span = max - min
+    const byRecordId: Record<string, FieldScalePresentation> = {}
+    for (const record of records) {
+      if (!record?.id) continue
+      const v = toComparableNumber(record.data?.[rule.fieldId])
+      if (v === null) continue
+      const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
+      const negative = v < 0
+      const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
+      byRecordId[record.id] = { barPct: pct, barColor, negative }
+    }
+    byField[rule.fieldId] = { rule, min, max, byRecordId }
+  }
+
+  if (Object.keys(byField).length === 0) return EMPTY_SCALE_MAP
+  return { byField }
 }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -259,6 +259,7 @@
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
           :conditional-formatting="conditionalFormattingByRecord"
+          :conditional-formatting-scale="conditionalFormattingScaleByField"
           :ai-run-enabled="effectiveRowActions.canEdit"
           :ai-run-pending="Boolean(aiShortcut.state.pending)"
           :ai-run-busy="aiShortcutBusy"
@@ -548,7 +549,7 @@ import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue }
 import { parseFrozenIds } from '../utils/frozen-columns'
 import { useAiShortcut } from '../composables/useAiShortcut'
 import type { AiShortcutConfigInput } from '../api/client'
-import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
+import { buildFieldScaleMap, buildRecordFormattingMap, extractRulesFromConfig, extractScaleRulesFromConfig } from '../utils/conditional-formatting'
 import {
   decorateAndSortBases,
   readFavoriteBaseIds,
@@ -904,6 +905,12 @@ const conditionalFormattingByRecord = computed(() => buildRecordFormattingMap(
   conditionalFormattingRules.value,
   grid.rows.value,
   scopedAllFields.value,
+))
+// A5-1: data-bar scale formatting. min/max over the already-loaded/masked rows
+// (client-side discipline; full-column server aggregate is a separate follow-up).
+const conditionalFormattingScaleByField = computed(() => buildFieldScaleMap(
+  extractScaleRulesFromConfig(workbench.activeView.value?.config),
+  grid.rows.value,
 ))
 const readOnlyFieldIds = computed(() =>
   Object.entries(effectiveFieldPermissions.value)

--- a/apps/web/tests/multitable-cf-scale.spec.ts
+++ b/apps/web/tests/multitable-cf-scale.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFieldScaleMap,
+  extractScaleRulesFromConfig,
+  sanitizeScaleRule,
+  sanitizeScaleRules,
+} from '../src/multitable/utils/conditional-formatting'
+import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../src/multitable/types'
+
+// Frontend mirror of the backend scale-rule tests
+// (packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts).
+// Keep behaviour identical — the FE builder must match the canonical backend.
+
+const validBar = (over: Record<string, unknown> = {}) => ({
+  id: 's1', fieldId: 'fld_n', kind: 'dataBar', order: 0,
+  range: { mode: 'auto' }, dataBar: { color: '#2196f3' }, ...over,
+})
+
+describe('FE conditional-formatting scale mirror (A5-1 data bar)', () => {
+  describe('sanitizeScaleRule', () => {
+    it('accepts a valid dataBar rule with auto range', () => {
+      expect(sanitizeScaleRule(validBar())).toEqual({
+        id: 's1', order: 0, fieldId: 'fld_n', kind: 'dataBar', enabled: true,
+        range: { mode: 'auto' }, dataBar: { color: '#2196f3' },
+      })
+    })
+
+    it('rejects colorScale / iconSet (A5-2 / A5-3)', () => {
+      expect(sanitizeScaleRule(validBar({ kind: 'colorScale' }))).toBeNull()
+      expect(sanitizeScaleRule(validBar({ kind: 'iconSet' }))).toBeNull()
+    })
+
+    it('requires id/fieldId/valid hex color', () => {
+      expect(sanitizeScaleRule(validBar({ id: '' }))).toBeNull()
+      expect(sanitizeScaleRule(validBar({ dataBar: { color: 'blue' } }))).toBeNull()
+    })
+
+    it('normalizes fixed range and rejects degenerate / non-numeric bounds', () => {
+      expect(sanitizeScaleRule(validBar({ range: { mode: 'fixed', min: 100, max: 0 } }))?.range)
+        .toEqual({ mode: 'fixed', min: 0, max: 100 })
+      expect(sanitizeScaleRule(validBar({ range: { mode: 'fixed', min: 5, max: 5 } }))).toBeNull()
+      expect(sanitizeScaleRule(validBar({ range: { mode: 'fixed', min: 'x', max: 9 } }))).toBeNull()
+    })
+
+    it('caps + order-sorts via sanitizeScaleRules; extractScaleRulesFromConfig reads the key', () => {
+      const many = Array.from({ length: CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT + 5 }, (_, i) => validBar({ id: `s${i}`, fieldId: `f${i}`, order: i }))
+      expect(sanitizeScaleRules(many)).toHaveLength(CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT)
+      expect(extractScaleRulesFromConfig({ conditionalFormattingScaleRules: [validBar()] })).toHaveLength(1)
+      expect(extractScaleRulesFromConfig({})).toEqual([])
+    })
+  })
+
+  describe('buildFieldScaleMap', () => {
+    const recs = [
+      { id: 'r1', data: { fld_n: 0 } },
+      { id: 'r2', data: { fld_n: 50 } },
+      { id: 'r3', data: { fld_n: 100 } },
+    ]
+    const rule = sanitizeScaleRule(validBar())!
+
+    it('maps values to fill percent over auto min/max', () => {
+      const f = buildFieldScaleMap([rule], recs).byField.fld_n
+      expect([f.min, f.max]).toEqual([0, 100])
+      expect(f.byRecordId.r1.barPct).toBe(0)
+      expect(f.byRecordId.r2.barPct).toBe(50)
+      expect(f.byRecordId.r3.barPct).toBe(100)
+    })
+
+    it('full bar on degenerate range; clamps fixed out-of-bounds; skips non-numeric', () => {
+      expect(buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 7 } }, { id: 'b', data: { fld_n: 7 } }]).byField.fld_n.byRecordId.a.barPct).toBe(100)
+      const fixed = sanitizeScaleRule(validBar({ range: { mode: 'fixed', min: 0, max: 100 } }))!
+      const m = buildFieldScaleMap([fixed], [
+        { id: 'a', data: { fld_n: 'n/a' } },
+        { id: 'b', data: { fld_n: 200 } },
+        { id: 'c', data: { fld_n: -50 } },
+      ]).byField.fld_n
+      expect(m.byRecordId.a).toBeUndefined()
+      expect(m.byRecordId.b.barPct).toBe(100)
+      expect(m.byRecordId.c.barPct).toBe(0)
+    })
+
+    it('colors negatives with negativeColor + flags them; first rule per field wins', () => {
+      const negRule = sanitizeScaleRule(validBar({ dataBar: { color: '#2196f3', negativeColor: '#f44336' } }))!
+      const nm = buildFieldScaleMap([negRule], [{ id: 'a', data: { fld_n: -10 } }, { id: 'b', data: { fld_n: 10 } }]).byField.fld_n
+      expect([nm.byRecordId.a.negative, nm.byRecordId.a.barColor]).toEqual([true, '#f44336'])
+      expect([nm.byRecordId.b.negative, nm.byRecordId.b.barColor]).toEqual([false, '#2196f3'])
+
+      const r1 = sanitizeScaleRule(validBar({ id: 'a', order: 0, dataBar: { color: '#111111' } }))!
+      const r2 = sanitizeScaleRule(validBar({ id: 'b', order: 1, dataBar: { color: '#222222' } }))!
+      expect(buildFieldScaleMap([r1, r2], recs).byField.fld_n.rule.id).toBe('a')
+    })
+
+    it('returns an empty map when a field has no numeric values', () => {
+      expect(buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
+    })
+  })
+})

--- a/apps/web/tests/multitable-grid-databar.spec.ts
+++ b/apps/web/tests/multitable-grid-databar.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField } from '../src/multitable/types'
+import { buildFieldScaleMap, sanitizeScaleRule } from '../src/multitable/utils/conditional-formatting'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount(); app = null
+  container?.remove(); container = null
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'amount', name: 'Amount', type: 'number' },
+  { id: 'label', name: 'Label', type: 'string' },
+]
+
+const ROWS = [
+  { id: 'r1', version: 1, data: { amount: 0, label: 'a' } },
+  { id: 'r2', version: 1, data: { amount: 50, label: 'b' } },
+  { id: 'r3', version: 1, data: { amount: 100, label: 'c' } },
+]
+
+function mountGrid(props: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: ROWS, visibleFields: FIELDS, sortRules: [], loading: false,
+        currentPage: 1, totalPages: 1, startIndex: 0, canEdit: true,
+        searchText: '', rowDensity: 'normal', ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+// The Amount cell is the 1st `.meta-grid__cell` of each row; with 3 rows the
+// data cells are [r1.amount, r1.label, r2.amount, r2.label, r3.amount, ...].
+function dataCells(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll('tbody .meta-grid__cell')) as HTMLElement[]
+}
+
+const scaleFor = (over: Record<string, unknown> = {}) =>
+  buildFieldScaleMap([sanitizeScaleRule({ id: 's1', fieldId: 'amount', kind: 'dataBar', order: 0, range: { mode: 'auto' }, dataBar: { color: '#2196f3' }, ...over })!], ROWS)
+
+describe('MetaGridTable — data-bar conditional formatting (A5-1c render)', () => {
+  it('renders a left-anchored gradient on the numeric cell scaled to the value', () => {
+    const root = mountGrid({ conditionalFormattingScale: scaleFor() })
+    const cells = dataCells(root)
+    // r1.amount = 0 → 0% ; r2.amount = 50 → 50% ; r3.amount = 100 → 100%
+    expect(cells[0].style.backgroundImage).toContain('0%')
+    expect(cells[2].style.backgroundImage).toContain('linear-gradient')
+    expect(cells[2].style.backgroundImage).toContain('50%')
+    expect(cells[4].style.backgroundImage).toContain('100%')
+  })
+
+  it('does not put a bar on a non-scaled field (Label)', () => {
+    const root = mountGrid({ conditionalFormattingScale: scaleFor() })
+    const cells = dataCells(root)
+    expect(cells[1].style.backgroundImage).toBe('') // r1.label — no scale rule
+  })
+
+  it('renders no gradient at all when no scale map is provided', () => {
+    const root = mountGrid({})
+    expect(dataCells(root)[0].style.backgroundImage).toBe('')
+  })
+
+  it('data bar takes the background but keeps an operator-rule textColor', () => {
+    const root = mountGrid({
+      conditionalFormattingScale: scaleFor(),
+      conditionalFormatting: {
+        rules: [],
+        byRecordId: new Map([['r2', { rowStyle: undefined, cellStyles: { amount: { backgroundColor: '#ffeeee', textColor: '#111111' } }, matchedRuleIds: [] }]]),
+      },
+    })
+    const cells = dataCells(root)
+    // r2.amount: bar present, operator backgroundColor dropped, textColor kept
+    expect(cells[2].style.backgroundImage).toContain('linear-gradient')
+    expect(cells[2].style.backgroundColor).toBe('') // operator bg dropped under the bar
+    expect(cells[2].style.color).toBe('rgb(17, 17, 17)') // textColor preserved
+  })
+})


### PR DESCRIPTION
## Summary

The FE half of the A5 data-bar feature (depends on the A5-1a backend contract #2639), shipped as one unit since the render can't exist without the mirror:

- **A5-1b (FE mirror):** ports the scale-rule types + `sanitizeScaleRule(s)` + `extractScaleRulesFromConfig` + `buildFieldScaleMap` into `conditional-formatting.ts` (the FE mirror of the canonical backend), behaviour identical to the backend.
- **A5-1c (render):** `MetaGridTable.cellStyle()` emits a left-anchored `linear-gradient` (barColor → barPct%, transparent after) when a field/record has a data-bar presentation — done in `cellStyle` so it covers **both** the grouped and flat render paths with no markup/layering risk. Per design-lock §2.3 the bar takes the cell background and the operator rule's backgroundColor is dropped (no double bg) while textColor still applies; frozen cells keep an opaque #fff base. `MultitableWorkbench` computes `buildFieldScaleMap` over the loaded rows and passes `:conditional-formatting-scale`.

## Verification

**13 FE tests** (9 mirror parity + 4 jsdom render: bar width scales 0/50/100%, non-scaled field gets no bar, no-map → no gradient, bar-bg + operator-textColor coexist). `vue-tsc` can't run on local Node 25 — CI's web build is the type gate.

**Note:** jsdom verifies bar presence/width/color/precedence; final visual polish (exact alignment/contrast) to be confirmed on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)