### PR TITLE
feat(multitable): native person/member field (coexistence-only) (Person)

### DIFF
--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -198,6 +198,14 @@
             :disabled="isFieldReadOnly(field.id)"
             @click="emit('open-link-picker', field)"
           >{{ linkButtonLabel(field.id) }}</button>
+          <button
+            v-else-if="field.type === 'person'"
+            type="button"
+            class="meta-form-view__link-btn"
+            data-test="form-person-picker-open"
+            :disabled="isFieldReadOnly(field.id)"
+            @click="emit('open-person-picker', field)"
+          >{{ linkButtonLabel(field.id) }}</button>
           <div v-else-if="field.type === 'attachment'" class="meta-form-view__attachment-field">
             <div v-if="!isFieldReadOnly(field.id)" class="meta-form-view__attachment-controls">
               <input
@@ -329,6 +337,7 @@ import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import type {
   FormLayoutConfig,
   LinkedRecordSummary,
+  PersonSummary,
   MetaAttachment,
   MetaAttachmentDeleteFn,
   MetaAttachmentUploadFn,
@@ -393,6 +402,7 @@ const props = defineProps<{
   fieldPermissions?: Record<string, MetaFieldPermission> | null
   rowActions?: MetaRowActions | null
   linkSummariesByField?: Record<string, LinkedRecordSummary[]> | null
+  personSummariesByField?: Record<string, PersonSummary[]> | null
   attachmentSummariesByField?: Record<string, MetaAttachment[]> | null
   uploadFn?: MetaAttachmentUploadFn
   deleteAttachmentFn?: MetaAttachmentDeleteFn
@@ -412,6 +422,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'submit', data: Record<string, unknown>): void
   (e: 'open-link-picker', field: MetaField): void
+  (e: 'open-person-picker', field: MetaField): void
   (e: 'update:dirty', dirty: boolean): void
   (e: 'comment-field', field: MetaField): void
 }>()
@@ -649,6 +660,7 @@ function readonlyFieldDisplay(field: MetaField): string {
     field,
     value: formData[field.id] ?? props.record?.data[field.id],
     linkSummaries: props.linkSummariesByField?.[field.id],
+    personSummaries: props.personSummariesByField?.[field.id],
     attachmentSummaries: props.attachmentSummariesByField?.[field.id],
     isZh: isZh.value,
   })

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -97,6 +97,7 @@
                     @confirm="confirmEdit(row)"
                     @cancel="cancelEdit"
                     @open-link-picker="openLinkPickerFromCell(row.id, field)"
+                    @open-person-picker="openPersonPickerFromCell(row.id, field)"
                     @ai-run="onAiRunFromCell(row.id, field)"
                   />
                   <MetaCellRenderer
@@ -104,6 +105,7 @@
                     :field="field"
                     :value="row.data[field.id]"
                     :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
+                    :person-summaries="props.personSummaries?.[row.id]?.[field.id]"
                     :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                     :button-pending="isButtonPending(row.id, field.id)"
                     :fetch-record="props.fetchRecord"
@@ -228,6 +230,7 @@
                   @yjs-commit="markYjsHandled(row.id, field.id)"
                   @cancel="cancelEdit"
                   @open-link-picker="openLinkPickerFromCell(row.id, field)"
+                  @open-person-picker="openPersonPickerFromCell(row.id, field)"
                   @ai-run="onAiRunFromCell(row.id, field)"
                 />
                 <MetaCellRenderer
@@ -235,6 +238,7 @@
                   :field="field"
                   :value="row.data[field.id]"
                   :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
+                  :person-summaries="props.personSummaries?.[row.id]?.[field.id]"
                   :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                   :button-pending="isButtonPending(row.id, field.id)"
                   :fetch-record="props.fetchRecord"
@@ -263,6 +267,7 @@
                         :field="field"
                         :value="row.data[field.id]"
                         :link-summaries="props.linkSummaries?.[row.id]?.[field.id]"
+                        :person-summaries="props.personSummaries?.[row.id]?.[field.id]"
                         :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                         :button-pending="isButtonPending(row.id, field.id)"
                         @run="emit('run-button', { recordId: row.id, field })"
@@ -403,6 +408,8 @@ const props = defineProps<{
   fieldReadOnlyIds?: string[]
   columnWidths?: Record<string, number>
   linkSummaries?: Record<string, Record<string, { id: string; display: string }[]>>
+  // Native person (人员) display source (userId → {id,display}), parallel to linkSummaries.
+  personSummaries?: Record<string, Record<string, { id: string; display: string }[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
   enableMultiSelect?: boolean
   groupField?: MetaField | null
@@ -448,6 +455,7 @@ const emit = defineEmits<{
   (e: 'patch-cell', recordId: string, fieldId: string, value: unknown, version: number): void
   (e: 'go-to-page', page: number): void
   (e: 'open-link-picker', ctx: { recordId: string; field: MetaField }): void
+  (e: 'open-person-picker', ctx: { recordId: string; field: MetaField }): void
   (e: 'resize-column', fieldId: string, width: number): void
   (e: 'selection-change', recordIds: string[]): void
   (e: 'bulk-delete', recordIds: string[]): void
@@ -825,6 +833,11 @@ function cancelEdit() { editCell.value = null; yjsHandledCellKey.value = null }
 function openLinkPickerFromCell(recordId: string, field: MetaField) {
   cancelEdit()
   emit('open-link-picker', { recordId, field })
+}
+
+function openPersonPickerFromCell(recordId: string, field: MetaField) {
+  cancelEdit()
+  emit('open-person-picker', { recordId, field })
 }
 
 // A3: cell-editor opt-in payload (null = host did not enable → no button).

--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -1,0 +1,196 @@
+<template>
+  <div v-if="visible" class="meta-person-picker__overlay" @click.self="emit('close')">
+    <div class="meta-person-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
+      <div class="meta-person-picker__header">
+        <h4 class="meta-person-picker__title">{{ titleText }}</h4>
+        <button class="meta-person-picker__close" :aria-label="pp('personPicker.close')" @click="emit('close')">&times;</button>
+      </div>
+      <div class="meta-person-picker__search">
+        <input v-model="search" class="meta-person-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
+      </div>
+      <div v-if="selectedSummaries.length" class="meta-person-picker__selected">
+        <div class="meta-person-picker__selected-header">
+          <span class="meta-person-picker__selected-label">{{ pp('personPicker.selected') }}</span>
+          <button class="meta-person-picker__clear" @click="clearSelection">{{ pp('personPicker.clear') }}</button>
+        </div>
+        <div class="meta-person-picker__chips">
+          <span v-for="item in selectedSummaries" :key="item.id" class="meta-person-picker__chip">
+            <span>{{ item.display || item.id }}</span>
+            <button type="button" class="meta-person-picker__chip-remove" @click="removeSelected(item.id)">&times;</button>
+          </span>
+        </div>
+      </div>
+      <div class="meta-person-picker__body">
+        <div v-if="loading" class="meta-person-picker__loading">{{ pp('personPicker.loading') }}</div>
+        <div v-else-if="errorMessage" class="meta-person-picker__error">{{ errorMessage }}</div>
+        <label v-for="member in members" :key="member.id" class="meta-person-picker__item" data-test="person-picker-member">
+          <input type="checkbox" :checked="selected.has(member.id)" @change="toggleSelect(member.id)" />
+          <span class="meta-person-picker__item-label">{{ member.display }}</span>
+          <span v-if="member.subtitle" class="meta-person-picker__item-sub">{{ member.subtitle }}</span>
+        </label>
+        <div v-if="!loading && !errorMessage && !members.length" class="meta-person-picker__empty">{{ pp('personPicker.empty') }}</div>
+      </div>
+      <div class="meta-person-picker__footer">
+        <span class="meta-person-picker__count">{{ selectedCountText }}</span>
+        <div class="meta-person-picker__actions">
+          <button class="meta-person-picker__cancel" @click="emit('close')">{{ pp('personPicker.cancel') }}</button>
+          <button class="meta-person-picker__confirm" data-test="person-picker-confirm" @click="onConfirm">{{ pp('personPicker.confirm') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type { MetaField, PersonSummary } from '../types'
+import { multitableClient } from '../api/client'
+import { isPersonSingleRecordField } from '../utils/person-fields'
+import {
+  personPickerLabel,
+  personPickerSelectedCount,
+  personPickerTitle,
+  type MetaPersonPickerLabelKey,
+} from '../utils/meta-person-picker-labels'
+
+// Native person (人员) picker. Member-scoped by construction: candidates come from the SHEET's
+// permission-candidates (the SAME set the write-time validator accepts) — NO global org directory.
+// Emits userId[] (NOT recordIds) + a personSummaries echo so the chip renders immediately.
+const props = defineProps<{
+  visible: boolean
+  field?: MetaField | null
+  sheetId: string
+  currentValue?: unknown
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'confirm', payload: { userIds: string[]; summaries: PersonSummary[] }): void
+}>()
+
+type PersonMember = { id: string; display: string; subtitle?: string | null }
+
+const search = ref('')
+const members = ref<PersonMember[]>([])
+const loading = ref(false)
+const errorMessage = ref('')
+const selected = reactive(new Set<string>())
+const summaryById = reactive<Record<string, PersonSummary>>({})
+const { isZh } = useLocale()
+const pp = (key: MetaPersonPickerLabelKey) => personPickerLabel(key, isZh.value)
+
+// limitSingleRecord default TRUE (matches the codec / legacy person) → single-select unless
+// explicitly multi. (No FE permission mirror; the server re-validates membership + the cap.)
+const singleSelect = computed(() => isPersonSingleRecordField(props.field))
+const titleText = computed(() => personPickerTitle(props.field?.name, isZh.value))
+const searchPlaceholder = computed(() => pp('personPicker.searchPlaceholder'))
+const selectedCountText = computed(() => personPickerSelectedCount(selected.size, isZh.value))
+
+watch(() => props.visible, async (visible) => {
+  if (!visible) {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    return
+  }
+  selected.clear()
+  Object.keys(summaryById).forEach((id) => delete summaryById[id])
+  const currentValue = props.currentValue
+  const ids = Array.isArray(currentValue) ? currentValue.map(String) : currentValue ? [String(currentValue)] : []
+  ids.forEach((id) => {
+    selected.add(id)
+    summaryById[id] = { id, display: id }
+  })
+  search.value = ''
+  await loadMembers()
+})
+
+async function loadMembers() {
+  if (!props.sheetId) return
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await multitableClient.listSheetPermissionCandidates(props.sheetId, {
+      q: search.value || undefined,
+      limit: 100,
+    })
+    members.value = (data.items ?? [])
+      .filter((item) => item.subjectType === 'user' && item.isActive)
+      .map((item) => ({ id: item.subjectId, display: item.label || item.subjectId, subtitle: item.subtitle ?? null }))
+    for (const member of members.value) {
+      if (selected.has(member.id) || summaryById[member.id]) {
+        summaryById[member.id] = { id: member.id, display: member.display }
+      }
+    }
+  } catch (error: any) {
+    members.value = []
+    errorMessage.value = error?.message ?? pp('personPicker.errorLoad')
+  } finally {
+    loading.value = false
+  }
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+function onSearch() {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => loadMembers(), 300)
+}
+
+function toggleSelect(id: string) {
+  if (selected.has(id)) {
+    selected.delete(id)
+    return
+  }
+  if (singleSelect.value) selected.clear()
+  selected.add(id)
+  const member = members.value.find((item) => item.id === id)
+  if (member) summaryById[id] = { id, display: member.display }
+}
+
+const selectedSummaries = computed<PersonSummary[]>(() =>
+  Array.from(selected).map((id) => summaryById[id] ?? { id, display: id }),
+)
+
+function clearSelection() {
+  selected.clear()
+}
+
+function removeSelected(id: string) {
+  selected.delete(id)
+}
+
+function onConfirm() {
+  const userIds = Array.from(selected)
+  emit('confirm', {
+    userIds,
+    summaries: userIds.map((id) => summaryById[id] ?? { id, display: id }),
+  })
+}
+</script>
+
+<style scoped>
+.meta-person-picker__overlay { position: fixed; inset: 0; background: rgba(0,0,0,.3); z-index: 100; display: flex; align-items: center; justify-content: center; }
+.meta-person-picker { width: 480px; max-height: 70vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.15); display: flex; flex-direction: column; }
+.meta-person-picker__header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid #eee; }
+.meta-person-picker__title { font-size: 14px; font-weight: 600; margin: 0; }
+.meta-person-picker__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
+.meta-person-picker__search { padding: 8px 16px; }
+.meta-person-picker__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
+.meta-person-picker__selected { padding: 0 16px 8px; border-bottom: 1px solid #f0f0f0; }
+.meta-person-picker__selected-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.meta-person-picker__selected-label { font-size: 12px; font-weight: 600; color: #606266; }
+.meta-person-picker__clear { border: none; background: none; color: #909399; font-size: 12px; cursor: pointer; }
+.meta-person-picker__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.meta-person-picker__chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 999px; background: #ecf5ff; color: #409eff; font-size: 12px; }
+.meta-person-picker__chip-remove { border: none; background: none; color: inherit; cursor: pointer; font-size: 14px; line-height: 1; padding: 0; }
+.meta-person-picker__body { flex: 1; overflow-y: auto; padding: 0 16px; max-height: 300px; }
+.meta-person-picker__item { display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 13px; cursor: pointer; }
+.meta-person-picker__item-sub { color: #909399; font-size: 12px; margin-left: auto; }
+.meta-person-picker__loading, .meta-person-picker__empty, .meta-person-picker__error { text-align: center; padding: 20px; color: #999; font-size: 13px; }
+.meta-person-picker__error { color: #f56c6c; }
+.meta-person-picker__footer { display: flex; justify-content: space-between; align-items: center; padding: 10px 16px; border-top: 1px solid #eee; }
+.meta-person-picker__count { font-size: 12px; color: #666; }
+.meta-person-picker__actions { display: flex; gap: 8px; }
+.meta-person-picker__cancel { padding: 6px 12px; background: #fff; color: #606266; border: 1px solid #dcdfe6; border-radius: 4px; cursor: pointer; font-size: 13px; }
+.meta-person-picker__confirm { padding: 6px 18px; background: #409eff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 13px; }
+.meta-person-picker__confirm:hover { background: #66b1ff; }
+</style>

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -220,6 +220,12 @@
             class="meta-record-drawer__link-btn"
             @click="emit('open-link-picker', field)"
           >{{ linkButtonLabel(field.id) }}</button>
+          <button
+            v-else-if="canEditField(field.id) && field.type === 'person'"
+            class="meta-record-drawer__link-btn"
+            data-test="drawer-person-picker-open"
+            @click="emit('open-person-picker', field)"
+          >{{ linkButtonLabel(field.id) }}</button>
           <div v-else-if="field.type === 'attachment'" class="meta-record-drawer__attachments">
             <MetaAttachmentList
               :attachments="attachmentItems(field.id)"
@@ -374,6 +380,7 @@
 import { computed, ref, watch } from 'vue'
 import type {
   LinkedRecordSummary,
+  PersonSummary,
   MetaAttachment,
   MetaAttachmentDeleteFn,
   MetaAttachmentUploadFn,
@@ -439,6 +446,7 @@ const props = withDefaults(defineProps<{
   rowActions?: MetaRowActions | null
   commentPresence?: MultitableCommentPresenceSummary | null
   linkSummariesByField?: Record<string, LinkedRecordSummary[]>
+  personSummariesByField?: Record<string, PersonSummary[]>
   attachmentSummariesByField?: Record<string, MetaAttachment[]>
   recordIds?: string[]
   uploadFn?: MetaAttachmentUploadFn
@@ -469,6 +477,7 @@ const emit = defineEmits<{
   (e: 'comment-field', field: MetaField): void
   (e: 'open-automation'): void
   (e: 'open-link-picker', field: MetaField): void
+  (e: 'open-person-picker', field: MetaField): void
   (e: 'navigate', recordId: string): void
   /** Slice 3: request restore of this record to a prior revision. The parent (workbench) owns
    * the apiClient.restoreRecordVersion call + confirm + record refresh — consistent with how the
@@ -803,6 +812,7 @@ function formatValue(field: MetaField, v: unknown): string {
     field,
     value: v,
     linkSummaries: props.linkSummariesByField?.[field.id],
+    personSummaries: props.personSummariesByField?.[field.id],
     attachmentSummaries: props.attachmentSummariesByField?.[field.id],
     isZh: isZh.value,
   })

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -180,6 +180,14 @@
       @click="emit('open-link-picker')"
     >{{ linkButtonLabel }}</button>
 
+    <!-- native person (人员): member-scoped picker (userId[]) — distinct from the link picker -->
+    <button
+      v-else-if="field.type === 'person'"
+      class="meta-cell-editor__link-btn"
+      data-test="person-picker-open"
+      @click="emit('open-person-picker')"
+    >{{ personButtonLabel }}</button>
+
     <!-- currency / percent: numeric input with field-specific step -->
     <input
       v-else-if="field.type === 'currency' || field.type === 'percent'"
@@ -387,6 +395,8 @@ const emit = defineEmits<{
   (e: 'confirm'): void
   (e: 'cancel'): void
   (e: 'open-link-picker'): void
+  /** Native person (人员): open the member-scoped person picker (emits userId[]). */
+  (e: 'open-person-picker'): void
   /**
    * Emitted *before* `confirm` when the user's edit was carried by the
    * Yjs opt-in path. Parents listening for this should suppress the
@@ -495,6 +505,13 @@ const linkButtonLabel = computed(() => {
   // If a future refactor exposes this branch to the DOM, localize it together with
   // a real render assertion; the reachable link branch below now receives locale.
   if (props.field.type !== 'link') return 'Choose linked records...'
+  const count = Array.isArray(props.modelValue) ? props.modelValue.length : props.modelValue ? 1 : 0
+  return formatLinkActionLabel(props.field, count, isZh.value)
+})
+
+// Native person button copy reuses linkActionLabel (it returns the people copy via isPersonField).
+const personButtonLabel = computed(() => {
+  if (props.field.type !== 'person') return ''
   const count = Array.isArray(props.modelValue) ? props.modelValue.length : props.modelValue ? 1 : 0
   return formatLinkActionLabel(props.field, count, isZh.value)
 })

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -205,11 +205,11 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import type { MetaAttachment, MetaField, LinkedRecordSummary, MetaRecordContext } from '../../types'
+import type { MetaAttachment, MetaField, LinkedRecordSummary, PersonSummary, MetaRecordContext } from '../../types'
 import MetaAttachmentList from '../MetaAttachmentList.vue'
 import MetaLinkedRecordPopover from '../MetaLinkedRecordPopover.vue'
 import { useLocale } from '../../../composables/useLocale'
-import { isPersonField } from '../../utils/link-fields'
+import { isNativePersonField, isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
 import { isSystemFieldType } from '../../utils/system-fields'
 import { resolveRatingFieldProperty, resolveButtonFieldProperty } from '../../utils/field-config'
@@ -221,6 +221,9 @@ const props = defineProps<{
   field: MetaField
   value: unknown
   linkSummaries?: LinkedRecordSummary[]
+  // Native person (人员) display source — userId → {id,display}. A native person has NO
+  // linkSummaries, so the chip reads this; legacy link-backed person still uses linkSummaries.
+  personSummaries?: PersonSummary[]
   attachmentSummaries?: MetaAttachment[]
   buttonPending?: boolean
   // A3: when the host supplies a cross-sheet record fetcher (getRecord with NO
@@ -262,6 +265,7 @@ const displayValue = computed(() => {
     field: props.field,
     value: props.value,
     linkSummaries: props.linkSummaries,
+    personSummaries: props.personSummaries,
     attachmentSummaries: props.attachmentSummaries,
     isZh: isZh.value,
   })
@@ -344,13 +348,32 @@ function personInitial(display: string): string {
   return [...trimmed][0]!.toUpperCase()
 }
 
-const personItems = computed(() =>
-  linkItems.value.map((item) => ({
+// Native person value = userId[]. Resolve display from personSummaries (userId → display);
+// fall back to the raw userId when a summary is missing (e.g. a removed/unknown user).
+const nativePersonIds = computed(() => {
+  const v = props.value
+  if (Array.isArray(v)) return v.map(String).filter((id) => id.length > 0)
+  if (v) return [String(v)]
+  return []
+})
+
+const personItems = computed(() => {
+  // NATIVE person (type='person', userId[]) → personSummaries. It has NO linkSummaries, so this
+  // is the load-bearing display source (an advisor-flagged hidden dependency).
+  if (isNativePersonField(props.field)) {
+    const summaryById = new Map((props.personSummaries ?? []).map((s) => [s.id, s.display]))
+    return nativePersonIds.value.map((id) => {
+      const display = summaryById.get(id) || id
+      return { id, display, initial: personInitial(display) }
+    })
+  }
+  // LEGACY link-backed person (type='link'+refKind:user, recordId[]) → linkSummaries (unchanged).
+  return linkItems.value.map((item) => ({
     id: item.id,
     display: item.display,
     initial: personInitial(item.display),
-  })),
-)
+  }))
+})
 
 // percentGauge: bar fill width 0..100 for the read-only progress gauge.
 // Percent values are stored as the percent number itself (e.g. 65 → "65%"),

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -11,6 +11,7 @@ import type {
   MetaRowActions,
   MetaViewPermission,
   PatchResult,
+  PersonSummary,
 } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
 import { isPropertyHiddenField } from '../utils/field-permissions'
@@ -365,6 +366,9 @@ export function useMultitableGrid(opts: {
   const fields = ref<MetaField[]>([])
   const rows = ref<MetaRecord[]>([])
   const linkSummaries = ref<Record<string, Record<string, LinkedRecordSummary[]>>>({})
+  // Native person (人员) display source (userId → {id,display}). Read-only here: refreshed on
+  // each loadViewData (a person write echoes the userId[] value; display re-hydrates on refetch).
+  const personSummaries = ref<Record<string, Record<string, PersonSummary[]>>>({})
   const attachmentSummaries = ref<Record<string, Record<string, MetaAttachment[]>>>({})
   const fieldPermissions = ref<Record<string, MetaFieldPermission>>({})
   const viewPermission = ref<MetaViewPermission | null>(null)
@@ -475,6 +479,7 @@ export function useMultitableGrid(opts: {
       fields.value = data.fields ?? []
       rows.value = serverRows
       linkSummaries.value = data.linkSummaries ?? {}
+      personSummaries.value = data.personSummaries ?? {}
       attachmentSummaries.value = data.attachmentSummaries ?? {}
       fieldPermissions.value = data.meta?.permissions?.fieldPermissions ?? {}
       const nextViewPermission = data.view?.id
@@ -1002,7 +1007,7 @@ export function useMultitableGrid(opts: {
 
   return {
     // State
-    fields, rows, linkSummaries, attachmentSummaries, fieldPermissions, viewPermission, capabilityOrigin, rowActions, rowActionOverrides, loading, error, conflict, page, hiddenFieldIds, visibleFields, readOnlyFieldIds,
+    fields, rows, linkSummaries, personSummaries, attachmentSummaries, fieldPermissions, viewPermission, capabilityOrigin, rowActions, rowActionOverrides, loading, error, conflict, page, hiddenFieldIds, visibleFields, readOnlyFieldIds,
     sortRules, filterRules, filterConjunction, sortFilterDirty,
     columnWidths, groupFieldId, groupField,
     editHistory, historyIndex, canUndo, canRedo,

--- a/apps/web/src/multitable/import/delimited.ts
+++ b/apps/web/src/multitable/import/delimited.ts
@@ -1,6 +1,6 @@
 import type { MetaField } from '../types'
 import { importResolverMissing, importValueResolveFailed } from '../utils/meta-import-labels'
-import { isLinkField, isPersonField } from '../utils/link-fields'
+import { isLinkField, isNativePersonField, isPersonField } from '../utils/link-fields'
 
 export type DelimitedParseResult = {
   delimiter: ',' | '\t'
@@ -151,7 +151,11 @@ export async function buildImportedRecords(params: {
       else if (field?.type === 'date' && val !== '') {
         const d = new Date(val)
         data[fieldId] = !Number.isNaN(d.getTime()) ? d.toISOString().split('T')[0] : val
-      } else if (field && isLinkField(field)) {
+      } else if (field && (isLinkField(field) || isNativePersonField(field))) {
+        // Link, legacy link-backed person (isLinkField), OR native person (isNativePersonField).
+        // All three resolve a delimited token to an id[] via the injected resolver; the resolver
+        // itself is kind-aware (native person → userIds, legacy person → People recordIds, link →
+        // linked recordIds).
         const rawValue = val.trim()
         if (!rawValue) {
           data[fieldId] = []

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -224,6 +224,7 @@ export interface MetaViewData {
   fields: MetaField[]
   rows: MetaRecord[]
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
+  personSummaries?: Record<string, Record<string, PersonSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
   view?: MetaView | null
   meta?: MetaViewMeta
@@ -288,6 +289,7 @@ export interface MetaRecordContext {
   rowActions?: MetaRowActions
   commentsScope: MetaCommentsScope
   linkSummaries?: Record<string, LinkedRecordSummary[]>
+  personSummaries?: Record<string, PersonSummary[]>
   attachmentSummaries?: Record<string, MetaAttachment[]>
 }
 
@@ -545,6 +547,15 @@ export interface MultitableSheetPresence {
 
 // --- Link records ---
 export interface LinkedRecordSummary {
+  id: string
+  display: string
+}
+
+// --- Native person (人员, design 2026-06-16) display source ---
+// Parallel to LinkedRecordSummary but keyed by `userId` (NOT a recordId): the native person
+// value is just `userId[]`, so the renderer hydrates display from `personSummaries` rather than
+// `linkSummaries`. Server-assembled from the users table at view-assembly time.
+export interface PersonSummary {
   id: string
   display: string
 }

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -1,4 +1,4 @@
-import type { LinkedRecordSummary, MetaAttachment, MetaField } from '../types'
+import type { LinkedRecordSummary, MetaAttachment, MetaField, PersonSummary } from '../types'
 import {
   formatCurrencyValue,
   formatNumberValue,
@@ -105,11 +105,21 @@ export function formatFieldDisplay(params: {
   field: MetaField
   value: unknown
   linkSummaries?: LinkedRecordSummary[] | null
+  personSummaries?: PersonSummary[] | null
   attachmentSummaries?: MetaAttachment[] | null
   isZh?: boolean
 }): string {
-  const { field, value, linkSummaries, attachmentSummaries, isZh = false } = params
+  const { field, value, linkSummaries, personSummaries, attachmentSummaries, isZh = false } = params
   if (value === null || value === undefined || value === '') return '—'
+
+  // Native person (人员): value = userId[]; resolve display from personSummaries (userId →
+  // display), falling back to the raw userId. (Legacy link-backed person is type='link' below.)
+  if (field.type === 'person') {
+    const ids = Array.isArray(value) ? value.map(String).filter((id) => id.trim().length > 0) : value ? [String(value)] : []
+    if (ids.length === 0) return '—'
+    const byId = new Map((personSummaries ?? []).map((s) => [s.id, s.display]))
+    return ids.map((id) => byId.get(id) || id).join(', ')
+  }
 
   if (field.type === 'date') return formatDate(value)
   if (field.type === 'dateTime') return formatDateTime(value, resolveDateTimeTimezone(field.property))

--- a/apps/web/src/multitable/utils/link-fields.ts
+++ b/apps/web/src/multitable/utils/link-fields.ts
@@ -1,11 +1,24 @@
 import type { MetaField } from '../types'
 
+// isLinkField — TRUE for a relational link field. NOTE (design 2026-06-16): a NATIVE person
+// (`type === 'person'`, value = userId[]) is NO LONGER a link — it has its own picker / import
+// resolver / personSummaries display source. A LEGACY person field is stored as `type === 'link'`
+// + refKind:'user', so it still matches here (and keeps its link-backed recordId behaviour). This
+// decoupling is load-bearing for coexistence: native person must not route through link summaries.
 export function isLinkField(field?: MetaField | null): boolean {
-  return field?.type === 'link' || field?.type === 'person'
+  return field?.type === 'link'
 }
 
+// isNativePersonField — TRUE only for the native userId[]-backed person (`type === 'person'`).
+export function isNativePersonField(field?: MetaField | null): boolean {
+  return field?.type === 'person'
+}
+
+// isPersonField — TRUE for EITHER representation (coexistence): the native `type === 'person'`
+// OR a legacy link-backed person (`type === 'link'` + refKind:'user'). Every person-aware copy /
+// chip / picker gate uses this so both kinds render as people.
 export function isPersonField(field?: MetaField | null): boolean {
-  return field?.type === 'person' || (isLinkField(field) && field?.property?.refKind === 'user')
+  return isNativePersonField(field) || (isLinkField(field) && field?.property?.refKind === 'user')
 }
 
 function linkEntityLabel(field?: MetaField | null, count?: number): string {

--- a/apps/web/src/multitable/utils/meta-person-picker-labels.ts
+++ b/apps/web/src/multitable/utils/meta-person-picker-labels.ts
@@ -1,0 +1,47 @@
+// Native person (人员, design 2026-06-16) picker modal chrome string table.
+//
+// Scope: MetaPersonPicker.vue static UI only. Member names/emails are user data and pass
+// through unchanged. This is the SOLE i18n extension point for the person picker — add new
+// keys to the union AND the record together (no dead keys, no inline UI strings).
+
+export type MetaPersonPickerLabelKey =
+  | 'personPicker.title'
+  | 'personPicker.searchPlaceholder'
+  | 'personPicker.selected'
+  | 'personPicker.clear'
+  | 'personPicker.loading'
+  | 'personPicker.empty'
+  | 'personPicker.loadMore'
+  | 'personPicker.cancel'
+  | 'personPicker.confirm'
+  | 'personPicker.close'
+  | 'personPicker.errorLoad'
+
+const META_PERSON_PICKER_LABELS: Record<MetaPersonPickerLabelKey, { en: string; zh: string }> = {
+  'personPicker.title': { en: 'Select People', zh: '选择人员' },
+  'personPicker.searchPlaceholder': { en: 'Search people...', zh: '搜索人员...' },
+  'personPicker.selected': { en: 'Selected', zh: '已选择' },
+  'personPicker.clear': { en: 'Clear', zh: '清除' },
+  'personPicker.loading': { en: 'Loading...', zh: '正在加载...' },
+  'personPicker.empty': { en: 'No members found', zh: '未找到成员' },
+  'personPicker.loadMore': { en: 'Load more', zh: '加载更多' },
+  'personPicker.cancel': { en: 'Cancel', zh: '取消' },
+  'personPicker.confirm': { en: 'Confirm', zh: '确认' },
+  'personPicker.close': { en: 'Close people picker', zh: '关闭人员选择器' },
+  'personPicker.errorLoad': { en: 'Failed to load members', zh: '加载成员失败' },
+}
+
+export function personPickerLabel(key: MetaPersonPickerLabelKey, isZh: boolean): string {
+  const entry = META_PERSON_PICKER_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function personPickerSelectedCount(count: number, isZh: boolean): string {
+  return isZh ? `已选择 ${count} 人` : `${count} selected`
+}
+
+// Picker title includes the field name when present (field name = user data).
+export function personPickerTitle(fieldName: string | undefined, isZh: boolean): string {
+  const prefix = personPickerLabel('personPicker.title', isZh)
+  return fieldName ? `${prefix} — ${fieldName}` : prefix
+}

--- a/apps/web/src/multitable/utils/meta-person-picker-labels.ts
+++ b/apps/web/src/multitable/utils/meta-person-picker-labels.ts
@@ -11,7 +11,6 @@ export type MetaPersonPickerLabelKey =
   | 'personPicker.clear'
   | 'personPicker.loading'
   | 'personPicker.empty'
-  | 'personPicker.loadMore'
   | 'personPicker.cancel'
   | 'personPicker.confirm'
   | 'personPicker.close'
@@ -24,7 +23,6 @@ const META_PERSON_PICKER_LABELS: Record<MetaPersonPickerLabelKey, { en: string; 
   'personPicker.clear': { en: 'Clear', zh: '清除' },
   'personPicker.loading': { en: 'Loading...', zh: '正在加载...' },
   'personPicker.empty': { en: 'No members found', zh: '未找到成员' },
-  'personPicker.loadMore': { en: 'Load more', zh: '加载更多' },
   'personPicker.cancel': { en: 'Cancel', zh: '取消' },
   'personPicker.confirm': { en: 'Confirm', zh: '确认' },
   'personPicker.close': { en: 'Close people picker', zh: '关闭人员选择器' },

--- a/apps/web/src/multitable/utils/person-fields.ts
+++ b/apps/web/src/multitable/utils/person-fields.ts
@@ -1,0 +1,9 @@
+import type { MetaField } from '../types'
+
+// Native person (人员) single-vs-multi resolution. Mirrors the backend codec default: undefined
+// `limitSingleRecord` defaults to TRUE (single person), matching the legacy person path so the
+// single/multi behaviour never silently flips between a legacy link-backed person and a native one.
+// This is display/picker convenience ONLY — the server re-validates the cap (no FE permission mirror).
+export function isPersonSingleRecordField(field?: MetaField | null): boolean {
+  return field?.property?.limitSingleRecord !== false
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -146,6 +146,7 @@
           :error-message="formErrorMessage"
           :field-errors="formFieldErrors"
           :link-summaries-by-field="selectedRecordLinkSummaries"
+          :person-summaries-by-field="selectedRecordPersonSummaries"
           :attachment-summaries-by-field="selectedRecordAttachmentSummaries"
           :upload-fn="uploadAttachmentFn"
           :delete-attachment-fn="deleteAttachmentFn"
@@ -289,6 +290,7 @@
         :row-actions="effectiveRowActions"
         :comment-presence="selectedRecordCommentPresence"
         :link-summaries-by-field="selectedRecordLinkSummaries"
+        :person-summaries-by-field="selectedRecordPersonSummaries"
         :attachment-summaries-by-field="selectedRecordAttachmentSummaries"
         :record-ids="drawerRecordIds"
         :upload-fn="uploadAttachmentFn"
@@ -785,6 +787,7 @@ const formSuccessMessage = ref<string | null>(null)
 const formErrorMessage = ref<string | null>(null)
 const formFieldErrors = ref<Record<string, string>>({})
 const deepLinkedRecordLinkSummaries = ref<Record<string, LinkedRecordSummary[]>>({})
+const deepLinkedRecordPersonSummaries = ref<Record<string, PersonSummary[]>>({})
 const deepLinkedRecordAttachmentSummaries = ref<Record<string, MetaAttachment[]>>({})
 const deepLinkedRecordCommentsScope = ref<MetaCommentsScope | null>(null)
 const deepLinkedRecordFieldPermissions = ref<Record<string, MetaFieldPermission>>({})
@@ -1021,6 +1024,16 @@ const selectedRecordLinkSummaries = computed<Record<string, LinkedRecordSummary[
   return {}
 })
 
+// Native person (人员) display for the drawer/form — grid summaries first, deep-record fallback.
+const selectedRecordPersonSummaries = computed<Record<string, PersonSummary[]>>(() => {
+  const recordId = selectedRecordId.value
+  if (!recordId) return {}
+  const fromGrid = grid.personSummaries.value[recordId]
+  if (fromGrid) return fromGrid
+  if (deepLinkedRecord.value?.id === recordId) return deepLinkedRecordPersonSummaries.value
+  return {}
+})
+
 const selectedRecordAttachmentSummaries = computed<Record<string, MetaAttachment[]>>(() => {
   const recordId = selectedRecordId.value
   if (!recordId) return {}
@@ -1150,6 +1163,24 @@ function applyLocalLinkSummaries(recordId: string, fieldId: string, summaries: L
   if (deepLinkedRecord.value?.id === recordId) {
     deepLinkedRecordLinkSummaries.value = {
       ...deepLinkedRecordLinkSummaries.value,
+      [fieldId]: summaries,
+    }
+  }
+}
+
+// Native person (人员): mirror applyLocalLinkSummaries so a just-picked person shows its display
+// name immediately (grid + drawer) instead of a raw userId until the next refetch.
+function applyLocalPersonSummaries(recordId: string, fieldId: string, summaries: PersonSummary[]) {
+  grid.personSummaries.value = {
+    ...grid.personSummaries.value,
+    [recordId]: {
+      ...(grid.personSummaries.value[recordId] ?? {}),
+      [fieldId]: summaries,
+    },
+  }
+  if (deepLinkedRecord.value?.id === recordId) {
+    deepLinkedRecordPersonSummaries.value = {
+      ...deepLinkedRecordPersonSummaries.value,
       [fieldId]: summaries,
     }
   }
@@ -1948,6 +1979,7 @@ async function onPersonPickerConfirm(payload: { userIds: string[]; summaries: Pe
       showError(grid.error.value)
       return
     }
+    applyLocalPersonSummaries(recordId, fieldId, payload.summaries)
   } else if (selectedRecordResolved.value?.id === recordId) {
     try {
       const result = await workbench.client.patchRecords({
@@ -1961,6 +1993,7 @@ async function onPersonPickerConfirm(payload: { userIds: string[]; summaries: Pe
         version: nextVersion,
         data: { ...selectedRecordResolved.value.data, [fieldId]: payload.userIds },
       }
+      applyLocalPersonSummaries(recordId, fieldId, payload.summaries)
     } catch (e: any) {
       showError(e.message ?? wb('toast.linkedRecordsUpdateFailed', isZh.value))
       return
@@ -2393,6 +2426,7 @@ function discardWorkbenchDraftsForExternalContextChange() {
   selectedRecordId.value = null
   deepLinkedRecord.value = null
   deepLinkedRecordLinkSummaries.value = {}
+  deepLinkedRecordPersonSummaries.value = {}
   deepLinkedRecordAttachmentSummaries.value = {}
   deepLinkedRecordCommentsScope.value = null
   showImportModal.value = false
@@ -3063,6 +3097,7 @@ async function resolveDeepLink(recordId: string, options?: { openComments?: bool
     })
     deepLinkedRecord.value = ctx.record
     deepLinkedRecordLinkSummaries.value = ctx.linkSummaries ?? {}
+    deepLinkedRecordPersonSummaries.value = ctx.personSummaries ?? {}
     deepLinkedRecordAttachmentSummaries.value = ctx.attachmentSummaries ?? {}
     deepLinkedRecordCommentsScope.value = ctx.commentsScope
     deepLinkedRecordFieldPermissions.value = ctx.fieldPermissions ?? {}
@@ -3077,6 +3112,7 @@ async function resolveDeepLink(recordId: string, options?: { openComments?: bool
 function clearDeepLinkedRecordState() {
   deepLinkedRecord.value = null
   deepLinkedRecordLinkSummaries.value = {}
+  deepLinkedRecordPersonSummaries.value = {}
   deepLinkedRecordAttachmentSummaries.value = {}
   deepLinkedRecordCommentsScope.value = null
   deepLinkedRecordFieldPermissions.value = {}
@@ -3106,6 +3142,7 @@ async function mergeRemoteRecordContext(recordId: string): Promise<boolean> {
     if (selectedRecordId.value === recordId) {
       deepLinkedRecord.value = ctx.record
       deepLinkedRecordLinkSummaries.value = ctx.linkSummaries ?? {}
+      deepLinkedRecordPersonSummaries.value = ctx.personSummaries ?? {}
       deepLinkedRecordAttachmentSummaries.value = ctx.attachmentSummaries ?? {}
       deepLinkedRecordCommentsScope.value = ctx.commentsScope
       deepLinkedRecordFieldPermissions.value = ctx.fieldPermissions ?? {}
@@ -3172,6 +3209,7 @@ async function refreshSelectedRecordContext(recordId: string) {
     if (selectedRecordId.value !== recordId) return
     deepLinkedRecord.value = ctx.record
     deepLinkedRecordLinkSummaries.value = ctx.linkSummaries ?? {}
+    deepLinkedRecordPersonSummaries.value = ctx.personSummaries ?? {}
     deepLinkedRecordAttachmentSummaries.value = ctx.attachmentSummaries ?? {}
     deepLinkedRecordCommentsScope.value = ctx.commentsScope
     deepLinkedRecordFieldPermissions.value = ctx.fieldPermissions ?? {}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -151,7 +151,7 @@
           :delete-attachment-fn="deleteAttachmentFn"
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="selectedRecordCommentPresence"
-          @submit="onFormSubmit" @open-link-picker="openLinkPicker" @update:dirty="formDirty = $event"
+          @submit="onFormSubmit" @open-link-picker="openLinkPicker" @open-person-picker="openPersonPicker" @update:dirty="formDirty = $event"
           @comment-field="onToggleFieldComments"
         />
         <MetaKanbanView
@@ -251,7 +251,7 @@
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
           :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :aggregation-config="activeAggregationConfig" :aggregates="aggregateValues" :aggregate-too-large="aggregateTooLarge" :aggregate-groups="aggregateGroups" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
-          :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
+          :link-summaries="grid.linkSummaries.value" :person-summaries="grid.personSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
           :group-field="grid.groupField.value"
           :search-text="searchText" :row-density="rowDensity"
@@ -268,7 +268,7 @@
           :fetch-record="fetchLinkedRecordFn"
           :mention-suggestions="commentMentionSuggestions"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
-          @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
+          @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @open-person-picker="onGridPersonPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
           @create-record="onAddRecord"
           @set-frozen="onSetFrozen"
@@ -297,7 +297,7 @@
         :button-run-pending="buttonRunPending"
         :mention-suggestions="commentMentionSuggestions"
         @close="onCloseDrawer" @delete="onDeleteRecord" @patch="onDrawerPatch"
-        @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker"
+        @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker" @open-person-picker="openPersonPicker"
         @toggle-lock="onToggleRecordLock"
         @navigate="onDrawerNavigate"
         @restore="onRestoreRecordVersion"
@@ -382,6 +382,14 @@
       :current-value="linkPickerCurrentValue"
       @close="linkPickerVisible = false"
       @confirm="onLinkPickerConfirm"
+    />
+    <MetaPersonPicker
+      :visible="personPickerVisible"
+      :field="personPickerField"
+      :sheet-id="workbench.activeSheetId.value"
+      :current-value="personPickerCurrentValue"
+      @close="personPickerVisible = false"
+      @confirm="onPersonPickerConfirm"
     />
     <MetaFieldManager
       :visible="showFieldManager"
@@ -504,6 +512,7 @@ import type {
   MetaFieldPermissionEntry,
   MetaViewPermissionEntry,
   MetaTemplate,
+  PersonSummary,
   RowDensity,
 } from '../types'
 import type { MultitableRole } from '../composables/useMultitableCapabilities'
@@ -528,6 +537,7 @@ import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaNotificationBell from '../components/MetaNotificationBell.vue'
 import MetaCommentsDrawer from '../components/MetaCommentsDrawer.vue'
 import MetaLinkPicker from '../components/MetaLinkPicker.vue'
+import MetaPersonPicker from '../components/MetaPersonPicker.vue'
 import MetaTemplateCard from '../components/MetaTemplateCard.vue'
 import MetaFieldManager from '../components/MetaFieldManager.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
@@ -552,7 +562,7 @@ import { bulkImportRecords } from '../import/bulk-import'
 import { extractImportTokens, type ImportBuildFailure, type ImportBuildResult, type ImportValueResolver } from '../import/delimited'
 import { buildXlsxBuffer } from '../import/xlsx-mapping'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
-import { isLinkField, isPersonField } from '../utils/link-fields'
+import { isLinkField, isNativePersonField, isPersonField } from '../utils/link-fields'
 import {
   calendarHolidaySyncNotice,
   type CalendarHolidayFetchState,
@@ -689,6 +699,11 @@ const linkPickerVisible = ref(false)
 const linkPickerField = ref<MetaField | null>(null)
 const linkPickerRecordId = ref<string | null>(null)
 const linkPickerCurrentValue = ref<unknown>(null)
+// Native person (人员) picker state — member-scoped userId[] selection (distinct from link picker).
+const personPickerVisible = ref(false)
+const personPickerField = ref<MetaField | null>(null)
+const personPickerRecordId = ref<string | null>(null)
+const personPickerCurrentValue = ref<unknown>(null)
 const showFieldManager = ref(false)
 const showPermissionManager = ref(false)
 const showAutomationManager = ref(false)
@@ -762,6 +777,9 @@ const importResult = ref<ImportResult | null>(null)
 const rowDensity = ref<RowDensity>('normal')
 const peopleResolverCache = new Map<string, Promise<ImportValueResolver | null>>()
 const linkResolverCache = new Map<string, Map<string, Promise<string[] | null>>>()
+// Native person (人员) import: resolve tokens (userId / name / email) → USERIDs against the
+// sheet member candidates (member-scoped, NOT the People-sheet recordIds). Keyed by sheetId.
+const nativePersonResolverCache = new Map<string, Promise<ImportValueResolver>>()
 const formSubmitting = ref(false)
 const formSuccessMessage = ref<string | null>(null)
 const formErrorMessage = ref<string | null>(null)
@@ -971,8 +989,16 @@ const importSurfaceFields = computed(() =>
 const importFieldResolvers = computed<Record<string, ImportValueResolver>>(() => {
   const resolvers: Record<string, ImportValueResolver> = {}
   for (const field of importSurfaceFields.value) {
-    if (!isLinkField(field)) continue
+    // Native person (人员) OR link (incl. legacy link-backed person). isLinkField no longer
+    // matches native person, so include it explicitly.
+    if (!isLinkField(field) && !isNativePersonField(field)) continue
     resolvers[field.id] = async (rawValue, currentField) => {
+      // Kind-aware switch: native person → USERIDs (member candidates); legacy person → People-sheet
+      // recordIds (getPeopleResolver); plain link → linked recordIds.
+      if (isNativePersonField(currentField)) {
+        const resolver = await getNativePersonResolver()
+        return resolver(rawValue, currentField)
+      }
       if (isPersonField(currentField)) {
         const resolver = await getPeopleResolver(currentField)
         return resolver ? resolver(rawValue, currentField) : null
@@ -1278,6 +1304,62 @@ async function getPeopleResolver(field: MetaField): Promise<ImportValueResolver 
   })
 
   peopleResolverCache.set(targetSheetId, promise)
+  return promise
+}
+
+// Native person (人员) import resolver — kind-aware switch (NOT resolvePeopleImportValue, which
+// returns People-sheet recordIds). Resolves each token to a member USERID by matching the sheet's
+// permission-candidate users on userId / label (name) / subtitle (email). Member-scoped: only the
+// candidate set the picker offers is resolvable; an unknown token fails the row (no egress).
+async function getNativePersonResolver(): Promise<ImportValueResolver> {
+  const sheetId = workbench.activeSheetId.value
+  const cached = nativePersonResolverCache.get(sheetId)
+  if (cached) return cached
+
+  const promise = (async (): Promise<ImportValueResolver> => {
+    const { items } = await workbench.client.listSheetPermissionCandidates(sheetId, { limit: 10000 })
+    const userIdByToken = new Map<string, string | null>()
+    const register = (token: string | null | undefined, userId: string) => {
+      if (!token) return
+      const key = normalizeImportLookupKey(token)
+      if (!key) return
+      const current = userIdByToken.get(key)
+      if (current !== undefined && current !== userId) {
+        userIdByToken.set(key, null) // ambiguous
+        return
+      }
+      userIdByToken.set(key, userId)
+    }
+    for (const item of items) {
+      if (item.subjectType !== 'user' || !item.isActive) continue
+      register(item.subjectId, item.subjectId)
+      register(item.label, item.subjectId)
+      register(item.subtitle ?? undefined, item.subjectId)
+    }
+
+    return async (rawValue: string, currentField?: MetaField): Promise<string[] | null> => {
+      const tokens = extractImportTokens(rawValue)
+      if (!tokens.length) return null
+      const resolved: string[] = []
+      for (const token of tokens) {
+        const key = normalizeImportLookupKey(token)
+        if (!key) continue
+        const match = userIdByToken.get(key)
+        if (match === null) throw new Error(isZh.value ? `匹配到多个人员："${token}"` : `Multiple people match "${token}"`)
+        if (typeof match === 'string') pushUniqueIds(resolved, [match])
+      }
+      if (!resolved.length) return null
+      if (currentField?.property?.limitSingleRecord !== false && resolved.length > 1) {
+        throw new Error(isZh.value ? `人员字段只允许一个人员：${rawValue}` : `Person field only allows one person: ${rawValue}`)
+      }
+      return resolved
+    }
+  })().catch((error) => {
+    nativePersonResolverCache.delete(sheetId)
+    throw error
+  })
+
+  nativePersonResolverCache.set(sheetId, promise)
   return promise
 }
 
@@ -1839,28 +1921,70 @@ async function onLinkPickerConfirm(payload: { recordIds: string[]; summaries: Li
   showSuccess(wb('toast.linkedRecordsUpdated', isZh.value))
 }
 
+// --- Native person (人员) picker ---
+function openPersonPicker(field: MetaField) {
+  personPickerField.value = field
+  personPickerRecordId.value = selectedRecordId.value
+  personPickerCurrentValue.value = selectedRecordResolved.value?.data[field.id] ?? null
+  personPickerVisible.value = true
+}
+function onGridPersonPicker(ctx: { recordId: string; field: MetaField }) {
+  const row = grid.rows.value.find((r) => r.id === ctx.recordId)
+  personPickerField.value = ctx.field
+  personPickerRecordId.value = ctx.recordId
+  personPickerCurrentValue.value = row?.data[ctx.field.id] ?? null
+  personPickerVisible.value = true
+}
+async function onPersonPickerConfirm(payload: { userIds: string[]; summaries: PersonSummary[] }) {
+  personPickerVisible.value = false
+  if (!personPickerRecordId.value || !personPickerField.value) return
+  const recordId = personPickerRecordId.value
+  if (!ensureCanEditRecord(recordId)) return
+  const fieldId = personPickerField.value.id
+  const row = grid.rows.value.find((r) => r.id === recordId)
+  if (row) {
+    await grid.patchCell(row.id, fieldId, payload.userIds, row.version)
+    if (grid.error.value) {
+      showError(grid.error.value)
+      return
+    }
+  } else if (selectedRecordResolved.value?.id === recordId) {
+    try {
+      const result = await workbench.client.patchRecords({
+        sheetId: workbench.activeSheetId.value || undefined,
+        viewId: workbench.activeViewId.value || undefined,
+        changes: [{ recordId, fieldId, value: payload.userIds, expectedVersion: selectedRecordResolved.value.version }],
+      })
+      const nextVersion = result.updated?.find((item) => item.recordId === recordId)?.version ?? selectedRecordResolved.value.version + 1
+      deepLinkedRecord.value = {
+        ...selectedRecordResolved.value,
+        version: nextVersion,
+        data: { ...selectedRecordResolved.value.data, [fieldId]: payload.userIds },
+      }
+    } catch (e: any) {
+      showError(e.message ?? wb('toast.linkedRecordsUpdateFailed', isZh.value))
+      return
+    }
+  } else {
+    return
+  }
+  showSuccess(wb('toast.linkedRecordsUpdated', isZh.value))
+}
+
 // --- Field management ---
 async function onCreateField(input: { sheetId: string; name: string; type: MetaFieldCreateType | string; property?: Record<string, unknown> }) {
   try {
-    if (input.type === 'person') {
-      const preset = await workbench.client.preparePersonField(input.sheetId)
-      await workbench.client.createField({
-        sheetId: input.sheetId,
-        name: input.name,
-        type: 'link',
-        property: {
-          ...preset.fieldProperty,
-          ...(input.property ?? {}),
-        },
-      })
-    } else {
-      await workbench.client.createField({
-        sheetId: input.sheetId,
-        name: input.name,
-        type: input.type as MetaFieldType,
-        property: input.property,
-      })
-    }
+    // Native person (人员, design 2026-06-16): NEWLY-created person fields are now first-class
+    // native `type:'person'` (value = userId[]) — sent straight through `createField`, NOT rewritten
+    // to a `link`+refKind:user against the system People sheet. COEXISTENCE: this changes only the
+    // NEW-field default; `preparePersonField`/the People-sheet preset stay intact for existing legacy
+    // link-backed person fields + direct API callers (now vestigial on this create path).
+    await workbench.client.createField({
+      sheetId: input.sheetId,
+      name: input.name,
+      type: input.type as MetaFieldType,
+      property: input.property,
+    })
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
   } catch (e: any) { showError(e.message ?? wb('toast.fieldCreateFailed', isZh.value)) }

--- a/apps/web/tests/multitable-cell-visual-display.spec.ts
+++ b/apps/web/tests/multitable-cell-visual-display.spec.ts
@@ -98,10 +98,12 @@ describe('MetaCellRenderer rating segments', () => {
 
 describe('MetaCellRenderer person avatar chip', () => {
   it('renders an avatar chip with an initial and name for a person-type field', async () => {
+    // Native person (人员, design 2026-06-16): the value is a userId[] and display resolves from
+    // personSummaries (NOT linkSummaries — a native person has none). userId 'user_1' → 'Jamie Park'.
     const { container, app } = mount({
       field: { id: 'fld_assignee', name: 'Assignee', type: 'person' },
       value: ['user_1'],
-      linkSummaries: [{ id: 'user_1', display: 'Jamie Park' }],
+      personSummaries: [{ id: 'user_1', display: 'Jamie Park' }],
     })
     await nextTick()
 

--- a/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
+++ b/apps/web/tests/multitable-crossbase-workbench-wiring.spec.ts
@@ -165,7 +165,7 @@ function createGridMock() {
     page: ref({ offset: 0, limit: 50, total: 0, hasMore: false }), visibleFields: ref([]), sortRules: ref([]),
     filterRules: ref([]), filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
     groupFieldId: ref<string | null>(null), groupField: ref(null), hiddenFieldIds: ref<string[]>([]),
-    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), attachmentSummaries: ref({}),
+    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), personSummaries: ref({}), attachmentSummaries: ref({}),
     fieldPermissions: ref({}), viewPermission: ref(null), rowActions: ref(null), rowActionOverrides: ref({}),
     capabilityOrigin: ref(null), conflict: ref(null), error: ref<string | null>(null), sortFilterDirty: ref(false),
     toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),

--- a/apps/web/tests/multitable-import-modal.spec.ts
+++ b/apps/web/tests/multitable-import-modal.spec.ts
@@ -807,7 +807,11 @@ describe('MetaImportModal', () => {
   it('re-enables zh people repair after reconciling a stale selected repair', async () => {
     useLocale().setLocale('zh')
     mockListLinkOptions.mockResolvedValue({
-      field: { id: 'fld_owner', name: '负责人', type: 'person', property: { refKind: 'user', foreignSheetId: 'sheet_people', limitSingleRecord: true } },
+      // LEGACY link-backed person (type='link' + refKind:user) — the picker-repair flow this test
+      // validates is a LINK-picker affordance (recordIds). A NATIVE type='person' field is no longer
+      // picker-repairable via the link record picker (design 2026-06-16), so this test uses the legacy
+      // storage shape it was always exercising.
+      field: { id: 'fld_owner', name: '负责人', type: 'link', property: { refKind: 'user', foreignSheetId: 'sheet_people', limitSingleRecord: true } },
       targetSheet: { id: 'sheet_people', baseId: 'base_1', name: '人员' },
       selected: [],
       records: [{ id: 'rec_owner_1', display: '张三' }],
@@ -825,7 +829,7 @@ describe('MetaImportModal', () => {
         const result = ref<any>(null)
         const fields = ref<any[]>([
           { id: 'fld_title', name: '标题', type: 'string' },
-          { id: 'fld_owner', name: '负责人', type: 'person', property: { refKind: 'user', foreignSheetId: 'sheet_people', limitSingleRecord: true } },
+          { id: 'fld_owner', name: '负责人', type: 'link', property: { refKind: 'user', foreignSheetId: 'sheet_people', limitSingleRecord: true } },
         ])
         const fieldResolvers = {
           fld_owner: async () => {

--- a/apps/web/tests/multitable-import.spec.ts
+++ b/apps/web/tests/multitable-import.spec.ts
@@ -72,6 +72,28 @@ describe('multitable import parsing', () => {
     expect(records.failures).toEqual([])
   })
 
+  it('resolves a NATIVE person field (type=person) to USERIDs via its kind-aware resolver', async () => {
+    // Native person is NO LONGER isLinkField, but delimited import must still route it through the
+    // injected resolver (which resolves to userIds, not People-sheet recordIds).
+    const resolver = vi.fn(async (rawValue: string) => {
+      expect(rawValue).toContain('alice@example.com')
+      return ['u_alice']
+    })
+    const records = await buildImportedRecords({
+      parsedRows: [['Alice <alice@example.com>']],
+      fieldMapping: { 0: 'fld_owner' },
+      fields: [
+        { id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } },
+      ],
+      fieldResolvers: { fld_owner: resolver },
+    })
+
+    expect(resolver).toHaveBeenCalledTimes(1)
+    expect(records.records).toEqual([{ fld_owner: ['u_alice'] }])
+    expect(records.rowIndexes).toEqual([0])
+    expect(records.failures).toEqual([])
+  })
+
   it('reports unresolved people values as preflight failures', async () => {
     const records = await buildImportedRecords({
       parsedRows: [['Unknown Person']],

--- a/apps/web/tests/multitable-person-field.spec.ts
+++ b/apps/web/tests/multitable-person-field.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import { isLinkField, isNativePersonField, isPersonField } from '../src/multitable/utils/link-fields'
+import { isPersonSingleRecordField } from '../src/multitable/utils/person-fields'
+import { formatFieldDisplay } from '../src/multitable/utils/field-display'
+import type { MetaField } from '../src/multitable/types'
+
+// Native person field (人员, design 2026-06-16) — COEXISTENCE FE specs.
+//
+// Two representations must both render as people chips:
+//   - NATIVE: type='person', value = userId[], display from personSummaries (NO linkSummaries).
+//   - LEGACY: type='link' + refKind:'user', value = recordId[], display from linkSummaries.
+
+const nativePersonField: MetaField = { id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }
+const legacyPersonField: MetaField = { id: 'fld_assignee', name: 'Assignee', type: 'link', property: { refKind: 'user' } }
+const plainLinkField: MetaField = { id: 'fld_vendor', name: 'Vendor', type: 'link' }
+
+function mountCell(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaCellRenderer, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('person field helpers (coexistence)', () => {
+  it('isNativePersonField is true ONLY for type=person', () => {
+    expect(isNativePersonField(nativePersonField)).toBe(true)
+    expect(isNativePersonField(legacyPersonField)).toBe(false)
+    expect(isNativePersonField(plainLinkField)).toBe(false)
+  })
+
+  it('isLinkField is FALSE for native person (decoupled), TRUE for legacy person + plain link', () => {
+    expect(isLinkField(nativePersonField)).toBe(false)
+    expect(isLinkField(legacyPersonField)).toBe(true)
+    expect(isLinkField(plainLinkField)).toBe(true)
+  })
+
+  it('isPersonField is true for BOTH native and legacy person, false for plain link', () => {
+    expect(isPersonField(nativePersonField)).toBe(true)
+    expect(isPersonField(legacyPersonField)).toBe(true)
+    expect(isPersonField(plainLinkField)).toBe(false)
+  })
+
+  it('isPersonSingleRecordField defaults to TRUE (undefined), false only when explicitly false', () => {
+    expect(isPersonSingleRecordField({ id: 'f', name: 'F', type: 'person' })).toBe(true)
+    expect(isPersonSingleRecordField({ id: 'f', name: 'F', type: 'person', property: { limitSingleRecord: false } })).toBe(false)
+    expect(isPersonSingleRecordField({ id: 'f', name: 'F', type: 'person', property: { limitSingleRecord: true } })).toBe(true)
+  })
+})
+
+describe('formatFieldDisplay — native person resolves userId → display', () => {
+  it('joins resolved member display names, falling back to userId when no summary', () => {
+    const out = formatFieldDisplay({
+      field: nativePersonField,
+      value: ['u1', 'u_unknown'],
+      personSummaries: [{ id: 'u1', display: 'Alice' }],
+    })
+    expect(out).toBe('Alice, u_unknown')
+  })
+
+  it('renders — for an empty native person value', () => {
+    expect(formatFieldDisplay({ field: nativePersonField, value: [] })).toBe('—')
+  })
+})
+
+describe('MetaCellRenderer — person chips (coexistence)', () => {
+  it('NATIVE person renders chips from personSummaries (no linkSummaries needed)', async () => {
+    const { container, app } = mountCell({
+      field: nativePersonField,
+      value: ['u1', 'u2'],
+      personSummaries: [
+        { id: 'u1', display: 'Alice' },
+        { id: 'u2', display: 'Bob' },
+      ],
+    })
+    await nextTick()
+    const chips = container.querySelectorAll('.meta-cell-renderer__person-chip')
+    expect(chips.length).toBe(2)
+    const names = Array.from(container.querySelectorAll('.meta-cell-renderer__person-name')).map((n) => n.textContent)
+    expect(names).toEqual(['Alice', 'Bob'])
+    const initials = Array.from(container.querySelectorAll('.meta-cell-renderer__person-avatar')).map((n) => n.textContent)
+    expect(initials).toEqual(['A', 'B'])
+    app.unmount()
+    container.remove()
+  })
+
+  it('NATIVE person falls back to the userId when a summary is missing', async () => {
+    const { container, app } = mountCell({
+      field: nativePersonField,
+      value: ['u_ghost'],
+      personSummaries: [],
+    })
+    await nextTick()
+    const names = Array.from(container.querySelectorAll('.meta-cell-renderer__person-name')).map((n) => n.textContent)
+    expect(names).toEqual(['u_ghost'])
+    app.unmount()
+    container.remove()
+  })
+
+  it('LEGACY link-backed person STILL renders chips from linkSummaries (coexistence regression)', async () => {
+    const { container, app } = mountCell({
+      field: legacyPersonField,
+      value: ['rec_1'],
+      linkSummaries: [{ id: 'rec_1', display: 'Carol' }],
+    })
+    await nextTick()
+    const chips = container.querySelectorAll('.meta-cell-renderer__person-chip')
+    expect(chips.length).toBe(1)
+    expect(container.querySelector('.meta-cell-renderer__person-name')?.textContent).toBe('Carol')
+    app.unmount()
+    container.remove()
+  })
+
+  it('empty native person renders no chips', async () => {
+    const { container, app } = mountCell({ field: nativePersonField, value: [], personSummaries: [] })
+    await nextTick()
+    expect(container.querySelectorAll('.meta-cell-renderer__person-chip').length).toBe(0)
+    app.unmount()
+    container.remove()
+  })
+})

--- a/apps/web/tests/multitable-person-picker.spec.ts
+++ b/apps/web/tests/multitable-person-picker.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+import MetaPersonPicker from '../src/multitable/components/MetaPersonPicker.vue'
+
+// Native person (人员) picker — MEMBER-SCOPED by construction (sources from
+// listSheetPermissionCandidates, NOT a global org directory) and emits userId[] (NOT recordIds).
+
+const { mockListCandidates } = vi.hoisted(() => ({ mockListCandidates: vi.fn() }))
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: { listSheetPermissionCandidates: mockListCandidates },
+}))
+
+const candidates = {
+  items: [
+    { subjectType: 'user', subjectId: 'u1', label: 'Alice', subtitle: 'alice@x.test', isActive: true },
+    { subjectType: 'user', subjectId: 'u2', label: 'Bob', subtitle: 'bob@x.test', isActive: true },
+    // non-user + inactive entries must be filtered out of the member roster
+    { subjectType: 'role', subjectId: 'role_x', label: 'Editor', subtitle: null, isActive: true },
+    { subjectType: 'user', subjectId: 'u_inactive', label: 'Ghost', subtitle: null, isActive: false },
+  ],
+  total: 4,
+  limit: 100,
+  query: '',
+}
+
+async function flush() {
+  await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick()
+}
+
+function mount(field: Record<string, unknown>, currentValue: unknown, onConfirm = vi.fn()) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const Harness = defineComponent({
+    setup() {
+      const visible = ref(false)
+      return { visible, onClose: () => { visible.value = false } }
+    },
+    render() {
+      return h(MetaPersonPicker, {
+        visible: this.visible,
+        field,
+        sheetId: 'sheet_1',
+        currentValue,
+        onClose: this.onClose,
+        onConfirm,
+      })
+    },
+  })
+  const app = createApp(Harness)
+  const vm = app.mount(container) as any
+  return { container, app, vm, onConfirm }
+}
+
+describe('MetaPersonPicker (member-scoped)', () => {
+  it('lists ONLY active user candidates (member-scoped; roles + inactive filtered out)', async () => {
+    mockListCandidates.mockResolvedValue(candidates)
+    const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, [])
+    vm.visible = true
+    await flush()
+    const rows = container.querySelectorAll('[data-test="person-picker-member"]')
+    expect(rows.length).toBe(2) // u1 + u2 only
+    expect(container.textContent).toContain('Alice')
+    expect(container.textContent).toContain('Bob')
+    expect(container.textContent).not.toContain('Editor')
+    expect(container.textContent).not.toContain('Ghost')
+    app.unmount(); container.remove()
+  })
+
+  it('emits userId[] (NOT recordIds) on confirm — multi when limitSingleRecord:false', async () => {
+    mockListCandidates.mockResolvedValue(candidates)
+    const onConfirm = vi.fn()
+    const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, [], onConfirm)
+    vm.visible = true
+    await flush()
+    const boxes = Array.from(container.querySelectorAll('[data-test="person-picker-member"] input[type="checkbox"]')) as HTMLInputElement[]
+    boxes[0]?.click(); boxes[1]?.click()
+    await nextTick()
+    ;(container.querySelector('[data-test="person-picker-confirm"]') as HTMLButtonElement)?.click()
+    expect(onConfirm).toHaveBeenCalledWith({
+      userIds: ['u1', 'u2'],
+      summaries: [{ id: 'u1', display: 'Alice' }, { id: 'u2', display: 'Bob' }],
+    })
+    app.unmount(); container.remove()
+  })
+
+  it('single-select replaces the prior pick when limitSingleRecord is true (default)', async () => {
+    mockListCandidates.mockResolvedValue(candidates)
+    const onConfirm = vi.fn()
+    // limitSingleRecord omitted → defaults to TRUE (single person)
+    const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person' }, ['u1'], onConfirm)
+    vm.visible = true
+    await flush()
+    const boxes = Array.from(container.querySelectorAll('[data-test="person-picker-member"] input[type="checkbox"]')) as HTMLInputElement[]
+    // pick u2 → should REPLACE u1 (single select)
+    boxes[1]?.click()
+    await nextTick()
+    ;(container.querySelector('[data-test="person-picker-confirm"]') as HTMLButtonElement)?.click()
+    expect(onConfirm).toHaveBeenCalledWith({
+      userIds: ['u2'],
+      summaries: [{ id: 'u2', display: 'Bob' }],
+    })
+    app.unmount(); container.remove()
+  })
+})

--- a/apps/web/tests/multitable-record-drawer-button.spec.ts
+++ b/apps/web/tests/multitable-record-drawer-button.spec.ts
@@ -90,3 +90,53 @@ describe('MetaRecordDrawer — button field (B1-e)', () => {
     expect(btn().disabled).toBe(false)
   })
 })
+
+// Native person (人员, design 2026-06-16): the drawer renders person display from
+// personSummariesByField (userId → name) and edits via an open-person-picker emit (NOT the
+// link picker). The drawer uses its OWN render chain (formatFieldDisplay), not MetaCellRenderer.
+describe('MetaRecordDrawer — native person field', () => {
+  const personField: MetaField = { id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } } as unknown as MetaField
+
+  it('resolves person display from personSummariesByField (userId → name)', async () => {
+    container = document.createElement('div'); document.body.appendChild(container)
+    app = createApp({
+      setup: () => () => h(MetaRecordDrawer, {
+        visible: true,
+        record: { id: 'rec_1', version: 1, data: { fld_owner: ['u1', 'u2'] } },
+        fields: [personField],
+        canEdit: false, canComment: false, canDelete: false,
+        personSummariesByField: { fld_owner: [{ id: 'u1', display: 'Alice' }, { id: 'u2', display: 'Bob' }] },
+      }),
+    })
+    app.mount(container)
+    await flushUi()
+    expect(container.textContent).toContain('Alice')
+    expect(container.textContent).toContain('Bob')
+    // raw userId is NOT shown when a summary resolves
+    expect(container.textContent).not.toContain('u1')
+  })
+
+  it('emits open-person-picker (NOT open-link-picker) when the editable person field is clicked', async () => {
+    const personEmits: MetaField[] = []
+    const linkEmits: MetaField[] = []
+    container = document.createElement('div'); document.body.appendChild(container)
+    app = createApp({
+      setup: () => () => h(MetaRecordDrawer, {
+        visible: true,
+        record: { id: 'rec_1', version: 1, data: { fld_owner: [] } },
+        fields: [personField],
+        canEdit: true, canComment: false, canDelete: false,
+        onOpenPersonPicker: (f: MetaField) => personEmits.push(f),
+        onOpenLinkPicker: (f: MetaField) => linkEmits.push(f),
+      }),
+    })
+    app.mount(container)
+    await flushUi()
+    const openBtn = container.querySelector<HTMLButtonElement>('[data-test="drawer-person-picker-open"]')
+    expect(openBtn).not.toBeNull()
+    openBtn!.click()
+    await flushUi()
+    expect(personEmits.map((f) => f.id)).toEqual(['fld_owner'])
+    expect(linkEmits).toHaveLength(0)
+  })
+})

--- a/apps/web/tests/multitable-workbench-1672-1673.spec.ts
+++ b/apps/web/tests/multitable-workbench-1672-1673.spec.ts
@@ -140,7 +140,7 @@ function createGridMock() {
     filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
     groupFieldId: ref(null), groupField: ref(null),
     hiddenFieldIds: ref([]), columnWidths: ref({}),
-    linkSummaries: ref({}), attachmentSummaries: ref({}),
+    linkSummaries: ref({}), personSummaries: ref({}), attachmentSummaries: ref({}),
     fieldPermissions: ref({}), viewPermission: ref(null),
     rowActions: ref(null), rowActionOverrides: ref({}),
     capabilityOrigin: ref(null), conflict: ref(null),

--- a/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
@@ -140,7 +140,7 @@ function createGridMock() {
     page: ref({ offset: 0, limit: 50, total: 0, hasMore: false }), visibleFields: ref([]), sortRules: ref([]),
     filterRules: ref([]), filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
     groupFieldId: ref<string | null>(null), groupField: ref(null), hiddenFieldIds: ref<string[]>([]),
-    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), attachmentSummaries: ref({}),
+    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), personSummaries: ref({}), attachmentSummaries: ref({}),
     fieldPermissions: ref({}), viewPermission: ref(null), rowActions: ref(null), rowActionOverrides: ref({}),
     capabilityOrigin: ref(null), conflict: ref(null), error: ref<string | null>(null), sortFilterDirty: ref(false),
     toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),

--- a/apps/web/tests/multitable-workbench-import-flow.spec.ts
+++ b/apps/web/tests/multitable-workbench-import-flow.spec.ts
@@ -228,6 +228,7 @@ function createGridMock(fields: Array<Record<string, unknown>>) {
     capabilityOrigin: ref('global-rbac'),
     columnWidths: ref<Record<string, number>>({}),
     linkSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
+    personSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     attachmentSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     fieldPermissions: ref({}),
     viewPermission: ref(null),

--- a/apps/web/tests/multitable-workbench-manager-flow.spec.ts
+++ b/apps/web/tests/multitable-workbench-manager-flow.spec.ts
@@ -206,6 +206,7 @@ function createGridMock() {
     hiddenFieldIds: ref<string[]>([]),
     columnWidths: ref<Record<string, number>>({}),
     linkSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
+    personSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     attachmentSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     fieldPermissions: ref({}),
     viewPermission: ref(null),

--- a/apps/web/tests/multitable-workbench-permission-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-permission-wiring.spec.ts
@@ -161,7 +161,7 @@ function createGridMock() {
     filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
     groupFieldId: ref(null), groupField: ref(null),
     hiddenFieldIds: ref([]), columnWidths: ref({}),
-    linkSummaries: ref({}), attachmentSummaries: ref({}),
+    linkSummaries: ref({}), personSummaries: ref({}), attachmentSummaries: ref({}),
     fieldPermissions: ref({}), viewPermission: ref(null),
     rowActions: ref(null), rowActionOverrides: ref({}),
     capabilityOrigin: ref(null), conflict: ref(null),

--- a/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
@@ -138,7 +138,7 @@ function createGridMock() {
     page: ref({ offset: 0, limit: 50, total: 0, hasMore: false }), visibleFields: ref([]), sortRules: ref([]),
     filterRules: ref([]), filterConjunction: ref('and'), canUndo: ref(false), canRedo: ref(false),
     groupFieldId: ref<string | null>(null), groupField: ref(null), hiddenFieldIds: ref<string[]>([]),
-    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), attachmentSummaries: ref({}),
+    columnWidths: ref<Record<string, number>>({}), linkSummaries: ref({}), personSummaries: ref({}), attachmentSummaries: ref({}),
     fieldPermissions: ref({}), viewPermission: ref(null), rowActions: ref(null), rowActionOverrides: ref({}),
     capabilityOrigin: ref(null), conflict: ref(null), error: ref<string | null>(null), sortFilterDirty: ref(false),
     toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -998,6 +998,7 @@ function createGridMock() {
     hiddenFieldIds: ref<string[]>([]),
     columnWidths: ref<Record<string, number>>({}),
     linkSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
+    personSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     attachmentSummaries: ref<Record<string, Record<string, unknown[]>>>({}),
     fieldPermissions: ref({}),
     viewPermission: ref(null),

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2197,6 +2197,7 @@ export class MetaSheetServer {
       const { YjsWebSocketAdapter } = await import('./collab/yjs-websocket-adapter')
       const { YjsRecordBridge } = await import('./collab/yjs-record-bridge')
       const { RecordWriteService } = await import('./multitable/record-write-service')
+      const { loadSheetMemberUserIdSet } = await import('./multitable/permission-service')
       const { createYjsInvalidationPostCommitHook } = await import('./multitable/post-commit-hooks')
       const { db: kyselyDbYjs } = await import('./db/db')
       const collabIO = this.injector.get(ICollabService).getIO()
@@ -2291,6 +2292,10 @@ export class MetaSheetServer {
           buildLinkSummaries: async () => new Map(),
           buildAttachmentSummaries: async () => new Map(),
           ensureAttachmentIdsExist: async () => null,
+          // Native person (人员): enforce the member boundary on the Yjs collab write path too —
+          // a real resolver (pure query) so a collaboratively-edited person cell can't store a
+          // non-member userId. (Unlike link validation, which is stubbed on this bridge path.)
+          loadSheetMemberUserIds: (q, sid) => loadSheetMemberUserIdSet(q, sid),
         })
 
         const yjsBridge = new YjsRecordBridge(

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -13,6 +13,7 @@ export type MultitableFieldType =
   | 'select'
   | 'multiSelect'
   | 'link'
+  | 'person'
   | 'lookup'
   | 'rollup'
   | 'attachment'
@@ -106,7 +107,12 @@ export function mapFieldType(type: string): MultitableFieldType | string {
     return 'multiSelect'
   }
   if (normalized === 'link') return 'link'
-  if (normalized === 'person') return 'link'
+  // Native person field (人员 / member, design 2026-06-16). Stored as a first-class
+  // `type='person'` whose value is `userId[]` — NOT aliased to `link` anymore.
+  // COEXISTENCE: legacy person fields are persisted as `type='link'`+`refKind:'user'`
+  // (they were never stored as 'person'), so this flip only affects NEW person fields
+  // and never reinterprets a stored link-backed person. See `validatePersonValue`.
+  if (normalized === 'person') return 'person'
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
@@ -255,6 +261,24 @@ function sanitizeFieldPropertyByType(
       ...(obj.twoWay === true ? { twoWay: true } : {}),
       ...(mirrorFieldId ? { mirrorFieldId } : {}),
       ...(mirrorOf ? { mirrorOf, readOnly: true } : {}),
+    }
+  }
+
+  if (type === 'person') {
+    // Native person (人员) — value is `userId[]`. The ONLY user-controlled option is
+    // `limitSingleRecord` (single vs multi). CRITICAL default: `!== false` → undefined
+    // defaults to TRUE, matching the legacy person path (univer-meta normalizeFieldWriteInput
+    // + people-import) so single/multi behaviour never silently flips between a legacy
+    // link-backed person and a native person. NOT readOnly (person is user-editable).
+    //
+    // `restrictToMemberGroupIds` is an OPTIONAL future narrowing config (member-group scope);
+    // sanitized to a deduped string[] when present, omitted otherwise. It is config-shape only
+    // here — write-time membership is enforced by `validatePersonValue` against the resolved
+    // sheet member set.
+    const restrict = sanitizeStringArray(obj.restrictToMemberGroupIds)
+    return {
+      limitSingleRecord: obj.limitSingleRecord !== false,
+      ...(restrict.length > 0 ? { restrictToMemberGroupIds: Array.from(new Set(restrict)) } : {}),
     }
   }
 
@@ -905,6 +929,77 @@ export function normalizeMultiSelectValue(
     }
   }
   return normalized
+}
+
+/**
+ * Native person (人员 / member) value validator — design 2026-06-16.
+ *
+ * The stored value is a deduped `userId[]` (mirrors {@link normalizeMultiSelectValue}'s
+ * array normalization, NOT the recordId[] of a legacy link-backed person). It enforces
+ * the SECURITY membership boundary: every userId MUST be in `allowedUserIds` (the sheet/
+ * base member set), reusing the SAME member-set resolved once per request batch by the
+ * caller (parallel to the link-target-exists loop) so a record cell and a notify recipient
+ * share one membership control.
+ *
+ * - empty / null / '' → `[]`
+ * - non-array → throws (callers surface as RecordValidationError)
+ * - each id: string|number, trimmed, deduped (order-preserving)
+ * - non-member id → throws (the 403/validation reject)
+ * - `limitSingleRecord` true → reject more than one id
+ *
+ * `allowedUserIds === null` means "membership not resolvable for this sheet" — treated as
+ * a CLOSED set (reject any non-empty value) so a missing member set can never become an
+ * open egress. Callers pass a real Set when a person field is present.
+ */
+export function validatePersonValue(
+  value: unknown,
+  fieldId: string,
+  allowedUserIds: ReadonlySet<string> | null,
+  limitSingleRecord: boolean,
+): string[] {
+  if (value === null || value === undefined || value === '') return []
+  if (!Array.isArray(value)) {
+    throw new Error(`Person value must be an array for ${fieldId}`)
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string' && typeof item !== 'number') {
+      throw new Error(`Person value must be an array of user ids for ${fieldId}`)
+    }
+    const userId = String(item).trim()
+    if (!userId) continue
+    if (userId.length > 50) {
+      throw new Error(`Person user id too long (>50) for ${fieldId}: ${userId}`)
+    }
+    if (!seen.has(userId)) {
+      seen.add(userId)
+      normalized.push(userId)
+    }
+  }
+
+  if (normalized.length === 0) return []
+
+  if (limitSingleRecord && normalized.length > 1) {
+    throw new Error(`Person field only allows a single user for ${fieldId}`)
+  }
+
+  // SECURITY: reject any userId outside the sheet member set. A null set is a closed set.
+  const allowed = allowedUserIds ?? new Set<string>()
+  const nonMembers = normalized.filter((userId) => !allowed.has(userId))
+  if (nonMembers.length > 0) {
+    throw new Error(
+      `Person user(s) not a member of this sheet for ${fieldId}: ${nonMembers.join(', ')}`,
+    )
+  }
+
+  return normalized
+}
+
+/** True iff `limitSingleRecord` is enabled on a person field property (default TRUE). */
+export function isPersonSingleRecord(property: Record<string, unknown> | undefined): boolean {
+  return property?.limitSingleRecord !== false
 }
 
 /**

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -272,9 +272,11 @@ function sanitizeFieldPropertyByType(
     // link-backed person and a native person. NOT readOnly (person is user-editable).
     //
     // `restrictToMemberGroupIds` is an OPTIONAL future narrowing config (member-group scope);
-    // sanitized to a deduped string[] when present, omitted otherwise. It is config-shape only
-    // here — write-time membership is enforced by `validatePersonValue` against the resolved
-    // sheet member set.
+    // sanitized to a deduped string[] when present, omitted otherwise. NOTE: it is config-shape
+    // ONLY and NOT YET ENFORCED — `validatePersonValue` checks SHEET membership, not the group
+    // subset, so a field carrying this still accepts any sheet member. Enforcement (intersect the
+    // member set with the configured groups) is a follow-up; until then this is a stored hint, not
+    // an active restriction. (Sanitizing the shape now keeps the contract stable for that follow-up.)
     const restrict = sanitizeStringArray(obj.restrictToMemberGroupIds)
     return {
       limitSingleRecord: obj.limitSingleRecord !== false,

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -575,6 +575,36 @@ export async function listSheetPermissionCandidates(
   return candidates.filter((_candidate, index) => eligibility[index])
 }
 
+/**
+ * Native person field (design 2026-06-16) member boundary.
+ *
+ * Returns the flat set of `userId`s that are valid members of `sheetId` — i.e. EXACTLY
+ * the active users {@link listSheetPermissionCandidates} offers as selectable people
+ * (the same eligibility filter: active + multitable read/write or admin). Reusing the
+ * candidate resolver here is load-bearing: the person PICKER and the person write-time
+ * VALIDATOR must accept/reject the identical set, or a user could pick someone the
+ * validator rejects (advisor §4 — single resolver, no drift).
+ *
+ * Resolved ONCE per request batch by record writers (parallel to the link-target-exists
+ * loop). The same boundary control is what the notify recipient dispatch reuses, so a
+ * person cell and a notify recipient share one membership set.
+ */
+export async function loadSheetMemberUserIdSet(
+  query: QueryFn,
+  sheetId: string,
+): Promise<Set<string>> {
+  // Bounded but generous; person fields validate against the full eligible-member roster.
+  const candidates = await listSheetPermissionCandidates(query, sheetId, { limit: 10000 })
+  const members = new Set<string>()
+  for (const candidate of candidates) {
+    if (candidate.subjectType !== 'user') continue
+    if (!candidate.isActive) continue
+    const id = candidate.subjectId.trim()
+    if (id) members.add(id)
+  }
+  return members
+}
+
 export async function enrichFormShareCandidatesWithDingTalkStatus(
   query: QueryFn,
   candidates: MultitableSheetPermissionCandidate[],

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -10,12 +10,15 @@ import {
   BATCH1_FIELD_TYPES,
   coerceBatch1Value,
   extractSelectOptions,
+  isPersonSingleRecord,
   normalizeMultiSelectValue,
   normalizeJson,
   normalizeJsonArray,
   validateLongTextValue,
+  validatePersonValue,
   type MultitableField,
 } from './field-codecs'
+import { loadSheetMemberUserIdSet } from './permission-service'
 import {
   HierarchyCycleError,
   assertNoHierarchyParentCycle,
@@ -242,6 +245,9 @@ function mapFieldType(type: string): UniverMetaField['type'] {
     return 'multiSelect'
   }
   if (normalized === 'link') return 'link'
+  // Native person field (人员, design 2026-06-16): first-class type='person' (userId[]),
+  // no longer aliased to 'link'. Legacy person stays type='link'+refKind:user (coexistence).
+  if (normalized === 'person') return 'person'
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
@@ -346,6 +352,12 @@ function buildCreateFieldGuardMap(rows: unknown[]): Map<string, CreateFieldGuard
         // DERIVED (mirror) side on the single-record create/patch path (bidirectional links MVP).
         property: normalizeJson(row.property),
       })
+      continue
+    }
+
+    // Native person (人员) — carry property so the write path reads `limitSingleRecord`.
+    if (type === 'person') {
+      guards.set(fieldId, { type, property: normalizeJson(row.property) })
       continue
     }
 
@@ -471,6 +483,16 @@ export class RecordService {
       const fieldById = buildCreateFieldGuardMap(fieldRes.rows)
       const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
+      // Native person (人员): resolve the sheet member set ONCE (lazily, only on the first person
+      // cell write) and reuse it for membership validation — parallel to the link-exists query.
+      let personMemberUserIds: Set<string> | null = null
+      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
+        if (personMemberUserIds === null) {
+          personMemberUserIds = await loadSheetMemberUserIdSet(query, sheetId)
+        }
+        return personMemberUserIds
+      }
+
       for (const [fieldId, value] of Object.entries(data)) {
         const field = fieldById.get(fieldId)
         if (!field) {
@@ -479,6 +501,16 @@ export class RecordService {
 
         if (isFieldAlwaysReadOnly(field)) {
           throw new RecordFieldForbiddenError(`Field is readonly: ${fieldId}`, fieldId)
+        }
+
+        if (field.type === 'person') {
+          try {
+            const allowed = await resolvePersonMemberUserIds()
+            patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
+          } catch (error) {
+            throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+          }
+          continue
         }
 
         if (field.type === 'select') {
@@ -795,6 +827,16 @@ export class RecordService {
     const patch: Record<string, unknown> = {}
     const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
+    // Native person (人员): resolve the sheet member set ONCE (lazily on the first person cell)
+    // and reuse it for membership validation.
+    let personMemberUserIds: Set<string> | null = null
+    const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
+      if (personMemberUserIds === null) {
+        personMemberUserIds = await loadSheetMemberUserIdSet(this.pool.query.bind(this.pool), sheetId)
+      }
+      return personMemberUserIds
+    }
+
     for (const [fieldId, value] of Object.entries(data)) {
       const field = fieldById.get(fieldId)
       if (!field) {
@@ -807,6 +849,15 @@ export class RecordService {
       }
       if (field.readOnly === true || field.type === 'lookup' || field.type === 'rollup') {
         fieldErrors[fieldId] = 'Field is readonly'
+        continue
+      }
+      if (field.type === 'person') {
+        try {
+          const allowed = await resolvePersonMemberUserIds()
+          patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
+        } catch (error) {
+          fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
+        }
         continue
       }
       if (field.type === 'select') {

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -22,7 +22,7 @@ import {
   type RecordPostCommitHook,
   type YjsInvalidator,
 } from './post-commit-hooks'
-import { BATCH1_FIELD_TYPES, coerceBatch1Value, normalizeMultiSelectValue, validateLongTextValue } from './field-codecs'
+import { BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, normalizeMultiSelectValue, validateLongTextValue, validatePersonValue } from './field-codecs'
 import {
   HierarchyCycleError,
   assertNoHierarchyParentCycle,
@@ -64,6 +64,7 @@ export type UniverMetaField = {
     | 'select'
     | 'multiSelect'
     | 'link'
+    | 'person'
     | 'lookup'
     | 'rollup'
     | 'attachment'
@@ -363,6 +364,13 @@ export interface RecordWriteHelpers {
     fieldId: string,
     ids: string[],
   ) => Promise<string | null>
+  /**
+   * Native person (人员, design 2026-06-16) membership boundary. Returns the flat set of
+   * valid member `userId`s for a sheet (the same set the person picker offers) so person
+   * cell writes reject non-member userIds. Resolved ONCE per patch op (only when a person
+   * field is written), parallel to the link-target-exists hot-path.
+   */
+  loadSheetMemberUserIds: (query: QueryFn, sheetId: string) => Promise<Set<string>>
 }
 
 // ---------------------------------------------------------------------------
@@ -480,6 +488,31 @@ export class RecordWriteService {
             normalizeMultiSelectValue(change.value, change.fieldId, field.options ?? [])
           } catch (error) {
             throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+          }
+        }
+
+        if (field.type === 'person') {
+          // Step-0 SHAPE-only pre-check (array / single-record cap / id length). The authoritative
+          // MEMBERSHIP rejection runs in the txn loop with the once-resolved member set (no member-set
+          // query in this pre-pass). Passing the empty set here would false-reject valid ids, so use a
+          // null set = closed only against itself: validatePersonValue with `null` would reject ALL ids,
+          // so instead we validate shape by checking the non-membership invariants directly.
+          if (change.value !== null && change.value !== undefined && change.value !== '') {
+            if (!Array.isArray(change.value)) {
+              throw new RecordValidationError(`Person value must be an array for ${change.fieldId}`)
+            }
+            const ids = change.value.map((v) => (typeof v === 'string' || typeof v === 'number' ? String(v).trim() : null))
+            if (ids.some((v) => v === null)) {
+              throw new RecordValidationError(`Person value must be an array of user ids for ${change.fieldId}`)
+            }
+            const nonEmpty = ids.filter((v): v is string => !!v)
+            const tooLong = nonEmpty.find((id) => id.length > 50)
+            if (tooLong) {
+              throw new RecordValidationError(`Person user id too long (>50) for ${change.fieldId}: ${tooLong}`)
+            }
+            if (isPersonSingleRecord(field.property) && new Set(nonEmpty).size > 1) {
+              throw new RecordValidationError(`Person field only allows a single user for ${change.fieldId}`)
+            }
           }
         }
 
@@ -606,6 +639,17 @@ export class RecordWriteService {
     const updates = await this.pool.transaction(async ({ query }) => {
       const updated: Array<{ recordId: string; version: number }> = []
 
+      // Native person (人员): resolve the sheet member set ONCE per patch op (lazily, only when a
+      // person field value is actually written), then reuse it for every person cell's write-time
+      // membership validation (SECURITY boundary) — parallel to the link-target-exists hot-path.
+      let personMemberUserIds: Set<string> | null = null
+      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
+        if (personMemberUserIds === null) {
+          personMemberUserIds = await h.loadSheetMemberUserIds(query, sheetId)
+        }
+        return personMemberUserIds
+      }
+
       for (const [recordId, changes] of changesByRecord.entries()) {
         const expectedVersion = Array.from(
           new Set(changes.map((c) => c.expectedVersion).filter((v): v is number => typeof v === 'number')),
@@ -685,6 +729,17 @@ export class RecordWriteService {
           if (field.type === 'multiSelect') {
             try {
               patch[change.fieldId] = normalizeMultiSelectValue(change.value, change.fieldId, field.options ?? [])
+            } catch (error) {
+              throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+            }
+            applied += 1
+            continue
+          }
+
+          if (field.type === 'person') {
+            try {
+              const allowed = await resolvePersonMemberUserIds()
+              patch[change.fieldId] = validatePersonValue(change.value, change.fieldId, allowed, isPersonSingleRecord(field.property))
             } catch (error) {
               throw new RecordValidationError(error instanceof Error ? error.message : String(error))
             }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -9902,6 +9902,17 @@ export function univerMetaRouter(): Router {
             allowedFieldIds,
           )
         : undefined
+      // Native person (人员) display for the single-record drawer/form — same users-table join as the
+      // grid view, masked through the SAME single-record layer-2∧3 composite as linkSummaries.
+      const personFieldsSingle = visiblePropertyFields.filter((field) => field.type === 'person')
+      const personSummaries = personFieldsSingle.length > 0
+        ? filterSingleRecordFieldSummaryMap(
+            serializePersonSummaryMap(
+              await buildPersonSummaries(pool.query.bind(pool), [record], personFieldsSingle),
+            )[record.id] ?? {},
+            allowedFieldIds,
+          )
+        : undefined
 
       const viewScopeMap = (access.userId && viewConfig) ? await loadViewPermissionScopeMap(pool.query.bind(pool), [viewConfig.id], access.userId) : new Map()
       const fieldPermissions = deriveFieldPermissions(fields, capabilities, {
@@ -9943,6 +9954,7 @@ export function univerMetaRouter(): Router {
             containerId: sheet.id,
           },
           linkSummaries,
+          ...(personSummaries ? { personSummaries } : {}),
           ...(attachmentSummaries ? { attachmentSummaries } : {}),
         },
       })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -48,6 +48,7 @@ import {
   loadFieldPermissionScopeMap,
   loadRecordCreatorMap,
   loadRecordPermissionScopeMap,
+  loadSheetMemberUserIdSet,
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
   requiresOwnWriteRowPolicy,
@@ -107,7 +108,7 @@ import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { FormulaEngine } from '../formula/engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
-import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue } from '../multitable/field-codecs'
+import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import {
   AutomationRuleValidationError,
@@ -279,6 +280,7 @@ type UniverMetaField = {
     | 'select'
     | 'multiSelect'
     | 'link'
+    | 'person'
     | 'lookup'
     | 'rollup'
     | 'attachment'
@@ -323,6 +325,7 @@ type UniverMetaView = {
   fields: UniverMetaField[]
   rows: UniverMetaRecord[]
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
+  personSummaries?: Record<string, Record<string, PersonSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MultitableAttachment[]>>
   view?: UniverMetaViewConfig
   meta?: {
@@ -398,6 +401,14 @@ type MultitableScopedPermissions = {
 }
 
 type LinkedRecordSummary = {
+  id: string
+  display: string
+}
+
+// Native person (人员, design 2026-06-16) display source. Parallel to LinkedRecordSummary
+// but keyed by `userId` (NOT a recordId) and resolved from the `users` table at view-assembly
+// time — the native person value carries no linkSummaries, so the renderer reads this instead.
+type PersonSummary = {
   id: string
   display: string
 }
@@ -1421,7 +1432,10 @@ function mapFieldType(type: string): UniverMetaField['type'] {
     return 'multiSelect'
   }
   if (normalized === 'link') return 'link'
-  if (normalized === 'person') return 'link'
+  // Native person field (人员, design 2026-06-16): stored as first-class `type='person'`
+  // (userId[]), no longer aliased to `link`. Legacy person fields are stored as
+  // `type='link'`+refKind:user, so this flip is coexistence-safe — see field-codecs.ts.
+  if (normalized === 'person') return 'person'
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
@@ -1634,6 +1648,20 @@ function sanitizeFieldPropertyByType(type: UniverMetaField['type'], property: un
       // services reject a PATCH on it (isFieldAlwaysReadOnly honors property.readOnly) — this is what
       // keeps the single canonical edge from gaining a second, materialized row.
       ...(mirrorOf ? { mirrorOf, readOnly: true } : {}),
+    }
+  }
+
+  if (type === 'person') {
+    // Native person (人员, design 2026-06-16) — value is `userId[]`. Mirrors the
+    // field-codecs.ts person branch: only `limitSingleRecord` is user-controlled and its
+    // default is TRUE (`!== false`), matching the legacy person path so single/multi never
+    // silently flips between a legacy link-backed person and a native person. NOT readOnly.
+    const restrict = Array.isArray(obj.restrictToMemberGroupIds)
+      ? Array.from(new Set(obj.restrictToMemberGroupIds.filter((v): v is string => typeof v === 'string' && v.trim().length > 0).map((v) => v.trim())))
+      : []
+    return {
+      limitSingleRecord: obj.limitSingleRecord !== false,
+      ...(restrict.length > 0 ? { restrictToMemberGroupIds: restrict } : {}),
     }
   }
 
@@ -3176,6 +3204,7 @@ export function createRecordWriteHelpers(req: Request, _pool?: { query: QueryFn 
     buildLinkSummaries: (q, sourceSheetId, rows, rl, lv) => buildLinkSummaries(req, q, sourceSheetId, rows, rl, lv),
     buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
     ensureAttachmentIdsExist,
+    loadSheetMemberUserIds: (q, sid) => loadSheetMemberUserIdSet(q, sid),
   }
 }
 
@@ -3738,32 +3767,26 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
 
 async function normalizeFieldWriteInput(
   query: QueryFn,
-  sheetId: string,
+  _sheetId: string,
   requestedType: MultitableFieldInputType | UniverMetaField['type'],
   rawProperty: unknown,
 ): Promise<{ type: UniverMetaField['type']; property: Record<string, unknown> }> {
-  if (requestedType !== 'person') {
-    return {
-      type: requestedType as UniverMetaField['type'],
-      property: sanitizeFieldProperty(requestedType as UniverMetaField['type'], rawProperty),
-    }
-  }
-
-  const sourceSheet = await loadSheetRow(query, sheetId)
-  if (!sourceSheet) throw new NotFoundError(`Sheet not found: ${sheetId}`)
-
-  const baseId = sourceSheet.baseId ?? await ensureLegacyBase(query)
-  const preset = await ensurePeopleSheetPreset(query, baseId)
-  const obj = normalizeJson(rawProperty)
-  const limitSingleRecord = obj.limitSingleRecord !== false
-
+  // Native person (人员, design 2026-06-16): `type:'person'` is now a FIRST-CLASS native
+  // field stored as `type='person'` (userId[]) — it flows through the generic branch and is
+  // NO LONGER rewritten to a `link`+refKind:user against the system People sheet. This is the
+  // default for newly-created person fields.
+  //
+  // COEXISTENCE: existing legacy person fields are persisted as `type='link'`+refKind:user
+  // and are untouched — they keep rendering/behaving as people. `ensurePeopleSheetPreset` and
+  // the `/person-fields/prepare` route stay intact (now vestigial for the FE create path, but
+  // preserved for legacy fields + direct API callers who still want the link-backed shape).
+  //
+  // The `query`/`_sheetId` params are retained for signature stability with the route call
+  // sites and any future per-type async normalization.
+  void query
   return {
-    type: 'link',
-    property: sanitizeFieldProperty('link', {
-      ...preset.fieldProperty,
-      limitSingleRecord,
-      refKind: 'user',
-    }),
+    type: requestedType as UniverMetaField['type'],
+    property: sanitizeFieldProperty(requestedType as UniverMetaField['type'], rawProperty),
   }
 }
 
@@ -3919,6 +3942,118 @@ async function buildAttachmentSummaries(
   attachmentFields: UniverMetaField[],
 ): Promise<Map<string, Map<string, MultitableAttachment[]>>> {
   return buildAttachmentSummariesShared({ query, req, sheetId, rows, attachmentFields })
+}
+
+/**
+ * Native person (人员, design 2026-06-16) display assembly. For each person field's
+ * `userId[]` cell, resolve a `{ id: userId, display }` summary from the `users` table
+ * (name → email → id fallback) — ONE query for all userIds across all person fields,
+ * parallel to buildLinkSummaries (no FE per-userId fetch / N+1). The native person value
+ * carries no linkSummaries, so the renderer reads THIS to draw the people chips.
+ */
+async function buildPersonSummaries(
+  query: QueryFn,
+  rows: UniverMetaRecord[],
+  personFields: UniverMetaField[],
+): Promise<Map<string, Map<string, PersonSummary[]>>> {
+  const result = new Map<string, Map<string, PersonSummary[]>>()
+  if (personFields.length === 0 || rows.length === 0) return result
+
+  const personFieldIds = personFields.map((f) => f.id)
+  const userIds = new Set<string>()
+  for (const row of rows) {
+    for (const fieldId of personFieldIds) {
+      const value = row.data[fieldId]
+      if (!Array.isArray(value)) continue
+      for (const item of value) {
+        if (typeof item === 'string' && item.trim()) userIds.add(item.trim())
+      }
+    }
+  }
+  if (userIds.size === 0) return result
+
+  const displayByUserId = new Map<string, string>()
+  try {
+    const usersRes = await query(
+      'SELECT id, email, name FROM users WHERE id = ANY($1::text[])',
+      [Array.from(userIds)],
+    )
+    for (const u of usersRes.rows as Array<{ id?: unknown; email?: unknown; name?: unknown }>) {
+      const id = typeof u.id === 'string' ? u.id : String(u.id ?? '')
+      if (!id) continue
+      const name = typeof u.name === 'string' ? u.name.trim() : ''
+      const email = typeof u.email === 'string' ? u.email.trim() : ''
+      displayByUserId.set(id, name || email || id)
+    }
+  } catch (err) {
+    // users table absent (minimal test harness) — fall back to userId as display below.
+    if (!(typeof (err as any)?.code === 'string' && (err as any).code === '42P01')) throw err
+  }
+
+  for (const row of rows) {
+    const fieldMap = new Map<string, PersonSummary[]>()
+    for (const fieldId of personFieldIds) {
+      const value = row.data[fieldId]
+      if (!Array.isArray(value)) continue
+      const summaries: PersonSummary[] = []
+      for (const item of value) {
+        if (typeof item !== 'string' || !item.trim()) continue
+        const userId = item.trim()
+        summaries.push({ id: userId, display: displayByUserId.get(userId) ?? userId })
+      }
+      if (summaries.length > 0) fieldMap.set(fieldId, summaries)
+    }
+    if (fieldMap.size > 0) result.set(row.id, fieldMap)
+  }
+  return result
+}
+
+/**
+ * Resolve a `userId → display` map for sort-by-display over native person fields. Scans the
+ * given records' person-sort-field cells for userIds, then joins the `users` table ONCE.
+ * Missing/absent users fall back to the userId (handled by the caller).
+ */
+async function resolvePersonSortDisplayMap(
+  query: QueryFn,
+  records: Array<{ data: Record<string, unknown> }>,
+  personFieldIds: ReadonlySet<string>,
+): Promise<Map<string, string>> {
+  const displayByUserId = new Map<string, string>()
+  const userIds = new Set<string>()
+  for (const record of records) {
+    for (const fieldId of personFieldIds) {
+      const value = record.data[fieldId]
+      if (!Array.isArray(value)) continue
+      for (const item of value) {
+        if (typeof item === 'string' && item.trim()) userIds.add(item.trim())
+      }
+    }
+  }
+  if (userIds.size === 0) return displayByUserId
+  try {
+    const usersRes = await query('SELECT id, email, name FROM users WHERE id = ANY($1::text[])', [Array.from(userIds)])
+    for (const u of usersRes.rows as Array<{ id?: unknown; email?: unknown; name?: unknown }>) {
+      const id = typeof u.id === 'string' ? u.id : String(u.id ?? '')
+      if (!id) continue
+      const name = typeof u.name === 'string' ? u.name.trim() : ''
+      const email = typeof u.email === 'string' ? u.email.trim() : ''
+      displayByUserId.set(id, name || email || id)
+    }
+  } catch (err) {
+    if (!(typeof (err as any)?.code === 'string' && (err as any).code === '42P01')) throw err
+  }
+  return displayByUserId
+}
+
+function serializePersonSummaryMap(
+  personSummaries: Map<string, Map<string, PersonSummary[]>>,
+): Record<string, Record<string, PersonSummary[]>> {
+  return Object.fromEntries(
+    Array.from(personSummaries.entries()).map(([recordId, fieldMap]) => [
+      recordId,
+      Object.fromEntries(Array.from(fieldMap.entries()).map(([fieldId, summaries]) => [fieldId, summaries])),
+    ]),
+  )
 }
 
 const serializeAttachmentSummaryMap = serializeAttachmentSummaryMapShared
@@ -8269,6 +8404,10 @@ export function univerMetaRouter(): Router {
         .map((f) => (f.type === 'link' ? { fieldId: f.id, cfg: parseLinkFieldConfig(f.property) } : null))
         .filter((v): v is { fieldId: string; cfg: LinkFieldConfig } => !!v && !!v.cfg)
       const attachmentFields = visiblePropertyFields.filter((field) => field.type === 'attachment')
+      // Native person (人员) fields — distinct from link fields (legacy link-backed person is
+      // `type='link'` and renders via linkSummaries; native person is `type='person'` and needs
+      // personSummaries). Coexistence: a sheet may have both.
+      const personFields = visiblePropertyFields.filter((field) => field.type === 'person')
       const computedFieldIdSet = new Set(
         visiblePropertyFields.filter((f) => f.type === 'lookup' || f.type === 'rollup').map((f) => f.id),
       )
@@ -8400,10 +8539,30 @@ export function univerMetaRouter(): Router {
           }
         }
 
+        // Native person (人员) sort-by-display: compareMetaSortValue's string fallback would order
+        // person cells by raw `String(userId[])`, not the visible name. Resolve a userId→display
+        // map once for the person fields that actually appear in the sort rules, then feed
+        // compareMetaSortValue the joined DISPLAY string instead of the raw userId array.
+        const personSortFieldIds = new Set(
+          sortRules.filter((rule) => fieldTypeById.get(rule.fieldId) === 'person').map((rule) => rule.fieldId),
+        )
+        const personSortDisplayByUserId = personSortFieldIds.size > 0
+          ? await resolvePersonSortDisplayMap(pool.query.bind(pool), all, personSortFieldIds)
+          : new Map<string, string>()
+        const personSortKey = (value: unknown): string => {
+          if (!Array.isArray(value) || value.length === 0) return ''
+          return value
+            .map((item) => (typeof item === 'string' && item.trim() ? (personSortDisplayByUserId.get(item.trim()) ?? item.trim()) : ''))
+            .filter(Boolean)
+            .join(', ')
+        }
+
         const sorted = sortRules.length > 0 ? [...all].sort((a, b) => {
           for (const rule of sortRules) {
             const fieldType = fieldTypeById.get(rule.fieldId) ?? 'string'
-            const cmp = compareMetaSortValue(fieldType, a.data[rule.fieldId], b.data[rule.fieldId], rule.desc)
+            const aValue = personSortFieldIds.has(rule.fieldId) ? personSortKey(a.data[rule.fieldId]) : a.data[rule.fieldId]
+            const bValue = personSortFieldIds.has(rule.fieldId) ? personSortKey(b.data[rule.fieldId]) : b.data[rule.fieldId]
+            const cmp = compareMetaSortValue(fieldType, aValue, bValue, rule.desc)
             if (cmp !== 0) return cmp
           }
 
@@ -8526,6 +8685,16 @@ export function univerMetaRouter(): Router {
             allowedFieldIds,
           )
         : undefined
+      // Native person (人员) display: ALWAYS assembled (not gated on includeLinkSummaries) because
+      // a native person chip has no other display source — the value is just userId[].
+      const personSummaries = personFields.length > 0
+        ? filterRecordFieldSummaryMap(
+            serializePersonSummaryMap(
+              await buildPersonSummaries(pool.query.bind(pool), rows, personFields),
+            ),
+            allowedFieldIds,
+          )
+        : undefined
       // Record-level permission filtering: remove records user cannot read (admin bypass)
       if (!access.isAdminRole && access.userId && rows.length > 0) {
         const hasRecordPerms = await hasRecordPermissionAssignments(pool.query.bind(pool), sheetId)
@@ -8600,6 +8769,7 @@ export function univerMetaRouter(): Router {
         fields: visiblePropertyFields,
         rows,
         ...(linkSummaries ? { linkSummaries } : {}),
+        ...(personSummaries ? { personSummaries } : {}),
         ...(attachmentSummaries ? { attachmentSummaries } : {}),
         ...(viewConfig ? { view: redactViewConfigFilterLiterals(viewConfig, allowedFieldIds) } : {}),
         ...(meta ? { meta } : {}),
@@ -8870,6 +9040,17 @@ export function univerMetaRouter(): Router {
       const patch: Record<string, unknown> = {}
       const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
+      // Native person (人员): resolve the sheet member set ONCE per request (lazily, only when a
+      // person field value is actually written) — parallel to the link-target-exists hot-path —
+      // and reuse it for every person cell's write-time membership validation (SECURITY boundary).
+      let personMemberUserIds: Set<string> | null = null
+      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
+        if (personMemberUserIds === null) {
+          personMemberUserIds = await loadSheetMemberUserIdSet(pool.query.bind(pool), view.sheetId)
+        }
+        return personMemberUserIds
+      }
+
       for (const [fieldId, value] of Object.entries(data)) {
         const field = fieldById.get(fieldId)
         if (!field) {
@@ -8904,6 +9085,16 @@ export function univerMetaRouter(): Router {
         if (field.type === 'multiSelect') {
           try {
             patch[fieldId] = normalizeMultiSelectValue(value, fieldId, field.options ?? [])
+          } catch (error) {
+            fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
+          }
+          continue
+        }
+
+        if (field.type === 'person') {
+          try {
+            const allowed = await resolvePersonMemberUserIds()
+            patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
           } catch (error) {
             fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
           }

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -1124,9 +1124,12 @@ describe('Multitable context API', () => {
     })
   })
 
-  test('creates native person field requests as system people link fields', async () => {
-    let peopleSheetId = ''
-
+  // Native person field (人员, design 2026-06-16): `type:'person'` is now a FIRST-CLASS native
+  // field stored as `type='person'` (value = userId[]) — it is NO LONGER rewritten to a
+  // `link`+refKind:user against a system People sheet. (Legacy link-backed person fields stay
+  // `type='link'` and are untouched — coexistence; `ensurePeopleSheetPreset`/`/person-fields/prepare`
+  // remain for them + direct API callers.)
+  test('creates a native person field stored as type=person (no People-sheet rewrite)', async () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
@@ -1134,70 +1137,28 @@ describe('Multitable context API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
         }
-        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
-          // loadSheetRow is hit TWICE here: once for the source sheet (sheet_ops) and once by the §2a.2
-          // cross-base wall (`validateLinkFieldConfig`) for the FOREIGN sheet — which, for a native person
-          // field, is the freshly-provisioned people sheet (`peopleSheetId`), since the person
-          // normalization overwrites the spoofed foreignSheetId. Echo a SAME-BASE (base_ops) row keyed by
-          // the requested id so source-base == foreign-base → the wall sees a same-base link and passes.
-          // A fixed ['sheet_ops'] assertion mis-fires on the peopleSheetId lookup.
-          const requestedSheetId = String(params?.[0] ?? '')
-          expect([requestedSheetId === 'sheet_ops', requestedSheetId === peopleSheetId]).toContain(true)
-          return { rows: [{ id: requestedSheetId, base_id: 'base_ops', name: 'Orders', description: null }] }
-        }
-        if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
-          expect(params).toEqual(['base_ops'])
-          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
-        }
-        if (sql.includes('INSERT INTO meta_sheets')) {
-          peopleSheetId = String(params?.[0] ?? '')
-          expect(params).toEqual([
-            expect.any(String),
-            'base_ops',
-            'People',
-            '__metasheet_system:people__',
-          ])
-          return { rows: [], rowCount: 1 }
-        }
-        if (sql.includes('SELECT id, name, type, "order" FROM meta_fields WHERE sheet_id = $1')) {
-          expect(params).toEqual([peopleSheetId])
-          return { rows: [] }
-        }
-        if (sql.includes('INSERT INTO meta_fields') && params?.[1] === peopleSheetId) {
-          return { rows: [], rowCount: 1 }
-        }
-        if (sql.includes('SELECT id, email, name, avatar_url') && sql.includes('FROM users')) {
-          return { rows: [] }
-        }
         if (sql.includes('SELECT COALESCE(MAX("order"), -1) AS max_order FROM meta_fields')) {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ max_order: 4 }] }
         }
         if (sql.includes('INSERT INTO meta_fields')) {
+          // Native person: persisted as type='person' with ONLY `limitSingleRecord` in property.
+          // The spoofed `foreignSheetId` is DROPPED (person sanitize keeps no foreign-sheet key),
+          // and NO People sheet is provisioned (no INSERT INTO meta_sheets handler is reachable).
           expect(params).toEqual([
             'fld_owner',
             'sheet_ops',
             'Owner',
-            'link',
-            JSON.stringify({
-              foreignSheetId: peopleSheetId,
-              limitSingleRecord: false,
-              refKind: 'user',
-              foreignDatasheetId: peopleSheetId,
-            }),
+            'person',
+            JSON.stringify({ limitSingleRecord: false }),
             5,
           ])
           return {
             rows: [{
               id: 'fld_owner',
               name: 'Owner',
-              type: 'link',
-              property: {
-                foreignSheetId: peopleSheetId,
-                limitSingleRecord: false,
-                refKind: 'user',
-                foreignDatasheetId: peopleSheetId,
-              },
+              type: 'person',
+              property: { limitSingleRecord: false },
               order: 5,
             }],
           }
@@ -1208,13 +1169,8 @@ describe('Multitable context API', () => {
             rows: [{
               id: 'fld_owner',
               name: 'Owner',
-              type: 'link',
-              property: {
-                foreignSheetId: peopleSheetId,
-                limitSingleRecord: false,
-                refKind: 'user',
-                foreignDatasheetId: peopleSheetId,
-              },
+              type: 'person',
+              property: { limitSingleRecord: false },
               order: 5,
             }],
           }
@@ -1232,6 +1188,7 @@ describe('Multitable context API', () => {
         type: 'person',
         property: {
           limitSingleRecord: false,
+          // A spoofed foreign-sheet key must NOT survive into a native person field's property.
           foreignSheetId: 'sheet_spoofed',
         },
       })
@@ -1240,20 +1197,19 @@ describe('Multitable context API', () => {
     expect(response.body.data.field).toMatchObject({
       id: 'fld_owner',
       name: 'Owner',
-      type: 'link',
+      type: 'person',
       order: 5,
-      property: {
-        foreignSheetId: peopleSheetId,
-        limitSingleRecord: false,
-        refKind: 'user',
-        foreignDatasheetId: peopleSheetId,
-      },
+      property: { limitSingleRecord: false },
     })
+    expect(response.body.data.field.property).not.toHaveProperty('refKind')
+    expect(response.body.data.field.property).not.toHaveProperty('foreignSheetId')
   })
 
-  test('updates native person field requests into system people link fields', async () => {
-    let peopleSheetId = ''
-
+  // PATCH `{type:'person'}` converts a field to a NATIVE person (type='person', userId[]) — no
+  // People-sheet rewrite. Coexistence note: a legacy person is `type='link'`; editing its config
+  // sends `{property}` only (no type), so `requestedType` falls back to 'link' and it can NEVER
+  // be silently flipped native (verified by the route's `requestedType ?? mapFieldType(stored)`).
+  test('updates a field into a native person field stored as type=person (no People-sheet rewrite)', async () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
@@ -1274,56 +1230,22 @@ describe('Multitable context API', () => {
             }],
           }
         }
-        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
-          // Same as the create-field test: loadSheetRow serves both the source sheet (sheet_ops) and the
-          // §2a.2 wall's FOREIGN-sheet lookup (the provisioned people sheet, peopleSheetId). Echo a
-          // SAME-BASE (base_ops) row keyed by the requested id so the wall sees a same-base link and passes.
-          const requestedSheetId = String(params?.[0] ?? '')
-          expect([requestedSheetId === 'sheet_ops', requestedSheetId === peopleSheetId]).toContain(true)
-          return { rows: [{ id: requestedSheetId, base_id: 'base_ops', name: 'Orders', description: null }] }
-        }
-        if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
-          expect(params).toEqual(['base_ops'])
-          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
-        }
-        if (sql.includes('INSERT INTO meta_sheets')) {
-          peopleSheetId = String(params?.[0] ?? '')
-          return { rows: [], rowCount: 1 }
-        }
-        if (sql.includes('SELECT id, name, type, "order" FROM meta_fields WHERE sheet_id = $1')) {
-          expect(params).toEqual([peopleSheetId])
-          return { rows: [] }
-        }
-        if (sql.includes('INSERT INTO meta_fields') && params?.[1] === peopleSheetId) {
-          return { rows: [], rowCount: 1 }
-        }
-        if (sql.includes('SELECT id, email, name, avatar_url') && sql.includes('FROM users')) {
-          return { rows: [] }
-        }
         if (sql.includes('UPDATE meta_fields') && sql.includes('SET name = $2, type = $3, property = $4::jsonb, "order" = $5')) {
+          // Native person: type='person', property carries ONLY limitSingleRecord. The spoofed
+          // foreignSheetId is DROPPED and NO People sheet is provisioned (no meta_sheets handler hit).
           expect(params).toEqual([
             'fld_assignee',
             'Assignee',
-            'link',
-            JSON.stringify({
-              foreignSheetId: peopleSheetId,
-              limitSingleRecord: true,
-              refKind: 'user',
-              foreignDatasheetId: peopleSheetId,
-            }),
+            'person',
+            JSON.stringify({ limitSingleRecord: true }),
             2,
           ])
           return {
             rows: [{
               id: 'fld_assignee',
               name: 'Assignee',
-              type: 'link',
-              property: {
-                foreignSheetId: peopleSheetId,
-                limitSingleRecord: true,
-                refKind: 'user',
-                foreignDatasheetId: peopleSheetId,
-              },
+              type: 'person',
+              property: { limitSingleRecord: true },
               order: 2,
             }],
           }
@@ -1346,15 +1268,12 @@ describe('Multitable context API', () => {
     expect(response.body.data.field).toMatchObject({
       id: 'fld_assignee',
       name: 'Assignee',
-      type: 'link',
+      type: 'person',
       order: 2,
-      property: {
-        foreignSheetId: peopleSheetId,
-        limitSingleRecord: true,
-        refKind: 'user',
-        foreignDatasheetId: peopleSheetId,
-      },
+      property: { limitSingleRecord: true },
     })
+    expect(response.body.data.field.property).not.toHaveProperty('refKind')
+    expect(response.body.data.field.property).not.toHaveProperty('foreignSheetId')
   })
 
   test('accepts date fields in create and update multitable field contracts', async () => {

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -57,7 +57,9 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     // 2026-06-16). The personSummaries egress is routed through the SAME layer-2 ∧ layer-3
     // `allowedFieldIds` composite as linkSummaries — `filterRecordFieldSummaryMap(serializePersonSummaryMap(...), allowedFieldIds)`.
     filterRecordFieldSummaryMap: 3,
-    filterSingleRecordFieldSummaryMap: 5,
+    // 6 = +1 for the single-record GET native person personSummaries channel (design 2026-06-16),
+    // routed through the same single-record layer-2∧3 `allowedFieldIds` composite as its linkSummaries.
+    filterSingleRecordFieldSummaryMap: 6,
   },
 }
 

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -53,7 +53,10 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     loadRecordSummaries: 3,
     buildLinkSummaries: 4,
     serializeLinkSummaryMap: 1,
-    filterRecordFieldSummaryMap: 2,
+    // 3 = linkSummaries + attachmentSummaries + native person (人员) personSummaries (design
+    // 2026-06-16). The personSummaries egress is routed through the SAME layer-2 ∧ layer-3
+    // `allowedFieldIds` composite as linkSummaries — `filterRecordFieldSummaryMap(serializePersonSummaryMap(...), allowedFieldIds)`.
+    filterRecordFieldSummaryMap: 3,
     filterSingleRecordFieldSummaryMap: 5,
   },
 }

--- a/packages/core-backend/tests/unit/multitable-permission-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-permission-service.test.ts
@@ -27,6 +27,7 @@ import {
   loadFieldPermissionScopeMap,
   loadRecordCreatorMap,
   loadRecordPermissionScopeMap,
+  loadSheetMemberUserIdSet,
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
   requiresOwnWriteRowPolicy,
@@ -527,6 +528,41 @@ describe('permission-service: request-keyed resolvers', () => {
     expect(calls[2].params?.[0]).toEqual(['user_reader'])
     expect(listUserPermissions).not.toHaveBeenCalled()
     expect(isAdmin).not.toHaveBeenCalled()
+  })
+
+  it('loadSheetMemberUserIdSet returns the active eligible USER ids (the picker = validator set)', async () => {
+    // Native person (人员): the member boundary reuses listSheetPermissionCandidates and keeps ONLY
+    // the active `user` subjects — so the person picker and the person write-time validator share
+    // EXACTLY one set. An inactive user + a role/member-group subject are excluded.
+    const { query } = makeQuery([
+      () => ({
+        rows: [
+          { subject_type: 'user', subject_id: 'u_active', user_name: 'Active', user_email: 'a@x.test', user_is_active: true, permission_codes: [] },
+          { subject_type: 'user', subject_id: 'u_inactive', user_name: 'Inactive', user_email: 'i@x.test', user_is_active: false, permission_codes: [] },
+          { subject_type: 'role', subject_id: 'role_editor', role_name: 'Editor', user_is_active: true, permission_codes: [] },
+          { subject_type: 'member-group', subject_id: 'grp_1', group_name: 'Group', user_is_active: true, permission_codes: [] },
+        ],
+      }),
+      // role permission lookup
+      () => ({ rows: [{ role_id: 'role_editor', permission_code: 'multitable:write' }] }),
+      // user eligibility (user_permissions / roles)
+      () => ({ rows: [
+        { user_id: 'u_active', permission_code: 'multitable:read' },
+        { user_id: 'u_inactive', permission_code: 'multitable:read' },
+      ] }),
+      // admin role lookup
+      () => ({ rows: [] }),
+      // legacy users.permissions lookup
+      () => ({ rows: [] }),
+    ])
+
+    const members = await loadSheetMemberUserIdSet(query, 'sheet_1')
+
+    expect(members.has('u_active')).toBe(true)
+    expect(members.has('u_inactive')).toBe(false) // inactive excluded
+    expect(members.has('role_editor')).toBe(false) // non-user subject excluded
+    expect(members.has('grp_1')).toBe(false) // member-group subject excluded
+    expect(members.size).toBe(1)
   })
 
   it('resolveSheetCapabilities labels origin as sheet-grant when scope expands base', async () => {

--- a/packages/core-backend/tests/unit/multitable-person-field-codec.test.ts
+++ b/packages/core-backend/tests/unit/multitable-person-field-codec.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Native person field (人员 / member, design 2026-06-16) — codec unit tests.
+ *
+ * Covers the storage + write-validation contract of a FIRST-CLASS person field whose value is
+ * `userId[]` (NOT the recordId[] of a legacy link-backed person). COEXISTENCE is the spine: a
+ * native person is stored as `type='person'`; legacy person fields stay `type='link'`+refKind:user
+ * and are unaffected by this codec.
+ *
+ * Asserts:
+ *   - mapFieldType('person') === 'person' (alias to 'link' REMOVED — this is the contract flip).
+ *   - sanitizeFieldProperty('person', …): limitSingleRecord default TRUE (matches legacy person);
+ *     junk dropped; NOT readOnly; restrictToMemberGroupIds normalized when present.
+ *   - validatePersonValue: dedupes, rejects non-member userId (SECURITY), enforces single-record
+ *     cap, accepts member userIds, empty → [], null member-set = closed set.
+ *   - serializeFieldRow round-trips a raw DB type='person' row as type='person' (NOT coerced to link).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  isPersonSingleRecord,
+  mapFieldType,
+  sanitizeFieldProperty,
+  serializeFieldRow,
+  validatePersonValue,
+} from '../../src/multitable/field-codecs'
+
+describe('native person field codec', () => {
+  describe('mapFieldType', () => {
+    it("maps 'person' to 'person' (alias to 'link' removed)", () => {
+      expect(mapFieldType('person')).toBe('person')
+      expect(mapFieldType('PERSON')).toBe('person')
+      // legacy link stays link
+      expect(mapFieldType('link')).toBe('link')
+    })
+  })
+
+  describe("sanitizeFieldProperty('person')", () => {
+    it('defaults limitSingleRecord to TRUE (matches legacy person), not the link default of false', () => {
+      expect(sanitizeFieldProperty('person', {})).toEqual({ limitSingleRecord: true })
+      expect(sanitizeFieldProperty('person', undefined)).toEqual({ limitSingleRecord: true })
+    })
+
+    it('honors explicit limitSingleRecord: false (multi-person)', () => {
+      expect(sanitizeFieldProperty('person', { limitSingleRecord: false })).toEqual({ limitSingleRecord: false })
+    })
+
+    it('drops junk keys (no foreignSheetId / refKind leak) and is NOT readOnly', () => {
+      const sanitized = sanitizeFieldProperty('person', {
+        limitSingleRecord: true,
+        foreignSheetId: 'sheet_spoofed',
+        refKind: 'user',
+        bogus: 1,
+      })
+      expect(sanitized).not.toHaveProperty('foreignSheetId')
+      expect(sanitized).not.toHaveProperty('refKind')
+      expect(sanitized).not.toHaveProperty('bogus')
+      expect(sanitized).not.toHaveProperty('readOnly')
+    })
+
+    it('normalizes restrictToMemberGroupIds (dedupe + trim) when present, omits when empty/absent', () => {
+      expect(
+        sanitizeFieldProperty('person', { restrictToMemberGroupIds: [' g1 ', 'g1', 'g2', 7, ''] }),
+      ).toEqual({ limitSingleRecord: true, restrictToMemberGroupIds: ['g1', 'g2'] })
+      expect(sanitizeFieldProperty('person', { restrictToMemberGroupIds: [] })).not.toHaveProperty(
+        'restrictToMemberGroupIds',
+      )
+    })
+  })
+
+  describe('isPersonSingleRecord', () => {
+    it('defaults to TRUE on undefined / missing flag', () => {
+      expect(isPersonSingleRecord(undefined)).toBe(true)
+      expect(isPersonSingleRecord({})).toBe(true)
+      expect(isPersonSingleRecord({ limitSingleRecord: true })).toBe(true)
+    })
+    it('is FALSE only when explicitly limitSingleRecord:false', () => {
+      expect(isPersonSingleRecord({ limitSingleRecord: false })).toBe(false)
+    })
+  })
+
+  describe('validatePersonValue', () => {
+    const members = new Set(['u1', 'u2', 'u3'])
+
+    it('returns [] for empty / null / undefined / ""', () => {
+      expect(validatePersonValue([], 'f', members, false)).toEqual([])
+      expect(validatePersonValue(null, 'f', members, false)).toEqual([])
+      expect(validatePersonValue(undefined, 'f', members, false)).toEqual([])
+      expect(validatePersonValue('', 'f', members, false)).toEqual([])
+    })
+
+    it('accepts member userIds and dedupes (order-preserving)', () => {
+      expect(validatePersonValue(['u1', 'u2', 'u1'], 'f', members, false)).toEqual(['u1', 'u2'])
+    })
+
+    it('trims and coerces numeric ids', () => {
+      expect(validatePersonValue([' u1 ', 2 as unknown as string], 'f', new Set(['u1', '2']), false)).toEqual(['u1', '2'])
+    })
+
+    it('rejects a non-member userId (SECURITY membership boundary)', () => {
+      expect(() => validatePersonValue(['u1', 'intruder'], 'f', members, false)).toThrow(/not a member/)
+    })
+
+    it('rejects more than one id when limitSingleRecord is true', () => {
+      expect(() => validatePersonValue(['u1', 'u2'], 'f', members, true)).toThrow(/single user/)
+      expect(validatePersonValue(['u1'], 'f', members, true)).toEqual(['u1'])
+    })
+
+    it('rejects a non-array value', () => {
+      expect(() => validatePersonValue('u1', 'f', members, false)).toThrow(/must be an array/)
+    })
+
+    it('treats a null member set as a CLOSED set (rejects any non-empty value, never open egress)', () => {
+      expect(validatePersonValue([], 'f', null, false)).toEqual([])
+      expect(() => validatePersonValue(['u1'], 'f', null, false)).toThrow(/not a member/)
+    })
+
+    it('rejects an over-long userId', () => {
+      const longId = 'u'.repeat(51)
+      expect(() => validatePersonValue([longId], 'f', new Set([longId]), false)).toThrow(/too long/)
+    })
+  })
+
+  describe('serializeFieldRow', () => {
+    it('round-trips a raw DB type=person row as type=person (NOT coerced to link)', () => {
+      const row = serializeFieldRow({
+        id: 'fld_owner',
+        name: 'Owner',
+        type: 'person',
+        property: { limitSingleRecord: false, foreignSheetId: 'junk' },
+        order: 3,
+      })
+      expect(row.type).toBe('person')
+      expect(row.property).toEqual({ limitSingleRecord: false })
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-person-filter-sort.test.ts
+++ b/packages/core-backend/tests/unit/multitable-person-filter-sort.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Native person field (人员, design 2026-06-16) — filter/sort semantics (pure functions, no DB).
+ *
+ * FILTER: a native person value is a `userId[]`. It reuses the multiSelect-parity path
+ * (the string fallback in evaluateMetaFilterCondition) — `contains` matches a userId inside
+ * the array, and `isEmpty`/`isNotEmpty` use the shared empty-array nullish rule. No dedicated
+ * person filter branch is needed; this test PINS that the shared path gives the right answers.
+ *
+ * SORT-by-display: compareMetaSortValue's string fallback orders a raw `userId[]` lexicographically.
+ * The view endpoint injects the resolved DISPLAY string before sorting (resolvePersonSortDisplayMap),
+ * which is exercised on the real `/view` wire (DB-gated). Here we PIN the raw-array fallback so the
+ * "display injection happens at the view layer, not in the comparator" contract is explicit.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { compareMetaSortValue, evaluateMetaFilterCondition } from '../../src/routes/univer-meta'
+
+const cond = (operator: string, value?: unknown) => ({ fieldId: 'f', operator, value })
+
+describe('native person filter (multiSelect-parity over userId[])', () => {
+  it('isEmpty / isNotEmpty over the userId array', () => {
+    expect(evaluateMetaFilterCondition('person', [], cond('isEmpty'))).toBe(true)
+    expect(evaluateMetaFilterCondition('person', null, cond('isEmpty'))).toBe(true)
+    expect(evaluateMetaFilterCondition('person', ['u1'], cond('isEmpty'))).toBe(false)
+    expect(evaluateMetaFilterCondition('person', ['u1'], cond('isNotEmpty'))).toBe(true)
+    expect(evaluateMetaFilterCondition('person', [], cond('isNotEmpty'))).toBe(false)
+  })
+
+  it('contains a specific userId', () => {
+    expect(evaluateMetaFilterCondition('person', ['u1', 'u2'], cond('contains', 'u2'))).toBe(true)
+    expect(evaluateMetaFilterCondition('person', ['u1', 'u2'], cond('contains', 'u3'))).toBe(false)
+    // empty filter value → no-op match (shared text-path semantics)
+    expect(evaluateMetaFilterCondition('person', ['u1'], cond('contains', ''))).toBe(true)
+  })
+
+  it('doesNotContain a userId', () => {
+    expect(evaluateMetaFilterCondition('person', ['u1', 'u2'], cond('doesNotContain', 'u3'))).toBe(true)
+    expect(evaluateMetaFilterCondition('person', ['u1', 'u2'], cond('doesNotContain', 'u1'))).toBe(false)
+  })
+})
+
+describe('native person sort (raw-array fallback; display injected at the view layer)', () => {
+  it('orders by the stringified userId array in the comparator (view layer substitutes display)', () => {
+    // Without the view-layer display injection, the comparator sees raw ids. This PINS that
+    // the comparator itself is display-agnostic — sort-by-display is a view-endpoint concern.
+    const rows = [['u_charlie'], ['u_alice'], ['u_bob']]
+    const sorted = [...rows].sort((a, b) => compareMetaSortValue('person', a, b, false))
+    expect(sorted).toEqual([['u_alice'], ['u_bob'], ['u_charlie']])
+  })
+
+  it('empty person cells sort last (nullish-last rule)', () => {
+    const rows: unknown[] = [['u_b'], [], ['u_a']]
+    const sorted = [...rows].sort((a, b) => compareMetaSortValue('person', a, b, false))
+    expect(sorted).toEqual([['u_a'], ['u_b'], []])
+  })
+})

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -58,6 +58,22 @@ function createMockPool(
     if (sql.includes('SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])')) {
       return responses.SELECT_LINK_TARGETS ?? { rows: [] }
     }
+    // Native person (人员) member-set resolution — listSheetPermissionCandidates + eligibility.
+    if (sql.includes('WITH user_candidates AS')) {
+      return responses.SELECT_PERSON_CANDIDATES ?? { rows: [] }
+    }
+    if (sql.includes('SELECT user_id, permission_code') && sql.includes('user_permissions')) {
+      return responses.SELECT_PERSON_USER_ELIGIBILITY ?? { rows: [] }
+    }
+    if (sql.includes('SELECT user_id') && sql.includes("role_id = $2")) {
+      return responses.SELECT_PERSON_ADMIN_ELIGIBILITY ?? { rows: [] }
+    }
+    if (sql.includes('SELECT id, permissions') && sql.includes('FROM users')) {
+      return responses.SELECT_PERSON_LEGACY_ELIGIBILITY ?? { rows: [] }
+    }
+    if (sql.includes('SELECT role_id, permission_code FROM role_permissions')) {
+      return responses.SELECT_PERSON_ROLE_PERMISSIONS ?? { rows: [] }
+    }
     if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
       return responses.INSERT_RECORD ?? { rows: [{ version: 1 }] }
     }
@@ -253,6 +269,66 @@ describe('RecordService', () => {
       expect.stringContaining('INSERT INTO meta_records'),
       [expect.any(String), 'sheet_ops', JSON.stringify({ fld_tags: ['Urgent', 'VIP'] }), 'user_1'],
     )
+  })
+
+  // --- Native person (人员, design 2026-06-16) single-record create/patch -----
+  const personCandidateRows = [
+    { subject_type: 'user', subject_id: 'u1', user_name: 'U1', user_email: 'u1@x.test', user_is_active: true, permission_codes: [] },
+    { subject_type: 'user', subject_id: 'u2', user_name: 'U2', user_email: 'u2@x.test', user_is_active: true, permission_codes: [] },
+  ]
+  const personEligibility = {
+    SELECT_PERSON_CANDIDATES: { rows: personCandidateRows },
+    SELECT_PERSON_USER_ELIGIBILITY: { rows: [
+      { user_id: 'u1', permission_code: 'multitable:read' },
+      { user_id: 'u2', permission_code: 'multitable:read' },
+    ] },
+  }
+
+  it('creates a record with a native person userId[] (member ids accepted, deduped)', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: { rows: [{ id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }] },
+      ...personEligibility,
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_owner: ['u1', 'u2', 'u1'] },
+      actorId: 'user_1',
+      capabilities: fullCapabilities,
+    })
+
+    expect(result.data).toEqual({ fld_owner: ['u1', 'u2'] })
+  })
+
+  it('rejects creating a record with a non-member userId in a native person field (SECURITY)', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: { rows: [{ id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }] },
+      ...personEligibility,
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_owner: ['u1', 'intruder'] },
+      actorId: 'user_1',
+      capabilities: fullCapabilities,
+    })).rejects.toThrow(RecordValidationError)
+  })
+
+  it('rejects creating a record with 2 users in a single-record native person field', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: { rows: [{ id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: true } }] },
+      ...personEligibility,
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_owner: ['u1', 'u2'] },
+      actorId: 'user_1',
+      capabilities: fullCapabilities,
+    })).rejects.toThrow(RecordValidationError)
   })
 
   it('allocates readonly autoNumber values during create', async () => {

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -54,6 +54,8 @@ function createMockHelpers(overrides: Partial<RecordWriteHelpers> = {}): RecordW
     buildLinkSummaries: vi.fn().mockResolvedValue(new Map()),
     buildAttachmentSummaries: vi.fn().mockResolvedValue(new Map()),
     ensureAttachmentIdsExist: vi.fn().mockResolvedValue(null),
+    // Native person (人员): default member set used by the person write-time validator.
+    loadSheetMemberUserIds: vi.fn().mockResolvedValue(new Set(['u1', 'u2', 'u3'])),
     ...overrides,
   }
 }
@@ -403,6 +405,81 @@ describe('RecordWriteService', () => {
     })
 
     await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+
+  // --- Native person (人员, design 2026-06-16) write path -------------------
+  function buildPersonInput(value: unknown, opts: { limitSingleRecord?: boolean } = {}) {
+    const property = opts.limitSingleRecord === false ? { limitSingleRecord: false } : { limitSingleRecord: true }
+    const fields: UniverMetaField[] = [{ id: 'fld_owner', name: 'Owner', type: 'person', property, order: 0 }]
+    return buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(['fld_owner']),
+      fieldById: new Map([
+        ['fld_owner', { type: 'person' as const, readOnly: false, hidden: false, property }],
+      ]) as any,
+      changesByRecord: new Map([['rec1', [{ fieldId: 'fld_owner', value }]]]),
+    })
+  }
+
+  it('persists a member userId[] for a native person field (multi)', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    await service.patchRecords(buildPersonInput(['u1', 'u2'], { limitSingleRecord: false }))
+    const updateCall = (pool.query as any).mock.calls.find((call: unknown[]) =>
+      typeof call[0] === 'string' && call[0].includes('UPDATE meta_records'),
+    )
+    expect(JSON.parse(updateCall[1][0])).toEqual({ fld_owner: ['u1', 'u2'] })
+  })
+
+  it('rejects a non-member userId at write time (SECURITY)', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    await expect(
+      service.patchRecords(buildPersonInput(['u1', 'intruder'], { limitSingleRecord: false })),
+    ).rejects.toThrow(RecordValidationError)
+  })
+
+  it('rejects more than one userId when limitSingleRecord is true (single person)', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    await expect(service.patchRecords(buildPersonInput(['u1', 'u2']))).rejects.toThrow(RecordValidationError)
+    // single value accepted
+    await service.patchRecords(buildPersonInput(['u1']))
+    const updateCall = (pool.query as any).mock.calls.find((call: unknown[]) =>
+      typeof call[0] === 'string' && call[0].includes('UPDATE meta_records'),
+    )
+    expect(JSON.parse(updateCall[1][0])).toEqual({ fld_owner: ['u1'] })
+  })
+
+  it('resolves the sheet member set ONCE per patch (hot-path) even across multiple person cells', async () => {
+    const loadSheetMemberUserIds = vi.fn().mockResolvedValue(new Set(['u1', 'u2', 'u3']))
+    helpers = createMockHelpers({ loadSheetMemberUserIds })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const fields: UniverMetaField[] = [
+      { id: 'fld_a', name: 'A', type: 'person', property: { limitSingleRecord: true }, order: 0 },
+      { id: 'fld_b', name: 'B', type: 'person', property: { limitSingleRecord: true }, order: 1 },
+    ]
+    const input = buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(['fld_a', 'fld_b']),
+      fieldById: new Map([
+        ['fld_a', { type: 'person' as const, readOnly: false, hidden: false, property: { limitSingleRecord: true } }],
+        ['fld_b', { type: 'person' as const, readOnly: false, hidden: false, property: { limitSingleRecord: true } }],
+      ]) as any,
+      changesByRecord: new Map([
+        ['rec1', [{ fieldId: 'fld_a', value: ['u1'] }, { fieldId: 'fld_b', value: ['u2'] }]],
+      ]),
+    })
+    await service.patchRecords(input)
+    expect(loadSheetMemberUserIds).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a native person field to [] on empty value', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    await service.patchRecords(buildPersonInput([], { limitSingleRecord: false }))
+    const updateCall = (pool.query as any).mock.calls.find((call: unknown[]) =>
+      typeof call[0] === 'string' && call[0].includes('UPDATE meta_records'),
+    )
+    expect(JSON.parse(updateCall[1][0])).toEqual({ fld_owner: [] })
   })
 
   it('should throw VersionConflictError when expectedVersion does not match', async () => {


### PR DESCRIPTION
## Person/Member field — first-class native people field (rank-1 backlog arc)

A native `type='person'` field storing `userId[]`, **coexisting with — not migrating** — the legacy link-backed person fields and the system People sheet.

### Backend
- `field-codecs.ts`: `person`→`person` (alias to `link` removed; legacy rows stay `type='link'`, so the flip is collision-free). Person sanitize branch (`limitSingleRecord` default TRUE) + `validatePersonValue` (deduped `userId[]`, **write-time non-member rejection**, single-record cap, null member-set = closed).
- `permission-service.ts`: `loadSheetMemberUserIdSet` reuses `listSheetPermissionCandidates` so the **picker and the write validator share one member set** (no drift).
- Write validation runs server-side at **all 5 entrypoints** (record create + patch, record-write txn loop covering grid/bulk/Yjs-bridge, public form-submit).
- `univer-meta.ts`: native person bypasses the link rewrite; `GET /view` + single-record GET assemble `personSummaries` (users-table join) **field-permission-masked identically to linkSummaries** (through the same layer-2∧3 `allowedFieldIds` composite — egress-coverage-guard GOLDEN updated to reflect it); sort-by-display; multiSelect-parity filter (contains/is_empty).

### Frontend
- `isLinkField` no longer matches person; `isNativePersonField` added; `isPersonField` still covers **both** representations (coexistence). New member-scoped `MetaPersonPicker.vue` (sources permission-candidates, emits `userId[]`, single/multi) + typed i18n module (en/zh, no dead keys). Cell/grid/drawer/form render person display; native-person import resolves to userIds (not People-sheet recordIds).

### Security (adversarial review: **ship**)
- Write control sound — no bypass; member boundary enforced even on the anonymous public form-submit; validator error names only the submitted id (no enumeration oracle).
- Egress safe — `personSummaries` masked before assembly, same gate as linkSummaries.

### Coexistence
- Legacy link-backed person fields render/behave unchanged (regression-tested); the field-UPDATE path can never silently flip a legacy field native (`requestedType` falls back to stored `link`).

### Tests
Backend tsc clean; 105/105 person unit (codec/filter-sort/write-service/permission) + context integration; FE vue-tsc clean (per build env) + 25/25 person/picker/form specs. Full web suite reds are pre-existing (stash-verified), zero new failures.

### Owner-deferred / follow-ups (no silent drop)
Tracked in **#2734**: by-value real-DB egress locking test for `personSummaries`; `restrictToMemberGroupIds` stored-but-not-enforced; member-group grants not expanded into the assignable set; legacy→native migration (explicit coexistence); `'user'`-vs-`'person'` rename for the dead DingTalk recipient checks.

Built + adversarially security-reviewed by subagents; rebased clean onto current main (A4 included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)