### PR TITLE
docs(multitable): benchmark-surpass arc goal + gated TODO

### DIFF
--- a/docs/development/multitable-autonomous-tier-closeout-20260615.md
+++ b/docs/development/multitable-autonomous-tier-closeout-20260615.md
@@ -8,9 +8,12 @@ tier of "余下多维表功能开发" driven to completion this session.
 
 Per #2650 §0, "余下开发" splits by terminal gate; only the **autonomous** tier
 (pure backend, unit + tsc closeable) can be driven to *done* without a privileged
-actor. This session drove that tier to completion:
+actor. That tier is now **complete on main** — though a parallel session won the
+merge race on the build slices. The state + this session's net durable contributions:
 
-- **A5-2 color-scale + A5-3 icon-set backend** — built, verified, draft **PR #2663**.
+- **A5-2 color-scale + A5-3 icon-set backend** — landed on main via **#2664**
+  (parallel session, incl. the kind-aware render); independently built here
+  (#2663, **closed redundant**) — convergent validation, 4th same-arc collision.
 - **A2 export masking-flag** — verified **SAFE** (no fix needed); concern closed.
 - **Button-arc independent audit** — produced a B1-c gate checklist (handoff).
 
@@ -18,7 +21,16 @@ The **browser-gated** and **owner/ops-gated** tiers cannot be auto-completed; th
 are design-locked and gate-marked in the tracker, not faked as "verified." Merge of
 #2663 is the owner's (nothing auto-merges).
 
-## 1. Development delivered — A5-2 / A5-3 conditional-format scale backend (PR #2663)
+## 1. A5-2 / A5-3 conditional-format scale backend — landed via #2664 (parallel); independently validated here
+
+**Status:** A5-2/A5-3 landed on `main` via the parallel session's **#2664**, which
+also shipped the kind-aware grid render. This session independently built the same
+slice (PR **#2663**, now **closed redundant**) — the two builds converged on the
+same sanitizer / `buildFieldScaleMap` extension, which is confirmatory. The
+contract + verification below describe this session's independent build; #2664 is
+the merged implementation (equivalent design — its degenerate `min==max` → max-stop
+vs this build's mid-stop is a documented design choice, not a defect — and #2664
+additionally shipped the render this build had deferred as browser-gated).
 
 Extends the A5-1 data-bar scale machinery to the two remaining range styles.
 
@@ -121,12 +133,12 @@ A3 inline-link expand · A4 form-logic depth · B4 dashboard widgets · B5 longT
 row-level rule permissions · B2 AI auto-trigger · B3 native synced tables · C1 SMTP
 creds · C2 template content · C4 mobile · A2 server-side full-dataset export.
 
-## 5. Cleanup + open PRs from this session
+## 5. PRs from this session
 
-- **PR #2663** — A5-2/A5-3 backend (draft, ready for review).
-- **PR #2647** — execution tracker + this closeout (draft).
-- **#2644** (button scope-gate) — superseded by merged #2645; recommend close.
-- **#2641** (飞书 refresh research) — overlaps merged #2629; owner to decide.
+- **PR #2647** — execution tracker + this closeout + the button-arc audit (open).
+- **#2663** (A5-2/A5-3) — **CLOSED redundant** (merged #2664 landed it + render).
+- **#2644** (button scope-gate) — **CLOSED** (superseded by merged #2645).
+- **#2641** (飞书 research) — **CLOSED** (overlaps merged #2629; branch retained).
 
 ## 6. Re-entry
 

--- a/docs/development/multitable-autonomous-tier-closeout-20260615.md
+++ b/docs/development/multitable-autonomous-tier-closeout-20260615.md
@@ -1,0 +1,136 @@
+# Multitable Remaining-Development — Autonomous-Tier Closeout (dev + verification) — 2026-06-15
+
+Companion to the execution tracker `multitable-benchmark-arc-todo-20260615.md` and
+the canonical map #2650. This is the dev + verification record for the autonomous
+tier of "余下多维表功能开发" driven to completion this session.
+
+## 0. Scope + honest completion statement
+
+Per #2650 §0, "余下开发" splits by terminal gate; only the **autonomous** tier
+(pure backend, unit + tsc closeable) can be driven to *done* without a privileged
+actor. This session drove that tier to completion:
+
+- **A5-2 color-scale + A5-3 icon-set backend** — built, verified, draft **PR #2663**.
+- **A2 export masking-flag** — verified **SAFE** (no fix needed); concern closed.
+- **Button-arc independent audit** — produced a B1-c gate checklist (handoff).
+
+The **browser-gated** and **owner/ops-gated** tiers cannot be auto-completed; they
+are design-locked and gate-marked in the tracker, not faked as "verified." Merge of
+#2663 is the owner's (nothing auto-merges).
+
+## 1. Development delivered — A5-2 / A5-3 conditional-format scale backend (PR #2663)
+
+Extends the A5-1 data-bar scale machinery to the two remaining range styles.
+
+**Built** (5 files; backend canonical + FE mirror):
+- `conditional-formatting-service.ts`: `ConditionalFormattingColorScaleConfig` +
+  `ConditionalFormattingIconSetConfig` types; per-kind `sanitizeConditionalFormattingScaleRule`
+  (replaced the `kind !== 'dataBar'` early-reject); RGB-interpolation helpers; a
+  3-kind `buildFieldScaleMap`.
+- `apps/web/.../utils/conditional-formatting.ts` + `types.ts`: byte-identical FE mirror.
+- Two unit specs: separate `colorScale` / `iconSet` describe blocks.
+
+**Contract:**
+- colorScale: 2 or 3 stops, each a valid `sanitizeHex` color, anchor set exactly
+  `{min,max}` (2) or `{min,mid,max}` (3) — dup/missing anchor, 1 stop, 4 stops all
+  reject. `scaleColor` = normalized `t=(v-min)/(max-min)` clamped [0,1]; 2-stop
+  linear RGB lerp; 3-stop piecewise with mid anchored at t=0.5. Degenerate
+  `min==max` → mid color (deliberately diverges from dataBar's degenerate=full-bar).
+- iconSet: `set ∈ {arrows3,traffic3,signs3}`, `thresholds=[t0,t1]` finite +
+  monotonic (`t0<=t1`). `iconKey` by ABSOLUTE thresholds (`v<t0`→low,
+  `t0<=v<t1`→mid, `v>=t1`→high); percentile mode noted as a follow-up.
+- dataBar path UNCHANGED; unknown kind → null (forward-dated-config guard kept).
+
+**Verified (all real):**
+- `tsc -p tsconfig.json` (core-backend) exit 0; `vue-tsc -b` (web) exit 0.
+- cond-format spec 70/70; full backend unit suite **3296/3296** (no regression);
+  FE cf-scale 24 + conditional-formatting 25 + grid-databar 4 + dialog-i18n 4.
+- **94 scale/cf tests** total (BE 70 + FE 24).
+- FE↔BE parity is load-bearing (separate vitest projects, no cross-package harness):
+  the 7 shared scale helpers + the expected `scaleColor`/`iconKey` literals were
+  diffed **byte-identical** across both specs — the mirror-drift trap closed.
+- Harden caught a real masked test gap: the 3-stop upper segment (mid↔max) was only
+  exercised at t=1 (where lerp returns `stops[2]` regardless), masking a plausible
+  bug; added an interior assertion at t=0.75 → `#80ff00`, proven non-vacuous
+  (injecting the wrong stop index yields `#808000` and fails it).
+
+**Render-slice blocker (carried in the PR):** the sanitizer now ACCEPTS
+colorScale/iconSet, but `MetaGridTable.vue:606` is still kind-blind (paints a
+data-bar gradient from any scale entry → `linear-gradient(…undefined…)`). Safe
+intermediate state today (the dialog, the only config producer, is dataBar-only),
+but the render slice MUST make the cell renderer kind-aware **before** colorScale/
+iconSet authoring ships.
+
+## 2. Verification delivered — A2 export masking (SAFE; no code)
+
+Question (#2650 §4): does the FE multitable export bypass server-side field masking?
+
+**Verdict: SAFE (high confidence) — investigate + adversarial-refute both agree.**
+
+- Read path masks VALUES: `GET /view` applies
+  `row.data = filterRecordDataByFieldIds(row.data, allowedFieldIds)` at
+  `univer-meta.ts:8128`; `filterRecordDataByFieldIds` (`:3133`) physically keeps
+  only allowed keys. `allowedFieldIds` = visible-gate (`:7855`) narrowed by the
+  formula-taint chokepoint `maskStoredRecordFieldIds` (`:7865`, monotone — only
+  deletes).
+- Export reads only `grid.rows` (set from the `/view` response,
+  `useMultitableGrid.ts:476`), columns bounded by `scopedGridFields` (`:898`) —
+  no unmasked re-read.
+- Set relationship (the crux): `scopedGridFields ⊆ allowedFieldIds`, so every
+  offered column is a value the server did NOT drop.
+- All four value-injection channels apply the full composite mask: `GET /view`
+  (8128), `GET /records/:id` (9319), submit echo (8804), PATCH echo (9024). The
+  strongest counter-case (formula-taint + realtime full-record refresh) was chased
+  and confirmed closed (taint-narrowing precedes the value filter on re-fetch).
+- Non-bypass caveats (display-preference, not leaks): layer-1 view-hidden-but-
+  readable values ride on the wire but the user could unhide them and
+  `scopedGridFields` excludes them from offered columns.
+
+The FE `scopedGridFields` filter is defense-in-depth; the **server data-mask is the
+security boundary**. No fix required.
+
+## 3. Verification delivered — button-arc independent audit (B1-c gate checklist)
+
+Full report: `/tmp/multitable-button-arc-audit-claude-20260615.md`. Read-only audit
+of the merged button arc (#2645/#2648/#2653/#2657), every high/medium finding
+adversarially refuted.
+
+**Verdict: sound today — every value-leak is LATENT** (no path on main creates a
+`button` field yet; `MULTITABLE_FIELD_INPUT_TYPES` omits it). But a real spec-gap
+pattern exists: the button write-less invariant is enforced **inconsistently across
+3+ serializers/write paths** (bulk-UPDATE rejects; single-record CREATE via
+`record-service.ts:222` and the route-layer `univer-meta` sanitizer do not). These
+go **live the instant B1-c wires button creation** — so they are a **B1-c gate
+checklist** (design-lock §2 mandates closing each there).
+
+- **Single highest-leverage fix:** add `'button'` to `isFieldAlwaysReadOnly`
+  (`permission-derivation.ts:58`) as a TYPE-level always-readonly — closes the
+  create/update/patch/xlsx asymmetry in one gate.
+- **AUDIT-1 (live spec divergence):** the merged `button/run` route only does
+  `logger.info`, not a durable `AutomationLogService.record()` row (design-lock
+  §5.2). Worth reconciling.
+
+## 4. Remaining ladder (gated — cannot be auto-completed)
+
+**browser-gated** (backend autonomous; terminal slice needs a real browser): B1-b /
+B1-c · A5-2/A5-3 grid render + dialog (+ the kind-aware renderer blocker above) ·
+A3 inline-link expand · A4 form-logic depth · B4 dashboard widgets · B5 longText
+@mention · B6 comment reactions.
+
+**owner/ops-gated:** A1 grid virtualization (owner S5b staging baseline) · B7
+row-level rule permissions · B2 AI auto-trigger · B3 native synced tables · C1 SMTP
+creds · C2 template content · C4 mobile · A2 server-side full-dataset export.
+
+## 5. Cleanup + open PRs from this session
+
+- **PR #2663** — A5-2/A5-3 backend (draft, ready for review).
+- **PR #2647** — execution tracker + this closeout (draft).
+- **#2644** (button scope-gate) — superseded by merged #2645; recommend close.
+- **#2641** (飞书 refresh research) — overlaps merged #2629; owner to decide.
+
+## 6. Re-entry
+
+The autonomous tier is closed. Next (each a named opt-in): review/merge #2663;
+fold the B1-c gate checklist into the B1-c PR when button creation is wired; then
+re-run the refresh audit to re-rank the gated ladder before opening any browser- or
+owner-gated arc.

--- a/docs/development/multitable-autonomous-tier-closeout-20260615.md
+++ b/docs/development/multitable-autonomous-tier-closeout-20260615.md
@@ -91,7 +91,7 @@ security boundary**. No fix required.
 
 ## 3. Verification delivered — button-arc independent audit (B1-c gate checklist)
 
-Full report: `/tmp/multitable-button-arc-audit-claude-20260615.md`. Read-only audit
+Full report: `docs/research/multitable-button-arc-audit-20260615.md`. Read-only audit
 of the merged button arc (#2645/#2648/#2653/#2657), every high/medium finding
 adversarially refuted.
 

--- a/docs/development/multitable-benchmark-arc-todo-20260615.md
+++ b/docs/development/multitable-benchmark-arc-todo-20260615.md
@@ -1,0 +1,79 @@
+# Multitable Benchmark-Surpass Track — Development Goal + TODO (2026-06-15)
+
+Type: development goal + gated TODO ledger (trackable). Not a schedule.
+
+Driver: the owner-set standing goal — multitable driven by **对标并超越** the
+leading 多维表格 product. Each refresh audit re-ranks the gap ladder; each arc and
+each slice within an arc is a **separate named opt-in** — never auto-advance.
+
+Rationale + the benchmark evidence (external-product comparison, citations) live
+in the research companion, NOT here: `docs/research/multitable-feishu-refresh-audit-20260615.md`
+(PR #2641). This committed plan uses MetaSheet's own capability names only.
+
+Markers: ✅ done · ⬜ ready / in progress (current opt-in) · 🔒 gated (needs its
+own named opt-in / a prereq).
+
+## 0. Current arc — B1: button / action field
+
+A value-less `button` field type whose cell, on click, runs **one** bound action
+on its row's record by reusing the existing single-action execution path. Inherits
+all record permission / lock / cross-base / redaction / observability gates — no
+new automation-engine code (prereq verified: synthetic `btn_` rule_id has no FK;
+the C1 runs read path is sheet-scoped).
+
+Scope gate (the contract): `multitable-button-action-field-scope-gate-20260615.md`
+(PR #2644, ready for review).
+
+| Slice | State | What | Acceptance |
+|---|---|---|---|
+| B1-a field-type + codec | ⬜ in progress (PR pending) | register the value-less `button` type; codec accepts `{label, exactly-one existing action}`, rejects empty label / 0 or 2+ actions / unknown action / the 4 suspending-branching actions; `validate` rejects any stored value | sanitizeProperty accept/reject unit tests + value-PATCH rejected; tsc clean |
+| B1-b run endpoint | 🔒 after B1-a + owner go | authenticated, record-scoped POST that runs the bound action via the existing single-action engine (synthetic non-persisted single-action `workflow_job_v1` envelope); explicit record-write capability check; lock / cross-base / redaction inherited; one C1 job + execution-log row | real-DB: action runs + writes; 401/403/lock/404 fail-closed; one C1 job (`resolved`) + log whose `btn_` rule_id resolves to no rule; wire round-trip; double-run = two executions |
+| B1-c FE cell | 🔒 after B1-b | render label + clickable control (not editable, no editor on dblclick); invoke the endpoint; in-flight disable + result toast; disabled when locked / no write capability | renders + invokes; never writes a value; disabled states |
+
+**Definition of done (B1):** all three slices landed + the real-DB B1-b E2E green;
+out-of-scope items below stay rejected.
+
+**B1 hard out-of-scope (each = its own future opt-in):** no new action types; no
+multi-action / conditional / triggered / scheduled runs; no suspending-branching
+bound actions (`wait_for_callback` / `start_approval` / `condition_branch` /
+`parallel_branch`); no new RBAC tier; no bypass of locks / permission / redaction;
+no public/unauthenticated endpoint; no persisted synthetic rule.
+
+## 1. Post-B1 ladder (demand-gated, ranked by the 2026-06-15 refresh audit)
+
+Each is a separate arc; open only on a named demand + when its gate clears. The
+ranking is the audit's; it re-ranks on the next refresh.
+
+| Arc | State | Capability | Gate |
+|---|---|---|---|
+| A1 | 🔒 | grid row virtualization / windowing (large tables) | L; ops — needs the perf baseline first |
+| B4 | 🔒 | dashboard non-chart widgets (metrics, pivot, filter linkage) | small chain → L; named demand |
+| A5 | 🔒 | conditional-format depth (data bars / color scales / icon sets) | M; named demand |
+| A4 | 🔒 | form-logic depth (required-if / multi-page / prefill / redirect) | M; named demand |
+| B2 | 🔒 | AI field rings + AI-automation node | L per ring; product charter |
+| B7 | 🔒 | row-level rule-engine permissions (value-based) | L; owner + adversarial review |
+| B3 | 🔒 | native synced / external-source tables | XL; owner — parked |
+
+**Already at parity-or-ahead (the "surpass" wins, keep, don't rebuild):** governed
+cross-base writes + rate quota + claim==truth; security-grade masked export + leak
+canary + sanitize/AI-taint chokepoints; formula-over-lookup with in-memory
+hydration; the just-landed branch-local wait + condition-branch + parallel join-all
+automation engine. Honest reverse-gap: the benchmark leads on AI / scale / BI
+richness — surpass concentrates in governance / security / workflow orchestration.
+
+## 2. Execution discipline
+
+- **One opt-in at a time.** B1-a is the only ⬜ now; B1-b/B1-c and every §1 arc are
+  🔒 until separately named. "Continue the arc" is enough to advance the next B1
+  slice; opening a §1 arc needs naming that capability + its gate clearing.
+- **Contract-first per arc:** scope-gate (docs) → owner review → runtime slices.
+- **Each runtime slice proves out** with the tests its scope-gate pins (real-DB for
+  any write/endpoint), and is reviewed before merge — nothing auto-merges.
+- **Refresh re-ranks:** before picking the arc after B1, re-run the audit (the
+  ladder above is a snapshot, not a queue).
+
+## 3. Re-entry
+
+After B1 closes: re-run the refresh audit → re-rank §1 → pick the next arc by
+value × reachability (A1 is highest-value but ops-gated; B4 is the likely next
+buildable). Update this ledger's markers as slices land.

--- a/docs/development/multitable-benchmark-arc-todo-20260615.md
+++ b/docs/development/multitable-benchmark-arc-todo-20260615.md
@@ -1,79 +1,105 @@
-# Multitable Benchmark-Surpass Track — Development Goal + TODO (2026-06-15)
+# Multitable Remaining-Development — Execution Tracker (goal) — 2026-06-15
 
-Type: development goal + gated TODO ledger (trackable). Not a schedule.
+Type: **execution tracker** for driving the remaining multitable development to
+completion as a goal. Not a schedule, not a competing map.
 
-Driver: the owner-set standing goal — multitable driven by **对标并超越** the
-leading 多维表格 product. Each refresh audit re-ranks the gap ladder; each arc and
-each slice within an arc is a **separate named opt-in** — never auto-advance.
+The canonical remaining-dev **map** (honest terminal-gate taxonomy + per-item
+verification status) is `multitable-remaining-goal-dev-verification-20260615.md`
+(#2650, merged). **This tracker references that map — it does not re-derive it.**
+The standing driver is the owner-set goal: multitable driven by 对标并超越 the
+leading 多维表格 product; the benchmark evidence lives in the research companion,
+not here. This tracker uses MetaSheet's own capability names only.
 
-Rationale + the benchmark evidence (external-product comparison, citations) live
-in the research companion, NOT here: `docs/research/multitable-feishu-refresh-audit-20260615.md`
-(PR #2641). This committed plan uses MetaSheet's own capability names only.
+## 0. Honest completion ceiling
 
-Markers: ✅ done · ⬜ ready / in progress (current opt-in) · 🔒 gated (needs its
-own named opt-in / a prereq).
+Per #2650 §0, "余下开发" splits by **terminal gate**, and only one tier can be
+driven to *done* without a privileged actor:
 
-## 0. Current arc — B1: button / action field
+- **autonomous** — pure backend, unit + tsc closeable → can be built + verified to
+  a reviewable draft PR by this session.
+- **browser-gated** — backend is autonomous, but the terminal slice (visual /
+  interaction) needs a real browser; render/dialog cannot be self-verified.
+- **owner/ops-gated** — needs a privileged action (staging baseline, ops creds,
+  product charter, security-review lane); no autonomous code path.
 
-A value-less `button` field type whose cell, on click, runs **one** bound action
-on its row's record by reusing the existing single-action execution path. Inherits
-all record permission / lock / cross-base / redaction / observability gates — no
-new automation-engine code (prereq verified: synthetic `btn_` rule_id has no FK;
-the C1 runs read path is sheet-scoped).
+So "持续开发直至完成" means: drive the **autonomous** tier to built + verified +
+draft-PR'd; design-lock + gate-mark the rest. Merge stays with the owner —
+nothing auto-merges; each slice is reviewed.
 
-Scope gate (the contract): `multitable-button-action-field-scope-gate-20260615.md`
-(PR #2644, ready for review).
+Markers: ✅ done + merged · 🟦 built, in review (draft PR this session) ·
+⬜ ready / in progress · 🔒 gated (own opt-in / prereq).
 
-| Slice | State | What | Acceptance |
-|---|---|---|---|
-| B1-a field-type + codec | ⬜ in progress (PR pending) | register the value-less `button` type; codec accepts `{label, exactly-one existing action}`, rejects empty label / 0 or 2+ actions / unknown action / the 4 suspending-branching actions; `validate` rejects any stored value | sanitizeProperty accept/reject unit tests + value-PATCH rejected; tsc clean |
-| B1-b run endpoint | 🔒 after B1-a + owner go | authenticated, record-scoped POST that runs the bound action via the existing single-action engine (synthetic non-persisted single-action `workflow_job_v1` envelope); explicit record-write capability check; lock / cross-base / redaction inherited; one C1 job + execution-log row | real-DB: action runs + writes; 401/403/lock/404 fail-closed; one C1 job (`resolved`) + log whose `btn_` rule_id resolves to no rule; wire round-trip; double-run = two executions |
-| B1-c FE cell | 🔒 after B1-b | render label + clickable control (not editable, no editor on dblclick); invoke the endpoint; in-flight disable + result toast; disabled when locked / no write capability | renders + invokes; never writes a value; disabled states |
+## 1. Button / action field (B1) — backend COMPLETE, FE gated
 
-**Definition of done (B1):** all three slices landed + the real-DB B1-b E2E green;
-out-of-scope items below stay rejected.
+| Slice | State | Evidence |
+|---|---|---|
+| B1-S0 design-lock (exclusion matrix + inert-action + run-API contract) | ✅ | #2645 |
+| B1-a0 backend codec + §2 value-field exclusions + write-rejection | ✅ | #2648 |
+| B1-a1 executor core — `record_click` inert action + `runSingleAction` seam | ✅ | #2653 |
+| B1-a1 route — `button/run` + univer-meta type-map drift fix | ✅ | #2657 |
+| B1-b grid / record-detail render (button cell, states) | 🔒 browser-gated | — |
+| B1-c FieldManager config UI (create/edit button, bind action, picker) | 🔒 browser-gated | — |
 
-**B1 hard out-of-scope (each = its own future opt-in):** no new action types; no
-multi-action / conditional / triggered / scheduled runs; no suspending-branching
-bound actions (`wait_for_callback` / `start_approval` / `condition_branch` /
-`parallel_branch`); no new RBAC tier; no bypass of locks / permission / redaction;
-no public/unauthenticated endpoint; no persisted synthetic rule.
+B1 backend is done end-to-end (codec → exclusions → executor seam → authenticated
+run endpoint, visible≠executable enforced server-side). Only the two **frontend**
+slices remain, both browser-gated (FE `types.ts` still has no `button` member by
+design — it lands with B1-b once a browser session can verify render→click).
 
-## 1. Post-B1 ladder (demand-gated, ranked by the 2026-06-15 refresh audit)
+## 2. Conditional-format range styles (A5) — data-bar done, scale backend in review
 
-Each is a separate arc; open only on a named demand + when its gate clears. The
-ranking is the audit's; it re-ranks on the next refresh.
+| Slice | State | Evidence |
+|---|---|---|
+| A5 design-lock (scale rule model + security locks + slice plan) | ✅ | #2637 |
+| A5-1 data-bar backend contract (`sanitize…ScaleRule` + `buildFieldScaleMap`) | ✅ | #2639 |
+| A5-1 data-bar FE mirror + grid render | ✅ | #2640 |
+| **A5-2 color-scale + A5-3 icon-set backend + FE mirror** | 🟦 **in review (this session)** | draft PR |
+| A5-2 / A5-3 grid render (MetaGridTable) + dialog (ConditionalFormattingDialog) | 🔒 browser-gated | — |
 
-| Arc | State | Capability | Gate |
-|---|---|---|---|
-| A1 | 🔒 | grid row virtualization / windowing (large tables) | L; ops — needs the perf baseline first |
-| B4 | 🔒 | dashboard non-chart widgets (metrics, pivot, filter linkage) | small chain → L; named demand |
-| A5 | 🔒 | conditional-format depth (data bars / color scales / icon sets) | M; named demand |
-| A4 | 🔒 | form-logic depth (required-if / multi-page / prefill / redirect) | M; named demand |
-| B2 | 🔒 | AI field rings + AI-automation node | L per ring; product charter |
-| B7 | 🔒 | row-level rule-engine permissions (value-based) | L; owner + adversarial review |
-| B3 | 🔒 | native synced / external-source tables | XL; owner — parked |
+A5-2 + A5-3 are combined into **one** backend PR (they extend the identical
+sanitizer / `buildFieldScaleMap` / FE-mirror functions — separate branches would
+conflict on those hot functions and stall on merge cadence), with separate test
+blocks per kind. Render + dialog stay browser-gated (visual contrast / alignment
+need a real browser, per the design-lock's honest verification boundary).
 
-**Already at parity-or-ahead (the "surpass" wins, keep, don't rebuild):** governed
-cross-base writes + rate quota + claim==truth; security-grade masked export + leak
-canary + sanitize/AI-taint chokepoints; formula-over-lookup with in-memory
-hydration; the just-landed branch-local wait + condition-branch + parallel join-all
-automation engine. Honest reverse-gap: the benchmark leads on AI / scale / BI
-richness — surpass concentrates in governance / security / workflow orchestration.
+## 3. Export full-fidelity (A2) — masking-flag verification
 
-## 2. Execution discipline
+| Item | State | Note |
+|---|---|---|
+| A2 export column/row picker | ✅ | #2635 |
+| A2 server-side masking-flag verification (+ fix if real) | ⬜ next (this session) | #2650 §4 flagged a possible FE-export bypass of server field masking; verify the `grid.rows`-already-masked claim, fix if the bypass is real |
 
-- **One opt-in at a time.** B1-a is the only ⬜ now; B1-b/B1-c and every §1 arc are
-  🔒 until separately named. "Continue the arc" is enough to advance the next B1
-  slice; opening a §1 arc needs naming that capability + its gate clearing.
-- **Contract-first per arc:** scope-gate (docs) → owner review → runtime slices.
-- **Each runtime slice proves out** with the tests its scope-gate pins (real-DB for
-  any write/endpoint), and is reviewed before merge — nothing auto-merges.
-- **Refresh re-ranks:** before picking the arc after B1, re-run the audit (the
-  ladder above is a snapshot, not a queue).
+## 4. Remaining ladder (gated — from #2650 §5)
 
-## 3. Re-entry
+**browser-gated** (backend autonomous; terminal slice needs a browser): B1-b /
+B1-c · A5-2/A5-3 render · A3 inline-link record expand · A4 form-logic depth
+(required-if / multi-page / prefill / redirect) · B4 dashboard non-chart widgets ·
+B5 longText in-cell @mention · B6 comment emoji reactions.
 
-After B1 closes: re-run the refresh audit → re-rank §1 → pick the next arc by
-value × reachability (A1 is highest-value but ops-gated; B4 is the likely next
-buildable). Update this ledger's markers as slices land.
+**owner/ops-gated** (need a privileged action): A1 grid virtualization (owner S5b
+staging baseline) · B7 row-level rule permissions (security-review lane) · B2 AI
+auto-trigger · B3 native synced tables (owner charter) · C1 SMTP (ops creds) ·
+C2 template industry content (PM/SME) · C4 mobile / PWA (no named demand).
+
+## 5. Execution discipline
+
+- **Autonomous tier, in order:** A5-2/A5-3 backend (in review) → A2 masking verify.
+  Each = contract-grounded build → adversarial verify → harden → **draft** PR with
+  the tests its design-lock pins; reviewed before merge; nothing auto-merges.
+- **Re-verify before each build** against `origin/main` AND open PRs/branches — a
+  parallel session has been shipping this arc; an in-flight PR won't appear in
+  `origin/main`. (This tracker's discipline after two same-arc collisions.)
+- **Gated tiers** get design-lock + honest markers, never an auto "verified".
+
+## 6. Cleanup (this session's superseded drafts)
+
+- #2644 (button scope-gate) — **superseded** by the merged design-lock #2645
+  (which deliberately chose a different design); close.
+- #2641 (飞书 refresh audit, research) — overlaps the merged ladder refresh #2629;
+  owner to confirm close vs keep.
+- This doc (#2647) — rewritten from the old B1-centric draft into this tracker.
+
+## 7. Re-entry
+
+When the autonomous tier closes, produce the dev + verification MD, then re-run
+the refresh audit to re-rank the gated ladder (§4) before opening any browser- or
+owner-gated arc — each remains a separate named opt-in.

--- a/docs/development/multitable-benchmark-arc-todo-20260615.md
+++ b/docs/development/multitable-benchmark-arc-todo-20260615.md
@@ -52,7 +52,7 @@ design — it lands with B1-b once a browser session can verify render→click).
 | A5 design-lock (scale rule model + security locks + slice plan) | ✅ | #2637 |
 | A5-1 data-bar backend contract (`sanitize…ScaleRule` + `buildFieldScaleMap`) | ✅ | #2639 |
 | A5-1 data-bar FE mirror + grid render | ✅ | #2640 |
-| **A5-2 color-scale + A5-3 icon-set backend + FE mirror** | 🟦 **in review** | **PR #2663** — BE 70 + FE 24 tests, tsc + vue-tsc green, suite 3296/3296; byte-identical FE↔BE mirror |
+| **A5-2 color-scale + A5-3 icon-set backend + FE mirror** | ✅ merged via **#2664** (parallel) | landed by the parallel session **incl. the kind-aware render**; this session's independent build (#2663) converged on the same sanitizer/`buildFieldScaleMap` design → **closed redundant** (4th same-arc collision) |
 | A5-2 / A5-3 grid render (MetaGridTable) + dialog (ConditionalFormattingDialog) | 🔒 browser-gated | — |
 
 A5-2 + A5-3 are combined into **one** backend PR (they extend the identical
@@ -61,12 +61,11 @@ conflict on those hot functions and stall on merge cadence), with separate test
 blocks per kind. Render + dialog stay browser-gated (visual contrast / alignment
 need a real browser, per the design-lock's honest verification boundary).
 
-**Render-slice blocker (carried from #2663):** the sanitizer now ACCEPTS
-colorScale/iconSet, but `MetaGridTable.vue:606` is still kind-blind (paints a
-data-bar gradient from any scale entry → `linear-gradient(…undefined…)` for the
-new kinds). Safe intermediate state today (the dialog, the only config producer,
-is still dataBar-only, so no reachable UI emits these), but the render slice MUST
-make the cell renderer kind-aware **before** colorScale/iconSet authoring ships.
+**Render-slice blocker — RESOLVED by #2664:** the kind-blind `MetaGridTable`
+window (a colorScale/iconSet config would have rendered `linear-gradient(…undefined…)`)
+was closed by #2664, which landed the kind-aware cell render alongside the
+sanitizer. (This session's #2663 had flagged it as a follow-up; #2664 did it in the
+same PR.)
 
 ## 3. Export full-fidelity (A2) — masking-flag verification
 
@@ -79,7 +78,7 @@ make the cell renderer kind-aware **before** colorScale/iconSet authoring ships.
 ## 4. Remaining ladder (gated — from #2650 §5)
 
 **browser-gated** (backend autonomous; terminal slice needs a browser): B1-b /
-B1-c · A5-2/A5-3 render · A3 inline-link record expand · A4 form-logic depth
+B1-c · A3 inline-link record expand · A4 form-logic depth
 (required-if / multi-page / prefill / redirect) · B4 dashboard non-chart widgets ·
 B5 longText in-cell @mention · B6 comment emoji reactions.
 
@@ -100,10 +99,9 @@ C2 template industry content (PM/SME) · C4 mobile / PWA (no named demand).
 
 ## 6. Cleanup (this session's superseded drafts)
 
-- #2644 (button scope-gate) — **superseded** by the merged design-lock #2645
-  (which deliberately chose a different design); close.
-- #2641 (飞书 refresh audit, research) — overlaps the merged ladder refresh #2629;
-  owner to confirm close vs keep.
+- #2644 (button scope-gate) — **CLOSED** (superseded by merged design-lock #2645).
+- #2641 (飞书 refresh research) — **CLOSED** (overlaps merged ladder #2629; branch retained).
+- #2663 (this session's A5-2/A5-3) — **CLOSED redundant** (merged #2664 landed it + render).
 - This doc (#2647) — rewritten from the old B1-centric draft into this tracker.
 
 ## 7. Re-entry

--- a/docs/development/multitable-benchmark-arc-todo-20260615.md
+++ b/docs/development/multitable-benchmark-arc-todo-20260615.md
@@ -73,7 +73,8 @@ make the cell renderer kind-aware **before** colorScale/iconSet authoring ships.
 | Item | State | Note |
 |---|---|---|
 | A2 export column/row picker | ✅ | #2635 |
-| A2 server-side masking-flag verification (+ fix if real) | ⬜ verifying (this session) | #2650 §4 flagged a possible FE-export bypass of server field masking; read-only investigate→refute running, fix only if the bypass is real |
+| A2 server-side masking-flag verification | ✅ verified SAFE — **no fix** | investigate + adversarial-refute both agree (high conf): server drops unauthorized values at `GET /view` (`univer-meta.ts:8128` `filterRecordDataByFieldIds`); FE export reads only already-masked `grid.rows` bounded by `scopedGridFields ⊆ allowedFieldIds`; all 4 value-injection channels apply the composite mask. #2650 §4 concern closed |
+| A2 server-side FULL export (beyond loaded page) | 🔒 gated | per design-lock §2.2 a server-aggregate full-dataset export is a separate opt-in; not part of this autonomous tier |
 
 ## 4. Remaining ladder (gated — from #2650 §5)
 

--- a/docs/development/multitable-benchmark-arc-todo-20260615.md
+++ b/docs/development/multitable-benchmark-arc-todo-20260615.md
@@ -52,7 +52,7 @@ design — it lands with B1-b once a browser session can verify render→click).
 | A5 design-lock (scale rule model + security locks + slice plan) | ✅ | #2637 |
 | A5-1 data-bar backend contract (`sanitize…ScaleRule` + `buildFieldScaleMap`) | ✅ | #2639 |
 | A5-1 data-bar FE mirror + grid render | ✅ | #2640 |
-| **A5-2 color-scale + A5-3 icon-set backend + FE mirror** | 🟦 **in review (this session)** | draft PR |
+| **A5-2 color-scale + A5-3 icon-set backend + FE mirror** | 🟦 **in review** | **PR #2663** — BE 70 + FE 24 tests, tsc + vue-tsc green, suite 3296/3296; byte-identical FE↔BE mirror |
 | A5-2 / A5-3 grid render (MetaGridTable) + dialog (ConditionalFormattingDialog) | 🔒 browser-gated | — |
 
 A5-2 + A5-3 are combined into **one** backend PR (they extend the identical
@@ -61,12 +61,19 @@ conflict on those hot functions and stall on merge cadence), with separate test
 blocks per kind. Render + dialog stay browser-gated (visual contrast / alignment
 need a real browser, per the design-lock's honest verification boundary).
 
+**Render-slice blocker (carried from #2663):** the sanitizer now ACCEPTS
+colorScale/iconSet, but `MetaGridTable.vue:606` is still kind-blind (paints a
+data-bar gradient from any scale entry → `linear-gradient(…undefined…)` for the
+new kinds). Safe intermediate state today (the dialog, the only config producer,
+is still dataBar-only, so no reachable UI emits these), but the render slice MUST
+make the cell renderer kind-aware **before** colorScale/iconSet authoring ships.
+
 ## 3. Export full-fidelity (A2) — masking-flag verification
 
 | Item | State | Note |
 |---|---|---|
 | A2 export column/row picker | ✅ | #2635 |
-| A2 server-side masking-flag verification (+ fix if real) | ⬜ next (this session) | #2650 §4 flagged a possible FE-export bypass of server field masking; verify the `grid.rows`-already-masked claim, fix if the bypass is real |
+| A2 server-side masking-flag verification (+ fix if real) | ⬜ verifying (this session) | #2650 §4 flagged a possible FE-export bypass of server field masking; read-only investigate→refute running, fix only if the bypass is real |
 
 ## 4. Remaining ladder (gated — from #2650 §5)
 

--- a/docs/research/multitable-button-arc-audit-20260615.md
+++ b/docs/research/multitable-button-arc-audit-20260615.md
@@ -1,0 +1,66 @@
+# Button Arc (#2645 / #2648 / #2653 / #2657) — Independent Adversarial Audit
+
+Date: 2026-06-15 · Scope: read-only against `origin/main` · Method: 4-lens audit
+(exclusion-matrix / executor-seam / shadow-copy / test-vacuity) → adversarial
+refutation of every high/medium finding → this synthesis (the workflow's synth
+step rate-limited; reconstructed by hand from the journal).
+
+## Headline verdict
+
+**The merged button arc is sound *today* — every value-leak is LATENT.** There is
+no path on `origin/main` to create a `button` field at all: `MULTITABLE_FIELD_INPUT_TYPES`
+omits `'button'`, and all field-create sinks (POST/PATCH `/fields`, people-sheet
+preset, provisioning) reject it. So no button cell can hold a value, and the
+"value-less" exclusions can't be exercised yet.
+
+But the audit found a real, coherent **spec-gap pattern**: the button write-less
+invariant (design-lock §2's #1 hard constraint) is enforced **inconsistently across
+3+ divergent field serializers / write paths**. These become **LIVE the instant
+B1-c wires `'button'` into field creation** — so they are a precise **B1-c gate
+checklist**, and design-lock §2 explicitly mandates each be closed (backend guard
++ fail-first test) in that same PR. One finding (AUDIT-1) is a spec divergence in
+the *already-merged* route, live now.
+
+All items are in already-merged code (a parallel session owns this arc); this is a
+**handoff checklist**, not a PR from this session.
+
+## The write-exclusion asymmetry (the core pattern)
+
+| Path | Button write-less enforced? | Where |
+|---|---|---|
+| Bulk UPDATE (`record-write-service.validateChanges`) | ✅ explicit type clause | `record-write-service.ts:444` (formula/lookup/rollup/**button**) |
+| Read / serialize (field-codecs) | ✅ injects `readOnly:true` | `field-codecs.ts:429` |
+| Single-record CREATE (`RecordService.createRecord`) | ❌ **no button rejection** | `record-service.ts:222` local `mapFieldType` drops button→`'string'`; sole guard `isFieldAlwaysReadOnly` (`:480`) omits button |
+| Field create/patch + button-route read (univer-meta) | ❌ **no button branch** | `univer-meta.ts:1595-1714` `sanitizeFieldPropertyByType` falls to `return obj`, no `readOnly` injection |
+
+So the load-bearing WRITE exclusion covers only the bulk path; the CREATE path and
+the route-layer sanitizer diverge.
+
+## Confirmed findings (ranked; all re-verified on origin/main, then reachability-graded)
+
+1. **LEAK-1 — CREATE path can write a real value into a button cell** (raw high → adversarially **latent/medium**). `RecordService.createRecord` uses a third, untracked `mapFieldType` (`record-service.ts:222`) with no button case (→`'string'`) and `isFieldAlwaysReadOnly`-only backstop (omits button). The bulk-path rejection (#2648) doesn't cover create. *Latent until button creation wired.* **Fix:** add `'button'` to `isFieldAlwaysReadOnly` (`permission-derivation.ts:58`) by TYPE — covers create+update+patch+xlsx in one gate.
+
+2. **LEAK-2 — export emits raw button cell value + a header column** (raw high → **latent/low**). xlsx export (`univer-meta.ts:7488-7508`) iterates all visible fields with no button exclusion; harmless only while the cell is empty (LEAK-1 breaks that premise). Header column already appears (minor §2 "不进列" deviation). **Fix:** drop `field.type==='button'` from the export field/column set (mirror the formula/lookup taint-drop at `:7447`).
+
+3. **AUDIT-1 — button/run route writes no durable audit row** (medium, **live**). Design-lock §5.2 + ledger §3 require best-effort `AutomationLogService.record()` (redacted, queryable). The merged route (`multitable-button.ts:108-113`) only does `logger.info('[multitable.button.run]', …)` — no durable execution record. (Note: this session's superseded B1-a1 build *did* use the real log service — more spec-compliant on this axis, but #2657 is what merged.) **Fix:** wire the route audit through `AutomationLogService.record()` best-effort in try/catch, or amend the spec if an app-log line is intentionally sufficient for the inert first action.
+
+4. **EXCL-1 / SHADOW-1 (permission-derivation)** — `isFieldAlwaysReadOnly` omits `'button'` (medium → **latent/low**). The single fix in LEAK-1 closes this too — it's the same type-gate.
+
+5. **SHADOW-1 (univer-meta sanitizer)** — route-layer `sanitizeFieldPropertyByType` has no button branch (`:1595-1714`), so a created/patched button field's property is passed through with no `readOnly` injection and arbitrary keys (medium → **latent/low**). **Fix:** add a button branch mirroring `field-codecs.ts:422-443`, or have the route delegate to field-codecs' sanitizer for button (one shared sanitizer).
+
+6. **TEST-1 — 5+ exclusion rows have neither guard nor test** (medium → **latent/low**). Only 3 of the §2 rows are covered (bulk-write, aggregation-numeric, codec round-trip); query/sort/filter, conditional-format, automation-conditions, xlsx, field-validation, record-create have zero button tests. LEAK-1 slipped through because the one write test used a **hand-built `type:'button'` fixture** (wire-vs-fixture drift). **Fix:** per uncovered §2 row, a fail-first test driving a REAL serialized button field (created via the actual field-create sanitizer, read via the actual loaders) — the create-rejection test is the one that catches LEAK-1.
+
+## Single highest-leverage fix
+
+Add `'button'` to `isFieldAlwaysReadOnly` (`permission-derivation.ts:58`) as a
+TYPE-level always-readonly (alongside formula/lookup/rollup). That one change makes
+create + update + patch + field-permission + xlsx reject button by type — closing
+LEAK-1, EXCL-1, and the SHADOW write-leak together, independent of any injected
+property flag. Then: button branch in univer-meta's sanitizer, button drop in
+export, and the per-row fail-first tests.
+
+## Note on INFO-1 (superseded)
+
+The originally-suspected gap (univer-meta `mapFieldType` lacking a button case) was
+**already fixed by #2657** (`univer-meta.ts:1399`). Recorded as resolved, not a
+finding.

--- a/docs/research/multitable-record-restore-review-20260615.md
+++ b/docs/research/multitable-record-restore-review-20260615.md
@@ -1,0 +1,196 @@
+# Record-Restore Stack — PR Review (#2654 / #2660 / #2662)
+
+Reviewer: Claude (Opus 4.8). Date: 2026-06-15. READ-ONLY review.
+
+Graded against the design-lock `docs/development/multitable-record-restore-layer1-design-20260615.md` and
+its companion `…-dev-verification-…md` (both carried on the L1 branch / #2654).
+
+Code read from the PR head refs (the two merged branches were deleted from origin; reviewed via
+`refs/pull/<n>/head`): #2654 = `59f660a`, #2660 = `35fe5d3`, #2662 = `ba1e06e`. The L2 branch carries its
+own copy of the L1 commit, so `record-write-service.ts` / `post-commit-hooks.ts` are byte-identical across
+#2654 and #2660; line cites below are valid on both unless noted.
+
+Merge status: **#2654 MERGED** (`ff3d1c6`), **#2660 MERGED** (`62f2ea9`, stacked), **#2662 OPEN** (FE).
+
+---
+
+## 1. Headline verdict per PR
+
+| PR | Scope | Verdict | Why |
+|---|---|---|---|
+| **#2654** (L1 backend) | scalar restore + unset + dual write-gate | **Sound as merged; 2 retrospective test follow-ups (medium)** | Every behavioral dimension PASSes (no data corruption, no permission bypass, atomic version re-check). Gaps are missing *isolation* tests, not live defects. |
+| **#2660** (L2 backend) | live link-field restore + retention | **Sound as merged; 3 retrospective test follow-ups (medium)** | Link write path correctly inherits the gate and the spine's atomic version/link validation. Gaps: reversed a security lock without a negative-permission test; an irreversible DELETE branch is unexercised. |
+| **#2662** (FE) | drawer Restore button + confirm + api client | **APPROVE** | Wire contract and error-code surfacing are tested non-vacuously; concurrency threaded correctly. Only gap is the workbench orchestration handler (low). |
+
+**No HIGH-severity findings survive.** The single raw "high" (unset-only test gap) was adversarially
+downgraded to medium because the silent-false-success it guards against is **unreachable on current code**
+— it only goes live under a hypothesized future deletion of one heavily-commented line. The behavioral
+dimensions are all PASS. There are no merge blockers; #2662 is a clean approve.
+
+**Confirmed: 0 high, 4 medium.**
+
+---
+
+## 2. CONFIRMED findings (ranked high → low)
+
+There are no confirmed high-severity findings. The four mediums follow, then the lows.
+
+### M1 — Unset-`applied` accounting (the sole guard against a silent false-success) has no isolating test  [#2654/#2660 · medium · TEST]
+
+The restore route emits `op:'unset'` for a field present in current `data` but absent from the target
+snapshot. In the spine, the *only* thing that stops an unset-only change set from hitting
+`if (applied === 0) continue` is the `applied += 1` after `unsetIds.push(...)`.
+
+- Guard: `packages/core-backend/src/multitable/record-write-service.ts:666-667` (`unsetIds.push`; `applied += 1`); skip at `:719`.
+- The UPDATE branch is keyed on `unsetIds.length > 0` (`record-write-service.ts:759`), **not** on `applied` — so this accounting line is genuinely load-bearing and has no spine backstop.
+- Route fallthrough: `univer-meta.ts:5837` (`result.updated.find(...)?.version ?? currentVersion + 1`) feeding `noop:false` at `:5838`; `restoredFieldIds` is computed from the diff at `:5809` regardless of whether the write landed. If the record were skipped it never enters `updated` (pushed at `record-write-service.ts:875`, past the skip), so the route would return `{noop:false, newVersion:Vcur+1, restoredFieldIds:[unset ids]}` — a restore the UI reports but the DB never performed.
+- Coverage gap: T1 (`multitable-record-restore.test.ts:169-194`) is the only test that emits an unset, and it is **set+unset** (current `{A:'a3',B:'b3',SECRET}` → v1 snap `{A:'a1',SECRET}`). The `set A` makes `applied>=1` independently and the UPDATE fires on `unsetIds.length>0`, so B is removed and T1 passes even if `:667` is deleted. No test isolates the unset-only path.
+
+Why medium not high: the silent-false-success shape is **unreachable today** — every unset hits `applied += 1`,
+so an unset-only diff always has `applied>=1`; the `?? currentVersion + 1` branch is defensive/dead. This is a
+regression-detection / fault-isolation gap on a real data-correctness consequence class, with a cheap missing test.
+
+**Fix:** add an unset-only integration test — seed current `{A:'shared', B:'extra'}` at v2 with a v1 snapshot
+`{A:'shared'}` (A identical, B added after v1); restore to v1 → diff is purely `unset B`. Bind response truth
+to DB truth: assert the live row drops B, version bumped, a NEW `source='restore'` revision exists with `B` in
+`changed_field_ids` and `patch.B === null`, and `restoredFieldIds === [B]` with `noop===false`.
+
+### M2 — keep-days retention DELETE branch is reachable but never executed by any test  [#2660 · medium · TEST]
+
+`sweepMetaRevisionRetention` has two DELETE branches. keep-last-n is exercised at the DB level by T13. The
+**keep-days** branch is never run.
+
+- Untested SQL: `meta-revision-retention.ts:96-113` (`WHERE ranked.rn > 1 AND ranked.created_at < now() - ($1::int * interval '1 day')`).
+- Reachable in production: `resolveMetaRevisionRetentionConfig` selects it on `MULTITABLE_META_REVISION_RETENTION_POLICY === 'keep-days'` (`:62`); `startMetaRevisionRetention` wires the resolved config into the live sweep (`:157,:167`).
+- No invocation: unit test `meta-revision-retention.test.ts:35-43` only asserts `resolveMetaRevisionRetentionConfig` returns `policy:'keep-days'` + a floored window — it never calls the sweep; integration T13 (`multitable-record-restore.test.ts:519`) uses `policy:'keep-last-n'`; T14 uses `enabled:false` (short-circuits at source `:93`); scheduler unit tests never advance timers so the callback never fires.
+
+keep-days is a first-class, spec-committed policy (design §3 frames the guarantee as "most recent N versions /
+D days"), so an untested **irreversible** DELETE covers half the retention contract. Not high because the
+`rn > 1` latest-keep guard (`:106`) is the same structural protection T13 proves on the near-identical
+keep-last-n SQL, so even a buggy date window cannot delete a record's current after-image — the realistic
+blast radius is off-window pruning of *non-latest* history, and it is opt-in/default-disabled.
+
+**Fix:** integration test seeding revisions with explicitly backdated `created_at` (some older than the window,
+some newer; latest always recent), call the sweep with `policy:'keep-days', retentionDays:30`, assert only aged
+non-latest rows are deleted and the latest is always retained even if itself old.
+
+### M3 — Spec matrix item T4b (static FieldMutationGuard rejection) is not implemented — the route's static pre-check is unproven  [#2654 · medium · TEST]
+
+Design §4 lists T4b ("a `property.readOnly`/`hidden` differing field is likewise refused"); the review
+dimension grades "read-only-field restore rejection." The test file has no T4b (header matrix
+`multitable-record-restore.test.ts:7-21` lists T4, not T4b; `grep` for T4b/static-guard finds nothing).
+
+- T4 (`multitable-record-restore.test.ts:236-252`) exercises only the **layer-3** term: it seeds a `field_permissions.read_only` row on `FLD_SECRET` for `USER_RO` (`:147`) and trips `RESTORE_FORBIDDEN` via `layer3Ok===false`.
+- Every seeded field uses `property '{}'` except `FLD_SEL`; none sets `property.readOnly`/`hidden`. So `isFieldAlwaysReadOnly`/`isFieldPermissionHidden` (`permission-derivation.ts:57-73`) return false for the restorable string fields, and the route's static term `staticOk = !!guard && !guard.hidden && guard.readOnly !== true` (`univer-meta.ts:5798`) is never the cause of any rejection.
+- The static term is **reachable, not dead**: the diff loop excludes by *type* only, so a string field with `property.readOnly:true` that differs would enter the diff and trip `!staticOk` pre-transaction at the shared `hasForbidden` return (`univer-meta.ts:5802-5806`).
+
+Not high: the spine backstops a readOnly/hidden field reaching the write loop —
+`RecordWriteService.validateChanges` throws `RecordFieldForbiddenError` (`record-write-service.ts:438-445`),
+which the catch maps to 403 (`univer-meta.ts:5816`, and both forbidden aliases at imports `:133`/`:142` are the
+same class). So a regression dropping `staticOk` would still refuse the write — but the spine's message
+*embeds the field id*, whereas the route's static branch exists to keep `RESTORE_FORBIDDEN` generic (the P3
+no-leak property T4 asserts at `:244`). The unguarded residual is therefore the `isFieldAlwaysReadOnly →
+guard → staticOk` wiring **and** the field-id-leak property — write-safety is backstopped, privacy is not.
+
+**Fix:** add T4b — seed a field with `property { "readOnly": true }` (and a hidden variant) that differs
+between versions, restore as a full-perms writer, assert atomic 403 `RESTORE_FORBIDDEN`, nothing written, and
+the forbidden field id absent from the response body.
+
+### M4 — L2 reverses Lock D for link fields (now a live write path through the gate) with ZERO negative-permission coverage on links  [#2660 · medium · PERMISSION]
+
+*(Confirmed by my own primary-source check; this finding's dimension had no separate adversarial verdict — it
+stands on the code read below, not on an adjudicated verdict.)*
+
+Slice-1 Lock D excluded link fields from the diff. #2660 reverses that: the diff loop now emits link fields as
+`op:'set'` routed through `patchRecords`, which re-syncs `meta_links` + the twoWay mirror fan-out — a real
+live-data write path.
+
+- L2 link branch: `univer-meta.ts:5777-5783` (`if (guard.type === 'link') { … diff.push({…, op:'set'}) }`).
+- Every link test added in #2660 runs as the default full-perm writer `USER_W`: T6 / T6e / T6a / T6f / T6g (`multitable-record-restore.test.ts:285-360`). None sets `testUserId = USER_RO` or seeds a `field_permissions` row / property-hidden on a *link* field.
+
+By inspection the `hasForbidden` gate **does** cover links (a link is in `fieldById` with the same gate
+evaluation as scalars; a read-only/denied/hidden link → forbidden), so this is a coverage gap, not a confirmed
+latent bug. But reversing a security-relevant lock and turning a previously-excluded type into a live write
+path *without* a negative-permission test is exactly the change a future refactor of the link branch could
+silently regress. The scalar layer-3 test T4 exists; the link analogue does not. (T6f does prove *atomicity*
+on the foreign-validation-failure path, but not on a permission failure.)
+
+**Fix:** add a link-field negative-permission test mirroring T4 — seed `field_permissions(field_id=<link>,
+subject_id=USER_RO, read_only=true)` (and a `visible=false` case), make the link value differ across versions,
+restore as `USER_RO`, assert 403 `RESTORE_FORBIDDEN`, `meta_links` unchanged (atomic), and no link/foreign id
+echoed in the response.
+
+---
+
+### Lower-severity confirmed findings (low)
+
+| ID | PR | Title | Cite | Note / fix |
+|---|---|---|---|---|
+| **L-LINK-CLEAR** | #2660 | Link restore clears live `meta_links` (cross-record blast radius) when the target snapshot lacks the link key, reported as `restored` | `univer-meta.ts:5778-5783` → spine full-clear `record-write-service.ts:806-823` | Faithful for current-era records (every live write mirrors link ids into `data` → snapshot — verified at `record-write-service.ts:641`, `record-service.ts:617/1044`, `univer-meta.ts:8928`, `records.ts`). Residual: a pre-mirroring legacy snapshot could clear edges it never captured; form-submit records no revision so is never a restore target. Document the snapshot-trust boundary in the L2 design; optionally gate a cross-record clear-on-absent behind confirm/skip. |
+| **L-VEXP-MISREPORT** | #2660 | `VERSION_EXPIRED` (410) is misreported for genuinely never-captured early versions | `univer-meta.ts:5717-5725` (`MIN(version)` floor) vs keystone `meta-revision-retention.ts:88-130` | `MIN(version)` is the earliest *captured* revision, not a true prune floor; a record predating revision capture (migration `zzzz20260430172000`) yields a 410 "has been pruned" when nothing was pruned. Classification/message only; writes nothing; fail-safe direction. Either document the conflation or only emit `VERSION_EXPIRED` when retention is actually enabled. |
+| **L-MIRROR-LINK** | #2660 | L2 link branch routes mirror/derived (`mirrorOf`) link fields to the SET path with no type carve-out | `univer-meta.ts:5777` (no `mirrorOf` exclusion); `:5798-5800` (`hasForbidden` trips on `guard.readOnly`); `permission-derivation.ts:65-66` | A mirror link is `isFieldAlwaysReadOnly===true`; if its projection ever appeared in data/snapshot and differed, the SET would enter the diff and the gate would atomically 403 an otherwise-restorable record. Not triggered today (mirror values have no materialized row → absent from data/snapshot → no diff entry). Defensive: exclude `mirrorOf` link fields by type; add a same-sheet mirror test. |
+| **SEC-LOCK-STATUS** | #2654 | Locked-record / own-write-row rejection surfaces as **400 VALIDATION_ERROR** instead of 423/403 | spine `ensureRecordNotLocked → RecordValidationError(…, 'FORBIDDEN')` `record-write-service.ts:639-644`; `ensureRecordWriteAllowed → RecordValidationError` `:619-633`; restore catch maps `RecordValidationError → 400` `univer-meta.ts:~5848` | Write is atomically refused (security PASS) but the status is a generic validation failure; the `'FORBIDDEN'` code on the error is available but unused for branching. Distinguish lock/own-write rejections → 423/403 so clients can branch on the contract. Cosmetic. |
+| **SEC-XBASE-LINK** | #2660 | Cross-base/foreign link restore writes `meta_links` edges to foreign records with no foreign-sheet permission check | spine link-target validation `record-write-service.ts:725` (existence-only `SELECT id … WHERE sheet_id=$1 AND id=ANY($2)`); foreign ids sourced from snapshot at `univer-meta.ts:5778` | Inherited `/patch` link-write model (shared spine), NOT introduced by restore; restore mildly amplifies by drawing foreign ids from the record's own historical snapshot. Out of scope for this slice; document as a known limitation; gate in the shared spine if a cross-base permission model lands. |
+| **INT-STRINGIFY** | #2654 | `sameValue` uses `JSON.stringify`, so object-key-order differences in object-valued fields (e.g. `location`) can produce a spurious extra revision | `univer-meta.ts:5679` (`JSON.stringify(a ?? null) === JSON.stringify(b ?? null)`) | Bounded: distinct JSON values can never stringify-equal, so only a redundant no-change revision/version bump, never a missed revert or corruption. Optional canonical compare for object-typed fields. |
+| **INT-DRIFT-AVAIL** | #2654 | `SCHEMA_DRIFT` rejects on ANY snapshot field id absent from the current schema, before type-filtering | `univer-meta.ts:5750-5755` (drift loop over all snapshot keys, before the restorable-type filter) | Matches the design's intended fail-closed lock, but a since-deleted *computed/link/system* field — one that would never enter the restore diff anyway — retroactively freezes restore for every prior revision that captured it. Availability cost; document the trade-off or restrict the drift check to restorable-typed keys (a noted Layer-2 follow-up). |
+| **FE-WORKBENCH** | #2662 | Workbench `onRestoreRecordVersion` (confirm-gate + noop/success branch + post-restore refresh) has zero coverage | `MultitableWorkbench.vue` `onRestoreRecordVersion` (`window.confirm` gate, `result.noop ? restoreNoop : restoreSuccess`, `error.message ?? errorRestore`, `grid.loadViewData` + `refreshSelectedRecordContext`); `meta-record-drawer-restore.spec.ts:8` header states the round trip "needs manual/e2e QA" | The client error-code surfacing IS tested non-vacuously through real `parseJson` (`multitable-record-restore-client.spec.ts`). The restore-specific confirm-gate and noop branch are unit-untested. Low (mirrors the tested `onToggleRecordLock` pattern). Extract to a testable composable or add a component test asserting confirm-cancel skips the call + the noop/success/error branches. |
+| **TEST-T13-FLOOR** | #2660 | T13 uses `keepN=10`, which equals `META_REVISION_RETENTION_MIN_KEEP_N`, so it cannot distinguish "keepN honored" from "always floored"; and the sweep is a global unfiltered DELETE | T13 `multitable-record-restore.test.ts:519`; floor `meta-revision-retention.ts:34,116`; global DELETE has no `record_id`/`sheet_id` WHERE filter | The per-record exact-window assertion `[4..13]` IS deterministic (record-scoped), but the `toBeGreaterThanOrEqual(3)` global count + cross-suite DELETE pollution are fragile if run in parallel with other DB suites. Run with `keepN` above the floor (seed 18, keepN=12, assert window `[7..18]`); note the global-sweep pollution risk. |
+| **TEST-T5-VACUOUS** | #2654 | T5 proves formula EXCLUSION but is vacuous as to RECOMPUTE | T5 `multitable-record-restore.test.ts:254-266` asserts `!== 'fx_old'` over an excluded, expression-less (`property '{}'`) formula field; recompute wiring (sound, inherited) `record-write-service.ts:1078` | The recompute path IS wired and unconditional on source, so this is low — only the assertion is vacuous. Seed a formula with a real expression depending on a restored scalar and assert it re-derives, or relabel T5 exclusion-only and add a separate recompute assertion. |
+| **TEST-T6A-FANOUT** | #2660 | T6a (twoWay link) asserts the forward edge but not the mirror fan-out it claims to prove | T6a `multitable-record-restore.test.ts:311-328` asserts only `linksOfField(FLD_LK_TW, rid)`; fan-out mechanism `record-write-service.ts:598,827,847` (`collectMirrorInvalidation`) | Forward-edge assertion is the correct primary check (the mirror is a derived single-edge projection with no materialized row), but the test name's "fan-out" claim is stronger than what is asserted. Drop the wording or capture the Yjs invalidator (as T11 does) and assert `FOREIGN_REC2` is among the invalidated ids. |
+
+---
+
+## 3. Refuted / downgraded / PASS (what was checked and dismissed)
+
+### Downgraded
+- **Unset-only test gap — raw HIGH → confirmed MEDIUM (M1).** Verified the silent-false-success is unreachable
+  on current code: `:5837` is only reached when `diff.length>0`; an all-unset diff has every entry hit
+  `applied += 1` at `record-write-service.ts:667`, so `applied>=1`, the `:719` skip never fires, the record
+  enters `updated` at `:875`, and the route gets the real version. The `?? currentVersion+1` branch is dead
+  today and only activates under a hypothesized future deletion of `:667`. Real consequence class, cheap
+  missing test, regression-contingent → medium.
+
+### Behavioral PASS (no defect — recorded for an auditable verdict)
+- **SEC-1 — Write-gate sound, NO privilege-escalation bypass.** The `hasForbidden` gate (`univer-meta.ts:5795-5806`)
+  fails closed on every axis: layer-3 `read_only` (`perm.readOnly===true`), read-denied `visible=false`
+  (`perm.visible===false`), property-hidden (absent from `fieldPermissions` built from `visiblePropertyFields`
+  → `perm` undefined → `!!perm` false; also `guard.hidden===true` on the static leg), and computed/link/system
+  excluded by type before the diff. Verified `buildRecordPatchContext` builds `fieldById` from ALL fields and
+  `fieldPermissions` from visible-only (`univer-meta.ts:3202-3243`), and `deriveFieldPermissions` default-allows
+  only when no `field_permissions` row exists (`permission-derivation.ts:96-103`). `expectedVersion` + auth
+  checked before any write; spine re-asserts under `FOR UPDATE` (`record-write-service.ts:647-648`). FE cannot
+  bypass (actor derived server-side; client sends only `{targetVersion, expectedVersion}`).
+- **VER-1 — Optimistic version re-check correct and atomic; no lost-update window.** Outer pre-check
+  (`univer-meta.ts:5705-5708`) is belt-and-suspenders; the authoritative guard re-asserts `expectedVersion`
+  under `SELECT … FOR UPDATE` (`record-write-service.ts:615-648`); the L2 `meta_links` re-sync runs in the
+  same transaction, so the version guard protects the join-table mutation too.
+- **INT-1 — `unset` is a true revert, not a merge; no Yjs/formula/revision desync.** `data = (data - keys) ||
+  setPatch` in one statement (`record-write-service.ts:759-766`); after-image drops the keys and the revision
+  patch marks `null` (`:782-787`); link/attachment unset rejected (`:461-466`); `source='restore'` ≠
+  `'yjs-bridge'` so the invalidator fires (T11).
+- **VER-2 — Forward-revision + edge cases correct:** current-version no-op (with the concurrency pre-check
+  *before* the no-op return, `univer-meta.ts:5699-5708`), delete-tombstone resolution (`.find(action !==
+  'delete')`), version-0 (`z.number().int().positive()`), non-existent target → 404, pruned floor → 410
+  (L2), hard-deleted current record → 404.
+- **VER-3 — FE threads the DISPLAYED `record.version` as `expectedVersion`** (`MetaRecordDrawer.vue:676`
+  `expectedVersion: record.version`; button gated to non-current versions `:667-669`), so a concurrent edit
+  surfaces as a 409 the user sees (`MultitableWorkbench.vue` handler → `showError`), never a silent clobber.
+
+---
+
+## 4. Per-PR recommendation
+
+- **#2654 (L1, MERGED):** Implementation sound. File two retrospective test follow-ups — **M1** (unset-only
+  isolation) and **M3** (T4b static-guard + no-leak). Lows (`INT-STRINGIFY`, `INT-DRIFT-AVAIL`,
+  `TEST-T5-VACUOUS`, `SEC-LOCK-STATUS`) are optional polish.
+- **#2660 (L2, MERGED):** Implementation sound; the link write path correctly inherits the gate and the
+  spine's atomic version/link-target validation. File three retrospective follow-ups — **M2** (keep-days DELETE
+  test), **M4** (link negative-permission test), and the documentation lows (`L-LINK-CLEAR` snapshot-trust
+  boundary, `L-VEXP-MISREPORT`). `L-MIRROR-LINK` is a defensive nicety.
+- **#2662 (FE, OPEN):** **APPROVE.** Wire contract and error-code surfacing are tested non-vacuously;
+  `expectedVersion` is threaded so concurrency surfaces as a visible 409. The only gap (`FE-WORKBENCH`,
+  low) is the workbench confirm/noop/refresh handler, already deferred to manual/e2e QA by the spec — worth a
+  follow-up component test but not a merge blocker.
+
+**Net: 0 high, 4 medium (all test-coverage / regression-detection gaps on irreversible or security-relevant
+paths). No behavioral data-corruption or permission-bypass defect. No merge blocker.**

--- a/docs/research/multitable-review-findings-closure-20260615.md
+++ b/docs/research/multitable-review-findings-closure-20260615.md
@@ -17,7 +17,7 @@ Date: 2026-06-15
 > - **#2685** `2b5e6ea3` — `mapRowToComment` read field-drop fix (5 read/emit surfaces) + `makeCommentRow` fixture top-up. MERGED.
 > - **#2686** `788050554` — record-restore M1–M4 coverage (T22–T25, CI-executed via the real-DB step). MERGED.
 > - **#2676** — this session's superseded oracle fix (uniform 403). CLOSED (replaced by #2677).
-> - **#2693** (draft) — trailing polish: sweep remaining comment test helpers to carry canonical container/target ids (fully closes the fixture-vs-wire drift). Open for review.
+> - **#2693** `8f7ac052c` — trailing polish: swept remaining comment test helpers to carry canonical container/target ids (fully closes the fixture-vs-wire drift). MERGED.
 > - Production bug surfaced + fixed in #2685: `mapRowToComment` dropped `containerId`/`targetId`/`targetFieldId` across five comment read/emit surfaces.
 
 Scope: documents this session's closure work on confirmed findings from two review MDs against

--- a/docs/research/multitable-review-findings-closure-20260615.md
+++ b/docs/research/multitable-review-findings-closure-20260615.md
@@ -1,0 +1,110 @@
+# Multitable — Review-Findings Closure: Per-Field Restore Oracle + Comment-Reaction CI
+
+Date: 2026-06-15
+
+> **STATUS UPDATE (post-merge reconciliation).** The per-field-restore oracle described
+> in §1.1 was fixed by THIS session as PR **#2676** (uniform 403 strategy) — but a parallel
+> session independently fixed the same oracle as PR **#2677** with a different, more complete
+> strategy (hidden/unknown selected field → **200 no-op**, indistinguishable; + schema-drift
+> scope + link-reorder no-op). **#2677 is canonical; #2676 was CLOSED.** §1.1 below documents
+> #2676's (now-retired) approach and its adversarial verification — kept as the analysis record,
+> not the landed fix. §1.3 (comment-reactions CI wiring, PR #2679) is independent and stands.
+> The record-restore M1–M4 coverage tests were deferred to land on top of #2677 once it merges.
+
+Scope: documents this session's closure work on confirmed findings from two review MDs against
+merged multitable code (#2672 per-field restore, #2673 comment emoji reactions).
+
+---
+
+## 1. What was closed
+
+### 1.1 #2672 follow-up — per-field-restore change-timeline oracle (security fix)
+
+- PR: https://github.com/zensgit/metasheet2/pull/2676 (draft, base `main`)
+- Branch: `fix/multitable-per-field-restore-oracle-20260615`
+- Commit: `4bdc278c28012cc6c5751456b7d87552c5c077dc`
+- Files:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+  - `packages/core-backend/tests/integration/multitable-record-restore.test.ts`
+
+What changed — the bug was live on merged #2672 (confirmed not already fixed on main). The route's per-field forbidden gate ran over `selectedDiff` (caller `fieldIds` ∩ changed fields), so a selection naming a `visible=false` / read-only field returned `403 RESTORE_FORBIDDEN` when that field changed at the target version, but `200` no-op when it had not changed. That status delta is an exact per-field oracle that recovers the modification timeline of a column whose revision history #2144's `redactRecordRevisionEntry` is designed to mask.
+
+Fix (`univer-meta.ts` ~:5797–5828): the forbidden gate now runs over
+
+```
+const gatedFieldIds = fieldIds ?? selectedDiff.map(ch => ch.fieldId)
+```
+
+i.e. in per-field mode it checks the caller-SELECTED `fieldIds` independent of whether they changed, using the SAME predicate the route already applies (static guard `!hidden && !readOnly` ∧ layer-3 `perm.visible !== false && perm.readOnly !== true`). Any selected forbidden id ⇒ constant generic `403` regardless of diff ⇒ the two oracle cases become byte-identical ⇒ oracle closed; M2 (selection-not-a-bypass) holds. Full-restore mode (no `fieldIds`) falls back to `selectedDiff.map(...)` and is byte-for-byte unchanged (gate still over the changed diff). The 403 body stays a static literal; no forbidden id is echoed into `skippedFieldIds`.
+
+Verification: `tsc` 0 errors; 29/29 record-restore integration tests green against local PG; T18 proven non-vacuous via a buggy-gate revert that reproduces the 403-vs-200 oracle signature.
+
+Note: T18 was strengthened mid-task — switched from `FLD_SECRET` (read-only-but-visible, already unmasked in the history endpoint) to a dedicated `visible=false FLD_HIDDEN`, the column #2144 actually masks, so the test exercises the precise mask-defeating case the PR claims to fix.
+
+### 1.2 Record-restore property suite (ships in PR #2676)
+
+The third named closure — the record-restore M-series property tests — lands in the SAME PR as the oracle fix (#2676), in `multitable-record-restore.test.ts`. These exercise the per-field restore gate end-to-end against real PG:
+
+- T15 / T16 / T17 — selection semantics: `fieldIds` restores ONLY the selected fields (unselected untouched); per-field lets you restore a writable picked field even when another diff field is forbidden; selecting an unchanged WRITABLE field is a clean no-op.
+- T18 — oracle keystone: a NEW `visible=false` field `FLD_HIDDEN` + a `field_permissions` row (`visible=false, read_only=false`) for `USER_RO` — the exact column #2144 masks. Asserts IDENTICAL status + body whether the field changed or not, generic 403, id absent from body and `skippedFieldIds`, atomic.
+- T19 (#2672 M2) — selection-not-a-bypass: write-denied selection ⇒ clean 403, atomic, id excluded, never a silent bypass.
+- T20 — regression: writable per-field restore still works; full-restore atomic-reject (changed-forbidden) and pass-through (unchanged-forbidden) unchanged.
+
+(The task's "M1–M4" shorthand maps to this record-restore property suite; the file labels only M2 explicitly at T19. Suite referenced generically rather than inventing per-test M-labels not present in the source.)
+
+Verification: `tsc` 0 errors; 29/29 record-restore integration tests green against local PG; T18 non-vacuity proven via buggy-gate revert (403-vs-200 oracle signature).
+
+### 1.3 #2673 — comment emoji-reaction keystone CI wiring
+
+- PR: https://github.com/zensgit/metasheet2/pull/2679 (draft)
+- Branch: `test/multitable-comment-reactions-ci-20260615`
+- Commit: `13f84b129dfe2dc8d1875a35ecab7d65416f4b59`
+- Files:
+  - `packages/core-backend/tests/integration/comment-reactions.api.test.ts` (new)
+  - `packages/core-backend/tests/integration/comments.api.test.ts`
+  - `packages/core-backend/vitest.config.ts`
+  - `.github/workflows/plugin-tests.yml`
+
+What changed — closed the invisible-debt trap: the #2673 B6 emoji-reaction keystone ran in NO CI workflow (excluded from the default unit run at `vitest.config.ts:32`, absent from every integration allowlist).
+
+1. CI wiring: extracted the keystone + permission negatives into a new self-contained `comment-reactions.api.test.ts` and wired it as a WHOLE FILE into a dedicated `Run comment-reaction keystone (real wire, real PG)` step in `plugin-tests.yml` (Node 20, real Postgres, every PR). Whole-file (not a `-t "reaction"` name filter) is deliberate: a name filter matching zero tests exits 0/green (silent no-op gate = reintroduced invisible debt), while a whole-file run exits 1 on missing/renamed file (`No test files found`) and on unreachable DB.
+2. Fail-loud (#1435/#1436): `beforeAll` asserts `canListen` + `address.port` (no `if (!baseUrl) return` escape hatch). Same fail-loud + DDL applied to the still-excluded `comments.api.test.ts` harness.
+3. DDL align: string id/timestamp columns now mirror real migration shapes (`text` + `timestamptz` for users / meta_bases / meta_sheets / meta_views / meta_comment_reads / meta_comment_reactions). `meta_comments` intentionally stays `varchar(50)` + plain `timestamp` because its earliest-ordered `formalize` migration wins the CREATE-IF-NOT-EXISTS race.
+4. Negatives (real wire): userA's DELETE is self-scoped and cannot remove userB's reaction (DB-row survival + `reactedByMe:true` as B); a reader-only token (`roles=viewer&perms=comments:read`, no `comments:write`) is denied 403 on add AND remove; deleting the comment cascades away its reactions.
+
+Verification: `tsc --noEmit` clean; `js-yaml` parses `plugin-tests.yml` (reaction step present, run command targets the whole new file); new file against fresh migrated PG = 2 passed (no skips, no name-filter coupling). Fail-loud verified 3 ways: bad `DATABASE_URL` ⇒ exit 1; missing/renamed file ⇒ exit 1; `-t` no-match anti-pattern ⇒ exit 0 (the fragility the dedicated-file approach avoids). No lint exposure (core-backend has no lint script; test files are eslint-ignored).
+
+Verified deviation: rather than wire the whole `comments.api.test.ts` (RED — 8 pre-existing real-wire failures, baseline 8 failed | 3 passed on fresh DB, all from `CommentService.mapRowToComment` dropping `containerId` / `targetId` / `targetFieldId` for `getComment` AND `getComments`), the keystone + negatives moved into the dedicated file. The 8-test `mapRowToComment` field-drop is surfaced in the PR body as separate, tracked debt needing its own opt-in fix (production code, out of scope here).
+
+---
+
+## 2. Oracle fix — adversarial verification verdict
+
+VERDICT: PASS. The per-field-restore change-timeline oracle is closed.
+
+| Check | Result |
+|---|---|
+| `oracleClosed` | VERIFIED |
+| `selectionBypassClosed` | VERIFIED |
+| `fullRestorePreserved` | VERIFIED |
+| `noSkippedLeak` | VERIFIED (structurally) |
+
+- oracleClosed — `univer-meta.ts:5817` `gatedFieldIds = fieldIds ?? selectedDiff.map(...)`. The zod schema (`:5655`) is `z.array(z.string().min(1)).min(1).optional()`, so a present `fieldIds` is a non-empty truthy array ⇒ `gatedFieldIds === fieldIds` (the FULL caller selection, not selection∩changed). The gate (`:5818–5824`) fires on a selected forbidden field regardless of whether it changed. Both oracle cases hit the literal 403 at `:5829` BEFORE the no-op (`:5835`) / success (`:5861`) returns ⇒ identical status + identical static body. Every pre-gate return enumerated — VERSION_CONFLICT (`:5703`), VERSION_NOT_FOUND/EXPIRED (`:5727/:5730`), RESTORE_UNSUPPORTED (`:5734`), SNAPSHOT_UNAVAILABLE (`:5737`), SCHEMA_DRIFT (`:5762`) — none keys off the forbidden field's VALUE-change; all key off version existence / snapshot keys / field EXISTENCE, identical across both oracle cases. T18 (`~:611`) asserts `resDiff.body` deepEquals `resSame.body`, both 403, non-vacuous (was 403-vs-200 pre-fix).
+- selectionBypassClosed — gate predicate (`:5821–5823`) returns forbidden when `!staticOk || !layer3Ok`. `fieldById` is built over ALL fields (`buildFieldMutationGuardMap`, `:3107–3128`) so the guard is defined for any real id; `fieldPermissions` is built over visible-property fields (`buildRecordPatchContext :3216–3223` → `deriveFieldPermissions`, `permission-derivation.ts:76–101`) which densely populates every visible field and drops property-hidden ones. Forbidden selected field (`visible=false` ⇒ perm absent OR `scope.visible=false` ⇒ `layer3Ok=false`; read-only ⇒ `!staticOk`/`!layer3Ok`) ⇒ 403. UNKNOWN id ⇒ guard undefined ⇒ `staticOk=false` ⇒ 403 (no silent no-op). The spine-level `ServiceFieldForbiddenError` catch (`:5866`) is defense-in-depth, reached only after the gate passes. T18/T19 confirm.
+- fullRestorePreserved — with no `fieldIds`, `:5817` falls to `selectedDiff.map(...)` (= changed diff, since `selectedDiff===diff` at `:5800`), so the gate runs over the CHANGED diff exactly as before — atomic reject if a changed field is forbidden, unchanged-forbidden does not block. Diff-build (`:5766–5795`) and downstream apply (`:5846–5859`) untouched. T20(ii) confirms.
+- noSkippedLeak — VERIFIED structurally. The 403 body (`:5829`) is a static literal `{ ok:false, error:{ code:'RESTORE_FORBIDDEN', message:'Not permitted to restore one or more fields in this revision' } }` with NO `data` object ⇒ no `skippedFieldIds` channel on the forbidden path. On success/no-op paths (`:5835`, `:5861`) `skippedFieldIds` is hardcoded `[]`. The forbidden id is never echoed. T18 asserts `JSON.stringify(body)` excludes `FLD_HIDDEN` and `body.data?.skippedFieldIds ?? []` excludes it.
+
+Intentional, non-defect behavior change (fail-safe direction): selecting an UNKNOWN field id in per-field mode now returns 403 (gate sees undefined guard) whereas pre-fix #2672 it was a no-op (unknown ids never entered `selectedDiff`). Knowingly accepted — old T17 "unchanged/unknown → no-op" renamed to "unchanged WRITABLE → no-op", unknown-id case dropped. This STRENGTHENS closure: a hidden id is indistinguishable from a garbage id ⇒ no field-enumeration oracle. Regression premise holds — `deriveFieldPermissions` default-allows writable fields (`visible=true, readOnly=false` when no deny scope), so an unchanged writable selected field passes the gate and reaches the 200 no-op branch.
+
+---
+
+## 3. Residual / deferred (not addressed in these changes)
+
+- LOW — pre-existing spine-forbidden message echo (out of scope). The spine-level catch at `univer-meta.ts:5866–5868` maps `ServiceFieldForbiddenError` to a 403 echoing `(err as Error).message`, which could in principle contain a field id. Reachable only AFTER the pre-gate passes (i.e. only on a gate/spine divergence, a defense-in-depth split) ⇒ cannot fire in the closed oracle scenario (a forbidden selection 403s generically at `:5829` first). No action required for this fix; flagged so it is not assumed clean by omission. Optional hardening (separate change): generalize the `:5867` spine-forbidden message to the same static string used at `:5829`, so even a gate/spine divergence cannot echo a derived field id.
+- DEBT — `CommentService.mapRowToComment` field-drop (8 real-wire failures). `getComment` and `getComments` drop `containerId` / `targetId` / `targetFieldId`. Production code, out of scope; surfaced in PR #2679's body as separately tracked debt requiring its own opt-in fix. The keystone CI step is isolated in the dedicated file, so this debt cannot run red in the new gate.
+
+---
+
+## 4. Closure note
+
+These two PRs close confirmed findings from the two review MDs on merged code — #2676 closes the per-field-restore change-timeline oracle (review of merged #2672), #2679 closes the un-gated emoji-reaction keystone (review of merged #2673). Both are additive (test + CI + a scoped route-gate change), non-colliding with main, and shipped as draft PRs pending opt-in merge.

--- a/docs/research/multitable-review-findings-closure-20260615.md
+++ b/docs/research/multitable-review-findings-closure-20260615.md
@@ -10,6 +10,15 @@ Date: 2026-06-15
 > #2676's (now-retired) approach and its adversarial verification — kept as the analysis record,
 > not the landed fix. §1.3 (comment-reactions CI wiring, PR #2679) is independent and stands.
 > The record-restore M1–M4 coverage tests were deferred to land on top of #2677 once it merges.
+>
+> **FINAL LANDING LEDGER (2026-06-16) — all merged to main:**
+> - **#2677** `73fd154c4` — canonical per-field oracle fix (200-noop + schema-drift + link-reorder). MERGED.
+> - **#2679** `cdab2cb2f` — comment-reactions keystone wired into CI + permission negatives. MERGED.
+> - **#2685** `2b5e6ea3` — `mapRowToComment` read field-drop fix (5 read/emit surfaces) + `makeCommentRow` fixture top-up. MERGED.
+> - **#2686** `788050554` — record-restore M1–M4 coverage (T22–T25, CI-executed via the real-DB step). MERGED.
+> - **#2676** — this session's superseded oracle fix (uniform 403). CLOSED (replaced by #2677).
+> - **#2693** (draft) — trailing polish: sweep remaining comment test helpers to carry canonical container/target ids (fully closes the fixture-vs-wire drift). Open for review.
+> - Production bug surfaced + fixed in #2685: `mapRowToComment` dropped `containerId`/`targetId`/`targetFieldId` across five comment read/emit surfaces.
 
 Scope: documents this session's closure work on confirmed findings from two review MDs against
 merged multitable code (#2672 per-field restore, #2673 comment emoji reactions).

--- a/docs/research/multitable-stream-review-2672-2673-20260615.md
+++ b/docs/research/multitable-stream-review-2672-2673-20260615.md
@@ -1,0 +1,116 @@
+# Multitable in-flight stream — per-PR review (Claude, 2026-06-15)
+
+Scope: two in-flight multitable PRs reviewed against their head commits.
+- **#2672** per-field (column-level) record restore — backend (`6ed4d9afc`)
+- **#2673** B6-a comment emoji reactions — storage + API (`7a62ff92d`)
+
+Each finding below carries its FINAL severity after an adversarial pass. Tags:
+`CONFIRMED` = verdict upheld at the original severity; `↓ X→Y` = downgraded with the
+reason that survived re-reading the code; `un-adjudicated` = raw finding self-consistent
+but not separately re-verified (listed at its self-rated severity, no verdict invented).
+Nothing in either PR was fully refuted.
+
+---
+
+## PR #2672 — per-field record restore
+
+### Headline: **REQUEST-CHANGES**
+
+Driver = the one finding that came through the adversarial pass **un-downgraded**: per-field
+restore reintroduces, through a side channel, the very change-history bit the record-history
+field mask (#2144) was built to hide. It is a confidentiality regression of a deliberately
+engineered control, and it has a concrete silent-drop fix. The other medium (M2, reject-branch
+coverage) was downgraded high→medium; the remaining four findings are low.
+
+### Confirmed / surviving findings (high → low)
+
+**M1 — Per-field restore is a single-field change-timeline oracle for `visible=false` columns** — **medium** · `CONFIRMED`
+`packages/core-backend/src/routes/univer-meta.ts:5801` (`selectedDiff` filter), `:5804-5816` (forbidden gate over `selectedDiff` → 403), `:5818-5821` (empty `selectedDiff` → 200 no-op). Defeats `redactRecordRevisionEntry` at `:3244-3250`, applied by the history GET at `:5615-5617`.
+- An actor with `canEditRecord` but `visible=false` (or `read_only`) on field `F` can probe `restore` with `fieldIds:[F]`: **403 RESTORE_FORBIDDEN** when `F` differs between target `vN` and current (`selectedDiff=[F]` → gate fires), vs **200 no-op** when `F` is unchanged at `vN` (`selectedDiff=[]` → gate skipped). 403-vs-200 is an exact per-field oracle for "did this confidential column change at version N"; sweeping `targetVersion` reconstructs the column's full modification timeline. Values stay hidden — this is metadata/timeline disclosure, gated behind record-edit capability, hence medium not high.
+- Diff is built over **all** fields against unmasked `currentData`/`targetSnapshot`, so `F` enters the diff purely on value-difference. The generalized 403 message (`:5811-5815`) was added precisely to avoid leaking hidden-field metadata; the per-field selector isolates one field and defeats it. Delta vs prior: full-record restore already 403s when *any* forbidden field differs (entangled signal); `fieldIds` makes it single-field precise. New leak is scoped to `visible=false`/`hidden` fields only — `visible+read_only` fields already show as changed in history, so no new bit there.
+- **Fix:** treat a selected-but-forbidden field identically to a selected-but-unchanged one — drop forbidden `fieldIds`-selected fields from `selectedDiff` **before** the `hasForbidden` gate, so the response is identical whether or not the confidential field changed (only NOT-selected forbidden fields, i.e. full-restore mode, keep atomic-reject). Trap: do **not** echo the dropped ids into `skippedFieldIds` — that re-leaks the same bit; `skippedFieldIds` may carry only non-forbidden skip reasons.
+
+**M2 — Per-field permission-gate REJECT branch is untested (selection-as-bypass unproven-safe)** — **medium** · `↓ high→medium`
+`packages/core-backend/src/routes/univer-meta.ts:5801-5817` (gate over `selectedDiff`); `tests/integration/multitable-record-restore.test.ts:557,576,591` (T15/T16/T17 all select writable/unchanged fields; no `fieldIds:[FLD_SECRET]`-as-USER_RO case anywhere).
+- The core security guarantee — naming a non-writable field in `fieldIds` must still 403, not bypass the gate — has no direct test. T16 proves only the permissive direction (`fieldIds:[FLD_A]` succeeds while a co-changed forbidden SECRET is *not* selected → 200). T4's 403 runs over the full diff with no `fieldIds`, so it never exercises the gate over a caller-selected subset.
+- **Downgraded because:** no live bug — tracing `fieldIds:[FLD_SECRET]` as USER_RO, the gate correctly returns 403. And the finding's own named regressions (gate-over-`diff`, apply-after-gating) are in fact **already caught**: T16-partial expects 200, which would flip to 403 (RED) if the gate ran over `diff`. The residual unpinned composition is narrow — the per-element predicate firing when the forbidden field *is* the selected one — and its halves are independently covered (T4 = predicate flags SECRET; T16 = gate iterates `selectedDiff`). The predicate is field-id-keyed, not position-keyed, so the unpinned case is low-likelihood.
+- **Fix:** add a real-DB test — seed `A`+`SECRET` both differing, `testUserId=USER_RO`, send `fieldIds:[FLD_SECRET]`; assert 403 / `RESTORE_FORBIDDEN`, body excludes `FLD_SECRET`, live data unchanged (atomic). One line; pins selection-is-not-a-bypass.
+
+**L1 — Link-field per-field restore has no coverage (`meta_links` sync + no-bleed)** — **low** · `↓ medium→low`
+`tests/integration/multitable-record-restore.test.ts:285-360` (T6/T6e/T6a/T6f/T6g all full-record, no `fieldIds`); route `univer-meta.ts:5780-5786` (link diff, pre-existing), `:5801` (type-blind filter), `:5834` (`changesByRecord: selectedDiff`).
+- Literal claim true — zero per-field × link coverage in either direction. **Downgraded because:** the new code adds no link-specific logic; the filter is type-blind (`diff.filter(ch => fieldIds.includes(ch.fieldId))`), a link `set` is shape-identical to a scalar `set`, and `meta_links` sync lives in `patchRecords` (already covered by T6e). Selecting `[FLD_LK]` alone = T15 behavior + T6e behavior; selecting a scalar while a link also differs drops the link from `selectedDiff` so its target value never reaches `patchRecords` (current link value unchanged → idempotent re-sync → no bleed mechanism exists). Belt-and-suspenders, not bug exposure.
+- **Fix (optional):** T18 `fieldIds:[FLD_LK]` → assert link + `meta_links` re-sync to target while an unselected scalar stays; T19 scalar-only selection while link differs → assert `meta_links` untouched.
+
+**L2 — Per-field UNSET isolation untested (the one new spine primitive × the new feature)** — **low** · `↓ medium→low`
+`packages/core-backend/src/routes/univer-meta.ts:~5793` (`unset` emitted when `inCur && !inSnap`), `:~5798` (filter); `tests/integration/multitable-record-restore.test.ts:550-596` (T15/T16/T17 all `set`/no-op, no `unset`); full-record `unset` only at T1 `:169-193`.
+- Gap real — no per-field test produces an `unset` diff entry, so neither "select `[A]`, B's unset must be filtered out so B survives" nor "select `[B]`, only B unsets" is asserted. **Downgraded because:** the untested code is provably correct — the route filter is op-agnostic (keys on `fieldId`), and the spine after-image (`record-write-service.ts:783` `{...previousData, ...patch}` then `:786` `delete afterImage[removedId]` only for `unsetIds`) is partial-safe: select-`[A]` → `unsetIds=[]` so B stays; select-`[B]` → after-image `{A}`, B removed from live row and stored after-image. Regression-protection over sound code.
+- **Fix (optional):** T1-style per-field test — current `{A,B}`, snapshot `{A:a1}`; `fieldIds:[FLD_A]` → A=a1 & B present; `fieldIds:[FLD_B]` → B absent from live row **and** `latestRevision().snapshot`, A unchanged.
+
+**L3 — `SCHEMA_DRIFT` runs before the `fieldIds` filter (parity asymmetry + uncovered)** — **low** · `↓ medium→low`
+`packages/core-backend/src/routes/univer-meta.ts:5760-5764` (drift loop over full `targetSnapshot`, returns 422) vs `:5801` (`selectedDiff` filter, strictly after); `:5804` forbidden gate over `selectedDiff`. Test gap: `tests/integration/multitable-record-restore.test.ts:362-371` (T6b full-record only); no per-field drift variant.
+- All three claims confirmed: a drifted **unselected** co-field 422s the whole per-field restore, which is inconsistent with the per-field "win" for permissions (T16 proves an unselected *forbidden* co-field does **not** block). **Downgraded because:** the behavior is fail-closed — the over-conservative path rejects (422) rather than writing anything wrong; no corruption, no bypass, no bleed. The Slice-1 design frames `SCHEMA_DRIFT` as a record-level "no cross-schema restore" invariant predating the per-field Gate. Likelihood moderate-low (needs a revision snapshot carrying a since-deleted field AND a selection of only survivors).
+- **Fix:** decide intended semantics and lock with a test — if drift should still hard-fail regardless of selection, document the asymmetry vs forbidden co-fields and add a `fieldIds:[FLD_A]`-still-422s test; if per-field should skip unselected drifted fields, move the drift check after the filter.
+
+**L4 — `skippedFieldIds` still hard-coded `[]`; OpenAPI still says "reserved for a future mode" — but this PR *is* that mode** — **low** · un-adjudicated
+`packages/core-backend/src/routes/univer-meta.ts:5821,5847` (`skippedFieldIds` always `[]`); `packages/openapi/src/paths/multitable.yml:~512` (response desc "reserved for a future partial-restore mode").
+- Caller passing `fieldIds:[A,B,C]` where only `A` is in the diff gets `restoredFieldIds:[A], skippedFieldIds:[]` — `B`/`C` silently dropped with zero signal. Contract/observability gap, not correctness; the response-side doc is now stale and a checkbox-driven frontend cannot reconcile which requested fields applied.
+- **Fix:** either (a) populate `skippedFieldIds` with **non-forbidden** requested-but-not-restored ids (respecting M1's leak constraint — never forbidden ids), or (b) at minimum update the OpenAPI response description and document the silent-drop semantics on the response side, mirroring the request-field note.
+
+**L5 — T17 title overclaims "unknown field" but only asserts an unchanged existing field** — **low** · un-adjudicated
+`tests/integration/multitable-record-restore.test.ts:590-596` (title says "unknown" but selects `FLD_B`, a real unchanged field).
+- The genuine unknown-id path (id not in schema → filter drops it → empty `selectedDiff` → no-op) is asserted by name only. A regression where an unknown id threw or matched-nothing-yet-wrote would not be caught.
+- **Fix:** fix the title to "unchanged field", or add `fieldIds:['fld_does_not_exist']` → expect 200 `noop:true`, live data unchanged.
+
+### What the adversarial pass changed
+M2/L1/L2/L3 all began higher (one high, three medium) and were re-rated after tracing the actual code: each is a real coverage/parity gap over **correct, fail-closed code**, not a latent defect. M1 is the lone finding that stayed at its rating — and it is the headline driver because it regresses an intentional control rather than merely under-testing it.
+
+---
+
+## PR #2673 — comment emoji reactions (B6-a)
+
+### Headline: **REQUEST-CHANGES**
+
+Driver = the keystone real-wire test (the PR's own headline anti-drift proof) runs in **no CI
+workflow**, while the unit suite that *does* run is vacuous about the load-bearing SQL —
+so idempotency, the aggregation, and self-scoped delete have **zero regression protection in
+CI**. This is the repo's own documented "invisible debt" / "wire-vs-fixture" trap, named in
+`vitest.config.ts`'s self-doc (#2052/#2068) and memory (#1435/#1436). One shared root cause and
+one shared fix span the two mediums and the low below.
+
+### Confirmed / surviving findings (high → low)
+
+**M1 — Mock-DB unit tests are vacuous about the SQL (idempotency / aggregation / self-scope asserted by nothing CI runs)** — **medium** · `CONFIRMED`
+`packages/core-backend/tests/unit/comment-reactions.test.ts` — mock harness `:14-56` (every chain method `vi.fn(chainFn)` ignoring args; `execute` shifts a pre-queued array), insert path `:170-174`, delete path `:182-185`, aggregation `:196-208`. Service: `CommentService.ts` `listReactionsForComments` projection callback and `addReaction` `ON CONFLICT … doNothing()` / `removeReaction` `where user_id` — **none invoked by the mock**.
+- The mock never runs the `.select(({fn})=>…)` or `.onConflict(oc=>…)` callbacks; zero call-arg assertions exist. So the unit suite proves only JS mapping/control-flow: (1) idempotency — "inserts when comment exists" queues `[]` and asserts undefined; `ON CONFLICT DO NOTHING` never exercised; (2) aggregation — hand-fed `{count, reacted_by_me}` rows mapped to `{count, reactedByMe}`; the `group by` / `count(*)` / `bool_or`-via-`max(CASE WHEN user_id=viewer)` SQL never runs; (3) **self-scope of delete** (the severity anchor) — "deletes (idempotent)" queues `[]`, nothing asserts the `where user_id = actor` filter that stops a user deleting another's reaction.
+- A refactor dropping the `user_id` filter — a permission-integrity guarantee — would let userA delete userB's reaction with no running CI job catching it. Code is structurally sound (composite PK + `ON CONFLICT`, user-scoped delete) and the integration test passes locally, which is why this is medium (missing-CI-guard) not high.
+- **Fix:** treat the real-wire integration test (M2) as the authoritative proof for `ON CONFLICT` idempotency, the aggregation SQL, and self-scoped delete, and ensure it runs in CI. Add a negative real-wire assertion that userA's DELETE cannot remove userB's reaction (only userA-removes-own is shown today).
+
+**M2 — Keystone real-wire integration test runs in NO CI workflow (+ test DDL drifts from migration)** — **medium** · `↓ high→medium`
+`packages/core-backend/vitest.config.ts:32` (excludes `comments.api.test.ts`; `:35-46` self-documents this exact "invisible debt / no CI job caught" trap citing #2052/#2068); `.github/workflows/plugin-tests.yml:135-160` (core-backend `test` step runs default `vitest` at `:137`, **before** Postgres starts at `:146`; integration allowlists `:168-235,288-296` omit the file — `grep -c` = 0); keystone test at `tests/integration/comments.api.test.ts:1228` (real PG + real HTTP).
+- The PR's central verification claim — idempotent add (`ON CONFLICT DO NOTHING`), the grouped aggregation, self-scoped delete (`where user_id`), the multi-codepoint `❤️` DELETE round-trip, delete-cascade — lives entirely in this excluded file. It passed only on the author's laptop. The exclusion is pre-existing, but this PR deposits its whole real-wire verification into it. Secondary: `ensureCommentsTables` hand-rolls `varchar(50)` ids vs the migration's `text` — so even if it ran it would test a fixture schema, not the migration's DDL.
+- **Downgraded because:** "the ONLY place those behaviors are exercised" overstates coverage. Layer the feature: migration DDL is covered by `migration-replay.yml` (runs `db:migrate` on fresh PG every PR, auto-discovers the new `meta_comment_reactions` migration); service JS logic is covered by the (non-excluded) unit suite. Only **layer 3 — real-SQL semantics** — is the genuine CI gap, on one low-stakes feature, with no live defect.
+- **Fix (shared with M1, L1):** add `tests/integration/comments.api.test.ts` to the real-DB integration step's explicit file list in `plugin-tests.yml` (after the Postgres-start step) so add/aggregate/idempotent-re-add/self-scoped-DELETE/cascade run against real PG on every PR. Align `ensureCommentsTables` string columns to `text`.
+
+**L1 — `comments:write` gate has zero test coverage and no anti-revert guard** — **low** · `↓ medium→low`
+`packages/core-backend/src/routes/comments.ts:400` (POST) and `:419` (DELETE) both `rbacGuard('comments','write')`, matching `createComment` `:296`; `tests/integration/comments.api.test.ts:120` (`RBAC_BYPASS='true'` in `beforeAll` — bypasses the guard for every request). The new unit suite is pure service-layer (no route/RBAC).
+- No test sends a reader-only token and asserts 403 on a reaction; the design-lock even *mandated* a reader-deny test for this route (line 68), which was dropped. Nothing prevents a future edit flipping `'write'` → `'read'` (read-only users writing attributed data).
+- **Downgraded because:** the gate is verified-correct, so present exploitability is zero — this is a missing regression guard, contingent on a hypothetical future edit. Quality/test-parity, caps at low. (Evidence-chain note: the cited "design-lock §3.4" does not exist; the accurate, stronger ref is design-lock line 68, the spec-promised-then-dropped reader-deny test.)
+- **Fix:** after wiring the suite into CI (M2), add a reaction request with a reader-only / no-write token asserting 403 (mint a token outside `RBAC_BYPASS` or add a focused route-guard unit test).
+
+**L2 — Skip-when-unreachable guard green-skips the keystone if PG/port is unavailable** — **low** · un-adjudicated
+`packages/core-backend/tests/integration/comments.api.test.ts:1229` (`if (!baseUrl) return`), `:121-122`/`:132-134` (`beforeAll` silently early-returns leaving `baseUrl` unset when the ephemeral port can't bind or the server has no address).
+- The documented skip-when-unreachable trap (#1435/#1436): with no live PG/port the test passes vacuously. Moot today (file runs in no workflow), but it becomes load-bearing the moment M2 wires the file in — without a hard assertion the wiring could green-skip and re-hide the same gap.
+- **Fix:** when wiring the file in (M2 fix), add a fail-loud assertion (assert `baseUrl` set in `beforeAll`, or `expect(baseUrl).toBeTruthy()` before the body) so a missing PG/port turns the keystone RED, not skipped-green.
+
+**L3 — add-reaction / delete-comment race leaves an orphaned reaction row (no FK)** — **low** · un-adjudicated
+`packages/core-backend/src/services/CommentService.ts:581-592` (`addReaction` insert is non-transactional, runs after a passing `getRequiredCommentRow`); `:220-224` (`deleteComment` txn cascade); migration `zzzz20260615190000_create_meta_comment_reactions.ts:14-21` (no `FOREIGN KEY`).
+- If `addReaction`'s `INSERT … ON CONFLICT DO NOTHING` lands after a concurrent `deleteComment` commits, the row inserts against a vanished `comment_id` (no DB FK, by design — comments sub-domain cascades at the app layer). Genuinely low and non-blocking: orphans are invisible to all read paths (`listReactionsForComments` is driven only by surviving `meta_comments` ids, which are non-recurring UUIDs), so it's a storage leak, not a count/desync bug. Matches the established `markCommentRead` no-FK pattern — not a new regression.
+- **Fix (optional, non-blocking):** (a) accept as the documented no-FK app-cascade pattern + periodic orphan-sweep if it ever matters; (b) add FK `ON DELETE CASCADE` (departs from sub-domain convention); or (c) re-check existence after insert and delete the just-inserted row if the parent vanished.
+
+**L4 — `emoji` body field has no max-length bound before NFC normalization** — **low** · un-adjudicated
+`packages/core-backend/src/routes/comments.ts:295,314` (`z.string().min(1)`, no `.max()`); `CommentService.ts:369-375` (`.normalize('NFC').trim()` on raw input before the allowlist check); `index.ts:950` (`express.json` 10mb cap).
+- Oversized input is ultimately 400'd by the `COMMENT_REACTION_EMOJIS` allowlist, so no persistence/integrity risk; the only ceiling before NFC normalization is the global 10mb body cap. Normalizing a multi-MB string per request is wasteful but negligible. Proto-pollution structurally absent (body parsed as `{emoji: string}`; only the string is consumed; allowlist `Set` membership can't be poisoned).
+- **Fix (defensive):** `z.string().min(1).max(64)` so absurd payloads are rejected before NFC normalization.
+
+### What the adversarial pass changed
+M2 began high and L1 began medium; both were re-rated after confirming the migration DDL and the service JS each have separate CI coverage, leaving only the real-SQL semantics genuinely unguarded — a real gap on a low-stakes feature with no live defect, not a broad coverage hole. M1 held at medium because its self-scoped-delete vacuity touches a permission-integrity guarantee. The two mediums and L1 share one root cause (keystone not in `plugin-tests.yml`) and one shared fix.


### PR DESCRIPTION
## Summary
Sets the **remaining multitable development as a tracked goal** (the gated TODO-checklist format): the current **B1 button/action field** arc — 3 gated slices (B1-a field-type+codec ⬜ in progress → B1-b run endpoint 🔒 → B1-c FE cell 🔒) with per-slice acceptance — plus the **post-B1 ladder** (A1/B4/A5/A4/B2/B7/B3) from the 2026-06-15 refresh audit, each demand-gated.

Markers ✅/⬜/🔒. Discipline: one opt-in at a time; contract-first per arc; nothing auto-advances or auto-merges; the ladder re-ranks on the next refresh audit.

Benchmark evidence (external-product comparison + citations) stays in the research companion #2641 (`docs/research/`); this committed plan uses MetaSheet's own capability names only (convention).

Docs-only. Companion to scope-gate #2644 (B1) and audit #2641.