### PR TITLE
feat(data-source): add C6 external-write review UI

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -250,6 +250,44 @@ export interface IntegrationPipelineRunResult {
   [key: string]: unknown
 }
 
+export interface IntegrationExternalWriteDryRunPayload extends IntegrationScope {
+  maxRows?: number
+}
+
+export interface IntegrationExternalWriteDryRunResult {
+  pipelineId?: string
+  status?: string
+  canApply?: boolean
+  dryRunToken?: string | null
+  revision?: string
+  counts?: Record<string, number>
+  evidence?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface IntegrationExternalWriteApplyPayload extends IntegrationScope {
+  confirm: {
+    dryRunToken: string
+  }
+}
+
+export interface IntegrationExternalWriteApplyResult {
+  pipelineId?: string
+  status?: string
+  dryRunRevision?: string
+  counts?: Record<string, number>
+  rowErrors?: unknown[]
+  deadLetters?: Record<string, unknown>
+  evidence?: Record<string, unknown>
+  run?: {
+    id?: string
+    status?: string
+    provenanceEventsPersisted?: number
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
 export interface IntegrationPipelineObservationQuery extends IntegrationScope {
   pipelineId: string
   status?: string
@@ -897,6 +935,28 @@ export async function runIntegrationPipeline(
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<IntegrationPipelineRunResult>(response)
+}
+
+export async function dryRunIntegrationExternalWrite(
+  pipelineId: string,
+  payload: IntegrationExternalWriteDryRunPayload,
+): Promise<IntegrationExternalWriteDryRunResult> {
+  const response = await apiFetch(`/api/integration/pipelines/${encodeURIComponent(pipelineId)}/external-write/dry-run`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationExternalWriteDryRunResult>(response)
+}
+
+export async function applyIntegrationExternalWrite(
+  pipelineId: string,
+  payload: IntegrationExternalWriteApplyPayload,
+): Promise<IntegrationExternalWriteApplyResult> {
+  const response = await apiFetch(`/api/integration/pipelines/${encodeURIComponent(pipelineId)}/external-write/apply`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationExternalWriteApplyResult>(response)
 }
 
 export async function listIntegrationPipelineRuns(

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -784,6 +784,60 @@
         {{ dryRunEmptyPreviewNotice }}
       </div>
 
+      <div class="integration-workbench__table-action" data-testid="external-write-panel">
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h3>外部写入 C6</h3>
+            <p>先 dry-run 复核计数，再用一次性 token apply；浏览器不提供 source、target、plan、payload 或 sheet scope。</p>
+          </div>
+          <span class="integration-workbench__badge" data-testid="external-write-permission-note">dry-run=read · apply=write/admin</span>
+        </div>
+        <p class="integration-workbench__hint" data-testid="external-write-boundary">
+          仅展示 status/count/error token；dry-run token 只保存在内存中，不显示、不复制到证据。
+        </p>
+        <div class="integration-workbench__actions">
+          <button
+            type="button"
+            class="integration-workbench__button"
+            data-testid="external-write-dry-run"
+            :disabled="!externalWriteCanDryRun"
+            @click="dryRunExternalWrite"
+          >
+            {{ runningExternalWrite === 'dry-run' ? '外部写 dry-run 中' : '外部写 dry-run' }}
+          </button>
+          <button
+            type="button"
+            class="integration-workbench__button integration-workbench__button--danger"
+            data-testid="external-write-apply"
+            :disabled="!externalWriteCanApply"
+            @click="applyExternalWrite"
+          >
+            {{ runningExternalWrite === 'apply' ? '外部写 apply 中' : 'Apply external write' }}
+          </button>
+        </div>
+        <div v-if="externalWriteDryRunResult" class="integration-workbench__table-action-review" data-testid="external-write-review">
+          <strong>{{ externalWriteReviewSummary }}</strong>
+          <div class="integration-workbench__metric-row">
+            <span v-for="metric in externalWriteDryRunMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
+          </div>
+          <p class="integration-workbench__hint" data-testid="external-write-token-state">
+            {{ externalWriteDryRunToken ? 'token 已签发（隐藏）' : '未签发可 apply token' }}
+          </p>
+          <label class="integration-workbench__inline-check">
+            <input v-model="externalWriteAcceptReview" type="checkbox" data-testid="external-write-accept-review" />
+            <span>我已复核 dry-run counts / status / error token；apply 将使用本次 dry-run token，服务端会重新计算并校验 revision。</span>
+          </label>
+          <pre v-if="externalWriteEvidenceText" data-testid="external-write-evidence">{{ externalWriteEvidenceText }}</pre>
+        </div>
+        <div v-if="externalWriteApplyResult" class="integration-workbench__table-action-review" data-testid="external-write-apply-result">
+          <strong>apply {{ externalWriteApplyResult.status || 'unknown' }}</strong>
+          <div class="integration-workbench__metric-row">
+            <span v-for="metric in externalWriteApplyMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
+          </div>
+          <p v-if="externalWriteApplyRunId" class="integration-workbench__hint">run {{ externalWriteApplyRunId }}</p>
+        </div>
+      </div>
+
       <div class="integration-workbench__table-action" data-testid="table-action-panel">
         <div class="integration-workbench__panel-head">
           <div>
@@ -1265,9 +1319,11 @@ import type { DataSourceListItem, DataSourceTableInfo } from '../data-sources/ty
 import {
   canReadFromSystem,
   canWriteToSystem,
+  applyIntegrationExternalWrite,
   applyIntegrationTableAction,
   deleteIntegrationTableActionConflictPolicies,
   deleteWorkbenchExternalSystem,
+  dryRunIntegrationExternalWrite,
   dryRunIntegrationTableAction,
   getDefaultIntegrationScope,
   isIntegrationScopedProjectId,
@@ -1303,6 +1359,8 @@ import {
   type PlmIntegrationCapabilitiesResult,
   type PlmIntegrationCapabilityFeature,
   type IntegrationDeadLetter,
+  type IntegrationExternalWriteApplyResult,
+  type IntegrationExternalWriteDryRunResult,
   type IntegrationPipelineMode,
   type IntegrationPipelineRun,
   type IntegrationPipelineRunResult,
@@ -1531,6 +1589,10 @@ const previewText = ref('尚未生成预览')
 const previewProvenance = ref<ReturnType<typeof summarizeFieldProvenance>>(null)
 const pipelineResultText = ref('尚未执行')
 const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
+const runningExternalWrite = ref<'dry-run' | 'apply' | ''>('')
+const externalWriteDryRunResult = ref<IntegrationExternalWriteDryRunResult | null>(null)
+const externalWriteApplyResult = ref<IntegrationExternalWriteApplyResult | null>(null)
+const externalWriteAcceptReview = ref(false)
 const tableActions = ref<IntegrationTableActionMetadata[]>([])
 const selectedTableActionId = ref('')
 const tableActionProjectNo = ref('')
@@ -2204,6 +2266,71 @@ const dryRunReadinessItems = computed(() => [
 // decoupled from the full BUILD checklist (dryRunReadinessItems, kept as authoring guidance): an operator
 // re-running an existing pipeline by pasting its ID must not be blocked by an unfilled builder. See #2232.
 const canRunPipeline = computed(() => savedPipelineId.value.trim() !== '')
+const externalWriteDryRunToken = computed(() => externalWriteDryRunResult.value?.dryRunToken || '')
+const externalWriteCanDryRun = computed(() => Boolean(
+  savedPipelineId.value.trim()
+  && runningExternalWrite.value === ''
+  && runningPipeline.value === '',
+))
+const externalWriteCanApply = computed(() => Boolean(
+  savedPipelineId.value.trim()
+  && externalWriteDryRunResult.value?.canApply === true
+  && externalWriteDryRunToken.value
+  && externalWriteAcceptReview.value
+  && auth.hasPermission('integration:write')
+  && runningExternalWrite.value === ''
+  && runningPipeline.value === '',
+))
+const externalWriteDryRunMetrics = computed(() => metricRowsFromCounts(externalWriteDryRunResult.value?.counts, [
+  'sourceRows',
+  'planned',
+  'add',
+  'update',
+  'skip',
+  'held',
+  'failed',
+]))
+const externalWriteApplyMetrics = computed(() => metricRowsFromCounts(externalWriteApplyResult.value?.counts, [
+  'add',
+  'update',
+  'skip',
+  'held',
+  'failed',
+  'written',
+]))
+const externalWriteApplyRunId = computed(() => {
+  const id = externalWriteApplyResult.value?.run?.id
+  return typeof id === 'string' ? id : ''
+})
+const externalWriteReviewSummary = computed(() => {
+  const result = externalWriteDryRunResult.value
+  if (!result) return '先执行外部写 dry-run；apply 必须使用本次 dry-run token。'
+  const status = typeof result.status === 'string' ? result.status : 'unknown'
+  const counts = result.counts || {}
+  const add = counts.add ?? counts.created ?? 0
+  const update = counts.update ?? counts.updated ?? 0
+  const failed = counts.failed ?? 0
+  return `dry-run ${status} · add ${add} / update ${update} / failed ${failed} · ${result.canApply === true ? '可申请 apply' : 'Apply blocked'}`
+})
+const externalWriteEvidenceText = computed(() => {
+  const result = externalWriteDryRunResult.value
+  if (!result) return ''
+  const evidence = isRecord(result.evidence) ? result.evidence : {}
+  const sourceRead = isRecord(evidence.sourceRead) ? evidence.sourceRead : null
+  return JSON.stringify({
+    status: typeof result.status === 'string' ? result.status : 'unknown',
+    canApply: result.canApply === true,
+    dryRunTokenPresent: Boolean(result.dryRunToken),
+    revisionPresent: Boolean(result.revision),
+    rowErrorTypes: valuesFreeTokenList(evidence.rowErrorTypes),
+    errorTypes: valuesFreeTokenList(evidence.errorTypes),
+    sourceRead: sourceRead ? {
+      complete: sourceRead.complete === true,
+      truncated: sourceRead.truncated === true,
+      pagesRead: typeof sourceRead.pagesRead === 'number' ? sourceRead.pagesRead : undefined,
+    } : undefined,
+  }, null, 2)
+})
 const dryRunBlockedSummary = computed(() => {
   const missing = dryRunReadinessItems.value.filter((item) => !item.ready)
   if (missing.length === 0) return '已满足 dry-run 前置条件。Dry-run 只生成 preview，不写外部系统。'
@@ -2931,6 +3058,32 @@ function numberMetric(value: unknown): string {
 
 function safeEvidenceToken(value: unknown): value is string {
   return typeof value === 'string' && /^[a-z][a-z0-9_]{0,80}$/i.test(value)
+}
+
+function valuesFreeTokenList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(safeEvidenceToken) : []
+}
+
+function metricRowsFromCounts(counts: Record<string, number> | undefined, keys: string[]): Array<{ id: string, label: string, value: string }> {
+  if (!counts) return []
+  return keys
+    .map((key) => {
+      const value = counts[key]
+      return typeof value === 'number' && Number.isFinite(value)
+        ? { id: key, label: key, value: String(value) }
+        : null
+    })
+    .filter((entry): entry is { id: string, label: string, value: string } => entry !== null)
+}
+
+function valuesFreeDeadLetterSummary(value: unknown): Record<string, number> {
+  if (!isRecord(value)) return {}
+  const out: Record<string, number> = {}
+  for (const key of ['attempted', 'persisted', 'failed']) {
+    const count = value[key]
+    if (typeof count === 'number' && Number.isFinite(count)) out[key] = count
+  }
+  return out
 }
 
 function isLargeBomBoundedTableActionResult(result: IntegrationTableActionDryRunResult | null): boolean {
@@ -3863,6 +4016,124 @@ async function executePipeline(dryRun: boolean): Promise<void> {
   }
 }
 
+function resetExternalWriteReview(): void {
+  externalWriteDryRunResult.value = null
+  externalWriteApplyResult.value = null
+  externalWriteAcceptReview.value = false
+}
+
+function externalWriteRequestSignature(pipelineId = savedPipelineId.value.trim()): string {
+  const resolvedScope = currentScope()
+  return JSON.stringify({
+    pipelineId,
+    tenantId: resolvedScope.tenantId,
+    workspaceId: resolvedScope.workspaceId,
+  })
+}
+
+async function dryRunExternalWrite(): Promise<void> {
+  const pipelineId = savedPipelineId.value.trim()
+  if (!pipelineId) {
+    setStatus('请先保存 Pipeline，或粘贴已有 Pipeline ID', 'error')
+    return
+  }
+  const requestSignature = externalWriteRequestSignature(pipelineId)
+  runningExternalWrite.value = 'dry-run'
+  externalWriteDryRunResult.value = null
+  externalWriteApplyResult.value = null
+  externalWriteAcceptReview.value = false
+  try {
+    const payload = currentScope()
+    const result = await dryRunIntegrationExternalWrite(pipelineId, payload)
+    if (externalWriteRequestSignature() !== requestSignature) {
+      setStatus('外部写 dry-run 结果已丢弃：Pipeline ID 或 scope 已变化。', 'idle')
+      return
+    }
+    externalWriteDryRunResult.value = result
+    pipelineResultText.value = JSON.stringify({
+      action: 'external-write-dry-run',
+      pipelineId,
+      payload,
+      result: {
+        status: result.status || 'unknown',
+        canApply: result.canApply === true,
+        dryRunTokenPresent: Boolean(result.dryRunToken),
+        revisionPresent: Boolean(result.revision),
+        counts: result.counts || {},
+      },
+    }, null, 2)
+    setStatus(result.canApply === true ? '外部写 dry-run 完成，可复核后 apply' : '外部写 dry-run 完成，但 apply 被阻塞', result.canApply === true ? 'success' : 'error')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    runningExternalWrite.value = ''
+  }
+}
+
+async function applyExternalWrite(): Promise<void> {
+  const pipelineId = savedPipelineId.value.trim()
+  if (!pipelineId) {
+    setStatus('请先保存 Pipeline，或粘贴已有 Pipeline ID', 'error')
+    return
+  }
+  if (!auth.hasPermission('integration:write')) {
+    setStatus('当前用户只有 dry-run 读取权限，不能执行外部写 apply。', 'error')
+    return
+  }
+  const dryRunToken = externalWriteDryRunToken.value
+  if (!dryRunToken) {
+    setStatus('请先执行外部写 dry-run；apply 必须使用服务端返回的一次性 dry-run token。', 'error')
+    return
+  }
+  if (!externalWriteAcceptReview.value) {
+    setStatus('Apply 前必须确认已复核 dry-run counts / status / error token。', 'error')
+    return
+  }
+  const requestSignature = externalWriteRequestSignature(pipelineId)
+  runningExternalWrite.value = 'apply'
+  externalWriteApplyResult.value = null
+  try {
+    const payload = {
+      ...currentScope(),
+      confirm: { dryRunToken },
+    }
+    const result = await applyIntegrationExternalWrite(pipelineId, payload)
+    if (externalWriteRequestSignature() !== requestSignature) {
+      setStatus('外部写 apply 结果未挂到当前视图：Pipeline ID 或 scope 已变化，请刷新运行记录确认。', 'idle')
+      return
+    }
+    externalWriteApplyResult.value = result
+    externalWriteDryRunResult.value = null
+    externalWriteAcceptReview.value = false
+    pipelineResultText.value = JSON.stringify({
+      action: 'external-write-apply',
+      pipelineId,
+      payload: {
+        tenantId: payload.tenantId,
+        workspaceId: payload.workspaceId,
+        confirm: { dryRunTokenPresent: true },
+      },
+      result: {
+        status: result.status || 'unknown',
+        dryRunRevision: result.dryRunRevision,
+        counts: result.counts || {},
+        deadLetters: valuesFreeDeadLetterSummary(result.deadLetters),
+        run: result.run ? {
+          id: result.run.id,
+          status: result.run.status,
+          provenanceEventsPersisted: result.run.provenanceEventsPersisted,
+        } : undefined,
+      },
+    }, null, 2)
+    await refreshPipelineObservation(true)
+    setStatus(`外部写 apply 完成：${result.status || 'unknown'}`, result.status === 'failed' ? 'error' : 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    runningExternalWrite.value = ''
+  }
+}
+
 function resetTableActionReview(): void {
   tableActionDryRunResult.value = null
   tableActionApplyResult.value = null
@@ -4226,6 +4497,14 @@ watch(showAdvancedConnectors, () => {
 
 watch(sourceSystemId, () => {
   void refreshPlmCapabilitiesForSystem(selectedSourceSystem.value)
+})
+
+watch(savedPipelineId, () => {
+  resetExternalWriteReview()
+})
+
+watch(() => [scope.tenantId, scope.workspaceId], () => {
+  resetExternalWriteReview()
 })
 
 watch(tableActionProjectNo, () => {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1190,6 +1190,240 @@ describe('IntegrationWorkbenchView', () => {
     expect(runSaveOnlyButton.disabled).toBe(true)
   })
 
+  it('C6-4: runs external-write dry-run then apply without exposing token or client-owned write scope', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const dryRunBodies: Array<Record<string, unknown>> = []
+    const applyBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'SQL readonly', roles: ['source'], supports: ['read'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/pipelines/pipe_1/external-write/dry-run') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        dryRunBodies.push(body)
+        return jsonResponse({
+          pipelineId: 'pipe_1',
+          status: 'ready',
+          canApply: true,
+          dryRunToken: 'dry-token-secret',
+          revision: 'rev-c6',
+          counts: { sourceRows: 2, planned: 2, add: 1, update: 1, skip: 0, held: 0, failed: 0 },
+          evidence: {
+            rowErrorTypes: [],
+            errorTypes: [],
+            sourceRead: { complete: true, pagesRead: 1, truncated: false },
+            targetPayload: 'target-row-secret',
+          },
+        })
+      }
+      if (url === '/api/integration/pipelines/pipe_1/external-write/apply') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        applyBodies.push(body)
+        return jsonResponse({
+          pipelineId: 'pipe_1',
+          status: 'succeeded',
+          dryRunRevision: 'rev-c6',
+          counts: { add: 1, update: 1, skip: 0, held: 0, failed: 0, written: 2 },
+          deadLetters: { attempted: 0, persisted: 0, payload: 'dead-letter-secret' },
+          evidence: { rowErrorTypes: [], dryRunTokenConsumed: true },
+          run: { id: 'run_c6', status: 'succeeded', provenanceEventsPersisted: 2 },
+        })
+      }
+      if (url.startsWith('/api/integration/runs?')) return jsonResponse([])
+      if (url.startsWith('/api/integration/dead-letters?')) return jsonResponse([])
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(8)
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_1'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="external-write-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+    expect(dryRunBodies).toHaveLength(1)
+    expect(dryRunBodies[0]).toEqual({
+      tenantId: 'default',
+      workspaceId: null,
+    })
+    expect(dryRunBodies[0]).not.toHaveProperty('source')
+    expect(dryRunBodies[0]).not.toHaveProperty('target')
+    expect(dryRunBodies[0]).not.toHaveProperty('plan')
+    expect(dryRunBodies[0]).not.toHaveProperty('payload')
+    expect(container.querySelector('[data-testid="external-write-review"]')?.textContent).toContain('add 1')
+    expect(container.querySelector('[data-testid="external-write-review"]')?.textContent).toContain('update 1')
+    expect(container.querySelector('[data-testid="external-write-token-state"]')?.textContent).toContain('token 已签发')
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('dry-token-secret')
+    expect(container.querySelector('[data-testid="pipeline-result"]')?.textContent).not.toContain('dry-token-secret')
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('target-row-secret')
+    expect(container.querySelector('[data-testid="pipeline-result"]')?.textContent).not.toContain('target-row-secret')
+
+    const applyButton = container.querySelector('[data-testid="external-write-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    ;(container.querySelector('[data-testid="external-write-accept-review"]') as HTMLInputElement).click()
+    await flushUi()
+    expect(applyButton.disabled).toBe(false)
+    applyButton.click()
+    await flushUi(10)
+
+    expect(applyBodies).toHaveLength(1)
+    expect(applyBodies[0]).toEqual({
+      tenantId: 'default',
+      workspaceId: null,
+      confirm: {
+        dryRunToken: 'dry-token-secret',
+      },
+    })
+    expect(applyBodies[0]).not.toHaveProperty('source')
+    expect(applyBodies[0]).not.toHaveProperty('target')
+    expect(applyBodies[0]).not.toHaveProperty('plan')
+    expect(applyBodies[0]).not.toHaveProperty('payload')
+    expect(container.querySelector('[data-testid="external-write-apply-result"]')?.textContent).toContain('apply succeeded')
+    expect(container.querySelector('[data-testid="external-write-apply-result"]')?.textContent).toContain('add 1')
+    expect(container.querySelector('[data-testid="external-write-apply-result"]')?.textContent).toContain('update 1')
+    expect(container.querySelector('[data-testid="external-write-apply-result"]')?.textContent).toContain('written 2')
+    expect(container.querySelector('[data-testid="external-write-apply-result"]')?.textContent).toContain('run run_c6')
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('dry-token-secret')
+    expect(container.querySelector('[data-testid="pipeline-result"]')?.textContent).not.toContain('dry-token-secret')
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('dead-letter-secret')
+    expect(container.querySelector('[data-testid="pipeline-result"]')?.textContent).not.toContain('dead-letter-secret')
+  })
+
+  it('C6-4: discards stale external-write dry-run results after pipeline id changes', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    let releaseDryRun: (() => void) | null = null
+    const dryRunGate = new Promise<void>((resolve) => {
+      releaseDryRun = resolve
+    })
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/pipelines/pipe_1/external-write/dry-run') {
+        await dryRunGate
+        return jsonResponse({
+          pipelineId: 'pipe_1',
+          status: 'ready',
+          canApply: true,
+          dryRunToken: 'stale-token-secret',
+          revision: 'rev-stale',
+          counts: { add: 1, update: 0, failed: 0 },
+          evidence: { rowErrorTypes: [] },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(8)
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_1'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="external-write-dry-run"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    pipelineIdInput.value = 'pipe_2'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    releaseDryRun?.()
+    await flushUi(10)
+
+    expect(container.querySelector('[data-testid="external-write-review"]')).toBeNull()
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('stale-token-secret')
+    expect(container.querySelector('[data-testid="pipeline-result"]')?.textContent).not.toContain('stale-token-secret')
+    expect((container.querySelector('[data-testid="external-write-apply"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.textContent).toContain('结果已丢弃')
+  })
+
+  it('C6-4: keeps external-write apply disabled for read-only users after dry-run', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:read']))
+    const applyBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/pipelines/pipe_1/external-write/dry-run') {
+        return jsonResponse({
+          pipelineId: 'pipe_1',
+          status: 'ready',
+          canApply: true,
+          dryRunToken: 'read-only-token-secret',
+          revision: 'rev-read-only',
+          counts: { add: 1, update: 0, failed: 0 },
+          evidence: { rowErrorTypes: [] },
+        })
+      }
+      if (url === '/api/integration/pipelines/pipe_1/external-write/apply') {
+        applyBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ status: 'succeeded' })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(8)
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_1'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="external-write-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+    expect(container.querySelector('[data-testid="external-write-review"]')?.textContent).toContain('add 1')
+    expect(container.querySelector('[data-testid="external-write-panel"]')?.textContent).not.toContain('read-only-token-secret')
+
+    ;(container.querySelector('[data-testid="external-write-accept-review"]') as HTMLInputElement).click()
+    await flushUi()
+    const applyButton = container.querySelector('[data-testid="external-write-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    applyButton.click()
+    await flushUi()
+    expect(applyBodies).toHaveLength(0)
+  })
+
   it('marks SQL Server source option as disabled when queryExecutor is missing', async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') {

--- a/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
+++ b/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
@@ -1,6 +1,6 @@
 # Data Source System Integration C6 - External Write Design
 
-Status: C6-0 design + C6-1 latent target + C6-2 dry-run route + C6-3 token-bound apply route; C6-4 UI / C6-5 entity-machine validation still gated
+Status: C6-0 design + C6-1 latent target + C6-2 dry-run route + C6-3 token-bound apply route; C6-4 UI in review; C6-5 entity-machine validation still gated
 Date: 2026-06-16
 
 ## Purpose

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -16,10 +16,11 @@
   C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
   中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
   Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
-- 下一门: C6-4 UI / C6-5 entity-machine smoke。C6 是最大风险刀；C6-0 只锁 design contract，
+- 下一门: C6-4 UI review/merge / C6-5 entity-machine smoke。C6 是最大风险刀；C6-0 只锁 design contract，
   C6-1 只落地 backend latent writer helper 和 write-gated target adapter 的关闭态合同；
   C6-2 只增加 read-only dry-run route + dry-run token，不授权 apply runtime 或 external write。
-  C6-3 增加 token-bound apply route；C6-4/C6-5 仍需逐片 opt-in、复审、fresh CI 和实体机 gate。
+  C6-3 增加 token-bound apply route；C6-4 正在补 UI dry-run -> review -> apply；C6-5 仍需
+  单独 opt-in、复审、fresh CI 和实体机 gate。
 
 ## 收口顺序
 
@@ -30,7 +31,7 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4/C6-5 gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI in review; C6-5 gated | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
 | Release | 总包 + 实体机验收 | gated | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
@@ -402,7 +403,14 @@ TODO:
   - row write failures are isolated and returned as values-free counts/error codes; response/evidence never echoes
     the bearer token, row values, credentials, connection strings, raw SQL, target payloads, or dataSourceId secrets。
   - boundary: no UI, no package, no C6 entity-machine smoke yet, no delete/raw SQL/generic query, no K3。
-- [ ] C6-4 UI: dry-run -> review -> apply。
+- [~] C6-4 UI: dry-run -> review -> apply。
+  - pipeline-level UI calls the C6 dry-run/apply routes separately from legacy Save-only and PLM table-action flows.
+  - browser request shape remains scope-only for dry-run and scope + `confirm.dryRunToken` for apply;
+    no client `source` / `target` / `plan` / `payload` / sheet scope is sent.
+  - review renders counts/status/error tokens only; dry-run token is held in memory and never displayed or copied
+    into the values-free evidence panel.
+  - apply is disabled for read-only users and requires an explicit review checkbox.
+  - changing pipeline id or scope clears the pending dry-run token/review.
 - [ ] C6-5 entity-machine smoke: apply、re-pull、rollback。
 
 完成条件:


### PR DESCRIPTION
## Summary

C6-4 UI slice: adds a pipeline-level external-write review/apply surface in the Integration Workbench.

- adds frontend client calls for:
  - `POST /api/integration/pipelines/:id/external-write/dry-run`
  - `POST /api/integration/pipelines/:id/external-write/apply`
- adds a dedicated C6 panel separate from legacy Save-only and PLM table actions;
- dry-run renders values-free counts/status/error-token evidence only;
- apply requires:
  - a saved/pasted pipeline id;
  - C6 dry-run result with `canApply=true`;
  - hidden in-memory dry-run token;
  - explicit review checkbox;
  - `integration:write` permission;
- apply request sends only scope + `confirm.dryRunToken`;
- stale in-flight dry-run/apply responses are discarded if pipeline id or scope changes;
- docs/TODO updated to mark C6-4 as in review, with C6-5 still gated.

## Security / boundary locks

- Browser never sends `source`, `target`, `plan`, `payload`, or sheet scope for C6.
- Dry-run token is not rendered in the DOM or `pipeline-result` text.
- Values-free display projects dry-run evidence to status/count/token-presence/error-token/source-read fields.
- Apply result projects dead-letter info to count-only fields.
- Read-only users can dry-run but cannot enable or send apply.
- Backend C6 count keys are aligned to the route contract: `add/update/skip/held/failed/written`.

## Review notes

Subagent review found and this PR fixed:

- stale in-flight dry-run responses could repopulate a token after pipeline/scope changes;
- raw `deadLetters` could be rendered in `pipelineResultText`;
- apply metrics originally used non-backend count keys.

Final subagent re-review: NO FINDINGS x2.

## Verification

Passed:

```text
pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
# 40 tests passed

pnpm --filter @metasheet/web type-check

pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue src/services/integration/workbench.ts --max-warnings=0

git diff --check
```

Also attempted:

```text
pnpm --filter @metasheet/web test
```

That broader local command is not a reliable gate in this worktree: it pulled Playwright verification specs into Vitest and hit unrelated existing multitable/attendance/feature-flag fixture failures. The focused C6 workbench spec and Vue type-check are green; CI should be the authoritative full matrix.

## Boundaries

No backend route changes, no C6 entity-machine smoke, no package, no external DB write executed, no K3 Save/Submit/Audit/BOM, no raw SQL, no credential/connection-string display.

C6-5 entity-machine validation remains a separate gated opt-in.
