### PR TITLE
feat(multitable): color-scale + icon-set conditional formatting backend (A5-2/A5-3)

### DIFF
--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -132,6 +132,19 @@ export interface ConditionalFormattingDataBarConfig {
   negativeColor?: string
   showValue?: boolean
 }
+/** A5-2 color scale: 2 stops (min/max) or 3 stops (min/mid/max), each a hex color. */
+export interface ConditionalFormattingColorScaleConfig {
+  stops: Array<{ at: 'min' | 'mid' | 'max'; color: string }>
+}
+/**
+ * A5-3 icon set: a 3-icon set keyed by two ascending thresholds (`[t0, t1]`).
+ * Thresholds are ABSOLUTE values (band by `v < t0` / `t0 <= v < t1` / `v >= t1`),
+ * not percentiles — a percentile mode over the field's min/max is a follow-up.
+ */
+export interface ConditionalFormattingIconSetConfig {
+  set: 'arrows3' | 'traffic3' | 'signs3'
+  thresholds: [number, number]
+}
 export interface ConditionalFormattingScaleRule {
   id: string
   order: number
@@ -140,6 +153,8 @@ export interface ConditionalFormattingScaleRule {
   enabled: boolean
   range: ConditionalFormattingScaleRange
   dataBar?: ConditionalFormattingDataBarConfig
+  colorScale?: ConditionalFormattingColorScaleConfig
+  iconSet?: ConditionalFormattingIconSetConfig
 }
 export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
 

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -5,7 +5,9 @@
 // when extending the rule schema.
 
 import type {
+  ConditionalFormattingColorScaleConfig,
   ConditionalFormattingDataBarConfig,
+  ConditionalFormattingIconSetConfig,
   ConditionalFormattingOperator,
   ConditionalFormattingRule,
   ConditionalFormattingScaleRange,
@@ -375,9 +377,12 @@ export function composeStyleObject(
 }
 
 // ===========================================================================
-// Range-based SCALE formatting (A5-1: data bar) — frontend mirror of
+// Range-based SCALE formatting (A5-1 data bar / A5-2 color scale / A5-3 icon
+// set) — frontend mirror of
 // packages/core-backend/src/multitable/conditional-formatting-service.ts.
-// Keep the sanitize/range/build semantics in sync with the canonical backend.
+// Keep the sanitize/range/interpolation/build semantics BYTE-IDENTICAL to the
+// canonical backend (no cross-package test harness — the only mirror-drift
+// guard is matching expected-hex literals in both unit specs).
 // ===========================================================================
 
 function toFiniteNumber(value: unknown): number | null {
@@ -389,36 +394,143 @@ function toFiniteNumber(value: unknown): number | null {
   return null
 }
 
+const ICON_SETS: ReadonlySet<ConditionalFormattingIconSetConfig['set']> = new Set([
+  'arrows3', 'traffic3', 'signs3',
+])
+
+/** Parse a sanitized `#rgb`/`#rrggbb`/`#rrggbbaa` hex into [r,g,b] 0..255 (alpha ignored). */
+function hexToRgb(hex: string): [number, number, number] {
+  let body = hex.slice(1)
+  if (body.length === 3) body = body[0] + body[0] + body[1] + body[1] + body[2] + body[2]
+  // length 8 (rgba) → drop the trailing alpha pair; interpolation is over RGB only.
+  const r = parseInt(body.slice(0, 2), 16)
+  const g = parseInt(body.slice(2, 4), 16)
+  const b = parseInt(body.slice(4, 6), 16)
+  return [r, g, b]
+}
+
+/** Emit a lowercase `#rrggbb` from [r,g,b], rounding + clamping each channel to 0..255. */
+function rgbToHex(rgb: [number, number, number]): string {
+  const toHex = (n: number): string => {
+    const clamped = Math.max(0, Math.min(255, Math.round(n)))
+    return clamped.toString(16).padStart(2, '0')
+  }
+  return `#${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}`
+}
+
+/** Linear-interpolate two hex colors at fraction t∈[0,1]; emits lowercase `#rrggbb`. */
+function lerpHex(from: string, to: string, t: number): string {
+  const a = hexToRgb(from)
+  const b = hexToRgb(to)
+  const f = Math.max(0, Math.min(1, t))
+  return rgbToHex([
+    a[0] + (b[0] - a[0]) * f,
+    a[1] + (b[1] - a[1]) * f,
+    a[2] + (b[2] - a[2]) * f,
+  ])
+}
+
+/**
+ * Color at normalized position `t`∈[0,1] across the (anchor-sorted) stops.
+ * 2 stops: lerp min↔max over t. 3 stops: piecewise with mid anchored at t=0.5
+ * (t<0.5 lerps min↔mid over t/0.5; else mid↔max over (t-0.5)/0.5; t=0.5 yields
+ * the mid color from either branch). Stops are pre-sorted min→mid→max.
+ */
+function colorScaleAt(stops: ReadonlyArray<{ at: 'min' | 'mid' | 'max'; color: string }>, t: number): string {
+  const clamped = Math.max(0, Math.min(1, t))
+  if (stops.length === 2) return lerpHex(stops[0].color, stops[1].color, clamped)
+  // 3 stops: [min, mid, max]
+  if (clamped <= 0.5) return lerpHex(stops[0].color, stops[1].color, clamped / 0.5)
+  return lerpHex(stops[1].color, stops[2].color, (clamped - 0.5) / 0.5)
+}
+
+/** Parse the shared `range` field (auto/fixed); returns null for an invalid fixed range. */
+function sanitizeScaleRange(raw: unknown): ConditionalFormattingScaleRange | null {
+  const rangeRaw = isPlainObject(raw) ? raw : {}
+  if (rangeRaw.mode === 'fixed') {
+    const min = toFiniteNumber(rangeRaw.min)
+    const max = toFiniteNumber(rangeRaw.max)
+    if (min === null || max === null || min === max) return null
+    return { mode: 'fixed', min: Math.min(min, max), max: Math.max(min, max) }
+  }
+  return { mode: 'auto' }
+}
+
+/** Parse + validate `colorScale.stops` (2 anchors min/max, or 3 anchors min/mid/max). */
+function sanitizeColorScale(raw: unknown): ConditionalFormattingColorScaleConfig | null {
+  if (!isPlainObject(raw) || !Array.isArray(raw.stops)) return null
+  const stops: Array<{ at: 'min' | 'mid' | 'max'; color: string }> = []
+  for (const stop of raw.stops) {
+    if (!isPlainObject(stop)) return null
+    const at = stop.at
+    if (at !== 'min' && at !== 'mid' && at !== 'max') return null
+    const color = sanitizeHex(stop.color)
+    if (!color) return null
+    stops.push({ at, color })
+  }
+  if (stops.length < 2 || stops.length > 3) return null
+  // Anchor set must EXACTLY match {min,max} (2) or {min,mid,max} (3) — no dup, no missing.
+  const anchors = new Set(stops.map((s) => s.at))
+  if (anchors.size !== stops.length) return null // duplicate anchor
+  const required = stops.length === 2 ? ['min', 'max'] : ['min', 'mid', 'max']
+  for (const a of required) if (!anchors.has(a as 'min' | 'mid' | 'max')) return null
+  // Normalize to min→mid→max so the builder is order-independent.
+  const order: Record<'min' | 'mid' | 'max', number> = { min: 0, mid: 1, max: 2 }
+  stops.sort((a, b) => order[a.at] - order[b.at])
+  return { stops }
+}
+
+/** Parse + validate `iconSet` (known set + finite, monotonic `[t0, t1]` thresholds). */
+function sanitizeIconSet(raw: unknown): ConditionalFormattingIconSetConfig | null {
+  if (!isPlainObject(raw)) return null
+  const set = raw.set
+  if (typeof set !== 'string' || !ICON_SETS.has(set as ConditionalFormattingIconSetConfig['set'])) return null
+  if (!Array.isArray(raw.thresholds) || raw.thresholds.length !== 2) return null
+  const t0 = toFiniteNumber(raw.thresholds[0])
+  const t1 = toFiniteNumber(raw.thresholds[1])
+  if (t0 === null || t1 === null || t0 > t1) return null // require monotonic ascending (t0 <= t1)
+  return { set: set as ConditionalFormattingIconSetConfig['set'], thresholds: [t0, t1] }
+}
+
 export function sanitizeScaleRule(input: unknown): ConditionalFormattingScaleRule | null {
   if (!isPlainObject(input)) return null
   const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
   const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
   if (!id || !fieldId) return null
-  if (input.kind !== 'dataBar') return null // A5-1: dataBar only (colorScale/iconSet = A5-2/A5-3)
 
   const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
   const enabled = input.enabled !== false
 
-  const rangeRaw = isPlainObject(input.range) ? input.range : {}
-  let range: ConditionalFormattingScaleRange
-  if (rangeRaw.mode === 'fixed') {
-    const min = toFiniteNumber(rangeRaw.min)
-    const max = toFiniteNumber(rangeRaw.max)
-    if (min === null || max === null || min === max) return null
-    range = { mode: 'fixed', min: Math.min(min, max), max: Math.max(min, max) }
-  } else {
-    range = { mode: 'auto' }
+  const range = sanitizeScaleRange(input.range)
+  if (!range) return null
+
+  const base = { id, order: Math.floor(orderRaw), fieldId, enabled, range }
+
+  // Per-kind config. Unknown kinds → null (keeps the forward-dated-config guard).
+  switch (input.kind) {
+    case 'dataBar': {
+      const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
+      const color = sanitizeHex(barRaw.color)
+      if (!color) return null
+      const dataBar: ConditionalFormattingDataBarConfig = { color }
+      const negativeColor = sanitizeHex(barRaw.negativeColor)
+      if (negativeColor) dataBar.negativeColor = negativeColor
+      if (barRaw.showValue === true) dataBar.showValue = true
+      return { ...base, kind: 'dataBar', dataBar }
+    }
+    case 'colorScale': {
+      const colorScale = sanitizeColorScale(input.colorScale)
+      if (!colorScale) return null
+      return { ...base, kind: 'colorScale', colorScale }
+    }
+    case 'iconSet': {
+      const iconSet = sanitizeIconSet(input.iconSet)
+      if (!iconSet) return null
+      return { ...base, kind: 'iconSet', iconSet }
+    }
+    default:
+      return null
   }
-
-  const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
-  const color = sanitizeHex(barRaw.color)
-  if (!color) return null
-  const dataBar: ConditionalFormattingDataBarConfig = { color }
-  const negativeColor = sanitizeHex(barRaw.negativeColor)
-  if (negativeColor) dataBar.negativeColor = negativeColor
-  if (barRaw.showValue === true) dataBar.showValue = true
-
-  return { id, order: Math.floor(orderRaw), fieldId, kind: 'dataBar', enabled, range, dataBar }
 }
 
 export function sanitizeScaleRules(input: unknown): ConditionalFormattingScaleRule[] {
@@ -440,10 +552,20 @@ export function extractScaleRulesFromConfig(config: unknown): ConditionalFormatt
   return sanitizeScaleRules(config.conditionalFormattingScaleRules)
 }
 
+/**
+ * Per-cell derived presentation. Fields are kind-specific and all optional:
+ * dataBar → `barPct`/`barColor`/`negative`; colorScale → `scaleColor`;
+ * iconSet → `iconKey`. Optional (not a discriminated union) so the kind-blind
+ * grid renderer's `${scale.barColor} ${scale.barPct}%` template still compiles.
+ */
 export interface FieldScalePresentation {
-  barPct: number
-  barColor: string
-  negative: boolean
+  barPct?: number
+  barColor?: string
+  negative?: boolean
+  /** Color-scale background — interpolated `#rrggbb` at the value's normalized position. */
+  scaleColor?: string
+  /** Icon-set band: `'low'` (v<t0) / `'mid'` (t0<=v<t1) / `'high'` (v>=t1). */
+  iconKey?: 'low' | 'mid' | 'high'
 }
 export interface FieldScaleResult {
   rule: ConditionalFormattingScaleRule
@@ -460,11 +582,16 @@ const EMPTY_SCALE_MAP: FieldScaleMap = Object.freeze({
 }) as FieldScaleMap
 
 /**
- * Pre-compute data-bar presentation per (fieldId, recordId). Mirrors the
- * backend `buildFieldScaleMap`: min/max over the passed records (auto) or the
- * rule's fixed range; each finite value → 0..100 fill; degenerate range → full
- * bar; negatives take negativeColor; non-numeric skipped; first rule per field
- * wins. Caller passes the already-loaded/masked rows (client-side discipline).
+ * Pre-compute per-(fieldId, recordId) scale presentation. Mirrors the backend
+ * `buildFieldScaleMap`: resolve min/max over the passed records (auto) or the
+ * rule's fixed range, then derive a kind-specific presentation per finite value:
+ * dataBar → `barPct` (0..100; degenerate min==max → 100) + `barColor`
+ * (negativeColor when v<0) + `negative`; colorScale → `scaleColor` interpolated
+ * at t=(v-min)/(max-min), degenerate → t=0.5; iconSet → `iconKey` banded by
+ * ABSOLUTE thresholds (v<t0 'low' / t0<=v<t1 'mid' / v>=t1 'high'). Non-numeric
+ * skipped; a field with no numeric values omitted; first rule per field wins.
+ * Caller passes the already-loaded/masked rows (client-side discipline). The
+ * grid renderer is still kind-blind (data bars only) — per-kind render is next.
  */
 export function buildFieldScaleMap(
   rules: ConditionalFormattingScaleRule[],
@@ -474,8 +601,11 @@ export function buildFieldScaleMap(
   const byField: Record<string, FieldScaleResult> = {}
 
   for (const rule of rules) {
-    if (!rule.enabled || rule.kind !== 'dataBar' || !rule.dataBar) continue
+    if (!rule.enabled) continue
     if (byField[rule.fieldId]) continue
+    if (rule.kind === 'dataBar' && !rule.dataBar) continue
+    if (rule.kind === 'colorScale' && !rule.colorScale) continue
+    if (rule.kind === 'iconSet' && !rule.iconSet) continue
 
     let min: number
     let max: number
@@ -502,10 +632,20 @@ export function buildFieldScaleMap(
       if (!record?.id) continue
       const v = toComparableNumber(record.data?.[rule.fieldId])
       if (v === null) continue
-      const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
-      const negative = v < 0
-      const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
-      byRecordId[record.id] = { barPct: pct, barColor, negative }
+
+      if (rule.kind === 'dataBar' && rule.dataBar) {
+        const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
+        const negative = v < 0
+        const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
+        byRecordId[record.id] = { barPct: pct, barColor, negative }
+      } else if (rule.kind === 'colorScale' && rule.colorScale) {
+        const t = span <= 0 ? 0.5 : (v - min) / span
+        byRecordId[record.id] = { scaleColor: colorScaleAt(rule.colorScale.stops, t) }
+      } else if (rule.kind === 'iconSet' && rule.iconSet) {
+        const [t0, t1] = rule.iconSet.thresholds
+        const iconKey: 'low' | 'mid' | 'high' = v < t0 ? 'low' : v < t1 ? 'mid' : 'high'
+        byRecordId[record.id] = { iconKey }
+      }
     }
     byField[rule.fieldId] = { rule, min, max, byRecordId }
   }

--- a/apps/web/tests/multitable-cf-scale.spec.ts
+++ b/apps/web/tests/multitable-cf-scale.spec.ts
@@ -25,9 +25,11 @@ describe('FE conditional-formatting scale mirror (A5-1 data bar)', () => {
       })
     })
 
-    it('rejects colorScale / iconSet (A5-2 / A5-3)', () => {
+    it('rejects an unknown kind and a colorScale/iconSet kind lacking its config (valid configs accepted in the A5-2/A5-3 blocks below)', () => {
+      // `validBar()` only supplies a `dataBar` config, so flipping the kind alone is still rejected.
       expect(sanitizeScaleRule(validBar({ kind: 'colorScale' }))).toBeNull()
       expect(sanitizeScaleRule(validBar({ kind: 'iconSet' }))).toBeNull()
+      expect(sanitizeScaleRule(validBar({ kind: 'gradientNeo' }))).toBeNull()
     })
 
     it('requires id/fieldId/valid hex color', () => {
@@ -92,6 +94,191 @@ describe('FE conditional-formatting scale mirror (A5-1 data bar)', () => {
 
     it('returns an empty map when a field has no numeric values', () => {
       expect(buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
+    })
+  })
+})
+
+// FE↔BE PARITY: there is no cross-package test harness (core-backend and
+// apps/web are separate vitest projects), so the only guard against mirror-drift
+// is that the expected sanitized rules + interpolated-hex literals below match
+// the canonical backend spec byte-for-byte
+// (packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts).
+describe('FE conditional-formatting scale mirror (A5-2 color scale)', () => {
+  const validColorScale = (over: Record<string, unknown> = {}) => ({
+    id: 'cs1', fieldId: 'fld_n', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+    colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'max', color: '#000000' }] },
+    ...over,
+  })
+  const ryg = { stops: [
+    { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' }, { at: 'max', color: '#00ff00' },
+  ] }
+
+  describe('sanitizeScaleRule', () => {
+    it('accepts a 2-stop color scale', () => {
+      expect(sanitizeScaleRule(validColorScale())).toEqual({
+        id: 'cs1', order: 0, fieldId: 'fld_n', kind: 'colorScale', enabled: true, range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'max', color: '#000000' }] },
+      })
+    })
+
+    it('accepts a 3-stop color scale and normalizes stop order to min→mid→max', () => {
+      const r = sanitizeScaleRule(validColorScale({
+        colorScale: { stops: [
+          { at: 'max', color: '#00ff00' }, { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' },
+        ] },
+      }))
+      expect(r?.colorScale?.stops.map((s) => s.at)).toEqual(['min', 'mid', 'max'])
+      expect(r?.colorScale?.stops.map((s) => s.color)).toEqual(['#ff0000', '#ffff00', '#00ff00'])
+    })
+
+    it('rejects 1 stop / 4 stops / bad anchor / bad hex / missing / duplicate anchor', () => {
+      expect(sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'min', color: '#ffffff' }] } }))).toBeNull()
+      expect(sanitizeScaleRule(validColorScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#ffffff' }, { at: 'mid', color: '#888888' },
+          { at: 'max', color: '#000000' }, { at: 'max', color: '#111111' },
+        ] },
+      }))).toBeNull()
+      expect(sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'min', color: '#fff' }, { at: 'middle', color: '#000' }] } }))).toBeNull()
+      expect(sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'min', color: 'white' }, { at: 'max', color: '#000000' }] } }))).toBeNull()
+      expect(sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'min', color: '#000000' }] } }))).toBeNull()
+      expect(sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'mid', color: '#ffffff' }, { at: 'max', color: '#000000' }] } }))).toBeNull()
+    })
+
+    it('rejects a missing colorScale config', () => {
+      expect(sanitizeScaleRule({ id: 'x', fieldId: 'f', kind: 'colorScale', order: 0, range: { mode: 'auto' } })).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (color scale)', () => {
+    const recs = [
+      { id: 'r1', data: { fld_n: 0 } },
+      { id: 'r2', data: { fld_n: 25 } },
+      { id: 'r3', data: { fld_n: 50 } },
+      { id: 'r4', data: { fld_n: 100 } },
+    ]
+
+    it('interpolates a 2-stop scale at min / interior / mid / max (exact hex)', () => {
+      const f = buildFieldScaleMap([sanitizeScaleRule(validColorScale())!], recs).byField.fld_n
+      expect([f.min, f.max]).toEqual([0, 100])
+      expect(f.byRecordId.r1.scaleColor).toBe('#ffffff')
+      expect(f.byRecordId.r2.scaleColor).toBe('#bfbfbf')
+      expect(f.byRecordId.r3.scaleColor).toBe('#808080')
+      expect(f.byRecordId.r4.scaleColor).toBe('#000000')
+      expect(f.byRecordId.r2.barPct).toBeUndefined()
+      expect(f.byRecordId.r2.iconKey).toBeUndefined()
+    })
+
+    it('interpolates a 3-stop scale piecewise with mid anchored at t=0.5 (exact hex)', () => {
+      const f = buildFieldScaleMap([sanitizeScaleRule(validColorScale({ colorScale: ryg }))!], recs).byField.fld_n
+      expect(f.byRecordId.r1.scaleColor).toBe('#ff0000')
+      expect(f.byRecordId.r2.scaleColor).toBe('#ff8000')
+      expect(f.byRecordId.r3.scaleColor).toBe('#ffff00')
+      expect(f.byRecordId.r4.scaleColor).toBe('#00ff00')
+    })
+
+    it('expands 3-digit shorthand hex before interpolating', () => {
+      const f = buildFieldScaleMap(
+        [sanitizeScaleRule(validColorScale({ colorScale: { stops: [{ at: 'min', color: '#f00' }, { at: 'max', color: '#00f' }] } }))!],
+        [{ id: 'a', data: { fld_n: 0 } }, { id: 'b', data: { fld_n: 100 } }, { id: 'm', data: { fld_n: 50 } }],
+      ).byField.fld_n
+      expect(f.byRecordId.m.scaleColor).toBe('#800080')
+    })
+
+    it('degenerate range → mid color (t=0.5): 3-stop mid, 2-stop midpoint blend', () => {
+      const m3 = buildFieldScaleMap([sanitizeScaleRule(validColorScale({ colorScale: ryg }))!], [{ id: 'a', data: { fld_n: 7 } }, { id: 'b', data: { fld_n: 7 } }]).byField.fld_n
+      expect(m3.byRecordId.a.scaleColor).toBe('#ffff00')
+      expect(m3.byRecordId.b.scaleColor).toBe('#ffff00')
+      const m2 = buildFieldScaleMap([sanitizeScaleRule(validColorScale())!], [{ id: 'a', data: { fld_n: 5 } }, { id: 'b', data: { fld_n: 5 } }]).byField.fld_n
+      expect(m2.byRecordId.a.scaleColor).toBe('#808080')
+    })
+
+    it('handles negatives and skips non-numeric / empty columns', () => {
+      const f = buildFieldScaleMap([sanitizeScaleRule(validColorScale())!], [
+        { id: 'a', data: { fld_n: -50 } },
+        { id: 'b', data: { fld_n: 0 } },
+        { id: 'c', data: { fld_n: 50 } },
+        { id: 'd', data: { fld_n: 'n/a' } },
+      ]).byField.fld_n
+      expect([f.min, f.max]).toEqual([-50, 50])
+      expect(f.byRecordId.a.scaleColor).toBe('#ffffff')
+      expect(f.byRecordId.b.scaleColor).toBe('#808080')
+      expect(f.byRecordId.c.scaleColor).toBe('#000000')
+      expect(f.byRecordId.d).toBeUndefined()
+      expect(buildFieldScaleMap([sanitizeScaleRule(validColorScale())!], [{ id: 'x', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
+    })
+  })
+})
+
+describe('FE conditional-formatting scale mirror (A5-3 icon set)', () => {
+  const validIconSet = (over: Record<string, unknown> = {}) => ({
+    id: 'is1', fieldId: 'fld_n', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+    iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    ...over,
+  })
+
+  describe('sanitizeScaleRule', () => {
+    it('accepts each valid set with finite ascending thresholds', () => {
+      for (const set of ['arrows3', 'traffic3', 'signs3'] as const) {
+        expect(sanitizeScaleRule(validIconSet({ iconSet: { set, thresholds: [10, 20] } }))?.iconSet).toEqual({ set, thresholds: [10, 20] })
+      }
+    })
+
+    it('accepts equal thresholds (t0 === t1)', () => {
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [5, 5] } }))?.iconSet?.thresholds).toEqual([5, 5])
+    })
+
+    it('rejects unknown set / non-finite / non-monotonic / wrong-arity thresholds / missing config', () => {
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'stars5', thresholds: [10, 20] } }))).toBeNull()
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [20, 10] } }))).toBeNull()
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [Number.NaN, 20] } }))).toBeNull()
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, Infinity] } }))).toBeNull()
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10] } }))).toBeNull()
+      expect(sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, 20, 30] } }))).toBeNull()
+      expect(sanitizeScaleRule({ id: 'x', fieldId: 'f', kind: 'iconSet', order: 0, range: { mode: 'auto' } })).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (icon set)', () => {
+    const rule = sanitizeScaleRule(validIconSet())! // thresholds [10, 20]
+
+    it('bands values by absolute thresholds (v<t0 low / t0<=v<t1 mid / v>=t1 high)', () => {
+      const f = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: 5 } },
+        { id: 'b', data: { fld_n: 10 } },
+        { id: 'c', data: { fld_n: 15 } },
+        { id: 'd', data: { fld_n: 20 } },
+        { id: 'e', data: { fld_n: 99 } },
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b.iconKey).toBe('mid')
+      expect(f.byRecordId.c.iconKey).toBe('mid')
+      expect(f.byRecordId.d.iconKey).toBe('high')
+      expect(f.byRecordId.e.iconKey).toBe('high')
+      expect(f.byRecordId.c.barPct).toBeUndefined()
+      expect(f.byRecordId.c.scaleColor).toBeUndefined()
+    })
+
+    it('with equal thresholds the middle band is empty', () => {
+      const eq = sanitizeScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, 10] } }))!
+      const f = buildFieldScaleMap([eq], [
+        { id: 'a', data: { fld_n: 9 } },
+        { id: 'b', data: { fld_n: 10 } },
+        { id: 'c', data: { fld_n: 11 } },
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b.iconKey).toBe('high')
+      expect(f.byRecordId.c.iconKey).toBe('high')
+    })
+
+    it('handles negatives and skips non-numeric / empty columns', () => {
+      const f = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: -5 } },
+        { id: 'b', data: { fld_n: 'n/a' } },
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b).toBeUndefined()
+      expect(buildFieldScaleMap([rule], [{ id: 'x', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
     })
   })
 })

--- a/apps/web/tests/multitable-cf-scale.spec.ts
+++ b/apps/web/tests/multitable-cf-scale.spec.ts
@@ -155,6 +155,7 @@ describe('FE conditional-formatting scale mirror (A5-2 color scale)', () => {
       { id: 'r1', data: { fld_n: 0 } },
       { id: 'r2', data: { fld_n: 25 } },
       { id: 'r3', data: { fld_n: 50 } },
+      { id: 'rU', data: { fld_n: 75 } },
       { id: 'r4', data: { fld_n: 100 } },
     ]
 
@@ -174,6 +175,7 @@ describe('FE conditional-formatting scale mirror (A5-2 color scale)', () => {
       expect(f.byRecordId.r1.scaleColor).toBe('#ff0000')
       expect(f.byRecordId.r2.scaleColor).toBe('#ff8000')
       expect(f.byRecordId.r3.scaleColor).toBe('#ffff00')
+      expect(f.byRecordId.rU.scaleColor).toBe('#80ff00') // t=0.75 → mid↔max halfway (upper-segment interior)
       expect(f.byRecordId.r4.scaleColor).toBe('#00ff00')
     })
 

--- a/packages/core-backend/src/multitable/conditional-formatting-service.ts
+++ b/packages/core-backend/src/multitable/conditional-formatting-service.ts
@@ -388,9 +388,16 @@ export function evaluateConditionalFormattingRules(
 // against the field's min/max range. min/max is computed over the records
 // passed in (caller scopes them to already-loaded, already-masked rows — the
 // same client-side discipline as the A2 export picker; a full-column server
-// aggregate is a separate gated follow-up). A5-1 implements `dataBar`;
-// `colorScale` / `iconSet` land in A5-2 / A5-3 (sanitizer rejects them until
-// then, so a forward-dated config can't half-render).
+// aggregate is a separate gated follow-up). A5-1 implements `dataBar`,
+// A5-2 `colorScale` (gradient background), A5-3 `iconSet` (threshold icons).
+//
+// RENDER NOTE (per design-lock §6 sequencing 先 schema/sanitizer → 镜像 → 渲染 →
+// dialog): `buildFieldScaleMap` now derives `scaleColor` / `iconKey` for the new
+// kinds, but the grid renderer (MetaGridTable, browser-gated, OUT of this slice)
+// is still kind-blind — it only paints `barColor`/`barPct` data bars. Per-kind
+// render (gradient bg / icon prefix) + the authoring dialog are the next slices;
+// until then the only producer of scale rules is the (still data-bar-only) dialog,
+// so a colorScale/iconSet config has no reachable UI source.
 // ===========================================================================
 
 export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
@@ -409,6 +416,21 @@ export type ConditionalFormattingDataBarConfig = {
   showValue?: boolean
 }
 
+/** A5-2 color scale: 2 stops (min/max) or 3 stops (min/mid/max), each a hex color. */
+export type ConditionalFormattingColorScaleConfig = {
+  stops: Array<{ at: 'min' | 'mid' | 'max'; color: string }>
+}
+
+/**
+ * A5-3 icon set: a 3-icon set keyed by two ascending thresholds (`[t0, t1]`).
+ * Thresholds are ABSOLUTE values (band by `v < t0` / `t0 <= v < t1` / `v >= t1`),
+ * not percentiles — a percentile mode over the field's min/max is a follow-up.
+ */
+export type ConditionalFormattingIconSetConfig = {
+  set: 'arrows3' | 'traffic3' | 'signs3'
+  thresholds: [number, number]
+}
+
 export type ConditionalFormattingScaleRule = {
   id: string
   order: number
@@ -417,6 +439,58 @@ export type ConditionalFormattingScaleRule = {
   enabled: boolean
   range: ConditionalFormattingScaleRange
   dataBar?: ConditionalFormattingDataBarConfig
+  colorScale?: ConditionalFormattingColorScaleConfig
+  iconSet?: ConditionalFormattingIconSetConfig
+}
+
+const ICON_SETS: ReadonlySet<ConditionalFormattingIconSetConfig['set']> = new Set([
+  'arrows3', 'traffic3', 'signs3',
+])
+
+/** Parse a sanitized `#rgb`/`#rrggbb`/`#rrggbbaa` hex into [r,g,b] 0..255 (alpha ignored). */
+function hexToRgb(hex: string): [number, number, number] {
+  let body = hex.slice(1)
+  if (body.length === 3) body = body[0] + body[0] + body[1] + body[1] + body[2] + body[2]
+  // length 8 (rgba) → drop the trailing alpha pair; interpolation is over RGB only.
+  const r = parseInt(body.slice(0, 2), 16)
+  const g = parseInt(body.slice(2, 4), 16)
+  const b = parseInt(body.slice(4, 6), 16)
+  return [r, g, b]
+}
+
+/** Emit a lowercase `#rrggbb` from [r,g,b], rounding + clamping each channel to 0..255. */
+function rgbToHex(rgb: [number, number, number]): string {
+  const toHex = (n: number): string => {
+    const clamped = Math.max(0, Math.min(255, Math.round(n)))
+    return clamped.toString(16).padStart(2, '0')
+  }
+  return `#${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}`
+}
+
+/** Linear-interpolate two hex colors at fraction t∈[0,1]; emits lowercase `#rrggbb`. */
+function lerpHex(from: string, to: string, t: number): string {
+  const a = hexToRgb(from)
+  const b = hexToRgb(to)
+  const f = Math.max(0, Math.min(1, t))
+  return rgbToHex([
+    a[0] + (b[0] - a[0]) * f,
+    a[1] + (b[1] - a[1]) * f,
+    a[2] + (b[2] - a[2]) * f,
+  ])
+}
+
+/**
+ * Color at normalized position `t`∈[0,1] across the (anchor-sorted) stops.
+ * 2 stops: lerp min↔max over t. 3 stops: piecewise with mid anchored at t=0.5
+ * (t<0.5 lerps min↔mid over t/0.5; else mid↔max over (t-0.5)/0.5; t=0.5 yields
+ * the mid color from either branch). Stops are pre-sorted min→mid→max.
+ */
+function colorScaleAt(stops: ReadonlyArray<{ at: 'min' | 'mid' | 'max'; color: string }>, t: number): string {
+  const clamped = Math.max(0, Math.min(1, t))
+  if (stops.length === 2) return lerpHex(stops[0].color, stops[1].color, clamped)
+  // 3 stops: [min, mid, max]
+  if (clamped <= 0.5) return lerpHex(stops[0].color, stops[1].color, clamped / 0.5)
+  return lerpHex(stops[1].color, stops[2].color, (clamped - 0.5) / 0.5)
 }
 
 function toFiniteNumber(value: unknown): number | null {
@@ -428,38 +502,93 @@ function toFiniteNumber(value: unknown): number | null {
   return null
 }
 
+/** Parse the shared `range` field (auto/fixed); returns null for an invalid fixed range. */
+function sanitizeScaleRange(raw: unknown): ConditionalFormattingScaleRange | null {
+  const rangeRaw = isPlainObject(raw) ? raw : {}
+  if (rangeRaw.mode === 'fixed') {
+    const min = toFiniteNumber(rangeRaw.min)
+    const max = toFiniteNumber(rangeRaw.max)
+    if (min === null || max === null || min === max) return null
+    return { mode: 'fixed', min: Math.min(min, max), max: Math.max(min, max) }
+  }
+  return { mode: 'auto' }
+}
+
+/** Parse + validate `colorScale.stops` (2 anchors min/max, or 3 anchors min/mid/max). */
+function sanitizeColorScale(raw: unknown): ConditionalFormattingColorScaleConfig | null {
+  if (!isPlainObject(raw) || !Array.isArray(raw.stops)) return null
+  const stops: Array<{ at: 'min' | 'mid' | 'max'; color: string }> = []
+  for (const stop of raw.stops) {
+    if (!isPlainObject(stop)) return null
+    const at = stop.at
+    if (at !== 'min' && at !== 'mid' && at !== 'max') return null
+    const color = sanitizeHex(stop.color)
+    if (!color) return null
+    stops.push({ at, color })
+  }
+  if (stops.length < 2 || stops.length > 3) return null
+  // Anchor set must EXACTLY match {min,max} (2) or {min,mid,max} (3) — no dup, no missing.
+  const anchors = new Set(stops.map((s) => s.at))
+  if (anchors.size !== stops.length) return null // duplicate anchor
+  const required = stops.length === 2 ? ['min', 'max'] : ['min', 'mid', 'max']
+  for (const a of required) if (!anchors.has(a as 'min' | 'mid' | 'max')) return null
+  // Normalize to min→mid→max so the builder is order-independent.
+  const order: Record<'min' | 'mid' | 'max', number> = { min: 0, mid: 1, max: 2 }
+  stops.sort((a, b) => order[a.at] - order[b.at])
+  return { stops }
+}
+
+/** Parse + validate `iconSet` (known set + finite, monotonic `[t0, t1]` thresholds). */
+function sanitizeIconSet(raw: unknown): ConditionalFormattingIconSetConfig | null {
+  if (!isPlainObject(raw)) return null
+  const set = raw.set
+  if (typeof set !== 'string' || !ICON_SETS.has(set as ConditionalFormattingIconSetConfig['set'])) return null
+  if (!Array.isArray(raw.thresholds) || raw.thresholds.length !== 2) return null
+  const t0 = toFiniteNumber(raw.thresholds[0])
+  const t1 = toFiniteNumber(raw.thresholds[1])
+  if (t0 === null || t1 === null || t0 > t1) return null // require monotonic ascending (t0 <= t1)
+  return { set: set as ConditionalFormattingIconSetConfig['set'], thresholds: [t0, t1] }
+}
+
 export function sanitizeConditionalFormattingScaleRule(input: unknown): ConditionalFormattingScaleRule | null {
   if (!isPlainObject(input)) return null
   const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
   const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
   if (!id || !fieldId) return null
 
-  // A5-1 supports dataBar only; colorScale / iconSet are added in A5-2 / A5-3.
-  if (input.kind !== 'dataBar') return null
-
   const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
   const enabled = input.enabled !== false
 
-  const rangeRaw = isPlainObject(input.range) ? input.range : {}
-  let range: ConditionalFormattingScaleRange
-  if (rangeRaw.mode === 'fixed') {
-    const min = toFiniteNumber(rangeRaw.min)
-    const max = toFiniteNumber(rangeRaw.max)
-    if (min === null || max === null || min === max) return null
-    range = { mode: 'fixed', min: Math.min(min, max), max: Math.max(min, max) }
-  } else {
-    range = { mode: 'auto' }
+  const range = sanitizeScaleRange(input.range)
+  if (!range) return null
+
+  const base = { id, order: Math.floor(orderRaw), fieldId, enabled, range }
+
+  // Per-kind config. Unknown kinds → null (keeps the forward-dated-config guard).
+  switch (input.kind) {
+    case 'dataBar': {
+      const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
+      const color = sanitizeHex(barRaw.color)
+      if (!color) return null
+      const dataBar: ConditionalFormattingDataBarConfig = { color }
+      const negativeColor = sanitizeHex(barRaw.negativeColor)
+      if (negativeColor) dataBar.negativeColor = negativeColor
+      if (barRaw.showValue === true) dataBar.showValue = true
+      return { ...base, kind: 'dataBar', dataBar }
+    }
+    case 'colorScale': {
+      const colorScale = sanitizeColorScale(input.colorScale)
+      if (!colorScale) return null
+      return { ...base, kind: 'colorScale', colorScale }
+    }
+    case 'iconSet': {
+      const iconSet = sanitizeIconSet(input.iconSet)
+      if (!iconSet) return null
+      return { ...base, kind: 'iconSet', iconSet }
+    }
+    default:
+      return null
   }
-
-  const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
-  const color = sanitizeHex(barRaw.color)
-  if (!color) return null
-  const dataBar: ConditionalFormattingDataBarConfig = { color }
-  const negativeColor = sanitizeHex(barRaw.negativeColor)
-  if (negativeColor) dataBar.negativeColor = negativeColor
-  if (barRaw.showValue === true) dataBar.showValue = true
-
-  return { id, order: Math.floor(orderRaw), fieldId, kind: 'dataBar', enabled, range, dataBar }
 }
 
 export function sanitizeConditionalFormattingScaleRules(input: unknown): ConditionalFormattingScaleRule[] {
@@ -481,14 +610,24 @@ export function extractScaleRulesFromConfig(config: unknown): ConditionalFormatt
   return sanitizeConditionalFormattingScaleRules(config.conditionalFormattingScaleRules)
 }
 
-/** Per-cell derived presentation for a scale rule. A5-1: data bar only. */
+/**
+ * Per-cell derived presentation for a scale rule. Fields are kind-specific and
+ * all optional: a `dataBar` rule populates `barPct`/`barColor`/`negative`; a
+ * `colorScale` rule populates `scaleColor`; an `iconSet` rule populates
+ * `iconKey`. (Optional, not a discriminated union, so the kind-blind grid
+ * renderer's `${scale.barColor} ${scale.barPct}%` template still type-checks.)
+ */
 export type FieldScalePresentation = {
   /** Data-bar fill, 0..100, as a fraction of (value - min) / (max - min). */
-  barPct: number
+  barPct?: number
   /** Bar color — `negativeColor` for negative values when configured, else `color`. */
-  barColor: string
+  barColor?: string
   /** True when the source value is negative (render may baseline differently). */
-  negative: boolean
+  negative?: boolean
+  /** Color-scale background — interpolated `#rrggbb` at the value's normalized position. */
+  scaleColor?: string
+  /** Icon-set band the value falls in: `'low'` (v<t0) / `'mid'` (t0<=v<t1) / `'high'` (v>=t1). */
+  iconKey?: 'low' | 'mid' | 'high'
 }
 
 export type FieldScaleResult = {
@@ -508,11 +647,20 @@ const EMPTY_SCALE_MAP: FieldScaleMap = Object.freeze({
 }) as FieldScaleMap
 
 /**
- * Pre-compute data-bar presentation per (fieldId, recordId). For each enabled
- * scale rule, compute the field's [min,max] over `records` (auto) or use the
- * rule's fixed range, then map each finite value to a fill percent. Records
- * whose value is non-numeric are skipped (no bar). A degenerate range
- * (min === max) renders a full bar for every present value.
+ * Pre-compute per-(fieldId, recordId) scale presentation for every enabled rule.
+ * For each rule, resolve the field's [min,max] over `records` (auto) or the
+ * rule's fixed range, then derive a kind-specific presentation per finite value:
+ *  - dataBar:    `barPct` (0..100 = (v-min)/(max-min), degenerate min==max → 100),
+ *                `barColor` (negativeColor when v<0 + configured), `negative`.
+ *  - colorScale: `scaleColor` = interpolated hex at the value's normalized
+ *                position t=(v-min)/(max-min); degenerate min==max → t=0.5
+ *                (mid color for 3-stop, midpoint blend for 2-stop — per design-lock).
+ *  - iconSet:    `iconKey` = band by ABSOLUTE thresholds (v<t0 → 'low',
+ *                t0<=v<t1 → 'mid', v>=t1 → 'high'); independent of min/max.
+ * Records whose value is non-numeric are skipped (no entry). A field with no
+ * numeric values is omitted entirely. First rule per field wins (mirrors
+ * cell-style precedence). NOTE: the grid renderer is still kind-blind (paints
+ * only data bars) — per-kind render is the next slice (design-lock §6).
  */
 export function buildFieldScaleMap(
   rules: ConditionalFormattingScaleRule[],
@@ -523,10 +671,14 @@ export function buildFieldScaleMap(
   const byField: Record<string, FieldScaleResult> = {}
 
   for (const rule of rules) {
-    if (!rule.enabled || rule.kind !== 'dataBar' || !rule.dataBar) continue
+    if (!rule.enabled) continue
     if (byField[rule.fieldId]) continue // first rule per field wins (mirrors cell-style precedence)
+    if (rule.kind === 'dataBar' && !rule.dataBar) continue
+    if (rule.kind === 'colorScale' && !rule.colorScale) continue
+    if (rule.kind === 'iconSet' && !rule.iconSet) continue
 
-    // Resolve range.
+    // Resolve range (shared by all kinds; iconSet bands on absolute thresholds but
+    // still carries the data min/max for diagnostics / a future percentile mode).
     let min: number
     let max: number
     if (rule.range.mode === 'fixed' && typeof rule.range.min === 'number' && typeof rule.range.max === 'number') {
@@ -546,7 +698,7 @@ export function buildFieldScaleMap(
           if (v < lo) lo = v
           if (v > hi) hi = v
         }
-        if (lo === Infinity) continue // no numeric values → no bars for this field
+        if (lo === Infinity) continue // no numeric values → omit this field
         min = lo
         max = hi
       }
@@ -558,10 +710,21 @@ export function buildFieldScaleMap(
       if (!record?.id) continue
       const v = toComparableNumber(record.data?.[rule.fieldId])
       if (v === null) continue
-      const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
-      const negative = v < 0
-      const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
-      byRecordId[record.id] = { barPct: pct, barColor, negative }
+
+      if (rule.kind === 'dataBar' && rule.dataBar) {
+        const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
+        const negative = v < 0
+        const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
+        byRecordId[record.id] = { barPct: pct, barColor, negative }
+      } else if (rule.kind === 'colorScale' && rule.colorScale) {
+        // Degenerate min==max → t=0.5 (mid/single color per design-lock), else clamp t∈[0,1].
+        const t = span <= 0 ? 0.5 : (v - min) / span
+        byRecordId[record.id] = { scaleColor: colorScaleAt(rule.colorScale.stops, t) }
+      } else if (rule.kind === 'iconSet' && rule.iconSet) {
+        const [t0, t1] = rule.iconSet.thresholds
+        const iconKey: 'low' | 'mid' | 'high' = v < t0 ? 'low' : v < t1 ? 'mid' : 'high'
+        byRecordId[record.id] = { iconKey }
+      }
     }
     byField[rule.fieldId] = { rule, min, max, byRecordId }
   }

--- a/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
+++ b/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
@@ -458,9 +458,12 @@ describe('conditional formatting — range-based SCALE rules (A5-1 data bar)', (
       expect(r).toEqual({ id: 's1', order: 0, fieldId: 'fld_n', kind: 'dataBar', enabled: true, range: { mode: 'auto' }, dataBar: { color: '#2196f3' } })
     })
 
-    it('rejects colorScale / iconSet until A5-2 / A5-3', () => {
+    it('rejects an unknown kind, and a colorScale/iconSet kind lacking its own config (A5-2/A5-3 add valid configs below)', () => {
+      // `validBar()` only supplies a `dataBar` config, so flipping the kind alone is still rejected.
       expect(sanitizeConditionalFormattingScaleRule(validBar({ kind: 'colorScale' }))).toBeNull()
       expect(sanitizeConditionalFormattingScaleRule(validBar({ kind: 'iconSet' }))).toBeNull()
+      // An unrecognised kind is still rejected (forward-dated-config guard).
+      expect(sanitizeConditionalFormattingScaleRule(validBar({ kind: 'gradientNeo' }))).toBeNull()
     })
 
     it('requires id, fieldId, and a valid hex bar color', () => {
@@ -554,6 +557,232 @@ describe('conditional formatting — range-based SCALE rules (A5-1 data bar)', (
     it('returns an empty map when a field has no numeric values', () => {
       const map = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }])
       expect(map.byField.fld_n).toBeUndefined()
+    })
+  })
+})
+
+describe('conditional formatting — SCALE rules (A5-2 color scale)', () => {
+  const validColorScale = (over: Record<string, unknown> = {}) => ({
+    id: 'cs1', fieldId: 'fld_n', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+    colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'max', color: '#000000' }] },
+    ...over,
+  })
+  // 3-stop classic red→yellow→green (min/mid/max).
+  const ryg = { stops: [
+    { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' }, { at: 'max', color: '#00ff00' },
+  ] }
+
+  describe('sanitizeConditionalFormattingScaleRule', () => {
+    it('accepts a 2-stop (min/max) color scale', () => {
+      const r = sanitizeConditionalFormattingScaleRule(validColorScale())
+      expect(r).toEqual({
+        id: 'cs1', order: 0, fieldId: 'fld_n', kind: 'colorScale', enabled: true, range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'max', color: '#000000' }] },
+      })
+    })
+
+    it('accepts a 3-stop (min/mid/max) color scale and normalizes stop order', () => {
+      // Supply stops out of order — sanitizer must sort min→mid→max.
+      const r = sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [
+          { at: 'max', color: '#00ff00' }, { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' },
+        ] },
+      }))
+      expect(r?.colorScale?.stops.map((s) => s.at)).toEqual(['min', 'mid', 'max'])
+      expect(r?.colorScale?.stops.map((s) => s.color)).toEqual(['#ff0000', '#ffff00', '#00ff00'])
+    })
+
+    it('rejects 1 stop and 4 stops', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'min', color: '#ffffff' }] },
+      }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#ffffff' }, { at: 'mid', color: '#888888' },
+          { at: 'max', color: '#000000' }, { at: 'max', color: '#111111' },
+        ] },
+      }))).toBeNull()
+    })
+
+    it('rejects a bad anchor, a bad hex color, and a missing/duplicate anchor', () => {
+      // bad anchor token
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'min', color: '#fff' }, { at: 'middle', color: '#000' }] },
+      }))).toBeNull()
+      // bad hex color
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'min', color: 'white' }, { at: 'max', color: '#000000' }] },
+      }))).toBeNull()
+      // 2-stop with min+min (duplicate, missing max)
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'min', color: '#ffffff' }, { at: 'min', color: '#000000' }] },
+      }))).toBeNull()
+      // 2-stop with mid+max (missing required min)
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'mid', color: '#ffffff' }, { at: 'max', color: '#000000' }] },
+      }))).toBeNull()
+      // 3-stop missing mid (min+max+max)
+      expect(sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#ffffff' }, { at: 'max', color: '#000000' }, { at: 'max', color: '#111111' },
+        ] },
+      }))).toBeNull()
+    })
+
+    it('rejects a missing colorScale config entirely', () => {
+      expect(sanitizeConditionalFormattingScaleRule({ id: 'x', fieldId: 'f', kind: 'colorScale', order: 0, range: { mode: 'auto' } })).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (color scale)', () => {
+    const recs = [
+      { id: 'r1', data: { fld_n: 0 } },
+      { id: 'r2', data: { fld_n: 25 } },
+      { id: 'r3', data: { fld_n: 50 } },
+      { id: 'r4', data: { fld_n: 100 } },
+    ]
+
+    it('interpolates a 2-stop scale at min / interior / mid / max (exact hex)', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validColorScale())!
+      const f = buildFieldScaleMap([rule], recs).byField.fld_n
+      expect(f.min).toBe(0)
+      expect(f.max).toBe(100)
+      expect(f.byRecordId.r1.scaleColor).toBe('#ffffff') // t=0  → min color
+      expect(f.byRecordId.r2.scaleColor).toBe('#bfbfbf') // t=0.25
+      expect(f.byRecordId.r3.scaleColor).toBe('#808080') // t=0.5
+      expect(f.byRecordId.r4.scaleColor).toBe('#000000') // t=1  → max color
+      // dataBar-only fields are absent on a colorScale presentation
+      expect(f.byRecordId.r2.barPct).toBeUndefined()
+      expect(f.byRecordId.r2.iconKey).toBeUndefined()
+    })
+
+    it('interpolates a 3-stop scale piecewise with mid anchored at t=0.5 (exact hex)', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validColorScale({ colorScale: ryg }))!
+      const f = buildFieldScaleMap([rule], recs).byField.fld_n
+      expect(f.byRecordId.r1.scaleColor).toBe('#ff0000') // t=0    → min (red)
+      expect(f.byRecordId.r2.scaleColor).toBe('#ff8000') // t=0.25 → min↔mid halfway (orange)
+      expect(f.byRecordId.r3.scaleColor).toBe('#ffff00') // t=0.5  → mid (yellow)
+      expect(f.byRecordId.r4.scaleColor).toBe('#00ff00') // t=1    → max (green)
+    })
+
+    it('expands 3-digit shorthand hex before interpolating', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validColorScale({
+        colorScale: { stops: [{ at: 'min', color: '#f00' }, { at: 'max', color: '#00f' }] },
+      }))!
+      const f = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 0 } }, { id: 'b', data: { fld_n: 100 } }, { id: 'm', data: { fld_n: 50 } }]).byField.fld_n
+      expect(f.byRecordId.m.scaleColor).toBe('#800080') // halfway #ff0000 ↔ #0000ff
+    })
+
+    it('degenerate (all-equal) range → mid color (t=0.5)', () => {
+      // 3-stop degenerate → the mid (yellow) stop.
+      const three = sanitizeConditionalFormattingScaleRule(validColorScale({ colorScale: ryg }))!
+      const m3 = buildFieldScaleMap([three], [{ id: 'a', data: { fld_n: 7 } }, { id: 'b', data: { fld_n: 7 } }]).byField.fld_n
+      expect(m3.byRecordId.a.scaleColor).toBe('#ffff00')
+      expect(m3.byRecordId.b.scaleColor).toBe('#ffff00')
+      // 2-stop degenerate → midpoint blend (#808080 for white↔black).
+      const two = sanitizeConditionalFormattingScaleRule(validColorScale())!
+      const m2 = buildFieldScaleMap([two], [{ id: 'a', data: { fld_n: 5 } }, { id: 'b', data: { fld_n: 5 } }]).byField.fld_n
+      expect(m2.byRecordId.a.scaleColor).toBe('#808080')
+    })
+
+    it('handles negatives across the range and skips non-numeric / empty columns', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validColorScale())!
+      const f = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: -50 } }, // min
+        { id: 'b', data: { fld_n: 0 } },   // midpoint of [-50, 50] → #808080
+        { id: 'c', data: { fld_n: 50 } },  // max
+        { id: 'd', data: { fld_n: 'n/a' } }, // skipped
+      ]).byField.fld_n
+      expect([f.min, f.max]).toEqual([-50, 50])
+      expect(f.byRecordId.a.scaleColor).toBe('#ffffff')
+      expect(f.byRecordId.b.scaleColor).toBe('#808080')
+      expect(f.byRecordId.c.scaleColor).toBe('#000000')
+      expect(f.byRecordId.d).toBeUndefined()
+      // all-non-numeric column → field omitted
+      expect(buildFieldScaleMap([rule], [{ id: 'x', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
+    })
+  })
+})
+
+describe('conditional formatting — SCALE rules (A5-3 icon set)', () => {
+  const validIconSet = (over: Record<string, unknown> = {}) => ({
+    id: 'is1', fieldId: 'fld_n', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+    iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    ...over,
+  })
+
+  describe('sanitizeConditionalFormattingScaleRule', () => {
+    it('accepts each valid set with finite ascending thresholds', () => {
+      for (const set of ['arrows3', 'traffic3', 'signs3'] as const) {
+        const r = sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set, thresholds: [10, 20] } }))
+        expect(r?.kind).toBe('iconSet')
+        expect(r?.iconSet).toEqual({ set, thresholds: [10, 20] })
+      }
+    })
+
+    it('accepts equal thresholds (t0 === t1, monotonic non-strict)', () => {
+      const r = sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [5, 5] } }))
+      expect(r?.iconSet?.thresholds).toEqual([5, 5])
+    })
+
+    it('rejects an unknown set', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'stars5', thresholds: [10, 20] } }))).toBeNull()
+    })
+
+    it('rejects non-finite or non-monotonic thresholds, and wrong-arity threshold tuples', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [20, 10] } }))).toBeNull() // descending
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [Number.NaN, 20] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, Infinity] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, 20, 30] } }))).toBeNull()
+    })
+
+    it('rejects a missing iconSet config entirely', () => {
+      expect(sanitizeConditionalFormattingScaleRule({ id: 'x', fieldId: 'f', kind: 'iconSet', order: 0, range: { mode: 'auto' } })).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (icon set)', () => {
+    const rule = sanitizeConditionalFormattingScaleRule(validIconSet())! // thresholds [10, 20]
+
+    it('bands values by absolute thresholds (v<t0 low / t0<=v<t1 mid / v>=t1 high)', () => {
+      const f = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: 5 } },   // < 10 → low
+        { id: 'b', data: { fld_n: 10 } },  // == t0 → mid (lower bound inclusive)
+        { id: 'c', data: { fld_n: 15 } },  // in [10,20) → mid
+        { id: 'd', data: { fld_n: 20 } },  // == t1 → high (upper bound inclusive)
+        { id: 'e', data: { fld_n: 99 } },  // > t1 → high
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b.iconKey).toBe('mid')
+      expect(f.byRecordId.c.iconKey).toBe('mid')
+      expect(f.byRecordId.d.iconKey).toBe('high')
+      expect(f.byRecordId.e.iconKey).toBe('high')
+      // dataBar fields absent on an iconSet presentation
+      expect(f.byRecordId.c.barPct).toBeUndefined()
+      expect(f.byRecordId.c.scaleColor).toBeUndefined()
+    })
+
+    it('with equal thresholds the middle band is empty (low or high only)', () => {
+      const eq = sanitizeConditionalFormattingScaleRule(validIconSet({ iconSet: { set: 'arrows3', thresholds: [10, 10] } }))!
+      const f = buildFieldScaleMap([eq], [
+        { id: 'a', data: { fld_n: 9 } },   // < 10 → low
+        { id: 'b', data: { fld_n: 10 } },  // 10 < 10 false, 10 < 10 false → high
+        { id: 'c', data: { fld_n: 11 } },  // high
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b.iconKey).toBe('high')
+      expect(f.byRecordId.c.iconKey).toBe('high')
+    })
+
+    it('handles negatives and skips non-numeric / empty columns', () => {
+      const f = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: -5 } },   // < 10 → low
+        { id: 'b', data: { fld_n: 'n/a' } }, // skipped
+      ]).byField.fld_n
+      expect(f.byRecordId.a.iconKey).toBe('low')
+      expect(f.byRecordId.b).toBeUndefined()
+      expect(buildFieldScaleMap([rule], [{ id: 'x', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
     })
   })
 })

--- a/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
+++ b/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
@@ -639,6 +639,7 @@ describe('conditional formatting — SCALE rules (A5-2 color scale)', () => {
       { id: 'r1', data: { fld_n: 0 } },
       { id: 'r2', data: { fld_n: 25 } },
       { id: 'r3', data: { fld_n: 50 } },
+      { id: 'rU', data: { fld_n: 75 } },
       { id: 'r4', data: { fld_n: 100 } },
     ]
 
@@ -662,6 +663,7 @@ describe('conditional formatting — SCALE rules (A5-2 color scale)', () => {
       expect(f.byRecordId.r1.scaleColor).toBe('#ff0000') // t=0    → min (red)
       expect(f.byRecordId.r2.scaleColor).toBe('#ff8000') // t=0.25 → min↔mid halfway (orange)
       expect(f.byRecordId.r3.scaleColor).toBe('#ffff00') // t=0.5  → mid (yellow)
+      expect(f.byRecordId.rU.scaleColor).toBe('#80ff00') // t=0.75 → mid↔max halfway (upper-segment interior)
       expect(f.byRecordId.r4.scaleColor).toBe('#00ff00') // t=1    → max (green)
     })
 


### PR DESCRIPTION
## Summary

Adds two range-based conditional-formatting **scale** kinds to the multitable backend, both extending the A5-1 data-bar scale machinery (the shared `sanitizeConditionalFormattingScaleRule` / `buildFieldScaleMap` pipeline that derives per-record presentation off an auto/fixed numeric range):

- **A5-2 color scale** — 2-stop (min/max) or 3-stop (min/mid/max) hex gradients. `buildFieldScaleMap` normalizes each value to `t ∈ [0,1]` over the field's range and emits an interpolated `scaleColor`. 3-stop is piecewise with `mid` anchored at `t=0.5` (`t≤0.5` lerps min↔mid over `t/0.5`, else mid↔max over `(t-0.5)/0.5`).
- **A5-3 icon set** — `arrows3` / `traffic3` / `signs3` sets banded by two absolute ascending thresholds (`v<t0` low / `t0≤v<t1` mid / `v≥t1` high), emitting a per-record `iconKey`.

Both reuse the same sanitizer (enum-strict kind dispatch, hex/anchor/threshold validation, rule-cap + order-sort) and the same `buildFieldScaleMap` field map, with `colorScale` populating `scaleColor` and `iconSet` populating `iconKey` (data-bar fields stay absent on each, and vice-versa). The FE mirror spec (`apps/web/tests/multitable-cf-scale.spec.ts`) locks the front-end's mirror of this contract byte-for-byte.

## Why A5-2 and A5-3 are combined in one PR

They edit the **identical** surface: the same `sanitizeConditionalFormattingScaleRule`, the same `buildFieldScaleMap`, and the same FE-mirror spec. Splitting them across two branches would put both branches in conflict on those exact files and stall on merge cadence (each rebase re-touching the shared sanitizer/build-map). Keeping them in one PR avoids the conflict while preserving review clarity — each kind has its **own dedicated test block** (separate `describe` for A5-2 color scale and A5-3 icon set) so the two contracts are validated independently.

## Hardening in this PR

The 3-stop color-scale build tests previously exercised `t ∈ {0, 0.25, 0.5, 1.0}`, so the upper segment (`mid↔max`, the `t>0.5` branch) only ran at its `t=1` endpoint — where the lerp returns `stops[2]` regardless of the stop indices/denominator, masking a plausible bug (wrong stop index or wrong denominator) in that branch. Added an interior record at value 75 (`t=0.75`) asserting `scaleColor` `#80ff00` (lerp `#ffff00`→`#00ff00` at 0.5) so the upper-segment interior is now covered. Mirrored byte-identically into the FE mirror spec to keep the mirror-drift guard intact. (Verified non-vacuous: injecting `stops[0]` for `stops[1]` in the upper branch yields `#808000` and fails the new assertion, while the old `t=1`-only test stayed green.)

## Scope note

This is backend/contract + unit coverage only. The grid render path (**MetaGridTable**) and the authoring dialog (**ConditionalFormattingDialog**) remain **browser-gated** and are not exercised here.

## Tests

- `packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts` — 70 passed (A5-1/A5-2/A5-3 sanitizer + build-map)
- `apps/web/tests/multitable-cf-scale.spec.ts` — 24 passed (FE mirror)
- `tsc --noEmit -p tsconfig.json` on `@metasheet/core-backend` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)