### PR TITLE
fix(multitable): mapRowToComment carries container/target/targetField ids (comment read field-drop)

### DIFF
--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -147,11 +147,15 @@ export const ICommentService = createIdentifier<ICommentService>('comment-servic
  * `spreadsheetId` as `containerId` and `rowId` as `targetId` -- both refer to
  * the same underlying identifiers.
  *
- * Deprecated DB columns (exist in schema but unused in code):
- *   - target_type, target_id, target_field_id, container_type, container_id
- *   These were added by migration zzzz20260318123000_formalize_meta_comments
- *   but are NOT read or written anywhere. They are kept for migration safety
- *   and should NOT be used in new code.
+ * Canonical container/target columns (migration zzzz20260318123000_formalize_meta_comments):
+ *   - container_id  → API `containerId` (mirrors spreadsheet_id)
+ *   - target_id     → API `targetId`    (mirrors row_id)
+ *   - target_field_id → API `targetFieldId` (mirrors field_id; null when record-level)
+ *   `createComment` writes these alongside the legacy spreadsheet_id/row_id/field_id
+ *   columns, and the read paths (`mapRowToComment`, presence/mention summaries) plus
+ *   the realtime payloads carry them back so the canonical aliases stay in sync.
+ *   The `container_type`/`target_type` discriminator columns are not surfaced on the
+ *   API and should not be relied on in new code.
  *
  * Mention parsing precedence:
  *   When creating or updating a comment, mentions can be supplied two ways:
@@ -259,6 +263,12 @@ export interface CommentRecord {
     rowId: string;
     /** Optional cell-level field scope. */
     fieldId?: string;
+    /** Canonical container alias for `spreadsheetId` (DB column `container_id`). */
+    containerId: string;
+    /** Canonical target alias for `rowId` (DB column `target_id`). */
+    targetId: string;
+    /** Canonical field-scope alias for `fieldId` (DB column `target_field_id`); null when record-level. */
+    targetFieldId: string | null;
     /** Comment body text. */
     content: string;
     /** Author user ID. */
@@ -299,8 +309,12 @@ export interface CommentInboxItem extends CommentRecord {
 
 /** Per-row comment presence summary used by the sheet grid indicator. */
 export interface CommentPresenceSummaryRecord {
+    /** Canonical container alias for `spreadsheetId`. */
+    containerId: string;
     spreadsheetId: string;
     rowId: string;
+    /** Canonical target alias for `rowId`. */
+    targetId: string;
     unresolvedCount: number;
     fieldCounts: Record<string, number>;
     mentionedCount: number;
@@ -309,7 +323,11 @@ export interface CommentPresenceSummaryRecord {
 
 /** Per-row mention summary item. */
 export interface CommentMentionSummaryItem {
+    /** Canonical container alias for `spreadsheetId`. */
+    containerId: string;
     rowId: string;
+    /** Canonical target alias for `rowId`. */
+    targetId: string;
     mentionedCount: number;
     unreadCount: number;
     mentionedFieldIds: string[];
@@ -317,6 +335,8 @@ export interface CommentMentionSummaryItem {
 
 /** Aggregated mention summary for a spreadsheet scoped to a single user. */
 export interface CommentMentionSummary {
+    /** Canonical container alias for `spreadsheetId`. */
+    containerId: string;
     spreadsheetId: string;
     unresolvedMentionCount: number;
     unreadMentionCount: number;

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -79,6 +79,12 @@ export interface Comment {
   spreadsheetId: string
   rowId: string
   fieldId?: string
+  /** Canonical container alias for `spreadsheetId` (DB column `container_id`). */
+  containerId: string
+  /** Canonical target alias for `rowId` (DB column `target_id`). */
+  targetId: string
+  /** Canonical field-scope alias for `fieldId` (DB column `target_field_id`); null when record-level. */
+  targetFieldId: string | null
   content: string
   authorId: string
   parentId?: string
@@ -91,8 +97,12 @@ export interface Comment {
 }
 
 export interface CommentPresenceSummary {
+  /** Canonical container alias for `spreadsheetId`. */
+  containerId: string
   spreadsheetId: string
   rowId: string
+  /** Canonical target alias for `rowId`. */
+  targetId: string
   unresolvedCount: number
   fieldCounts: Record<string, number>
   mentionedCount: number
@@ -104,6 +114,9 @@ type CommentRow = {
   spreadsheet_id: string
   row_id: string
   field_id: string | null
+  target_id: string
+  target_field_id: string | null
+  container_id: string
   content: string
   author_id: string
   parent_id: string | null
@@ -137,6 +150,12 @@ type MentionGroupedCountRow = {
 
 type CommentActivityPayload = {
   kind: 'created' | 'updated' | 'resolved' | 'deleted'
+  /** Canonical container alias for `spreadsheetId`. */
+  containerId: string
+  /** Canonical target alias for `rowId`. */
+  targetId: string
+  /** Canonical field-scope alias for `fieldId`; null when record-level. */
+  targetFieldId: string | null
   spreadsheetId: string
   rowId: string
   fieldId?: string
@@ -193,6 +212,9 @@ export class CommentService {
     for (const mentionUserId of mentions) {
       if (!mentionUserId || mentionUserId === normalizedUserId || previousMentions.includes(mentionUserId)) continue
       this.collabService.sendTo(mentionUserId, 'comment:mention', {
+        containerId: comment.containerId,
+        targetId: comment.targetId,
+        targetFieldId: comment.targetFieldId,
         spreadsheetId: comment.spreadsheetId,
         rowId: comment.rowId,
         fieldId: comment.fieldId,
@@ -305,6 +327,9 @@ export class CommentService {
     await this.markCommentRead(id, data.authorId)
 
     const createdPayload = {
+      containerId: data.spreadsheetId,
+      targetId: data.rowId,
+      targetFieldId: effectiveFieldId ?? null,
       spreadsheetId: data.spreadsheetId,
       rowId: data.rowId,
       fieldId: effectiveFieldId,
@@ -325,6 +350,9 @@ export class CommentService {
       'comment:activity',
       {
         kind: 'created',
+        containerId: data.spreadsheetId,
+        targetId: data.rowId,
+        targetFieldId: effectiveFieldId ?? null,
         spreadsheetId: data.spreadsheetId,
         rowId: data.rowId,
         fieldId: effectiveFieldId,
@@ -482,6 +510,13 @@ export class CommentService {
         'c.spreadsheet_id',
         'c.row_id',
         'c.field_id',
+        // Carry the canonical container/target columns so inbox items expose the
+        // same containerId/targetId/targetFieldId linkage that mapRowToComment
+        // maps — this is an explicit projection, not selectAll(), so they must
+        // be listed or they'd round-trip as undefined.
+        'c.container_id',
+        'c.target_id',
+        'c.target_field_id',
         'c.content',
         'c.author_id',
         'c.parent_id',
@@ -721,8 +756,10 @@ export class CommentService {
     const items = orderedRowIds.map((rowId) => {
       const summary = summaryByRow.get(rowId)!
       return {
+        containerId: spreadsheetId,
         spreadsheetId,
         rowId,
+        targetId: rowId,
         unresolvedCount: summary.unresolvedCount,
         fieldCounts: summary.fieldCounts,
         mentionedCount: summary.mentionedCount,
@@ -737,13 +774,19 @@ export class CommentService {
     spreadsheetId: string,
     mentionUserId: string,
   ): Promise<{
+    /** Canonical container alias for `spreadsheetId`. */
+    containerId: string
     spreadsheetId: string
     unresolvedMentionCount: number
     unreadMentionCount: number
     mentionedRecordCount: number
     unreadRecordCount: number
     items: Array<{
+      /** Canonical container alias for `spreadsheetId`. */
+      containerId: string
       rowId: string
+      /** Canonical target alias for `rowId`. */
+      targetId: string
       mentionedCount: number
       unreadCount: number
       mentionedFieldIds: string[]
@@ -752,6 +795,7 @@ export class CommentService {
     const normalizedUserId = mentionUserId.trim()
     if (!normalizedUserId) {
       return {
+        containerId: spreadsheetId,
         spreadsheetId,
         unresolvedMentionCount: 0,
         unreadMentionCount: 0,
@@ -789,13 +833,16 @@ export class CommentService {
     const items = [...byRow.entries()]
       .sort((a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]))
       .map(([rowId, data]) => ({
+        containerId: spreadsheetId,
         rowId,
+        targetId: rowId,
         mentionedCount: data.count,
         unreadCount: data.unread,
         mentionedFieldIds: [...data.fieldIds].sort(),
       }))
 
     return {
+      containerId: spreadsheetId,
       spreadsheetId,
       unresolvedMentionCount: items.reduce((sum, item) => sum + item.mentionedCount, 0),
       unreadMentionCount: items.reduce((sum, item) => sum + item.unreadCount, 0),
@@ -901,6 +948,9 @@ export class CommentService {
 
     if (result) {
       const resolvedPayload = {
+        containerId: result.container_id,
+        targetId: result.target_id,
+        targetFieldId: result.target_field_id ?? null,
         spreadsheetId: result.spreadsheet_id,
         rowId: result.row_id,
         fieldId: result.field_id ?? undefined,
@@ -921,6 +971,9 @@ export class CommentService {
         'comment:activity',
         {
           kind: 'resolved',
+          containerId: result.container_id,
+          targetId: result.target_id,
+          targetFieldId: result.target_field_id ?? null,
           spreadsheetId: result.spreadsheet_id,
           rowId: result.row_id,
           fieldId: result.field_id ?? undefined,
@@ -960,6 +1013,9 @@ export class CommentService {
 
   private publishCommentUpdated(comment: Comment, authorId: string): void {
     const payload = {
+      containerId: comment.containerId,
+      targetId: comment.targetId,
+      targetFieldId: comment.targetFieldId,
       spreadsheetId: comment.spreadsheetId,
       rowId: comment.rowId,
       fieldId: comment.fieldId,
@@ -980,6 +1036,9 @@ export class CommentService {
       'comment:activity',
       {
         kind: 'updated',
+        containerId: comment.containerId,
+        targetId: comment.targetId,
+        targetFieldId: comment.targetFieldId,
         spreadsheetId: comment.spreadsheetId,
         rowId: comment.rowId,
         fieldId: comment.fieldId,
@@ -991,6 +1050,9 @@ export class CommentService {
 
   private publishCommentDeleted(row: CommentRow, authorId: string): void {
     const payload = {
+      containerId: row.container_id,
+      targetId: row.target_id,
+      targetFieldId: row.target_field_id ?? null,
       spreadsheetId: row.spreadsheet_id,
       rowId: row.row_id,
       fieldId: row.field_id ?? undefined,
@@ -1011,6 +1073,9 @@ export class CommentService {
       'comment:activity',
       {
         kind: 'deleted',
+        containerId: row.container_id,
+        targetId: row.target_id,
+        targetFieldId: row.target_field_id ?? null,
         spreadsheetId: row.spreadsheet_id,
         rowId: row.row_id,
         fieldId: row.field_id ?? undefined,
@@ -1033,6 +1098,13 @@ export class CommentService {
       spreadsheetId: row.spreadsheet_id,
       rowId: row.row_id,
       fieldId: row.field_id || undefined,
+      // Canonical container/target aliases carried from their own DB columns so
+      // read paths (getComment/getComments) expose the same target linkage that
+      // createComment writes. targetFieldId stays `null` (not coerced to
+      // undefined) to match the API contract for record-level comments.
+      containerId: row.container_id,
+      targetId: row.target_id,
+      targetFieldId: row.target_field_id ?? null,
       content: row.content,
       authorId: row.author_id,
       parentId: row.parent_id || undefined,

--- a/packages/core-backend/tests/integration/comments.api.test.ts
+++ b/packages/core-backend/tests/integration/comments.api.test.ts
@@ -300,6 +300,11 @@ describe('Comments API', () => {
     expect(inboxItem.sheetId).toBe(spreadsheetId)
     expect(inboxItem.viewId).toBe(viewId)
     expect(inboxItem.recordId).toBe(rowId)
+    // Inbox uses an explicit column projection (not selectAll); assert the
+    // canonical container/target linkage round-trips through that projection.
+    expect(inboxItem.containerId).toBe(spreadsheetId)
+    expect(inboxItem.targetId).toBe(rowId)
+    expect(inboxItem.targetFieldId).toBeNull()
     expect(plainInboxItem).toBeTruthy()
     expect(plainInboxItem.unread).toBe(true)
     expect(plainInboxItem.mentioned).toBe(false)
@@ -918,7 +923,12 @@ describe('Comments API', () => {
     createdSheetIds.push(spreadsheetId)
 
     const authorToken = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_ws_author`)).json()).token as string
-    const socket = ioClient(`${baseUrl}?userId=user_ws_target`, { transports: ['websocket'] })
+    // Authenticate the socket with a real token so the server joins the trusted
+    // per-user room. Personal `comment:mention` deliveries go through
+    // sendTo(userId) → the authenticated-user room, which is only joined after
+    // token verification (the spoofable query `userId` is intentionally ignored).
+    const targetToken = (await (await fetch(`${baseUrl}/api/auth/dev-token?userId=user_ws_target`)).json()).token as string
+    const socket = ioClient(`${baseUrl}?userId=user_ws_target`, { transports: ['websocket'], auth: { token: targetToken } })
 
     await new Promise<void>((resolve, reject) => {
       const t = setTimeout(() => reject(new Error('socket connect timeout')), 3000)

--- a/packages/core-backend/tests/unit/comment-service.test.ts
+++ b/packages/core-backend/tests/unit/comment-service.test.ts
@@ -121,6 +121,12 @@ function makeCommentRow(overrides: Record<string, unknown> = {}) {
     spreadsheet_id: 'sheet-1',
     row_id: 'row-1',
     field_id: null,
+    // Canonical container/target columns (mirror spreadsheet_id/row_id/field_id).
+    // The mapper must surface these as containerId/targetId/targetFieldId — keeping
+    // them on the fixture prevents the fixture-vs-wire drift that hid the read field-drop.
+    container_id: 'sheet-1',
+    target_id: 'row-1',
+    target_field_id: null,
     content: 'Hello world',
     author_id: 'user-author',
     parent_id: null,
@@ -185,6 +191,11 @@ describe('CommentService', () => {
       })
 
       expect(comment.mentions).toEqual(['user-123'])
+      // Fixture-vs-wire guard: the mapper must surface the canonical container/target
+      // columns (regression lock for the read field-drop fixed in this PR).
+      expect(comment.containerId).toBe('sheet-1')
+      expect(comment.targetId).toBe('row-1')
+      expect(comment.targetFieldId).toBeNull()
     })
 
     it('notifies record watchers for new comments and suppresses the author in the notifier', async () => {


### PR DESCRIPTION
## The bug

`CommentService.mapRowToComment` dropped the canonical container/target columns the row carries. Every comment read through `getComment` / `getComments` lost its target linkage: the returned comment exposed `spreadsheetId` / `rowId` / `fieldId` but **not** `containerId` / `targetId` / `targetFieldId` — even though `createComment` already writes those columns (`container_id` / `target_id` / `target_field_id`). Surfaced by the #2679 CI-wiring review.

## Dropped columns → restored API fields

| DB column (in `meta_comments`) | API field (now restored) | Notes |
|---|---|---|
| `container_id` | `containerId` (`string`) | mirrors `spreadsheet_id`, NOT NULL |
| `target_id` | `targetId` (`string`) | mirrors `row_id`, NOT NULL |
| `target_field_id` | `targetFieldId` (`string \| null`) | mirrors `field_id`; **`null`** (not `undefined`) for record-level comments |

(`container_type` / `target_type` are intentionally not surfaced — not asserted, not part of the API contract.)

## Five read/emit surfaces fixed

The same field-drop manifested wherever a comment/summary object is assembled. `mapRowToComment` is the keystone, but the committed `comments.api.test.ts` (#2673) asserts the canonical fields on more surfaces that build their objects directly (not via the mapper):

1. **`mapRowToComment`** — `getComment` / `getComments` / reply read paths.
2. **`getCommentPresenceSummary`** items — built inline.
3. **`getMentionSummary`** response + items — built inline.
4. **`getInbox`** items — an **explicit column projection** (not `selectAll()`) that omitted the three columns. Left unfixed, inbox items would have carried `containerId` / `targetId` = `undefined` while the widened type claims `string` (the select-projection round-trip trap). The columns are now selected; a new inbox assertion locks the round-trip.
5. **Realtime payloads** — `comment:created` / `:updated` / `:resolved` / `:deleted` / `:activity` / `:mention` top-level objects.

Shared types (`Comment`, `CommentRow`, presence/mention summary shapes) and their DI copies in `identifiers.ts` are kept in sync (tsc backstop); the stale "deprecated, unused in code" note on those columns is corrected (it was already false — `createComment` writes them).

**Write paths are untouched.** `createComment`'s `.insertInto('meta_comments').values({...})` already writes `container_id` / `target_id` / `target_field_id` correctly; only read/emit assembly is changed.

## The 8 real-wire tests this fixes

`tests/integration/comments.api.test.ts` went from **8 failed | 3 passed → 11/11 pass**. The 8 that were red:

1. creates, lists, resolves, and exposes inbox activity state
2. updates authored comments and only deletes leaf comments
3. returns mention-aware unresolved comment summaries for the current requester
4. creates field comments and one-level replies with inherited field scope
5. filters listed comments by field scope when fieldId is provided
6. returns current-user mention-summary with correct aggregation, unread counts, and sort order
7. returns unresolved comment presence summaries per row and field
8. broadcasts global inbox activity for comment create and resolve

### Test touches (allowed)

- **Socket auth (test 8):** the realtime `comment:mention` assertion connected an **unauthenticated** socket (spoofable query `userId`), which can never receive `sendTo(userId)` personal deliveries — by design the trusted per-user room is joined only after token verification (`CollabService`). This was masked before (test 8 died earlier at the HTTP `containerId` assert). The socket now authenticates with a real dev-token, exercising the production `sendTo` path. **No `CollabService` auth code was changed.**
- **Inbox round-trip (test 1):** added `containerId` / `targetId` / `targetFieldId` assertions on the inbox item so the explicit-projection fix is locked against regression.

## Verification

- Real-wire: `comments.api.test.ts` **11/11 pass** (deterministic across re-runs), against local Postgres.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit -p tsconfig.json` → **0 errors**.
- Unit suite: **3327/3327 pass** (incl. the 4 comment unit tests).

## Note on #2679

#2679 wired the reaction keystone test separately precisely because this field-drop was already turning the same `comments.api.test.ts` suite red. This PR removes that blocker.