### PR TITLE
test(multitable): sweep comment test helpers to carry canonical container/target ids

### DIFF
--- a/packages/core-backend/tests/unit/comment-reactions.test.ts
+++ b/packages/core-backend/tests/unit/comment-reactions.test.ts
@@ -92,6 +92,10 @@ beforeEach(async () => {
 function makeCommentRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 'cmt_test-1', spreadsheet_id: 'sheet-1', row_id: 'row-1', field_id: null,
+    // Canonical container/target columns (mirror spreadsheet_id/row_id/field_id) so
+    // the readback row matches the real DB shape mapRowToComment reads — drift-prevention
+    // follow-up to #2685.
+    container_id: 'sheet-1', target_id: 'row-1', target_field_id: null,
     content: 'Hello world', author_id: 'user-author', parent_id: null, resolved: false,
     created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z',
     mentions: '[]', ...overrides,

--- a/packages/core-backend/tests/unit/comment-service-formal-scope.test.ts
+++ b/packages/core-backend/tests/unit/comment-service-formal-scope.test.ts
@@ -74,6 +74,13 @@ function makeCommentRow(overrides: Record<string, unknown> = {}) {
     spreadsheet_id: 'sheet_scope',
     row_id: 'rec_scope',
     field_id: 'fld_scope',
+    // Canonical container/target columns (mirror spreadsheet_id/row_id/field_id) so the
+    // createComment readback row matches the real DB shape mapRowToComment reads. This is a
+    // field-level fixture (target_field_id non-null), complementing the record-level coverage
+    // #2685 added in comment-service.test.ts — drift-prevention follow-up.
+    container_id: 'sheet_scope',
+    target_id: 'rec_scope',
+    target_field_id: 'fld_scope',
     content: 'Scope check',
     author_id: 'user_scope',
     parent_id: null,
@@ -100,7 +107,7 @@ describe('CommentService formalized scope writes', () => {
 
     const service = new CommentService(makeCollabService(), makeLogger())
 
-    await service.createComment({
+    const created = await service.createComment({
       spreadsheetId: 'sheet_scope',
       rowId: 'rec_scope',
       fieldId: 'fld_scope',
@@ -118,5 +125,12 @@ describe('CommentService formalized scope writes', () => {
       container_type: 'meta_sheet',
       container_id: 'sheet_scope',
     })
+
+    // Fixture-vs-wire read guard: the createComment readback runs mapRowToComment, which must
+    // surface the canonical container/target aliases. This locks the FIELD-LEVEL read surface
+    // (target_field_id non-null) — complementing #2685's record-level (null) assertion.
+    expect(created.containerId).toBe('sheet_scope')
+    expect(created.targetId).toBe('rec_scope')
+    expect(created.targetFieldId).toBe('fld_scope')
   })
 })


### PR DESCRIPTION
## What

TEST-ONLY drift-prevention sweep, following up the merged **#2685** (`mapRowToComment` read field-drop fix). #2685 already topped up `makeCommentRow()` in `comment-service.test.ts`; this sweep covers the **remaining** comment unit-test ROW fixtures that still omitted the canonical `container_id` / `target_id` / `target_field_id` columns, fully closing the fixture-vs-wire drift for the comment read path.

Per the forward rule (any field surfaced via field-by-field mapping needs a fixture/test that round-trips it through the real wire), every comment ROW fixture that flows through `mapRowToComment` should carry the canonical container/target columns so the test row matches the real DB shape.

## Fixtures / helpers updated

| File | Helper | Change |
|---|---|---|
| `packages/core-backend/tests/unit/comment-reactions.test.ts` | `makeCommentRow()` | Added `container_id: 'sheet-1'`, `target_id: 'row-1'`, `target_field_id: null` mirroring `spreadsheet_id` / `row_id` / `field_id` (record-level fixture). |
| `packages/core-backend/tests/unit/comment-service-formal-scope.test.ts` | `makeCommentRow()` | Added `container_id: 'sheet_scope'`, `target_id: 'rec_scope'`, `target_field_id: 'fld_scope'` (field-level fixture, non-null `target_field_id`). |
| `packages/core-backend/tests/unit/comment-service-formal-scope.test.ts` | `it('writes canonical target/container columns …')` | Captured the `createComment` return and added a **read assertion** — `containerId` / `targetId` / `targetFieldId` — locking the mapper on the **field-level** read surface (`target_field_id` non-null), complementing #2685's record-level (`null`) assertion. |

## Intentionally skipped

- `comment-service.test.ts` — `makeCommentRow()` **already fixed by #2685** (out of scope).
- `comment-contracts.test.ts` — no DB-row builders; its camelCase literals are `CommentCreateInput` *write-input* shapes (server-derived ids never appear in client input), not post-mapping comment OBJECTs.
- `GroupedCountRow` / `MentionGroupedCountRow` literals (`{ row_id, field_id, comment_count }`) — aggregate count rows, not comment rows.
- The `makeCommentRow({ spreadsheet_id, row_id })` override in `comment-service.test.ts` (line ~203) — its overrides match the #2685 defaults, no drift.

## Scope discipline

Test-only — no production / source / write-path / integration-test changes.

## Verify

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/comment-reactions.test.ts tests/unit/comment-service-formal-scope.test.ts` → **2 files, 17 tests passed**.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit -p tsconfig.json` → exit 0. Note: the package `tsconfig.json` `exclude`s `**/*.test.ts`, so tsc does **not** type-check these test edits — the vitest run is the real check (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)