### PR TITLE
fix(data-source): make SQL bridge errors actionable

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1634,7 +1634,7 @@ async function loadBridgeDataSources(): Promise<void> {
     bridgeDataSources.value = await listDataSources()
     bridgeDataSourcesLoaded.value = true
   } catch (error) {
-    bridgeDataSourcesError.value = error instanceof Error ? error.message : String(error)
+    bridgeDataSourcesError.value = formatWorkbenchConnectionError(error, 'bridge-data-sources')
   }
 }
 
@@ -1697,7 +1697,7 @@ async function loadBridgeDataSourceObjects(dataSourceId: string): Promise<void> 
     ]
   } catch (error) {
     if (requestId !== bridgeDataSourceObjectRequestId || connectionDraft.dataSourceId.trim() !== id) return
-    bridgeDataSourceObjectsError.value = error instanceof Error ? error.message : String(error)
+    bridgeDataSourceObjectsError.value = formatWorkbenchConnectionError(error, 'bridge-schema')
   } finally {
     if (requestId === bridgeDataSourceObjectRequestId) bridgeDataSourceObjectsLoading.value = false
   }
@@ -2418,6 +2418,62 @@ function setStatus(message: string, kind: 'success' | 'error' | 'idle' = 'idle')
   statusKind.value = kind
 }
 
+type WorkbenchConnectionErrorContext = 'bridge-data-sources' | 'bridge-schema' | 'test' | 'objects' | 'schema'
+
+function rawErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error || '')
+}
+
+function friendlyConnectionErrorMessage(message: string): string {
+  const text = message || ''
+  if (/Data source with id ['"][^'"]+['"] not found|ExternalSystemNotFound|DATA_SOURCE_NOT_FOUND|external system .*not found/i.test(text)) {
+    return '引用的连接或数据源不存在、已删除，或不属于当前账号/工作区；请重新选择 /data-sources 连接并保存。'
+  }
+  if (/^(?:401|403)(?:\s|$)|DATA_SOURCE_PRINCIPAL_REQUIRED|owner principal|principal required|missing principal|unauthori[sz]ed|forbidden|access denied|permission|无权|权限/i.test(text)) {
+    return '当前账号无权读取该连接或 schema；请确认登录账号、tenant/workspace、以及 /data-sources 权限。'
+  }
+  if (/object required|missing object|object not found|table not found|unknown object|unknown table|relation .*does not exist|找不到.*(?:对象|表|视图)/i.test(text)) {
+    return '找不到当前对象/表/视图；请重新加载对象列表并选择仍存在的对象。'
+  }
+  if (/not found|不存在|已删除/i.test(text)) {
+    return '引用的连接或数据源不存在、已删除，或不属于当前账号/工作区；请重新选择 /data-sources 连接并保存。'
+  }
+  if (/schema blocked|schema unavailable|empty schema|no columns|columns?|schema|列信息/i.test(text)) {
+    return '无法读取 schema/列信息；请检查数据源权限、schema 可见性或数据库驱动返回。'
+  }
+  if (/unsupported|writable|not readable|source kind|adapter|不支持|不可读/i.test(text)) {
+    return '当前连接不是可读 source 或不支持 SQL 只读通道；请选择 data-source:sql-readonly source。'
+  }
+  // SQL/data-source bridge errors can contain driver messages, object names, or connection hints.
+  // Keep the bridge fallback values-free; non-bridge systems still use the legacy raw path.
+  return '连接请求失败；请重试，或让管理员查看服务端日志中的对应错误。'
+}
+
+function workbenchConnectionErrorPrefix(context: WorkbenchConnectionErrorContext, side?: WorkbenchSide): string {
+  const label = side === 'target' ? '目标' : '来源'
+  if (context === 'bridge-data-sources') return '加载 /data-sources 连接失败'
+  if (context === 'bridge-schema') return '加载 SQL 表/视图失败'
+  if (context === 'test') return `${label}连接测试失败`
+  if (context === 'schema') return `加载${label} schema 失败`
+  return `加载${label}对象失败`
+}
+
+function formatWorkbenchConnectionError(error: unknown, context: WorkbenchConnectionErrorContext, side?: WorkbenchSide): string {
+  return `${workbenchConnectionErrorPrefix(context, side)}：${friendlyConnectionErrorMessage(rawErrorMessage(error))}`
+}
+
+function selectedSystemForSide(side: WorkbenchSide): WorkbenchExternalSystem | null {
+  return side === 'source' ? selectedSourceSystem.value : selectedTargetSystem.value
+}
+
+function formatSideConnectionError(error: unknown, context: Extract<WorkbenchConnectionErrorContext, 'test' | 'objects' | 'schema'>, side: WorkbenchSide, systemKind?: string): string {
+  if (systemKind === DATA_SOURCE_BRIDGE_KIND) {
+    return formatWorkbenchConnectionError(error, context, side)
+  }
+  return rawErrorMessage(error)
+}
+
 function currentScope() {
   return {
     tenantId: scope.tenantId.trim() || 'default',
@@ -3075,7 +3131,13 @@ async function refreshTableActionConflictPolicies(actionId = selectedTableAction
 function connectionStatusLabel(system: WorkbenchExternalSystem | null): string {
   if (!system) return '未选择'
   if (system.status === 'active') return system.lastTestedAt ? '已连接' : '可用'
-  if (system.status === 'error') return system.lastError ? `异常：${system.lastError}（点击"测试连接"重新激活）` : '异常（点击"测试连接"重新激活）'
+  if (system.status === 'error') {
+    if (!system.lastError) return '异常（点击"测试连接"重新激活）'
+    const message = system.kind === DATA_SOURCE_BRIDGE_KIND
+      ? friendlyConnectionErrorMessage(system.lastError)
+      : system.lastError
+    return `异常：${message}（点击"测试连接"重新激活）`
+  }
   return '未启用'
 }
 
@@ -3096,19 +3158,25 @@ async function testSystem(side: WorkbenchSide): Promise<void> {
     return
   }
   const label = side === 'source' ? '数据源' : '目标'
+  const requestSystem = selectedSystemForSide(side)
+  const requestSystemKind = requestSystem?.kind || ''
   // Capture the status BEFORE the test so a recovery (error → active) can be reported explicitly —
   // result.system already carries the post-test status, so it can't tell us where we came from.
-  const priorStatus = (side === 'source' ? selectedSourceSystem.value : selectedTargetSystem.value)?.status
+  const priorStatus = requestSystem?.status
   try {
     const result = await testExternalSystemConnection(systemId, currentScope())
     if (result.system) replaceSystem(result.system)
     if (result.ok) {
       setStatus(priorStatus === 'error' ? `${label}连接已恢复，已重新激活` : `${label}连接测试通过`, 'success')
     } else {
-      setStatus(`${label}连接测试失败：${result.message || result.code || 'unknown error'}`, 'error')
+      const failure = result.message || result.code || 'unknown error'
+      const failureMessage = requestSystemKind === DATA_SOURCE_BRIDGE_KIND
+        ? formatWorkbenchConnectionError(failure, 'test', side)
+        : `${label}连接测试失败：${failure}`
+      setStatus(failureMessage, 'error')
     }
   } catch (error) {
-    setStatus(error instanceof Error ? error.message : String(error), 'error')
+    setStatus(formatSideConnectionError(error, 'test', side, requestSystemKind), 'error')
   }
 }
 
@@ -3118,6 +3186,7 @@ async function loadObjects(side: WorkbenchSide): Promise<void> {
     setStatus(`${side === 'source' ? '数据源' : '目标'}系统未选择`, 'error')
     return
   }
+  const requestSystemKind = selectedSystemForSide(side)?.kind || ''
   try {
     const objects = await listExternalSystemObjects(systemId, currentScope())
     if (side === 'source') {
@@ -3130,7 +3199,7 @@ async function loadObjects(side: WorkbenchSide): Promise<void> {
     if (objects.length > 0) await loadSchema(side)
     setStatus(`已加载 ${objects.length} 个${side === 'source' ? '来源' : '目标'}数据集`, 'success')
   } catch (error) {
-    setStatus(error instanceof Error ? error.message : String(error), 'error')
+    setStatus(formatSideConnectionError(error, 'objects', side, requestSystemKind), 'error')
   }
 }
 
@@ -3142,9 +3211,14 @@ function handleSourceSystemChange(): void {
 }
 
 async function handleSourceObjectChange(): Promise<void> {
+  const requestSystemKind = selectedSourceSystem.value?.kind || ''
   sourceSchema.value = { object: '', fields: [] }
   sourceSchemaSystemId.value = ''
-  await loadSchema('source')
+  try {
+    await loadSchema('source')
+  } catch (error) {
+    setStatus(formatSideConnectionError(error, 'schema', 'source', requestSystemKind), 'error')
+  }
 }
 
 async function loadSchema(side: WorkbenchSide): Promise<void> {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2279,7 +2279,7 @@ describe('IntegrationWorkbenchView', () => {
       if (url === '/api/integration/staging/descriptors') return jsonResponse([])
       if (url === '/api/data-sources/pg-1/schema') return pgSchema
       if (url === '/api/data-sources/mssql-2/schema') {
-        return new Response(JSON.stringify({ error: { message: 'schema blocked' } }), {
+        return new Response(JSON.stringify({ error: { message: 'schema blocked for project P-001 token=abc' } }), {
           status: 403,
           headers: { 'Content-Type': 'application/json' },
         })
@@ -2324,7 +2324,10 @@ describe('IntegrationWorkbenchView', () => {
     dsSelect.value = 'mssql-2'
     dsSelect.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi(8)
-    expect(container.querySelector('[data-testid="data-source-bridge-object-error"]')?.textContent).toContain('schema blocked')
+    const errorText = container.querySelector('[data-testid="data-source-bridge-object-error"]')?.textContent || ''
+    expect(errorText).toContain('无法读取 schema/列信息')
+    expect(errorText).not.toContain('P-001')
+    expect(errorText).not.toContain('token=abc')
     expect((container.querySelector('[data-testid="data-source-bridge-object"]') as HTMLSelectElement).disabled).toBe(true)
     expect((container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).disabled).toBe(true)
     ;(container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).click()
@@ -2333,6 +2336,275 @@ describe('IntegrationWorkbenchView', () => {
 
     resolvePgSchema(jsonResponse({ tables: [{ name: 'items', schema: 'public' }], views: [] }))
     await flushUi()
+  })
+
+  it('C4-4: shows a values-free actionable message when a SQL bridge source binding is missing', async () => {
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: false, guardrails: { write: { supported: false } } },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'ds-403-gone', object: 'public.items' },
+          },
+          {
+            id: 'ds_bridge_error',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Broken warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'error',
+            lastError: "Data source with id 'ds-403-gone' not found",
+            config: { dataSourceId: 'ds-403-gone', object: 'public.items' },
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return new Response(JSON.stringify({ error: { message: "Data source with id 'ds-403-gone' not found" } }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const statusText = container.textContent || ''
+    expect(statusText).toContain('引用的连接或数据源不存在、已删除')
+    expect(statusText).toContain('重新选择 /data-sources')
+    expect(apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/integration/external-systems/ds_bridge_1/objects'))).toBe(true)
+    expect(statusText).not.toContain('当前账号无权')
+    expect(statusText).not.toContain('ds-403-gone')
+  })
+
+  it('C4-4: does not echo unknown SQL bridge connection errors into the workbench status', async () => {
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: false, guardrails: { write: { supported: false } } },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'ds-1', object: 'public.items' },
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return new Response(JSON.stringify({ error: { message: 'Failed to connect to SQL Server password=secret token=abc database=stockorder' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const statusText = container.textContent || ''
+    expect(statusText).toContain('连接请求失败')
+    expect(apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/integration/external-systems/ds_bridge_1/objects'))).toBe(true)
+    expect(statusText).not.toContain('password=secret')
+    expect(statusText).not.toContain('token=abc')
+    expect(statusText).not.toContain('stockorder')
+  })
+
+  it('C4-4: maps missing bridge owner-principal errors to the permission guidance', async () => {
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: false, guardrails: { write: { supported: false } } },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'ds-1', object: 'public.items' },
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return new Response(JSON.stringify({ error: { message: 'DATA_SOURCE_PRINCIPAL_REQUIRED: data source read requires an owner principal (none provided)' } }), {
+          status: 422,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    const statusText = container.textContent || ''
+    expect(statusText).toContain('当前账号无权读取该连接或 schema')
+    expect(statusText).toContain('/data-sources 权限')
+    expect(statusText).not.toContain('owner principal')
+    expect(statusText).not.toContain('none provided')
+  })
+
+  it('C4-4: keeps delayed SQL bridge errors values-free even after switching the selected source', async () => {
+    let resolveBridgeObjects!: (response: Response) => void
+    const bridgeObjectsResponse = new Promise<Response>((resolve) => { resolveBridgeObjects = resolve })
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === '/api/data-sources') return { ok: true, data: { items: [] } }
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: false, guardrails: { write: { supported: false } } },
+          { kind: 'http', label: 'HTTP API', roles: ['source'], supports: ['read'], advanced: false },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'ds_bridge_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'Warehouse bridge',
+            kind: 'data-source:sql-readonly',
+            role: 'source',
+            status: 'active',
+            config: { dataSourceId: 'ds-1', object: 'public.items' },
+          },
+          {
+            id: 'http_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'HTTP Source',
+            kind: 'http',
+            role: 'source',
+            status: 'active',
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) return bridgeObjectsResponse
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi()
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/integration/external-systems/ds_bridge_1/objects'))).toBe(true)
+    expect(container.textContent || '').not.toContain('连接请求失败')
+    sourceSystemSelect.value = 'http_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container.textContent || '').not.toContain('连接请求失败')
+
+    resolveBridgeObjects(new Response(JSON.stringify({ error: { message: 'Failed to connect password=secret token=abc database=stockorder' } }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    await flushUi(8)
+
+    const statusText = container.textContent || ''
+    expect(statusText).toContain('连接请求失败')
+    expect(statusText).not.toContain('password=secret')
+    expect(statusText).not.toContain('token=abc')
+    expect(statusText).not.toContain('stockorder')
   })
 
   it('C4-2: maps source fields through a schema-backed picker and sends the selected field in preview', async () => {


### PR DESCRIPTION
## Summary
- map SQL readonly/data-source bridge failures to values-free actionable Workbench messages
- cover schema picker errors, source object loading/test failures, bridge lastError badges, owner-principal errors, and delayed async failures after source switching
- preserve legacy raw error display for non-bridge systems; no backend/API/runtime changes

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
- pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue tests/IntegrationWorkbenchView.spec.ts  # 0 errors, existing warnings only
- pnpm --filter @metasheet/web build
- git diff --check

## Review
- subagent review found values-free, not-found classification, lastError badge, async race, and test-wire gaps; all were fixed
- final subagent review: no actionable findings remain

## Boundaries
- frontend-only
- no service/backend contract changes
- no DB/K3/external write changes
- unknown SQL bridge errors use values-free generic fallback because driver messages can contain connection hints or object names
