### PR TITLE
feat(attendance): annual-leave L4b — provenance-snapshot expires_at backfill

### DIFF
--- a/docs/development/attendance-annual-leave-expiry-design-lock-20260616.md
+++ b/docs/development/attendance-annual-leave-expiry-design-lock-20260616.md
@@ -27,7 +27,20 @@ The accrual run computes the boundary **once** from the run's own policy snapsho
 
 An application-layer, idempotent backfill (not a database migration — mutable policy/timezone/carryover must not be baked into a migration) sets `expires_at` on `annual_accrual` lots whose expiry is still null. For each lot it derives the **grant-time** carryover, timezone, and period from that lot's accrual-run provenance — `lot.source_id` (the run-item id) → run-item → run → the run's serialized policy snapshot (carryover), the run's `period_key`, and the run's `timezone` — never from today's settings. So changing the carryover setting today never re-expires past years.
 
-The backfill never guesses: a lot whose grant-time snapshot cannot be recovered is skipped, counted under a reason code, and left null (grandfathered). Reason codes: `NON_ACCRUAL_SOURCE`, `MISSING_RUN_ITEM`, `MISSING_RUN`, `UNPARSEABLE_POLICY_VERSION`, `MISSING_TIMEZONE`, `UNPARSEABLE_PERIOD_KEY`. It returns an auditable summary `{ scanned, updated, skipped, dryRun, reasons }`; a dry run previews without writing; re-running is idempotent (it scans only null-expiry lots and re-checks null in the update).
+The backfill never guesses: a lot whose grant-time snapshot cannot be recovered — or whose provenance does not validly belong to it — is skipped, counted under a reason code, and left null (grandfathered). The provenance must validate, not merely join: the run-item must be this org's *granted annual* item and the run must be this org's *real (non-dry-run) annual* run, else the snapshot is not this lot's and is not used.
+
+Reason codes (each = one skipped, grandfathered lot):
+
+- `MISSING_RUN_ITEM` — `source_id` resolves to no run-item.
+- `INVALID_RUN_ITEM` — the run-item is wrong-tenant, non-annual, or not `granted`.
+- `MISSING_RUN` — the run-item's run does not resolve.
+- `INVALID_RUN` — the run is wrong-tenant, non-annual, or a dry run.
+- `UNPARSEABLE_POLICY_VERSION` — the run's serialized policy snapshot is not parseable / lacks carryover.
+- `MISSING_TIMEZONE` — the run's timezone is absent or not a valid IANA identifier.
+- `UNPARSEABLE_PERIOD_KEY` — the run's `period_key` is not `annual:YYYY`.
+- `ALREADY_SET` — a concurrent backfill set the expiry between this run's scan and update; the 0-row update is recorded here, **not** counted as updated.
+
+It returns an auditable summary `{ scanned, updated, skipped, dryRun, reasons }` where `updated` counts only rows this run actually wrote (verified via `RETURNING`); a dry run previews without writing; re-running is idempotent (it scans only null-expiry lots and re-checks null in the update). The endpoint declares the target org explicitly in its request contract rather than reading it implicitly. (A `NON_ACCRUAL_SOURCE` guard exists defensively in code but is unreachable while the scan is filtered to `source_type = 'annual_accrual'`.)
 
 ## Scope boundary
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5105,12 +5105,12 @@ attendanceIntegrationDescribe(
     if (!token) { await pool.end().catch(() => undefined); return }
     const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
     const pvOf = (carryover: boolean, tz = 'Asia/Shanghai') => JSON.stringify({ tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [], timezone: tz, carryover: { enabled: carryover } })
-    const mkRun = async (policyVersion: string, periodKey = 'annual:2026', timezone = 'Asia/Shanghai') => (await pool.query<{ id: string }>(
-      `INSERT INTO attendance_leave_accrual_runs (org_id, period_key, leave_type_code, policy_version, tenure_mode, timezone, standard_day_minutes, tiers, triggered_by, as_of)
-       VALUES ($1,$2,'annual',$3,'cumulative_service',$4,480,'[]'::jsonb,'manual','2026-01-01') RETURNING id`, [org, periodKey, policyVersion, timezone])).rows[0].id
-    const mkRunItem = async (runId: string, userId: string) => (await pool.query<{ id: string }>(
-      `INSERT INTO attendance_leave_accrual_run_items (run_id, org_id, user_id, leave_type_code, tenure_years, tier_days, proration_factor, entitlement_minutes, status)
-       VALUES ($1,$2,$3,'annual',5,5,1,2400,'granted') RETURNING id`, [runId, org, userId])).rows[0].id
+    const mkRun = async (policyVersion: string, periodKey = 'annual:2026', timezone = 'Asia/Shanghai', dryRunFlag = false) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_accrual_runs (org_id, period_key, leave_type_code, policy_version, tenure_mode, timezone, standard_day_minutes, tiers, triggered_by, dry_run, as_of)
+       VALUES ($1,$2,'annual',$3,'cumulative_service',$4,480,'[]'::jsonb,'manual',$5,'2026-01-01') RETURNING id`, [org, periodKey, policyVersion, timezone, dryRunFlag])).rows[0].id
+    const mkRunItem = async (runId: string, userId: string, status = 'granted', skipReason: string | null = null) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_accrual_run_items (run_id, org_id, user_id, leave_type_code, tenure_years, tier_days, proration_factor, entitlement_minutes, status, skip_reason)
+       VALUES ($1,$2,$3,'annual',5,5,1,2400,$4,$5) RETURNING id`, [runId, org, userId, status, skipReason])).rows[0].id
     const mkLot = async (userId: string, sourceId: string | null, tag: string) => (await pool.query<{ id: string }>(
       `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, granted_at, expires_at)
        VALUES ($1,$2,'annual',2400,2400,'annual_accrual',$3,$4,'active','2026-01-01',NULL) RETURNING id`, [org, userId, sourceId, `l4b:${runSuffix}:${tag}`])).rows[0].id
@@ -5127,28 +5127,31 @@ attendanceIntegrationDescribe(
       const uPv = seed('pv'); const lotPv = await mkLot(uPv, await mkRunItem(await mkRun('not-json'), uPv), 'pv') // unparseable policy_version
       const uTz = seed('tz'); const lotTz = await mkLot(uTz, await mkRunItem(await mkRun(pvOf(false), 'annual:2026', ''), uTz), 'tz') // empty timezone
       const uPk = seed('pk'); const lotPk = await mkLot(uPk, await mkRunItem(await mkRun(pvOf(false), 'annual:bad'), uPk), 'pk')       // unparseable period_key
+      // wrong provenance shape → NOT a recoverable grant snapshot (never guess from mismatched provenance):
+      const uSk = seed('sk'); const lotSk = await mkLot(uSk, await mkRunItem(await mkRun(pvOf(false)), uSk, 'skipped', 'NO_MATCHING_TIER'), 'sk') // run_item not 'granted' → INVALID_RUN_ITEM
+      const uDry = seed('dry'); const lotDry = await mkLot(uDry, await mkRunItem(await mkRun(pvOf(false), 'annual:2026', 'Asia/Shanghai', true), uDry), 'dry') // dry-run run → INVALID_RUN
 
       // (A) dryRun → previews 2 updatable, writes nothing.
       const dry = await backfill(true)
       expect(dry.status, JSON.stringify(dry.body)).toBe(200)
       const dryData = (dry.body as { data?: { scanned?: number; updated?: number; skipped?: number; dryRun?: boolean } } | undefined)?.data
-      expect(dryData).toMatchObject({ scanned: 6, updated: 2, skipped: 4, dryRun: true })
+      expect(dryData).toMatchObject({ scanned: 8, updated: 2, skipped: 6, dryRun: true })
       expect(await expiryOf(lotA)).toBeNull() // dryRun wrote nothing
 
       // (B) real backfill → 2 updated to the provenance-derived expiry, 4 skipped with auditable reasons.
       const real = await backfill(false)
       expect(real.status, JSON.stringify(real.body)).toBe(200)
       const realData = (real.body as { data?: { updated?: number; skipped?: number; reasons?: Record<string, number> } } | undefined)?.data
-      expect(realData).toMatchObject({ scanned: 6, updated: 2, skipped: 4 })
-      expect(realData?.reasons).toMatchObject({ MISSING_RUN_ITEM: 1, UNPARSEABLE_POLICY_VERSION: 1, MISSING_TIMEZONE: 1, UNPARSEABLE_PERIOD_KEY: 1 })
+      expect(realData).toMatchObject({ scanned: 8, updated: 2, skipped: 6 })
+      expect(realData?.reasons).toMatchObject({ MISSING_RUN_ITEM: 1, UNPARSEABLE_POLICY_VERSION: 1, MISSING_TIMEZONE: 1, UNPARSEABLE_PERIOD_KEY: 1, INVALID_RUN_ITEM: 1, INVALID_RUN: 1 })
       expect(new Date((await expiryOf(lotA))!).toISOString()).toBe('2026-12-31T16:00:00.000Z') // carryover=false → Jan 1 2027 CST
       expect(new Date((await expiryOf(lotB))!).toISOString()).toBe('2027-12-31T16:00:00.000Z') // carryover=true  → Jan 1 2028 CST
-      for (const l of [lotMI, lotPv, lotTz, lotPk]) expect(await expiryOf(l)).toBeNull() // grandfathered, never guessed
+      for (const l of [lotMI, lotPv, lotTz, lotPk, lotSk, lotDry]) expect(await expiryOf(l)).toBeNull() // grandfathered, never guessed
 
       // (C) idempotent re-run → the 2 good lots are now excluded (expires_at set); only the 4 unrecoverable remain, re-skipped.
       const again = await backfill(false)
       const againData = (again.body as { data?: { scanned?: number; updated?: number; skipped?: number } } | undefined)?.data
-      expect(againData).toMatchObject({ scanned: 4, updated: 0, skipped: 4 })
+      expect(againData).toMatchObject({ scanned: 6, updated: 0, skipped: 6 })
     } finally {
       await pool.query(`DELETE FROM attendance_leave_balances WHERE org_id = $1`, [org]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_leave_accrual_run_items WHERE org_id = $1`, [org]).catch(() => undefined)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5092,6 +5092,72 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④/年假 L4b — provenance-snapshot expires_at backfill: idempotent, dryRun, auditable skip reasons', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const adminId = `al-l4b-admin-${runSuffix}`
+    const org = `al-l4b-org-${runSuffix}` // unique org → backfill scans ONLY my lots
+    const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${adminId}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) { await pool.end().catch(() => undefined); return }
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    const pvOf = (carryover: boolean, tz = 'Asia/Shanghai') => JSON.stringify({ tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [], timezone: tz, carryover: { enabled: carryover } })
+    const mkRun = async (policyVersion: string, periodKey = 'annual:2026', timezone = 'Asia/Shanghai') => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_accrual_runs (org_id, period_key, leave_type_code, policy_version, tenure_mode, timezone, standard_day_minutes, tiers, triggered_by, as_of)
+       VALUES ($1,$2,'annual',$3,'cumulative_service',$4,480,'[]'::jsonb,'manual','2026-01-01') RETURNING id`, [org, periodKey, policyVersion, timezone])).rows[0].id
+    const mkRunItem = async (runId: string, userId: string) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_accrual_run_items (run_id, org_id, user_id, leave_type_code, tenure_years, tier_days, proration_factor, entitlement_minutes, status)
+       VALUES ($1,$2,$3,'annual',5,5,1,2400,'granted') RETURNING id`, [runId, org, userId])).rows[0].id
+    const mkLot = async (userId: string, sourceId: string | null, tag: string) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, granted_at, expires_at)
+       VALUES ($1,$2,'annual',2400,2400,'annual_accrual',$3,$4,'active','2026-01-01',NULL) RETURNING id`, [org, userId, sourceId, `l4b:${runSuffix}:${tag}`])).rows[0].id
+    const expiryOf = async (lotId: string) => (await pool.query(`SELECT expires_at FROM attendance_leave_balances WHERE id=$1`, [lotId])).rows[0]?.expires_at as Date | null
+    const backfill = (dryRun: boolean) => requestJson(`${baseUrl}/api/attendance/annual-leave-expiry-backfill`, { method: 'POST', headers, body: JSON.stringify({ dryRun, orgId: org }) })
+    const ids: string[] = []
+    const seed = (tag: string) => { const id = `al-l4b-${runSuffix}-${tag}`; ids.push(id); return id }
+    try {
+      // good lots (recoverable provenance):
+      const uA = seed('a'); const lotA = await mkLot(uA, await mkRunItem(await mkRun(pvOf(false)), uA), 'a')   // carryover=false → Jan1 2027
+      const uB = seed('b'); const lotB = await mkLot(uB, await mkRunItem(await mkRun(pvOf(true)), uB), 'b')    // carryover=true  → Jan1 2028
+      // unrecoverable lots → must skip with a reason, stay NULL (grandfather, never guess):
+      const uMI = seed('mi'); const lotMI = await mkLot(uMI, '00000000-0000-4000-8000-000000000000', 'mi')     // source_id resolves to no run_item
+      const uPv = seed('pv'); const lotPv = await mkLot(uPv, await mkRunItem(await mkRun('not-json'), uPv), 'pv') // unparseable policy_version
+      const uTz = seed('tz'); const lotTz = await mkLot(uTz, await mkRunItem(await mkRun(pvOf(false), 'annual:2026', ''), uTz), 'tz') // empty timezone
+      const uPk = seed('pk'); const lotPk = await mkLot(uPk, await mkRunItem(await mkRun(pvOf(false), 'annual:bad'), uPk), 'pk')       // unparseable period_key
+
+      // (A) dryRun → previews 2 updatable, writes nothing.
+      const dry = await backfill(true)
+      expect(dry.status, JSON.stringify(dry.body)).toBe(200)
+      const dryData = (dry.body as { data?: { scanned?: number; updated?: number; skipped?: number; dryRun?: boolean } } | undefined)?.data
+      expect(dryData).toMatchObject({ scanned: 6, updated: 2, skipped: 4, dryRun: true })
+      expect(await expiryOf(lotA)).toBeNull() // dryRun wrote nothing
+
+      // (B) real backfill → 2 updated to the provenance-derived expiry, 4 skipped with auditable reasons.
+      const real = await backfill(false)
+      expect(real.status, JSON.stringify(real.body)).toBe(200)
+      const realData = (real.body as { data?: { updated?: number; skipped?: number; reasons?: Record<string, number> } } | undefined)?.data
+      expect(realData).toMatchObject({ scanned: 6, updated: 2, skipped: 4 })
+      expect(realData?.reasons).toMatchObject({ MISSING_RUN_ITEM: 1, UNPARSEABLE_POLICY_VERSION: 1, MISSING_TIMEZONE: 1, UNPARSEABLE_PERIOD_KEY: 1 })
+      expect(new Date((await expiryOf(lotA))!).toISOString()).toBe('2026-12-31T16:00:00.000Z') // carryover=false → Jan 1 2027 CST
+      expect(new Date((await expiryOf(lotB))!).toISOString()).toBe('2027-12-31T16:00:00.000Z') // carryover=true  → Jan 1 2028 CST
+      for (const l of [lotMI, lotPv, lotTz, lotPk]) expect(await expiryOf(l)).toBeNull() // grandfathered, never guessed
+
+      // (C) idempotent re-run → the 2 good lots are now excluded (expires_at set); only the 4 unrecoverable remain, re-skipped.
+      const again = await backfill(false)
+      const againData = (again.body as { data?: { scanned?: number; updated?: number; skipped?: number } } | undefined)?.data
+      expect(againData).toMatchObject({ scanned: 4, updated: 0, skipped: 4 })
+    } finally {
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE org_id = $1`, [org]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_accrual_run_items WHERE org_id = $1`, [org]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_accrual_runs WHERE org_id = $1`, [org]).catch(() => undefined)
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [ids.concat([adminId])]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('④/年假 L2c — manual adjustment: positive lot+grant / negative FIFO-deduct / insufficient-422-rollback / idempotency / delta-0 / org-scoping', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15775,7 +15775,10 @@ async function applyAnnualLeaveManualAdjustment(trx, { orgId, userId, deltaMinut
 // grant-time snapshot can't be recovered is skipped with a reason code and left NULL (grandfathered). dryRun previews.
 async function backfillAnnualLeaveAccrualExpiry(trx, { orgId, dryRun }) {
   const lots = await trx.query(
-    `SELECT b.id, b.source_id, b.source_type, ri.run_id, r.policy_version, r.period_key, r.timezone
+    `SELECT b.id, b.source_id, b.source_type,
+            ri.id AS ri_id, ri.org_id AS ri_org, ri.leave_type_code AS ri_ltc, ri.status AS ri_status, ri.run_id,
+            r.id AS r_id, r.org_id AS r_org, r.leave_type_code AS r_ltc, r.dry_run AS r_dry,
+            r.policy_version, r.period_key, r.timezone
        FROM attendance_leave_balances b
        LEFT JOIN attendance_leave_accrual_run_items ri ON ri.id::text = b.source_id
        LEFT JOIN attendance_leave_accrual_runs r ON r.id = ri.run_id
@@ -15787,24 +15790,32 @@ async function backfillAnnualLeaveAccrualExpiry(trx, { orgId, dryRun }) {
   const skip = (code) => { summary.skipped += 1; summary.reasons[code] = (summary.reasons[code] || 0) + 1 }
   for (const lot of lots) {
     if (lot.source_type !== 'annual_accrual') { skip('NON_ACCRUAL_SOURCE'); continue }
-    if (!lot.source_id || !lot.run_id) { skip('MISSING_RUN_ITEM'); continue }       // source_id didn't resolve to a run_item
-    if (!lot.period_key) { skip('MISSING_RUN'); continue }                          // run_item.run_id didn't resolve to a run
+    if (!lot.source_id || !lot.ri_id) { skip('MISSING_RUN_ITEM'); continue }        // source_id didn't resolve to a run_item
+    // the run_item must be THIS org's GRANTED ANNUAL item — a wrong-tenant / non-annual / non-granted (e.g. skipped)
+    // item is not valid grant provenance for this lot, so we never derive an expiry from it (grandfather, never guess).
+    if (lot.ri_org !== orgId || lot.ri_ltc !== 'annual' || lot.ri_status !== 'granted') { skip('INVALID_RUN_ITEM'); continue }
+    if (!lot.r_id) { skip('MISSING_RUN'); continue }                                // run_item.run_id didn't resolve to a run
+    // the run must be THIS org's REAL (non-dry-run) ANNUAL run — a dry-run created no real lots, a wrong-tenant /
+    // non-annual run is not this lot's grant snapshot.
+    if (lot.r_org !== orgId || lot.r_ltc !== 'annual' || lot.r_dry === true) { skip('INVALID_RUN'); continue }
     let carryoverEnabled
     try {
       const pv = JSON.parse(lot.policy_version)
       if (!pv || typeof pv !== 'object' || !pv.carryover || typeof pv.carryover.enabled !== 'boolean') { skip('UNPARSEABLE_POLICY_VERSION'); continue }
       carryoverEnabled = pv.carryover.enabled
     } catch { skip('UNPARSEABLE_POLICY_VERSION'); continue }
-    if (typeof lot.timezone !== 'string' || !lot.timezone) { skip('MISSING_TIMEZONE'); continue }
+    // a present-but-INVALID timezone would UTC-fall-back in zonedTimeToUtc → wrong instant; treat as unusable.
+    if (typeof lot.timezone !== 'string' || !isValidTimeZoneIdentifier(lot.timezone)) { skip('MISSING_TIMEZONE'); continue }
     const m = /^annual:(\d{4})$/.exec(String(lot.period_key))
     if (!m) { skip('UNPARSEABLE_PERIOD_KEY'); continue }
     const expiresAt = annualLeaveLotExpiryUtc(Number(m[1]), carryoverEnabled, lot.timezone)
     if (!expiresAt) { skip('MISSING_TIMEZONE'); continue }                          // helper guards; defensive
-    if (!dryRun) {
-      // expires_at IS NULL re-checked in the UPDATE → idempotent + safe against a concurrent set.
-      await trx.query(`UPDATE attendance_leave_balances SET expires_at = $1, updated_at = now() WHERE id = $2 AND expires_at IS NULL`, [expiresAt, lot.id])
-    }
-    summary.updated += 1
+    if (dryRun) { summary.updated += 1; continue }                                  // would-update (preview only)
+    // count ACTUAL writes via RETURNING: a concurrent runner that set expires_at between our SELECT and this UPDATE
+    // makes `WHERE expires_at IS NULL` match 0 rows — that must NOT inflate `updated` (auditable summary).
+    const updatedRows = await trx.query(`UPDATE attendance_leave_balances SET expires_at = $1, updated_at = now() WHERE id = $2 AND expires_at IS NULL RETURNING id`, [expiresAt, lot.id])
+    if (updatedRows[0]?.id) summary.updated += 1
+    else skip('ALREADY_SET')                                                        // concurrently set — not ours to count
   }
   return summary
 }
@@ -37841,7 +37852,10 @@ module.exports = {
       withPermission('attendance:admin', async (req, res) => {
         // 年假/法定假 L4b: idempotent backfill of expires_at for pre-L4a annual_accrual lots (NULL expiry), from each
         // lot's accrual-run provenance snapshot (not today's settings). dryRun previews; returns an auditable summary.
-        const schema = z.object({ dryRun: z.boolean().optional() })
+        // orgId is part of the contract (the target org of a mutating admin backfill) — declared explicitly rather
+        // than silently picked up from the raw body by getOrgId. getOrgId still resolves the effective org (body →
+        // query → header → user context → default); declaring it here makes the request shape honest + validated.
+        const schema = z.object({ dryRun: z.boolean().optional(), orgId: z.string().min(1).optional() })
         const parsed = schema.safeParse(req.body ?? {})
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15767,6 +15767,48 @@ async function applyAnnualLeaveManualAdjustment(trx, { orgId, userId, deltaMinut
   return { id: adjustmentId, delta, applied: true, alreadyApplied: false }
 }
 
+// 年假/法定假 L4b (owner design-lock 2026-06-16): idempotent application-layer backfill of expires_at for
+// annual_accrual lots that predate L4a (expires_at IS NULL). Derives the GRANT-TIME carryover/timezone/period from
+// the lot's accrual-run PROVENANCE — lot.source_id = run_item.id → run_item.run_id → run.policy_version[JSON].carryover
+// + run.period_key + run.timezone — NOT today's settings, so flipping carryover now never retroactively re-expires
+// past years. Returns an AUDITABLE summary { scanned, updated, skipped, reasons } and NEVER guesses: any lot whose
+// grant-time snapshot can't be recovered is skipped with a reason code and left NULL (grandfathered). dryRun previews.
+async function backfillAnnualLeaveAccrualExpiry(trx, { orgId, dryRun }) {
+  const lots = await trx.query(
+    `SELECT b.id, b.source_id, b.source_type, ri.run_id, r.policy_version, r.period_key, r.timezone
+       FROM attendance_leave_balances b
+       LEFT JOIN attendance_leave_accrual_run_items ri ON ri.id::text = b.source_id
+       LEFT JOIN attendance_leave_accrual_runs r ON r.id = ri.run_id
+      WHERE b.org_id = $1 AND b.leave_type_code = 'annual' AND b.source_type = 'annual_accrual' AND b.expires_at IS NULL
+      ORDER BY b.id ASC`,
+    [orgId]
+  )
+  const summary = { scanned: lots.length, updated: 0, skipped: 0, dryRun: !!dryRun, reasons: {} }
+  const skip = (code) => { summary.skipped += 1; summary.reasons[code] = (summary.reasons[code] || 0) + 1 }
+  for (const lot of lots) {
+    if (lot.source_type !== 'annual_accrual') { skip('NON_ACCRUAL_SOURCE'); continue }
+    if (!lot.source_id || !lot.run_id) { skip('MISSING_RUN_ITEM'); continue }       // source_id didn't resolve to a run_item
+    if (!lot.period_key) { skip('MISSING_RUN'); continue }                          // run_item.run_id didn't resolve to a run
+    let carryoverEnabled
+    try {
+      const pv = JSON.parse(lot.policy_version)
+      if (!pv || typeof pv !== 'object' || !pv.carryover || typeof pv.carryover.enabled !== 'boolean') { skip('UNPARSEABLE_POLICY_VERSION'); continue }
+      carryoverEnabled = pv.carryover.enabled
+    } catch { skip('UNPARSEABLE_POLICY_VERSION'); continue }
+    if (typeof lot.timezone !== 'string' || !lot.timezone) { skip('MISSING_TIMEZONE'); continue }
+    const m = /^annual:(\d{4})$/.exec(String(lot.period_key))
+    if (!m) { skip('UNPARSEABLE_PERIOD_KEY'); continue }
+    const expiresAt = annualLeaveLotExpiryUtc(Number(m[1]), carryoverEnabled, lot.timezone)
+    if (!expiresAt) { skip('MISSING_TIMEZONE'); continue }                          // helper guards; defensive
+    if (!dryRun) {
+      // expires_at IS NULL re-checked in the UPDATE → idempotent + safe against a concurrent set.
+      await trx.query(`UPDATE attendance_leave_balances SET expires_at = $1, updated_at = now() WHERE id = $2 AND expires_at IS NULL`, [expiresAt, lot.id])
+    }
+    summary.updated += 1
+  }
+  return summary
+}
+
 async function loadAttendanceComprehensiveActualMinutesByUser(db, orgId, userIds, period) {
   const actualMinutesByUser = new Map()
   const actualDetailsByUser = new Map()
@@ -37789,6 +37831,33 @@ module.exports = {
           const code = error?.code || (status >= 500 ? 'INTERNAL_ERROR' : 'VALIDATION_ERROR')
           if (status >= 500) logger.error('Annual leave manual adjustment failed', error)
           res.status(status).json({ ok: false, error: { code, message: error instanceof Error ? error.message : String(error) } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/annual-leave-expiry-backfill',
+      withPermission('attendance:admin', async (req, res) => {
+        // 年假/法定假 L4b: idempotent backfill of expires_at for pre-L4a annual_accrual lots (NULL expiry), from each
+        // lot's accrual-run provenance snapshot (not today's settings). dryRun previews; returns an auditable summary.
+        const schema = z.object({ dryRun: z.boolean().optional() })
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        try {
+          const summary = await db.transaction(async (trx) => backfillAnnualLeaveAccrualExpiry(trx, { orgId, dryRun: parsed.data.dryRun === true }))
+          res.json({ ok: true, data: summary })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Annual leave expiry backfill failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
         }
       })
     )


### PR DESCRIPTION
## ④/年假 L4b — provenance-snapshot expires_at backfill

**Stacked on L4a (#2717)** — base is the L4a branch; retarget to `main` after L4a merges. Backfills `expires_at` for `annual_accrual` lots that predate L4a (NULL expiry).

- **Application-layer idempotent backfill** (not a migration — mutable policy/tz/carryover must not be baked into a migration). Derives the **grant-time** carryover/timezone/period from each lot's accrual-run **provenance** (`lot.source_id = run_item.id` [cast `ri.id::text = b.source_id`] → `run_item.run_id` → `run.policy_version`[JSON].carryover + `run.period_key` + `run.timezone`), never today's settings — so flipping carryover now never retroactively re-expires past years.
- **Never guesses**: an unrecoverable lot is skipped, counted under a reason code, and left NULL (grandfathered): `NON_ACCRUAL_SOURCE` / `MISSING_RUN_ITEM` / `MISSING_RUN` / `UNPARSEABLE_POLICY_VERSION` / `MISSING_TIMEZONE` / `UNPARSEABLE_PERIOD_KEY`.
- Returns an auditable `{ scanned, updated, skipped, dryRun, reasons }`. `dryRun` previews; re-run is idempotent (NULL-only scan + `expires_at IS NULL` re-check in the UPDATE).
- `POST /api/attendance/annual-leave-expiry-backfill` (`attendance:admin`) `{ dryRun? }`.

### Verification
- Integration test (real endpoint): 2 recoverable lots → correct provenance-derived expiry (`carryover=false` → Jan 1 2027 CST; `carryover=true` → Jan 1 2028 CST); 4 unrecoverable → right reason codes + left NULL; dryRun writes nothing; re-run `updated=0`.
- 5-agent adversarial pass all SAFE (reuses L4a's exact helper from the same run row; never current settings; every skip path continues before the single UPDATE; manual-adjust lots excluded by 3 structural layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)