### PR TITLE
feat(multitable): button field backend contract + exclusions (B1-a0)

### DIFF
--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -31,6 +31,7 @@ export type MultitableFieldType =
   | 'modifiedTime'
   | 'createdBy'
   | 'modifiedBy'
+  | 'button'
 
 export type MultitableField = {
   id: string
@@ -95,6 +96,7 @@ export function mapFieldType(type: string): MultitableFieldType | string {
     return 'dateTime'
   }
   if (normalized === 'formula') return 'formula'
+  if (normalized === 'button') return 'button'
   if (normalized === 'select') return 'select'
   if (
     normalized === 'multiselect' ||
@@ -415,6 +417,29 @@ function sanitizeFieldPropertyByType(
 
   if (type === 'autoNumber') {
     return normalizeAutoNumberProperty(obj)
+  }
+
+  if (type === 'button') {
+    // Button (B1): a value-less, non-editable action trigger. Sanitize the §6
+    // config SHAPE only; `actionType ∈ AutomationActionType` is enforced at the
+    // field create/update route + at execution (B1-a1), NOT here — this read-path
+    // codec stays dependency-light / acyclic (no import of automation-actions).
+    // All §6 keys are whitelisted (so editing one never drops actionConfig), and
+    // the field is always readOnly (clicked, never edited).
+    const next: Record<string, unknown> = { readOnly: true }
+    if (typeof obj.label === 'string' && obj.label.trim()) next.label = obj.label.trim()
+    if (obj.variant === 'primary' || obj.variant === 'secondary' || obj.variant === 'danger') {
+      next.variant = obj.variant
+    }
+    if (typeof obj.actionType === 'string' && obj.actionType.trim()) next.actionType = obj.actionType.trim()
+    if (isPlainObject(obj.actionConfig)) next.actionConfig = obj.actionConfig
+    if (isPlainObject(obj.confirm)) {
+      const c = obj.confirm
+      const confirm: Record<string, unknown> = { enabled: c.enabled === true }
+      if (typeof c.message === 'string' && c.message.trim()) confirm.message = c.message.trim()
+      next.confirm = confirm
+    }
+    return next
   }
 
   if (SYSTEM_FIELD_TYPES.has(type)) {

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -82,6 +82,7 @@ export type UniverMetaField = {
     | 'modifiedTime'
     | 'createdBy'
     | 'modifiedBy'
+    | 'button'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>
@@ -438,7 +439,9 @@ export class RecordWriteService {
         // derived server-side, never written by clients. `deriveFieldPermissions`
         // already marks them readonly for the UI; reject here too as the backend
         // backstop so a non-UI client can't pollute record data with a written value.
-        if (field.type === 'formula' || field.type === 'lookup' || field.type === 'rollup') {
+        // button (B1) joins this non-data class: it stores no value and is a click
+        // trigger, never a written cell — reject writes as the same backend backstop.
+        if (field.type === 'formula' || field.type === 'lookup' || field.type === 'rollup' || field.type === 'button') {
           throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
         }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -292,6 +292,7 @@ type UniverMetaField = {
     | 'modifiedTime'
     | 'createdBy'
     | 'modifiedBy'
+    | 'button'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>

--- a/packages/core-backend/tests/unit/aggregation-helpers.test.ts
+++ b/packages/core-backend/tests/unit/aggregation-helpers.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { aggregateField, groupRowsByField } from '../../src/multitable/aggregation-helpers'
+import { aggregateField, groupRowsByField, isNumericFieldType } from '../../src/multitable/aggregation-helpers'
 
 describe('aggregateField (locked fns)', () => {
   it('sum/avg/min/max over numeric, skipping non-numeric', () => {
@@ -54,5 +54,14 @@ describe('groupRowsByField (#4-3b-2a)', () => {
   it('a primitive value and its JSON form do not collide', () => {
     const buckets = groupRowsByField([{ g: 1 }, { g: '1' }], 'g')
     expect(buckets.length).toBe(2) // number 1 and string "1" are distinct groups
+  })
+})
+
+describe('button field — aggregation exclusion (B1-a0)', () => {
+  it('isNumericFieldType excludes button (value-less → never aggregated)', () => {
+    expect(isNumericFieldType('button')).toBe(false)
+    // sanity: the numeric allowlist still includes the real numeric types
+    expect(isNumericFieldType('number')).toBe(true)
+    expect(isNumericFieldType('currency')).toBe(true)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -646,3 +646,42 @@ describe('exported regex patterns', () => {
     expect(PHONE_REGEX.test('123')).toBe(false)
   })
 })
+
+describe('button field — B1-a0 backend contract', () => {
+  it('mapFieldType recognises button (not falling through to string)', () => {
+    expect(mapFieldType('button')).toBe('button')
+  })
+
+  it('sanitizeFieldProperty round-trips a valid button config + forces readOnly', () => {
+    const p = sanitizeFieldProperty('button', {
+      label: 'Run', variant: 'primary', actionType: 'update_record',
+      actionConfig: { fields: { a: 1 } }, confirm: { enabled: true, message: 'Sure?' },
+    })
+    expect(p).toEqual({
+      readOnly: true, label: 'Run', variant: 'primary', actionType: 'update_record',
+      actionConfig: { fields: { a: 1 } }, confirm: { enabled: true, message: 'Sure?' },
+    })
+  })
+
+  it('drops invalid variant / non-string label / non-object actionConfig; trims actionType; still readOnly', () => {
+    const p = sanitizeFieldProperty('button', {
+      label: 42, variant: 'huge', actionType: '  send_webhook ', actionConfig: 'nope',
+    }) as Record<string, unknown>
+    expect(p.readOnly).toBe(true)
+    expect(p.label).toBeUndefined()
+    expect(p.variant).toBeUndefined()
+    expect(p.actionType).toBe('send_webhook')
+    expect(p.actionConfig).toBeUndefined()
+  })
+
+  it('coerces confirm.enabled to a strict boolean and keeps a string message', () => {
+    const p = sanitizeFieldProperty('button', { confirm: { enabled: 'yes', message: 'ok' } }) as Record<string, unknown>
+    expect(p.confirm).toEqual({ enabled: false, message: 'ok' }) // 'yes' !== true → false
+  })
+
+  it('serializeFieldRow preserves the button type + sanitized property', () => {
+    const f = serializeFieldRow({ id: 'f1', name: 'Act', type: 'button', property: { label: 'Go', actionType: 'update_record' } })
+    expect(f.type).toBe('button')
+    expect(f.property).toMatchObject({ readOnly: true, label: 'Go', actionType: 'update_record' })
+  })
+})

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -691,9 +691,10 @@ describe('RecordWriteService', () => {
         .rejects.toThrow(RecordFieldForbiddenError)
     })
 
-    it('rejects computed fields (formula/lookup/rollup)', async () => {
+    it('rejects computed + non-data fields (formula/lookup/rollup/button)', async () => {
       const service = new RecordWriteService(pool, eventBus as any, helpers)
-      for (const type of ['formula', 'lookup', 'rollup'] as const) {
+      // button (B1) is value-less / click-only — joins the non-data write-rejection class.
+      for (const type of ['formula', 'lookup', 'rollup', 'button'] as const) {
         const changesByRecord = new Map([
           ['rec1', [{ fieldId: 'fld1', value: 'x' }]],
         ])


### PR DESCRIPTION
## Summary

Backend field contract for the button/action field (design-lock **B1-S0**, #2645). **Backend-only** by design — the FE type-union + render land in B1-b (where vue-tsc/tests exercise them; vue-tsc can't run on the local Node 25).

- **field-codecs**: `MultitableFieldType += 'button'`; `mapFieldType('button')` (else it falls through to `'string'`); `sanitizeFieldProperty` button block — whitelists the §6 config (label/variant/actionType/actionConfig/confirm), always `readOnly`, dependency-light (no `automation-actions` import; `actionType ∈ AutomationActionType` is enforced at route + execution, B1-a1).
- **record-write-service**: button joins the `formula`/`lookup`/`rollup` non-data write-rejection (backend backstop — a non-UI client can't pollute a button cell with a value).
- **Two parallel `UniverMetaField` unions** (`record-write-service.ts:54` + `univer-meta.ts:264`) also get `'button'` — **caught by tsc, not assumed**.

## Exclusions

- Aggregation is **allowlist** (`NUMERIC_FIELD_TYPES`) → button auto-excluded.
- Write → **explicitly guarded**.
- `tsc` shows **no exhaustive-switch breaks** → button falls into safe defaults everywhere else (value-less field, never written).

## Verification

146 tests in the 3 touched files (mapFieldType; sanitizeFieldProperty round-trip + invalid-drop + readOnly + confirm-coercion; serializeFieldRow; record-write rejection loop now covers button; `isNumericFieldType('button')===false`). `tsc` clean. Next: **B1-a1** (run endpoint + executor-owned `record_click` inert action + dispatch auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)