### PR TITLE
feat(multitable): render + run button field cells (B1-b)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -888,6 +888,13 @@ export interface AiShortcutRunData {
   model: string | null
 }
 
+/** B1-b button run result. `failed` arrives at HTTP 200 (resolves, not throws). */
+export interface ButtonRunData {
+  status: 'succeeded' | 'failed'
+  executionId: string
+  message?: string
+}
+
 export interface AiSuggestFormulaData {
   status: 'succeeded'
   action: 'suggest'
@@ -1255,6 +1262,23 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ recordId: input.recordId, fieldId: input.fieldId }),
     })
+    return this.parseJson(res)
+  }
+
+  // --- Button field run (B1-b) ---
+  // Runs the button's configured (server-persisted) action against one record.
+  // IMPORTANT: an action that FAILS returns HTTP 200 with { status: 'failed' } —
+  // this resolves (does not throw); the caller MUST branch on `data.status`.
+  // Only contract/permission/server errors (400/403/404/500) throw MultitableApiError.
+  async runButton(sheetId: string, recordId: string, fieldId: string, requestId?: string): Promise<ButtonRunData> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/fields/${encodeURIComponent(fieldId)}/button/run`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestId ? { requestId } : {}),
+      },
+    )
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -104,6 +104,8 @@
                     :value="row.data[field.id]"
                     :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
                     :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
+                    :button-pending="isButtonPending(row.id, field.id)"
+                    @run="emit('run-button', { recordId: row.id, field })"
                   />
                   <button
                     v-if="resolveRowActions(row.id).canComment && focusRow === flatIndex(group, ri) && focusCol === ci"
@@ -231,6 +233,8 @@
                   :value="row.data[field.id]"
                   :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
                   :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
+                  :button-pending="isButtonPending(row.id, field.id)"
+                  @run="emit('run-button', { recordId: row.id, field })"
                 />
                 <button
                   v-if="resolveRowActions(row.id).canComment && focusRow === ri && focusCol === ci"
@@ -256,6 +260,8 @@
                         :value="row.data[field.id]"
                         :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
                         :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
+                        :button-pending="isButtonPending(row.id, field.id)"
+                        @run="emit('run-button', { recordId: row.id, field })"
                       />
                     </span>
                   </div>
@@ -414,6 +420,9 @@ const props = defineProps<{
   aiRunEnabled?: boolean
   aiRunPending?: boolean
   aiRunBusy?: boolean
+  // B1-b: per-cell in-flight keys `${recordId}:${fieldId}` for button runs
+  // (keyed so one running button doesn't disable the others).
+  buttonRunPending?: string[]
 }>()
 
 const emit = defineEmits<{
@@ -435,6 +444,8 @@ const emit = defineEmits<{
   (e: 'set-aggregation', payload: { fieldId: string; fn: string | null }): void
   // A3: AI shortcut run requested from a cell editor.
   (e: 'ai-run', recordId: string, field: MetaField): void
+  // B1-b: a button-field cell was clicked (run its configured action).
+  (e: 'run-button', payload: { recordId: string; field: MetaField }): void
 }>()
 
 const { isZh } = useLocale()
@@ -671,6 +682,11 @@ function readableTextOn(hex: string): string {
 function cellHasScaleFill(rid: string, fid: string): boolean {
   const e = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
   return !!e && (typeof e.barPct === 'number' || typeof e.scaleColor === 'string')
+}
+
+/** B1-b: is this button cell's run in flight? (disables the button, prevents double-fire) */
+function isButtonPending(rid: string, fid: string): boolean {
+  return (props.buttonRunPending ?? []).includes(`${rid}:${fid}`)
 }
 
 // A5-3 icon set render: map an `iconKey` (`${set}:${index}`) to a glyph + color.

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -162,6 +162,21 @@
       <template v-else>{{ displayValue }}</template>
     </template>
 
+    <!-- button (B1-b): clickable cell action. @click.stop so the cell's own
+         select-record click doesn't fire; the grid supplies recordId on `run`. -->
+    <template v-else-if="field.type === 'button'">
+      <button
+        type="button"
+        class="meta-cell-renderer__button"
+        :class="`meta-cell-renderer__button--${buttonProp.variant}`"
+        :disabled="buttonPending"
+        :aria-label="buttonLabel"
+        :title="buttonLabel"
+        data-test="cell-button"
+        @click.stop="emit('run')"
+      >{{ buttonLabel }}</button>
+    </template>
+
     <!-- lookup / rollup -->
     <template v-else>{{ displayValue }}</template>
   </span>
@@ -175,13 +190,20 @@ import { useLocale } from '../../../composables/useLocale'
 import { isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
 import { isSystemFieldType } from '../../utils/system-fields'
-import { resolveRatingFieldProperty } from '../../utils/field-config'
+import { resolveRatingFieldProperty, resolveButtonFieldProperty } from '../../utils/field-config'
 import { percentGaugeAria, ratingGaugeAria } from '../../utils/meta-core-labels'
 import { qrSvgFromText } from '../../utils/qr-code'
 import { isRichLongTextField, richLongTextToPlainTextFE } from '../../utils/rich-longtext'
 
-const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[] }>()
+const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[]; buttonPending?: boolean }>()
+const emit = defineEmits<{ (e: 'run'): void }>()
 const { isZh } = useLocale()
+
+// B1-b button field: label + variant from the field property; the empty-label
+// fallback is the field name (never a hardcoded literal — strict-zero i18n) so
+// the accessible name is always non-empty.
+const buttonProp = computed(() => resolveButtonFieldProperty(props.field.property))
+const buttonLabel = computed(() => buttonProp.value.label || props.field.name)
 
 const displayValue = computed(() => {
   return formatFieldDisplay({
@@ -505,4 +527,23 @@ const conditionalClass = computed(() => {
 .meta-cell-renderer__phone:hover {
   color: #1d4ed8;
 }
+/* B1-b button field cell */
+.meta-cell-renderer__button {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 2px 10px;
+  font-size: 12px;
+  line-height: 18px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.meta-cell-renderer__button:disabled { opacity: 0.6; cursor: default; }
+.meta-cell-renderer__button--primary { background: #2563eb; color: #fff; }
+.meta-cell-renderer__button--secondary { background: #f1f5f9; color: #1f2937; border-color: #cbd5e1; }
+.meta-cell-renderer__button--danger { background: #ef4444; color: #fff; }
 </style>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -32,6 +32,7 @@ export type MetaFieldType =
   | 'modifiedTime'
   | 'createdBy'
   | 'modifiedBy'
+  | 'button'
 
 export type MetaFieldCreateType = MetaFieldType
 

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -66,6 +66,19 @@ export type NormalizedAutoNumberFieldProperty = {
   start: number
 }
 
+export type ButtonFieldVariant = 'primary' | 'secondary' | 'danger'
+export type NormalizedButtonFieldProperty = {
+  label: string
+  variant: ButtonFieldVariant
+  actionType: string
+  /** Raw action config (opaque on the FE; authored/validated server-side). */
+  actionConfig: Record<string, unknown> | null
+  /** Confirm-before-run affordance. PARSED here but enforcement is deferred to
+   *  the first side-effecting-action slice (see B1-S0 design-lock §3.4); B1-b
+   *  renders + runs only the inert action, where confirming a no-op is pointless. */
+  confirm: { enabled: boolean; message: string }
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -211,6 +224,25 @@ export function resolveAutoNumberFieldProperty(value: unknown): NormalizedAutoNu
   const startRaw = typeof property.start === 'number' ? property.start : Number(property.start ?? property.startAt)
   const start = Number.isFinite(startRaw) && startRaw > 0 ? Math.floor(startRaw) : 1
   return { prefix, digits, start }
+}
+
+const BUTTON_VARIANTS: ReadonlySet<ButtonFieldVariant> = new Set(['primary', 'secondary', 'danger'])
+export function resolveButtonFieldProperty(value: unknown): NormalizedButtonFieldProperty {
+  const property = asRecord(value)
+  const label = typeof property.label === 'string' ? property.label.trim() : ''
+  const variant = typeof property.variant === 'string' && BUTTON_VARIANTS.has(property.variant as ButtonFieldVariant)
+    ? (property.variant as ButtonFieldVariant)
+    : 'secondary'
+  const actionType = typeof property.actionType === 'string' ? property.actionType.trim() : ''
+  const actionConfig = property.actionConfig && typeof property.actionConfig === 'object' && !Array.isArray(property.actionConfig)
+    ? (property.actionConfig as Record<string, unknown>)
+    : null
+  const confirmRaw = asRecord(property.confirm)
+  const confirm = {
+    enabled: confirmRaw.enabled === true,
+    message: typeof confirmRaw.message === 'string' ? confirmRaw.message.trim() : '',
+  }
+  return { label, variant, actionType, actionConfig, confirm }
 }
 
 const CURRENCY_SYMBOL_BY_CODE: Record<string, string> = {

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -43,6 +43,7 @@ export type WorkbenchLabelKey =
   | 'toast.commentUpdateFailed' | 'toast.commentAddFailed'
   | 'toast.commentResolveFailed' | 'toast.commentDeleteFailed'
   | 'toast.commentReactFailed'
+  | 'toast.buttonRunSuccess' | 'toast.buttonRunFailed'
   | 'toast.linkedRecordsUpdateFailed'
   | 'toast.fieldCreateFailed' | 'toast.fieldUpdateFailed' | 'toast.fieldDeleteFailed'
   | 'toast.viewCreateFailed' | 'toast.viewUpdateFailed' | 'toast.viewDeleteFailed'
@@ -156,6 +157,8 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.commentResolveFailed': { en: 'Failed to resolve comment', zh: '解决评论失败' },
   'toast.commentDeleteFailed': { en: 'Failed to delete comment', zh: '删除评论失败' },
   'toast.commentReactFailed': { en: 'Failed to update reaction', zh: '更新表情失败' },
+  'toast.buttonRunSuccess': { en: 'Button action ran', zh: '按钮已执行' },
+  'toast.buttonRunFailed': { en: 'Button action failed', zh: '按钮执行失败' },
   'toast.linkedRecordsUpdateFailed': { en: 'Failed to update linked records', zh: '更新关联记录失败' },
   'toast.fieldCreateFailed': { en: 'Failed to create field', zh: '创建字段失败' },
   'toast.fieldUpdateFailed': { en: 'Failed to update field', zh: '更新字段失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -263,6 +263,7 @@
           :ai-run-enabled="effectiveRowActions.canEdit"
           :ai-run-pending="Boolean(aiShortcut.state.pending)"
           :ai-run-busy="aiShortcutBusy"
+          :button-run-pending="buttonRunPending"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
@@ -273,6 +274,7 @@
           @open-field-comments="onOpenGridFieldComments"
           @toggle-lock="onToggleRecordLock"
           @ai-run="onGridAiRun"
+          @run-button="onRunButton"
           @selection-change="onGridSelectionChange"
         />
       </div>
@@ -626,6 +628,31 @@ function onAiRunField(field: MetaField) {
 
 function onGridAiRun(recordId: string, field: MetaField) {
   void aiShortcut.run(recordId, field.id)
+}
+
+// B1-b: run a button field's configured action against one record. Per-cell
+// in-flight keys disable just that button + guard double-fire. A FAILED action
+// returns HTTP 200 (resolves), so branch on result.status; reserve catch for
+// contract/permission/server errors (403/etc.).
+const buttonRunPending = ref<string[]>([])
+async function onRunButton({ recordId, field }: { recordId: string; field: MetaField }) {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  const key = `${recordId}:${field.id}`
+  if (buttonRunPending.value.includes(key)) return
+  buttonRunPending.value = [...buttonRunPending.value, key]
+  try {
+    const result = await workbench.client.runButton(sheetId, recordId, field.id)
+    if (result.status === 'failed') {
+      showError(result.message || wb('toast.buttonRunFailed', isZh.value))
+    } else {
+      showSuccess(wb('toast.buttonRunSuccess', isZh.value))
+    }
+  } catch (e: any) {
+    showError(e?.message ?? wb('toast.buttonRunFailed', isZh.value))
+  } finally {
+    buttonRunPending.value = buttonRunPending.value.filter((k) => k !== key)
+  }
 }
 
 // MetaFieldManager is emit/fn-prop based (dryRunFn precedent): config-time

--- a/apps/web/tests/multitable-button-run-client.spec.ts
+++ b/apps/web/tests/multitable-button-run-client.spec.ts
@@ -1,0 +1,54 @@
+// B1-b: MultitableApiClient.runButton — POST .../button/run.
+// The keystone is the HTTP-200-on-failure contract: a FAILED action resolves
+// (does not throw); only non-2xx throws MultitableApiError.
+import { describe, expect, it, vi } from 'vitest'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+type ApiErr = Error & { status?: number; code?: string }
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+describe('MultitableApiClient.runButton (B1-b)', () => {
+  it('POSTs to the encoded run path with an empty body and returns succeeded', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'axe_btn_1' } }))
+    const client = new MultitableApiClient({ fetchFn })
+    const res = await client.runButton('s1', 'r1', 'f1')
+    expect(res).toEqual({ status: 'succeeded', executionId: 'axe_btn_1' })
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/multitable/sheets/s1/records/r1/fields/f1/button/run',
+      expect.objectContaining({ method: 'POST', body: '{}' }),
+    )
+  })
+
+  it('RESOLVES (does not throw) when the action fails — HTTP 200 ok:false data.status=failed', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      json({ ok: false, data: { status: 'failed', executionId: 'axe_btn_2', message: 'boom' } }, 200),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+    const res = await client.runButton('s1', 'r1', 'f1')
+    expect(res).toEqual({ status: 'failed', executionId: 'axe_btn_2', message: 'boom' })
+  })
+
+  it('includes requestId in the body only when provided', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'x' } }))
+    const client = new MultitableApiClient({ fetchFn })
+    await client.runButton('s1', 'r1', 'f1', 'req-9')
+    expect(fetchFn).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ body: JSON.stringify({ requestId: 'req-9' }) }))
+  })
+
+  it('encodeURIComponents all three path segments', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'x' } }))
+    const client = new MultitableApiClient({ fetchFn })
+    await client.runButton('s/1', 'r 1', 'f#1')
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/multitable/sheets/s%2F1/records/r%201/fields/f%231/button/run',
+      expect.anything(),
+    )
+  })
+
+  it('THROWS MultitableApiError on a non-2xx (permission/contract) error', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: false, error: { code: 'FORBIDDEN', message: 'nope' } }, 403))
+    const client = new MultitableApiClient({ fetchFn })
+    await expect(client.runButton('s1', 'r1', 'f1')).rejects.toMatchObject({ name: 'MultitableApiError', status: 403 } as ApiErr)
+  })
+})

--- a/apps/web/tests/multitable-cell-button.spec.ts
+++ b/apps/web/tests/multitable-cell-button.spec.ts
@@ -1,0 +1,52 @@
+// B1-b: MetaCellRenderer button-field cell render + click→run emit.
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import type { MetaField } from '../src/multitable/types'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+afterEach(() => { app?.unmount(); app = null; container?.remove(); container = null })
+
+function mount(field: MetaField, extra: Record<string, unknown> = {}) {
+  const runs: number[] = []
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({
+    setup: () => () => h(MetaCellRenderer, { field, value: undefined, ...extra, onRun: () => runs.push(1) }),
+  })
+  app.mount(container)
+  return { runs, root: container, btn: () => container!.querySelector<HTMLButtonElement>('[data-test="cell-button"]')! }
+}
+
+const buttonField = (property: Record<string, unknown> = {}): MetaField =>
+  ({ id: 'f1', name: 'Do it', type: 'button', property } as unknown as MetaField)
+
+describe('MetaCellRenderer — button field (B1-b)', () => {
+  it('renders a button with the property label + variant class', () => {
+    const { btn } = mount(buttonField({ label: 'Approve', variant: 'primary' }))
+    expect(btn().textContent?.trim()).toBe('Approve')
+    expect(btn().classList.contains('meta-cell-renderer__button--primary')).toBe(true)
+    expect(btn().getAttribute('aria-label')).toBe('Approve')
+  })
+
+  it('falls back to the field name when label is empty (non-empty accessible name)', () => {
+    const { btn } = mount(buttonField({}))
+    expect(btn().textContent?.trim()).toBe('Do it')
+    expect(btn().getAttribute('aria-label')).toBe('Do it')
+    // unknown/empty variant → secondary default
+    expect(btn().classList.contains('meta-cell-renderer__button--secondary')).toBe(true)
+  })
+
+  it('emits run on click', () => {
+    const { btn, runs } = mount(buttonField({ label: 'Go' }))
+    btn().click()
+    expect(runs).toEqual([1])
+  })
+
+  it('disables the button and emits nothing while pending', () => {
+    const { btn, runs } = mount(buttonField({ label: 'Go' }), { buttonPending: true })
+    expect(btn().disabled).toBe(true)
+    btn().click()
+    expect(runs).toEqual([])
+  })
+})

--- a/apps/web/verification/cf-reactions-harness.ts
+++ b/apps/web/verification/cf-reactions-harness.ts
@@ -1,8 +1,9 @@
 // Browser-verification harness (dev/CI only — NOT part of the app build/typecheck;
 // lives outside src/ so vue-tsc + vite build ignore it). Mounts the real
-// MetaGridTable (data-bar / color-scale / icon-set) + MetaCommentReactions with
-// fixtures so a real browser (Playwright in CI) can confirm the visual/interaction
-// render that jsdom can't. Reactions are reactive so click → chip change is observable.
+// MetaGridTable (data-bar / color-scale / icon-set / button — B1-b) +
+// MetaCommentReactions with fixtures so a real browser (Playwright in CI) can
+// confirm the visual/interaction render jsdom can't. Reactions + the button run
+// are stubbed reactively so click → state-change is observable.
 import { createApp, h, ref } from 'vue'
 import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
 import MetaCommentReactions from '../src/multitable/components/MetaCommentReactions.vue'
@@ -13,6 +14,7 @@ const FIELDS = [
   { id: 'bar', name: 'Data bar', type: 'number' },
   { id: 'scale', name: 'Color scale', type: 'number' },
   { id: 'icon', name: 'Icon set', type: 'number' },
+  { id: 'act', name: 'Run', type: 'button', property: { label: 'Run', variant: 'primary' } },
   { id: 'label', name: 'Label', type: 'string' },
 ]
 const ROWS = [0, 25, 50, 75, 100].map((n, i) => ({
@@ -23,6 +25,20 @@ const scaleMap = buildFieldScaleMap([
   sanitizeScaleRule({ id: 'c', fieldId: 'scale', kind: 'colorScale', order: 1, range: { mode: 'auto' }, colorScale: { stops: [{ at: 'min', color: '#ff5252' }, { at: 'mid', color: '#ffeb3b' }, { at: 'max', color: '#4caf50' }] } })!,
   sanitizeScaleRule({ id: 'i', fieldId: 'icon', kind: 'iconSet', order: 2, range: { mode: 'auto' }, iconSet: { set: 'arrows3', thresholds: [33, 66] } })!,
 ], ROWS)
+
+// B1-b: stub the run so click→pending→done is observable without a backend.
+const buttonRunPending = ref<string[]>([])
+const lastRun = ref('')
+function onRunButton({ recordId, field }: { recordId: string; field: { id: string } }) {
+  const key = `${recordId}:${field.id}`
+  if (buttonRunPending.value.includes(key)) return
+  buttonRunPending.value = [...buttonRunPending.value, key]
+  // 500ms so a real browser reliably observes the disabled-during-in-flight state.
+  setTimeout(() => {
+    lastRun.value = `ran:${recordId}`
+    buttonRunPending.value = buttonRunPending.value.filter((k) => k !== key)
+  }, 500)
+}
 
 const reactions = ref<MultitableCommentReaction[]>([
   { emoji: '👍', count: 3, reactedByMe: true },
@@ -51,8 +67,11 @@ createApp({
           rows: ROWS, visibleFields: FIELDS, sortRules: [], loading: false,
           currentPage: 1, totalPages: 1, startIndex: 0, canEdit: true,
           searchText: '', rowDensity: 'normal', conditionalFormattingScale: scaleMap,
+          buttonRunPending: buttonRunPending.value,
+          onRunButton,
         }),
       ]),
+      h('div', { 'data-test': 'button-last-run', style: 'margin-bottom:16px;color:#333' }, `last button run: ${lastRun.value || '(none)'}`),
       h('div', { style: 'padding:12px;border:1px solid #ddd;max-width:360px' }, [
         h('div', { style: 'margin-bottom:8px;color:#333' }, 'Reaction chips + picker:'),
         h(MetaCommentReactions, {

--- a/apps/web/verification/cf-reactions.spec.ts
+++ b/apps/web/verification/cf-reactions.spec.ts
@@ -51,6 +51,17 @@ test('multitable conditional-formatting + reactions render in a real browser', a
   await expect(page.locator('[data-test="reaction-chip-🚀"]')).toBeVisible()
   await page.screenshot({ path: `${OUT}/bv-reactions-after.png` })
 
+  // B1-b button field: a button cell renders per row; clicking it disables
+  // (in-flight) and the stubbed run resolves to an observable "ran" marker.
+  const buttons = page.locator('[data-test="cell-button"]')
+  expect(await buttons.count(), 'expected ≥1 button cell').toBeGreaterThan(0)
+  await buttons.first().click()
+  await expect(buttons.first(), 'button disables while running').toBeDisabled()
+  await page.screenshot({ path: `${OUT}/bv-button-running.png` })
+  await expect(page.locator('[data-test="button-last-run"]'), 'run resolves to a marker').toContainText('ran:r0')
+  await expect(buttons.first(), 'button re-enables after run').toBeEnabled()
+  await page.screenshot({ path: `${OUT}/bv-button-done.png` })
+
   // Fail loud on any console / page error captured from load through interaction.
   expect(errs, `console/page errors:\n${errs.join('\n')}`).toEqual([])
 })

--- a/docs/development/multitable-button-field-b1s0-designlock-20260615.md
+++ b/docs/development/multitable-button-field-b1s0-designlock-20260615.md
@@ -61,6 +61,7 @@
 
 - **B1-a1 inert `record_click` 的审计 = `logger.info`(ephemeral),有意,不写持久行**。理由:inert action **零已提交状态**(不写记录/不外发/不起 job),没有"对数据发生的事"可追;为一个 no-op 写一条持久 `multitable_automation_executions` 行不是审计严谨而是 ceremony。**且会污染**该表所驱动的规则执行分析与 DF-N1 运行监控 UI(非-rule 的 `rule_id='btn_*'` 行会出现在 `getRecent`/`listExecutions`/监控列表等非 rule-scoped 面)。
 - **持久审计行 = 行为级硬前置,挂在"首个有副作用的 button action"那一刀上**(即 §3.3 中 `send_notification` 起):**该 slice 必须经 `AutomationLogService.record()` 写一条已脱敏的 `multitable_automation_executions` 执行行,并带一条断言该行落库的测试**。这样审计随"button 真正做事"同 PR 落地——正是"feature 一能用,审计最易丢"防线生效处。
+- **confirm-before-run 同此前置(AUDIT-1 的孪生)**:button property 的 `confirm:{enabled,message?}` 在 B1-b 仅**解析**(`resolveButtonFieldProperty`),**不强制**——理由对齐:confirm 只能在 B1-c 配置 UI 里**被设置**(B1-b 前无配置面),且当前唯一启用的 action 是 inert `record_click`(确认一个 no-op 无意义),confirm 本质是**破坏性 action 的安全闸**。故 **confirm 强制与首个有副作用 action 同 slice 落地 + 带测**——与持久审计行捆绑:"button 能做事"那一刀同时带上"做之前先确认 + 落审计"。
 - **覆盖既有 §run-API 第 2 步措辞**:那条"写执行记录行(走既有 log-service + redact)"针对**有副作用 action**;inert 首刀按本节用 `logger.info`。
 - 例外(会翻成"现在就建"):出现明确要求**连 inert 点击也须持久可查**的合规/安全诉求时再建,并须先确认所有会浮现的执行查询面(运行监控 + recent/list)都是 rule-scoped,否则即引入污染。
 


### PR DESCRIPTION
## Summary

The FE half of the button field (B1-b): a **clickable button cell** that runs the field's configured action via the B1-a1 run route. Backend was already in place (#2648/#2653); this adds render + click→run + status, **lane-verified in a real browser**. B1-c (FieldManager config authoring) is next, separate.

## What changed
- **types**: `'button'` added to `MetaFieldType` (was backend-only).
- **field-config**: `resolveButtonFieldProperty` → `{ label, variant, actionType, actionConfig, confirm }`. **`confirm` is parsed but not enforced** in B1-b — deferred to the first side-effecting-action slice, bundled with the durable-audit precondition (design-lock §3.4); only the inert `record_click` is enabled today, so confirming a no-op is pointless.
- **MetaCellRenderer**: a `button` branch (variant class, `@click.stop`, label→`field.name` fallback for a non-empty a11y name) + a `run` emit + `buttonPending` prop. Renders on field-visible; the **server** re-evaluates the actor gate at dispatch (no FE permission mirror).
- **MetaGridTable**: translate `run` → `run-button {recordId,field}` at all 3 cell sites (frozen + main + expand-row) + a **keyed** `buttonRunPending` prop (one running button doesn't disable the rest).
- **MultitableWorkbench**: `onRunButton` → `client.runButton` → **branch on `result.status`** (a FAILED action is HTTP 200 / resolves, not a throw) → success/failed toast; per-cell in-flight key (set-before-await, clear-in-finally, re-entry guard).
- **client.runButton**: POST the run route, `encodeURIComponent` all segments, `requestId` omitted when absent.

## Verification
- jsdom: client **5** (URL/encode/empty-body/requestId/**HTTP-200-failure-resolves**/non-2xx-throws) + MetaCellRenderer **4** (label/variant/fallback/emit/disabled-pending). No regressions across grid/client/reactions/field-config.
- **Browser lane** (`#2689`): harness extended with a button column + stubbed async run; the spec asserts render → click → **disabled-in-flight** → resolved marker → re-enabled in real Chromium, and **re-runs on this PR**. New screenshots `bv-button-running.png` / `bv-button-done.png`.

## Honest scope
B1-b ships render + run of the **inert** action; side-effecting actions + confirm enforcement + the durable audit row are gated follow-ups (§3.3/§3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)