### PR TITLE
fix(multitable): close per-field-restore change-timeline oracle for hidden columns (#2672 follow-up)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5794,24 +5794,38 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      // Per-field (column-level) restore: when the caller passes `fieldIds`, restrict the diff to that
-      // selection. The atomic gate below then runs over only the selected subset — so a user can restore
-      // the writable fields they picked even if another changed field in the revision is forbidden. A
-      // requested field that is unchanged / non-restorable / unknown simply isn't in the diff (no error).
+      // Per-field (column-level) restore: when the caller passes `fieldIds`, restrict the applied diff to
+      // that selection. A selected field that is unchanged / non-restorable simply isn't in the diff and is
+      // a clean no-op for that field — it is NOT silently treated as writable below (see the forbidden gate).
       const selectedDiff = fieldIds ? diff.filter((ch) => fieldIds.includes(ch.fieldId)) : diff
 
-      // Lock B: gate every (selected) diff field on BOTH the static guard and restore's own layer-3 pre-check.
-      const hasForbidden = selectedDiff.some((ch) => {
-        const guard = fieldById.get(ch.fieldId)
-        const perm = fieldPermissions[ch.fieldId]
+      // Lock B (the forbidden gate). The permission predicate (static guard ∧ restore's layer-3 pre-check)
+      // is the SAME in both modes; only the SET it runs over differs:
+      //
+      //  • FULL restore (no `fieldIds`): gate the changed diff — an atomic reject when any CHANGED field is
+      //    forbidden. Unchanged forbidden fields are not in the diff and don't block (existing behavior,
+      //    constraint (1) — kept verbatim). This carries no per-field bit (the caller named no field).
+      //
+      //  • PER-FIELD (`fieldIds` present): gate the caller-SELECTED ids INDEPENDENT of whether they changed.
+      //    #2672 follow-up — gating per-field over `selectedDiff` (= selection ∩ changed) made a forbidden
+      //    field's response depend on whether it changed between the target and current version (403 when it
+      //    changed vs. 200 no-op when it didn't) = a CHANGE-TIMELINE ORACLE for visible=false / read-only
+      //    columns, defeating the #2144 record-history redaction mask. Gating over the SELECTED ids makes the
+      //    response constant (403) regardless of diff → the oracle is closed, and selecting a field you cannot
+      //    write can never silently fall through to a no-op bypass (M2). Unknown / non-restorable selected ids
+      //    fail the predicate too, so a forbidden id is indistinguishable from a non-field — no metadata leak.
+      const gatedFieldIds = fieldIds ?? selectedDiff.map((ch) => ch.fieldId)
+      const hasForbidden = gatedFieldIds.some((fid) => {
+        const guard = fieldById.get(fid)
+        const perm = fieldPermissions[fid]
         const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
         const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
         return !staticOk || !layer3Ok
       })
       if (hasForbidden) {
-        // Generalized message — the forbidden ids are DERIVED server-side from the unmasked snapshot
-        // (not caller-submitted like /patch), so echoing them would leak hidden-field metadata to an
-        // actor denied visibility. The diff is atomic: nothing is written.
+        // Generalized message — the forbidden ids are DERIVED server-side from the unmasked snapshot /
+        // schema (not caller-trusted like /patch), so echoing them (here or via skippedFieldIds) would leak
+        // hidden-field metadata to an actor denied visibility. The diff is atomic: nothing is written.
         return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: 'Not permitted to restore one or more fields in this revision' } })
       }
 

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -40,6 +40,9 @@ const FOREIGN_REC2 = `frec2_rstr_${TS}`
 const FLD_A = `fld_rstr_a_${TS}`
 const FLD_B = `fld_rstr_b_${TS}`
 const FLD_SECRET = `fld_rstr_secret_${TS}`
+// #2672: a field USER_RO cannot SEE (layer-3 visible=false, NOT read_only). #2144's history mask redacts
+// THIS field's change-timeline from USER_RO — so the per-field-restore oracle is the only recovery channel.
+const FLD_HIDDEN = `fld_rstr_hidden_${TS}`
 const FLD_FX = `fld_rstr_fx_${TS}`
 const FLD_AUN = `fld_rstr_aun_${TS}`
 const FLD_LK = `fld_rstr_lk_${TS}`
@@ -134,6 +137,7 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     await f(FLD_A, 'A', 'string', '{}', 1)
     await f(FLD_B, 'B', 'string', '{}', 2)
     await f(FLD_SECRET, 'Secret', 'string', '{}', 3)
+    await f(FLD_HIDDEN, 'Hidden', 'string', '{}', 10)
     await f(FLD_FX, 'Formula', 'formula', '{}', 4)
     await f(FLD_AUN, 'AutoNum', 'autoNumber', '{}', 5)
     await f(FLD_LK, 'Link', 'link', JSON.stringify({ foreignSheetId: FSHEET_ID }), 6)
@@ -145,6 +149,10 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
 
     // Layer-3: USER_RO is read_only on SECRET (and a separate visible=false would also gate).
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_RO, true, true])
+    // #2672: USER_RO is visible=false (but NOT read_only) on HIDDEN — i.e. CANNOT SEE it. This is the field
+    // #2144's record-history mask redacts from USER_RO, so the per-field-restore response is the only path
+    // by which its change-timeline could leak. read_only=false isolates the visible=false predicate branch.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_HIDDEN, 'user', USER_RO, false, false])
   })
 
   beforeEach(() => {
@@ -581,16 +589,126 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     expect(data[FLD_SECRET]).toBe('sec_now') // forbidden field untouched
   })
 
-  test('T17: fieldIds selecting an unchanged/unknown field is a no-op (nothing in the gated subset)', async () => {
+  test('T17: fieldIds selecting an unchanged WRITABLE field is a no-op (nothing in the gated subset)', async () => {
     const rid = await seedRecord(
       { [FLD_A]: 'a2', [FLD_B]: 'b2' },
       2,
       [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_B]: 'b2' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_B]: 'b2' } }],
     )
-    // B is unchanged between v1 and current; selecting only B → empty diff → no-op
+    // B is a writable field, unchanged between v1 and current; selecting only B → empty diff → no-op.
+    // (B is writable, so it passes the forbidden gate; only its absence from the diff makes this a no-op.)
     const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_B] })
     expect(res.status).toBe(200)
     expect(res.body.data.noop).toBe(true)
     expect((await liveData(rid))[FLD_A]).toBe('a2') // A unchanged (not selected)
+  })
+
+  // ---- #2672 follow-up: per-field restore must NOT be a change-timeline oracle for hidden columns ----
+  //
+  // The original per-field gate ran the forbidden check over `selectedDiff` (= caller selection ∩
+  // fields-that-actually-changed). So selecting a forbidden field F returned 403 when F CHANGED between the
+  // target version and current, vs. a 200 no-op when F was UNCHANGED — an exact per-field oracle for "did
+  // this confidential column change at version N", defeating the #2144 record-history mask. T18 exercises a
+  // visible=false (FLD_HIDDEN) field specifically because that is the column whose change-timeline #2144
+  // actually redacts from USER_RO — so the per-field-restore response is the ONLY channel it could leak from
+  // (a read_only-but-visible field like FLD_SECRET is already unmasked in the history endpoint).
+  // Fix: the gate runs over the caller-SELECTED fieldIds, independent of the diff → constant 403.
+
+  test('T18 (#2672 oracle): selecting a visible=false field returns an IDENTICAL response whether or not it changed', async () => {
+    testUserId = USER_RO // visible=false (cannot see) on HIDDEN — #2144 masks its change-timeline in history
+
+    // Record 1 — HIDDEN DIFFERS between v1 (h_old) and current (h_now).
+    const ridDiff = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_HIDDEN]: 'h_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_HIDDEN]: 'h_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_HIDDEN]: 'h_now' } }],
+    )
+    // Record 2 — HIDDEN is UNCHANGED between v1 and current (same 'h_same').
+    const ridSame = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_HIDDEN]: 'h_same' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_HIDDEN]: 'h_same' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_HIDDEN]: 'h_same' } }],
+    )
+
+    const resDiff = await restoreReq(ridDiff, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_HIDDEN] })
+    const resSame = await restoreReq(ridSame, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_HIDDEN] })
+
+    // KEYSTONE: the two responses must be IDENTICAL — same status AND same body. Under the old gate the
+    // CHANGED case was 403 while the UNCHANGED case was a 200 no-op (the timeline oracle). They are now a
+    // constant 403, so the response leaks nothing about whether HIDDEN changed at version 1 — restoring the
+    // #2144 mask property (which redacts HIDDEN's change-timeline from USER_RO in the history endpoint).
+    expect(resDiff.status).toBe(resSame.status)
+    expect(resDiff.body).toEqual(resSame.body)
+
+    // …and that constant is a generic 403 that names NO field id (neither in the message nor skippedFieldIds).
+    expect(resDiff.status).toBe(403)
+    expect(resDiff.body.error.code).toBe('RESTORE_FORBIDDEN')
+    expect(JSON.stringify(resDiff.body)).not.toContain(FLD_HIDDEN)
+    // No skippedFieldIds channel may re-leak the forbidden id (the 403 body carries no `data`).
+    expect(resDiff.body.data?.skippedFieldIds ?? []).not.toContain(FLD_HIDDEN)
+
+    // Atomic in BOTH cases: nothing written, no version bump.
+    for (const rid of [ridDiff, ridSame]) {
+      const data = await liveData(rid)
+      expect(data[FLD_A]).toBe('a2')
+      const ver = await q('SELECT version FROM meta_records WHERE id = $1', [rid])
+      expect(Number((ver.rows[0] as { version: number }).version)).toBe(2)
+    }
+  })
+
+  test('T19 (#2672 M2): selecting a field you cannot write is a clean 403, never a silent bypass', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' } }],
+    )
+    testUserId = USER_RO // read_only on SECRET → FLD_SECRET is forbidden
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_SECRET] })
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('RESTORE_FORBIDDEN')
+    // M2: selection must not bypass the gate — the forbidden value is never written, and the body must not
+    // name the forbidden field anywhere (message or skippedFieldIds).
+    expect(JSON.stringify(res.body)).not.toContain(FLD_SECRET)
+    const data = await liveData(rid) // atomic: live data unchanged
+    expect(data[FLD_A]).toBe('a2')
+    expect(data[FLD_SECRET]).toBe('sec_now')
+    const ver = await q('SELECT version FROM meta_records WHERE id = $1', [rid])
+    expect(Number((ver.rows[0] as { version: number }).version)).toBe(2)
+  })
+
+  test('T20 (#2672 regression): a writable per-field restore still works; full-restore atomic-reject unchanged', async () => {
+    // (i) a normal per-field restore of a WRITABLE field still applies (the fix only changes the gate SET).
+    const ridW = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_B]: 'b2' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_B]: 'b1' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_B]: 'b2' } }],
+    )
+    const okRes = await restoreReq(ridW, { targetVersion: 1, expectedVersion: 2, fieldIds: [FLD_A] })
+    expect(okRes.status).toBe(200)
+    expect(okRes.body.data.restoredFieldIds).toEqual([FLD_A])
+    const wData = await liveData(ridW)
+    expect(wData[FLD_A]).toBe('a1') // restored
+    expect(wData[FLD_B]).toBe('b2') // not selected → untouched
+
+    // (ii) FULL restore (no fieldIds) keeps its atomic-reject: a CHANGED forbidden field still 403s, and an
+    // UNCHANGED forbidden field still does NOT block (constraint (1) — full mode behavior is unchanged).
+    testUserId = USER_RO // read_only on SECRET
+    const ridFullForbidden = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec_old' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_now' } }],
+    )
+    const fullForbidden = await restoreReq(ridFullForbidden, { targetVersion: 1, expectedVersion: 2 })
+    expect(fullForbidden.status).toBe(403) // SECRET changed + forbidden → atomic reject
+    expect((await liveData(ridFullForbidden))[FLD_A]).toBe('a2') // nothing written
+
+    const ridFullOk = await seedRecord(
+      { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_same' },
+      2,
+      [{ version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_SECRET]: 'sec_same' } }, { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_SECRET]: 'sec_same' } }],
+    )
+    const fullOk = await restoreReq(ridFullOk, { targetVersion: 1, expectedVersion: 2 })
+    expect(fullOk.status).toBe(200) // SECRET unchanged → only writable A in the diff → restored
+    expect((await liveData(ridFullOk))[FLD_A]).toBe('a1')
   })
 })


### PR DESCRIPTION
## The oracle (security bug on merged #2672 code)

The per-field record-restore route (`POST /sheets/:sheetId/records/:recordId/restore` with `fieldIds`) is a **change-timeline oracle** for `visible=false` / read-only columns, defeating the #2144 record-history redaction mask.

The forbidden-field gate ran over `selectedDiff` = (caller `fieldIds` ∩ fields-that-**actually changed** between target version and current). So selecting a forbidden field `F`:
- returns **403** when `F` **changed** at the target version, vs
- returns **200 no-op** when `F` was **unchanged**.

That is an exact per-field oracle for *"did this confidential column change at version N"* — sweep `targetVersion` → recover the full modification timeline. Values stay hidden; the leaked bit is the change-timeline. #2144's `redactRecordRevisionEntry` masks exactly that history for a `visible=false` field, so this route silently un-masks it.

## The fix (`packages/core-backend/src/routes/univer-meta.ts`)

In **per-field** mode (`fieldIds` present), run the forbidden check over the caller-**selected** `fieldIds`, independent of whether they changed, using the **same** permission predicate the route already uses (static guard `!hidden && !readOnly` ∧ layer-3 `visible !== false && readOnly !== true`). Any selected forbidden id → **403 `RESTORE_FORBIDDEN` regardless of diff** → constant response → **oracle closed**, and a selected field you cannot write can never silently fall through to a no-op bypass (**M2**).

Constraints honored:
1. **FULL-restore** mode (no `fieldIds`) keeps its existing atomic-reject behavior verbatim — the gate still runs over the changed diff (`gatedFieldIds = fieldIds ?? selectedDiff.map(...)`).
2. No forbidden id is echoed into `skippedFieldIds` (success path only reaches when every selected field passed, so `skippedFieldIds` stays `[]`).
3. The 403 message stays generic (no field id). A forbidden id is now indistinguishable from a non-field id (both fail the predicate) — no metadata re-leak.

This **restores the #2144 mask property**: a `visible=false` column's change-timeline can no longer be recovered through the restore response.

## Tests (real-DB integration, `tests/integration/multitable-record-restore.test.ts`)

- **T18 (oracle keystone)** — a `visible=false` field `FLD_HIDDEN` (the column #2144 redacts from the read-only actor's history) selected via `fieldIds` returns an **IDENTICAL** response (same status **and** body) whether or not it changed at vN. Both are a constant generic 403 with no field id in the body and the id not in `skippedFieldIds`; live data unchanged (atomic) in both. Chosen as `visible=false` (not the read_only-but-visible `FLD_SECRET`, which is already unmasked in the history endpoint) so the test exercises the exact mask-defeating case.
- **T19 (M2)** — selecting a write-denied field as the read-only user → 403 `RESTORE_FORBIDDEN`, body excludes the field id, live data unchanged.
- **T20 (regression)** — a writable per-field restore still applies; full-restore atomic-reject (changed-forbidden → 403, unchanged-forbidden → only the writable field in the diff) unchanged.

**Non-vacuity proof**: with the pre-fix `selectedDiff` gate temporarily reverted, **T18 fails** with `expected 403 to be 200` — the changed case is 403 while the unchanged case is a 200 no-op (the exact oracle signature). It passes only with the gate-over-selected-fields fix. (T19/T20 hold on both old and new code by design — they assert the M2-differing and regression cases, which were already correct; T18 is the single bug-discriminating keystone.)

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit -p tsconfig.json` → 0 errors.
- New + existing record-restore suite: **29/29 green** (26 prior + T18/T19/T20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)