### PR TITLE
feat(multitable): record_click inert action + runSingleAction (B1-a1 executor core)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260615150000_add_record_click_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260615150000_add_record_click_automation_action.ts
@@ -1,0 +1,72 @@
+/**
+ * Migration: B1-a1 — widen the automation action-type CHECK constraint to
+ * include `record_click` (the executor-owned INERT action behind the button
+ * field; audit-only click, zero business side effect).
+ *
+ * Keeps `chk_automation_action_type` aligned with the app-level
+ * `ALL_ACTION_TYPES`. NULL-safe: only the enum widens; no table or column is
+ * added in this slice.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'delete_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+  'parallel_branch',
+  'record_click',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'delete_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+  'parallel_branch',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK)
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -17,6 +17,10 @@ export type AutomationActionType =
   | 'condition_branch'
   | 'start_approval'
   | 'parallel_branch'
+  // B1: executor-owned INERT action for the button field. Audit-only click, zero
+  // business side effect (no record write / no outbound / no job). Dispatched
+  // through the SAME executor path as every other action (no parallel path).
+  | 'record_click'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
@@ -32,6 +36,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'condition_branch',
   'start_approval',
   'parallel_branch',
+  'record_click',
 ]
 
 /** Config shape for update_record */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1570,6 +1570,22 @@ export class AutomationExecutor {
     }
   }
 
+  /**
+   * B1-a1: run a SINGLE action with a caller-built context, reusing the exact
+   * per-action dispatch (`executeSingleAction`) — same handlers, same audit
+   * hooks — as the rule-triggered path, WITHOUT the rule-execution/job shell.
+   * Used by the button/run route so a button click is NOT a parallel execution
+   * path. The CALLER is responsible for dispatch-time authorization (visibility
+   * != executability — re-evaluate the underlying action's own gate as the
+   * actor, server-side) and for writing the audit row.
+   */
+  async runSingleAction(
+    action: AutomationAction,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    return this.executeSingleAction(action, context)
+  }
+
   private async executeSingleAction(
     action: AutomationAction,
     context: ExecutionContext,
@@ -1612,6 +1628,14 @@ export class AutomationExecutor {
             status: 'failed',
             error: 'start_approval requires execution_mode workflow_job_v1',
           }
+          break
+        case 'record_click':
+          // B1 button field — executor-owned INERT action. Records an auditable
+          // click with ZERO business side effect (no record write, no outbound,
+          // no job). The audit row is written by the caller (button/run route);
+          // here we only return a succeeded step so the click runs through the
+          // SAME dispatch as every other action (no parallel path).
+          result = { actionType: 'record_click', status: 'success' }
           break
         default:
           result = {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -5,6 +5,7 @@ import { AutomationScheduler, parseCronToIntervalMs } from '../../src/multitable
 import { matchesTrigger } from '../../src/multitable/automation-triggers'
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
 import { EventBus } from '../../src/integration/events/event-bus'
+import { ALL_ACTION_TYPES, type AutomationAction } from '../../src/multitable/automation-actions'
 
 // ── DB mock for AutomationLogService ──────────────────────────────────────
 
@@ -4034,5 +4035,36 @@ describe('AutomationJobService — A6-1 persistence + C1 read', () => {
     expect(views[0].error).toBeUndefined() // null → absent (C1)
     expect(views[1].error).toBe('boom')
     for (const v of views) expect(() => normalizeWorkflowJob(v)).not.toThrow()
+  })
+})
+
+describe('runSingleAction — B1-a1 executor-owned record_click inert action', () => {
+  const ctx = () => ({
+    executionId: 'btn_test', ruleId: 'btn', sheetId: 's1', recordId: 'r1',
+    recordData: {}, ruleCreatedBy: '', actorId: 'u1', triggerEvent: {},
+  })
+
+  it('record_click is a registered action type', () => {
+    expect(ALL_ACTION_TYPES).toContain('record_click')
+  })
+
+  it('dispatches record_click to a succeeded step with ZERO side effect', async () => {
+    const deps = createMockDeps()
+    const executor = new AutomationExecutor(deps)
+    const action: AutomationAction = { type: 'record_click', config: {} }
+    const result = await executor.runSingleAction(action, ctx())
+    expect(result.actionType).toBe('record_click')
+    expect(result.status).toBe('success')
+    // inert: no DB write/read, no outbound — proves it is not a real-action path
+    expect(deps.queryFn).not.toHaveBeenCalled()
+    expect(deps.fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('runSingleAction reuses the same dispatch as the rule path (unknown type -> failed, not thrown)', async () => {
+    const deps = createMockDeps()
+    const executor = new AutomationExecutor(deps)
+    const result = await executor.runSingleAction({ type: 'definitely_not_a_type' as AutomationAction['type'], config: {} }, ctx())
+    expect(result.status).toBe('failed')
+    expect(result.error).toContain('Unknown action type')
   })
 })

--- a/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/delete-record-automation-action-migration.test.ts
@@ -6,10 +6,13 @@ import {
 } from '../../src/db/migrations/zzzz20260614120000_add_delete_record_automation_action'
 
 describe('delete_record automation action migration (Phase C2)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
-    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
-    // action type added to the app without a DB migration trips this drift guard RED.
+  it('keeps this constraint in sync with app-level action types except those added by later migrations', () => {
+    // No longer the LATEST migration (record_click widened the constraint afterwards — see
+    // record-click-automation-action-migration.test.ts for the live "latest in sync" guard). Every
+    // app-level action type except the ones introduced by a strictly-later migration must be here.
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['record_click'])
     for (const actionType of ALL_ACTION_TYPES) {
+      if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_DELETE_RECORD).toContain(actionType)
     }
   })

--- a/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
@@ -10,7 +10,7 @@ describe('parallel_branch automation action migration (A6-3-4 / W3-1)', () => {
     // This is no longer the LATEST migration (delete_record widened the constraint afterwards — see
     // `delete-record-automation-action-migration.test.ts` for the live "latest in sync" guard). Every
     // app-level action type except the ones introduced by a strictly-later migration must already be here.
-    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record'])
+    const ADDED_BY_LATER_MIGRATIONS = new Set<string>(['delete_record', 'record_click'])
     for (const actionType of ALL_ACTION_TYPES) {
       if (ADDED_BY_LATER_MIGRATIONS.has(actionType)) continue
       expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain(actionType)

--- a/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/record-click-automation-action-migration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK,
+  AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK,
+} from '../../src/db/migrations/zzzz20260615150000_add_record_click_automation_action'
+
+describe('record_click automation action migration (B1-a1)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    // This migration widens chk_automation_action_type to the CURRENT ALL_ACTION_TYPES — so a future
+    // action type added to the app without a DB migration trips this drift guard RED.
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK).toContain(actionType)
+    }
+  })
+
+  it('adds record_click on top of the prior delete_record action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK).toContain('record_click')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK).not.toContain('record_click')
+    expect(AUTOMATION_ACTION_TYPES_WITH_RECORD_CLICK.filter((a) => a !== 'record_click'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK])
+  })
+
+  it('rolls back only the record_click widening (delete_record + parallel_branch remain)', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK).not.toContain('record_click')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK).toContain('delete_record')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_RECORD_CLICK).toContain('parallel_branch')
+  })
+})


### PR DESCRIPTION
## Summary

The **executor core** of B1-a1 (button execution), per design-lock #2645 §3 — backend, fully unit-verified.

- `automation-actions`: `AutomationActionType` + `ALL_ACTION_TYPES` += `record_click` — the **executor-owned INERT action** for the button field (audit-only click, zero business side effect).
- `automation-executor`: `case 'record_click'` in `executeSingleAction` (**:1581**, the real switch — the design-lock's `:1346` was stale, fixed in #2650) returns a `success` step with no record write / outbound / job; + a public **`runSingleAction(action, context)`** that reuses `executeSingleAction`, so a button click dispatches through the **same path as the rule trigger — no parallel path**. Dispatch-time actor authz + the audit row are the caller's (route) responsibility.

`tsc` caught a real bug — `status: 'succeeded'` → must be `'success'` (the executor's step enum differs from the AI-route wording).

## Verification
3 unit tests (record_click registered; dispatch → `success` with **zero** `queryFn`/`fetchFn` side effect; unknown type → failed-not-thrown, proving the shared dispatch). **183/183** in `automation-v1.test.ts` + **tsc clean** (no exhaustive-switch breaks).

## Next (B1-a1 route)
`POST .../fields/:fieldId/button/run` — preflight (button field + actor record-read gate via `resolveSheetCapabilities`) → `runSingleAction(record_click)` → audit → settle (mirror #2623). Open decision: audit destination (reuse `multitable_automation_executions` vs redacted structured log for the rule-less click). Security-sensitive (actor-gate-at-dispatch) → its own focused pass with a mock-pool route test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)