### PR TITLE
feat(data-source): wire K3 SQL executor to MSSQL helper

### DIFF
--- a/docs/development/data-source-system-integration-c5-k3-executor-helper-verification-20260615.md
+++ b/docs/development/data-source-system-integration-c5-k3-executor-helper-verification-20260615.md
@@ -1,0 +1,51 @@
+# Data Source System Integration C5-3 Verification - K3 SQL Server Executor Helper Wire
+
+Date: 2026-06-15
+Scope: C5-3 K3 default SQL Server executor minimal helper wire
+
+## Summary
+
+This slice wires the built-in `erp:k3-wise-sqlserver` read-only executor to the neutral
+`@metasheet/mssql-readonly-utils` helper introduced in C5-1.
+
+Migrated to helper:
+
+- SQL Server endpoint parsing for `server` / optional `port`;
+- timeout and limit normalization, with the K3 executor's existing policy values;
+- SQL Server identifier quoting primitive;
+- structured simple `SELECT TOP ... FROM ... WHERE ... ORDER BY ...` query construction.
+
+Kept K3-local:
+
+- K3 strict identifier policy remains the first gate before the helper is called: at most `schema.table`, and every
+  segment must start with a letter or underscore;
+- K3 object manifests, read/write table allowlists, operation checks, and direct-table write gate stay in the K3 SQL
+  Server channel;
+- the built-in executor's `insertMany` still throws `SQLSERVER_WRITE_EXECUTOR_DISABLED`;
+- Submit / Audit / BOM / generic DB write remain unopened.
+
+## Guardrails Verified
+
+- Existing SQL Server channel tests still assert the exact structured SELECT SQL and bound parameters.
+- The executor now accepts shared-helper endpoint coverage for SQL Server named instances with ports
+  (`server\instance,port`).
+- Regression tests pin that the K3 executor does not inherit the generic helper's wider identifier policy:
+  `tenant.dbo.table` and numeric-leading identifiers still fail closed before helper query construction.
+- The plugin CJS consumer smoke still resolves `@metasheet/mssql-readonly-utils`.
+- The helper contract suite still confirms the helper package stays neutral and read-only.
+
+## Verification Commands
+
+```bash
+pnpm --filter plugin-integration-core test:k3-wise-adapters
+pnpm --filter plugin-integration-core test:mssql-readonly-utils
+pnpm --filter @metasheet/mssql-readonly-utils test
+```
+
+## Boundaries
+
+- No `DataSourceManager` or generic `MSSQLAdapter` dependency added to the K3 plugin path.
+- No route, UI, migration, package release, or entity-machine smoke change.
+- No K3 Save / Submit / Audit / BOM behavior opened.
+- No generic DB write behavior opened.
+- No credentials, row values, connection strings, raw SQL evidence, or K3 payloads added to docs.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -224,7 +224,8 @@ TODO:
 
 状态: C5-0 设计切片已写入 `docs/development/data-source-system-integration-c5-k3-generic-mssql-seam-design-20260615.md`；
 C5-1 latent helper contract 已落地为 `@metasheet/mssql-readonly-utils`；C5-2 已把 generic `MSSQLAdapter`
-的 endpoint/TLS/identifier 稳定面接到 helper。K3 executor 生产调用点仍未迁移；C5-3/C5-4 保持后续 gated opt-in。
+的 endpoint/TLS/identifier 稳定面接到 helper；C5-3 已把 K3 default SQL Server executor 的 endpoint/timeout/limit/simple-select
+接到 helper，同时保留 K3 strict identifier/read/write guard。C5-4 保持后续 gated opt-in。
 
 边界:
 
@@ -260,7 +261,11 @@ TODO:
     INFORMATION_SCHEMA schema introspection 仍留在 `MSSQLAdapter`，等 C5-4 smoke 对齐。
   - core-backend 将 helper 从 devDependency 提升为 runtime dependency；generic adapter 生产代码现在按 package name
     import helper。
-- [ ] C5-3: K3 default SQL Server executor 迁移到 helper 的 test/select 路径，保持 K3 read/write guard 不漂移。
+- [x] C5-3: K3 default SQL Server executor 迁移到 helper 的 test/select 路径，保持 K3 read/write guard 不漂移。
+  - 已迁移: endpoint parsing、timeout / limit policy、structured simple SELECT builder、identifier quoting primitive。
+  - K3 guard 保留: executor 在调用 helper 前仍先执行 K3 strict identifier policy（最多 schema.table、每段字母/下划线开头）；
+    不继承 generic MSSQL helper 的 numeric-leading / 多段 identifier 放宽。
+  - built-in `insertMany` 仍抛 `SQLSERVER_WRITE_EXECUTOR_DISABLED`；K3 Submit/Audit/BOM/direct table write scope 不变。
 - [ ] C5-4: TLS / schema introspection / read-only smoke 与 generic MSSQL 对齐，并跑实体机 K3/MSSQL smoke。
 - [ ] 实体机 K3/MSSQL smoke。
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -297,6 +297,13 @@ function testSqlServerConnectionConfigNormalization() {
   assert.equal(matchingExplicitPort.server, 'sql.local')
   assert.equal(matchingExplicitPort.port, 1433)
 
+  const namedInstancePort = sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
+    server: 'sql.local\\WISE,14330',
+    database: 'AIS_TEST',
+  }, credentials))
+  assert.equal(namedInstancePort.server, 'sql.local\\WISE')
+  assert.equal(namedInstancePort.port, 14330)
+
   let conflictingPort = null
   try {
     sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
@@ -309,6 +316,75 @@ function testSqlServerConnectionConfigNormalization() {
   }
   assert.equal(conflictingPort && conflictingPort.code, 'SQLSERVER_PORT_INVALID')
   assert.match(conflictingPort.message, /must match/)
+}
+
+function testK3SqlServerExecutorKeepsK3IdentifierPolicy() {
+  assert.equal(sqlExecutorInternals.quoteIdentifier('dbo.t_ICItem'), '[dbo].[t_ICItem]')
+
+  assert.throws(
+    () => sqlExecutorInternals.quoteIdentifier('tenant.dbo.t_ICItem'),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 executor must not inherit generic helper multi-part identifier policy',
+  )
+  assert.throws(
+    () => sqlExecutorInternals.quoteIdentifier('2024_orders'),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 executor must not inherit generic helper numeric-leading identifier policy',
+  )
+
+  const request = {
+    input() {
+      return request
+    },
+  }
+  assert.throws(
+    () => sqlExecutorInternals.buildSelectQuery({
+      request,
+      table: 'tenant.dbo.t_ICItem',
+      columns: ['FItemID'],
+    }),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 select builder keeps the K3 table allowlist shape before calling the helper',
+  )
+  assert.throws(
+    () => sqlExecutorInternals.buildSelectQuery({
+      request,
+      table: 'dbo.t_ICItem',
+      columns: ['2024_orders'],
+    }),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 select builder keeps the K3 column shape before calling the helper',
+  )
+  assert.throws(
+    () => sqlExecutorInternals.buildSelectQuery({
+      request,
+      table: 'dbo.t_ICItem',
+      columns: ['FItemID'],
+      orderBy: '2024_orders',
+    }),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 select builder keeps the K3 orderBy shape before calling the helper',
+  )
+  assert.throws(
+    () => sqlExecutorInternals.buildSelectQuery({
+      request,
+      table: 'dbo.t_ICItem',
+      columns: ['FItemID'],
+      filters: { 'tenant.dbo.FNumber': 'MAT-001' },
+    }),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 select builder keeps the K3 filter field shape before calling the helper',
+  )
+  assert.throws(
+    () => sqlExecutorInternals.buildSelectQuery({
+      request,
+      table: 'dbo.t_ICItem',
+      columns: ['FItemID'],
+      watermark: { '2024_updated': '2026-01-01T00:00:00.000Z' },
+    }),
+    (error) => error && error.code === 'SQLSERVER_IDENTIFIER_INVALID',
+    'K3 select builder keeps the K3 watermark field shape before calling the helper',
+  )
 }
 
 async function testK3WebApiAdapter() {
@@ -1406,6 +1482,7 @@ async function main() {
   await testK3WebApiNestedDataSaveParse()
   await testK3WebApiCustomerProfile()
   testSqlServerConnectionConfigNormalization()
+  testK3SqlServerExecutorKeepsK3IdentifierPolicy()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()
   console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs
@@ -9,6 +9,14 @@
 // disabled unless a deployment explicitly injects a different executor.
 // ---------------------------------------------------------------------------
 
+const {
+  buildSimpleSelectQuery: buildSharedSimpleSelectQuery,
+  normalizeLimit: normalizeSharedLimit,
+  normalizeTimeout: normalizeSharedTimeout,
+  parseSqlServerEndpoint,
+  quoteSqlServerIdentifier,
+} = require('@metasheet/mssql-readonly-utils')
+
 const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
 const QUALIFIED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
@@ -52,21 +60,23 @@ function normalizeIdentifier(value, field) {
 
 function quoteIdentifier(value, field = 'identifier') {
   const normalized = normalizeIdentifier(value, field)
-  return normalized.split('.').map((part) => {
-    if (!SIMPLE_IDENTIFIER_PATTERN.test(part)) {
-      throw new SqlServerExecutorError('SQLSERVER_IDENTIFIER_INVALID', `${field} must be a simple identifier`, { field })
-    }
-    return `[${part}]`
-  }).join('.')
+  try {
+    return quoteSqlServerIdentifier(normalized, field)
+  } catch (error) {
+    throw wrapHelperError(error, 'SQLSERVER_IDENTIFIER_INVALID', `${field} must be a simple identifier`)
+  }
 }
 
 function normalizeLimit(value) {
-  if (value === undefined || value === null || value === '') return DEFAULT_MAX_LIMIT
-  const numeric = Number(value)
-  if (!Number.isInteger(numeric) || numeric <= 0) {
-    throw new SqlServerExecutorError('SQLSERVER_LIMIT_INVALID', 'limit must be a positive integer', { field: 'limit' })
+  try {
+    return normalizeSharedLimit(value, {
+      defaultLimit: DEFAULT_MAX_LIMIT,
+      maxLimit: MAX_LIMIT,
+      overMax: 'clamp',
+    })
+  } catch (error) {
+    throw wrapHelperError(error, 'SQLSERVER_LIMIT_INVALID', 'limit must be a positive integer')
   }
-  return Math.min(numeric, MAX_LIMIT)
 }
 
 function coerceBoolean(value, fallback) {
@@ -82,34 +92,32 @@ function coerceBoolean(value, fallback) {
 }
 
 function parseServerAndPort(serverValue, portValue) {
-  const server = requiredString(serverValue, 'system.config.server')
-  const configuredPort = portValue === undefined || portValue === null || portValue === ''
-    ? null
-    : Number(portValue)
-  if (configuredPort !== null && (!Number.isInteger(configuredPort) || configuredPort <= 0 || configuredPort > 65535)) {
-    throw new SqlServerExecutorError('SQLSERVER_PORT_INVALID', 'system.config.port must be a TCP port', {
-      field: 'system.config.port',
+  try {
+    const endpoint = parseSqlServerEndpoint({
+      server: requiredString(serverValue, 'system.config.server'),
+      port: portValue,
     })
-  }
-
-  const hostPortMatch = server.match(/^([^,:\\]+)([:,])(\d+)$/)
-  if (hostPortMatch) {
-    const parsedPort = Number(hostPortMatch[3])
-    if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
-      throw new SqlServerExecutorError('SQLSERVER_PORT_INVALID', 'system.config.server contains an invalid port', {
-        field: 'system.config.server',
-      })
-    }
-    if (configuredPort !== null && configuredPort !== parsedPort) {
+    return { server: endpoint.server, port: endpoint.port === undefined ? null : endpoint.port }
+  } catch (error) {
+    if (error && error.code === 'SQLSERVER_PORT_INVALID') {
+      const message = String(error.message || '')
+      if (message.includes('Conflicting port')) {
+        throw new SqlServerExecutorError(
+          'SQLSERVER_PORT_INVALID',
+          'system.config.server port must match system.config.port when both are provided',
+          { field: 'system.config.server' },
+        )
+      }
       throw new SqlServerExecutorError(
         'SQLSERVER_PORT_INVALID',
-        'system.config.server port must match system.config.port when both are provided',
-        { field: 'system.config.server' },
+        error.details && error.details.field === 'server'
+          ? 'system.config.server contains an invalid port'
+          : 'system.config.port must be a TCP port',
+        { field: error.details && error.details.field === 'server' ? 'system.config.server' : 'system.config.port' },
       )
     }
-    return { server: hostPortMatch[1], port: configuredPort === null ? parsedPort : configuredPort }
+    throw wrapHelperError(error, 'SQLSERVER_CONFIG_REQUIRED', 'system.config.server is required')
   }
-  return { server, port: configuredPort }
 }
 
 function resolveConnectionConfig(system = {}) {
@@ -136,12 +144,11 @@ function resolveConnectionConfig(system = {}) {
 }
 
 function normalizeTimeout(value, fallback, field) {
-  if (value === undefined || value === null || value === '') return fallback
-  const numeric = Number(value)
-  if (!Number.isInteger(numeric) || numeric <= 0) {
+  try {
+    return normalizeSharedTimeout(value, { defaultValue: fallback, field, allowZero: false })
+  } catch (error) {
     throw new SqlServerExecutorError('SQLSERVER_TIMEOUT_INVALID', `${field} must be a positive integer`, { field })
   }
-  return numeric
 }
 
 function loadMssqlDriver(requireImpl = require) {
@@ -173,68 +180,49 @@ async function withPool({ driver, system, fn }) {
   }
 }
 
-function normalizeScalar(value, field) {
-  if (value === undefined) return { skip: true }
-  if (value === null) return { value: null }
-  if (value instanceof Date) return { value }
-  if (['string', 'number', 'boolean'].includes(typeof value)) return { value }
-  throw new SqlServerExecutorError('SQLSERVER_FILTER_INVALID', `${field} must be a scalar value`, { field })
-}
-
-function addInput(request, name, value) {
-  request.input(name, value)
-  return `@${name}`
-}
-
-function appendStructuredPredicates({ request, values, operator, parts, prefix }) {
+function assertK3PredicateIdentifiers(values, prefix) {
   if (!isPlainObject(values)) return
-  let index = 0
-  for (const [field, value] of Object.entries(values)) {
-    const quotedField = quoteIdentifier(field, `${prefix}.${field}`)
-    if (Array.isArray(value)) {
-      if (value.length === 0) {
-        parts.push('1 = 0')
-        continue
-      }
-      const placeholders = value.map((item, itemIndex) => {
-        const scalar = normalizeScalar(item, `${prefix}.${field}[${itemIndex}]`)
-        if (scalar.skip) {
-          throw new SqlServerExecutorError('SQLSERVER_FILTER_INVALID', `${prefix}.${field}[${itemIndex}] must be a scalar value`, {
-            field: `${prefix}.${field}[${itemIndex}]`,
-          })
-        }
-        const paramName = `${prefix}_${index}_${itemIndex}`.replace(/[^A-Za-z0-9_]/g, '_')
-        return addInput(request, paramName, scalar.value)
-      })
-      parts.push(`${quotedField} IN (${placeholders.join(', ')})`)
-      index += 1
-      continue
-    }
-    const scalar = normalizeScalar(value, `${prefix}.${field}`)
-    if (scalar.skip) continue
-    if (scalar.value === null) {
-      parts.push(`${quotedField} IS NULL`)
-      index += 1
-      continue
-    }
-    const paramName = `${prefix}_${index}`.replace(/[^A-Za-z0-9_]/g, '_')
-    parts.push(`${quotedField} ${operator} ${addInput(request, paramName, scalar.value)}`)
-    index += 1
+  for (const field of Object.keys(values)) {
+    normalizeIdentifier(field, `${prefix}.${field}`)
   }
 }
 
 function buildSelectQuery({ request, table, columns, limit, filters, watermark, orderBy }) {
-  const safeLimit = normalizeLimit(limit)
-  const tableSql = quoteIdentifier(table, 'table')
-  const columnSql = Array.isArray(columns) && columns.length > 0
-    ? columns.map((column, index) => quoteIdentifier(column, `columns[${index}]`)).join(', ')
-    : '*'
-  const parts = []
-  appendStructuredPredicates({ request, values: filters, operator: '=', parts, prefix: 'filter' })
-  appendStructuredPredicates({ request, values: watermark, operator: '>', parts, prefix: 'watermark' })
-  const whereSql = parts.length > 0 ? ` WHERE ${parts.join(' AND ')}` : ''
-  const orderSql = orderBy ? ` ORDER BY ${quoteIdentifier(orderBy, 'orderBy')}` : ''
-  return `SELECT TOP ${safeLimit} ${columnSql} FROM ${tableSql}${whereSql}${orderSql}`
+  const k3Table = normalizeIdentifier(table, 'table')
+  const k3Columns = Array.isArray(columns) && columns.length > 0
+    ? columns.map((column, index) => normalizeIdentifier(column, `columns[${index}]`))
+    : columns
+  const k3OrderBy = orderBy ? normalizeIdentifier(orderBy, 'orderBy') : orderBy
+  assertK3PredicateIdentifiers(filters, 'filter')
+  assertK3PredicateIdentifiers(watermark, 'watermark')
+
+  try {
+    return buildSharedSimpleSelectQuery({
+      request,
+      table: k3Table,
+      columns: k3Columns,
+      limit,
+      filters,
+      watermark,
+      orderBy: k3OrderBy,
+      limitPolicy: {
+        defaultLimit: DEFAULT_MAX_LIMIT,
+        maxLimit: MAX_LIMIT,
+        overMax: 'clamp',
+      },
+    })
+  } catch (error) {
+    throw wrapHelperError(error, error && error.code ? error.code : 'SQLSERVER_QUERY_INVALID', 'invalid SQL Server query')
+  }
+}
+
+function wrapHelperError(error, fallbackCode, fallbackMessage) {
+  if (error instanceof SqlServerExecutorError) return error
+  return new SqlServerExecutorError(
+    error && typeof error.code === 'string' ? error.code : fallbackCode,
+    error && error.message ? error.message : fallbackMessage,
+    error && isPlainObject(error.details) ? error.details : {},
+  )
 }
 
 function normalizeQueryResult(result) {


### PR DESCRIPTION
## Summary

C5-3 of `docs/development/data-source-system-integration-delivery-todo-20260614.md`.

This wires the built-in K3 WISE SQL Server read-only executor to the neutral `@metasheet/mssql-readonly-utils` helper for the stable read-only MSSQL primitives:

- endpoint parsing;
- timeout / limit policy normalization;
- SQL Server identifier quoting primitive;
- structured simple `SELECT TOP ... WHERE ... ORDER BY ...` query construction.

## Guardrails

- K3 strict identifier policy remains the first gate before the helper is called: at most `schema.table`, and every segment must start with a letter or underscore.
- Tests pin that the K3 executor does **not** inherit the generic helper's wider identifier support for numeric-leading or multi-part identifiers.
- `insertMany` still throws `SQLSERVER_WRITE_EXECUTOR_DISABLED` in the built-in executor.
- No `DataSourceManager` / generic `MSSQLAdapter` dependency is added to the K3 plugin path.
- No K3 Save / Submit / Audit / BOM / generic DB write behavior is opened.

## Verification

Local:

```bash
pnpm --filter plugin-integration-core test:k3-wise-adapters
pnpm --filter plugin-integration-core test:mssql-readonly-utils
pnpm --filter @metasheet/mssql-readonly-utils test
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/mssql-adapter.test.ts tests/unit/data-source-identifier-quoting.test.ts tests/unit/mssql-readonly-utils-consumer.test.ts --reporter=dot
pnpm --filter plugin-integration-core test:host-loader
pnpm --filter plugin-integration-core test
git diff --check
```

Subagent review:

- K3 safety boundary review: no findings.
- helper/packaging/test boundary review: one P3 missing pre-gate coverage finding; fixed by adding `orderBy` / `filters` / `watermark` negative tests; re-review passed with no findings.

## Out of scope

- C5-4 TLS / schema introspection / read-only smoke alignment.
- Entity-machine K3/MSSQL smoke.
- Any K3 write expansion.
