### PR TITLE
feat(multitable): native duration field type (h:mm, seconds-backed)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1395,6 +1395,7 @@ function conditionOperatorsForField(fieldId: string): ConditionOperatorOption[] 
     case 'currency':
     case 'percent':
     case 'rating':
+    case 'duration':
     case 'date':
     case 'dateTime':
     case 'createdTime':
@@ -1508,6 +1509,7 @@ function isNumericConditionFieldType(fieldType: string | undefined): boolean {
     fieldType === 'currency' ||
     fieldType === 'percent' ||
     fieldType === 'rating' ||
+    fieldType === 'duration' ||
     fieldType === 'autoNumber'
 }
 

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -544,6 +544,7 @@ const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
   'currency',
   'percent',
   'rating',
+  'duration',
   'boolean',
   'date',
   'dateTime',
@@ -552,7 +553,7 @@ const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
   'lookup',
   'rollup',
 ])
-const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'rollup'])
+const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'duration', 'rollup'])
 const AGGREGATIONS_REQUIRING_VALUE = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max'])
 // v2-d: only additive aggregations make a stacked total meaningful (Σ segments == the single bar).
 const ADDITIVE_AGGREGATIONS = new Set<AggregationFunction>(['sum', 'count'])

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -469,6 +469,16 @@
           </label>
         </template>
 
+        <template v-else-if="configTargetType === 'duration'">
+          <label class="meta-field-mgr__field">
+            <span>{{ ml('field.durationFormat') }}</span>
+            <select v-model="durationDraft.durationFormat" class="meta-field-mgr__select">
+              <option value="h:mm">{{ ml('field.durationFormatHmm') }}</option>
+              <option value="mm:ss">{{ ml('field.durationFormatMmss') }}</option>
+            </select>
+          </label>
+        </template>
+
         <template v-else-if="configTargetType === 'button'">
           <label class="meta-field-mgr__field">
             <span>{{ ml('field.buttonLabelText') }}</span>
@@ -713,13 +723,14 @@ import {
 } from '../utils/formula-docs'
 import { localizeDryRunDiagnostic } from '../utils/meta-formula-labels'
 import type { DryRunResult, DryRunDiagnostic } from '../api/client'
-import type { ButtonFieldVariant } from '../utils/field-config'
+import type { ButtonFieldVariant, DurationFormat } from '../utils/field-config'
 import {
   normalizeStringArray,
   resolveAutoNumberFieldProperty,
   resolveAttachmentFieldProperty,
   resolveButtonFieldProperty,
   resolveCurrencyFieldProperty,
+  resolveDurationFieldProperty,
   resolveFormulaFieldProperty,
   resolveLinkFieldProperty,
   resolveLookupFieldProperty,
@@ -853,13 +864,13 @@ function rulesToProperty(rules: FieldValidationRule[]): Array<Record<string, unk
 const FIELD_TYPES: MetaFieldCreateType[] = [
   'string', 'longText', 'number', 'boolean', 'date', 'dateTime', 'select', 'multiSelect', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
-  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode', 'qrcode', 'location', 'button',
+  'currency', 'percent', 'rating', 'duration', 'url', 'email', 'phone', 'barcode', 'qrcode', 'location', 'button',
   ...SYSTEM_FIELD_TYPES,
 ]
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', dateTime: '\u{1F552}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
-  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', qrcode: '\u25A6', location: '\u{1F4CD}',
+  currency: '\u00A4', percent: '%', rating: '\u2605', duration: '\u23F1', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', qrcode: '\u25A6', location: '\u{1F4CD}',
   autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB', button: '\u{1F518}',
 }
 
@@ -995,6 +1006,9 @@ const percentDraft = reactive<{ decimals: number }>({
 })
 const ratingDraft = reactive<{ max: number }>({
   max: 5,
+})
+const durationDraft = reactive<{ durationFormat: DurationFormat }>({
+  durationFormat: 'h:mm',
 })
 // B1-c button field config draft. `actionConfig` is carried OPAQUELY (the form
 // doesn't edit it) so a label/variant edit re-emits it intact — update-field
@@ -1186,7 +1200,7 @@ const configTargetType = computed(() => {
 })
 
 // ---- #5b formula dry-run (C1–C4 per design #1869) ----
-const DRY_RUN_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'autoNumber'])
+const DRY_RUN_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
 const dryRunSamples = reactive<Record<string, string>>({})
 const dryRunResult = ref<DryRunResult | null>(null)
 const dryRunRunning = ref(false)
@@ -1433,7 +1447,7 @@ function onNumberDecimalsInput(event: Event) {
 function requiresConfig(type: MetaFieldCreateType): boolean {
   return [
     'select', 'multiSelect', 'link', 'person', 'lookup', 'rollup', 'formula', 'attachment',
-    'number', 'currency', 'percent', 'rating', 'longText', 'autoNumber', 'button',
+    'number', 'currency', 'percent', 'rating', 'duration', 'longText', 'autoNumber', 'button',
   ].includes(type)
 }
 
@@ -1489,6 +1503,7 @@ function resetDrafts() {
   numberDraft.unit = ''
   percentDraft.decimals = 1
   ratingDraft.max = 5
+  durationDraft.durationFormat = 'h:mm'
   autoNumberDraft.prefix = ''
   autoNumberDraft.digits = 0
   autoNumberDraft.start = 1
@@ -1570,6 +1585,9 @@ function serializeFieldDraft(type: string | null): string {
   }
   if (type === 'rating') {
     return JSON.stringify({ max: ratingDraft.max })
+  }
+  if (type === 'duration') {
+    return JSON.stringify({ durationFormat: durationDraft.durationFormat })
   }
   if (type === 'button') {
     return JSON.stringify({
@@ -1692,6 +1710,8 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
   } else if (fieldType === 'rating') {
     const property = resolveRatingFieldProperty(field.property)
     ratingDraft.max = property.max
+  } else if (fieldType === 'duration') {
+    durationDraft.durationFormat = resolveDurationFieldProperty(field.property).durationFormat
   } else if (fieldType === 'autoNumber') {
     const property = resolveAutoNumberFieldProperty(field.property)
     autoNumberDraft.prefix = property.prefix
@@ -2017,7 +2037,7 @@ watch(aiShortcutSectionVisible, (visible) => {
 })
 
 function currentDraftProperty(type: MetaFieldCreateType | string): Record<string, unknown> | undefined {
-  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'autoNumber' || type === 'button'
+  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'duration' || type === 'autoNumber' || type === 'button'
     ? type
     : null
   fieldConfigError.value = ''
@@ -2174,6 +2194,10 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       return undefined
     }
     return { max: Math.round(max) }
+  }
+  if (normalizedType === 'duration') {
+    // durationFormat is a constrained <select> (h:mm | mm:ss); no error path needed.
+    return { durationFormat: durationDraft.durationFormat }
   }
   if (normalizedType === 'button') {
     const actionType = buttonDraft.actionType.trim()

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -260,6 +260,22 @@
               @click="onRatingPick(field.id, n)"
             >★</button>
           </div>
+          <!-- duration: format-aware text (h:mm / mm:ss) that parses to seconds.
+               Parses on `change` (blur/enter), not `input`, so the displayed value
+               is not reformatted under the typist's cursor on every keystroke. -->
+          <input
+            v-else-if="field.type === 'duration'"
+            :id="`field_${field.id}`"
+            class="meta-form-view__input"
+            :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
+            type="text"
+            inputmode="numeric"
+            :placeholder="durationPlaceholderFor(field)"
+            :disabled="isFieldReadOnly(field.id)"
+            :aria-required="field.required ? 'true' : undefined"
+            :value="durationDisplayFor(field)"
+            @change="onDurationChange(field, ($event.target as HTMLInputElement).value)"
+          />
           <input
             v-else-if="field.type === 'url'"
             :id="`field_${field.id}`"
@@ -358,7 +374,10 @@ import {
 } from '../utils/comment-affordance'
 import {
   attachmentAcceptAttr,
+  durationSecondsFromInput,
+  formatDurationValue,
   resolveAttachmentFieldProperty,
+  resolveDurationFieldProperty,
   resolveRatingFieldProperty,
   shouldReplaceAttachmentSelection,
   validateAttachmentSelection,
@@ -638,6 +657,22 @@ function ratingValueFor(fieldId: string): number {
 
 function onRatingPick(fieldId: string, value: number) {
   formData[fieldId] = value === ratingValueFor(fieldId) ? null : value
+}
+
+// --- duration (seconds-backed) form helpers ---
+function durationPlaceholderFor(field: MetaField): string {
+  return resolveDurationFieldProperty(field.property).durationFormat
+}
+
+function durationDisplayFor(field: MetaField): string {
+  const v = formData[field.id]
+  const num = typeof v === 'number' ? v : Number(v)
+  if (v === null || v === undefined || v === '' || !Number.isFinite(num)) return ''
+  return formatDurationValue(num, resolveDurationFieldProperty(field.property).durationFormat)
+}
+
+function onDurationChange(field: MetaField, raw: string) {
+  formData[field.id] = durationSecondsFromInput(raw, resolveDurationFieldProperty(field.property).durationFormat)
 }
 
 function linkPreview(fieldId: string): string {

--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -233,7 +233,7 @@ watch(
 
 const dateFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'dateTime'))
 const titleFields = computed(() => props.fields)
-const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating'].includes(field.type)))
+const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating', 'duration'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'date', 'dateTime'].includes(field.type)))
 const dependencyFields = computed(() => props.fields.filter((field) => isSelfTableLinkField(field, props.sheetId)))
 const canResizeTasks = computed(() => Boolean(props.canEdit && startFieldId.value && endFieldId.value && startFieldId.value !== endFieldId.value))

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -741,7 +741,7 @@ function onToggleFreeze(i: number) {
 }
 
 // ── aggregation footer (#4-3b-1): SERVER-RESPONSE ONLY, no local fallback ──
-const AGG_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'autoNumber'])
+const AGG_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
 const AGG_FNS_NUMERIC = ['sum', 'avg', 'min', 'max', 'count', 'countNonEmpty', 'countDistinct']
 const AGG_FNS_OTHER = ['count', 'countNonEmpty', 'countDistinct']
 function aggFnOptions(field: MetaField): string[] {

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -609,7 +609,7 @@ const configTargetFields = computed(() => props.fields)
 const attachmentFields = computed(() => props.fields.filter((field) => field.type === 'attachment'))
 const dateFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'dateTime'))
 const dateLikeFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'dateTime' || field.type === 'string' || field.type === 'number'))
-const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
+const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating', 'duration'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
 // S4 — hierarchy parent candidates only: reparent writes `[parentRecordId]` over this field,
 // so multi-value links are excluded here (and from validLinkFieldIds below, which makes a
@@ -1058,7 +1058,8 @@ function operatorsForField(fieldId: string) {
 
 function inputTypeForField(fieldId: string): string {
   const fieldType = props.fields.find((field) => field.id === fieldId)?.type ?? 'string'
-  if (fieldType === 'number' || fieldType === 'currency' || fieldType === 'percent' || fieldType === 'rating') return 'number'
+  // duration filters on raw seconds (v1) → a numeric input, like percent/rating.
+  if (fieldType === 'number' || fieldType === 'currency' || fieldType === 'percent' || fieldType === 'rating' || fieldType === 'duration') return 'number'
   if (fieldType === 'date') return 'date'
   return 'text'
 }
@@ -1095,7 +1096,7 @@ function updateFilterValue(index: number, value: string) {
   const fieldType = props.fields.find((field) => field.id === rule.fieldId)?.type ?? 'string'
   filterDraft.conditions[index] = {
     ...rule,
-    value: ['number', 'currency', 'percent', 'rating'].includes(fieldType) && value !== '' ? Number(value) : value,
+    value: ['number', 'currency', 'percent', 'rating', 'duration'].includes(fieldType) && value !== '' ? Number(value) : value,
   }
 }
 

--- a/apps/web/src/multitable/components/ScaleFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ScaleFormattingDialog.vue
@@ -301,7 +301,7 @@ const { isZh } = useLocale()
 const ml = (key: Parameters<typeof managerLabel>[0]) => managerLabel(key, isZh.value)
 const pickColorLabel = (color: string) => formattingPickColor(color, isZh.value)
 
-const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating'])
+const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'duration'])
 
 const BAR_PALETTE = ['#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#0ea5e9', '#1f2937'] as const
 const STOP_PALETTE = ['#f8696b', '#ffeb84', '#63be7b', '#ffffff', '#3b82f6', '#fce4e4', '#e0f3d8'] as const

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -201,6 +201,24 @@
       @keydown.escape="emit('cancel')"
     />
 
+    <!-- duration: format-aware text (h:mm / mm:ss) parsed to seconds. A LOCAL
+         buffer (durationText), seeded once from modelValue, drives the input so
+         the displayed value is never reformatted under the cursor while typing.
+         @input parses the buffer → emits seconds; the buffer itself is the
+         source of the visible text. -->
+    <input
+      v-else-if="field.type === 'duration'"
+      ref="inputRef"
+      class="meta-cell-editor__input"
+      type="text"
+      inputmode="numeric"
+      :placeholder="durationFormat"
+      :value="durationText"
+      @input="onDurationInput"
+      @keydown.enter="emit('confirm')"
+      @keydown.escape="emit('cancel')"
+    />
+
     <!-- rating: click-to-set stars -->
     <div v-else-if="field.type === 'rating'" class="meta-cell-editor__rating">
       <button
@@ -327,8 +345,11 @@ import MetaRichLongTextEditor from './MetaRichLongTextEditor.vue'
 import { isRichLongTextField } from '../../utils/rich-longtext'
 import {
   attachmentAcceptAttr,
+  durationSecondsFromInput,
+  formatDurationValue,
   resolveAttachmentFieldProperty,
   resolveCurrencyFieldProperty,
+  resolveDurationFieldProperty,
   resolveNumberFieldProperty,
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
@@ -630,6 +651,24 @@ const numericStep = computed(() => {
   }
   return 'any'
 })
+
+// --- duration (seconds-backed, format-aware) ---
+const durationFormat = computed(() => resolveDurationFieldProperty(props.field.property).durationFormat)
+// LOCAL buffer seeded ONCE at setup from modelValue. Bound to the input and
+// updated only by the user's keystrokes — never re-derived from modelValue —
+// so reformatting can't fight the typist (advisor B). The parsed seconds are
+// emitted via update:modelValue; the buffer stays the literal typed text.
+const durationText = ref(
+  props.field.type === 'duration' && props.modelValue !== null && props.modelValue !== undefined && props.modelValue !== ''
+    && Number.isFinite(Number(props.modelValue))
+    ? formatDurationValue(Number(props.modelValue), resolveDurationFieldProperty(props.field.property).durationFormat)
+    : '',
+)
+function onDurationInput(event: Event) {
+  const text = (event.target as HTMLInputElement).value
+  durationText.value = text
+  emit('update:modelValue', durationSecondsFromInput(text, durationFormat.value))
+}
 
 const ratingMax = computed(() => {
   if (props.field.type !== 'rating') return 5

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -20,6 +20,7 @@ export type MetaFieldType =
   | 'currency'
   | 'percent'
   | 'rating'
+  | 'duration'
   | 'url'
   | 'email'
   | 'phone'

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -54,6 +54,17 @@ export type NormalizedRatingFieldProperty = {
   max: number
 }
 
+// Native duration (时长) — supported display formats. The stored value is always
+// seconds; the format only chooses presentation (h:mm vs mm:ss). Mirrors the
+// backend codec (`DURATION_FORMATS` in field-codecs.ts). h:mm:ss deferred (v1).
+export const DURATION_FORMATS = ['h:mm', 'mm:ss'] as const
+export type DurationFormat = (typeof DURATION_FORMATS)[number]
+export const DEFAULT_DURATION_FORMAT: DurationFormat = 'h:mm'
+
+export type NormalizedDurationFieldProperty = {
+  durationFormat: DurationFormat
+}
+
 export type NormalizedNumberFieldProperty = {
   decimals: number | null
   thousands: boolean
@@ -200,6 +211,16 @@ export function resolveRatingFieldProperty(value: unknown): NormalizedRatingFiel
   return { max }
 }
 
+export function resolveDurationFieldProperty(value: unknown): NormalizedDurationFieldProperty {
+  const property = asRecord(value)
+  const fmt = property.durationFormat
+  const durationFormat: DurationFormat =
+    typeof fmt === 'string' && (DURATION_FORMATS as readonly string[]).includes(fmt)
+      ? (fmt as DurationFormat)
+      : DEFAULT_DURATION_FORMAT
+  return { durationFormat }
+}
+
 export function resolveNumberFieldProperty(value: unknown): NormalizedNumberFieldProperty {
   const property = asRecord(value)
   const decimalsRaw = typeof property.decimals === 'number' ? property.decimals : Number(property.decimals)
@@ -288,6 +309,61 @@ export function formatPercentValue(value: number, decimals: number): string {
   } catch {
     return `${value.toFixed(decimals)}%`
   }
+}
+
+// ---------------------------------------------------------------------------
+// Duration (时长) format / parse pair — seconds-backed, format-aware.
+// The codec stores SECONDS; these convert between seconds and the displayed
+// "h:mm" / "mm:ss" text. Behaviour is defined explicitly (and locked by tests):
+//   - format truncates sub-unit seconds (h:mm drops leftover seconds; never rounds up)
+//   - the leading unit (hours for h:mm, minutes for mm:ss) is UNBOUNDED ("25:30", "90:00")
+//   - the trailing unit is zero-padded to 2 digits
+//   - parse accepts "H:MM" / "M:SS" (trailing part normalized: ≥60 carries over) and a
+//     bare number (interpreted as the LEADING unit, e.g. "2" in h:mm → 2h = 7200s)
+//   - parse returns null for empty/invalid input; negatives are rejected (null)
+// ---------------------------------------------------------------------------
+
+/** Format an integer number of seconds as "h:mm" or "mm:ss" (leading unit unbounded). */
+export function formatDurationValue(totalSeconds: number, format: DurationFormat): string {
+  if (!Number.isFinite(totalSeconds)) return ''
+  const sign = totalSeconds < 0 ? '-' : ''
+  const abs = Math.trunc(Math.abs(totalSeconds))
+  if (format === 'mm:ss') {
+    const minutes = Math.trunc(abs / 60)
+    const seconds = abs % 60
+    return `${sign}${minutes}:${String(seconds).padStart(2, '0')}`
+  }
+  // h:mm — drop leftover seconds (truncate to the whole minute).
+  const totalMinutes = Math.trunc(abs / 60)
+  const hours = Math.trunc(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${sign}${hours}:${String(minutes).padStart(2, '0')}`
+}
+
+/**
+ * Parse a "h:mm" / "mm:ss" (or bare-number) string into an integer number of
+ * seconds. Returns null on empty/invalid/negative input. The caller emits this
+ * number to the server (the server never parses formatted strings).
+ */
+export function durationSecondsFromInput(input: string, format: DurationFormat): number | null {
+  const trimmed = input.trim()
+  if (trimmed === '') return null
+  if (trimmed.startsWith('-')) return null
+  const secondsPerLeadingUnit = format === 'mm:ss' ? 60 : 3600
+  // Bare number → leading unit (hours for h:mm, minutes for mm:ss).
+  if (/^\d+$/.test(trimmed)) {
+    const lead = Number(trimmed)
+    return Number.isFinite(lead) ? lead * secondsPerLeadingUnit : null
+  }
+  const match = /^(\d+):(\d+)$/.exec(trimmed)
+  if (!match) return null
+  const lead = Number(match[1])
+  const trail = Number(match[2])
+  if (!Number.isFinite(lead) || !Number.isFinite(trail)) return null
+  // The trailing unit is sub-60 (minutes-in-hour, or seconds-in-minute); a value
+  // ≥60 carries over into the leading unit instead of being rejected (lenient).
+  const trailSeconds = format === 'mm:ss' ? trail : trail * 60
+  return lead * secondsPerLeadingUnit + trailSeconds
 }
 
 function splitFixedNumber(value: number, decimals: number | null): { sign: string; integer: string; fraction: string } {

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -1,10 +1,12 @@
 import type { LinkedRecordSummary, MetaAttachment, MetaField, PersonSummary } from '../types'
 import {
   formatCurrencyValue,
+  formatDurationValue,
   formatNumberValue,
   formatPercentValue,
   resolveAutoNumberFieldProperty,
   resolveCurrencyFieldProperty,
+  resolveDurationFieldProperty,
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
 } from './field-config'
@@ -154,6 +156,13 @@ export function formatFieldDisplay(params: {
     const { max } = resolveRatingFieldProperty(field.property)
     const filled = Math.max(0, Math.min(max, Math.round(num)))
     return `${'★'.repeat(filled)}${'☆'.repeat(max - filled)}`
+  }
+
+  if (field.type === 'duration') {
+    const num = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(num)) return String(value)
+    const { durationFormat } = resolveDurationFieldProperty(field.property)
+    return formatDurationValue(num, durationFormat)
   }
 
   if (field.type === 'location') {

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -335,6 +335,7 @@ const FIELD_TYPE_LABELS: Record<string, { en: string; zh: string }> = {
   currency: { en: 'currency', zh: '货币' },
   percent: { en: 'percent', zh: '百分比' },
   rating: { en: 'rating', zh: '评分' },
+  duration: { en: 'duration', zh: '时长' },
   url: { en: 'URL', zh: '网址' },
   email: { en: 'email', zh: '邮箱' },
   phone: { en: 'phone', zh: '电话' },

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -66,6 +66,7 @@ export type MetaManagerLabelKey =
   | 'field.decimals' | 'field.preserve' | 'field.unit'
   | 'field.useThousandsSeparators' | 'field.currencyCode'
   | 'field.maxRating' | 'field.prefix' | 'field.digits' | 'field.startAt'
+  | 'field.durationFormat' | 'field.durationFormatHmm' | 'field.durationFormatMmss'
   | 'field.buttonLabelText' | 'field.buttonVariant' | 'field.buttonVariantPrimary' | 'field.buttonVariantSecondary' | 'field.buttonVariantDanger'
   | 'field.buttonActionType' | 'field.buttonActionRecordClick' | 'field.buttonConfirmEnable' | 'field.buttonConfirmMessage' | 'field.buttonConfirmHint'
   | 'field.autoNumberHint' | 'field.saveSettings' | 'field.applyDefaults'
@@ -311,6 +312,9 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.useThousandsSeparators': { en: 'Use thousands separators', zh: '使用千位分隔符' },
   'field.currencyCode': { en: 'Currency code (ISO 4217)', zh: '货币代码（ISO 4217）' },
   'field.maxRating': { en: 'Maximum rating (1-10)', zh: '最高评分（1-10）' },
+  'field.durationFormat': { en: 'Display format', zh: '显示格式' },
+  'field.durationFormatHmm': { en: 'Hours:minutes (h:mm)', zh: '时:分（h:mm）' },
+  'field.durationFormatMmss': { en: 'Minutes:seconds (mm:ss)', zh: '分:秒（mm:ss）' },
   'field.buttonLabelText': { en: 'Button label', zh: '按钮文字' },
   'field.buttonVariant': { en: 'Style', zh: '样式' },
   'field.buttonVariantPrimary': { en: 'Primary', zh: '主要' },

--- a/apps/web/tests/multitable-duration-field.spec.ts
+++ b/apps/web/tests/multitable-duration-field.spec.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import MetaFormView from '../src/multitable/components/MetaFormView.vue'
+import {
+  DEFAULT_DURATION_FORMAT,
+  DURATION_FORMATS,
+  durationSecondsFromInput,
+  formatDurationValue,
+  resolveDurationFieldProperty,
+} from '../src/multitable/utils/field-config'
+import { formatFieldDisplay } from '../src/multitable/utils/field-display'
+
+async function flushUi(cycles = 3) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('duration field — format/parse helpers (seconds-backed)', () => {
+  it('exposes the two supported formats with h:mm default', () => {
+    expect(DURATION_FORMATS).toEqual(['h:mm', 'mm:ss'])
+    expect(DEFAULT_DURATION_FORMAT).toBe('h:mm')
+  })
+
+  it('resolveDurationFieldProperty clamps junk to the default format', () => {
+    expect(resolveDurationFieldProperty({ durationFormat: 'mm:ss' }).durationFormat).toBe('mm:ss')
+    expect(resolveDurationFieldProperty({ durationFormat: 'h:mm:ss' }).durationFormat).toBe('h:mm')
+    expect(resolveDurationFieldProperty({}).durationFormat).toBe('h:mm')
+    expect(resolveDurationFieldProperty(undefined).durationFormat).toBe('h:mm')
+  })
+
+  it('formats h:mm — truncates leftover seconds, unbounded hours, zero-padded minutes', () => {
+    expect(formatDurationValue(5400, 'h:mm')).toBe('1:30')
+    expect(formatDurationValue(5430, 'h:mm')).toBe('1:30') // leftover 30s truncated, never rounded up
+    expect(formatDurationValue(0, 'h:mm')).toBe('0:00')
+    expect(formatDurationValue(540, 'h:mm')).toBe('0:09') // 9 minutes → zero-padded
+    expect(formatDurationValue(91 * 3600, 'h:mm')).toBe('91:00') // hours unbounded
+  })
+
+  it('formats mm:ss — unbounded minutes, zero-padded seconds', () => {
+    expect(formatDurationValue(90, 'mm:ss')).toBe('1:30')
+    expect(formatDurationValue(5, 'mm:ss')).toBe('0:05')
+    expect(formatDurationValue(5400, 'mm:ss')).toBe('90:00') // 90 minutes, minutes unbounded
+  })
+
+  it('parses h:mm to seconds (round-trip with format)', () => {
+    expect(durationSecondsFromInput('1:30', 'h:mm')).toBe(5400)
+    expect(durationSecondsFromInput('0:09', 'h:mm')).toBe(540)
+    expect(durationSecondsFromInput('25:30', 'h:mm')).toBe(25 * 3600 + 30 * 60)
+  })
+
+  it('parses mm:ss to seconds', () => {
+    expect(durationSecondsFromInput('1:30', 'mm:ss')).toBe(90)
+    expect(durationSecondsFromInput('90:00', 'mm:ss')).toBe(5400)
+  })
+
+  it('treats a bare number as the leading unit', () => {
+    expect(durationSecondsFromInput('2', 'h:mm')).toBe(7200) // 2 hours
+    expect(durationSecondsFromInput('2', 'mm:ss')).toBe(120) // 2 minutes
+  })
+
+  it('carries over a trailing value >= 60 (lenient) rather than rejecting it', () => {
+    expect(durationSecondsFromInput('1:90', 'h:mm')).toBe(3600 + 90 * 60)
+    expect(durationSecondsFromInput('0:75', 'mm:ss')).toBe(75)
+  })
+
+  it('returns null for empty, negative, or invalid input', () => {
+    expect(durationSecondsFromInput('', 'h:mm')).toBeNull()
+    expect(durationSecondsFromInput('   ', 'h:mm')).toBeNull()
+    expect(durationSecondsFromInput('-1:30', 'h:mm')).toBeNull()
+    expect(durationSecondsFromInput('abc', 'h:mm')).toBeNull()
+    expect(durationSecondsFromInput('1:2:3', 'h:mm')).toBeNull()
+  })
+})
+
+describe('duration field — display formatting', () => {
+  it('formatFieldDisplay renders seconds in the field format', () => {
+    expect(formatFieldDisplay({
+      field: { id: 'fld_dur', name: 'Spent', type: 'duration', property: { durationFormat: 'h:mm' } },
+      value: 5400,
+    })).toBe('1:30')
+    expect(formatFieldDisplay({
+      field: { id: 'fld_dur', name: 'Lap', type: 'duration', property: { durationFormat: 'mm:ss' } },
+      value: 90,
+    })).toBe('1:30')
+  })
+
+  it('formatFieldDisplay defaults to h:mm when format property is absent', () => {
+    expect(formatFieldDisplay({
+      field: { id: 'fld_dur', name: 'Spent', type: 'duration', property: {} },
+      value: 3661,
+    })).toBe('1:01')
+  })
+
+  it('renders a duration cell as formatted text', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      render() {
+        return h(MetaCellRenderer, {
+          field: { id: 'fld_dur', name: 'Spent', type: 'duration', property: { durationFormat: 'h:mm' } },
+          value: 5400,
+        })
+      },
+    })
+    app.mount(container)
+    await flushUi()
+    expect(container.textContent).toContain('1:30')
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('duration field — cell editor parses to seconds', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('emits parsed seconds (type 1:30 → 5400) and confirms on Enter', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+    const confirmSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_dur', name: 'Spent', type: 'duration', property: { durationFormat: 'h:mm' } },
+          modelValue: null,
+          'onUpdate:modelValue': updateSpy,
+          onConfirm: confirmSpy,
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+          onOpenPersonPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement | null
+    expect(input).not.toBeNull()
+    input!.value = '1:30'
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+
+    expect(updateSpy).toHaveBeenCalledWith(5400)
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('seeds the input buffer from an existing seconds value', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_dur', name: 'Spent', type: 'duration', property: { durationFormat: 'mm:ss' } },
+          modelValue: 90,
+          'onUpdate:modelValue': vi.fn(),
+          onConfirm: vi.fn(),
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+          onOpenPersonPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement | null
+    expect(input).not.toBeNull()
+    expect(input!.value).toBe('1:30')
+
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('duration field — field manager create + reopen', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('creates a duration field with the chosen durationFormat property', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const createSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    expect(Array.from(typeSelect.options).map((option) => option.value)).toContain('duration')
+
+    nameInput.value = 'Time spent'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'duration'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const formatSelect = container.querySelector('.meta-field-mgr__config .meta-field-mgr__select') as HTMLSelectElement
+    expect(formatSelect).not.toBeNull()
+    formatSelect.value = 'mm:ss'
+    formatSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await flushUi()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Time spent',
+      type: 'duration',
+      property: { durationFormat: 'mm:ss' },
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('reopening an existing duration field hydrates the stored format', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_dur', name: 'Lap', type: 'duration', property: { durationFormat: 'mm:ss' } },
+          ],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await flushUi()
+
+    const formatSelect = container.querySelector('.meta-field-mgr__config .meta-field-mgr__select') as HTMLSelectElement
+    expect(formatSelect).not.toBeNull()
+    expect(formatSelect.value).toBe('mm:ss')
+
+    app.unmount()
+    container.remove()
+  })
+})
+
+describe('duration field — form view submits seconds', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('parses h:mm text into seconds on change', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const submitSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFormView, {
+          fields: [{ id: 'fld_dur', name: 'Spent', type: 'duration', property: { durationFormat: 'h:mm' } }],
+          record: { id: 'rec_1', version: 1, data: { fld_dur: null } },
+          loading: false,
+          readOnly: false,
+          onSubmit: submitSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement | null
+    expect(input).not.toBeNull()
+    input!.value = '2:15'
+    input!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const form = container.querySelector('form') as HTMLFormElement | null
+    form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    await flushUi()
+
+    expect(submitSpy).toHaveBeenCalledTimes(1)
+    const submitted = submitSpy.mock.calls[0][0] as Record<string, unknown>
+    expect(submitted.fld_dur).toBe(2 * 3600 + 15 * 60)
+
+    app.unmount()
+    container.remove()
+  })
+})

--- a/packages/core-backend/src/multitable/aggregation-helpers.ts
+++ b/packages/core-backend/src/multitable/aggregation-helpers.ts
@@ -10,7 +10,8 @@ export type AggregationFn = 'sum' | 'avg' | 'min' | 'max' | 'count' | 'countNonE
 
 const FN_SET: ReadonlySet<string> = new Set<AggregationFn>(['sum', 'avg', 'min', 'max', 'count', 'countNonEmpty', 'countDistinct'])
 // Numeric field types (only these accept sum/avg/min/max).
-const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'autoNumber'])
+// `duration` is seconds-backed → numeric, so sum/avg over seconds works (raw-seconds result, v1).
+const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
 const NUMERIC_ONLY_FNS: ReadonlySet<AggregationFn> = new Set<AggregationFn>(['sum', 'avg', 'min', 'max'])
 
 export function isNumericFieldType(type: string): boolean {

--- a/packages/core-backend/src/multitable/automation-conditions.ts
+++ b/packages/core-backend/src/multitable/automation-conditions.ts
@@ -265,6 +265,7 @@ function allowedOperatorsForFieldType(fieldType: string): ReadonlySet<ConditionO
     case 'currency':
     case 'percent':
     case 'rating':
+    case 'duration':
     case 'date':
     case 'dateTime':
     case 'createdTime':
@@ -296,6 +297,7 @@ function expectedValueKindForFieldType(fieldType: string): 'number' | 'boolean' 
     case 'currency':
     case 'percent':
     case 'rating':
+    case 'duration':
     case 'autoNumber':
       return 'number'
     case 'boolean':

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -20,6 +20,7 @@ export type MultitableFieldType =
   | 'currency'
   | 'percent'
   | 'rating'
+  | 'duration'
   | 'url'
   | 'email'
   | 'phone'
@@ -119,6 +120,9 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'currency') return 'currency'
   if (normalized === 'percent') return 'percent'
   if (normalized === 'rating') return 'rating'
+  // Native duration field (时长, design 2026-06-16): seconds-backed number, rendered as
+  // h:mm or mm:ss (durationFormat property). First-class union member like percent/rating.
+  if (normalized === 'duration') return 'duration'
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
@@ -415,6 +419,13 @@ function sanitizeFieldPropertyByType(
     return { ...obj, max }
   }
 
+  if (type === 'duration') {
+    // `durationFormat` chooses how the seconds-backed value renders. Enum-strict
+    // (clamp junk → default 'h:mm'), mirroring the rating `max` clamp. The stored
+    // VALUE is always seconds (a number); the format is presentation-only.
+    return { ...obj, durationFormat: normalizeDurationFormat(obj.durationFormat) }
+  }
+
   if (type === 'dateTime') {
     const rawTimezone = typeof obj.timezone === 'string' ? obj.timezone.trim() : ''
     let timezone = rawTimezone || 'UTC'
@@ -556,6 +567,39 @@ export function coerceRatingValue(
   }
   if (num < 0 || num > max) {
     throw new Error(`Rating value must be between 0 and ${max} for ${fieldId}`)
+  }
+  return num
+}
+
+// Native duration (时长) — supported display formats. The VALUE is always seconds;
+// these only pick how it renders (h:mm vs mm:ss). h:mm:ss is intentionally deferred (v1).
+export const DURATION_FORMATS = ['h:mm', 'mm:ss'] as const
+export type DurationFormat = (typeof DURATION_FORMATS)[number]
+export const DEFAULT_DURATION_FORMAT: DurationFormat = 'h:mm'
+
+/** Clamp an arbitrary `durationFormat` to the enum, defaulting to 'h:mm'. */
+export function normalizeDurationFormat(value: unknown): DurationFormat {
+  return typeof value === 'string' && (DURATION_FORMATS as readonly string[]).includes(value)
+    ? (value as DurationFormat)
+    : DEFAULT_DURATION_FORMAT
+}
+
+/**
+ * Coerce / validate a duration value. The stored value is an INTEGER number of
+ * SECONDS (matching Feishu/Airtable). The server NEVER parses a formatted "h:mm"
+ * string — the FE editor parses to seconds before sending — so a non-numeric
+ * string (e.g. "1:30") is rejected, while a numeric string ("5400") is accepted
+ * (consistent with every other numeric coerce). Negative / non-integer rejected.
+ */
+export function coerceDurationValue(value: unknown, fieldId: string): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const num = coerceNumericValue(value, fieldId, 'Duration')
+  if (num === null) return null
+  if (!Number.isInteger(num)) {
+    throw new Error(`Duration value must be an integer number of seconds for ${fieldId}`)
+  }
+  if (num < 0) {
+    throw new Error(`Duration value must not be negative for ${fieldId}`)
   }
   return num
 }
@@ -1022,6 +1066,7 @@ export function coerceBatch1Value(
     const max = Number(sanitized.max)
     return coerceRatingValue(value, fieldId, Number.isFinite(max) && max > 0 ? max : 5)
   }
+  if (fieldType === 'duration') return coerceDurationValue(value, fieldId)
   if (fieldType === 'url') return validateUrlValue(value, fieldId)
   if (fieldType === 'email') return validateEmailValue(value, fieldId)
   if (fieldType === 'phone') return validatePhoneValue(value, fieldId)
@@ -1036,6 +1081,7 @@ export const BATCH1_FIELD_TYPES: ReadonlySet<string> = new Set([
   'currency',
   'percent',
   'rating',
+  'duration',
   'url',
   'email',
   'phone',

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -39,7 +39,8 @@ const EXCEL_ERROR_SENTINELS: ReadonlySet<string> = new Set([
   '#ERROR!', '#DIV/0!', '#N/A', '#VALUE!', '#NAME?', '#NUM!', '#REF!', '#NULL!',
 ])
 // Field types that hold numeric values (for the type-mismatch warning).
-const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'autoNumber'])
+// `duration` is seconds-backed → numeric, same as percent/rating.
+const NUMERIC_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
 
 /**
  * Best-effort detector for spreadsheet A1/cell and A1:B3 range references, which dry-run does NOT

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -254,6 +254,10 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'currency') return 'currency'
   if (normalized === 'percent') return 'percent'
   if (normalized === 'rating') return 'rating'
+  // Native duration (时长, design 2026-06-16): seconds-backed number. This dup mapFieldType
+  // has NO registry fallback (returns 'string'), so duration needs an explicit branch here or
+  // the runtime read path would silently downgrade it to text. Mirrors the percent/rating lines.
+  if (normalized === 'duration') return 'duration'
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -71,6 +71,7 @@ export type UniverMetaField = {
     | 'currency'
     | 'percent'
     | 'rating'
+    | 'duration'
     | 'url'
     | 'email'
     | 'phone'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -246,6 +246,7 @@ const MULTITABLE_FIELD_TYPES = [
   'currency',
   'percent',
   'rating',
+  'duration',
   'url',
   'email',
   'phone',
@@ -287,6 +288,7 @@ type UniverMetaField = {
     | 'currency'
     | 'percent'
     | 'rating'
+    | 'duration'
     | 'url'
     | 'email'
     | 'phone'
@@ -1803,7 +1805,8 @@ function parseMetaSortRules(sortInfo: unknown): MetaSortRule[] {
  * See docs/development/multitable-typed-query-polish-design-20260603.md.
  */
 export function isNumericQueryFieldType(type: string): boolean {
-  return type === 'number' || type === 'currency' || type === 'percent' || type === 'rating'
+  // `duration` is a seconds-backed number → sorts/range-filters as a JS number, same as percent/rating.
+  return type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'duration'
 }
 
 export function compareMetaSortValue(type: UniverMetaField['type'], valueA: unknown, valueB: unknown, desc: boolean): number {

--- a/packages/core-backend/tests/unit/aggregation-helpers.test.ts
+++ b/packages/core-backend/tests/unit/aggregation-helpers.test.ts
@@ -17,6 +17,11 @@ describe('aggregateField (locked fns)', () => {
   it('sum on a non-numeric field type is not applicable → null (caller omits)', () => {
     expect(aggregateField(['a', 'b'], 'sum', 'string')).toBeNull()
   })
+  it('duration sum/avg aggregate over raw seconds (scatter guard — v1 shows seconds)', () => {
+    // 1h(3600) + 30m(1800) + 10m(600) = 6000s total; avg 2000s.
+    expect(aggregateField([3600, 1800, 600], 'sum', 'duration')).toBe(6000)
+    expect(aggregateField([3600, 1800, 600], 'avg', 'duration')).toBe(2000)
+  })
   it('countNonEmpty treats null/undefined/""/[] as empty', () => {
     expect(aggregateField(['x', '', null, undefined, [], 'y'], 'countNonEmpty', 'string')).toBe(2)
   })
@@ -63,5 +68,7 @@ describe('button field — aggregation exclusion (B1-a0)', () => {
     // sanity: the numeric allowlist still includes the real numeric types
     expect(isNumericFieldType('number')).toBe(true)
     expect(isNumericFieldType('currency')).toBe(true)
+    // duration is seconds-backed → numeric (scatter guard for aggregation-helpers set)
+    expect(isNumericFieldType('duration')).toBe(true)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -18,8 +18,12 @@ import {
   URL_REGEX,
   coerceBatch1Value,
   coerceCurrencyValue,
+  coerceDurationValue,
   coercePercentValue,
   coerceRatingValue,
+  DEFAULT_DURATION_FORMAT,
+  DURATION_FORMATS,
+  normalizeDurationFormat,
   mapFieldType,
   normalizeMultiSelectValue,
   sanitizeFieldProperty,
@@ -39,6 +43,7 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('currency')).toBe('currency')
     expect(mapFieldType('percent')).toBe('percent')
     expect(mapFieldType('rating')).toBe('rating')
+    expect(mapFieldType('duration')).toBe('duration')
     expect(mapFieldType('url')).toBe('url')
     expect(mapFieldType('email')).toBe('email')
     expect(mapFieldType('phone')).toBe('phone')
@@ -99,7 +104,7 @@ describe('mapFieldType — MF2 batch-1', () => {
 
   it('exposes BATCH1_FIELD_TYPES set with normalized runtime types', () => {
     expect(Array.from(BATCH1_FIELD_TYPES).sort()).toEqual([
-      'barcode', 'currency', 'dateTime', 'email', 'location', 'percent', 'phone', 'qrcode', 'rating', 'url',
+      'barcode', 'currency', 'dateTime', 'duration', 'email', 'location', 'percent', 'phone', 'qrcode', 'rating', 'url',
     ])
   })
 })
@@ -189,6 +194,64 @@ describe('sanitizeFieldProperty — rating', () => {
     expect(sanitizeFieldProperty('rating', { max: 0 })).toEqual({ max: 5 })
     expect(sanitizeFieldProperty('rating', { max: 99 })).toEqual({ max: 5 })
     expect(sanitizeFieldProperty('rating', { max: 'bad' })).toEqual({ max: 5 })
+  })
+})
+
+describe('sanitizeFieldProperty — duration', () => {
+  it('round-trips the two supported formats', () => {
+    expect(sanitizeFieldProperty('duration', { durationFormat: 'h:mm' })).toEqual({ durationFormat: 'h:mm' })
+    expect(sanitizeFieldProperty('duration', { durationFormat: 'mm:ss' })).toEqual({ durationFormat: 'mm:ss' })
+  })
+
+  it('defaults to h:mm on missing or invalid format', () => {
+    expect(sanitizeFieldProperty('duration', {})).toEqual({ durationFormat: 'h:mm' })
+    expect(sanitizeFieldProperty('duration', { durationFormat: 'h:mm:ss' })).toEqual({ durationFormat: 'h:mm' })
+    expect(sanitizeFieldProperty('duration', { durationFormat: 42 })).toEqual({ durationFormat: 'h:mm' })
+  })
+
+  it('normalizeDurationFormat clamps junk to the default', () => {
+    expect(normalizeDurationFormat('mm:ss')).toBe('mm:ss')
+    expect(normalizeDurationFormat('bogus')).toBe(DEFAULT_DURATION_FORMAT)
+    expect(normalizeDurationFormat(undefined)).toBe('h:mm')
+    expect(DURATION_FORMATS).toEqual(['h:mm', 'mm:ss'])
+  })
+
+  it('serializeFieldRow keeps type + format through a round-trip', () => {
+    const row = serializeFieldRow({ id: 'f1', name: 'Spent', type: 'duration', property: { durationFormat: 'mm:ss' }, order: 3 })
+    expect(row.type).toBe('duration')
+    expect(row.property).toEqual({ durationFormat: 'mm:ss' })
+    expect(row.order).toBe(3)
+  })
+})
+
+describe('coerceDurationValue — seconds-backed, reject formatted strings', () => {
+  it('accepts a non-negative integer number of seconds', () => {
+    expect(coerceDurationValue(5400, 'f1')).toBe(5400)
+    expect(coerceDurationValue(0, 'f1')).toBe(0)
+  })
+
+  it('accepts a NUMERIC string (server never parses h:mm, but "5400" is a number)', () => {
+    expect(coerceDurationValue('5400', 'f1')).toBe(5400)
+  })
+
+  it('returns null for empty input', () => {
+    expect(coerceDurationValue('', 'f1')).toBeNull()
+    expect(coerceDurationValue(null, 'f1')).toBeNull()
+    expect(coerceDurationValue(undefined, 'f1')).toBeNull()
+  })
+
+  it('rejects a FORMATTED "h:mm" string (the server must receive seconds)', () => {
+    expect(() => coerceDurationValue('1:30', 'f1')).toThrow()
+  })
+
+  it('rejects negative and non-integer seconds', () => {
+    expect(() => coerceDurationValue(-1, 'f1')).toThrow()
+    expect(() => coerceDurationValue(1.5, 'f1')).toThrow()
+  })
+
+  it('coerceBatch1Value dispatches duration to the seconds coercer', () => {
+    expect(coerceBatch1Value('duration', { durationFormat: 'h:mm' }, 'f1', 5400)).toBe(5400)
+    expect(() => coerceBatch1Value('duration', { durationFormat: 'h:mm' }, 'f1', '1:30')).toThrow()
   })
 })
 

--- a/packages/core-backend/tests/unit/multitable-typed-query-numeric.test.ts
+++ b/packages/core-backend/tests/unit/multitable-typed-query-numeric.test.ts
@@ -19,8 +19,8 @@ const cond = (operator: string, value?: unknown) => ({ fieldId: 'f', operator, v
 const sortAsc = (type: any, arr: unknown[]) => [...arr].sort((a, b) => compareMetaSortValue(type, a, b, false))
 
 describe('isNumericQueryFieldType', () => {
-  it('is true for number/currency/percent/rating', () => {
-    for (const t of ['number', 'currency', 'percent', 'rating']) {
+  it('is true for number/currency/percent/rating/duration', () => {
+    for (const t of ['number', 'currency', 'percent', 'rating', 'duration']) {
       expect(isNumericQueryFieldType(t)).toBe(true)
     }
   })
@@ -49,6 +49,10 @@ describe('compareMetaSortValue — numeric reclassification', () => {
   })
   it('rating sorts numerically (was already fine for integers; still correct)', () => {
     expect(sortAsc('rating', [3, 1, 5, 2])).toEqual([1, 2, 3, 5])
+  })
+  it('duration sorts by its seconds value (scatter guard — numeric, not lexicographic)', () => {
+    // 600s(10m) < 5400s(1h30) < 90000s(25h) — lexicographic would give 5400, 600, 90000.
+    expect(sortAsc('duration', [5400, 600, 90000])).toEqual([600, 5400, 90000])
   })
   it('currency tolerates string-stored numbers (legacy/mixed storage)', () => {
     expect(compareMetaSortValue('currency', '12.5', 2, false)).toBeGreaterThan(0) // 12.5 after 2
@@ -89,6 +93,11 @@ describe('evaluateMetaFilterCondition — numeric reclassification', () => {
   it('percent range ops compare numerically', () => {
     expect(evaluateMetaFilterCondition('percent', 0.5, cond('greater', 0.25))).toBe(true)
     expect(evaluateMetaFilterCondition('percent', 0.05, cond('greater', 0.25))).toBe(false)
+  })
+  it('duration range ops compare on raw seconds (scatter guard)', () => {
+    expect(evaluateMetaFilterCondition('duration', 5400, cond('greaterEqual', 3600))).toBe(true)
+    expect(evaluateMetaFilterCondition('duration', 600, cond('greaterEqual', 3600))).toBe(false)
+    expect(evaluateMetaFilterCondition('duration', 3600, cond('less', 3600))).toBe(false)
   })
   it('isEmpty/isNotEmpty unchanged for numeric types', () => {
     expect(evaluateMetaFilterCondition('currency', null, cond('isEmpty'))).toBe(true)

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2234,6 +2234,7 @@ components:
         - currency
         - percent
         - rating
+        - duration
         - url
         - email
         - phone

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3119,6 +3119,7 @@
           "currency",
           "percent",
           "rating",
+          "duration",
           "url",
           "email",
           "phone",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2234,6 +2234,7 @@ components:
         - currency
         - percent
         - rating
+        - duration
         - url
         - email
         - phone

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2051,6 +2051,7 @@ components:
         - currency
         - percent
         - rating
+        - duration
         - url
         - email
         - phone


### PR DESCRIPTION
## Duration field type
Native `duration` field (seconds-backed; h:mm / mm:ss formats) following the rating/percent precedent: `MetaFieldType` union + codec branch + formatted renderer + editor + field-manager config. Distinct from `number`.

Tests: backend unit (codec round-trip) + FE 17/17 (render formatting + editor parse). vue-tsc + backend tsc clean. Typed i18n, no dead keys.

Built + adversarially reviewed by subagents (verdict: ship). Final autonomous polish wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)