### PR TITLE
feat(attendance): annual-leave L4a — grant-time year-end expires_at (org-tz)

### DIFF
--- a/docs/development/attendance-annual-leave-expiry-design-lock-20260616.md
+++ b/docs/development/attendance-annual-leave-expiry-design-lock-20260616.md
@@ -1,0 +1,34 @@
+# Annual leave — carryover / year-end expiry (design-lock)
+
+Status: locked 2026-06-16. Scope: L4 of the annual-leave balance engine (follows L2b accrual, L2c manual adjustment, L3 approval deduction). Split into **L4a** (grant-time expiry) and **L4b** (backfill of pre-L4a lots).
+
+## Principle
+
+Annual-leave entitlement for a period year expires at a **year-end boundary** in the organization's timezone. L4 is responsible only for writing the correct `expires_at` onto annual accrual lots; the existing leave-balance expiry scheduler reaps lots past their `expires_at` and records an expiry event. No new reaper is introduced.
+
+## Boundary
+
+For an accrual of period year `Y`, the lot's `expires_at` is the **first-invalid instant** — `Jan 1 00:00:00` of the next boundary year, in the org timezone, stored as a UTC instant:
+
+```
+expires_at = zonedTimeToUtc({ year: Y + (carryover.enabled ? 2 : 1), month: 1, day: 1, hour: 0, minute: 0, second: 0 }, timezone)
+```
+
+- `carryover.enabled = false` → usable through the end of `Y` → expires `Jan 1 (Y+1) 00:00` org-tz.
+- `carryover.enabled = true` → carries through `Y+1` → expires `Jan 1 (Y+2) 00:00` org-tz.
+
+The first-invalid instant (rather than `Dec 31 23:59:59`) matches the scheduler's `expires_at <= now()` semantics: `Dec 31 23:59:59` org-tz is still valid; `Jan 1 00:00:00` org-tz is expired. Carryover grace is one year and is not configurable in v1; capped/partial carryover is deferred.
+
+## L4a — grant-time expiry
+
+The accrual run computes the boundary **once** from the run's own policy snapshot (period + carryover + timezone) and stamps it on each `annual_accrual` lot it grants. A later change to the carryover setting does not retroactively change already-granted lots (the grant is `ON CONFLICT DO NOTHING`; nothing re-stamps an existing lot). Lots granted before L4a retain a null expiry (never-expiring) until the L4b backfill sets them.
+
+## L4b — provenance-snapshot backfill
+
+An application-layer, idempotent backfill (not a database migration — mutable policy/timezone/carryover must not be baked into a migration) sets `expires_at` on `annual_accrual` lots whose expiry is still null. For each lot it derives the **grant-time** carryover, timezone, and period from that lot's accrual-run provenance — `lot.source_id` (the run-item id) → run-item → run → the run's serialized policy snapshot (carryover), the run's `period_key`, and the run's `timezone` — never from today's settings. So changing the carryover setting today never re-expires past years.
+
+The backfill never guesses: a lot whose grant-time snapshot cannot be recovered is skipped, counted under a reason code, and left null (grandfathered). Reason codes: `NON_ACCRUAL_SOURCE`, `MISSING_RUN_ITEM`, `MISSING_RUN`, `UNPARSEABLE_POLICY_VERSION`, `MISSING_TIMEZONE`, `UNPARSEABLE_PERIOD_KEY`. It returns an auditable summary `{ scanned, updated, skipped, dryRun, reasons }`; a dry run previews without writing; re-running is idempotent (it scans only null-expiry lots and re-checks null in the update).
+
+## Scope boundary
+
+L4 touches **annual accrual lots only**. Manually-adjusted lots are intentionally left with a null expiry — an administrator's deliberate grant is not silently auto-expired; a separate lifecycle would be a deliberate future decision. Comp-time and the rest of the accrual run behavior are unchanged.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5071,6 +5071,15 @@ attendanceIntegrationDescribe(
 
       // (C) the no-carry lot from run A is idempotent under run B (ON CONFLICT) — its expiry is NOT retroactively changed.
       expect(new Date((await lotExpiry(uNoCarry))!).toISOString()).toBe('2026-12-31T16:00:00.000Z')
+
+      // (D) an enabled policy with an INVALID timezone is rejected at the settings gate (else zonedTimeToUtc would
+      // silently UTC-fall-back and stamp the wrong expiry). 422 ANNUAL_LEAVE_TIMEZONE_INVALID — never guess.
+      const badTz = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT', headers,
+        body: JSON.stringify({ annualLeavePolicy: { enabled: true, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [{ minYears: 1, maxYears: null, days: 5 }], carryover: { enabled: false }, timezone: 'Not/AZone' } }),
+      })
+      expect(badTz.status).toBe(422)
+      expect((badTz.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ANNUAL_LEAVE_TIMEZONE_INVALID')
     } finally {
       await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ annualLeavePolicy: origPolicy }) }).catch(() => undefined)
       const all = ids.concat([adminId])

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5021,6 +5021,68 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④/年假 L4a — accrual lot carries year-end expires_at (first-invalid instant, org-tz); carryover shifts +1yr', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const adminId = `al-l4a-admin-${runSuffix}`
+    const org = `al-l4a-org-${runSuffix}` // unique org → accrual enumerates ONLY my seeded users (no cross-test pollution)
+    const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${adminId}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) { await pool.end().catch(() => undefined); return }
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    const period = 2026
+    const U = (t: string) => `al-l4a-${runSuffix}-${t}`
+    const seedUser = async (tag: string) => {
+      const id = U(tag)
+      await pool.query(`INSERT INTO users (id, email, password_hash, is_active, hire_date, cumulative_service_start_date)
+         VALUES ($1,$2,'no-login',true,'2010-01-01','2010-01-01')
+         ON CONFLICT (id) DO UPDATE SET is_active=true, hire_date=EXCLUDED.hire_date, cumulative_service_start_date=EXCLUDED.cumulative_service_start_date`, [id, `${id}@example.com`])
+      await pool.query(`INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1,$2,true) ON CONFLICT (user_id, org_id) DO UPDATE SET is_active=true`, [id, org])
+      return id
+    }
+    const origRes = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })
+    const origPolicy = ((origRes.body as { data?: { annualLeavePolicy?: Record<string, unknown> } } | undefined)?.data?.annualLeavePolicy) ?? { enabled: false }
+    const setPolicy = (carryover: boolean) => requestJson(`${baseUrl}/api/attendance/settings`, {
+      method: 'PUT', headers,
+      body: JSON.stringify({ annualLeavePolicy: { enabled: true, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [{ minYears: 1, maxYears: null, days: 5 }], carryover: { enabled: carryover }, timezone: 'Asia/Shanghai' } }),
+    })
+    const runAccrual = () => requestJson(`${baseUrl}/api/attendance/annual-leave-accrual/run`, { method: 'POST', headers, body: JSON.stringify({ period, asOf: '2026-12-31', dryRun: false, orgId: org }) })
+    const lotExpiry = async (userId: string) => (await pool.query(`SELECT expires_at FROM attendance_leave_balances WHERE user_id=$1 AND leave_type_code='annual' AND source_type='annual_accrual'`, [userId])).rows[0]?.expires_at as Date | null
+    const ids: string[] = []
+    try {
+      // (A) carryover=false → period 2026 usable through end of 2026 → expires Jan 1 2027 00:00 Asia/Shanghai (UTC+8) = 2026-12-31T16:00:00Z.
+      const uNoCarry = await seedUser('nocarry'); ids.push(uNoCarry)
+      expect((await setPolicy(false)).status).toBe(200)
+      expect((await runAccrual()).status, 'accrual A').toBe(200)
+      const exp1 = await lotExpiry(uNoCarry)
+      expect(exp1, 'no-carry lot exists').toBeTruthy()
+      expect(new Date(exp1!).toISOString()).toBe('2026-12-31T16:00:00.000Z')
+
+      // (B) carryover=true → carry through 2027 → expires Jan 1 2028 00:00 Asia/Shanghai = 2027-12-31T16:00:00Z.
+      const uCarry = await seedUser('carry'); ids.push(uCarry)
+      expect((await setPolicy(true)).status).toBe(200)
+      expect((await runAccrual()).status, 'accrual B').toBe(200)
+      const exp2 = await lotExpiry(uCarry)
+      expect(exp2, 'carry lot exists').toBeTruthy()
+      expect(new Date(exp2!).toISOString()).toBe('2027-12-31T16:00:00.000Z')
+
+      // (C) the no-carry lot from run A is idempotent under run B (ON CONFLICT) — its expiry is NOT retroactively changed.
+      expect(new Date((await lotExpiry(uNoCarry))!).toISOString()).toBe('2026-12-31T16:00:00.000Z')
+    } finally {
+      await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ annualLeavePolicy: origPolicy }) }).catch(() => undefined)
+      const all = ids.concat([adminId])
+      await pool.query(`DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])`, [all]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])`, [all]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_accrual_runs WHERE org_id = $1`, [org]).catch(() => undefined)
+      await pool.query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [all]).catch(() => undefined)
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [all]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('④/年假 L2c — manual adjustment: positive lot+grant / negative FIFO-deduct / insufficient-422-rollback / idempotency / delta-0 / org-scoping', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15579,6 +15579,12 @@ async function runAnnualLeaveAccrual(trx, { orgId, period, asOf, dryRun }) {
   if (!policy.timezone) {
     throw new HttpError(422, 'ANNUAL_LEAVE_TIMEZONE_REQUIRED', 'annualLeavePolicy.timezone is required to run accrual')
   }
+  // L4a: the timezone is used for the year-end expiry boundary (zonedTimeToUtc). An INVALID identifier would
+  // silently fall back to UTC (getZonedParts), stamping the wrong expiry — reject it (org-tz boundary, no UTC
+  // fallback, never guess) rather than compute a wrong instant.
+  if (!isValidTimeZoneIdentifier(policy.timezone)) {
+    throw new HttpError(422, 'ANNUAL_LEAVE_TIMEZONE_INVALID', 'annualLeavePolicy.timezone must be a valid IANA timezone identifier')
+  }
   const asOfParts = annualLeaveDateParts(asOf)
   if (!asOfParts) throw new HttpError(400, 'ANNUAL_LEAVE_INVALID_ASOF', 'asOf must be a valid YYYY-MM-DD date')
   const periodKey = `annual:${period}`
@@ -37843,6 +37849,12 @@ module.exports = {
           // policy persists freely.
           if (merged.annualLeavePolicy?.enabled === true && !merged.annualLeavePolicy?.timezone) {
             res.status(422).json({ ok: false, error: { code: 'ANNUAL_LEAVE_TIMEZONE_REQUIRED', message: 'annualLeavePolicy.timezone is required when annualLeavePolicy.enabled is true' } })
+            return
+          }
+          // L4a: an enabled policy's timezone drives the year-end expiry boundary — it MUST be a real IANA zone,
+          // else zonedTimeToUtc silently falls back to UTC and stamps the wrong expiry. Reject typos at the gate.
+          if (merged.annualLeavePolicy?.enabled === true && !isValidTimeZoneIdentifier(merged.annualLeavePolicy.timezone)) {
+            res.status(422).json({ ok: false, error: { code: 'ANNUAL_LEAVE_TIMEZONE_INVALID', message: 'annualLeavePolicy.timezone must be a valid IANA timezone identifier' } })
             return
           }
           const saved = await saveSettings(db, merged)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15558,6 +15558,18 @@ function annualLeavePolicyVersion(policy) {
 // user; for granted (non-dryRun) users, grants the annual lot idempotently (mirrors the C2 pattern). The
 // run + run_items are ALWAYS written (audit); dryRun writes NO lots/events and consumes NO source_key.
 // Caller supplies the transaction (`trx`).
+// 年假/法定假 L4a (owner design-lock 2026-06-16): the first-invalid instant for a period-Y annual_accrual lot.
+// carryover disabled → usable through end of Y → expires Jan 1 (Y+1) 00:00:00 org-tz; carryover enabled → carry
+// through Y+1 → expires Jan 1 (Y+2) 00:00:00 org-tz. Returned as a UTC instant; AttendanceExpiryService reaps via
+// expires_at <= now(), so the FIRST-INVALID instant (Jan 1 next, NOT Dec 31 23:59:59) is the clean boundary.
+// Returns a Date, or null if period/timezone is unusable (caller then leaves expires_at NULL = never-expire,
+// never guess). period + (carryover ? 2 : 1).
+function annualLeaveLotExpiryUtc(period, carryoverEnabled, timezone) {
+  if (!Number.isInteger(period) || typeof timezone !== 'string' || !timezone) return null
+  const year = period + (carryoverEnabled ? 2 : 1)
+  return new Date(zonedTimeToUtc({ year, month: 1, day: 1, hour: 0, minute: 0, second: 0 }, timezone))
+}
+
 async function runAnnualLeaveAccrual(trx, { orgId, period, asOf, dryRun }) {
   const settings = await getSettings(trx)
   const policy = settings?.annualLeavePolicy
@@ -15591,6 +15603,9 @@ async function runAnnualLeaveAccrual(trx, { orgId, period, asOf, dryRun }) {
     [orgId]
   )
   const summary = { runId, periodKey, asOf: asOfParts.str, dryRun: !!dryRun, granted: 0, skipped: 0, grantedMinutes: 0, lotsCreated: 0, alreadyGranted: 0, skipReasons: {} }
+  // 年假/法定假 L4a: every annual_accrual lot this run grants carries the same year-end expiry, computed ONCE from
+  // this run's policy snapshot (period + carryover, org-tz). The grant stamps it; the existing expiry scheduler reaps.
+  const lotExpiresAt = annualLeaveLotExpiryUtc(period, policy.carryover?.enabled === true, policy.timezone)
   for (const user of users) {
     const r = computeAnnualLeaveAccrualForUser(policy, user, period, asOfParts)
     const itemRows = await trx.query(
@@ -15605,15 +15620,17 @@ async function runAnnualLeaveAccrual(trx, { orgId, period, asOf, dryRun }) {
       summary.granted += 1   // computed-grantable — the count a dry-run reports
       summary.grantedMinutes += r.entitlementMinutes
       if (!dryRun) {
-        // expires_at stays NULL here; L4 owns carryover/year-end expiry (and backfills these lots).
+        // L4a: stamp the year-end expiry (first-invalid instant, org-tz) computed above. annual_accrual lots
+        // granted by L2b BEFORE L4a keep expires_at NULL (never-expiring) until the L4b provenance-snapshot
+        // backfill sets them. annual_manual_adjust lots (L2c) are intentionally out of scope (stay NULL).
         const sourceKey = `annual_accrual:${user.id}:${periodKey}`
         const lotRows = await trx.query(
           `INSERT INTO attendance_leave_balances
-             (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status)
-           VALUES ($1, $2, 'annual', $3, $3, 'annual_accrual', $4, $5, 'active')
+             (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, expires_at)
+           VALUES ($1, $2, 'annual', $3, $3, 'annual_accrual', $4, $5, 'active', $6)
            ON CONFLICT (org_id, source_key) DO NOTHING
            RETURNING id`,
-          [orgId, user.id, r.entitlementMinutes, runItemId, sourceKey]
+          [orgId, user.id, r.entitlementMinutes, runItemId, sourceKey, lotExpiresAt]
         )
         const newLotId = lotRows[0]?.id
         if (newLotId) {


### PR DESCRIPTION
## ④/年假 L4a — grant-time year-end expires_at

Follows L2c (#2687, merged) and L3 (#2713). Annual `annual_accrual` lots are now granted with a year-end `expires_at`, so the **existing** `AttendanceExpiryService` reaps them and writes `annual_leave_expiry` (via L1) — no new reaper.

Design-lock doc included (`docs/development/attendance-annual-leave-expiry-design-lock-20260616.md`).

- **Boundary** (`annualLeaveLotExpiryUtc`): first-invalid instant `Jan 1 00:00:00` org-tz of `period + (carryover ? 2 : 1)`, as a UTC instant. `carryover=false` → usable through end of Y (Jan 1 Y+1); `carryover=true` → carry through Y+1 (Jan 1 Y+2). Matches the scheduler's `expires_at <= now()` semantics. Returns null on unusable period/timezone (→ NULL, never guess).
- **Grant-time snapshot**: computed once from the run's policy (period + carryover + org-tz); a later carryover flip never retroactively changes already-granted lots (`ON CONFLICT DO NOTHING`).
- **Scope**: `annual_accrual` only. `annual_manual_adjust` (L2c) stays NULL. Pre-L4a lots stay NULL until the L4b backfill.

### Verification
- Integration test (real accrual endpoint, org-isolated): `carryover=false` period 2026 → `2026-12-31T16:00:00Z` (Jan 1 2027 00:00 Asia/Shanghai); `carryover=true` → `2027-12-31T16:00:00Z`; re-run idempotent, no retroactive change.
- L2b/L2c not regressed; 5-agent adversarial pass all SAFE (boundary across UTC/+8/−5/DST/fractional zones; only NULL-guarded writers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)