### PR TITLE
docs(multitable): record B1-b shipped grid-only + queue B1-e record-detail render

### DIFF
--- a/docs/development/multitable-button-field-b1s0-designlock-20260615.md
+++ b/docs/development/multitable-button-field-b1s0-designlock-20260615.md
@@ -114,9 +114,10 @@ button 字段本身不存每行值;展示全来自此 property。
 | **B1-S0** | 本设计锁(排除矩阵 + inert-action 决策 + run API 契约 + 不变量) | docs | ✅ 现在 |
 | **B1-a0** | 后端字段契约:`MetaFieldType='button'` + property sanitizer + **§2 全排除 guard** | backend | ✅ 纯单测 + tsc |
 | **B1-a1** | 执行:`button/run` + executor-owned `record_click` inert action + 审计 + dispatch 授权 | backend | ✅ 单测(含 §4 闸 / §5 失败语义 fail-first) |
-| **B1-b** | grid/记录详情 render button(可见/禁用/执行中/错误态,不含配置 UI) | frontend | ⚠️ jsdom 验渲染/emit/禁用;真实 click→execute→state 需浏览器 |
-| **B1-c** | FieldManager 配置 UI(创建/编辑 button 字段、绑定动作、picker 可见性) | frontend | ⚠️ 最高回归面,需浏览器验 configure→save→render→click 真路径 |
+| **B1-b** | **grid** render button(可见/禁用/执行中/错误态,不含配置 UI)。**SHIPPED #2699(grid only)**;原 S0 文写"grid/记录详情"但实交付仅 grid(经 MetaCellRenderer);记录详情面是 MetaRecordDrawer 的并行 per-type 链,拆为 **B1-e**(见下) | frontend | ✅ jsdom 渲染/emit/禁用 + **真实 Chromium lane**(render→click→pending→done) |
+| **B1-c** | FieldManager 配置 UI(创建/编辑 button、label/variant/actionType/confirm authoring、actionConfig clobber-guard)。**SHIPPED #2703** | frontend | ✅ jsdom(create + keystone actionConfig 保留)+ lane 验 🔘 header icon |
 | **B1-d** | 验证 + tracker closeout(fail-first 证据、CI 锁、剩余项登记) | docs/test | ✅ |
+| **B1-e**(新,queued — owner 2026-06-16「可排队不急」) | **记录详情(MetaRecordDrawer)clickable button render** —— 其独立 per-type 链(非 MetaCellRenderer);今天 button 在记录详情走默认只读、不崩、但不可点。**form-view 保持出范围(§7);如启用须先定 hide / read-only 展示 / clickable 动作**。续做 button arc 时**优先 record drawer**,form-view 仅设计决定 | frontend | ⚠️ jsdom + lane(harness 需扩 MetaRecordDrawer) |
 
 ## 9. 验证计划(实现期)
 


### PR DESCRIPTION
Scope-truth + tracker hygiene from the B1-c review thread.

The B1-S0 slice table said **"B1-b: grid/记录详情 render button"**, but B1-b (#2699) shipped the **grid render only** (via `MetaCellRenderer`). The record-detail surface (`MetaRecordDrawer`) is a *parallel* per-type render chain that wasn't touched — so it's an unfinished half, now tracked rather than silently mislabeled.

- Annotate **B1-b** (SHIPPED #2699, grid only) + **B1-c** (SHIPPED #2703).
- Add **B1-e** (queued per owner — "可排队不急"): clickable button render in `MetaRecordDrawer`. Today a button **degrades to default read-only there (no crash, not clickable)**. **form-view stays out of scope (§7)**; if ever enabled it needs a design decision first (hide / read-only display / clickable action). When the arc resumes: record drawer first, form-view design-decision-only.

docs-only — durably queues the follow-up so it isn't lost with the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)