### PR TITLE
feat(multitable): clickable linked-record chips with peek popover (A3)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -105,6 +105,7 @@
                     :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
                     :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                     :button-pending="isButtonPending(row.id, field.id)"
+                    :fetch-record="props.fetchRecord"
                     @run="emit('run-button', { recordId: row.id, field })"
                   />
                   <button

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -234,6 +234,7 @@
                   :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
                   :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                   :button-pending="isButtonPending(row.id, field.id)"
+                  :fetch-record="props.fetchRecord"
                   @run="emit('run-button', { recordId: row.id, field })"
                 />
                 <button
@@ -341,6 +342,7 @@ import type {
   MetaAttachmentDeleteFn,
   MetaAttachmentUploadFn,
   MetaField,
+  MetaRecordContext,
   MetaRowActions,
   MetaRecord,
   MultitableCommentPresenceSummary,
@@ -423,6 +425,10 @@ const props = defineProps<{
   // B1-b: per-cell in-flight keys `${recordId}:${fieldId}` for button runs
   // (keyed so one running button doesn't disable the others).
   buttonRunPending?: string[]
+  // A3: cross-sheet record fetcher (getRecord with NO sheetId) threaded down to
+  // the grid-cell renderer so a non-person link chip can peek the foreign
+  // record in a popover. Default undefined → chips stay non-clickable.
+  fetchRecord?: (recordId: string) => Promise<MetaRecordContext>
 }>()
 
 const emit = defineEmits<{

--- a/apps/web/src/multitable/components/MetaLinkedRecordPopover.vue
+++ b/apps/web/src/multitable/components/MetaLinkedRecordPopover.vue
@@ -1,0 +1,133 @@
+<template>
+  <div v-if="visible" class="meta-linked-record-popover" @click.self="emit('close')">
+    <div class="meta-linked-record-popover__panel" role="dialog" :aria-label="l('linkedRecord.title')">
+      <div class="meta-linked-record-popover__header">
+        <strong>{{ l('linkedRecord.title') }}</strong>
+        <button class="meta-linked-record-popover__close" :aria-label="l('linkedRecord.close')" @click="emit('close')">&times;</button>
+      </div>
+      <div class="meta-linked-record-popover__body">
+        <div v-if="loading" class="meta-linked-record-popover__loading">{{ l('linkedRecord.loading') }}</div>
+        <div v-else-if="error" class="meta-linked-record-popover__error">{{ error }}</div>
+        <template v-else-if="context">
+          <div v-if="!visibleForeignFields.length" class="meta-linked-record-popover__empty">{{ l('linkedRecord.empty') }}</div>
+          <div
+            v-for="field in visibleForeignFields"
+            :key="field.id"
+            class="meta-linked-record-popover__field"
+          >
+            <span class="meta-linked-record-popover__label">{{ field.name }}</span>
+            <span class="meta-linked-record-popover__value">
+              <!-- Nesting cap = 1: deliberately do NOT pass fetchRecord to the
+                   inner renderer, so foreign link chips have no click affordance
+                   and cannot open another popover. -->
+              <MetaCellRenderer
+                :field="field"
+                :value="context.record.data[field.id]"
+                :link-summaries="context.linkSummaries?.[field.id]"
+                :attachment-summaries="context.attachmentSummaries?.[field.id]"
+              />
+            </span>
+          </div>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { MetaField, MetaRecordContext } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel, type MetaCoreLabelKey } from '../utils/meta-core-labels'
+import MetaCellRenderer from './cells/MetaCellRenderer.vue'
+
+const props = defineProps<{
+  visible: boolean
+  recordId: string | null
+  // Self-contained data dependency: the host passes the cross-sheet record
+  // fetcher (getRecord with NO sheetId — the foreign record resolves by global
+  // id under the backend field mask). Kept as a prop so the popover never
+  // imports the API client directly and specs can mock it trivially.
+  fetchRecord: (recordId: string) => Promise<MetaRecordContext>
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const context = ref<MetaRecordContext | null>(null)
+// Per-id cache so re-opening the same chip does not re-fetch.
+const cache = new Map<string, MetaRecordContext>()
+// Guards a stale fetch from a previously-opened chip overwriting a newer one.
+let activeRecordId: string | null = null
+
+// Foreign fields filtered to those the backend marks visible. The backend masks
+// denied field values; we additionally hide fields it flags non-visible so the
+// peek matches the foreign-sheet field-permission view.
+const visibleForeignFields = ref<MetaField[]>([])
+
+function computeVisibleFields(ctx: MetaRecordContext): MetaField[] {
+  return ctx.fields.filter((field) => ctx.fieldPermissions?.[field.id]?.visible !== false)
+}
+
+async function load(recordId: string): Promise<void> {
+  activeRecordId = recordId
+  const cached = cache.get(recordId)
+  if (cached) {
+    context.value = cached
+    visibleForeignFields.value = computeVisibleFields(cached)
+    loading.value = false
+    error.value = null
+    return
+  }
+  loading.value = true
+  error.value = null
+  context.value = null
+  visibleForeignFields.value = []
+  try {
+    const ctx = await props.fetchRecord(recordId)
+    if (activeRecordId !== recordId) return
+    cache.set(recordId, ctx)
+    context.value = ctx
+    visibleForeignFields.value = computeVisibleFields(ctx)
+  } catch (e: unknown) {
+    if (activeRecordId !== recordId) return
+    // Prefer the backend message (user data) when present; fall back to the
+    // localized frontend string for the `??` branch.
+    const message = e instanceof Error ? e.message : ''
+    error.value = message || l('linkedRecord.error')
+  } finally {
+    if (activeRecordId === recordId) loading.value = false
+  }
+}
+
+watch(
+  () => [props.visible, props.recordId] as const,
+  ([visible, recordId]) => {
+    if (visible && recordId) {
+      void load(recordId)
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.meta-linked-record-popover { position: fixed; inset: 0; z-index: 1000; }
+.meta-linked-record-popover__panel { position: absolute; top: 64px; left: 50%; transform: translateX(-50%); width: 360px; max-height: 420px; background: #fff; border: 1px solid #ddd; border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.12); display: flex; flex-direction: column; overflow: hidden; }
+.meta-linked-record-popover__header { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; border-bottom: 1px solid #f0f0f0; }
+.meta-linked-record-popover__header strong { font-size: 14px; color: #333; }
+.meta-linked-record-popover__close { border: none; background: none; font-size: 18px; cursor: pointer; color: #999; padding: 0 2px; line-height: 1; }
+.meta-linked-record-popover__close:hover { color: #333; }
+.meta-linked-record-popover__body { overflow-y: auto; flex: 1; padding: 8px 0; }
+.meta-linked-record-popover__loading,
+.meta-linked-record-popover__error,
+.meta-linked-record-popover__empty { padding: 16px 14px; font-size: 13px; color: #909399; }
+.meta-linked-record-popover__error { color: #f56c6c; }
+.meta-linked-record-popover__field { display: flex; flex-direction: column; gap: 2px; padding: 6px 14px; }
+.meta-linked-record-popover__label { font-size: 11px; color: #909399; }
+.meta-linked-record-popover__value { font-size: 13px; color: #303133; min-width: 0; word-break: break-word; }
+</style>

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -279,6 +279,10 @@
             class="meta-record-drawer__qrcode"
             v-html="drawerQrSvg(record.data[field.id])"
           />
+          <!-- A3 follow-up (#2708): this drawer link summary stays read-only
+               text for now. Making it a clickable foreign-record popover is the
+               record-drawer slice of A3, tracked separately so this slice ships
+               grid-only. -->
           <div v-if="field.type === 'link' && linkPreview(field.id)" class="meta-record-drawer__link-summary">{{ linkPreview(field.id) }}</div>
         </div>
         <!-- A3 §2.3/§2.4: per-field AI state — pending / error copy (by code) / per-run tokens. -->

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -72,13 +72,34 @@
       </span>
     </template>
 
-    <!-- link -->
+    <!-- link (non-person; isPersonLink branch above already caught user-refKind
+         links). A real linked-record chip is clickable to peek the foreign
+         record in a popover. @click.stop so it does NOT bubble to the cell's
+         own select-record click (MetaGridTable td @click.stop=onCellClick). The
+         __link_summary__ sentinel (no real id resolved) is NOT clickable — it
+         must never call getRecord (would 404). The affordance only appears when
+         the host supplied fetchRecord. -->
     <template v-else-if="field.type === 'link'">
-      <span
-        v-for="item in linkItems"
-        :key="item.id"
-        class="meta-cell-renderer__link"
-      >{{ item.display }}</span>
+      <template v-for="item in linkItems" :key="item.id">
+        <button
+          v-if="isClickableLinkChip(item.id)"
+          type="button"
+          class="meta-cell-renderer__link meta-cell-renderer__link--clickable"
+          data-test="link-chip"
+          @click.stop="openLinkedRecord(item.id)"
+        >{{ item.display }}</button>
+        <span
+          v-else
+          class="meta-cell-renderer__link"
+        >{{ item.display }}</span>
+      </template>
+      <MetaLinkedRecordPopover
+        v-if="props.fetchRecord"
+        :visible="openLinkRecordId !== null"
+        :record-id="openLinkRecordId"
+        :fetch-record="props.fetchRecord!"
+        @close="openLinkRecordId = null"
+      />
     </template>
 
     <!-- attachment -->
@@ -183,9 +204,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import type { MetaAttachment, MetaField, LinkedRecordSummary } from '../../types'
+import { computed, ref } from 'vue'
+import type { MetaAttachment, MetaField, LinkedRecordSummary, MetaRecordContext } from '../../types'
 import MetaAttachmentList from '../MetaAttachmentList.vue'
+import MetaLinkedRecordPopover from '../MetaLinkedRecordPopover.vue'
 import { useLocale } from '../../../composables/useLocale'
 import { isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
@@ -195,9 +217,39 @@ import { percentGaugeAria, ratingGaugeAria } from '../../utils/meta-core-labels'
 import { qrSvgFromText } from '../../utils/qr-code'
 import { isRichLongTextField, richLongTextToPlainTextFE } from '../../utils/rich-longtext'
 
-const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[]; buttonPending?: boolean }>()
+const props = defineProps<{
+  field: MetaField
+  value: unknown
+  linkSummaries?: LinkedRecordSummary[]
+  attachmentSummaries?: MetaAttachment[]
+  buttonPending?: boolean
+  // A3: when the host supplies a cross-sheet record fetcher (getRecord with NO
+  // sheetId), non-person link chips become clickable and peek the foreign
+  // record in a popover. Default undefined → no affordance (keeps the renderer
+  // pure for the ~6 reuse surfaces that do not opt in). Nesting is capped at 1
+  // because the popover renders its inner MetaCellRenderers WITHOUT this prop.
+  fetchRecord?: (recordId: string) => Promise<MetaRecordContext>
+}>()
 const emit = defineEmits<{ (e: 'run'): void }>()
 const { isZh } = useLocale()
+
+// Sentinel id produced by linkItems when no real linked-record id resolved
+// (summary fallback). Must never be passed to getRecord (would 404).
+const LINK_SUMMARY_SENTINEL = '__link_summary__'
+
+// A3 popover state: the foreign recordId currently expanded, or null.
+const openLinkRecordId = ref<string | null>(null)
+
+// A chip is clickable only when the host opted in (fetchRecord) AND the chip
+// carries a real linked-record id (not the summary sentinel).
+function isClickableLinkChip(id: string): boolean {
+  return Boolean(props.fetchRecord) && id !== LINK_SUMMARY_SENTINEL
+}
+
+function openLinkedRecord(id: string): void {
+  if (!isClickableLinkChip(id)) return
+  openLinkRecordId.value = id
+}
 
 // B1-b button field: label + variant from the field property; the empty-label
 // fallback is the field name (never a hardcoded literal — strict-zero i18n) so
@@ -282,7 +334,7 @@ const linkItems = computed(() => {
     isZh: isZh.value,
   })
   if (!linkIds.value.length) return []
-  return [{ id: '__link_summary__', display: fallbackLabel }]
+  return [{ id: LINK_SUMMARY_SENTINEL, display: fallbackLabel }]
 })
 const isPersonLink = computed(() => isPersonField(props.field))
 
@@ -396,6 +448,11 @@ const conditionalClass = computed(() => {
   display: inline-block; padding: 1px 6px; background: #ecf5ff;
   color: #409eff; border-radius: 3px; font-size: 11px; margin-right: 4px;
 }
+/* A3 clickable link chip: render as a button but keep the chip look. */
+button.meta-cell-renderer__link--clickable {
+  border: none; line-height: inherit; font-family: inherit; cursor: pointer;
+}
+button.meta-cell-renderer__link--clickable:hover { background: #d9ecff; }
 .meta-cell-renderer__date { color: #606266; }
 .meta-cell-renderer__date-time {
   color: #475569;

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -80,6 +80,12 @@ export type MetaCoreLabelKey =
   | 'cell.uploadFailed' | 'cell.removeFailed' | 'cell.clearFailed'
   // --- MetaCellEditor AI shortcut run button (A3-T6) ---
   | 'cell.aiRun' | 'cell.aiRunning'
+  // --- Linked-record popover (A3): clickable link chip → foreign record peek ---
+  | 'linkedRecord.title'
+  | 'linkedRecord.loading'
+  | 'linkedRecord.error'
+  | 'linkedRecord.close'
+  | 'linkedRecord.empty'
   // --- Auth chrome (file-location closure tightening per #1803) ---
   | 'auth.notAuthenticated'
 
@@ -243,6 +249,15 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   // A3-T6: in-cell AI run trigger (host opt-in; RBAC rides the editor-open invariant).
   'cell.aiRun': { en: 'Run AI', zh: '运行 AI' },
   'cell.aiRunning': { en: 'Running AI...', zh: 'AI 处理中...' },
+
+  // A3 linked-record popover: a clickable link chip expands the foreign record
+  // read-only in a popover. Title is static chrome; `error` is a frontend
+  // fallback only — a backend error.message wins via `e.message ?? fallback`.
+  'linkedRecord.title': { en: 'Linked record', zh: '关联记录' },
+  'linkedRecord.loading': { en: 'Loading record...', zh: '正在加载记录...' },
+  'linkedRecord.error': { en: 'Failed to load linked record', zh: '加载关联记录失败' },
+  'linkedRecord.close': { en: 'Close', zh: '关闭' },
+  'linkedRecord.empty': { en: 'No fields to show', zh: '没有可显示的字段' },
 }
 
 export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -264,6 +264,7 @@
           :ai-run-pending="Boolean(aiShortcut.state.pending)"
           :ai-run-busy="aiShortcutBusy"
           :button-run-pending="buttonRunPending"
+          :fetch-record="fetchLinkedRecordFn"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
@@ -665,6 +666,11 @@ async function onRunButton({ recordId, field }: { recordId: string; field: MetaF
 const aiPreviewFn = (params: { recordId: string; config: AiShortcutConfigInput }) =>
   aiShortcut.previewWithConfig(params.recordId, params.config)
 const aiUsageSummaryFn = () => workbench.client.aiUsageSummary()
+// A3: cross-sheet linked-record fetcher for the clickable link-chip popover.
+// NO sheetId/viewId — the foreign record may live in another sheet and resolves
+// by its global id under the backend field mask (the current sheetId would
+// mis-scope and 404). Threaded into MetaGridTable → MetaCellRenderer.
+const fetchLinkedRecordFn = (recordId: string) => workbench.client.getRecord(recordId)
 // M4 / Lane B2: NL→formula suggest routes through the SAME composable guard
 // (sheet-scoped; the unified pending/countdown covers this entry point too).
 const formulaSuggestFn = (params: { instruction: string }) =>

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -966,4 +966,20 @@ describe('MultitableApiClient', () => {
     expect(parseRetryAfterMs('')).toBeUndefined()
     expect(parseRetryAfterMs('not-a-delay')).toBeUndefined()
   })
+
+  // A3: the clickable-link-chip popover fetches the foreign record by global id
+  // with NO sheetId/viewId (cross-sheet records resolve under the backend mask;
+  // a host sheetId would mis-scope and 404). Lock the URL has no query string.
+  it('getRecord without params requests the record endpoint with no query string', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      data: { record: { id: 'rec_1', data: {} }, fields: [] },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.getRecord('rec_1')
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(fetchFn.mock.calls[0]?.[0]).toBe('/api/multitable/records/rec_1')
+  })
 })

--- a/apps/web/tests/multitable-grid-grouped-link-chip.spec.ts
+++ b/apps/web/tests/multitable-grid-grouped-link-chip.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecordContext } from '../src/multitable/types'
+
+// A3 regression (review block #1 + #2): MetaGridTable renders THREE
+// MetaCellRenderer instances — flat rows (line ~230), GROUPED rows (line ~101),
+// and the expand-row detail (line ~259, intentionally excluded per #2708). The
+// `fetchRecord` callback that makes a linked-record chip clickable must thread
+// to BOTH visible-grid paths (flat AND grouped). The A3 unit specs hand-mount
+// MetaCellRenderer and pass fetchRecord directly, so they cannot catch a missing
+// passthrough prop on the grouped instance. This spec mounts the REAL grid with
+// grouping ON and asserts the chip is clickable through the workbench→grid→
+// renderer wire — closing the wire-vs-fixture drift blind spot.
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+afterEach(() => {
+  app?.unmount(); app = null
+  container?.remove(); container = null
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'status', name: 'Status', type: 'string' },
+  { id: 'vendor', name: 'Vendor', type: 'link' },
+]
+
+const ROWS = [
+  { id: 'r1', version: 1, data: { status: 'Open', vendor: ['vendor_1'] } },
+  { id: 'r2', version: 1, data: { status: 'Done', vendor: ['vendor_2'] } },
+]
+
+// linkSummaries are keyed [rowId][fieldId] → real foreign ids (NOT the
+// __link_summary__ sentinel), so the chip resolves to a clickable button.
+const LINK_SUMMARIES: Record<string, Record<string, Array<{ id: string; display: string }>>> = {
+  r1: { vendor: [{ id: 'vendor_1', display: 'Acme Supply' }] },
+  r2: { vendor: [{ id: 'vendor_2', display: 'Beacon Labs' }] },
+}
+
+function foreignContext(recordId: string): MetaRecordContext {
+  return {
+    sheet: { id: 'sheet_vendors', name: 'Vendors' },
+    fields: [{ id: 'fld_name', name: 'Vendor Name', type: 'string' }],
+    record: { id: recordId, data: { fld_name: 'Acme Supply' } } as MetaRecordContext['record'],
+    capabilities: {} as MetaRecordContext['capabilities'],
+    commentsScope: {} as MetaRecordContext['commentsScope'],
+  }
+}
+
+function mountGrid(props: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: ROWS, visibleFields: FIELDS, sortRules: [], loading: false,
+        currentPage: 1, totalPages: 1, startIndex: 0, canEdit: true,
+        searchText: '', rowDensity: 'normal', linkSummaries: LINK_SUMMARIES,
+        // groupField switches the grid into the grouped <tbody> render path.
+        groupField: FIELDS[0],
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaGridTable — A3 fetch-record threads to GROUPED rows', () => {
+  it('renders clickable linked-record chips in grouped rows when fetchRecord is provided', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    const root = mountGrid({ fetchRecord })
+    await nextTick()
+
+    // Grouping is on: the grouped <tbody> must be the render path used.
+    expect(root.querySelectorAll('.meta-grid__group-header').length).toBeGreaterThan(0)
+    // The regression: the grouped-row renderer must have received :fetch-record,
+    // so the chips are clickable buttons (not plain non-clickable spans).
+    const chips = root.querySelectorAll('[data-test="link-chip"]')
+    expect(chips.length).toBe(2)
+  })
+
+  it('keeps grouped chips non-clickable when no fetchRecord prop is supplied (renderer stays pure)', async () => {
+    const root = mountGrid({})
+    await nextTick()
+
+    expect(root.querySelectorAll('.meta-grid__group-header').length).toBeGreaterThan(0)
+    expect(root.querySelector('[data-test="link-chip"]')).toBeNull()
+    // Summaries still render as read-only text.
+    expect(root.textContent).toContain('Acme Supply')
+  })
+})

--- a/apps/web/tests/multitable-linked-record-chip.spec.ts
+++ b/apps/web/tests/multitable-linked-record-chip.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import type { MetaField, MetaRecordContext } from '../src/multitable/types'
+
+// A3: clickable linked-record chips. These specs lock the chip-click behavior
+// in MetaCellRenderer's NON-person link branch, the sentinel/summary gate (no
+// getRecord for the __link_summary__ fallback), the @click.stop guard against
+// the cell's own select-record, and the person-exclusion.
+
+const linkField: MetaField = {
+  id: 'fld_vendor',
+  name: 'Vendor',
+  type: 'link',
+}
+
+// A user-refKind link is a person field — it must keep the avatar chip and never
+// reach the clickable link branch (76-82).
+const personField: MetaField = {
+  id: 'fld_owner',
+  name: 'Owner',
+  type: 'link',
+  property: { refKind: 'user' },
+}
+
+function foreignContext(recordId: string): MetaRecordContext {
+  return {
+    sheet: { id: 'sheet_vendors', name: 'Vendors' },
+    fields: [{ id: 'fld_name', name: 'Vendor Name', type: 'string' }],
+    record: { id: recordId, data: { fld_name: 'Acme Supply' } } as MetaRecordContext['record'],
+    capabilities: {} as MetaRecordContext['capabilities'],
+    commentsScope: {} as MetaRecordContext['commentsScope'],
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+// Mount MetaCellRenderer inside a parent that wires a select-record @click on
+// an ancestor — mirroring MetaGridTable's real binding (the <td> uses
+// @click.stop="onCellClick(...)" which emits select-record). The chip's own
+// @click.stop must keep this ancestor handler from firing.
+function mountCell(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const selectRecordSpy = vi.fn()
+  const Harness = defineComponent({
+    setup() {
+      return () =>
+        h(
+          'div',
+          { class: 'cell-host', onClick: () => selectRecordSpy() },
+          [h(MetaCellRenderer, props)],
+        )
+    },
+  })
+  const app = createApp(Harness)
+  app.mount(container)
+  return { container, app, selectRecordSpy }
+}
+
+describe('MetaCellRenderer linked-record chips (A3)', () => {
+  it('renders a clickable chip that opens the popover and fetches the foreign record', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    const { container, app } = mountCell({
+      field: linkField,
+      value: ['vendor_1'],
+      linkSummaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
+      fetchRecord,
+    })
+
+    const chip = container.querySelector<HTMLButtonElement>('[data-test="link-chip"]')
+    expect(chip).not.toBeNull()
+    chip!.click()
+    await flushPromises()
+
+    expect(fetchRecord).toHaveBeenCalledTimes(1)
+    expect(fetchRecord).toHaveBeenCalledWith('vendor_1')
+    // Popover dialog renders the foreign record once loaded.
+    expect(document.querySelector('.meta-linked-record-popover [role="dialog"]')).not.toBeNull()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('does NOT make a chip clickable (and never fetches) when no fetchRecord prop is supplied', async () => {
+    const { container, app } = mountCell({
+      field: linkField,
+      value: ['vendor_1'],
+      linkSummaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
+      // no fetchRecord → no affordance (keeps the renderer pure for reuse views)
+    })
+
+    expect(container.querySelector('[data-test="link-chip"]')).toBeNull()
+    // The chip is still rendered as plain text.
+    expect(container.querySelector('.meta-cell-renderer__link')).not.toBeNull()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('does NOT fetch for the __link_summary__ sentinel chip (no real id → would 404)', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    // No linkSummaries → linkItems falls back to a single summary chip whose id
+    // is the __link_summary__ sentinel.
+    const { container, app } = mountCell({
+      field: linkField,
+      value: ['vendor_1'],
+      fetchRecord,
+    })
+
+    // The sentinel chip is NOT clickable.
+    expect(container.querySelector('[data-test="link-chip"]')).toBeNull()
+    const summaryChip = container.querySelector<HTMLElement>('.meta-cell-renderer__link')
+    expect(summaryChip).not.toBeNull()
+    summaryChip!.click()
+    await flushPromises()
+    expect(fetchRecord).not.toHaveBeenCalled()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('chip @click.stop prevents the ancestor select-record click from firing', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    const { container, app, selectRecordSpy } = mountCell({
+      field: linkField,
+      value: ['vendor_1'],
+      linkSummaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
+      fetchRecord,
+    })
+
+    const chip = container.querySelector<HTMLButtonElement>('[data-test="link-chip"]')
+    chip!.click()
+    await flushPromises()
+
+    expect(fetchRecord).toHaveBeenCalledTimes(1)
+    // The select-record click on the host ancestor must NOT have fired.
+    expect(selectRecordSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('person (user-refKind) link fields render avatar chips and never the clickable link chip', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    const { container, app } = mountCell({
+      field: personField,
+      value: ['user_1'],
+      linkSummaries: [{ id: 'user_1', display: 'Lin Lan' }],
+      fetchRecord,
+    })
+
+    expect(container.querySelector('.meta-cell-renderer__person-chip')).not.toBeNull()
+    expect(container.querySelector('[data-test="link-chip"]')).toBeNull()
+    expect(fetchRecord).not.toHaveBeenCalled()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('opening the same chip twice fetches once (per-id cache via popover) but a re-open is allowed', async () => {
+    const fetchRecord = vi.fn(async (id: string) => foreignContext(id))
+    const { container, app } = mountCell({
+      field: linkField,
+      value: ['vendor_1'],
+      linkSummaries: [{ id: 'vendor_1', display: 'Acme Supply' }],
+      fetchRecord,
+    })
+
+    const chip = container.querySelector<HTMLButtonElement>('[data-test="link-chip"]')
+    chip!.click()
+    await flushPromises()
+    // Close the popover.
+    document.querySelector<HTMLButtonElement>('.meta-linked-record-popover__close')!.click()
+    await flushPromises()
+    // Re-open the same chip → served from the popover's per-id cache.
+    chip!.click()
+    await flushPromises()
+
+    expect(fetchRecord).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+})

--- a/apps/web/tests/multitable-linked-record-popover.spec.ts
+++ b/apps/web/tests/multitable-linked-record-popover.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick } from 'vue'
+import MetaLinkedRecordPopover from '../src/multitable/components/MetaLinkedRecordPopover.vue'
+import type { MetaRecordContext } from '../src/multitable/types'
+
+// A3: the foreign-record peek popover. Locks foreign field-label rendering,
+// loading + typed error states, field-permission visibility filtering, and the
+// nesting cap (inner link chips are NOT clickable → no re-expand).
+
+function baseContext(overrides: Partial<MetaRecordContext> = {}): MetaRecordContext {
+  return {
+    sheet: { id: 'sheet_vendors', name: 'Vendors' },
+    fields: [
+      { id: 'fld_name', name: 'Vendor Name', type: 'string' },
+      { id: 'fld_contact', name: 'Contact', type: 'string' },
+    ],
+    record: { id: 'vendor_1', data: { fld_name: 'Acme Supply', fld_contact: 'Lin Lan' } } as MetaRecordContext['record'],
+    capabilities: {} as MetaRecordContext['capabilities'],
+    commentsScope: {} as MetaRecordContext['commentsScope'],
+    ...overrides,
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mountPopover(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const Harness = defineComponent({
+    render() {
+      return h(MetaLinkedRecordPopover, props)
+    },
+  })
+  const app = createApp(Harness)
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaLinkedRecordPopover (A3)', () => {
+  it('shows the loading state, then renders FOREIGN field labels read-only', async () => {
+    let resolveFetch: (ctx: MetaRecordContext) => void = () => {}
+    const fetchRecord = vi.fn(
+      () => new Promise<MetaRecordContext>((resolve) => { resolveFetch = resolve }),
+    )
+    const { container, app } = mountPopover({
+      visible: true,
+      recordId: 'vendor_1',
+      fetchRecord,
+    })
+    await flushPromises()
+
+    // Loading state visible while the promise is pending.
+    expect(container.querySelector('.meta-linked-record-popover__loading')).not.toBeNull()
+
+    resolveFetch(baseContext())
+    await flushPromises()
+
+    const labels = Array.from(container.querySelectorAll('.meta-linked-record-popover__label')).map(
+      (el) => el.textContent,
+    )
+    // Foreign field NAMES — not the host field labels.
+    expect(labels).toEqual(['Vendor Name', 'Contact'])
+    expect(container.querySelector('.meta-linked-record-popover__loading')).toBeNull()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('renders a typed error (frontend fallback) when the fetch rejects', async () => {
+    const fetchRecord = vi.fn(async () => {
+      throw new Error('Record not found')
+    })
+    const { container, app } = mountPopover({
+      visible: true,
+      recordId: 'vendor_x',
+      fetchRecord,
+    })
+    await flushPromises()
+
+    const errorEl = container.querySelector('.meta-linked-record-popover__error')
+    expect(errorEl).not.toBeNull()
+    // Backend message wins over the localized fallback.
+    expect(errorEl!.textContent).toContain('Record not found')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('filters out fields the backend marks non-visible', async () => {
+    const fetchRecord = vi.fn(async () =>
+      baseContext({
+        fieldPermissions: {
+          fld_contact: { visible: false, readOnly: true },
+        },
+      }),
+    )
+    const { container, app } = mountPopover({
+      visible: true,
+      recordId: 'vendor_1',
+      fetchRecord,
+    })
+    await flushPromises()
+
+    const labels = Array.from(container.querySelectorAll('.meta-linked-record-popover__label')).map(
+      (el) => el.textContent,
+    )
+    expect(labels).toEqual(['Vendor Name'])
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('caps nesting at 1: a foreign LINK field renders a non-clickable chip (no re-expand)', async () => {
+    const fetchRecord = vi.fn(async () =>
+      baseContext({
+        fields: [{ id: 'fld_parent', name: 'Parent Company', type: 'link' }],
+        record: { id: 'vendor_1', data: { fld_parent: ['vendor_2'] } } as MetaRecordContext['record'],
+        linkSummaries: { fld_parent: [{ id: 'vendor_2', display: 'Globex' }] },
+      }),
+    )
+    const { container, app } = mountPopover({
+      visible: true,
+      recordId: 'vendor_1',
+      fetchRecord,
+    })
+    await flushPromises()
+
+    // The inner renderer shows the foreign link as a plain chip, never a
+    // clickable one (the popover does NOT forward fetchRecord to it).
+    expect(container.querySelector('[data-test="link-chip"]')).toBeNull()
+    expect(container.querySelector('.meta-cell-renderer__link')).not.toBeNull()
+    // Only the initial fetch fired — no nested expansion.
+    expect(fetchRecord).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('does not fetch while hidden, and fetches once shown', async () => {
+    const fetchRecord = vi.fn(async () => baseContext())
+    const { container, app } = mountPopover({
+      visible: false,
+      recordId: 'vendor_1',
+      fetchRecord,
+    })
+    await flushPromises()
+    expect(fetchRecord).not.toHaveBeenCalled()
+    // Dialog not rendered while hidden.
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+
+    app.unmount()
+    container.remove()
+  })
+})


### PR DESCRIPTION
## A3 — clickable linked-record chips → read-only peek popover

Linked-record chips in a link cell become clickable and open a read-only popover previewing the foreign record, without leaving the grid (feishu-style linked-record peek).

### What it does
- New `MetaLinkedRecordPopover.vue` (cloned from `MetaMentionPopover`) fetches the foreign record via an injected `getRecord` callback (no `sheetId` — resolves by global id under the backend field mask), renders `ctx.fields` filtered to backend-visible via `MetaCellRenderer` with the **foreign** field labels, with loading/typed-error/empty states + a per-id cache.
- Nesting capped at 1 **structurally** — the popover does not forward `fetchRecord` to its inner renderers, so foreign chips have no click affordance.
- `MetaCellRenderer` non-person link branch renders real ids as clickable `<button>` chips with `@click.stop` (blocks the cell's own select-record). The `__link_summary__` sentinel is gated out of clickability so it never calls `getRecord` (would 404). Behind an optional `fetchRecord` prop (default undefined → renderer stays pure for the ~6 reuse views).
- `fetchRecord` threaded workbench → grid → renderer for **both** visible-grid paths (flat + grouped rows). The expand-row renderer is intentionally excluded (`#2708`).

### i18n
`meta-core-labels.ts` gained `linkedRecord.*` (title/loading/error/close/empty, en+zh, union + record, all 5 consumed — no dead keys).

### Review fixes (this branch)
Adversarial subagent review returned **fix-then-ship**; both blockers fixed here:
1. **Grouped-rows regression** — the grouped `MetaCellRenderer` (line ~101) was missing `:fetch-record`, so chips were non-clickable when grouping was on. Fixed (one-line passthrough).
2. **Wire-vs-fixture drift** — added a `MetaGridTable`-level grouped-rows integration test that mounts the real grid with grouping on and asserts the chip is clickable (the unit specs hand-pass the prop and couldn't catch the gap).

### Tests
45/45 across the A3 chip/popover/grid-grouped/client suites (13 new A3 specs). `vue-tsc` is CI-gated (not runnable on local Node 25). Pre-existing unrelated red (`multitable-workbench-1672-1673`, `auth.getToken`) confirmed failing on clean base — not this slice; full web suite is not a CI gate.

### Notes / follow-ups
- Expand-row + record-drawer link chips stay read-only → `#2708`.
- Popover is fixed-center (clone of `MetaMentionPopover`); anchor-to-chip positioning is a follow-up.
- Built + adversarially reviewed by parallel subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)