### PR TITLE
feat(multitable): clickable button-field in record-detail drawer (B1-e)

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -255,6 +255,24 @@
             v-else-if="field.type === 'longText' && isRichLongTextField(field)"
             :html="record.data[field.id]"
           />
+          <!-- button (B1-e): clickable action in the record-detail drawer, mirroring
+               the B1-b grid cell. It is an ACTION, not an editable value, so it is
+               NOT gated on canEditField — it renders whenever the field is visible
+               (the server gates execution). The run intent surfaces up to the
+               workbench (run-button), which owns the EXISTING onRunButton/runButton
+               path + status branching; the drawer never duplicates the run logic.
+               @click.stop so a parent click handler doesn't also fire. -->
+          <button
+            v-else-if="field.type === 'button'"
+            type="button"
+            class="meta-record-drawer__button"
+            :class="`meta-record-drawer__button--${buttonVariant(field)}`"
+            :disabled="buttonPendingFor(field.id)"
+            :aria-label="buttonLabel(field)"
+            :title="buttonLabel(field)"
+            data-test="drawer-button"
+            @click.stop="emit('run-button', { recordId: record.id, field })"
+          >{{ buttonLabel(field) }}</button>
           <span v-else class="meta-record-drawer__text">{{ formatValue(field, record.data[field.id]) }}</span>
           <div
             v-if="field.type === 'qrcode' && drawerQrSvg(record.data[field.id])"
@@ -375,7 +393,7 @@ import {
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
-import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../utils/field-config'
+import { attachmentAcceptAttr, resolveAttachmentFieldProperty, resolveButtonFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
 import { useLocale } from '../../composables/useLocale'
 import {
@@ -424,8 +442,13 @@ const props = withDefaults(defineProps<{
   apiClient?: MultitableApiClient
   /** A3: shared AI shortcut UI state from the workbench useAiShortcut instance. */
   aiShortcut?: AiShortcutState | null
+  /** B1-e: in-flight button runs keyed `${recordId}:${fieldId}` — the SAME ref
+   *  the grid (MetaGridTable) receives, so a run from either surface disables
+   *  the button on both. Matches the workbench `onRunButton` pending-key format. */
+  buttonRunPending?: string[]
 }>(), {
   recordIds: () => [],
+  buttonRunPending: () => [],
 })
 
 const emit = defineEmits<{
@@ -445,6 +468,11 @@ const emit = defineEmits<{
   /** A3: AI shortcut triggers (workbench resolves them through useAiShortcut). */
   (e: 'ai-preview', field: MetaField): void
   (e: 'ai-run', field: MetaField): void
+  /** B1-e: run a button field's configured action. Same shape the grid emits
+   * (`run-button { recordId, field }`) so the workbench's existing onRunButton
+   * handler — which owns the runButton call + result.status branching + the
+   * shared buttonRunPending key — handles both surfaces with no extra logic. */
+  (e: 'run-button', payload: { recordId: string; field: MetaField }): void
 }>()
 
 const { isZh } = useLocale()
@@ -796,6 +824,24 @@ function multiSelectEventValue(event: Event): string[] {
   return Array.from(select.selectedOptions).map((option) => option.value)
 }
 
+// B1-e button field: label + variant from the field property. The empty-label
+// fallback is the field name (user data, never a hardcoded literal — strict-zero
+// i18n, identical to the B1-b grid cell) so the accessible name is always
+// non-empty.
+function buttonLabel(field: MetaField): string {
+  return resolveButtonFieldProperty(field.property).label || field.name
+}
+
+function buttonVariant(field: MetaField): string {
+  return resolveButtonFieldProperty(field.property).variant
+}
+
+function buttonPendingFor(fieldId: string): boolean {
+  const recordId = props.record?.id
+  if (!recordId) return false
+  return props.buttonRunPending.includes(`${recordId}:${fieldId}`)
+}
+
 function linkButtonLabel(fieldId: string): string {
   const count = linkSummaryCount(fieldId)
   const field = props.fields.find((item) => item.id === fieldId) ?? null
@@ -1043,6 +1089,12 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 }
 .meta-record-drawer__check { cursor: pointer; }
 .meta-record-drawer__link-btn { padding: 4px 10px; border: 1px solid #409eff; border-radius: 3px; background: #ecf5ff; color: #409eff; cursor: pointer; font-size: 12px; }
+/* B1-e button field (record drawer); mirrors the B1-b grid cell variants. */
+.meta-record-drawer__button { display: inline-flex; align-items: center; max-width: 100%; padding: 4px 12px; font-size: 13px; line-height: 18px; border: 1px solid transparent; border-radius: 4px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-record-drawer__button:disabled { opacity: 0.6; cursor: default; }
+.meta-record-drawer__button--primary { background: #2563eb; color: #fff; }
+.meta-record-drawer__button--secondary { background: #f1f5f9; color: #1f2937; border-color: #cbd5e1; }
+.meta-record-drawer__button--danger { background: #ef4444; color: #fff; }
 .meta-record-drawer__link-summary { margin-top: 6px; font-size: 12px; color: #606266; }
 .meta-record-drawer__attachments { display: flex; flex-direction: column; gap: 6px; }
 .meta-record-drawer__attachment-add { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -291,12 +291,14 @@
         :upload-fn="uploadAttachmentFn"
         :delete-attachment-fn="deleteAttachmentFn"
         :ai-shortcut="aiShortcut.state"
+        :button-run-pending="buttonRunPending"
         @close="onCloseDrawer" @delete="onDeleteRecord" @patch="onDrawerPatch"
         @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker"
         @toggle-lock="onToggleRecordLock"
         @navigate="onDrawerNavigate"
         @restore="onRestoreRecordVersion"
         @ai-preview="onAiPreviewField" @ai-run="onAiRunField"
+        @run-button="onRunButton"
       />
       <MetaCommentsDrawer
         :visible="showComments && !!selectedRecordId" :comments="commentsState.comments.value"

--- a/apps/web/tests/multitable-record-drawer-button.spec.ts
+++ b/apps/web/tests/multitable-record-drawer-button.spec.ts
@@ -1,0 +1,92 @@
+// B1-e: MetaRecordDrawer button-field cell render + click→run-button emit,
+// mirroring the B1-b grid behavior (multitable-cell-button.spec.ts). The drawer
+// has its OWN per-field-type render chain (NOT MetaCellRenderer), so this asserts
+// the drawer renders the button and surfaces the run intent up to the workbench.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+import type { MetaField } from '../src/multitable/types'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+afterEach(() => { app?.unmount(); app = null; container?.remove(); container = null })
+
+async function flushUi(cycles = 4) {
+  for (let i = 0; i < cycles; i += 1) { await Promise.resolve(); await nextTick() }
+}
+
+const buttonField = (property: Record<string, unknown> = {}): MetaField =>
+  ({ id: 'f_btn', name: 'Do it', type: 'button', property } as unknown as MetaField)
+
+async function mount(field: MetaField, extra: Record<string, unknown> = {}) {
+  const runs: Array<{ recordId: string; field: MetaField }> = []
+  container = document.createElement('div'); document.body.appendChild(container)
+  app = createApp({
+    setup: () => () => h(MetaRecordDrawer, {
+      visible: true,
+      record: { id: 'rec_1', version: 1, data: {} },
+      fields: [field],
+      canEdit: true,
+      canComment: false,
+      canDelete: false,
+      onRunButton: (payload: { recordId: string; field: MetaField }) => runs.push(payload),
+      ...extra,
+    }),
+  })
+  app.mount(container)
+  await flushUi()
+  return { runs, btn: () => container!.querySelector<HTMLButtonElement>('[data-test="drawer-button"]')! }
+}
+
+describe('MetaRecordDrawer — button field (B1-e)', () => {
+  it('renders a button with the property label + variant class', async () => {
+    const { btn } = await mount(buttonField({ label: 'Approve', variant: 'primary' }))
+    expect(btn()).not.toBeNull()
+    expect(btn().textContent?.trim()).toBe('Approve')
+    expect(btn().classList.contains('meta-record-drawer__button--primary')).toBe(true)
+    expect(btn().getAttribute('aria-label')).toBe('Approve')
+  })
+
+  it('falls back to the field name when label is empty (non-empty accessible name)', async () => {
+    const { btn } = await mount(buttonField({}))
+    expect(btn().textContent?.trim()).toBe('Do it')
+    expect(btn().getAttribute('aria-label')).toBe('Do it')
+    // unknown/empty variant → secondary default (mirrors resolveButtonFieldProperty)
+    expect(btn().classList.contains('meta-record-drawer__button--secondary')).toBe(true)
+  })
+
+  it('renders the button even though it is NOT an editable field (action, not value)', async () => {
+    // canEdit is true but a button is never gated on canEditField; render on field-visible.
+    const { btn } = await mount(buttonField({ label: 'Run' }))
+    expect(btn()).not.toBeNull()
+    // It is a <button>, not the read-only text span.
+    expect(container!.querySelector('.meta-record-drawer__text')).toBeNull()
+  })
+
+  it('emits run-button { recordId, field } on click', async () => {
+    const field = buttonField({ label: 'Go' })
+    const { btn, runs } = await mount(field)
+    btn().click()
+    await flushUi()
+    expect(runs).toHaveLength(1)
+    expect(runs[0]!.recordId).toBe('rec_1')
+    expect(runs[0]!.field.id).toBe('f_btn')
+  })
+
+  it('disables the button and emits nothing while its run is pending', async () => {
+    const { btn, runs } = await mount(buttonField({ label: 'Go' }), {
+      buttonRunPending: ['rec_1:f_btn'],
+    })
+    expect(btn().disabled).toBe(true)
+    btn().click()
+    await flushUi()
+    expect(runs).toHaveLength(0)
+  })
+
+  it('does NOT disable when a different record/field is pending (key match is exact)', async () => {
+    const { btn } = await mount(buttonField({ label: 'Go' }), {
+      buttonRunPending: ['rec_OTHER:f_btn', 'rec_1:f_other'],
+    })
+    expect(btn().disabled).toBe(false)
+  })
+})

--- a/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, createApp, defineComponent, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
+
+// Wire-drift lock for the B1-e record-drawer button (mirrors the restore-wiring
+// lock #2662). The drawer emits `run-button { recordId, field }`; the ONLY
+// untested link between that emit and `client.runButton` is the `@run-button`
+// listener the workbench wires onto <MetaRecordDrawer> + the existing
+// onRunButton handler. The drawer-emit (multitable-record-drawer-button.spec)
+// and the client call (multitable-button-run-client.spec) are covered, but a
+// drawer-component test stays green even if the workbench forgets `@run-button`,
+// so the feature would ship dead (the #1779/#1781 wire-vs-fixture trap). This
+// captures the real listener the workbench passes down and asserts the payload
+// round-trips into the exact client args + the failed (HTTP-200) status branch.
+
+const showErrorSpy = vi.fn()
+const showSuccessSpy = vi.fn()
+
+let capturedDrawerAttrs: Record<string, unknown> | null = null
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return { ...actual, useRouter: () => ({ push: vi.fn().mockResolvedValue(undefined) }) }
+})
+
+function stubComponent(name: string) {
+  return defineComponent({ name, render() { return h('div', { [`data-stub-${name}`]: 'true' }) } })
+}
+
+let workbenchMock: any
+let gridMock: any
+
+vi.mock('../src/multitable/composables/useMultitableWorkbench', () => ({
+  useMultitableWorkbench: () => workbenchMock,
+}))
+vi.mock('../src/multitable/composables/useMultitableGrid', () => ({
+  useMultitableGrid: () => gridMock,
+}))
+vi.mock('../src/multitable/composables/useMultitableCapabilities', () => ({
+  useMultitableCapabilities: () => ({
+    canRead: ref(true), canCreateRecord: ref(true), canEditRecord: ref(true), canDeleteRecord: ref(true),
+    canManageFields: ref(true), canManageSheetAccess: ref(true), canManageViews: ref(true), canComment: ref(true),
+    canManageAutomation: ref(false), canExport: ref(true),
+  }),
+}))
+vi.mock('../src/multitable/composables/useMultitableComments', () => ({
+  useMultitableComments: () => ({
+    comments: ref([]), loading: ref(false), submitting: ref(false), resolvingIds: ref<string[]>([]),
+    updatingIds: ref<string[]>([]), deletingIds: ref<string[]>([]), error: ref<string | null>(null),
+    reactingKeys: ref<string[]>([]),
+    loadComments: vi.fn(), addComment: vi.fn(), updateComment: vi.fn(), deleteComment: vi.fn(), resolveComment: vi.fn(),
+    addReaction: vi.fn(), removeReaction: vi.fn(),
+  }),
+}))
+vi.mock('../src/multitable/composables/useMultitableCommentInbox', () => ({
+  useMultitableCommentInbox: () => ({ unreadCount: ref(0), refreshUnreadCount: vi.fn().mockResolvedValue(0) }),
+}))
+vi.mock('../src/multitable/composables/useMultitableCommentRealtime', () => ({ useMultitableCommentRealtime: vi.fn() }))
+vi.mock('../src/multitable/composables/useMultitableSheetRealtime', () => ({ useMultitableSheetRealtime: vi.fn() }))
+vi.mock('../src/multitable/import/bulk-import', () => ({ bulkImportRecords: vi.fn() }))
+
+vi.mock('../src/multitable/components/MetaViewTabBar.vue', () => ({ default: stubComponent('MetaViewTabBar') }))
+vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({ default: stubComponent('MetaToolbar') }))
+vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({ default: stubComponent('MetaGridTable') }))
+vi.mock('../src/multitable/components/MetaFormView.vue', () => ({ default: stubComponent('MetaFormView') }))
+// Capturing stub for the component under wiring test — records the real listeners.
+vi.mock('../src/multitable/components/MetaRecordDrawer.vue', () => ({
+  default: defineComponent({
+    name: 'MetaRecordDrawer',
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+      capturedDrawerAttrs = attrs as Record<string, unknown>
+      return () => h('div', { 'data-stub-MetaRecordDrawer': 'true' })
+    },
+  }),
+}))
+vi.mock('../src/multitable/components/MetaCommentsDrawer.vue', () => ({ default: stubComponent('MetaCommentsDrawer') }))
+vi.mock('../src/multitable/components/MetaLinkPicker.vue', () => ({ default: stubComponent('MetaLinkPicker') }))
+vi.mock('../src/multitable/components/MetaFieldManager.vue', () => ({ default: stubComponent('MetaFieldManager') }))
+vi.mock('../src/multitable/components/MetaKanbanView.vue', () => ({ default: stubComponent('MetaKanbanView') }))
+vi.mock('../src/multitable/components/MetaGalleryView.vue', () => ({ default: stubComponent('MetaGalleryView') }))
+vi.mock('../src/multitable/components/MetaCalendarView.vue', () => ({ default: stubComponent('MetaCalendarView') }))
+vi.mock('../src/multitable/components/MetaTimelineView.vue', () => ({ default: stubComponent('MetaTimelineView') }))
+vi.mock('../src/multitable/components/MetaImportModal.vue', () => ({ default: stubComponent('MetaImportModal') }))
+vi.mock('../src/multitable/components/MetaBasePicker.vue', () => ({ default: stubComponent('MetaBasePicker') }))
+vi.mock('../src/multitable/components/MetaToast.vue', () => ({
+  default: defineComponent({
+    name: 'MetaToast',
+    setup(_, { expose }) {
+      expose({ showError: showErrorSpy, showSuccess: showSuccessSpy })
+      return () => h('div', { 'data-toast': 'true' })
+    },
+  }),
+}))
+
+import MultitableWorkbench from '../src/multitable/views/MultitableWorkbench.vue'
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) { await Promise.resolve(); await nextTick() }
+}
+
+const buttonField = { id: 'fld_btn', name: 'Approve', type: 'button', property: { label: 'Approve', variant: 'primary' } }
+
+function createWorkbenchMock() {
+  const activeBaseId = ref('base_ops')
+  const activeSheetId = ref<string | null>('sheet_orders')
+  const activeViewId = ref('view_grid')
+  const views = ref([{ id: 'view_grid', sheetId: 'sheet_orders', name: 'Grid', type: 'grid' }])
+  return {
+    client: {
+      listBases: vi.fn().mockResolvedValue({ bases: [{ id: 'base_ops', name: 'Ops Base' }] }),
+      loadContext: vi.fn().mockResolvedValue({ base: { id: 'base_ops' }, sheet: null, sheets: [], views: [], capabilities: {} }),
+      loadFormContext: vi.fn(), getRecord: vi.fn(), createSheet: vi.fn(), createBase: vi.fn(),
+      createField: vi.fn(), preparePersonField: vi.fn(), updateField: vi.fn(), deleteField: vi.fn(),
+      createView: vi.fn(), deleteView: vi.fn(), patchRecords: vi.fn(), submitForm: vi.fn(), updateView: vi.fn(),
+      // The function under test:
+      runButton: vi.fn().mockResolvedValue({ status: 'succeeded', executionId: 'exec_1' }),
+    },
+    sheets: ref([{ id: 'sheet_orders', baseId: 'base_ops', name: 'Orders', description: null }]),
+    fields: ref([buttonField]),
+    views, activeBaseId, activeSheetId, activeViewId,
+    capabilities: ref({
+      canRead: true, canCreateRecord: true, canEditRecord: true, canDeleteRecord: true, canManageFields: true,
+      canManageSheetAccess: true, canManageViews: true, canComment: true, canManageAutomation: false, canExport: true,
+    }),
+    capabilityOrigin: ref(null), fieldPermissions: ref({}), viewPermissions: ref({}),
+    activeView: computed(() => views.value.find((v) => v.id === activeViewId.value) ?? null),
+    loading: ref(false), error: ref<string | null>(null),
+    loadSheets: vi.fn().mockResolvedValue(true), loadBaseContext: vi.fn().mockResolvedValue(true),
+    loadSheetMeta: vi.fn().mockResolvedValue(true), switchBase: vi.fn().mockResolvedValue(true),
+    syncExternalContext: vi.fn().mockResolvedValue(true),
+    selectBase: vi.fn((id: string) => { activeBaseId.value = id }),
+    selectSheet: vi.fn((id: string) => { activeSheetId.value = id }),
+    selectView: vi.fn((id: string) => { activeViewId.value = id }),
+  }
+}
+
+function createGridMock() {
+  return {
+    fields: ref([]), rows: ref([]), loading: ref(false), currentPage: ref(1), totalPages: ref(1),
+    page: ref({ offset: 0, limit: 50, total: 0, hasMore: false }), visibleFields: ref([]), sortRules: ref([]),
+    filterRules: ref([]), filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
+    groupFieldId: ref<string | null>(null), groupField: ref(null), hiddenFieldIds: ref<string[]>([]),
+    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), attachmentSummaries: ref({}),
+    fieldPermissions: ref({}), viewPermission: ref(null), rowActions: ref(null), rowActionOverrides: ref({}),
+    capabilityOrigin: ref(null), conflict: ref(null), error: ref<string | null>(null), sortFilterDirty: ref(false),
+    toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),
+    updateFilterRule: vi.fn(), removeFilterRule: vi.fn(), clearFilters: vi.fn(), applySortFilter: vi.fn(),
+    undo: vi.fn(), redo: vi.fn(), setGroupField: vi.fn(), goToPage: vi.fn(), patchCell: vi.fn(),
+    createRecord: vi.fn(), deleteRecord: vi.fn(), resolveRowActions: vi.fn(() => null),
+    loadViewData: vi.fn().mockResolvedValue(true), reloadCurrentPage: vi.fn(), dismissConflict: vi.fn(),
+    retryConflict: vi.fn(), setColumnWidth: vi.fn(), setSearchQuery: vi.fn(),
+  }
+}
+
+type RunButtonFn = (p: { recordId: string; field: { id: string } }) => Promise<void>
+
+describe('MultitableWorkbench drawer run-button handler wiring (B1-e)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    workbenchMock = createWorkbenchMock()
+    gridMock = createGridMock()
+    capturedDrawerAttrs = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null; container = null
+    showErrorSpy.mockReset(); showSuccessSpy.mockReset()
+    vi.unstubAllGlobals(); vi.clearAllMocks()
+  })
+
+  async function mountAndGetRunButton(): Promise<RunButtonFn> {
+    const Host = defineComponent({ setup() { return () => h(MultitableWorkbench as Component) } })
+    app = createApp(Host)
+    app.mount(container!)
+    await flushUi()
+    expect(capturedDrawerAttrs).not.toBeNull()
+    // The wire under test: the workbench MUST pass `@run-button` down to the drawer.
+    const onRunButton = capturedDrawerAttrs!.onRunButton as RunButtonFn
+    expect(typeof onRunButton).toBe('function')
+    return onRunButton
+  }
+
+  it('threads the drawer emit into client.runButton(sheetId, recordId, fieldId) and shows the success toast', async () => {
+    const onRunButton = await mountAndGetRunButton()
+    await onRunButton({ recordId: 'rec_42', field: { id: 'fld_btn' } })
+    await flushUi()
+    expect(workbenchMock.client.runButton).toHaveBeenCalledTimes(1)
+    // Active sheet from the workbench + record + field id, in order — a reorder would silently
+    // run the wrong button; caught here.
+    expect(workbenchMock.client.runButton).toHaveBeenCalledWith('sheet_orders', 'rec_42', 'fld_btn')
+    expect(showSuccessSpy).toHaveBeenCalledTimes(1)
+    expect(showErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('branches on a failed (HTTP-200, resolved) result and shows an error toast (not a throw)', async () => {
+    workbenchMock.client.runButton.mockResolvedValueOnce({ status: 'failed', executionId: 'exec_2', message: 'Action rejected' })
+    const onRunButton = await mountAndGetRunButton()
+    await onRunButton({ recordId: 'rec_42', field: { id: 'fld_btn' } })
+    await flushUi()
+    expect(showErrorSpy).toHaveBeenCalledTimes(1)
+    expect(showErrorSpy.mock.calls[0][0]).toBe('Action rejected')
+    expect(showSuccessSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes a buttonRunPending array down to the drawer (shared in-flight key surface)', async () => {
+    await mountAndGetRunButton()
+    // Plain (non-event) attrs land under their kebab-case key in `attrs`.
+    const pending = capturedDrawerAttrs!['button-run-pending'] ?? capturedDrawerAttrs!.buttonRunPending
+    expect(Array.isArray(pending)).toBe(true)
+  })
+
+  it('does nothing when there is no active sheet', async () => {
+    const onRunButton = await mountAndGetRunButton()
+    workbenchMock.activeSheetId.value = null
+    await onRunButton({ recordId: 'rec_42', field: { id: 'fld_btn' } })
+    await flushUi()
+    expect(workbenchMock.client.runButton).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## B1-e — button-field render in the record-detail drawer

Mirrors the shipped B1-b grid behavior in the record-detail drawer (`MetaRecordDrawer.vue`). The drawer has its own per-field-type render chain (not `MetaCellRenderer`), so a `button` branch was added in the value block — placed before the read-only text `v-else` fallback and **not** gated on `canEditField` (it's an action, not an editable value; renders on field-visible, server gates execution).

### What it does
- Renders the button via `resolveButtonFieldProperty` (label = `property.label || field.name` for a non-empty accessible name; variant default `secondary`), `@click.stop`, disabled while its run is in flight.
- Run intent surfaces up via `run-button { recordId, field }` — the **exact shape the grid emits** — and `MultitableWorkbench` routes it into the **existing** `onRunButton`/`client.runButton` path (2-line wiring: `:button-run-pending` + `@run-button`). Status branching (failed = HTTP 200, resolves) stays solely in the existing handler, never duplicated.
- Shares the grid's `buttonRunPending` ref → a run from either surface disables both (intended single-flight).

### i18n
Zero new keys by design — label/aria/title are all `property.label || field.name` (user data, identical to B1-b). Adding a key would be a dead key (forbidden by strict-zero discipline).

### Tests
New: `multitable-record-drawer-button.spec.ts` (6/6) + `multitable-workbench-drawer-button-wiring.spec.ts` (4/4). Regression: 47/47 across record-drawer / cell-button / button-run-client / restore-wiring / drawer-restore / drawer-i18n. `vue-tsc -b` clean (verified by reviewer in CI-capable env).

### Notes
- Pre-existing (NOT this PR): `multitable-workbench-view` + `permission-wiring` suites are red on `origin/main` due to a stale `useMultitableComments` mock missing `reactingKeys` (added by B6-b #2674 at `MultitableWorkbench.vue:316`). These are not CI-gated (full web suite isn't a required check) and are out of B1-e's scope — flagged for a separate stale-mock cleanup.
- Built + adversarially reviewed by parallel subagents (verdict: ship, no blocking items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)