### PR TITLE
feat(multitable): conditional-formatting color scale + icon set (A5-2/A5-3)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -601,7 +601,12 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   // Per design-lock §2.3 the bar takes the cell background; the operator rule's
   // textColor still applies, but its backgroundColor is dropped so the two
   // don't fight. Covers both the grouped and flat render paths (both call this).
-  const scale = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
+  const scaleEntry = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
+  // A5-1c renders only the data-bar kind here. A colorScale/iconSet presentation
+  // (scaleColor/iconKey, no barPct — A5-2/A5-3 contracts) must NOT build a bar
+  // gradient, or it would emit `linear-gradient(… undefined% …)` and regress the
+  // shipped data-bar render. Their own render is browser-gated future work.
+  const scale = scaleEntry && typeof scaleEntry.barPct === 'number' ? scaleEntry : undefined
   const scaleStyle: Record<string, string> | undefined = scale
     ? { backgroundImage: `linear-gradient(to right, ${scale.barColor} ${scale.barPct}%, transparent ${scale.barPct}%)` }
     : undefined

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -132,6 +132,10 @@ export interface ConditionalFormattingDataBarConfig {
   negativeColor?: string
   showValue?: boolean
 }
+export interface ConditionalFormattingColorScaleStop { at: 'min' | 'mid' | 'max'; color: string }
+export interface ConditionalFormattingColorScaleConfig { stops: ConditionalFormattingColorScaleStop[] }
+export type ConditionalFormattingIconSetName = 'arrows3' | 'traffic3' | 'signs3'
+export interface ConditionalFormattingIconSetConfig { set: ConditionalFormattingIconSetName; thresholds: [number, number] }
 export interface ConditionalFormattingScaleRule {
   id: string
   order: number
@@ -140,6 +144,8 @@ export interface ConditionalFormattingScaleRule {
   enabled: boolean
   range: ConditionalFormattingScaleRange
   dataBar?: ConditionalFormattingDataBarConfig
+  colorScale?: ConditionalFormattingColorScaleConfig
+  iconSet?: ConditionalFormattingIconSetConfig
 }
 export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
 

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -5,7 +5,11 @@
 // when extending the rule schema.
 
 import type {
+  ConditionalFormattingColorScaleConfig,
+  ConditionalFormattingColorScaleStop,
   ConditionalFormattingDataBarConfig,
+  ConditionalFormattingIconSetConfig,
+  ConditionalFormattingIconSetName,
   ConditionalFormattingOperator,
   ConditionalFormattingRule,
   ConditionalFormattingScaleRange,
@@ -389,12 +393,33 @@ function toFiniteNumber(value: unknown): number | null {
   return null
 }
 
+const ICON_SET_NAMES: ReadonlySet<string> = new Set(['arrows3', 'traffic3', 'signs3'])
+
+/** Linear-interpolate two #rgb / #rrggbb / #rrggbbaa hex colors (alpha stripped). Mirror of backend. */
+export function lerpHexColor(a: string, b: string, t: number): string {
+  const parse = (hex: string): [number, number, number] => {
+    let h = hex.trim().replace(/^#/, '')
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('')
+    if (h.length === 8) h = h.slice(0, 6)
+    const n = parseInt(h.slice(0, 6), 16)
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+  }
+  const clampT = Math.max(0, Math.min(1, t))
+  const [ar, ag, ab] = parse(a)
+  const [br, bg, bb] = parse(b)
+  const mix = (x: number, y: number) => Math.round(x + (y - x) * clampT)
+  const hx = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${hx(mix(ar, br))}${hx(mix(ag, bg))}${hx(mix(ab, bb))}`
+}
+
 export function sanitizeScaleRule(input: unknown): ConditionalFormattingScaleRule | null {
   if (!isPlainObject(input)) return null
   const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
   const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
   if (!id || !fieldId) return null
-  if (input.kind !== 'dataBar') return null // A5-1: dataBar only (colorScale/iconSet = A5-2/A5-3)
+
+  const kind = input.kind
+  if (kind !== 'dataBar' && kind !== 'colorScale' && kind !== 'iconSet') return null
 
   const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
   const enabled = input.enabled !== false
@@ -410,15 +435,46 @@ export function sanitizeScaleRule(input: unknown): ConditionalFormattingScaleRul
     range = { mode: 'auto' }
   }
 
-  const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
-  const color = sanitizeHex(barRaw.color)
-  if (!color) return null
-  const dataBar: ConditionalFormattingDataBarConfig = { color }
-  const negativeColor = sanitizeHex(barRaw.negativeColor)
-  if (negativeColor) dataBar.negativeColor = negativeColor
-  if (barRaw.showValue === true) dataBar.showValue = true
+  const base = { id, order: Math.floor(orderRaw), fieldId, enabled, range }
 
-  return { id, order: Math.floor(orderRaw), fieldId, kind: 'dataBar', enabled, range, dataBar }
+  if (kind === 'dataBar') {
+    const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
+    const color = sanitizeHex(barRaw.color)
+    if (!color) return null
+    const dataBar: ConditionalFormattingDataBarConfig = { color }
+    const negativeColor = sanitizeHex(barRaw.negativeColor)
+    if (negativeColor) dataBar.negativeColor = negativeColor
+    if (barRaw.showValue === true) dataBar.showValue = true
+    return { ...base, kind: 'dataBar', dataBar }
+  }
+
+  if (kind === 'colorScale') {
+    const csRaw = isPlainObject(input.colorScale) ? input.colorScale : {}
+    if (!Array.isArray(csRaw.stops)) return null
+    const stops: ConditionalFormattingColorScaleStop[] = []
+    const seen = new Set<string>()
+    for (const s of csRaw.stops) {
+      if (!isPlainObject(s)) return null
+      const at = s.at
+      if (at !== 'min' && at !== 'mid' && at !== 'max') return null
+      if (seen.has(at)) return null
+      const color = sanitizeHex(s.color)
+      if (!color) return null
+      seen.add(at)
+      stops.push({ at, color })
+    }
+    if ((stops.length !== 2 && stops.length !== 3) || !seen.has('min') || !seen.has('max')) return null
+    if (stops.length === 3 && !seen.has('mid')) return null
+    return { ...base, kind: 'colorScale', colorScale: { stops } }
+  }
+
+  const isRaw = isPlainObject(input.iconSet) ? input.iconSet : {}
+  if (!ICON_SET_NAMES.has(isRaw.set as string)) return null
+  if (!Array.isArray(isRaw.thresholds) || isRaw.thresholds.length !== 2) return null
+  const t0 = toFiniteNumber(isRaw.thresholds[0])
+  const t1 = toFiniteNumber(isRaw.thresholds[1])
+  if (t0 === null || t1 === null || t0 >= t1) return null
+  return { ...base, kind: 'iconSet', iconSet: { set: isRaw.set as ConditionalFormattingIconSetName, thresholds: [t0, t1] } }
 }
 
 export function sanitizeScaleRules(input: unknown): ConditionalFormattingScaleRule[] {
@@ -440,10 +496,33 @@ export function extractScaleRulesFromConfig(config: unknown): ConditionalFormatt
   return sanitizeScaleRules(config.conditionalFormattingScaleRules)
 }
 
+// ADDITIVE by kind (not a discriminated union — mirror of backend; a `kind:`
+// field would break the shipped data-bar renderer/tests).
 export interface FieldScalePresentation {
-  barPct: number
-  barColor: string
-  negative: boolean
+  barPct?: number
+  barColor?: string
+  negative?: boolean
+  scaleColor?: string
+  iconKey?: string
+}
+
+/** A5-2: interpolate a value's color from the by-name stops. Mirror of backend. */
+function colorScaleColor(cfg: ConditionalFormattingColorScaleConfig, v: number, min: number, max: number): string {
+  const at = (name: 'min' | 'mid' | 'max') => cfg.stops.find((s) => s.at === name)?.color
+  const minC = at('min') ?? '#000000'
+  const maxC = at('max') ?? '#ffffff'
+  const midC = at('mid')
+  const span = max - min
+  const t = span <= 0 ? 1 : Math.max(0, Math.min(1, (v - min) / span))
+  if (!midC) return lerpHexColor(minC, maxC, t)
+  return t <= 0.5 ? lerpHexColor(minC, midC, t * 2) : lerpHexColor(midC, maxC, (t - 0.5) * 2)
+}
+
+/** A5-3: bucket a value into an icon index via the two absolute thresholds. Mirror of backend. */
+function iconSetKey(cfg: ConditionalFormattingIconSetConfig, v: number): string {
+  const [t0, t1] = cfg.thresholds
+  const index = v < t0 ? 0 : v < t1 ? 1 : 2
+  return `${cfg.set}:${index}`
 }
 export interface FieldScaleResult {
   rule: ConditionalFormattingScaleRule
@@ -474,7 +553,10 @@ export function buildFieldScaleMap(
   const byField: Record<string, FieldScaleResult> = {}
 
   for (const rule of rules) {
-    if (!rule.enabled || rule.kind !== 'dataBar' || !rule.dataBar) continue
+    if (!rule.enabled) continue
+    if (rule.kind === 'dataBar' && !rule.dataBar) continue
+    if (rule.kind === 'colorScale' && !rule.colorScale) continue
+    if (rule.kind === 'iconSet' && !rule.iconSet) continue
     if (byField[rule.fieldId]) continue
 
     let min: number
@@ -502,10 +584,16 @@ export function buildFieldScaleMap(
       if (!record?.id) continue
       const v = toComparableNumber(record.data?.[rule.fieldId])
       if (v === null) continue
-      const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
-      const negative = v < 0
-      const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
-      byRecordId[record.id] = { barPct: pct, barColor, negative }
+      if (rule.kind === 'dataBar' && rule.dataBar) {
+        const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
+        const negative = v < 0
+        const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
+        byRecordId[record.id] = { barPct: pct, barColor, negative }
+      } else if (rule.kind === 'colorScale' && rule.colorScale) {
+        byRecordId[record.id] = { scaleColor: colorScaleColor(rule.colorScale, v, min, max) }
+      } else if (rule.kind === 'iconSet' && rule.iconSet) {
+        byRecordId[record.id] = { iconKey: iconSetKey(rule.iconSet, v) }
+      }
     }
     byField[rule.fieldId] = { rule, min, max, byRecordId }
   }

--- a/apps/web/tests/multitable-cf-scale.spec.ts
+++ b/apps/web/tests/multitable-cf-scale.spec.ts
@@ -4,6 +4,7 @@ import {
   extractScaleRulesFromConfig,
   sanitizeScaleRule,
   sanitizeScaleRules,
+  lerpHexColor,
 } from '../src/multitable/utils/conditional-formatting'
 import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../src/multitable/types'
 
@@ -25,7 +26,7 @@ describe('FE conditional-formatting scale mirror (A5-1 data bar)', () => {
       })
     })
 
-    it('rejects colorScale / iconSet (A5-2 / A5-3)', () => {
+    it('rejects colorScale / iconSet kinds without a matching config', () => {
       expect(sanitizeScaleRule(validBar({ kind: 'colorScale' }))).toBeNull()
       expect(sanitizeScaleRule(validBar({ kind: 'iconSet' }))).toBeNull()
     })
@@ -93,5 +94,93 @@ describe('FE conditional-formatting scale mirror (A5-1 data bar)', () => {
     it('returns an empty map when a field has no numeric values', () => {
       expect(buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }]).byField.fld_n).toBeUndefined()
     })
+  })
+})
+
+describe('FE conditional-formatting scale mirror (A5-2 color scale)', () => {
+  const validScale = (over: Record<string, unknown> = {}) => ({
+    id: 'cs1', fieldId: 'fld_n', kind: 'colorScale', order: 0,
+    range: { mode: 'auto' },
+    colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+    ...over,
+  })
+  const recs = [
+    { id: 'r1', data: { fld_n: 0 } },
+    { id: 'r2', data: { fld_n: 50 } },
+    { id: 'r3', data: { fld_n: 100 } },
+  ]
+
+  it('accepts 2-stop and 3-stop scales and rejects malformed ones', () => {
+    expect(sanitizeScaleRule(validScale())).toEqual({
+      id: 'cs1', order: 0, fieldId: 'fld_n', kind: 'colorScale', enabled: true,
+      range: { mode: 'auto' },
+      colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+    })
+    expect(sanitizeScaleRule(validScale({ colorScale: { stops: [
+      { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' }, { at: 'max', color: '#00ff00' },
+    ] } }))?.colorScale?.stops).toHaveLength(3)
+    // missing max
+    expect(sanitizeScaleRule(validScale({ colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'mid', color: '#808080' }] } }))).toBeNull()
+    // non-hex
+    expect(sanitizeScaleRule(validScale({ colorScale: { stops: [{ at: 'min', color: 'black' }, { at: 'max', color: '#ffffff' }] } }))).toBeNull()
+    // duplicate
+    expect(sanitizeScaleRule(validScale({ colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'min', color: '#111111' }] } }))).toBeNull()
+  })
+
+  it('maps endpoints + midpoint and never emits barPct (Trap E)', () => {
+    const rule = sanitizeScaleRule(validScale())!
+    const f = buildFieldScaleMap([rule], recs).byField.fld_n
+    expect(f.byRecordId.r1.scaleColor).toBe('#000000')
+    expect(f.byRecordId.r2.scaleColor).toBe('#808080')
+    expect(f.byRecordId.r3.scaleColor).toBe('#ffffff')
+    expect(f.byRecordId.r2.barPct).toBeUndefined()
+    expect(f.byRecordId.r2.barColor).toBeUndefined()
+  })
+
+  it('maps every value to the max stop on a degenerate range; skips non-numeric', () => {
+    const rule = sanitizeScaleRule(validScale())!
+    const m = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 7 } }, { id: 'b', data: { fld_n: 'x' } }]).byField.fld_n
+    expect(m.byRecordId.a.scaleColor).toBe('#ffffff')
+    expect(m.byRecordId.b).toBeUndefined()
+  })
+})
+
+describe('FE conditional-formatting scale mirror (A5-3 icon set)', () => {
+  const validIcon = (over: Record<string, unknown> = {}) => ({
+    id: 'is1', fieldId: 'fld_n', kind: 'iconSet', order: 0,
+    range: { mode: 'auto' },
+    iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    ...over,
+  })
+
+  it('accepts known sets with monotonic thresholds and rejects malformed ones', () => {
+    expect(sanitizeScaleRule(validIcon())?.iconSet).toEqual({ set: 'arrows3', thresholds: [10, 20] })
+    expect(sanitizeScaleRule(validIcon({ iconSet: { set: 'stars5', thresholds: [1, 2] } }))).toBeNull()
+    expect(sanitizeScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [1] } }))).toBeNull()
+    expect(sanitizeScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [20, 10] } }))).toBeNull()
+  })
+
+  it('buckets values at the absolute thresholds and never emits barPct/scaleColor', () => {
+    const rule = sanitizeScaleRule(validIcon())!
+    const f = buildFieldScaleMap([rule], [
+      { id: 'a', data: { fld_n: 5 } },
+      { id: 'b', data: { fld_n: 10 } },
+      { id: 'c', data: { fld_n: 20 } },
+    ]).byField.fld_n.byRecordId
+    expect(f.a.iconKey).toBe('arrows3:0')
+    expect(f.b.iconKey).toBe('arrows3:1')
+    expect(f.c.iconKey).toBe('arrows3:2')
+    expect(f.b.barPct).toBeUndefined()
+    expect(f.b.scaleColor).toBeUndefined()
+  })
+})
+
+describe('FE lerpHexColor parity', () => {
+  it('matches the backend interpolation', () => {
+    expect(lerpHexColor('#000000', '#ffffff', 0.5)).toBe('#808080')
+    expect(lerpHexColor('#000', '#fff', 0.5)).toBe('#808080')
+    expect(lerpHexColor('#000000ff', '#ffffff00', 0.5)).toBe('#808080')
+    expect(lerpHexColor('#000000', '#ffffff', -1)).toBe('#000000')
+    expect(lerpHexColor('#000000', '#ffffff', 2)).toBe('#ffffff')
   })
 })

--- a/apps/web/tests/multitable-grid-databar.spec.ts
+++ b/apps/web/tests/multitable-grid-databar.spec.ts
@@ -86,4 +86,37 @@ describe('MetaGridTable — data-bar conditional formatting (A5-1c render)', () 
     expect(cells[2].style.backgroundColor).toBe('') // operator bg dropped under the bar
     expect(cells[2].style.color).toBe('rgb(17, 17, 17)') // textColor preserved
   })
+
+  // Trap E regression: a colorScale / iconSet presentation has no barPct, so the
+  // grid's data-bar render must NOT build a `linear-gradient(… undefined% …)`.
+  // (A5-2/A5-3 have their own browser-gated render; the grid only draws bars.)
+  it('does NOT render a data-bar gradient for a colorScale presentation', () => {
+    const colorScale = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'cs1', fieldId: 'amount', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: colorScale })
+    const cells = dataCells(root)
+    for (const idx of [0, 2, 4]) {
+      expect(cells[idx].style.backgroundImage).toBe('')
+      expect(cells[idx].style.backgroundImage).not.toContain('undefined')
+    }
+  })
+
+  it('does NOT render a data-bar gradient for an iconSet presentation', () => {
+    const iconSet = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'is1', fieldId: 'amount', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+        iconSet: { set: 'arrows3', thresholds: [10, 20] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: iconSet })
+    const cells = dataCells(root)
+    for (const idx of [0, 2, 4]) {
+      expect(cells[idx].style.backgroundImage).toBe('')
+      expect(cells[idx].style.backgroundImage).not.toContain('undefined')
+    }
+  })
 })

--- a/packages/core-backend/src/multitable/conditional-formatting-service.ts
+++ b/packages/core-backend/src/multitable/conditional-formatting-service.ts
@@ -388,9 +388,11 @@ export function evaluateConditionalFormattingRules(
 // against the field's min/max range. min/max is computed over the records
 // passed in (caller scopes them to already-loaded, already-masked rows — the
 // same client-side discipline as the A2 export picker; a full-column server
-// aggregate is a separate gated follow-up). A5-1 implements `dataBar`;
-// `colorScale` / `iconSet` land in A5-2 / A5-3 (sanitizer rejects them until
-// then, so a forward-dated config can't half-render).
+// aggregate is a separate gated follow-up). All three kinds are CONTRACT-level
+// here: `dataBar` (A5-1), `colorScale` (A5-2, by-name stop interpolation),
+// `iconSet` (A5-3, absolute-threshold bucketing). The data-bar GRADIENT render
+// shipped (#2640); the colorScale/iconSet RENDER is browser-gated future work —
+// builders produce scaleColor/iconKey but no cell drawing here.
 // ===========================================================================
 
 export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
@@ -409,6 +411,15 @@ export type ConditionalFormattingDataBarConfig = {
   showValue?: boolean
 }
 
+// A5-2 color scale: 2 or 3 stops, resolved BY NAME (`at`), interpolated over the
+// field min/max. A5-3 icon set: a named glyph set + two ABSOLUTE monotonic
+// thresholds splitting values into 3 buckets (percentile mode deferred — the
+// locked type has no mode field).
+export type ConditionalFormattingColorScaleStop = { at: 'min' | 'mid' | 'max'; color: string }
+export type ConditionalFormattingColorScaleConfig = { stops: ConditionalFormattingColorScaleStop[] }
+export type ConditionalFormattingIconSetName = 'arrows3' | 'traffic3' | 'signs3'
+export type ConditionalFormattingIconSetConfig = { set: ConditionalFormattingIconSetName; thresholds: [number, number] }
+
 export type ConditionalFormattingScaleRule = {
   id: string
   order: number
@@ -417,6 +428,27 @@ export type ConditionalFormattingScaleRule = {
   enabled: boolean
   range: ConditionalFormattingScaleRange
   dataBar?: ConditionalFormattingDataBarConfig
+  colorScale?: ConditionalFormattingColorScaleConfig
+  iconSet?: ConditionalFormattingIconSetConfig
+}
+
+const ICON_SET_NAMES: ReadonlySet<string> = new Set(['arrows3', 'traffic3', 'signs3'])
+
+/** Linear-interpolate two #rgb / #rrggbb / #rrggbbaa hex colors (alpha stripped). */
+export function lerpHexColor(a: string, b: string, t: number): string {
+  const parse = (hex: string): [number, number, number] => {
+    let h = hex.trim().replace(/^#/, '')
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('') // #abc -> #aabbcc
+    if (h.length === 8) h = h.slice(0, 6) // strip alpha
+    const n = parseInt(h.slice(0, 6), 16)
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+  }
+  const clampT = Math.max(0, Math.min(1, t))
+  const [ar, ag, ab] = parse(a)
+  const [br, bg, bb] = parse(b)
+  const mix = (x: number, y: number) => Math.round(x + (y - x) * clampT)
+  const hx = (n: number) => n.toString(16).padStart(2, '0')
+  return `#${hx(mix(ar, br))}${hx(mix(ag, bg))}${hx(mix(ab, bb))}`
 }
 
 function toFiniteNumber(value: unknown): number | null {
@@ -434,8 +466,8 @@ export function sanitizeConditionalFormattingScaleRule(input: unknown): Conditio
   const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
   if (!id || !fieldId) return null
 
-  // A5-1 supports dataBar only; colorScale / iconSet are added in A5-2 / A5-3.
-  if (input.kind !== 'dataBar') return null
+  const kind = input.kind
+  if (kind !== 'dataBar' && kind !== 'colorScale' && kind !== 'iconSet') return null
 
   const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
   const enabled = input.enabled !== false
@@ -451,15 +483,49 @@ export function sanitizeConditionalFormattingScaleRule(input: unknown): Conditio
     range = { mode: 'auto' }
   }
 
-  const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
-  const color = sanitizeHex(barRaw.color)
-  if (!color) return null
-  const dataBar: ConditionalFormattingDataBarConfig = { color }
-  const negativeColor = sanitizeHex(barRaw.negativeColor)
-  if (negativeColor) dataBar.negativeColor = negativeColor
-  if (barRaw.showValue === true) dataBar.showValue = true
+  const base = { id, order: Math.floor(orderRaw), fieldId, enabled, range }
 
-  return { id, order: Math.floor(orderRaw), fieldId, kind: 'dataBar', enabled, range, dataBar }
+  if (kind === 'dataBar') {
+    const barRaw = isPlainObject(input.dataBar) ? input.dataBar : {}
+    const color = sanitizeHex(barRaw.color)
+    if (!color) return null
+    const dataBar: ConditionalFormattingDataBarConfig = { color }
+    const negativeColor = sanitizeHex(barRaw.negativeColor)
+    if (negativeColor) dataBar.negativeColor = negativeColor
+    if (barRaw.showValue === true) dataBar.showValue = true
+    return { ...base, kind: 'dataBar', dataBar }
+  }
+
+  if (kind === 'colorScale') {
+    // A5-2: crash-safe nested access; stops resolved BY NAME (`at`), 2 or 3, hex,
+    // no duplicate `at`, must include min+max (+mid when 3-stop).
+    const csRaw = isPlainObject(input.colorScale) ? input.colorScale : {}
+    if (!Array.isArray(csRaw.stops)) return null
+    const stops: ConditionalFormattingColorScaleStop[] = []
+    const seen = new Set<string>()
+    for (const s of csRaw.stops) {
+      if (!isPlainObject(s)) return null
+      const at = s.at
+      if (at !== 'min' && at !== 'mid' && at !== 'max') return null
+      if (seen.has(at)) return null
+      const color = sanitizeHex(s.color)
+      if (!color) return null
+      seen.add(at)
+      stops.push({ at, color })
+    }
+    if ((stops.length !== 2 && stops.length !== 3) || !seen.has('min') || !seen.has('max')) return null
+    if (stops.length === 3 && !seen.has('mid')) return null
+    return { ...base, kind: 'colorScale', colorScale: { stops } }
+  }
+
+  // A5-3 iconSet: named set + two ABSOLUTE monotonic thresholds (no silent swap).
+  const isRaw = isPlainObject(input.iconSet) ? input.iconSet : {}
+  if (!ICON_SET_NAMES.has(isRaw.set as string)) return null
+  if (!Array.isArray(isRaw.thresholds) || isRaw.thresholds.length !== 2) return null
+  const t0 = toFiniteNumber(isRaw.thresholds[0])
+  const t1 = toFiniteNumber(isRaw.thresholds[1])
+  if (t0 === null || t1 === null || t0 >= t1) return null
+  return { ...base, kind: 'iconSet', iconSet: { set: isRaw.set as ConditionalFormattingIconSetName, thresholds: [t0, t1] } }
 }
 
 export function sanitizeConditionalFormattingScaleRules(input: unknown): ConditionalFormattingScaleRule[] {
@@ -481,14 +547,44 @@ export function extractScaleRulesFromConfig(config: unknown): ConditionalFormatt
   return sanitizeConditionalFormattingScaleRules(config.conditionalFormattingScaleRules)
 }
 
-/** Per-cell derived presentation for a scale rule. A5-1: data bar only. */
+/**
+ * Per-cell derived presentation for a scale rule. ADDITIVE by kind (NOT a
+ * discriminated union — a `kind:` field would force itself onto the shipped
+ * data-bar presentation and break #2640's renderer/tests). dataBar sets
+ * barPct/barColor/negative; colorScale sets scaleColor; iconSet sets iconKey.
+ * A consumer keys on the field it cares about (e.g. the data-bar renderer must
+ * guard on barPct !== undefined — see MetaGridTable cellStyle).
+ */
 export type FieldScalePresentation = {
-  /** Data-bar fill, 0..100, as a fraction of (value - min) / (max - min). */
-  barPct: number
-  /** Bar color — `negativeColor` for negative values when configured, else `color`. */
-  barColor: string
-  /** True when the source value is negative (render may baseline differently). */
-  negative: boolean
+  /** dataBar — fill 0..100 = (value - min) / (max - min). */
+  barPct?: number
+  /** dataBar — `negativeColor` for negatives when configured, else `color`. */
+  barColor?: string
+  /** dataBar — true when the source value is negative. */
+  negative?: boolean
+  /** colorScale (A5-2) — interpolated cell background hex (#rrggbb). */
+  scaleColor?: string
+  /** iconSet (A5-3) — `${set}:${index}` where index ∈ {0,1,2}. */
+  iconKey?: string
+}
+
+/** A5-2: resolve a value's interpolated color from the (by-name) stops. */
+function colorScaleColor(cfg: ConditionalFormattingColorScaleConfig, v: number, min: number, max: number): string {
+  const at = (name: 'min' | 'mid' | 'max') => cfg.stops.find((s) => s.at === name)?.color
+  const minC = at('min') ?? '#000000'
+  const maxC = at('max') ?? '#ffffff'
+  const midC = at('mid')
+  const span = max - min
+  const t = span <= 0 ? 1 : Math.max(0, Math.min(1, (v - min) / span)) // degenerate -> max stop
+  if (!midC) return lerpHexColor(minC, maxC, t)
+  return t <= 0.5 ? lerpHexColor(minC, midC, t * 2) : lerpHexColor(midC, maxC, (t - 0.5) * 2)
+}
+
+/** A5-3: bucket a value into an icon index via the two absolute thresholds. */
+function iconSetKey(cfg: ConditionalFormattingIconSetConfig, v: number): string {
+  const [t0, t1] = cfg.thresholds
+  const index = v < t0 ? 0 : v < t1 ? 1 : 2
+  return `${cfg.set}:${index}`
 }
 
 export type FieldScaleResult = {
@@ -523,7 +619,10 @@ export function buildFieldScaleMap(
   const byField: Record<string, FieldScaleResult> = {}
 
   for (const rule of rules) {
-    if (!rule.enabled || rule.kind !== 'dataBar' || !rule.dataBar) continue
+    if (!rule.enabled) continue
+    if (rule.kind === 'dataBar' && !rule.dataBar) continue
+    if (rule.kind === 'colorScale' && !rule.colorScale) continue
+    if (rule.kind === 'iconSet' && !rule.iconSet) continue
     if (byField[rule.fieldId]) continue // first rule per field wins (mirrors cell-style precedence)
 
     // Resolve range.
@@ -558,10 +657,16 @@ export function buildFieldScaleMap(
       if (!record?.id) continue
       const v = toComparableNumber(record.data?.[rule.fieldId])
       if (v === null) continue
-      const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
-      const negative = v < 0
-      const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
-      byRecordId[record.id] = { barPct: pct, barColor, negative }
+      if (rule.kind === 'dataBar' && rule.dataBar) {
+        const pct = span <= 0 ? 100 : Math.max(0, Math.min(100, ((v - min) / span) * 100))
+        const negative = v < 0
+        const barColor = negative && rule.dataBar.negativeColor ? rule.dataBar.negativeColor : rule.dataBar.color
+        byRecordId[record.id] = { barPct: pct, barColor, negative }
+      } else if (rule.kind === 'colorScale' && rule.colorScale) {
+        byRecordId[record.id] = { scaleColor: colorScaleColor(rule.colorScale, v, min, max) }
+      } else if (rule.kind === 'iconSet' && rule.iconSet) {
+        byRecordId[record.id] = { iconKey: iconSetKey(rule.iconSet, v) }
+      }
     }
     byField[rule.fieldId] = { rule, min, max, byRecordId }
   }

--- a/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
+++ b/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
@@ -13,6 +13,7 @@ import {
   extractScaleRulesFromConfig,
   sanitizeConditionalFormattingScaleRule,
   sanitizeConditionalFormattingScaleRules,
+  lerpHexColor,
 } from '../../src/multitable/conditional-formatting-service'
 import type { MultitableField } from '../../src/multitable/field-codecs'
 
@@ -458,7 +459,9 @@ describe('conditional formatting — range-based SCALE rules (A5-1 data bar)', (
       expect(r).toEqual({ id: 's1', order: 0, fieldId: 'fld_n', kind: 'dataBar', enabled: true, range: { mode: 'auto' }, dataBar: { color: '#2196f3' } })
     })
 
-    it('rejects colorScale / iconSet until A5-2 / A5-3', () => {
+    it('rejects colorScale / iconSet kinds that carry no valid config (A5-2 / A5-3 land in their own blocks)', () => {
+      // validBar only supplies a dataBar config; switching `kind` without a
+      // matching colorScale/iconSet config must still be rejected.
       expect(sanitizeConditionalFormattingScaleRule(validBar({ kind: 'colorScale' }))).toBeNull()
       expect(sanitizeConditionalFormattingScaleRule(validBar({ kind: 'iconSet' }))).toBeNull()
     })
@@ -555,5 +558,233 @@ describe('conditional formatting — range-based SCALE rules (A5-1 data bar)', (
       const map = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }])
       expect(map.byField.fld_n).toBeUndefined()
     })
+  })
+})
+
+describe('conditional formatting — color scale SCALE rules (A5-2)', () => {
+  const validScale = (over: Record<string, unknown> = {}) => ({
+    id: 'cs1', fieldId: 'fld_n', kind: 'colorScale', order: 0,
+    range: { mode: 'auto' },
+    colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+    ...over,
+  })
+
+  describe('sanitizeConditionalFormattingScaleRule (color scale)', () => {
+    it('accepts a 2-stop (min/max) color scale and round-trips it', () => {
+      const r = sanitizeConditionalFormattingScaleRule(validScale())
+      expect(r).toEqual({
+        id: 'cs1', order: 0, fieldId: 'fld_n', kind: 'colorScale', enabled: true,
+        range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+      })
+    })
+
+    it('accepts a 3-stop (min/mid/max) color scale', () => {
+      const r = sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#ff0000' }, { at: 'mid', color: '#ffff00' }, { at: 'max', color: '#00ff00' },
+        ] },
+      }))
+      expect(r?.colorScale?.stops).toHaveLength(3)
+      expect(r?.dataBar).toBeUndefined()
+      expect(r?.iconSet).toBeUndefined()
+    })
+
+    it('rejects a stop count other than 2 or 3', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [{ at: 'min', color: '#000000' }] },
+      }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#000000' }, { at: 'mid', color: '#808080' },
+          { at: 'max', color: '#ffffff' }, { at: 'max', color: '#eeeeee' },
+        ] },
+      }))).toBeNull()
+    })
+
+    it('rejects a non-hex stop color', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [{ at: 'min', color: 'black' }, { at: 'max', color: '#ffffff' }] },
+      }))).toBeNull()
+    })
+
+    it('rejects an unknown or duplicate stop position', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [{ at: 'low', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+      }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'min', color: '#111111' }] },
+      }))).toBeNull()
+    })
+
+    it('requires min + max (and mid when 3-stop)', () => {
+      // 2 stops but missing max
+      expect(sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'mid', color: '#808080' }] },
+      }))).toBeNull()
+      // stops not an array
+      expect(sanitizeConditionalFormattingScaleRule(validScale({ colorScale: { stops: 'x' } }))).toBeNull()
+      // colorScale config missing entirely
+      expect(sanitizeConditionalFormattingScaleRule(validScale({ colorScale: undefined }))).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (color scale)', () => {
+    const recs = [
+      { id: 'r1', data: { fld_n: 0 } },
+      { id: 'r2', data: { fld_n: 50 } },
+      { id: 'r3', data: { fld_n: 100 } },
+    ]
+
+    it('maps endpoints to the exact stop colors and the midpoint to the interpolated color', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validScale())!
+      const map = buildFieldScaleMap([rule], recs)
+      const f = map.byField.fld_n
+      expect(f.min).toBe(0)
+      expect(f.max).toBe(100)
+      expect(f.byRecordId.r1.scaleColor).toBe('#000000')
+      expect(f.byRecordId.r3.scaleColor).toBe('#ffffff')
+      // #000000 -> #ffffff at t=0.5 = #808080
+      expect(f.byRecordId.r2.scaleColor).toBe('#808080')
+    })
+
+    it('a color-scale presentation sets scaleColor and never barPct/barColor (Trap B/E)', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validScale())!
+      const map = buildFieldScaleMap([rule], recs)
+      const cell = map.byField.fld_n.byRecordId.r2
+      expect(cell.scaleColor).toBeDefined()
+      expect(cell.barPct).toBeUndefined()
+      expect(cell.barColor).toBeUndefined()
+      expect(cell.negative).toBeUndefined()
+      expect(cell.iconKey).toBeUndefined()
+    })
+
+    it('splits a 3-stop scale at the midpoint', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validScale({
+        colorScale: { stops: [
+          { at: 'min', color: '#000000' }, { at: 'mid', color: '#ff0000' }, { at: 'max', color: '#ffffff' },
+        ] },
+      }))!
+      const map = buildFieldScaleMap([rule], recs)
+      const f = map.byField.fld_n
+      // exactly at the mid value resolves to the mid stop
+      expect(f.byRecordId.r2.scaleColor).toBe('#ff0000')
+      // quarter point (value 25) interpolates min->mid at t*2 = 0.5: #000000 -> #ff0000 = #800000
+      const map2 = buildFieldScaleMap([rule], [{ id: 'q', data: { fld_n: 25 } }, ...recs])
+      expect(map2.byField.fld_n.byRecordId.q.scaleColor).toBe('#800000')
+    })
+
+    it('maps every value to the max stop for a degenerate (all-equal) range', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validScale())!
+      const map = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 7 } }, { id: 'b', data: { fld_n: 7 } }])
+      expect(map.byField.fld_n.byRecordId.a.scaleColor).toBe('#ffffff')
+      expect(map.byField.fld_n.byRecordId.b.scaleColor).toBe('#ffffff')
+    })
+
+    it('skips non-numeric values (no presentation)', () => {
+      const rule = sanitizeConditionalFormattingScaleRule(validScale())!
+      const map = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: 'n/a' } },
+        { id: 'b', data: { fld_n: 100 } },
+      ])
+      expect(map.byField.fld_n.byRecordId.a).toBeUndefined()
+      expect(map.byField.fld_n.byRecordId.b.scaleColor).toBe('#ffffff')
+    })
+  })
+})
+
+describe('conditional formatting — icon set SCALE rules (A5-3)', () => {
+  const validIcon = (over: Record<string, unknown> = {}) => ({
+    id: 'is1', fieldId: 'fld_n', kind: 'iconSet', order: 0,
+    range: { mode: 'auto' },
+    iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    ...over,
+  })
+
+  describe('sanitizeConditionalFormattingScaleRule (icon set)', () => {
+    it('accepts each known set with monotonic thresholds and round-trips it', () => {
+      for (const set of ['arrows3', 'traffic3', 'signs3']) {
+        const r = sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set, thresholds: [1, 2] } }))
+        expect(r?.iconSet).toEqual({ set, thresholds: [1, 2] })
+        expect(r?.dataBar).toBeUndefined()
+        expect(r?.colorScale).toBeUndefined()
+      }
+    })
+
+    it('rejects an unknown set name', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'stars5', thresholds: [1, 2] } }))).toBeNull()
+    })
+
+    it('rejects thresholds that are not exactly two numbers', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [1] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [1, 2, 3] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: ['a', 2] } }))).toBeNull()
+    })
+
+    it('rejects non-monotonic thresholds (no silent swap)', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [20, 10] } }))).toBeNull()
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: { set: 'arrows3', thresholds: [10, 10] } }))).toBeNull()
+    })
+
+    it('rejects a missing iconSet config', () => {
+      expect(sanitizeConditionalFormattingScaleRule(validIcon({ iconSet: undefined }))).toBeNull()
+    })
+  })
+
+  describe('buildFieldScaleMap (icon set)', () => {
+    const rule = sanitizeConditionalFormattingScaleRule(validIcon())! // thresholds [10, 20]
+
+    it('buckets values into 3 icon indices at the absolute thresholds', () => {
+      const map = buildFieldScaleMap([rule], [
+        { id: 'a', data: { fld_n: 5 } },   // < t0 -> 0
+        { id: 'b', data: { fld_n: 10 } },  // == t0 -> 1
+        { id: 'c', data: { fld_n: 15 } },  // t0..t1 -> 1
+        { id: 'd', data: { fld_n: 20 } },  // == t1 -> 2
+        { id: 'e', data: { fld_n: 25 } },  // >= t1 -> 2
+      ])
+      const f = map.byField.fld_n.byRecordId
+      expect(f.a.iconKey).toBe('arrows3:0')
+      expect(f.b.iconKey).toBe('arrows3:1')
+      expect(f.c.iconKey).toBe('arrows3:1')
+      expect(f.d.iconKey).toBe('arrows3:2')
+      expect(f.e.iconKey).toBe('arrows3:2')
+    })
+
+    it('an icon-set presentation sets iconKey and never barPct/scaleColor', () => {
+      const map = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 15 } }])
+      const cell = map.byField.fld_n.byRecordId.a
+      expect(cell.iconKey).toBe('arrows3:1')
+      expect(cell.barPct).toBeUndefined()
+      expect(cell.barColor).toBeUndefined()
+      expect(cell.scaleColor).toBeUndefined()
+    })
+
+    it('skips non-numeric values (no presentation)', () => {
+      const map = buildFieldScaleMap([rule], [{ id: 'a', data: { fld_n: 'x' } }, { id: 'b', data: { fld_n: 30 } }])
+      expect(map.byField.fld_n.byRecordId.a).toBeUndefined()
+      expect(map.byField.fld_n.byRecordId.b.iconKey).toBe('arrows3:2')
+    })
+  })
+})
+
+describe('lerpHexColor (A5-2 helper)', () => {
+  it('returns the endpoints at t=0 and t=1', () => {
+    expect(lerpHexColor('#000000', '#ffffff', 0)).toBe('#000000')
+    expect(lerpHexColor('#000000', '#ffffff', 1)).toBe('#ffffff')
+  })
+
+  it('interpolates the midpoint', () => {
+    expect(lerpHexColor('#000000', '#ffffff', 0.5)).toBe('#808080')
+    expect(lerpHexColor('#ff0000', '#0000ff', 0.5)).toBe('#800080')
+  })
+
+  it('clamps t outside [0,1]', () => {
+    expect(lerpHexColor('#000000', '#ffffff', -1)).toBe('#000000')
+    expect(lerpHexColor('#000000', '#ffffff', 2)).toBe('#ffffff')
+  })
+
+  it('expands 3-digit hex and strips 8-digit alpha', () => {
+    expect(lerpHexColor('#000', '#fff', 0.5)).toBe('#808080')
+    expect(lerpHexColor('#000000ff', '#ffffff00', 0.5)).toBe('#808080')
   })
 })


### PR DESCRIPTION
## Summary

Completes the A5 range-based scale-rule family by adding the **colorScale (A5-2)** and **iconSet (A5-3)** kinds to the canonical backend conditional-formatting service and its identical FE mirror, alongside the already-shipped **dataBar (A5-1)**.

This is the **autonomous-backend** half of A5-2/3: contracts + builder + sanitizers, fully unit-tested. The on-grid *render* of color scales and icon sets is browser-gated follow-up work — the grid intentionally renders only the data-bar kind today (see Trap E below).

## What changed

**Backend `conditional-formatting-service.ts` (canonical)**
- `colorScale` config: 2 or 3 stops resolved **by name** (`at` ∈ `min|mid|max`), hex-validated, no duplicate position, requires `min`+`max` (and `mid` for a 3-stop scale).
- `iconSet` config: named set (`arrows3|traffic3|signs3`) + two **absolute, monotonic** thresholds (rejected, never silently swapped); buckets a value into 3 indices.
- `lerpHexColor()`: handles `#rgb` / `#rrggbb` / `#rrggbbaa` (alpha stripped), `t` clamped to `[0,1]`.
- `FieldScalePresentation` is **additive** (not a discriminated union): `dataBar→barPct/barColor/negative`, `colorScale→scaleColor`, `iconSet→iconKey`. Adding a `kind:` discriminator would force itself onto the shipped data-bar presentation and break the #2640 renderer/tests.
- Builder: degenerate (`min===max`) range maps every value to the **max** stop; non-numeric values are skipped (no presentation).

**FE mirror `utils/conditional-formatting.ts` + `types.ts`** — behaviour identical to the backend.

**`MetaGridTable.vue` cellStyle (Trap E fix)** — the data-bar render now guards on `typeof barPct === 'number'`, so a `colorScale`/`iconSet` presentation (which has no `barPct`) can never emit `linear-gradient(… undefined% …)` and regress the shipped data-bar render.

## Tests
- Backend **+23** tests: per-kind sanitizer (stop count / hex / unknown+dup position / missing min·max·mid; icon set name / threshold length / monotonicity), builder (endpoints exact, midpoint interpolation `#000000→#ffffff @0.5 = #808080`, 3-stop split, degenerate→max, bucket boundaries at exactly `t0`/`t1`), and `lerpHexColor` edges (3-digit, 8-digit alpha strip, clamp). → 75 passed.
- FE parity in `multitable-cf-scale.spec.ts`. → 15 passed.
- Two jsdom **Trap-E regression guards** in `multitable-grid-databar.spec.ts`: a colorScale / iconSet byField entry produces **no** data-bar gradient (no `undefined%`). → 6 passed.
- Backend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)