### PR TITLE
feat(data-source): show SQL read-only boundary notice

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1221,6 +1221,13 @@
             生成 JSON 预览
           </button>
         </div>
+        <p
+          v-if="sourceReadOnlyBoundaryNotice"
+          class="integration-workbench__hint integration-workbench__hint--strong"
+          data-testid="source-readonly-boundary-notice"
+        >
+          {{ sourceReadOnlyBoundaryNotice }}
+        </p>
         <pre data-testid="payload-preview">{{ previewText }}</pre>
         <div
           v-if="previewProvenance"
@@ -2038,6 +2045,10 @@ const protocolSplitNotice = computed(() => {
   return ''
 })
 const isSqlReadonlySourceSelected = computed(() => selectedSourceSystem.value?.kind === DATA_SOURCE_BRIDGE_KIND)
+const sourceReadOnlyBoundaryNotice = computed(() => {
+  if (!isSqlReadonlySourceSelected.value) return ''
+  return '当前来源是 SQL 只读通道：Payload 预览和 dry-run 只读取数据库源；Save-only 只写目标系统，不会写回该数据库连接。'
+})
 const showWatermarkConfig = computed(() => pipelineMode.value === 'incremental')
 const watermarkConfigError = computed(() => {
   if (!showWatermarkConfig.value) return ''

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2438,6 +2438,8 @@ describe('IntegrationWorkbenchView', () => {
     const sourceField = container.querySelector('[data-testid="source-field-0"]') as HTMLSelectElement
     expect(sourceField.tagName).toBe('SELECT')
     expect(container.querySelector('[data-testid="source-field-picker-help-0"]')?.textContent).toContain('不显示行值')
+    expect(container.querySelector('[data-testid="source-readonly-boundary-notice"]')?.textContent).toContain('SQL 只读通道')
+    expect(container.querySelector('[data-testid="source-readonly-boundary-notice"]')?.textContent).toContain('不会写回该数据库连接')
     const optionTexts = Array.from(sourceField.options).map((option) => option.textContent?.trim())
     expect(optionTexts).toContain('当前值 · code（未在来源 schema 中）')
     expect(optionTexts).toContain('Material Code · materialCode · string')


### PR DESCRIPTION
## Summary
- Shows a SQL read-only/source-only boundary notice in the Workbench payload preview panel when the selected source is `data-source:sql-readonly`.
- The notice clarifies that preview/dry-run only read the database source, while Save-only writes only the target system and never writes back to the database connection.

## Boundaries
- Frontend display-only polish.
- No backend, runner, adapter, DB, K3, or external-write changes.
- Does not alter preview/save/run request bodies.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false -t "C4-2"`
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue tests/IntegrationWorkbenchView.spec.ts` (0 errors; existing spec warnings only)
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- Subagent review: APPROVE, display-only boundary confirmed.
