### PR TITLE
feat(multitable): comment emoji reactions — storage + API (B6-a)

### DIFF
--- a/docs/development/multitable-comment-reactions-b6a-dev-verification-20260615.md
+++ b/docs/development/multitable-comment-reactions-b6a-dev-verification-20260615.md
@@ -1,0 +1,60 @@
+# 多维表评论 Emoji 反应 B6-a — 开发 & 校验 — 2026-06-15
+
+> Status: **DONE + VERIFIED（autonomous 后端半）**。B6 弧的 autonomous 半 = 反应存储 + API，本文记录其开发与校验。emoji picker UI + 实时广播 = B6-b（browser-gated，待具名 opt-in）。
+>
+> 设计锁：`multitable-comment-reactions-b6s0-designlock-20260615.md`（三处关键分叉经 advisor 复核为有意决策）。grounded：评论子系统逐文件核验 + dynamic workflow `wf_c8626e35-f6f` 五路并行 map。
+
+## 1. 开发（做了什么）
+
+| 层 | 文件 | 改动 |
+|---|---|---|
+| 迁移 | `db/migrations/zzzz20260615190000_create_meta_comment_reactions.ts`（新） | `meta_comment_reactions(comment_id, user_id, emoji, created_at, PRIMARY KEY(comment_id,user_id,emoji))` + `idx ON (comment_id)`；镜像 `meta_comment_reads`；无 FK（评论子域约定）；自动发现，无注册 |
+| kysely 类型 | `db/types.ts` | `MetaCommentReactionsTable` + 在 `Database` 注册 `meta_comment_reactions` |
+| 契约 | `di/identifiers.ts` | `CommentReactionSummary {emoji,count,reactedByMe}`；`CommentRecord.reactions?`；`CommentQueryOptions.viewerId?`；`ICommentService` 加 `addReaction`/`removeReaction` |
+| 服务 | `services/CommentService.ts` | `COMMENT_REACTION_EMOJIS` 白名单常量 + 导出的 `normalizeCommentReactionEmoji`（NFC+白名单）；`addReaction`（insert + `onConflict.doNothing` 幂等，先校验 emoji 再 `getRequiredCommentRow` 404）；`removeReaction`（按 user_id 自作用域删，幂等）；`listReactionsForComments`（空 ids 短路、`group by comment_id,emoji`、`count`、`bool_or(user_id=viewer)`）；`getComments` 末尾挂 `reactions`（新增 `viewerId` 入 options）；`deleteComment` 事务内级联删反应 |
+| 路由 | `routes/comments.ts` | `POST /api/comments/:commentId/reactions {emoji}` + `DELETE …/reactions {emoji}`（emoji 入 body）；`rbacGuard('comments','write')`；`getComments` 传 `viewerId=getUserId(req)`；错误经 `respondCommentError` 映射 |
+
+## 2. 三处关键决策（advisor 复核，详见设计锁 §3）
+
+1. **权限闸 = `comments:write`**（非 `read`）。反应是署名、持久、对他人可见的产物 = 创建桶，与 `createComment` 同闸。可逆性不对称（write→read 放宽兼容；read→write 收紧是破坏性变更 + 期间已让只读用户写数据）。自作用域：行以 actor `user_id` 为键，删按 `user_id=actor` 过滤，用户只能动自己的反应。最初我按 mark-read 类比误选 `read`，被 advisor + workflow 权限路双双纠正。
+2. **emoji 白名单 = 代码常量，非 DB CHECK**。emoji 是展示 token（非法值仅"长得怪"，无正确性/安全影响），调色板 UX 驱动会变；DB CHECK 会让每次微调变迁移+sync-test（本会话刚在 action-type 上付过此成本）。
+3. **DELETE 的 emoji 入 body + NFC 归一 + 删除测试走真实 HTTP wire**。`❤️`=❤+U+FE0F；emoji 入 path 会因编码/NFC 漂移让删除匹配零行。对策：body 传参绕开 path 编码 + 加删共用 `normalizeCommentReactionEmoji`(NFC) 使存储字节一致 + 真实路由删除测试。
+
+## 3. 校验（怎么证的）
+
+| 校验项 | 结果 |
+|---|---|
+| 后端 `tsc --noEmit` | exit 0 |
+| 后端**全量** unit 套件 `tests/unit` | **3320 passed / 262 files**（di/types 广引用，零回归；日志中的 error 均为故意负路径探针） |
+| 新增 `comment-reactions.test.ts`（mock DB + 纯函数） | **16 passed** |
+| 既有 5 个评论套件（mock） | 118 passed（getComments/deleteComment/Comment 改动无回归） |
+| **真实 PG + 真实 HTTP** 反应流（`comments.api.test.ts` 新测，本地 metasheet_test 实跑） | **PASS** |
+| 其余 comments.api 既有用例本地失败 | **环境性**（本地 metasheet_test 未全量迁移）；stash 我的改动后同样失败 → 证非我引入；CI 绿 main 上它们通过 |
+
+### 3.1 真实 wire 反应测试覆盖（advisor 反漂移要点）
+
+`adds, aggregates, idempotently re-adds, and removes comment reactions (real wire, multi-codepoint emoji)`：userA 加 `❤️`(多码点) → 幂等重加（仍 1 行）→ userB 加 → 列出聚合 `{emoji:'❤️',count:2,reactedByMe:true}` → 非白名单 `💩` → **400** → **userA 经真实 DELETE wire 删 `❤️` → 204 → 直接查 DB 确认该行已删**（仅剩 userB）→ 聚合变 `count:1,reactedByMe:false`。这是"in-process service 调用会 false-green、真实 HTTP 路才暴露"的反漂移关键覆盖。
+
+### 3.2 纯函数 NFC 守卫直测
+
+`normalizeCommentReactionEmoji`：白名单各 emoji round-trip 为 NFC 形；trim 空白；`❤️` 多码点归一幂等；非白名单/裸 `❤`/空/非串 → `CommentValidationError`。加与删共用此函数 → 存储字节天然一致（结构性消除漂移，非靠测试绕过）。
+
+### 3.3 幂等与级联
+
+幂等：PK `(comment_id,user_id,emoji)` + `ON CONFLICT DO NOTHING`（真实 wire 测重加证 count 不变）。级联：`deleteComment` 事务内追加 `deleteFrom('meta_comment_reactions')`（无 DB FK，应用层级联，与既有 reads 级联同款）。
+
+### 3.4 残余（诚实记录，均不阻塞）
+
+- **`comments:write` 闸无独测**：唯一的真实-wire 套件以 `RBAC_BYPASS='true'` 运行，故无用例直接验证 write 闸、也无回归守卫防它被改回 `read`。代码中此闸正确（与 `createComment` 同款、显见无误），且不劣于既有规范（`createComment` 的闸本身也无单独 gate 测）。记此为本切片最高风险行无测试守卫——B6-b 接真客户端时可补一条 reader-only token → 403 的用例。
+- **迁移文件本身未在测试中执行**：真实-wire 集成测经 `ensureCommentsTables` 用自带 DDL 建表，非走迁移文件。迁移与 reads 迁移近乎逐字相同（风险低），由 CI `migration-replay` 在 fresh PG 实跑验证（落地前已确认 `migration-replay` 绿、非 skipped）。
+- **B6-b 部署路提示**：DELETE 走 body 在本系统正确（Express 解析、测试已证），但部分 API 网关/CDN 会剥离 DELETE 请求体——B6-b 接真客户端时需确认部署链路无此行为，否则 `removeReaction` 会静默 no-op。属部署路问题、非代码问题。
+
+## 4. Goal 边界（诚实）
+
+- ✅ **B6-a（反应存储 + API）= autonomous 后端半，done + verified。**
+- ⏸ **B6-b（emoji picker UI + 实时广播 + i18n）= browser-gated，本弧不做**：picker 的 configure→render→click 真路径 + 视觉/交互目检需真浏览器，jsdom 证不了；实时广播随 picker 落（后端已把持久化/聚合做正确，事件层不留半成品）。
+- B6-b 待具名 opt-in（staged-opt-in lineage 纪律）。
+
+## 5. 落地
+
+B6-S0 设计锁 + B6-a（迁移 + types + di + service + 路由 + 单测 + 真实-wire 集成测）+ 本开发&校验记录，单 PR。CI `migration-replay` 在 fresh PG 验迁移；`test (18.x/20.x)` 验单测 + tsc。

--- a/docs/development/multitable-comment-reactions-b6s0-designlock-20260615.md
+++ b/docs/development/multitable-comment-reactions-b6s0-designlock-20260615.md
@@ -1,0 +1,73 @@
+# 多维表评论 Emoji 反应 — B6-S0 设计锁 — 2026-06-15
+
+> Status: **DESIGN-LOCK**（新弧 B6，owner 已 opt-in 2026-06-15「按建议执行」）。本弧的 autonomous 半 = **反应存储 + API**（后端，单测/真实 DB 可闭环）；emoji picker UI = B6-b（browser-gated，本弧不做）。realtime 广播随 picker 落（本弧推迟）。
+>
+> 方法：grounded against `origin/main`（评论子系统逐文件核验 + dynamic workflow `wf_c8626e35-f6f` 五路并行 map）；三处关键分叉经 advisor 复核后**作为有意决策**记录于 §3。
+
+## 1. 范围（切片）
+
+- **B6-a（本弧 autonomous）**：`meta_comment_reactions` 存储 + `addReaction/removeReaction` service + 聚合读 + 两个路由 + 删评论级联 + 单测/集成测。
+- **B6-b（browser-gated，推迟）**：emoji picker UI + 实时广播 + i18n 标签。
+- **非目标**：反应通知/收件箱集成、反应权限细分、自定义 emoji、跨表反应。
+
+## 2. 存储（镜像 `meta_comment_reads` 先例）
+
+迁移 `zzzz20260615190000_create_meta_comment_reactions.ts`（自动发现，无需注册；命名排在既有评论迁移之后）：
+
+```sql
+CREATE TABLE IF NOT EXISTS meta_comment_reactions (
+  comment_id text NOT NULL,
+  user_id    text NOT NULL,
+  emoji      text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (comment_id, user_id, emoji)
+);
+CREATE INDEX IF NOT EXISTS idx_meta_comment_reactions_comment
+  ON meta_comment_reactions(comment_id);
+```
+
+- 三元组主键 = 同一用户对同一评论同一 emoji 只一行 → **加 = 幂等**（`ON CONFLICT (comment_id,user_id,emoji) DO NOTHING`）；一个用户可对同一评论加多个不同 emoji。
+- **无 FK**（遵从评论子域全程无 FK 的既有约定；级联在应用层做，见 §4）。
+- kysely 类型：`db/types.ts` 加 `MetaCommentReactionsTable { comment_id: string; user_id: string; emoji: string; created_at: CreatedAt }` + 在 `Database` 接口注册 `meta_comment_reactions`。
+- 迁移**不**需 lockfile / sync-test 改动（仅依赖既有 kysely；无 DB 枚举约束，见 §3.2）。
+
+## 3. 三处关键决策（advisor 复核，有意而非沿袭类比）
+
+### 3.1 权限闸 = `comments:write`（非 `read`）
+
+反应是**署名、持久、对他人可见的产物** → 属"创建评论"桶，非"已读回执"桶。可逆性不对称：以 `write` 上线后放宽到 `read` 向后兼容；以 `read` 上线后收紧到 `write` 是破坏性变更、且期间已让只读用户写了不该写的数据。故 `rbacGuard('comments', 'write')`，与 `createComment` 一致（workflow 权限路也指明 `comments:write`）。
+
+自作用域安全：反应行以 actor 的 `user_id` 为键，`removeReaction` 按 `user_id = actor` 过滤 → 用户只能加/删**自己**的反应，无法动他人的。`addReaction` 经 `getRequiredCommentRow` 校验评论存在（不存在 → 404），与 `createComment`/`deleteComment` 同款（评论子系统的授权模型是粗粒度 capability，本弧不引入也不回退 per-sheet ACL）。
+
+### 3.2 emoji 白名单 = 代码常量，**不用 DB CHECK 约束**
+
+存在 `chk_automation_action_type` 这一 DB-CHECK + drift-guard sync-test 先例，但那适用于 action-type（executor 据以派发的**协议枚举**，非法值=bug/安全洞）。emoji 是**展示 token**：非法值仅"长得怪"，无正确性/安全影响，且调色板是 UX 驱动、会变。DB CHECK 会让每次调色板微调都变成迁移 + sync-test（本会话刚在 action-type 上付过这笔记账成本）。故白名单放服务端常量 `COMMENT_REACTION_EMOJIS`，未知 emoji → `CommentValidationError`(400)；将来若要放开自定义 emoji，删一处校验即可、零迁移。无 DB 枚举 → 无 drift-test 需求，仅单测「服务端拒非白名单 emoji」。
+
+### 3.3 DELETE 的 emoji 走**请求体**，不走 path 参数；删除测试走真实 HTTP wire
+
+`❤️` = ❤ + U+FE0F（变体选择符）。emoji 入 URL path 参数时，客户端编码与服务端解码间任何 NFC/NFD 或变体符差异会让 `DELETE … WHERE emoji = $1` 匹配零行 → 反应删不掉（典型 wire-vs-fixture 漂移：in-process 调 `removeReaction` 的单测过、真实 HTTP 路却丢行）。对策三重：(a) DELETE 的 emoji 入 **请求体**（Express 允许 DELETE-with-body），与 POST 对称、绕开 path 编码；(b) service 在加/删/校验前对 emoji 做 `.normalize('NFC')`，存储规范化；(c) 删除有一条**经真实路由**的集成测（编码→路由→断言行已删）。
+
+## 4. Service / 路由契约
+
+Service（`CommentService.ts`，kysely）：
+- `addReaction(commentId, userId, emoji)`: normalizeUserId → NFC-normalize emoji → 白名单校验(否则 `CommentValidationError`) → `getRequiredCommentRow`(否则 `CommentNotFoundError`) → `insertInto('meta_comment_reactions').values({...,created_at: now}).onConflict(oc => oc.columns(['comment_id','user_id','emoji']).doNothing())`。
+- `removeReaction(commentId, userId, emoji)`: normalizeUserId → NFC-normalize → 白名单校验 → `deleteFrom('meta_comment_reactions').where(all three)`（删不存在 = no-op，幂等）。
+- `listReactionsForComments(commentIds, viewerId?)`: **空 ids → 立即返回空 Map**（避免 `IN ()` 语法错 500）；否则 `select comment_id, emoji, count(*) as count, bool_or(user_id = viewer) as reacted_by_me ... group by comment_id, emoji order by emoji`，返回 `Map<commentId, {emoji,count,reactedByMe}[]>`。
+- `getComments` 末尾按返回的评论 id 调上者并把 `reactions` 挂到每条（镜像 inbox 挂 reads 的方式）；新增可选 `viewerId` 入 `CommentQueryOptions`，路由传 `getUserId(req)`。
+- `deleteComment` 事务内追加 `trx.deleteFrom('meta_comment_reactions').where('comment_id','=',commentId)`（应用层级联，§2 无 FK）。
+
+DTO：`Comment`（service）+ `CommentRecord`（di）加 `reactions?: CommentReactionSummary[]`；新增 `CommentReactionSummary { emoji: string; count: number; reactedByMe: boolean }`。`ICommentService` 加 `addReaction`/`removeReaction` 签名。
+
+路由（`routes/comments.ts`，信封 `{ok,data,error}`，错误经 `respondCommentError` 映射）：
+- `POST /api/comments/:commentId/reactions`，`rbacGuard('comments','write')`，body `{ emoji: string }` → `addReaction(commentId, getUserId(req), emoji)` → `201 {ok:true,data:{}}`。
+- `DELETE /api/comments/:commentId/reactions`，`rbacGuard('comments','write')`，body `{ emoji: string }` → `removeReaction(...)` → `204`。
+
+## 5. 验证计划
+
+- 单测（`comment-service.test.ts` 或新 `comment-reactions.test.ts`，真实 PG）：加→持久；幂等（加两次=1 行）；删；删不存在=no-op；非白名单 emoji→`CommentValidationError`；缺评论→`CommentNotFoundError`；`getComments` 返回聚合 `{emoji,count,reactedByMe}`，count 正确、reactedByMe 随 viewer 变；`deleteComment` 后反应行清零；空 ids 聚合不炸。
+- 集成（`comments.api.test.ts`，真实 HTTP）：POST 加（write 闸：无 write 能力→403）；**DELETE 经真实路由删 `❤️`（多码点）后断言行已删**（§3.3 反漂移）；envelope/status 契约。
+- `tsc` 干净；CI `test (18.x/20.x)`（含 migration-replay 在真实 PG 跑新迁移）。
+
+## 6. 落地
+
+B6-S0（本设计锁，docs）→ B6-a（迁移 + types + service + 路由 + di + 测）。B6-b（picker + realtime + i18n）browser-gated，待具名 opt-in。

--- a/packages/core-backend/src/db/migrations/zzzz20260615190000_create_meta_comment_reactions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260615190000_create_meta_comment_reactions.ts
@@ -1,0 +1,32 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+// B6-a: per-user-per-emoji comment reactions. Mirrors meta_comment_reads
+// (composite PK, timestamptz, no surrogate id, NO foreign key — the comments
+// sub-domain enforces cascade at the application layer in CommentService).
+// The (comment_id, user_id, emoji) primary key makes "add reaction" idempotent
+// (INSERT ... ON CONFLICT DO NOTHING) and lets a user attach several distinct
+// emojis to one comment. The emoji palette is validated by a code-level
+// allowlist in CommentService, NOT a DB CHECK constraint (an emoji is a display
+// token, not a protocol enum — see design-lock B6-S0 §3.2).
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_comment_reactions (
+      comment_id text NOT NULL,
+      user_id text NOT NULL,
+      emoji text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (comment_id, user_id, emoji)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_comment_reactions_comment
+    ON meta_comment_reactions(comment_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_comment_reactions_comment`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_comment_reactions`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -108,6 +108,7 @@ export interface Database {
   meta_links: MetaLinksTable
   meta_comments: MetaCommentsTable
   meta_comment_reads: MetaCommentReadsTable
+  meta_comment_reactions: MetaCommentReactionsTable
   meta_dashboards: MetaDashboardsTable
   meta_widgets: MetaWidgetsTable
   // Multitable automation & dashboard
@@ -703,6 +704,13 @@ export interface MetaCommentReadsTable {
   comment_id: string
   user_id: string
   read_at: UpdatedAt
+  created_at: CreatedAt
+}
+
+export interface MetaCommentReactionsTable {
+  comment_id: string
+  user_id: string
+  emoji: string
   created_at: CreatedAt
 }
 

--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -178,6 +178,21 @@ export interface CommentQueryOptions {
     limit?: number;
     /** Pagination offset (default 0). */
     offset?: number;
+    /**
+     * The viewing user, used only to compute `reactedByMe` on each comment's
+     * reaction summary. Omitted → `reactedByMe` is false for all reactions.
+     */
+    viewerId?: string;
+}
+
+/** Aggregated emoji-reaction summary attached to a comment (B6). */
+export interface CommentReactionSummary {
+    /** The reaction emoji (NFC-normalized). */
+    emoji: string;
+    /** How many distinct users reacted with this emoji. */
+    count: number;
+    /** Whether the requesting viewer is one of them. */
+    reactedByMe: boolean;
 }
 
 /**
@@ -258,6 +273,12 @@ export interface CommentRecord {
     updatedAt: string;
     /** User IDs mentioned in this comment. */
     mentions: string[];
+    /**
+     * Aggregated emoji reactions on this comment (B6). Present on list responses
+     * (`getComments`); each entry is one emoji with its total count and whether
+     * the viewer reacted. Undefined when reactions were not hydrated.
+     */
+    reactions?: CommentReactionSummary[];
 }
 
 /** An inbox entry extends CommentRecord with read/mention state and navigation context. */
@@ -365,6 +386,19 @@ export interface ICommentService {
      */
     getUnreadSummary(userId: string): Promise<CommentUnreadSummary>;
     markCommentRead(commentId: string, userId: string): Promise<void>;
+    /**
+     * Add an emoji reaction by `userId` to a comment (B6). Idempotent: re-adding
+     * the same (comment, user, emoji) is a no-op. Rejects emojis outside the
+     * server allowlist (CommentValidationError) and missing comments
+     * (CommentNotFoundError).
+     */
+    addReaction(commentId: string, userId: string, emoji: string): Promise<void>;
+    /**
+     * Remove `userId`'s emoji reaction from a comment (B6). Idempotent: removing
+     * a reaction that does not exist is a no-op. A user can only remove their
+     * own reaction (the row is keyed by user_id).
+     */
+    removeReaction(commentId: string, userId: string, emoji: string): Promise<void>;
     getCommentPresenceSummary(
       spreadsheetId: string,
       rowIds?: string[],

--- a/packages/core-backend/src/routes/comments.ts
+++ b/packages/core-backend/src/routes/comments.ts
@@ -151,6 +151,8 @@ export function commentsRouter(injector?: Injector): Router {
         resolved: parsed.data.resolved,
         limit,
         offset,
+        // B6: lets getComments compute reactedByMe on each comment's reactions.
+        viewerId: getUserId(req),
       }
       const result = await commentService.getComments(spreadsheetId, options)
       return res.json({ ok: true, data: { items: result.items, total: result.total, limit, offset } })
@@ -388,6 +390,48 @@ export function commentsRouter(injector?: Injector): Router {
     } catch (error) {
       logger.error('Failed to mark comment as read', error as Error)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to mark comment as read' } })
+    }
+  })
+
+  // B6 reactions. Gate = comments:write (a reaction is an attributed, persistent,
+  // visible artifact = create-bucket, like createComment — NOT a read-receipt).
+  // The emoji travels in the BODY for both add and remove (Express allows a
+  // DELETE body) to sidestep multi-codepoint path-encoding drift (e.g. `❤️`).
+  router.post('/api/comments/:commentId/reactions', rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
+    const commentId = req.params.commentId
+    if (!commentId || commentId.trim().length === 0) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'commentId required' } })
+    }
+    const parsed = z.object({ emoji: z.string().min(1) }).safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    try {
+      await commentService.addReaction(commentId, getUserId(req), parsed.data.emoji)
+      return res.status(201).json({ ok: true, data: {} })
+    } catch (error) {
+      logger.error('Failed to add comment reaction', error as Error)
+      return respondCommentError(res, error, 'Failed to add comment reaction')
+    }
+  })
+
+  router.delete('/api/comments/:commentId/reactions', rbacGuard('comments', 'write'), async (req: Request, res: Response) => {
+    const commentId = req.params.commentId
+    if (!commentId || commentId.trim().length === 0) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'commentId required' } })
+    }
+    const parsed = z.object({ emoji: z.string().min(1) }).safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    try {
+      await commentService.removeReaction(commentId, getUserId(req), parsed.data.emoji)
+      return res.status(204).end()
+    } catch (error) {
+      logger.error('Failed to remove comment reaction', error as Error)
+      return respondCommentError(res, error, 'Failed to remove comment reaction')
     }
   })
 

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -7,6 +7,7 @@ import {
   type CommentMentionCandidate,
   type CommentPresenceViewer,
   type CommentQueryOptions,
+  type CommentReactionSummary,
   type CommentUnreadSummary,
 } from '../di/identifiers'
 import type { CollabService } from './CollabService'
@@ -14,6 +15,36 @@ import { db } from '../db/db'
 import { nowTimestamp } from '../db/type-helpers'
 import { buildCommentInboxRoom, buildCommentRecordRoom, buildCommentSheetRoom } from './commentRooms'
 import { notifyRecordSubscribersWithKysely } from '../multitable/record-subscription-service'
+
+/**
+ * Server-side emoji allowlist for comment reactions (B6, design-lock §3.2).
+ * An emoji is a display token, not a protocol enum, so the palette is validated
+ * here in code (reject unknown → 400) rather than via a DB CHECK constraint —
+ * extending it is a one-line change, no migration. Authored in NFC so the
+ * membership check (which NFC-normalizes input) is consistent.
+ */
+export const COMMENT_REACTION_EMOJIS = [
+  '👍', '👎', '❤️', '😄', '🎉', '😮', '😢', '🚀',
+] as const
+
+const COMMENT_REACTION_EMOJI_SET: ReadonlySet<string> = new Set(
+  COMMENT_REACTION_EMOJIS.map((e) => e.normalize('NFC')),
+)
+
+/**
+ * Validate + NFC-normalize a reaction emoji (B6, design-lock §3.3). NFC makes
+ * storage canonical so a later remove (which normalizes too) always matches the
+ * stored bytes — this is the structural guard against the multi-codepoint trap
+ * (e.g. `❤️` = ❤ + U+FE0F). Throws CommentValidationError on an emoji outside
+ * the server allowlist. Exported for direct unit testing of the guard.
+ */
+export function normalizeCommentReactionEmoji(emoji: string): string {
+  const normalized = (typeof emoji === 'string' ? emoji : '').normalize('NFC').trim()
+  if (!normalized || !COMMENT_REACTION_EMOJI_SET.has(normalized)) {
+    throw new CommentValidationError('Unsupported reaction emoji')
+  }
+  return normalized
+}
 
 export class CommentValidationError extends Error {
   constructor(message: string) {
@@ -55,6 +86,8 @@ export interface Comment {
   createdAt: string
   updatedAt: string
   mentions: string[]
+  /** Aggregated emoji reactions (B6); populated by getComments, else undefined. */
+  reactions?: CommentReactionSummary[]
 }
 
 export interface CommentPresenceSummary {
@@ -187,6 +220,8 @@ export class CommentService {
 
     await db.transaction().execute(async (trx) => {
       await trx.deleteFrom('meta_comment_reads').where('comment_id', '=', commentId).execute()
+      // B6: app-level cascade (no DB FK in the comments sub-domain).
+      await trx.deleteFrom('meta_comment_reactions').where('comment_id', '=', commentId).execute()
       await trx.deleteFrom('meta_comments').where('id', '=', commentId).execute()
     })
 
@@ -343,7 +378,18 @@ export class CommentService {
 
     const rows = await query.selectAll().orderBy('created_at', 'asc').limit(limit).offset(offset).execute()
 
-    return { items: rows.map((row) => this.mapRowToComment(row)), total }
+    const items = rows.map((row) => this.mapRowToComment(row))
+    // Hydrate emoji reactions (B6). Single grouped query over the page's ids;
+    // reactedByMe uses the optional viewer. Empty page → no query (guarded).
+    const reactionsByComment = await this.listReactionsForComments(
+      items.map((c) => c.id),
+      options?.viewerId,
+    )
+    for (const item of items) {
+      item.reactions = reactionsByComment.get(item.id) ?? []
+    }
+
+    return { items, total }
   }
 
   async listMentionCandidates(
@@ -526,6 +572,84 @@ export class CommentService {
         }),
       )
       .execute()
+  }
+
+  /**
+   * Add an emoji reaction (B6). Idempotent via the (comment_id,user_id,emoji)
+   * primary key + ON CONFLICT DO NOTHING. Mirrors markCommentRead's upsert shape.
+   */
+  async addReaction(commentId: string, userId: string, emoji: string): Promise<void> {
+    const normalizedUserId = this.normalizeUserId(userId)
+    const normalizedEmoji = normalizeCommentReactionEmoji(emoji)
+    // 404 a missing comment (same guard updateComment/deleteComment use).
+    await this.getRequiredCommentRow(commentId)
+
+    await db
+      .insertInto('meta_comment_reactions')
+      .values({
+        comment_id: commentId,
+        user_id: normalizedUserId,
+        emoji: normalizedEmoji,
+        created_at: new Date().toISOString(),
+      })
+      .onConflict((oc) => oc.columns(['comment_id', 'user_id', 'emoji']).doNothing())
+      .execute()
+  }
+
+  /**
+   * Remove the caller's emoji reaction (B6). Idempotent: removing a reaction
+   * that does not exist is a no-op. Self-scoped: filters on user_id so a user
+   * can only remove their own reaction.
+   */
+  async removeReaction(commentId: string, userId: string, emoji: string): Promise<void> {
+    const normalizedUserId = this.normalizeUserId(userId)
+    const normalizedEmoji = normalizeCommentReactionEmoji(emoji)
+
+    await db
+      .deleteFrom('meta_comment_reactions')
+      .where('comment_id', '=', commentId)
+      .where('user_id', '=', normalizedUserId)
+      .where('emoji', '=', normalizedEmoji)
+      .execute()
+  }
+
+  /**
+   * Aggregate reactions for a set of comments into per-comment summaries
+   * ({ emoji, count, reactedByMe }). Empty input → empty map (guards the
+   * `IN ()` SQL error on an empty comment list). Ordered by emoji for stable
+   * output. `reactedByMe` is false when no viewer is supplied.
+   */
+  async listReactionsForComments(
+    commentIds: string[],
+    viewerId?: string,
+  ): Promise<Map<string, CommentReactionSummary[]>> {
+    const result = new Map<string, CommentReactionSummary[]>()
+    if (!commentIds.length) return result
+
+    const viewer = viewerId?.trim() || ''
+    const rows = await db
+      .selectFrom('meta_comment_reactions')
+      .select(({ fn }) => [
+        'comment_id',
+        'emoji',
+        fn.countAll<number>().as('count'),
+        fn.max(sql<number>`CASE WHEN user_id = ${viewer} THEN 1 ELSE 0 END`).as('reacted_by_me'),
+      ])
+      .where('comment_id', 'in', commentIds)
+      .groupBy(['comment_id', 'emoji'])
+      .orderBy('emoji', 'asc')
+      .execute()
+
+    for (const row of rows) {
+      const list = result.get(row.comment_id) ?? []
+      list.push({
+        emoji: row.emoji,
+        count: Number(row.count),
+        reactedByMe: Number(row.reacted_by_me) > 0,
+      })
+      result.set(row.comment_id, list)
+    }
+    return result
   }
 
   async getCommentPresenceSummary(

--- a/packages/core-backend/tests/integration/comments.api.test.ts
+++ b/packages/core-backend/tests/integration/comments.api.test.ts
@@ -93,9 +93,19 @@ async function ensureCommentsTables() {
       PRIMARY KEY (comment_id, user_id)
     );
   `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_comment_reactions (
+      comment_id varchar(50) NOT NULL,
+      user_id varchar(50) NOT NULL,
+      emoji text NOT NULL,
+      created_at timestamp DEFAULT now(),
+      PRIMARY KEY (comment_id, user_id, emoji)
+    );
+  `)
   await pool.query('CREATE INDEX IF NOT EXISTS idx_comments_sheet ON meta_comments(spreadsheet_id);')
   await pool.query('CREATE INDEX IF NOT EXISTS idx_comments_row ON meta_comments(row_id);')
   await pool.query('CREATE INDEX IF NOT EXISTS idx_comment_reads_user ON meta_comment_reads(user_id, read_at DESC);')
+  await pool.query('CREATE INDEX IF NOT EXISTS idx_comment_reactions_comment ON meta_comment_reactions(comment_id);')
 }
 
 describe('Comments API', () => {
@@ -129,6 +139,7 @@ describe('Comments API', () => {
     try {
       const pool = poolManager.get()
       if (createdCommentIds.length > 0) {
+        await pool.query('DELETE FROM meta_comment_reactions WHERE comment_id = ANY($1::text[])', [createdCommentIds])
         await pool.query('DELETE FROM meta_comment_reads WHERE comment_id = ANY($1::text[])', [createdCommentIds])
         await pool.query('DELETE FROM meta_comments WHERE id = ANY($1::text[])', [createdCommentIds])
       }
@@ -1208,5 +1219,103 @@ describe('Comments API', () => {
     })
 
     socket.close()
+  })
+
+  // B6: emoji reactions through the REAL HTTP wire. The remove path is the
+  // anti-drift keystone — a multi-codepoint emoji (❤️ = ❤ + U+FE0F) must round
+  // trip add → aggregate → delete and actually remove the row, which an
+  // in-process service call could false-green (design-lock §3.3).
+  it('adds, aggregates, idempotently re-adds, and removes comment reactions (real wire, multi-codepoint emoji)', async () => {
+    if (!baseUrl) return
+
+    const ts = Date.now()
+    const baseId = `base_react_${ts}`.slice(0, 50)
+    const spreadsheetId = `sheet_react_${ts}`.slice(0, 50)
+    const rowId = `rec_react_${ts}`.slice(0, 50)
+    const pool = poolManager.get()
+
+    await pool.query('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [baseId, 'React Base'])
+    createdBaseIds.push(baseId)
+    await pool.query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [spreadsheetId, baseId, 'React Sheet'])
+    createdSheetIds.push(spreadsheetId)
+
+    const userA = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_a`)).json()).token as string
+    const userB = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_b`)).json()).token as string
+
+    // Create a comment to react to.
+    const createRes = await fetch(`${baseUrl}/api/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ spreadsheetId, rowId, content: 'react to me' }),
+    })
+    expect(createRes.status).toBe(201)
+    const comment = (await createRes.json()).data.comment
+    createdCommentIds.push(comment.id)
+
+    const EMOJI = '❤️' // U+2764 U+FE0F — the multi-codepoint case
+    const reactUrl = `${baseUrl}/api/comments/${comment.id}/reactions`
+    const listUrl = `${baseUrl}/api/comments?spreadsheetId=${spreadsheetId}`
+
+    // userA adds ❤️
+    const addA = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addA.status).toBe(201)
+
+    // Idempotent: userA re-adds the same emoji → still one row for A.
+    const addAgain = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addAgain.status).toBe(201)
+
+    // userB also adds ❤️ → count becomes 2.
+    const addB = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userB}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addB.status).toBe(201)
+
+    // List as userA → aggregate count 2, reactedByMe true.
+    const listA = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
+    const itemA = listA.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemA.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
+
+    // List as a non-reactor (userB removed below; here a third viewer) → reactedByMe reflects viewer.
+    const listB = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userB}` } })).json()
+    const itemB = listB.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemB.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
+
+    // Invalid emoji → 400 (allowlist).
+    const bad = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: '💩' }),
+    })
+    expect(bad.status).toBe(400)
+
+    // KEYSTONE: userA removes ❤️ through the real DELETE wire → row actually gone.
+    const del = await fetch(reactUrl, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(del.status).toBe(204)
+
+    // Confirm in the DB the row is gone for A (count drops to 1, B remains).
+    const remaining = await pool.query(
+      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1 AND emoji = $2 ORDER BY user_id',
+      [comment.id, EMOJI.normalize('NFC')],
+    )
+    expect(remaining.rows.map((r: { user_id: string }) => r.user_id)).toEqual(['user_react_b'])
+
+    // And the aggregate now shows count 1, reactedByMe false for A.
+    const listAfter = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
+    const itemAfter = listAfter.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemAfter.reactions).toEqual([{ emoji: EMOJI, count: 1, reactedByMe: false }])
   })
 })

--- a/packages/core-backend/tests/unit/comment-reactions.test.ts
+++ b/packages/core-backend/tests/unit/comment-reactions.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ILogger } from '../../src/di/identifiers'
+
+// B6 comment-reaction tests. Mirrors the mock-DB harness used by
+// comment-service.test.ts (this repo's comment suites are mock-DB; real-PG
+// behaviour of the migration is covered by CI migration-replay). The NFC
+// allowlist guard is a pure exported function, tested directly below.
+
+// ── DB mock (identical shape to comment-service.test.ts) ─────────────────────
+vi.mock('../../src/db/db', () => {
+  const _executeResults: unknown[] = []
+  const _executeTakeFirstResults: unknown[] = []
+
+  function makeChain(): Record<string, unknown> {
+    const self: Record<string, unknown> = {}
+    const chainFn = (..._args: unknown[]) => self
+    const methods = [
+      'selectFrom', 'selectAll', 'select', 'where', 'orderBy',
+      'limit', 'offset', 'groupBy', 'insertInto', 'values',
+      'onConflict', 'columns', 'doUpdateSet', 'doNothing',
+      'updateTable', 'set', 'deleteFrom', 'returningAll', 'leftJoin',
+    ]
+    for (const m of methods) self[m] = vi.fn(chainFn)
+    self.execute = vi.fn(async () => _executeResults.shift() ?? [])
+    self.executeTakeFirst = vi.fn(async () => _executeTakeFirstResults.shift())
+    return self
+  }
+
+  const rootChain: Record<string, unknown> = {}
+  for (const m of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
+    rootChain[m] = vi.fn(() => makeChain())
+  }
+
+  const dbProxy = new Proxy(rootChain, {
+    get(target, prop) {
+      if (prop === 'transaction') {
+        return () => ({
+          execute: async (fn: (trx: unknown) => Promise<void>) => {
+            const trxRoot: Record<string, unknown> = {}
+            for (const m of ['selectFrom', 'insertInto', 'updateTable', 'deleteFrom']) {
+              trxRoot[m] = vi.fn(() => makeChain())
+            }
+            await fn(trxRoot)
+          },
+        })
+      }
+      return target[prop as string]
+    },
+  })
+
+  return {
+    db: dbProxy,
+    __executeResults: _executeResults,
+    __executeTakeFirstResults: _executeTakeFirstResults,
+  }
+})
+
+vi.mock('../../src/db/type-helpers', () => ({ nowTimestamp: () => 'NOW()' }))
+
+const mockCollabService = {
+  broadcastTo: vi.fn(), sendTo: vi.fn(), broadcast: vi.fn(),
+  initialize: vi.fn(), join: vi.fn(), leave: vi.fn(), onConnection: vi.fn(),
+}
+const mockLogger: ILogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+
+const mockNotifyRecordSubscribersWithKysely = vi.fn()
+vi.mock('../../src/multitable/record-subscription-service', () => ({
+  notifyRecordSubscribersWithKysely: (...args: unknown[]) => mockNotifyRecordSubscribersWithKysely(...args),
+}))
+
+import {
+  CommentService,
+  CommentValidationError,
+  CommentNotFoundError,
+  COMMENT_REACTION_EMOJIS,
+  normalizeCommentReactionEmoji,
+} from '../../src/services/CommentService'
+import type { CollabService } from '../../src/services/CollabService'
+
+let queueExec: unknown[]
+let queueTakeFirst: unknown[]
+
+beforeEach(async () => {
+  const dbModule = await import('../../src/db/db') as unknown as {
+    __executeResults: unknown[]
+    __executeTakeFirstResults: unknown[]
+  }
+  queueExec = dbModule.__executeResults
+  queueTakeFirst = dbModule.__executeTakeFirstResults
+})
+
+function makeCommentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cmt_test-1', spreadsheet_id: 'sheet-1', row_id: 'row-1', field_id: null,
+    content: 'Hello world', author_id: 'user-author', parent_id: null, resolved: false,
+    created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z',
+    mentions: '[]', ...overrides,
+  }
+}
+const pushTakeFirst = (...r: unknown[]) => queueTakeFirst.push(...r)
+const pushExec = (...r: unknown[]) => queueExec.push(...r)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normalizeCommentReactionEmoji — the NFC + allowlist guard (pure, no DB)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('normalizeCommentReactionEmoji', () => {
+  it('accepts every allowlisted emoji and returns it NFC-normalized', () => {
+    for (const e of COMMENT_REACTION_EMOJIS) {
+      expect(normalizeCommentReactionEmoji(e)).toBe(e.normalize('NFC'))
+    }
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(normalizeCommentReactionEmoji('  👍  ')).toBe('👍')
+  })
+
+  it('normalizes a multi-codepoint emoji consistently (❤️ = ❤ + U+FE0F)', () => {
+    // The same heart with an explicit variation selector must normalize to the
+    // stored allowlist form so add + remove always agree on the bytes.
+    const heartVs16 = '❤️'
+    expect(normalizeCommentReactionEmoji(heartVs16)).toBe('❤️'.normalize('NFC'))
+    // Idempotent: normalizing the result again yields the same value.
+    const once = normalizeCommentReactionEmoji(heartVs16)
+    expect(normalizeCommentReactionEmoji(once)).toBe(once)
+  })
+
+  it('rejects an emoji outside the allowlist', () => {
+    expect(() => normalizeCommentReactionEmoji('💩')).toThrow(CommentValidationError)
+    // bare heart without the variation selector is NOT the allowlisted form
+    expect(() => normalizeCommentReactionEmoji('❤')).toThrow(CommentValidationError)
+  })
+
+  it('rejects empty / non-string input', () => {
+    expect(() => normalizeCommentReactionEmoji('')).toThrow(CommentValidationError)
+    expect(() => normalizeCommentReactionEmoji('   ')).toThrow(CommentValidationError)
+    expect(() => normalizeCommentReactionEmoji(undefined as unknown as string)).toThrow(CommentValidationError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service methods (mock DB)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CommentService reactions', () => {
+  let service: CommentService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queueExec.length = 0
+    queueTakeFirst.length = 0
+    mockNotifyRecordSubscribersWithKysely.mockResolvedValue({ inserted: 0, userIds: [] })
+    service = new CommentService(mockCollabService as unknown as CollabService, mockLogger)
+  })
+
+  describe('addReaction', () => {
+    it('rejects a non-allowlisted emoji before any DB access', async () => {
+      await expect(service.addReaction('cmt_test-1', 'user-1', '💩')).rejects.toBeInstanceOf(CommentValidationError)
+      // validation happens before the comment lookup → no takeFirst consumed
+      expect(queueTakeFirst.length).toBe(0)
+    })
+
+    it('rejects an empty author id', async () => {
+      await expect(service.addReaction('cmt_test-1', '   ', '👍')).rejects.toThrow()
+    })
+
+    it('404s a missing comment', async () => {
+      pushTakeFirst(undefined) // getRequiredCommentRow → not found
+      await expect(service.addReaction('cmt_missing', 'user-1', '👍')).rejects.toBeInstanceOf(CommentNotFoundError)
+    })
+
+    it('inserts when the comment exists and the emoji is valid', async () => {
+      pushTakeFirst(makeCommentRow()) // getRequiredCommentRow
+      pushExec([]) // insert
+      await expect(service.addReaction('cmt_test-1', 'user-1', '👍')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('removeReaction', () => {
+    it('rejects a non-allowlisted emoji', async () => {
+      await expect(service.removeReaction('cmt_test-1', 'user-1', 'nope')).rejects.toBeInstanceOf(CommentValidationError)
+    })
+
+    it('deletes (idempotent — no comment lookup, no-op if absent)', async () => {
+      pushExec([]) // delete
+      await expect(service.removeReaction('cmt_test-1', 'user-1', '👍')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('listReactionsForComments', () => {
+    it('returns an empty map for empty input WITHOUT querying (IN () guard)', async () => {
+      const map = await service.listReactionsForComments([], 'user-1')
+      expect(map.size).toBe(0)
+      // guard short-circuits before any execute()
+      expect(queueExec.length).toBe(0)
+    })
+
+    it('aggregates rows into per-comment summaries with numeric count + boolean reactedByMe', async () => {
+      pushExec([
+        { comment_id: 'c1', emoji: '👍', count: 3, reacted_by_me: 1 },
+        { comment_id: 'c1', emoji: '❤️', count: 1, reacted_by_me: 0 },
+        { comment_id: 'c2', emoji: '👍', count: 2, reacted_by_me: 0 },
+      ])
+      const map = await service.listReactionsForComments(['c1', 'c2'], 'user-1')
+      expect(map.get('c1')).toEqual([
+        { emoji: '👍', count: 3, reactedByMe: true },
+        { emoji: '❤️', count: 1, reactedByMe: false },
+      ])
+      expect(map.get('c2')).toEqual([{ emoji: '👍', count: 2, reactedByMe: false }])
+    })
+  })
+
+  describe('getComments hydrates reactions', () => {
+    it('attaches the aggregated reactions to each returned comment', async () => {
+      pushTakeFirst({ c: 1 }) // count
+      pushExec([makeCommentRow({ id: 'cmt_test-1' })]) // comment rows
+      pushExec([{ comment_id: 'cmt_test-1', emoji: '🎉', count: 2, reacted_by_me: 1 }]) // reactions
+      const { items } = await service.getComments('sheet-1', { viewerId: 'user-1' })
+      expect(items[0].reactions).toEqual([{ emoji: '🎉', count: 2, reactedByMe: true }])
+    })
+
+    it('sets reactions to [] for a comment with none', async () => {
+      pushTakeFirst({ c: 1 })
+      pushExec([makeCommentRow({ id: 'cmt_test-1' })])
+      pushExec([]) // no reactions
+      const { items } = await service.getComments('sheet-1')
+      expect(items[0].reactions).toEqual([])
+    })
+  })
+
+  describe('deleteComment cascades reactions', () => {
+    it('completes (reaction rows removed in the same transaction)', async () => {
+      pushTakeFirst(makeCommentRow({ author_id: 'user-author' })) // getRequiredCommentRow
+      pushTakeFirst(undefined) // no child comment
+      await expect(service.deleteComment('cmt_test-1', 'user-author')).resolves.toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The **autonomous backend half** of comment emoji reactions (B6-a): persistence + add/remove/aggregate API. The emoji **picker UI and realtime broadcast** (B6-b) are browser-gated follow-ups, deferred.

New arc opt-in: owner "按建议执行" (2026-06-15). Design-lock: `multitable-comment-reactions-b6s0-designlock-20260615.md`.

## What changed
- **Storage** — new `meta_comment_reactions` side table mirroring `meta_comment_reads`: `(comment_id, user_id, emoji, created_at)`, `PRIMARY KEY (comment_id, user_id, emoji)` (idempotent add via `ON CONFLICT DO NOTHING`; a user may attach several distinct emojis). No DB FK — the comments sub-domain cascades at the app layer; `deleteComment` now removes reactions in its transaction. kysely `MetaCommentReactionsTable` registered in `db/types.ts`.
- **Service** — `addReaction` / `removeReaction` (mirror `markCommentRead`'s insert+onConflict / delete) + `listReactionsForComments` (empty-ids guard against `IN ()`; grouped `count` + `bool_or(user_id = viewer)` → `reactedByMe`), hydrated onto `getComments` via a new optional `viewerId`.
- **Routes** — `POST` / `DELETE /api/comments/:commentId/reactions`, both `rbacGuard('comments','write')`, emoji in the **request body** for both verbs.

## Three decisions (advisor-reviewed; see design-lock §3)
1. **Gate = `comments:write`** — a reaction is an attributed, persistent, visible artifact (create-bucket, like `createComment`), not a read-receipt. Self-scoped: a user can only add/remove their own `user_id` row.
2. **emoji allowlist = code constant, not a DB CHECK** — an emoji is a display token, not a protocol enum; the palette is UX-driven and will change. Service-layer validation gives consistency without a migration per tweak.
3. **emoji in DELETE body + NFC-normalize + real-wire remove test** — kills the multi-codepoint drift (`❤️` = ❤ + U+FE0F): body sidesteps path encoding, shared `normalizeCommentReactionEmoji` (NFC) makes add/remove agree on stored bytes.

## Verification
- Backend `tsc --noEmit` clean.
- Full backend unit suite: **3320 passed / 262 files** (di/types are widely imported — zero regressions).
- New `comment-reactions.test.ts`: **16** (NFC/allowlist guard, idempotency, 404, empty-ids guard, aggregation mapping, getComments hydration, delete cascade).
- **Real-PG + real-HTTP** integration test (`comments.api.test.ts`): add → aggregate (count 2, reactedByMe) → idempotent re-add → invalid emoji 400 → **DELETE a multi-codepoint `❤️` through the real wire → 204 → row confirmed gone in the DB** (anti wire-vs-fixture-drift keystone). Passed locally against a real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)