### PR TITLE
test(multitable): record-restore coverage M1-M4 (unset-only/keep-days/readonly-reject/link-perm)

### DIFF
--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -102,11 +102,11 @@ const restoreReq = (recordId: string, body: Record<string, unknown>) =>
 
 async function latestRevision(recordId: string) {
   const res = await q(
-    `SELECT version, action, source, changed_field_ids, snapshot
+    `SELECT version, action, source, changed_field_ids, patch, snapshot
      FROM meta_record_revisions WHERE record_id = $1 ORDER BY version DESC, created_at DESC LIMIT 1`,
     [recordId],
   )
-  return res.rows[0] as { version: number; action: string; source: string; changed_field_ids: string[]; snapshot: Record<string, unknown> | null }
+  return res.rows[0] as { version: number; action: string; source: string; changed_field_ids: string[]; patch: Record<string, unknown> | null; snapshot: Record<string, unknown> | null }
 }
 async function liveData(recordId: string): Promise<Record<string, unknown>> {
   const res = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
@@ -697,5 +697,225 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
     expect(res.body.data.noop).toBe(true) // reorder-only → no diff → no version bump
     const ver = await q('SELECT version FROM meta_records WHERE id = $1', [rid])
     expect(Number((ver.rows[0] as { version: number }).version)).toBe(2) // unchanged
+  })
+
+  // ===========================================================================================
+  // Retrospective coverage M1–M4 (lands on top of merged #2677). These cover FULL-restore /
+  // retention paths that #2677's per-field additions (T18–T21: hidden/unknown/deleted selection,
+  // link reorder) do not touch, so they are consistent with #2677's canonical semantics.
+  // ===========================================================================================
+
+  // M1 — pure-unset isolation. Distinct from T1 (which has a set AND an unset in the same diff):
+  // here A is byte-identical between v1 and current, and B was ADDED after v1. So the full restore
+  // to v1 produces a diff of EXACTLY ONE unset (B), nothing else. This pins the `applied += 1`
+  // unset accounting (record-write-service.ts:667) and the revision serialization that marks a
+  // removed key with the explicit `null` sentinel in `patch` (record-write-service.ts:784-788),
+  // while `changed_field_ids` carries only the removed id.
+  test('T22 (M1): unset-only restore — A unchanged, B added-after-v1 → diff is purely unset B; patch[B]===null, changed=[B]', async () => {
+    const rid = await seedRecord(
+      { [FLD_A]: 'shared', [FLD_B]: 'extra' }, // current v2
+      2,
+      [
+        { version: 1, action: 'create', snapshot: { [FLD_A]: 'shared' } }, // A identical; B absent (added after v1)
+        { version: 2, snapshot: { [FLD_A]: 'shared', [FLD_B]: 'extra' } },
+      ],
+    )
+    const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body.data.noop).toBe(false)
+    expect(res.body.data.newVersion).toBe(3) // version bumped
+    // ONLY B is restored (unset); A is unchanged so it is NOT in the diff.
+    expect(res.body.data.restoredFieldIds).toEqual([FLD_B])
+
+    // live row drops B; A retained.
+    const data = await liveData(rid)
+    expect(data[FLD_A]).toBe('shared')
+    expect(Object.prototype.hasOwnProperty.call(data, FLD_B)).toBe(false)
+
+    // a NEW source='restore' revision: changed_field_ids = [B], patch[B] = null sentinel, B absent from after-image.
+    const rev = await latestRevision(rid)
+    expect(rev.version).toBe(3)
+    expect(rev.source).toBe('restore')
+    expect(rev.action).toBe('update')
+    expect(rev.changed_field_ids).toEqual([FLD_B]) // ONLY the removed id — proves A is not in the diff
+    expect(rev.patch).not.toBeNull()
+    expect(Object.prototype.hasOwnProperty.call(rev.patch ?? {}, FLD_B)).toBe(true)
+    expect((rev.patch ?? {})[FLD_B]).toBeNull() // explicit null sentinel for the removal
+    // A must NOT appear in the patch (it was identical → never applied).
+    expect(Object.prototype.hasOwnProperty.call(rev.patch ?? {}, FLD_A)).toBe(false)
+    expect(rev.snapshot && Object.prototype.hasOwnProperty.call(rev.snapshot, FLD_B)).toBe(false) // B dropped from after-image
+    expect(rev.snapshot?.[FLD_A]).toBe('shared')
+  })
+
+  // M2 — keep-days retention DELETE branch (meta-revision-retention.ts:96-113). T13/T14 only cover
+  // keep-last-n and the disabled no-op; the keep-days age-window branch is otherwise unexercised.
+  // Two records prove BOTH guards independently:
+  //   recAged : ALL its revisions (incl. the latest) are older than the window → proves the rn=1
+  //             INVARIANT (NOT recency) is what retains the latest. This is the non-vacuous case.
+  //   recMixed: a mix of aged + recent non-latest rows + a recent latest → proves only aged
+  //             NON-latest rows are deleted.
+  test('T23 (M2): keep-days deletes only aged non-latest revisions; the latest is ALWAYS retained even when it too is aged', async () => {
+    const ageDays = async (recordId: string, version: number, days: number) =>
+      q(`UPDATE meta_record_revisions SET created_at = now() - ($1::int * interval '1 day') WHERE record_id = $2 AND version = $3`, [days, recordId, version])
+
+    // recAged: versions 1..3, the LATEST (v3) is also aged (60d > 30d window). Only rn=1 protects it.
+    const recAged = await seedRecord({ [FLD_A]: 'a3' }, 3, [
+      { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1' } },
+      { version: 2, snapshot: { [FLD_A]: 'a2' } },
+      { version: 3, snapshot: { [FLD_A]: 'a3' } },
+    ])
+    await ageDays(recAged, 1, 90)
+    await ageDays(recAged, 2, 60)
+    await ageDays(recAged, 3, 50) // latest is ALSO older than 30d — recency would NOT keep it; rn=1 must.
+
+    // recMixed: v1 aged (90d), v2 aged (45d), v3 recent latest (0d).
+    const recMixed = await seedRecord({ [FLD_A]: 'm3' }, 3, [
+      { version: 1, action: 'create', snapshot: { [FLD_A]: 'm1' } },
+      { version: 2, snapshot: { [FLD_A]: 'm2' } },
+      { version: 3, snapshot: { [FLD_A]: 'm3' } },
+    ])
+    await ageDays(recMixed, 1, 90)
+    await ageDays(recMixed, 2, 45)
+    // v3 stays recent (created_at = now()).
+
+    const versionsOf = async (recordId: string): Promise<number[]> => {
+      const r = await q('SELECT version FROM meta_record_revisions WHERE record_id = $1 ORDER BY version', [recordId])
+      return (r.rows as Array<{ version: number }>).map((x) => Number(x.version))
+    }
+
+    const deleted = await sweepMetaRevisionRetention(q, { enabled: true, policy: 'keep-days', keepN: 200, retentionDays: 30, batchSize: 5000 })
+    // recAged loses v1,v2 (aged non-latest); recMixed loses v1,v2 (aged non-latest) → ≥4 from our two records
+    // (bounded ≥; other suites' rows may also age out, but our two records' deletions are exact below).
+    expect(deleted).toBeGreaterThanOrEqual(4)
+
+    // recAged: ONLY the latest (v3) survives even though it too is aged → rn=1 INVARIANT, not recency.
+    expect(await versionsOf(recAged)).toEqual([3])
+    // recMixed: aged non-latest (v1,v2) deleted; recent latest (v3) retained.
+    expect(await versionsOf(recMixed)).toEqual([3])
+
+    // Non-vacuity check: a FRESH record whose rows are ALL recent loses NOTHING under the same policy.
+    const recFresh = await seedRecord({ [FLD_A]: 'f2' }, 2, [
+      { version: 1, action: 'create', snapshot: { [FLD_A]: 'f1' } },
+      { version: 2, snapshot: { [FLD_A]: 'f2' } },
+    ])
+    const deleted2 = await sweepMetaRevisionRetention(q, { enabled: true, policy: 'keep-days', keepN: 200, retentionDays: 30, batchSize: 5000 })
+    expect(await versionsOf(recFresh)).toEqual([1, 2]) // both recent → both kept
+    void deleted2 // (other suites' aged rows may still drain; recFresh is the controlled assertion)
+  })
+
+  // M3 — FULL-restore static read_only / hidden rejection + no-leak. T4 already proves the atomic
+  // 403 + no-id-leak shape via a LAYER-3 (field_permissions row) read_only difference. What M3 adds
+  // is the STATIC schema-property gate INPUT: a field whose `property.readOnly:true` (resp.
+  // `property.hidden:true`) feeds isFieldAlwaysReadOnly / isFieldPermissionHidden → guard.readOnly /
+  // guard.hidden → staticOk=false at the route gate, independent of any field_permissions row.
+  // (isFieldAlwaysReadOnly also feeds perm.readOnly via deriveFieldPermissions, so this is the
+  // static-property branch, not staticOk in isolation.) Full restore (no fieldIds) as a FULL-PERMS
+  // writer must atomic-403 and never echo the forbidden id.
+  test('T24 (M3): full restore atomic-403s on a statically read_only OR hidden field that differs; nothing written, id not leaked', async () => {
+    const FLD_STATIC_RO = `fld_rstr_sro_${TS}`
+    const FLD_STATIC_HID = `fld_rstr_shid_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATIC_RO, SHEET_ID, 'StaticRO', 'string', JSON.stringify({ readOnly: true }), 20])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATIC_HID, SHEET_ID, 'StaticHidden', 'string', JSON.stringify({ hidden: true }), 21])
+    try {
+      // --- read_only variant: FLD_STATIC_RO differs v1→current ---
+      const ridRo = await seedRecord(
+        { [FLD_A]: 'a2', [FLD_STATIC_RO]: 'ro_now' },
+        2,
+        [
+          { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_STATIC_RO]: 'ro_old' } },
+          { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_STATIC_RO]: 'ro_now' } },
+        ],
+      )
+      // testUserId = USER_W (full perms, default per beforeEach) — the rejection is from the STATIC property, not a row.
+      const resRo = await restoreReq(ridRo, { targetVersion: 1, expectedVersion: 2 })
+      expect(resRo.status).toBe(403)
+      expect(resRo.body.error.code).toBe('RESTORE_FORBIDDEN')
+      expect(JSON.stringify(resRo.body)).not.toContain(FLD_STATIC_RO) // forbidden id ABSENT from the body
+      // atomic: nothing written (the writable A would otherwise have restored to 'a1').
+      const dataRo = await liveData(ridRo)
+      expect(dataRo[FLD_A]).toBe('a2')
+      expect(dataRo[FLD_STATIC_RO]).toBe('ro_now')
+      const verRo = await q('SELECT version FROM meta_records WHERE id = $1', [ridRo])
+      expect(Number((verRo.rows[0] as { version: number }).version)).toBe(2) // unchanged
+
+      // --- hidden variant: FLD_STATIC_HID differs v1→current ---
+      const ridHid = await seedRecord(
+        { [FLD_A]: 'a2', [FLD_STATIC_HID]: 'hid_now' },
+        2,
+        [
+          { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_STATIC_HID]: 'hid_old' } },
+          { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_STATIC_HID]: 'hid_now' } },
+        ],
+      )
+      const resHid = await restoreReq(ridHid, { targetVersion: 1, expectedVersion: 2 })
+      expect(resHid.status).toBe(403)
+      expect(resHid.body.error.code).toBe('RESTORE_FORBIDDEN')
+      expect(JSON.stringify(resHid.body)).not.toContain(FLD_STATIC_HID)
+      const dataHid = await liveData(ridHid)
+      expect(dataHid[FLD_A]).toBe('a2') // atomic — A not restored
+      const verHid = await q('SELECT version FROM meta_records WHERE id = $1', [ridHid])
+      expect(Number((verHid.rows[0] as { version: number }).version)).toBe(2)
+
+      // Non-vacuity: with the forbidden field set to the SAME value in both versions (no diff), the
+      // very same full restore succeeds — proving the 403 above is driven by the changed forbidden
+      // field, not by the field merely existing.
+      const ridOk = await seedRecord(
+        { [FLD_A]: 'a2', [FLD_STATIC_RO]: 'ro_same' },
+        2,
+        [
+          { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_STATIC_RO]: 'ro_same' } },
+          { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_STATIC_RO]: 'ro_same' } },
+        ],
+      )
+      const resOk = await restoreReq(ridOk, { targetVersion: 1, expectedVersion: 2 })
+      expect(resOk.status).toBe(200)
+      expect((await liveData(ridOk))[FLD_A]).toBe('a1') // A restored; RO field unchanged → not in diff
+    } finally {
+      await q('DELETE FROM meta_fields WHERE id = ANY($1::text[])', [[FLD_STATIC_RO, FLD_STATIC_HID]]).catch(() => {})
+    }
+  })
+
+  // M4 — link-field FULL-restore negative permission (layer-3). The T6 family covers link restore
+  // HAPPY paths; none gate a link restore on a field_permissions read_only row. Here USER_RO is
+  // read_only on the LINK field and the link value differs across versions → full restore must
+  // atomic-403, leave meta_links untouched, and echo no link/foreign id.
+  test('T25 (M4): full restore is 403 when the actor is read_only on a CHANGED link field; meta_links unchanged, no foreign id leaked', async () => {
+    // Seed the negative permission LOCAL to this test so it cannot perturb T1–T24's link assertions.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_LK, 'user', USER_RO, true, true])
+    try {
+      const rid = await seedRecord(
+        { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] }, // current → FOREIGN_REC
+        2,
+        [
+          { version: 1, action: 'create', snapshot: { [FLD_A]: 'a1', [FLD_LK]: [FOREIGN_REC2] } }, // v1 → FOREIGN_REC2 (differs)
+          { version: 2, snapshot: { [FLD_A]: 'a2', [FLD_LK]: [FOREIGN_REC] } },
+        ],
+      )
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}_m4_${recordSeq}`, FLD_LK, rid, FOREIGN_REC])
+
+      testUserId = USER_RO // read_only on the LINK field
+      const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+      expect(res.status).toBe(403)
+      expect(res.body.error.code).toBe('RESTORE_FORBIDDEN')
+      // no link/foreign id echoed in the error
+      expect(JSON.stringify(res.body)).not.toContain(FLD_LK)
+      expect(JSON.stringify(res.body)).not.toContain(FOREIGN_REC2)
+      // atomic: meta_links untouched (still the current edge), data unchanged.
+      const links = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2 ORDER BY foreign_record_id', [FLD_LK, rid])
+      expect((links.rows as Array<{ foreign_record_id: string }>).map((x) => x.foreign_record_id)).toEqual([FOREIGN_REC])
+      const data = await liveData(rid)
+      expect((data[FLD_LK] as string[])).toEqual([FOREIGN_REC])
+
+      // Non-vacuity: a FULL-perms writer (USER_W) CAN do the same restore → proves the 403 is the
+      // negative permission, not a structural block on link restore.
+      testUserId = USER_W
+      const ok = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+      expect(ok.status).toBe(200)
+      expect(ok.body.data.restoredFieldIds).toContain(FLD_LK)
+      const linksAfter = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2 ORDER BY foreign_record_id', [FLD_LK, rid])
+      expect((linksAfter.rows as Array<{ foreign_record_id: string }>).map((x) => x.foreign_record_id)).toEqual([FOREIGN_REC2]) // edge re-pointed to v1
+    } finally {
+      await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2 AND subject_id = $3', [SHEET_ID, FLD_LK, USER_RO]).catch(() => {})
+    }
   })
 })


### PR DESCRIPTION
## Retrospective test coverage for record-restore (M1–M4)

TEST-ONLY. Adds four real-DB integration tests for the **already-merged** multitable record-restore feature (#2654 Layer 1 / #2660 Slice 2a link+retention / #2672 per-field), landing **on top of the merged per-field oracle fix #2677**. No source change.

#2677 added its own per-field tests (T18–T21: hidden/unknown/deleted-in-snapshot selection → 200 no-op; pure link reorder → no-op). These four are about **FULL-restore / retention** paths that #2677 does not touch, so they are consistent with #2677's canonical semantics. Numbered **T22–T25** (T21 was the prior numeric max; renumbered to avoid collision).

### Gaps closed

- **T22 (M1) — unset-only isolation.** `A` is byte-identical between v1 and current; `B` was added after v1. A full restore to v1 → diff is purely **unset B** (distinct from T1, which mixes a set + an unset). Asserts the live row drops `B`, version bumps, and a new `source='restore'` revision has `changed_field_ids === [B]`, `patch.B === null` (the explicit removal sentinel), `restoredFieldIds === [B]`, `noop === false`. Pins the `applied += 1` unset accounting (`record-write-service.ts:667`) and the null-sentinel patch serialization (`record-write-service.ts:784-788`).
- **T23 (M2) — keep-days retention DELETE branch.** Backdated `created_at` on seeded revisions; `sweepMetaRevisionRetention({policy:'keep-days', retentionDays:30})`. Only **aged non-latest** rows are deleted, and the latest is retained **even when it too is aged** — which is the only configuration that proves the `rn=1` invariant (not recency) protects the latest. Exercises `meta-revision-retention.ts:96-113`, uncovered by T13/T14 (keep-last-n / disabled only).
- **T24 (M3) — full-restore static read_only/hidden rejection + no-leak.** A field whose `property.readOnly:true` (and a `property.hidden:true` variant) **differs** across versions → FULL restore (no `fieldIds`) as a full-perms writer → atomic **403 RESTORE_FORBIDDEN**, nothing written, forbidden id ABSENT from the body. T4 already proves the atomic-reject + no-leak shape via a **layer-3** `field_permissions` row; M3 adds the **static schema-property** gate input (`isFieldAlwaysReadOnly` / `isFieldPermissionHidden` → `guard.readOnly`/`guard.hidden`). Note `isFieldAlwaysReadOnly` feeds both `guard.readOnly` and `perm.readOnly`, so this is the static-property branch, not `staticOk` in isolation.
- **T25 (M4) — link-field full-restore negative permission.** `field_permissions(field_id=<link>, subject_id=USER_RO, read_only=true)` + a differing link value across versions → FULL restore as USER_RO → **403 RESTORE_FORBIDDEN**, `meta_links` unchanged (atomic), no link/foreign id echoed. Complements the T6 link happy-paths (none gate a link restore on a negative permission).

### Verification
- Each test proven **non-vacuous** by mutation (wrong expectation → the specific test fails; confirmed all four flip red).
- `tsc --noEmit` clean (0 errors).
- Full file green against local Postgres: **34/34 passed** (30 prior + 4 new), all executed (not skipped — the `sentinel: DATABASE_URL set` ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)