### PR TITLE
test(multitable): de-flake crossbase wiring spec (stale comments mock since B6)

### DIFF
--- a/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
+++ b/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
@@ -55,7 +55,11 @@ vi.mock('../src/multitable/composables/useMultitableComments', () => ({
   useMultitableComments: () => ({
     comments: ref([]), loading: ref(false), submitting: ref(false), resolvingIds: ref<string[]>([]),
     updatingIds: ref<string[]>([]), deletingIds: ref<string[]>([]), error: ref<string | null>(null),
+    // B6 (#2674) added these to the composable; the workbench reads reactingKeys.value at render time,
+    // so without them this mount throws and the spec only "passed" via suite module-ordering luck.
+    reactingKeys: ref<string[]>([]),
     loadComments: vi.fn(), addComment: vi.fn(), updateComment: vi.fn(), deleteComment: vi.fn(), resolveComment: vi.fn(),
+    addReaction: vi.fn(), removeReaction: vi.fn(),
   }),
 }))
 vi.mock('../src/multitable/composables/useMultitableCommentInbox', () => ({


### PR DESCRIPTION
Found while adding the #2662 restore-handler wiring test. The crossbase workbench wiring spec's `useMultitableComments` mock predates B6 (#2674 added `reactingKeys`/`addReaction`/`removeReaction`). The workbench reads `commentsState.reactingKeys.value` at render (`MultitableWorkbench.vue:314`), so the mount **throws** — the spec only "passed" in CI via suite module-ordering (a sibling spec's mock leaking) and **fails in isolation**. That's the false-green class the codebase guards against.

Fix: add the 3 missing fields to the mock. Now **1/1 in isolation**. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)