### PR TITLE
feat(multitable): notification bell + inbox UI (Notification Center S1b)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1368,6 +1368,32 @@ export class MultitableApiClient {
     return normalizeRecordSubscriptionNotifications(data)
   }
 
+  // Notification Center S1 — self-scoped read-state (the bell binds to these).
+  async getRecordSubscriptionUnreadCount(): Promise<number> {
+    const res = await this.fetch('/api/multitable/record-subscription-notifications/unread-count')
+    const data = await this.parseJson<{ count?: number }>(res)
+    return typeof data?.count === 'number' ? data.count : 0
+  }
+
+  async markRecordSubscriptionNotificationsRead(ids: string[]): Promise<number> {
+    const res = await this.fetch('/api/multitable/record-subscription-notifications/mark-read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    })
+    const data = await this.parseJson<{ updated?: number }>(res)
+    return typeof data?.updated === 'number' ? data.updated : 0
+  }
+
+  async markAllRecordSubscriptionNotificationsRead(): Promise<number> {
+    const res = await this.fetch('/api/multitable/record-subscription-notifications/mark-all-read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const data = await this.parseJson<{ updated?: number }>(res)
+    return typeof data?.updated === 'number' ? data.updated : 0
+  }
+
   async createRecord(input: CreateRecordInput, opts?: { signal?: AbortSignal }): Promise<{ record: MetaRecord }> {
     const res = await this.fetch('/api/multitable/records', {
       method: 'POST',

--- a/apps/web/src/multitable/components/MetaNotificationBell.vue
+++ b/apps/web/src/multitable/components/MetaNotificationBell.vue
@@ -25,7 +25,9 @@
       <div v-if="loading" class="meta-notif-bell__state">…</div>
       <div v-else-if="error" class="meta-notif-bell__state meta-notif-bell__state--error">{{ error }}</div>
       <div v-else-if="notifications.length === 0" class="meta-notif-bell__state" data-test="notification-empty">{{ l('notification.empty') }}</div>
-      <ul v-else class="meta-notif-bell__list">
+      <!-- list renders independently of `error`: a transient mark-read/mark-all failure shows the error
+           banner above WITHOUT replacing the still-loaded list (the dead-state the review caught). -->
+      <ul v-if="!loading && notifications.length" class="meta-notif-bell__list">
         <li
           v-for="n in notifications"
           :key="n.id"

--- a/apps/web/src/multitable/components/MetaNotificationBell.vue
+++ b/apps/web/src/multitable/components/MetaNotificationBell.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="meta-notif-bell" data-test="notification-bell">
+    <button
+      type="button"
+      class="meta-notif-bell__btn"
+      :class="{ 'meta-notif-bell__btn--attention': hasUnread }"
+      :title="l('notification.bell')"
+      data-test="notification-bell-btn"
+      @click="toggle"
+    >
+      🔔 {{ l('notification.bell') }}
+      <span v-if="hasUnread" class="meta-notif-bell__badge" data-test="notification-bell-badge">{{ unreadCount }}</span>
+    </button>
+    <div v-if="open" class="meta-notif-bell__panel" data-test="notification-panel">
+      <div class="meta-notif-bell__head">
+        <span class="meta-notif-bell__title">{{ l('notification.title') }}</span>
+        <button
+          v-if="hasUnread"
+          type="button"
+          class="meta-notif-bell__mark-all"
+          data-test="notification-mark-all"
+          @click="markAllRead"
+        >{{ l('notification.markAllRead') }}</button>
+      </div>
+      <div v-if="loading" class="meta-notif-bell__state">…</div>
+      <div v-else-if="error" class="meta-notif-bell__state meta-notif-bell__state--error">{{ error }}</div>
+      <div v-else-if="notifications.length === 0" class="meta-notif-bell__state" data-test="notification-empty">{{ l('notification.empty') }}</div>
+      <ul v-else class="meta-notif-bell__list">
+        <li
+          v-for="n in notifications"
+          :key="n.id"
+          class="meta-notif-bell__item"
+          :class="{ 'meta-notif-bell__item--unread': !n.readAt }"
+          data-test="notification-item"
+          @click="onItemClick(n)"
+        >
+          <span v-if="!n.readAt" class="meta-notif-bell__dot" data-test="notification-unread-dot" aria-hidden="true"></span>
+          <span class="meta-notif-bell__event">{{ eventLabel(n.eventType) }}</span>
+          <span class="meta-notif-bell__time">{{ formatTime(n.createdAt) }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
+import { useNotificationInbox } from '../composables/useNotificationInbox'
+import type { MetaRecordSubscriptionNotification } from '../types'
+import type { MultitableApiClient } from '../api/client'
+
+const props = defineProps<{ apiClient?: MultitableApiClient }>()
+const emit = defineEmits<{ (e: 'navigate', payload: { sheetId: string; recordId: string }): void }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordLabelKey) => recordLabel(key, isZh.value)
+
+const { notifications, unreadCount, loading, error, hasUnread, eventLabel, loadInbox, refreshUnreadCount, markRead, markAllRead } =
+  useNotificationInbox(props.apiClient)
+
+const open = ref(false)
+
+function formatTime(value: string): string {
+  if (!value) return ''
+  const ts = Date.parse(value)
+  return Number.isNaN(ts) ? value : new Date(ts).toLocaleString()
+}
+
+async function toggle(): Promise<void> {
+  open.value = !open.value
+  if (open.value) await loadInbox({ limit: 50 })
+}
+
+async function onItemClick(n: MetaRecordSubscriptionNotification): Promise<void> {
+  if (!n.readAt) void markRead([n.id])
+  emit('navigate', { sheetId: n.sheetId, recordId: n.recordId })
+  open.value = false
+}
+
+// Ambient badge: surface the unread count without requiring the panel to be opened.
+void refreshUnreadCount()
+</script>
+
+<style scoped>
+.meta-notif-bell { position: relative; display: inline-block; }
+.meta-notif-bell__btn { position: relative; }
+.meta-notif-bell__badge { display: inline-block; min-width: 16px; padding: 0 5px; margin-left: 4px; border-radius: 9px; background: #ef4444; color: #fff; font-size: 11px; line-height: 16px; text-align: center; }
+.meta-notif-bell__panel { position: absolute; right: 0; top: calc(100% + 6px); z-index: 20; width: 320px; max-height: 420px; overflow-y: auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12); }
+.meta-notif-bell__head { display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border-bottom: 1px solid #f1f5f9; }
+.meta-notif-bell__title { font-weight: 600; color: #0f172a; }
+.meta-notif-bell__mark-all { font-size: 12px; color: #2563eb; background: none; border: none; cursor: pointer; }
+.meta-notif-bell__state { padding: 16px 12px; color: #64748b; font-size: 13px; }
+.meta-notif-bell__state--error { color: #b91c1c; }
+.meta-notif-bell__list { list-style: none; margin: 0; padding: 4px 0; }
+.meta-notif-bell__item { display: flex; align-items: baseline; gap: 8px; padding: 8px 12px; cursor: pointer; }
+.meta-notif-bell__item:hover { background: #f8fafc; }
+.meta-notif-bell__item--unread { background: #eff6ff; }
+.meta-notif-bell__dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: #2563eb; align-self: center; }
+.meta-notif-bell__event { flex: 1 1 auto; color: #0f172a; font-size: 13px; }
+.meta-notif-bell__time { flex: 0 0 auto; color: #94a3b8; font-size: 11px; }
+</style>

--- a/apps/web/src/multitable/composables/useNotificationInbox.ts
+++ b/apps/web/src/multitable/composables/useNotificationInbox.ts
@@ -24,6 +24,8 @@ export function useNotificationInbox(client?: MultitableApiClient) {
       : recordLabel('notification.eventRecordUpdated', isZh.value)
   }
 
+  // UI-facing actions NEVER throw — they surface failure via `error` and resolve. The bell is ambient
+  // toolbar chrome; a rejected click would leak as an unhandled rejection / Vue console error.
   async function loadInbox(params?: { limit?: number; offset?: number }): Promise<MetaRecordSubscriptionNotification[]> {
     loading.value = true
     error.value = null
@@ -33,7 +35,7 @@ export function useNotificationInbox(client?: MultitableApiClient) {
       return items
     } catch (e: any) {
       error.value = e?.message ?? recordLabel('notification.loadError', isZh.value)
-      throw e
+      return notifications.value
     } finally {
       loading.value = false
     }
@@ -60,6 +62,9 @@ export function useNotificationInbox(client?: MultitableApiClient) {
       const set = new Set(targets)
       notifications.value = notifications.value.map((n) => (set.has(n.id) && !n.readAt ? { ...n, readAt: now } : n))
       await refreshUnreadCount()
+    } catch (e: any) {
+      // swallow — never reject a click handler (would be an unhandled rejection / console error)
+      error.value = e?.message ?? recordLabel('notification.loadError', isZh.value)
     } finally {
       const done = new Set(targets)
       busyIds.value = busyIds.value.filter((id) => !done.has(id))

--- a/apps/web/src/multitable/composables/useNotificationInbox.ts
+++ b/apps/web/src/multitable/composables/useNotificationInbox.ts
@@ -1,0 +1,85 @@
+// Notification Center S1 — watcher-notification inbox state for the workbench bell.
+// Mirrors useMultitableCommentInbox: a list + an unread badge count + self-scoped mark-read actions
+// over the existing meta_record_subscription_notifications rows (read-state only; no delivery/prefs).
+import { computed, ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type { MetaRecordSubscriptionNotification, MetaRecordSubscriptionNotificationType } from '../types'
+import { MultitableApiClient, multitableClient } from '../api/client'
+import { recordLabel } from '../utils/meta-record-labels'
+
+export function useNotificationInbox(client?: MultitableApiClient) {
+  const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const notifications = ref<MetaRecordSubscriptionNotification[]>([])
+  const unreadCount = ref(0)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const busyIds = ref<string[]>([])
+
+  const hasUnread = computed(() => unreadCount.value > 0)
+
+  function eventLabel(eventType: MetaRecordSubscriptionNotificationType): string {
+    return eventType === 'comment.created'
+      ? recordLabel('notification.eventCommentCreated', isZh.value)
+      : recordLabel('notification.eventRecordUpdated', isZh.value)
+  }
+
+  async function loadInbox(params?: { limit?: number; offset?: number }): Promise<MetaRecordSubscriptionNotification[]> {
+    loading.value = true
+    error.value = null
+    try {
+      const items = await api.listRecordSubscriptionNotifications(params)
+      notifications.value = items
+      return items
+    } catch (e: any) {
+      error.value = e?.message ?? recordLabel('notification.loadError', isZh.value)
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // Badge refresh is intentionally non-fatal: a transient failure keeps the prior count rather than
+  // flashing an error on the toolbar (the bell is ambient chrome, not a primary action).
+  async function refreshUnreadCount(): Promise<number> {
+    try {
+      unreadCount.value = await api.getRecordSubscriptionUnreadCount()
+    } catch {
+      /* keep prior count */
+    }
+    return unreadCount.value
+  }
+
+  async function markRead(ids: string[]): Promise<void> {
+    const targets = ids.filter((id) => id && !busyIds.value.includes(id))
+    if (targets.length === 0) return
+    busyIds.value = [...busyIds.value, ...targets]
+    try {
+      await api.markRecordSubscriptionNotificationsRead(targets)
+      const now = new Date().toISOString()
+      const set = new Set(targets)
+      notifications.value = notifications.value.map((n) => (set.has(n.id) && !n.readAt ? { ...n, readAt: now } : n))
+      await refreshUnreadCount()
+    } finally {
+      const done = new Set(targets)
+      busyIds.value = busyIds.value.filter((id) => !done.has(id))
+    }
+  }
+
+  async function markAllRead(): Promise<void> {
+    try {
+      await api.markAllRecordSubscriptionNotificationsRead()
+      const now = new Date().toISOString()
+      notifications.value = notifications.value.map((n) => (n.readAt ? n : { ...n, readAt: now }))
+      unreadCount.value = 0
+    } catch (e: any) {
+      error.value = e?.message ?? recordLabel('notification.loadError', isZh.value)
+    }
+  }
+
+  function isBusy(id: string): boolean {
+    return busyIds.value.includes(id)
+  }
+
+  return { notifications, unreadCount, loading, error, hasUnread, eventLabel, loadInbox, refreshUnreadCount, markRead, markAllRead, isBusy }
+}

--- a/apps/web/src/multitable/composables/useNotificationInbox.ts
+++ b/apps/web/src/multitable/composables/useNotificationInbox.ts
@@ -55,6 +55,7 @@ export function useNotificationInbox(client?: MultitableApiClient) {
   async function markRead(ids: string[]): Promise<void> {
     const targets = ids.filter((id) => id && !busyIds.value.includes(id))
     if (targets.length === 0) return
+    error.value = null // clear any prior failure so a successful action recovers the panel
     busyIds.value = [...busyIds.value, ...targets]
     try {
       await api.markRecordSubscriptionNotificationsRead(targets)
@@ -72,6 +73,7 @@ export function useNotificationInbox(client?: MultitableApiClient) {
   }
 
   async function markAllRead(): Promise<void> {
+    error.value = null // clear any prior failure so a successful action recovers the panel
     try {
       await api.markAllRecordSubscriptionNotificationsRead()
       const now = new Date().toISOString()

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -53,8 +53,19 @@ export type MetaRecordLabelKey =
   | 'form.loading' | 'form.readOnly'
   | 'form.discardConfirm'
   | 'form.save' | 'form.saving' | 'form.create' | 'form.reset'
+  // --- Notification Center S1 (watcher inbox bell) ---
+  | 'notification.bell' | 'notification.title' | 'notification.empty'
+  | 'notification.markAllRead' | 'notification.loadError'
+  | 'notification.eventRecordUpdated' | 'notification.eventCommentCreated'
 
 const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }> = {
+  'notification.bell': { en: 'Notifications', zh: '通知' },
+  'notification.title': { en: 'Notifications', zh: '通知' },
+  'notification.empty': { en: 'No notifications', zh: '暂无通知' },
+  'notification.markAllRead': { en: 'Mark all read', zh: '全部标为已读' },
+  'notification.loadError': { en: 'Failed to load notifications', zh: '加载通知失败' },
+  'notification.eventRecordUpdated': { en: 'Record updated', zh: '记录有更新' },
+  'notification.eventCommentCreated': { en: 'New comment', zh: '新增评论' },
   'record.title': { en: 'Record Detail', zh: '记录详情' },
   'record.previous': { en: 'Previous record', zh: '上一条记录' },
   'record.next': { en: 'Next record', zh: '下一条记录' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -51,6 +51,7 @@
         &#x1F4AC; {{ wb('toolbar.commentInbox', isZh) }}
         <span v-if="commentInboxBadgeCount > 0" class="mt-workbench__mgr-badge">{{ commentInboxBadgeCount }}</span>
       </button>
+      <MetaNotificationBell :api-client="workbench.client" @navigate="onNotificationNavigate" />
       <button v-if="caps.canManageFields.value" class="mt-workbench__mgr-btn" @click="showFieldManager = true">&#x2699; {{ wb('toolbar.fields', isZh) }}</button>
       <button v-if="caps.canManageSheetAccess.value" class="mt-workbench__mgr-btn" @click="showPermissionManager = true; void loadPermissionEntries()">&#x1F512; {{ wb('toolbar.access', isZh) }}</button>
       <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; {{ wb('toolbar.views', isZh) }}</button>
@@ -519,6 +520,7 @@ import MetaGridTable from '../components/MetaGridTable.vue'
 import MetaExportDialog, { type ExportConfirmPayload } from '../components/MetaExportDialog.vue'
 import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
+import MetaNotificationBell from '../components/MetaNotificationBell.vue'
 import MetaCommentsDrawer from '../components/MetaCommentsDrawer.vue'
 import MetaLinkPicker from '../components/MetaLinkPicker.vue'
 import MetaTemplateCard from '../components/MetaTemplateCard.vue'
@@ -2120,6 +2122,15 @@ function onSelectSheet(sheetId: string) {
   if (sheetId === workbench.activeSheetId.value) return
   if (!confirmDiscardContextChanges()) return
   workbench.selectSheet(sheetId)
+}
+
+// Notification Center S1 — click-to-locate from the bell. Switch to the notification's sheet first
+// (resolveDeepLink resolves against the active sheet); a same-sheet target skips the switch.
+async function onNotificationNavigate(payload: { sheetId: string; recordId: string }) {
+  if (payload.sheetId && payload.sheetId !== workbench.activeSheetId.value) {
+    onSelectSheet(payload.sheetId)
+  }
+  await resolveDeepLink(payload.recordId)
 }
 
 function onSelectView(viewId: string) {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -2118,17 +2118,23 @@ function rememberWorkbenchBaseOpen(baseId: string) {
   recentBaseOpens.value = rememberRecentBaseOpen(baseId)
 }
 
-function onSelectSheet(sheetId: string) {
-  if (sheetId === workbench.activeSheetId.value) return
-  if (!confirmDiscardContextChanges()) return
+// Returns whether the active sheet is now `sheetId`: true if already there or switched, false if the
+// user cancelled the discard-unsaved-changes confirm. Callers that depend on the switch (e.g. the
+// notification bell's click-to-locate) MUST honor a false return.
+function onSelectSheet(sheetId: string): boolean {
+  if (sheetId === workbench.activeSheetId.value) return true
+  if (!confirmDiscardContextChanges()) return false
   workbench.selectSheet(sheetId)
+  return true
 }
 
 // Notification Center S1 — click-to-locate from the bell. Switch to the notification's sheet first
-// (resolveDeepLink resolves against the active sheet); a same-sheet target skips the switch.
+// (resolveDeepLink resolves against the active sheet); a same-sheet target skips the switch. If the
+// switch is cancelled (unsaved-changes discard declined), do NOT locate — that would look the record
+// up in the wrong sheet and report not-found.
 async function onNotificationNavigate(payload: { sheetId: string; recordId: string }) {
   if (payload.sheetId && payload.sheetId !== workbench.activeSheetId.value) {
-    onSelectSheet(payload.sheetId)
+    if (!onSelectSheet(payload.sheetId)) return
   }
   await resolveDeepLink(payload.recordId)
 }

--- a/apps/web/tests/meta-notification-bell.spec.ts
+++ b/apps/web/tests/meta-notification-bell.spec.ts
@@ -68,6 +68,18 @@ describe('MetaNotificationBell (S1b)', () => {
     expect(m.apiClient.markAllRecordSubscriptionNotificationsRead).toHaveBeenCalled()
   })
 
+  it('a failed mark-all shows the error WITHOUT hiding the still-loaded list (no dead-state)', async () => {
+    const m = mount({ markAllRecordSubscriptionNotificationsRead: vi.fn(async () => { throw new Error('mark fail') }) }); mounted = m
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-mark-all"]')!.click()
+    await flush()
+    expect(m.container.querySelector('.meta-notif-bell__state--error')?.textContent).toContain('mark fail')
+    // the list is NOT replaced by the error — both render
+    expect(m.container.querySelectorAll('[data-test="notification-item"]').length).toBe(2)
+  })
+
   it('does not crash when the client fails — renders the error state instead (P2-1)', async () => {
     const m = mount({ listRecordSubscriptionNotifications: vi.fn(async () => { throw new Error('netfail') }) }); mounted = m
     await flush()

--- a/apps/web/tests/meta-notification-bell.spec.ts
+++ b/apps/web/tests/meta-notification-bell.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Notification Center S1b — MetaNotificationBell render + interaction.
+ * Bell + unread badge, panel open loads the list, unread dot, click-to-locate emits navigate +
+ * marks the item read, mark-all-read. A failing client must not crash the component (P2-1).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaNotificationBell from '../src/multitable/components/MetaNotificationBell.vue'
+import type { MetaRecordSubscriptionNotification } from '../src/multitable/types'
+
+function notif(id: string, readAt: string | null = null): MetaRecordSubscriptionNotification {
+  return { id, sheetId: 's1', recordId: `rec_${id}`, userId: 'u1', eventType: 'record.updated', actorId: null, revisionId: null, commentId: null, createdAt: '2026-06-16T00:00:00Z', readAt }
+}
+const flush = async () => { await nextTick(); await Promise.resolve(); await Promise.resolve(); await nextTick() }
+
+function mount(over: Record<string, unknown> = {}, onNavigate?: (p: unknown) => void) {
+  const apiClient = {
+    listRecordSubscriptionNotifications: vi.fn(async () => [notif('a'), notif('b', '2026-06-16T01:00:00Z')]),
+    getRecordSubscriptionUnreadCount: vi.fn(async () => 2),
+    markRecordSubscriptionNotificationsRead: vi.fn(async () => 1),
+    markAllRecordSubscriptionNotificationsRead: vi.fn(async () => 1),
+    ...over,
+  }
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaNotificationBell, { apiClient: apiClient as never, ...(onNavigate ? { onNavigate } : {}) }) })
+  app.mount(container)
+  return { container, app, apiClient }
+}
+
+describe('MetaNotificationBell (S1b)', () => {
+  let mounted: { container: HTMLElement; app: App } | null = null
+  afterEach(() => { if (mounted) { mounted.app.unmount(); mounted.container.remove(); mounted = null } })
+
+  it('shows the unread badge from the ambient count, then lists notifications on open', async () => {
+    const m = mount(); mounted = m
+    await flush()
+    expect(m.container.querySelector('[data-test="notification-bell-badge"]')?.textContent).toBe('2')
+    // panel is closed until clicked
+    expect(m.container.querySelector('[data-test="notification-panel"]')).toBeNull()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    expect(m.container.querySelector('[data-test="notification-panel"]')).not.toBeNull()
+    expect(m.container.querySelectorAll('[data-test="notification-item"]').length).toBe(2)
+    // the unread one (a) shows a dot; the read one (b) does not
+    expect(m.container.querySelectorAll('[data-test="notification-unread-dot"]').length).toBe(1)
+  })
+
+  it('clicking an item emits navigate {sheetId, recordId} and marks it read', async () => {
+    const onNavigate = vi.fn()
+    const m = mount({}, onNavigate); mounted = m
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    m.container.querySelector<HTMLElement>('[data-test="notification-item"]')!.click() // first item = unread 'a'
+    await flush()
+    expect(onNavigate).toHaveBeenCalledWith({ sheetId: 's1', recordId: 'rec_a' })
+    expect(m.apiClient.markRecordSubscriptionNotificationsRead).toHaveBeenCalledWith(['a'])
+  })
+
+  it('mark-all-read calls the client and the panel closes the item back to read', async () => {
+    const m = mount(); mounted = m
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-mark-all"]')!.click()
+    await flush()
+    expect(m.apiClient.markAllRecordSubscriptionNotificationsRead).toHaveBeenCalled()
+  })
+
+  it('does not crash when the client fails — renders the error state instead (P2-1)', async () => {
+    const m = mount({ listRecordSubscriptionNotifications: vi.fn(async () => { throw new Error('netfail') }) }); mounted = m
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    // panel still renders; error surfaced; no throw escaped the click
+    expect(m.container.querySelector('[data-test="notification-panel"]')).not.toBeNull()
+    expect(m.container.querySelector('.meta-notif-bell__state--error')?.textContent).toContain('netfail')
+  })
+})

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -889,6 +889,34 @@ describe('MultitableApiClient', () => {
     expect(fetchFn).toHaveBeenCalledWith('/api/multitable/record-subscription-notifications?sheetId=sheet_1&recordId=rec_1&limit=10')
   })
 
+  // Notification Center S1b — real-wire coverage for the 3 read-state methods (#1779/#1781 forward
+  // rule: every contract-consuming method must round-trip URL/method/envelope, not be mocked away).
+  it('getRecordSubscriptionUnreadCount GETs the unread-count route and unwraps data.count', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: { count: 4 } }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    await expect(client.getRecordSubscriptionUnreadCount()).resolves.toBe(4)
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/record-subscription-notifications/unread-count')
+  })
+
+  it('markRecordSubscriptionNotificationsRead POSTs ids to /mark-read and unwraps data.updated', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: { updated: 2 } }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    await expect(client.markRecordSubscriptionNotificationsRead(['n1', 'n2'])).resolves.toBe(2)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/record-subscription-notifications/mark-read')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({ ids: ['n1', 'n2'] })
+  })
+
+  it('markAllRecordSubscriptionNotificationsRead POSTs to /mark-all-read and unwraps data.updated', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: { updated: 9 } }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    await expect(client.markAllRecordSubscriptionNotificationsRead()).resolves.toBe(9)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/record-subscription-notifications/mark-all-read')
+    expect(init.method).toBe('POST')
+  })
+
   it('parses Retry-After seconds and http-date values', () => {
     expect(parseRetryAfterMs('2')).toBe(2000)
     expect(parseRetryAfterMs('Wed, 25 Mar 2026 12:00:05 GMT')).toBe(5000)

--- a/apps/web/tests/use-notification-inbox.spec.ts
+++ b/apps/web/tests/use-notification-inbox.spec.ts
@@ -65,6 +65,19 @@ describe('useNotificationInbox (S1b)', () => {
     expect(inbox.unreadCount.value).toBe(0)
   })
 
+  it('markAllRead failure sets error but keeps the list; a later success clears error (no dead-state)', async () => {
+    const markAll = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(1)
+    const inbox = useNotificationInbox(fakeClient({ markAllRecordSubscriptionNotificationsRead: markAll }))
+    await inbox.loadInbox()
+    expect(inbox.notifications.value.length).toBe(2)
+    await inbox.markAllRead() // fails
+    expect(inbox.error.value).toBe('boom')
+    expect(inbox.notifications.value.length).toBe(2) // list NOT cleared
+    await inbox.markAllRead() // succeeds → error must clear (recovers the panel)
+    expect(inbox.error.value).toBeNull()
+    expect(inbox.notifications.value.every((n) => n.readAt)).toBe(true)
+  })
+
   it('refreshUnreadCount keeps the prior count on failure (non-fatal badge)', async () => {
     const get = vi.fn().mockResolvedValueOnce(5).mockRejectedValueOnce(new Error('x'))
     const inbox = useNotificationInbox(fakeClient({ getRecordSubscriptionUnreadCount: get }))

--- a/apps/web/tests/use-notification-inbox.spec.ts
+++ b/apps/web/tests/use-notification-inbox.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Notification Center S1b — useNotificationInbox composable.
+ * Locks: list/mark logic + the review-fixed invariant that UI-facing actions NEVER throw (a rejected
+ * bell click would leak as an unhandled rejection / Vue console error). loadInbox + markRead resolve
+ * and set `error` on failure rather than rejecting; refreshUnreadCount is non-fatal.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../src/composables/useLocale', () => ({ useLocale: () => ({ isZh: { value: false } }) }))
+
+import { useNotificationInbox } from '../src/multitable/composables/useNotificationInbox'
+import type { MetaRecordSubscriptionNotification } from '../src/multitable/types'
+
+function notif(id: string, readAt: string | null = null): MetaRecordSubscriptionNotification {
+  return { id, sheetId: 's1', recordId: `rec_${id}`, userId: 'u1', eventType: 'record.updated', actorId: null, revisionId: null, commentId: null, createdAt: '2026-06-16T00:00:00Z', readAt }
+}
+function fakeClient(over: Record<string, unknown> = {}) {
+  return {
+    listRecordSubscriptionNotifications: vi.fn(async () => [notif('a'), notif('b', '2026-06-16T01:00:00Z')]),
+    getRecordSubscriptionUnreadCount: vi.fn(async () => 1),
+    markRecordSubscriptionNotificationsRead: vi.fn(async () => 1),
+    markAllRecordSubscriptionNotificationsRead: vi.fn(async () => 1),
+    ...over,
+  } as never
+}
+
+describe('useNotificationInbox (S1b)', () => {
+  it('loadInbox populates notifications on success', async () => {
+    const inbox = useNotificationInbox(fakeClient())
+    const items = await inbox.loadInbox()
+    expect(items.length).toBe(2)
+    expect(inbox.notifications.value.length).toBe(2)
+    expect(inbox.error.value).toBeNull()
+  })
+
+  it('loadInbox sets error and RESOLVES on failure (no unhandled rejection)', async () => {
+    const inbox = useNotificationInbox(fakeClient({ listRecordSubscriptionNotifications: vi.fn(async () => { throw new Error('boom') }) }))
+    await expect(inbox.loadInbox()).resolves.toBeDefined()
+    expect(inbox.error.value).toBe('boom')
+    expect(inbox.loading.value).toBe(false)
+  })
+
+  it('markRead sets readAt locally + refreshes the badge on success', async () => {
+    const client = fakeClient({ getRecordSubscriptionUnreadCount: vi.fn(async () => 0) })
+    const inbox = useNotificationInbox(client)
+    await inbox.loadInbox()
+    await inbox.markRead(['a'])
+    expect(inbox.notifications.value.find((n) => n.id === 'a')?.readAt).toBeTruthy()
+    expect(inbox.unreadCount.value).toBe(0)
+    expect((client as unknown as { markRecordSubscriptionNotificationsRead: ReturnType<typeof vi.fn> }).markRecordSubscriptionNotificationsRead).toHaveBeenCalledWith(['a'])
+  })
+
+  it('markRead sets error and RESOLVES on failure (no unhandled rejection)', async () => {
+    const inbox = useNotificationInbox(fakeClient({ markRecordSubscriptionNotificationsRead: vi.fn(async () => { throw new Error('netfail') }) }))
+    await inbox.loadInbox()
+    await expect(inbox.markRead(['a'])).resolves.toBeUndefined()
+    expect(inbox.error.value).toBe('netfail')
+  })
+
+  it('markAllRead marks every local row read and zeroes the badge', async () => {
+    const inbox = useNotificationInbox(fakeClient())
+    await inbox.loadInbox()
+    await inbox.markAllRead()
+    expect(inbox.notifications.value.every((n) => n.readAt)).toBe(true)
+    expect(inbox.unreadCount.value).toBe(0)
+  })
+
+  it('refreshUnreadCount keeps the prior count on failure (non-fatal badge)', async () => {
+    const get = vi.fn().mockResolvedValueOnce(5).mockRejectedValueOnce(new Error('x'))
+    const inbox = useNotificationInbox(fakeClient({ getRecordSubscriptionUnreadCount: get }))
+    await inbox.refreshUnreadCount()
+    expect(inbox.unreadCount.value).toBe(5)
+    await inbox.refreshUnreadCount() // fails → keeps 5, never rejects
+    expect(inbox.unreadCount.value).toBe(5)
+  })
+})


### PR DESCRIPTION
FE half of **Notification Center S1** — the watcher-notification inbox bell, against the parity-locked S1a contract (#2714). Owner scope: surface existing rows; **out**: send_notification sink, push/WS, email, preferences.

## What
- `client`: getRecordSubscriptionUnreadCount / markRecordSubscriptionNotificationsRead / markAll.
- `useNotificationInbox` composable (mirrors comment-inbox): list + unread badge + self-scoped mark-read/all; **UI-facing actions never throw** (set `error`, resolve).
- `MetaNotificationBell.vue`: 🔔 toolbar button + unread badge + dropdown (event label / time / unread dot), Mark-all-read, click-to-locate (emits `navigate {sheetId, recordId}`, marks item read).
- workbench: bell in the toolbar + `onNotificationNavigate` (cross-sheet switch → resolveDeepLink).
- 7 typed `notification.*` i18n keys (no raw strings).

## Review fixes (both P2 from FE review)
- **P2-1** async failure leaked as unhandled rejection → composable actions resolve + set `error`.
- **P2-2** cross-sheet locate continued after a cancelled discard-confirm → `onSelectSheet` returns boolean; navigate bails on false.

## Verification
`vue-tsc -b` clean · `useNotificationInbox` **6/6** (incl. loadInbox/markRead resolve-not-reject) · `MetaNotificationBell` **4/4** · Path A browser: **0 console/pageerror on both happy + failure paths** + open-panel visual. Reconciled to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)