### PR TITLE
feat(multitable): per-field (column-level) restore — backend

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5650,12 +5650,15 @@ export function univerMetaRouter(): Router {
     const schema = z.object({
       targetVersion: z.number().int().positive(),
       expectedVersion: z.number().int().nonnegative(),
+      // Per-field (column-level) restore: optional subset of field ids. Omitted → restore the whole
+      // restorable diff (full-record). Present → restrict to those fields (still atomic over the subset).
+      fieldIds: z.array(z.string().min(1)).min(1).optional(),
     })
     const parsed = schema.safeParse(req.body)
     if (!parsed.success) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
     }
-    const { targetVersion, expectedVersion } = parsed.data
+    const { targetVersion, expectedVersion, fieldIds } = parsed.data
 
     const asRecord = (value: unknown): Record<string, unknown> => {
       if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
@@ -5791,8 +5794,14 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      // Lock B: gate every diff field on BOTH the static guard and restore's own layer-3 pre-check.
-      const hasForbidden = diff.some((ch) => {
+      // Per-field (column-level) restore: when the caller passes `fieldIds`, restrict the diff to that
+      // selection. The atomic gate below then runs over only the selected subset — so a user can restore
+      // the writable fields they picked even if another changed field in the revision is forbidden. A
+      // requested field that is unchanged / non-restorable / unknown simply isn't in the diff (no error).
+      const selectedDiff = fieldIds ? diff.filter((ch) => fieldIds.includes(ch.fieldId)) : diff
+
+      // Lock B: gate every (selected) diff field on BOTH the static guard and restore's own layer-3 pre-check.
+      const hasForbidden = selectedDiff.some((ch) => {
         const guard = fieldById.get(ch.fieldId)
         const perm = fieldPermissions[ch.fieldId]
         const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
@@ -5806,9 +5815,9 @@ export function univerMetaRouter(): Router {
         return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: 'Not permitted to restore one or more fields in this revision' } })
       }
 
-      const restoredFieldIds = diff.map((ch) => ch.fieldId)
+      const restoredFieldIds = selectedDiff.map((ch) => ch.fieldId)
       // No-op: nothing to restore (concurrency already verified above).
-      if (diff.length === 0) {
+      if (selectedDiff.length === 0) {
         return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [], skippedFieldIds: [] } })
       }
 
@@ -5822,7 +5831,7 @@ export function univerMetaRouter(): Router {
       try {
         const result = await recordWriteService.patchRecords({
           sheetId,
-          changesByRecord: new Map([[recordId, diff]]),
+          changesByRecord: new Map([[recordId, selectedDiff]]),
           actorId: getRequestActorId(req),
           fields,
           visiblePropertyFields: readableEchoFields,

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -546,4 +546,51 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     const after = await q('SELECT count(*)::int AS n FROM meta_record_revisions WHERE record_id = $1', [rid])
     expect((after.rows[0] as { n: number }).n).toBe((before.rows[0] as { n: number }).n)
   })
+
+  // ---- Per-field (column-level) restore ----
+  test('T15: fieldIds restores ONLY the selected fields; unselected fields are untouched', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_B]: 'b2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_B]: 'b1' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_B]: 'b2' } }],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_A] })
+    expect(res.status).toBe(200)
+    expect(res.body.data.restoredFieldIds).toEqual([FLD_A])
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('a1') // restored
+    expect(data[FLD_B]).toBe('b2') // NOT selected → untouched
+  })
+
+  test('T16: per-field lets you restore the writable field you picked even when another diff field is forbidden', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' } }],
+    )
+    testUserId = USER_RO // read_only on SECRET
+    // full restore would be RESTORE_FORBIDDEN (SECRET differs + is forbidden)…
+    const full = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(full.status).toBe(403)
+    // …but selecting only the writable field A succeeds (SECRET not in the gated subset)
+    const partial = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_A] })
+    expect(partial.status).toBe(200)
+    expect(partial.body.data.restoredFieldIds).toEqual([FLD_A])
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('a1') // restored
+    expect(data[FLD_SECRET]).toBe('sec_now') // forbidden field untouched
+  })
+
+  test('T17: fieldIds selecting an unchanged/unknown field is a no-op (nothing in the gated subset)', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_B]: 'b2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_B]: 'b2' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_B]: 'b2' } }],
+    )
+    // B is unchanged between v1 and current; selecting only B → empty diff → no-op
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_B] })
+    expect(res.status).toBe(200)
+    expect(res.body.data.noop).toBe(true)
+    expect((await liveData(rid))[FLD_A]).toBe('a2') // A unchanged (not selected)
+  })
 })

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -13061,6 +13061,17 @@ paths:
                   description: >-
                     Optimistic-concurrency token; must equal the current server
                     version.
+                fieldIds:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: string
+                  description: >-
+                    Optional per-field (column-level) restore. When provided,
+                    only these fields are restored (still atomic over the
+                    subset); omitted = full-record restore. A requested field
+                    that is unchanged / non-restorable / unknown is simply not
+                    restored.
               required:
                 - targetVersion
                 - expectedVersion

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -19818,6 +19818,14 @@
                     "type": "integer",
                     "minimum": 0,
                     "description": "Optimistic-concurrency token; must equal the current server version."
+                  },
+                  "fieldIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional per-field (column-level) restore. When provided, only these fields are restored (still atomic over the subset); omitted = full-record restore. A requested field that is unchanged / non-restorable / unknown is simply not restored."
                   }
                 },
                 "required": [

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -13061,6 +13061,17 @@ paths:
                   description: >-
                     Optimistic-concurrency token; must equal the current server
                     version.
+                fieldIds:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: string
+                  description: >-
+                    Optional per-field (column-level) restore. When provided,
+                    only these fields are restored (still atomic over the
+                    subset); omitted = full-record restore. A requested field
+                    that is unchanged / non-restorable / unknown is simply not
+                    restored.
               required:
                 - targetVersion
                 - expectedVersion

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -478,6 +478,14 @@ paths:
                   type: integer
                   minimum: 0
                   description: Optimistic-concurrency token; must equal the current server version.
+                fieldIds:
+                  type: array
+                  minItems: 1
+                  items: { type: string }
+                  description: >-
+                    Optional per-field (column-level) restore. When provided, only these fields are
+                    restored (still atomic over the subset); omitted = full-record restore. A requested
+                    field that is unchanged / non-restorable / unknown is simply not restored.
               required: [targetVersion, expectedVersion]
       responses:
         '200':


### PR DESCRIPTION
Opens the **deferred Gate** from the Layer 1 design lock (Lock B: "per-field partial restore is a separate future Gate"). Independent backend slice on `main` (Slice 1 + 2a + retention already landed).

## What
`POST /api/multitable/sheets/:sheetId/records/:recordId/restore` takes an optional **`fieldIds`** array:
- **omitted** → full-record restore (unchanged behavior).
- **present** → the restorable diff is filtered to that selection, and the atomic Lock-B gate runs over **only the subset**. So a user can restore the writable fields they picked **even if another changed field in the revision is forbidden** (the key per-field win). A requested field that is unchanged / non-restorable / unknown is simply not restored (no error).

Atomicity, no-op, concurrency, Lock A/B/C/D all unchanged — `fieldIds` only narrows the diff before gating.

## Verification (local, real Postgres)
- `tsc --noEmit` 0 errors
- restore matrix **26/26** — T15 (selective restore, others untouched), T16 (restore writable pick while another diff field is forbidden), T17 (unchanged selection → no-op)
- OpenAPI + parity green

## Follow-up
Frontend per-field checkboxes (drawer history item → select fields → send `fieldIds`) is a stacked FE PR, verified at unit/component level + manual QA (same wire-QA boundary as #2662).

🤖 Generated with [Claude Code](https://claude.com/claude-code)