### PR TITLE
feat(multitable): dashboard non-chart widgets — metric/text/filter (B4)

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -46,6 +46,7 @@
           @click="openCreateChart"
         >{{ viewRenderLabel('dashboard.newChart', isZh) }}</button>
         <button class="meta-dashboard__btn" type="button" data-action="add-panel" @click="showAddPanel = true">{{ viewRenderLabel('dashboard.addPanel', isZh) }}</button>
+        <button class="meta-dashboard__btn" type="button" data-action="add-widget" :disabled="!activeDashboard" @click="openAddWidget">{{ viewRenderLabel('dashboard.addWidget', isZh) }}</button>
         <button class="meta-dashboard__btn meta-dashboard__btn--primary" type="button" data-action="create-dashboard" @click="onCreateDashboard">{{ viewRenderLabel('dashboard.newDashboard', isZh) }}</button>
       </div>
     </div>
@@ -63,9 +64,10 @@
         class="meta-dashboard__panel"
         :class="`meta-dashboard__panel--${panel.size}`"
         :data-panel-id="panel.id"
+        :data-panel-type="panelType(panel)"
       >
         <div class="meta-dashboard__panel-header">
-          <span class="meta-dashboard__panel-chart-name">{{ chartNameById(panel.chartId) }}</span>
+          <span class="meta-dashboard__panel-chart-name">{{ panelTitle(panel) }}</span>
           <div class="meta-dashboard__panel-controls">
             <select
               :value="panel.size"
@@ -86,13 +88,58 @@
           </div>
         </div>
         <div class="meta-dashboard__panel-body">
-          <MetaChartRenderer
-            v-if="chartDataMap[panel.chartId]"
-            :chart-data="chartDataMap[panel.chartId]"
-            :display-config="chartConfigMap[panel.chartId]?.displayConfig"
-            :aggregation="chartConfigMap[panel.chartId]?.dataSource?.aggregation?.function"
-          />
-          <div v-else class="meta-dashboard__panel-loading">{{ viewRenderLabel('dashboard.loadingChart', isZh) }}</div>
+          <!-- B4: branch the body on the widget kind. A legacy panel (no `type`) is a chart. -->
+          <!-- Chart widget (default / legacy). Data/config resolved via helpers (which narrow the
+               now-optional chartId inside a function body) so the bindings never depend on
+               cross-element template narrowing that vue-tsc may not perform. -->
+          <template v-if="panelType(panel) === 'chart'">
+            <MetaChartRenderer
+              v-if="panelChartData(panel)"
+              :chart-data="panelChartData(panel)!"
+              :display-config="panelChartConfig(panel)?.displayConfig"
+              :aggregation="panelChartConfig(panel)?.dataSource?.aggregation?.function"
+            />
+            <div v-else class="meta-dashboard__panel-loading">{{ viewRenderLabel('dashboard.loadingChart', isZh) }}</div>
+          </template>
+          <!-- Metric / number card: computed via the field-read-enforced preview-data path, keyed by panel.id. -->
+          <template v-else-if="panelType(panel) === 'metric'">
+            <MetaChartRenderer
+              v-if="metricDataMap[panel.id]"
+              :chart-data="metricDataMap[panel.id]"
+              :display-config="metricDisplayConfig(panel)"
+              :aggregation="panel.metricConfig?.aggregation"
+            />
+            <div v-else class="meta-dashboard__panel-loading" data-metric-loading="true">{{ viewRenderLabel('dashboard.loadingMetric', isZh) }}</div>
+          </template>
+          <!-- Text / markdown note: rendered through the SHARED rich-longtext DOMPurify chokepoint (never raw v-html). -->
+          <template v-else-if="panelType(panel) === 'text'">
+            <MetaRichLongTextRender
+              v-if="panel.textConfig?.content"
+              class="meta-dashboard__text-widget"
+              data-widget="text"
+              :html="panel.textConfig.content"
+            />
+            <div v-else class="meta-dashboard__panel-loading" data-widget="text-empty">{{ viewRenderLabel('dashboard.textEmpty', isZh) }}</div>
+          </template>
+          <!-- Filter / control: PRESENTATIONAL ONLY — local UI state, drives no other panel. -->
+          <template v-else-if="panelType(panel) === 'filter'">
+            <div class="meta-dashboard__filter-widget" data-widget="filter">
+              <select
+                :value="filterSelections[panel.id] ?? ''"
+                class="meta-dashboard__select meta-dashboard__select--sm"
+                data-field="filter-control"
+                @change="onFilterControlChange(panel.id, ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="">{{ viewRenderLabel('dashboard.filterAllOption', isZh) }}</option>
+                <option
+                  v-for="field in chartFields"
+                  :key="field.id"
+                  :value="field.id"
+                >{{ field.name }}</option>
+              </select>
+              <small class="meta-dashboard__hint" data-hint="filter-presentational">{{ viewRenderLabel('dashboard.filterPresentationalNote', isZh) }}</small>
+            </div>
+          </template>
         </div>
       </div>
     </div>
@@ -134,6 +181,114 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <!-- B4: Add non-chart widget modal (metric / text / filter). Closed by default. -->
+    <div v-if="showAddWidget" class="meta-dashboard__modal-overlay" @click.self="showAddWidget = false">
+      <form class="meta-dashboard__modal" data-modal="add-widget" @submit.prevent="onSubmitWidget">
+        <div class="meta-dashboard__modal-header">
+          <h4>{{ viewRenderLabel('dashboard.addWidgetTitle', isZh) }}</h4>
+          <button class="meta-dashboard__btn meta-dashboard__btn--icon" type="button" @click="showAddWidget = false">&times;</button>
+        </div>
+        <div class="meta-dashboard__modal-body">
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.widgetKind', isZh) }}</span>
+            <select v-model="widgetDraft.kind" class="meta-dashboard__select" data-field="widget-kind">
+              <option value="metric">{{ viewRenderLabel('dashboard.widgetKindMetric', isZh) }}</option>
+              <option value="text">{{ viewRenderLabel('dashboard.widgetKindText', isZh) }}</option>
+              <option value="filter">{{ viewRenderLabel('dashboard.widgetKindFilter', isZh) }}</option>
+            </select>
+          </label>
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.widgetTitle', isZh) }}</span>
+            <input
+              v-model="widgetDraft.title"
+              class="meta-dashboard__input"
+              type="text"
+              data-field="widget-title"
+            />
+          </label>
+
+          <!-- Metric config -->
+          <template v-if="widgetDraft.kind === 'metric'">
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.aggregation', isZh) }}</span>
+              <select v-model="widgetDraft.aggregation" class="meta-dashboard__select" data-field="widget-aggregation">
+                <option value="count">count</option>
+                <option value="sum">sum</option>
+                <option value="avg">avg</option>
+                <option value="min">min</option>
+                <option value="max">max</option>
+              </select>
+            </label>
+            <label v-if="widgetRequiresValueField" class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.valueField', isZh) }}</span>
+              <select v-model="widgetDraft.valueFieldId" class="meta-dashboard__select" data-field="widget-value-field">
+                <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+                <option v-for="field in numericFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+              <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
+            </label>
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.metricPrefix', isZh) }}</span>
+              <input
+                v-model="widgetDraft.prefix"
+                class="meta-dashboard__input"
+                type="text"
+                data-field="widget-prefix"
+              />
+            </label>
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.metricSuffix', isZh) }}</span>
+              <input
+                v-model="widgetDraft.suffix"
+                class="meta-dashboard__input"
+                type="text"
+                data-field="widget-suffix"
+              />
+            </label>
+          </template>
+
+          <!-- Text config (routes through the rich-longtext sanitizer on render) -->
+          <template v-else-if="widgetDraft.kind === 'text'">
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.textContent', isZh) }}</span>
+              <textarea
+                v-model="widgetDraft.textContent"
+                class="meta-dashboard__input meta-dashboard__textarea"
+                data-field="widget-text-content"
+                :placeholder="viewRenderLabel('dashboard.textContentPlaceholder', isZh)"
+                rows="4"
+              ></textarea>
+            </label>
+          </template>
+
+          <!-- Filter config (presentational only) -->
+          <template v-else-if="widgetDraft.kind === 'filter'">
+            <label class="meta-dashboard__field">
+              <span>{{ viewRenderLabel('dashboard.filterField', isZh) }}</span>
+              <select v-model="widgetDraft.filterFieldId" class="meta-dashboard__select" data-field="widget-filter-field">
+                <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+                <option v-for="field in chartFields" :key="field.id" :value="field.id">
+                  {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+                </option>
+              </select>
+              <small class="meta-dashboard__hint" data-hint="filter-presentational-config">{{ viewRenderLabel('dashboard.filterPresentationalNote', isZh) }}</small>
+            </label>
+          </template>
+        </div>
+        <div class="meta-dashboard__modal-footer">
+          <button class="meta-dashboard__btn" type="button" @click="showAddWidget = false">{{ viewRenderLabel('dashboard.cancel', isZh) }}</button>
+          <button
+            class="meta-dashboard__btn meta-dashboard__btn--primary"
+            type="submit"
+            data-action="submit-add-widget"
+            :disabled="addWidgetDisabled || addingWidget"
+          >{{ viewRenderLabel('dashboard.addWidgetAction', isZh) }}</button>
+        </div>
+      </form>
     </div>
 
     <!-- Create chart modal -->
@@ -341,12 +496,13 @@ const MetaChartRenderer = defineAsyncComponent({
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
-import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
+import type { AggregationFunction, ChartDisplayConfig, ChartType, Dashboard, DashboardPanel, DashboardPanelType, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { useLocale } from '../../composables/useLocale'
 import { dashboardDefaultName, viewRenderLabel, viewSizeLabel } from '../utils/meta-view-render-labels'
 import { fieldTypeLabel } from '../utils/meta-core-labels'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
+import MetaRichLongTextRender from './cells/MetaRichLongTextRender.vue'
 
 const props = defineProps<{
   sheetId: string
@@ -360,8 +516,16 @@ const dashboards = ref<Dashboard[]>([])
 const charts = ref<ChartConfig[]>([])
 const chartDataMap = ref<Record<string, ChartData>>({})
 const chartConfigMap = ref<Record<string, ChartConfig>>({})
+// B4: metric-card data is keyed by panel.id (a metric has no chartId) so it never
+// collides with the chartId-keyed chartDataMap.
+const metricDataMap = ref<Record<string, ChartData>>({})
+// B4: presentational filter selections — LOCAL UI state only, keyed by panel.id.
+// Deliberately not persisted and drives nothing else (scoped-out functional filter).
+const filterSelections = ref<Record<string, string>>({})
 const activeDashboardId = ref<string>(props.dashboardId ?? '')
 const showAddPanel = ref(false)
+const showAddWidget = ref(false)
+const addingWidget = ref(false)
 const showCreateChart = ref(false)
 const editingChartId = ref<string | null>(null)
 const creatingChart = ref(false)
@@ -411,6 +575,21 @@ const chartDraft = ref({
   yFieldId: '',
   colorFieldId: '',
   sizeFieldId: '',
+})
+
+// B4: the non-chart widget authoring draft (metric / text / filter).
+const widgetDraft = ref({
+  kind: 'metric' as Exclude<DashboardPanelType, 'chart'>,
+  title: '',
+  // metric
+  aggregation: 'count' as AggregationFunction,
+  valueFieldId: '',
+  prefix: '',
+  suffix: '',
+  // text
+  textContent: '',
+  // filter (presentational)
+  filterFieldId: '',
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
@@ -473,6 +652,76 @@ const sortedPanels = computed(() => {
 
 function chartNameById(chartId: string): string {
   return chartConfigMap.value[chartId]?.name ?? chartId
+}
+
+// B4: a legacy panel (no `type`) is a chart — read the discriminator everywhere as `type ?? 'chart'`.
+function panelType(panel: DashboardPanel): DashboardPanelType {
+  return panel.type ?? 'chart'
+}
+
+// B4: resolve a chart panel's loaded data / config from its (now-optional) chartId. The narrowing
+// happens inside the function body, so the template bindings stay independent of cross-element
+// vue-tsc narrowing of `panel.chartId`.
+function panelChartData(panel: DashboardPanel): ChartData | undefined {
+  return panel.chartId ? chartDataMap.value[panel.chartId] : undefined
+}
+function panelChartConfig(panel: DashboardPanel): ChartConfig | undefined {
+  return panel.chartId ? chartConfigMap.value[panel.chartId] : undefined
+}
+
+// B4: header title. Chart panels use the chart name (legacy behavior); non-chart panels use
+// their own `title`, falling back to a localized "Untitled" — NEVER a raw chartId, which a
+// chartId-less widget does not have anyway.
+function panelTitle(panel: DashboardPanel): string {
+  if (panelType(panel) === 'chart') return chartNameById(panel.chartId ?? '')
+  return panel.title?.trim() || viewRenderLabel('dashboard.untitledWidget', isZh.value)
+}
+
+// B4: synthesize the metric card's display config (title + optional prefix/suffix) so the
+// reused MetaChartRenderer 'number' branch shows the KPI with the same chrome as a number chart.
+function metricDisplayConfig(panel: DashboardPanel): ChartDisplayConfig {
+  return {
+    prefix: panel.metricConfig?.prefix,
+    suffix: panel.metricConfig?.suffix,
+  }
+}
+
+// B4: presentational filter — update LOCAL state only. No data refetch, no cross-panel effect.
+function onFilterControlChange(panelId: string, value: string) {
+  filterSelections.value = { ...filterSelections.value, [panelId]: value }
+}
+
+// B4: metric needs a value field only for sum/avg/min/max (count aggregates row presence).
+const widgetRequiresValueField = computed(() =>
+  AGGREGATIONS_REQUIRING_VALUE.has(widgetDraft.value.aggregation),
+)
+const addWidgetDisabled = computed(() => {
+  if (!activeDashboard.value) return true
+  if (widgetDraft.value.kind === 'metric') {
+    return widgetRequiresValueField.value && !widgetDraft.value.valueFieldId
+  }
+  // text + filter have no required inputs (an empty text widget is allowed and editable later).
+  return false
+})
+
+// B4: build the synthesized number-chart input a metric card computes through preview-data.
+// Same field-read-enforced path a 'number' chart preview uses — NO field-perm bypass.
+function buildMetricChartInput(panel: DashboardPanel): ChartCreateInput {
+  const cfg = panel.metricConfig
+  const aggregation = cfg?.aggregation ?? 'count'
+  const needsField = AGGREGATIONS_REQUIRING_VALUE.has(aggregation)
+  const dataSource: ChartDataSource = {
+    sheetId: props.sheetId,
+    aggregation: {
+      function: aggregation,
+      ...(needsField && cfg?.valueFieldId ? { fieldId: cfg.valueFieldId } : {}),
+    },
+  }
+  return {
+    name: panel.title?.trim() || viewRenderLabel('dashboard.untitledWidget', isZh.value),
+    chartType: 'number',
+    dataSource,
+  }
 }
 
 function resetChartDraft() {
@@ -553,16 +802,46 @@ async function loadData() {
 async function loadPanelData() {
   if (!props.client || !activeDashboard.value) return
   const panels = activeDashboard.value.panels
+  // B4: iterate ALL panel kinds. Chart panels load via getChartData (chartId-keyed);
+  // metric panels compute via previewChartData (panel.id-keyed); text/filter need no data.
   const promises = panels.map(async (panel) => {
-    if (chartDataMap.value[panel.chartId]) return
-    try {
-      const data = await props.client!.getChartData(props.sheetId, panel.chartId)
-      chartDataMap.value[panel.chartId] = data
-    } catch {
-      // skip
+    const kind = panelType(panel)
+    if (kind === 'chart') {
+      if (!panel.chartId || chartDataMap.value[panel.chartId]) return
+      try {
+        const data = await props.client!.getChartData(props.sheetId, panel.chartId)
+        chartDataMap.value[panel.chartId] = data
+      } catch {
+        // skip
+      }
+      return
+    }
+    if (kind === 'metric') {
+      await loadMetricData(panel)
     }
   })
   await Promise.all(promises)
+}
+
+// B4: compute a metric card's single value through the NON-persisting, field-read-enforced
+// preview-data endpoint (isChartDataRestricted is applied server-side). Never bypasses
+// field permissions; a restricted result renders MetaChartRenderer's restricted notice.
+//
+// loadPanelData can fire twice in quick succession (the sheetId immediate watch + the
+// activeDashboard.id watch) before the first preview resolves, so an in-flight set
+// dedupes concurrent loads — the resolved-data guard only catches already-loaded panels.
+const metricInFlight = new Set<string>()
+async function loadMetricData(panel: DashboardPanel) {
+  if (!props.client || metricDataMap.value[panel.id] || metricInFlight.has(panel.id)) return
+  metricInFlight.add(panel.id)
+  try {
+    const data = await props.client.previewChartData(props.sheetId, buildMetricChartInput(panel))
+    metricDataMap.value[panel.id] = data
+  } catch {
+    // skip — panel keeps its loading state
+  } finally {
+    metricInFlight.delete(panel.id)
+  }
 }
 
 async function onCreateDashboard() {
@@ -584,28 +863,106 @@ async function onAddPanel(chartId: string) {
 
 async function addPanelForChart(chartId: string) {
   if (!props.client || !activeDashboard.value) return
-  const db = activeDashboard.value
   const newPanel: DashboardPanel = {
     id: `panel_${Date.now()}`,
+    type: 'chart',
     chartId,
     size: 'medium',
-    order: db.panels.length,
+    order: activeDashboard.value.panels.length,
   }
+  const appended = await appendPanel(newPanel)
+  if (!appended) return
+  // Load chart data
+  if (!chartDataMap.value[chartId]) {
+    try {
+      chartDataMap.value[chartId] = await props.client.getChartData(props.sheetId, chartId)
+    } catch {
+      // skip
+    }
+  }
+}
+
+// B4: shared panel-append (PATCH the full panels list, sync local state). Used by
+// chart panels and the metric/text/filter widget flow. Returns true on success.
+async function appendPanel(newPanel: DashboardPanel): Promise<boolean> {
+  if (!props.client || !activeDashboard.value) return false
+  const db = activeDashboard.value
   const updated = [...db.panels, newPanel]
   try {
     const result = await props.client.updateDashboard(props.sheetId, db.id, { panels: updated })
     const idx = dashboards.value.findIndex((d) => d.id === db.id)
     if (idx >= 0) dashboards.value[idx] = result
-    // Load chart data
-    if (!chartDataMap.value[chartId]) {
-      try {
-        chartDataMap.value[chartId] = await props.client.getChartData(props.sheetId, chartId)
-      } catch {
-        // skip
+    return true
+  } catch {
+    return false
+  }
+}
+
+function openAddWidget() {
+  if (!activeDashboard.value) return
+  widgetDraft.value = {
+    kind: 'metric',
+    title: '',
+    aggregation: 'count',
+    valueFieldId: '',
+    prefix: '',
+    suffix: '',
+    textContent: '',
+    filterFieldId: '',
+  }
+  showAddWidget.value = true
+}
+
+// B4: build the tagged-union panel for the chosen widget kind and append it. Only the
+// active kind's config sub-object is set, so a metric/text/filter panel round-trips
+// cleanly through the opaque-JSONB wire.
+async function onSubmitWidget() {
+  if (!props.client || !activeDashboard.value || addWidgetDisabled.value) return
+  addingWidget.value = true
+  try {
+    const kind = widgetDraft.value.kind
+    const title = widgetDraft.value.title.trim()
+    const base: Pick<DashboardPanel, 'id' | 'size' | 'order'> = {
+      id: `panel_${Date.now()}`,
+      size: 'medium',
+      order: activeDashboard.value.panels.length,
+    }
+    let newPanel: DashboardPanel
+    if (kind === 'metric') {
+      const needsField = AGGREGATIONS_REQUIRING_VALUE.has(widgetDraft.value.aggregation)
+      newPanel = {
+        ...base,
+        type: 'metric',
+        ...(title ? { title } : {}),
+        metricConfig: {
+          aggregation: widgetDraft.value.aggregation,
+          ...(needsField && widgetDraft.value.valueFieldId ? { valueFieldId: widgetDraft.value.valueFieldId } : {}),
+          ...(widgetDraft.value.prefix.trim() ? { prefix: widgetDraft.value.prefix.trim() } : {}),
+          ...(widgetDraft.value.suffix.trim() ? { suffix: widgetDraft.value.suffix.trim() } : {}),
+        },
+      }
+    } else if (kind === 'text') {
+      newPanel = {
+        ...base,
+        type: 'text',
+        ...(title ? { title } : {}),
+        textConfig: { content: widgetDraft.value.textContent },
+      }
+    } else {
+      newPanel = {
+        ...base,
+        type: 'filter',
+        ...(title ? { title } : {}),
+        filterConfig: { ...(widgetDraft.value.filterFieldId ? { fieldId: widgetDraft.value.filterFieldId } : {}) },
       }
     }
-  } catch {
-    // skip
+    const appended = await appendPanel(newPanel)
+    if (appended) {
+      showAddWidget.value = false
+      if (kind === 'metric') await loadMetricData(newPanel)
+    }
+  } finally {
+    addingWidget.value = false
   }
 }
 
@@ -975,6 +1332,21 @@ onBeforeUnmount(resetChartPreview)
 
 .meta-dashboard__panel-body { padding: 12px 14px; flex: 1; display: flex; align-items: center; justify-content: center; }
 .meta-dashboard__panel-loading { font-size: 12px; color: #94a3b8; }
+
+/* B4: non-chart widget bodies left-align their content (KPI / note / control). */
+.meta-dashboard__text-widget { align-self: stretch; width: 100%; }
+.meta-dashboard__filter-widget {
+  align-self: stretch;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.meta-dashboard__textarea {
+  resize: vertical;
+  min-height: 80px;
+  font-family: inherit;
+}
 
 .meta-dashboard__modal-overlay {
   position: fixed;

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1113,9 +1113,52 @@ export interface ChartData {
 }
 
 // --- Dashboard ---
+// B4: a panel is no longer chart-only. `type` is the widget discriminator and is
+// OPTIONAL — a legacy panel (no `type`) is a chart, so every consumer MUST read
+// `panel.type ?? 'chart'`. This keeps existing DB rows (opaque JSONB, no `type`)
+// rendering unchanged and needs no migration. Per-widget config lives in optional
+// sub-objects; only the active widget's sub-object is meaningful.
+export type DashboardPanelType = 'chart' | 'metric' | 'text' | 'filter'
+
+// B4 metric/number card: a standalone KPI computed via the non-persisting,
+// field-read-enforced preview-data endpoint (NOT a saved ChartConfig row). The
+// metric never persists a chart; it stores only its data source + label here.
+export interface DashboardMetricConfig {
+  /** Aggregation function for the single value (count needs no field). */
+  aggregation: AggregationFunction
+  /** Value field for sum/avg/min/max (ignored by count). */
+  valueFieldId?: string
+  /** Optional display affixes around the number (e.g. ¥ / %). */
+  prefix?: string
+  suffix?: string
+}
+
+// B4 text/markdown note: rich HTML routed through the SHARED rich-longtext
+// DOMPurify chokepoint (RICH_LONGTEXT_SANITIZE_CONFIG) on every render — never raw.
+export interface DashboardTextConfig {
+  /** Raw (re-sanitized on render) rich-text HTML content. */
+  content: string
+}
+
+// B4 filter/control: PRESENTATIONAL-ONLY in this arc — it renders a control whose
+// value lives in local UI state and drives NOTHING else. A functional cross-panel
+// filter is a separate, design-locked slice (see designDecisions in the arc map).
+export interface DashboardFilterConfig {
+  /** Field the (presentational) control is labeled against. */
+  fieldId?: string
+}
+
 export interface DashboardPanel {
   id: string
-  chartId: string
+  /** Widget kind. Absent → 'chart' (legacy panels). Read as `type ?? 'chart'`. */
+  type?: DashboardPanelType
+  /** Required for a chart panel; absent for metric/text/filter widgets. */
+  chartId?: string
+  /** Optional widget title for non-chart panels (chart panels use the chart name). */
+  title?: string
+  metricConfig?: DashboardMetricConfig
+  textConfig?: DashboardTextConfig
+  filterConfig?: DashboardFilterConfig
   size: 'small' | 'medium' | 'large'
   order: number
 }

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -128,6 +128,24 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.deleteChart'
   | 'dashboard.deleteChartConfirm'
   | 'dashboard.editChartError'
+  | 'dashboard.addWidget'
+  | 'dashboard.addWidgetTitle'
+  | 'dashboard.widgetKind'
+  | 'dashboard.widgetKindMetric'
+  | 'dashboard.widgetKindText'
+  | 'dashboard.widgetKindFilter'
+  | 'dashboard.widgetTitle'
+  | 'dashboard.untitledWidget'
+  | 'dashboard.metricPrefix'
+  | 'dashboard.metricSuffix'
+  | 'dashboard.textContent'
+  | 'dashboard.textContentPlaceholder'
+  | 'dashboard.textEmpty'
+  | 'dashboard.filterField'
+  | 'dashboard.filterPresentationalNote'
+  | 'dashboard.filterAllOption'
+  | 'dashboard.addWidgetAction'
+  | 'dashboard.loadingMetric'
   | 'chart.label'
   | 'chart.value'
   | 'chart.restrictedTitle'
@@ -254,6 +272,24 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.deleteChart',
   'dashboard.deleteChartConfirm',
   'dashboard.editChartError',
+  'dashboard.addWidget',
+  'dashboard.addWidgetTitle',
+  'dashboard.widgetKind',
+  'dashboard.widgetKindMetric',
+  'dashboard.widgetKindText',
+  'dashboard.widgetKindFilter',
+  'dashboard.widgetTitle',
+  'dashboard.untitledWidget',
+  'dashboard.metricPrefix',
+  'dashboard.metricSuffix',
+  'dashboard.textContent',
+  'dashboard.textContentPlaceholder',
+  'dashboard.textEmpty',
+  'dashboard.filterField',
+  'dashboard.filterPresentationalNote',
+  'dashboard.filterAllOption',
+  'dashboard.addWidgetAction',
+  'dashboard.loadingMetric',
   'chart.label',
   'chart.value',
   'chart.restrictedTitle',
@@ -387,6 +423,27 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.deleteChart': { en: 'Delete', zh: '删除' },
   'dashboard.deleteChartConfirm': { en: 'Delete this chart? Panels showing it will be removed.', zh: '删除此图表？引用它的面板将被移除。' },
   'dashboard.editChartError': { en: 'Failed to save chart.', zh: '保存图表失败。' },
+  'dashboard.addWidget': { en: '+ Add Widget', zh: '+ 添加组件' },
+  'dashboard.addWidgetTitle': { en: 'Add widget', zh: '添加组件' },
+  'dashboard.widgetKind': { en: 'Widget type', zh: '组件类型' },
+  'dashboard.widgetKindMetric': { en: 'Metric card', zh: '指标卡' },
+  'dashboard.widgetKindText': { en: 'Text note', zh: '文本说明' },
+  'dashboard.widgetKindFilter': { en: 'Filter (preview)', zh: '筛选器（预览）' },
+  'dashboard.widgetTitle': { en: 'Title', zh: '标题' },
+  'dashboard.untitledWidget': { en: 'Untitled', zh: '未命名' },
+  'dashboard.metricPrefix': { en: 'Prefix (optional)', zh: '前缀（可选）' },
+  'dashboard.metricSuffix': { en: 'Suffix (optional)', zh: '后缀（可选）' },
+  'dashboard.textContent': { en: 'Content', zh: '内容' },
+  'dashboard.textContentPlaceholder': { en: 'Write a note (basic formatting allowed)…', zh: '撰写说明（支持基础格式）…' },
+  'dashboard.textEmpty': { en: 'Empty text widget. Edit it to add content.', zh: '空文本组件。编辑以添加内容。' },
+  'dashboard.filterField': { en: 'Field', zh: '字段' },
+  'dashboard.filterPresentationalNote': {
+    en: 'Preview only — this control does not filter other panels yet.',
+    zh: '仅供预览——此控件暂不会筛选其他面板。',
+  },
+  'dashboard.filterAllOption': { en: 'All', zh: '全部' },
+  'dashboard.addWidgetAction': { en: 'Add', zh: '添加' },
+  'dashboard.loadingMetric': { en: 'Loading metric...', zh: '正在加载指标...' },
   'chart.label': { en: 'Label', zh: '标签' },
   'chart.value': { en: 'Value', zh: '值' },
   'chart.restrictedTitle': { en: 'Chart data restricted', zh: '图表数据受限' },

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -1180,4 +1180,252 @@ describe('MetaDashboardView', () => {
     expect(container.querySelector('[data-chart-canvas]')).toBeTruthy()
     expect(container.querySelector('[data-legend]')).toBeTruthy()
   })
+
+  // ---- B4: dashboard non-chart widgets (metric / text / filter) ----
+
+  it('B4 backward-compat: a legacy panel with NO `type` renders as a chart', async () => {
+    // The fakeDashboard panel is {id,chartId,size,order} with no `type` — the canonical legacy row.
+    const { client } = mockClient([fakeDashboard()], [fakeChart()])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const panel = container.querySelector('[data-panel-id="panel_1"]')
+    expect(panel).toBeTruthy()
+    expect(panel?.getAttribute('data-panel-type')).toBe('chart')
+    // The chart renderer (canvas) mounts for the legacy panel exactly as before.
+    expect(panel?.querySelector('[data-chart-canvas]')).toBeTruthy()
+    // Header still shows the chart name (not a raw chartId).
+    expect(panel?.querySelector('.meta-dashboard__panel-chart-name')?.textContent).toContain('Sales Chart')
+  })
+
+  it('B4 metric: renders a metric panel via the field-read-enforced preview-data path, keyed by panel.id', async () => {
+    const metricDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_metric', type: 'metric', title: 'Total revenue', size: 'small', order: 0, metricConfig: { aggregation: 'sum', valueFieldId: 'fld_amount' } },
+      ],
+    })
+    const { client, fetchFn } = mockClient([metricDashboard], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({
+      chartType: 'number',
+      dataPoints: [{ label: 'Total revenue', value: 1234 }],
+      total: 1234,
+    })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    const panel = container.querySelector('[data-panel-id="panel_metric"]')
+    expect(panel?.getAttribute('data-panel-type')).toBe('metric')
+    // Computes through previewChartData (NOT getChartData) with a synthesized number config.
+    expect(previewSpy).toHaveBeenCalledTimes(1)
+    expect(previewSpy).toHaveBeenCalledWith('sheet_1', expect.objectContaining({
+      chartType: 'number',
+      dataSource: expect.objectContaining({ aggregation: { function: 'sum', fieldId: 'fld_amount' } }),
+    }))
+    // No persisted chart fetch (no chartId on a metric panel).
+    const dataLoads = fetchFn.mock.calls.filter(([url]: [string]) => /\/charts\/[^/]+\/data/.test(url))
+    expect(dataLoads.length).toBe(0)
+    // The aggregated value renders through MetaChartRenderer's number branch.
+    const number = panel?.querySelector('[data-chart="number"]')
+    expect(number?.textContent).toContain('1234')
+  })
+
+  it('B4 metric: a restricted metric surfaces the restricted notice (no field-perm bypass)', async () => {
+    const metricDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_metric', type: 'metric', title: 'Restricted KPI', size: 'small', order: 0, metricConfig: { aggregation: 'sum', valueFieldId: 'fld_amount' } },
+      ],
+    })
+    const { client } = mockClient([metricDashboard], [])
+    // The server-side preview-data path returns a restricted ChartData when the user can't read the field.
+    vi.spyOn(client, 'previewChartData').mockResolvedValue({
+      chartType: 'number',
+      dataPoints: [],
+      total: 0,
+      metadata: { restricted: true, recordCount: 0 },
+    })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    const panel = container.querySelector('[data-panel-id="panel_metric"]')
+    expect(panel?.querySelector('[data-chart-restricted]')).toBeTruthy()
+    expect(panel?.textContent).toContain('Chart data restricted')
+  })
+
+  it('B4 text: renders sanitized content through the rich-longtext chokepoint (strips XSS, keeps benign tags)', async () => {
+    const textDashboard = fakeDashboard({
+      panels: [
+        {
+          id: 'panel_text',
+          type: 'text',
+          title: 'Note',
+          size: 'medium',
+          order: 0,
+          textConfig: {
+            content: '<strong>Important</strong> <a href="https://ok.example">link</a><img src=x onerror="alert(1)"><script>alert(2)</script>',
+          },
+        },
+      ],
+    })
+    const { client } = mockClient([textDashboard], [])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    const panel = container.querySelector('[data-panel-id="panel_text"]')
+    expect(panel?.getAttribute('data-panel-type')).toBe('text')
+    const widget = panel?.querySelector('[data-widget="text"]') as HTMLElement
+    expect(widget).toBeTruthy()
+    // XSS canaries stripped.
+    expect(widget.innerHTML).not.toContain('onerror')
+    expect(widget.innerHTML.toLowerCase()).not.toContain('<script')
+    expect(widget.querySelector('img')).toBeNull()
+    expect(widget.querySelector('script')).toBeNull()
+    // Benign formatting survives; links are hardened with rel/target.
+    expect(widget.querySelector('strong')?.textContent).toBe('Important')
+    const link = widget.querySelector('a')
+    expect(link?.getAttribute('href')).toBe('https://ok.example')
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(link?.getAttribute('target')).toBe('_blank')
+  })
+
+  it('B4 filter: renders a PRESENTATIONAL control and updates local state only (no refetch / no cross-panel effect)', async () => {
+    const filterDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_chart', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
+        { id: 'panel_filter', type: 'filter', title: 'Status filter', size: 'small', order: 1, filterConfig: { fieldId: 'fld_status' } },
+      ],
+    })
+    const { client, fetchFn } = mockClient([filterDashboard], [fakeChart()])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    const filterPanel = container.querySelector('[data-panel-id="panel_filter"]')
+    expect(filterPanel?.getAttribute('data-panel-type')).toBe('filter')
+    const control = filterPanel?.querySelector('[data-field="filter-control"]') as HTMLSelectElement
+    expect(control).toBeTruthy()
+    // Clearly labeled as presentational.
+    expect(filterPanel?.querySelector('[data-hint="filter-presentational"]')).toBeTruthy()
+
+    const dataCallsBefore = getDataSpy.mock.calls.length
+    const patchBefore = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH').length
+
+    control.value = 'fld_status'
+    control.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // Changing the control triggers NO data refetch and NO dashboard PATCH (local UI state only).
+    expect(getDataSpy.mock.calls.length).toBe(dataCallsBefore)
+    const patchAfter = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH').length
+    expect(patchAfter).toBe(patchBefore)
+    // The chart panel still renders unchanged (filter does not drive it).
+    expect(container.querySelector('[data-panel-id="panel_chart"] [data-chart-canvas]')).toBeTruthy()
+  })
+
+  it('B4 mixed: a dashboard with [chart, metric, text] renders all three widget kinds in one grid', async () => {
+    const mixedDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_chart', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
+        { id: 'panel_metric', type: 'metric', title: 'KPI', size: 'small', order: 1, metricConfig: { aggregation: 'count' } },
+        { id: 'panel_text', type: 'text', title: 'Heading', size: 'medium', order: 2, textConfig: { content: '<h2>Section</h2>' } },
+      ],
+    })
+    const { client } = mockClient([mixedDashboard], [fakeChart()])
+    vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'number', dataPoints: [{ label: 'KPI', value: 7 }], total: 7 })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    expect(container.querySelector('[data-panel-id="panel_chart"] [data-chart-canvas]')).toBeTruthy()
+    expect(container.querySelector('[data-panel-id="panel_metric"] [data-chart="number"]')?.textContent).toContain('7')
+    expect(container.querySelector('[data-panel-id="panel_text"] [data-widget="text"] h2')?.textContent).toBe('Section')
+  })
+
+  it('B4 add-widget: adds a metric widget and PATCHes the tagged-union panel into the panel list', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client, fetchFn } = mockClient([dashboard], [])
+    vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'number', dataPoints: [{ label: 'm', value: 3 }], total: 3 })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-widget"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const kindSelect = container.querySelector('[data-field="widget-kind"]') as HTMLSelectElement
+    expect(kindSelect).toBeTruthy()
+    kindSelect.value = 'metric'
+    kindSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="widget-title"]') as HTMLInputElement
+    titleInput.value = 'Order count'
+    titleInput.dispatchEvent(new Event('input'))
+    const aggSelect = container.querySelector('[data-field="widget-aggregation"]') as HTMLSelectElement
+    aggSelect.value = 'sum'
+    aggSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    const valueSelect = container.querySelector('[data-field="widget-value-field"]') as HTMLSelectElement
+    valueSelect.value = 'fld_amount'
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="submit-add-widget"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH')
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1].body as string)
+    expect(body.panels).toEqual([
+      expect.objectContaining({
+        type: 'metric',
+        title: 'Order count',
+        size: 'medium',
+        order: 0,
+        metricConfig: { aggregation: 'sum', valueFieldId: 'fld_amount' },
+      }),
+    ])
+    // No persisted chart was created for the metric widget.
+    const chartPosts = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => /\/charts(\?|$)/.test(url) && init?.method === 'POST')
+    expect(chartPosts.length).toBe(0)
+  })
+
+  it('B4 add-widget: adds a text widget carrying its content in the PATCH body', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client, fetchFn } = mockClient([dashboard], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-widget"]') as HTMLButtonElement).click()
+    await flushPromises()
+    const kindSelect = container.querySelector('[data-field="widget-kind"]') as HTMLSelectElement
+    kindSelect.value = 'text'
+    kindSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    const textArea = container.querySelector('[data-field="widget-text-content"]') as HTMLTextAreaElement
+    textArea.value = '<strong>Hello</strong>'
+    textArea.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="submit-add-widget"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patchCalls = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH')
+    expect(patchCalls.length).toBe(1)
+    const body = JSON.parse(patchCalls[0][1].body as string)
+    expect(body.panels[0]).toMatchObject({ type: 'text', textConfig: { content: '<strong>Hello</strong>' } })
+  })
+
+  it('B4 i18n: the add-widget chrome localizes under zh-CN with no hardcoded strings', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    expect(container.textContent).toContain('+ 添加组件')
+    ;(container.querySelector('[data-action="add-widget"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(container.textContent).toContain('添加组件')
+    expect(container.textContent).toContain('组件类型')
+    expect(container.textContent).toContain('指标卡')
+    expect(container.textContent).toContain('文本说明')
+    expect(container.textContent).toContain('筛选器（预览）')
+  })
 })

--- a/packages/core-backend/src/multitable/dashboard.ts
+++ b/packages/core-backend/src/multitable/dashboard.ts
@@ -1,11 +1,34 @@
 /**
  * Dashboard model definitions for multitable dashboard V1.
+ *
+ * NOTE: panels are stored as OPAQUE JSONB — this type is documentation only and
+ * is NOT used to validate or reshape the persisted panel (DashboardService spreads
+ * `input.panels` straight into the row). The de-facto contract is the frontend
+ * `DashboardPanel` (apps/web/src/multitable/types.ts). Kept in sync for honesty.
+ *
+ * B4: a panel is a tagged union over an OPTIONAL `type` discriminator. A legacy
+ * panel (no `type`) is a chart; consumers read `type ?? 'chart'`. No migration is
+ * needed because the panel round-trips opaquely.
  */
+
+export type DashboardPanelType = 'chart' | 'metric' | 'text' | 'filter'
 
 export interface DashboardPanel {
   id: string
-  chartId: string
-  position: { x: number; y: number; w: number; h: number } // grid layout
+  /** Absent → 'chart' (legacy panels). */
+  type?: DashboardPanelType
+  /** Required for a chart panel; absent for metric/text/filter widgets. */
+  chartId?: string
+  /** Optional widget title for non-chart panels. */
+  title?: string
+  /** Per-widget config (only the active widget's sub-object is meaningful). */
+  metricConfig?: { aggregation: string; valueFieldId?: string; prefix?: string; suffix?: string }
+  textConfig?: { content: string }
+  filterConfig?: { fieldId?: string }
+  size?: 'small' | 'medium' | 'large'
+  order?: number
+  /** Legacy V1 grid layout (superseded by `size`/`order`); tolerated on read. */
+  position?: { x: number; y: number; w: number; h: number }
 }
 
 export interface Dashboard {


### PR DESCRIPTION
## B4 — dashboard non-chart widgets
Extends `DashboardPanel` into a **backward-compatible** tagged union: optional `type` discriminator ('chart'|'metric'|'text'|'filter'); every consumer reads `panel.type ?? 'chart'`, so legacy panels (no type, opaque JSONB) render as charts with **no migration**.

- **Metric card** computes via the existing non-persisting, field-read-enforced `previewChartData` endpoint (keyed by panel.id, no chartId/persisted ChartConfig row), renders through MetaChartRenderer's number branch, surfaces the restricted notice when the field is unreadable (**no field-perm bypass**).
- **Text widget** renders through the shared rich-longText DOMPurify chokepoint (`RICH_LONGTEXT_SANITIZE_CONFIG`) — never raw v-html.
- **Filter widget** presentational-only (local state, clearly labeled).
- All new UI strings typed i18n (union+record, en+zh; no dead keys).

**Tests**: 55/55 (48 dashboard incl. 8 new B4 + 7 label). **Review verdict: ship** (security: text-widget XSS surface closed; metric reuses the restricted preview route; no new write-authz).

**Owner-deferred (safe defaults)**: filter is presentational-only (functional cross-panel filter is a separate arc); metric reuses MetaChartRenderer's number branch vs a dedicated MetricCard; dashboard.ts type aligned for doc honesty; metric value field gated to sum/avg/min/max.

Built + adversarially reviewed by parallel subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)