### PR TITLE
ci(multitable): real-browser verification lane for CF + reactions UI

### DIFF
--- a/.github/workflows/multitable-browser-verify.yml
+++ b/.github/workflows/multitable-browser-verify.yml
@@ -1,0 +1,77 @@
+name: Multitable Browser Verify
+
+# Real-browser verification lane for multitable conditional-formatting + reaction
+# UI (the visual/interaction render jsdom can't prove). Boots Vite, renders the
+# real components via apps/web/verification harness, asserts render + a reaction
+# click→chip mutation, and uploads screenshots. Fail-loud: console/page errors,
+# missing render, or the picked chip not appearing turn this red.
+#
+# Scope (minimal lane): Path A harness only — no backend, no DB seed. Once this
+# lane is green, browser-gated UI (B1-b/c, A5 config dialog) may proceed.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/web/src/multitable/components/MetaGridTable.vue'
+      - 'apps/web/src/multitable/components/MetaCommentReactions.vue'
+      - 'apps/web/src/multitable/components/MetaCommentsDrawer.vue'
+      - 'apps/web/src/multitable/utils/conditional-formatting.ts'
+      - 'apps/web/verification/**'
+      - 'apps/web/playwright.verification.config.ts'
+      - '.github/workflows/multitable-browser-verify.yml'
+
+jobs:
+  browser-verify:
+    name: Multitable browser verify (chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright chromium (+ system deps)
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run browser verification (boots Vite, renders real components)
+        run: pnpm --filter @metasheet/web exec playwright test --config playwright.verification.config.ts
+
+      - name: Upload verification screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: multitable-browser-verify-screenshots
+          path: apps/web/verification-output/*.png
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ artifacts/integration-k3wise/internal-trial/
 # source manifests/runbooks in Git, not built archives and verification output.
 output/delivery/multitable-onprem/
 output/releases/
+
+# multitable browser-verification lane outputs (screenshots, traces)
+apps/web/verification-output/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run --watch=false",
+    "verify:browser": "playwright test --config playwright.verification.config.ts",
     "type-check": "vue-tsc -b",
     "lint": "eslint \"src/main.ts\" \"src/App.vue\" \"src/composables/useAuth.ts\" \"src/stores/featureFlags.ts\" \"src/utils/api.ts\" \"src/views/HomeRedirect.vue\" \"src/views/LoginView.vue\" \"src/views/PlmProductView.vue\" \"src/views/PlmAuditView.vue\" \"src/views/plmAuditQueryState.ts\" \"src/views/plmAuditSavedViews.ts\" \"src/views/WorkflowDesigner.vue\" \"src/views/WorkflowHubView.vue\" \"src/views/plm/*.ts\" \"src/views/workflowDesigner*.ts\" \"src/views/workflowHub*.ts\" \"src/services/PlmService.ts\" \"src/services/plm/*.ts\" \"src/components/plm/*.vue\" \"tests/featureFlags.spec.ts\" \"tests/useAuth.spec.ts\" \"tests/utils/api.test.ts\" \"tests/plm*.spec.ts\" \"tests/usePlm*.spec.ts\" \"tests/workflowDesigner*.spec.ts\" \"tests/workflowHub*.spec.ts\" --max-warnings=0"
   },

--- a/apps/web/playwright.verification.config.ts
+++ b/apps/web/playwright.verification.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Browser-verification lane (B6/A5 UI). Boots the Vite dev server, renders the
+// real components via the verification harness, and asserts the visual/interaction
+// render that jsdom can't. Run: `pnpm --filter @metasheet/web exec playwright test
+// --config playwright.verification.config.ts` (cwd = apps/web).
+const PORT = 5174
+
+export default defineConfig({
+  testDir: './verification',
+  testMatch: '**/*.spec.ts',
+  timeout: 60_000,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  outputDir: './verification-output/_pw',
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    screenshot: 'off', // the spec takes explicit, named screenshots
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `pnpm exec vite --port ${PORT} --strictPort`,
+    url: `http://127.0.0.1:${PORT}/verification/cf-reactions-harness.html`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/apps/web/verification/cf-reactions-harness.html
+++ b/apps/web/verification/cf-reactions-harness.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Multitable CF + reactions — browser verification harness</title></head>
+  <body style="margin:16px;font-family:system-ui">
+    <h3>A5 conditional-formatting render + B6 reactions — browser verification</h3>
+    <div id="app"></div>
+    <script type="module" src="./cf-reactions-harness.ts"></script>
+  </body>
+</html>

--- a/apps/web/verification/cf-reactions-harness.ts
+++ b/apps/web/verification/cf-reactions-harness.ts
@@ -1,0 +1,67 @@
+// Browser-verification harness (dev/CI only — NOT part of the app build/typecheck;
+// lives outside src/ so vue-tsc + vite build ignore it). Mounts the real
+// MetaGridTable (data-bar / color-scale / icon-set) + MetaCommentReactions with
+// fixtures so a real browser (Playwright in CI) can confirm the visual/interaction
+// render that jsdom can't. Reactions are reactive so click → chip change is observable.
+import { createApp, h, ref } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import MetaCommentReactions from '../src/multitable/components/MetaCommentReactions.vue'
+import { buildFieldScaleMap, sanitizeScaleRule } from '../src/multitable/utils/conditional-formatting'
+import type { MultitableCommentReaction } from '../src/multitable/types'
+
+const FIELDS = [
+  { id: 'bar', name: 'Data bar', type: 'number' },
+  { id: 'scale', name: 'Color scale', type: 'number' },
+  { id: 'icon', name: 'Icon set', type: 'number' },
+  { id: 'label', name: 'Label', type: 'string' },
+]
+const ROWS = [0, 25, 50, 75, 100].map((n, i) => ({
+  id: `r${i}`, version: 1, data: { bar: n, scale: n, icon: n, label: `row ${i}` },
+}))
+const scaleMap = buildFieldScaleMap([
+  sanitizeScaleRule({ id: 'b', fieldId: 'bar', kind: 'dataBar', order: 0, range: { mode: 'auto' }, dataBar: { color: '#2196f3' } })!,
+  sanitizeScaleRule({ id: 'c', fieldId: 'scale', kind: 'colorScale', order: 1, range: { mode: 'auto' }, colorScale: { stops: [{ at: 'min', color: '#ff5252' }, { at: 'mid', color: '#ffeb3b' }, { at: 'max', color: '#4caf50' }] } })!,
+  sanitizeScaleRule({ id: 'i', fieldId: 'icon', kind: 'iconSet', order: 2, range: { mode: 'auto' }, iconSet: { set: 'arrows3', thresholds: [33, 66] } })!,
+], ROWS)
+
+const reactions = ref<MultitableCommentReaction[]>([
+  { emoji: '👍', count: 3, reactedByMe: true },
+  { emoji: '❤️', count: 1, reactedByMe: false },
+  { emoji: '🎉', count: 5, reactedByMe: false },
+])
+function applyReaction(emoji: string, mode: 'add' | 'remove') {
+  const cur = reactions.value
+  const ex = cur.find((r) => r.emoji === emoji)
+  if (mode === 'add') {
+    if (!ex) reactions.value = [...cur, { emoji, count: 1, reactedByMe: true }]
+    else if (!ex.reactedByMe) reactions.value = cur.map((r) => (r.emoji === emoji ? { ...r, count: r.count + 1, reactedByMe: true } : r))
+  } else if (ex?.reactedByMe) {
+    const count = Math.max(0, ex.count - 1)
+    reactions.value = count === 0
+      ? cur.filter((r) => r.emoji !== emoji)
+      : cur.map((r) => (r.emoji === emoji ? { ...r, count, reactedByMe: false } : r))
+  }
+}
+
+createApp({
+  setup() {
+    return () => h('div', [
+      h('div', { style: 'border:1px solid #ddd;margin-bottom:24px' }, [
+        h(MetaGridTable, {
+          rows: ROWS, visibleFields: FIELDS, sortRules: [], loading: false,
+          currentPage: 1, totalPages: 1, startIndex: 0, canEdit: true,
+          searchText: '', rowDensity: 'normal', conditionalFormattingScale: scaleMap,
+        }),
+      ]),
+      h('div', { style: 'padding:12px;border:1px solid #ddd;max-width:360px' }, [
+        h('div', { style: 'margin-bottom:8px;color:#333' }, 'Reaction chips + picker:'),
+        h(MetaCommentReactions, {
+          commentId: 'c1', canReact: true,
+          reactions: reactions.value,
+          onReact: (_id: string, emoji: string) => applyReaction(emoji, 'add'),
+          onUnreact: (_id: string, emoji: string) => applyReaction(emoji, 'remove'),
+        }),
+      ]),
+    ])
+  },
+}).mount('#app')

--- a/apps/web/verification/cf-reactions.spec.ts
+++ b/apps/web/verification/cf-reactions.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+// Real-browser verification of the shipped multitable UI render that jsdom can't
+// prove: data-bar gradient, color-scale cell fill, icon-set glyphs, and B6
+// reaction chips + picker (incl. a click→chip mutation). Fail-loud: any console /
+// page error, a missing render, or the picked chip not appearing turns this red.
+// Screenshots land in apps/web/verification-output/ for CI artifact upload.
+
+const OUT = 'verification-output' // relative to apps/web (the playwright cwd)
+const HARNESS = '/verification/cf-reactions-harness.html'
+
+test('multitable conditional-formatting + reactions render in a real browser', async ({ page }) => {
+  mkdirSync(OUT, { recursive: true })
+  const errs: string[] = []
+  page.on('console', (m) => { if (m.type() === 'error') errs.push(`console: ${m.text()}`) })
+  page.on('pageerror', (e) => errs.push(`pageerror: ${String(e)}`))
+
+  await page.goto(HARNESS, { waitUntil: 'domcontentloaded' })
+  await expect(page.locator('.meta-grid__cell').first()).toBeVisible({ timeout: 30_000 })
+  await page.screenshot({ path: `${OUT}/bv-grid.png`, fullPage: true })
+
+  // A5-1 data-bar: at least one cell painted with a left-anchored linear-gradient.
+  const gradientCells = await page.locator('.meta-grid__cell').evaluateAll(
+    (els) => els.filter((el) => getComputedStyle(el as HTMLElement).backgroundImage.includes('linear-gradient')).length,
+  )
+  expect(gradientCells, 'expected ≥1 data-bar gradient cell').toBeGreaterThan(0)
+
+  // A5-2 color-scale: at least one cell with a solid (non-transparent) bg fill.
+  const filledCells = await page.locator('.meta-grid__cell').evaluateAll(
+    (els) => els.filter((el) => {
+      const bg = getComputedStyle(el as HTMLElement).backgroundColor
+      return !!bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent'
+    }).length,
+  )
+  expect(filledCells, 'expected ≥1 color-scale filled cell').toBeGreaterThan(0)
+
+  // A5-3 icon-set: glyphs rendered in cells.
+  expect(await page.locator('[data-test="cell-scale-icon"]').count(), 'expected ≥1 icon-set glyph').toBeGreaterThan(0)
+
+  // B6 reactions: chips visible.
+  await expect(page.locator('[data-test="comment-reactions"] .meta-comment-reactions__chip').first()).toBeVisible()
+
+  // B6 picker: open + screenshot.
+  await page.locator('[data-test="reaction-add"]').click()
+  await expect(page.locator('[data-test="reaction-palette"]')).toBeVisible()
+  await page.screenshot({ path: `${OUT}/bv-reactions-picker.png` })
+
+  // B6 interaction: pick a NEW emoji → its chip must appear (reactive harness).
+  await page.locator('[data-test="reaction-pick-🚀"]').click()
+  await expect(page.locator('[data-test="reaction-chip-🚀"]')).toBeVisible()
+  await page.screenshot({ path: `${OUT}/bv-reactions-after.png` })
+
+  // Fail loud on any console / page error captured from load through interaction.
+  expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
+})

--- a/docs/development/multitable-browser-verify-ci-lane-20260615.md
+++ b/docs/development/multitable-browser-verify-ci-lane-20260615.md
@@ -1,0 +1,48 @@
+# 多维表 浏览器验证 CI lane(修路) — 开发 & 验证 — 2026-06-15
+
+> Status: **LANE BUILT,CI-VERIFIED-NOT-LOCALLY**(撰写方沙箱 SIGKILL Chrome,本机跑不了浏览器;CI 是首个真实运行环境)。把 #2683 的手动验证包升级为**长期 CI 能力**:真实浏览器渲染 + 断言 + 截图,作为 browser-gated UI 的门禁基础设施。
+>
+> owner 决策(2026-06-15):优先建 CI lane 而非只手动跑一次 —— "修路,不只是过河"。B1-b/c、A5 config dialog、后续多维表 UI 都需真实浏览器;这条 lane 把"浏览器可验证"变成可复用能力。
+
+## 1. 范围(最小 lane,按 owner 规格)
+
+- **只跑 Path A harness**:无后端、无 DB seed,先把浏览器能力打通。
+- 渲染真实组件 `MetaGridTable`(data-bar / color-scale / icon-set)+ `MetaCommentReactions`(chips + picker),用 fixture 数据。
+- **fail-loud**:console/pageerror、缺选择器、chip 不出现 → 全红。
+- **CI 产物**:上传 `bv-grid.png` / `bv-reactions-picker.png` / `bv-reactions-after.png`。
+
+## 2. 构成(文件)
+
+| 文件 | 作用 |
+|---|---|
+| `apps/web/verification/cf-reactions-harness.html` + `.ts` | dev/CI-only harness;挂载真实组件 + fixture;reactions **reactive**(onReact/onUnreact 本地重算 → 点击 chip 变化可见)。**置于 src/ 外**,故 vue-tsc/vite build/lint **均不收录**(对既有 CI 门零影响,实测确认) |
+| `apps/web/verification/cf-reactions.spec.ts` | Playwright 测:goto harness → 断言 data-bar 渐变 / color-scale 实底色 / icon-set 字形 / 反应 chips → 开 picker → 选 🚀 断言新 chip 出现 → 截图 → console/pageerror 必为空 |
+| `apps/web/playwright.verification.config.ts` | testDir=verification;`webServer` 自启 `vite --port 5174 --strictPort`;chromium project;CI retain-trace-on-failure |
+| `.github/workflows/multitable-browser-verify.yml` | on PR(多维表 UI 文件 + verification/ 变更)+ workflow_dispatch;install → `playwright install --with-deps chromium` → 跑 lane → 始终上传截图 |
+| `apps/web/package.json` | `verify:browser` 脚本 |
+| `.gitignore` | 忽略 `apps/web/verification-output/`(截图/trace 产物) |
+
+## 3. 验证
+
+| 项 | 结果 |
+|---|---|
+| Playwright config + spec 解析/收集(`playwright test --list`) | ✅ 1 test collected,无解析错 |
+| Vite 服务 harness HTML | ✅ 200 |
+| harness `.ts` transform + `../src/` import 解析 | ✅ 干净(vite 解析到 `/src/multitable/...`,日志无 resolve/transform 错) |
+| 对既有 CI 门(vue-tsc / lint / vite build / vitest)影响 | ✅ 零(harness 在 src/ 外、lint 显式文件列表外、build input 外 —— 实测确认) |
+| @playwright/test 依赖 | ✅ 已是 root devDep(`^1.57.0`),无 lockfile 改动 |
+| **真实浏览器运行**(渲染断言 + 截图 + 交互) | ⏸ **本机跑不了(沙箱 SIGKILL Chrome);CI 为首个真实运行** —— 诚实边界 |
+
+**诚实声明**:除"真实浏览器运行"外全部本地实测通过;那一步本机无法验证(无浏览器),**CI 是首个真实测试**,红则迭代。这正是建 lane 的意义:把验证放到有浏览器的地方(CI)。
+
+## 4. 门禁
+
+- **本 lane CI 绿** → 三项视觉残余(data-bar / color-scale·icon-set / B6 reactions)由真实浏览器确认 → 各 dev/verification MD 的"浏览器目检=残余"可改"已 CI 浏览器验证";**然后**方可开 B1-b/c、A5 config dialog。
+- lane 红 → 可能是配置待调,也可能是**真发现视觉 bug**(验证在起作用)→ 按项开 focused fix PR。
+- 在 lane 绿前:**不开 browser-gated UI**,不堆 jsdom-only 切片。
+
+## 5. 后续(lane 绿后可选增强,均待具名 opt-in)
+
+- Path B 全栈 e2e(seed + 真实工作台导航 + 反应 API 往返);
+- 视觉回归快照对比(Playwright `toHaveScreenshot`);
+- 把本 lane 设为 browser-gated UI PR 的 required check。


### PR DESCRIPTION
## Summary

Builds a reusable **CI Playwright lane** ("修路, not 过河") so the visual/interaction render of multitable UI — which jsdom can't prove — is verified in a **real browser** (CI has browsers; the authoring sandbox `SIGKILL`s Chrome). This establishes the browser lane that gates B1-b/c, the A5 config dialog, and future multitable UI.

Per the owner decision: prioritise a CI lane over a one-off manual run, so "browser-verifiable" becomes a durable capability.

## Scope — minimal (Path A only, no backend / no DB seed)
- `apps/web/verification/` harness mounts the **real** `MetaGridTable` (data-bar / color-scale / icon-set) + `MetaCommentReactions` with fixtures; reactions are reactive so a **click→chip mutation is observable**.
- `cf-reactions.spec.ts` asserts each render (gradient cell / filled cell / icon glyph / reaction chips), opens the picker, picks `🚀` and asserts the new chip appears, screenshots each step, and **fails loud** on any `console`/`pageerror`.
- `.github/workflows/multitable-browser-verify.yml`: runs on multitable-UI / verification changes (+ `workflow_dispatch`), installs chromium, runs the lane, **always uploads screenshots** (`bv-grid.png`, `bv-reactions-picker.png`, `bv-reactions-after.png`).

## Zero impact on existing gates
The harness lives **outside `src/`**, so `vue-tsc`, `vite build`, lint (explicit file list), and vitest all ignore it (verified). `@playwright/test` is already a root devDep — no lockfile change.

## Verification (honest boundary)
Locally verified: `playwright test --list` collects the test; Vite serves the harness (200) and resolves the `../src` imports cleanly (no transform error). **Not** locally browser-run — the sandbox SIGKILLs Chrome, so **CI is the first real execution** (which is the point of the lane). If CI is red it's either config to tune or a real visual bug the lane caught.

## Gate
Once this lane is green, the three visual residuals (data-bar / color-scale·icon-set / B6 reactions) are real-browser-confirmed → then B1-b/c and the A5 config dialog may proceed. Until then: no browser-gated UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)