### PR TITLE
docs(data-source): lock release observability boundary

### DIFF
--- a/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
+++ b/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
@@ -1,6 +1,6 @@
 # Data Source System Integration C6 - External Write Design
 
-Status: C6-0 design + C6-1 latent target + C6-2 dry-run route + C6-3 token-bound apply route; C6-4 UI in review; C6-5 entity-machine validation still gated
+Status: C6-0 design + C6-1 latent target + C6-2 dry-run route + C6-3 token-bound apply route + C6-4 UI merged; C6-5 entity-machine validation still gated
 Date: 2026-06-16
 
 ## Purpose
@@ -297,6 +297,28 @@ C6 evidence must not include:
 - raw payload JSON;
 - target request bodies;
 - stack traces with values.
+
+## Release Observability Boundary
+
+Release for the database/system-connection track does not add a new read-side
+DF-N unification slice. The scoped v1 boundary is:
+
+- C2/C3 database reads executed through the existing pipeline runner may use the
+  existing `integration_runs` run ledger and run details, including C3
+  watermark/cursor details already designed for values-free evidence.
+- C2/C3 do not promise per-row DB-read provenance events in
+  `integration_provenance_by_row`, read-side dead-letters for successful reads,
+  or a new DF-N monitoring surface as part of this delivery.
+- C6 apply is different because it mutates an external target. C6 write
+  outcomes must remain visible through values-free run/dead-letter/provenance
+  evidence when attribution is available, as locked by the C6-3 apply route.
+- Release notes must describe the delivered read capability as database source
+  connectivity plus pipeline/run metrics, not as full per-row read lineage.
+
+A future DF-N/read-observability slice may add source-read provenance or a
+unified monitoring surface for database reads, but it is not a prerequisite for
+C6-5 sandbox smoke. That future slice must be a separate opt-in with its own
+tests and values-free evidence contract.
 
 ## Implementation Slices
 

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -429,21 +429,27 @@ TODO:
 
 ## Cross-Cutting - 运行账本 / 可观测层 Seam
 
-当前计划主要覆盖 connector/read/write 能力，但还必须在 Release 前定清它和既有 Data Factory 可观测层的关系。
+当前计划主要覆盖 connector/read/write 能力。Release 前的可观测层边界已按 C6 design 固化:
+本交付不新增 read-side DF-N 统一账本切片；C2/C3 读路径使用既有 pipeline run/run details 能力，
+不承诺 per-row DB-read provenance。C6 apply 因为会写外部目标，仍必须进入 values-free
+dead-letter/provenance/run evidence。
 
-待定问题:
+决策:
 
-- [ ] `data-source:sql-readonly` 读是否必须进入同一运行账本。
-- [ ] DB source run 是否产出 provenance。
+- [x] `data-source:sql-readonly` 读不新增单独 DF-N 统一账本要求；通过既有 pipeline runner 执行时保留
+  `integration_runs` run/run details。
+- [x] DB source read v1 不产出 per-row source-read provenance；这是后续 DF-N/read-observability track。
 - [x] C6 apply per-row failure 进入 values-free dead-letter / provenance（C6-3 route 已接线；C2/C3 read/run
-  观测层是否统一纳入仍待 Release 前定清）。
-- [ ] 是否接入既有 run-record / DF-N 监控面。
+  侧不扩大到 per-row source-read provenance）。
+- [x] Release 文档不得把“可读”误描述为“完整 DF-N per-row read lineage”；若后续要接入统一
+  run-record / DF-N 监控面，必须另开 opt-in。
 
 完成条件:
 
-- 如果要求纳入统一 Data Factory 运行账本，C3/C2 read/run 侧仍需补 provenance/dead-letter/run-record
-  接线和测试；C6 apply 侧已由 C6-3 route 写入 run/provenance/dead-letter。
-- 如果暂不纳入，Release 文档必须明确这是另一条 track，不得把“可读”误描述为“已接入完整 DF 观测层”。
+- 当前 Release scope 暂不纳入 read-side DF-N 统一账本；这是另一条 track。
+- 不得把“可读数据库源”误描述为“已接入完整 DF per-row read lineage”。
+- 若未来要求纳入统一 Data Factory 运行账本，C3/C2 read/run 侧仍需补 provenance/dead-letter/run-record
+  接线和测试。
 - C6 per-row result 字段必须有 wire-vs-fixture 集成测试，断言真实 route body/response，不只测 helper fixture。
 
 ## Release - 总包与实体机验收


### PR DESCRIPTION
## Summary

- lock the Release observability boundary for the data-source/system-connection track
- state that C2/C3 database reads do not add a new read-side DF-N unification slice or per-row DB-read provenance in this delivery
- keep C6 apply write outcomes under values-free run/dead-letter/provenance evidence
- refresh the C6 design status now that #2719 is merged

## Verification

- `git diff --check`
- inspected C6 apply route: it starts/finishes an integration run and submits values-free provenance events/dead-letter evidence for write outcomes
- verified #2720 remains the C6-5 entity-machine smoke gate; this PR does not mark it complete

## Boundaries

Docs-only. No runtime, route, UI, package, K3, raw SQL, external write, production, or batch changes.
