### PR TITLE
docs(data-source): record C5 smoke package gate

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -13,7 +13,9 @@
   read-only/source-only 边界提示、SQL bridge values-free 错误提示）。
   Large-BOM #2425 的 scoped C3/C4 实体机全链路验证已 PASS/CLOSED；Windows 短 TEMP zip 部署 caveat
   另由 #2642 跟踪，不阻塞 runtime gate。
-- 不建议: 现在直接开 C6。C6 是最大风险刀，必须等只读链路、增量链路、K3 generic seam 都稳定后再开。
+  C5 K3/MSSQL smoke harness 已发包并打开 #2670，等待实体机 values-free smoke 证据。
+- 不建议: 现在直接开 C6。C6 是最大风险刀，必须等只读链路、增量链路、K3 generic seam 都稳定后再开；
+  当前 C6 仍以 #2670 通过为前置 gate。
 
 ## 收口顺序
 
@@ -23,7 +25,7 @@
 | C2-close | 只读数据库链路 smoke 收口 | done (issue #2600) | 证明当前 read-only bridge 可稳定测试 | 实体机配置漂移 |
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
-| C5 | K3 generic MSSQL seam | C5-0/C5-1 done; C5-2+ gated | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
+| C5 | K3 generic MSSQL seam | C5-0..C5-4a done; C5-4b package published, issue #2670 pending | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
 | C6 | external write | gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
 | Release | 总包 + 实体机验收 | gated | 交付签收 | 包内容/部署/证据不完整 |
 
@@ -225,7 +227,8 @@ TODO:
 状态: C5-0 设计切片已写入 `docs/development/data-source-system-integration-c5-k3-generic-mssql-seam-design-20260615.md`；
 C5-1 latent helper contract 已落地为 `@metasheet/mssql-readonly-utils`；C5-2 已把 generic `MSSQLAdapter`
 的 endpoint/TLS/identifier 稳定面接到 helper；C5-3 已把 K3 default SQL Server executor 的 endpoint/timeout/limit/simple-select
-接到 helper，同时保留 K3 strict identifier/read/write guard。C5-4 保持后续 gated opt-in。
+接到 helper，同时保留 K3 strict identifier/read/write guard。C5-4a smoke harness 已落地，#2669 修复了 helper-backed
+executor 的 on-prem package/verifier seam。C5-4b 实体机 smoke 已发包并打开 #2670，等待实体机 evidence。
 
 边界:
 
@@ -275,7 +278,20 @@ TODO:
     跑 values-free `testConnection` + bounded read。
   - 新增 C5 K3/MSSQL smoke runbook，明确 generic `smoke:sqlserver` 负责 schema introspection，K3 smoke 负责
     `erp:k3-wise-sqlserver` test/select。
+- [x] C5 package/verifier seam for helper-backed K3 executor。
+  - #2669 / squash `8cd6ca7ef`.
+  - on-prem package 现在包含 `packages/mssql-readonly-utils` 本体，而不是只留下
+    `plugin-integration-core/node_modules/@metasheet/mssql-readonly-utils` workspace symlink。
+  - package verifier 锁住 backend/plugin 两侧 runtime dependency、`pnpm-lock.yaml` workspace link、
+    helper `package.json` 的 `name/main`、helper bounded `SELECT TOP` builder、以及 K3
+    `SQLSERVER_WRITE_EXECUTOR_DISABLED` marker。
+  - 这是 C5-4b 发包前置修复；不改变 runtime 行为、不打开任何 K3 写能力。
 - [ ] C5-4b: 实体机 K3/MSSQL smoke。
+  - issue: #2670 `[Data Source] C5 K3/MSSQL entity-machine smoke gate`。
+  - release: `multitable-onprem-datasource-c5-k3-mssql-smoke-20260615-8cd6ca7ef`。
+  - package: `metasheet-multitable-onprem-v2.5.0-datasource-c5-k3-mssql-smoke-20260615-8cd6ca7ef`。
+  - package verify: assetCount=10；`SHA256SUMS` OK；tgz/zip verify `ok=true`
+    with `checksum,required-content,deployability-contract,no-github-links`。
   - 同一批准环境中运行 generic SQL Server smoke + K3 SQL Server executor smoke。
   - 只回传 package fingerprint、status、TLS knob 名称/布尔、operator-configured object/table 名、计数；
     不回传 credentials、connection string、raw SQL、row values、K3 payload。


### PR DESCRIPTION
## Summary

- record #2669 as the C5 package/verifier seam fix for the helper-backed K3 SQL Server executor
- record the published C5 K3/MSSQL smoke package and #2670 entity-machine smoke gate
- keep C5-4b pending on entity-machine values-free evidence and keep C6 gated on #2670

## Verification

- `rg -n "#2670|8cd6ca7ef|C5-4b|C6|multitable-onprem-datasource-c5" docs/development/data-source-system-integration-delivery-todo-20260614.md`
- `git diff --check`
- subagent review: no findings

## Boundaries

- docs-only
- no runtime change
- does not mark C5 complete
- does not open C6 external write
