### PR TITLE
feat(multitable): scale-rule authoring dialog + preserve-on-save fix (A5)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -351,6 +351,7 @@ import type {
 } from '../types'
 import type { SortRule } from '../composables/useMultitableGrid'
 import { composeStyleObject, type EvaluatedFormatting, type FieldScaleMap } from '../utils/conditional-formatting'
+import { glyphForIconKey, type ScaleIconGlyph } from '../utils/scale-icons'
 
 interface ConditionalFormattingByRecord {
   byRecordId: Map<string, EvaluatedFormatting>
@@ -697,23 +698,12 @@ function isButtonPending(rid: string, fid: string): boolean {
 }
 
 // A5-3 icon set render: map an `iconKey` (`${set}:${index}`) to a glyph + color.
-// The backend (conditional-formatting-service) only emits index ∈ {0,1,2}; an
-// out-of-range or unknown set yields no icon (fail-safe).
-const SCALE_ICON_GLYPHS: Record<string, ReadonlyArray<{ glyph: string; color: string }>> = {
-  arrows3: [{ glyph: '↓', color: '#e53935' }, { glyph: '→', color: '#fb8c00' }, { glyph: '↑', color: '#43a047' }],
-  traffic3: [{ glyph: '●', color: '#e53935' }, { glyph: '●', color: '#fbc02d' }, { glyph: '●', color: '#43a047' }],
-  signs3: [{ glyph: '✕', color: '#e53935' }, { glyph: '!', color: '#fb8c00' }, { glyph: '✓', color: '#43a047' }],
-}
-function cellScaleIcon(rid: string, fid: string): { glyph: string; color: string } | null {
+// The glyph table is shared with the authoring dialog (utils/scale-icons) so the
+// in-dialog preview matches the grid render exactly.
+function cellScaleIcon(rid: string, fid: string): ScaleIconGlyph | null {
   const entry = props.conditionalFormattingScale?.byField[fid]?.byRecordId[rid]
   if (!entry || typeof entry.iconKey !== 'string') return null
-  const sep = entry.iconKey.lastIndexOf(':')
-  if (sep < 0) return null
-  const set = entry.iconKey.slice(0, sep)
-  const idx = Number(entry.iconKey.slice(sep + 1))
-  const glyphs = SCALE_ICON_GLYPHS[set]
-  if (!glyphs || !Number.isInteger(idx) || idx < 0 || idx >= glyphs.length) return null
-  return glyphs[idx]
+  return glyphForIconKey(entry.iconKey)
 }
 
 // ── frozen columns (left-prefix) ──────────────────────────────────────────

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -31,6 +31,7 @@
             <span class="meta-view-mgr__type">{{ viewTypeLabel(view.type, isZh) }}</span>
             <button class="meta-view-mgr__action" :title="ml('action.configure')" @click="openConfig(view)">&#x2699;</button>
             <button class="meta-view-mgr__action" :title="ml('action.conditionalFormatting')" @click="openConditionalFormatting(view)">&#x1F3A8;</button>
+            <button class="meta-view-mgr__action" :title="ml('formatting.scaleAction')" @click="openScaleFormatting(view)">&#x1F4CA;</button>
             <button class="meta-view-mgr__action" :title="ml('action.rename')" @click="startRename(view)">&#x270E;</button>
             <button
               class="meta-view-mgr__action meta-view-mgr__action--danger"
@@ -431,6 +432,14 @@
       @close="closeConditionalFormatting"
       @save="onSaveConditionalFormatting"
     />
+    <ScaleFormattingDialog
+      :visible="scaleFormattingTargetId !== null"
+      :fields="fields"
+      :view-config="scaleFormattingTargetView?.config"
+      @update:dirty="scaleFormattingDirty = $event"
+      @close="closeScaleFormatting"
+      @save="onSaveScaleFormatting"
+    />
   </div>
 </template>
 
@@ -439,6 +448,7 @@ import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import type {
   ConditionalFormattingRule,
+  ConditionalFormattingScaleRule,
   MetaCalendarViewConfig,
   MetaField,
   MetaFieldPermission,
@@ -480,6 +490,7 @@ import {
   zoomLabel,
 } from '../utils/meta-manager-labels'
 import ConditionalFormattingDialog from './ConditionalFormattingDialog.vue'
+import ScaleFormattingDialog from './ScaleFormattingDialog.vue'
 
 const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt', 'hierarchy'] as const
 const VIEW_ICONS: Record<string, string> = {
@@ -583,10 +594,15 @@ const viewConfigLiveRefreshText = ref('')
 const viewConfigSourceSignature = ref('')
 const conditionalFormattingTargetId = ref<string | null>(null)
 const conditionalFormattingDirty = ref(false)
+const scaleFormattingTargetId = ref<string | null>(null)
+const scaleFormattingDirty = ref(false)
 
 const configTarget = computed(() => props.views.find((view) => view.id === configTargetId.value) ?? null)
 const conditionalFormattingTargetView = computed(() =>
   props.views.find((view) => view.id === conditionalFormattingTargetId.value) ?? null,
+)
+const scaleFormattingTargetView = computed(() =>
+  props.views.find((view) => view.id === scaleFormattingTargetId.value) ?? null,
 )
 const deleteTarget = computed(() => props.views.find((view) => view.id === deleteTargetId.value) ?? null)
 const configTargetFields = computed(() => props.fields)
@@ -772,6 +788,8 @@ function resetTransientState() {
   viewConfigSourceSignature.value = ''
   conditionalFormattingTargetId.value = null
   conditionalFormattingDirty.value = false
+  scaleFormattingTargetId.value = null
+  scaleFormattingDirty.value = false
   resetConfigDrafts()
 }
 
@@ -1003,15 +1021,22 @@ function toggleFieldSelection(values: string[], fieldId: string) {
   values.splice(0, values.length, ...next)
 }
 
+// The per-type config builders below pass a FRESH config object (no spread of the
+// existing config), so any config key the builder doesn't know about would be
+// dropped on save. Re-inject BOTH conditional-formatting families. NOTE: each key
+// is checked independently — a view that has scale rules but NO operator rules
+// (or vice-versa) must not lose the family it does have. (Bug A5: the prior
+// early-return on the operator key alone silently dropped scale rules.)
 function preserveConditionalFormattingRules(target: MetaView, config: Record<string, unknown>): Record<string, unknown> {
   const existingConfig = target.config ?? {}
-  if (!Object.prototype.hasOwnProperty.call(existingConfig, 'conditionalFormattingRules')) {
-    return config
+  const next = { ...config }
+  if (Object.prototype.hasOwnProperty.call(existingConfig, 'conditionalFormattingRules')) {
+    next.conditionalFormattingRules = existingConfig.conditionalFormattingRules
   }
-  return {
-    ...config,
-    conditionalFormattingRules: existingConfig.conditionalFormattingRules,
+  if (Object.prototype.hasOwnProperty.call(existingConfig, 'conditionalFormattingScaleRules')) {
+    next.conditionalFormattingScaleRules = existingConfig.conditionalFormattingScaleRules
   }
+  return next
 }
 
 const UNARY_FILTER_OPERATORS = new Set(['isEmpty', 'isNotEmpty'])
@@ -1237,7 +1262,7 @@ const renameDirty = computed(() => {
   return editingName.value.trim() !== (props.views.find((view) => view.id === editingId.value)?.name ?? '')
 })
 
-const hasPendingDrafts = computed(() => viewConfigDirty.value || newViewDraftDirty.value || renameDirty.value || conditionalFormattingDirty.value)
+const hasPendingDrafts = computed(() => viewConfigDirty.value || newViewDraftDirty.value || renameDirty.value || conditionalFormattingDirty.value || scaleFormattingDirty.value)
 const managerDirty = computed(() => props.visible && hasPendingDrafts.value)
 
 function confirmDiscardViewManagerChanges() {
@@ -1268,6 +1293,29 @@ function onSaveConditionalFormatting(rules: ConditionalFormattingRule[]) {
   nextConfig.conditionalFormattingRules = rules
   emit('update-view', target.id, { config: nextConfig })
   closeConditionalFormatting()
+}
+
+function openScaleFormatting(view: MetaView) {
+  if (scaleFormattingTargetId.value && scaleFormattingTargetId.value !== view.id) {
+    if (scaleFormattingDirty.value && !window.confirm(ml('view.discardFormattingConfirm'))) return
+  }
+  scaleFormattingTargetId.value = view.id
+}
+
+function closeScaleFormatting() {
+  scaleFormattingTargetId.value = null
+  scaleFormattingDirty.value = false
+}
+
+function onSaveScaleFormatting(rules: ConditionalFormattingScaleRule[]) {
+  const target = scaleFormattingTargetView.value
+  if (!target) return
+  // Start from the existing config so a scale save preserves operator rules
+  // (conditionalFormattingRules) and any other config keys.
+  const nextConfig: Record<string, unknown> = { ...(target.config ?? {}) }
+  nextConfig.conditionalFormattingScaleRules = rules
+  emit('update-view', target.id, { config: nextConfig })
+  closeScaleFormatting()
 }
 
 watch(

--- a/apps/web/src/multitable/components/ScaleFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ScaleFormattingDialog.vue
@@ -1,0 +1,585 @@
+<template>
+  <div v-if="visible" class="scf-dlg__overlay" @click.self="close">
+    <div class="scf-dlg" role="dialog" :aria-label="ml('formatting.scaleAriaTitle')">
+      <div class="scf-dlg__header">
+        <h4 class="scf-dlg__title">{{ ml('formatting.scaleTitle') }}</h4>
+        <span class="scf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
+        <button class="scf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</button>
+      </div>
+      <div class="scf-dlg__body">
+        <p v-if="!draftRules.length" class="scf-dlg__empty">{{ ml('formatting.scaleEmpty') }}</p>
+        <div v-else class="scf-dlg__rule-list">
+          <div
+            v-for="(rule, index) in draftRules"
+            :key="rule.id"
+            class="scf-dlg__rule"
+            :class="{ 'scf-dlg__rule--disabled': !rule.enabled }"
+          >
+            <div class="scf-dlg__rule-row">
+              <span class="scf-dlg__rule-index">{{ index + 1 }}.</span>
+              <label class="scf-dlg__inline">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleField') }}</span>
+                <select v-model="rule.fieldId" class="scf-dlg__select">
+                  <option
+                    v-for="field in fieldOptionsFor(rule)"
+                    :key="field.id"
+                    :value="field.id"
+                    :disabled="field.disabled"
+                  >{{ field.name }}</option>
+                </select>
+              </label>
+              <label class="scf-dlg__inline">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleKind') }}</span>
+                <select v-model="rule.kind" class="scf-dlg__select">
+                  <option value="dataBar">{{ ml('formatting.scaleKindDataBar') }}</option>
+                  <option value="colorScale">{{ ml('formatting.scaleKindColorScale') }}</option>
+                  <option value="iconSet">{{ ml('formatting.scaleKindIconSet') }}</option>
+                </select>
+              </label>
+              <label class="scf-dlg__check-inline">
+                <input type="checkbox" :checked="rule.enabled" @change="rule.enabled = ($event.target as HTMLInputElement).checked" />
+                <span>{{ ml('formatting.enabled') }}</span>
+              </label>
+            </div>
+
+            <!-- dataBar -->
+            <template v-if="rule.kind === 'dataBar'">
+              <div class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleBarColor') }}</span>
+                <div class="scf-dlg__palette">
+                  <button
+                    v-for="preset in BAR_PALETTE"
+                    :key="preset"
+                    type="button"
+                    class="scf-dlg__swatch"
+                    :class="{ 'scf-dlg__swatch--active': rule.barColor === preset }"
+                    :style="{ backgroundColor: preset }"
+                    :aria-label="pickColorLabel(preset)"
+                    @click="rule.barColor = preset"
+                  />
+                  <input
+                    type="text"
+                    class="scf-dlg__hex"
+                    :value="rule.barColor"
+                    @input="rule.barColor = ($event.target as HTMLInputElement).value"
+                    placeholder="#RRGGBB"
+                    maxlength="9"
+                  />
+                </div>
+              </div>
+              <div class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleBarNegativeColor') }}</span>
+                <div class="scf-dlg__palette">
+                  <input
+                    type="text"
+                    class="scf-dlg__hex"
+                    :value="rule.barNegativeColor"
+                    @input="rule.barNegativeColor = ($event.target as HTMLInputElement).value"
+                    placeholder="#RRGGBB"
+                    maxlength="9"
+                  />
+                </div>
+                <label class="scf-dlg__check-inline">
+                  <input type="checkbox" :checked="rule.barShowValue" @change="rule.barShowValue = ($event.target as HTMLInputElement).checked" />
+                  <span>{{ ml('formatting.scaleBarShowValue') }}</span>
+                </label>
+              </div>
+            </template>
+
+            <!-- colorScale -->
+            <template v-else-if="rule.kind === 'colorScale'">
+              <div class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleStopMin') }}</span>
+                <div class="scf-dlg__palette">
+                  <button
+                    v-for="preset in STOP_PALETTE"
+                    :key="preset"
+                    type="button"
+                    class="scf-dlg__swatch"
+                    :class="{ 'scf-dlg__swatch--active': rule.stopMin === preset }"
+                    :style="{ backgroundColor: preset }"
+                    :aria-label="pickColorLabel(preset)"
+                    @click="rule.stopMin = preset"
+                  />
+                  <input
+                    type="text"
+                    class="scf-dlg__hex"
+                    :value="rule.stopMin"
+                    @input="rule.stopMin = ($event.target as HTMLInputElement).value"
+                    placeholder="#RRGGBB"
+                    maxlength="9"
+                  />
+                </div>
+              </div>
+              <div v-if="rule.hasMid" class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleStopMid') }}</span>
+                <div class="scf-dlg__palette">
+                  <button
+                    v-for="preset in STOP_PALETTE"
+                    :key="preset"
+                    type="button"
+                    class="scf-dlg__swatch"
+                    :class="{ 'scf-dlg__swatch--active': rule.stopMid === preset }"
+                    :style="{ backgroundColor: preset }"
+                    :aria-label="pickColorLabel(preset)"
+                    @click="rule.stopMid = preset"
+                  />
+                  <input
+                    type="text"
+                    class="scf-dlg__hex"
+                    :value="rule.stopMid"
+                    @input="rule.stopMid = ($event.target as HTMLInputElement).value"
+                    placeholder="#RRGGBB"
+                    maxlength="9"
+                  />
+                </div>
+                <button type="button" class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = false">{{ ml('formatting.scaleDropMidStop') }}</button>
+              </div>
+              <div class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scaleStopMax') }}</span>
+                <div class="scf-dlg__palette">
+                  <button
+                    v-for="preset in STOP_PALETTE"
+                    :key="preset"
+                    type="button"
+                    class="scf-dlg__swatch"
+                    :class="{ 'scf-dlg__swatch--active': rule.stopMax === preset }"
+                    :style="{ backgroundColor: preset }"
+                    :aria-label="pickColorLabel(preset)"
+                    @click="rule.stopMax = preset"
+                  />
+                  <input
+                    type="text"
+                    class="scf-dlg__hex"
+                    :value="rule.stopMax"
+                    @input="rule.stopMax = ($event.target as HTMLInputElement).value"
+                    placeholder="#RRGGBB"
+                    maxlength="9"
+                  />
+                </div>
+              </div>
+              <div v-if="!rule.hasMid" class="scf-dlg__rule-row">
+                <button type="button" class="scf-dlg__btn scf-dlg__btn--ghost" @click="rule.hasMid = true">{{ ml('formatting.scaleAddMidStop') }}</button>
+              </div>
+              <div class="scf-dlg__rule-row">
+                <span class="scf-dlg__label">{{ ml('formatting.scalePreview') }}</span>
+                <span class="scf-dlg__preview-bar" :style="{ backgroundImage: colorScaleGradient(rule) }" />
+              </div>
+            </template>
+
+            <!-- iconSet -->
+            <template v-else>
+              <div class="scf-dlg__rule-row">
+                <label class="scf-dlg__inline">
+                  <span class="scf-dlg__label">{{ ml('formatting.scaleIconSet') }}</span>
+                  <select v-model="rule.iconSetName" class="scf-dlg__select">
+                    <option value="arrows3">{{ ml('formatting.scaleIconSetArrows') }}</option>
+                    <option value="traffic3">{{ ml('formatting.scaleIconSetTraffic') }}</option>
+                    <option value="signs3">{{ ml('formatting.scaleIconSetSigns') }}</option>
+                  </select>
+                </label>
+                <span class="scf-dlg__label">{{ ml('formatting.scalePreview') }}</span>
+                <span class="scf-dlg__icon-preview">
+                  <span
+                    v-for="(g, gi) in iconGlyphsFor(rule.iconSetName)"
+                    :key="gi"
+                    class="scf-dlg__icon-glyph"
+                    :style="{ color: g.color }"
+                  >{{ g.glyph }}</span>
+                </span>
+              </div>
+              <div class="scf-dlg__rule-row">
+                <label class="scf-dlg__inline">
+                  <span class="scf-dlg__label">{{ ml('formatting.scaleThresholdLower') }}</span>
+                  <input
+                    type="number"
+                    class="scf-dlg__input scf-dlg__input--mini"
+                    :value="rule.t0"
+                    @input="rule.t0 = ($event.target as HTMLInputElement).value"
+                  />
+                </label>
+                <label class="scf-dlg__inline">
+                  <span class="scf-dlg__label">{{ ml('formatting.scaleThresholdUpper') }}</span>
+                  <input
+                    type="number"
+                    class="scf-dlg__input scf-dlg__input--mini"
+                    :value="rule.t1"
+                    @input="rule.t1 = ($event.target as HTMLInputElement).value"
+                  />
+                </label>
+              </div>
+              <p v-if="thresholdError(rule)" class="scf-dlg__error">{{ ml('formatting.scaleThresholdError') }}</p>
+            </template>
+
+            <!-- range (shared) -->
+            <div class="scf-dlg__rule-row scf-dlg__rule-row--secondary">
+              <span class="scf-dlg__label">{{ ml('formatting.scaleRangeMode') }}</span>
+              <label class="scf-dlg__radio">
+                <input type="radio" :checked="rule.rangeMode === 'auto'" @change="rule.rangeMode = 'auto'" />
+                <span>{{ ml('formatting.scaleRangeAuto') }}</span>
+              </label>
+              <label class="scf-dlg__radio">
+                <input type="radio" :checked="rule.rangeMode === 'fixed'" @change="rule.rangeMode = 'fixed'" />
+                <span>{{ ml('formatting.scaleRangeFixed') }}</span>
+              </label>
+              <template v-if="rule.rangeMode === 'fixed'">
+                <label class="scf-dlg__inline">
+                  <span class="scf-dlg__label">{{ ml('formatting.scaleRangeMin') }}</span>
+                  <input
+                    type="number"
+                    class="scf-dlg__input scf-dlg__input--mini"
+                    :value="rule.rangeMin"
+                    @input="rule.rangeMin = ($event.target as HTMLInputElement).value"
+                  />
+                </label>
+                <label class="scf-dlg__inline">
+                  <span class="scf-dlg__label">{{ ml('formatting.scaleRangeMax') }}</span>
+                  <input
+                    type="number"
+                    class="scf-dlg__input scf-dlg__input--mini"
+                    :value="rule.rangeMax"
+                    @input="rule.rangeMax = ($event.target as HTMLInputElement).value"
+                  />
+                </label>
+              </template>
+            </div>
+            <p v-if="rule.rangeMode === 'fixed' && rangeSameError(rule)" class="scf-dlg__error">{{ ml('formatting.scaleRangeSameError') }}</p>
+            <p v-else-if="rule.rangeMode === 'auto'" class="scf-dlg__hint">{{ ml('formatting.scaleAutoRangeHint') }}</p>
+
+            <div class="scf-dlg__rule-row scf-dlg__rule-row--actions">
+              <button type="button" class="scf-dlg__btn scf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</button>
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="scf-dlg__btn scf-dlg__btn--primary"
+          :disabled="!canAddRule"
+          @click="addRule"
+        >{{ ml('formatting.scaleAddRule') }}</button>
+        <p v-if="!numericFields.length" class="scf-dlg__hint">{{ ml('formatting.scaleNoFieldsHint') }}</p>
+        <p v-else-if="!availableFields.length" class="scf-dlg__hint">{{ ml('formatting.scaleAllFieldsUsedHint') }}</p>
+      </div>
+      <div class="scf-dlg__footer">
+        <button type="button" class="scf-dlg__btn" @click="close">{{ ml('action.cancel') }}</button>
+        <button type="button" class="scf-dlg__btn scf-dlg__btn--primary" :disabled="!dirty || hasInvalidRule" @click="save">{{ ml('formatting.saveRules') }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type {
+  ConditionalFormattingColorScaleStop,
+  ConditionalFormattingIconSetName,
+  ConditionalFormattingScaleKind,
+  ConditionalFormattingScaleRule,
+  MetaField,
+} from '../types'
+import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
+import { HEX_COLOR_RE, extractScaleRulesFromConfig, lerpHexColor } from '../utils/conditional-formatting'
+import { SCALE_ICON_GLYPHS, type ScaleIconGlyph } from '../utils/scale-icons'
+import { formattingPickColor, managerLabel } from '../utils/meta-manager-labels'
+
+const props = defineProps<{
+  visible: boolean
+  fields: MetaField[]
+  /** Current view config; scale rules are read from `config.conditionalFormattingScaleRules`. */
+  viewConfig?: Record<string, unknown>
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'save', rules: ConditionalFormattingScaleRule[]): void
+  (e: 'update:dirty', dirty: boolean): void
+}>()
+
+const ruleLimit = CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT
+const { isZh } = useLocale()
+const ml = (key: Parameters<typeof managerLabel>[0]) => managerLabel(key, isZh.value)
+const pickColorLabel = (color: string) => formattingPickColor(color, isZh.value)
+
+const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating'])
+
+const BAR_PALETTE = ['#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#0ea5e9', '#1f2937'] as const
+const STOP_PALETTE = ['#f8696b', '#ffeb84', '#63be7b', '#ffffff', '#3b82f6', '#fce4e4', '#e0f3d8'] as const
+
+// Draft uses a flat shape with all kind-specific fields present so switching
+// kinds is non-destructive and color/threshold inputs keep their values. Numeric
+// inputs are held as strings (so a half-typed "-" doesn't coerce to 0) and parsed
+// only at save. Color-scale stops are keyed by at-name (min/mid?/max); the
+// sanitizer resolves by name so emit order is irrelevant.
+interface ScaleDraft {
+  id: string
+  fieldId: string
+  kind: ConditionalFormattingScaleKind
+  enabled: boolean
+  rangeMode: 'auto' | 'fixed'
+  rangeMin: string
+  rangeMax: string
+  barColor: string
+  barNegativeColor: string
+  barShowValue: boolean
+  stopMin: string
+  stopMid: string
+  stopMax: string
+  hasMid: boolean
+  iconSetName: ConditionalFormattingIconSetName
+  t0: string
+  t1: string
+}
+
+const draftRules = ref<ScaleDraft[]>([])
+const baseline = ref('[]')
+
+const fieldsById = computed(() => {
+  const map = new Map<string, MetaField>()
+  for (const field of props.fields) map.set(field.id, field)
+  return map
+})
+
+const numericFields = computed(() => props.fields.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
+
+/** Numeric fields not yet claimed by a draft rule (one-scale-rule-per-field). */
+const availableFields = computed(() => {
+  const used = new Set(draftRules.value.map((rule) => rule.fieldId))
+  return numericFields.value.filter((field) => !used.has(field.id))
+})
+
+const canAddRule = computed(() => draftRules.value.length < ruleLimit && availableFields.value.length > 0)
+
+/**
+ * Field <select> options for a rule: numeric fields, with fields used by OTHER
+ * rules disabled so the same field can't carry two scale rules (buildFieldScaleMap
+ * is first-rule-per-field — a second rule would silently never render).
+ */
+function fieldOptionsFor(rule: ScaleDraft): Array<{ id: string; name: string; disabled: boolean }> {
+  const usedByOthers = new Set(draftRules.value.filter((r) => r !== rule).map((r) => r.fieldId))
+  return numericFields.value.map((field) => ({
+    id: field.id,
+    name: field.name,
+    disabled: usedByOthers.has(field.id),
+  }))
+}
+
+function newId(): string {
+  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? `scr_${crypto.randomUUID()}`
+    : `scr_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+function fromRule(rule: ConditionalFormattingScaleRule): ScaleDraft {
+  const stops = rule.colorScale?.stops ?? []
+  const stopAt = (at: 'min' | 'mid' | 'max') => stops.find((s) => s.at === at)?.color
+  return {
+    id: rule.id,
+    fieldId: rule.fieldId,
+    kind: rule.kind,
+    enabled: rule.enabled,
+    rangeMode: rule.range.mode === 'fixed' ? 'fixed' : 'auto',
+    rangeMin: typeof rule.range.min === 'number' ? String(rule.range.min) : '',
+    rangeMax: typeof rule.range.max === 'number' ? String(rule.range.max) : '',
+    barColor: rule.dataBar?.color ?? BAR_PALETTE[0],
+    barNegativeColor: rule.dataBar?.negativeColor ?? '',
+    barShowValue: rule.dataBar?.showValue === true,
+    stopMin: stopAt('min') ?? STOP_PALETTE[0],
+    stopMid: stopAt('mid') ?? STOP_PALETTE[1],
+    stopMax: stopAt('max') ?? STOP_PALETTE[2],
+    hasMid: stops.some((s) => s.at === 'mid'),
+    iconSetName: rule.iconSet?.set ?? 'arrows3',
+    t0: rule.iconSet ? String(rule.iconSet.thresholds[0]) : '0',
+    t1: rule.iconSet ? String(rule.iconSet.thresholds[1]) : '1',
+  }
+}
+
+function blankDraft(fieldId: string): ScaleDraft {
+  return {
+    id: newId(),
+    fieldId,
+    kind: 'dataBar',
+    enabled: true,
+    rangeMode: 'auto',
+    rangeMin: '',
+    rangeMax: '',
+    barColor: BAR_PALETTE[0],
+    barNegativeColor: '',
+    barShowValue: false,
+    stopMin: STOP_PALETTE[0],
+    stopMid: STOP_PALETTE[1],
+    stopMax: STOP_PALETTE[2],
+    hasMid: true,
+    iconSetName: 'arrows3',
+    t0: '0',
+    t1: '1',
+  }
+}
+
+function snapshot(rules: ScaleDraft[]): string {
+  return JSON.stringify(rules)
+}
+
+function hydrate() {
+  const initial = extractScaleRulesFromConfig(props.viewConfig).map(fromRule)
+  draftRules.value = reactive(initial) as ScaleDraft[]
+  baseline.value = snapshot(draftRules.value)
+}
+
+watch(() => props.visible, (visible) => {
+  if (visible) hydrate()
+}, { immediate: true })
+
+watch(() => props.viewConfig, () => {
+  if (props.visible) hydrate()
+})
+
+const dirty = computed(() => props.visible && snapshot(draftRules.value) !== baseline.value)
+watch(dirty, (value) => emit('update:dirty', value), { immediate: true })
+
+function parseNumber(value: string): number | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const n = Number(trimmed)
+  return Number.isFinite(n) ? n : null
+}
+
+function thresholdError(rule: ScaleDraft): boolean {
+  if (rule.kind !== 'iconSet') return false
+  const t0 = parseNumber(rule.t0)
+  const t1 = parseNumber(rule.t1)
+  return t0 === null || t1 === null || t0 >= t1
+}
+
+function rangeSameError(rule: ScaleDraft): boolean {
+  if (rule.rangeMode !== 'fixed') return false
+  const min = parseNumber(rule.rangeMin)
+  const max = parseNumber(rule.rangeMax)
+  return min === null || max === null || min === max
+}
+
+function ruleInvalid(rule: ScaleDraft): boolean {
+  if (rangeSameError(rule)) return true
+  if (rule.kind === 'dataBar') {
+    if (!HEX_COLOR_RE.test(rule.barColor)) return true
+    if (rule.barNegativeColor.trim() && !HEX_COLOR_RE.test(rule.barNegativeColor)) return true
+  } else if (rule.kind === 'colorScale') {
+    if (!HEX_COLOR_RE.test(rule.stopMin) || !HEX_COLOR_RE.test(rule.stopMax)) return true
+    if (rule.hasMid && !HEX_COLOR_RE.test(rule.stopMid)) return true
+  } else if (rule.kind === 'iconSet') {
+    if (thresholdError(rule)) return true
+  }
+  return false
+}
+
+const hasInvalidRule = computed(() => draftRules.value.some(ruleInvalid))
+
+function iconGlyphsFor(set: ConditionalFormattingIconSetName): ReadonlyArray<ScaleIconGlyph> {
+  return SCALE_ICON_GLYPHS[set] ?? []
+}
+
+/** CSS gradient preview built from the draft stops (min→mid?→max). */
+function colorScaleGradient(rule: ScaleDraft): string {
+  const min = HEX_COLOR_RE.test(rule.stopMin) ? rule.stopMin : '#000000'
+  const max = HEX_COLOR_RE.test(rule.stopMax) ? rule.stopMax : '#ffffff'
+  if (rule.hasMid) {
+    const mid = HEX_COLOR_RE.test(rule.stopMid) ? rule.stopMid : lerpHexColor(min, max, 0.5)
+    return `linear-gradient(to right, ${min}, ${mid}, ${max})`
+  }
+  return `linear-gradient(to right, ${min}, ${max})`
+}
+
+function addRule() {
+  const field = availableFields.value[0]
+  if (!field) return
+  draftRules.value.push(reactive(blankDraft(field.id)) as ScaleDraft)
+}
+
+function removeRule(index: number) {
+  draftRules.value.splice(index, 1)
+}
+
+function toRule(draft: ScaleDraft, order: number): ConditionalFormattingScaleRule {
+  let range: ConditionalFormattingScaleRule['range']
+  if (draft.rangeMode === 'fixed') {
+    // Emit the canonical form (min<=max) so emitted === sanitizeScaleRule output;
+    // the sanitizer normalizes with min/max too, so this avoids a non-canonical wire.
+    const a = parseNumber(draft.rangeMin) ?? 0
+    const b = parseNumber(draft.rangeMax) ?? 0
+    range = { mode: 'fixed', min: Math.min(a, b), max: Math.max(a, b) }
+  } else {
+    range = { mode: 'auto' }
+  }
+  const base = { id: draft.id, order, fieldId: draft.fieldId, enabled: draft.enabled, range }
+  if (draft.kind === 'dataBar') {
+    const dataBar: ConditionalFormattingScaleRule['dataBar'] = { color: draft.barColor }
+    if (draft.barNegativeColor.trim()) dataBar.negativeColor = draft.barNegativeColor.trim()
+    if (draft.barShowValue) dataBar.showValue = true
+    return { ...base, kind: 'dataBar', dataBar }
+  }
+  if (draft.kind === 'colorScale') {
+    const stops: ConditionalFormattingColorScaleStop[] = [{ at: 'min', color: draft.stopMin }]
+    if (draft.hasMid) stops.push({ at: 'mid', color: draft.stopMid })
+    stops.push({ at: 'max', color: draft.stopMax })
+    return { ...base, kind: 'colorScale', colorScale: { stops } }
+  }
+  return {
+    ...base,
+    kind: 'iconSet',
+    iconSet: { set: draft.iconSetName, thresholds: [parseNumber(draft.t0) ?? 0, parseNumber(draft.t1) ?? 0] },
+  }
+}
+
+function close() {
+  if (dirty.value && !window.confirm(ml('view.discardFormattingConfirm'))) return
+  emit('close')
+}
+
+function save() {
+  if (hasInvalidRule.value) return
+  const rules = draftRules.value.map((draft, index) => toRule(draft, index))
+  emit('save', rules)
+}
+</script>
+
+<style scoped>
+.scf-dlg__overlay { position: fixed; inset: 0; background: rgba(0,0,0,.35); z-index: 110; display: flex; align-items: center; justify-content: center; }
+.scf-dlg { width: 720px; max-height: 85vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.18); display: flex; flex-direction: column; }
+.scf-dlg__header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid #eee; }
+.scf-dlg__title { flex: 1; font-size: 15px; font-weight: 600; margin: 0; }
+.scf-dlg__count { font-size: 12px; color: #666; }
+.scf-dlg__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; padding: 0 4px; }
+.scf-dlg__body { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+.scf-dlg__empty { font-size: 13px; color: #777; margin: 0; }
+.scf-dlg__rule-list { display: flex; flex-direction: column; gap: 10px; }
+.scf-dlg__rule { border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px; background: #fafafa; display: flex; flex-direction: column; gap: 6px; }
+.scf-dlg__rule--disabled { opacity: 0.55; }
+.scf-dlg__rule-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.scf-dlg__rule-row--secondary { gap: 12px; }
+.scf-dlg__rule-row--actions { justify-content: flex-end; }
+.scf-dlg__rule-index { font-weight: 600; font-size: 12px; color: #666; min-width: 18px; }
+.scf-dlg__inline { display: flex; align-items: center; gap: 6px; }
+.scf-dlg__radio { display: flex; align-items: center; gap: 4px; font-size: 12px; color: #444; cursor: pointer; }
+.scf-dlg__select, .scf-dlg__input { padding: 4px 8px; border: 1px solid #d0d5dc; border-radius: 4px; font-size: 12px; background: #fff; }
+.scf-dlg__input--mini { width: 90px; }
+.scf-dlg__label { font-size: 12px; color: #555; }
+.scf-dlg__palette { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.scf-dlg__swatch { width: 22px; height: 22px; border-radius: 4px; border: 1px solid #d0d5dc; cursor: pointer; padding: 0; }
+.scf-dlg__swatch--active { box-shadow: 0 0 0 2px #1d4ed8; }
+.scf-dlg__hex { width: 100px; padding: 3px 6px; border: 1px solid #d0d5dc; border-radius: 4px; font-size: 12px; }
+.scf-dlg__check-inline { display: flex; align-items: center; gap: 4px; font-size: 12px; color: #444; cursor: pointer; }
+.scf-dlg__preview-bar { display: inline-block; width: 180px; height: 16px; border-radius: 3px; border: 1px solid #d0d5dc; }
+.scf-dlg__icon-preview { display: inline-flex; align-items: center; gap: 8px; }
+.scf-dlg__icon-glyph { font-size: 16px; font-weight: 700; }
+.scf-dlg__error { font-size: 12px; color: #b91c1c; margin: 0; }
+.scf-dlg__hint { font-size: 12px; color: #888; margin: 0; }
+.scf-dlg__btn { padding: 5px 12px; border: 1px solid #d0d5dc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px; color: #333; }
+.scf-dlg__btn:hover:not(:disabled) { background: #f3f4f6; }
+.scf-dlg__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.scf-dlg__btn--primary { background: #2563eb; border-color: #2563eb; color: #fff; }
+.scf-dlg__btn--primary:hover:not(:disabled) { background: #1d4ed8; }
+.scf-dlg__btn--danger { color: #b91c1c; border-color: #fecaca; }
+.scf-dlg__btn--danger:hover:not(:disabled) { background: #fef2f2; }
+.scf-dlg__btn--ghost { border-color: transparent; }
+.scf-dlg__footer { display: flex; gap: 8px; justify-content: flex-end; padding: 12px 16px; border-top: 1px solid #eee; }
+</style>

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -20,7 +20,9 @@ import type {
 } from '../types'
 import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../types'
 
-const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+// Single hex-validation surface, shared with the scale-rule authoring dialog
+// (ScaleFormattingDialog.vue) so editor-side validation matches the sanitizer.
+export const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
 
 const KNOWN_OPERATORS: ReadonlySet<ConditionalFormattingOperator> = new Set([
   'gt', 'gte', 'lt', 'lte', 'eq', 'neq', 'between',

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -20,6 +20,25 @@ export type MetaManagerLabelKey =
   | 'formatting.color' | 'formatting.applyToRow' | 'formatting.enabled'
   | 'formatting.up' | 'formatting.down' | 'formatting.addRule'
   | 'formatting.noFieldsHint' | 'formatting.saveRules'
+  // Range-based SCALE formatting authoring (A5: data bar / color scale / icon set)
+  | 'formatting.scaleTitle' | 'formatting.scaleAriaTitle'
+  | 'formatting.scaleEmpty' | 'formatting.scaleAction'
+  | 'formatting.scaleAddRule' | 'formatting.scaleNoFieldsHint'
+  | 'formatting.scaleAllFieldsUsedHint' | 'formatting.scaleAutoRangeHint'
+  | 'formatting.scaleKind' | 'formatting.scaleKindDataBar'
+  | 'formatting.scaleKindColorScale' | 'formatting.scaleKindIconSet'
+  | 'formatting.scaleField' | 'formatting.scaleRangeMode'
+  | 'formatting.scaleRangeAuto' | 'formatting.scaleRangeFixed'
+  | 'formatting.scaleRangeMin' | 'formatting.scaleRangeMax'
+  | 'formatting.scaleRangeSameError' | 'formatting.scaleBarColor'
+  | 'formatting.scaleBarNegativeColor' | 'formatting.scaleBarShowValue'
+  | 'formatting.scaleStopMin' | 'formatting.scaleStopMid'
+  | 'formatting.scaleStopMax' | 'formatting.scaleAddMidStop'
+  | 'formatting.scaleDropMidStop' | 'formatting.scaleIconSet'
+  | 'formatting.scaleIconSetArrows' | 'formatting.scaleIconSetTraffic'
+  | 'formatting.scaleIconSetSigns' | 'formatting.scaleThresholdLower'
+  | 'formatting.scaleThresholdUpper' | 'formatting.scaleThresholdError'
+  | 'formatting.scalePreview'
   | 'field.title' | 'field.empty' | 'field.options' | 'field.optionValue'
   | 'field.targetSheet' | 'field.selectSheet' | 'field.limitSingleLinkedRecord'
   | 'field.hierarchyParentLinkLocked'
@@ -162,6 +181,60 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'formatting.addRule': { en: '+ Add rule', zh: '+ 添加规则' },
   'formatting.noFieldsHint': { en: 'Add fields to the sheet to create formatting rules.', zh: '请先向 Sheet 添加字段，再创建格式规则。' },
   'formatting.saveRules': { en: 'Save rules', zh: '保存规则' },
+
+  'formatting.scaleTitle': { en: 'Scale formatting', zh: '色阶格式' },
+  'formatting.scaleAriaTitle': { en: 'Scale formatting rules', zh: '色阶格式规则' },
+  'formatting.scaleEmpty': {
+    en: 'No scale rules yet. Add a rule to show a data bar, color scale, or icon set across a numeric field.',
+    zh: '暂无色阶规则。添加规则后，可为数值字段显示数据条、色阶或图标集。',
+  },
+  'formatting.scaleAction': { en: 'Scale formatting', zh: '色阶格式' },
+  'formatting.scaleAddRule': { en: '+ Add scale rule', zh: '+ 添加色阶规则' },
+  'formatting.scaleNoFieldsHint': {
+    en: 'Add a numeric field (number, currency, percent, or rating) to create scale rules.',
+    zh: '请先添加数值字段（数字、货币、百分比或评分），再创建色阶规则。',
+  },
+  'formatting.scaleAllFieldsUsedHint': {
+    en: 'Every numeric field already has a scale rule. Each field supports one scale rule.',
+    zh: '每个数值字段都已有色阶规则。每个字段仅支持一条色阶规则。',
+  },
+  'formatting.scaleAutoRangeHint': {
+    en: 'Auto range is computed over the loaded rows, so the scale may shift as more rows load.',
+    zh: '自动范围基于已加载的行计算，加载更多行时范围可能变化。',
+  },
+  'formatting.scaleKind': { en: 'Style', zh: '样式' },
+  'formatting.scaleKindDataBar': { en: 'Data bar', zh: '数据条' },
+  'formatting.scaleKindColorScale': { en: 'Color scale', zh: '色阶' },
+  'formatting.scaleKindIconSet': { en: 'Icon set', zh: '图标集' },
+  'formatting.scaleField': { en: 'Field', zh: '字段' },
+  'formatting.scaleRangeMode': { en: 'Range', zh: '范围' },
+  'formatting.scaleRangeAuto': { en: 'Auto', zh: '自动' },
+  'formatting.scaleRangeFixed': { en: 'Fixed', zh: '固定' },
+  'formatting.scaleRangeMin': { en: 'Min', zh: '最小值' },
+  'formatting.scaleRangeMax': { en: 'Max', zh: '最大值' },
+  'formatting.scaleRangeSameError': {
+    en: 'Min and max must differ.',
+    zh: '最小值与最大值必须不同。',
+  },
+  'formatting.scaleBarColor': { en: 'Bar color', zh: '数据条颜色' },
+  'formatting.scaleBarNegativeColor': { en: 'Negative color', zh: '负值颜色' },
+  'formatting.scaleBarShowValue': { en: 'Show value', zh: '显示数值' },
+  'formatting.scaleStopMin': { en: 'Low', zh: '低' },
+  'formatting.scaleStopMid': { en: 'Mid', zh: '中' },
+  'formatting.scaleStopMax': { en: 'High', zh: '高' },
+  'formatting.scaleAddMidStop': { en: '+ Add midpoint', zh: '+ 添加中间点' },
+  'formatting.scaleDropMidStop': { en: 'Remove midpoint', zh: '移除中间点' },
+  'formatting.scaleIconSet': { en: 'Icon set', zh: '图标集' },
+  'formatting.scaleIconSetArrows': { en: 'Arrows', zh: '箭头' },
+  'formatting.scaleIconSetTraffic': { en: 'Traffic lights', zh: '交通灯' },
+  'formatting.scaleIconSetSigns': { en: 'Signs', zh: '标记' },
+  'formatting.scaleThresholdLower': { en: 'Lower threshold', zh: '下阈值' },
+  'formatting.scaleThresholdUpper': { en: 'Upper threshold', zh: '上阈值' },
+  'formatting.scaleThresholdError': {
+    en: 'Lower threshold must be less than the upper threshold.',
+    zh: '下阈值必须小于上阈值。',
+  },
+  'formatting.scalePreview': { en: 'Preview', zh: '预览' },
 
   'field.title': { en: 'Manage Fields', zh: '管理字段' },
   'field.empty': { en: 'No fields defined', zh: '暂无字段' },

--- a/apps/web/src/multitable/utils/scale-icons.ts
+++ b/apps/web/src/multitable/utils/scale-icons.ts
@@ -1,0 +1,53 @@
+// Shared icon-set glyph table for range-based SCALE conditional formatting
+// (A5 icon-set kind). Extracted from MetaGridTable.vue so the renderer and the
+// scale-rule authoring dialog (ScaleFormattingDialog.vue) draw the SAME glyphs —
+// duplicating the constant would let the in-dialog preview drift from the actual
+// grid render (the team's wire-vs-fixture drift trap).
+//
+// The backend (conditional-formatting-service) only emits index ∈ {0,1,2}; an
+// out-of-range or unknown set yields no icon (fail-safe).
+import type { ConditionalFormattingIconSetName } from '../types'
+
+export interface ScaleIconGlyph {
+  glyph: string
+  color: string
+}
+
+export const SCALE_ICON_GLYPHS: Record<string, ReadonlyArray<ScaleIconGlyph>> = {
+  arrows3: [
+    { glyph: '↓', color: '#e53935' },
+    { glyph: '→', color: '#fb8c00' },
+    { glyph: '↑', color: '#43a047' },
+  ],
+  traffic3: [
+    { glyph: '●', color: '#e53935' },
+    { glyph: '●', color: '#fbc02d' },
+    { glyph: '●', color: '#43a047' },
+  ],
+  signs3: [
+    { glyph: '✕', color: '#e53935' },
+    { glyph: '!', color: '#fb8c00' },
+    { glyph: '✓', color: '#43a047' },
+  ],
+}
+
+/** The three authorable icon sets, in display order. */
+export const SCALE_ICON_SET_NAMES: ReadonlyArray<ConditionalFormattingIconSetName> = [
+  'arrows3',
+  'traffic3',
+  'signs3',
+]
+
+/**
+ * Resolve a glyph from a packed `iconKey` (`${set}:${index}`). Returns null for
+ * an unknown set or out-of-range index (fail-safe, mirrors the grid renderer).
+ */
+export function glyphForIconKey(iconKey: string): ScaleIconGlyph | null {
+  const sep = iconKey.lastIndexOf(':')
+  if (sep < 0) return null
+  const set = iconKey.slice(0, sep)
+  const idx = Number(iconKey.slice(sep + 1))
+  const glyphs = SCALE_ICON_GLYPHS[set]
+  if (!glyphs || !Number.isInteger(idx) || idx < 0 || idx >= glyphs.length) return null
+  return glyphs[idx]
+}

--- a/apps/web/tests/multitable-view-manager-scale.spec.ts
+++ b/apps/web/tests/multitable-view-manager-scale.spec.ts
@@ -1,0 +1,182 @@
+import { createApp, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import MetaViewManager from '../src/multitable/components/MetaViewManager.vue'
+import type { ConditionalFormattingScaleRule } from '../src/multitable/types'
+
+function scaleRule(): ConditionalFormattingScaleRule {
+  return {
+    id: 'scr_keep',
+    order: 0,
+    fieldId: 'fld_amount',
+    kind: 'dataBar',
+    enabled: true,
+    range: { mode: 'auto' },
+    dataBar: { color: '#3b82f6' },
+  }
+}
+
+function mountManager(views: unknown[], activeViewId: string) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const updateSpy = vi.fn()
+  const app = createApp({
+    render() {
+      return h(MetaViewManager, {
+        visible: true,
+        sheetId: 'sheet_1',
+        activeViewId,
+        fields: [
+          { id: 'fld_name', name: 'Name', type: 'string' },
+          { id: 'fld_amount', name: 'Amount', type: 'number' },
+          { id: 'fld_cover', name: 'Cover', type: 'attachment' },
+        ],
+        views,
+        onUpdateView: updateSpy,
+      })
+    },
+  })
+  app.mount(container)
+  return { app, container, updateSpy }
+}
+
+describe('MetaViewManager scale formatting', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('saving a scale rule emits config with scale rules AND preserves operator rules', async () => {
+    const { app, container, updateSpy } = mountManager(
+      [
+        {
+          id: 'view_grid',
+          sheetId: 'sheet_1',
+          name: 'Grid',
+          type: 'grid',
+          config: {
+            conditionalFormattingRules: [
+              { id: 'cfr_1', order: 0, fieldId: 'fld_amount', operator: 'gt', value: 5, style: { backgroundColor: '#fce4e4' }, enabled: true },
+            ],
+          },
+        },
+      ],
+      'view_grid',
+    )
+
+    // open the scale-formatting dialog
+    const scaleBtn = container.querySelector('.meta-view-mgr__action[title="Scale formatting"]') as HTMLButtonElement
+    expect(scaleBtn).toBeTruthy()
+    scaleBtn.click()
+    await nextTick()
+
+    // add a scale rule and save
+    const addBtn = Array.from(container.querySelectorAll('.scf-dlg__body > .scf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Add scale rule')) as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const saveBtn = Array.from(container.querySelectorAll('.scf-dlg__footer .scf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Save')) as HTMLButtonElement
+    saveBtn.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [viewId, payload] = updateSpy.mock.calls[0]
+    expect(viewId).toBe('view_grid')
+    const config = payload.config as Record<string, unknown>
+    expect(Array.isArray(config.conditionalFormattingScaleRules)).toBe(true)
+    expect((config.conditionalFormattingScaleRules as unknown[]).length).toBe(1)
+    // operator rules preserved by the {...target.config} spread
+    expect(config.conditionalFormattingRules).toEqual([
+      { id: 'cfr_1', order: 0, fieldId: 'fld_amount', operator: 'gt', value: 5, style: { backgroundColor: '#fce4e4' }, enabled: true },
+    ])
+    app.unmount()
+  })
+
+  // REGRESSION (Bug A5): saving an unrelated per-type view config must NOT drop
+  // pre-existing scale rules. The fixture is SCALE-RULES-ONLY (no operator rules)
+  // — that's the case the prior early-return-on-operator-key fix would have
+  // silently dropped.
+  it('saving a non-grid (gallery) view config preserves pre-existing scale rules (scale-only)', async () => {
+    const { app, container, updateSpy } = mountManager(
+      [
+        {
+          id: 'view_gallery',
+          sheetId: 'sheet_1',
+          name: 'Cards',
+          type: 'gallery',
+          config: {
+            // NOTE: scale rules only — NO conditionalFormattingRules key.
+            conditionalFormattingScaleRules: [scaleRule()],
+            fieldIds: [],
+            columns: 3,
+            cardSize: 'medium',
+          },
+        },
+      ],
+      'view_gallery',
+    )
+
+    // open the per-type config panel
+    const configBtn = container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement
+    configBtn.click()
+    await nextTick()
+
+    // make a change so the draft is dirty (set a title field), then save
+    const select = container.querySelector('.meta-view-mgr__config select') as HTMLSelectElement
+    select.value = 'fld_name'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const saveBtn = Array.from(container.querySelectorAll('.meta-view-mgr__btn-add'))
+      .find((b) => b.textContent?.includes('Save view settings')) as HTMLButtonElement
+    expect(saveBtn).toBeTruthy()
+    saveBtn.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [viewId, payload] = updateSpy.mock.calls[0]
+    expect(viewId).toBe('view_gallery')
+    const config = payload.config as Record<string, unknown>
+    // the bug: this key was dropped. Assert it survives the gallery config save.
+    expect(config.conditionalFormattingScaleRules).toEqual([scaleRule()])
+    app.unmount()
+  })
+
+  it('saving an operator-rule preserves pre-existing scale rules (cross-family)', async () => {
+    const { app, container, updateSpy } = mountManager(
+      [
+        {
+          id: 'view_grid',
+          sheetId: 'sheet_1',
+          name: 'Grid',
+          type: 'grid',
+          config: {
+            conditionalFormattingScaleRules: [scaleRule()],
+          },
+        },
+      ],
+      'view_grid',
+    )
+
+    const cfBtn = container.querySelector('.meta-view-mgr__action[title="Conditional formatting"]') as HTMLButtonElement
+    cfBtn.click()
+    await nextTick()
+
+    const addBtn = Array.from(container.querySelectorAll('.cf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Add rule')) as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const saveBtn = Array.from(container.querySelectorAll('.cf-dlg__footer .cf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Save')) as HTMLButtonElement
+    saveBtn.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const config = updateSpy.mock.calls[0][1].config as Record<string, unknown>
+    expect(config.conditionalFormattingScaleRules).toEqual([scaleRule()])
+    expect(Array.isArray(config.conditionalFormattingRules)).toBe(true)
+    app.unmount()
+  })
+})

--- a/apps/web/tests/scale-formatting-dialog.spec.ts
+++ b/apps/web/tests/scale-formatting-dialog.spec.ts
@@ -1,0 +1,401 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+
+import { useLocale } from '../src/composables/useLocale'
+import ScaleFormattingDialog from '../src/multitable/components/ScaleFormattingDialog.vue'
+import type { ConditionalFormattingScaleRule, MetaField } from '../src/multitable/types'
+import { sanitizeScaleRule } from '../src/multitable/utils/conditional-formatting'
+
+const fields: MetaField[] = [
+  { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
+  { id: 'fld_price', name: 'Price', type: 'currency', property: {} },
+  { id: 'fld_rate', name: 'Rate', type: 'percent', property: {} },
+  { id: 'fld_stars', name: 'Stars', type: 'rating', property: {} },
+  { id: 'fld_title', name: 'Title', type: 'string', property: {} },
+  { id: 'fld_due', name: 'Due', type: 'date', property: {} },
+  {
+    id: 'fld_status',
+    name: 'Status',
+    type: 'select',
+    options: [{ value: 'Pending' }, { value: 'Done' }],
+    property: {},
+  },
+]
+
+function dataBarRule(partial: Partial<ConditionalFormattingScaleRule> = {}): ConditionalFormattingScaleRule {
+  return {
+    id: 'scr_bar',
+    order: 0,
+    fieldId: 'fld_amount',
+    kind: 'dataBar',
+    enabled: true,
+    range: { mode: 'auto' },
+    dataBar: { color: '#3b82f6' },
+    ...partial,
+  }
+}
+
+function colorScaleRule(partial: Partial<ConditionalFormattingScaleRule> = {}): ConditionalFormattingScaleRule {
+  return {
+    id: 'scr_cs',
+    order: 1,
+    fieldId: 'fld_price',
+    kind: 'colorScale',
+    enabled: true,
+    range: { mode: 'auto' },
+    colorScale: {
+      stops: [
+        { at: 'min', color: '#f8696b' },
+        { at: 'mid', color: '#ffeb84' },
+        { at: 'max', color: '#63be7b' },
+      ],
+    },
+    ...partial,
+  }
+}
+
+function iconSetRule(partial: Partial<ConditionalFormattingScaleRule> = {}): ConditionalFormattingScaleRule {
+  return {
+    id: 'scr_icon',
+    order: 2,
+    fieldId: 'fld_rate',
+    kind: 'iconSet',
+    enabled: true,
+    range: { mode: 'auto' },
+    iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    ...partial,
+  }
+}
+
+function mountDialog(propsOverride: Partial<{
+  visible: boolean
+  fields: MetaField[]
+  viewConfig: Record<string, unknown>
+  onClose: () => void
+  onSave: (rules: ConditionalFormattingScaleRule[]) => void
+  'onUpdate:dirty': (dirty: boolean) => void
+}> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const props = {
+    visible: true,
+    fields,
+    viewConfig: {
+      conditionalFormattingScaleRules: [dataBarRule(), colorScaleRule(), iconSetRule()],
+    },
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+    'onUpdate:dirty': vi.fn(),
+    ...propsOverride,
+  }
+  const app: App = createApp({ render: () => h(ScaleFormattingDialog, props) })
+  app.mount(container)
+  return { app, container, props }
+}
+
+async function flush() {
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+function getSaveButton(container: HTMLElement): HTMLButtonElement {
+  return Array.from(container.querySelectorAll('.scf-dlg__footer .scf-dlg__btn'))
+    .find((b) => b.textContent?.includes('Save')) as HTMLButtonElement
+}
+
+describe('ScaleFormattingDialog', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    useLocale().setLocale('en')
+    vi.restoreAllMocks()
+  })
+
+  it('hydrates a draft row per kind from the view config', async () => {
+    const { app, container } = mountDialog()
+    await flush()
+
+    const rules = container.querySelectorAll('.scf-dlg__rule')
+    expect(rules).toHaveLength(3)
+    // each kind's distinctive control is present
+    expect(container.textContent).toContain('Bar color') // dataBar
+    expect(container.textContent).toContain('Lower threshold') // iconSet
+    expect(container.querySelector('.scf-dlg__preview-bar')).toBeTruthy() // colorScale gradient preview
+    app.unmount()
+  })
+
+  it('authors a dataBar rule (added from scratch) that round-trips through the sanitizer unchanged', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [] },
+    })
+    await flush()
+
+    // adding a rule makes the draft dirty (default kind = dataBar)
+    const addBtn = Array.from(container.querySelectorAll('.scf-dlg__body > .scf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Add scale rule')) as HTMLButtonElement
+    addBtn.click()
+    await flush()
+
+    expect(getSaveButton(container).disabled).toBe(false)
+    getSaveButton(container).click()
+    await flush()
+
+    expect(props.onSave).toHaveBeenCalledTimes(1)
+    const emitted = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as ConditionalFormattingScaleRule[]
+    expect(emitted).toHaveLength(1)
+    const sane = sanitizeScaleRule(emitted[0])
+    expect(sane).not.toBeNull()
+    // wire-vs-fixture-drift guard: emitted shape survives the contract verbatim
+    expect(sane).toEqual(emitted[0])
+    expect(emitted[0].kind).toBe('dataBar')
+    expect(emitted[0].dataBar?.color).toBe('#3b82f6')
+    app.unmount()
+  })
+
+  it('authors a colorScale rule (3-stop) that the sanitizer accepts', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [colorScaleRule()] },
+    })
+    await flush()
+
+    // edit the min stop's hex
+    const hex = container.querySelector('.scf-dlg__hex') as HTMLInputElement
+    hex.value = '#112233'
+    hex.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    getSaveButton(container).click()
+    await flush()
+
+    const emitted = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as ConditionalFormattingScaleRule[]
+    const sane = sanitizeScaleRule(emitted[0])
+    expect(sane).not.toBeNull()
+    expect(sane).toEqual(emitted[0])
+    expect(emitted[0].kind).toBe('colorScale')
+    const stops = emitted[0].colorScale?.stops ?? []
+    expect(stops.map((s) => s.at).sort()).toEqual(['max', 'mid', 'min'])
+    expect(stops.find((s) => s.at === 'min')?.color).toBe('#112233')
+    app.unmount()
+  })
+
+  it('drops the mid stop into a valid 2-stop colorScale', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [colorScaleRule()] },
+    })
+    await flush()
+
+    const dropBtn = Array.from(container.querySelectorAll('.scf-dlg__btn--ghost'))
+      .find((b) => b.textContent?.includes('Remove midpoint')) as HTMLButtonElement
+    expect(dropBtn).toBeTruthy()
+    dropBtn.click()
+    await flush()
+
+    getSaveButton(container).click()
+    await flush()
+
+    const emitted = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as ConditionalFormattingScaleRule[]
+    const sane = sanitizeScaleRule(emitted[0])
+    expect(sane).not.toBeNull()
+    const stops = emitted[0].colorScale?.stops ?? []
+    expect(stops.map((s) => s.at).sort()).toEqual(['max', 'min'])
+    app.unmount()
+  })
+
+  it('authors an iconSet rule with t0<t1 that the sanitizer accepts', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [iconSetRule()] },
+    })
+    await flush()
+
+    // edit the upper threshold (10 < 25) so the draft is dirty and still valid
+    const minis = Array.from(container.querySelectorAll('.scf-dlg__input--mini')) as HTMLInputElement[]
+    minis[1].value = '25'
+    minis[1].dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    expect(getSaveButton(container).disabled).toBe(false)
+    getSaveButton(container).click()
+    await flush()
+
+    const emitted = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as ConditionalFormattingScaleRule[]
+    const sane = sanitizeScaleRule(emitted[0])
+    expect(sane).not.toBeNull()
+    expect(sane).toEqual(emitted[0])
+    expect(emitted[0].iconSet?.thresholds).toEqual([10, 25])
+    app.unmount()
+  })
+
+  it('blocks save and shows an error when iconSet t0 >= t1', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [iconSetRule({ iconSet: { set: 'arrows3', thresholds: [5, 9] } })] },
+    })
+    await flush()
+
+    const numberInputs = Array.from(container.querySelectorAll('.scf-dlg__input--mini')) as HTMLInputElement[]
+    // first two minis on an iconSet rule are lower/upper threshold
+    const upper = numberInputs[1]
+    upper.value = '3' // now lower(5) >= upper(3)
+    upper.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    expect(container.textContent).toContain('Lower threshold must be less than the upper threshold.')
+    expect(getSaveButton(container).disabled).toBe(true)
+
+    getSaveButton(container).click()
+    await flush()
+    expect(props.onSave).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('blocks save when a fixed range has min == max', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [dataBarRule()] },
+    })
+    await flush()
+
+    // switch range to fixed
+    const fixedRadio = Array.from(container.querySelectorAll('.scf-dlg__radio input[type=radio]'))[1] as HTMLInputElement
+    fixedRadio.checked = true
+    fixedRadio.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const minis = Array.from(container.querySelectorAll('.scf-dlg__input--mini')) as HTMLInputElement[]
+    // dataBar has no thresholds, so the two minis here are the fixed min/max
+    minis[0].value = '5'
+    minis[0].dispatchEvent(new Event('input', { bubbles: true }))
+    minis[1].value = '5'
+    minis[1].dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    expect(container.textContent).toContain('Min and max must differ.')
+    expect(getSaveButton(container).disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('emits a canonical fixed range (min<=max) even when entered reversed', async () => {
+    const { app, container, props } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [dataBarRule()] },
+    })
+    await flush()
+
+    const fixedRadio = Array.from(container.querySelectorAll('.scf-dlg__radio input[type=radio]'))[1] as HTMLInputElement
+    fixedRadio.checked = true
+    fixedRadio.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const minis = Array.from(container.querySelectorAll('.scf-dlg__input--mini')) as HTMLInputElement[]
+    minis[0].value = '20' // min input
+    minis[0].dispatchEvent(new Event('input', { bubbles: true }))
+    minis[1].value = '10' // max input (reversed)
+    minis[1].dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    // min != max → save allowed
+    expect(getSaveButton(container).disabled).toBe(false)
+    getSaveButton(container).click()
+    await flush()
+
+    const emitted = (props.onSave as ReturnType<typeof vi.fn>).mock.calls[0][0] as ConditionalFormattingScaleRule[]
+    expect(emitted[0].range).toEqual({ mode: 'fixed', min: 10, max: 20 })
+    // and it equals what the sanitizer produces (no non-canonical wire)
+    expect(sanitizeScaleRule(emitted[0])).toEqual(emitted[0])
+    app.unmount()
+  })
+
+  it('lists only numeric fields in the field selector', async () => {
+    const { app, container } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [dataBarRule()] },
+    })
+    await flush()
+
+    const fieldSelect = container.querySelector('.scf-dlg__rule select') as HTMLSelectElement
+    const optionTexts = Array.from(fieldSelect.options).map((o) => o.textContent ?? '')
+    expect(optionTexts).toContain('Amount')
+    expect(optionTexts).toContain('Price')
+    expect(optionTexts).toContain('Rate')
+    expect(optionTexts).toContain('Stars')
+    expect(optionTexts).not.toContain('Title')
+    expect(optionTexts).not.toContain('Due')
+    expect(optionTexts).not.toContain('Status')
+    app.unmount()
+  })
+
+  it('prevents a second scale rule on a field already used by another rule', async () => {
+    // amount is used by the existing dataBar rule; add a new rule and confirm
+    // the amount option is disabled for it.
+    const { app, container } = mountDialog({
+      viewConfig: { conditionalFormattingScaleRules: [dataBarRule()] },
+    })
+    await flush()
+
+    const addBtn = Array.from(container.querySelectorAll('.scf-dlg__body > .scf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Add scale rule')) as HTMLButtonElement
+    addBtn.click()
+    await flush()
+
+    const ruleEls = container.querySelectorAll('.scf-dlg__rule')
+    expect(ruleEls).toHaveLength(2)
+    // the second rule's field select must have Amount disabled (used by rule 1)
+    const secondSelect = ruleEls[1].querySelector('select') as HTMLSelectElement
+    const amountOption = Array.from(secondSelect.options).find((o) => o.textContent === 'Amount')
+    expect(amountOption?.disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('disables Add when all numeric fields already have a scale rule', async () => {
+    const { app, container } = mountDialog({
+      viewConfig: {
+        conditionalFormattingScaleRules: [
+          dataBarRule({ id: 'a', fieldId: 'fld_amount' }),
+          dataBarRule({ id: 'b', fieldId: 'fld_price' }),
+          dataBarRule({ id: 'c', fieldId: 'fld_rate' }),
+          dataBarRule({ id: 'd', fieldId: 'fld_stars' }),
+        ],
+      },
+    })
+    await flush()
+
+    const addBtn = Array.from(container.querySelectorAll('.scf-dlg__body > .scf-dlg__btn'))
+      .find((b) => b.textContent?.includes('Add scale rule')) as HTMLButtonElement
+    expect(addBtn.disabled).toBe(true)
+    expect(container.textContent).toContain('Every numeric field already has a scale rule.')
+    app.unmount()
+  })
+
+  it('renders chrome and icon-set names in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const { app, container } = mountDialog()
+    await flush()
+
+    expect(container.querySelector('.scf-dlg')?.getAttribute('aria-label')).toBe('色阶格式规则')
+    expect(container.textContent).toContain('色阶格式')
+    expect(container.textContent).toContain('数据条')
+    expect(container.textContent).toContain('色阶')
+    expect(container.textContent).toContain('图标集')
+    expect(container.textContent).toContain('下阈值')
+    expect(container.textContent).toContain('保存规则')
+    app.unmount()
+  })
+
+  it('renders English chrome by default', async () => {
+    const { app, container } = mountDialog()
+    await flush()
+
+    expect(container.querySelector('.scf-dlg')?.getAttribute('aria-label')).toBe('Scale formatting rules')
+    expect(container.textContent).toContain('Scale formatting')
+    expect(container.textContent).toContain('Data bar')
+    expect(container.textContent).toContain('Icon set')
+    app.unmount()
+  })
+
+  it('shows the no-numeric-fields hint when no eligible fields exist', async () => {
+    const { app, container } = mountDialog({
+      fields: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }],
+      viewConfig: { conditionalFormattingScaleRules: [] },
+    })
+    await flush()
+
+    expect(container.textContent).toContain('Add a numeric field')
+    app.unmount()
+  })
+})


### PR DESCRIPTION
## A5 — conditional-formatting SCALE-rule authoring UI
Render shipped earlier (#2640/#2680); scale rules were only authorable via raw API. Adds the authoring surface.

- New `ScaleFormattingDialog.vue`: kind selector (dataBar/colorScale/iconSet), numeric-only field eligibility, one-rule-per-field (buildFieldScaleMap is first-rule-wins), 3-stop colorScale default + drop-mid toggle, iconSet strict t0<t1, fixed-range min≠max guard, palette swatch + hex input, live preview. Emitted rules round-trip through `sanitizeScaleRule` verbatim.
- Wired into `MetaViewManager.vue` (second action button + state pair + save preserving operator rules + dirty/reset).
- Extracted `SCALE_ICON_GLYPHS` → new `utils/scale-icons.ts` (shared by grid + dialog so they can't drift); exported `HEX_COLOR_RE` as the single hex-validation surface.
- **Bug-fix**: `preserveConditionalFormattingRules` early-returned on the operator key, so saving a non-grid (or scale-only) view config silently dropped `conditionalFormattingScaleRules`. Restructured to check each family independently; regression test uses a **scale-only** fixture (the discriminating case).

**Tests**: 82/82 across 8 specs (14 new dialog + 3 new view-manager incl. the preserve regression). **Review verdict: ship** (security: all hex gated through `HEX_COLOR_RE`).

**Owner-deferred (safe defaults chosen)**: used distinct bar/stop palettes (saturated/Excel-style) vs the operator dialog's pastels — swap to the shared PALETTE if uniform swatches preferred; auto-range is page-scoped (hint copy, not a full-column server preview); `negativeColor` is hex-only (no preset).

Built + adversarially reviewed by parallel subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)