### PR TITLE
feat(multitable): expand formula function library (+10 Feishu-parity functions)

### DIFF
--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -10,6 +10,10 @@ import { Logger } from '../core/logger'
 
 const logger = new Logger('FormulaEngine')
 
+// The string sentinels the engine emits for error results (returned, not thrown). IFERROR/ISERROR
+// test membership here so a downstream formula can trap an upstream error.
+const FORMULA_ERROR_SENTINELS = new Set(['#VALUE!', '#ERROR!', '#DIV/0!', '#N/A', '#NAME?', '#REF!', '#NUM!', '#NULL!'])
+
 export interface CellReference {
   sheet?: string
   row: number
@@ -228,6 +232,32 @@ export class FormulaEngine {
     this.functions.set('DATEDIF', this.datedif.bind(this))
     this.functions.set('DATEDIFF', this.datediff.bind(this))
     this.functions.set('COUNTA', this.counta.bind(this))
+
+    // Formula library expansion (Feishu parity): error-handling, multi-branch conditional,
+    // criteria-count, weekday, directional rounding, logical XOR, type predicates.
+    this.functions.set('IFERROR', (value: unknown, fallback: unknown) => this.isErrorValue(value) ? fallback : value)
+    this.functions.set('ISERROR', (value: unknown) => this.isErrorValue(value))
+    this.functions.set('ISBLANK', (value: unknown) => value === null || value === undefined || value === '')
+    this.functions.set('ISNUMBER', (value: unknown) => typeof value === 'number' && !Number.isNaN(value))
+    this.functions.set('IFS', (...args: unknown[]) => this.ifs(...args))
+    this.functions.set('XOR', (...args: unknown[]) => this.flattenValues(args).filter((v) => !!v).length % 2 === 1)
+    this.functions.set('COUNTIF', (range: unknown, criteria: unknown) => this.countif(range, criteria))
+    this.functions.set('WEEKDAY', (date: unknown, type: unknown = 1) => {
+      const d = date instanceof Date ? date : new Date(String(date))
+      if (Number.isNaN(d.getTime())) return '#VALUE!'
+      const dow = d.getDay() // 0=Sun..6=Sat
+      return Number(type) === 2 ? (dow === 0 ? 7 : dow) : dow + 1 // type 2: Mon=1..Sun=7; default: Sun=1..Sat=7
+    })
+    this.functions.set('ROUNDUP', (x: unknown, digits: unknown = 0) => {
+      const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
+      const f = Math.pow(10, Number(digits) || 0)
+      return (n >= 0 ? Math.ceil(n * f) : Math.floor(n * f)) / f
+    })
+    this.functions.set('ROUNDDOWN', (x: unknown, digits: unknown = 0) => {
+      const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
+      const f = Math.pow(10, Number(digits) || 0)
+      return (n >= 0 ? Math.floor(n * f) : Math.ceil(n * f)) / f
+    })
   }
 
   /**
@@ -851,6 +881,50 @@ export class FormulaEngine {
 
   private orFunction(...args: unknown[]): boolean {
     return this.flattenValues(args).some(val => !!val)
+  }
+
+  private isErrorValue(value: unknown): boolean {
+    return typeof value === 'string' && FORMULA_ERROR_SENTINELS.has(value)
+  }
+
+  // IFS(cond1, val1, cond2, val2, ...) — first truthy condition's value; #N/A if none match.
+  private ifs(...args: unknown[]): unknown {
+    for (let i = 0; i + 1 < args.length; i += 2) {
+      if (args[i]) return args[i + 1]
+    }
+    return '#N/A'
+  }
+
+  private countif(range: unknown, criteria: unknown): number {
+    return this.flattenValues([range]).filter((v) => this.matchesCriteria(v, criteria)).length
+  }
+
+  // criteria may be a comparator string (">5", "<>x"), a bare number, or text. CRITICAL: coerce with
+  // String(criteria) FIRST — a bare unquoted comparator like `>5` parses upstream to the boolean
+  // `false` (and a bare number to a number), so calling string methods on the raw value would throw or
+  // silently mis-count; stringifying makes both shapes behave predictably.
+  private matchesCriteria(value: unknown, criteria: unknown): boolean {
+    const c = String(criteria)
+    const m = c.match(/^(>=|<=|<>|>|<|=)(.*)$/)
+    if (m) {
+      const op = m[1]
+      const operand = m[2].trim()
+      const numV = Number(value)
+      const numO = Number(operand)
+      const bothNum = operand !== '' && !Number.isNaN(numV) && !Number.isNaN(numO)
+      switch (op) {
+        case '>': return bothNum && numV > numO
+        case '<': return bothNum && numV < numO
+        case '>=': return bothNum && numV >= numO
+        case '<=': return bothNum && numV <= numO
+        case '<>': return String(value) !== operand
+        case '=': return bothNum ? numV === numO : String(value) === operand
+      }
+    }
+    const numV = Number(value)
+    const numC = Number(c)
+    if (c.trim() !== '' && !Number.isNaN(numV) && !Number.isNaN(numC)) return numV === numC
+    return String(value) === c
   }
 
   private vlookup(lookupValue: unknown, range: unknown, colIndex: unknown, exactMatch: unknown = true): unknown {

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -243,20 +243,33 @@ export class FormulaEngine {
     this.functions.set('XOR', (...args: unknown[]) => this.flattenValues(args).filter((v) => !!v).length % 2 === 1)
     this.functions.set('COUNTIF', (range: unknown, criteria: unknown) => this.countif(range, criteria))
     this.functions.set('WEEKDAY', (date: unknown, type: unknown = 1) => {
-      const d = date instanceof Date ? date : new Date(String(date))
+      // Parse a date-only 'YYYY-MM-DD' string as LOCAL midnight (matching DATE(), which builds local
+      // midnight) so getDay() is timezone-stable; `new Date('YYYY-MM-DD')` would parse as UTC midnight
+      // and getDay() (local) would shift the weekday back a day on negative-UTC-offset hosts.
+      let d: Date
+      if (date instanceof Date) d = date
+      else {
+        const s = String(date)
+        const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+        d = iso ? new Date(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3])) : new Date(s)
+      }
       if (Number.isNaN(d.getTime())) return '#VALUE!'
       const dow = d.getDay() // 0=Sun..6=Sat
       return Number(type) === 2 ? (dow === 0 ? 7 : dow) : dow + 1 // type 2: Mon=1..Sun=7; default: Sun=1..Sat=7
     })
+    // ROUNDUP/ROUNDDOWN: strip binary-float noise (0.29*100 === 28.999…996) via toPrecision(15) before
+    // floor/ceil, else everyday monetary values round the wrong way. Sign-aware (away-from / toward zero).
     this.functions.set('ROUNDUP', (x: unknown, digits: unknown = 0) => {
       const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
       const f = Math.pow(10, Number(digits) || 0)
-      return (n >= 0 ? Math.ceil(n * f) : Math.floor(n * f)) / f
+      const scaled = Number((n * f).toPrecision(15))
+      return (n >= 0 ? Math.ceil(scaled) : Math.floor(scaled)) / f
     })
     this.functions.set('ROUNDDOWN', (x: unknown, digits: unknown = 0) => {
       const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
       const f = Math.pow(10, Number(digits) || 0)
-      return (n >= 0 ? Math.floor(n * f) : Math.ceil(n * f)) / f
+      const scaled = Number((n * f).toPrecision(15))
+      return (n >= 0 ? Math.floor(scaled) : Math.ceil(scaled)) / f
     })
   }
 
@@ -884,6 +897,8 @@ export class FormulaEngine {
   }
 
   private isErrorValue(value: unknown): boolean {
+    // A NaN number is itself an error result (e.g. SQRT(-1)); trap it alongside the string sentinels.
+    if (typeof value === 'number') return Number.isNaN(value)
     return typeof value === 'string' && FORMULA_ERROR_SENTINELS.has(value)
   }
 
@@ -905,26 +920,31 @@ export class FormulaEngine {
   // silently mis-count; stringifying makes both shapes behave predictably.
   private matchesCriteria(value: unknown, criteria: unknown): boolean {
     const c = String(criteria)
+    const numV = Number(value)
+    // A value counts as numeric ONLY if it's a real number or a non-blank numeric string — never
+    // null/''/boolean (Number() coerces those to 0/1 and would over-count comparators like ">0").
+    const valIsNum = (typeof value === 'number' && !Number.isNaN(value))
+      || (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(numV))
+    // COUNTIF text equality is case-INSENSITIVE (Excel/Feishu parity).
+    const eqText = (a: unknown, b: string): boolean => String(a).toLowerCase() === b.toLowerCase()
     const m = c.match(/^(>=|<=|<>|>|<|=)(.*)$/)
     if (m) {
       const op = m[1]
       const operand = m[2].trim()
-      const numV = Number(value)
       const numO = Number(operand)
-      const bothNum = operand !== '' && !Number.isNaN(numV) && !Number.isNaN(numO)
+      const bothNum = valIsNum && operand !== '' && !Number.isNaN(numO)
       switch (op) {
         case '>': return bothNum && numV > numO
         case '<': return bothNum && numV < numO
         case '>=': return bothNum && numV >= numO
         case '<=': return bothNum && numV <= numO
-        case '<>': return String(value) !== operand
-        case '=': return bothNum ? numV === numO : String(value) === operand
+        case '<>': return bothNum ? numV !== numO : !eqText(value, operand)
+        case '=': return bothNum ? numV === numO : eqText(value, operand)
       }
     }
-    const numV = Number(value)
     const numC = Number(c)
-    if (c.trim() !== '' && !Number.isNaN(numV) && !Number.isNaN(numC)) return numV === numC
-    return String(value) === c
+    if (valIsNum && c.trim() !== '' && !Number.isNaN(numC)) return numV === numC
+    return eqText(value, c)
   }
 
   private vlookup(lookupValue: unknown, range: unknown, colIndex: unknown, exactMatch: unknown = true): unknown {

--- a/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
+++ b/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Formula library expansion (Feishu parity): IFERROR / ISERROR / ISBLANK / ISNUMBER / IFS / XOR /
+ * COUNTIF / WEEKDAY / ROUNDUP / ROUNDDOWN. Locks behavior incl. the review-flagged COUNTIF criteria
+ * coercion (String(criteria) — a non-string criteria must never throw or mis-count).
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { FormulaEngine, type FormulaContext } from '../../src/formula/engine'
+import { createMockDb, type MockDB } from '../utils/test-db'
+import { TEST_IDS } from '../utils/test-fixtures'
+
+describe('Formula library expansion', () => {
+  let engine: FormulaEngine
+  let context: FormulaContext
+  let mockDb: MockDB
+
+  beforeEach(() => {
+    mockDb = createMockDb()
+    engine = new FormulaEngine({ db: mockDb })
+    context = { sheetId: TEST_IDS.SHEET_1, spreadsheetId: TEST_IDS.SPREADSHEET_1, currentCell: { row: 0, col: 0 }, cache: new Map() }
+  })
+  afterEach(() => { vi.clearAllMocks(); vi.resetModules() })
+  const calc = (f: string) => engine.calculate(f, context)
+
+  test('IFERROR traps an error result and passes a clean value through', async () => {
+    expect(await calc('=IFERROR(1/0, "fallback")')).toBe('fallback') // 1/0 => #DIV/0!
+    expect(await calc('=IFERROR(5, "fallback")')).toBe(5)
+  })
+
+  test('ISERROR / ISBLANK / ISNUMBER predicates', async () => {
+    expect(await calc('=ISERROR(1/0)')).toBe(true)
+    expect(await calc('=ISERROR(5)')).toBe(false)
+    expect(await calc('=ISBLANK("")')).toBe(true)
+    expect(await calc('=ISBLANK("x")')).toBe(false)
+    expect(await calc('=ISNUMBER(5)')).toBe(true)
+    expect(await calc('=ISNUMBER("x")')).toBe(false)
+  })
+
+  test('IFS returns the first truthy branch', async () => {
+    expect(await calc('=IFS(1>2, "a", 3>2, "b")')).toBe('b')
+    expect(await calc('=IFS(2>1, "a", 3>2, "b")')).toBe('a')
+  })
+
+  test('XOR is true iff an odd number of args are truthy', async () => {
+    expect(await calc('=XOR(TRUE(), FALSE())')).toBe(true)
+    expect(await calc('=XOR(TRUE(), TRUE())')).toBe(false)
+    expect(await calc('=XOR(TRUE(), TRUE(), TRUE())')).toBe(true)
+  })
+
+  test('COUNTIF supports comparator, numeric, and text criteria', async () => {
+    expect(await calc('=COUNTIF([[1, 2, 3, 4, 5]], ">2")')).toBe(3)
+    expect(await calc('=COUNTIF([[1, 2, 3, 4, 5]], "<=2")')).toBe(2)
+    expect(await calc('=COUNTIF([[1, 2, 2, 3]], 2)')).toBe(2) // bare-number criteria (non-string) must not throw
+    expect(await calc('=COUNTIF([["a", "b", "a"]], "a")')).toBe(2)
+  })
+
+  test('WEEKDAY returns 1..7 for a valid date, #VALUE! for garbage', async () => {
+    const r = await calc('=WEEKDAY(DATE(2026, 1, 4))')
+    expect(typeof r).toBe('number')
+    expect(r as number).toBeGreaterThanOrEqual(1)
+    expect(r as number).toBeLessThanOrEqual(7)
+    expect(await calc('=WEEKDAY("not-a-date")')).toBe('#VALUE!')
+  })
+
+  test('ROUNDUP / ROUNDDOWN round away-from / toward zero at the given precision', async () => {
+    expect(await calc('=ROUNDUP(2.1, 0)')).toBe(3)
+    expect(await calc('=ROUNDDOWN(2.9, 0)')).toBe(2)
+    expect(await calc('=ROUNDUP(2.144, 1)')).toBeCloseTo(2.2, 10)
+    expect(await calc('=ROUNDDOWN(2.166, 1)')).toBeCloseTo(2.1, 10)
+    expect(await calc('=ROUNDUP(-2.1, 0)')).toBe(-3)
+    expect(await calc('=ROUNDDOWN(-2.9, 0)')).toBe(-2)
+  })
+})

--- a/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
+++ b/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
@@ -53,11 +53,23 @@ describe('Formula library expansion', () => {
     expect(await calc('=COUNTIF([["a", "b", "a"]], "a")')).toBe(2)
   })
 
-  test('WEEKDAY returns 1..7 for a valid date, #VALUE! for garbage', async () => {
-    const r = await calc('=WEEKDAY(DATE(2026, 1, 4))')
-    expect(typeof r).toBe('number')
-    expect(r as number).toBeGreaterThanOrEqual(1)
-    expect(r as number).toBeLessThanOrEqual(7)
+  test('COUNTIF text matching is case-INSENSITIVE (Excel/Feishu parity)', async () => {
+    expect(await calc('=COUNTIF([["Apple", "APPLE", "apple"]], "apple")')).toBe(3)
+    expect(await calc('=COUNTIF([["Cat", "cat", "dog"]], "=CAT")')).toBe(2)
+  })
+
+  test('COUNTIF numeric comparators do NOT over-count blanks/booleans (Number() coercion guard)', async () => {
+    expect(await calc('=COUNTIF([[5, null]], ">-1")')).toBe(1)   // null is not 0
+    expect(await calc('=COUNTIF([[5, null, ""]], ">=0")')).toBe(1) // null/"" excluded
+    expect(await calc('=COUNTIF([[null]], "=0")')).toBe(0)
+  })
+
+  test('WEEKDAY is timezone-stable for date-only strings (parsed as local, matching DATE())', async () => {
+    // exact weekday, computed via the SAME local-midnight construction the fix uses → TZ-independent.
+    const dow = new Date(2026, 0, 4).getDay() // 2026-01-04
+    expect(await calc('=WEEKDAY("2026-01-04")')).toBe(dow + 1)              // type 1: Sun=1..Sat=7
+    expect(await calc('=WEEKDAY("2026-01-04", 2)')).toBe(dow === 0 ? 7 : dow) // type 2: Mon=1..Sun=7
+    expect(await calc('=WEEKDAY(DATE(2026, 1, 4))')).toBe(dow + 1)          // DATE() path agrees
     expect(await calc('=WEEKDAY("not-a-date")')).toBe('#VALUE!')
   })
 
@@ -68,5 +80,18 @@ describe('Formula library expansion', () => {
     expect(await calc('=ROUNDDOWN(2.166, 1)')).toBeCloseTo(2.1, 10)
     expect(await calc('=ROUNDUP(-2.1, 0)')).toBe(-3)
     expect(await calc('=ROUNDDOWN(-2.9, 0)')).toBe(-2)
+  })
+
+  test('ROUNDUP/ROUNDDOWN are float-precision-safe on everyday monetary values', async () => {
+    // 0.29*100 === 28.999…996 / 0.07*100 === 7.000…001 — naive floor/ceil rounds the wrong way.
+    expect(await calc('=ROUNDDOWN(0.29, 2)')).toBeCloseTo(0.29, 10)
+    expect(await calc('=ROUNDDOWN(0.58, 2)')).toBeCloseTo(0.58, 10)
+    expect(await calc('=ROUNDDOWN(1.16, 2)')).toBeCloseTo(1.16, 10)
+    expect(await calc('=ROUNDUP(0.07, 2)')).toBeCloseTo(0.07, 10)
+  })
+
+  test('ISERROR/IFERROR also trap a NaN numeric error (e.g. SQRT(-1))', async () => {
+    expect(await calc('=ISERROR(SQRT(-1))')).toBe(true)
+    expect(await calc('=IFERROR(SQRT(-1), "x")')).toBe('x')
   })
 })


### PR DESCRIPTION
First slice of #20 (formula depth) — purely additive scalar functions, **no row-permission surface** (the COUNTALL/lookup row-perm concern is the separate rollup slice, deferred).

Adds **IFERROR, ISERROR, ISBLANK, ISNUMBER, IFS, XOR, COUNTIF, WEEKDAY, ROUNDUP, ROUNDDOWN** (46 → 56).

- IFERROR/ISERROR trap the engine's returned error sentinels (`FORMULA_ERROR_SENTINELS`).
- **COUNTIF `matchesCriteria` coerces `String(criteria)` first** (the reviewed fix): a non-string criteria (bare number, or a bare comparator that parses to a boolean) never throws or silently mis-counts. Comparators (`>`,`<`,`>=`,`<=`,`<>`,`=`) + numeric + text.
- WEEKDAY type 1/2 + `#VALUE!` on bad date; ROUNDUP/ROUNDDOWN sign-correct.

`tsc` clean · +7 unit tests · existing formula suite **103/103** (no regression). RECORD_ID deferred (needs the multitable wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)