### PR TITLE
docs(data-source): design C6 external write gate

### DIFF
--- a/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
+++ b/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
@@ -1,0 +1,422 @@
+# Data Source System Integration C6 - External Write Design
+
+Status: design-first / no runtime
+Date: 2026-06-16
+
+## Purpose
+
+C6 is the final delivery gate for the database/system-connection track: external
+write. C2-C5 prove the read path, incremental read path, operator configuration
+surface, and K3/MSSQL read-only seam. They do not authorize writes.
+
+C6 defines the write contract before any implementation:
+
+- what external target may be written;
+- who may dry-run and who may apply;
+- how an operator proves that the apply writes the same revision they reviewed;
+- how per-row failures are isolated;
+- how dead-letter/provenance/evidence stay values-free;
+- how sandbox-first validation proves idempotence and rollback posture before
+  production is discussed.
+
+## Grounding In Current Code
+
+Current code has three relevant pieces:
+
+1. `/data-sources` adapters are write-capable in the generic manager, but default
+   read-only. `BaseDataAdapter.isReadOnly()` returns true unless
+   `options.readOnly === false`, and `DataSourceManager.insert/update/delete`
+   call `adapter.assertWritable()` before mutating.
+   Current generic query routes also allow raw SQL execution against writable
+   data sources. C6 must not point its gated target at a plain writable data
+   source that is still queryable through that generic surface.
+2. The Data Factory bridge `data-source:sql-readonly` is intentionally
+   source-only. Its host facade exposes only `test/getSchema/getTableInfo/select`
+   and rejects writable data-source rows at the read choke point. It has no
+   create/update/delete/credential methods.
+3. `pipeline-runner.cjs` can already run dry-run versus live mode, and can write
+   target results/dead-letters/provenance. But its live path writes immediately
+   once `dryRun=false`; it has no cross-request dry-run token, no reviewed
+   revision fence, and no external DB target adapter.
+
+Existing PLM stock-preparation table actions already prove a safer apply shape:
+server-side action config, dry-run token, revision hash, target-scoped writer,
+per-row held/manual-confirm handling, values-free evidence, and entity-machine
+re-pull idempotence. C6 reuses that discipline as a pattern; it does not copy
+PLM-specific BOM or MetaSheet target logic.
+
+## Non-Goals
+
+C6 does not:
+
+- mutate `data-source:sql-readonly` into a writable adapter;
+- expose `DataSourceManager` or credentials to the integration plugin;
+- accept raw SQL, stored procedures, CTEs, triggers, or user-provided SQL;
+- support delete in v1;
+- support arbitrary K3 Save/Submit/Audit/BOM or direct K3 table writes;
+- make C5 K3/MSSQL read-only smoke count as write authorization;
+- leave a C6 write target reachable through generic raw query, execute, or
+  delete routes;
+- apply without a fresh dry-run token;
+- batch-abort after partially writing without itemized row outcomes;
+- auto-retry external writes without an explicit retry policy;
+- post credentials, connection strings, SQL text, row values, raw payloads, or
+  value-bearing stack traces to evidence.
+
+## V1 Target Contract
+
+Introduce a separate explicit target family, for example:
+
+```text
+data-source:sql-write-gated
+```
+
+The exact adapter name may be finalized in C6-1, but the contract is fixed:
+
+- role: target only;
+- references a `/data-sources` row by `dataSourceId`;
+- never copies credentials into `integration_external_systems`;
+- requires the referenced data source to be explicitly writable
+  (`options.readOnly === false`);
+- requires that writable row to be target-only/non-queryable for generic
+  `/data-sources/:id/query` style routes, or to carry an equivalent server-side
+  capability flag that makes those generic raw-query/delete paths fail closed;
+- requires an operator-approved writable database account whose database grants
+  are still least-privilege;
+- writes only a configured object/table/view-like target;
+- writes only configured `writableFields`;
+- identifies rows only through configured `keyFields`;
+- supports v1 `upsert` by read-then-insert/update through structured adapter
+  methods, not raw `MERGE`, `ON CONFLICT`, or vendor SQL strings;
+- may later add `insert_only` or `update_only`, but delete remains out of scope.
+
+Example server-owned target config shape:
+
+```json
+{
+  "kind": "data-source:sql-write-gated",
+  "role": "target",
+  "config": {
+    "dataSourceId": "ds_...",
+    "object": "schema.table",
+    "keyFields": ["externalId"],
+    "writableFields": ["name", "status", "updatedAt"],
+    "mode": "upsert",
+    "maxBatchSize": 100,
+    "maxInFlight": 1,
+    "environment": "sandbox",
+    "genericQueryDisabled": true
+  }
+}
+```
+
+This is configuration shape only. C6-0 does not add runtime, routes, UI, or
+migrations.
+
+## Trust Boundary
+
+The browser may provide only:
+
+- pipeline/action id;
+- allowed parameters;
+- dry-run token during apply;
+- explicit confirmation flags.
+
+The browser must never provide:
+
+- `dataSourceId`;
+- credentials;
+- target object/table;
+- `keyFields`;
+- `writableFields`;
+- write mode;
+- row payloads;
+- a dry-run plan;
+- a target SQL statement.
+
+All target binding and write scope are server-side/admin-reviewed. Apply must
+recompute the plan server-side and compare the recomputed revision with the
+stored dry-run token.
+
+## Permissions
+
+Dry-run:
+
+- requires integration read permission;
+- may read source rows and read target rows needed to classify
+  add/update/skip/conflict;
+- never mutates the target.
+
+Apply:
+
+- requires integration write/admin permission from the authenticated user;
+- requires a valid, unexpired, single-use dry-run token;
+- requires the token's revision to match a fresh server recompute;
+- requires the configured target data source to remain writable and visible to
+  the server-side authorized principal;
+- requires the configured target data source to remain non-queryable through
+  generic raw query/delete surfaces;
+- must fail closed if any principal/source/target identity is missing.
+
+No path may fall back to tenant, workspace, system, admin, or service identity
+when a required principal is missing.
+
+The target data-source principal is deliberately not "who clicked Apply" unless
+the route is a direct target test/schema route. For pipeline execution, the
+write facade must receive the pipeline owner (`pipeline.createdBy`) as the
+data-source owner principal, matching the read bridge's C2a rule. The
+authenticated user controls authorization to run/apply; `pipeline.createdBy`
+controls visibility to the configured `/data-sources` row. A null
+`pipeline.createdBy` is a configuration error and blocks before target lookup or
+write.
+
+The dry-run token is principal-scoped. In v1, apply must be performed by the
+same authenticated principal that produced the dry-run token unless a later
+handoff design explicitly adds delegated approval. The token revision must bind
+both the authenticated dry-run user and the target data-source owner principal
+used for source/target visibility.
+
+## Dry-Run Contract
+
+C6 dry-run must:
+
+1. load server-owned source and target config;
+2. read source rows through the existing source adapter path;
+3. transform and validate rows through the existing mapping/validation path;
+4. read target rows by configured key fields using structured equality filters;
+5. produce a write plan with only counts and row status metadata in the response;
+6. create a dry-run token only when the plan is apply-eligible;
+7. bind the token to a revision hash that covers:
+   - pipeline/action id;
+   - allowed parameters;
+   - tenant/workspace/project identity;
+   - authenticated dry-run user id/email;
+   - pipeline owner / target data-source principal (`pipeline.createdBy` for
+     pipeline execution);
+   - source binding;
+   - target binding;
+   - target data-source target-only/non-queryable capability state;
+   - field mappings;
+   - key field list;
+   - writable field list;
+   - transformed row fingerprints;
+   - target lookup fingerprints;
+   - plan decisions.
+
+The response must be values-free. It may report counts, operation/status tokens,
+field names, error codes, and whether a token is present. It must not report row
+values or target payloads.
+
+## Apply Contract
+
+C6 apply must:
+
+1. require `confirm.dryRunToken`;
+2. consume the token once;
+3. recompute dry-run server-side;
+4. reject with revision mismatch if anything changed;
+5. write only rows whose decisions are apply-eligible;
+6. skip/hold manual-confirm or conflicted rows;
+7. isolate row failures;
+8. return `succeeded`, `partial`, or `failed` with values-free counts;
+9. write dead-letter/provenance for per-row failures and successes where
+   attribution is unambiguous;
+10. never retry failed external writes automatically in the same request.
+
+`update` must not create on miss unless the decision is explicitly `add` under
+the reviewed `upsert` plan. `insert` must not create duplicates when the key
+already exists. Delete remains unsupported.
+
+## Failure And Retry Policy
+
+Row failures:
+
+- are itemized by row fingerprint/idempotency key hash only;
+- become dead-letter entries with sanitized payloads;
+- do not abort clean sibling rows unless the failure is a global configuration,
+  permission, target-readiness, or circuit-breaker error.
+
+Global failures:
+
+- missing principal;
+- missing target binding;
+- target data source not visible;
+- target data source still read-only;
+- missing key field/writable field config;
+- target data source still reachable through generic raw query/delete routes;
+- raw-SQL request shape;
+- revision mismatch;
+- circuit breaker open;
+- target schema drift that makes key/writable fields unsafe.
+
+Global failures block apply before any external write.
+
+Automatic retry is disabled in v1. A later retry slice must be token/revision
+aware and must prove idempotence with values-free evidence.
+
+## Throughput Guardrails
+
+C6 must protect the external target:
+
+- default `maxInFlight=1` for v1;
+- bounded batch size;
+- max rows per apply request/job;
+- per-target circuit breaker;
+- failure-rate trip threshold;
+- no unbounded loop over an external target;
+- no synchronous large-volume write path that can timeout mid-batch without a
+  checkpoint/retry story.
+
+Large-volume external write should use a checkpoint job model, not a single HTTP
+request. The large-BOM checkpoint apply path is precedent for job shape, not a
+license to skip C6-specific target safeguards.
+
+## Evidence
+
+C6 evidence may include:
+
+- pipeline/action id;
+- target kind;
+- operation mode token;
+- counts: planned, created, updated, skipped, held, failed;
+- error code tokens;
+- dry-run token present/absent;
+- revision match/mismatch;
+- idempotence signal (`secondRun.add=0`);
+- rollback/re-pull outcome tokens;
+- package fingerprint and route names.
+
+C6 evidence must not include:
+
+- credentials;
+- connection strings;
+- host/database/table values unless already redacted or operator-approved as
+  names-only metadata;
+- SQL text;
+- row values;
+- raw payload JSON;
+- target request bodies;
+- stack traces with values.
+
+## Implementation Slices
+
+### C6-0 - design lock
+
+This document plus the delivery TODO update. No runtime, no route, no UI, no
+package, no external write.
+
+### C6-1 - host write facade + latent target adapter
+
+Add a narrow write facade separate from `context.api.dataSources` read facade.
+The write facade may expose only structured, bounded methods needed by C6, for
+example `lookupByKey`, `insertRows`, and `updateRows`. It must not expose raw
+`query`, credentials, adapter instances, transactions, or delete.
+
+Add a latent `data-source:sql-write-gated` target adapter using the facade.
+
+Required locks:
+
+- referenced data source must be explicitly writable;
+- referenced data source must also be blocked from generic raw
+  `/data-sources/:id/query`, execute, and delete routes;
+- missing principal fails closed;
+- pipeline writes pass `pipeline.createdBy` to the write facade, not request user
+  and not a default identity;
+- direct target test/schema routes pass the request user;
+- read-only source fails closed on every write method;
+- generic raw-query route against the same configured target fails closed before
+  executing SQL;
+- raw SQL is impossible by type/shape;
+- delete is unsupported;
+- adapter metadata advertises target-only write guardrails;
+- existing `data-source:sql-readonly` source adapter remains source-only and
+  still rejects writable bindings.
+
+### C6-2 - dry-run route
+
+Add a route that recomputes the write plan and issues a dry-run token. No apply
+route yet.
+
+Required locks:
+
+- read-only permission can dry-run;
+- dry-run performs no write;
+- token is not issued for invalid/unready/conflicted plans unless the conflict
+  is explicitly held and apply-safe;
+- response is values-free;
+- client cannot supply target object/keyFields/writableFields/plan/payload.
+
+### C6-3 - apply route
+
+Add token-bound apply.
+
+Required locks:
+
+- write/admin permission required;
+- missing token rejected;
+- expired/used token rejected;
+- revision mismatch rejected before any write;
+- apply recomputes server-side;
+- client-supplied plan/payload/target binding rejected;
+- row failures are isolated;
+- dead-letter/provenance emitted values-free;
+- no automatic retry;
+- target writes stay within configured object and writable fields.
+
+### C6-4 - UI
+
+Add a review surface:
+
+- dry-run first;
+- show counts/status/error tokens;
+- require explicit confirmation;
+- disable apply for read-only users;
+- do not render row values from external target payloads;
+- do not expose dry-run token as copyable evidence;
+- reset review when parameters/config change.
+
+### C6-5 - entity-machine smoke
+
+Run sandbox-first validation:
+
+1. configure a writable sandbox SQL target with least-privilege credentials;
+2. dry-run and verify no target mutation;
+3. apply with token;
+4. re-pull/re-dry-run and prove idempotence (`add=0`);
+5. validate row-level failure behavior using a controlled bad row;
+6. validate read-only user cannot apply;
+7. validate rollback/cleanup using operator-local target controls;
+8. post values-free evidence.
+
+Only after C6-5 passes can the Release gate discuss production/batch.
+
+## Acceptance Checklist
+
+- [ ] C6-0 design merged before runtime.
+- [ ] New write target is a separate explicit target contract, not
+  `data-source:sql-readonly`.
+- [ ] Existing read-only bridge facade remains read-only by construction.
+- [ ] Target config is server-owned/admin-reviewed.
+- [ ] Credentials stay only in `/data-sources`.
+- [ ] C6 write target is not reachable through generic raw
+  `/data-sources/:id/query`, execute, or delete paths.
+- [ ] Dry-run is read-only and token-producing.
+- [ ] Apply requires write/admin permission plus fresh single-use token.
+- [ ] Revision fencing is hard; mismatch blocks before write.
+- [ ] Per-row failures are isolated and observable.
+- [ ] Dead-letter/provenance are values-free.
+- [ ] No raw SQL, delete, stored procedure, CTE, trigger, or user SQL path.
+- [ ] Max-in-flight/circuit-breaker/batch limits protect the external target.
+- [ ] Entity-machine smoke proves apply, re-pull idempotence, and rollback
+  posture before production.
+
+## Relationship To Release
+
+Before C6-5 passes, the product can be described as:
+
+```text
+read-only database connection as a Data Factory source is available
+```
+
+It must not be described as full database/system connection delivery. Full
+delivery requires C6 write completion plus entity-machine evidence.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -16,8 +16,8 @@
   C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
   中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
   Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
-- 下一门: C6-0 design-first。C6 是最大风险刀；#2670 通过只解除 read-only smoke 前置 gate，
-  不授权任何 C6 runtime 或 external write。
+- 下一门: C6-1 backend latent writer helper。C6 是最大风险刀；C6-0 只锁 design contract，
+  不授权任何 C6 runtime 或 external write；C6-1+ 仍需逐片 opt-in、复审、fresh CI 和实体机 gate。
 
 ## 收口顺序
 
@@ -28,7 +28,7 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | next gated design-first | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| C6 | external write | C6-0 design locked; C6-1+ gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
 | Release | 总包 + 实体机验收 | gated | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
@@ -337,26 +337,35 @@ TODO:
 
 目标: 最终交付门槛。外部系统写回能力必须设计优先、分阶段、实体机验证。
 
+设计锚点:
+
+- C6-0 design: `docs/development/data-source-system-integration-c6-external-write-design-20260616.md`。
+- 设计结论: C6 写能力必须走显式 write-gated target contract；不能把既有
+  `data-source:sql-readonly` source adapter 改成可写。
+- C6-0 只锁合同，不引入 runtime、route、UI、package 或 external write。
+
 必须设计先行:
 
-- [ ] 写入对象和目标系统范围。
-- [ ] 权限模型: 谁可以 dry-run，谁可以 apply。
-- [ ] dry-run / apply 双阶段。
-- [ ] token/revision 绑定，防止“看的是 A，写的是 B”。
-- [ ] 幂等键和重复写保护。
-- [ ] 每行失败隔离。
-- [ ] dead-letter / provenance。
-- [ ] rollback / re-pull 验证。
-- [ ] owner-gated + sandbox-first；首次外部写不得直接生产。
-- [ ] max-in-flight / 熔断 / 外部系统保护。
-- [ ] values-free 审计轨: 记录谁、何时、用哪个 dry-run token apply；不记录外部系统值。
-- [ ] revision fencing 是硬围栏，不是提示；目标自 dry-run 后变化时必须拒绝 apply。
-- [ ] 禁止 batch-abort 后不可恢复的半写状态。
-- [ ] 禁止自动重试打爆外部系统。
+- [x] 写入对象和目标系统范围。
+- [x] 权限模型: 谁可以 dry-run，谁可以 apply。
+- [x] dry-run / apply 双阶段。
+- [x] token/revision 绑定，防止“看的是 A，写的是 B”。
+- [x] 幂等键和重复写保护。
+- [x] 每行失败隔离。
+- [x] dead-letter / provenance。
+- [x] rollback / re-pull 验证。
+- [x] owner-gated + sandbox-first；首次外部写不得直接生产。
+- [x] max-in-flight / 熔断 / 外部系统保护。
+- [x] values-free 审计轨: 记录谁、何时、用哪个 dry-run token apply；不记录外部系统值。
+- [x] revision fencing 是硬围栏，不是提示；目标自 dry-run 后变化时必须拒绝 apply。
+- [x] 禁止 batch-abort 后不可恢复的半写状态。
+- [x] 禁止自动重试打爆外部系统。
+- [x] C6 写目标必须关闭 generic raw query / execute / delete 绕行面；不能只引用普通
+  `readOnly:false` data source。
 
 实现切片建议:
 
-- [ ] C6-0 design: 写合同、权限、幂等、回滚、证据。
+- [x] C6-0 design: 写合同、权限、幂等、回滚、证据。
 - [ ] C6-1 backend latent writer helper: 不接 UI，不自动运行。
 - [ ] C6-2 dry-run route: read-only，values-free evidence。
 - [ ] C6-3 apply route: token-bound，permission-bound，per-row result。


### PR DESCRIPTION
## Summary

- add the C6 external-write design contract for the data-source/system-integration delivery track
- update the delivery TODO so C6-0 is the locked design gate and C6-1+ remain separate opt-in runtime slices
- hard-lock the highest-risk C6 boundary: a writable SQL target must be target-only/non-queryable and cannot remain reachable through generic raw `/data-sources/:id/query`, execute, or delete paths

## Design Locks

- `data-source:sql-readonly` stays source-only and read-only by construction
- C6 uses a separate write-gated target contract, not a mutation of the read bridge
- dry-run/apply are separated by single-use token + revision fencing
- revision binds tenant/workspace/project, authenticated dry-run user, `pipeline.createdBy`/target data-source principal, target binding, field/key/write config, row fingerprints, target lookup fingerprints, plan decisions, and target non-queryable capability state
- apply is write/admin gated, recompute-before-write, row-failure isolated, values-free, sandbox-first, no raw SQL/delete/stored procedure/CTE/trigger/user SQL, no K3 Save/Submit/Audit/BOM

## Verification

- `git diff --check HEAD~1..HEAD`
- subagent security review: initial P1/P2 found and fixed; final re-review no findings
- subagent planning/docs review: initial status conflict fixed; final re-review no findings

## Boundary

Docs only: no runtime, route, UI, migration, package, or external write is introduced. C6-1+ remain gated and require separate review/fresh CI/entity-machine gates.
