### PR TITLE
feat(data-source): add source field picker

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -580,7 +580,24 @@
           <div class="integration-workbench__mapping-editor">
             <label>
               <span>源字段</span>
-              <input v-model="mapping.sourceField" :data-testid="`source-field-${index}`" placeholder="例如 code" />
+              <select
+                v-if="hasSourceFieldOptions"
+                v-model="mapping.sourceField"
+                :data-testid="`source-field-${index}`"
+              >
+                <option value="">请选择来源字段</option>
+                <option
+                  v-for="option in sourceFieldOptionsForMapping(mapping)"
+                  :key="`${option.stale ? 'stale' : 'schema'}:${option.value}`"
+                  :value="option.value"
+                >
+                  {{ sourceFieldOptionText(option) }}
+                </option>
+              </select>
+              <input v-else v-model="mapping.sourceField" :data-testid="`source-field-${index}`" placeholder="例如 code" />
+              <small v-if="hasSourceFieldOptions" class="integration-workbench__field-help" :data-testid="`source-field-picker-help-${index}`">
+                字段来自来源 schema；这里只保存字段名，不显示行值。
+              </small>
             </label>
             <label>
               <span>目标字段</span>
@@ -1271,6 +1288,13 @@ interface EditableMapping {
   maxValueText: string
 }
 
+interface SourceFieldOption {
+  value: string
+  label: string
+  type: string
+  stale: boolean
+}
+
 interface StagingDatasetCard {
   id: string
   name: string
@@ -1428,6 +1452,19 @@ const stagingSheetId = ref('')
 const sourceSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
 const targetSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
 const mappings = ref<EditableMapping[]>([])
+const sourceFieldOptions = computed<SourceFieldOption[]>(() => sourceSchema.value.fields
+  .map((field) => {
+    const value = field.name.trim()
+    if (!value) return null
+    return {
+      value,
+      label: field.label ? `${field.label} · ${value}` : value,
+      type: typeof field.type === 'string' ? field.type : '',
+      stale: false,
+    }
+  })
+  .filter((item): item is SourceFieldOption => item !== null))
+const hasSourceFieldOptions = computed(() => sourceFieldOptions.value.length > 0)
 const previewText = ref('尚未生成预览')
 // DF-T1.5: read-only provenance summary derived from a DF-T1 targetPayloadPreview (null = nothing to show).
 const previewProvenance = ref<ReturnType<typeof summarizeFieldProvenance>>(null)
@@ -3173,6 +3210,27 @@ async function useStagingAsTarget(objectId: string): Promise<void> {
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }
+}
+
+function sourceFieldOptionText(option: SourceFieldOption): string {
+  if (option.type) return `${option.label} · ${option.type}`
+  return option.label
+}
+
+function sourceFieldOptionsForMapping(mapping: EditableMapping): SourceFieldOption[] {
+  const currentValue = mapping.sourceField.trim()
+  if (!currentValue || sourceFieldOptions.value.some((option) => option.value === currentValue)) {
+    return sourceFieldOptions.value
+  }
+  return [
+    {
+      value: currentValue,
+      label: `当前值 · ${currentValue}（未在来源 schema 中）`,
+      type: '',
+      stale: true,
+    },
+    ...sourceFieldOptions.value,
+  ]
 }
 
 function guessSourceField(targetField: string): string {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2334,6 +2334,130 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
   })
 
+  it('C4-2: maps source fields through a schema-backed picker and sends the selected field in preview', async () => {
+    const previewBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP Target', roles: ['target'], supports: ['upsert'], advanced: false },
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['read'], advanced: true },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'pg-1', object: 'public.items' },
+          },
+          {
+            id: 'target_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'ERP target',
+            kind: 'http',
+            role: 'target',
+            status: 'active',
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return jsonResponse([{ name: 'public.items', label: 'Items', operations: ['read'], source: 'data-source:sql-readonly' }])
+      }
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/schema')) {
+        return jsonResponse({
+          object: 'public.items',
+          fields: [
+            { name: 'materialCode', label: 'Material Code', type: 'string' },
+            { name: 'itemName', label: 'Item Name', type: 'string' },
+          ],
+        })
+      }
+      if (url.startsWith('/api/integration/external-systems/target_1/objects')) {
+        return jsonResponse([{ name: 'material', label: 'Material', operations: ['upsert'], target: 'http' }])
+      }
+      if (url.startsWith('/api/integration/external-systems/target_1/schema')) {
+        return jsonResponse({
+          object: 'material',
+          fields: [
+            { name: 'FNumber', label: 'Material number', type: 'string', required: true },
+            { name: 'FName', label: 'Material name', type: 'string' },
+          ],
+          template: { id: 'material.v1', bodyKey: 'Data' },
+        })
+      }
+      if (url === '/api/integration/templates/preview') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        previewBodies.push(body)
+        return jsonResponse({
+          valid: true,
+          payload: { Data: { FNumber: 'MAT-001' } },
+          targetRecord: { FNumber: 'MAT-001' },
+          errors: [],
+          transformErrors: [],
+          validationErrors: [],
+          schemaErrors: [],
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).checked = true
+    container.querySelector('[data-testid="show-advanced-connectors"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const targetSystemSelect = container.querySelector('[data-testid="target-system"]') as HTMLSelectElement
+    targetSystemSelect.value = 'target_1'
+    targetSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-target-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const sourceField = container.querySelector('[data-testid="source-field-0"]') as HTMLSelectElement
+    expect(sourceField.tagName).toBe('SELECT')
+    expect(container.querySelector('[data-testid="source-field-picker-help-0"]')?.textContent).toContain('不显示行值')
+    const optionTexts = Array.from(sourceField.options).map((option) => option.textContent?.trim())
+    expect(optionTexts).toContain('当前值 · code（未在来源 schema 中）')
+    expect(optionTexts).toContain('Material Code · materialCode · string')
+    expect(optionTexts).toContain('Item Name · itemName · string')
+
+    sourceField.value = 'materialCode'
+    sourceField.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    expect(previewBodies).toHaveLength(1)
+    expect(previewBodies[0]).toMatchObject({
+      fieldMappings: [
+        { sourceField: 'materialCode', targetField: 'FNumber' },
+        { sourceField: 'name', targetField: 'FName' },
+      ],
+    })
+    expect(JSON.stringify(previewBodies[0])).not.toMatch(/password|token|secret|credential/i)
+  })
+
   it('C3: shows an enabled approval automation entry for an entitled Yuantus PLM data-source bridge and marks stubbed actions', async () => {
     const capabilityCalls: string[] = []
     apiFetchMock.mockImplementation(async (url: string) => {


### PR DESCRIPTION
## Summary

- add a schema-backed source-field picker to the Integration Workbench mapping editor when the selected source schema has fields
- keep the existing free-text source-field input as the fallback when no source schema fields are loaded
- preserve stale existing sourceField values as an explicit current-value option so the picker does not silently blank or drop existing mappings

## Boundaries

- frontend-only C4-2 slice
- no backend/runtime/watermark/K3/external-write changes
- picker options use schema field name/label/type only; the existing preview request contract is unchanged and still carries the operator sample record where that flow already did

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue tests/IntegrationWorkbenchView.spec.ts` (0 errors, existing RouterLink/test-component warnings)
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- subagent read-only review: APPROVE, no P1/P2/P3 findings
