### PR TITLE
fix(multitable): readable text over conditional-formatting scale fills (A5)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -72,7 +72,7 @@
                   v-for="(field, ci) in visibleFields"
                   :key="field.id"
                   class="meta-grid__cell"
-                  :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === flatIndex(group, ri) && focusCol === ci }"
+                  :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === flatIndex(group, ri) && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(row.id, field.id) }"
                   :style="cellStyle(row.id, field.id, ci)"
                   @dblclick="startEdit(row, field)"
                   @click.stop="onCellClick(flatIndex(group, ri), ci, row.id)"
@@ -197,7 +197,7 @@
                 role="gridcell"
                 :aria-label="field.name"
                 class="meta-grid__cell"
-                :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci }"
+                :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(row.id, field.id) }"
                 :style="cellStyle(row.id, field.id, ci)"
                 @dblclick="startEdit(row, field)"
                 @click.stop="onCellClick(ri, ci, row.id)"
@@ -637,8 +637,40 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   const frozenStyle: Record<string, string> | undefined = frozen
     ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: colorScaleFill ?? effectiveFormat?.backgroundColor ?? '#fff' }
     : undefined
-  if (!widthStyle && !effectiveFormat && !scaleStyle && !frozenStyle) return undefined
-  return { ...(widthStyle ?? {}), ...(effectiveFormat ?? {}), ...(scaleStyle ?? {}), ...(frozenStyle ?? {}) }
+  // Over a scale fill, force a readable text color via a CSS var the cell-renderer
+  // sign-colors inherit (see the `.meta-grid__cell--scale-fill` :deep rule). A
+  // single neutral color can't be readable on every fill (color-scale spans
+  // black→white), so pick dark/white by the fill's luminance. dataBar uses a
+  // default dark (the bar is left-anchored; over-engineering per-bar isn't worth it).
+  const scaleTextColor = colorScaleFill
+    ? readableTextOn(colorScaleFill)
+    : barEntry
+      ? '#111827'
+      : undefined
+  const scaleTextVar: Record<string, string> | undefined = scaleTextColor
+    ? { '--meta-grid-scale-text-color': scaleTextColor }
+    : undefined
+  if (!widthStyle && !effectiveFormat && !scaleStyle && !frozenStyle && !scaleTextVar) return undefined
+  return { ...(widthStyle ?? {}), ...(effectiveFormat ?? {}), ...(scaleStyle ?? {}), ...(frozenStyle ?? {}), ...(scaleTextVar ?? {}) }
+}
+
+// Pick a readable text color (#111827 dark / #ffffff white) for a given fill hex,
+// by perceived luminance (YIQ). Used so cell-renderer sign-colors don't go
+// low-contrast over a color-scale fill (which can be any color incl. black/white).
+function readableTextOn(hex: string): string {
+  const h = hex.trim().replace(/^#/, '')
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h.slice(0, 6)
+  const n = parseInt(full, 16)
+  if (!Number.isFinite(n)) return '#111827'
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  return yiq >= 140 ? '#111827' : '#ffffff'
+}
+
+/** True when a cell carries a data-bar or color-scale fill (drives the scale-fill class). */
+function cellHasScaleFill(rid: string, fid: string): boolean {
+  const e = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
+  return !!e && (typeof e.barPct === 'number' || typeof e.scaleColor === 'string')
 }
 
 // A5-3 icon set render: map an `iconKey` (`${set}:${index}`) to a glyph + color.
@@ -860,6 +892,13 @@ function onKeydown(e: KeyboardEvent) {
 .meta-grid__cell--readonly { color: #666; }
 .meta-grid__cell--focused { outline: 2px solid #409eff; outline-offset: -2px; }
 .meta-grid__cell-scale-icon { display: inline-block; margin-right: 4px; font-weight: 700; vertical-align: middle; }
+/* Over a data-bar / color-scale fill, force the cell-renderer's number sign-colors
+   (green/red, set on an inner span that out-specifies the cell) to a luminance-
+   picked readable color so values stay legible on saturated fills. */
+.meta-grid__cell--scale-fill :deep(.meta-cell-renderer--positive),
+.meta-grid__cell--scale-fill :deep(.meta-cell-renderer--negative) {
+  color: var(--meta-grid-scale-text-color, inherit) !important;
+}
 .meta-grid__comment-action,
 .meta-grid__field-comment-action {
   display: inline-flex;

--- a/apps/web/tests/multitable-grid-databar.spec.ts
+++ b/apps/web/tests/multitable-grid-databar.spec.ts
@@ -166,4 +166,44 @@ describe('MetaGridTable — color scale (A5-2) + icon set (A5-3) render', () => 
     // cells[1] is r1.label (no scale rule) → no icon
     expect(cells[1].querySelector('[data-test="cell-scale-icon"]')).toBeNull()
   })
+
+  // Contrast fix (surfaced by the #2689 browser lane): cell-renderer number
+  // sign-colors go low-contrast over scale fills, so scale-fill cells get a
+  // luminance-picked readable text var + a class the :deep rule keys on.
+  it('sets a luminance-picked readable text var on color-scale cells (dark fill → white, light fill → dark)', () => {
+    const colorScale = buildFieldScaleMap([
+      sanitizeScaleRule({
+        id: 'cs1', fieldId: 'amount', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+        colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+      })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: colorScale })
+    const cells = dataCells(root)
+    // cells[0] = amount 0 → fill #000000 (dark) → white text var
+    expect(cells[0].classList.contains('meta-grid__cell--scale-fill')).toBe(true)
+    expect(cells[0].style.getPropertyValue('--meta-grid-scale-text-color')).toBe('#ffffff')
+    // cells[4] = amount 100 → fill #ffffff (light) → dark text var
+    expect(cells[4].style.getPropertyValue('--meta-grid-scale-text-color')).toBe('#111827')
+  })
+
+  it('sets a default dark text var + scale-fill class on data-bar cells', () => {
+    const dataBar = buildFieldScaleMap([
+      sanitizeScaleRule({ id: 'b1', fieldId: 'amount', kind: 'dataBar', order: 0, range: { mode: 'auto' }, dataBar: { color: '#2196f3' } })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: dataBar })
+    const cells = dataCells(root)
+    expect(cells[2].classList.contains('meta-grid__cell--scale-fill')).toBe(true)
+    expect(cells[2].style.getPropertyValue('--meta-grid-scale-text-color')).toBe('#111827')
+  })
+
+  it('does not set the scale-text var or class on a field with no scale rule', () => {
+    const dataBar = buildFieldScaleMap([
+      sanitizeScaleRule({ id: 'b1', fieldId: 'amount', kind: 'dataBar', order: 0, range: { mode: 'auto' }, dataBar: { color: '#2196f3' } })!,
+    ], ROWS)
+    const root = mountGrid({ conditionalFormattingScale: dataBar })
+    const cells = dataCells(root)
+    // cells[1] = r1.label (no rule) → no var, no class
+    expect(cells[1].classList.contains('meta-grid__cell--scale-fill')).toBe(false)
+    expect(cells[1].style.getPropertyValue('--meta-grid-scale-text-color')).toBe('')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the legibility bug the **#2689 browser lane surfaced on its first run**: `MetaCellRenderer` always sign-colors numbers (positive→green `#67c23a`, negative→red) on an inner span that out-specifies the cell, so values over a data-bar / color-scale fill render **low-contrast** (green on green/yellow/blue). The render was correct; the text wasn't readable.

## Fix (grid-layer — forces the child renderer's sign-color)
- `cellStyle` sets `--meta-grid-scale-text-color` on scale-fill cells: **luminance-picked** `#111827` (dark) / `#ffffff` (white) for a color-scale fill — a single neutral color can't be readable across a black→white scale — and a default dark for data-bar (no per-bar over-engineering).
- Scale-fill cells get a `meta-grid__cell--scale-fill` class; a scoped `:deep()` rule forces `.meta-cell-renderer--positive/--negative` to the var, so the sign-color no longer fights the fill.

This follows the reviewer's exact prescription (CSS var + luminance dark/white + scale-fill class + `:deep` force).

## Verification
- **+3 jsdom** tests: var = white on a dark fill / dark on a light fill / dark on data-bar; scale-fill class present on scale cells, absent on unscaled fields. **61 passed** across grid/cf/frozen suites.
- The **#2689 browser lane re-runs on this PR** (touches `MetaGridTable.vue`) to **visually confirm** the values are now legible over the fills — the real test of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)