### PR TITLE
feat(data-source): wire MSSQL adapter to readonly helper

### DIFF
--- a/docs/development/data-source-system-integration-c5-mssql-adapter-helper-verification-20260615.md
+++ b/docs/development/data-source-system-integration-c5-mssql-adapter-helper-verification-20260615.md
@@ -1,0 +1,55 @@
+# Data Source System Integration C5-2 Verification - Generic MSSQL Adapter Helper Wire
+
+Date: 2026-06-15
+Scope: C5-2 generic `MSSQLAdapter` minimal production wire to `@metasheet/mssql-readonly-utils`
+
+## Summary
+
+This slice wires the generic SQL Server data-source adapter to the shared helper package introduced in C5-1.
+
+Migrated to helper:
+
+- SQL Server endpoint parsing (`host` / `server` + optional port);
+- legacy TLS option normalization;
+- MSSQL identifier quoting.
+
+Kept local for later gated slices:
+
+- `WhereClause` generation stays in `BaseAdapter`; moving it would affect shared Postgres/MySQL/MSSQL semantics and is not part of C5-2;
+- INFORMATION_SCHEMA schema introspection stays in `MSSQLAdapter`; C5-4 owns schema/read-only smoke alignment;
+- K3 SQL Server executor stays unchanged until C5-3.
+
+## Guardrails Verified
+
+- Existing MSSQL config mapping and legacy-TLS tests still pass.
+- Existing MSSQL SQL-generation tests still pass.
+- Existing identifier-quoting tests still pass.
+- Compatibility hardening covers instance-style server ports (`db\inst,1444`), SQL Server identifiers with numeric
+  leading segments / more than two dot-separated segments, and the old boolean/string-only coercion for
+  security-sensitive TLS/encryption knobs.
+- Existing result-boundary tests still pass.
+- Core-backend now depends on `@metasheet/mssql-readonly-utils` at runtime, because production adapter code imports it.
+- No K3 SQL Server executor behavior changed.
+- No write-path behavior changed.
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/mssql-adapter.test.ts \
+  tests/unit/data-source-identifier-quoting.test.ts \
+  tests/unit/data-source-result-boundary.test.ts \
+  tests/unit/mssql-readonly-utils-consumer.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/mssql-readonly-utils test
+git diff --check
+```
+
+## Boundaries
+
+- No K3 executor migration.
+- No K3 Submit/Audit/BOM behavior opened.
+- No generic DB write behavior opened.
+- No route/UI/package release change.
+- No external DB write change.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -223,8 +223,8 @@ TODO:
 目标: 把 K3 SQL Server 相关通道逐步靠近 generic MSSQL 能力，但不打开 K3 禁区。
 
 状态: C5-0 设计切片已写入 `docs/development/data-source-system-integration-c5-k3-generic-mssql-seam-design-20260615.md`；
-C5-1 latent helper contract 已落地为 `@metasheet/mssql-readonly-utils`，但 generic MSSQL / K3 executor
-生产调用点仍未迁移。C5-2/C5-3/C5-4 保持后续 gated opt-in。
+C5-1 latent helper contract 已落地为 `@metasheet/mssql-readonly-utils`；C5-2 已把 generic `MSSQLAdapter`
+的 endpoint/TLS/identifier 稳定面接到 helper。K3 executor 生产调用点仍未迁移；C5-3/C5-4 保持后续 gated opt-in。
 
 边界:
 
@@ -254,7 +254,12 @@ TODO:
   - 边界: 不改 `MSSQLAdapter`、不改 `k3-wise-sqlserver-executor.cjs`、不改任何 production call site。
 - [x] 结构守卫测试: shared helper 不导出任何写接口，neutral helper 不 import core/plugin internals；
   core-backend 不 import plugin internals，K3 plugin 不 import `DataSourceManager` / `MSSQLAdapter`。
-- [ ] C5-2: generic `MSSQLAdapter` 迁移到 helper，保持现有 MSSQL adapter tests / smoke harness 行为不漂移。
+- [x] C5-2: generic `MSSQLAdapter` 最小生产接线到 helper，保持现有 MSSQL adapter tests / smoke harness 行为不漂移。
+  - 已迁移: server/port parsing、legacy TLS option building、MSSQL identifier quoting。
+  - 未迁移: `WhereClause` builder 仍留在 `BaseAdapter`，避免本刀改变 Postgres/MySQL/MSSQL shared where 语义；
+    INFORMATION_SCHEMA schema introspection 仍留在 `MSSQLAdapter`，等 C5-4 smoke 对齐。
+  - core-backend 将 helper 从 devDependency 提升为 runtime dependency；generic adapter 生产代码现在按 package name
+    import helper。
 - [ ] C5-3: K3 default SQL Server executor 迁移到 helper 的 test/select 路径，保持 K3 read/write guard 不漂移。
 - [ ] C5-4: TLS / schema introspection / read-only smoke 与 generic MSSQL 对齐，并跑实体机 K3/MSSQL smoke。
 - [ ] 实体机 K3/MSSQL smoke。

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -33,6 +33,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "@metasheet/mssql-readonly-utils": "workspace:*",
     "@types/bcryptjs": "^3.0.0",
     "@wendellhu/redi": "^1.1.0",
     "ajv": "^8.12.0",
@@ -70,7 +71,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@metasheet/mssql-readonly-utils": "workspace:*",
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.25",

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -6,6 +6,13 @@
 // unreachable cases (RC4/3DES needing the OpenSSL legacy provider, or plaintext)
 // stay on the sidecar / Bridge Agent line. stream() uses batch fetch, not a true
 // cursor.
+import {
+  buildLegacyTlsOptions,
+  parseSqlServerEndpoint,
+  quoteSqlServerIdentifier,
+  VALID_TLS_MIN_VERSIONS,
+  type LegacyTlsOptions,
+} from '@metasheet/mssql-readonly-utils'
 import type {
   QueryOptions,
   QueryResult,
@@ -60,12 +67,12 @@ interface MssqlColumnRow {
   numeric_scale: number | null
 }
 
-function coerceBoolean(value: unknown, fallback: boolean): boolean {
+function coerceMssqlConfigBoolean(value: unknown, fallback: boolean): boolean {
   if (typeof value === 'boolean') return value
   if (typeof value === 'string') {
-    const s = value.trim().toLowerCase()
-    if (['false', '0', 'no', 'off'].includes(s)) return false
-    if (['true', '1', 'yes', 'on'].includes(s)) return true
+    const normalized = value.trim().toLowerCase()
+    if (['false', '0', 'no', 'off'].includes(normalized)) return false
+    if (['true', '1', 'yes', 'on'].includes(normalized)) return true
   }
   return fallback
 }
@@ -96,32 +103,23 @@ export class MSSQLAdapter extends BaseDataAdapter {
     const serverRaw = getStringConfig(this.config.connection.server)
     const explicitPort = getNumberConfig(this.config.connection.port)
 
-    if (host) {
-      return { server: host, ...(explicitPort != null ? { port: explicitPort } : {}) }
+    if (!host && !serverRaw) {
+      throw new Error('SQL Server data source requires connection.host or connection.server')
     }
-    if (serverRaw) {
-      const m = serverRaw.match(/^(.*?)[:,](\d+)$/)
-      if (m) {
-        const parsedPort = parseInt(m[2], 10)
-        if (explicitPort != null && explicitPort !== parsedPort) {
+    try {
+      return parseSqlServerEndpoint({ host, server: serverRaw, port: explicitPort })
+    } catch (error) {
+      if ((error as { code?: string }).code === 'SQLSERVER_PORT_INVALID') {
+        const message = (error as Error).message
+        if (message.startsWith('Conflicting port:')) {
           throw new Error(
-            `Conflicting port: connection.port=${explicitPort} but connection.server specifies ${parsedPort}`
+            `Conflicting port: connection.port=${explicitPort} but connection.server specifies ${String(serverRaw).split(/[,:]/).pop()}`
           )
         }
-        return { server: m[1], port: explicitPort ?? parsedPort }
       }
-      return { server: serverRaw, ...(explicitPort != null ? { port: explicitPort } : {}) }
+      throw error
     }
-    throw new Error('SQL Server data source requires connection.host or connection.server')
   }
-
-  // Valid TLS protocol floors accepted by Node's tls module (B3 validation).
-  private static readonly VALID_TLS_MIN_VERSIONS: readonly string[] = [
-    'TLSv1',
-    'TLSv1.1',
-    'TLSv1.2',
-    'TLSv1.3'
-  ]
 
   /**
    * B3 — per-connection legacy-TLS escape hatch. SECURE BY DEFAULT: returns
@@ -138,59 +136,48 @@ export class MSSQLAdapter extends BaseDataAdapter {
    * The wire stays encrypted (this lowers the floor, it is not `encrypt:false`).
    * Lowering below the secure default emits an audit signal.
    */
-  private buildLegacyTlsOptions(conn: ConnectionConfig): { minVersion?: string; ciphers?: string } | undefined {
-    const legacyTls = coerceBoolean(conn.legacyTls, false)
-    let minVersion = getStringConfig(conn.tlsMinVersion)
-    let ciphers = getStringConfig(conn.tlsCiphers)
-
-    if (legacyTls) {
-      // Documented legacy defaults; explicit keys win.
-      minVersion = minVersion ?? 'TLSv1'
-      ciphers = ciphers ?? 'DEFAULT@SECLEVEL=0'
+  private buildLegacyTlsOptions(conn: ConnectionConfig): LegacyTlsOptions | undefined {
+    let legacyTls: LegacyTlsOptions | undefined
+    try {
+      legacyTls = buildLegacyTlsOptions({
+        legacyTls: coerceMssqlConfigBoolean(conn.legacyTls, false),
+        tlsMinVersion: conn.tlsMinVersion,
+        tlsCiphers: conn.tlsCiphers,
+        encrypt: coerceMssqlConfigBoolean(conn.encrypt, true),
+      })
+    } catch (error) {
+      const code = (error as { code?: string }).code
+      if (code === 'SQLSERVER_TLS_CONFLICT') {
+        throw new Error(
+          'connection.encrypt=false cannot be combined with the legacy-TLS lever ' +
+            '(legacyTls / tlsMinVersion / tlsCiphers): the TLS downgrade keeps the wire ' +
+            'encrypted, while encrypt=false is a separate plaintext escape hatch — use one or the other.'
+        )
+      }
+      if (code === 'SQLSERVER_TLS_MIN_VERSION_INVALID') {
+        throw new Error(
+          `Invalid connection.tlsMinVersion "${getStringConfig(conn.tlsMinVersion)}" ` +
+            `(expected one of ${VALID_TLS_MIN_VERSIONS.join(', ')})`
+        )
+      }
+      throw error
     }
-
-    // No downgrade requested → keep Node/tedious secure defaults (TLSv1.2 floor).
-    if (minVersion === undefined && ciphers === undefined) return undefined
-
-    // B3 lowers the TLS floor but keeps the wire ENCRYPTED. It must not be
-    // combined with connection.encrypt=false — that is a SEPARATE plaintext
-    // escape hatch with a different security posture. Allowing both would make
-    // the audit below falsely claim "wire stays encrypted" for a plaintext
-    // source. Reject the contradiction loudly; the plaintext path is opt-in on
-    // its own (encrypt=false with no TLS-downgrade keys).
-    if (coerceBoolean(conn.encrypt, true) === false) {
-      throw new Error(
-        'connection.encrypt=false cannot be combined with the legacy-TLS lever ' +
-          '(legacyTls / tlsMinVersion / tlsCiphers): the TLS downgrade keeps the wire ' +
-          'encrypted, while encrypt=false is a separate plaintext escape hatch — use one or the other.'
-      )
-    }
-
-    // Enum-strict: never silently fall back to a default for a bad floor value.
-    if (minVersion !== undefined && !MSSQLAdapter.VALID_TLS_MIN_VERSIONS.includes(minVersion)) {
-      throw new Error(
-        `Invalid connection.tlsMinVersion "${minVersion}" ` +
-          `(expected one of ${MSSQLAdapter.VALID_TLS_MIN_VERSIONS.join(', ')})`
-      )
-    }
+    if (legacyTls === undefined) return undefined
 
     // Audit: this source is connecting with a deliberately lowered TLS posture.
     const detail = [
-      minVersion !== undefined ? `minVersion=${minVersion}` : null,
-      ciphers !== undefined ? `ciphers=${ciphers}` : null
+      legacyTls.minVersion !== undefined ? `minVersion=${legacyTls.minVersion}` : null,
+      legacyTls.ciphers !== undefined ? `ciphers=${legacyTls.ciphers}` : null
     ]
       .filter(Boolean)
       .join(', ')
-    this.emit('tls-downgrade', { adapter: this.config.name, minVersion, ciphers })
+    this.emit('tls-downgrade', { adapter: this.config.name, minVersion: legacyTls.minVersion, ciphers: legacyTls.ciphers })
     console.warn(
       `[MSSQLAdapter] legacy TLS enabled for data source "${this.config.name}" (${detail}); ` +
         `wire stays encrypted, scope is this connection only.`
     )
 
-    return {
-      ...(minVersion !== undefined ? { minVersion } : {}),
-      ...(ciphers !== undefined ? { ciphers } : {})
-    }
+    return legacyTls
   }
 
   private buildPoolConfig(): Record<string, unknown> {
@@ -209,8 +196,8 @@ export class MSSQLAdapter extends BaseDataAdapter {
       // cryptoCredentialsDetails (B3) lowers the TLS floor/ciphers per-source
       // for genuinely old servers — still encrypted, opt-in only.
       options: {
-        encrypt: coerceBoolean(conn.encrypt, true),
-        trustServerCertificate: coerceBoolean(conn.trustServerCertificate, true),
+        encrypt: coerceMssqlConfigBoolean(conn.encrypt, true),
+        trustServerCertificate: coerceMssqlConfigBoolean(conn.trustServerCertificate, true),
         ...(legacyTls ? { cryptoCredentialsDetails: legacyTls } : {})
       },
       // ?? (not ||) so an explicit 0 ("no timeout" in mssql) is not overridden.
@@ -272,7 +259,14 @@ export class MSSQLAdapter extends BaseDataAdapter {
   // A2: bracket-quote PER SEGMENT so a schema-qualified name becomes [schema].[table]. The base
   // sanitizer validates each segment and throws on illegal input.
   private quoteIdent(identifier: string): string {
-    return this.sanitizeIdentifier(identifier).split('.').map(seg => `[${seg}]`).join('.')
+    try {
+      return quoteSqlServerIdentifier(identifier)
+    } catch (error) {
+      if ((error as { code?: string }).code === 'SQLSERVER_IDENTIFIER_INVALID') {
+        throw new Error(`Invalid identifier: ${identifier}`)
+      }
+      throw error
+    }
   }
 
   async query<T = Record<string, DbValue>>(sql: string, params?: DbValue[]): Promise<QueryResult<T>> {

--- a/packages/core-backend/tests/unit/data-source-identifier-quoting.test.ts
+++ b/packages/core-backend/tests/unit/data-source-identifier-quoting.test.ts
@@ -52,6 +52,8 @@ describe('A2 identifier validation + per-segment quoting', () => {
   it('MSSQL brackets PER SEGMENT: dbo.orders -> [dbo].[orders]; illegal throws', () => {
     expect(mssqlQuote('orders')).toBe('[orders]')
     expect(mssqlQuote('dbo.orders')).toBe('[dbo].[orders]')
+    expect(mssqlQuote('2024_orders')).toBe('[2024_orders]')
+    expect(mssqlQuote('tenant.dbo.orders')).toBe('[tenant].[dbo].[orders]')
     expect(() => mssqlQuote('bad-name')).toThrow(/Invalid identifier/)
   })
 

--- a/packages/core-backend/tests/unit/mssql-adapter.test.ts
+++ b/packages/core-backend/tests/unit/mssql-adapter.test.ts
@@ -89,6 +89,19 @@ describe('MSSQLAdapter — config mapping', () => {
     expect(cfg.requestTimeout).toBe(12000)
   })
 
+  it('keeps numeric boolean-like security knobs on the legacy fallback path', () => {
+    const cfg = poolConfig({
+      host: 'db',
+      database: 'D',
+      encrypt: 0,
+      legacyTls: 1,
+      trustServerCertificate: 0,
+    })
+    expect(cfg.options.encrypt).toBe(true)
+    expect(cfg.options.trustServerCertificate).toBe(true)
+    expect(cfg.options.cryptoCredentialsDetails).toBeUndefined()
+  })
+
   it('passes an explicit timeout of 0 through (no-timeout), not the default', () => {
     const cfg = poolConfig({ host: 'db', database: 'D', connectionTimeoutMs: 0, requestTimeoutMs: 0 })
     expect(cfg.connectionTimeout).toBe(0)
@@ -98,11 +111,13 @@ describe('MSSQLAdapter — config mapping', () => {
   it('parses server alias (host:port and host,port) and host wins over server', () => {
     expect(poolConfig({ server: 'h1:1444', database: 'D' })).toMatchObject({ server: 'h1', port: 1444 })
     expect(poolConfig({ server: 'h2,1455', database: 'D' })).toMatchObject({ server: 'h2', port: 1455 })
+    expect(poolConfig({ server: 'db\\inst,1444', database: 'D' })).toMatchObject({ server: 'db\\inst', port: 1444 })
     expect(poolConfig({ host: 'hWin', server: 'hLose,1466', port: 1433, database: 'D' })).toMatchObject({ server: 'hWin', port: 1433 })
   })
 
   it('throws on a server-embedded port that conflicts with an explicit port', () => {
     expect(() => poolConfig({ server: 'h,1444', port: 9999, database: 'D' })).toThrow(/Conflicting port/)
+    expect(() => poolConfig({ server: 'db\\inst,1444', port: 9999, database: 'D' })).toThrow(/Conflicting port/)
   })
 })
 
@@ -192,6 +207,19 @@ describe('MSSQLAdapter — SQL generation (fake driver)', () => {
     expect(sql).toMatch(/@p0/)
     expect(sql).not.toMatch(/\$\d/)
     expect(params.p0).toBe(true)
+  })
+
+  it('select: preserves legacy-compatible SQL Server identifier shapes through the helper', async () => {
+    const fp = fakePool()
+    await adapterWithFakePool(fp).select('tenant.dbo.2024_orders', {
+      select: ['2024_amount'],
+      orderBy: [{ column: 'tenant.dbo.2024_created_at', direction: 'asc' }],
+      limit: 5,
+    })
+    const { sql } = fp.calls[0]
+    expect(sql).toContain('[tenant].[dbo].[2024_orders]')
+    expect(sql).toContain('[2024_amount]')
+    expect(sql).toContain('[tenant].[dbo].[2024_created_at] ASC')
   })
 
   it('select: OFFSET/FETCH with ORDER BY when offset is given', async () => {

--- a/packages/mssql-readonly-utils/__tests__/helper-contract.test.cjs
+++ b/packages/mssql-readonly-utils/__tests__/helper-contract.test.cjs
@@ -95,7 +95,9 @@ function testEndpointAndTls() {
     port: 1433,
   })
   assert.deepEqual(helper.parseSqlServerEndpoint({ server: 'db,1444' }), { server: 'db', port: 1444 })
+  assert.deepEqual(helper.parseSqlServerEndpoint({ server: 'db\\inst,1444' }), { server: 'db\\inst', port: 1444 })
   assertThrowsCode(() => helper.parseSqlServerEndpoint({ server: 'db,1444', port: 1433 }), 'SQLSERVER_PORT_INVALID')
+  assertThrowsCode(() => helper.parseSqlServerEndpoint({ server: 'db\\inst,1444', port: 1433 }), 'SQLSERVER_PORT_INVALID')
 
   assert.deepEqual(helper.buildLegacyTlsOptions({ legacyTls: true }), {
     minVersion: 'TLSv1',
@@ -117,6 +119,15 @@ function testConsumerPolicies() {
   assert.equal(helper.normalizeLimit(undefined, { defaultLimit: 10000, maxLimit: 10000, overMax: 'throw' }), 10000)
   assertThrowsCode(() => helper.normalizeLimit(10001, { maxLimit: 10000, overMax: 'throw' }), 'SQLSERVER_LIMIT_INVALID')
   assert.equal(helper.normalizeLimit(10001, { defaultLimit: 1000, maxLimit: 10000, overMax: 'clamp' }), 10000)
+}
+
+function testSqlServerIdentifierCompatibility() {
+  assert.equal(helper.quoteSqlServerIdentifier('orders'), '[orders]')
+  assert.equal(helper.quoteSqlServerIdentifier('2024_orders'), '[2024_orders]')
+  assert.equal(helper.quoteSqlServerIdentifier('dbo.2024_orders'), '[dbo].[2024_orders]')
+  assert.equal(helper.quoteSqlServerIdentifier('tenant.dbo.orders'), '[tenant].[dbo].[orders]')
+  assertThrowsCode(() => helper.quoteSqlServerIdentifier('tenant..orders'), 'SQLSERVER_IDENTIFIER_INVALID')
+  assertThrowsCode(() => helper.quoteSqlServerIdentifier('bad-name'), 'SQLSERVER_IDENTIFIER_INVALID')
 }
 
 function testGenericWhereClause() {
@@ -190,6 +201,7 @@ testNeutralRuntimeBoundary()
 testRepoImportBoundaries()
 testEndpointAndTls()
 testConsumerPolicies()
+testSqlServerIdentifierCompatibility()
 testGenericWhereClause()
 testSimpleSelectQuery()
 

--- a/packages/mssql-readonly-utils/index.cjs
+++ b/packages/mssql-readonly-utils/index.cjs
@@ -1,7 +1,7 @@
 'use strict'
 
-const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
-const QUALIFIED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/
+const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z0-9_]+$/
+const QUALIFIED_IDENTIFIER_PATTERN = /^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$/
 const VALID_TLS_MIN_VERSIONS = Object.freeze(['TLSv1', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3'])
 
 class SqlServerReadonlyHelperError extends Error {
@@ -84,7 +84,7 @@ function parseSqlServerEndpoint(input = {}) {
   }
 
   const server = requiredString(serverRaw, 'server')
-  const match = server.match(/^([^,:\\]+)([:,])(\d+)$/)
+  const match = server.match(/^(.*?)([:,])(\d+)$/)
   if (!match) {
     return { server, ...(explicitPort === undefined ? {} : { port: explicitPort }) }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
 
   packages/core-backend:
     dependencies:
+      '@metasheet/mssql-readonly-utils':
+        specifier: workspace:*
+        version: link:../mssql-readonly-utils
       '@types/bcryptjs':
         specifier: ^3.0.0
         version: 3.0.0
@@ -254,9 +257,6 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
-      '@metasheet/mssql-readonly-utils':
-        specifier: workspace:*
-        version: link:../mssql-readonly-utils
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2


### PR DESCRIPTION
## Summary

C5-2 for the data-source/system-integration delivery plan: wire the generic `MSSQLAdapter` to the shared `@metasheet/mssql-readonly-utils` helper for the stable low-level surfaces only.

What changed:
- `MSSQLAdapter` now uses the helper for endpoint parsing, legacy TLS option building, and SQL Server identifier quoting.
- `@metasheet/mssql-readonly-utils` is now a core-backend runtime dependency because production adapter code imports it.
- Added compatibility tests for edge cases caught in review: instance-style `db\\inst,1444` port parsing/conflicts, numeric-leading and multi-part SQL Server identifiers, and old boolean/string-only semantics for security-sensitive TLS/encryption knobs.
- Updated C5 TODO and added the C5-2 verification note.

Boundary:
- No K3 executor migration; C5-3 remains gated.
- No `WhereClause` migration; it stays in `BaseAdapter` to avoid cross-adapter behavior drift.
- No INFORMATION_SCHEMA/schema-introspection migration; C5-4 owns smoke alignment.
- No K3 Submit/Audit/BOM or external write behavior opened.

## Verification

Local:
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/mssql-adapter.test.ts tests/unit/data-source-identifier-quoting.test.ts tests/unit/data-source-result-boundary.test.ts tests/unit/mssql-readonly-utils-consumer.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/mssql-readonly-utils test`
- `pnpm --filter plugin-integration-core test:k3-wise-adapters`
- `git diff --check`

Subagent review:
- MSSQL adapter behavior review: initial P2s fixed; final no findings.
- Packaging/dependency/scope review: initial P2 fixed; final no findings.
