### PR TITLE
docs(multitable): refresh stale scale-render comments after A5-2/A5-3

### DIFF
--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -539,11 +539,13 @@ const EMPTY_SCALE_MAP: FieldScaleMap = Object.freeze({
 }) as FieldScaleMap
 
 /**
- * Pre-compute data-bar presentation per (fieldId, recordId). Mirrors the
- * backend `buildFieldScaleMap`: min/max over the passed records (auto) or the
- * rule's fixed range; each finite value → 0..100 fill; degenerate range → full
- * bar; negatives take negativeColor; non-numeric skipped; first rule per field
- * wins. Caller passes the already-loaded/masked rows (client-side discipline).
+ * Pre-compute scale presentation (data-bar / color-scale / icon-set) per
+ * (fieldId, recordId). Mirrors the backend `buildFieldScaleMap`: min/max over
+ * the passed records (auto) or the rule's fixed range; dataBar → 0..100 fill
+ * (degenerate range → full bar, negatives take negativeColor); colorScale →
+ * interpolated scaleColor; iconSet → iconKey bucket; non-numeric skipped; first
+ * rule per field wins. The grid renders all three (MetaGridTable, #2640/#2680).
+ * Caller passes the already-loaded/masked rows (client-side discipline).
  */
 export function buildFieldScaleMap(
   rules: ConditionalFormattingScaleRule[],

--- a/packages/core-backend/src/multitable/conditional-formatting-service.ts
+++ b/packages/core-backend/src/multitable/conditional-formatting-service.ts
@@ -390,9 +390,10 @@ export function evaluateConditionalFormattingRules(
 // same client-side discipline as the A2 export picker; a full-column server
 // aggregate is a separate gated follow-up). All three kinds are CONTRACT-level
 // here: `dataBar` (A5-1), `colorScale` (A5-2, by-name stop interpolation),
-// `iconSet` (A5-3, absolute-threshold bucketing). The data-bar GRADIENT render
-// shipped (#2640); the colorScale/iconSet RENDER is browser-gated future work —
-// builders produce scaleColor/iconKey but no cell drawing here.
+// `iconSet` (A5-3, absolute-threshold bucketing). All three render in the grid:
+// data-bar gradient (#2640), colorScale cell background + iconSet glyph (#2680).
+// The builders here only produce barPct/scaleColor/iconKey; the cell drawing
+// lives in MetaGridTable (cellStyle + cellScaleIcon), not in this service.
 // ===========================================================================
 
 export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20


### PR DESCRIPTION
Comment-only follow-up to #2680 (flagged in review). Two implementation comments still called colorScale/iconSet render "browser-gated future work" / described `buildFieldScaleMap` as data-bar-only, contradicting the render shipped in #2680.

- `conditional-formatting-service.ts`: all three kinds now render in the grid (data-bar #2640, colorScale bg + iconSet glyph #2680); builder emits barPct/scaleColor/iconKey, drawing lives in `MetaGridTable`.
- `utils/conditional-formatting.ts`: `buildFieldScaleMap` doc covers all three presentations.

No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)