### PR TITLE
docs(data-source): mark C5 smoke gate passed

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -13,11 +13,11 @@
   read-only/source-only 边界提示、SQL bridge values-free 错误提示）。
   Large-BOM #2425 的 scoped C3/C4 实体机全链路验证已 PASS/CLOSED；Windows 短 TEMP zip 部署 caveat
   另由 #2642 跟踪，不阻塞 runtime gate。
-  C5 K3/MSSQL smoke harness 已发包并打开 #2670；#2675 / #2684 已修复两轮包内容与 deploy
-  entry blocker；`dea391a1` 包的实体机复测已把 generic smoke 推进到真实 SQL Server
-  connection 层，当前 HOLD 在 operator/runtime SQL 登录、数据库 scope、表权限确认。
-- 不建议: 现在直接开 C6。C6 是最大风险刀，必须等只读链路、增量链路、K3 generic seam 都稳定后再开；
-  当前 C6 仍以 #2670 通过为前置 gate。
+  C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
+  中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
+  Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
+- 下一门: C6-0 design-first。C6 是最大风险刀；#2670 通过只解除 read-only smoke 前置 gate，
+  不授权任何 C6 runtime 或 external write。
 
 ## 收口顺序
 
@@ -27,8 +27,8 @@
 | C2-close | 只读数据库链路 smoke 收口 | done (issue #2600) | 证明当前 read-only bridge 可稳定测试 | 实体机配置漂移 |
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
-| C5 | K3 generic MSSQL seam | C5-0..C5-4a done; C5-4b package loop patched through #2684; #2670 active HOLD on SQL login/database/table scope | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
+| C6 | external write | next gated design-first | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
 | Release | 总包 + 实体机验收 | gated | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
@@ -230,10 +230,11 @@ TODO:
 C5-1 latent helper contract 已落地为 `@metasheet/mssql-readonly-utils`；C5-2 已把 generic `MSSQLAdapter`
 的 endpoint/TLS/identifier 稳定面接到 helper；C5-3 已把 K3 default SQL Server executor 的 endpoint/timeout/limit/simple-select
 接到 helper，同时保留 K3 strict identifier/read/write guard。C5-4a smoke harness 已落地，#2669 修复了 helper-backed
-executor 的 on-prem package/verifier seam。C5-4b 实体机 smoke 已打开 #2670；#2675 修复包内容缺少 runbook /
+executor 的 on-prem package/verifier seam。C5-4b 实体机 smoke 已通过 #2670；#2675 修复包内容缺少 runbook /
 generic smoke script，#2684 修复 packaged generic smoke 的 deploy `dist` adapter entrypoint。`dea391a1`
-包的实体机 evidence 确认 generic smoke 不再在 SQL 前置 entrypoint 失败，已到达 compiled adapter +
-SQL Server connection 层；当前剩余 blocker 是 operator/runtime SQL 登录、数据库 scope、表权限确认。
+包的实体机 scope-adjusted rerun 已 PASS：generic SQL Server smoke 通过 connect/schema/tableInfo/select，
+K3 SQL Server executor smoke 通过 testConnection/read，issue #2670 已关闭。#2700 已把本次暴露出的
+SQL auth/scope triage 固化进 runbook，后续同类失败先按 operator-side scope 分类，不直接回到代码改动。
 
 边界:
 
@@ -291,7 +292,7 @@ TODO:
     helper `package.json` 的 `name/main`、helper bounded `SELECT TOP` builder、以及 K3
     `SQLSERVER_WRITE_EXECUTOR_DISABLED` marker。
   - 这是 C5-4b 发包前置修复；不改变 runtime 行为、不打开任何 K3 写能力。
-- [ ] C5-4b: 实体机 K3/MSSQL smoke。
+- [x] C5-4b: 实体机 K3/MSSQL smoke。
   - issue: #2670 `[Data Source] C5 K3/MSSQL entity-machine smoke gate`。
   - first package attempt: `multitable-onprem-datasource-c5-k3-mssql-smoke-20260615-8cd6ca7ef`
     (`metasheet-multitable-onprem-v2.5.0-datasource-c5-k3-mssql-smoke-20260615-8cd6ca7ef`)。
@@ -312,9 +313,15 @@ TODO:
     smoke；package fingerprint=`dea391a1`，deploy/health/package-content 均通过。
   - [x] generic smoke 不再以 `script_runtime_import_missing_source_asset` / `MODULE_NOT_FOUND`
     在 SQL connection 前失败；它已到达 compiled deployable `MSSQLAdapter` + SQL Server connection 层。
-  - [ ] operator-approved SQL 登录、数据库 scope、表权限确认后，重跑 generic SQL Server smoke；
-    当前结果为 `login_failed`，不是 package/entrypoint 问题。
-  - [ ] K3 SQL Server executor smoke 仍需 PASS；当前 public error 仍为 `SQLSERVER_TEST_FAILED`。
+  - [x] operator-approved SQL 登录、数据库 scope、表权限确认后，重跑 generic SQL Server smoke；
+    scope-adjusted entity-machine rerun PASS: `connected=pass`、`schemaIntrospection=pass`、
+    `tableInfo=pass`、`select=pass`。
+  - [x] K3 SQL Server executor smoke PASS: `testConnection=pass`、bounded read PASS、`rows=1`。
+  - [x] output boundary PASS: credentials / connection string / row values not printed；target object/table
+    redacted；values-free evidence preserved。
+  - [x] #2700 / squash `e1b010ca5`: C5 smoke runbook now includes SQL auth/scope triage for
+    `login_failed` / `SQLSERVER_TEST_FAILED`, with least-privilege read-only scope guidance and values-free
+    evidence fields.
   - saved MetaSheet SQL Server source `connected` 只是必要条件，不是 C5 PASS；official smoke 更严格，
     会携带明确 read target 并在实体机 runtime adapter path 下验证。
   - 只回传 package fingerprint、status、TLS knob 名称/布尔、operator-configured object/table 名、计数；
@@ -324,6 +331,7 @@ TODO:
 
 - K3 路径可复用 generic MSSQL 的稳定能力，但红线不变。
 - 任何 K3 写能力仍走自己的显式 gate。
+- C5 read-only smoke gate 已在 #2670 关闭；这不授权 C6 external write，也不授权 K3 Save/Submit/Audit/BOM。
 
 ## C6 - External Write
 
@@ -392,7 +400,7 @@ TODO:
 - [ ] C2 read-only smoke。
 - [ ] C3 incremental resume smoke。
 - [ ] C4 UI config smoke。
-- [ ] C5 K3 seam smoke。
+- [x] C5 K3 seam smoke。
 - [ ] C6 dry-run/apply/re-pull/rollback smoke。
 - [ ] issue 上贴 values-free 验收证据。
 


### PR DESCRIPTION
## Summary

- mark #2670 C5 K3/MSSQL read-only smoke as PASS/CLOSED in the delivery TODO
- record the scope-adjusted `dea391a1` entity-machine evidence: generic SQL Server smoke passed and K3 SQL Server executor smoke passed
- keep the C6 boundary explicit: next gate is C6-0 design-first; no C6 runtime/external write is authorized
- record #2700 as the runbook triage follow-up for SQL auth/scope failures

## Verification

- `git diff --check`
- scanned for stale C5 HOLD / unfinished smoke wording
- subagent review: no findings; confirmed C5 PASS wording matches #2670 and C6 remains gated

## Boundaries

- docs-only
- no runtime, package, DB, K3, or external write changes
