### PR TITLE
docs(data-source): record C6 readonly smoke pass

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -21,8 +21,8 @@
   C6-2 只增加 read-only dry-run route + dry-run token，不授权 apply runtime 或 external write。
   C6-3 增加 token-bound apply route；C6-4 UI dry-run -> review -> apply 已合并并发出实体机
   smoke 包；#2720 已完成 sandbox 配置和核心 dry-run/apply/re-pull/rollback smoke，
-  但 read-only 子门仍 HOLD，下一步需确认实体机 read-only 检查命中的是
-  C6 专用 `/external-write/dry-run` 路由，而不是普通 write-gated pipeline `/dry-run` 路由。
+  且 #2737 后的 read-only dedicated-route 子门已 PASS。下一步是 controlled bad-row
+  row-level failure smoke；production/batch 仍关闭。
 
 ## 收口顺序
 
@@ -34,7 +34,7 @@
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
 | C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | C6-5 smoke package published; #2720 core C6 sandbox smoke PASS, read-only subgate HOLD | 交付签收 | 包内容/部署/证据不完整 |
+| Release | 总包 + 实体机验收 | C6-5 smoke package published; #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row pending | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -426,10 +426,12 @@ TODO:
   - #2720 core sandbox smoke PASS: C6 dry-run returned ready without mutating target; token-confirmed
     apply wrote sandbox rows only; re-pull was idempotent (`add=0`, no duplicates); operator-local
     cleanup restored baseline.
-  - remaining HOLD: read-only subgate reported `403` for dry-run and apply. Apply `403` is correct,
-    but dry-run must be rechecked against the dedicated C6 route
-    `POST /api/integration/pipelines/:id/external-write/dry-run`, not ordinary
-    `POST /api/integration/pipelines/:id/dry-run` (ordinary pipeline dry-run remains write-gated).
+  - #2720 read-only dedicated-route subgate PASS after #2737: `integration:read` can call
+    `POST /api/integration/pipelines/:id/external-write/dry-run` (`200`) while
+    `POST /api/integration/pipelines/:id/external-write/apply` remains blocked (`403`) with
+    no target write request accepted.
+  - remaining HOLD: controlled bad-row smoke has not run yet; it must prove row-level failure
+    evidence is values-free and clean sibling rows are not silently swallowed.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:
@@ -487,8 +489,8 @@ TODO:
 - [ ] C4 UI config smoke。
 - [x] C5 K3 seam smoke。
 - [ ] C6 dry-run/apply/re-pull/rollback smoke（#2720）。
-  - core sandbox smoke PASS; read-only dedicated dry-run subgate remains HOLD until endpoint-specific
-    rerun proves `integration:read` can call `/external-write/dry-run` while apply stays blocked.
+  - core sandbox smoke PASS; read-only dedicated dry-run subgate PASS; controlled bad-row remains
+    pending before C6-5 can close.
 - [ ] issue 上贴 values-free 验收证据。
 
 交付判据:

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -4,11 +4,12 @@ Purpose: run or continue #2720's sandbox-only C6 external-write smoke.
 
 Current #2720 status as of 2026-06-16: the sandbox write target, write-gated
 external system, active C6 pipeline, core dry-run/apply/re-pull/rollback path
-have already passed on the entity machine. The remaining HOLD is the read-only
-subgate: verify an `integration:read` user can call the dedicated C6
-`/external-write/dry-run` route while apply remains blocked. If continuing that
-run, do not recreate the sandbox or rerun Apply just to test the read-only
-endpoint.
+have already passed on the entity machine. After #2737, the read-only subgate
+also passed on the dedicated C6 route: an `integration:read` user can call
+`/external-write/dry-run`, while `/external-write/apply` remains blocked. The
+remaining HOLD is the controlled bad-row check. If continuing that run, do not
+recreate the sandbox or rerun write/admin Apply just to repeat already-passed
+checks.
 
 This runbook sets up the minimum sandbox-only shape needed to run the C6
 dry-run -> apply -> re-pull -> rollback/cleanup smoke. It does not authorize
@@ -329,6 +330,7 @@ Expected:
 
 - one controlled bad row creates row-level failure evidence;
 - clean sibling rows are not silently swallowed;
+- production/batch remain closed regardless of the result;
 - no credentials, raw SQL, row values, or payload JSON appear in evidence.
 
 Evidence:
@@ -514,7 +516,9 @@ Pass requires all of:
 - apply requires token + explicit confirmation + write permission;
 - re-pull shows `add=0` and no duplicate target rows;
 - read-only user cannot send apply;
-- controlled bad-row evidence, if run, is row-level and values-free;
+- controlled bad-row evidence is row-level and values-free;
+- if the sandbox cannot safely run the controlled bad-row check, keep C6-5 at
+  HOLD rather than marking this runbook PASS;
 - rollback/cleanup restores the sandbox target baseline without using a
   MetaSheet product delete/raw SQL path;
 - all forbidden boundaries remain false.

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -207,8 +207,10 @@ c5K3Mssql:
 
 ## 7. C6 Sandbox External-Write Smoke
 
-Run the dedicated C6 sandbox runbook. Do not compress or skip its ordered
-sequence.
+Run or continue the dedicated C6 sandbox runbook. For a fresh run, do not
+compress or skip its ordered sequence. If issue evidence already proves earlier
+steps, continue from the next pending step and cite those passed checkpoints
+instead of rerunning write/admin Apply solely to repeat evidence.
 
 Reference runbook:
 
@@ -235,6 +237,14 @@ c6Sandbox:
   valuesFreeEvidence=true
 ```
 
+Current #2720 checkpoint as of 2026-06-16:
+
+- core sandbox dry-run/apply/re-pull/rollback: passed;
+- dedicated read-only route subgate: passed
+  (`/external-write/dry-run` allowed for `integration:read`; `/external-write/apply`
+  blocked for the same read-only user);
+- controlled bad-row: pending.
+
 ## Stop Rules
 
 Stop and report HOLD if any of these occur:
@@ -248,7 +258,8 @@ Stop and report HOLD if any of these occur:
 - C5 touches K3 Save / Submit / Audit / BOM or external DB write;
 - C6 sandbox target/pipeline is missing;
 - C6 dry-run mutates the target;
-- C6 dedicated `/external-write/dry-run` rejects an `integration:read` user;
+- C6 dedicated `/external-write/dry-run` rejects an `integration:read` user
+  in a fresh rerun;
 - C6 apply can be sent by a read-only user;
 - C6 re-pull produces duplicate target rows or `add>0` after a successful
   apply;


### PR DESCRIPTION
## Summary
- record #2720's post-#2737 read-only dedicated-route PASS in the data-source delivery TODO
- update the C6 sandbox/release smoke runbooks so the remaining C6-5 HOLD is controlled bad-row, not read-only routing
- make controlled bad-row mandatory before C6-5 can close; if it cannot safely run, C6-5 stays HOLD

## Verification
- git diff --check
- rg guard checks for stale read-only HOLD wording
- subagent review: runtime/status consistency APPROVE after fixing bad-row pass-criteria P2
- subagent review: values-free/boundary consistency APPROVE after fixing continue-from-existing-evidence P2

## Boundaries
- docs-only
- no runtime / route / UI / package changes
- no production or batch authorization
- no K3 Save / Submit / Audit / BOM
