### PR TITLE
feat(multitable): per-field (column-level) restore checkbox UI (Arc1·S2)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1417,13 +1417,18 @@ export class MultitableApiClient {
     recordId: string,
     targetVersion: number,
     expectedVersion: number,
+    fieldIds?: string[],
   ): Promise<RestoreRecordResult> {
+    // Per-field (column-level) restore: when fieldIds is a non-empty list, the backend (#2672)
+    // restricts the restore to that selection; omit it for a full-record restore.
+    const body: { targetVersion: number; expectedVersion: number; fieldIds?: string[] } = { targetVersion, expectedVersion }
+    if (fieldIds && fieldIds.length > 0) body.fieldIds = fieldIds
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/restore`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetVersion, expectedVersion }),
+        body: JSON.stringify(body),
       },
     )
     return this.parseJson<RestoreRecordResult>(res)

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -300,6 +300,15 @@
                 class="meta-record-drawer__history-diff"
                 data-test="history-field-diff"
               >
+                <input
+                  v-if="canRestoreTo(item)"
+                  type="checkbox"
+                  class="meta-record-drawer__history-diff-select"
+                  data-test="history-field-select"
+                  :checked="isRestoreFieldSelected(item, d.fieldId)"
+                  :aria-label="d.label"
+                  @change="toggleRestoreField(item, d.fieldId)"
+                />
                 <span class="meta-record-drawer__history-diff-label">{{ d.label }}</span>
                 <span class="meta-record-drawer__history-diff-values">
                   <span
@@ -318,6 +327,7 @@
               class="meta-record-drawer__history-restore"
               data-test="record-history-restore"
               :title="l('record.restoreTitle')"
+              :disabled="selectedRestoreFields(item).length === 0"
               @click="requestRestore(item)"
             >{{ l('record.restore') }}</button>
           </li>
@@ -431,7 +441,7 @@ const emit = defineEmits<{
   /** Slice 3: request restore of this record to a prior revision. The parent (workbench) owns
    * the apiClient.restoreRecordVersion call + confirm + record refresh — consistent with how the
    * drawer emits 'patch' / 'delete' / 'toggle-lock' rather than mutating directly. */
-  (e: 'restore', payload: { recordId: string; targetVersion: number; expectedVersion: number }): void
+  (e: 'restore', payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }): void
   /** A3: AI shortcut triggers (workbench resolves them through useAiShortcut). */
   (e: 'ai-preview', field: MetaField): void
   (e: 'ai-run', field: MetaField): void
@@ -686,10 +696,33 @@ function canRestoreTo(item: MetaRecordRevision): boolean {
   )
 }
 
+// Per-field restore selection, keyed by revision id. Default (no entry) = ALL changed fields selected
+// (full restore, the prior behavior). Unchecking narrows to a subset → emits fieldIds; re-checking all
+// → omits fieldIds (canonical full restore). Only the actor-visible changedFieldIds are selectable
+// (they are already permission-masked server-side), so a hidden field can never be targeted.
+const restoreFieldSelection = ref<Record<string, Set<string>>>({})
+function isRestoreFieldSelected(item: MetaRecordRevision, fieldId: string): boolean {
+  const sel = restoreFieldSelection.value[item.id]
+  return sel ? sel.has(fieldId) : true
+}
+function toggleRestoreField(item: MetaRecordRevision, fieldId: string): void {
+  const next = new Set(restoreFieldSelection.value[item.id] ?? item.changedFieldIds)
+  if (next.has(fieldId)) next.delete(fieldId)
+  else next.add(fieldId)
+  restoreFieldSelection.value = { ...restoreFieldSelection.value, [item.id]: next }
+}
+function selectedRestoreFields(item: MetaRecordRevision): string[] {
+  return item.changedFieldIds.filter((fieldId) => isRestoreFieldSelected(item, fieldId))
+}
+
 function requestRestore(item: MetaRecordRevision): void {
   const record = props.record
   if (!record || !canRestoreTo(item)) return
-  emit('restore', { recordId: record.id, targetVersion: item.version, expectedVersion: record.version })
+  const selected = selectedRestoreFields(item)
+  if (selected.length === 0) return // nothing selected → no-op (button is also disabled)
+  // All changed fields selected → full restore (omit fieldIds); a proper subset → per-field restore.
+  const fieldIds = selected.length === item.changedFieldIds.length ? undefined : selected
+  emit('restore', { recordId: record.id, targetVersion: item.version, expectedVersion: record.version, ...(fieldIds ? { fieldIds } : {}) })
 }
 
 // Per-field before→after diff for a revision. LEAK-SAFE BY CONSTRUCTION: the backend
@@ -1037,4 +1070,6 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__history-diff-before { color: #94a3b8; text-decoration: line-through; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 45%; }
 .meta-record-drawer__history-diff-arrow { flex: 0 0 auto; color: #cbd5e1; }
 .meta-record-drawer__history-diff-after { color: #0f172a; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.meta-record-drawer__history-diff-select { flex: 0 0 auto; margin: 0 2px 0 0; cursor: pointer; }
+.meta-record-drawer__history-restore:disabled { opacity: 0.45; cursor: not-allowed; }
 </style>

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1594,7 +1594,7 @@ async function onToggleRecordLock(payload: { recordId: string; locked: boolean }
 // confirm + API call + refresh (mirrors onToggleRecordLock). The backend error carries `.code`
 // (VERSION_CONFLICT / VERSION_EXPIRED / RESTORE_UNSUPPORTED / SNAPSHOT_UNAVAILABLE / SCHEMA_DRIFT /
 // RESTORE_FORBIDDEN); we surface error.message (already localized server-side) with a static fallback.
-async function onRestoreRecordVersion(payload: { recordId: string; targetVersion: number; expectedVersion: number }) {
+async function onRestoreRecordVersion(payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
   const sheetId = workbench.activeSheetId.value
   if (!sheetId) return
   if (!window.confirm(recordLabel('record.restoreConfirm', isZh.value))) return
@@ -1604,6 +1604,7 @@ async function onRestoreRecordVersion(payload: { recordId: string; targetVersion
       payload.recordId,
       payload.targetVersion,
       payload.expectedVersion,
+      payload.fieldIds,
     )
     showSuccess(recordLabel(result.noop ? 'record.restoreNoop' : 'record.restoreSuccess', isZh.value))
     await grid.loadViewData(grid.page.value.offset)

--- a/apps/web/tests/meta-record-drawer-history-diff.spec.ts
+++ b/apps/web/tests/meta-record-drawer-history-diff.spec.ts
@@ -28,7 +28,7 @@ function rev(version: number, action: MetaRecordRevision['action'], over: Partia
 
 const flush = async () => { await nextTick(); await Promise.resolve(); await Promise.resolve(); await nextTick() }
 
-function mountDrawer(revisions: MetaRecordRevision[]): { container: HTMLElement; app: App } {
+function mountDrawer(revisions: MetaRecordRevision[], onRestore?: (p: unknown) => void): { container: HTMLElement; app: App } {
   const apiClient = {
     listRecordHistory: vi.fn(async () => revisions),
     getRecordSubscriptionStatus: vi.fn(async () => ({ subscribed: false, subscription: null })),
@@ -40,6 +40,7 @@ function mountDrawer(revisions: MetaRecordRevision[]): { container: HTMLElement;
       return h(MetaRecordDrawer, {
         visible: true, record: RECORD, fields: FIELDS, canEdit: true, canComment: false,
         canDelete: false, sheetId: 'sheet_1', apiClient: apiClient as never,
+        ...(onRestore ? { onRestore } : {}),
       })
     },
   })
@@ -104,5 +105,53 @@ describe('MetaRecordDrawer history value-diff (Arc1·S1)', () => {
     // and only the changed field rendered a diff row
     const labels = [...mounted.container.querySelectorAll('.meta-record-drawer__history-diff-label')].map((e) => e.textContent)
     expect(labels.every((l) => l?.includes('Title'))).toBe(true)
+  })
+})
+
+describe('MetaRecordDrawer per-field restore selection (Arc1·S2)', () => {
+  let mounted: { container: HTMLElement; app: App } | null = null
+  afterEach(() => { if (mounted) { mounted.app.unmount(); mounted.container.remove(); mounted = null } })
+
+  // v2 < record v3 → restorable; changed TWO visible fields → two selectable checkboxes.
+  const TWO_FIELD_REVS = [
+    rev(2, 'update', { changedFieldIds: ['fld_t', 'fld_s'], snapshot: { fld_t: 'old title', fld_s: 'old status' }, patch: { fld_t: 'old title', fld_s: 'old status' } }),
+    rev(1, 'create', { changedFieldIds: ['fld_t', 'fld_s'], snapshot: { fld_t: 'init', fld_s: 'init' }, patch: {} }),
+  ]
+
+  it('emits a FULL restore (no fieldIds) when all changed fields stay checked', async () => {
+    const onRestore = vi.fn()
+    mounted = mountDrawer(TWO_FIELD_REVS, onRestore)
+    await openHistory(mounted.container)
+    const btn = mounted.container.querySelector<HTMLButtonElement>('[data-test="record-history-restore"]')!
+    expect(btn.disabled).toBe(false)
+    btn.click(); await flush()
+    expect(onRestore).toHaveBeenCalledTimes(1)
+    expect(onRestore.mock.calls[0][0]).toEqual({ recordId: 'rec_1', targetVersion: 2, expectedVersion: 3 })
+  })
+
+  it('emits fieldIds for the checked SUBSET after unchecking a field', async () => {
+    const onRestore = vi.fn()
+    mounted = mountDrawer(TWO_FIELD_REVS, onRestore)
+    await openHistory(mounted.container)
+    // checkboxes: [v2.fld_t, v2.fld_s, v1.fld_t, v1.fld_s] — uncheck v2.fld_s (index 1)
+    const checks = mounted.container.querySelectorAll<HTMLInputElement>('[data-test="history-field-select"]')
+    checks[1].click(); await flush()
+    const btn = mounted.container.querySelector<HTMLButtonElement>('[data-test="record-history-restore"]')!
+    btn.click(); await flush()
+    expect(onRestore).toHaveBeenCalledTimes(1)
+    expect(onRestore.mock.calls[0][0]).toEqual({ recordId: 'rec_1', targetVersion: 2, expectedVersion: 3, fieldIds: ['fld_t'] })
+  })
+
+  it('disables restore when ALL fields are unchecked (no all-fields ambiguity)', async () => {
+    const onRestore = vi.fn()
+    mounted = mountDrawer(TWO_FIELD_REVS, onRestore)
+    await openHistory(mounted.container)
+    const checks = mounted.container.querySelectorAll<HTMLInputElement>('[data-test="history-field-select"]')
+    checks[0].click(); await flush() // uncheck v2.fld_t
+    checks[1].click(); await flush() // uncheck v2.fld_s
+    const btn = mounted.container.querySelector<HTMLButtonElement>('[data-test="record-history-restore"]')!
+    expect(btn.disabled).toBe(true)
+    btn.click(); await flush()
+    expect(onRestore).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/tests/multitable-record-restore-client.spec.ts
+++ b/apps/web/tests/multitable-record-restore-client.spec.ts
@@ -36,6 +36,18 @@ describe('MultitableApiClient.restoreRecordVersion (Slice 3)', () => {
     expect(result).toEqual(OK_WIRE.data)
   })
 
+  it('includes fieldIds in the body for a per-field restore, omits it when empty (Arc1·S2)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(OK_WIRE))
+    const client = new MultitableApiClient({ fetchFn })
+    await client.restoreRecordVersion('sheet_1', 'rec_1', 2, 3, ['fld_a', 'fld_b'])
+    expect(JSON.parse(String((fetchFn.mock.calls[0] as [string, RequestInit])[1].body)))
+      .toEqual({ targetVersion: 2, expectedVersion: 3, fieldIds: ['fld_a', 'fld_b'] })
+    // empty selection must NOT send a fieldIds key (would be an all-fields 422/no-op ambiguity)
+    await client.restoreRecordVersion('sheet_1', 'rec_1', 2, 3, [])
+    expect(JSON.parse(String((fetchFn.mock.calls[1] as [string, RequestInit])[1].body)))
+      .toEqual({ targetVersion: 2, expectedVersion: 3 })
+  })
+
   it('encodes path segments', async () => {
     const fetchFn = vi.fn(async () => jsonResponse(OK_WIRE))
     const client = new MultitableApiClient({ fetchFn })

--- a/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
@@ -186,19 +186,27 @@ describe('MultitableWorkbench record-restore handler wiring (#2662)', () => {
     return onRestore
   }
 
-  it('threads the emitted payload into client.restoreRecordVersion(sheetId, recordId, targetVersion, expectedVersion) — exact positions (wire-drift lock)', async () => {
+  it('threads the emitted payload into client.restoreRecordVersion(sheetId, recordId, targetVersion, expectedVersion, fieldIds) — exact positions (wire-drift lock)', async () => {
     const onRestore = await mountAndGetRestore()
     await onRestore({ recordId: 'rec_42', targetVersion: 2, expectedVersion: 5 })
     await flushUi()
     expect(workbenchMock.client.restoreRecordVersion).toHaveBeenCalledTimes(1)
-    // Active sheet from the workbench + the three payload fields, in order. A reorder
-    // (e.g. target/expected swapped) would silently corrupt restore — this catches it.
-    expect(workbenchMock.client.restoreRecordVersion).toHaveBeenCalledWith('sheet_orders', 'rec_42', 2, 5)
+    // Active sheet from the workbench + the three payload fields, in order, + fieldIds (undefined for
+    // a full restore). A reorder (e.g. target/expected swapped) would silently corrupt restore — caught.
+    expect(workbenchMock.client.restoreRecordVersion).toHaveBeenCalledWith('sheet_orders', 'rec_42', 2, 5, undefined)
     // success branch: toast + grid refresh
     expect(showSuccessSpy).toHaveBeenCalledTimes(1)
     expect(showSuccessSpy.mock.calls[0][0]).toMatch(/Restored|已恢复/)
     expect(gridMock.loadViewData).toHaveBeenCalledWith(0)
     expect(showErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('threads a per-field selection (fieldIds) through to the client (Arc1·S2)', async () => {
+    const onRestore = await mountAndGetRestore()
+    await onRestore({ recordId: 'rec_42', targetVersion: 2, expectedVersion: 5, fieldIds: ['fld_a', 'fld_b'] })
+    await flushUi()
+    expect(workbenchMock.client.restoreRecordVersion).toHaveBeenCalledWith('sheet_orders', 'rec_42', 2, 5, ['fld_a', 'fld_b'])
+    expect(showSuccessSpy).toHaveBeenCalledTimes(1)
   })
 
   it('does nothing when the user cancels the confirm', async () => {


### PR DESCRIPTION
Second slice of the **Record History & Recovery** arc — surfaces the already-shipped #2672 `fieldIds` backend param in the drawer (FE-only chain).

## UX
Each restorable revision's diff rows get a default-checked checkbox. Restore restores the **checked subset** — omits `fieldIds` when all are checked (canonical full restore), disables when none are.

## Chain
- `client.restoreRecordVersion(..., fieldIds?)` — body carries `fieldIds` only when non-empty.
- workbench `onRestoreRecordVersion` threads `payload.fieldIds` through.
- drawer emits `restore { ..., fieldIds? }`; selection keyed by revision id (default = all changed fields). Only actor-visible (already-masked) `changedFieldIds` are selectable → a hidden field can never be targeted.

## Verification
`vue-tsc -b` clean · restore specs **26/26** (workbench wire-drift updated to the 5-arg call + per-field pass-through; drawer subset-emit + disable-when-none; client body with/without `fieldIds`) · Path A browser evidence (4 checkboxes, 0 console errors). No new i18n strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)