### PR TITLE
docs(multitable): flip A5-2/3 + B6-b residuals to CI-browser-verified

### DIFF
--- a/docs/development/multitable-cf-scale-a5-2-a5-3-render-dev-verification-20260615.md
+++ b/docs/development/multitable-cf-scale-a5-2-a5-3-render-dev-verification-20260615.md
@@ -1,6 +1,6 @@
 # 多维表条件格式 A5-2/A5-3 网格渲染 — 开发 & 校验 — 2026-06-15
 
-> Status: **DONE（jsdom 逻辑验证）+ 浏览器目检为残余**。补齐 A5 范围型条件格式弧的最后渲染半：色阶(A5-2) 单元格底色 + 图标集(A5-3) 字形。后端契约 + FE 镜像 + scale map 已于 #2664 落地；本 slice 仅补 `MetaGridTable` 的渲染消费（A5-1c data-bar 渲染的同款 jsdom-可验证先例）。
+> Status: **DONE + CI-BROWSER-VERIFIED**(jsdom 逻辑 + 真实 Chromium 截图确认)。补齐 A5 范围型条件格式弧的最后渲染半:色阶(A5-2) 单元格底色 + 图标集(A5-3) 字形。后端契约 + FE 镜像 + scale map 已于 #2664 落地;本 slice 仅补 `MetaGridTable` 的渲染消费。浏览器目检已由 CI lane(#2689)完成,截图确认色阶/图标渲染正确;首跑发现的数值低对比 bug 已修(#2694)并经 lane 复跑截图确认可读。
 
 ## 1. 开发（做了什么）
 
@@ -25,7 +25,7 @@
 ## 3. Goal 边界（诚实残余）
 
 - ✅ **A5-2/3 网格渲染逻辑 jsdom 验证到位**（cellStyle 输出 + 图标 DOM）。
-- ⏸ **浏览器目检 = 残余**（同 A5-1c / B6-b）：jsdom 证 style/DOM，证不了真实色阶对比度可读性、图标字形跨平台渲染、frozen 滚动观感。有浏览器/app 访问后做一次目检（本地 app + Playwright 或 owner staging）。
+- ✅ **浏览器目检 = 已由 CI lane 完成**（#2689 真实 Chromium 截图）：色阶红→黄→绿插值、图标 ↓/→/↑ 分桶、data-bar 缩放均渲染正确。**首跑捕获真实视觉 bug**(数值正负号绿/红色在 scale 底色上低对比)→ #2694 修(亮度选 dark/white 文本)→ lane 复跑截图确认数值在蓝/黄/绿底色上均可读。frozen 滚动观感未单独验,非本弧阻塞。
 - ⏸ **配置 UI 仍缺**：色阶/图标集规则需经条件格式配置对话框创建（browser-gated，未做）；本 slice 渲染**已配置**的规则。配置对话框 = 后续 browser-gated slice。
 
 ## 4. 落地

--- a/docs/development/multitable-comment-reactions-b6b-dev-verification-20260615.md
+++ b/docs/development/multitable-comment-reactions-b6b-dev-verification-20260615.md
@@ -1,6 +1,6 @@
 # 多维表评论 Emoji 反应 B6-b — 开发 & 校验 — 2026-06-15
 
-> Status: **DONE（逻辑层 jsdom/单测验证）+ 浏览器目检为残余**。B6 弧的 UI 半 = 评论反应展示 + 选择器 + 组合式/客户端接线。延续 B6-a（存储 + API，已合并 #2673）。realtime 广播仍推迟（见 §4）。
+> Status: **DONE + CI-BROWSER-VERIFIED**(jsdom/单测 + 真实 Chromium 截图确认)。B6 弧的 UI 半 = 评论反应展示 + 选择器 + 组合式/客户端接线。延续 B6-a(存储 + API,已合并 #2673)。浏览器目检已由 CI lane(#2689)完成:chips(含 reactedByMe 高亮)、picker popover、点选 🚀 → 新 chip 出现的交互均截图确认。realtime 广播仍推迟(见 §4)。
 >
 > 设计延续 B6-S0 设计锁；FE 接面经 dynamic workflow `wf_55831f49-88b`(3 路) + 逐文件独立核验 grounded。A5-1c 先例：FE 渲染可凭 jsdom 逻辑测落地，视觉/交互为浏览器残余。
 
@@ -41,7 +41,7 @@
 ## 4. Goal 边界（诚实残余）
 
 - ✅ **逻辑层（client/composable/component emit + render 状态）jsdom/单测验证到位。**
-- ⏸ **浏览器目检 = 残余**（同 A5-1c）：jsdom 证 emit/state/class，证不了 popover 定位、对齐、对比度、真实点击手感、frozen/滚动观感。有浏览器/app 访问后做一次目检（可经本地 app + playwright，或 owner staging）。
+- ✅ **浏览器目检 = 已由 CI lane 完成**（#2689 真实 Chromium 截图）：reaction chips（含 reactedByMe 高亮）、picker popover 定位、点选 🚀 → 新 chip 即时出现的交互均确认。frozen/滚动观感与全栈 realtime 仍未单独验，非本弧阻塞（realtime 见 §4，仍为具名 opt-in）。
 - ⏸ **realtime 广播仍推迟**：他人反应不会实时推达本端（反应非 comment 事件；本端反应即时本地重算）。后端先把持久化/聚合/读做正确；realtime 作为后续具名 opt-in。upsert 保留修复已确保既有 comment realtime 更新不抹除本端 reactions。
 - ⏸ **palette 漂移**：FE 调色板硬编码镜像后端白名单；漂移时后端 400 兜底（失败安全，不损数据）。理想为共享常量，YAGNI 暂缓。
 


### PR DESCRIPTION
The browser lane (#2689) + contrast fix (#2694) closed the visual residual for the A5 conditional-formatting render and B6 reactions UI.

Real-Chromium screenshots (CI artifact) confirm: color-scale red→yellow→green, icon-set ↓/→/↑ bucketing, data-bar scaling, and the reaction chips / picker popover / click-to-add interaction. The contrast bug the lane caught on its first run (number sign-colors low-contrast over scale fills) is fixed (#2694) and re-confirmed legible.

This flips the "浏览器目检为残余 / ⏸" lines in the two dev/verification MDs to **✅ CI-browser-verified**. docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)