### PR TITLE
feat(data-source): add C6 external-write apply route

### DIFF
--- a/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
+++ b/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
@@ -1,6 +1,6 @@
 # Data Source System Integration C6 - External Write Design
 
-Status: C6-0 design + C6-1 latent target + C6-2 dry-run route; no apply runtime / no external write
+Status: C6-0 design + C6-1 latent target + C6-2 dry-run route + C6-3 token-bound apply route; C6-4 UI / C6-5 entity-machine validation still gated
 Date: 2026-06-16
 
 ## Purpose
@@ -370,6 +370,29 @@ Required locks:
 - no automatic retry;
 - target writes stay within configured object and writable fields.
 
+Implemented shape:
+
+- route: `POST /api/integration/pipelines/:id/external-write/apply`;
+- request body accepts only `tenantId`, `workspaceId`, and
+  `confirm.dryRunToken`;
+- route requires integration write/admin permission;
+- apply consumes the token once, recomputes the same server-side dry-run plan,
+  and rejects revision drift before any insert/update;
+- host durable plugin storage exposes atomic token `consume()` (`DELETE ...
+  RETURNING`) and the apply helper falls back to an in-process per-token lock
+  only for non-durable test/local storage;
+- source reads and target writes use `pipeline.createdBy` as the data-source
+  owner principal; the authenticated user only authorizes apply;
+- per-row write failures emit values-free row error summaries, values-free
+  provenance events, and values-free dead-letter entries when the host
+  `deadLetterStore.createDeadLetter` capability is present;
+- when the route creates a pipeline run, dead-letter and provenance entries use
+  that real `run.id` so existing run/provenance/dead-letter lookup surfaces can
+  find the C6 row results;
+- response is values-free and does not echo the bearer token, row values,
+  credentials, connection strings, raw SQL, target payloads, or client-provided
+  scope.
+
 ### C6-4 - UI
 
 Add a review surface:
@@ -410,11 +433,11 @@ Only after C6-5 passes can the Release gate discuss production/batch.
 - [x] C6-1 target adapter is latent: metadata/test/schema only; `upsert` stays
   unsupported until C6-3 token-bound apply.
 - [x] Dry-run is read-only and token-producing.
-- [ ] Apply requires write/admin permission plus fresh single-use token.
-- [ ] Revision fencing is hard; mismatch blocks before write.
-- [ ] Per-row failures are isolated and observable.
-- [ ] Dead-letter/provenance are values-free.
-- [ ] No raw SQL, delete, stored procedure, CTE, trigger, or user SQL path.
+- [x] Apply requires write/admin permission plus fresh single-use token.
+- [x] Revision fencing is hard; mismatch blocks before write.
+- [x] Per-row failures are isolated and observable.
+- [x] Dead-letter/provenance are values-free.
+- [x] No raw SQL, delete, stored procedure, CTE, trigger, or user SQL path.
 - [ ] Max-in-flight/circuit-breaker/batch limits protect the external target.
 - [ ] Entity-machine smoke proves apply, re-pull idempotence, and rollback
   posture before production.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -16,10 +16,10 @@
   C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
   中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
   Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
-- 下一门: C6-3 apply route。C6 是最大风险刀；C6-0 只锁 design contract，
+- 下一门: C6-4 UI / C6-5 entity-machine smoke。C6 是最大风险刀；C6-0 只锁 design contract，
   C6-1 只落地 backend latent writer helper 和 write-gated target adapter 的关闭态合同；
   C6-2 只增加 read-only dry-run route + dry-run token，不授权 apply runtime 或 external write。
-  C6-3+ 仍需逐片 opt-in、复审、fresh CI 和实体机 gate。
+  C6-3 增加 token-bound apply route；C6-4/C6-5 仍需逐片 opt-in、复审、fresh CI 和实体机 gate。
 
 ## 收口顺序
 
@@ -30,7 +30,7 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3+ gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4/C6-5 gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
 | Release | 总包 + 实体机验收 | gated | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
@@ -387,7 +387,21 @@ TODO:
     dry-run token only for apply-eligible plans.
   - response/evidence are values-free; token is returned for future C6-3 apply but is not included in evidence.
   - boundary: no apply route, no UI, no insert/update/upsert/delete, no package, no K3。
-- [ ] C6-3 apply route: token-bound，permission-bound，per-row result。
+- [x] C6-3 apply route: token-bound，permission-bound，per-row result。
+  - route: `POST /api/integration/pipelines/:id/external-write/apply`。
+  - request body only accepts `tenantId` / `workspaceId` / `confirm.dryRunToken`；client-supplied
+    `source` / `target` / `plan` / `payload` 等 scope/payload 字段在 pipeline load 前拒绝。
+  - apply requires integration write/admin and the same authenticated principal that produced the dry-run token.
+  - token is single-use and revision-bound；apply consumes the token, recomputes the same server-side plan,
+    and rejects before any write if source/target/capability/mapping/lookup/decision drifted。
+  - host durable plugin storage provides atomic token consume (`DELETE ... RETURNING`)；non-durable local/test
+    storage is additionally guarded by an in-process per-token lock。
+  - writes only apply-eligible `add`/`update` rows through `context.api.dataSourceWrites` structured
+    `insertRows` / `updateRows`; `skip` rows are no-write, conflicted/held rows remain blocked by the
+    apply-eligible dry-run requirement。
+  - row write failures are isolated and returned as values-free counts/error codes; response/evidence never echoes
+    the bearer token, row values, credentials, connection strings, raw SQL, target payloads, or dataSourceId secrets。
+  - boundary: no UI, no package, no C6 entity-machine smoke yet, no delete/raw SQL/generic query, no K3。
 - [ ] C6-4 UI: dry-run -> review -> apply。
 - [ ] C6-5 entity-machine smoke: apply、re-pull、rollback。
 
@@ -406,12 +420,14 @@ TODO:
 
 - [ ] `data-source:sql-readonly` 读是否必须进入同一运行账本。
 - [ ] DB source run 是否产出 provenance。
-- [ ] per-row failure 是否进入 dead-letter。
+- [x] C6 apply per-row failure 进入 values-free dead-letter / provenance（C6-3 route 已接线；C2/C3 read/run
+  观测层是否统一纳入仍待 Release 前定清）。
 - [ ] 是否接入既有 run-record / DF-N 监控面。
 
 完成条件:
 
-- 如果要求纳入统一 Data Factory 运行账本，C3/C6 必须补 provenance/dead-letter/run-record 接线和测试。
+- 如果要求纳入统一 Data Factory 运行账本，C3/C2 read/run 侧仍需补 provenance/dead-letter/run-record
+  接线和测试；C6 apply 侧已由 C6-3 route 写入 run/provenance/dead-letter。
 - 如果暂不纳入，Release 文档必须明确这是另一条 track，不得把“可读”误描述为“已接入完整 DF 观测层”。
 - C6 per-row result 字段必须有 wire-vs-fixture 集成测试，断言真实 route body/response，不只测 helper fixture。
 

--- a/packages/core-backend/src/plugins/plugin-durable-storage.ts
+++ b/packages/core-backend/src/plugins/plugin-durable-storage.ts
@@ -76,6 +76,13 @@ export function createMemoryPluginStorage(): MemoryPluginStorage {
     async set<T = unknown>(key: string, value: T): Promise<void> {
       storageCache.set(normalizeStorageKey(key), value)
     },
+    async consume<T = unknown>(key: string): Promise<T | null> {
+      const storageKey = normalizeStorageKey(key)
+      if (!storageCache.has(storageKey)) return null
+      const value = storageCache.get(storageKey) as T
+      storageCache.delete(storageKey)
+      return value
+    },
     async delete(key: string): Promise<void> {
       storageCache.delete(normalizeStorageKey(key))
     },
@@ -118,6 +125,19 @@ export function createPluginDurableStorage(options: DurableStorageOptions): Dura
          DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
         [pluginName, storageKey, serialized],
       )
+    },
+    async consume<T = unknown>(key: string): Promise<T | null> {
+      const result = await runStorageQuery(
+        pluginName,
+        'consume',
+        query,
+        `DELETE FROM plugin_kv
+          WHERE plugin = $1 AND key = $2
+          RETURNING value`,
+        [pluginName, normalizeStorageKey(key)],
+      )
+      if (result.rows.length === 0) return null
+      return (result.rows[0] as { value: T }).value
     },
     async delete(key: string): Promise<void> {
       await runStorageQuery(

--- a/packages/core-backend/src/plugins/types.ts
+++ b/packages/core-backend/src/plugins/types.ts
@@ -169,6 +169,7 @@ export interface PluginStorage {
   durable?: boolean
   get: (key: string) => Promise<unknown>
   set: (key: string, value: unknown) => Promise<void>
+  consume?: (key: string) => Promise<unknown>
   delete: (key: string) => Promise<void>
   list: () => Promise<string[]>
 }

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -898,6 +898,7 @@ export interface PluginStorage {
   durable?: boolean
   get<T = unknown>(key: string): Promise<T | null>
   set<T = unknown>(key: string, value: T): Promise<void>
+  consume?<T = unknown>(key: string): Promise<T | null>
   delete(key: string): Promise<void>
   list(): Promise<string[]>
 }

--- a/packages/core-backend/tests/unit/plugin-durable-storage.test.ts
+++ b/packages/core-backend/tests/unit/plugin-durable-storage.test.ts
@@ -29,6 +29,13 @@ function createFakeQuery(): { query: PluginStorageQuery; calls: Array<{ sql: str
         const found = rows.get(storageKey(pluginName, key))
         return { rows: found === undefined ? [] : [{ value: found }] }
       }
+      if (sql.includes('DELETE FROM plugin_kv') && sql.includes('RETURNING value')) {
+        const [pluginName, key] = params ?? []
+        const mapKey = storageKey(pluginName, key)
+        const found = rows.get(mapKey)
+        rows.delete(mapKey)
+        return { rows: found === undefined ? [] : [{ value: found }] }
+      }
       if (sql.includes('DELETE FROM plugin_kv')) {
         const [pluginName, key] = params ?? []
         rows.delete(storageKey(pluginName, key))
@@ -91,6 +98,18 @@ describe('plugin durable storage', () => {
 
     await storage.set(longKey, { status: 'queued' })
     await expect(storage.get(longKey)).resolves.toEqual({ status: 'queued' })
+  })
+
+  it('atomically consumes a stored value via delete returning', async () => {
+    const db = createFakeQuery()
+    const storage = createPluginDurableStorage({ pluginName: 'plugin-integration-core', query: db.query })
+
+    await storage.set('dry-run-token', { revision: 'rev_1' })
+
+    await expect(storage.consume?.('dry-run-token')).resolves.toEqual({ revision: 'rev_1' })
+    await expect(storage.consume?.('dry-run-token')).resolves.toBeNull()
+    await expect(storage.get('dry-run-token')).resolves.toBeNull()
+    expect(db.calls.some((call) => call.sql.includes('DELETE FROM plugin_kv') && call.sql.includes('RETURNING value'))).toBe(true)
   })
 
   it('scopes list/get/delete by plugin name', async () => {

--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -3,14 +3,26 @@
 const assert = require('node:assert/strict')
 const path = require('node:path')
 
-const { dryRunExternalWrite } = require(path.join(__dirname, '..', 'lib', 'external-write-dry-run.cjs'))
+const { applyExternalWrite, dryRunExternalWrite } = require(path.join(__dirname, '..', 'lib', 'external-write-dry-run.cjs'))
 
 function memoryStore() {
   const map = new Map()
+  const delays = []
   return {
     map,
-    async get(key) { return map.get(key) || null },
+    delays,
+    async get(key) {
+      if (delays.length > 0) await delays.shift()
+      return map.get(key) || null
+    },
     async set(key, value) { map.set(key, JSON.parse(JSON.stringify(value))) },
+    async consume(key) {
+      if (delays.length > 0) await delays.shift()
+      const value = map.get(key) || null
+      map.delete(key)
+      return value
+    },
+    async delete(key) { map.delete(key) },
   }
 }
 
@@ -72,8 +84,16 @@ function baseInput(overrides = {}) {
         if (key.externalId === 'P-002') return { data: [{ externalId: 'P-002', name: 'Old gadget', status: 'old' }], metadata: {} }
         return { data: [], metadata: {} }
       },
-      async insertRows() { calls.insertRows.push([...arguments]); throw new Error('insertRows must not be called by dry-run') },
-      async updateRows() { calls.updateRows.push([...arguments]); throw new Error('updateRows must not be called by dry-run') },
+      async insertRows(id, object, rows, policy, principal) {
+        calls.insertRows.push({ id, object, rows, policy, principal })
+        if (overrides.insertRows) return overrides.insertRows({ id, object, rows, policy, principal })
+        return { data: rows, metadata: {} }
+      },
+      async updateRows(id, object, rows, policy, principal) {
+        calls.updateRows.push({ id, object, rows, policy, principal })
+        if (overrides.updateRows) return overrides.updateRows({ id, object, rows, policy, principal })
+        return { rowCount: rows.length, results: [] }
+      },
     },
     tokenStore: memoryStore(),
     dryRunUser: 'user_read',
@@ -113,6 +133,192 @@ async function testReadyDryRunIssuesTokenAndStaysValuesFree() {
   assert.equal(result.evidence.dryRunTokenPresent, true)
 }
 
+async function testApplyConsumesTokenRecomputesAndWritesEligibleRows() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+    runId: 'run_c6_apply_1',
+  })
+  assert.equal(apply.status, 'succeeded')
+  assert.equal(apply.dryRunRevision, dryRun.revision)
+  assert.equal(apply.counts.add, 1)
+  assert.equal(apply.counts.update, 1)
+  assert.equal(apply.counts.skip, 0)
+  assert.equal(apply.counts.failed, 0)
+  assert.equal(apply.counts.written, 2)
+  assert.equal(calls.insertRows.length, 1)
+  assert.equal(calls.updateRows.length, 1)
+  assert.deepEqual(calls.insertRows[0].rows, [{ externalId: 'P-001', name: 'Widget', status: 'new' }])
+  assert.deepEqual(calls.updateRows[0].rows, [{ externalId: 'P-002', name: 'Gadget', status: 'old' }])
+  assert.equal(calls.insertRows[0].principal, 'owner-7')
+  assert.equal(calls.updateRows[0].principal, 'owner-7')
+  assert.equal(input.tokenStore.map.size, 0, 'apply consumes the dry-run token')
+  const responseText = JSON.stringify(apply)
+  assert.equal(responseText.includes(dryRun.dryRunToken), false, 'apply response never echoes the bearer token')
+  assert.equal(JSON.stringify(apply.evidence).includes('P-001'), false, 'apply evidence does not include source key values')
+  assert.equal(JSON.stringify(apply.evidence).includes('Widget'), false, 'apply evidence does not include source field values')
+  assert.deepEqual(apply.evidence.provenanceEventCounts, { target_write_succeeded: 2 })
+  assert.ok(apply.provenanceEvents.every((event) => event.runId === 'run_c6_apply_1'), 'apply provenance uses the real run id when provided')
+}
+
+async function testApplyTokenIsSingleUseAndPrincipalBound() {
+  const { input } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: 'user_other',
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH',
+  )
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: 'user_write',
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_INVALID',
+  )
+}
+
+async function testApplyRequiresAuthenticatedApplyUser() {
+  const { input } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: '',
+    }),
+    (error) => error && error.code === 'C6_WRITE_APPLY_USER_REQUIRED',
+  )
+}
+
+async function testApplyRejectsRevisionMismatchBeforeWrite() {
+  let drift = false
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+    },
+    lookupByKey: ({ key }) => {
+      if (!drift && key.externalId === 'P-002') return { data: [{ externalId: 'P-002', name: 'Old gadget', status: 'old' }], metadata: {} }
+      if (drift && key.externalId === 'P-001') return { data: [{ externalId: 'P-001', name: 'Widget', status: 'new' }], metadata: {} }
+      if (drift && key.externalId === 'P-002') return { data: [{ externalId: 'P-002', name: 'Gadget', status: 'old' }], metadata: {} }
+      return { data: [], metadata: {} }
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  drift = true
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: 'user_write',
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH',
+  )
+  assert.equal(calls.insertRows.length, 0, 'revision mismatch fails before insert')
+  assert.equal(calls.updateRows.length, 0, 'revision mismatch fails before update')
+}
+
+async function testApplyIsolatesRowWriteFailuresAndStaysValuesFree() {
+  const { input, calls } = baseInput({
+    sourceRows: [
+      { code: 'P-001', name: 'Widget', status: 'new' },
+      { code: 'P-002', name: 'Gadget', status: 'new' },
+    ],
+    input: {
+      dryRunUser: 'user_write',
+    },
+    lookupByKey: () => ({ data: [], metadata: {} }),
+    insertRows: ({ rows }) => {
+      if (rows[0].externalId === 'P-002') {
+        const error = new Error('duplicate key P-002 Widget')
+        error.code = 'DUPLICATE_P-002_WIDGET'
+        throw error
+      }
+      return { data: rows, metadata: {} }
+    },
+  })
+  const deadLetters = []
+  const dryRun = await dryRunExternalWrite(input)
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+    runId: 'run_c6_partial_1',
+    deadLetterStore: {
+      async createDeadLetter(entry) {
+        deadLetters.push(entry)
+        return { ...entry, id: `dl_${deadLetters.length}` }
+      },
+    },
+  })
+  assert.equal(apply.status, 'partial')
+  assert.equal(apply.counts.add, 1)
+  assert.equal(apply.counts.failed, 1)
+  assert.equal(apply.counts.written, 1)
+  assert.equal(calls.insertRows.length, 2, 'row failures are isolated by per-row writes')
+  assert.deepEqual(apply.evidence.rowErrorTypes, ['WRITE_FAILED'])
+  assert.deepEqual(apply.deadLetters, { attempted: 1, persisted: 1 })
+  assert.equal(deadLetters.length, 1)
+  assert.equal(deadLetters[0].errorCode, 'WRITE_FAILED')
+  assert.equal(deadLetters[0].errorMessage, 'WRITE_FAILED')
+  assert.equal(deadLetters[0].runId, 'run_c6_partial_1')
+  assert.equal(deadLetters[0].sourcePayload.keyFingerprint, apply.rowErrors[0].keyFingerprint)
+  assert.ok(apply.provenanceEvents.every((event) => event.runId === 'run_c6_partial_1'), 'failure provenance uses the real run id when provided')
+  const responseText = JSON.stringify(apply)
+  assert.equal(responseText.includes('P-002'), false, 'failure response does not include key values from thrown messages')
+  assert.equal(responseText.includes('Widget'), false, 'failure response does not include row values from thrown messages')
+  assert.equal(responseText.includes('DUPLICATE_P-002_WIDGET'), false, 'unsafe error codes are not exposed')
+}
+
+async function testApplyTokenIsSingleUseUnderConcurrency() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+    },
+  })
+  let releaseRead
+  input.tokenStore.delays.push(new Promise((resolve) => { releaseRead = resolve }))
+  const dryRun = await dryRunExternalWrite(input)
+  const first = applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+  })
+  const second = applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+  })
+  releaseRead()
+  const results = await Promise.allSettled([first, second])
+  const fulfilled = results.filter((result) => result.status === 'fulfilled')
+  const rejected = results.filter((result) => result.status === 'rejected')
+  assert.equal(fulfilled.length, 1, 'only one concurrent apply can consume the token')
+  assert.equal(rejected.length, 1, 'the competing apply fails closed')
+  assert.equal(rejected[0].reason.code, 'C6_WRITE_DRY_RUN_TOKEN_INVALID')
+  assert.equal(calls.insertRows.length, 1)
+  assert.equal(calls.updateRows.length, 1)
+}
+
 async function testAmbiguousTargetKeyHoldsAndDoesNotIssueToken() {
   const { input } = baseInput({
     sourceRows: [{ code: 'P-009', name: 'Dup', status: 'new' }],
@@ -148,10 +354,8 @@ async function testRejectsNonC6Target() {
   await assert.rejects(() => dryRunExternalWrite(input), /requires target kind data-source:sql-write-gated/)
 }
 
-async function testRevisionBindsTargetCapabilityState() {
-  const { input: lockedInput } = baseInput()
-  const locked = await dryRunExternalWrite(lockedInput)
-  const { input: driftedInput } = baseInput({
+async function testUnsafeCapabilityStateFailsClosed() {
+  const { input, calls } = baseInput({
     test: () => ({
       success: true,
       capabilityState: {
@@ -161,8 +365,11 @@ async function testRevisionBindsTargetCapabilityState() {
       },
     }),
   })
-  const drifted = await dryRunExternalWrite(driftedInput)
-  assert.notEqual(drifted.revision, locked.revision, 'revision changes when the facade-reported target C6 capability state drifts')
+  await assert.rejects(
+    () => dryRunExternalWrite(input),
+    (error) => error && error.code === 'C6_WRITE_TARGET_CAPABILITY_UNSAFE',
+  )
+  assert.equal(calls.lookupByKey.length, 0, 'unsafe target capability state fails before target lookup')
 }
 
 async function testRejectsMissingCapabilityState() {
@@ -196,9 +403,15 @@ async function main() {
   await testAmbiguousTargetKeyHoldsAndDoesNotIssueToken()
   await testTruncatedSourceReadDoesNotIssueToken()
   await testRejectsNonC6Target()
-  await testRevisionBindsTargetCapabilityState()
+  await testUnsafeCapabilityStateFailsClosed()
   await testRejectsMissingCapabilityState()
   await testRejectsFailedTargetCapabilityCheck()
+  await testApplyConsumesTokenRecomputesAndWritesEligibleRows()
+  await testApplyTokenIsSingleUseAndPrincipalBound()
+  await testApplyTokenIsSingleUseUnderConcurrency()
+  await testApplyRequiresAuthenticatedApplyUser()
+  await testApplyRejectsRevisionMismatchBeforeWrite()
+  await testApplyIsolatesRowWriteFailuresAndStaysValuesFree()
   console.log('external-write-dry-run.test.cjs OK')
 }
 

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1581,6 +1581,543 @@ async function testPipelineExternalWriteDryRunRoute() {
   assert.equal(calls.length, callsBeforeInvalidBody, 'client-supplied target scope is rejected before loading the pipeline')
 }
 
+async function testPipelineExternalWriteApplyRoute() {
+  const calls = []
+  const storage = createMemoryStorage()
+  const sourceSystem = {
+    id: 'source_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'Readonly SQL source',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    status: 'active',
+    config: { dataSourceId: 'readonly-ds', object: 'public.source_items' },
+  }
+  const targetSystem = {
+    id: 'target_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'Gated SQL target',
+    kind: 'data-source:sql-write-gated',
+    role: 'target',
+    status: 'active',
+    config: {
+      dataSourceId: 'writable-ds',
+      object: 'public.target_items',
+      keyFields: ['externalId'],
+      writableFields: ['name'],
+    },
+  }
+  const pipeline = {
+    id: 'pipe_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'C6 external write apply',
+    status: 'active',
+    sourceSystemId: sourceSystem.id,
+    sourceObject: 'public.source_items',
+    targetSystemId: targetSystem.id,
+    targetObject: 'public.target_items',
+    createdBy: 'owner-7',
+    fieldMappings: [
+      { sourceField: 'code', targetField: 'externalId' },
+      { sourceField: 'name', targetField: 'name' },
+    ],
+  }
+  const sourceReadCalls = []
+  const writeCalls = { test: [], lookupByKey: [], insertRows: [], updateRows: [] }
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        if (input.id === sourceSystem.id) return { ...sourceSystem }
+        return null
+      },
+      async getExternalSystem(input) {
+        calls.push(['getExternalSystem', input])
+        if (input.id === targetSystem.id) return { ...targetSystem }
+        return null
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', { system, deps }])
+        assert.equal(system.id, sourceSystem.id, 'external-write apply creates only the source adapter')
+        assert.equal(deps.principal, 'owner-7', 'source adapter reads as pipeline.createdBy')
+        return {
+          async read(readInput) {
+            sourceReadCalls.push(readInput)
+            return {
+              records: [
+                { code: 'P-001', name: 'Widget' },
+                { code: 'P-002', name: 'Gadget' },
+              ],
+              done: true,
+              nextCursor: null,
+            }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      async getPipeline(input) {
+        calls.push(['getPipeline', input])
+        return { ...pipeline, id: input.id }
+      },
+    },
+  })
+  const dataSourceWrites = {
+    async test(dataSourceId, principal) {
+      writeCalls.test.push({ dataSourceId, principal })
+      return {
+        success: true,
+        capabilityState: {
+          readOnly: false,
+          c6WriteTarget: true,
+          genericQueryDisabled: true,
+        },
+      }
+    },
+    async lookupByKey(dataSourceId, object, key, policy, principal) {
+      writeCalls.lookupByKey.push({ dataSourceId, object, key, policy, principal })
+      if (key.externalId === 'P-002') return { data: [{ externalId: 'P-002', name: 'Old Gadget' }], metadata: {} }
+      return { data: [], metadata: {} }
+    },
+    async insertRows(dataSourceId, object, rows, policy, principal) {
+      writeCalls.insertRows.push({ dataSourceId, object, rows, policy, principal })
+      return { data: rows, metadata: {} }
+    },
+    async updateRows(dataSourceId, object, rows, policy, principal) {
+      writeCalls.updateRows.push({ dataSourceId, object, rows, policy, principal })
+      return { rowCount: rows.length, results: [] }
+    },
+  }
+  const { routes, registered } = mountRoutes(services, { storage, dataSourceWrites })
+  assert.ok(
+    registered.includes('POST /api/integration/pipelines/:id/external-write/apply'),
+    'external-write apply route registered',
+  )
+
+  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: {} },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_TOKEN_REQUIRED')
+  assert.equal(calls.length, 0, 'missing token is rejected before loading pipeline/systems/adapters')
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  const token = res.body.data.dryRunToken
+  assert.equal(typeof token, 'string')
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: READ_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assert.equal(res.statusCode, 403, 'read-only integration user cannot apply C6 writes')
+  assert.equal(writeCalls.insertRows.length, 0)
+  assert.equal(writeCalls.updateRows.length, 0)
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'succeeded')
+  assert.equal(res.body.data.counts.add, 1)
+  assert.equal(res.body.data.counts.update, 1)
+  assert.equal(res.body.data.counts.written, 2)
+  assert.equal(writeCalls.insertRows.length, 1)
+  assert.equal(writeCalls.updateRows.length, 1)
+  assert.deepEqual(writeCalls.insertRows[0].rows, [{ externalId: 'P-001', name: 'Widget' }])
+  assert.deepEqual(writeCalls.updateRows[0].rows, [{ externalId: 'P-002', name: 'Gadget' }])
+  assert.equal(writeCalls.insertRows[0].principal, 'owner-7')
+  assert.equal(writeCalls.updateRows[0].principal, 'owner-7')
+  assert.equal(storage.map.size, 0, 'apply consumes the route dry-run token')
+  assert.equal(JSON.stringify(res.body.data).includes(token), false, 'apply route never echoes the bearer token')
+  assert.equal(JSON.stringify(res.body.data.evidence).includes('P-001'), false, 'apply evidence does not include key values')
+  assert.equal(JSON.stringify(res.body.data.evidence).includes('Widget'), false, 'apply evidence does not include row values')
+
+  const writesAfterSuccess = writeCalls.insertRows.length + writeCalls.updateRows.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assert.equal(res.statusCode, 409)
+  assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_TOKEN_INVALID')
+  assert.equal(writeCalls.insertRows.length + writeCalls.updateRows.length, writesAfterSuccess, 'used token cannot trigger another write')
+
+  for (const key of ['target', 'source', 'plan', 'payload']) {
+    const callsBeforeInvalidBody = calls.length
+    res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+      user: WRITE_USER,
+      params: { id: pipeline.id },
+      body: {
+        tenantId: 'tenant_1',
+        workspaceId: 'workspace_1',
+        confirm: { dryRunToken: 'ignored' },
+        [key]: { dataSourceId: 'evil' },
+      },
+    })
+    assert.equal(res.statusCode, 400)
+    assert.equal(res.body.error.code, 'C6_WRITE_APPLY_REQUEST_INVALID')
+    assert.equal(calls.length, callsBeforeInvalidBody, `client-supplied ${key} scope is rejected before loading the pipeline`)
+  }
+
+  const callsBeforeNestedConfirm = calls.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      confirm: { dryRunToken: 'ignored', target: { dataSourceId: 'evil' } },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'C6_WRITE_APPLY_REQUEST_INVALID')
+  assert.equal(calls.length, callsBeforeNestedConfirm, 'nested confirm scope is rejected before loading the pipeline')
+}
+
+async function testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance() {
+  const calls = []
+  const runWrites = []
+  const deadLetterWrites = []
+  const storage = createMemoryStorage()
+  const sourceSystem = {
+    id: 'source_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    status: 'active',
+    config: { dataSourceId: 'readonly-ds', object: 'public.source_items' },
+  }
+  const targetSystem = {
+    id: 'target_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-write-gated',
+    role: 'target',
+    status: 'active',
+    config: {
+      dataSourceId: 'writable-ds',
+      object: 'public.target_items',
+      keyFields: ['externalId'],
+      writableFields: ['name'],
+    },
+  }
+  const pipeline = {
+    id: 'pipe_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'C6 external write apply partial',
+    status: 'active',
+    sourceSystemId: sourceSystem.id,
+    sourceObject: 'public.source_items',
+    targetSystemId: targetSystem.id,
+    targetObject: 'public.target_items',
+    createdBy: 'owner-7',
+    fieldMappings: [
+      { sourceField: 'code', targetField: 'externalId' },
+      { sourceField: 'name', targetField: 'name' },
+    ],
+  }
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        if (input.id === sourceSystem.id) return { ...sourceSystem }
+        return null
+      },
+      async getExternalSystem(input) {
+        calls.push(['getExternalSystem', input])
+        if (input.id === targetSystem.id) return { ...targetSystem }
+        return null
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', { system, deps }])
+        assert.equal(system.id, sourceSystem.id)
+        assert.equal(deps.principal, 'owner-7')
+        return {
+          async read() {
+            return {
+              records: [
+                { code: 'P-001', name: 'Widget' },
+                { code: 'P-002', name: 'Gadget' },
+              ],
+              done: true,
+              nextCursor: null,
+            }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      async getPipeline(input) {
+        calls.push(['getPipeline', input])
+        return { ...pipeline, id: input.id }
+      },
+      async createPipelineRun(input) {
+        calls.push(['createPipelineRun', input])
+        runWrites.push(['create', input])
+        return {
+          id: 'run_c6_partial',
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: input.pipelineId,
+          status: input.status,
+          mode: input.mode,
+          startedAt: input.startedAt,
+          details: input.details || {},
+        }
+      },
+      async updatePipelineRun(input) {
+        calls.push(['updatePipelineRun', input])
+        runWrites.push(['update', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: pipeline.id,
+          status: input.status,
+          provenanceEvents: input.provenanceEvents || [],
+          details: input.details || {},
+        }
+      },
+    },
+    deadLetterStore: {
+      async listDeadLetters() {
+        return []
+      },
+      async createDeadLetter(input) {
+        calls.push(['createDeadLetter', input])
+        deadLetterWrites.push(input)
+        return { ...input, id: `dl_${deadLetterWrites.length}` }
+      },
+    },
+  })
+  const dataSourceWrites = {
+    async test() {
+      return {
+        success: true,
+        capabilityState: {
+          readOnly: false,
+          c6WriteTarget: true,
+          genericQueryDisabled: true,
+        },
+      }
+    },
+    async lookupByKey() {
+      return { data: [], metadata: {} }
+    },
+    async insertRows(_dataSourceId, _object, rows) {
+      if (rows[0].externalId === 'P-002') {
+        const error = new Error('target duplicate P-002 Widget')
+        error.code = 'LEAK_P-002_WIDGET'
+        throw error
+      }
+      return { data: rows, metadata: {} }
+    },
+    async updateRows() {
+      throw new Error('updateRows not expected')
+    },
+  }
+  const { routes } = mountRoutes(services, { storage, dataSourceWrites })
+
+  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  const token = res.body.data.dryRunToken
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'partial')
+  assert.equal(res.body.data.counts.add, 1)
+  assert.equal(res.body.data.counts.failed, 1)
+  assert.deepEqual(res.body.data.evidence.rowErrorTypes, ['WRITE_FAILED'])
+  assert.deepEqual(res.body.data.deadLetters, { attempted: 1, persisted: 1 })
+  assert.equal(deadLetterWrites.length, 1)
+  assert.equal(deadLetterWrites[0].errorCode, 'WRITE_FAILED')
+  assert.equal(deadLetterWrites[0].errorMessage, 'WRITE_FAILED')
+  assert.equal(deadLetterWrites[0].runId, res.body.data.run.id)
+  assert.equal(typeof deadLetterWrites[0].sourcePayload.keyFingerprint, 'string')
+  const update = runWrites.find(([kind]) => kind === 'update')[1]
+  assert.equal(update.status, 'partial')
+  assert.equal(update.rowsWritten, 1)
+  assert.equal(update.rowsFailed, 1)
+  assert.equal(update.provenanceEvents.length, 2)
+  assert.deepEqual(
+    update.provenanceEvents.map((event) => event.eventType).sort(),
+    ['target_write_failed', 'target_write_succeeded'],
+  )
+  assert.ok(update.provenanceEvents.every((event) => event.runId === res.body.data.run.id), 'provenance events are linked to the public pipeline run id')
+  assert.equal(update.provenanceEvents.find((event) => event.eventType === 'target_write_failed').attrs.errorCode, 'WRITE_FAILED')
+  assert.equal(Object.prototype.hasOwnProperty.call(res.body.data, 'provenanceEvents'), false, 'route response does not expose raw provenance events')
+  assert.equal(res.body.data.run.provenanceEventsPersisted, 2)
+  const publicText = JSON.stringify(res.body.data)
+  assert.equal(publicText.includes('P-002'), false, 'route response does not leak source key values')
+  assert.equal(publicText.includes('Widget'), false, 'route response does not leak source row values')
+  assert.equal(publicText.includes('LEAK_P-002_WIDGET'), false, 'route response does not leak unsafe adapter error codes')
+  const persistedText = JSON.stringify({ runWrites, deadLetterWrites })
+  assert.equal(persistedText.includes('P-002'), false, 'persisted provenance/dead-letter data does not leak source key values')
+  assert.equal(persistedText.includes('Widget'), false, 'persisted provenance/dead-letter data does not leak source row values')
+  assert.equal(persistedText.includes('LEAK_P-002_WIDGET'), false, 'persisted provenance/dead-letter data does not leak unsafe adapter error codes')
+}
+
+async function testPipelineExternalWriteApplyDoesNotOverstateProvenancePersistence() {
+  const storage = createMemoryStorage()
+  const sourceSystem = {
+    id: 'source_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    status: 'active',
+    config: { dataSourceId: 'readonly-ds', object: 'public.source_items' },
+  }
+  const targetSystem = {
+    id: 'target_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-write-gated',
+    role: 'target',
+    status: 'active',
+    config: {
+      dataSourceId: 'writable-ds',
+      object: 'public.target_items',
+      keyFields: ['externalId'],
+      writableFields: ['name'],
+    },
+  }
+  const pipeline = {
+    id: 'pipe_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'C6 external write apply no returned provenance',
+    status: 'active',
+    sourceSystemId: sourceSystem.id,
+    sourceObject: 'public.source_items',
+    targetSystemId: targetSystem.id,
+    targetObject: 'public.target_items',
+    createdBy: 'owner-7',
+    fieldMappings: [
+      { sourceField: 'code', targetField: 'externalId' },
+      { sourceField: 'name', targetField: 'name' },
+    ],
+  }
+  const runUpdates = []
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        if (input.id === sourceSystem.id) return { ...sourceSystem }
+        return null
+      },
+      async getExternalSystem(input) {
+        if (input.id === targetSystem.id) return { ...targetSystem }
+        return null
+      },
+    },
+    adapterRegistry: {
+      createAdapter() {
+        return {
+          async read() {
+            return {
+              records: [{ code: 'P-001', name: 'Widget' }],
+              done: true,
+              nextCursor: null,
+            }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      async getPipeline(input) {
+        return { ...pipeline, id: input.id }
+      },
+      async createPipelineRun(input) {
+        return {
+          id: 'run_c6_no_returned_provenance',
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: input.pipelineId,
+          status: input.status,
+          mode: input.mode,
+          startedAt: input.startedAt,
+          details: input.details || {},
+        }
+      },
+      async updatePipelineRun(input) {
+        runUpdates.push(input)
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: pipeline.id,
+          status: input.status,
+          details: input.details || {},
+        }
+      },
+    },
+  })
+  const dataSourceWrites = {
+    async test() {
+      return {
+        success: true,
+        capabilityState: {
+          readOnly: false,
+          c6WriteTarget: true,
+          genericQueryDisabled: true,
+        },
+      }
+    },
+    async lookupByKey() {
+      return { data: [], metadata: {} }
+    },
+    async insertRows(_dataSourceId, _object, rows) {
+      return { data: rows, metadata: {} }
+    },
+    async updateRows() {
+      throw new Error('updateRows not expected')
+    },
+  }
+  const { routes } = mountRoutes(services, { storage, dataSourceWrites })
+  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: res.body.data.dryRunToken } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(runUpdates.length, 1)
+  assert.equal(runUpdates[0].provenanceEvents.length, 1, 'route submits provenance events to the run logger')
+  assert.equal(res.body.data.run.provenanceEventsPersisted, null, 'response does not overstate persistence when the registry does not return events')
+}
+
 async function testPipelineExternalWriteDryRunPreflightFailsClosed() {
   const calls = []
   const makeServices = (pipelineOverride) => createMockServices({
@@ -3862,6 +4399,9 @@ async function main() {
   await testDocumentTemplateValidation()
   await testPipelineRoutes()
   await testPipelineExternalWriteDryRunRoute()
+  await testPipelineExternalWriteApplyRoute()
+  await testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance()
+  await testPipelineExternalWriteApplyDoesNotOverstateProvenancePersistence()
   await testPipelineExternalWriteDryRunPreflightFailsClosed()
   await testTemplatePreviewRoute()
   await testTemplatesDeriveRoute()

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -1,10 +1,8 @@
 'use strict'
 
-// C6-2: values-free external-write dry-run for `data-source:sql-write-gated`.
-// This module reads source rows, transforms them with the existing pipeline
-// mapping, performs structured target key lookups through the host write facade,
-// and issues a dry-run token only for a complete, apply-eligible plan. It never
-// calls insert/update/upsert/delete.
+// C6 external-write helper for `data-source:sql-write-gated`.
+// C6-2 dry-run and C6-3 apply intentionally share one planner so the reviewed
+// revision is the same decision surface that apply recomputes before writing.
 
 const crypto = require('node:crypto')
 
@@ -18,6 +16,24 @@ const MAX_ROWS = 10000
 const DEFAULT_PAGE_SIZE = 100
 const MAX_PAGES = 100
 const TARGET_KIND = 'data-source:sql-write-gated'
+const CONSUMING_TOKEN_KEYS = new Set()
+const SAFE_WRITE_ERROR_CODES = new Set([
+  'AdapterValidationError',
+  'DATA_SOURCE_BRIDGE_CONFIG_ERROR',
+  'DATA_SOURCE_GENERIC_QUERY_DISABLED_REQUIRED',
+  'DATA_SOURCE_NOT_C6_WRITE_TARGET',
+  'DATA_SOURCE_NOT_FOUND',
+  'DATA_SOURCE_NOT_VISIBLE',
+  'DATA_SOURCE_NOT_WRITABLE',
+  'DATA_SOURCE_PRINCIPAL_REQUIRED',
+  'DATA_SOURCE_QUERY_INVALID',
+  'DataSourceBridgeConfigError',
+  'DataSourceNotC6WriteTargetError',
+  'DataSourceNotWritableError',
+  'DataSourceQueryDisabledError',
+  'DataSourceUnavailableError',
+  'DUPLICATE_KEY',
+])
 
 class ExternalWriteDryRunError extends Error {
   constructor(status, code, message, details = {}) {
@@ -81,6 +97,14 @@ function requireTokenStore(tokenStore) {
   return tokenStore
 }
 
+function requireConsumableTokenStore(tokenStore) {
+  const store = requireTokenStore(tokenStore)
+  if (typeof store.consume !== 'function' && typeof store.delete !== 'function') {
+    throw new ExternalWriteDryRunError(501, 'C6_WRITE_DRY_RUN_TOKEN_STORE_UNAVAILABLE', 'C6 write apply requires consumable plugin storage for tokens')
+  }
+  return store
+}
+
 async function createDryRunToken(tokenStore, record) {
   const store = requireTokenStore(tokenStore)
   const token = crypto.randomBytes(24).toString('base64url')
@@ -90,6 +114,49 @@ async function createDryRunToken(tokenStore, record) {
     expiresAt: new Date(Date.now() + DEFAULT_C6_DRY_RUN_TOKEN_TTL_MS).toISOString(),
   })
   return token
+}
+
+async function consumeDryRunToken(tokenStore, token, expected) {
+  const store = requireConsumableTokenStore(tokenStore)
+  const dryRunToken = optionalString(token)
+  if (!dryRunToken) {
+    throw new ExternalWriteDryRunError(400, 'C6_WRITE_DRY_RUN_TOKEN_REQUIRED', 'dryRunToken is required for apply', { field: 'confirm.dryRunToken' })
+  }
+  const key = tokenStoreKey(dryRunToken)
+  if (CONSUMING_TOKEN_KEYS.has(key)) {
+    throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_INVALID', 'dryRunToken is missing, expired, or already used')
+  }
+  CONSUMING_TOKEN_KEYS.add(key)
+  try {
+    let stored
+    if (typeof store.consume === 'function') {
+      stored = await store.consume(key)
+    } else {
+      stored = await store.get(key)
+      await store.delete(key)
+    }
+    if (!isPlainObject(stored)) {
+      throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_INVALID', 'dryRunToken is missing, expired, or already used')
+    }
+    const expiresAt = Date.parse(stored.expiresAt)
+    if (!Number.isNaN(expiresAt) && expiresAt < Date.now()) {
+      throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_INVALID', 'dryRunToken is expired')
+    }
+    const storedWorkspaceId = stored.workspaceId || null
+    const expectedWorkspaceId = expected.workspaceId || null
+    if (
+      stored.pipelineId !== expected.pipelineId ||
+      stored.tenantId !== expected.tenantId ||
+      storedWorkspaceId !== expectedWorkspaceId ||
+      stored.dryRunUser !== expected.dryRunUser ||
+      stored.dataSourceOwnerPrincipal !== expected.dataSourceOwnerPrincipal
+    ) {
+      throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH', 'dryRunToken does not match this pipeline/user scope')
+    }
+    return stored
+  } finally {
+    CONSUMING_TOKEN_KEYS.delete(key)
+  }
 }
 
 function normalizeFieldList(value, field) {
@@ -154,6 +221,12 @@ function normalizeTargetCapabilityState(result) {
   }
 }
 
+function assertSafeTargetCapabilityState(state) {
+  if (state.readOnly !== false || state.c6WriteTarget !== true || state.genericQueryDisabled !== true) {
+    throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_CAPABILITY_UNSAFE', 'C6 write target capability state is unsafe')
+  }
+}
+
 function statusCounts() {
   return { add: 0, update: 0, skip: 0, held: 0, failed: 0 }
 }
@@ -187,6 +260,14 @@ function writableDataFromRecord(record, writableFields) {
     if (value !== undefined) data[field] = value
   }
   return data
+}
+
+function writeRowFromRecord(record, targetConfig) {
+  const { key } = keyFromRecord(record, targetConfig.keyFields)
+  return {
+    ...key,
+    ...writableDataFromRecord(record, targetConfig.writableFields),
+  }
 }
 
 function classifyExisting({ existingRows, targetRecord, writableFields }) {
@@ -253,6 +334,17 @@ function buildRevision(input) {
   })
 }
 
+function valuesFreeErrorCode(error) {
+  if (!error) return 'UNKNOWN_ERROR'
+  const raw = error.code || error.name || 'WRITE_FAILED'
+  const normalized = String(raw).replace(/[^A-Za-z0-9_:-]/g, '_').slice(0, 80)
+  return SAFE_WRITE_ERROR_CODES.has(normalized) ? normalized : 'WRITE_FAILED'
+}
+
+function publicRowErrorTypes(rowErrors) {
+  return Array.from(new Set(rowErrors.map((entry) => entry.errorCode || entry.reason || 'write_failed'))).sort()
+}
+
 function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, canApply, sourceRead, rowErrorTypes, dryRunToken }) {
   return {
     pipelineId: pipeline.id,
@@ -274,17 +366,49 @@ function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, 
   }
 }
 
-async function dryRunExternalWrite(input = {}) {
+function publicApplyEvidence({ pipeline, targetConfig, sourceKind, status, counts, revision, sourceRead, rowErrors, provenanceEvents }) {
+  return {
+    pipelineId: pipeline.id,
+    targetKind: TARGET_KIND,
+    sourceKind: sourceKind || null,
+    operationMode: 'upsert',
+    keyFields: targetConfig.keyFields.slice(),
+    writableFields: targetConfig.writableFields.slice(),
+    status,
+    counts: cloneJson(counts),
+    rowErrorTypes: publicRowErrorTypes(rowErrors),
+    rowFailureCount: rowErrors.length,
+    sourceRead: {
+      complete: sourceRead.complete === true,
+      pagesRead: sourceRead.pagesRead,
+      truncated: sourceRead.truncated === true,
+    },
+    dryRunRevision: revision,
+    dryRunTokenConsumed: true,
+    provenanceEventCounts: provenanceEvents.reduce((acc, event) => {
+      acc[event.eventType] = (acc[event.eventType] || 0) + 1
+      return acc
+    }, {}),
+    deadLetterCount: rowErrors.length,
+  }
+}
+
+function validatePlannerInput(input = {}, phase = 'dry-run') {
   const pipeline = input.pipeline
   if (!pipeline || !pipeline.id) {
     throw new ExternalWriteDryRunError(422, 'C6_WRITE_DRY_RUN_CONFIG_INVALID', 'pipeline is required')
   }
   if (typeof input.dataSourceOwnerPrincipal !== 'string' || input.dataSourceOwnerPrincipal.trim() === '') {
-    throw new ExternalWriteDryRunError(422, 'C6_WRITE_OWNER_PRINCIPAL_REQUIRED', 'pipeline.createdBy is required for C6 write dry-run')
+    throw new ExternalWriteDryRunError(422, 'C6_WRITE_OWNER_PRINCIPAL_REQUIRED', `pipeline.createdBy is required for C6 write ${phase}`)
   }
   if (typeof input.dryRunUser !== 'string' || input.dryRunUser.trim() === '') {
-    throw new ExternalWriteDryRunError(401, 'C6_WRITE_DRY_RUN_USER_REQUIRED', 'authenticated dry-run user is required')
+    throw new ExternalWriteDryRunError(401, 'C6_WRITE_DRY_RUN_USER_REQUIRED', `authenticated dry-run user is required for C6 write ${phase}`)
   }
+  return pipeline
+}
+
+async function computeExternalWritePlan(input = {}) {
+  const pipeline = validatePlannerInput(input, input.phase || 'dry-run')
   const targetConfig = normalizeTargetConfig(input.targetSystem)
   const dataSourceWrites = requireDataSourceWritesApi(input.dataSourceWrites)
   const targetCapabilityState = normalizeTargetCapabilityState(
@@ -293,6 +417,7 @@ async function dryRunExternalWrite(input = {}) {
   if (targetCapabilityState.success !== true) {
     throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_TEST_FAILED', 'C6 write target test did not pass')
   }
+  assertSafeTargetCapabilityState(targetCapabilityState)
   if (!input.sourceAdapter || typeof input.sourceAdapter.read !== 'function') {
     throw new ExternalWriteDryRunError(501, 'C6_WRITE_SOURCE_ADAPTER_UNAVAILABLE', 'source adapter read is required')
   }
@@ -309,6 +434,7 @@ async function dryRunExternalWrite(input = {}) {
   }
   const rowErrorTypes = []
   const rowFingerprints = []
+  const planRows = []
   const policy = {
     keyFields: targetConfig.keyFields,
     writableFields: targetConfig.writableFields,
@@ -350,9 +476,16 @@ async function dryRunExternalWrite(input = {}) {
       targetRecord: transformed.value,
       writableFields: targetConfig.writableFields,
     })
+    const writeRow = writeRowFromRecord(transformed.value, targetConfig)
     counts[decision] += 1
     counts.planned += 1
     if (decision === 'held') rowErrorTypes.push('ambiguous_target_key')
+    planRows.push({
+      decision,
+      key,
+      keyFingerprint: hashJson(key),
+      row: writeRow,
+    })
     rowFingerprints.push({
       status: decision,
       key: hashJson(key),
@@ -379,46 +512,277 @@ async function dryRunExternalWrite(input = {}) {
     counts,
     completeSourceRead: sourceRead.complete === true,
   })
+  return {
+    pipeline,
+    targetConfig,
+    dataSourceWrites,
+    targetCapabilityState,
+    sourceKind: input.sourceSystem && input.sourceSystem.kind,
+    sourceRead,
+    counts,
+    rowErrorTypes,
+    rowFingerprints,
+    planRows,
+    policy,
+    canApply,
+    revision,
+    maxRows,
+  }
+}
+
+async function dryRunExternalWrite(input = {}) {
+  const plan = await computeExternalWritePlan(input)
   let dryRunToken = null
-  if (canApply) {
+  if (plan.canApply) {
     dryRunToken = await createDryRunToken(input.tokenStore, {
-      pipelineId: pipeline.id,
-      tenantId: pipeline.tenantId,
-      workspaceId: pipeline.workspaceId || null,
+      pipelineId: plan.pipeline.id,
+      tenantId: plan.pipeline.tenantId,
+      workspaceId: plan.pipeline.workspaceId || null,
       dryRunUser: input.dryRunUser,
       dataSourceOwnerPrincipal: input.dataSourceOwnerPrincipal,
-      revision,
-      counts: cloneJson(counts),
+      revision: plan.revision,
+      counts: cloneJson(plan.counts),
+      maxRows: plan.maxRows,
     })
   }
   return {
-    pipelineId: pipeline.id,
-    status: canApply ? 'ready' : 'not_applyable',
-    canApply,
+    pipelineId: plan.pipeline.id,
+    status: plan.canApply ? 'ready' : 'not_applyable',
+    canApply: plan.canApply,
     dryRunToken,
-    revision,
-    counts,
+    revision: plan.revision,
+    counts: plan.counts,
     evidence: publicEvidence({
-      pipeline,
-      targetConfig,
-      sourceKind: input.sourceSystem && input.sourceSystem.kind,
-      counts,
-      revision,
-      canApply,
-      sourceRead,
-      rowErrorTypes,
+      pipeline: plan.pipeline,
+      targetConfig: plan.targetConfig,
+      sourceKind: plan.sourceKind,
+      counts: plan.counts,
+      revision: plan.revision,
+      canApply: plan.canApply,
+      sourceRead: plan.sourceRead,
+      rowErrorTypes: plan.rowErrorTypes,
       dryRunToken,
+    }),
+  }
+}
+
+function applyStatus(counts) {
+  if (counts.failed === 0) return 'succeeded'
+  if (counts.add > 0 || counts.update > 0 || counts.skip > 0) return 'partial'
+  return 'failed'
+}
+
+function syntheticRunId(pipeline, revision) {
+  return `c6-external-write:${pipeline.id}:${revision}`
+}
+
+function provenanceEvent({ pipeline, revision, runId, row, eventType, attrs = {} }) {
+  return {
+    runId: runId || syntheticRunId(pipeline, revision),
+    rowId: row && row.keyFingerprint ? row.keyFingerprint : hashJson({ pipelineId: pipeline.id, eventType, attrs }),
+    eventType,
+    at: new Date().toISOString(),
+    attrs: {
+      targetKind: TARGET_KIND,
+      dryRunRevision: revision,
+      ...attrs,
+    },
+  }
+}
+
+function deadLetterForRowFailure({ pipeline, revision, runId, rowError }) {
+  return {
+    tenantId: pipeline.tenantId,
+    workspaceId: pipeline.workspaceId || null,
+    runId: runId || syntheticRunId(pipeline, revision),
+    pipelineId: pipeline.id,
+    idempotencyKey: rowError.keyFingerprint,
+    sourcePayload: {
+      c6ExternalWrite: true,
+      keyFingerprint: rowError.keyFingerprint,
+      decision: rowError.decision,
+    },
+    transformedPayload: null,
+    errorCode: rowError.errorCode || 'WRITE_FAILED',
+    errorMessage: rowError.errorCode || 'WRITE_FAILED',
+    status: 'open',
+  }
+}
+
+async function persistDeadLetters({ deadLetterStore, pipeline, revision, runId, rowErrors }) {
+  if (!deadLetterStore || typeof deadLetterStore.createDeadLetter !== 'function') return []
+  const persisted = []
+  for (const rowError of rowErrors) {
+    persisted.push(await deadLetterStore.createDeadLetter(deadLetterForRowFailure({
+      pipeline,
+      revision,
+      runId,
+      rowError,
+    })))
+  }
+  return persisted
+}
+
+async function applyExternalWrite(input = {}) {
+  const applyUser = optionalString(input.applyUser)
+  if (!applyUser) {
+    throw new ExternalWriteDryRunError(401, 'C6_WRITE_APPLY_USER_REQUIRED', 'authenticated apply user is required')
+  }
+  const pipeline = validatePlannerInput({
+    ...input,
+    dryRunUser: applyUser,
+  }, 'apply')
+  const tokenRecord = await consumeDryRunToken(input.tokenStore, input.dryRunToken, {
+    pipelineId: pipeline.id,
+    tenantId: pipeline.tenantId,
+    workspaceId: pipeline.workspaceId || null,
+    dryRunUser: applyUser,
+    dataSourceOwnerPrincipal: input.dataSourceOwnerPrincipal,
+  })
+  const plan = await computeExternalWritePlan({
+    ...input,
+    dryRunUser: tokenRecord.dryRunUser,
+    maxRows: tokenRecord.maxRows || input.maxRows,
+    phase: 'apply',
+  })
+  if (tokenRecord.revision !== plan.revision) {
+    throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH', 'dryRunToken does not match the current dry-run revision')
+  }
+  if (!plan.canApply) {
+    throw new ExternalWriteDryRunError(409, 'C6_WRITE_DRY_RUN_NOT_APPLYABLE', 'current dry-run is not applyable')
+  }
+
+  const counts = {
+    sourceRows: plan.counts.sourceRows,
+    planned: plan.counts.planned,
+    add: 0,
+    update: 0,
+    skip: 0,
+    held: 0,
+    failed: 0,
+    written: 0,
+  }
+  const rowErrors = []
+  const provenanceEvents = []
+  const runId = optionalString(input.runId) || syntheticRunId(plan.pipeline, plan.revision)
+  for (const row of plan.planRows) {
+    if (row.decision === 'skip') {
+      counts.skip += 1
+      provenanceEvents.push(provenanceEvent({
+        pipeline: plan.pipeline,
+        revision: plan.revision,
+        runId,
+        row,
+        eventType: 'target_write_succeeded',
+        attrs: { decision: 'skip', writePerformed: false },
+      }))
+      continue
+    }
+    if (row.decision === 'held') {
+      counts.held += 1
+      provenanceEvents.push(provenanceEvent({
+        pipeline: plan.pipeline,
+        revision: plan.revision,
+        runId,
+        row,
+        eventType: 'target_write_failed',
+        attrs: { decision: 'held', errorCode: 'C6_WRITE_ROW_HELD' },
+      }))
+      continue
+    }
+    try {
+      if (row.decision === 'add') {
+        await plan.dataSourceWrites.insertRows(
+          plan.targetConfig.dataSourceId,
+          plan.targetConfig.object,
+          [row.row],
+          plan.policy,
+          input.dataSourceOwnerPrincipal,
+        )
+        counts.add += 1
+      } else if (row.decision === 'update') {
+        await plan.dataSourceWrites.updateRows(
+          plan.targetConfig.dataSourceId,
+          plan.targetConfig.object,
+          [row.row],
+          plan.policy,
+          input.dataSourceOwnerPrincipal,
+        )
+        counts.update += 1
+      } else {
+        counts.held += 1
+        continue
+      }
+      counts.written += 1
+      provenanceEvents.push(provenanceEvent({
+        pipeline: plan.pipeline,
+        revision: plan.revision,
+        runId,
+        row,
+        eventType: 'target_write_succeeded',
+        attrs: { decision: row.decision, writePerformed: true },
+      }))
+    } catch (error) {
+      counts.failed += 1
+      const errorCode = valuesFreeErrorCode(error)
+      rowErrors.push({ decision: row.decision, errorCode, keyFingerprint: row.keyFingerprint })
+      provenanceEvents.push(provenanceEvent({
+        pipeline: plan.pipeline,
+        revision: plan.revision,
+        runId,
+        row,
+        eventType: 'target_write_failed',
+        attrs: { decision: row.decision, errorCode },
+      }))
+    }
+  }
+  const status = applyStatus(counts)
+  const persistedDeadLetters = await persistDeadLetters({
+    deadLetterStore: input.deadLetterStore,
+    pipeline: plan.pipeline,
+    revision: plan.revision,
+    runId,
+    rowErrors,
+  })
+  return {
+    pipelineId: plan.pipeline.id,
+    status,
+    dryRunRevision: plan.revision,
+    counts,
+    rowErrors: rowErrors.map((entry) => ({
+      decision: entry.decision,
+      errorCode: entry.errorCode,
+      keyFingerprint: entry.keyFingerprint,
+    })),
+    provenanceEvents,
+    deadLetters: {
+      attempted: rowErrors.length,
+      persisted: persistedDeadLetters.length,
+    },
+    evidence: publicApplyEvidence({
+      pipeline: plan.pipeline,
+      targetConfig: plan.targetConfig,
+      sourceKind: plan.sourceKind,
+      status,
+      counts,
+      revision: plan.revision,
+      sourceRead: plan.sourceRead,
+      rowErrors,
+      provenanceEvents,
     }),
   }
 }
 
 module.exports = {
   ExternalWriteDryRunError,
+  applyExternalWrite,
   dryRunExternalWrite,
   __internals: {
     C6_WRITE_DRY_RUN_TOKEN_PREFIX,
     TARGET_KIND,
     buildRevision,
+    computeExternalWritePlan,
+    consumeDryRunToken,
     normalizeTargetConfig,
     valuesEqual,
   },

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -24,6 +24,7 @@ const ROUTES = [
   ['POST', '/api/integration/pipelines/:id/run', 'pipelinesRun'],
   ['POST', '/api/integration/pipelines/:id/dry-run', 'pipelinesDryRun'],
   ['POST', '/api/integration/pipelines/:id/external-write/dry-run', 'pipelinesExternalWriteDryRun'],
+  ['POST', '/api/integration/pipelines/:id/external-write/apply', 'pipelinesExternalWriteApply'],
   ['GET', '/api/integration/table-actions', 'tableActionsList'],
   ['POST', '/api/integration/table-actions/:actionId/dry-run', 'tableActionDryRun'],
   ['POST', '/api/integration/table-actions/:actionId/apply', 'tableActionApply'],
@@ -52,6 +53,7 @@ const ROUTES = [
 ]
 const EXTERNAL_SYSTEM_OBJECTS_MAX_ITEMS = 1000
 const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
+const { createRunLogger } = require('./run-log.cjs')
 const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 // DF-T1-0/DF-T1: compose the no-write preview through the SAME K3 Save-body composer the
 // adapter uses, so the preview is byte-identical to the real Save (single source of truth —
@@ -70,6 +72,7 @@ const { deriveK3MaterialTemplateDraft, summarizeTemplateForEvidence, TemplateDer
 const { validateRecord } = require('./validator.cjs')
 const {
   ExternalWriteDryRunError,
+  applyExternalWrite,
   dryRunExternalWrite,
 } = require('./external-write-dry-run.cjs')
 const {
@@ -375,6 +378,8 @@ const VALID_TABLE_ACTION_LARGE_BOM_PLAN_BODY_KEYS = new Set(['conflictPolicyRevi
 const VALID_TABLE_ACTION_LARGE_BOM_APPLY_START_BODY_KEYS = new Set(['confirm'])
 const VALID_EMPTY_REQUEST_KEYS = new Set()
 const VALID_C6_WRITE_DRY_RUN_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'maxRows'])
+const VALID_C6_WRITE_APPLY_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'confirm'])
+const VALID_C6_WRITE_APPLY_CONFIRM_KEYS = new Set(['dryRunToken'])
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
   'tenantId',
@@ -410,6 +415,37 @@ function normalizeC6WriteDryRunBody(body = {}) {
     tenantId: firstString(body.tenantId),
     workspaceId: firstString(body.workspaceId),
     maxRows: body.maxRows,
+  }
+}
+
+function normalizeC6WriteApplyBody(body = {}) {
+  if (!isPlainObject(body)) {
+    throw new HttpRouteError(400, 'C6_WRITE_APPLY_REQUEST_INVALID', 'request body must be an object')
+  }
+  for (const key of Object.keys(body)) {
+    if (!VALID_C6_WRITE_APPLY_BODY_KEYS.has(key)) {
+      throw new HttpRouteError(400, 'C6_WRITE_APPLY_REQUEST_INVALID', `unsupported request field: ${key}`, { field: key })
+    }
+  }
+  const confirm = body.confirm === undefined || body.confirm === null ? {} : body.confirm
+  if (!isPlainObject(confirm)) {
+    throw new HttpRouteError(400, 'C6_WRITE_APPLY_REQUEST_INVALID', 'confirm must be an object', { field: 'confirm' })
+  }
+  for (const key of Object.keys(confirm)) {
+    if (!VALID_C6_WRITE_APPLY_CONFIRM_KEYS.has(key)) {
+      throw new HttpRouteError(400, 'C6_WRITE_APPLY_REQUEST_INVALID', `unsupported confirm field: ${key}`, { field: `confirm.${key}` })
+    }
+  }
+  const dryRunToken = firstString(confirm.dryRunToken)
+  if (!dryRunToken) {
+    throw new HttpRouteError(400, 'C6_WRITE_DRY_RUN_TOKEN_REQUIRED', 'dryRunToken is required for apply', { field: 'confirm.dryRunToken' })
+  }
+  return {
+    tenantId: firstString(body.tenantId),
+    workspaceId: firstString(body.workspaceId),
+    confirm: {
+      dryRunToken,
+    },
   }
 }
 
@@ -1286,6 +1322,44 @@ function createHandlers(services, options = {}) {
     return isAdmin(user) ? 'admin' : 'write'
   }
 
+  function getOptionalRunLogger() {
+    if (
+      typeof pipelineRegistry.createPipelineRun !== 'function' ||
+      typeof pipelineRegistry.updatePipelineRun !== 'function'
+    ) {
+      return null
+    }
+    return createRunLogger({ pipelineRegistry })
+  }
+
+  function externalWriteApplyMetrics(result = {}) {
+    const counts = result.counts || {}
+    return {
+      rowsRead: counts.sourceRows || 0,
+      rowsCleaned: counts.planned || 0,
+      rowsWritten: counts.written || 0,
+      rowsFailed: counts.failed || 0,
+    }
+  }
+
+  function externalWriteRunStatus(status) {
+    if (status === 'succeeded') return 'succeeded'
+    if (status === 'partial') return 'partial'
+    return 'failed'
+  }
+
+  function publicExternalWriteApplyResult(result, run) {
+    const { provenanceEvents: _provenanceEvents, ...safe } = result
+    if (run) {
+      safe.run = {
+        id: run.id,
+        status: run.status,
+        provenanceEventsPersisted: Array.isArray(run.provenanceEvents) ? run.provenanceEvents.length : null,
+      }
+    }
+    return safe
+  }
+
   const handlers = {
     async status(req, res) {
       requireAccess(req, 'read')
@@ -1512,6 +1586,119 @@ function createHandlers(services, options = {}) {
         dataSourceOwnerPrincipal: ownerPrincipal,
         maxRows: body.maxRows,
       }))
+    },
+
+    async pipelinesExternalWriteApply(req, res) {
+      requireAccess(req, 'write')
+      const body = normalizeC6WriteApplyBody(requestBody(req))
+      const scope = scopedInput(req, {
+        id: requestParams(req).id,
+        tenantId: body.tenantId,
+        workspaceId: body.workspaceId,
+        includeFieldMappings: true,
+      })
+      const pipeline = await pipelineRegistry.getPipeline(scope)
+      if (pipeline.status && pipeline.status !== 'active') {
+        throw new HttpRouteError(422, 'PIPELINE_INACTIVE', 'pipeline must be active for C6 external-write apply', {
+          pipelineId: pipeline.id,
+          status: pipeline.status,
+        })
+      }
+      const ownerPrincipal = firstString(pipeline.createdBy)
+      if (!ownerPrincipal) {
+        throw new HttpRouteError(422, 'C6_WRITE_OWNER_PRINCIPAL_REQUIRED', 'pipeline.createdBy is required for C6 external-write apply', {
+          pipelineId: pipeline.id,
+        })
+      }
+      const loadSourceSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const sourceSystem = await loadSourceSystem(scopedInput(req, {
+        id: pipeline.sourceSystemId,
+        tenantId: body.tenantId,
+        workspaceId: body.workspaceId,
+      }))
+      const targetSystem = await externalSystems.getExternalSystem(scopedInput(req, {
+        id: pipeline.targetSystemId,
+        tenantId: body.tenantId,
+        workspaceId: body.workspaceId,
+      }))
+      if (!sourceSystem) {
+        throw new HttpRouteError(404, 'SOURCE_SYSTEM_NOT_FOUND', 'source external system not found')
+      }
+      if (!targetSystem) {
+        throw new HttpRouteError(404, 'TARGET_SYSTEM_NOT_FOUND', 'target external system not found')
+      }
+      if (sourceSystem.status && sourceSystem.status !== 'active') {
+        throw new HttpRouteError(422, 'SOURCE_SYSTEM_INACTIVE', 'source external system must be active', {
+          sourceSystemId: sourceSystem.id,
+          status: sourceSystem.status,
+        })
+      }
+      if (targetSystem.status && targetSystem.status !== 'active') {
+        throw new HttpRouteError(422, 'TARGET_SYSTEM_INACTIVE', 'target external system must be active', {
+          targetSystemId: targetSystem.id,
+          status: targetSystem.status,
+        })
+      }
+      const sourceAdapter = adapterRegistry.createAdapter(sourceSystem, {
+        role: 'source',
+        principal: ownerPrincipal,
+      })
+      const runLogger = getOptionalRunLogger()
+      let run = null
+      if (runLogger) {
+        run = await runLogger.startRun({
+          tenantId: pipeline.tenantId,
+          workspaceId: pipeline.workspaceId,
+          pipelineId: pipeline.id,
+          mode: 'manual',
+          triggeredBy: 'api',
+          details: {
+            c6ExternalWrite: true,
+            targetKind: targetSystem.kind,
+          },
+        })
+      }
+      try {
+        const result = await applyExternalWrite({
+          pipeline,
+          sourceSystem,
+          targetSystem,
+          sourceAdapter,
+          dataSourceWrites: context && context.api && context.api.dataSourceWrites,
+          tokenStore: context.storage,
+          deadLetterStore: deadLetters,
+          dryRunToken: body.confirm.dryRunToken,
+          applyUser: requestPrincipal(req),
+          dataSourceOwnerPrincipal: ownerPrincipal,
+          runId: run && run.id,
+        })
+        if (runLogger && run) {
+          run = await runLogger.finishRun(run, externalWriteApplyMetrics(result), externalWriteRunStatus(result.status), {
+            provenanceEvents: result.provenanceEvents,
+            details: {
+              c6ExternalWrite: true,
+              dryRunRevision: result.dryRunRevision,
+              status: result.status,
+              counts: result.counts,
+              deadLetters: result.deadLetters,
+            },
+          })
+        }
+        return sendOk(res, publicExternalWriteApplyResult(result, run))
+      } catch (error) {
+        if (runLogger && run) {
+          await runLogger.failRun(run, error, { rowsFailed: 1 }, {
+            details: {
+              c6ExternalWrite: true,
+              status: 'failed',
+              errorCode: error && (error.code || error.name) ? String(error.code || error.name) : 'C6_WRITE_APPLY_FAILED',
+            },
+          })
+        }
+        throw error
+      }
     },
 
     async tableActionsList(req, res) {


### PR DESCRIPTION
## Summary
- adds C6-3 token-bound external-write apply route: POST /api/integration/pipelines/:id/external-write/apply
- shares the C6 dry-run planner, consumes a single-use dry-run token, recomputes the plan, and rejects revision drift before any insert/update
- writes only structured add/update rows through context.api.dataSourceWrites; skip is no-write and conflicted/held plans remain not applyable
- persists values-free run/provenance/dead-letter data under the real pipeline run id when the host capabilities are present
- adds atomic plugin storage consume() for durable token consumption (DELETE ... RETURNING), with local/test fallback guarded by an in-process per-token lock

## Safety boundaries
- no UI, no package, no C6 entity-machine smoke in this slice
- no delete/raw SQL/generic query path, no client-supplied source/target/plan/payload, no target credential exposure
- no K3 Save/Submit/Audit/BOM changes
- response/evidence do not echo bearer tokens, row values, credentials, connection strings, raw SQL, or target payloads

## Review hardening folded in
- concurrent token reuse now fails closed
- unknown adapter/facade write error codes map to WRITE_FAILED
- unsafe target capability state fails closed even if success=true
- route-level dead-letter/provenance persistence is tested, and entries use the real public run id
- public provenanceEventsPersisted is based on the run logger returned result, not the helper's attempted count

## Verification
- node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-durable-storage.test.ts --watch=false
- pnpm --filter plugin-integration-core test
- pnpm --filter @metasheet/core-backend build
- git diff --check