### PR TITLE
feat(multitable): button/run route + fix univer-meta button type-map drift (B1-a1 route)

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -153,6 +153,7 @@ import { univerMetaRouter } from './routes/univer-meta'
 import { dashboardRouter } from './routes/dashboard'
 import { createAutomationRoutes } from './routes/automation'
 import { createMultitableAiRoutes } from './routes/multitable-ai'
+import { createMultitableButtonRoutes } from './routes/multitable-button'
 import { apiTokensRouter } from './routes/api-tokens'
 import { SnapshotService } from './services/SnapshotService'
 import { MetricsStreamService } from './services/MetricsStreamService'
@@ -1111,6 +1112,8 @@ export class MetaSheetServer {
     //   A2 shortcut (POST /sheets/:sheetId/ai/shortcut/{preview,run}, record RBAC).
     // See routes/multitable-ai.ts header.
     this.app.use('/api/multitable', createMultitableAiRoutes())
+    // B1-a1 button field run endpoint. See routes/multitable-button.ts header.
+    this.app.use('/api/multitable', createMultitableButtonRoutes())
     this.app.use(apiTokensRouter())
     // Keep the legacy dev alias while existing tools/worktrees still reference it.
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -1,0 +1,128 @@
+/**
+ * Multitable BUTTON field run route (B1-a1).
+ *
+ * POST /sheets/:sheetId/records/:recordId/fields/:fieldId/button/run
+ *
+ * Runs a button field's configured action against the current record, mirroring
+ * the AI-shortcut-run shape (#2623): preflight gates -> dispatch through the
+ * existing automation executor (NO parallel path) -> redacted audit -> settle.
+ *
+ * Security (design-lock #2645): VISIBILITY != EXECUTABILITY. Seeing a button
+ * requires the field to be visible; RUNNING it re-evaluates the action's own
+ * gate server-side, as the actor, at dispatch. B1-a1 enables ONLY the
+ * executor-owned INERT `record_click` action (gate = record-readable); real
+ * actions (update_record / send_webhook / ...) are gated follow-ups, each of
+ * which must add its own per-action actor gate before being enabled here.
+ */
+
+import { Router, type Request, type Response } from 'express'
+import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
+import { buildRecordPatchContext, requireRecordReadable } from './univer-meta'
+import { type ConnectionPool, type QueryFn } from '../multitable/record-write-service'
+import { poolManager } from '../integration/db/connection-pool'
+import { eventBus } from '../integration/events/event-bus'
+import { AutomationExecutor, type ExecutionContext } from '../multitable/automation-executor'
+import { normalizeJson } from '../multitable/field-codecs'
+import { Logger } from '../core/logger'
+
+type PoolLike = ConnectionPool & { query: QueryFn }
+const logger = new Logger('MultitableButton')
+
+// B1-a1 enables ONLY the executor-owned INERT action from a button click. Real
+// actions are gated follow-ups: each needs its own actor-permission mapping at
+// dispatch (e.g. update_record -> canEditRecord) before it can be enabled here.
+const ENABLED_BUTTON_ACTIONS = new Set<string>(['record_click'])
+
+export function createMultitableButtonRoutes(): Router {
+  const router = Router()
+
+  router.post('/sheets/:sheetId/records/:recordId/fields/:fieldId/button/run', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    const fieldId = typeof req.params.fieldId === 'string' ? req.params.fieldId.trim() : ''
+    const parsed = z.object({ requestId: z.string().min(1).max(100).optional() }).safeParse(req.body ?? {})
+    if (!sheetId || !recordId || !fieldId || !parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, recordId, fieldId are required' } })
+    }
+    const requestId = parsed.data.requestId
+
+    try {
+      const pool = poolManager.get() as unknown as PoolLike
+      const query = pool.query.bind(pool) as QueryFn
+
+      // 1) Actor RECORD-READ gate (also 404s a record not on this sheet, 401 unauth).
+      //    This IS the inert record_click's own gate (visibility != executability,
+      //    re-evaluated server-side as the actor).
+      const readable = await requireRecordReadable(req, query, sheetId, recordId)
+      if ('status' in readable) {
+        return res.status(readable.status).json(readable.body)
+      }
+      const { access, capabilities } = readable
+
+      // 2) Load the field + its derived permissions for THIS actor.
+      const ctx = await buildRecordPatchContext(req, query, sheetId, access, capabilities)
+      if (!ctx) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const field = ctx.fields.find((f) => f.id === fieldId)
+      if (!field) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Field not found: ${fieldId}` } })
+      }
+      if (field.type !== 'button') {
+        return res.status(400).json({ ok: false, error: { code: 'NOT_A_BUTTON', message: `Field is not a button: ${fieldId}` } })
+      }
+      // FIELD-VISIBLE gate: a button the actor cannot see cannot be clicked.
+      if (ctx.fieldPermissions[fieldId]?.visible === false) {
+        return res.status(403).json({ ok: false, error: { code: 'FIELD_FORBIDDEN', message: `Button field is not visible: ${fieldId}` } })
+      }
+
+      const property = normalizeJson(field.property)
+      const actionType = typeof property.actionType === 'string' ? property.actionType.trim() : ''
+      if (!actionType) {
+        return res.status(400).json({ ok: false, error: { code: 'BUTTON_NOT_CONFIGURED', message: 'Button has no actionType configured' } })
+      }
+      if (!ENABLED_BUTTON_ACTIONS.has(actionType)) {
+        // Real action types are not yet enabled from a button (B1-a1 ships the inert action only).
+        return res.status(400).json({ ok: false, error: { code: 'BUTTON_ACTION_NOT_ENABLED', message: `Button action not yet enabled: ${actionType}` } })
+      }
+
+      // 3) Dispatch through the SAME executor path as a rule trigger (no parallel path).
+      const executionId = `axe_btn_${randomUUID()}`
+      const context: ExecutionContext = {
+        executionId,
+        ruleId: `btn_${fieldId}`,
+        sheetId,
+        recordId,
+        recordData: {},
+        ruleCreatedBy: '',
+        actorId: access.userId,
+        triggerEvent: { _trigger: 'button', fieldId, requestId },
+      }
+      const executor = new AutomationExecutor({ eventBus, queryFn: query })
+      const step = await executor.runSingleAction(
+        { type: 'record_click', config: normalizeJson(property.actionConfig) },
+        context,
+      )
+
+      // 4) Audit — redacted by construction: only ids + actionType + status are
+      //    logged (never the action config values), so no secret-shaped value leaks.
+      logger.info('[multitable.button.run]', {
+        executionId, sheetId, recordId, fieldId, actionType,
+        actorId: access.userId, status: step.status, requestId,
+      })
+
+      // 5) Settle. Errors are NOT swallowed: a failed step surfaces with its message.
+      if (step.status === 'success') {
+        return res.json({ ok: true, data: { status: 'succeeded', executionId } })
+      }
+      return res.status(200).json({ ok: false, data: { status: 'failed', executionId, message: step.error ?? 'action failed' } })
+    } catch (err) {
+      // Fail-closed: never leak internals; never 500-swallow into a fake success.
+      console.error('[multitable-button] run failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'button run failed' } })
+    }
+  })
+
+  return router
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1396,6 +1396,7 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   const normalized = type.trim().toLowerCase()
   if (normalized === 'number') return 'number'
   if (normalized === 'boolean' || normalized === 'checkbox') return 'boolean'
+  if (normalized === 'button') return 'button'
   if (normalized === 'date') return 'date'
   if (
     normalized === 'datetime' ||

--- a/packages/core-backend/tests/unit/multitable-button-routes.test.ts
+++ b/packages/core-backend/tests/unit/multitable-button-routes.test.ts
@@ -1,0 +1,108 @@
+/**
+ * B1-a1 button/run route — mock-pool unit tests (no live DB). Mirrors the
+ * AI-shortcut-run route test harness. Focus: the security-critical gates
+ * (visibility != executability) + the inert-only restriction + fail semantics.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+
+const SHEET_ID = 'sheet_btn'
+const RECORD_ID = 'rec_btn'
+
+const FIELDS = [
+  { id: 'fld_btn', name: 'Run', type: 'button', property: { actionType: 'record_click', label: 'Go', actionConfig: {} }, order: 1 },
+  { id: 'fld_btn_webhook', name: 'Hook', type: 'button', property: { actionType: 'send_webhook', actionConfig: {} }, order: 2 },
+  { id: 'fld_btn_unconf', name: 'Unconf', type: 'button', property: {}, order: 3 },
+  { id: 'fld_text', name: 'Text', type: 'string', property: {}, order: 4 },
+]
+
+let currentUser: { id: string; roles: string[]; perms: string[] } | undefined
+let noRecord = false
+
+function createMockPool() {
+  const query = vi.fn(async (sql: string): Promise<{ rows: any[]; rowCount?: number }> => {
+    if (/FROM meta_records WHERE id/i.test(sql)) {
+      return noRecord ? { rows: [] } : { rows: [{ id: RECORD_ID, sheet_id: SHEET_ID }] }
+    }
+    if (/FROM meta_fields WHERE sheet_id/i.test(sql)) {
+      return { rows: FIELDS.map((f) => ({ ...f })) }
+    }
+    if (/FROM meta_sheets WHERE id/i.test(sql)) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    // permission scope tables (sheet/record/field) → empty: role perms govern.
+    return { rows: [], rowCount: 0 }
+  })
+  return { query, transaction: vi.fn(async (fn: (c: { query: typeof query }) => Promise<unknown>) => fn({ query })) }
+}
+
+let app: Express
+
+async function buildApp() {
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { createMultitableButtonRoutes } = await import('../../src/routes/multitable-button')
+  vi.spyOn(poolManager, 'get').mockReturnValue(createMockPool() as any)
+  const built = express()
+  built.use(express.json())
+  built.use((req, _res, next) => { if (currentUser) (req as any).user = currentUser; next() })
+  built.use('/api/multitable', createMultitableButtonRoutes())
+  return built
+}
+
+const runUrl = (fieldId: string) => `/api/multitable/sheets/${SHEET_ID}/records/${RECORD_ID}/fields/${fieldId}/button/run`
+const reader = { id: 'u_read', roles: ['member'], perms: ['multitable:read'] }
+// A genuine authenticated non-reader: non-empty perms (so resolveRequestAccess
+// reads them directly, no DB lookup) that do NOT include multitable read/write.
+const nonReader = { id: 'u_none', roles: ['member'], perms: ['multitable:comment'] }
+
+describe('B1-a1 button/run route (mock pool)', () => {
+  beforeEach(async () => { currentUser = reader; noRecord = false; app = await buildApp() })
+  afterEach(() => { vi.restoreAllMocks(); currentUser = undefined; noRecord = false })
+
+  it('runs an inert record_click button → 200 succeeded', async () => {
+    const res = await request(app).post(runUrl('fld_btn')).send({})
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.status).toBe('succeeded')
+    expect(res.body.data.executionId).toMatch(/^axe_btn_/)
+  })
+
+  it('SECURITY: a non-reader cannot execute (403) — visibility != executability', async () => {
+    currentUser = nonReader
+    app = await buildApp()
+    const res = await request(app).post(runUrl('fld_btn')).send({})
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('FORBIDDEN')
+  })
+
+  it('record not on the sheet → 404', async () => {
+    noRecord = true
+    app = await buildApp()
+    const res = await request(app).post(runUrl('fld_btn')).send({})
+    expect(res.status).toBe(404)
+  })
+
+  it('non-button field → 400 NOT_A_BUTTON', async () => {
+    const res = await request(app).post(runUrl('fld_text')).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('NOT_A_BUTTON')
+  })
+
+  it('button with no actionType → 400 BUTTON_NOT_CONFIGURED', async () => {
+    const res = await request(app).post(runUrl('fld_btn_unconf')).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('BUTTON_NOT_CONFIGURED')
+  })
+
+  it('a non-inert actionType (send_webhook) is NOT enabled from a button yet → 400', async () => {
+    const res = await request(app).post(runUrl('fld_btn_webhook')).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('BUTTON_ACTION_NOT_ENABLED')
+  })
+
+  it('unknown field → 404', async () => {
+    const res = await request(app).post(runUrl('fld_missing')).send({})
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary

The **clickable B1-a1 endpoint** + a **security fix** to merged B1-a0 that building the route surfaced.

`POST /sheets/:sheetId/records/:recordId/fields/:fieldId/button/run` (mirrors AI-shortcut-run #2623): preflight → dispatch → audit → settle.
- **Gates (visibility ≠ executability):** actor **record-read** (`requireRecordReadable`) + **field-visible**; the inert `record_click`'s own gate is record-readable, re-evaluated server-side as the actor.
- **Dispatch:** `executor.runSingleAction` — same path as a rule trigger, **no parallel path**.
- **Inert-only:** B1-a1 enables `record_click` only; real action types → `400 BUTTON_ACTION_NOT_ENABLED` (each needs its own actor-gate mapping first).
- **Audit:** redacted structured log (ids + actionType + status — never config values). **Errors not swallowed**; fail-closed 500.

## Security fix (the important part)
Building the route's **real-path** test exposed that `univer-meta.ts` has its **own** `mapFieldType`/`serializeFieldRow`, separate from `field-codecs`. B1-a0 patched field-codecs' mapper but not univer-meta's, so on the real record read/write path a `button` field deserialized as `'string'`. tsc couldn't catch it (valid type, wrong value), and B1-a0's write-rejection test used a hand-built `type:'button'` field (**wire-vs-fixture drift**) — so the guard *looked* covered but **would not have fired on the real path** (button cell writable = the pseudo-value leak the design-lock warns against). Fixed by adding `button` to univer-meta's `mapFieldType`; the route test now exercises the real serializer.

## Verification
**7 route tests** (mock pool) incl. the security gates: non-reader **403**, non-button **400**, unconfigured **400**, non-inert action **400**, record-not-found **404**, inert `record_click` **200 succeeded**. **328/328** across the B1-a1 suites + **tsc clean**.

B1-a1 is now a clickable, gated, audited endpoint. Remaining B1: **b/c** (FE render + config UI — browser-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)