### PR TITLE
feat(multitable): notification mark-read + unread-count routes (Notification Center S1a)

### DIFF
--- a/packages/core-backend/src/multitable/record-subscription-service.ts
+++ b/packages/core-backend/src/multitable/record-subscription-service.ts
@@ -256,6 +256,54 @@ export async function listRecordSubscriptionNotifications(
   return (result.rows as Array<Record<string, unknown>>).map(serializeNotification)
 }
 
+// Notification Center S1 — mark-read / unread-count over the actor's OWN notifications.
+// SELF-SCOPED: every statement filters `user_id = $1`, so a caller can only ever touch their own
+// rows — passing another user's notification id is a silent no-op (0 rows), never a cross-user write.
+export async function markRecordSubscriptionNotificationsRead(
+  query: QueryFn,
+  input: { userId: string; ids: string[] },
+): Promise<number> {
+  const ids = input.ids.filter((id) => typeof id === 'string' && id.length > 0)
+  if (ids.length === 0) return 0
+  // Only flip still-unread rows so the returned count is the number actually transitioned (idempotent
+  // re-marks return 0). `user_id = $1` is the cross-user guard. Compare `id::text = ANY($2)` rather than
+  // casting the input to uuid[] — a malformed/non-uuid id then simply fails to match (0 rows) instead of
+  // throwing a Postgres invalid-uuid error that would surface as a 500.
+  const result = await query(
+    `UPDATE meta_record_subscription_notifications
+     SET read_at = now()
+     WHERE user_id = $1 AND id::text = ANY($2) AND read_at IS NULL`,
+    [input.userId, ids],
+  )
+  return Number(result.rowCount ?? 0)
+}
+
+export async function markAllRecordSubscriptionNotificationsRead(
+  query: QueryFn,
+  input: { userId: string },
+): Promise<number> {
+  const result = await query(
+    `UPDATE meta_record_subscription_notifications
+     SET read_at = now()
+     WHERE user_id = $1 AND read_at IS NULL`,
+    [input.userId],
+  )
+  return Number(result.rowCount ?? 0)
+}
+
+export async function countUnreadRecordSubscriptionNotifications(
+  query: QueryFn,
+  input: { userId: string },
+): Promise<number> {
+  const result = await query(
+    `SELECT COUNT(*)::int AS count
+     FROM meta_record_subscription_notifications
+     WHERE user_id = $1 AND read_at IS NULL`,
+    [input.userId],
+  )
+  return Number((result.rows[0] as { count: number } | undefined)?.count ?? 0)
+}
+
 function serializeSubscription(row: Record<string, unknown>): RecordSubscription {
   return {
     id: String(row.id),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -157,8 +157,11 @@ import {
 } from '../multitable/post-commit-hooks'
 import { listRecordRevisions, type RecordRevisionEntry } from '../multitable/record-history-service'
 import {
+  countUnreadRecordSubscriptionNotifications,
   getRecordSubscriptionStatus,
   listRecordSubscriptionNotifications,
+  markAllRecordSubscriptionNotificationsRead,
+  markRecordSubscriptionNotificationsRead,
   subscribeRecord,
   unsubscribeRecord,
 } from '../multitable/record-subscription-service'
@@ -6015,6 +6018,59 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list record subscription notifications failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record subscription notifications' } })
+    }
+  })
+
+  // Notification Center S1 — unread count for the bell badge (actor's own notifications).
+  router.get('/record-subscription-notifications/unread-count', async (req: Request, res: Response) => {
+    try {
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      const count = await countUnreadRecordSubscriptionNotifications(poolManager.get().query.bind(poolManager.get()), { userId: access.userId })
+      return res.json({ ok: true, data: { count } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_subscription_notifications')) return res.json({ ok: true, data: { count: 0 } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] unread notification count failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to count unread notifications' } })
+    }
+  })
+
+  // Notification Center S1 — mark a set of the actor's OWN notifications read (self-scoped in SQL).
+  router.post('/record-subscription-notifications/mark-read', async (req: Request, res: Response) => {
+    const rawIds = (req.body as { ids?: unknown } | null | undefined)?.ids
+    if (!Array.isArray(rawIds)) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'ids must be an array' } })
+    }
+    const ids = rawIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    try {
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      const updated = await markRecordSubscriptionNotificationsRead(poolManager.get().query.bind(poolManager.get()), { userId: access.userId, ids })
+      return res.json({ ok: true, data: { updated } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_subscription_notifications')) return res.json({ ok: true, data: { updated: 0 } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] mark notifications read failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to mark notifications read' } })
+    }
+  })
+
+  // Notification Center S1 — mark ALL of the actor's own notifications read.
+  router.post('/record-subscription-notifications/mark-all-read', async (req: Request, res: Response) => {
+    try {
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      const updated = await markAllRecordSubscriptionNotificationsRead(poolManager.get().query.bind(poolManager.get()), { userId: access.userId })
+      return res.json({ ok: true, data: { updated } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_subscription_notifications')) return res.json({ ok: true, data: { updated: 0 } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] mark all notifications read failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to mark all notifications read' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-notification-markread.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-notification-markread.api.test.ts
@@ -51,15 +51,16 @@ describe('Notification Center S1 — mark-read / unread-count routes', () => {
   afterEach(() => { vi.restoreAllMocks(); vi.resetModules() })
 
   test('unread-count COUNTs scoped to the authenticated user', async () => {
-    let params: unknown[] | undefined
-    const { app } = await createApp({ queryHandler: async (sql, p) => {
-      if (sql.includes('COUNT(*)') && sql.includes('meta_record_subscription_notifications')) { params = p; return { rows: [{ count: 3 }] } }
+    let params: unknown[] | undefined; let sql = ''
+    const { app } = await createApp({ queryHandler: async (s, p) => {
+      if (s.includes('COUNT(*)') && s.includes('meta_record_subscription_notifications')) { sql = s; params = p; return { rows: [{ count: 3 }] } }
       return { rows: [] }
     } })
     const res = await request(app).get(UNREAD)
     expect(res.status).toBe(200)
     expect(res.body.data.count).toBe(3)
     expect(params).toEqual(['user_a'])
+    expect(sql).toContain('read_at IS NULL') // "unread" = read_at IS NULL (mutation-proof, not just SQL-shape)
   })
 
   test('mark-read UPDATEs only the AUTH user rows — a userId in the body is ignored (cross-user write impossible)', async () => {
@@ -74,19 +75,21 @@ describe('Notification Center S1 — mark-read / unread-count routes', () => {
     expect(res.body.data.updated).toBe(2)
     expect(sql).toContain('user_id = $1')
     expect(sql).toContain('id::text = ANY($2)') // text compare → malformed ids harmlessly miss, no uuid-cast 500
+    expect(sql).toContain('read_at IS NULL') // idempotent: only flips still-unread rows (mutation-proof)
     expect(params).toEqual(['user_a', ['n1', 'n2']]) // auth user, NOT 'victim'
   })
 
   test('mark-all-read UPDATEs the user unread rows, self-scoped', async () => {
-    let params: unknown[] | undefined
+    let params: unknown[] | undefined; let sql = ''
     const { app } = await createApp({ queryHandler: async (s, p) => {
-      if (s.includes('UPDATE meta_record_subscription_notifications') && !s.includes('= ANY')) { params = p; return { rows: [], rowCount: 5 } }
+      if (s.includes('UPDATE meta_record_subscription_notifications') && !s.includes('= ANY')) { sql = s; params = p; return { rows: [], rowCount: 5 } }
       return { rows: [] }
     } })
     const res = await request(app).post(MARK_ALL).send({})
     expect(res.status).toBe(200)
     expect(res.body.data.updated).toBe(5)
     expect(params).toEqual(['user_a'])
+    expect(sql).toContain('read_at IS NULL') // idempotent: only flips still-unread rows (mutation-proof)
   })
 
   test('mark-read rejects a non-array ids body (400) before any query', async () => {

--- a/packages/core-backend/tests/integration/multitable-notification-markread.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-notification-markread.api.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Notification Center S1 — mark-read / mark-all-read / unread-count routes.
+ *
+ * The security-critical property is SELF-SCOPING: every statement filters `user_id = $1` where $1 is
+ * the AUTHENTICATED user (resolved server-side), and no route accepts a userId from the body — so a
+ * caller can never mark or count another user's notifications. These contract tests assert the SQL is
+ * self-scoped and the user param is the auth user (not a body-supplied one), plus auth + validation.
+ */
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type QueryResult = { rows: any[]; rowCount?: number }
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+function createMockPool(queryHandler: QueryHandler) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM spreadsheet_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (c: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(args: { queryHandler: QueryHandler; userId?: string | null }) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false), userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]), invalidateUserPerms: vi.fn(), getPermCacheStatus: vi.fn(),
+  }))
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(args.queryHandler)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    if (args.userId !== null) (req as any).user = { id: args.userId ?? 'user_a', roles: [], perms: ['multitable:read'] }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return { app }
+}
+
+const UNREAD = '/api/multitable/record-subscription-notifications/unread-count'
+const MARK = '/api/multitable/record-subscription-notifications/mark-read'
+const MARK_ALL = '/api/multitable/record-subscription-notifications/mark-all-read'
+
+describe('Notification Center S1 — mark-read / unread-count routes', () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.resetModules() })
+
+  test('unread-count COUNTs scoped to the authenticated user', async () => {
+    let params: unknown[] | undefined
+    const { app } = await createApp({ queryHandler: async (sql, p) => {
+      if (sql.includes('COUNT(*)') && sql.includes('meta_record_subscription_notifications')) { params = p; return { rows: [{ count: 3 }] } }
+      return { rows: [] }
+    } })
+    const res = await request(app).get(UNREAD)
+    expect(res.status).toBe(200)
+    expect(res.body.data.count).toBe(3)
+    expect(params).toEqual(['user_a'])
+  })
+
+  test('mark-read UPDATEs only the AUTH user rows — a userId in the body is ignored (cross-user write impossible)', async () => {
+    let sql = ''; let params: unknown[] | undefined
+    const { app } = await createApp({ queryHandler: async (s, p) => {
+      if (s.includes('UPDATE meta_record_subscription_notifications') && s.includes('= ANY')) { sql = s; params = p; return { rows: [], rowCount: 2 } }
+      return { rows: [] }
+    } })
+    // body carries a malicious userId — there is no userId channel, so it cannot change the scope
+    const res = await request(app).post(MARK).send({ ids: ['n1', 'n2'], userId: 'victim' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.updated).toBe(2)
+    expect(sql).toContain('user_id = $1')
+    expect(sql).toContain('id::text = ANY($2)') // text compare → malformed ids harmlessly miss, no uuid-cast 500
+    expect(params).toEqual(['user_a', ['n1', 'n2']]) // auth user, NOT 'victim'
+  })
+
+  test('mark-all-read UPDATEs the user unread rows, self-scoped', async () => {
+    let params: unknown[] | undefined
+    const { app } = await createApp({ queryHandler: async (s, p) => {
+      if (s.includes('UPDATE meta_record_subscription_notifications') && !s.includes('= ANY')) { params = p; return { rows: [], rowCount: 5 } }
+      return { rows: [] }
+    } })
+    const res = await request(app).post(MARK_ALL).send({})
+    expect(res.status).toBe(200)
+    expect(res.body.data.updated).toBe(5)
+    expect(params).toEqual(['user_a'])
+  })
+
+  test('mark-read rejects a non-array ids body (400) before any query', async () => {
+    let queried = false
+    const { app } = await createApp({ queryHandler: async () => { queried = true; return { rows: [] } } })
+    const res = await request(app).post(MARK).send({ ids: 'nope' })
+    expect(res.status).toBe(400)
+    expect(queried).toBe(false)
+  })
+
+  test('all three routes 401 without an authenticated user', async () => {
+    const { app } = await createApp({ userId: null, queryHandler: async () => ({ rows: [] }) })
+    expect((await request(app).get(UNREAD)).status).toBe(401)
+    expect((await request(app).post(MARK).send({ ids: ['n1'] })).status).toBe(401)
+    expect((await request(app).post(MARK_ALL).send({})).status).toBe(401)
+  })
+})

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -13351,6 +13351,126 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/multitable/record-subscription-notifications/unread-count:
+    get:
+      summary: Unread notification count for the current user (bell badge)
+      description: >-
+        Self-scoped — counts only the authenticated user's unread (read_at IS
+        NULL) notifications.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Unread count for the authenticated user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                    required:
+                      - count
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/multitable/record-subscription-notifications/mark-read:
+    post:
+      summary: Mark a set of the current user's notifications read
+      description: >-
+        Self-scoped — only the authenticated user's own notifications are
+        affected; ids belonging to other users are silently ignored. Idempotent
+        (already-read rows are not re-counted).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - ids
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      updated:
+                        type: integer
+                    required:
+                      - updated
+                required:
+                  - ok
+                  - data
+        '400':
+          description: ids missing or not an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/multitable/record-subscription-notifications/mark-all-read:
+    post:
+      summary: Mark all of the current user's notifications read
+      description: >-
+        Self-scoped — transitions every unread notification belonging to the
+        authenticated user.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      updated:
+                        type: integer
+                    required:
+                      - updated
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -20250,6 +20250,191 @@
         }
       }
     },
+    "/api/multitable/record-subscription-notifications/unread-count": {
+      "get": {
+        "summary": "Unread notification count for the current user (bell badge)",
+        "description": "Self-scoped — counts only the authenticated user's unread (read_at IS NULL) notifications.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unread count for the authenticated user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "count": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "count"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/multitable/record-subscription-notifications/mark-read": {
+      "post": {
+        "summary": "Mark a set of the current user's notifications read",
+        "description": "Self-scoped — only the authenticated user's own notifications are affected; ids belonging to other users are silently ignored. Idempotent (already-read rows are not re-counted).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Number of notifications transitioned to read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "updated": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "updated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "ids missing or not an array",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/multitable/record-subscription-notifications/mark-all-read": {
+      "post": {
+        "summary": "Mark all of the current user's notifications read",
+        "description": "Self-scoped — transitions every unread notification belonging to the authenticated user.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Number of notifications transitioned to read",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "updated": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "updated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}": {
       "put": {
         "summary": "Set a sheet access level for a person or role",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -13351,6 +13351,126 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/multitable/record-subscription-notifications/unread-count:
+    get:
+      summary: Unread notification count for the current user (bell badge)
+      description: >-
+        Self-scoped — counts only the authenticated user's unread (read_at IS
+        NULL) notifications.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Unread count for the authenticated user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                    required:
+                      - count
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/multitable/record-subscription-notifications/mark-read:
+    post:
+      summary: Mark a set of the current user's notifications read
+      description: >-
+        Self-scoped — only the authenticated user's own notifications are
+        affected; ids belonging to other users are silently ignored. Idempotent
+        (already-read rows are not re-counted).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - ids
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      updated:
+                        type: integer
+                    required:
+                      - updated
+                required:
+                  - ok
+                  - data
+        '400':
+          description: ids missing or not an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/multitable/record-subscription-notifications/mark-all-read:
+    post:
+      summary: Mark all of the current user's notifications read
+      description: >-
+        Self-scoped — transitions every unread notification belonging to the
+        authenticated user.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      updated:
+                        type: integer
+                    required:
+                      - updated
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -683,6 +683,93 @@ paths:
                     required: [items, limit, offset]
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/multitable/record-subscription-notifications/unread-count:
+    get:
+      summary: Unread notification count for the current user (bell badge)
+      description: Self-scoped — counts only the authenticated user's unread (read_at IS NULL) notifications.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: Unread count for the authenticated user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      count: { type: integer }
+                    required: [count]
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/multitable/record-subscription-notifications/mark-read:
+    post:
+      summary: Mark a set of the current user's notifications read
+      description: Self-scoped — only the authenticated user's own notifications are affected; ids belonging to other users are silently ignored. Idempotent (already-read rows are not re-counted).
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  items: { type: string }
+              required: [ids]
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      updated: { type: integer }
+                    required: [updated]
+                required: [ok, data]
+        '400':
+          description: ids missing or not an array
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  error:
+                    type: object
+                    properties:
+                      code: { type: string }
+                      message: { type: string }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+  /api/multitable/record-subscription-notifications/mark-all-read:
+    post:
+      summary: Mark all of the current user's notifications read
+      description: Self-scoped — transitions every unread notification belonging to the authenticated user.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: Number of notifications transitioned to read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  data:
+                    type: object
+                    properties:
+                      updated: { type: integer }
+                    required: [updated]
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -76,6 +76,40 @@ test('multitable openapi stays aligned with runtime contracts', () => {
     paths['/api/multitable/record-subscription-notifications']?.get,
     'missing record subscription notification list endpoint',
   )
+  // Notification Center S1 read-state routes — lock route shape + response shape so the SDK/contract
+  // guards against drift (these are the routes the FE bell binds to).
+  assert.ok(
+    paths['/api/multitable/record-subscription-notifications/unread-count']?.get,
+    'missing notification unread-count endpoint',
+  )
+  assert.equal(
+    paths['/api/multitable/record-subscription-notifications/unread-count']?.get?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.properties?.count?.type,
+    'integer',
+    'unread-count must return data.count: integer',
+  )
+  assert.ok(
+    paths['/api/multitable/record-subscription-notifications/mark-read']?.post,
+    'missing notification mark-read endpoint',
+  )
+  assert.equal(
+    paths['/api/multitable/record-subscription-notifications/mark-read']?.post?.requestBody?.content?.['application/json']?.schema?.properties?.ids?.type,
+    'array',
+    'mark-read request body must accept ids: array',
+  )
+  assert.equal(
+    paths['/api/multitable/record-subscription-notifications/mark-read']?.post?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.properties?.updated?.type,
+    'integer',
+    'mark-read must return data.updated: integer',
+  )
+  assert.ok(
+    paths['/api/multitable/record-subscription-notifications/mark-all-read']?.post,
+    'missing notification mark-all-read endpoint',
+  )
+  assert.equal(
+    paths['/api/multitable/record-subscription-notifications/mark-all-read']?.post?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.properties?.updated?.type,
+    'integer',
+    'mark-all-read must return data.updated: integer',
+  )
 
   assert.deepEqual(schemas.MultitableFieldType?.enum, expectedFieldTypes)
   assert.deepEqual(schemas.MultitableViewType?.enum, expectedViewTypes)


### PR DESCRIPTION
Backend half of **Notification Center S1** (owner-scoped: watcher-notification inbox, *not* the Button send_notification sink). Makes the existing `meta_record_subscription_notifications` rows consumable.

## Adds (self-scoped service fns + routes over existing `read_at`)
- `GET /record-subscription-notifications/unread-count` — bell badge
- `POST /record-subscription-notifications/mark-read` (body `{ids}`)
- `POST /record-subscription-notifications/mark-all-read`

## Security — self-scoped by construction
Every statement filters `user_id = $1` = the **authenticated** user (`resolveRequestAccess`); no route takes a userId from the body → cross-user marking/counting is impossible. mark-read uses `id::text = ANY($2)` (not `::uuid[]`) so a malformed id harmlessly misses instead of a uuid-cast 500. Idempotent (flips only `read_at IS NULL`).

## Out of scope (owner lock)
Button `send_notification` sink, push/WebSocket, email/DingTalk, preferences. FE bell + inbox is **S1b** (next).

`tsc` clean · 5/5 contract tests (self-scoping SQL · auth-user-not-body · 400 non-array · 401 unauth · idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)