### PR TITLE
feat(multitable): button field config authoring in FieldManager (B1-c)

### DIFF
--- a/.github/workflows/multitable-browser-verify.yml
+++ b/.github/workflows/multitable-browser-verify.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     paths:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
+      - 'apps/web/src/multitable/components/MetaFieldHeader.vue'
+      - 'apps/web/src/multitable/components/cells/MetaCellRenderer.vue'
       - 'apps/web/src/multitable/components/MetaCommentReactions.vue'
       - 'apps/web/src/multitable/components/MetaCommentsDrawer.vue'
       - 'apps/web/src/multitable/utils/conditional-formatting.ts'

--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -41,7 +41,7 @@ const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', dateTime: '\u{1F552}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', qrcode: '\u25A6', location: '\u{1F4CD}',
-  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
+  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB', button: '\u{1F518}',
 }
 
 const props = defineProps<{

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -469,6 +469,36 @@
           </label>
         </template>
 
+        <template v-else-if="configTargetType === 'button'">
+          <label class="meta-field-mgr__field">
+            <span>{{ ml('field.buttonLabelText') }}</span>
+            <input v-model="buttonDraft.label" class="meta-field-mgr__input" type="text" :placeholder="configTarget?.name ?? newFieldName" />
+          </label>
+          <label class="meta-field-mgr__field">
+            <span>{{ ml('field.buttonVariant') }}</span>
+            <select v-model="buttonDraft.variant" class="meta-field-mgr__input">
+              <option value="primary">{{ ml('field.buttonVariantPrimary') }}</option>
+              <option value="secondary">{{ ml('field.buttonVariantSecondary') }}</option>
+              <option value="danger">{{ ml('field.buttonVariantDanger') }}</option>
+            </select>
+          </label>
+          <label class="meta-field-mgr__field">
+            <span>{{ ml('field.buttonActionType') }}</span>
+            <select v-model="buttonDraft.actionType" class="meta-field-mgr__input">
+              <option v-for="t in BUTTON_ACTION_TYPES" :key="t" :value="t">{{ ml('field.buttonActionRecordClick') }}</option>
+            </select>
+          </label>
+          <label class="meta-field-mgr__toggle">
+            <input v-model="buttonDraft.confirm.enabled" type="checkbox" />
+            <span>{{ ml('field.buttonConfirmEnable') }}</span>
+          </label>
+          <label v-if="buttonDraft.confirm.enabled" class="meta-field-mgr__field">
+            <span>{{ ml('field.buttonConfirmMessage') }}</span>
+            <input v-model="buttonDraft.confirm.message" class="meta-field-mgr__input" type="text" />
+          </label>
+          <p class="meta-field-mgr__hint">{{ ml('field.buttonConfirmHint') }}</p>
+        </template>
+
         <template v-else-if="configTargetType === 'autoNumber'">
           <div class="meta-field-mgr__grid">
             <label class="meta-field-mgr__field">
@@ -683,10 +713,12 @@ import {
 } from '../utils/formula-docs'
 import { localizeDryRunDiagnostic } from '../utils/meta-formula-labels'
 import type { DryRunResult, DryRunDiagnostic } from '../api/client'
+import type { ButtonFieldVariant } from '../utils/field-config'
 import {
   normalizeStringArray,
   resolveAutoNumberFieldProperty,
   resolveAttachmentFieldProperty,
+  resolveButtonFieldProperty,
   resolveCurrencyFieldProperty,
   resolveFormulaFieldProperty,
   resolveLinkFieldProperty,
@@ -821,14 +853,14 @@ function rulesToProperty(rules: FieldValidationRule[]): Array<Record<string, unk
 const FIELD_TYPES: MetaFieldCreateType[] = [
   'string', 'longText', 'number', 'boolean', 'date', 'dateTime', 'select', 'multiSelect', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
-  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode', 'qrcode', 'location',
+  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode', 'qrcode', 'location', 'button',
   ...SYSTEM_FIELD_TYPES,
 ]
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', dateTime: '\u{1F552}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', qrcode: '\u25A6', location: '\u{1F4CD}',
-  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
+  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB', button: '\u{1F518}',
 }
 
 const props = defineProps<{
@@ -964,6 +996,26 @@ const percentDraft = reactive<{ decimals: number }>({
 const ratingDraft = reactive<{ max: number }>({
   max: 5,
 })
+// B1-c button field config draft. `actionConfig` is carried OPAQUELY (the form
+// doesn't edit it) so a label/variant edit re-emits it intact — update-field
+// replaces property wholesale, so dropping it here would clobber a server-
+// authored action config (the design-lock §3.4 "edit label keeps actionConfig").
+const buttonDraft = reactive<{
+  label: string
+  variant: ButtonFieldVariant
+  actionType: string
+  confirm: { enabled: boolean; message: string }
+  actionConfig: Record<string, unknown> | null
+}>({
+  label: '',
+  variant: 'secondary',
+  actionType: 'record_click',
+  confirm: { enabled: false, message: '' },
+  actionConfig: null,
+})
+// Only record_click is runnable today (run route ENABLED_BUTTON_ACTIONS); the
+// picker offers exactly it so an authored button can't 400 on run.
+const BUTTON_ACTION_TYPES = ['record_click'] as const
 const autoNumberDraft = reactive<{ prefix: string; digits: number; start: number }>({
   prefix: '',
   digits: 0,
@@ -1381,7 +1433,7 @@ function onNumberDecimalsInput(event: Event) {
 function requiresConfig(type: MetaFieldCreateType): boolean {
   return [
     'select', 'multiSelect', 'link', 'person', 'lookup', 'rollup', 'formula', 'attachment',
-    'number', 'currency', 'percent', 'rating', 'longText', 'autoNumber',
+    'number', 'currency', 'percent', 'rating', 'longText', 'autoNumber', 'button',
   ].includes(type)
 }
 
@@ -1440,6 +1492,11 @@ function resetDrafts() {
   autoNumberDraft.prefix = ''
   autoNumberDraft.digits = 0
   autoNumberDraft.start = 1
+  buttonDraft.label = ''
+  buttonDraft.variant = 'secondary'
+  buttonDraft.actionType = 'record_click'
+  buttonDraft.confirm = { enabled: false, message: '' }
+  buttonDraft.actionConfig = null
   validationDraft.value = []
   validationDraftTouched.value = false
   fieldConfigError.value = ''
@@ -1513,6 +1570,15 @@ function serializeFieldDraft(type: string | null): string {
   }
   if (type === 'rating') {
     return JSON.stringify({ max: ratingDraft.max })
+  }
+  if (type === 'button') {
+    return JSON.stringify({
+      label: buttonDraft.label.trim(),
+      variant: buttonDraft.variant,
+      actionType: buttonDraft.actionType.trim(),
+      confirm: { enabled: buttonDraft.confirm.enabled, message: buttonDraft.confirm.message.trim() },
+      actionConfig: buttonDraft.actionConfig,
+    })
   }
   if (type === 'autoNumber') {
     return JSON.stringify({
@@ -1631,6 +1697,17 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     autoNumberDraft.prefix = property.prefix
     autoNumberDraft.digits = property.digits
     autoNumberDraft.start = property.start
+  } else if (fieldType === 'button') {
+    // B1-c CLOBBER GUARD (mirrors the A3 aiShortcut leg below): hydrate
+    // actionConfig into the draft so EVERY save re-emits it — a label/variant
+    // edit must not drop a server-authored actionConfig (update-field replaces
+    // property wholesale; design-lock §3.4).
+    const property = resolveButtonFieldProperty(field.property)
+    buttonDraft.label = property.label
+    buttonDraft.variant = property.variant
+    buttonDraft.actionType = property.actionType
+    buttonDraft.confirm = { enabled: property.confirm.enabled, message: property.confirm.message }
+    buttonDraft.actionConfig = property.actionConfig
   } else if (fieldType === 'string' || fieldType === 'longText') {
     // A3 CLOBBER GUARD leg 1 (LOCKED §2.1): hydrate the persisted aiShortcut
     // into the draft so EVERY subsequent save re-emits it (see
@@ -1940,7 +2017,7 @@ watch(aiShortcutSectionVisible, (visible) => {
 })
 
 function currentDraftProperty(type: MetaFieldCreateType | string): Record<string, unknown> | undefined {
-  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'autoNumber'
+  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'autoNumber' || type === 'button'
     ? type
     : null
   fieldConfigError.value = ''
@@ -2097,6 +2174,23 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       return undefined
     }
     return { max: Math.round(max) }
+  }
+  if (normalizedType === 'button') {
+    const actionType = buttonDraft.actionType.trim()
+    if (!actionType) {
+      fieldConfigError.value = ml('field.error.buttonActionType')
+      return undefined
+    }
+    // KEYSTONE: re-emit actionConfig from the draft (hydrated on edit) so a
+    // label/variant change never drops a server-authored config — update-field
+    // replaces property wholesale (design-lock §3.4). actionConfig stays opaque.
+    return {
+      label: buttonDraft.label.trim(),
+      variant: buttonDraft.variant,
+      actionType,
+      confirm: { enabled: buttonDraft.confirm.enabled, message: buttonDraft.confirm.message.trim() },
+      ...(buttonDraft.actionConfig ? { actionConfig: buttonDraft.actionConfig } : {}),
+    }
   }
   if (normalizedType === 'autoNumber') {
     const prefix = autoNumberDraft.prefix.trim()

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -328,6 +328,7 @@ const FIELD_TYPE_LABELS: Record<string, { en: string; zh: string }> = {
   modifiedTime: { en: 'modified time', zh: '修改时间' },
   createdBy: { en: 'created by', zh: '创建人' },
   modifiedBy: { en: 'modified by', zh: '修改人' },
+  button: { en: 'button', zh: '按钮' },
 }
 export function fieldTypeLabel(type: string, isZh: boolean): string {
   const entry = FIELD_TYPE_LABELS[type]

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -47,6 +47,8 @@ export type MetaManagerLabelKey =
   | 'field.decimals' | 'field.preserve' | 'field.unit'
   | 'field.useThousandsSeparators' | 'field.currencyCode'
   | 'field.maxRating' | 'field.prefix' | 'field.digits' | 'field.startAt'
+  | 'field.buttonLabelText' | 'field.buttonVariant' | 'field.buttonVariantPrimary' | 'field.buttonVariantSecondary' | 'field.buttonVariantDanger'
+  | 'field.buttonActionType' | 'field.buttonActionRecordClick' | 'field.buttonConfirmEnable' | 'field.buttonConfirmMessage' | 'field.buttonConfirmHint'
   | 'field.autoNumberHint' | 'field.saveSettings' | 'field.applyDefaults'
   | 'field.namePlaceholder' | 'field.addButton'
   | 'field.changedTypeBlocking' | 'field.changedWarning'
@@ -63,7 +65,7 @@ export type MetaManagerLabelKey =
   | 'field.error.numberDecimals'
   | 'field.error.numberUnit'
   | 'field.error.percentDecimals'
-  | 'field.error.ratingMax'
+  | 'field.error.ratingMax' | 'field.error.buttonActionType'
   | 'field.error.autoNumberPrefix'
   | 'field.error.autoNumberDigits'
   | 'field.error.autoNumberStart'
@@ -236,6 +238,16 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.useThousandsSeparators': { en: 'Use thousands separators', zh: '使用千位分隔符' },
   'field.currencyCode': { en: 'Currency code (ISO 4217)', zh: '货币代码（ISO 4217）' },
   'field.maxRating': { en: 'Maximum rating (1-10)', zh: '最高评分（1-10）' },
+  'field.buttonLabelText': { en: 'Button label', zh: '按钮文字' },
+  'field.buttonVariant': { en: 'Style', zh: '样式' },
+  'field.buttonVariantPrimary': { en: 'Primary', zh: '主要' },
+  'field.buttonVariantSecondary': { en: 'Secondary', zh: '次要' },
+  'field.buttonVariantDanger': { en: 'Danger', zh: '危险' },
+  'field.buttonActionType': { en: 'Action', zh: '动作' },
+  'field.buttonActionRecordClick': { en: 'Record click (audit only)', zh: '记录点击（仅审计）' },
+  'field.buttonConfirmEnable': { en: 'Confirm before running', zh: '运行前确认' },
+  'field.buttonConfirmMessage': { en: 'Confirm message', zh: '确认提示' },
+  'field.buttonConfirmHint': { en: 'Takes effect when the button runs a side-effecting action (coming later).', zh: '在按钮执行有副作用的动作时生效（后续上线）。' },
   'field.prefix': { en: 'Prefix', zh: '前缀' },
   'field.digits': { en: 'Digits', zh: '位数' },
   'field.startAt': { en: 'Start at', zh: '起始值' },
@@ -269,6 +281,7 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.error.numberUnit': { en: 'Number unit must be 24 characters or fewer', zh: '数字单位不能超过 24 个字符' },
   'field.error.percentDecimals': { en: 'Percent decimals must be between 0 and 6', zh: '百分比小数位必须在 0 到 6 之间' },
   'field.error.ratingMax': { en: 'Rating max must be between 1 and 10', zh: '评分上限必须在 1 到 10 之间' },
+  'field.error.buttonActionType': { en: 'Choose a button action', zh: '请选择按钮动作' },
   'field.error.autoNumberPrefix': { en: 'Auto number prefix must be 32 characters or fewer', zh: '自动编号前缀不能超过 32 个字符' },
   'field.error.autoNumberDigits': { en: 'Auto number digits must be between 0 and 12', zh: '自动编号位数必须在 0 到 12 之间' },
   'field.error.autoNumberStart': { en: 'Auto number start must be at least 1', zh: '自动编号起始值至少为 1' },

--- a/apps/web/tests/multitable-button-field-config.spec.ts
+++ b/apps/web/tests/multitable-button-field-config.spec.ts
@@ -1,0 +1,94 @@
+// B1-c: MetaFieldManager button-field config authoring.
+// KEYSTONE: editing a button field's label must NOT drop a server-authored
+// actionConfig (update-field replaces property wholesale; design-lock §3.4).
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+
+describe('MetaFieldManager — button field config (B1-c)', () => {
+  afterEach(() => { document.body.innerHTML = ''; vi.restoreAllMocks() })
+
+  it('creates a button field with the default action + variant (panel opens, property built)', async () => {
+    const container = document.createElement('div'); document.body.appendChild(container)
+    const createSpy = vi.fn()
+    const app = createApp({
+      render: () => h(MetaFieldManager, { visible: true, sheetId: 'sheet_1', sheets: [], fields: [], onCreateField: createSpy }),
+    })
+    app.mount(container)
+    await nextTick()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    nameInput.value = 'Approve'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'button'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    // config panel must open for a new button field (requiresConfig)
+    expect(container.querySelector('.meta-field-mgr__config')).toBeTruthy()
+    // set a label via the first config text input
+    const labelInput = container.querySelector('.meta-field-mgr__config input[type="text"]') as HTMLInputElement
+    labelInput.value = 'Approve'
+    labelInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((b) => b.textContent?.includes('+ Add'))?.click()
+    await nextTick()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Approve',
+      type: 'button',
+      property: { label: 'Approve', variant: 'secondary', actionType: 'record_click', confirm: { enabled: false, message: '' } },
+    })
+    app.unmount()
+  })
+
+  it('KEYSTONE: editing the label preserves the existing actionConfig', async () => {
+    const container = document.createElement('div'); document.body.appendChild(container)
+    const updateSpy = vi.fn()
+    const Harness = defineComponent({
+      setup: () => ({ updateSpy }),
+      render() {
+        return h(MetaFieldManager, {
+          visible: true, sheetId: 'sheet_1', sheets: [],
+          fields: [{
+            id: 'fld_btn', name: 'Run', type: 'button',
+            property: { label: 'Go', variant: 'primary', actionType: 'record_click', actionConfig: { foo: 'bar', n: 1 }, confirm: { enabled: false, message: '' } },
+          }],
+          onUpdateField: this.updateSpy,
+        })
+      },
+    })
+    const app = createApp(Harness)
+    app.mount(container)
+    await nextTick()
+
+    // open config for the existing button field
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    // change ONLY the label
+    const labelInput = container.querySelector('.meta-field-mgr__config input[type="text"]') as HTMLInputElement
+    expect(labelInput.value).toBe('Go') // hydrated from property
+    labelInput.value = 'Renamed'
+    labelInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((b) => b.textContent?.includes('Save field settings'))?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [fieldId, input] = updateSpy.mock.calls[0]
+    expect(fieldId).toBe('fld_btn')
+    // the keystone: actionConfig survived a label-only edit, byte-for-byte
+    expect(input.property.actionConfig).toEqual({ foo: 'bar', n: 1 })
+    expect(input.property.label).toBe('Renamed')
+    expect(input.property.variant).toBe('primary')
+    expect(input.property.actionType).toBe('record_click')
+    app.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Makes `button` a fully **creatable + configurable** field type (B1-c, your sequencing after B1-b). Authoring: **label**, **variant** (primary/secondary/danger), **actionType** (`record_click` — the only runnable action today), and **confirm**{enabled,message}. Closes the cosmetic `"?"` residual the lane surfaced (button now has an icon + type label).

## Wiring — every silent-failure site (verified by tests, not memory)
- `FIELD_TYPES` picker + **both** `FIELD_ICONS` maps (header + manager list) + `FIELD_TYPE_LABELS` (`button → 🔘 / "button"/"按钮"`).
- `requiresConfig('button')` (config panel opens for new button fields).
- `currentDraftProperty`: `'button'` in the normalizedType allowlist **and** a build branch.
- `serializeFieldDraft('button')` (edit dirty-tracking enables save).
- `buttonDraft` state + `resetDrafts` + `hydrateExistingFieldConfig` branch.
- Typed i18n keys (no literals).

## KEYSTONE — actionConfig clobber guard (design-lock §3.4)
`update-field` replaces property **wholesale**, so the button draft **carries `actionConfig` opaquely** (hydrated on edit, re-emitted on every save) — editing the label never drops a server-authored `actionConfig`. **A test asserts exactly this** (label-only edit → emitted property still has the original `actionConfig` byte-for-byte).

## Scope honesty
- `confirm` is **authored** here (stored) with a hint that enforcement applies to side-effecting actions (deferred per §3.4 — today only the inert `record_click` runs).
- `actionType` offers only `record_click` (mirrors the run-route allowlist, so an authored button can't 400).

## Verification
- jsdom: button create (panel opens + property built — proves the 3 allowlists) + the **actionConfig keystone**; **47 passing** across field-manager/i18n/cell-button suites, no regressions.
- Browser lane paths extended (`MetaFieldHeader` + `MetaCellRenderer`) so the lane re-runs and confirms the `🔘` header icon. B1-c authoring is jsdom-verified (no backend in the lane — configure→persist e2e is out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)