### PR TITLE
fix(data-source): load SQL smoke adapter from deploy dist

### DIFF
--- a/packages/core-backend/scripts/smoke-sqlserver.test.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { buildConfig } from './smoke-sqlserver'
+import { buildConfig, loadMSSQLAdapter, MSSQL_ADAPTER_CANDIDATES } from './smoke-sqlserver'
 
 // Verifies the smoke harness EXPOSES the B3 legacy-TLS lever via env — i.e. MSSQL_LEGACY_TLS /
 // MSSQL_TLS_MIN_VERSION / MSSQL_TLS_CIPHERS actually reach connection.{legacyTls,tlsMinVersion,tlsCiphers},
@@ -61,5 +61,14 @@ describe('smoke-sqlserver buildConfig — B3 legacy-TLS env exposure', () => {
     setRequired()
     process.env.MSSQL_LEGACY_TLS = 'maybe'
     expect(() => buildConfig()).toThrow(/boolean-like/)
+  })
+
+  it('loads the deployable compiled adapter path before the local source fallback', () => {
+    expect(MSSQL_ADAPTER_CANDIDATES[0]).toBe('../dist/src/data-adapters/MSSQLAdapter.js')
+    expect(MSSQL_ADAPTER_CANDIDATES).toContain('../src/data-adapters/MSSQLAdapter.ts')
+  })
+
+  it('loads an MSSQLAdapter constructor without opening a connection', async () => {
+    expect(typeof (await loadMSSQLAdapter())).toBe('function')
   })
 })

--- a/packages/core-backend/scripts/smoke-sqlserver.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.ts
@@ -1,9 +1,97 @@
+import { createRequire } from 'node:module'
 import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { MSSQLAdapter } from '../src/data-adapters/MSSQLAdapter'
 import type { ConfigValue, DataSourceConfig } from '../src/data-adapters/BaseAdapter'
 
 const env = process.env
+const requireFromScript = createRequire(import.meta.url)
+
+type MSSQLAdapterConstructor = new (config: DataSourceConfig) => {
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+  testConnection(): Promise<boolean>
+  query<T>(sql: string, params?: unknown[]): Promise<{ data: T[]; error?: Error }>
+  getSchema(schema?: string): Promise<{ tables: unknown[]; views?: unknown[] }>
+  tableExists(tableName: string, schema?: string): Promise<boolean>
+  getTableInfo(tableName: string, schema?: string): Promise<{
+    columns: Array<{ name: string }>
+    primaryKey?: string[]
+  }>
+  select(
+    tableName: string,
+    options?: {
+      limit?: number
+      offset?: number
+      orderBy?: Array<{ column: string; direction: 'asc' | 'desc' }>
+    }
+  ): Promise<{ data: unknown[]; error?: Error }>
+}
+
+export const MSSQL_ADAPTER_CANDIDATES = [
+  // Deployable on-prem packages ship compiled backend dist, not the TS source tree.
+  '../dist/src/data-adapters/MSSQLAdapter.js',
+  // Local development / test fallback.
+  '../src/data-adapters/MSSQLAdapter.ts'
+] as const
+
+function moduleNotFoundForCandidate(
+  error: unknown,
+  candidate: string,
+  resolved?: string
+): boolean {
+  if (!error || typeof error !== 'object') return false
+  const maybeError = error as { code?: unknown; message?: unknown }
+  if (maybeError.code !== 'MODULE_NOT_FOUND' && maybeError.code !== 'ERR_MODULE_NOT_FOUND') {
+    return false
+  }
+  return (
+    typeof maybeError.message === 'string' &&
+    (maybeError.message.includes(candidate) ||
+      (resolved ? maybeError.message.includes(resolved) : false))
+  )
+}
+
+type MSSQLAdapterModule = {
+  MSSQLAdapter?: MSSQLAdapterConstructor
+  default?: MSSQLAdapterConstructor | { MSSQLAdapter?: MSSQLAdapterConstructor }
+}
+
+function getMSSQLAdapterExport(
+  loaded: MSSQLAdapterModule,
+  candidate: string
+): MSSQLAdapterConstructor {
+  const adapter =
+    loaded.MSSQLAdapter ??
+    (typeof loaded.default === 'function' ? loaded.default : loaded.default?.MSSQLAdapter)
+  if (!adapter) {
+    throw new Error(`MSSQLAdapter export missing from ${candidate}`)
+  }
+  return adapter
+}
+
+export async function loadMSSQLAdapter(): Promise<MSSQLAdapterConstructor> {
+  const missing: string[] = []
+  for (const candidate of MSSQL_ADAPTER_CANDIDATES) {
+    let resolved: string | undefined
+    try {
+      // Resolve first so an absent deploy artifact can fall back to source, but a present module with
+      // a broken dependency still fails loudly instead of masking a real deploy/runtime bug.
+      resolved = requireFromScript.resolve(candidate)
+      const loaded = (await import(pathToFileURL(resolved).href)) as MSSQLAdapterModule
+      return getMSSQLAdapterExport(loaded, candidate)
+    } catch (error) {
+      if (moduleNotFoundForCandidate(error, candidate, resolved)) {
+        missing.push(candidate)
+        continue
+      }
+      throw error
+    }
+  }
+
+  throw new Error(
+    `Unable to load MSSQLAdapter for SQL Server smoke. Tried: ${missing.join(', ')}`
+  )
+}
 
 function printHelp(): void {
   console.log(`Usage: pnpm --filter @metasheet/core-backend smoke:sqlserver
@@ -134,6 +222,7 @@ async function main(): Promise<void> {
   const table = env.MSSQL_TABLE
   const skipSchema = optionalBoolean('MSSQL_SKIP_SCHEMA') === true
 
+  const MSSQLAdapter = await loadMSSQLAdapter()
   const adapter = new MSSQLAdapter(config)
 
   console.log('[sqlserver-smoke] target', {

--- a/scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
+++ b/scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
@@ -31,6 +31,11 @@ test('on-prem verifier follows the helper-backed K3 SQL Server executor seam', (
   )
   assert.match(
     verifyScript,
+    /packages\/core-backend\/dist\/src\/data-adapters\/MSSQLAdapter\.js/,
+    'the verifier must require the deployable compiled MSSQL adapter that the generic smoke loads',
+  )
+  assert.match(
+    verifyScript,
     /plugins\/plugin-integration-core\/scripts\/smoke-k3-sqlserver-executor\.cjs/,
     'the verifier must require the packaged K3 SQL Server smoke script',
   )
@@ -43,6 +48,16 @@ test('on-prem verifier follows the helper-backed K3 SQL Server executor seam', (
     verifyScript,
     /smoke:sqlserver": "tsx scripts\/smoke-sqlserver\.ts"/,
     'the verifier must lock the package.json smoke:sqlserver command to a packaged script',
+  )
+  assert.match(
+    verifyScript,
+    /\.\.\/dist\/src\/data-adapters\/MSSQLAdapter\.js/,
+    'the verifier must lock the generic smoke to the deployable compiled adapter path',
+  )
+  assert.match(
+    verifyScript,
+    /\.\.\/src\/data-adapters\/MSSQLAdapter\.ts/,
+    'the verifier must lock the generic smoke local source fallback',
   )
   assert.match(
     verifyScript,

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -173,6 +173,8 @@ function verify_integration_plugin_runtime_dependencies() {
 
   search_fixed_string '"smoke:sqlserver": "tsx scripts/smoke-sqlserver.ts"' "$core_backend_package_json" || die "core-backend package.json must expose the generic SQL Server smoke command"
   search_fixed_string 'export function buildConfig' "$generic_sqlserver_smoke" || die "generic SQL Server smoke script must be packaged and export buildConfig for its test seam"
+  search_fixed_string '../dist/src/data-adapters/MSSQLAdapter.js' "$generic_sqlserver_smoke" || die "generic SQL Server smoke script must load the deployable compiled MSSQLAdapter path"
+  search_fixed_string '../src/data-adapters/MSSQLAdapter.ts' "$generic_sqlserver_smoke" || die "generic SQL Server smoke script must keep a local source fallback for development/tests"
   search_fixed_string 'MSSQL_LEGACY_TLS' "$generic_sqlserver_smoke" || die "generic SQL Server smoke script must expose legacy TLS knobs"
   search_fixed_string '"@metasheet/mssql-readonly-utils"' "$core_backend_package_json" || die "core-backend package.json must include the shared MSSQL read-only helper dependency"
   search_fixed_string '"mssql"' "$plugin_package_json" || die "plugin-integration-core package.json must include mssql for the built-in SQL Server read executor"
@@ -699,6 +701,7 @@ required=(
   "apps/web/dist/index.html"
   "apps/web/package.json"
   "packages/core-backend/dist/src/index.js"
+  "packages/core-backend/dist/src/data-adapters/MSSQLAdapter.js"
   "packages/core-backend/dist/src/db/migrate.js"
   "packages/core-backend/dist/src/db/migration-provider.js"
   "packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js"


### PR DESCRIPTION
## Summary

Fixes the second #2670 generic SQL Server smoke blocker found after the refreshed package:

- the on-prem package now includes `packages/core-backend/scripts/smoke-sqlserver.ts`, but the script statically imported `../src/data-adapters/MSSQLAdapter`;
- deployable on-prem packages ship compiled backend `dist`, not the TS source adapter tree;
- the smoke now resolves the adapter through a deploy-shape loader that tries `../dist/src/data-adapters/MSSQLAdapter.js` first and keeps `../src/data-adapters/MSSQLAdapter.ts` only as the local/dev fallback.

The loader only falls back when the candidate module itself is absent. If the compiled adapter exists but has a broken dependency, the error still fails loudly instead of being hidden by the source fallback.

Package verification is also tightened so the on-prem verifier requires:
- the generic SQL Server smoke script;
- the compiled deployable `MSSQLAdapter.js`;
- the dist-first smoke loader path and local fallback marker.

This does not change SQL read behavior or any write boundary. K3 `login_failed` in #2670 remains a separate operator/environment gate.

## Verification

Focused checks:
- `pnpm --filter @metasheet/core-backend exec vitest run scripts/smoke-sqlserver.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsx scripts/smoke-sqlserver.ts --help`
- `pnpm --filter @metasheet/core-backend exec tsx scripts/smoke-sqlserver.ts` (skip path, no target)
- `node --test scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs`
- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`

Package-shape checks:
- `OUTPUT_DIR=/tmp/metasheet-c5-generic-smoke-entry-local BUILD_WEB=1 BUILD_BACKEND=1 PACKAGE_TAG=c5-generic-smoke-entry-local scripts/ops/multitable-onprem-package-build.sh`
- verified both generated `.tgz` and `.zip` with `scripts/ops/multitable-onprem-package-verify.sh`
- extracted `.tgz` and confirmed:
  - `packages/core-backend/src/data-adapters/MSSQLAdapter.ts` is absent;
  - `packages/core-backend/dist/src/data-adapters/MSSQLAdapter.js` is present;
  - packaged `smoke-sqlserver.ts` contains both dist-first and source fallback candidates.
- ran a deploy-shape loader probe from the extracted package after dependency install:
  - `loadMSSQLAdapter()` returned the compiled `MSSQLAdapter` constructor with `../dist/src/data-adapters/MSSQLAdapter.js` as the first candidate.

Subagent review: no findings; non-blocking hardening to require compiled adapter in package verifier was folded in before opening this PR.