### PR TITLE
feat(multitable): record-restore backend remainder — Slice 2a link restore + retention

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -72,6 +72,7 @@ import { getBuildInfo } from './config/build-info'
 import { isDatabaseSchemaError } from './utils/database-errors'
 import { startOperationAuditRetention } from './audit/operation-audit-retention'
 import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan-retention'
+import { startMetaRevisionRetention } from './multitable/meta-revision-retention'
 import { AutomationService, setAutomationServiceInstance } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
@@ -228,6 +229,7 @@ export class MetaSheetServer {
   private observabilityEnabled = false
   private stopOperationAuditRetention?: () => void
   private stopMultitableAttachmentCleanup?: () => void
+  private stopMetaRevisionRetention?: () => void
   private automationService?: AutomationService
   private apiGateway?: APIGateway
   private yjsCleanupTimer?: NodeJS.Timeout
@@ -1771,6 +1773,7 @@ export class MetaSheetServer {
     }))
     shutdownTasks.push(Promise.resolve().then(() => {
       try {
+        this.stopMetaRevisionRetention?.()
         this.stopMultitableAttachmentCleanup?.()
       } catch (err) {
         this.logger.warn(`Multitable attachment cleanup stop error: ${err instanceof Error ? err.message : String(err)}`)
@@ -2469,6 +2472,7 @@ export class MetaSheetServer {
     if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
       this.stopOperationAuditRetention = startOperationAuditRetention({ logger: this.logger })
       this.stopMultitableAttachmentCleanup = startMultitableAttachmentCleanup({ logger: this.logger })
+      this.stopMetaRevisionRetention = startMetaRevisionRetention({ logger: this.logger })
     }
 
     // Register signal handlers only for real runtime, not test runners.

--- a/packages/core-backend/src/multitable/meta-revision-retention.ts
+++ b/packages/core-backend/src/multitable/meta-revision-retention.ts
@@ -1,0 +1,128 @@
+/**
+ * Retention sweep for `meta_record_revisions` (the append-only per-record version log that
+ * Layer 1 restore reads from). Without aging the log grows unbounded.
+ *
+ * Design-lock §3 (retention coupling): the guarantee shape is "restore is guaranteed for the most
+ * recent N versions / D days; older points are restorable only if captured by a Layer-2 base
+ * snapshot." This module is the prune MECHANISM; the policy VALUES (N / D / enable) are an owner
+ * decision exposed via env. It is **disabled by default** so the restore guarantee is preserved
+ * until the owner opts in — turning it on is the explicit decision.
+ *
+ * INVARIANT (foot-gun shut): the sweep NEVER deletes the latest revision of a record (row_number=1
+ * over version DESC). A record always keeps its current after-image, so restore-to-current and the
+ * version-resolution rule cannot be orphaned by retention. `VERSION_EXPIRED` (wired in the restore
+ * route) is data-driven off the surviving MIN(version) — it does not depend on this sweep running.
+ *
+ * Mirrors the bounded-DELETE discipline of `sweepAiUsageLedgerRetention` (ctid/id sub-select + LIMIT
+ * so one pass drains a backlog over ticks rather than one long statement).
+ */
+
+export type RetentionQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export const META_REVISION_RETENTION_TABLE = 'meta_record_revisions'
+
+export type MetaRevisionRetentionPolicy = 'keep-last-n' | 'keep-days'
+
+/** keep-last-N defaults: keep the 200 most recent versions/record; floor at 10 so a mis-set can't gut history. */
+export const META_REVISION_RETENTION_DEFAULT_KEEP_N = 200
+export const META_REVISION_RETENTION_MIN_KEEP_N = 10
+/** keep-days defaults: keep 365 days; floor at 30 days. */
+export const META_REVISION_RETENTION_DEFAULT_DAYS = 365
+export const META_REVISION_RETENTION_MIN_DAYS = 30
+/** Per-pass DELETE bound — drains a backlog over ticks, never one huge statement. */
+export const META_REVISION_RETENTION_DEFAULT_BATCH = 5000
+
+export interface MetaRevisionRetentionConfig {
+  /** Opt-in: when false (the default) the sweep is a no-op (deletes 0). */
+  enabled: boolean
+  policy: MetaRevisionRetentionPolicy
+  /** keep-last-n: versions retained per record (already floored). */
+  keepN: number
+  /** keep-days: retention window in days (already floored). */
+  retentionDays: number
+  /** Per-pass row cap. */
+  batchSize: number
+}
+
+/**
+ * Resolve from env. DISABLED BY DEFAULT (`...RETENTION_ENABLED` must be exactly '1' to enable),
+ * so shipping this module changes nothing until the owner turns it on and picks a policy.
+ */
+export function resolveMetaRevisionRetentionConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): MetaRevisionRetentionConfig {
+  const enabled = env.MULTITABLE_META_REVISION_RETENTION_ENABLED === '1'
+  const policy: MetaRevisionRetentionPolicy =
+    env.MULTITABLE_META_REVISION_RETENTION_POLICY === 'keep-days' ? 'keep-days' : 'keep-last-n'
+
+  const rawKeep = Number(env.MULTITABLE_META_REVISION_RETENTION_KEEP_N)
+  const keepN = Math.max(
+    META_REVISION_RETENTION_MIN_KEEP_N,
+    Math.floor(Number.isFinite(rawKeep) && rawKeep > 0 ? rawKeep : META_REVISION_RETENTION_DEFAULT_KEEP_N),
+  )
+
+  const rawDays = Number(env.MULTITABLE_META_REVISION_RETENTION_DAYS)
+  const retentionDays = Math.max(
+    META_REVISION_RETENTION_MIN_DAYS,
+    Math.floor(Number.isFinite(rawDays) && rawDays > 0 ? rawDays : META_REVISION_RETENTION_DEFAULT_DAYS),
+  )
+
+  const rawBatch = Number(env.MULTITABLE_META_REVISION_RETENTION_BATCH)
+  const batchSize = Math.max(1, Math.floor(Number.isFinite(rawBatch) && rawBatch > 0 ? rawBatch : META_REVISION_RETENTION_DEFAULT_BATCH))
+
+  return { enabled, policy, keepN, retentionDays, batchSize }
+}
+
+/**
+ * Prune old revisions per the config. Returns rows deleted (0 when disabled). The latest revision
+ * of every record (row_number=1 over version DESC, created_at DESC) is ALWAYS retained.
+ * - keep-last-n: delete rows whose per-record recency rank exceeds keepN.
+ * - keep-days:   delete non-latest rows older than the retention window.
+ * Bounded per pass by batchSize.
+ */
+export async function sweepMetaRevisionRetention(
+  query: RetentionQueryFn,
+  config: MetaRevisionRetentionConfig,
+): Promise<number> {
+  if (!config.enabled) return 0
+  const batchSize = Math.max(1, Math.floor(config.batchSize))
+
+  if (config.policy === 'keep-days') {
+    const days = Math.max(META_REVISION_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+    const result = await query(
+      `DELETE FROM ${META_REVISION_RETENTION_TABLE}
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id, created_at,
+                   row_number() OVER (PARTITION BY sheet_id, record_id ORDER BY version DESC, created_at DESC) AS rn
+            FROM ${META_REVISION_RETENTION_TABLE}
+          ) ranked
+          WHERE ranked.rn > 1
+            AND ranked.created_at < now() - ($1::int * interval '1 day')
+          LIMIT $2
+        )`,
+      [days, batchSize],
+    )
+    return result.rowCount ?? 0
+  }
+
+  // keep-last-n (default)
+  const keepN = Math.max(META_REVISION_RETENTION_MIN_KEEP_N, Math.floor(config.keepN))
+  const result = await query(
+    `DELETE FROM ${META_REVISION_RETENTION_TABLE}
+      WHERE id IN (
+        SELECT id FROM (
+          SELECT id,
+                 row_number() OVER (PARTITION BY sheet_id, record_id ORDER BY version DESC, created_at DESC) AS rn
+          FROM ${META_REVISION_RETENTION_TABLE}
+        ) ranked
+        WHERE ranked.rn > $1
+        LIMIT $2
+      )`,
+    [keepN, batchSize],
+  )
+  return result.rowCount ?? 0
+}

--- a/packages/core-backend/src/multitable/meta-revision-retention.ts
+++ b/packages/core-backend/src/multitable/meta-revision-retention.ts
@@ -17,6 +17,9 @@
  * so one pass drains a backlog over ticks rather than one long statement).
  */
 
+import { Logger } from '../core/logger'
+import { query as dbQuery } from '../db/pg'
+
 export type RetentionQueryFn = (
   sql: string,
   params?: unknown[],
@@ -125,4 +128,48 @@ export async function sweepMetaRevisionRetention(
     [keepN, batchSize],
   )
   return result.rowCount ?? 0
+}
+
+/** Default sweep cadence (24h), env-overridable, clamped to [1m, 24h]. */
+export const META_REVISION_RETENTION_DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+function resolveIntervalMs(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return META_REVISION_RETENTION_DEFAULT_INTERVAL_MS
+  return Math.min(Math.max(Math.floor(parsed), 60_000), META_REVISION_RETENTION_DEFAULT_INTERVAL_MS)
+}
+
+export interface MetaRevisionRetentionSchedulerOptions {
+  logger?: Logger
+  query?: RetentionQueryFn
+  intervalMs?: number
+  env?: NodeJS.ProcessEnv
+}
+
+/**
+ * Runtime entry: start the periodic retention sweep. **No-op (returns immediately) when retention is
+ * disabled** — which is the default — so wiring this into bootstrap changes nothing until the owner
+ * sets `MULTITABLE_META_REVISION_RETENTION_ENABLED=1`. Mirrors `startMultitableAttachmentCleanup`
+ * (setInterval + returned stop fn; errors are logged, never crash the process). Returns a stop fn.
+ */
+export function startMetaRevisionRetention(options: MetaRevisionRetentionSchedulerOptions = {}): () => void {
+  const env = options.env ?? process.env
+  const config = resolveMetaRevisionRetentionConfig(env)
+  const logger = options.logger ?? new Logger('MetaRevisionRetention')
+  if (!config.enabled) {
+    logger.info('Meta-revision retention disabled (set MULTITABLE_META_REVISION_RETENTION_ENABLED=1 to enable)')
+    return () => {}
+  }
+  const queryFn = options.query ?? (dbQuery as unknown as RetentionQueryFn)
+  const intervalMs = options.intervalMs ?? resolveIntervalMs(env.MULTITABLE_META_REVISION_RETENTION_INTERVAL_MS)
+  const runSweep = () => {
+    void Promise.resolve()
+      .then(() => sweepMetaRevisionRetention(queryFn, config))
+      .then((deleted) => { if (deleted > 0) logger.info(`Meta-revision retention pruned ${deleted} revision(s)`) })
+      .catch((error) => logger.warn('Meta-revision retention sweep failed', error as Error))
+  }
+  const timer = setInterval(runSweep, intervalMs)
+  if (typeof timer === 'object' && 'unref' in timer) (timer as { unref: () => void }).unref()
+  logger.info(`Meta-revision retention started (policy=${config.policy}, keepN=${config.keepN}, days=${config.retentionDays}, intervalMs=${intervalMs})`)
+  return () => clearInterval(timer)
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5667,10 +5667,10 @@ export function univerMetaRouter(): Router {
       }
       return {}
     }
-    // Lock D: only fields whose authoritative value is a scalar in meta_records.data. Everything the
-    // write spine refuses to write (computed, link, attachment, system-auto, and the no-value `button`
-    // trigger) is excluded here too — otherwise a legacy `button`/system key lingering in data would
-    // enter the diff and turn into a spine RESTORE_FORBIDDEN, blocking an otherwise-restorable record.
+    // Lock D: this set gates the SCALAR-data path. Computed/system-auto/attachment are non-data and
+    // excluded; `button` is the no-value trigger (also caught by raw type below). `link` is listed as a
+    // defensive backstop, but link fields never reach this check — they are handled by a dedicated SET
+    // path (Slice 2a) above the scalar branch, which re-syncs meta_links + the mirror through the spine.
     const NON_RESTORABLE_TYPES = new Set([
       'formula', 'lookup', 'rollup', 'link', 'attachment', 'button',
       'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy',
@@ -5748,13 +5748,27 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      // Faithful set ∪ unset diff over restorable fields only.
+      // Faithful set ∪ unset diff over restorable fields.
+      const asLinkIds = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
       const diff: RecordChange[] = []
       for (const [fid, guard] of fieldById.entries()) {
-        if (!isRestorableType(guard.type)) continue
         if (rawTypeById.get(fid) === 'button') continue // no-value trigger (mapFieldType folds it to 'string')
         const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
         const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
+        // Slice 2a — link fields: restore the snapshot's link id array (or [] when absent at version N)
+        // as a SET routed through patchRecords, which re-syncs meta_links + the twoWay mirror fan-out.
+        // NEVER a data-`unset` (that touches only the data mirror and would desync the join table).
+        // Only emit when the id set actually differs (preserves no-op). The link config (guard.link)
+        // drives the spine's meta_links sync; a snapshot referencing a now-deleted foreign record is
+        // rejected fail-closed by the spine's link-target validation (VALIDATION_ERROR).
+        if (guard.type === 'link') {
+          const target = inSnap ? asLinkIds(targetSnapshot[fid]) : []
+          if (!sameValue(asLinkIds(currentData[fid]), target)) {
+            diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
+          }
+          continue
+        }
+        if (!isRestorableType(guard.type)) continue
         if (inSnap) {
           if (!sameValue(currentData[fid], targetSnapshot[fid])) {
             diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5712,6 +5712,18 @@ export function univerMetaRouter(): Router {
       )
       const revRows = revRes.rows as Array<{ action?: unknown; snapshot?: unknown }>
       if (revRows.length === 0) {
+        // Distinguish a PRUNED target (retention aged it out) from one that never existed: if the
+        // target is below the surviving floor (MIN retained version for this record), it was pruned
+        // → VERSION_EXPIRED. This is data-driven (true whether or not the retention sweep is enabled;
+        // with retention off, MIN is the create version so this never fires spuriously).
+        const floorRes = await pool.query(
+          'SELECT MIN(version) AS min_version FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2',
+          [sheetId, recordId],
+        )
+        const minVersion = Number((floorRes.rows[0] as { min_version?: unknown } | undefined)?.min_version ?? 0)
+        if (minVersion > 0 && targetVersion < minVersion) {
+          return res.status(410).json({ ok: false, error: { code: 'VERSION_EXPIRED', message: `Version ${targetVersion} is older than the retained floor (v${minVersion}) and has been pruned` } })
+        }
         return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: `No revision at version ${targetVersion}` } })
       }
       const targetRev = revRows.find((r) => r.action !== 'delete')

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5761,7 +5761,6 @@ export function univerMetaRouter(): Router {
       }
 
       // Faithful set ∪ unset diff over restorable fields.
-      const asLinkIds = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
       const diff: RecordChange[] = []
       for (const [fid, guard] of fieldById.entries()) {
         if (rawTypeById.get(fid) === 'button') continue // no-value trigger (mapFieldType folds it to 'string')
@@ -5772,10 +5771,12 @@ export function univerMetaRouter(): Router {
         // NEVER a data-`unset` (that touches only the data mirror and would desync the join table).
         // Only emit when the id set actually differs (preserves no-op). The link config (guard.link)
         // drives the spine's meta_links sync; a snapshot referencing a now-deleted foreign record is
-        // rejected fail-closed by the spine's link-target validation (VALIDATION_ERROR).
+        // rejected fail-closed by the spine's link-target validation (VALIDATION_ERROR). Use the CANONICAL
+        // normalizeLinkIds (handles legacy `'["a","b"]'` / `'a,b'` / trim / dedup) so a legacy-shaped
+        // snapshot or current value is parsed identically to the write path, not mis-read as one id.
         if (guard.type === 'link') {
-          const target = inSnap ? asLinkIds(targetSnapshot[fid]) : []
-          if (!sameValue(asLinkIds(currentData[fid]), target)) {
+          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
+          if (!sameValue(normalizeLinkIds(currentData[fid]), target)) {
             diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
           }
           continue

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -340,6 +340,25 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     expect(await linksOf(rid)).toEqual([FOREIGN_REC]) // atomic: unchanged
   })
 
+  test('T6g (Slice 2a): legacy-shaped link snapshot (JSON-array string) is parsed by the canonical normalizer, not mis-read as one id', async () => {
+    // The v1 snapshot stores the link as a legacy JSON-array STRING ('["frec2..."]') rather than an
+    // array; current stores it as an array. A naive parser would treat the whole string as one foreign
+    // id → spurious VALIDATION_ERROR. normalizeLinkIds parses it identically to the write path.
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] },
+      2,
+      [
+        { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: JSON.stringify([FOREIGN_REC2]) } },
+        { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } },
+      ],
+    )
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_g_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toContain(FLD_LK)
+    expect(await linksOf(rid)).toEqual([FOREIGN_REC2]) // legacy string parsed → edge re-pointed
+  })
+
   test('T6b: snapshot field absent from current schema → SCHEMA_DRIFT', async () => {
     const rid = await seedRecord(
       { [FLD_A]: 'a2' },

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -26,6 +26,7 @@ import request from 'supertest'
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
+import { sweepMetaRevisionRetention } from '../../src/multitable/meta-revision-retention'
 import { setYjsInvalidatorForRoutes, univerMetaRouter } from '../../src/routes/univer-meta'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
@@ -485,5 +486,45 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
     expect(res.status).toBe(403)
     expect((await liveData(rid))[FLD_A]).toBe('a2') // untouched
+  })
+
+  // ---- Retention (prune + VERSION_EXPIRED) ----
+  const seedManyRevisions = async (count: number): Promise<string> => {
+    const revs: RevSeed[] = Array.from({ length: count }, (_, i) => ({
+      version: i + 1,
+      action: i === 0 ? 'create' : 'update',
+      snapshot: { [FLD_A]: `v${i + 1}` },
+    }))
+    return seedRecord({ [FLD_A]: `v${count}` }, count, revs)
+  }
+
+  test('T13: keep-last-N sweep prunes old versions (keeps the latest); restore to a pruned version → VERSION_EXPIRED', async () => {
+    const rid = await seedManyRevisions(13) // versions 1..13, current = 13
+    const deleted = await sweepMetaRevisionRetention(q, { enabled: true, policy: 'keep-last-n', keepN: 10, retentionDays: 365, batchSize: 5000 })
+    expect(deleted).toBeGreaterThanOrEqual(3) // versions 1,2,3 pruned (may include other suites' rows; bounded)
+
+    // this record retains exactly the latest 10 (versions 4..13); the latest (13) is always kept
+    const rows = await q('SELECT version FROM meta_record_revisions WHERE record_id = $1 ORDER BY version', [rid])
+    const versions = (rows.rows as Array<{ version: number }>).map((r) => Number(r.version))
+    expect(versions).toEqual([4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+
+    // restore to a pruned version → VERSION_EXPIRED (410), distinct from a never-existed VERSION_NOT_FOUND
+    const expired = await restoreReq(rid, { targetVersion: 2, expectedVersion: 13 })
+    expect(expired.status).toBe(410)
+    expect(expired.body.error.code).toBe('VERSION_EXPIRED')
+
+    // a surviving version still restores
+    const ok = await restoreReq(rid, { targetVersion: 5, expectedVersion: 13 })
+    expect(ok.status).toBe(200)
+    expect((await liveData(rid))[FLD_A]).toBe('v5')
+  })
+
+  test('T14: retention disabled (default) is a no-op — deletes nothing', async () => {
+    const rid = await seedManyRevisions(12)
+    const before = await q('SELECT count(*)::int AS n FROM meta_record_revisions WHERE record_id = $1', [rid])
+    const deleted = await sweepMetaRevisionRetention(q, { enabled: false, policy: 'keep-last-n', keepN: 10, retentionDays: 365, batchSize: 5000 })
+    expect(deleted).toBe(0)
+    const after = await q('SELECT count(*)::int AS n FROM meta_record_revisions WHERE record_id = $1', [rid])
+    expect((after.rows[0] as { n: number }).n).toBe((before.rows[0] as { n: number }).n)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -35,6 +35,7 @@ const BASE_ID = `base_rstr_${TS}`
 const SHEET_ID = `sheet_rstr_${TS}`
 const FSHEET_ID = `fsheet_rstr_${TS}`
 const FOREIGN_REC = `frec_rstr_${TS}`
+const FOREIGN_REC2 = `frec2_rstr_${TS}`
 const FLD_A = `fld_rstr_a_${TS}`
 const FLD_B = `fld_rstr_b_${TS}`
 const FLD_SECRET = `fld_rstr_secret_${TS}`
@@ -43,6 +44,8 @@ const FLD_AUN = `fld_rstr_aun_${TS}`
 const FLD_LK = `fld_rstr_lk_${TS}`
 const FLD_BTN = `fld_rstr_btn_${TS}`
 const FLD_SEL = `fld_rstr_sel_${TS}`
+const FLD_LK_TW = `fld_rstr_lktw_${TS}` // twoWay link → FSHEET, mirrorFieldId = FLD_MIRROR
+const FLD_MIRROR = `fld_rstr_mirror_${TS}` // mirror side on FSHEET
 const USER_W = `u_rstr_writer_${TS}`
 const USER_RO = `u_rstr_ro_${TS}`
 
@@ -123,6 +126,7 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Restore Sheet'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FSHEET_ID, BASE_ID, 'Foreign Sheet'])
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FOREIGN_REC, FSHEET_ID, '{}'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FOREIGN_REC2, FSHEET_ID, '{}'])
 
     const f = (id: string, name: string, type: string, property: string, order: number) =>
       q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [id, SHEET_ID, name, type, property, order])
@@ -131,9 +135,12 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     await f(FLD_SECRET, 'Secret', 'string', '{}', 3)
     await f(FLD_FX, 'Formula', 'formula', '{}', 4)
     await f(FLD_AUN, 'AutoNum', 'autoNumber', '{}', 5)
-    await f(FLD_LK, 'Link', 'link', '{}', 6)
+    await f(FLD_LK, 'Link', 'link', JSON.stringify({ foreignSheetId: FSHEET_ID }), 6)
     await f(FLD_BTN, 'Button', 'button', '{}', 7)
     await f(FLD_SEL, 'Select', 'select', JSON.stringify({ options: [{ value: 'x' }, { value: 'y' }] }), 8)
+    await f(FLD_LK_TW, 'LinkTwoWay', 'link', JSON.stringify({ foreignSheetId: FSHEET_ID, twoWay: true, mirrorFieldId: FLD_MIRROR }), 9)
+    // mirror side lives on the foreign sheet (derived single-edge projection — no materialized row)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_MIRROR, FSHEET_ID, 'Mirror', 'link', JSON.stringify({ foreignSheetId: SHEET_ID, twoWay: true, mirrorFieldId: FLD_LK_TW, mirrorOf: FLD_LK_TW }), 1])
 
     // Layer-3: USER_RO is read_only on SECRET (and a separate visible=false would also gate).
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_RO, true, true])
@@ -269,18 +276,67 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     expect((await liveData(rid))[FLD_AUN]).toBe(2) // unchanged
   })
 
-  test('T6: link field excluded — not written, meta_links left untouched', async () => {
+  const linksOf = async (recordId: string): Promise<string[]> => {
+    const r = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2 ORDER BY foreign_record_id', [FLD_LK, recordId])
+    return (r.rows as Array<{ foreign_record_id: string }>).map((x) => x.foreign_record_id)
+  }
+
+  test('T6 (Slice 2a): link field restored — meta_links cleared when the target version had no link', async () => {
     const rid = await seedRecord(
       { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] },
       2,
       [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: [] } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } }],
     )
-    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_a_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
     expect(res.status).toBe(200)
-    expect(res.body.data.restoredFieldIds).not.toContain(FLD_LK)
-    const links = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2', [FLD_LK, rid])
-    expect((links.rows as Array<{ foreign_record_id: string }>).map((r) => r.foreign_record_id)).toEqual([FOREIGN_REC])
+    expect(res.body.data.restoredFieldIds).toContain(FLD_LK)
+    expect(await linksOf(rid)).toEqual([]) // re-synced to version 1 (no link)
+  })
+
+  test('T6e (Slice 2a): link field restored — meta_links re-pointed to the target version edges', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: [FOREIGN_REC2] } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } }],
+    )
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_e_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toContain(FLD_LK)
+    expect(await linksOf(rid)).toEqual([FOREIGN_REC2]) // edge re-pointed
+  })
+
+  test('T6a (Slice 2a): a twoWay-configured link restores cleanly — the edge the mirror derives from is re-synced', async () => {
+    const linksOfField = async (fid: string, recordId: string): Promise<string[]> => {
+      const r = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2 ORDER BY foreign_record_id', [fid, recordId])
+      return (r.rows as Array<{ foreign_record_id: string }>).map((x) => x.foreign_record_id)
+    }
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_LK_TW]: [FOREIGN_REC] },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK_TW]: [FOREIGN_REC2] } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK_TW]: [FOREIGN_REC] } }],
+    )
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_tw_${recordSeq}`, FLD_LK_TW, rid, FOREIGN_REC])
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toContain(FLD_LK_TW)
+    // The single edge (which BOTH the forward link and the foreign record's derived mirror resolve from)
+    // is re-pointed to the version-1 target; the mirror projection on FOREIGN_REC2 derives from this.
+    expect(await linksOfField(FLD_LK_TW, rid)).toEqual([FOREIGN_REC2])
+  })
+
+  test('T6f (Slice 2a): link to a now-deleted foreign record → VALIDATION_ERROR (fail-closed), nothing written', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: [`frec_gone_${TS}`] } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } }],
+    )
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_f_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(await linksOf(rid)).toEqual([FOREIGN_REC]) // atomic: unchanged
   })
 
   test('T6b: snapshot field absent from current schema → SCHEMA_DRIFT', async () => {

--- a/packages/core-backend/tests/unit/meta-revision-retention.test.ts
+++ b/packages/core-backend/tests/unit/meta-revision-retention.test.ts
@@ -5,7 +5,10 @@ import {
   META_REVISION_RETENTION_MIN_DAYS,
   META_REVISION_RETENTION_MIN_KEEP_N,
   resolveMetaRevisionRetentionConfig,
+  startMetaRevisionRetention,
 } from '../../src/multitable/meta-revision-retention'
+
+const silentLogger = { info() {}, warn() {}, error() {}, debug() {} } as never
 
 describe('meta-revision retention config', () => {
   test('disabled by default (no env) — preserves the restore guarantee until opt-in', () => {
@@ -45,5 +48,26 @@ describe('meta-revision retention config', () => {
       MULTITABLE_META_REVISION_RETENTION_KEEP_N: '50',
     })
     expect(cfg.keepN).toBe(50)
+  })
+
+  test('scheduler: disabled (default) is a no-op — returns a stop fn, never touches the DB', () => {
+    let called = 0
+    const queryFn = (async () => { called++; return { rows: [], rowCount: 0 } }) as never
+    const stop = startMetaRevisionRetention({ env: {}, query: queryFn, logger: silentLogger, intervalMs: 60_000 })
+    expect(typeof stop).toBe('function')
+    expect(called).toBe(0)
+    stop()
+  })
+
+  test('scheduler: enabled returns a working stop fn (sweep runs on the interval, not synchronously)', () => {
+    const queryFn = (async () => ({ rows: [], rowCount: 0 })) as never
+    const stop = startMetaRevisionRetention({
+      env: { MULTITABLE_META_REVISION_RETENTION_ENABLED: '1' },
+      query: queryFn,
+      logger: silentLogger,
+      intervalMs: 3_600_000,
+    })
+    expect(typeof stop).toBe('function')
+    stop() // clears the interval without error
   })
 })

--- a/packages/core-backend/tests/unit/meta-revision-retention.test.ts
+++ b/packages/core-backend/tests/unit/meta-revision-retention.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  META_REVISION_RETENTION_DEFAULT_KEEP_N,
+  META_REVISION_RETENTION_MIN_DAYS,
+  META_REVISION_RETENTION_MIN_KEEP_N,
+  resolveMetaRevisionRetentionConfig,
+} from '../../src/multitable/meta-revision-retention'
+
+describe('meta-revision retention config', () => {
+  test('disabled by default (no env) — preserves the restore guarantee until opt-in', () => {
+    const cfg = resolveMetaRevisionRetentionConfig({})
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.policy).toBe('keep-last-n')
+    expect(cfg.keepN).toBe(META_REVISION_RETENTION_DEFAULT_KEEP_N)
+  })
+
+  test('enabled only when explicitly "1"', () => {
+    expect(resolveMetaRevisionRetentionConfig({ MULTITABLE_META_REVISION_RETENTION_ENABLED: '0' }).enabled).toBe(false)
+    expect(resolveMetaRevisionRetentionConfig({ MULTITABLE_META_REVISION_RETENTION_ENABLED: 'true' }).enabled).toBe(false)
+    expect(resolveMetaRevisionRetentionConfig({ MULTITABLE_META_REVISION_RETENTION_ENABLED: '1' }).enabled).toBe(true)
+  })
+
+  test('keep-last-n value is floored so a mis-set cannot gut history', () => {
+    const cfg = resolveMetaRevisionRetentionConfig({
+      MULTITABLE_META_REVISION_RETENTION_ENABLED: '1',
+      MULTITABLE_META_REVISION_RETENTION_KEEP_N: '1',
+    })
+    expect(cfg.keepN).toBe(META_REVISION_RETENTION_MIN_KEEP_N) // floored, not 1
+  })
+
+  test('keep-days policy + floored window', () => {
+    const cfg = resolveMetaRevisionRetentionConfig({
+      MULTITABLE_META_REVISION_RETENTION_ENABLED: '1',
+      MULTITABLE_META_REVISION_RETENTION_POLICY: 'keep-days',
+      MULTITABLE_META_REVISION_RETENTION_DAYS: '2',
+    })
+    expect(cfg.policy).toBe('keep-days')
+    expect(cfg.retentionDays).toBe(META_REVISION_RETENTION_MIN_DAYS) // floored
+  })
+
+  test('explicit valid values pass through', () => {
+    const cfg = resolveMetaRevisionRetentionConfig({
+      MULTITABLE_META_REVISION_RETENTION_ENABLED: '1',
+      MULTITABLE_META_REVISION_RETENTION_KEEP_N: '50',
+    })
+    expect(cfg.keepN).toBe(50)
+  })
+})

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -13115,6 +13115,33 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '410':
+          description: >-
+            VERSION_EXPIRED — the target version is older than the retained
+            floor and has been pruned by the meta-revision retention policy
+            (distinct from VERSION_NOT_FOUND for a version that never existed).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - VERSION_EXPIRED
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                required:
+                  - ok
+                  - error
         '422':
           description: >-
             Restore not possible — RESTORE_UNSUPPORTED (target is a delete

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -13025,12 +13025,12 @@ paths:
     post:
       summary: Restore a multitable record to a prior revision (Layer 1)
       description: >-
-        Restores a live record's scalar user-data fields to a prior revision's
-        recorded values. Forward-change semantics — a value-changing restore
-        emits a new revision (source=restore) and bumps version; an empty diff
-        is a no-op. Computed/link/system-auto/attachment fields are excluded by
-        type. Atomically rejected if any restorable differing field is not
-        writable.
+        Restores a live record's user-data fields to a prior revision's recorded
+        values, including link fields (re-synced through meta_links + the twoWay
+        mirror). Forward-change semantics — a value-changing restore emits a new
+        revision (source=restore) and bumps version; an empty diff is a no-op.
+        Computed / system-auto / attachment fields are excluded by type.
+        Atomically rejected if any restorable differing field is not writable.
       security:
         - bearerAuth: []
       parameters:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -19894,6 +19894,43 @@
           "409": {
             "$ref": "#/components/responses/Conflict"
           },
+          "410": {
+            "description": "VERSION_EXPIRED — the target version is older than the retained floor and has been pruned by the meta-revision retention policy (distinct from VERSION_NOT_FOUND for a version that never existed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "VERSION_EXPIRED"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "422": {
             "description": "Restore not possible — RESTORE_UNSUPPORTED (target is a delete revision), SNAPSHOT_UNAVAILABLE (revision has a null snapshot), or SCHEMA_DRIFT (a snapshot field no longer exists in the current schema).",
             "content": {

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -19778,7 +19778,7 @@
     "/api/multitable/sheets/{sheetId}/records/{recordId}/restore": {
       "post": {
         "summary": "Restore a multitable record to a prior revision (Layer 1)",
-        "description": "Restores a live record's scalar user-data fields to a prior revision's recorded values. Forward-change semantics — a value-changing restore emits a new revision (source=restore) and bumps version; an empty diff is a no-op. Computed/link/system-auto/attachment fields are excluded by type. Atomically rejected if any restorable differing field is not writable.",
+        "description": "Restores a live record's user-data fields to a prior revision's recorded values, including link fields (re-synced through meta_links + the twoWay mirror). Forward-change semantics — a value-changing restore emits a new revision (source=restore) and bumps version; an empty diff is a no-op. Computed / system-auto / attachment fields are excluded by type. Atomically rejected if any restorable differing field is not writable.",
         "security": [
           {
             "bearerAuth": []

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -13115,6 +13115,33 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '410':
+          description: >-
+            VERSION_EXPIRED — the target version is older than the retained
+            floor and has been pruned by the meta-revision retention policy
+            (distinct from VERSION_NOT_FOUND for a version that never existed).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - VERSION_EXPIRED
+                      message:
+                        type: string
+                    required:
+                      - code
+                      - message
+                required:
+                  - ok
+                  - error
         '422':
           description: >-
             Restore not possible — RESTORE_UNSUPPORTED (target is a delete

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -13025,12 +13025,12 @@ paths:
     post:
       summary: Restore a multitable record to a prior revision (Layer 1)
       description: >-
-        Restores a live record's scalar user-data fields to a prior revision's
-        recorded values. Forward-change semantics — a value-changing restore
-        emits a new revision (source=restore) and bumps version; an empty diff
-        is a no-op. Computed/link/system-auto/attachment fields are excluded by
-        type. Atomically rejected if any restorable differing field is not
-        writable.
+        Restores a live record's user-data fields to a prior revision's recorded
+        values, including link fields (re-synced through meta_links + the twoWay
+        mirror). Forward-change semantics — a value-changing restore emits a new
+        revision (source=restore) and bumps version; an empty diff is a no-op.
+        Computed / system-auto / attachment fields are excluded by type.
+        Atomically rejected if any restorable differing field is not writable.
       security:
         - bearerAuth: []
       parameters:

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -528,6 +528,24 @@ paths:
                       message: { type: string }
                     required: [code, message]
                 required: [ok, error]
+        '410':
+          description: >-
+            VERSION_EXPIRED — the target version is older than the retained floor and has been pruned
+            by the meta-revision retention policy (distinct from VERSION_NOT_FOUND for a version that
+            never existed).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  error:
+                    type: object
+                    properties:
+                      code: { type: string, enum: [VERSION_EXPIRED] }
+                      message: { type: string }
+                    required: [code, message]
+                required: [ok, error]
   /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
     get:
       summary: Load current user's subscription status for a record

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -448,10 +448,11 @@ paths:
     post:
       summary: Restore a multitable record to a prior revision (Layer 1)
       description: >-
-        Restores a live record's scalar user-data fields to a prior revision's recorded values.
-        Forward-change semantics — a value-changing restore emits a new revision (source=restore)
-        and bumps version; an empty diff is a no-op. Computed/link/system-auto/attachment fields are
-        excluded by type. Atomically rejected if any restorable differing field is not writable.
+        Restores a live record's user-data fields to a prior revision's recorded values, including
+        link fields (re-synced through meta_links + the twoWay mirror). Forward-change semantics — a
+        value-changing restore emits a new revision (source=restore) and bumps version; an empty diff
+        is a no-op. Computed / system-auto / attachment fields are excluded by type. Atomically
+        rejected if any restorable differing field is not writable.
       security: [ { bearerAuth: [] } ]
       parameters:
         - in: path


### PR DESCRIPTION
**Stacked on #2654 (Slice 1).** Base = `claude/multitable-record-restore-l1-20260615`; will auto-retarget to `main` when #2654 merges. Two commits, each a separate slice.

## Slice 2a — live-record link-field restore
Lifts the Lock D link exclusion for **live** records: link fields are restored as SET changes (the snapshot stores the link id array in `data`), routed through `patchRecords`' existing `meta_links` sync + twoWay mirror fan-out — never the data-`unset` op (which would desync the join table). Emitted only when the id set differs (no-op preserved). A snapshot referencing a now-deleted foreign record is rejected fail-closed by the spine's link-target validation (`VALIDATION_ERROR`). **Undelete (Slice 2b) stays gated** — the delete revision never captured the link edges; needs a forward-capture change + product decision.

## Retention — prune + `VERSION_EXPIRED`
New `MetaRevisionRetention` service (keep-last-N primary / keep-days), mirroring the `ai-usage-ledger` bounded-DELETE discipline. **Disabled by default** (`MULTITABLE_META_REVISION_RETENTION_ENABLED=1` to enable) so the restore guarantee is preserved until the owner opts in and picks N/D. Invariant: never deletes a record's latest revision. The restore route now returns **410 `VERSION_EXPIRED`** when a target is below the surviving `MIN(version)` floor (data-driven — correct whether or not the sweep is scheduled), distinct from `VERSION_NOT_FOUND`. OpenAPI + parity updated.

## Verification (local, real Postgres)
- `tsc --noEmit`: 0 errors
- restore matrix **22/22** (Slice 1 T1–T12 + Slice 2a T6/T6a/T6e/T6f + retention T13/T14)
- retention config unit **5/5**; lock-guard scanner 4/4; mirror-links 12/12; patch 6/6; OpenAPI parity green

## Gated (not in this PR — reasons in the dev report)
Slice 2b undelete (link-edge data gap + product call), Layer 2 `MetaSnapshotService` (separate program), `plugin-intelligent-restore` deletion (cross-cutting cleanup decision), revision partial-unique-index migration, per-field (column-level) frontend restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)