### PR TITLE
feat(automation): A6-3-3b branch-local wait_for_callback authoring UI

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -928,7 +928,7 @@
                   <button class="meta-rule-editor__btn" type="button" data-action="add-branch-condition" @click="addBranchCondition(branch)">{{ automationLabel('condition.addCondition', isZh) }}</button>
                   <div v-for="(bAct, aIdx) in branch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-branch-action-index="aIdx">
                     <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
-                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
+                      <option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
                     </select>
                     <template v-if="bAct.type === 'update_record'">
                       <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
@@ -945,6 +945,10 @@
                       <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
                       <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
                     </template>
+                    <!-- A6-3-3b branch-local wait_for_callback: zero-param suspend point (no fields to author) -->
+                    <template v-else-if="bAct.type === 'wait_for_callback'">
+                      <span class="meta-rule-editor__hint" data-field="branch-wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</span>
+                    </template>
                     <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(branch, aIdx)">&times;</button>
                   </div>
                   <button class="meta-rule-editor__btn" type="button" data-action="add-branch-action" @click="addBranchAction(branch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</button>
@@ -956,9 +960,9 @@
                     <input v-model="action.config.defaultBranch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="default-branch-key" />
                     <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-default-branch" @click="removeDefaultBranch(action)">&times;</button>
                   </div>
-                  <div v-for="(bAct, aIdx) in action.config.defaultBranch.actions" :key="aIdx" class="meta-rule-editor__branch-action">
+                  <div v-for="(bAct, aIdx) in action.config.defaultBranch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-default-branch-action-index="aIdx">
                     <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
-                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
+                      <option v-for="t in CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
                     </select>
                     <template v-if="bAct.type === 'update_record'">
                       <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
@@ -974,6 +978,10 @@
                     <template v-else-if="bAct.type === 'send_notification'">
                       <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
                       <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
+                    </template>
+                    <!-- A6-3-3b branch-local wait_for_callback (default branch): zero-param suspend point -->
+                    <template v-else-if="bAct.type === 'wait_for_callback'">
+                      <span class="meta-rule-editor__hint" data-field="branch-wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</span>
                     </template>
                     <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(action.config.defaultBranch, aIdx)">&times;</button>
                   </div>
@@ -1133,6 +1141,7 @@ import {
   type BranchDraft,
   type DefaultBranchDraft,
   BRANCH_AUTHORABLE_ACTION_TYPES,
+  CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES,
   buildConditionBranchConfig,
   conditionBranchUnsupportedReason,
   parseConditionBranchDraft,
@@ -1904,6 +1913,11 @@ function removeBranchAction(branch: BranchDraft | DefaultBranchDraft | ParallelB
 function onBranchActionTypeChange(action: BranchActionDraft): void {
   if (action.type === 'update_record') {
     action.fieldUpdates = action.fieldUpdates ?? []
+    delete action.userId
+    delete action.message
+  } else if (action.type === 'wait_for_callback') {
+    // A6-3-3b: zero-param suspend point — clear every field so the draft round-trips to `config: {}`.
+    delete action.fieldUpdates
     delete action.userId
     delete action.message
   } else {

--- a/apps/web/src/multitable/utils/conditionBranchAuthoring.ts
+++ b/apps/web/src/multitable/utils/conditionBranchAuthoring.ts
@@ -4,10 +4,11 @@
 // UI can faithfully round-trip it — `buildConditionBranchConfig(parseConditionBranchDraft(config))`
 // is semantically equal to `config`. Anything the v1 UI cannot represent losslessly
 // (nested condition groups, non-string `update_record` values, comma/whitespace-bearing `userIds`,
-// branch action types outside the simple subset, `wait_for_callback`/nested `condition_branch`)
-// returns a non-null `conditionBranchUnsupportedReason` → the editor opens read-only and never
-// flattens. Mirrors the backend `validateConditionBranchConfig` boundaries (SAFE_BRANCH_KEY,
-// no wait/nesting in branches).
+// branch action types outside the simple subset, nested `condition_branch`/`parallel_branch`/
+// `start_approval`, or a `wait_for_callback` carrying any config keys) returns a non-null
+// `conditionBranchUnsupportedReason` → the editor opens read-only and never flattens. Mirrors the
+// backend `validateConditionBranchConfig` boundaries (SAFE_BRANCH_KEY; A6-3-3 allows ONLY a
+// branch-local zero-param `wait_for_callback`, still rejects nested branch/parallel/start_approval).
 import type {
   AutomationAction,
   AutomationActionType,
@@ -17,15 +18,29 @@ import type {
 // Mirror of backend automation-service.ts SAFE_BRANCH_KEY.
 export const SAFE_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
 
-// The v1 subset of action types authorable INSIDE a branch (simple, round-trippable config).
+// The shared simple subset authorable inside ANY branch container (round-trippable config).
+// `parallel_branch` uses exactly this set — the backend still forbids a branch-local wait there.
 export const BRANCH_AUTHORABLE_ACTION_TYPES = ['update_record', 'send_notification'] as const
 export type BranchAuthorableActionType = (typeof BRANCH_AUTHORABLE_ACTION_TYPES)[number]
 
+// A6-3-3b: `condition_branch` ADDITIONALLY allows a branch-local `wait_for_callback` — the only
+// nested primitive A6-3-3a opened. Kept as a SEPARATE constant so `parallel_branch` never offers it.
+// condition_branch / parallel_branch / start_approval stay OUT of the menu — they remain
+// non-authorable inside a branch (the editor must not offer them; the backend rejects them).
+export const CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES = [
+  'update_record',
+  'send_notification',
+  'wait_for_callback',
+] as const
+export type ConditionBranchAuthorableActionType =
+  (typeof CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES)[number]
+
 export interface BranchActionDraft {
-  type: BranchAuthorableActionType
+  type: ConditionBranchAuthorableActionType
   fieldUpdates?: Array<{ fieldId: string; value: string }> // update_record
   userId?: string // send_notification (comma/space-joined)
   message?: string // send_notification
+  // wait_for_callback carries NO params (zero-param suspend point) — nothing to draft.
 }
 export interface BranchDraft {
   key: string
@@ -76,11 +91,22 @@ function sendNotificationRoundTrippable(config: unknown): boolean {
   return true
 }
 
+// A6-3-3b: a branch-local `wait_for_callback` is a ZERO-param suspend point. The v1 UI authors no
+// fields for it, so it round-trips ONLY when its config is empty/absent. A wait carrying ANY config
+// key (e.g. `{ reason }`) is something the UI can't represent → read-only (re-emit verbatim, never
+// flatten to `{}`). This asymmetry IS the never-flatten guard for the newly-authorable wait.
+function waitForCallbackRoundTrippable(config: unknown): boolean {
+  if (config === undefined) return true
+  if (!isPlainRecord(config)) return false
+  return Object.keys(config).length === 0
+}
+
 function branchActionRoundTrippable(action: unknown): boolean {
   if (!isPlainRecord(action)) return false
   if (action.type === 'update_record') return updateRecordRoundTrippable(action.config)
   if (action.type === 'send_notification') return sendNotificationRoundTrippable(action.config)
-  // outside the subset (incl. wait_for_callback / nested condition_branch) → read-only
+  if (action.type === 'wait_for_callback') return waitForCallbackRoundTrippable(action.config)
+  // outside the subset (nested condition_branch / parallel_branch / start_approval / …) → read-only
   return false
 }
 
@@ -131,6 +157,11 @@ function actionToDraft(action: AutomationAction): BranchActionDraft {
       fieldUpdates: Object.entries(fields).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') })),
     }
   }
+  // A6-3-3b: zero-param wait — preceded by the update_record check; must come BEFORE the
+  // send_notification fallthrough so a wait is not mis-parsed into a notification draft.
+  if (action.type === 'wait_for_callback') {
+    return { type: 'wait_for_callback' }
+  }
   const userIds = Array.isArray(action.config.userIds) ? action.config.userIds : []
   return {
     type: 'send_notification',
@@ -147,6 +178,11 @@ function draftToAction(action: BranchActionDraft): AutomationAction {
       if (fieldId) fields[fieldId] = pair.value
     }
     return { type: 'update_record', config: { fields } }
+  }
+  // A6-3-3b: emit exactly the backend-accepted zero-param wait shape. Empty config (no `reason`/etc.)
+  // mirrors the editor's `defaultConfigForActionType('wait_for_callback')` and the A6-2 suspend point.
+  if (action.type === 'wait_for_callback') {
+    return { type: 'wait_for_callback', config: {} }
   }
   return {
     type: 'send_notification',
@@ -224,4 +260,11 @@ export function validateConditionBranchKeys(draft: ConditionBranchDraft): string
 
 export function isBranchAuthorableActionType(type: AutomationActionType): type is BranchAuthorableActionType {
   return (BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).includes(type)
+}
+
+// A6-3-3b: the condition_branch-only authorable set (adds branch-local `wait_for_callback`).
+export function isConditionBranchAuthorableActionType(
+  type: AutomationActionType,
+): type is ConditionBranchAuthorableActionType {
+  return (CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).includes(type)
 }

--- a/apps/web/tests/conditionBranchAuthoring.spec.ts
+++ b/apps/web/tests/conditionBranchAuthoring.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES,
   buildConditionBranchConfig,
   conditionBranchUnsupportedReason,
+  isConditionBranchAuthorableActionType,
   parseConditionBranchDraft,
   validateConditionBranchKeys,
 } from '../src/multitable/utils/conditionBranchAuthoring'
@@ -81,15 +83,29 @@ describe('conditionBranchUnsupportedReason — read-only guard (point #3: never 
     ['action type outside subset (create_record)', {
       branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'create_record', config: { sheetId: 's', data: {} } }] }],
     }],
-    ['wait_for_callback inside a branch', {
-      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'wait_for_callback', config: {} }] }],
+    // A6-3-3b never-flatten guard: an EMPTY-config wait is now authorable (see the supported block
+    // below), but a wait carrying ANY config key cannot be represented by the zero-param UI and must
+    // stay read-only — re-emitted verbatim, NEVER flattened to `config: {}`.
+    ['wait_for_callback carrying config keys (reason)', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'wait_for_callback', config: { reason: 'high-risk' } }] }],
     }],
     ['nested condition_branch inside a branch', {
       branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'condition_branch', config: { branches: [] } }] }],
     }],
+    // A6-3-3b keeps these other nested primitives NON-authorable (mirrors the backend validator).
+    ['parallel_branch inside a branch', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'parallel_branch', config: { joinMode: 'all', branches: [] } }] }],
+    }],
+    ['start_approval inside a branch', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'start_approval', config: { templateId: 't', formDataMapping: { a: 'b' } } }] }],
+    }],
     ['defaultBranch action outside subset', {
       branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [] }],
       defaultBranch: { key: 'd', actions: [{ type: 'send_email', config: {} }] },
+    }],
+    ['defaultBranch wait_for_callback carrying config keys', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [] }],
+      defaultBranch: { key: 'd', actions: [{ type: 'wait_for_callback', config: { reason: 'x' } }] },
     }],
     ['branches not an array', { branches: 'nope' }],
   ]
@@ -125,5 +141,88 @@ describe('validateConditionBranchKeys — frontend mirror of backend (point #1)'
   })
   it('rejects a defaultBranch key colliding with a branch key', () => {
     expect(validateConditionBranchKeys(make([{ key: 'a' }], { key: 'a' }))).toContain('unique')
+  })
+})
+
+// A6-3-3b — the FE half of branch-local wait_for_callback. The seam must author EXACTLY the
+// backend-accepted shape (`{ type: 'wait_for_callback', config: {} }`) inside a selected branch,
+// keep the other nested primitives non-authorable, and never flatten a richer/unknown wait.
+describe('A6-3-3b — branch-local wait_for_callback authoring', () => {
+  // The acceptance scenario's high-risk branch: notify → wait_for_callback → update_record, with the
+  // wait sitting MID-branch so order preservation (notify, wait, update) is exercised, not assumed.
+  const HIGH_RISK = {
+    branches: [
+      {
+        key: 'high',
+        conditions: { conjunction: 'AND', conditions: [{ fieldId: 'amount', operator: 'gt', value: '100000' }] },
+        actions: [
+          { type: 'send_notification', config: { userIds: ['owner1'], message: 'review' } },
+          { type: 'wait_for_callback', config: {} },
+          { type: 'update_record', config: { fields: { status: 'approved_after_review' } } },
+        ],
+      },
+    ],
+    defaultBranch: {
+      key: 'low',
+      actions: [{ type: 'update_record', config: { fields: { status: 'auto_approved' } } }],
+    },
+  }
+
+  it('treats an empty-config branch-local wait as supported (editable, not read-only)', () => {
+    expect(conditionBranchUnsupportedReason(HIGH_RISK)).toBeNull()
+  })
+
+  it('round-trips a mid-branch wait losslessly (build∘parse = identity, order preserved)', () => {
+    const built = buildConditionBranchConfig(parseConditionBranchDraft(HIGH_RISK))
+    // Exact equality proves the backend-accepted wait shape AND that notify/wait/update order survives.
+    expect(built).toEqual(HIGH_RISK)
+    const actions = (built as any).branches[0].actions
+    expect(actions.map((a: any) => a.type)).toEqual(['send_notification', 'wait_for_callback', 'update_record'])
+    // The emitted wait is the zero-param shape the backend validator + executor accept.
+    expect(actions[1]).toEqual({ type: 'wait_for_callback', config: {} })
+  })
+
+  it('emits the exact backend-accepted wait config from a freshly drafted wait action', () => {
+    // A wait draft authored fresh in the UI carries no fields → serializes to `config: {}` (not undefined).
+    const draft = { branches: [{ key: 'b', label: '', conjunction: 'AND' as const, conditions: [], actions: [{ type: 'wait_for_callback' as const }] }], defaultBranch: null }
+    const built = buildConditionBranchConfig(draft) as any
+    expect(built.branches[0].actions).toEqual([{ type: 'wait_for_callback', config: {} }])
+  })
+
+  it('allows a branch-local wait in the defaultBranch too (validator accepts it there)', () => {
+    const cfg = {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [] }],
+      defaultBranch: { key: 'd', actions: [{ type: 'wait_for_callback', config: {} }] },
+    }
+    expect(conditionBranchUnsupportedReason(cfg)).toBeNull()
+    expect(buildConditionBranchConfig(parseConditionBranchDraft(cfg))).toEqual(cfg)
+  })
+
+  it('NEVER flattens a wait carrying config keys — it stays read-only (anti-drift keystone)', () => {
+    const rich = {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'wait_for_callback', config: { reason: 'high-risk', resumeToken: 'tok' } }] }],
+    }
+    // The richer wait is flagged read-only (so the editor preserves the original verbatim, never
+    // round-trips it through parse→build, which WOULD drop `reason`/`resumeToken`).
+    expect(conditionBranchUnsupportedReason(rich)).not.toBeNull()
+  })
+
+  it('keeps nested condition_branch / parallel_branch / start_approval NON-authorable inside a branch', () => {
+    for (const type of ['condition_branch', 'parallel_branch', 'start_approval'] as const) {
+      const cfg = { branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type, config: {} }] }] }
+      expect(conditionBranchUnsupportedReason(cfg)).not.toBeNull()
+    }
+  })
+
+  it('exposes wait_for_callback in the condition-branch action set but excludes the nested primitives', () => {
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES).toContain('wait_for_callback')
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES).toContain('update_record')
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES).toContain('send_notification')
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).not.toContain('condition_branch')
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).not.toContain('parallel_branch')
+    expect(CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).not.toContain('start_approval')
+    expect(isConditionBranchAuthorableActionType('wait_for_callback')).toBe(true)
+    expect(isConditionBranchAuthorableActionType('condition_branch')).toBe(false)
+    expect(isConditionBranchAuthorableActionType('parallel_branch')).toBe(false)
   })
 })

--- a/apps/web/tests/conditionBranchEditor.spec.ts
+++ b/apps/web/tests/conditionBranchEditor.spec.ts
@@ -159,3 +159,95 @@ describe('A6-3-2a condition_branch editor', () => {
     expect((container.querySelector('[data-field="executionMode"]') as HTMLInputElement).disabled).toBe(false)
   })
 })
+
+// A6-3-3b UI tests — branch-local wait_for_callback is authorable INSIDE the existing condition_branch
+// builder; the other nested primitives stay out of the menu; auto-lock + payload-shape preserved.
+describe('A6-3-3b branch-local wait_for_callback editor', () => {
+  it('the branch action menu OFFERS wait_for_callback but EXCLUDES the nested primitives', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+    setInput(container, '[data-field="name"]', 'Wait rule')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    const branchActionSelect = container.querySelector(
+      '[data-action-config="condition_branch"] [data-branch-action-index="0"] select',
+    ) as HTMLSelectElement
+    const options = Array.from(branchActionSelect.options).map((o) => o.value)
+    expect(options).toContain('wait_for_callback')
+    expect(options).toContain('update_record')
+    expect(options).toContain('send_notification')
+    // rule #3: nested condition_branch / parallel_branch / start_approval remain non-authorable in a branch
+    expect(options).not.toContain('condition_branch')
+    expect(options).not.toContain('parallel_branch')
+    expect(options).not.toContain('start_approval')
+  })
+
+  it('adding a branch-local wait_for_callback saves the zero-param config AND keeps workflow_job_v1 locked', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flush()
+    setInput(container, '[data-field="name"]', 'High-risk review')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    // auto-lock is already in effect because the rule action is condition_branch
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+    // branch_1 action 0: switch its type select to wait_for_callback
+    const branchActionSelect = container.querySelector(
+      '[data-action-config="condition_branch"] [data-branch-action-index="0"] select',
+    ) as HTMLSelectElement
+    branchActionSelect.value = 'wait_for_callback'
+    branchActionSelect.dispatchEvent(new Event('change'))
+    await flush()
+    // the zero-param hint renders (no fields to author for a wait)
+    expect(
+      container.querySelector('[data-branch-action-index="0"] [data-field="branch-wait-for-callback-hint"]'),
+    ).not.toBeNull()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.executionMode).toBe('workflow_job_v1') // auto-lock preserved
+    const branchActions = payload.actions[0].config.branches[0].actions
+    // exact backend-accepted shape (zero-param wait)
+    expect(branchActions).toEqual([{ type: 'wait_for_callback', config: {} }])
+  })
+
+  it('round-trips a loaded supported branch with a mid-branch wait without flattening it', async () => {
+    const config = {
+      branches: [{
+        key: 'high',
+        conditions: { conjunction: 'AND', conditions: [{ fieldId: 'fld_2', operator: 'equals', value: 'big' }] },
+        actions: [
+          { type: 'send_notification', config: { userIds: ['u1'], message: 'review' } },
+          { type: 'wait_for_callback', config: {} },
+          { type: 'update_record', config: { fields: { fld_1: 'done' } } },
+        ],
+      }],
+    }
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithBranch(config), onSave: saved })
+    await flush()
+    // editable (NOT read-only) — the wait is now supported
+    expect(container.querySelector('[data-field="condition-branch-readonly"]')).toBeNull()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+    expect(saved.mock.calls[0][0].actions[0].config).toEqual(config)
+  })
+
+  it('keeps a loaded richer wait (config keys) READ-ONLY and never flattens it (save blocked)', async () => {
+    const config = {
+      branches: [{
+        key: 'high', conditions: { conjunction: 'AND', conditions: [] },
+        actions: [{ type: 'wait_for_callback', config: { reason: 'high-risk', resumeToken: 'tok' } }], // richer than the UI
+      }],
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithBranch(config) })
+    await flush()
+    expect(container.querySelector('[data-field="condition-branch-readonly"]')).not.toBeNull()
+    // save is blocked while read-only (the never-flatten floor); the builder is not rendered
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.querySelector('[data-action-config="condition_branch"] [data-branch-index="0"]')).toBeNull()
+  })
+})

--- a/apps/web/tests/parallelBranchEditor.spec.ts
+++ b/apps/web/tests/parallelBranchEditor.spec.ts
@@ -158,6 +158,31 @@ describe('A6-3-4/W3-2a parallel_branch editor', () => {
     expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
   })
 
+  // A6-3-3b parity guard — the mirror of conditionBranchEditor.spec.ts's "menu OFFERS wait_for_callback".
+  // condition_branch split into a SEPARATE constant (CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES adds
+  // wait_for_callback) so parallel_branch keeps BRANCH_AUTHORABLE_ACTION_TYPES (no wait). The backend
+  // rejects a branch-local wait inside a parallel branch, so the parallel authoring MENU must EXCLUDE it.
+  // This goes red if line :1010 is ever "simplified" to share the condition constant.
+  it('the parallel branch action menu EXCLUDES wait_for_callback (and the other nested primitives)', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+
+    setInput(container, '[data-field="name"]', 'Parallel menu')
+    selectAction0(container, 'parallel_branch')
+    await flush()
+
+    const branchActionSelect = container.querySelector(
+      '[data-action-config="parallel_branch"] [data-parallel-branch-action-index="0"] select',
+    ) as HTMLSelectElement
+    const options = Array.from(branchActionSelect.options).map((o) => o.value)
+    expect(options).toContain('update_record')
+    expect(options).toContain('send_notification')
+    expect(options).not.toContain('wait_for_callback')
+    expect(options).not.toContain('condition_branch')
+    expect(options).not.toContain('parallel_branch')
+    expect(options).not.toContain('start_approval')
+  })
+
   it('blocks saving when the component draft exceeds the branch cap', async () => {
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
     await flush()


### PR DESCRIPTION
## What

Extends the multitable automation rule editor (`MetaAutomationRuleEditor.vue`) so a `wait_for_callback` can be authored **inside** a `condition_branch` builder — the only nested primitive A6-3-3a opened for branch-local use. The change splits the single `BRANCH_AUTHORABLE_ACTION_TYPES` into two constants in `conditionBranchAuthoring.ts`:

- `CONDITION_BRANCH_AUTHORABLE_ACTION_TYPES` = `update_record` + `send_notification` + **`wait_for_callback`** → drives the condition-branch action menus (`:931`, `:965`).
- `BRANCH_AUTHORABLE_ACTION_TYPES` = `update_record` + `send_notification` (no wait) → still drives the **parallel**-branch action menu (`:1010`), because the backend rejects a branch-local wait inside a parallel branch.

`wait_for_callback` renders as a zero-param config row via the conditional templates; its config is the empty `{}` shape the executor expects.

## Preserved FE rules

1. **`workflow_job_v1` auto-lock** — selecting `condition_branch` forces the execution-mode toggle checked+disabled and `buildPayload` enforces `executionMode: 'workflow_job_v1'` on save. Authoring a branch-local wait does not unlock it.
2. **Read-only-never-flatten** — an unsupported loaded branch shape (an action outside the authorable subset) opens read-only with the banner and blocks save; the builder is never rendered and the config is never silently rewritten.
3. **Only `wait_for_callback`** — among the nested primitives, only `wait_for_callback` is newly authorable in a condition branch. `condition_branch` / `parallel_branch` / `start_approval` stay OUT of every branch menu, and the parallel-branch menu additionally excludes `wait_for_callback`.

## Backend

Backend A6-3-3a (#2626) already landed — the branch-local wait runtime + validation exist; this PR is the front-end authoring surface for it.

## Tests (this commit)

Adds the **symmetric parity guard** that was missing: `parallelBranchEditor.spec.ts` now asserts the parallel-branch action `<option>` list **includes** `update_record`/`send_notification` and **EXCLUDES** `wait_for_callback`/`condition_branch`/`parallel_branch`/`start_approval`. This mirrors the existing condition-branch menu test and locks the separate-constant invariant this branch introduced — it goes red precisely if `:1010` is ever simplified to share the condition constant (verified non-vacuous by temporarily swapping the constant). `vue-tsc -b` clean; 36/36 across the three branch-editor specs.

## Honest ceiling

jsdom covers the component's **emit/payload-shape and the authoring guards** (menu contents, auto-lock, read-only round-trip, save-blocking). It does **not** exercise the visual configure → render → click path in a real browser; the rendered wait row, locale labels, and end-to-end save-from-UI still need browser QA before this is product-ready.