### PR TITLE
feat(multitable): comment emoji reaction UI — picker + display (B6-b)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -31,6 +31,7 @@ import type {
   PatchRecordsInput,
   FormSubmitInput,
   MultitableComment,
+  MultitableCommentReaction,
   MultitableCommentPresenceSummary,
   CommentMentionSummary,
   CommentMentionSummaryItem,
@@ -379,6 +380,31 @@ export function normalizeMultitableCommentMentions(payload: MultitableCommentMen
   return payload.mentions.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
 }
 
+/**
+ * Normalize the per-comment `reactions` aggregate (B6). The whitelist normalizer
+ * drops unknown raw fields, so reactions MUST be carried explicitly here or the
+ * backend's reactions array is silently lost on the wire (wire-vs-fixture drift).
+ * Returns undefined when absent (so a comment whose reactions weren't hydrated is
+ * distinguishable from one with zero reactions).
+ */
+export function normalizeMultitableCommentReactions(
+  payload: { reactions?: unknown } | null | undefined,
+): MultitableCommentReaction[] | undefined {
+  if (!Array.isArray(payload?.reactions)) return undefined
+  const out: MultitableCommentReaction[] = []
+  for (const raw of payload.reactions) {
+    if (!raw || typeof raw !== 'object') continue
+    const r = raw as Record<string, unknown>
+    if (typeof r.emoji !== 'string' || !r.emoji) continue
+    out.push({
+      emoji: r.emoji,
+      count: typeof r.count === 'number' && Number.isFinite(r.count) ? r.count : 0,
+      reactedByMe: r.reactedByMe === true,
+    })
+  }
+  return out
+}
+
 function normalizeCommentPresenceList(payload: { items?: MultitableCommentPresenceSummary[] } | null | undefined): {
   items: MultitableCommentPresenceSummary[]
 } {
@@ -405,6 +431,7 @@ export function normalizeMultitableComment(payload: RawComment | null | undefine
     resolved: payload?.resolved === true,
     createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
     updatedAt: typeof payload?.updatedAt === 'string' ? payload.updatedAt : undefined,
+    reactions: normalizeMultitableCommentReactions(payload),
   }
 }
 
@@ -1550,6 +1577,26 @@ export class MultitableApiClient {
 
   async deleteComment(commentId: string): Promise<void> {
     const res = await this.fetch(`/api/comments/${commentId}`, { method: 'DELETE' })
+    return this.parseJson(res)
+  }
+
+  // B6: emoji reactions. The emoji travels in the BODY for both verbs (the
+  // backend rejects path-encoded multi-codepoint emoji drift; see B6-a §3.3).
+  async addReaction(commentId: string, emoji: string): Promise<void> {
+    const res = await this.fetch(`/api/comments/${commentId}/reactions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ emoji }),
+    })
+    return this.parseJson(res)
+  }
+
+  async removeReaction(commentId: string, emoji: string): Promise<void> {
+    const res = await this.fetch(`/api/comments/${commentId}/reactions`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ emoji }),
+    })
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaCommentReactions.vue
+++ b/apps/web/src/multitable/components/MetaCommentReactions.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="meta-comment-reactions" data-test="comment-reactions">
+    <button
+      v-for="r in reactions"
+      :key="r.emoji"
+      type="button"
+      class="meta-comment-reactions__chip"
+      :class="{ 'meta-comment-reactions__chip--mine': r.reactedByMe }"
+      :data-test="`reaction-chip-${r.emoji}`"
+      :data-reacted="r.reactedByMe ? 'true' : 'false'"
+      :disabled="disabled || !canReact || isPending(r.emoji)"
+      :aria-pressed="r.reactedByMe ? 'true' : 'false'"
+      @click="toggle(r.emoji, r.reactedByMe)"
+    >
+      <span class="meta-comment-reactions__emoji">{{ r.emoji }}</span>
+      <span class="meta-comment-reactions__count">{{ r.count }}</span>
+    </button>
+
+    <div v-if="canReact" class="meta-comment-reactions__picker">
+      <button
+        type="button"
+        class="meta-comment-reactions__add"
+        data-test="reaction-add"
+        :title="addLabel"
+        :aria-label="addLabel"
+        :aria-expanded="pickerOpen ? 'true' : 'false'"
+        :disabled="disabled"
+        @click="pickerOpen = !pickerOpen"
+      >☺＋</button>
+      <div v-if="pickerOpen" class="meta-comment-reactions__palette" role="menu" data-test="reaction-palette">
+        <button
+          v-for="emoji in palette"
+          :key="emoji"
+          type="button"
+          class="meta-comment-reactions__palette-item"
+          :data-test="`reaction-pick-${emoji}`"
+          :disabled="isPending(emoji)"
+          role="menuitem"
+          @click="pick(emoji)"
+        >{{ emoji }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { COMMENT_REACTION_PALETTE, type MultitableCommentReaction } from '../types'
+
+const props = withDefaults(defineProps<{
+  commentId: string
+  reactions?: MultitableCommentReaction[]
+  addLabel?: string
+  disabled?: boolean
+  /** Whether the viewer may add/toggle reactions. Counts are shown to everyone
+   *  who can see the comment; only commenters get the picker + clickable chips. */
+  canReact?: boolean
+  /** in-flight toggle keys `${commentId}:${emoji}` (from the composable). */
+  pendingKeys?: string[]
+  palette?: string[]
+}>(), {
+  reactions: () => [],
+  addLabel: 'Add reaction',
+  disabled: false,
+  canReact: true,
+  pendingKeys: () => [],
+  palette: () => COMMENT_REACTION_PALETTE,
+})
+
+const emit = defineEmits<{
+  (e: 'react', commentId: string, emoji: string): void
+  (e: 'unreact', commentId: string, emoji: string): void
+}>()
+
+const pickerOpen = ref(false)
+
+function isPending(emoji: string): boolean {
+  return props.pendingKeys.includes(`${props.commentId}:${emoji}`)
+}
+
+function toggle(emoji: string, reactedByMe: boolean) {
+  if (reactedByMe) emit('unreact', props.commentId, emoji)
+  else emit('react', props.commentId, emoji)
+}
+
+function pick(emoji: string) {
+  pickerOpen.value = false
+  // Picking an emoji the user already reacted with is a server/composable no-op.
+  emit('react', props.commentId, emoji)
+}
+</script>
+
+<style scoped>
+.meta-comment-reactions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+.meta-comment-reactions__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 7px;
+  font-size: 12px;
+  line-height: 18px;
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 10px;
+  background: var(--surface-2, #f5f5f5);
+  cursor: pointer;
+}
+.meta-comment-reactions__chip--mine {
+  border-color: var(--primary-color, #2196f3);
+  background: var(--primary-bg, #e3f2fd);
+}
+.meta-comment-reactions__chip:disabled { opacity: 0.6; cursor: default; }
+.meta-comment-reactions__count { color: var(--text-secondary, #666); }
+.meta-comment-reactions__picker { position: relative; display: inline-flex; }
+.meta-comment-reactions__add {
+  font-size: 12px;
+  line-height: 18px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-secondary, #666);
+}
+.meta-comment-reactions__palette {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  display: flex;
+  gap: 2px;
+  padding: 4px;
+  background: var(--surface-1, #fff);
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  z-index: 10;
+}
+.meta-comment-reactions__palette-item {
+  font-size: 16px;
+  padding: 2px 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.meta-comment-reactions__palette-item:hover { background: var(--surface-2, #f0f0f0); }
+</style>

--- a/apps/web/src/multitable/components/MetaCommentsDrawer.vue
+++ b/apps/web/src/multitable/components/MetaCommentsDrawer.vue
@@ -57,6 +57,16 @@
             <span v-if="thread.resolved" class="meta-comments-drawer__badge">{{ l('comment.resolved') }}</span>
           </div>
           <p class="meta-comments-drawer__content">{{ formatContent(thread.content) }}</p>
+          <MetaCommentReactions
+            v-if="canComment || (thread.reactions && thread.reactions.length > 0)"
+            :comment-id="thread.id"
+            :reactions="thread.reactions"
+            :can-react="canComment"
+            :pending-keys="reactingKeys"
+            :add-label="l('comment.addReaction')"
+            @react="(id, emoji) => emit('react', id, emoji)"
+            @unreact="(id, emoji) => emit('unreact', id, emoji)"
+          />
         </div>
         <div
           v-for="reply in repliesByParentId[thread.id] ?? []"
@@ -84,6 +94,16 @@
             >{{ deletingIds.includes(reply.id) ? l('comment.deleting') : l('comment.delete') }}</button>
           </div>
           <p class="meta-comments-drawer__content">{{ formatContent(reply.content) }}</p>
+          <MetaCommentReactions
+            v-if="canComment || (reply.reactions && reply.reactions.length > 0)"
+            :comment-id="reply.id"
+            :reactions="reply.reactions"
+            :can-react="canComment"
+            :pending-keys="reactingKeys"
+            :add-label="l('comment.addReaction')"
+            @react="(id, emoji) => emit('react', id, emoji)"
+            @unreact="(id, emoji) => emit('unreact', id, emoji)"
+          />
         </div>
       </div>
     </div>
@@ -136,6 +156,7 @@ import {
   type MetaCommentLabelKey,
 } from '../utils/meta-comment-labels'
 import MetaCommentComposer from './MetaCommentComposer.vue'
+import MetaCommentReactions from './MetaCommentReactions.vue'
 
 export type MentionCandidateInput = {
   userId: string
@@ -161,6 +182,7 @@ const props = withDefaults(defineProps<{
   resolvingIds?: string[]
   updatingIds?: string[]
   deletingIds?: string[]
+  reactingKeys?: string[]
   currentUserId?: string | null
   mentionSuggestions?: MetaCommentMentionSuggestion[]
   composerInitialMentions?: MetaCommentMentionSuggestion[]
@@ -178,6 +200,7 @@ const props = withDefaults(defineProps<{
   resolvingIds: () => [],
   updatingIds: () => [],
   deletingIds: () => [],
+  reactingKeys: () => [],
   currentUserId: null,
   mentionSuggestions: () => [],
   composerInitialMentions: () => [],
@@ -195,6 +218,8 @@ const emit = defineEmits<{
   (e: 'cancel-edit'): void
   (e: 'update:draft', value: string): void
   (e: 'retry'): void
+  (e: 'react', commentId: string, emoji: string): void
+  (e: 'unreact', commentId: string, emoji: string): void
 }>()
 
 const draftModel = computed({

--- a/apps/web/src/multitable/composables/useMultitableComments.ts
+++ b/apps/web/src/multitable/composables/useMultitableComments.ts
@@ -17,6 +17,8 @@ export function useMultitableComments(client?: MultitableApiClient) {
   const resolvingIds = ref<string[]>([])
   const updatingIds = ref<string[]>([])
   const deletingIds = ref<string[]>([])
+  // B6: in-flight reaction toggles keyed `${commentId}:${emoji}` (debounces double-clicks).
+  const reactingKeys = ref<string[]>([])
 
   async function loadComments(params: CommentsTarget) {
     loading.value = true
@@ -96,17 +98,84 @@ export function useMultitableComments(client?: MultitableApiClient) {
     }
   }
 
+  // B6: add/remove the caller's emoji reaction. Await-then-mutate (mirrors
+  // resolveComment): the endpoints return no reaction data, so on success we
+  // locally recompute the comment's reactions aggregate. A re-add of an emoji
+  // the user already reacted with (or a remove of one they didn't) is a no-op
+  // both server-side (idempotent) and locally.
+  async function addReaction(commentId: string, emoji: string) {
+    const key = `${commentId}:${emoji}`
+    error.value = null
+    if (reactingKeys.value.includes(key)) return
+    reactingKeys.value = [...reactingKeys.value, key]
+    try {
+      await api.addReaction(commentId, emoji)
+      applyReaction(commentId, emoji, 'add')
+    } catch (e: any) {
+      error.value = e.message ?? fallback('comment.errorAddReaction')
+      throw e
+    } finally {
+      reactingKeys.value = reactingKeys.value.filter((k) => k !== key)
+    }
+  }
+
+  async function removeReaction(commentId: string, emoji: string) {
+    const key = `${commentId}:${emoji}`
+    error.value = null
+    if (reactingKeys.value.includes(key)) return
+    reactingKeys.value = [...reactingKeys.value, key]
+    try {
+      await api.removeReaction(commentId, emoji)
+      applyReaction(commentId, emoji, 'remove')
+    } catch (e: any) {
+      error.value = e.message ?? fallback('comment.errorRemoveReaction')
+      throw e
+    } finally {
+      reactingKeys.value = reactingKeys.value.filter((k) => k !== key)
+    }
+  }
+
+  /** Local recompute of one comment's reactions aggregate after a successful toggle. */
+  function applyReaction(commentId: string, emoji: string, mode: 'add' | 'remove') {
+    const index = comments.value.findIndex((item) => item.id === commentId)
+    if (index < 0) return
+    const current = comments.value[index].reactions ?? []
+    const existing = current.find((r) => r.emoji === emoji)
+    let next = current
+    if (mode === 'add') {
+      if (!existing) {
+        next = [...current, { emoji, count: 1, reactedByMe: true }]
+      } else if (!existing.reactedByMe) {
+        next = current.map((r) => (r.emoji === emoji ? { ...r, count: r.count + 1, reactedByMe: true } : r))
+      } // already reactedByMe → no-op
+    } else {
+      if (existing?.reactedByMe) {
+        const count = Math.max(0, existing.count - 1)
+        next = count === 0
+          ? current.filter((r) => r.emoji !== emoji)
+          : current.map((r) => (r.emoji === emoji ? { ...r, count, reactedByMe: false } : r))
+      } // not reactedByMe → no-op
+    }
+    comments.value[index] = { ...comments.value[index], reactions: next }
+  }
+
   function clearComments() {
     comments.value = []
     error.value = null
     updatingIds.value = []
     deletingIds.value = []
+    reactingKeys.value = []
   }
 
   function upsertComment(comment: MultitableComment) {
     const index = comments.value.findIndex((item) => item.id === comment.id)
     if (index >= 0) {
-      comments.value[index] = { ...comments.value[index], ...comment }
+      const merged = { ...comments.value[index], ...comment }
+      // B6: edit/realtime comment payloads are NOT reaction-hydrated (only
+      // getComments hydrates reactions), so an incoming `undefined` must not
+      // wipe the reactions already shown — preserve the existing aggregate.
+      if (comment.reactions === undefined) merged.reactions = comments.value[index].reactions
+      comments.value[index] = merged
       return
     }
     comments.value = [comment, ...comments.value]
@@ -135,11 +204,15 @@ export function useMultitableComments(client?: MultitableApiClient) {
     resolvingIds,
     updatingIds,
     deletingIds,
+    reactingKeys,
     loadComments,
     addComment,
     updateComment,
     deleteComment,
     resolveComment,
+    addReaction,
+    removeReaction,
+    applyReaction,
     clearComments,
     upsertComment,
     applyResolvedComment,

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -413,6 +413,20 @@ export interface MetaCommentMentionSuggestion {
   subtitle?: string
 }
 
+/** Aggregated emoji reaction on a comment (B6). Mirrors the backend CommentReactionSummary. */
+export interface MultitableCommentReaction {
+  emoji: string
+  count: number
+  reactedByMe: boolean
+}
+
+/**
+ * Reaction picker palette. Mirrors the backend allowlist
+ * (CommentService.COMMENT_REACTION_EMOJIS); the backend rejects anything
+ * off-list (400), so a drifted entry fails safe rather than corrupting data.
+ */
+export const COMMENT_REACTION_PALETTE = ['👍', '👎', '❤️', '😄', '🎉', '😮', '😢', '🚀']
+
 export interface MultitableComment {
   id: string
   containerId: string
@@ -429,6 +443,8 @@ export interface MultitableComment {
   resolved: boolean
   createdAt: string
   updatedAt?: string
+  /** Aggregated emoji reactions (B6); from GET /api/comments. Absent until hydrated. */
+  reactions?: MultitableCommentReaction[]
 }
 
 export interface MultitableCommentPresenceSummary {

--- a/apps/web/src/multitable/utils/meta-comment-labels.ts
+++ b/apps/web/src/multitable/utils/meta-comment-labels.ts
@@ -34,11 +34,14 @@ export type MetaCommentLabelKey =
   | 'comment.hintBase'
   | 'comment.hintWithMention'
   | 'comment.discardDraftConfirm'
+  | 'comment.addReaction'
   | 'comment.errorLoad'
   | 'comment.errorAdd'
   | 'comment.errorResolve'
   | 'comment.errorUpdate'
   | 'comment.errorDelete'
+  | 'comment.errorAddReaction'
+  | 'comment.errorRemoveReaction'
   | 'comment.errorLoadInbox'
   | 'comment.errorLoadUnreadCount'
   | 'comment.errorMarkRead'
@@ -79,11 +82,14 @@ const META_COMMENT_LABELS: Record<MetaCommentLabelKey, { en: string; zh: string 
     en: 'Discard unsaved comment draft?',
     zh: '放弃未保存的评论草稿吗？',
   },
+  'comment.addReaction': { en: 'Add reaction', zh: '添加表情' },
   'comment.errorLoad': { en: 'Failed to load comments', zh: '加载评论失败' },
   'comment.errorAdd': { en: 'Failed to add comment', zh: '添加评论失败' },
   'comment.errorResolve': { en: 'Failed to resolve comment', zh: '解决评论失败' },
   'comment.errorUpdate': { en: 'Failed to update comment', zh: '更新评论失败' },
   'comment.errorDelete': { en: 'Failed to delete comment', zh: '删除评论失败' },
+  'comment.errorAddReaction': { en: 'Failed to add reaction', zh: '添加表情失败' },
+  'comment.errorRemoveReaction': { en: 'Failed to remove reaction', zh: '移除表情失败' },
   'comment.errorLoadInbox': { en: 'Failed to load comment inbox', zh: '加载评论收件箱失败' },
   'comment.errorLoadUnreadCount': { en: 'Failed to load unread comment count', zh: '加载未读评论数失败' },
   'comment.errorMarkRead': { en: 'Failed to mark comment as read', zh: '标记评论已读失败' },

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -42,6 +42,7 @@ export type WorkbenchLabelKey =
   | 'toast.formSubmitFailed'
   | 'toast.commentUpdateFailed' | 'toast.commentAddFailed'
   | 'toast.commentResolveFailed' | 'toast.commentDeleteFailed'
+  | 'toast.commentReactFailed'
   | 'toast.linkedRecordsUpdateFailed'
   | 'toast.fieldCreateFailed' | 'toast.fieldUpdateFailed' | 'toast.fieldDeleteFailed'
   | 'toast.viewCreateFailed' | 'toast.viewUpdateFailed' | 'toast.viewDeleteFailed'
@@ -154,6 +155,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.commentAddFailed': { en: 'Failed to add comment', zh: '添加评论失败' },
   'toast.commentResolveFailed': { en: 'Failed to resolve comment', zh: '解决评论失败' },
   'toast.commentDeleteFailed': { en: 'Failed to delete comment', zh: '删除评论失败' },
+  'toast.commentReactFailed': { en: 'Failed to update reaction', zh: '更新表情失败' },
   'toast.linkedRecordsUpdateFailed': { en: 'Failed to update linked records', zh: '更新关联记录失败' },
   'toast.fieldCreateFailed': { en: 'Failed to create field', zh: '创建字段失败' },
   'toast.fieldUpdateFailed': { en: 'Failed to update field', zh: '更新字段失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -308,10 +308,11 @@
         :resolving-ids="commentsState.resolvingIds.value"
         :updating-ids="commentsState.updatingIds.value"
         :deleting-ids="commentsState.deletingIds.value"
+        :reacting-keys="commentsState.reactingKeys.value"
         :current-user-id="currentUserId"
         :mention-suggestions="commentMentionSuggestions"
         :composer-initial-mentions="commentComposerInitialMentions"
-        @close="onCloseComments" @submit="onSubmitComment" @resolve="onResolveComment" @reply="onReplyToComment" @edit="onEditComment" @delete="onDeleteComment" @cancel-reply="onCancelCommentReply" @cancel-edit="onCancelCommentEdit" @update:draft="commentDraft = $event"
+        @close="onCloseComments" @submit="onSubmitComment" @resolve="onResolveComment" @reply="onReplyToComment" @edit="onEditComment" @delete="onDeleteComment" @cancel-reply="onCancelCommentReply" @cancel-edit="onCancelCommentEdit" @update:draft="commentDraft = $event" @react="onReactToComment" @unreact="onUnreactToComment"
       />
     </div>
     <div v-if="showShortcuts" class="mt-workbench__shortcuts-overlay" @click.self="showShortcuts = false">
@@ -1708,6 +1709,22 @@ async function onDeleteComment(commentId: string) {
     showSuccess(wb('toast.commentDeleted', isZh.value))
   } catch (e: any) {
     showError(commentsState.error.value ?? e.message ?? wb('toast.commentDeleteFailed', isZh.value))
+  }
+}
+
+async function onReactToComment(commentId: string, emoji: string) {
+  try {
+    await commentsState.addReaction(commentId, emoji)
+  } catch (e: any) {
+    showError(commentsState.error.value ?? e.message ?? wb('toast.commentReactFailed', isZh.value))
+  }
+}
+
+async function onUnreactToComment(commentId: string, emoji: string) {
+  try {
+    await commentsState.removeReaction(commentId, emoji)
+  } catch (e: any) {
+    showError(commentsState.error.value ?? e.message ?? wb('toast.commentReactFailed', isZh.value))
   }
 }
 

--- a/apps/web/tests/multitable-comment-reactions.spec.ts
+++ b/apps/web/tests/multitable-comment-reactions.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaCommentReactions from '../src/multitable/components/MetaCommentReactions.vue'
+import type { MultitableCommentReaction } from '../src/multitable/types'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount(); app = null
+  container?.remove(); container = null
+})
+
+function mount(props: Record<string, unknown>) {
+  const events: Array<{ type: string; commentId: string; emoji: string }> = []
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaCommentReactions, {
+        commentId: 'c1',
+        ...props,
+        onReact: (commentId: string, emoji: string) => events.push({ type: 'react', commentId, emoji }),
+        onUnreact: (commentId: string, emoji: string) => events.push({ type: 'unreact', commentId, emoji }),
+      })
+    },
+  })
+  app.mount(container)
+  return { events, root: container }
+}
+
+// jsdom CSS attribute selectors don't reliably match astral-plane emoji, so we
+// locate elements by class + emoji text content instead of [data-test="…👍"].
+function chip(root: HTMLElement, emoji: string): HTMLButtonElement | undefined {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>('.meta-comment-reactions__chip'))
+    .find((el) => el.querySelector('.meta-comment-reactions__emoji')?.textContent === emoji)
+}
+function paletteItem(root: HTMLElement, emoji: string): HTMLButtonElement | undefined {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>('.meta-comment-reactions__palette-item'))
+    .find((el) => el.textContent === emoji)
+}
+const palette = (root: HTMLElement) => root.querySelector('.meta-comment-reactions__palette')
+const addBtn = (root: HTMLElement) => root.querySelector<HTMLButtonElement>('.meta-comment-reactions__add')!
+
+const reactions = (over: Partial<MultitableCommentReaction>[] = []): MultitableCommentReaction[] =>
+  over.map((o) => ({ emoji: '👍', count: 1, reactedByMe: false, ...o }))
+
+describe('MetaCommentReactions', () => {
+  it('renders a chip per reaction with count and a reactedByMe highlight', () => {
+    const { root } = mount({ reactions: [
+      { emoji: '👍', count: 3, reactedByMe: true },
+      { emoji: '❤️', count: 1, reactedByMe: false },
+    ] })
+    const mine = chip(root, '👍')!
+    const other = chip(root, '❤️')!
+    expect(mine).toBeTruthy()
+    expect(mine.textContent).toContain('3')
+    expect(mine.getAttribute('data-reacted')).toBe('true')
+    expect(mine.classList.contains('meta-comment-reactions__chip--mine')).toBe(true)
+    expect(mine.getAttribute('aria-pressed')).toBe('true')
+    expect(other.getAttribute('data-reacted')).toBe('false')
+    expect(other.classList.contains('meta-comment-reactions__chip--mine')).toBe(false)
+  })
+
+  it('clicking a not-yet-reacted chip emits react; clicking my own emits unreact', () => {
+    const { events, root } = mount({ reactions: [
+      { emoji: '👍', count: 1, reactedByMe: false },
+      { emoji: '❤️', count: 2, reactedByMe: true },
+    ] })
+    chip(root, '👍')!.click()
+    chip(root, '❤️')!.click()
+    expect(events).toEqual([
+      { type: 'react', commentId: 'c1', emoji: '👍' },
+      { type: 'unreact', commentId: 'c1', emoji: '❤️' },
+    ])
+  })
+
+  it('opens the palette and emits react for a picked emoji, then closes', async () => {
+    const { events, root } = mount({ reactions: [] })
+    expect(palette(root)).toBeNull()
+    addBtn(root).click()
+    await nextTick()
+    expect(palette(root)).toBeTruthy()
+    paletteItem(root, '🎉')!.click()
+    expect(events).toEqual([{ type: 'react', commentId: 'c1', emoji: '🎉' }])
+    await nextTick()
+    expect(palette(root)).toBeNull()
+  })
+
+  it('disables a chip whose toggle is in flight (pendingKeys)', () => {
+    const { events, root } = mount({
+      reactions: reactions([{ emoji: '👍', count: 1, reactedByMe: true }]),
+      pendingKeys: ['c1:👍'],
+    })
+    const c = chip(root, '👍')!
+    expect(c.disabled).toBe(true)
+    c.click()
+    expect(events).toEqual([])
+  })
+
+  it('renders no chips for an empty reactions list but still shows the add button', () => {
+    const { root } = mount({ reactions: [] })
+    expect(root.querySelectorAll('.meta-comment-reactions__chip').length).toBe(0)
+    expect(addBtn(root)).toBeTruthy()
+  })
+
+  it('read-only viewer (canReact=false) sees counts but no picker and cannot toggle', () => {
+    const { events, root } = mount({
+      reactions: [{ emoji: '👍', count: 5, reactedByMe: false }],
+      canReact: false,
+    })
+    const c = chip(root, '👍')!
+    expect(c).toBeTruthy()
+    expect(c.textContent).toContain('5') // count still visible
+    expect(c.disabled).toBe(true) // not interactive
+    expect(root.querySelector('.meta-comment-reactions__add')).toBeNull() // no picker
+    c.click()
+    expect(events).toEqual([]) // disabled → no emit
+  })
+})

--- a/apps/web/tests/multitable-comments.spec.ts
+++ b/apps/web/tests/multitable-comments.spec.ts
@@ -219,4 +219,94 @@ describe('useMultitableComments', () => {
 
     expect(state.error.value).toBe('backend raw')
   })
+
+  // ── B6 reactions ───────────────────────────────────────────────────────────
+
+  it('carries the reactions aggregate through the client normalizer (wire-drift guard)', async () => {
+    const comments = [{
+      id: 'c1', spreadsheetId: 's1', rowId: 'r1', fieldId: null, mentions: [], authorId: 'u1',
+      content: 'hi', resolved: false, createdAt: '2026-01-01',
+      reactions: [
+        { emoji: '👍', count: 2, reactedByMe: true },
+        { emoji: '❤️', count: 1, reactedByMe: false },
+        { bad: 'entry' }, // malformed → filtered out
+      ],
+    }]
+    const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: { comments } }), { status: 200 }))
+    ;(client as any).fetch = fetch
+    const state = useMultitableComments(client)
+    await state.loadComments({ containerId: 's1', targetId: 'r1' })
+    expect(state.comments.value[0].reactions).toEqual([
+      { emoji: '👍', count: 2, reactedByMe: true },
+      { emoji: '❤️', count: 1, reactedByMe: false },
+    ])
+  })
+
+  it('addReaction POSTs the emoji in the body and recomputes locally', async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: {} }), { status: 201 }))
+    ;(client as any).fetch = fetch
+    const state = useMultitableComments(client)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'x', resolved: false, createdAt: '2026-01-01', reactions: [] }]
+    await state.addReaction('c1', '👍')
+    expect(fetch).toHaveBeenCalledWith('/api/comments/c1/reactions', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ emoji: '👍' }),
+    }))
+    expect(state.comments.value[0].reactions).toEqual([{ emoji: '👍', count: 1, reactedByMe: true }])
+  })
+
+  it('addReaction increments an existing emoji once, and is a no-op if already reacted', async () => {
+    const fetch = vi.fn().mockImplementation(async () => new Response(JSON.stringify({ ok: true, data: {} }), { status: 201 }))
+    ;(client as any).fetch = fetch
+    const state = useMultitableComments(client)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'x', resolved: false, createdAt: '2026-01-01', reactions: [{ emoji: '👍', count: 1, reactedByMe: false }] }]
+    await state.addReaction('c1', '👍')
+    expect(state.comments.value[0].reactions).toEqual([{ emoji: '👍', count: 2, reactedByMe: true }])
+    // re-add (already reactedByMe) → server idempotent, local no-op
+    await state.addReaction('c1', '👍')
+    expect(state.comments.value[0].reactions).toEqual([{ emoji: '👍', count: 2, reactedByMe: true }])
+  })
+
+  it('removeReaction DELETEs the emoji in the body and drops the entry at zero', async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    ;(client as any).fetch = fetch
+    const state = useMultitableComments(client)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'x', resolved: false, createdAt: '2026-01-01', reactions: [{ emoji: '👍', count: 1, reactedByMe: true }] }]
+    await state.removeReaction('c1', '👍')
+    expect(fetch).toHaveBeenCalledWith('/api/comments/c1/reactions', expect.objectContaining({
+      method: 'DELETE',
+      body: JSON.stringify({ emoji: '👍' }),
+    }))
+    expect(state.comments.value[0].reactions).toEqual([]) // count hit 0 → entry removed
+  })
+
+  it('removeReaction decrements but keeps the entry when others still reacted', async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    ;(client as any).fetch = fetch
+    const state = useMultitableComments(client)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'x', resolved: false, createdAt: '2026-01-01', reactions: [{ emoji: '👍', count: 3, reactedByMe: true }] }]
+    await state.removeReaction('c1', '👍')
+    expect(state.comments.value[0].reactions).toEqual([{ emoji: '👍', count: 2, reactedByMe: false }])
+  })
+
+  it('upsertComment preserves an existing reactions aggregate when the incoming payload lacks one', () => {
+    const state = useMultitableComments(client)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'old', resolved: false, createdAt: '2026-01-01', reactions: [{ emoji: '👍', count: 2, reactedByMe: true }] }]
+    // an edit/realtime payload (no reactions hydrated)
+    state.upsertComment({ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'edited', resolved: false, createdAt: '2026-01-01' } as any)
+    expect(state.comments.value[0].content).toBe('edited')
+    expect(state.comments.value[0].reactions).toEqual([{ emoji: '👍', count: 2, reactedByMe: true }])
+  })
+
+  it('surfaces a localized fallback when addReaction fails', async () => {
+    useLocale().setLocale('en')
+    const state = useMultitableComments({
+      addReaction: vi.fn().mockRejectedValue({}),
+    } as any)
+    state.comments.value = [{ id: 'c1', containerId: 's1', targetId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'x', resolved: false, createdAt: '2026-01-01', reactions: [] }]
+    await expect(state.addReaction('c1', '👍')).rejects.toBeTruthy()
+    expect(state.error.value).toBe('Failed to add reaction')
+    // failed call must NOT mutate local state
+    expect(state.comments.value[0].reactions).toEqual([])
+  })
 })

--- a/docs/development/multitable-comment-reactions-b6b-dev-verification-20260615.md
+++ b/docs/development/multitable-comment-reactions-b6b-dev-verification-20260615.md
@@ -1,0 +1,50 @@
+# 多维表评论 Emoji 反应 B6-b — 开发 & 校验 — 2026-06-15
+
+> Status: **DONE（逻辑层 jsdom/单测验证）+ 浏览器目检为残余**。B6 弧的 UI 半 = 评论反应展示 + 选择器 + 组合式/客户端接线。延续 B6-a（存储 + API，已合并 #2673）。realtime 广播仍推迟（见 §4）。
+>
+> 设计延续 B6-S0 设计锁；FE 接面经 dynamic workflow `wf_55831f49-88b`(3 路) + 逐文件独立核验 grounded。A5-1c 先例：FE 渲染可凭 jsdom 逻辑测落地，视觉/交互为浏览器残余。
+
+## 1. 开发（做了什么）
+
+| 层 | 文件 | 改动 |
+|---|---|---|
+| 类型 | `multitable/types.ts` | `MultitableCommentReaction {emoji,count,reactedByMe}` + `MultitableComment.reactions?` + `COMMENT_REACTION_PALETTE`(镜像后端白名单) |
+| 客户端 | `multitable/api/client.ts` | `normalizeMultitableCommentReactions` + 在 `normalizeMultitableComment` 显式携带 `reactions`（**修 wire-drift**）；`addReaction`/`removeReaction`（POST/DELETE `/reactions`，emoji 入 body，镜像 createComment 的 Content-Type+JSON.stringify） |
+| 组合式 | `multitable/composables/useMultitableComments.ts` | `addReaction`/`removeReaction`（await-then-mutate，镜像 resolveComment）+ `applyReaction` 本地重算 + `reactingKeys` 在途去抖 + `upsertComment` **保留既有 reactions**（修 edit/realtime 抹除 bug）|
+| 组件 | `multitable/components/MetaCommentReactions.vue`（新） | reaction chips（emoji+count，reactedByMe 高亮）+ 选择器 popover（8-emoji 调色板）；emits `react`/`unreact`；`pendingKeys` 禁用在途 chip |
+| 抽屉 | `multitable/components/MetaCommentsDrawer.vue` | 在 thread root + reply 内容下嵌 `<MetaCommentReactions>`；新增 emits `react`/`unreact` + `reactingKeys` prop（保持 presentational：emit 给父） |
+| 父接线 | `multitable/views/MultitableWorkbench.vue` | `@react/@unreact` → `commentsState.addReaction/removeReaction` + `:reacting-keys` |
+| i18n | `meta-comment-labels.ts` + `workbench-labels.ts` | `comment.addReaction`/`errorAddReaction`/`errorRemoveReaction` + `toast.commentReactFailed`（zh/en）|
+
+## 2. 关键设计点
+
+- **wire-drift 修复（headline）**：`normalizeMultitableComment` 是白名单逐字段拷贝，**默认丢弃** raw 的 `reactions`。三处必改：`MultitableComment` 类型 + `RawComment`(经 Partial 继承) + 规范化器显式携带（新 `normalizeMultitableCommentReactions` 镜像 `normalizeMultitableCommentMentions`）。否则后端返回的 reactions 在 FE 静默消失。**有 round-trip 单测守卫**。
+- **await-then-mutate（非乐观）**：反应端点不回任何 reaction 数据（POST→201 `{}`、DELETE→204），故先 `await api` 成功再本地重算 `comment.reactions`（镜像 resolveComment 约定）；失败抛错且**不**改本地态。无 target 记忆 → 本地重算优于 refetch。
+- **本地重算 `applyReaction`**：add 新 emoji→push count1/me=true；add 已存在未 me→count+1/me=true；add 已 me→no-op；remove me→count-1/me=false，归零则删条目；remove 非 me→no-op。与后端幂等语义一致。
+- **upsert 保留 reactions（修 bug）**：edit/realtime 的 comment 载荷未 hydrate reactions，`{...old,...new}` 会用 `undefined` 抹除已显示的 reactions；upsert 现于 incoming.reactions===undefined 时保留旧值。
+- **emoji 入 body**（add+remove 对称）：沿 B6-a §3.3，绕开多码点 path 编码漂移。
+- **可见 ≠ 可操作（canReact）**：reaction **计数对所有能看该评论的人可见**（后端对所有 reader 返回 reactions），仅**添加/切换**需 `comments:write`。故 `MetaCommentReactions` 加 `canReact` prop：chips 始终渲染（read-only 时禁用、仅显示计数），选择器(add)仅 `canReact` 时显示；抽屉以 `canComment || 有reactions` 决定是否渲染该组件、并传 `:can-react="canComment"`。（advisor 复核：原先整组件 `v-if=canComment` 会把计数也对只读者隐藏，已改为有意区分。）
+
+## 3. 校验
+
+| 校验项 | 结果 |
+|---|---|
+| 组合式 + 客户端规范化 `multitable-comments.spec.ts`（真实 client + mock fetch） | 含 B6 新增（wire-drift round-trip、add POST body+本地重算、增量/幂等、remove DELETE body+归零删条目、保留既有他人计数、upsert 保留、失败不改态本地化兜底） |
+| 组件 `multitable-comment-reactions.spec.ts`（jsdom mount） | chip 渲染+count+reactedByMe 高亮/aria；点未反应 chip→react、点己 chip→unreact；开调色板→pick→react→关；pendingKeys 禁用在途；空列表仍显加按钮 |
+| 两文件合计 | **25 + (component) passed**（合并跑 25 composable/client，component 套件单列全绿）|
+| 回归：drawer/i18n/composer/labels/client 既有套件 | 50 passed（抽屉改动无回归）|
+| 本地 tsc（pure-TS 变更文件，过滤模块解析噪声）| 无类型错误 |
+| FE 类型门 `vue-tsc -b` | **CI `test (18.x/20.x)` 为权威门**（本机 Node 25 跑不了 vue-tsc）|
+
+> jsdom CSS 属性选择器无法可靠匹配星平面 emoji 字符 → 组件测按 class + emoji 文本内容定位（非 `[data-test="…👍"]`）；已记为测试基建注意点。
+
+## 4. Goal 边界（诚实残余）
+
+- ✅ **逻辑层（client/composable/component emit + render 状态）jsdom/单测验证到位。**
+- ⏸ **浏览器目检 = 残余**（同 A5-1c）：jsdom 证 emit/state/class，证不了 popover 定位、对齐、对比度、真实点击手感、frozen/滚动观感。有浏览器/app 访问后做一次目检（可经本地 app + playwright，或 owner staging）。
+- ⏸ **realtime 广播仍推迟**：他人反应不会实时推达本端（反应非 comment 事件；本端反应即时本地重算）。后端先把持久化/聚合/读做正确；realtime 作为后续具名 opt-in。upsert 保留修复已确保既有 comment realtime 更新不抹除本端 reactions。
+- ⏸ **palette 漂移**：FE 调色板硬编码镜像后端白名单；漂移时后端 400 兜底（失败安全，不损数据）。理想为共享常量，YAGNI 暂缓。
+
+## 5. 落地
+
+B6-b（types + client + composable + component + drawer + workbench + i18n + 测）+ 本记录，单 PR。CI `test (18.x/20.x)` 验单测 + `vue-tsc -b`。B6 弧后端(B6-a)+UI 逻辑(B6-b)闭合；剩 realtime + 浏览器目检为具名 opt-in / 访问门。


### PR DESCRIPTION
## Summary

The **FE half** of comment emoji reactions, consuming the B6-a API (#2673): a reaction **display** (chips with count + reactedByMe highlight) and an 8-emoji **picker** on each comment in the comments drawer.

B6-b is the browser-gated UI layer; its logic is verified by jsdom/unit tests (A5-1c precedent), with **real-browser visual/interaction check + realtime broadcast as recorded residuals** (see `multitable-comment-reactions-b6b-dev-verification-20260615.md`).

## What changed
- **Wire-drift fix (headline)** — `normalizeMultitableComment` is a whitelist field-by-field mapper that silently dropped the backend's `reactions`. Carried it explicitly via a new `normalizeMultitableCommentReactions` helper (mirrors the mentions normalizer), guarded by a round-trip test.
- **Client** — `addReaction`/`removeReaction` (POST/DELETE `/api/comments/:id/reactions`, emoji in the **body** for both, mirroring `createComment`).
- **Composable** — `addReaction`/`removeReaction` are **await-then-mutate** (mirror `resolveComment`; the endpoints return no reaction data, so on success `applyReaction` recomputes the aggregate locally); `reactingKeys` debounces in-flight toggles; failures throw without mutating local state. **`upsertComment` now preserves an existing reactions aggregate** when an incoming edit/realtime payload lacks one (those aren't reaction-hydrated — a naive spread would wipe displayed reactions).
- **UI** — new presentational `MetaCommentReactions.vue` (chips + picker popover, emits `react`/`unreact`, `pendingKeys` disables in-flight); embedded in `MetaCommentsDrawer` under thread roots + replies; `MultitableWorkbench` wires `@react`/`@unreact` to the composable. Typed i18n labels added.

## Verification
- Composable + real-client normalize (`multitable-comments.spec.ts`): wire-drift round-trip, add/remove body shape, local recompute, idempotency, zero-removal, **upsert preserve**, localized fallback.
- jsdom component (`multitable-comment-reactions.spec.ts`): chip render/highlight/aria, click→react/unreact, picker open→pick→close, pending disable.
- Existing comment/drawer/i18n/client suites still green (50). Local `tsc` on changed TS clean; **`vue-tsc -b` gated by CI `test (18.x/20.x)`** (can't run on local Node 25).

## Residuals (honest)
- **Browser visual check** (popover positioning, contrast, real click feel) — same as A5-1c; do via local app + playwright or owner staging.
- **Realtime broadcast deferred** — others' reactions don't push live (reactions aren't comment events); your own reactions update locally. The upsert-preserve fix ensures existing comment-realtime updates don't wipe local reactions.
- **Palette drift** — FE palette mirrors the backend allowlist; drift fails safe (backend 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)