### PR TITLE
feat(multitable): render color scale + icon set in the grid (A5-2/A5-3)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -77,6 +77,12 @@
                   @dblclick="startEdit(row, field)"
                   @click.stop="onCellClick(flatIndex(group, ri), ci, row.id)"
                 >
+                  <span
+                    v-if="!isEditing(row.id, field.id) && cellScaleIcon(row.id, field.id)"
+                    class="meta-grid__cell-scale-icon"
+                    data-test="cell-scale-icon"
+                    :style="{ color: cellScaleIcon(row.id, field.id)!.color }"
+                  >{{ cellScaleIcon(row.id, field.id)!.glyph }}</span>
                   <MetaCellEditor
                     v-if="isEditing(row.id, field.id)"
                     :field="field"
@@ -196,6 +202,12 @@
                 @dblclick="startEdit(row, field)"
                 @click.stop="onCellClick(ri, ci, row.id)"
               >
+                <span
+                  v-if="!isEditing(row.id, field.id) && cellScaleIcon(row.id, field.id)"
+                  class="meta-grid__cell-scale-icon"
+                  data-test="cell-scale-icon"
+                  :style="{ color: cellScaleIcon(row.id, field.id)!.color }"
+                >{{ cellScaleIcon(row.id, field.id)!.glyph }}</span>
                 <MetaCellEditor
                   v-if="isEditing(row.id, field.id)"
                   :field="field"
@@ -602,15 +614,20 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   // textColor still applies, but its backgroundColor is dropped so the two
   // don't fight. Covers both the grouped and flat render paths (both call this).
   const scaleEntry = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
-  // A5-1c renders only the data-bar kind here. A colorScale/iconSet presentation
-  // (scaleColor/iconKey, no barPct — A5-2/A5-3 contracts) must NOT build a bar
-  // gradient, or it would emit `linear-gradient(… undefined% …)` and regress the
-  // shipped data-bar render. Their own render is browser-gated future work.
-  const scale = scaleEntry && typeof scaleEntry.barPct === 'number' ? scaleEntry : undefined
-  const scaleStyle: Record<string, string> | undefined = scale
-    ? { backgroundImage: `linear-gradient(to right, ${scale.barColor} ${scale.barPct}%, transparent ${scale.barPct}%)` }
-    : undefined
-  const effectiveFormat: Record<string, string> | undefined = scale
+  // Each scale kind renders its own way: dataBar (A5-1) = left-anchored gradient;
+  // colorScale (A5-2) = solid cell background; iconSet (A5-3) = a glyph rendered
+  // in the cell template (see cellScaleIcon), no cell-style change. The barPct
+  // guard keeps colorScale/iconSet out of the gradient path (no `undefined%`).
+  const barEntry = scaleEntry && typeof scaleEntry.barPct === 'number' ? scaleEntry : undefined
+  const colorScaleFill = scaleEntry && typeof scaleEntry.scaleColor === 'string' ? scaleEntry.scaleColor : undefined
+  const scaleStyle: Record<string, string> | undefined = barEntry
+    ? { backgroundImage: `linear-gradient(to right, ${barEntry.barColor} ${barEntry.barPct}%, transparent ${barEntry.barPct}%)` }
+    : colorScaleFill
+      ? { backgroundColor: colorScaleFill }
+      : undefined
+  // dataBar + colorScale take the cell background, so drop the operator rule's
+  // backgroundColor (keep its textColor) to avoid two fills fighting.
+  const effectiveFormat: Record<string, string> | undefined = (barEntry || colorScaleFill)
     ? (formatStyle?.color ? { color: formatStyle.color } : undefined)
     : formatStyle
   // frozen body cell: sticky-left + an OPAQUE bg (occludes scrolled-under content). Preserve any
@@ -618,10 +635,30 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   // hover/selection tint is still not shown on frozen cells — accepted MVP limitation; conditional
   // formatting is NOT lost.) With a data bar present, the opaque base is #fff so the gradient shows.
   const frozenStyle: Record<string, string> | undefined = frozen
-    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: effectiveFormat?.backgroundColor ?? '#fff' }
+    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: colorScaleFill ?? effectiveFormat?.backgroundColor ?? '#fff' }
     : undefined
   if (!widthStyle && !effectiveFormat && !scaleStyle && !frozenStyle) return undefined
   return { ...(widthStyle ?? {}), ...(effectiveFormat ?? {}), ...(scaleStyle ?? {}), ...(frozenStyle ?? {}) }
+}
+
+// A5-3 icon set render: map an `iconKey` (`${set}:${index}`) to a glyph + color.
+// The backend (conditional-formatting-service) only emits index ∈ {0,1,2}; an
+// out-of-range or unknown set yields no icon (fail-safe).
+const SCALE_ICON_GLYPHS: Record<string, ReadonlyArray<{ glyph: string; color: string }>> = {
+  arrows3: [{ glyph: '↓', color: '#e53935' }, { glyph: '→', color: '#fb8c00' }, { glyph: '↑', color: '#43a047' }],
+  traffic3: [{ glyph: '●', color: '#e53935' }, { glyph: '●', color: '#fbc02d' }, { glyph: '●', color: '#43a047' }],
+  signs3: [{ glyph: '✕', color: '#e53935' }, { glyph: '!', color: '#fb8c00' }, { glyph: '✓', color: '#43a047' }],
+}
+function cellScaleIcon(rid: string, fid: string): { glyph: string; color: string } | null {
+  const entry = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
+  if (!entry || typeof entry.iconKey !== 'string') return null
+  const sep = entry.iconKey.lastIndexOf(':')
+  if (sep < 0) return null
+  const set = entry.iconKey.slice(0, sep)
+  const idx = Number(entry.iconKey.slice(sep + 1))
+  const glyphs = SCALE_ICON_GLYPHS[set]
+  if (!glyphs || !Number.isInteger(idx) || idx < 0 || idx >= glyphs.length) return null
+  return glyphs[idx]
 }
 
 // ── frozen columns (left-prefix) ──────────────────────────────────────────
@@ -822,6 +859,7 @@ function onKeydown(e: KeyboardEvent) {
 .meta-grid__cell--editing { padding: 2px 4px; background: #fff; }
 .meta-grid__cell--readonly { color: #666; }
 .meta-grid__cell--focused { outline: 2px solid #409eff; outline-offset: -2px; }
+.meta-grid__cell-scale-icon { display: inline-block; margin-right: 4px; font-weight: 700; vertical-align: middle; }
 .meta-grid__comment-action,
 .meta-grid__field-comment-action {
   display: inline-flex;

--- a/apps/web/tests/multitable-grid-databar.spec.ts
+++ b/apps/web/tests/multitable-grid-databar.spec.ts
@@ -120,3 +120,50 @@ describe('MetaGridTable — data-bar conditional formatting (A5-1c render)', () 
     }
   })
 })
+
+describe('MetaGridTable — color scale (A5-2) + icon set (A5-3) render', () => {
+  it('paints the cell background with the colorScale color (no gradient)', () => {
+    const colorScale = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'cs1', fieldId: 'amount', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: colorScale })
+    const cells = dataCells(root)
+    // amount 0 → min stop #000000, 100 → max stop #ffffff, 50 → #808080
+    expect(cells[0].style.backgroundColor).toBe('rgb(0, 0, 0)')
+    expect(cells[2].style.backgroundColor).toBe('rgb(128, 128, 128)')
+    expect(cells[4].style.backgroundColor).toBe('rgb(255, 255, 255)')
+    expect(cells[2].style.backgroundImage).toBe('') // colorScale is a solid fill, not a bar
+  })
+
+  it('renders an icon glyph for each bucket of an iconSet rule', () => {
+    const iconSet = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'is1', fieldId: 'amount', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+        iconSet: { set: 'arrows3', thresholds: [10, 20] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: iconSet })
+    const cells = dataCells(root)
+    // amount 0 (<10) → index 0 ↓ ; 50 (>=20) → index 2 ↑ ; 100 (>=20) → index 2 ↑
+    const icon = (cell: HTMLElement) => cell.querySelector('[data-test="cell-scale-icon"]')
+    expect(icon(cells[0])?.textContent).toBe('↓')
+    expect(icon(cells[2])?.textContent).toBe('↑')
+    expect(icon(cells[4])?.textContent).toBe('↑')
+  })
+
+  it('renders no icon on a field with no scale rule', () => {
+    const iconSet = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'is1', fieldId: 'amount', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+        iconSet: { set: 'arrows3', thresholds: [10, 20] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: iconSet })
+    const cells = dataCells(root)
+    // cells[1] is r1.label (no scale rule) → no icon
+    expect(cells[1].querySelector('[data-test="cell-scale-icon"]')).toBeNull()
+  })
+})

--- a/docs/development/multitable-cf-scale-a5-2-a5-3-render-dev-verification-20260615.md
+++ b/docs/development/multitable-cf-scale-a5-2-a5-3-render-dev-verification-20260615.md
@@ -1,0 +1,33 @@
+# 多维表条件格式 A5-2/A5-3 网格渲染 — 开发 & 校验 — 2026-06-15
+
+> Status: **DONE（jsdom 逻辑验证）+ 浏览器目检为残余**。补齐 A5 范围型条件格式弧的最后渲染半：色阶(A5-2) 单元格底色 + 图标集(A5-3) 字形。后端契约 + FE 镜像 + scale map 已于 #2664 落地；本 slice 仅补 `MetaGridTable` 的渲染消费（A5-1c data-bar 渲染的同款 jsdom-可验证先例）。
+
+## 1. 开发（做了什么）
+
+仅 `apps/web/src/multitable/components/MetaGridTable.vue`（渲染消费）：
+
+- **A5-2 色阶**：`cellStyle` 增 `colorScaleFill = scaleEntry.scaleColor` 分支 → 单元格 `backgroundColor`（实底色，非 data-bar 的渐变）。与 data-bar 一样吃单元格底色 → 抑制算子规则的 `backgroundColor`（保留 textColor）。冻结列 base 改 `colorScaleFill ?? format.bg ?? #fff`（否则 sticky 的 `#fff` 会盖掉色阶）。`barPct` 守卫保留 → 色阶不进渐变路径（无 `undefined%`）。
+- **A5-3 图标集**：新 `cellScaleIcon(rid,fid)` 解析 `iconKey`(`${set}:${index}`) → `{glyph,color}`；`SCALE_ICON_GLYPHS` 映射 3 套（arrows3 ↓→↑ / traffic3 ●●● / signs3 ✕!✓，各配红/琥珀/绿）；越界或未知 set → 无图标（fail-safe）。两条渲染路径（分组 + 平铺）各在 `<MetaCellEditor>` 前插一独立 `v-if` 的 `<span class="meta-grid__cell-scale-icon">`（不破坏 editor/renderer 的 v-if/v-else 配对；逻辑全在共享 helper，避免双定义漂移）。+ scoped 样式。
+
+数据已就位：workbench 的 `buildFieldScaleMap`(#2664) 已产 `scaleColor`/`iconKey`，经 `:conditional-formatting-scale` 传入网格；本 slice 仅补“画出来”。
+
+## 2. 校验
+
+| 校验项 | 结果 |
+|---|---|
+| 网格渲染 jsdom `multitable-grid-databar.spec.ts` | **9 passed**（原 6 + A5-2/3 渲染 3）|
+| 含既有 **Trap-E** 守卫 | 仍绿（色阶用 `backgroundColor` 非 `backgroundImage`、图标用 span，皆不产渐变 → 无 `undefined%`）|
+| 回归：grid-databar + cf-scale + conditional-formatting + frozen-columns | **58 passed**（冻结列 colorScale base 改动无回归）|
+| FE 类型门 `vue-tsc -b` | **CI `test (18.x/20.x)` 为权威门**（本机 Node 25 跑不了 vue-tsc）|
+
+新增渲染断言：色阶 amount 0/50/100 → 单元格 bg `rgb(0,0,0)`/`rgb(128,128,128)`/`rgb(255,255,255)` 且无渐变；图标集桶 0/2/2 → 字形 `↓`/`↑`/`↑`；无规则字段无图标。
+
+## 3. Goal 边界（诚实残余）
+
+- ✅ **A5-2/3 网格渲染逻辑 jsdom 验证到位**（cellStyle 输出 + 图标 DOM）。
+- ⏸ **浏览器目检 = 残余**（同 A5-1c / B6-b）：jsdom 证 style/DOM，证不了真实色阶对比度可读性、图标字形跨平台渲染、frozen 滚动观感。有浏览器/app 访问后做一次目检（本地 app + Playwright 或 owner staging）。
+- ⏸ **配置 UI 仍缺**：色阶/图标集规则需经条件格式配置对话框创建（browser-gated，未做）；本 slice 渲染**已配置**的规则。配置对话框 = 后续 browser-gated slice。
+
+## 4. 落地
+
+A5-2/3 渲染（MetaGridTable + 测）+ 本记录，单 PR。CI `test (18.x/20.x)` 验单测 + `vue-tsc -b`。A5 弧渲染半闭合；剩条件格式配置对话框 = browser-gated 后续。


### PR DESCRIPTION
## Summary

Completes the A5 scale-rule family by **rendering** the colorScale (A5-2) and iconSet (A5-3) presentations the backend already emits (#2664) — only the grid render was missing. Same jsdom-verifiable precedent as A5-1c (data-bar render).

- **colorScale** → `cellStyle` paints the cell `backgroundColor` with the interpolated `scaleColor` (solid fill; operator backgroundColor dropped, textColor kept; frozen cells use the fill as sticky base). The `barPct` guard keeps it out of the gradient path.
- **iconSet** → `cellScaleIcon(rid,fid)` maps `iconKey` `${set}:${index}` to a glyph+color (arrows3 ↓→↑ / traffic3 ●●● / signs3 ✕!✓); out-of-range/unknown → no icon. A leading `<span>` renders before the cell renderer in both grid paths (grouped + flat), logic in the shared helper (no two-definition drift).

## Verification
- Grid jsdom: colorScale endpoints/midpoint cell bg + no gradient; iconSet bucket glyphs (↓/↑); no icon on unscaled fields. **9** in the grid-databar spec; **58** across grid/cf/frozen suites (no regression; existing Trap-E guards still hold). `vue-tsc -b` gated by CI `test (18.x/20.x)`.

## Residuals (honest)
- **Real-browser visual check** (color contrast/readability, glyph cross-platform render, frozen scroll) — same as A5-1c/B6-b; via local app + Playwright or owner staging.
- **Config dialog** to *create* colorScale/iconSet rules remains a browser-gated slice; this PR renders already-configured rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)