### PR TITLE
feat(data-source): add incremental watermark config UI

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -258,7 +258,7 @@
           <h2>1. 来源对象选择</h2>
           <label>
             <span>数据源系统</span>
-            <select v-model="sourceSystemId" data-testid="source-system">
+            <select v-model="sourceSystemId" data-testid="source-system" @change="handleSourceSystemChange">
               <option value="">请选择数据源系统</option>
               <option
                 v-for="system in sourceSystems"
@@ -343,7 +343,7 @@
           </div>
           <label>
             <span>来源数据集（从哪里取数）</span>
-            <select v-model="sourceObjectName" data-testid="source-object" @change="loadSchema('source')">
+            <select v-model="sourceObjectName" data-testid="source-object" @change="handleSourceObjectChange">
               <option value="">请选择来源数据集</option>
               <option v-for="object in sourceObjects" :key="object.name" :value="object.name">
                 {{ object.label || object.name }}
@@ -663,6 +663,51 @@
           </select>
           <small class="integration-workbench__field-help" data-testid="pipeline-mode-help">manual 手工触发；incremental 用水位增量；full 重新扫描来源数据集。</small>
         </label>
+        <div v-if="showWatermarkConfig" class="integration-workbench__watermark-config" data-testid="watermark-config">
+          <div class="integration-workbench__grid integration-workbench__grid--compact">
+            <label>
+              <span>水位类型</span>
+              <select v-model="watermarkType" data-testid="watermark-type">
+                <option value="updated_at">updated_at</option>
+                <option value="monotonic_id">monotonic_id</option>
+              </select>
+            </label>
+            <label>
+              <span>水位字段</span>
+              <select v-if="hasSourceFieldOptions" v-model="watermarkField" data-testid="watermark-field">
+                <option value="">请选择水位字段</option>
+                <option
+                  v-for="option in sourceFieldOptionsForValue(watermarkField)"
+                  :key="`${option.stale ? 'stale' : 'schema'}:${option.value}`"
+                  :value="option.value"
+                >
+                  {{ sourceFieldOptionText(option) }}
+                </option>
+              </select>
+              <input v-else v-model="watermarkField" data-testid="watermark-field" placeholder="updated_at" />
+            </label>
+            <label v-if="watermarkType === 'updated_at'">
+              <span>并列判别字段</span>
+              <select v-if="hasSourceFieldOptions" v-model="watermarkTiebreaker" data-testid="watermark-tiebreaker">
+                <option value="">请选择 tiebreaker</option>
+                <option
+                  v-for="option in sourceFieldOptionsForValue(watermarkTiebreaker)"
+                  :key="`${option.stale ? 'stale' : 'schema'}:${option.value}`"
+                  :value="option.value"
+                >
+                  {{ sourceFieldOptionText(option) }}
+                </option>
+              </select>
+              <input v-else v-model="watermarkTiebreaker" data-testid="watermark-tiebreaker" placeholder="id" />
+            </label>
+          </div>
+          <p class="integration-workbench__hint" data-testid="watermark-config-help">
+            保存只写入增量读取配置；不读取数据库、不推进水位、不写外部系统。updated_at 对 SQL 只读源必须配置不同的 tiebreaker。
+          </p>
+          <p v-if="watermarkConfigError" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="watermark-config-error">
+            {{ watermarkConfigError }}
+          </p>
+        </div>
         <label>
           <span>幂等字段</span>
           <input v-model="idempotencyFieldsText" data-testid="idempotency-fields" placeholder="code 或 sourceId,revision" />
@@ -1276,6 +1321,7 @@ import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
 type ExportFormat = 'csv' | 'xlsx'
+type WatermarkType = 'updated_at' | 'monotonic_id'
 
 interface EditableMapping {
   id: string
@@ -1450,6 +1496,7 @@ const sourceObjectName = ref('')
 const targetObjectName = ref('')
 const stagingSheetId = ref('')
 const sourceSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
+const sourceSchemaSystemId = ref('')
 const targetSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
 const mappings = ref<EditableMapping[]>([])
 const sourceFieldOptions = computed<SourceFieldOption[]>(() => sourceSchema.value.fields
@@ -1465,6 +1512,13 @@ const sourceFieldOptions = computed<SourceFieldOption[]>(() => sourceSchema.valu
   })
   .filter((item): item is SourceFieldOption => item !== null))
 const hasSourceFieldOptions = computed(() => sourceFieldOptions.value.length > 0)
+const sourceFieldOptionValues = computed(() => new Set(sourceFieldOptions.value.map((option) => option.value)))
+const sourceSchemaMatchesSelection = computed(() => Boolean(
+  sourceSystemId.value
+  && sourceObjectName.value
+  && sourceSchemaSystemId.value === sourceSystemId.value
+  && sourceSchema.value.object === sourceObjectName.value,
+))
 const previewText = ref('尚未生成预览')
 // DF-T1.5: read-only provenance summary derived from a DF-T1 targetPayloadPreview (null = nothing to show).
 const previewProvenance = ref<ReturnType<typeof summarizeFieldProvenance>>(null)
@@ -1502,6 +1556,9 @@ const statusKind = ref<'idle' | 'success' | 'error'>('idle')
 const pipelineName = ref('')
 const pipelineMode = ref<IntegrationPipelineMode>('manual')
 const pipelineRunMode = ref<IntegrationPipelineMode>('manual')
+const watermarkType = ref<WatermarkType>('updated_at')
+const watermarkField = ref('updated_at')
+const watermarkTiebreaker = ref('id')
 const idempotencyFieldsText = ref('code')
 const pipelineSampleLimit = ref('20')
 const savedPipelineId = ref('')
@@ -1980,6 +2037,28 @@ const protocolSplitNotice = computed(() => {
   }
   return ''
 })
+const isSqlReadonlySourceSelected = computed(() => selectedSourceSystem.value?.kind === DATA_SOURCE_BRIDGE_KIND)
+const showWatermarkConfig = computed(() => pipelineMode.value === 'incremental')
+const watermarkConfigError = computed(() => {
+  if (!showWatermarkConfig.value) return ''
+  const field = watermarkField.value.trim()
+  const tiebreaker = watermarkTiebreaker.value.trim()
+  if (!field) return 'incremental 模式必须选择水位字段。'
+  if (isSqlReadonlySourceSelected.value && (!sourceSchemaMatchesSelection.value || !hasSourceFieldOptions.value)) {
+    return '请先加载当前来源 schema，再配置 SQL 增量水位字段。'
+  }
+  if (isSqlReadonlySourceSelected.value && hasSourceFieldOptions.value && !sourceFieldOptionValues.value.has(field)) {
+    return '水位字段必须来自当前来源 schema。'
+  }
+  if (watermarkType.value === 'updated_at') {
+    if (isSqlReadonlySourceSelected.value && !tiebreaker) return 'SQL 只读源的 updated_at 水位必须选择 tiebreaker，避免同一时间戳漏读。'
+    if (tiebreaker && tiebreaker === field) return 'tiebreaker 不能和水位字段相同。'
+    if (isSqlReadonlySourceSelected.value && hasSourceFieldOptions.value && tiebreaker && !sourceFieldOptionValues.value.has(tiebreaker)) {
+      return 'tiebreaker 必须来自当前来源 schema。'
+    }
+  }
+  return ''
+})
 const recommendedStagingSourceObject = computed(() => {
   const recommended = recommendedStagingSourceByTarget[targetObjectName.value]
   if (!recommended) return ''
@@ -2040,6 +2119,12 @@ const savePipelineReadinessItems = computed(() => [
     label: '填写幂等字段',
     ready: hasIdempotencyFields.value,
     detail: hasIdempotencyFields.value ? '幂等字段已填写。' : '例如 code 或 sourceId,revision。',
+  },
+  {
+    id: 'watermark',
+    label: '配置增量水位',
+    ready: !watermarkConfigError.value,
+    detail: watermarkConfigError.value || (showWatermarkConfig.value ? '增量水位配置已就绪。' : '非 incremental 模式不需要水位配置。'),
   },
 ])
 const canSavePipeline = computed(() => savePipelineReadinessItems.value.every((item) => item.ready))
@@ -3038,6 +3123,19 @@ async function loadObjects(side: WorkbenchSide): Promise<void> {
   }
 }
 
+function handleSourceSystemChange(): void {
+  sourceObjects.value = []
+  sourceObjectName.value = ''
+  sourceSchema.value = { object: '', fields: [] }
+  sourceSchemaSystemId.value = ''
+}
+
+async function handleSourceObjectChange(): Promise<void> {
+  sourceSchema.value = { object: '', fields: [] }
+  sourceSchemaSystemId.value = ''
+  await loadSchema('source')
+}
+
 async function loadSchema(side: WorkbenchSide): Promise<void> {
   const systemId = side === 'source' ? sourceSystemId.value : targetSystemId.value
   const objectName = side === 'source' ? sourceObjectName.value : targetObjectName.value
@@ -3048,6 +3146,7 @@ async function loadSchema(side: WorkbenchSide): Promise<void> {
   })
   if (side === 'source') {
     sourceSchema.value = schema
+    sourceSchemaSystemId.value = systemId
   } else {
     targetSchema.value = schema
     seedMappingsFromTargetSchema(schema.fields)
@@ -3140,6 +3239,7 @@ async function activateStagingAsSource(objectId: string, successMessage?: string
     sourceSystemId.value = system.id
     sourceObjects.value = buildStagingSourceObjects()
     sourceObjectName.value = objectId
+    sourceSchemaSystemId.value = system.id
     sourceSchema.value = {
       object: objectId,
       fields: descriptorToSchemaFields(descriptor),
@@ -3217,8 +3317,8 @@ function sourceFieldOptionText(option: SourceFieldOption): string {
   return option.label
 }
 
-function sourceFieldOptionsForMapping(mapping: EditableMapping): SourceFieldOption[] {
-  const currentValue = mapping.sourceField.trim()
+function sourceFieldOptionsForValue(value: string): SourceFieldOption[] {
+  const currentValue = value.trim()
   if (!currentValue || sourceFieldOptions.value.some((option) => option.value === currentValue)) {
     return sourceFieldOptions.value
   }
@@ -3231,6 +3331,10 @@ function sourceFieldOptionsForMapping(mapping: EditableMapping): SourceFieldOpti
     },
     ...sourceFieldOptions.value,
   ]
+}
+
+function sourceFieldOptionsForMapping(mapping: EditableMapping): SourceFieldOption[] {
+  return sourceFieldOptionsForValue(mapping.sourceField)
 }
 
 function guessSourceField(targetField: string): string {
@@ -3358,6 +3462,19 @@ function parseOptionalPositiveInteger(value: string): number | undefined {
   return numeric
 }
 
+function buildWatermarkConfig(): Record<string, string> | undefined {
+  if (!showWatermarkConfig.value) return undefined
+  if (watermarkConfigError.value) throw new Error(watermarkConfigError.value)
+  const config: Record<string, string> = {
+    type: watermarkType.value,
+    field: watermarkField.value.trim(),
+  }
+  if (watermarkType.value === 'updated_at' && watermarkTiebreaker.value.trim()) {
+    config.tiebreaker = watermarkTiebreaker.value.trim()
+  }
+  return config
+}
+
 function defaultPipelineName(): string {
   const sourceName = selectedSourceSystem.value?.name || sourceSystemId.value || 'source'
   const targetName = selectedTargetSystem.value?.name || targetSystemId.value || 'target'
@@ -3411,6 +3528,7 @@ function buildPipelinePayload() {
 
   const templateMeta = selectedTemplateMeta()
   const hasTemplate = typeof templateMeta.id === 'string' || typeof templateMeta.endpointPath === 'string'
+  const watermarkConfig = buildWatermarkConfig()
   return {
     ...(savedPipelineId.value.trim() ? { id: savedPipelineId.value.trim() } : {}),
     ...resolvedScope,
@@ -3433,6 +3551,7 @@ function buildPipelinePayload() {
         source: 'generic-integration-workbench',
         version: 'v1',
       },
+      ...(watermarkConfig ? { watermark: watermarkConfig } : {}),
       ...(hasTemplate ? { k3Template: templateMeta } : {}),
     },
     fieldMappings,
@@ -4558,6 +4677,14 @@ watch(selectedTableActionId, (actionId) => {
 
 .integration-workbench__grid--compact {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.integration-workbench__watermark-config {
+  grid-column: 1 / -1;
+  padding: 12px;
+  border: 1px solid #d7deea;
+  border-radius: 8px;
+  background: #f8fafc;
 }
 
 .integration-workbench__dataset-grid {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -715,6 +715,7 @@ describe('IntegrationWorkbenchView', () => {
         },
       },
     })
+    expect(pipelineBodies[0].options).not.toHaveProperty('watermark')
     expect((container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement).value).toBe('pipe_1')
     expect(container.textContent).toContain('Pipeline 已保存：pipe_1')
     expect(container.textContent).toContain('已满足 dry-run 前置条件')
@@ -2456,6 +2457,180 @@ describe('IntegrationWorkbenchView', () => {
       ],
     })
     expect(JSON.stringify(previewBodies[0])).not.toMatch(/password|token|secret|credential/i)
+  })
+
+  it('C4-3: saves schema-backed watermark config for incremental SQL source pipelines', async () => {
+    const pipelineBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP Target', roles: ['target'], supports: ['upsert'], advanced: false },
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['read'], advanced: true },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'pg-1', object: 'public.items' },
+          },
+          {
+            id: 'target_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'ERP target',
+            kind: 'http',
+            role: 'target',
+            status: 'active',
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return jsonResponse([
+          { name: 'public.items', label: 'Items', operations: ['read'], source: 'data-source:sql-readonly' },
+          { name: 'public.archive_items', label: 'Archived items', operations: ['read'], source: 'data-source:sql-readonly' },
+        ])
+      }
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/schema')) {
+        const requestUrl = new URL(url, 'http://localhost')
+        if (requestUrl.searchParams.get('object') === 'public.archive_items') {
+          return jsonResponse({
+            object: 'public.archive_items',
+            fields: [
+              { name: 'code', label: 'Code', type: 'string' },
+            ],
+          })
+        }
+        return jsonResponse({
+          object: 'public.items',
+          fields: [
+            { name: 'id', label: 'ID', type: 'number' },
+            { name: 'updated_at', label: 'Updated at', type: 'timestamp' },
+            { name: 'code', label: 'Code', type: 'string' },
+          ],
+        })
+      }
+      if (url.startsWith('/api/integration/external-systems/target_1/objects')) {
+        return jsonResponse([{ name: 'material', label: 'Material', operations: ['upsert'], target: 'http' }])
+      }
+      if (url.startsWith('/api/integration/external-systems/target_1/schema')) {
+        return jsonResponse({
+          object: 'material',
+          fields: [
+            { name: 'FNumber', label: 'Material number', type: 'string', required: true },
+          ],
+        })
+      }
+      if (url === '/api/integration/pipelines') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        pipelineBodies.push(body)
+        return jsonResponse({
+          id: 'pipe_watermark',
+          tenantId: 'default',
+          workspaceId: null,
+          ...body,
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).checked = true
+    container.querySelector('[data-testid="show-advanced-connectors"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const targetSystemSelect = container.querySelector('[data-testid="target-system"]') as HTMLSelectElement
+    targetSystemSelect.value = 'target_1'
+    targetSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-target-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const modeSelect = container.querySelector('[data-testid="pipeline-mode"]') as HTMLSelectElement
+    modeSelect.value = 'incremental'
+    modeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="watermark-config-help"]')?.textContent).toContain('不读取数据库')
+    const fieldSelect = container.querySelector('[data-testid="watermark-field"]') as HTMLSelectElement
+    const tiebreakerSelect = container.querySelector('[data-testid="watermark-tiebreaker"]') as HTMLSelectElement
+    expect(fieldSelect.tagName).toBe('SELECT')
+    expect(Array.from(fieldSelect.options).map((option) => option.value)).toEqual(expect.arrayContaining(['updated_at', 'id', 'code']))
+
+    tiebreakerSelect.value = ''
+    tiebreakerSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container.querySelector('[data-testid="watermark-config-error"]')?.textContent).toContain('必须选择 tiebreaker')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(true)
+
+    fieldSelect.value = 'updated_at'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    tiebreakerSelect.value = 'id'
+    tiebreakerSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container.querySelector('[data-testid="watermark-config-error"]')).toBeNull()
+
+    const sourceObjectSelect = container.querySelector('[data-testid="source-object"]') as HTMLSelectElement
+    expect(Array.from(sourceObjectSelect.options).map((option) => option.value)).toEqual(expect.arrayContaining(['public.items', 'public.archive_items']))
+    sourceObjectSelect.value = 'public.archive_items'
+    sourceObjectSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(8)
+    expect((container.querySelector('[data-testid="source-object"]') as HTMLSelectElement).value).toBe('public.archive_items')
+    expect(container.querySelector('[data-testid="watermark-config-error"]')?.textContent).toContain('水位字段必须来自当前来源 schema')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(true)
+    ;(container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(pipelineBodies).toHaveLength(0)
+
+    ;(container.querySelector('[data-testid="source-object"]') as HTMLSelectElement).value = 'public.items'
+    container.querySelector('[data-testid="source-object"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(8)
+    ;(container.querySelector('[data-testid="watermark-field"]') as HTMLSelectElement).value = 'updated_at'
+    container.querySelector('[data-testid="watermark-field"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    ;(container.querySelector('[data-testid="watermark-tiebreaker"]') as HTMLSelectElement).value = 'id'
+    container.querySelector('[data-testid="watermark-tiebreaker"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container.querySelector('[data-testid="watermark-config-error"]')).toBeNull()
+    ;(container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    expect(pipelineBodies).toHaveLength(1)
+    expect(pipelineBodies[0]).toMatchObject({
+      sourceSystemId: 'ds_bridge_1',
+      sourceObject: 'public.items',
+      targetSystemId: 'target_1',
+      targetObject: 'material',
+      mode: 'incremental',
+      options: {
+        watermark: {
+          type: 'updated_at',
+          field: 'updated_at',
+          tiebreaker: 'id',
+        },
+      },
+    })
+    expect(JSON.stringify(pipelineBodies[0])).not.toMatch(/password|token|secret|credential/i)
   })
 
   it('C3: shows an enabled approval automation entry for an entitled Yuantus PLM data-source bridge and marks stubbed actions', async () => {


### PR DESCRIPTION
## Summary
- Adds the Workbench incremental watermark config UI for pipeline save payloads.
- Persists `options.watermark` only in incremental mode, with `type`, `field`, and optional `tiebreaker`.
- For `data-source:sql-readonly` + `updated_at`, fails closed unless the current source schema is loaded, the field and tiebreaker come from that schema, and the tiebreaker differs from the watermark field.

## Boundaries
- Frontend-only: no backend, runner, adapter, database, K3, or external-write changes.
- The saved payload carries field names/config only; no source row values or credentials.
- Manual/full mode payloads remain byte-shape compatible and do not include `options.watermark`.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false -t "C4-3"`
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue tests/IntegrationWorkbenchView.spec.ts` (0 errors; existing spec warnings only)
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- Subagent review: APPROVE, including stale-schema closure and frontend-only boundary.
