### PR TITLE
fix(onprem): package shared MSSQL readonly helper

### DIFF
--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -30,6 +30,7 @@ REQUIRED_PATHS=(
   "apps/web/package.json"
   "packages/core-backend/dist"
   "packages/core-backend/package.json"
+  "packages/mssql-readonly-utils"
   # The packaged migration runner loads SQL migrations from
   # packages/core-backend/migrations via migration-provider.ts. Keep this
   # source directory in the package so Windows/on-prem installs apply
@@ -355,6 +356,7 @@ EOF
     "apps/web/dist",
     "packages/core-backend/dist",
     "packages/core-backend/migrations",
+    "packages/mssql-readonly-utils",
     "plugins",
     "scripts/ops",
     "docker",

--- a/scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
+++ b/scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const verifyScript = fs.readFileSync(path.join(repoRoot, 'scripts/ops/multitable-onprem-package-verify.sh'), 'utf8')
+const buildScript = fs.readFileSync(path.join(repoRoot, 'scripts/ops/multitable-onprem-package-build.sh'), 'utf8')
+
+test('on-prem verifier follows the helper-backed K3 SQL Server executor seam', () => {
+  assert.match(
+    buildScript,
+    /"packages\/mssql-readonly-utils"/,
+    'the deploy package must include the shared helper package that plugin workspace symlinks resolve to',
+  )
+  assert.match(
+    verifyScript,
+    /pnpm-workspace\.yaml.*packages\/\*/s,
+    'the verifier must lock the workspace package glob used during deploy dependency refresh',
+  )
+  assert.match(
+    verifyScript,
+    /pnpm-lock\.yaml.*link:\.\.\/\.\.\/packages\/mssql-readonly-utils/s,
+    'the verifier must lock the plugin workspace dependency link for frozen deploy installs',
+  )
+  assert.match(
+    verifyScript,
+    /core-backend package\.json.*@metasheet\/mssql-readonly-utils/s,
+    'the verifier must lock the backend runtime helper dependency',
+  )
+  assert.match(
+    verifyScript,
+    /pnpm-lock\.yaml.*link:\.\.\/mssql-readonly-utils/s,
+    'the verifier must lock the core-backend workspace dependency link for frozen deploy installs',
+  )
+  assert.match(
+    verifyScript,
+    /packages\/mssql-readonly-utils\/package\.json/,
+    'the verifier must inspect the packaged helper manifest, not only index.cjs',
+  )
+  assert.match(
+    verifyScript,
+    /"main": "index\.cjs"/,
+    'the packaged helper manifest must point runtime resolution at index.cjs',
+  )
+  assert.match(
+    verifyScript,
+    /"@metasheet\/mssql-readonly-utils"/,
+    'the packaged plugin must carry the helper as a runtime dependency',
+  )
+  assert.match(
+    verifyScript,
+    /buildSharedSimpleSelectQuery/,
+    'the K3 executor should be verified through its call into the shared bounded-select helper',
+  )
+  assert.match(
+    verifyScript,
+    /function buildSimpleSelectQuery/,
+    'the package must contain the helper bounded-select builder',
+  )
+  assert.match(
+    verifyScript,
+    /SELECT TOP.*mssql_helper/s,
+    'bounded SELECT evidence should come from the packaged helper, not stale executor-local SQL text',
+  )
+  assert.match(
+    verifyScript,
+    /SQLSERVER_WRITE_EXECUTOR_DISABLED/,
+    'K3 built-in writes must remain explicitly disabled',
+  )
+})

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -159,13 +159,27 @@ function verify_root_runtime_dependencies() {
 
 function verify_integration_plugin_runtime_dependencies() {
   local root="$1"
+  local workspace_yaml="${root}/pnpm-workspace.yaml"
+  local lockfile="${root}/pnpm-lock.yaml"
+  local core_backend_package_json="${root}/packages/core-backend/package.json"
   local plugin_package_json="${root}/plugins/plugin-integration-core/package.json"
   local sql_executor="${root}/plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs"
+  local mssql_helper_package_json="${root}/packages/mssql-readonly-utils/package.json"
+  local mssql_helper="${root}/packages/mssql-readonly-utils/index.cjs"
   local plugin_entry="${root}/plugins/plugin-integration-core/index.cjs"
 
+  search_fixed_string '"@metasheet/mssql-readonly-utils"' "$core_backend_package_json" || die "core-backend package.json must include the shared MSSQL read-only helper dependency"
   search_fixed_string '"mssql"' "$plugin_package_json" || die "plugin-integration-core package.json must include mssql for the built-in SQL Server read executor"
+  search_fixed_string '"@metasheet/mssql-readonly-utils"' "$plugin_package_json" || die "plugin-integration-core package.json must include the shared MSSQL read-only helper dependency"
+  search_fixed_string "  - 'packages/*'" "$workspace_yaml" || die "pnpm-workspace.yaml must include packages/* so workspace helper packages resolve during deploy dependency refresh"
+  search_fixed_string 'version: link:../mssql-readonly-utils' "$lockfile" || die "pnpm-lock.yaml must link core-backend to packages/mssql-readonly-utils for frozen deploy installs"
+  search_fixed_string 'version: link:../../packages/mssql-readonly-utils' "$lockfile" || die "pnpm-lock.yaml must link plugin-integration-core to packages/mssql-readonly-utils for frozen deploy installs"
+  search_fixed_string '"name": "@metasheet/mssql-readonly-utils"' "$mssql_helper_package_json" || die "shared MSSQL helper package.json must declare @metasheet/mssql-readonly-utils"
+  search_fixed_string '"main": "index.cjs"' "$mssql_helper_package_json" || die "shared MSSQL helper package.json must expose index.cjs as its runtime main"
   search_fixed_string 'createK3WiseSqlServerReadOnlyExecutor' "$sql_executor" || die "SQL Server read-only executor must be packaged"
-  search_fixed_string 'SELECT TOP' "$sql_executor" || die "SQL Server executor must build bounded read-only SELECT statements"
+  search_fixed_string 'buildSharedSimpleSelectQuery' "$sql_executor" || die "SQL Server executor must call the shared bounded read-only SELECT helper"
+  search_fixed_string 'function buildSimpleSelectQuery' "$mssql_helper" || die "shared MSSQL helper must package the bounded SELECT builder"
+  search_fixed_string 'SELECT TOP' "$mssql_helper" || die "shared MSSQL helper must build bounded read-only SELECT statements"
   search_fixed_string 'SQLSERVER_WRITE_EXECUTOR_DISABLED' "$sql_executor" || die "SQL Server executor must keep built-in writes disabled"
   search_fixed_string 'createK3WiseSqlServerChannelFactory({ queryExecutor: sqlServerQueryExecutor })' "$plugin_entry" || die "plugin runtime must inject the built-in SQL Server query executor"
 }


### PR DESCRIPTION
## Summary

- include `packages/mssql-readonly-utils` in the multitable on-prem package so the plugin workspace dependency has a real packaged target
- update package verification for the C5 helper-backed K3 SQL Server executor: verify the executor calls the shared bounded-select helper, the helper is packaged, and K3 built-in writes remain disabled
- add an ops contract test for the helper-backed package/verifier seam

## Why

The C5 K3/MSSQL smoke package workflow failed after #2668 because the verifier still searched for `SELECT TOP` inside `k3-wise-sqlserver-executor.cjs`. C5-3 moved SELECT construction into `@metasheet/mssql-readonly-utils`. Local package inspection also showed the package carried only the plugin workspace symlink, not the helper package body, so this fixes the real packaging dependency rather than just relaxing the verifier.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh`
- `node --test scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend build`
- `PACKAGE_TAG=verifier-c5-helper-local INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh`
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-verifier-c5-helper-local.tgz`
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-verifier-c5-helper-local.zip`

## Boundaries

- package/verifier only
- no runtime behavior change
- no K3 Submit/Audit/BOM/write enablement
- no credentials/raw SQL/customer values
