### PR TITLE
fix(approval): guard main-path graph cycles + lock dispatch FOR-UPDATE invariant

### DIFF
--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -720,9 +720,23 @@ export class ApprovalGraphExecutor {
   ): ApprovalGraphResolution {
     const ccEvents: ApprovalCcEvent[] = []
     const autoApprovalEvents: ApprovalGraphAutoApprovalEvent[] = []
+    // Cycle guard: a main-path loop made purely of condition/cc nodes (with no
+    // approval/parallel/end node to return at) would otherwise spin this walker
+    // forever — hanging the worker thread at instance creation
+    // (`resolveInitialState`) or during dispatch while it holds the
+    // `approval_instances` row lock. Publish-time validation only checks
+    // parallel branches for cycles, so this runtime guard mirrors the other
+    // three walkers (`resolveBranchAdvance`, `listVisitedApprovalNodeKeysUntil`)
+    // and fails fast instead of looping.
+    const visited = new Set<string>()
     let currentKey: string | null = nodeKey
 
     while (currentKey) {
+      if (visited.has(currentKey)) {
+        throw new Error(`Runtime graph contains a cycle near ${currentKey}`)
+      }
+      visited.add(currentKey)
+
       const node = this.nodeMap.get(currentKey)
       if (!node) {
         throw new Error(`Runtime graph references unknown node ${currentKey}`)

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -651,6 +651,68 @@ describe('ApprovalGraphExecutor', () => {
       },
     ])
   })
+
+  it('throws instead of looping when the main path forms a pure cc cycle', () => {
+    // Two cc nodes pointing at each other with no approval/parallel/end node in
+    // the loop. Before the cycle guard this spun resolveFromNode forever and
+    // hung the worker at instance creation; it must now fail fast.
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'notify-a', type: 'cc', config: { targetType: 'role', targetIds: ['ops'] } },
+        { key: 'notify-b', type: 'cc', config: { targetType: 'role', targetIds: ['it'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-a', source: 'start', target: 'notify-a' },
+        { key: 'edge-a-b', source: 'notify-a', target: 'notify-b' },
+        { key: 'edge-b-a', source: 'notify-b', target: 'notify-a' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    expect(() => executor.resolveInitialState()).toThrowError(/cycle near/)
+  })
+
+  it('throws instead of looping when a condition routes back into a cc cycle (latent trigger)', () => {
+    // The cycle hides behind a condition branch, so most submissions resolve
+    // normally and only a specific form value routes into the loop — the nasty
+    // case that survives casual review. The guard must catch it at runtime.
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              { edgeKey: 'edge-loop', rules: [{ fieldId: 'kind', operator: 'eq', value: 'cyclic' }] },
+            ],
+            defaultEdgeKey: 'edge-normal',
+          },
+        },
+        { key: 'review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'notify', type: 'cc', config: { targetType: 'role', targetIds: ['ops'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-normal', source: 'route', target: 'review' },
+        { key: 'edge-loop', source: 'route', target: 'notify' },
+        { key: 'edge-notify-route', source: 'notify', target: 'route' },
+        { key: 'edge-review-end', source: 'review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    // Normal form data resolves to the approval node as usual.
+    expect(new ApprovalGraphExecutor(runtimeGraph, { kind: 'normal' }).resolveInitialState().currentNodeKey)
+      .toBe('review')
+    // The cyclic branch fails fast rather than hanging.
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, { kind: 'cyclic' }).resolveInitialState())
+      .toThrowError(/cycle near/)
+  })
 })
 
 describe('validateApprovalFormData', () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -363,6 +363,74 @@ describe('ApprovalProductService', () => {
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
+  it('locks the instance row with FOR UPDATE during dispatch (concurrency invariant)', async () => {
+    // Guards the dispatch serialization invariant: concurrent actions on one
+    // instance — including two approvers acting on two parallel branches at
+    // once — are serialized by a row lock on approval_instances, NOT by
+    // optimistic retry. A refactor that drops `FOR UPDATE` would silently
+    // reintroduce a lost-update on the JSONB parallelBranchStates
+    // read-modify-write. This pins the SELECT shape so that regression fails CI.
+    // (True two-session race coverage is an integration test requiring a real
+    // Postgres; tracked separately as a DB-harness follow-up.)
+    const runtimeGraph = buildRuntimeGraph()
+    const captured: string[] = []
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      captured.push(sql)
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return { rows: [buildInstanceRow()], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT COUNT(*)::text AS count')) {
+        return { rows: [{ count: '0' }], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_instances SET status = 'revoked'")) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'revoked',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    await service.dispatchAction('apr-1', { action: 'revoke', comment: 'cancel' }, { userId: 'user-1' })
+
+    const instanceSelect = captured.find((sql) =>
+      /SELECT \* FROM approval_instances WHERE id = \$1/.test(sql))
+    expect(instanceSelect, 'dispatch must SELECT the instance row').toBeDefined()
+    expect(instanceSelect).toMatch(/FOR UPDATE/)
+  })
+
   it('emits a completion event when the requester revokes an approval', async () => {
     const runtimeGraph = buildRuntimeGraph()
 


### PR DESCRIPTION
Two small, capability-neutral hardening fixes surfaced during a deep read of the approval engine. No behavior change for any valid template; pure de-risking ahead of v1 trial closeout.

## 1. `fix(approval)`: cycle guard on the main graph walker
`ApprovalGraphExecutor.resolveFromNode` was the only one of four graph walkers without a visited-set cycle guard (the parallel-branch walker, `listVisitedApprovalNodeKeysUntil`, and `resolveBranchAdvance` all have one). Publish-time validation (`normalizeApprovalGraph`) only checks **parallel branches** for cycles — the main linear path is unchecked.

A published template whose main path loops through `condition`/`cc` nodes with **no** `approval`/`parallel`/`end` node in the loop would spin `resolveFromNode` forever, hanging the worker at instance creation (`resolveInitialState`) or during dispatch **while holding the `approval_instances` row lock**. The condition-gated variant is latent: most submissions resolve normally and only a specific form value routes into the loop.

Fix: a visited-set guard mirroring the sibling walkers — a cyclic graph now throws immediately instead of looping. Tests cover the direct `cc↔cc` case and the latent condition-gated case.

## 2. `test(approval)`: lock the dispatch `FOR UPDATE` invariant
The dispatch path serializes concurrent actions on one instance — including two approvers on two parallel branches at once — via `SELECT ... approval_instances ... FOR UPDATE`, not optimistic retry. That invariant was untested: dropping the row lock in a refactor would silently reintroduce a lost-update on the JSONB `parallelBranchStates` read-modify-write with nothing going red.

Added a unit guard asserting the dispatch instance-row SELECT carries `FOR UPDATE`. **Follow-up:** true two-session race coverage is an integration test requiring a real Postgres (DB-harness).

## Tests
`approval-graph-executor.test.ts` + `approval-product-service.test.ts` — **57 passed** (18 + 39), incl. the 3 new guards. Fast pass itself proves the loop is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)