### PR TITLE
feat(multitable): record-level version restore (Layer 1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -191,6 +191,7 @@ jobs:
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
+            tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \

--- a/docs/development/multitable-record-restore-layer1-design-20260615.md
+++ b/docs/development/multitable-record-restore-layer1-design-20260615.md
@@ -38,7 +38,7 @@ Reuse the canonical bulk write spine end-to-end (transaction + optimistic versio
 
 - **`source: 'restore'` extends `RecordWriteSource`.** `post-commit-hooks.ts:1` types it `'rest' | 'yjs-bridge'`; add `'restore'`. The invalidator skip is `=== 'yjs-bridge'`, so `'restore'` correctly **fires** the Yjs invalidation (it is not bridge-origin). The revision `source` column stores `'restore'` too.
 - **No-op still validates `expectedVersion` first.** The optimistic-concurrency check runs before the empty-diff no-op returns (a stale caller must get `VERSION_CONFLICT`, not a misleading `noop: true`). See §3 algorithm ordering.
-- **Schema drift is explicit, not silent.** A snapshot field id that no longer exists in the current sheet schema, or whose type changed since capture, → reject with `SCHEMA_DRIFT` (fail-closed; Slice 1 does not do cross-schema restore). Type-based exclusions (Lock D: computed/link/system-auto/attachment) are handled by type and are *not* drift.
+- **Schema drift is explicit, not silent — to the extent detectable in Slice 1.** A snapshot field id that no longer exists in the current schema → reject with `SCHEMA_DRIFT` (fail-closed). A field whose *type* changed since capture is **not** detected as drift in Slice 1 — no schema-at-capture is stored (that is Layer 2); instead the spine's per-type value validators reject an incompatible old value (→ `VALIDATION_ERROR`, atomic, nothing written). The only residual gap is an old value valid under *both* the old and new type (a benign coercion), accepted and documented as a Layer-2 follow-up. Type-based exclusions (Lock D: computed/link/system-auto/attachment/button) are handled by type and are *not* drift.
 
 ## 1. Evidence
 
@@ -99,8 +99,8 @@ Gap that couples to retention: nothing prunes `meta_record_revisions` — the lo
 - No link-field value restore (Lock D): link fields are excluded from the Slice 1 diff and restored together with `meta_links` handling in Slice 2.
 - No attachment-field restore unless Gate 0 decides otherwise. Recommended deferral: attachment ids in `data` reference externally-retained blobs (attachment-orphan-retention), so an old attachment set may point at GC'd files; restoring it cleanly needs retention-aware handling, not a raw `data` write.
 - No set-to-empty unset (decided): unset is faithful key removal (§3), so version-N reproduction is exact, not merely observable.
-- No restore of computed / link / system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`) fields — excluded by type (Lock D).
-- No cross-schema restore: drifted field ids / changed types → `SCHEMA_DRIFT`, not a silent partial restore.
+- No restore of computed / link / `button` / system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`) fields — excluded by type (Lock D).
+- No cross-schema restore: a snapshot field id absent from the current schema → `SCHEMA_DRIFT`. A *type* change is not detected as drift in Slice 1 (handled fail-closed by the value validators; see §0); precise type-snapshot detection is Layer 2.
 - No per-field partial-skip restore in this slice; atomic reject is the default (`skippedFieldIds` always `[]`). Partial restore is a deferred opt-in.
 - No new permission model, no RBAC/auth central-file changes — endpoint-scoped kernel polish under the standing K3 lock.
 - No base/sheet-level or schema-inclusive snapshot (Layer 2). No revival or repointing of the dormant view-level `SnapshotService`.
@@ -118,7 +118,7 @@ Request `{ targetVersion, expectedVersion }`; response `{ recordId, newVersion, 
 - `RESTORE_UNSUPPORTED` — `targetVersion` resolves only to a `delete` revision (→ Slice 2). (A hard-deleted current record is `404 NOT_FOUND`, not this.)
 - `RESTORE_FORBIDDEN` — a restorable differing field fails the static guard or the layer-3 pre-check (atomic-reject default).
 - `SNAPSHOT_UNAVAILABLE` — resolved revision has a `null` snapshot (legacy/edge rows); restore cannot source values and refuses rather than guessing.
-- `SCHEMA_DRIFT` — the snapshot references a field absent from the current schema, or a field whose type changed since capture; Slice 1 does not do cross-schema restore.
+- `SCHEMA_DRIFT` — the snapshot references a field absent from the current schema. (A *type* change is not detected as drift in Slice 1 — it is handled fail-closed by the value validators; see §0.)
 - `VERSION_EXPIRED` — reserved: target older than the retention floor once retention lands.
 
 OpenAPI: add the path + all seven error codes + the `noop` response field, parity-locked with `packages/openapi`. Lock that `patch` values MAY be `null` to denote field removal (see the unset primitive below).
@@ -129,7 +129,7 @@ Given current record (`data = C`, server version `Vcur`) and target revision N (
 
 1. Existence: if the current record is absent from `meta_records` → `404 NOT_FOUND` (undelete is Slice 2). Resolve the target: `WHERE version = $targetVersion AND action <> 'delete' ORDER BY created_at DESC LIMIT 1`; none but a `delete` at that version → `RESTORE_UNSUPPORTED`; no revision at all → `VERSION_NOT_FOUND`. If the resolved revision's snapshot is `null` → `SNAPSHOT_UNAVAILABLE` (do not fall back to patch replay).
 2. **Concurrency pre-check (before any no-op):** read current `(C, Vcur)`; if `expectedVersion !== Vcur` → `VERSION_CONFLICT`. This runs for the no-op path too, so a stale caller never gets a misleading `noop: true`.
-3. Compute the **restore diff** over restorable fields only. Exclude **by type** (Lock D): computed (`formula`/`lookup`/`rollup`), `link`, system/auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`), and `attachment` (unless Gate 0 opts in). **Schema drift:** if `S` carries a field id absent from the current schema, or whose type changed since capture → `SCHEMA_DRIFT` (do not silently skip).
+3. Compute the **restore diff** over restorable fields only. Exclude **by type** (Lock D): computed (`formula`/`lookup`/`rollup`), `link`, `button`, system/auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`), and `attachment` (unless Gate 0 opts in). **Schema drift:** if `S` carries a field id absent from the current schema → `SCHEMA_DRIFT` (do not silently skip). A type-changed-but-still-present field is not flagged here; an incompatible old value is rejected downstream by the spine value validators.
    - field in `S` and `C[f] !== S[f]` → **set** f to `S[f]`.
    - field in `C` but not in `S` → **unset** f (it did not exist at version N).
    - (An all-empty `S = {}` is valid — every current restorable field becomes an unset, gated below; it is not a null and not an error.)
@@ -166,7 +166,9 @@ Seed: a record with a visible-writable field, a `read_only` field (layer-3), a c
 - `T5` computed exclusion: a formula field differing between versions does not block restore and is recomputed, not written verbatim.
 - `T5b` system/auto exclusion (Lock D): an `autoNumber` field differing between versions neither blocks restore nor is overwritten — it is excluded by type, and the live `autoNumber` value is unchanged.
 - `T6` link exclusion (Lock D): a link field differing between versions is not written by restore, and `meta_links` for the record is left exactly as-is (no desync); the response reports it neither restored nor as a hard failure.
-- `T6b` schema drift: a snapshot field id absent from the current schema (or whose type changed) → `SCHEMA_DRIFT`; nothing written, no silent partial.
+- `T6b` schema drift: a snapshot field id absent from the current schema → `SCHEMA_DRIFT`; nothing written, no silent partial.
+- `T6c` type-change fail-closed: a field present-but-type-changed whose old value is incompatible with the new type is rejected (`VALIDATION_ERROR`), not silently written.
+- `T6d` button exclusion (Lock D): a legacy `button` key differing between versions does not block restore and is not written.
 - `T7` delete boundary + resolution (Lock C): a version that resolves only to a `delete` revision → `RESTORE_UNSUPPORTED`; a hard-deleted current record → `404`; a version shared by an `update` and a `delete` revision resolves to the `update` after-image.
 - `T8` null-snapshot guard: a resolved revision with `snapshot = null` returns `SNAPSHOT_UNAVAILABLE`; no write, no patch-replay fallback.
 - `T9` empty diff no-op: restoring to the current state with a correct `expectedVersion` writes nothing, bumps no version, emits no revision, returns `noop: true`. A no-op restore with a **stale** `expectedVersion` still returns `VERSION_CONFLICT` (the concurrency check precedes the no-op).
@@ -182,7 +184,7 @@ CI wiring is explicit, not glob-based: the new `tests/integration/multitable-rec
 - Restore sources the unmasked snapshot but runs its **own** layer-3 pre-check (the spine does not); no `visible=false` / `read_only=true` / unknown-permission field is ever written or echoed (Lock B enforced).
 - Computed, `link`, and system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`) fields are excluded **by type** (Lock D); `meta_links` is never mutated by Slice 1; dependent computed fields are recomputed via `recalculateFormulaFields` (not `formulaRecalcHook`).
 - Unset is faithful key removal (`unsetFieldIds`), not set-to-empty; removed fields are `null` in the revision `patch` and listed in `changedFieldIds`.
-- Drifted field ids / changed types → `SCHEMA_DRIFT`; a `null` resolved snapshot → `SNAPSHOT_UNAVAILABLE`; neither falls back to patch replay or silent partial.
+- A snapshot field absent from the current schema → `SCHEMA_DRIFT`; a `null` resolved snapshot → `SNAPSHOT_UNAVAILABLE`; a type-changed field with an incompatible old value → `VALIDATION_ERROR` (fail-closed). None falls back to patch replay or a silent partial.
 - A value-changing restore emits exactly one new revision and bumps `version`; an empty-diff restore is a no-op (no revision, no bump) filtered before the `applied===0` skip — but the `expectedVersion` concurrency check still runs (stale no-op → `VERSION_CONFLICT`).
 - `targetVersion` resolution excludes `delete` revisions; hard-deleted record → `404`; ambiguous version resolves to the `update` after-image.
 - `RecordWriteSource` includes `'restore'`; the invalidator skip (`=== 'yjs-bridge'`) leaves restore firing the Yjs invalidator — no live-editor stale-overwrite.

--- a/docs/development/multitable-record-restore-layer1-design-20260615.md
+++ b/docs/development/multitable-record-restore-layer1-design-20260615.md
@@ -1,0 +1,198 @@
+# Multitable Record-Level Version Restore Design (Layer 1, Gate 0)
+
+Status: design-lock — Gate 0 (all three open decisions resolved + maintainer review findings P1–P3 folded + pre-landing boundary patch locked, 2026-06-15). Ready for Slice 1 contracts on owner confirmation of landing. No code written yet.
+
+Grounding: read against `origin/main` @ `c71b7dd12` on 2026-06-15 (revised after maintainer review; the restore/write/history core has no material drift from the earlier `e37f7bc12` read). Builds directly on the record-history arc — the append-only `meta_record_revisions` store (migration `zzzz20260430172000_create_meta_record_revisions.ts`) and the F1 history-egress field mask (`#2144`, `multitable-record-history-field-mask-design-20260530.md`) — and on the canonical `RecordWriteService` write path. Today record history is **observable but not restorable**: the history endpoint lists revisions read-only; there is no server-side revert, and the frontend drawer timeline has no restore affordance.
+
+## 0. Decision
+
+Add a server-side restore for a single multitable record back to one of its prior revisions, as a tightly scoped first slice:
+
+```text
+POST /api/multitable/sheets/:sheetId/records/:recordId/restore
+body: { targetVersion: number, expectedVersion: number }
+```
+
+Five principles are locked here and must hold for every later layer (the forward-change/no-op rule, plus Locks A–D):
+
+- **A value-changing restore is a forward change, never a destructive time-rewind.** A restore that changes data produces a *new* revision (`action='update'`, `source='restore'`, `version = current + 1`); `meta_record_revisions` stays append-only, no history row is mutated or deleted. A restore whose restorable diff is **empty** (current already equals the target over restorable fields) is a **no-op**: it writes nothing, bumps no version, and emits no revision (it returns `{ noop: true, newVersion: current }`). This reconciles with the canonical spine, which already skips when `applied === 0` (see §1); "every restore emits a revision" would otherwise contradict it.
+- **Faithful value reproduction, not patch replay (Lock A).** Restore reproduces version N's *recorded field values*: set fields whose current value differs from N to N's value, and clear fields that did not exist at N. It is computed as a `set ∪ unset` diff against the target snapshot — it must **not** re-apply the stored incremental `patch` through the merge write (`data || patch`), which would leave post-N fields intact and silently fail to reproduce version N. Source of truth is the target revision's stored after-image `snapshot` (reliably populated at all capture sites on current main — see §1); restore guards an absent snapshot explicitly (`SNAPSHOT_UNAVAILABLE`) rather than assuming presence, and never silently falls back to patch replay.
+- **Scalar user-data fields only (Lock D).** Slice 1 restores only fields whose authoritative value is a user-written scalar in `meta_records.data`. Excluded **by field type** (not by relying on the `readOnly` guard catching them):
+  - computed: `formula` / `lookup` / `rollup` (derived server-side, recomputed afterward);
+  - `link` (authoritative in `meta_links` with twoWay/mirror fan-out, only mirrored into `data` — a `data`-only write desyncs the join table; → Slice 2);
+  - system/auto-assigned: `autoNumber` / `createdTime` / `modifiedTime` / `createdBy` / `modifiedBy` (system owns these; restoring an old `autoNumber` would corrupt the sequence, and if such a field is only soft-`readOnly` it would otherwise block the whole atomic restore — so exclude up front);
+  - `attachment`: Gate-0 call, recommended deferral (ids reference externally-retained blobs — see §2).
+  Restorable set is therefore the plain scalar types (text/number/boolean/date/dateTime/select/multiSelect/currency/percent/rating/url/email/phone/barcode/qrcode/location/longText).
+- **Write-gated, not read-gated, and the layer-3 gate is restore's own (Lock B).** Restore reads the **unmasked server-side snapshot** as its source, but must authorize each differing field on **write**. Two gates apply, and they are NOT the same code: (1) the canonical spine already rejects the static `FieldMutationGuard` (`field.hidden` / `field.readOnly`) and computed types — restore inherits this; (2) but the spine **deliberately does not execute the per-subject layer-3 `field_permissions` write gate** (`fieldById` is built from ALL fields so a write-only-no-read field stays writable — see §1) — so restore **must implement the layer-3 pre-check itself**, exactly as the AI-shortcut run path does (`multitable-ai.ts:530`): reject a field whose `fieldPermissions[fieldId]` is missing, `visible === false`, or `readOnly === true`. Net policy: restore only writes fields the actor can both read and write; masked / read-only / unknown-permission fields are never written or read back. Default behavior is **atomic reject** if any restorable (non-computed, non-link) differing field fails either gate; per-field partial-skip is a deferred opt-in.
+- **Update-restore only; undelete is out of scope (Lock C).** The endpoint operates on a **live** record: if the current record no longer exists in `meta_records` (hard-deleted), it returns `404 NOT_FOUND` first — undelete (resurrect + rebuild `meta_links`) is Slice 2. `targetVersion` resolution must be explicit because `(sheet_id, record_id, version)` is **not unique** (a `delete` revision reuses the pre-delete `serverVersion` without bumping — see §1): restore selects `WHERE version = $target AND action <> 'delete' ORDER BY created_at DESC LIMIT 1`; if none but a `delete` revision exists at that version → `RESTORE_UNSUPPORTED`; if no revision at all → `VERSION_NOT_FOUND`.
+
+Reuse the canonical bulk write spine end-to-end (transaction + optimistic version check + static `FieldMutationGuard` + revision emit + `recalculateFormulaFields` + Yjs invalidation). Add exactly two restore-owned pieces on top: the layer-3 write pre-check (Lock B) and the unset primitive (§3). Introduce no parallel permission primitive and no second write path.
+
+### Resolved Gate-0 decisions (owner sign-off 2026-06-15)
+
+- **Write-gate conflict → atomic reject.** Slice 1 is fail-closed: any restorable differing field failing the static or layer-3 gate fails the whole restore (`RESTORE_FORBIDDEN`). `skippedFieldIds` stays in the contract but is **always `[]`** this slice; per-field partial restore is a separate future Gate.
+- **Unset → faithful key removal.** Extend the bulk spine with `unsetFieldIds` and write `data = (data - unsetKeys) || setPatch` in one statement. Set-to-empty is rejected — it would erode Lock A (filter/formula and the empty/null/absent distinctions all come back to bite).
+- **No revision-uniqueness migration in Slice 1.** Rely on the resolution rule (non-`delete` first; `delete`-only → `RESTORE_UNSUPPORTED`). A future hardening may add a **partial** unique index `… WHERE action <> 'delete'` (a blanket `(sheet_id, record_id, version)` unique is wrong — `delete` deliberately reuses the version).
+
+### Pre-landing boundary patch (must be locked before Slice 1 implementation)
+
+- **`source: 'restore'` extends `RecordWriteSource`.** `post-commit-hooks.ts:1` types it `'rest' | 'yjs-bridge'`; add `'restore'`. The invalidator skip is `=== 'yjs-bridge'`, so `'restore'` correctly **fires** the Yjs invalidation (it is not bridge-origin). The revision `source` column stores `'restore'` too.
+- **No-op still validates `expectedVersion` first.** The optimistic-concurrency check runs before the empty-diff no-op returns (a stale caller must get `VERSION_CONFLICT`, not a misleading `noop: true`). See §3 algorithm ordering.
+- **Schema drift is explicit, not silent.** A snapshot field id that no longer exists in the current sheet schema, or whose type changed since capture, → reject with `SCHEMA_DRIFT` (fail-closed; Slice 1 does not do cross-schema restore). Type-based exclusions (Lock D: computed/link/system-auto/attachment) are handled by type and are *not* drift.
+
+## 1. Evidence
+
+Revision capture is already transaction-inline on every write path, storing a full after-image `snapshot` plus the incremental `patch` and `changedFieldIds`:
+
+- `packages/core-backend/src/multitable/record-service.ts:627` (create, `snapshot = patch`) and `:744` (delete, `snapshot = ` pre-delete data, `patch = {}`).
+- `packages/core-backend/src/multitable/record-write-service.ts:735` (update, `snapshot = { ...previousData, ...patch }`).
+- Store + read API: `packages/core-backend/src/multitable/record-history-service.ts` (`recordRecordRevision`, `listRecordRevisions`).
+
+The version counter is the same optimistic-concurrency field the write paths already bump:
+
+- `meta_records.version` — `packages/core-backend/src/db/migrations/zzz20251231_create_meta_schema.ts:48` (`NOT NULL DEFAULT 1`).
+- `record-write-service.ts:726`: `SET data = data || $1::jsonb, ... version = version + 1`. This shallow JSONB **merge** is exactly why Lock A is needed.
+
+The canonical write path fail-closes only on the **static** field guard — the per-subject layer-3 gate is deliberately NOT in it, which is why Lock B has restore enforce layer-3 itself:
+
+- `record-write-service.ts:429-443`: `validateChanges` rejects `field.hidden` (`FIELD_HIDDEN`), `field.readOnly === true` (the static `FieldMutationGuard`, not per-subject), and computed types (`formula`/`lookup`/`rollup`).
+- `univer-meta.ts:3181-3190`: the `/patch` context builds `fieldById` (the write gate) from **ALL** fields "so a write-only-no-read field remains writable", and states `patchRecords` itself **never executes the layer-3 write gate**; `fieldPermissions` is exposed for callers that need a layer-3 pre-check.
+- `multitable-ai.ts:530`: the AI-shortcut run path IS such a caller — it pre-checks `fieldPermissions[fieldId]` (`visible === false || readOnly === true` → `403 FIELD_FORBIDDEN`) before delegating. Restore follows this exact precedent.
+- Per-subject permission source: `permission-service.ts` `loadFieldPermissionScopeMap` (~`:807-848`) reads `field_permissions.visible` + `read_only` into `{ visible, readOnly }`. Columns: `zzzz20260411140100_create_field_permissions.ts` (`visible`, `read_only`).
+
+The history read endpoint is **read-masked**, which is precisely why restore must source from the unmasked snapshot and gate on writes instead:
+
+- `univer-meta.ts` `router.get('/sheets/:sheetId/records/:recordId/history')` (~`:5562`) → `maskStoredRecordFieldIds` + `redactRecordRevisionEntry` filter `patch`/`snapshot`/`changedFieldIds` by the actor's readable set.
+
+Bulk writes to `meta_records.data` already have a realtime-collab reconciliation that restore must trigger:
+
+- `index.ts:2370-2380`: REST→Yjs invalidator — `yjsBridge.cancelPending(recordIds)` + `yjsSyncService.invalidateDocs(recordIds)`; bridge-origin writes (`source:'yjs-bridge'`, `index.ts:2351-2356`) intentionally skip it.
+
+Formula recompute on the bulk spine (so restored source values re-derive dependent computed fields):
+
+- `record-write-service.ts:1021` `helpers.recalculateFormulaFields(...)` — this is the recompute the bulk `patchRecords` path uses. (Do **not** cite `record-service.ts` `formulaRecalcHook` / `:409` / `:650` — that is the create/single-service hook, a different path; restore is built on the bulk spine.)
+
+Link values are mirrored into `data`, not exclusive to it (why Lock D excludes them):
+
+- `record-write-service.ts:641`: `patch[fieldId] = ids` writes the link id array into `patch` → `data` → the after-image `snapshot`, while `:755-818` syncs `meta_links` separately. A `data`-only restore would leave `meta_links` (and its mirror projection) stale.
+
+Snapshot is reliably populated; the "often null" comment is stale:
+
+- All four capture sites pass a (possibly empty `{}`, never `null`) snapshot object: `record-service.ts:636` (create), `:753` (delete), `:1009` (update), `record-write-service.ts:744` (bulk update). yjs-bridge and automation writes route through these same sites, so they populate it too.
+- The column is nullable and the F1-era comment `univer-meta.ts:5611` ("snapshot capture is often null anyway") is stale for current writes — restore still guards `S == null` defensively but keeps snapshot-read primary.
+
+The spine skips zero-change writes, and the revision row has no native deletion marker (why §3 must lock unset + no-op semantics):
+
+- `record-write-service.ts:687`: `if (applied === 0) continue` — a change set that mutates nothing produces no write and no revision.
+- `record-history-service.ts:63`: the revision `patch` is stored as a plain JSON object (`JSON.stringify(input.patch ?? {})`); `changed_field_ids` is a separate `text[]`. There is no built-in representation for "field removed" — §3 defines one (`null` in `patch` = cleared; the field id still appears in `changedFieldIds`).
+
+Delete revisions reuse the pre-delete version, and the table has no version uniqueness (why Lock C pins `targetVersion` resolution):
+
+- `record-service.ts:744-747`: the `delete` revision is written with `version: serverVersion` (not bumped).
+- `zzzz20260430172000_create_meta_record_revisions.ts`: only `id uuid PRIMARY KEY` — no unique constraint on `(sheet_id, record_id, version)`, so an `update` and a `delete` revision can share a version.
+
+Gap that couples to retention: nothing prunes `meta_record_revisions` — the log grows unbounded and has no aging policy. Any "restore to any version" promise is only as durable as the (currently absent) retention rule.
+
+## 2. Non-Goals
+
+- No undelete / deleted-record resurrection, and no `meta_links` reconstruction (Slice 2).
+- No link-field value restore (Lock D): link fields are excluded from the Slice 1 diff and restored together with `meta_links` handling in Slice 2.
+- No attachment-field restore unless Gate 0 decides otherwise. Recommended deferral: attachment ids in `data` reference externally-retained blobs (attachment-orphan-retention), so an old attachment set may point at GC'd files; restoring it cleanly needs retention-aware handling, not a raw `data` write.
+- No set-to-empty unset (decided): unset is faithful key removal (§3), so version-N reproduction is exact, not merely observable.
+- No restore of computed / link / system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`) fields — excluded by type (Lock D).
+- No cross-schema restore: drifted field ids / changed types → `SCHEMA_DRIFT`, not a silent partial restore.
+- No per-field partial-skip restore in this slice; atomic reject is the default (`skippedFieldIds` always `[]`). Partial restore is a deferred opt-in.
+- No new permission model, no RBAC/auth central-file changes — endpoint-scoped kernel polish under the standing K3 lock.
+- No base/sheet-level or schema-inclusive snapshot (Layer 2). No revival or repointing of the dormant view-level `SnapshotService`.
+- No frontend in this slice (Slice 3); existing clients keep using the read-only timeline until the FE opt-in.
+- No retention/prune implementation here, but its contract (see §3) is co-designed so the restore guarantee cannot silently rot.
+
+## 3. Implementation Shape
+
+### Contract (contracts-first; lock before runtime)
+
+Request `{ targetVersion, expectedVersion }`; response `{ recordId, newVersion, noop, restoredFieldIds, skippedFieldIds }` (`noop: true` ⇒ empty restorable diff, `newVersion === current`, no revision). Error enum:
+
+- `VERSION_NOT_FOUND` — no revision at `targetVersion` for this (sheet, record).
+- `VERSION_CONFLICT` — `expectedVersion` ≠ current server version (optimistic concurrency).
+- `RESTORE_UNSUPPORTED` — `targetVersion` resolves only to a `delete` revision (→ Slice 2). (A hard-deleted current record is `404 NOT_FOUND`, not this.)
+- `RESTORE_FORBIDDEN` — a restorable differing field fails the static guard or the layer-3 pre-check (atomic-reject default).
+- `SNAPSHOT_UNAVAILABLE` — resolved revision has a `null` snapshot (legacy/edge rows); restore cannot source values and refuses rather than guessing.
+- `SCHEMA_DRIFT` — the snapshot references a field absent from the current schema, or a field whose type changed since capture; Slice 1 does not do cross-schema restore.
+- `VERSION_EXPIRED` — reserved: target older than the retention floor once retention lands.
+
+OpenAPI: add the path + all seven error codes + the `noop` response field, parity-locked with `packages/openapi`. Lock that `patch` values MAY be `null` to denote field removal (see the unset primitive below).
+
+### Restore algorithm (the runtime contract)
+
+Given current record (`data = C`, server version `Vcur`) and target revision N (full after-image `S`, read **unmasked** server-side):
+
+1. Existence: if the current record is absent from `meta_records` → `404 NOT_FOUND` (undelete is Slice 2). Resolve the target: `WHERE version = $targetVersion AND action <> 'delete' ORDER BY created_at DESC LIMIT 1`; none but a `delete` at that version → `RESTORE_UNSUPPORTED`; no revision at all → `VERSION_NOT_FOUND`. If the resolved revision's snapshot is `null` → `SNAPSHOT_UNAVAILABLE` (do not fall back to patch replay).
+2. **Concurrency pre-check (before any no-op):** read current `(C, Vcur)`; if `expectedVersion !== Vcur` → `VERSION_CONFLICT`. This runs for the no-op path too, so a stale caller never gets a misleading `noop: true`.
+3. Compute the **restore diff** over restorable fields only. Exclude **by type** (Lock D): computed (`formula`/`lookup`/`rollup`), `link`, system/auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`), and `attachment` (unless Gate 0 opts in). **Schema drift:** if `S` carries a field id absent from the current schema, or whose type changed since capture → `SCHEMA_DRIFT` (do not silently skip).
+   - field in `S` and `C[f] !== S[f]` → **set** f to `S[f]`.
+   - field in `C` but not in `S` → **unset** f (it did not exist at version N).
+   - (An all-empty `S = {}` is valid — every current restorable field becomes an unset, gated below; it is not a null and not an error.)
+4. Gate each differing field through **both** gates: (a) the static `FieldMutationGuard` the spine already enforces (`!hidden ∧ !readOnly`); (b) restore's own **layer-3 pre-check**, following `multitable-ai.ts:530` — reject if `fieldPermissions[fieldId]` is missing, `visible === false`, or `readOnly === true`. Any restorable differing field failing either → `RESTORE_FORBIDDEN` (atomic; nothing written). Masked / read-only fields are thereby never written or read back (Lock B).
+5. If the gated diff is empty → **no-op**: return `{ noop: true, newVersion: Vcur, restoredFieldIds: [], skippedFieldIds: [] }` (no write, no revision; concurrency already checked in step 2). Otherwise apply within the canonical spine: `SELECT … FOR UPDATE` → **re-assert** `expectedVersion` (authoritative, anti-TOCTOU) → write the set ∪ unset diff (unsets must count toward `applied` so the write is not skipped — see the unset primitive) → `version = version + 1` → `recordRecordRevision({ action:'update', source:'restore', actorId, changedFieldIds: diff (incl. removed), patch (removed ⇒ null), snapshot: newAfterImage })`.
+6. Recompute dependent computed fields via the bulk spine's `recalculateFormulaFields` (NOT `formulaRecalcHook`); trigger the REST→Yjs invalidator for `recordId` (a non-bridge write — `source:'restore'` is not skipped).
+7. Return `{ recordId, newVersion: Vcur + 1, noop: false, restoredFieldIds: gatedDiff, skippedFieldIds: [] }` (`skippedFieldIds` always `[]` under atomic reject; meaningful only under the deferred partial-skip opt-in).
+
+### The one new primitive: unset (mechanism decided — faithful key removal)
+
+The canonical update is merge-only (`data || patch`) and cannot remove a key, short-circuits when `applied === 0` (`record-write-service.ts:687`), and the revision row has no deletion marker (`record-history-service.ts:63`). The unset primitive locks three things:
+
+1. **Mechanism (decided): faithful key removal.** Extend the bulk spine to accept `unsetFieldIds` and write `data = (data - unsetKeys) || setPatch` in one statement — exact version-N reproduction. Set-to-empty is rejected: it erodes Lock A (filter/formula behavior and the empty/null/absent distinctions diverge from a true version-N state).
+2. **`applied` accounting** — an unset-only restore must NOT hit the `applied === 0` skip: removals count toward `applied` so the write + revision happen. (The step-5 no-op path filters the empty diff out *before* the spine, so the skip never fires spuriously.)
+3. **Revision representation** — a removed field appears in `changedFieldIds`, and its `patch` value is the locked sentinel `null` (= "cleared/removed"). The after-image `snapshot` simply omits the key. OpenAPI documents `null`-as-removal.
+
+The extended write stays on the canonical validation + revision-emit path; no second write path is created (avoids wire-vs-fixture / parallel-primitive drift).
+
+### Retention coupling (co-designed, may ship separately)
+
+Lock the guarantee shape now even if prune lands later: "restore is guaranteed for the most recent N versions / D days; older points are restorable only if captured by a Layer-2 base snapshot." When retention prunes a target, restore returns `VERSION_EXPIRED`, never a silent half-restore. This is also the cleanest justification for Layer 2 existing.
+
+## 4. Tests
+
+Real-DB integration test (`describeIfDatabase`), wired into the Node 20 multitable real-DB CI step, mirroring `multitable-record-history-field-mask.test.ts`.
+
+Seed: a record with a visible-writable field, a `read_only` field (layer-3), a computed (`formula`) field, a **link** field, and an `autoNumber` field — plus at least three versions so a non-trivial diff and a post-N-added field exist.
+
+- `T1` faithful set+unset (Lock A): restore to N reproduces N's values exactly; a field added after N is **removed** (key absent, via `unsetFieldIds`), not set to empty; a blind `data || patch` would leave it and must fail this test.
+- `T2` forward change: a new revision appears (`action='update'`, `source='restore'`, `version = Vcur+1`); the prior versions remain in history.
+- `T3` undo of a restore: restoring to N creates revision M (= N's after-image at version `Vcur+1`); to undo it, restoring to the **pre-restore** version (the revision that was current before the restore) returns to that state. Re-restoring M itself is a redo/no-op, NOT a return to the pre-restore state — assert both.
+- `T4` layer-3 write-gate (Lock B): a field with `field_permissions.read_only=true` (or `visible=false`) that differs between versions → atomic `RESTORE_FORBIDDEN`; nothing written; the value never appears in the response. (Proves restore's own layer-3 pre-check, since the spine does not enforce it.)
+- `T4b` static-guard: a `property.readOnly`/`hidden` differing field is likewise refused.
+- `T5` computed exclusion: a formula field differing between versions does not block restore and is recomputed, not written verbatim.
+- `T5b` system/auto exclusion (Lock D): an `autoNumber` field differing between versions neither blocks restore nor is overwritten — it is excluded by type, and the live `autoNumber` value is unchanged.
+- `T6` link exclusion (Lock D): a link field differing between versions is not written by restore, and `meta_links` for the record is left exactly as-is (no desync); the response reports it neither restored nor as a hard failure.
+- `T6b` schema drift: a snapshot field id absent from the current schema (or whose type changed) → `SCHEMA_DRIFT`; nothing written, no silent partial.
+- `T7` delete boundary + resolution (Lock C): a version that resolves only to a `delete` revision → `RESTORE_UNSUPPORTED`; a hard-deleted current record → `404`; a version shared by an `update` and a `delete` revision resolves to the `update` after-image.
+- `T8` null-snapshot guard: a resolved revision with `snapshot = null` returns `SNAPSHOT_UNAVAILABLE`; no write, no patch-replay fallback.
+- `T9` empty diff no-op: restoring to the current state with a correct `expectedVersion` writes nothing, bumps no version, emits no revision, returns `noop: true`. A no-op restore with a **stale** `expectedVersion` still returns `VERSION_CONFLICT` (the concurrency check precedes the no-op).
+- `T10` concurrency: a competing write between read and apply → `VERSION_CONFLICT`.
+- `T11` Yjs reconciliation: restore invalidates the record's Y.Doc (cancel pending bridge flush + invalidate), so a live editor re-seeds from the restored DB row.
+- `T12` authz floor: a non-writer (sheet/record-level) is rejected before any field logic.
+
+CI wiring is explicit, not glob-based: the new `tests/integration/multitable-record-restore.test.ts` must be added to the **enumerated `vitest ... run \` file list** in the Node 20 multitable real-DB step (`.github/workflows/plugin-tests.yml:~170`), and its suite added to that step's descriptive name. Without both edits it will not run in CI.
+
+## 5. Review Checklist
+
+- No code path re-applies the stored `patch` through `data || patch` to restore (Lock A enforced).
+- Restore sources the unmasked snapshot but runs its **own** layer-3 pre-check (the spine does not); no `visible=false` / `read_only=true` / unknown-permission field is ever written or echoed (Lock B enforced).
+- Computed, `link`, and system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`) fields are excluded **by type** (Lock D); `meta_links` is never mutated by Slice 1; dependent computed fields are recomputed via `recalculateFormulaFields` (not `formulaRecalcHook`).
+- Unset is faithful key removal (`unsetFieldIds`), not set-to-empty; removed fields are `null` in the revision `patch` and listed in `changedFieldIds`.
+- Drifted field ids / changed types → `SCHEMA_DRIFT`; a `null` resolved snapshot → `SNAPSHOT_UNAVAILABLE`; neither falls back to patch replay or silent partial.
+- A value-changing restore emits exactly one new revision and bumps `version`; an empty-diff restore is a no-op (no revision, no bump) filtered before the `applied===0` skip — but the `expectedVersion` concurrency check still runs (stale no-op → `VERSION_CONFLICT`).
+- `targetVersion` resolution excludes `delete` revisions; hard-deleted record → `404`; ambiguous version resolves to the `update` after-image.
+- `RecordWriteSource` includes `'restore'`; the invalidator skip (`=== 'yjs-bridge'`) leaves restore firing the Yjs invalidator — no live-editor stale-overwrite.
+- One write path only; no parallel permission or write primitive introduced.
+- Endpoint-scoped; no RBAC/auth central-file change (K3 lock).
+
+## 6. Follow-Ups (each a separate gated opt-in)
+
+- **Slice 2** — link-aware restore: (a) restore link-field values for live records by re-syncing `meta_links` + mirror fan-out (deferred from Slice 1 by Lock D); (b) undelete deleted records and rebuild their `meta_links` edges — first close the data gap (edges were hard-deleted and never captured in the snapshot).
+- **Slice 3** — frontend: "restore to this version" + per-field (column-level) restore in the record drawer timeline; the natural re-home for `plugin-intelligent-restore` (else delete that unwired scaffold).
+- **Retention** — implement the aging/prune policy co-designed in §3 and wire `VERSION_EXPIRED`.
+- **Revision integrity hardening** — consider a **partial** unique index `(sheet_id, record_id, version) WHERE action <> 'delete'` (a blanket unique is wrong — `delete` reuses the version) plus link-value restore (Slice 2); not a Slice 1 migration.
+- **Layer 2** — native `MetaSnapshotService`: base/sheet-level, schema-inclusive (`meta_fields`/`meta_views`/`meta_links`) checkpoints, borrowing the governance surface (lock / protection level / protection-rule block / expiry / tags / checksum / restore_log / metrics / audit) from the dormant view-level `SnapshotService` while keeping a multitable-native capture/restore core.

--- a/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
+++ b/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
@@ -101,6 +101,9 @@ Tests  31 passed (31)
 
 - **Type-change drift** is only partially covered: a snapshot field *missing* from the schema → `SCHEMA_DRIFT`; a field whose *type changed* since capture is not detectable without a stored schema snapshot (Layer 2), so it falls through to the spine's value validators (→ `VALIDATION_ERROR`), not `SCHEMA_DRIFT`. Documented, fail-closed either way.
 - **Value equality** uses `JSON.stringify` comparison — exact for scalars/arrays; object-key-order is stable because both sides come from the same JSON serializer. Adequate for Slice 1's scalar scope.
+- **Inherited, not independently re-tested (coverage honesty):**
+  - *Row-level write scope (own-vs-all):* enforced by the shared spine — `ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'edit')` runs inside the `FOR UPDATE` loop (`record-write-service.ts:621`). Restore passes `sheetScope`/`access`, so an own-records-only actor cannot restore another user's record. This is covered by the record-patch suite; the restore matrix uses a full-perm writer and does not re-seed sheet-scope assignments to re-prove it.
+  - *In-transaction anti-TOCTOU:* the restore matrix's T10 exercises the route's **pre-check** (`expectedVersion` ≠ current). The in-txn re-check (a write landing between the route read and the spine's `FOR UPDATE`) is inherited unchanged from `patchRecords` and covered by the patch suite; it is not separately simulated. T10's comment says so.
 - **Not run here:** the full CI multitable real-DB list (ran the affected subset); frontend (Slice 3 — none built); cross-browser. CI will run the new test via the enumerated list on Node 20.
 - **Deferred (separate gated opt-ins, unchanged from the design):** Slice 2 (undelete + link-value restore), Slice 3 (frontend / plugin re-home), retention (`VERSION_EXPIRED`), revision partial-unique index, partial-restore mode.
 

--- a/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
+++ b/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
@@ -1,0 +1,114 @@
+# Layer 1 Record-Level Version Restore — Development & Verification Report (2026-06-15)
+
+Companion to the design-lock: `docs/development/multitable-record-restore-layer1-design-20260615.md`.
+
+- **Branch / worktree:** `worktree-claude+multitable-record-restore-l1-20260615` (isolated worktree off `origin/main` @ `c71b7dd12`).
+- **Commit:** `cf25ccd89` — `feat(multitable): record-level version restore (Layer 1)`.
+- **Status:** Implemented + verified locally (typecheck, unit regression, real-DB matrix, OpenAPI parity all green). **Not pushed, no PR opened** — awaiting owner go.
+
+---
+
+## 1. What was built
+
+A server-side endpoint to restore a single **live** multitable record's scalar user-data fields to one of its prior revisions:
+
+```
+POST /api/multitable/sheets/:sheetId/records/:recordId/restore
+body:    { targetVersion: int≥1, expectedVersion: int≥0 }
+200:     { ok, data: { recordId, newVersion, noop, restoredFieldIds[], skippedFieldIds[] } }
+errors:  VERSION_NOT_FOUND(404) · VERSION_CONFLICT(409) · RESTORE_UNSUPPORTED(422)
+         · RESTORE_FORBIDDEN(403) · SNAPSHOT_UNAVAILABLE(422) · SCHEMA_DRIFT(422)
+         · NOT_FOUND(404, hard-deleted record)
+```
+
+It reuses the canonical `RecordWriteService.patchRecords` spine end-to-end (transaction, optimistic version re-check, revision emit, Yjs invalidation, `recalculateFormulaFields`), adding only two restore-owned pieces: the layer-3 write pre-check and the `unset` primitive.
+
+The five locked principles all hold and are test-pinned:
+
+- **Forward-change / no-op** — a value-changing restore emits a new `action='update', source='restore'` revision and bumps version; an empty restorable diff is a no-op (no write, no revision) but still runs the concurrency check.
+- **Lock A faithful set∪unset** — diff is computed against the unmasked stored after-image snapshot; never replays the stored incremental `patch`.
+- **Lock B write-gated, own layer-3** — every differing field is gated by BOTH the static `FieldMutationGuard` (spine) AND restore's own `field_permissions` pre-check (the spine does **not** enforce layer-3 — confirmed at `univer-meta.ts:3181` / `multitable-ai.ts:530`). Atomic reject (`skippedFieldIds` always `[]`).
+- **Lock C update-restore only** — hard-deleted record → 404; `targetVersion` resolves `action<>'delete'` (delete-only → `RESTORE_UNSUPPORTED`; update+delete at one version → uses the update).
+- **Lock D scalar-only** — computed (`formula`/`lookup`/`rollup`), `link`, system-auto (`autoNumber`/`createdTime`/`modifiedTime`/`createdBy`/`modifiedBy`), and `attachment` excluded **by type**.
+
+Plus the pre-landing boundary patch: `RecordWriteSource += 'restore'`, no-op-precedes-conflict-check ordering, and `SCHEMA_DRIFT` for snapshot fields no longer in the schema.
+
+## 2. Files changed (commit `cf25ccd89`, +1333/−12)
+
+| File | Change |
+|---|---|
+| `packages/core-backend/src/multitable/post-commit-hooks.ts` | `RecordWriteSource` += `'restore'` (non-bridge → fires Yjs invalidation). |
+| `packages/core-backend/src/multitable/record-write-service.ts` | `RecordChange.op?: 'set'\|'unset'`; `validateChanges` gates unset (writability + forbids link/attachment unset); write loop applies `data=(data-keys)||patch`, **after-image drops removed keys**, `changedFieldIds` includes removals, revision `patch` marks removal with `null`. Set-only writes keep byte-identical SQL. |
+| `packages/core-backend/src/routes/univer-meta.ts` | New `POST …/restore` route (+`type RecordChange` import). Resolution, concurrency pre-check, snapshot read+null guard, Lock D exclusion, schema-drift, dual write-gate, no-op, delegates to `patchRecords` with `source:'restore'`. |
+| `packages/openapi/src/paths/multitable.yml` (+ regenerated `dist/*`) | Restore path: request body, 200 shape, 7 documented statuses. |
+| `packages/core-backend/tests/integration/multitable-record-restore.test.ts` | New real-DB matrix (15 cases). |
+| `.github/workflows/plugin-tests.yml` | Test added to the enumerated Node-20 multitable real-DB step + step name. |
+| `docs/development/multitable-record-restore-layer1-design-20260615.md` | Design-lock (carried in; grounding bumped to `c71b7dd12`). |
+
+## 3. Verification — commands and results
+
+Environment: local Postgres (`metasheet-dev-postgres`, PG15) at `:5432`. CI's `postgres@…/metasheet_test` role/db is owned by another role here, so a **fresh DB owned by the connecting superuser** was created and migrated to remove both the permission and any stale-schema variable:
+
+```
+createdb metasheet_restore_l1
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_restore_l1 pnpm --filter @metasheet/core-backend migrate   # all migrations OK
+```
+
+**Harness baseline (proved on known-good code before writing the new test):**
+```
+vitest … run tests/integration/multitable-record-history-field-mask.test.ts   → 8 passed (8)
+```
+
+**Typecheck:** `npx tsc --noEmit` (packages/core-backend) → **exit 0, 0 errors**.
+
+**Unit regression (the hot write path I edited):**
+```
+vitest run tests/unit/record-write-service.test.ts record-service.test.ts yjs-rest-invalidation.test.ts → 77 passed (77)
+```
+
+**Integration — new matrix + spine/history regression (single run):**
+```
+vitest --config vitest.integration.config.ts run \
+  multitable-record-restore.test.ts            → 15 passed
+  multitable-record-history-field-mask.test.ts →  8 passed
+  multitable-record-patch.api.test.ts          →  6 passed
+  multitable-patch-partial-success.api.test.ts →  2 passed
+Tests  31 passed (31)
+```
+(Executed counts are non-zero — not a `describeIfDatabase` skip-green.)
+
+**OpenAPI parity:** `pnpm run verify:multitable-openapi:parity` → build OK; `✔ multitable openapi stays aligned with runtime contracts` (1 pass, 0 fail).
+
+### Test matrix → assertions
+
+| Case | What it pins |
+|---|---|
+| T1 | Faithful set+unset; **removed key absent from the stored after-image snapshot**, not just the live row (the advisor's catch-2). |
+| T2 | New revision is `action=update, source=restore`, version bumped; prior versions intact. |
+| T3 | Undo = restore to the **pre-restore** version; re-restoring the current version is a no-op. |
+| T4 | Layer-3 `read_only` differing field → atomic `RESTORE_FORBIDDEN`; nothing written. |
+| T5 / T5b | Differing `formula` / `autoNumber` neither blocks nor is overwritten (Lock D by type). |
+| T6 | Differing `link` not written; `meta_links` row left untouched. |
+| T6b | Snapshot field absent from current schema → `SCHEMA_DRIFT`. |
+| T7 | Delete-only version → `RESTORE_UNSUPPORTED`; update+delete → uses update; hard-deleted record → 404. |
+| T8 | `null` snapshot → `SNAPSHOT_UNAVAILABLE` (no patch-replay fallback). |
+| T9 | Empty diff → `noop:true`; **stale `expectedVersion` → `VERSION_CONFLICT` even for a no-op**. |
+| T10 | Stale `expectedVersion` vs current → `VERSION_CONFLICT`. |
+| T11 | Restore fires the Yjs invalidator for the record (`source='restore'` is not bridge-origin). |
+| T12 | Non-writer rejected before any field logic. |
+
+## 4. Scope notes / honest gaps
+
+- **Type-change drift** is only partially covered: a snapshot field *missing* from the schema → `SCHEMA_DRIFT`; a field whose *type changed* since capture is not detectable without a stored schema snapshot (Layer 2), so it falls through to the spine's value validators (→ `VALIDATION_ERROR`), not `SCHEMA_DRIFT`. Documented, fail-closed either way.
+- **Value equality** uses `JSON.stringify` comparison — exact for scalars/arrays; object-key-order is stable because both sides come from the same JSON serializer. Adequate for Slice 1's scalar scope.
+- **Not run here:** the full CI multitable real-DB list (ran the affected subset); frontend (Slice 3 — none built); cross-browser. CI will run the new test via the enumerated list on Node 20.
+- **Deferred (separate gated opt-ins, unchanged from the design):** Slice 2 (undelete + link-value restore), Slice 3 (frontend / plugin re-home), retention (`VERSION_EXPIRED`), revision partial-unique index, partial-restore mode.
+
+## 5. Landing instructions (owner action)
+
+Nothing is pushed. To land:
+1. Push the branch and open a PR against `main` (the worktree is already based on `origin/main` @ `c71b7dd12`; rebase if main advanced).
+2. CI runs the new matrix automatically (enumerated in `plugin-tests.yml`).
+3. The local throwaway DB `metasheet_restore_l1` can be dropped (`dropdb metasheet_restore_l1`).
+
+Self-review checklist from the design's §5 is satisfied: no patch-replay restore; restore runs its own layer-3 gate; computed/link/system-auto excluded by type and `meta_links` untouched; `SCHEMA_DRIFT`/`SNAPSHOT_UNAVAILABLE` guards; value-change emits exactly one revision while no-op emits none (concurrency still checked); removed fields are `null` in the revision patch; `targetVersion` resolution excludes deletes; `RecordWriteSource` includes `'restore'`; one write path only; endpoint-scoped (no RBAC/auth central-file change).

--- a/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
+++ b/docs/development/multitable-record-restore-layer1-dev-verification-20260615.md
@@ -2,9 +2,8 @@
 
 Companion to the design-lock: `docs/development/multitable-record-restore-layer1-design-20260615.md`.
 
-- **Branch / worktree:** `worktree-claude+multitable-record-restore-l1-20260615` (isolated worktree off `origin/main` @ `c71b7dd12`).
-- **Commit:** `cf25ccd89` — `feat(multitable): record-level version restore (Layer 1)`.
-- **Status:** Implemented + verified locally (typecheck, unit regression, real-DB matrix, OpenAPI parity all green). **Not pushed, no PR opened** — awaiting owner go.
+- **Branch:** `claude/multitable-record-restore-l1-20260615` (rebased onto current `origin/main`). **PR [#2654](https://github.com/zensgit/metasheet2/pull/2654)**.
+- **Status:** Implemented + verified locally (typecheck, unit 81/81, integration 33/33, OpenAPI parity). Maintainer review round (PR #2654) findings P1–P3 addressed — see §7.
 
 ---
 
@@ -61,21 +60,22 @@ vitest … run tests/integration/multitable-record-history-field-mask.test.ts   
 
 **Typecheck:** `npx tsc --noEmit` (packages/core-backend) → **exit 0, 0 errors**.
 
-**Unit regression (the hot write path I edited):**
+**Unit regression (the hot write path I edited + the RANK-8 lock-guard scanner):**
 ```
-vitest run tests/unit/record-write-service.test.ts record-service.test.ts yjs-rest-invalidation.test.ts → 77 passed (77)
+vitest run record-write-service.test.ts record-service.test.ts yjs-rest-invalidation.test.ts \
+            multitable-record-lock-guard.guard.test.ts → 81 passed (81)
 ```
 
 **Integration — new matrix + spine/history regression (single run):**
 ```
 vitest --config vitest.integration.config.ts run \
-  multitable-record-restore.test.ts            → 15 passed
+  multitable-record-restore.test.ts            → 17 passed
   multitable-record-history-field-mask.test.ts →  8 passed
   multitable-record-patch.api.test.ts          →  6 passed
   multitable-patch-partial-success.api.test.ts →  2 passed
-Tests  31 passed (31)
+Tests  33 passed (33)
 ```
-(Executed counts are non-zero — not a `describeIfDatabase` skip-green.)
+(Executed counts are non-zero — not a `describeIfDatabase` skip-green. One combined run flaked once on DB-pool timing and re-ran clean; the standalone restore suite is deterministically 17/17.)
 
 **OpenAPI parity:** `pnpm run verify:multitable-openapi:parity` → build OK; `✔ multitable openapi stays aligned with runtime contracts` (1 pass, 0 fail).
 
@@ -90,6 +90,8 @@ Tests  31 passed (31)
 | T5 / T5b | Differing `formula` / `autoNumber` neither blocks nor is overwritten (Lock D by type). |
 | T6 | Differing `link` not written; `meta_links` row left untouched. |
 | T6b | Snapshot field absent from current schema → `SCHEMA_DRIFT`. |
+| T6c | Type-change fail-closed: old value invalid under the current field type → `VALIDATION_ERROR`, nothing written. |
+| T6d | `button` (no-value trigger) excluded by raw type — neither blocks nor is written. |
 | T7 | Delete-only version → `RESTORE_UNSUPPORTED`; update+delete → uses update; hard-deleted record → 404. |
 | T8 | `null` snapshot → `SNAPSHOT_UNAVAILABLE` (no patch-replay fallback). |
 | T9 | Empty diff → `noop:true`; **stale `expectedVersion` → `VERSION_CONFLICT` even for a no-op**. |
@@ -109,9 +111,15 @@ Tests  31 passed (31)
 
 ## 5. Landing instructions (owner action)
 
-Nothing is pushed. To land:
-1. Push the branch and open a PR against `main` (the worktree is already based on `origin/main` @ `c71b7dd12`; rebase if main advanced).
-2. CI runs the new matrix automatically (enumerated in `plugin-tests.yml`).
-3. The local throwaway DB `metasheet_restore_l1` can be dropped (`dropdb metasheet_restore_l1`).
+On PR [#2654](https://github.com/zensgit/metasheet2/pull/2654), rebased onto current `main`. CI runs the new matrix automatically (enumerated in `plugin-tests.yml`). The local throwaway DB `metasheet_restore_l1` can be dropped (`dropdb metasheet_restore_l1`).
 
 Self-review checklist from the design's §5 is satisfied: no patch-replay restore; restore runs its own layer-3 gate; computed/link/system-auto excluded by type and `meta_links` untouched; `SCHEMA_DRIFT`/`SNAPSHOT_UNAVAILABLE` guards; value-change emits exactly one revision while no-op emits none (concurrency still checked); removed fields are `null` in the revision patch; `targetVersion` resolution excludes deletes; `RecordWriteSource` includes `'restore'`; one write path only; endpoint-scoped (no RBAC/auth central-file change).
+
+## 6. Maintainer review round (PR #2654) — findings addressed
+
+- **[P1, blocker] RANK-8 lock-guard CI failure.** Splitting the spine UPDATE into a set-only / unset+set ternary moved the SQL beyond the single `// lock-guarded:` marker's 3-line scan window, so the structural guard reported "2 mutation site(s) with NO lock disposition" (this was the red `test (18.x)`; `20.x` was the fail-fast cancel). Fix: a `// lock-guarded:` marker now sits immediately above **each** UPDATE template. Verified: `multitable-record-lock-guard.guard.test.ts` 4/4.
+- **[P2] `button` not excluded (Lock D).** `button` is a no-value trigger the write spine refuses. Added it to the Lock D exclusion. Root cause found while fixing: `mapFieldType` has no `button` case, so it folds `button`→`string` and `guard.type` never reports `'button'` (the spine's own `field.type === 'button'` rejection is therefore currently inert too). To stay correct regardless of that shared mapper, restore excludes `button` by its **raw DB type**. New test `T6d`. **Flagged for the button-field track:** `mapFieldType` should map `button`→`button` so the type union + spine rejection + serialization are consistent — intentionally NOT changed here to keep this PR scoped.
+- **[P2] design ↔ impl mismatch on type-change drift.** The design claimed type-change → `SCHEMA_DRIFT`, which Slice 1 cannot detect (no schema-at-capture). Design/checklist corrected to the real semantic: missing-field → `SCHEMA_DRIFT`; type-change → caught fail-closed by the spine value validators (`VALIDATION_ERROR`); precise type-snapshot is Layer 2. New test `T6c` locks the fail-closed behavior.
+- **[P3] forbidden-field-id leak.** `RESTORE_FORBIDDEN` echoed server-derived forbidden field ids (unlike `/patch`, restore derives them from the unmasked snapshot), leaking hidden-field metadata. Message generalized; `T4` now asserts the hidden id is absent from the response.
+
+Not a blocker (per review): the Gemini bot's `recordId` redundancy comment.

--- a/packages/core-backend/src/multitable/post-commit-hooks.ts
+++ b/packages/core-backend/src/multitable/post-commit-hooks.ts
@@ -1,4 +1,7 @@
-export type RecordWriteSource = 'rest' | 'yjs-bridge'
+// 'restore' is a record-level version restore (Layer 1). It is NOT bridge-origin,
+// so the invalidator below (skips only 'yjs-bridge') correctly fires for it — a
+// restore writes meta_records.data and any live Y.Doc must re-seed from the DB.
+export type RecordWriteSource = 'rest' | 'yjs-bridge' | 'restore'
 
 export type YjsInvalidator = (recordIds: string[]) => Promise<void> | void
 

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -752,10 +752,12 @@ export class RecordWriteService {
           }
         }
 
-        // lock-guarded: bulk/multi-record PATCH — ensureRecordNotLocked enforced per record above.
-        // When there are unset keys, subtract them first: `(data - keys) || patch`. The empty-array
-        // case is avoided by branching, so existing set-only writes keep byte-identical SQL.
+        // bulk/multi-record PATCH (+restore unset path): the lock rule is enforced per record above via
+        // ensureRecordNotLocked. When there are unset keys, subtract them first: `(data - keys) || patch`;
+        // the empty-array case is branched so existing set-only writes keep byte-identical SQL. Each UPDATE
+        // template below carries its own adjacent lock-guarded marker for the RANK-8 structural scanner.
         const updateRes = unsetIds.length > 0
+          // lock-guarded: ensureRecordNotLocked enforced per record above (unset+set path)
           ? await query(
               `UPDATE meta_records
                SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
@@ -763,6 +765,7 @@ export class RecordWriteService {
                RETURNING version`,
               [JSON.stringify(patch), sheetId, recordId, actorId, unsetIds],
             )
+          // lock-guarded: ensureRecordNotLocked enforced per record above (set-only path)
           : await query(
               `UPDATE meta_records
                SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -175,6 +175,15 @@ export type RecordChange = {
   fieldId: string
   value: unknown
   expectedVersion?: number
+  /**
+   * Mutation op. Default (undefined) = 'set'. 'unset' removes the field key from
+   * `meta_records.data` entirely (used by record-level version restore — Layer 1 —
+   * to reproduce a prior version that did not have the field). For 'unset', `value`
+   * is ignored. Removal is gated by the same writability rules as a set (not hidden,
+   * not readOnly, not computed) and additionally forbidden for link/attachment types,
+   * whose authoritative state lives outside `data`.
+   */
+  op?: 'set' | 'unset'
 }
 
 export type MultitableCapabilities = {
@@ -445,6 +454,17 @@ export class RecordWriteService {
           throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
         }
 
+        // Unset (key removal) is gated by the same writability rules above, but its
+        // value is ignored so it skips the per-type value-shape checks below. link /
+        // attachment are forbidden — their authoritative state lives outside `data`
+        // (meta_links / attachment store), so a bare `data` key removal would desync it.
+        if (change.op === 'unset') {
+          if (field.type === 'link' || field.type === 'attachment') {
+            throw new RecordFieldForbiddenError(`Field type cannot be unset: ${change.fieldId}`, change.fieldId)
+          }
+          continue
+        }
+
         if (field.type === 'select') {
           if (typeof change.value !== 'string') {
             throw new RecordValidationError(`Select value must be string: ${change.fieldId}`)
@@ -630,6 +650,7 @@ export class RecordWriteService {
         const previousData = h.normalizeJson(recordRow?.data)
 
         const patch: Record<string, unknown> = {}
+        const unsetIds: string[] = []
         const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
         let applied = 0
 
@@ -638,6 +659,14 @@ export class RecordWriteService {
           if (!field) continue
           // Note: formula/lookup/rollup are rejected up-front in validateChanges
           // (Step 0), so no computed-field change reaches this write loop.
+
+          // Unset (key removal) — validated in Step 0 (writability + not link/attachment).
+          // Collected separately so the UPDATE can subtract the keys; never added to `patch`.
+          if (change.op === 'unset') {
+            unsetIds.push(change.fieldId)
+            applied += 1
+            continue
+          }
 
           if (field.type === 'link' && field.link) {
             const ids = h.normalizeLinkIds(change.value)
@@ -724,17 +753,36 @@ export class RecordWriteService {
         }
 
         // lock-guarded: bulk/multi-record PATCH — ensureRecordNotLocked enforced per record above.
-        const updateRes = await query(
-          `UPDATE meta_records
-           SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
-           WHERE sheet_id = $2 AND id = $3
-           RETURNING version`,
-          [JSON.stringify(patch), sheetId, recordId, actorId],
-        )
+        // When there are unset keys, subtract them first: `(data - keys) || patch`. The empty-array
+        // case is avoided by branching, so existing set-only writes keep byte-identical SQL.
+        const updateRes = unsetIds.length > 0
+          ? await query(
+              `UPDATE meta_records
+               SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
+               WHERE sheet_id = $2 AND id = $3
+               RETURNING version`,
+              [JSON.stringify(patch), sheetId, recordId, actorId, unsetIds],
+            )
+          : await query(
+              `UPDATE meta_records
+               SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
+               WHERE sheet_id = $2 AND id = $3
+               RETURNING version`,
+              [JSON.stringify(patch), sheetId, recordId, actorId],
+            )
         if ((updateRes.rows as any[]).length === 0) {
           throw new RecordNotFoundError(`Record not found: ${recordId}`)
         }
         const nextVersion = Number((updateRes.rows[0] as any).version)
+        // After-image MUST drop the removed keys (not just the live row) so a later
+        // restore-of-this-revision reproduces the absence; `changedFieldIds` lists the
+        // removed ids and the revision `patch` marks each removal with the `null` sentinel.
+        const afterImage: Record<string, unknown> = { ...previousData, ...patch }
+        const revisionPatch: Record<string, unknown> = { ...patch }
+        for (const removedId of unsetIds) {
+          delete afterImage[removedId]
+          revisionPatch[removedId] = null
+        }
         const revisionId = await recordRecordRevision(query, {
           sheetId,
           recordId,
@@ -742,9 +790,9 @@ export class RecordWriteService {
           action: 'update',
           source: source ?? 'rest',
           actorId,
-          changedFieldIds: Object.keys(patch),
-          patch,
-          snapshot: { ...previousData, ...patch },
+          changedFieldIds: [...Object.keys(patch), ...unsetIds],
+          patch: revisionPatch,
+          snapshot: afterImage,
         })
         pendingSubscriberNotifications.push({
           sheetId,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5666,10 +5666,15 @@ export function univerMetaRouter(): Router {
       }
       return {}
     }
-    // Lock D: only fields whose authoritative value is a scalar in meta_records.data.
-    const isRestorableType = (t: string): boolean =>
-      t !== 'formula' && t !== 'lookup' && t !== 'rollup' && t !== 'link' && t !== 'attachment'
-      && t !== 'autoNumber' && t !== 'createdTime' && t !== 'modifiedTime' && t !== 'createdBy' && t !== 'modifiedBy'
+    // Lock D: only fields whose authoritative value is a scalar in meta_records.data. Everything the
+    // write spine refuses to write (computed, link, attachment, system-auto, and the no-value `button`
+    // trigger) is excluded here too — otherwise a legacy `button`/system key lingering in data would
+    // enter the diff and turn into a spine RESTORE_FORBIDDEN, blocking an otherwise-restorable record.
+    const NON_RESTORABLE_TYPES = new Set([
+      'formula', 'lookup', 'rollup', 'link', 'attachment', 'button',
+      'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy',
+    ])
+    const isRestorableType = (t: string): boolean => !NON_RESTORABLE_TYPES.has(t)
     const sameValue = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
 
     try {
@@ -5724,6 +5729,15 @@ export function univerMetaRouter(): Router {
       }
       const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
 
+      // Raw DB field types — `mapFieldType` currently folds the no-value `button` trigger into
+      // `string`, so guard.type never reports 'button'. Restore excludes the no-value `button` by its
+      // RAW type so it is skipped regardless of that mapping (otherwise a legacy button key in data
+      // would enter the diff and the spine would refuse it, blocking an otherwise-restorable record).
+      const rawTypeRes = await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
+      const rawTypeById = new Map<string, string>(
+        (rawTypeRes.rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]),
+      )
+
       // Schema drift: a snapshot field id absent from the current schema cannot be restored.
       // (A type-change since capture is not detectable without a stored schema snapshot; the value
       //  validators in the spine act as the backstop, rejecting an incompatible old value.)
@@ -5737,6 +5751,7 @@ export function univerMetaRouter(): Router {
       const diff: RecordChange[] = []
       for (const [fid, guard] of fieldById.entries()) {
         if (!isRestorableType(guard.type)) continue
+        if (rawTypeById.get(fid) === 'button') continue // no-value trigger (mapFieldType folds it to 'string')
         const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
         const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
         if (inSnap) {
@@ -5749,17 +5764,18 @@ export function univerMetaRouter(): Router {
       }
 
       // Lock B: gate every diff field on BOTH the static guard and restore's own layer-3 pre-check.
-      const forbidden = diff
-        .filter((ch) => {
-          const guard = fieldById.get(ch.fieldId)
-          const perm = fieldPermissions[ch.fieldId]
-          const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
-          const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
-          return !staticOk || !layer3Ok
-        })
-        .map((ch) => ch.fieldId)
-      if (forbidden.length > 0) {
-        return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: `Not permitted to restore field(s): ${forbidden.join(', ')}` } })
+      const hasForbidden = diff.some((ch) => {
+        const guard = fieldById.get(ch.fieldId)
+        const perm = fieldPermissions[ch.fieldId]
+        const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
+        const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
+        return !staticOk || !layer3Ok
+      })
+      if (hasForbidden) {
+        // Generalized message — the forbidden ids are DERIVED server-side from the unmasked snapshot
+        // (not caller-submitted like /patch), so echoing them would leak hidden-field metadata to an
+        // actor denied visibility. The diff is atomic: nothing is written.
+        return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: 'Not permitted to restore one or more fields in this revision' } })
       }
 
       const restoredFieldIds = diff.map((ch) => ch.fieldId)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -132,6 +132,7 @@ import {
   RecordValidationError as ServiceValidationError,
   RecordFieldForbiddenError as ServiceFieldForbiddenError,
   type RecordWriteHelpers,
+  type RecordChange,
 } from '../multitable/record-write-service'
 import {
   RecordService,
@@ -5622,6 +5623,195 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list record history failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record history' } })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Layer 1 — record-level version restore.
+  // Design-lock: docs/development/multitable-record-restore-layer1-design-20260615.md
+  //
+  // Restore a single LIVE record's scalar user-data fields back to a prior
+  // revision's recorded values. Properties locked in the design:
+  //  - forward-change: a value-changing restore emits a NEW 'restore' revision
+  //    (action='update') and bumps version; an empty diff is a no-op.
+  //  - Lock A faithful set∪unset diff vs the unmasked stored snapshot (never patch replay).
+  //  - Lock B write-gated: BOTH the static FieldMutationGuard AND restore's own
+  //    layer-3 pre-check (the spine does not enforce layer-3 — see #2106 / multitable-ai.ts).
+  //  - Lock C update-restore only: hard-deleted record → 404; delete-target → RESTORE_UNSUPPORTED.
+  //  - Lock D scalar-only: computed/link/system-auto/attachment excluded by type.
+  // ---------------------------------------------------------------------------
+  router.post('/sheets/:sheetId/records/:recordId/restore', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    }
+    const schema = z.object({
+      targetVersion: z.number().int().positive(),
+      expectedVersion: z.number().int().nonnegative(),
+    })
+    const parsed = schema.safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+    const { targetVersion, expectedVersion } = parsed.data
+
+    const asRecord = (value: unknown): Record<string, unknown> => {
+      if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+      if (typeof value === 'string') {
+        try {
+          const p = JSON.parse(value)
+          if (p && typeof p === 'object' && !Array.isArray(p)) return p as Record<string, unknown>
+        } catch { /* fall through */ }
+      }
+      return {}
+    }
+    // Lock D: only fields whose authoritative value is a scalar in meta_records.data.
+    const isRestorableType = (t: string): boolean =>
+      t !== 'formula' && t !== 'lookup' && t !== 'rollup' && t !== 'link' && t !== 'attachment'
+      && t !== 'autoNumber' && t !== 'createdTime' && t !== 'modifiedTime' && t !== 'createdBy' && t !== 'modifiedBy'
+    const sameValue = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      if (!capabilities.canEditRecord) return sendForbidden(res)
+
+      // Live record only — undelete (resurrect + meta_links rebuild) is Slice 2.
+      const currentRes = await pool.query(
+        'SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [recordId, sheetId],
+      )
+      if (currentRes.rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+      const currentRow = currentRes.rows[0] as { version?: unknown; data?: unknown }
+      const currentVersion = Number(currentRow.version ?? 0)
+      // Concurrency pre-check BEFORE the no-op branch: a stale caller must get a conflict, never noop.
+      if (expectedVersion !== currentVersion) {
+        return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: `Record is at version ${currentVersion}, expected ${expectedVersion}` } })
+      }
+      const currentData = asRecord(currentRow.data)
+
+      // Resolve the target revision: non-delete wins; delete-only at that version → unsupported.
+      // (meta_record_revisions has no (sheet,record,version) uniqueness; delete reuses the version.)
+      const revRes = await pool.query(
+        `SELECT action, snapshot FROM meta_record_revisions
+         WHERE sheet_id = $1 AND record_id = $2 AND version = $3
+         ORDER BY created_at DESC`,
+        [sheetId, recordId, targetVersion],
+      )
+      const revRows = revRes.rows as Array<{ action?: unknown; snapshot?: unknown }>
+      if (revRows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: `No revision at version ${targetVersion}` } })
+      }
+      const targetRev = revRows.find((r) => r.action !== 'delete')
+      if (!targetRev) {
+        return res.status(422).json({ ok: false, error: { code: 'RESTORE_UNSUPPORTED', message: `Version ${targetVersion} is a delete revision; undelete is not supported in this slice` } })
+      }
+      if (targetRev.snapshot === null || targetRev.snapshot === undefined) {
+        return res.status(422).json({ ok: false, error: { code: 'SNAPSHOT_UNAVAILABLE', message: `Revision ${targetVersion} has no stored snapshot to restore from` } })
+      }
+      const targetSnapshot = asRecord(targetRev.snapshot)
+
+      // Field + permission context — single source of truth shared with /patch and the AI shortcut.
+      const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+      if (!patchContext) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
+
+      // Schema drift: a snapshot field id absent from the current schema cannot be restored.
+      // (A type-change since capture is not detectable without a stored schema snapshot; the value
+      //  validators in the spine act as the backstop, rejecting an incompatible old value.)
+      for (const fid of Object.keys(targetSnapshot)) {
+        if (!fieldById.has(fid)) {
+          return res.status(422).json({ ok: false, error: { code: 'SCHEMA_DRIFT', message: `Field ${fid} in revision ${targetVersion} no longer exists in the current schema` } })
+        }
+      }
+
+      // Faithful set ∪ unset diff over restorable fields only.
+      const diff: RecordChange[] = []
+      for (const [fid, guard] of fieldById.entries()) {
+        if (!isRestorableType(guard.type)) continue
+        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
+        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
+        if (inSnap) {
+          if (!sameValue(currentData[fid], targetSnapshot[fid])) {
+            diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })
+          }
+        } else if (inCur) {
+          diff.push({ recordId, fieldId: fid, value: null, expectedVersion: currentVersion, op: 'unset' })
+        }
+      }
+
+      // Lock B: gate every diff field on BOTH the static guard and restore's own layer-3 pre-check.
+      const forbidden = diff
+        .filter((ch) => {
+          const guard = fieldById.get(ch.fieldId)
+          const perm = fieldPermissions[ch.fieldId]
+          const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
+          const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
+          return !staticOk || !layer3Ok
+        })
+        .map((ch) => ch.fieldId)
+      if (forbidden.length > 0) {
+        return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: `Not permitted to restore field(s): ${forbidden.join(', ')}` } })
+      }
+
+      const restoredFieldIds = diff.map((ch) => ch.fieldId)
+      // No-op: nothing to restore (concurrency already verified above).
+      if (diff.length === 0) {
+        return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [], skippedFieldIds: [] } })
+      }
+
+      // Apply through the canonical spine: atomic txn + version re-check + 'restore' revision
+      // (faithful unset after-image) + Yjs invalidation + formula recompute.
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) {
+        recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      }
+      try {
+        const result = await recordWriteService.patchRecords({
+          sheetId,
+          changesByRecord: new Map([[recordId, diff]]),
+          actorId: getRequestActorId(req),
+          fields,
+          visiblePropertyFields: readableEchoFields,
+          visiblePropertyFieldIds: readableEchoFieldIds,
+          attachmentFields,
+          fieldById,
+          capabilities,
+          sheetScope,
+          access,
+          source: 'restore',
+        })
+        const newVersion = result.updated.find((u) => u.recordId === recordId)?.version ?? currentVersion + 1
+        return res.json({ ok: true, data: { recordId, newVersion, noop: false, restoredFieldIds, skippedFieldIds: [] } })
+      } catch (err) {
+        if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) {
+          return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: (err as Error).message } })
+        }
+        if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) {
+          return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: (err as Error).message } })
+        }
+        if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: (err as Error).message } })
+        }
+        throw err
+      }
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) {
+        return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] record restore failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to restore record' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -339,19 +339,28 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     expect(noop.status).toBe(200)
     expect(noop.body.data.noop).toBe(true)
     expect(noop.body.data.newVersion).toBe(2)
+    // The no-op touched nothing in the DB: version unchanged AND no new revision row.
+    const verRes = await q('SELECT version FROM meta_records WHERE id = $1', [rid])
+    expect(Number((verRes.rows[0] as { version: number }).version)).toBe(2)
+    const cntRes = await q('SELECT count(*)::int AS n FROM meta_record_revisions WHERE record_id = $1', [rid])
+    expect((cntRes.rows[0] as { n: number }).n).toBe(1)
     // stale expectedVersion → conflict (the concurrency check precedes the no-op)
     const stale = await restoreReq(rid, { targetVersion: 2, expectedVersion: 1 })
     expect(stale.status).toBe(409)
     expect(stale.body.error.code).toBe('VERSION_CONFLICT')
   })
 
-  test('T10: a competing version bump between read and apply → VERSION_CONFLICT', async () => {
+  // NOTE: this exercises the route's step-2 concurrency PRE-CHECK (expectedVersion ≠ current).
+  // The in-transaction anti-TOCTOU re-check (a write landing between the route read and the spine's
+  // FOR UPDATE) is inherited unchanged from RecordWriteService.patchRecords and is covered by the
+  // record-patch suite; it is not separately simulated here.
+  test('T10: stale expectedVersion vs current → VERSION_CONFLICT (pre-check)', async () => {
     const rid = await seedRecord(
       { [FLD_A]: 'a2' },
       2,
       [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
     )
-    // Caller believes version is 1, but the record is actually at 2 → conflict (mirrors the TOCTOU race).
+    // Caller believes version is 1, but the record is actually at 2 → conflict.
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 1 })
     expect(res.status).toBe(409)
     expect(res.body.error.code).toBe('VERSION_CONFLICT')

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -41,6 +41,8 @@ const FLD_SECRET = `fld_rstr_secret_${TS}`
 const FLD_FX = `fld_rstr_fx_${TS}`
 const FLD_AUN = `fld_rstr_aun_${TS}`
 const FLD_LK = `fld_rstr_lk_${TS}`
+const FLD_BTN = `fld_rstr_btn_${TS}`
+const FLD_SEL = `fld_rstr_sel_${TS}`
 const USER_W = `u_rstr_writer_${TS}`
 const USER_RO = `u_rstr_ro_${TS}`
 
@@ -130,6 +132,8 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     await f(FLD_FX, 'Formula', 'formula', '{}', 4)
     await f(FLD_AUN, 'AutoNum', 'autoNumber', '{}', 5)
     await f(FLD_LK, 'Link', 'link', '{}', 6)
+    await f(FLD_BTN, 'Button', 'button', '{}', 7)
+    await f(FLD_SEL, 'Select', 'select', JSON.stringify({ options: [{ value: 'x' }, { value: 'y' }] }), 8)
 
     // Layer-3: USER_RO is read_only on SECRET (and a separate visible=false would also gate).
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_RO, true, true])
@@ -231,6 +235,8 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
     expect(res.status).toBe(403)
     expect(res.body.error.code).toBe('RESTORE_FORBIDDEN')
+    // P3: the error must NOT echo server-derived forbidden field ids (would leak hidden-field metadata).
+    expect(JSON.stringify(res.body)).not.toContain(FLD_SECRET)
     // atomic: nothing written, version unchanged
     const data = await liveData(rid)
     expect(data[FLD_A]).toBe('a2')
@@ -286,6 +292,36 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
     expect(res.status).toBe(422)
     expect(res.body.error.code).toBe('SCHEMA_DRIFT')
+  })
+
+  test('T6c: type-change fail-closed — old value invalid under the current field type → VALIDATION_ERROR, nothing written', async () => {
+    // FLD_SEL is now a select with options [x,y]; the v1 snapshot holds a value that is no longer a
+    // valid option (simulating a field whose type/constraints changed since capture).
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SEL]: 'x' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SEL]: 'no_longer_valid' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SEL]: 'x' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    // atomic: nothing written (validation precedes the transaction)
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('a2')
+    expect(data[FLD_SEL]).toBe('x')
+  })
+
+  test('T6d: button (no-value trigger) excluded — a legacy button key neither blocks nor is written', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_BTN]: 'legacy_btn_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_BTN]: 'legacy_btn_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_BTN]: 'legacy_btn_now' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toContain(FLD_A)
+    expect(res.body.data.restoredFieldIds).not.toContain(FLD_BTN)
+    expect((await liveData(rid))[FLD_BTN]).toBe('legacy_btn_now') // untouched
   })
 
   test('T7: delete-only version → RESTORE_UNSUPPORTED; update+delete → uses update; hard-deleted record → 404', async () => {

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Real-DB integration test for Layer 1 — record-level version restore.
+ * Design-lock: docs/development/multitable-record-restore-layer1-design-20260615.md
+ *
+ * POST /api/multitable/sheets/:sheetId/records/:recordId/restore
+ *
+ * Covers the locked matrix:
+ *  T1  faithful set+unset (Lock A) — incl. removed key absent from the STORED revision snapshot
+ *  T2  forward-change — new revision (action=update, source=restore), version bumped
+ *  T3  undo a restore — restore to the PRE-restore version returns to it; re-restoring the restore rev is a no-op
+ *  T4  layer-3 write-gate (Lock B) — read_only field difference → atomic RESTORE_FORBIDDEN
+ *  T5  computed exclusion (Lock D) — differing formula field neither blocks nor is written
+ *  T5b system/auto exclusion (Lock D) — differing autoNumber neither blocks nor is overwritten
+ *  T6  link exclusion (Lock D) — differing link field not written; meta_links untouched
+ *  T6b schema drift — snapshot field absent from current schema → SCHEMA_DRIFT
+ *  T7  delete-resolution (Lock C) — delete-only version → RESTORE_UNSUPPORTED; update+delete → uses update; hard-deleted record → 404
+ *  T8  null snapshot → SNAPSHOT_UNAVAILABLE
+ *  T9  no-op + stale conflict — correct expectedVersion → noop; stale → VERSION_CONFLICT
+ *  T10 concurrency — competing bump between read and apply → VERSION_CONFLICT
+ *  T11 Yjs reconciliation — restore fires the invalidator for the record (source='restore' is not bridge-origin)
+ *  T12 authz floor — non-writer rejected before any field logic
+ */
+import { randomUUID } from 'crypto'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { setYjsInvalidatorForRoutes, univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_rstr_${TS}`
+const SHEET_ID = `sheet_rstr_${TS}`
+const FSHEET_ID = `fsheet_rstr_${TS}`
+const FOREIGN_REC = `frec_rstr_${TS}`
+const FLD_A = `fld_rstr_a_${TS}`
+const FLD_B = `fld_rstr_b_${TS}`
+const FLD_SECRET = `fld_rstr_secret_${TS}`
+const FLD_FX = `fld_rstr_fx_${TS}`
+const FLD_AUN = `fld_rstr_aun_${TS}`
+const FLD_LK = `fld_rstr_lk_${TS}`
+const USER_W = `u_rstr_writer_${TS}`
+const USER_RO = `u_rstr_ro_${TS}`
+
+let app: Express
+let testUserId = USER_W
+let testPerms: string[] = ['multitable:read', 'multitable:write']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+type RevSeed = {
+  version: number
+  action?: 'create' | 'update' | 'delete'
+  snapshot: Record<string, unknown> | null
+  changedFieldIds?: string[]
+}
+
+let recordSeq = 0
+async function seedRecord(
+  currentData: Record<string, unknown>,
+  currentVersion: number,
+  revisions: RevSeed[],
+): Promise<string> {
+  const recordId = `rec_rstr_${TS}_${recordSeq++}`
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,$4)', [
+    recordId,
+    SHEET_ID,
+    JSON.stringify(currentData),
+    currentVersion,
+  ])
+  for (const rev of revisions) {
+    await q(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot)
+       VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8::text[],$9::jsonb,$10::jsonb)`,
+      [
+        randomUUID(),
+        SHEET_ID,
+        recordId,
+        rev.version,
+        rev.action ?? 'update',
+        'rest',
+        USER_W,
+        rev.changedFieldIds ?? Object.keys(rev.snapshot ?? {}),
+        JSON.stringify(rev.snapshot ?? {}),
+        rev.snapshot === null ? null : JSON.stringify(rev.snapshot),
+      ],
+    )
+  }
+  return recordId
+}
+
+const restoreReq = (recordId: string, body: Record<string, unknown>) =>
+  request(app).post(`/api/multitable/sheets/${SHEET_ID}/records/${recordId}/restore`).send(body)
+
+async function latestRevision(recordId: string) {
+  const res = await q(
+    `SELECT version, action, source, changed_field_ids, snapshot
+     FROM meta_record_revisions WHERE record_id = $1 ORDER BY version DESC, created_at DESC LIMIT 1`,
+    [recordId],
+  )
+  return res.rows[0] as { version: number; action: string; source: string; changed_field_ids: string[]; snapshot: Record<string, unknown> | null }
+}
+async function liveData(recordId: string): Promise<Record<string, unknown>> {
+  const res = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  return (res.rows[0] as { data: Record<string, unknown> }).data
+}
+
+describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Restore Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Restore Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FSHEET_ID, BASE_ID, 'Foreign Sheet'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FOREIGN_REC, FSHEET_ID, '{}'])
+
+    const f = (id: string, name: string, type: string, property: string, order: number) =>
+      q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [id, SHEET_ID, name, type, property, order])
+    await f(FLD_A, 'A', 'string', '{}', 1)
+    await f(FLD_B, 'B', 'string', '{}', 2)
+    await f(FLD_SECRET, 'Secret', 'string', '{}', 3)
+    await f(FLD_FX, 'Formula', 'formula', '{}', 4)
+    await f(FLD_AUN, 'AutoNum', 'autoNumber', '{}', 5)
+    await f(FLD_LK, 'Link', 'link', '{}', 6)
+
+    // Layer-3: USER_RO is read_only on SECRET (and a separate visible=false would also gate).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_RO, true, true])
+  })
+
+  beforeEach(() => {
+    testUserId = USER_W
+    testPerms = ['multitable:read', 'multitable:write']
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('T1: faithful set+unset; removed key absent from the stored after-image snapshot', async () => {
+    // current v3 has A,B,SECRET(same as v1); v1 snapshot has only A → set A, unset B; SECRET unchanged.
+    const rid = await seedRecord(
+      { [FLD_A]: 'a3', [FLD_B]: 'b3', [FLD_SECRET]: 'sec' },
+      3,
+      [
+        { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec' } },
+        { version: 3, snapshot: { [FLD_A]: 'a3', [FLD_B]: 'b3', [FLD_SECRET]: 'sec' } },
+      ],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 3 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.noop).toBe(false)
+    expect(res.body.data.newVersion).toBe(4)
+    expect(res.body.data.restoredFieldIds.sort()).toEqual([FLD_A, FLD_B].sort())
+
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('a1')
+    expect(Object.prototype.hasOwnProperty.call(data, FLD_B)).toBe(false) // B removed from the live row
+    expect(data[FLD_SECRET]).toBe('sec') // unchanged (equal in v1 snapshot)
+
+    const rev = await latestRevision(rid)
+    expect(rev.version).toBe(4)
+    expect(rev.snapshot?.[FLD_A]).toBe('a1')
+    // KEYSTONE: the removed key must be absent from the stored after-image, not merely the live row.
+    expect(rev.snapshot && Object.prototype.hasOwnProperty.call(rev.snapshot, FLD_B)).toBe(false)
+    expect(rev.changed_field_ids.sort()).toEqual([FLD_A, FLD_B].sort())
+  })
+
+  test('T2: forward-change — new revision is action=update, source=restore', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    const rev = await latestRevision(rid)
+    expect(rev.action).toBe('update')
+    expect(rev.source).toBe('restore')
+    expect(rev.version).toBe(3)
+    // prior versions remain in history
+    const all = await q('SELECT DISTINCT version FROM meta_record_revisions WHERE record_id = $1 ORDER BY version', [rid])
+    expect((all.rows as Array<{ version: number }>).map((r) => Number(r.version))).toEqual([1, 2, 3])
+  })
+
+  test('T3: undo a restore = restore to the pre-restore version; re-restoring the restore rev is a no-op', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    // restore to v1 → v3 (A='a1')
+    const r1 = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(r1.status).toBe(200)
+    expect((await liveData(rid))[FLD_A]).toBe('a1')
+    // undo = restore to v2 (the pre-restore version) → v4 (A='a2')
+    const undo = await restoreReq(rid, { targetVersion: 2, expectedVersion: 3 })
+    expect(undo.status).toBe(200)
+    expect((await liveData(rid))[FLD_A]).toBe('a2')
+    // re-restoring the restore revision (v3, A='a1' after-image) from current(A='a2') is NOT a no-op (A differs);
+    // but re-restoring to the CURRENT version (v4) is the no-op case.
+    const redo = await restoreReq(rid, { targetVersion: 4, expectedVersion: 4 })
+    expect(redo.status).toBe(200)
+    expect(redo.body.data.noop).toBe(true)
+  })
+
+  test('T4: layer-3 read_only field difference → atomic RESTORE_FORBIDDEN, nothing written', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' } }],
+    )
+    testUserId = USER_RO // read_only on SECRET
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('RESTORE_FORBIDDEN')
+    // atomic: nothing written, version unchanged
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('a2')
+    expect(data[FLD_SECRET]).toBe('sec_now')
+  })
+
+  test('T5: differing formula field neither blocks restore nor is written verbatim', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_FX]: 'fx_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_FX]: 'fx_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_FX]: 'fx_now' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toContain(FLD_A)
+    expect(res.body.data.restoredFieldIds).not.toContain(FLD_FX)
+    // formula value not overwritten with the old snapshot value
+    expect((await liveData(rid))[FLD_FX]).not.toBe('fx_old')
+  })
+
+  test('T5b: differing autoNumber (system) is excluded — not blocked, not overwritten', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_AUN]: 2 },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_AUN]: 1 } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_AUN]: 2 } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).not.toContain(FLD_AUN)
+    expect((await liveData(rid))[FLD_AUN]).toBe(2) // unchanged
+  })
+
+  test('T6: link field excluded — not written, meta_links left untouched', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: [] } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } }],
+    )
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).not.toContain(FLD_LK)
+    const links = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2', [FLD_LK, rid])
+    expect((links.rows as Array<{ foreign_record_id: string }>).map((r) => r.foreign_record_id)).toEqual([FOREIGN_REC])
+  })
+
+  test('T6b: snapshot field absent from current schema → SCHEMA_DRIFT', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', ghost_field_gone: 'x' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('SCHEMA_DRIFT')
+  })
+
+  test('T7: delete-only version → RESTORE_UNSUPPORTED; update+delete → uses update; hard-deleted record → 404', async () => {
+    // delete-only at v2
+    const ridDel = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, action: 'delete', snapshot: { [FLD_A]: 'a2' } }],
+    )
+    const delRes = await restoreReq(ridDel, { targetVersion: 2, expectedVersion: 2 })
+    expect(delRes.status).toBe(422)
+    expect(delRes.body.error.code).toBe('RESTORE_UNSUPPORTED')
+
+    // version with BOTH update and delete → resolves to update
+    const ridBoth = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [
+        { version: 1, action: 'update', snapshot: { [FLD_A]: 'a1' } },
+        { version: 1, action: 'delete', snapshot: { [FLD_A]: 'a1' } },
+        { version: 2, snapshot: { [FLD_A]: 'a2' } },
+      ],
+    )
+    const bothRes = await restoreReq(ridBoth, { targetVersion: 1, expectedVersion: 2 })
+    expect(bothRes.status).toBe(200) // picked the update revision, not the delete
+
+    // hard-deleted current record → 404 (undelete is Slice 2)
+    const res404 = await restoreReq(`rec_rstr_missing_${TS}`, { targetVersion: 1, expectedVersion: 0 })
+    expect(res404.status).toBe(404)
+  })
+
+  test('T8: null snapshot → SNAPSHOT_UNAVAILABLE', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: null }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('SNAPSHOT_UNAVAILABLE')
+  })
+
+  test('T9: empty diff → noop with correct version; stale expectedVersion → VERSION_CONFLICT even for a no-op', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    // restore to the current state = no-op
+    const noop = await restoreReq(rid, { targetVersion: 2, expectedVersion: 2 })
+    expect(noop.status).toBe(200)
+    expect(noop.body.data.noop).toBe(true)
+    expect(noop.body.data.newVersion).toBe(2)
+    // stale expectedVersion → conflict (the concurrency check precedes the no-op)
+    const stale = await restoreReq(rid, { targetVersion: 2, expectedVersion: 1 })
+    expect(stale.status).toBe(409)
+    expect(stale.body.error.code).toBe('VERSION_CONFLICT')
+  })
+
+  test('T10: a competing version bump between read and apply → VERSION_CONFLICT', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    // Caller believes version is 1, but the record is actually at 2 → conflict (mirrors the TOCTOU race).
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 1 })
+    expect(res.status).toBe(409)
+    expect(res.body.error.code).toBe('VERSION_CONFLICT')
+  })
+
+  test('T11: restore fires the Yjs invalidator for the record (source=restore is not bridge-origin)', async () => {
+    const invalidated: string[] = []
+    setYjsInvalidatorForRoutes((ids) => { invalidated.push(...ids) })
+    try {
+      const rid = await seedRecord(
+        { [FLD_A]: 'a2' },
+        2,
+        [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+      )
+      const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+      expect(res.status).toBe(200)
+      expect(invalidated).toContain(rid)
+    } finally {
+      setYjsInvalidatorForRoutes(null)
+    }
+  })
+
+  test('T12: a non-writer is rejected before any field logic', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } }, { version: 2, snapshot: { [FLD_A]: 'a2' } }],
+    )
+    testPerms = ['multitable:read'] // read only, no write
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(403)
+    expect((await liveData(rid))[FLD_A]).toBe('a2') // untouched
+  })
+})

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -13021,6 +13021,130 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/restore:
+    post:
+      summary: Restore a multitable record to a prior revision (Layer 1)
+      description: >-
+        Restores a live record's scalar user-data fields to a prior revision's
+        recorded values. Forward-change semantics — a value-changing restore
+        emits a new revision (source=restore) and bumps version; an empty diff
+        is a no-op. Computed/link/system-auto/attachment fields are excluded by
+        type. Atomically rejected if any restorable differing field is not
+        writable.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetVersion:
+                  type: integer
+                  minimum: 1
+                  description: The record version to restore to.
+                expectedVersion:
+                  type: integer
+                  minimum: 0
+                  description: >-
+                    Optimistic-concurrency token; must equal the current server
+                    version.
+              required:
+                - targetVersion
+                - expectedVersion
+      responses:
+        '200':
+          description: >-
+            Restore applied, or a no-op when the current state already matches
+            the target.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      recordId:
+                        type: string
+                      newVersion:
+                        type: integer
+                      noop:
+                        type: boolean
+                        description: >-
+                          true when the restorable diff was empty (no write, no
+                          new revision).
+                      restoredFieldIds:
+                        type: array
+                        items:
+                          type: string
+                      skippedFieldIds:
+                        type: array
+                        items:
+                          type: string
+                        description: >-
+                          Always empty under atomic reject; reserved for a
+                          future partial-restore mode.
+                    required:
+                      - recordId
+                      - newVersion
+                      - noop
+                      - restoredFieldIds
+                      - skippedFieldIds
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: >-
+            Restore not possible — RESTORE_UNSUPPORTED (target is a delete
+            revision), SNAPSHOT_UNAVAILABLE (revision has a null snapshot), or
+            SCHEMA_DRIFT (a snapshot field no longer exists in the current
+            schema).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - RESTORE_UNSUPPORTED
+                          - SNAPSHOT_UNAVAILABLE
+                          - SCHEMA_DRIFT
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                required:
+                  - ok
+                  - error
   /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
     get:
       summary: Load current user's subscription status for a record

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -19775,6 +19775,167 @@
         }
       }
     },
+    "/api/multitable/sheets/{sheetId}/records/{recordId}/restore": {
+      "post": {
+        "summary": "Restore a multitable record to a prior revision (Layer 1)",
+        "description": "Restores a live record's scalar user-data fields to a prior revision's recorded values. Forward-change semantics — a value-changing restore emits a new revision (source=restore) and bumps version; an empty diff is a no-op. Computed/link/system-auto/attachment fields are excluded by type. Atomically rejected if any restorable differing field is not writable.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sheetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recordId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "targetVersion": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "The record version to restore to."
+                  },
+                  "expectedVersion": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Optimistic-concurrency token; must equal the current server version."
+                  }
+                },
+                "required": [
+                  "targetVersion",
+                  "expectedVersion"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Restore applied, or a no-op when the current state already matches the target.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "recordId": {
+                          "type": "string"
+                        },
+                        "newVersion": {
+                          "type": "integer"
+                        },
+                        "noop": {
+                          "type": "boolean",
+                          "description": "true when the restorable diff was empty (no write, no new revision)."
+                        },
+                        "restoredFieldIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "skippedFieldIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Always empty under atomic reject; reserved for a future partial-restore mode."
+                        }
+                      },
+                      "required": [
+                        "recordId",
+                        "newVersion",
+                        "noop",
+                        "restoredFieldIds",
+                        "skippedFieldIds"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "422": {
+            "description": "Restore not possible — RESTORE_UNSUPPORTED (target is a delete revision), SNAPSHOT_UNAVAILABLE (revision has a null snapshot), or SCHEMA_DRIFT (a snapshot field no longer exists in the current schema).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "RESTORE_UNSUPPORTED",
+                            "SNAPSHOT_UNAVAILABLE",
+                            "SCHEMA_DRIFT"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions": {
       "get": {
         "summary": "Load current user's subscription status for a record",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -13021,6 +13021,130 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/restore:
+    post:
+      summary: Restore a multitable record to a prior revision (Layer 1)
+      description: >-
+        Restores a live record's scalar user-data fields to a prior revision's
+        recorded values. Forward-change semantics — a value-changing restore
+        emits a new revision (source=restore) and bumps version; an empty diff
+        is a no-op. Computed/link/system-auto/attachment fields are excluded by
+        type. Atomically rejected if any restorable differing field is not
+        writable.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetVersion:
+                  type: integer
+                  minimum: 1
+                  description: The record version to restore to.
+                expectedVersion:
+                  type: integer
+                  minimum: 0
+                  description: >-
+                    Optimistic-concurrency token; must equal the current server
+                    version.
+              required:
+                - targetVersion
+                - expectedVersion
+      responses:
+        '200':
+          description: >-
+            Restore applied, or a no-op when the current state already matches
+            the target.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      recordId:
+                        type: string
+                      newVersion:
+                        type: integer
+                      noop:
+                        type: boolean
+                        description: >-
+                          true when the restorable diff was empty (no write, no
+                          new revision).
+                      restoredFieldIds:
+                        type: array
+                        items:
+                          type: string
+                      skippedFieldIds:
+                        type: array
+                        items:
+                          type: string
+                        description: >-
+                          Always empty under atomic reject; reserved for a
+                          future partial-restore mode.
+                    required:
+                      - recordId
+                      - newVersion
+                      - noop
+                      - restoredFieldIds
+                      - skippedFieldIds
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: >-
+            Restore not possible — RESTORE_UNSUPPORTED (target is a delete
+            revision), SNAPSHOT_UNAVAILABLE (revision has a null snapshot), or
+            SCHEMA_DRIFT (a snapshot field no longer exists in the current
+            schema).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - RESTORE_UNSUPPORTED
+                          - SNAPSHOT_UNAVAILABLE
+                          - SCHEMA_DRIFT
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                required:
+                  - ok
+                  - error
   /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
     get:
       summary: Load current user's subscription status for a record

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -444,6 +444,90 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+  /api/multitable/sheets/{sheetId}/records/{recordId}/restore:
+    post:
+      summary: Restore a multitable record to a prior revision (Layer 1)
+      description: >-
+        Restores a live record's scalar user-data fields to a prior revision's recorded values.
+        Forward-change semantics — a value-changing restore emits a new revision (source=restore)
+        and bumps version; an empty diff is a no-op. Computed/link/system-auto/attachment fields are
+        excluded by type. Atomically rejected if any restorable differing field is not writable.
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: recordId
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetVersion:
+                  type: integer
+                  minimum: 1
+                  description: The record version to restore to.
+                expectedVersion:
+                  type: integer
+                  minimum: 0
+                  description: Optimistic-concurrency token; must equal the current server version.
+              required: [targetVersion, expectedVersion]
+      responses:
+        '200':
+          description: Restore applied, or a no-op when the current state already matches the target.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      recordId: { type: string }
+                      newVersion: { type: integer }
+                      noop:
+                        type: boolean
+                        description: true when the restorable diff was empty (no write, no new revision).
+                      restoredFieldIds:
+                        type: array
+                        items: { type: string }
+                      skippedFieldIds:
+                        type: array
+                        items: { type: string }
+                        description: Always empty under atomic reject; reserved for a future partial-restore mode.
+                    required: [recordId, newVersion, noop, restoredFieldIds, skippedFieldIds]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422':
+          description: >-
+            Restore not possible — RESTORE_UNSUPPORTED (target is a delete revision),
+            SNAPSHOT_UNAVAILABLE (revision has a null snapshot), or SCHEMA_DRIFT (a snapshot field
+            no longer exists in the current schema).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum: [RESTORE_UNSUPPORTED, SNAPSHOT_UNAVAILABLE, SCHEMA_DRIFT]
+                      message: { type: string }
+                    required: [code, message]
+                required: [ok, error]
   /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
     get:
       summary: Load current user's subscription status for a record


### PR DESCRIPTION
## What

Server-side endpoint to restore a **live** multitable record's scalar user-data fields to a prior revision:

`POST /api/multitable/sheets/:sheetId/records/:recordId/restore` → `{ targetVersion, expectedVersion }`

Reuses the canonical `RecordWriteService.patchRecords` spine end-to-end (transaction, optimistic version re-check, revision emit, Yjs invalidation, `recalculateFormulaFields`); adds only two restore-owned pieces — the layer-3 write pre-check and an `unset` primitive.

Design-lock: `docs/development/multitable-record-restore-layer1-design-20260615.md`
Dev+verification report: `docs/development/multitable-record-restore-layer1-dev-verification-20260615.md`

## Locked principles (all test-pinned)

- **Forward-change / no-op** — value-changing restore emits a new `action=update, source=restore` revision + version bump; empty diff = no-op (still runs the concurrency check).
- **Lock A** faithful set∪unset diff vs the unmasked stored snapshot (never patch replay). Removed keys drop from the **stored after-image**, not just the live row.
- **Lock B** atomic write-gate: static `FieldMutationGuard` **+ restore's own layer-3 pre-check** (the spine does not enforce layer-3 — `univer-meta.ts` / `multitable-ai.ts`).
- **Lock C** live-record only: hard-deleted → 404; target resolution excludes `delete` revisions.
- **Lock D** scalar-only: computed / link / system-auto / attachment excluded by type.
- Plus `RecordWriteSource:'restore'` (fires Yjs invalidation as a non-bridge write), `SCHEMA_DRIFT` + `SNAPSHOT_UNAVAILABLE` guards.

## Spine change (hot file, minimal)

`RecordChange.op:'unset'` → `data=(data-keys)||patch`, after-image drops removed keys, `null` sentinel in the revision patch, removals counted toward `applied`. Set-only writes keep byte-identical SQL.

## Verification (local, real Postgres)

- `tsc --noEmit`: 0 errors
- Unit regression (write path): 77/77
- Integration: 31/31 — 15-case restore matrix (T1–T12) + history/patch/patch-partial regressions
- OpenAPI parity: pass · CI-wired into the Node-20 multitable real-DB step
- Rebased onto current `main`; re-verified green post-rebase

## Scope / gates

Deferred (separate gated opt-ins): Slice 2 (undelete + link-value restore), Slice 3 (frontend / plugin re-home), retention (`VERSION_EXPIRED`), revision partial-unique index, partial-restore mode. Row-level write scope and the in-transaction anti-TOCTOU re-check are inherited from `patchRecords` (enforced at `record-write-service.ts:621`, covered by the patch suite) — see report §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)