### PR TITLE
test(multitable): wire comment-reactions keystone into CI + permission negatives (#2673 follow-up)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -235,6 +235,25 @@ jobs:
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             --reporter=dot
 
+      - name: Run comment-reaction keystone (real wire, real PG)
+        # B6 emoji-reaction keystone (#2673 follow-up). Wired as a WHOLE FILE (not a
+        # `-t` name filter) so the gate is robust: a name filter that matches zero
+        # tests exits 0/green and would silently reintroduce the invisible debt this
+        # exists to kill, whereas a whole-file run fails if the file is empty/broken.
+        # comment-reactions.api.test.ts covers add / aggregate / idempotent re-add /
+        # self-scoped DELETE / reader-deny 403 / cascade against real Postgres, with a
+        # fail-loud beforeAll (missing PG/port → RED, not skipped-green). The sibling
+        # comments.api.test.ts is intentionally NOT wired: 8 of its tests have a
+        # pre-existing real-wire failure (CommentService.mapRowToComment drops
+        # containerId/targetId/targetFieldId), tracked separately under its own opt-in.
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for comment-reaction keystone}"
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/comment-reactions.api.test.ts --reporter=dot
+
       - name: Start core backend (background)
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test

--- a/packages/core-backend/tests/integration/comment-reactions.api.test.ts
+++ b/packages/core-backend/tests/integration/comment-reactions.api.test.ts
@@ -1,0 +1,372 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+
+// B6 emoji-reaction keystone — split into its OWN file (not a `-t` name filter on
+// comments.api.test.ts) so the CI gate is robust: a whole-file wire fails loud if
+// the file is empty/renamed, whereas a `vitest -t "reaction"` that matches zero
+// tests exits 0 (green) and would silently reintroduce the invisible-debt this
+// suite exists to kill. comments.api.test.ts itself stays CI-excluded for now
+// because 8 of its OTHER tests have a pre-existing real-wire failure
+// (CommentService.mapRowToComment drops containerId/targetId/targetFieldId),
+// tracked separately under its own opt-in fix.
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const s = net.createServer()
+    s.once('error', () => resolve(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+  })
+}
+
+// The CREATE TABLE IF NOT EXISTS string columns below mirror the REAL migration
+// shapes so a fresh DB (local run before db:migrate, or a brand-new CI database)
+// tests the same column types the app runs against — text + timestamptz for
+// users / meta_bases / meta_sheets / meta_comment_reads / meta_comment_reactions
+// (their migrations are kysely text/timestamptz). The lone exception is
+// meta_comments, whose production shape is varchar(50) + plain timestamp because
+// its earliest-ordered `formalize` migration wins the IF NOT EXISTS race
+// (zzzz20260318 < zzzz20260326), so that block stays varchar(50).
+async function ensureCommentsTables() {
+  const pool = poolManager.get()
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id text PRIMARY KEY,
+      email text NOT NULL,
+      name text,
+      password_hash text NOT NULL DEFAULT '',
+      role text NOT NULL DEFAULT 'editor',
+      permissions jsonb NOT NULL DEFAULT '[]'::jsonb,
+      avatar_url text,
+      is_active boolean NOT NULL DEFAULT true,
+      is_admin boolean NOT NULL DEFAULT false,
+      last_login_at timestamptz,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now()
+    );
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_bases (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      icon text,
+      color text,
+      owner_id text,
+      workspace_id text,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      deleted_at timestamptz
+    );
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_sheets (
+      id text PRIMARY KEY,
+      base_id text,
+      name text NOT NULL,
+      description text,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      deleted_at timestamptz
+    );
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_comments (
+      id varchar(50) PRIMARY KEY,
+      spreadsheet_id varchar(50) NOT NULL,
+      row_id varchar(50) NOT NULL,
+      field_id varchar(50),
+      content text NOT NULL,
+      author_id varchar(50) NOT NULL,
+      parent_id varchar(50),
+      resolved boolean DEFAULT false,
+      created_at timestamp DEFAULT now(),
+      updated_at timestamp DEFAULT now(),
+      mentions jsonb
+    );
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_comment_reads (
+      comment_id text NOT NULL,
+      user_id text NOT NULL,
+      read_at timestamptz DEFAULT now(),
+      created_at timestamptz DEFAULT now(),
+      PRIMARY KEY (comment_id, user_id)
+    );
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS meta_comment_reactions (
+      comment_id text NOT NULL,
+      user_id text NOT NULL,
+      emoji text NOT NULL,
+      created_at timestamptz DEFAULT now(),
+      PRIMARY KEY (comment_id, user_id, emoji)
+    );
+  `)
+  await pool.query('CREATE INDEX IF NOT EXISTS idx_comments_sheet ON meta_comments(spreadsheet_id);')
+  await pool.query('CREATE INDEX IF NOT EXISTS idx_comments_row ON meta_comments(row_id);')
+  await pool.query('CREATE INDEX IF NOT EXISTS idx_comment_reactions_comment ON meta_comment_reactions(comment_id);')
+}
+
+describe('Comment Reactions API (B6, real wire)', () => {
+  let server: MetaSheetServer
+  let baseUrl: string
+  const createdCommentIds: string[] = []
+  const createdSheetIds: string[] = []
+  const createdBaseIds: string[] = []
+
+  beforeAll(async () => {
+    process.env.RBAC_BYPASS = 'true'
+    // FAIL-LOUD (skip-when-unreachable trap #1435/#1436): a missing PG / unbindable
+    // port must turn this keystone RED, not skipped-green. There is intentionally no
+    // `if (!baseUrl) return` escape hatch anywhere below — an unreachable backend
+    // throws here in beforeAll, failing the whole file.
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureCommentsTables()
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address!.port}`
+    expect(baseUrl).toBeTruthy()
+  })
+
+  afterAll(async () => {
+    delete process.env.RBAC_BYPASS
+    try {
+      const pool = poolManager.get()
+      if (createdCommentIds.length > 0) {
+        await pool.query('DELETE FROM meta_comment_reactions WHERE comment_id = ANY($1::text[])', [createdCommentIds])
+        await pool.query('DELETE FROM meta_comment_reads WHERE comment_id = ANY($1::text[])', [createdCommentIds])
+        await pool.query('DELETE FROM meta_comments WHERE id = ANY($1::text[])', [createdCommentIds])
+      }
+      if (createdSheetIds.length > 0) {
+        await pool.query('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [createdSheetIds])
+      }
+      if (createdBaseIds.length > 0) {
+        await pool.query('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [createdBaseIds])
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+
+    if (server && (server as any).stop) {
+      await server.stop()
+    }
+  })
+
+  // B6: emoji reactions through the REAL HTTP wire. The remove path is the
+  // anti-drift keystone — a multi-codepoint emoji (❤️ = ❤ + U+FE0F) must round
+  // trip add → aggregate → delete and actually remove the row, which an
+  // in-process service call could false-green (design-lock §3.3).
+  it('adds, aggregates, idempotently re-adds, and removes comment reactions (real wire, multi-codepoint emoji)', async () => {
+    // FAIL-LOUD: this keystone must not skip-green if the backend never came up.
+    expect(baseUrl).toBeTruthy()
+
+    const ts = Date.now()
+    const baseId = `base_react_${ts}`.slice(0, 50)
+    const spreadsheetId = `sheet_react_${ts}`.slice(0, 50)
+    const rowId = `rec_react_${ts}`.slice(0, 50)
+    const pool = poolManager.get()
+
+    await pool.query('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [baseId, 'React Base'])
+    createdBaseIds.push(baseId)
+    await pool.query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [spreadsheetId, baseId, 'React Sheet'])
+    createdSheetIds.push(spreadsheetId)
+
+    const userA = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_a`)).json()).token as string
+    const userB = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_b`)).json()).token as string
+
+    // Create a comment to react to.
+    const createRes = await fetch(`${baseUrl}/api/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ spreadsheetId, rowId, content: 'react to me' }),
+    })
+    expect(createRes.status).toBe(201)
+    const comment = (await createRes.json()).data.comment
+    createdCommentIds.push(comment.id)
+
+    const EMOJI = '❤️' // U+2764 U+FE0F — the multi-codepoint case
+    const reactUrl = `${baseUrl}/api/comments/${comment.id}/reactions`
+    const listUrl = `${baseUrl}/api/comments?spreadsheetId=${spreadsheetId}`
+
+    // userA adds ❤️
+    const addA = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addA.status).toBe(201)
+
+    // Idempotent: userA re-adds the same emoji → still one row for A.
+    const addAgain = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addAgain.status).toBe(201)
+
+    // userB also adds ❤️ → count becomes 2.
+    const addB = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userB}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(addB.status).toBe(201)
+
+    // List as userA → aggregate count 2, reactedByMe true.
+    const listA = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
+    const itemA = listA.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemA.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
+
+    // List as a non-reactor (userB removed below; here a third viewer) → reactedByMe reflects viewer.
+    const listB = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userB}` } })).json()
+    const itemB = listB.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemB.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
+
+    // Invalid emoji → 400 (allowlist).
+    const bad = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: '💩' }),
+    })
+    expect(bad.status).toBe(400)
+
+    // KEYSTONE: userA removes ❤️ through the real DELETE wire → row actually gone.
+    const del = await fetch(reactUrl, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(del.status).toBe(204)
+
+    // Confirm in the DB the row is gone for A (count drops to 1, B remains).
+    const remaining = await pool.query(
+      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1 AND emoji = $2 ORDER BY user_id',
+      [comment.id, EMOJI.normalize('NFC')],
+    )
+    expect(remaining.rows.map((r: { user_id: string }) => r.user_id)).toEqual(['user_react_b'])
+
+    // And the aggregate now shows count 1, reactedByMe false for A.
+    const listAfter = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
+    const itemAfter = listAfter.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemAfter.reactions).toEqual([{ emoji: EMOJI, count: 1, reactedByMe: false }])
+  })
+
+  // B6 permission-integrity negatives (design-lock §3.3 promised-then-dropped
+  // reader-deny + cross-user self-scope). Real HTTP wire, real PG.
+  it('scopes reaction removal to self, denies write to a reader-only token, and cascades on comment delete', async () => {
+    // FAIL-LOUD: never skip-green when the backend is down.
+    expect(baseUrl).toBeTruthy()
+
+    const ts = Date.now()
+    const baseId = `base_react_neg_${ts}`.slice(0, 50)
+    const spreadsheetId = `sheet_react_neg_${ts}`.slice(0, 50)
+    const rowId = `rec_react_neg_${ts}`.slice(0, 50)
+    const pool = poolManager.get()
+
+    await pool.query('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [baseId, 'React Neg Base'])
+    createdBaseIds.push(baseId)
+    await pool.query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [spreadsheetId, baseId, 'React Neg Sheet'])
+    createdSheetIds.push(spreadsheetId)
+
+    // Default dev-token = roles=admin, perms=*:* → passes comments:write.
+    const userA = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_neg_a`)).json()).token as string
+    const userB = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_neg_b`)).json()).token as string
+    // Reader-only token: an explicit non-admin role + a perms set WITHOUT comments:write.
+    // The route is gated by rbacGuard('comments','write'); with RBAC_TOKEN_TRUST the
+    // trusted-token claims govern, so this token must be rejected at the guard → 403.
+    const reader = (
+      await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_neg_reader&roles=viewer&perms=comments:read`)).json()
+    ).token as string
+
+    const createRes = await fetch(`${baseUrl}/api/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ spreadsheetId, rowId, content: 'react integrity' }),
+    })
+    expect(createRes.status).toBe(201)
+    const comment = (await createRes.json()).data.comment
+    createdCommentIds.push(comment.id)
+
+    const EMOJI = '👍'
+    const reactUrl = `${baseUrl}/api/comments/${comment.id}/reactions`
+    const listUrl = `${baseUrl}/api/comments?spreadsheetId=${spreadsheetId}`
+
+    // userA and userB each add 👍 → count 2.
+    for (const tok of [userA, userB]) {
+      const add = await fetch(reactUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${tok}` },
+        body: JSON.stringify({ emoji: EMOJI }),
+      })
+      expect(add.status).toBe(201)
+    }
+
+    // NEGATIVE (a): userA's DELETE is self-scoped — it removes A's row only and
+    // CANNOT remove userB's reaction. The route exposes no target-user field, so
+    // there is no way for A to address B's row; we prove the row survives.
+    const delByA = await fetch(reactUrl, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(delByA.status).toBe(204)
+
+    const afterSelfDelete = await pool.query(
+      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1 AND emoji = $2 ORDER BY user_id',
+      [comment.id, EMOJI.normalize('NFC')],
+    )
+    // userB's reaction is untouched by A's delete; only A's own row is gone.
+    expect(afterSelfDelete.rows.map((r: { user_id: string }) => r.user_id)).toEqual(['user_neg_b'])
+
+    // And from B's viewpoint the aggregate still shows B's own reaction.
+    const listAsB = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userB}` } })).json()
+    const itemAsB = listAsB.data.items.find((c: { id: string }) => c.id === comment.id)
+    expect(itemAsB.reactions).toEqual([{ emoji: EMOJI, count: 1, reactedByMe: true }])
+
+    // NEGATIVE (b): a reader-only token (no comments:write) is denied at the guard.
+    const readerAdd = await fetch(reactUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${reader}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(readerAdd.status).toBe(403)
+
+    const readerDelete = await fetch(reactUrl, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${reader}` },
+      body: JSON.stringify({ emoji: EMOJI }),
+    })
+    expect(readerDelete.status).toBe(403)
+
+    // The reader's denied write left the data untouched (B's row still the only one).
+    const afterReader = await pool.query(
+      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1 AND emoji = $2 ORDER BY user_id',
+      [comment.id, EMOJI.normalize('NFC')],
+    )
+    expect(afterReader.rows.map((r: { user_id: string }) => r.user_id)).toEqual(['user_neg_b'])
+
+    // CASCADE: deleting the (leaf) comment removes its surviving reactions through
+    // the app-level cascade in CommentService.deleteComment (no DB FK in this
+    // sub-domain — design-lock B6-a). userA authored the comment, so A may delete it.
+    const deleteComment = await fetch(`${baseUrl}/api/comments/${comment.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${userA}` },
+    })
+    expect(deleteComment.status).toBe(204)
+    const afterCommentDelete = await pool.query(
+      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1',
+      [comment.id],
+    )
+    expect(afterCommentDelete.rows).toHaveLength(0)
+  })
+})

--- a/packages/core-backend/tests/integration/comments.api.test.ts
+++ b/packages/core-backend/tests/integration/comments.api.test.ts
@@ -12,11 +12,19 @@ async function canListenOnEphemeralPort(): Promise<boolean> {
   })
 }
 
+// The CREATE TABLE IF NOT EXISTS string columns below mirror the REAL migration
+// shapes so a fresh DB (local run before db:migrate, or a brand-new CI database)
+// tests the same column types the app runs against — text + timestamptz for
+// users / meta_bases / meta_sheets / meta_views / meta_comment_reads /
+// meta_comment_reactions (their migrations are kysely text/timestamptz). The lone
+// exception is meta_comments, whose production shape is varchar(50) + plain
+// timestamp because its earliest-ordered `formalize` migration wins the
+// IF NOT EXISTS race (zzzz20260318 < zzzz20260326), so that block stays varchar(50).
 async function ensureCommentsTables() {
   const pool = poolManager.get()
   await pool.query(`
     CREATE TABLE IF NOT EXISTS users (
-      id varchar(50) PRIMARY KEY,
+      id text PRIMARY KEY,
       email text NOT NULL,
       name text,
       password_hash text NOT NULL DEFAULT '',
@@ -25,39 +33,39 @@ async function ensureCommentsTables() {
       avatar_url text,
       is_active boolean NOT NULL DEFAULT true,
       is_admin boolean NOT NULL DEFAULT false,
-      last_login_at timestamp,
-      created_at timestamp DEFAULT now(),
-      updated_at timestamp DEFAULT now()
+      last_login_at timestamptz,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now()
     );
   `)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS meta_bases (
-      id varchar(50) PRIMARY KEY,
+      id text PRIMARY KEY,
       name text NOT NULL,
       icon text,
       color text,
       owner_id text,
       workspace_id text,
-      created_at timestamp DEFAULT now(),
-      updated_at timestamp DEFAULT now(),
-      deleted_at timestamp
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      deleted_at timestamptz
     );
   `)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS meta_sheets (
-      id varchar(50) PRIMARY KEY,
-      base_id varchar(50),
+      id text PRIMARY KEY,
+      base_id text,
       name text NOT NULL,
       description text,
-      created_at timestamp DEFAULT now(),
-      updated_at timestamp DEFAULT now(),
-      deleted_at timestamp
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      deleted_at timestamptz
     );
   `)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS meta_views (
-      id varchar(50) PRIMARY KEY,
-      sheet_id varchar(50) NOT NULL,
+      id text PRIMARY KEY,
+      sheet_id text NOT NULL,
       name text NOT NULL,
       type text NOT NULL,
       filter_info jsonb DEFAULT '{}'::jsonb,
@@ -65,8 +73,8 @@ async function ensureCommentsTables() {
       group_info jsonb DEFAULT '{}'::jsonb,
       hidden_field_ids jsonb DEFAULT '[]'::jsonb,
       config jsonb DEFAULT '{}'::jsonb,
-      created_at timestamp DEFAULT now(),
-      updated_at timestamp DEFAULT now()
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now()
     );
   `)
   await pool.query(`
@@ -86,19 +94,19 @@ async function ensureCommentsTables() {
   `)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS meta_comment_reads (
-      comment_id varchar(50) NOT NULL,
-      user_id varchar(50) NOT NULL,
-      read_at timestamp DEFAULT now(),
-      created_at timestamp DEFAULT now(),
+      comment_id text NOT NULL,
+      user_id text NOT NULL,
+      read_at timestamptz DEFAULT now(),
+      created_at timestamptz DEFAULT now(),
       PRIMARY KEY (comment_id, user_id)
     );
   `)
   await pool.query(`
     CREATE TABLE IF NOT EXISTS meta_comment_reactions (
-      comment_id varchar(50) NOT NULL,
-      user_id varchar(50) NOT NULL,
+      comment_id text NOT NULL,
+      user_id text NOT NULL,
       emoji text NOT NULL,
-      created_at timestamp DEFAULT now(),
+      created_at timestamptz DEFAULT now(),
       PRIMARY KEY (comment_id, user_id, emoji)
     );
   `)
@@ -118,8 +126,12 @@ describe('Comments API', () => {
 
   beforeAll(async () => {
     process.env.RBAC_BYPASS = 'true'
+    // FAIL-LOUD (skip-when-unreachable trap #1435/#1436): a missing PG / unbindable
+    // port must turn this keystone RED, not skipped-green. These were `if (!x) return`
+    // early-returns that silently disabled every test below; they are now hard
+    // assertions so an unreachable backend throws in beforeAll → the whole file fails.
     const canListen = await canListenOnEphemeralPort()
-    if (!canListen) return
+    expect(canListen).toBe(true)
 
     await ensureCommentsTables()
 
@@ -130,8 +142,9 @@ describe('Comments API', () => {
     })
     await server.start()
     const address = server.getAddress()
-    if (!address?.port) return
-    baseUrl = `http://127.0.0.1:${address.port}`
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address!.port}`
+    expect(baseUrl).toBeTruthy()
   })
 
   afterAll(async () => {
@@ -1221,101 +1234,9 @@ describe('Comments API', () => {
     socket.close()
   })
 
-  // B6: emoji reactions through the REAL HTTP wire. The remove path is the
-  // anti-drift keystone — a multi-codepoint emoji (❤️ = ❤ + U+FE0F) must round
-  // trip add → aggregate → delete and actually remove the row, which an
-  // in-process service call could false-green (design-lock §3.3).
-  it('adds, aggregates, idempotently re-adds, and removes comment reactions (real wire, multi-codepoint emoji)', async () => {
-    if (!baseUrl) return
-
-    const ts = Date.now()
-    const baseId = `base_react_${ts}`.slice(0, 50)
-    const spreadsheetId = `sheet_react_${ts}`.slice(0, 50)
-    const rowId = `rec_react_${ts}`.slice(0, 50)
-    const pool = poolManager.get()
-
-    await pool.query('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [baseId, 'React Base'])
-    createdBaseIds.push(baseId)
-    await pool.query('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [spreadsheetId, baseId, 'React Sheet'])
-    createdSheetIds.push(spreadsheetId)
-
-    const userA = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_a`)).json()).token as string
-    const userB = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_react_b`)).json()).token as string
-
-    // Create a comment to react to.
-    const createRes = await fetch(`${baseUrl}/api/comments`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
-      body: JSON.stringify({ spreadsheetId, rowId, content: 'react to me' }),
-    })
-    expect(createRes.status).toBe(201)
-    const comment = (await createRes.json()).data.comment
-    createdCommentIds.push(comment.id)
-
-    const EMOJI = '❤️' // U+2764 U+FE0F — the multi-codepoint case
-    const reactUrl = `${baseUrl}/api/comments/${comment.id}/reactions`
-    const listUrl = `${baseUrl}/api/comments?spreadsheetId=${spreadsheetId}`
-
-    // userA adds ❤️
-    const addA = await fetch(reactUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
-      body: JSON.stringify({ emoji: EMOJI }),
-    })
-    expect(addA.status).toBe(201)
-
-    // Idempotent: userA re-adds the same emoji → still one row for A.
-    const addAgain = await fetch(reactUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
-      body: JSON.stringify({ emoji: EMOJI }),
-    })
-    expect(addAgain.status).toBe(201)
-
-    // userB also adds ❤️ → count becomes 2.
-    const addB = await fetch(reactUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userB}` },
-      body: JSON.stringify({ emoji: EMOJI }),
-    })
-    expect(addB.status).toBe(201)
-
-    // List as userA → aggregate count 2, reactedByMe true.
-    const listA = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
-    const itemA = listA.data.items.find((c: { id: string }) => c.id === comment.id)
-    expect(itemA.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
-
-    // List as a non-reactor (userB removed below; here a third viewer) → reactedByMe reflects viewer.
-    const listB = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userB}` } })).json()
-    const itemB = listB.data.items.find((c: { id: string }) => c.id === comment.id)
-    expect(itemB.reactions).toEqual([{ emoji: EMOJI, count: 2, reactedByMe: true }])
-
-    // Invalid emoji → 400 (allowlist).
-    const bad = await fetch(reactUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
-      body: JSON.stringify({ emoji: '💩' }),
-    })
-    expect(bad.status).toBe(400)
-
-    // KEYSTONE: userA removes ❤️ through the real DELETE wire → row actually gone.
-    const del = await fetch(reactUrl, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${userA}` },
-      body: JSON.stringify({ emoji: EMOJI }),
-    })
-    expect(del.status).toBe(204)
-
-    // Confirm in the DB the row is gone for A (count drops to 1, B remains).
-    const remaining = await pool.query(
-      'SELECT user_id FROM meta_comment_reactions WHERE comment_id = $1 AND emoji = $2 ORDER BY user_id',
-      [comment.id, EMOJI.normalize('NFC')],
-    )
-    expect(remaining.rows.map((r: { user_id: string }) => r.user_id)).toEqual(['user_react_b'])
-
-    // And the aggregate now shows count 1, reactedByMe false for A.
-    const listAfter = await (await fetch(listUrl, { headers: { Authorization: `Bearer ${userA}` } })).json()
-    const itemAfter = listAfter.data.items.find((c: { id: string }) => c.id === comment.id)
-    expect(itemAfter.reactions).toEqual([{ emoji: EMOJI, count: 1, reactedByMe: false }])
-  })
+  // NOTE: the B6 emoji-reaction keystone + permission negatives moved to the
+  // dedicated, CI-wired tests/integration/comment-reactions.api.test.ts. This file
+  // stays CI-excluded until its pre-existing container-model read-mapping failures
+  // (CommentService.mapRowToComment drops containerId/targetId/targetFieldId) are
+  // fixed under their own opt-in; wiring the whole file before that would be red.
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -29,6 +29,18 @@ export default defineConfig({
       'tests/integration/attendance-schedule-dispatch.test.ts',
       'tests/integration/attendance-shift-swap.test.ts',
       'tests/integration/attendance-unscheduled-reminder.test.ts',
+      // comment-reactions.api.test.ts needs setup.integration.ts + a live DB (real
+      // MetaSheetServer on an ephemeral port + rbacGuard). It is excluded from the
+      // default unit run HERE but wired as a WHOLE FILE into the dedicated
+      // `Run comment-reaction keystone` step in plugin-tests.yml, where it runs
+      // against real Postgres every PR — the B6 keystone (add/aggregate/idempotent
+      // re-add/self-scoped DELETE/reader-deny 403/cascade) is no longer invisible debt.
+      'tests/integration/comment-reactions.api.test.ts',
+      // comments.api.test.ts needs setup.integration.ts + a live DB. It stays
+      // CI-excluded (NOT wired) because 8 of its tests have a pre-existing real-wire
+      // failure (CommentService.mapRowToComment drops containerId/targetId/
+      // targetFieldId), tracked separately under its own opt-in fix. The reaction
+      // keystone that used to live here moved to comment-reactions.api.test.ts.
       'tests/integration/comments.api.test.ts',
       'tests/integration/events-api.test.ts',
       'tests/integration/multitable-attachments.api.test.ts',


### PR DESCRIPTION
## Why

The B6 emoji-reaction keystone (added in #2673) ran in **no CI workflow**: it lived in `comments.api.test.ts`, which is excluded from the default unit run (`vitest.config.ts`) and was absent from every integration allowlist. So idempotency / aggregation / self-scoped-DELETE / cascade had **zero CI regression protection** — the repo's documented invisible-debt trap.

## What changed

1. **New dedicated file** `packages/core-backend/tests/integration/comment-reactions.api.test.ts` — the keystone + permission negatives, self-contained (own DDL-aligned `ensureCommentsTables` + fail-loud `beforeAll`). Wired as a **WHOLE FILE** into a new `Run comment-reaction keystone (real wire, real PG)` step in `plugin-tests.yml` (Node 20, real Postgres, every PR).
   - **Whole-file, not `-t "reaction"` name filter** — deliberate robustness: a name filter matching zero tests `exits 0/green` (verified locally: a renamed test → silent no-op gate), which would reintroduce the exact invisible debt this PR kills. A whole-file run fails if the file is empty/broken/renamed.
2. **Fail-loud** (skip-when-unreachable trap #1435/#1436) — `beforeAll` asserts `canListen` + `address.port`; there is no `if (!baseUrl) return` escape hatch. Verified: a bad `DATABASE_URL` fails the file with **exit 1**, not skipped-green.
3. **DDL align** — string id + timestamp columns mirror the real migration shapes (`text` + `timestamptz` for `users` / `meta_bases` / `meta_sheets` / `meta_views` / `meta_comment_reads` / `meta_comment_reactions`). `meta_comments` intentionally stays `varchar(50)` + plain `timestamp` because its earliest-ordered `formalize` migration (`zzzz20260318` < `zzzz20260326`) wins the `CREATE TABLE IF NOT EXISTS` race — that is the production shape. The same alignment + fail-loud is also applied to the (still CI-excluded) `comments.api.test.ts` harness.
4. **Permission negatives** (real wire, real PG):
   - userA's DELETE is **self-scoped** and cannot remove userB's reaction (asserted via DB row survival + `list-as-B` `reactedByMe:true`).
   - a **reader-only token** (`roles=viewer&perms=comments:read`, no `comments:write`) is denied **403** on both add and remove (the design-lock's promised-then-dropped reader-deny).
   - deleting the comment **cascades** away its surviving reactions (app-level cascade, no DB FK).

## Pre-existing debt surfaced (tracked, not fixed here)

`comments.api.test.ts` itself is **intentionally NOT wired**: 8 of its tests have a pre-existing, CI-invisible real-wire failure. Root cause: `CommentService.mapRowToComment` (used by `getComment` AND `getComments`) never returns `containerId` / `targetId` / `targetFieldId`, although the route accepts those fields and the service writes them — a violation of the repo's field-round-trip convention. Baseline on a fresh DB: **8 failed | 3 passed**; the 8 assertions (`comment.containerId` etc.) have always been `undefined`, hidden only because the file ran in no CI job (and `if(!baseUrl) return` skip-green hid it locally too).

The 8 failing tests, all the same drop: `creates, lists, resolves…` (`:224`), `updates authored comments…` (`:398`), `mention-aware summaries…` (`:505`), `field comments + one-level replies…` (`:590`), `filters by field scope…` (`:658`), `current-user mention-summary…` (`:793`), `presence summaries per row/field…` (`:887`), `broadcasts global inbox activity…` (`:985`).

This is left as **a separate fix needing its own opt-in** (fix `mapRowToComment` + the summary mappers, then wire the whole file). This PR converts the keystone from invisible debt into CI-gated coverage and the rest into **tracked** debt.

## Verification

- `tsc --noEmit` clean (exit 0). (core-backend has no lint script + test files are eslint-ignored → no lint exposure.)
- `js-yaml` parses `plugin-tests.yml` (valid; reaction step present; run command targets the whole new file).
- New file against real PG: **2 passed (2)** — no skips, no name-filter coupling.
- Fail-loud: bad `DATABASE_URL` → `Test Files 1 failed`, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)