### PR TITLE
feat(multitable): duplicate/clone record (permission-masked copy)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1409,6 +1409,18 @@ export class MultitableApiClient {
     return this.parseJson(res)
   }
 
+  // Duplicate / clone a record (design 2026-06-16): the server reads the source row, copies the field values
+  // the actor can both read AND write into a NEW row, and returns the masked echo of the clone. `sheetId` /
+  // `viewId` give the server the context to resolve the source sheet (parity with create/lock).
+  async duplicateRecord(recordId: string, params?: { sheetId?: string; viewId?: string }): Promise<{ record: MetaRecord }> {
+    const res = await this.fetch(`/api/multitable/records/${recordId}/duplicate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(params ?? {}),
+    })
+    return this.parseJson(res)
+  }
+
   // Record locking (design #2278 follow-up): { locked: true } locks, { locked: false } unlocks.
   async setRecordLock(
     recordId: string,

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -50,6 +50,7 @@
                 :class="{ 'meta-grid__row--selected': row.id === selectedRecordId, 'meta-grid__row--focused': focusRow === flatIndex(group, ri) }"
                 :style="rowStyle(row.id)"
                 @click="emit('select-record', row.id)"
+                @contextmenu="onRowContextMenu($event, row.id)"
               >
                 <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
                   <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
@@ -162,6 +163,7 @@
               :class="{ 'meta-grid__row--selected': row.id === selectedRecordId, 'meta-grid__row--focused': focusRow === ri }"
               :style="rowStyle(row.id)"
               @click="emit('select-record', row.id)"
+              @contextmenu="onRowContextMenu($event, row.id)"
             >
               <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
                 <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
@@ -460,6 +462,9 @@ const emit = defineEmits<{
   (e: 'selection-change', recordIds: string[]): void
   (e: 'bulk-delete', recordIds: string[]): void
   (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
+  // Duplicate / clone record (design 2026-06-16): right-click a row → request a duplicate. The native
+  // context menu is suppressed so the row affordance is the menu; the workbench owns the create + clone-open.
+  (e: 'duplicate-record', recordId: string): void
   (e: 'reorder-field', fromFieldId: string, toFieldId: string): void
   (e: 'create-record'): void
   (e: 'set-frozen', frozenLeftColumnIds: string[]): void
@@ -610,6 +615,16 @@ function resolveRowActions(recordId: string): MetaRowActions {
     canDelete: props.canDelete !== false,
     canComment: props.canComment !== false,
   }
+}
+
+// Duplicate / clone record (design 2026-06-16): right-click a row → emit a duplicate request. Net-new grid
+// context affordance — no floating menu component, just the native contextmenu suppressed when actionable.
+// Gated on `canCreate` (a duplicate is a create; the server re-enforces it). NOT active while a cell is being
+// edited, so the native menu (copy/paste) still works inside the cell editor.
+function onRowContextMenu(e: MouseEvent, recordId: string): void {
+  if (!props.canCreate || editCell.value) return
+  e.preventDefault()
+  emit('duplicate-record', recordId)
 }
 // Record-locking (design #2278 follow-up): index rows so the lock indicator + lock/unlock action +
 // read-only-while-locked visual can resolve a row's lock state by id without scanning.

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -31,6 +31,7 @@
         </button>
         <button v-if="canManageAutomation" class="meta-record-drawer__btn" :title="l('record.workflowTitle')" @click="emit('open-automation')">&#x2699; {{ l('record.workflow') }}</button>
         <button v-if="canManageRecordPermissions" class="meta-record-drawer__btn" :title="l('record.permissionsTitle')" @click="showRecordPermissions = true">&#x1F512; {{ l('record.permissions') }}</button>
+        <button v-if="record && canCreate" class="meta-record-drawer__btn meta-record-drawer__btn--duplicate" :title="l('record.duplicateTitle')" type="button" @click="emit('duplicate')">{{ l('record.duplicate') }}</button>
         <button v-if="resolvedCanDelete" class="meta-record-drawer__btn meta-record-drawer__btn--danger" @click="emit('delete')">{{ l('record.delete') }}</button>
         <button class="meta-record-drawer__close" :aria-label="l('record.close')" @click="emit('close')">&times;</button>
       </div>
@@ -441,6 +442,9 @@ const props = withDefaults(defineProps<{
   canEdit: boolean
   canComment: boolean
   canDelete: boolean
+  // Duplicate / clone record (design 2026-06-16): sheet-level canCreateRecord (a duplicate is a create).
+  // Gates the drawer's Duplicate button; the server re-enforces it (no FE permission mirror).
+  canCreate?: boolean
   canManageAutomation?: boolean
   fieldPermissions?: Record<string, MetaFieldPermission> | null
   rowActions?: MetaRowActions | null
@@ -471,6 +475,7 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
   (e: 'delete'): void
+  (e: 'duplicate'): void
   (e: 'patch', fieldId: string, value: unknown): void
   (e: 'toggle-lock', payload: { recordId: string; locked: boolean }): void
   (e: 'toggle-comments'): void

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -657,6 +657,29 @@ export function useMultitableGrid(opts: {
     }
   }
 
+  // Duplicate / clone a record (design 2026-06-16). The server owns the value-copy + field-mask (a field is
+  // copied iff the actor can read AND write it) — there is intentionally NO front-end permission mirror.
+  // Returns the NEW record id on success (so the caller can open/select the clone), or null on failure with
+  // `error` set; mirrors the create/delete catch shape.
+  async function duplicateRecord(recordId: string): Promise<string | null> {
+    error.value = null
+    const context = resolveCreateRecordContext({
+      sheetId: opts.sheetId.value,
+      viewId: opts.viewId.value,
+    })
+    try {
+      const { record } = await client.duplicateRecord(recordId, {
+        sheetId: context.sheetId,
+        viewId: context.viewId,
+      })
+      await loadViewData(page.value.offset)
+      return record?.id ?? null
+    } catch (e: any) {
+      error.value = e.message ?? fallback('grid.errorDuplicateRecord')
+      return null
+    }
+  }
+
   async function deleteRecord(recordId: string): Promise<boolean> {
     error.value = null
     if (resolveRowActions(recordId)?.canDelete === false) return rejectRowDelete()
@@ -1020,7 +1043,7 @@ export function useMultitableGrid(opts: {
     addSortRule, removeSortRule,
     addFilterRule, updateFilterRule, removeFilterRule, clearFilters,
     applySortFilter,
-    createRecord, deleteRecord, patchCell, bulkPatch,
+    createRecord, duplicateRecord, deleteRecord, patchCell, bulkPatch,
     // A3: exposed as the single echo-application seam for the AI shortcut
     // run adapter (useAiShortcut synthesizes a PatchResult and feeds it here).
     applyPatchResult,

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -69,7 +69,7 @@ export type MetaCoreLabelKey =
   | 'grid.errorLoadViewData'
   | 'grid.errorEditRowBlocked' | 'grid.errorDeleteRowBlocked'
   | 'grid.errorContextRequired'
-  | 'grid.errorCreateRecord' | 'grid.errorDeleteRecord'
+  | 'grid.errorCreateRecord' | 'grid.errorDeleteRecord' | 'grid.errorDuplicateRecord'
   | 'grid.errorCellUpdatedElsewhere' | 'grid.errorPatchCell'
   | 'grid.errorRecordVersionUnavailable' | 'grid.errorPatchFailed'
   // --- MetaCellEditor static (T3A2) ---
@@ -212,6 +212,7 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.errorContextRequired': { en: 'sheetId or viewId is required', zh: '需要 sheetId 或 viewId' },
   'grid.errorCreateRecord': { en: 'Failed to create record', zh: '创建记录失败' },
   'grid.errorDeleteRecord': { en: 'Failed to delete record', zh: '删除记录失败' },
+  'grid.errorDuplicateRecord': { en: 'Failed to duplicate record', zh: '复制记录失败' },
   'grid.errorCellUpdatedElsewhere': {
     en: 'This cell was updated elsewhere. Reload and retry.',
     zh: '该单元格已在别处更新。请重新加载后重试。',

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -33,6 +33,8 @@ export type MetaRecordLabelKey =
   // --- Record locking (design #2278 follow-up) ---
   | 'record.locked' | 'record.lockedBy' | 'record.lockedAt'
   | 'record.lock' | 'record.unlock'
+  // --- Duplicate / clone record (design 2026-06-16) ---
+  | 'record.duplicate' | 'record.duplicateTitle'
   | 'record.delete' | 'record.close'
   | 'record.tabsAria'
   | 'record.details' | 'record.history'
@@ -85,6 +87,8 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.lockedAt': { en: 'Locked at', zh: '锁定时间' },
   'record.lock': { en: 'Lock', zh: '锁定' },
   'record.unlock': { en: 'Unlock', zh: '解锁' },
+  'record.duplicate': { en: 'Duplicate', zh: '复制' },
+  'record.duplicateTitle': { en: 'Duplicate this record', zh: '复制此记录' },
   'record.delete': { en: 'Delete', zh: '删除' },
   'record.close': { en: 'Close record drawer', zh: '关闭记录抽屉' },
   'record.tabsAria': { en: 'Record drawer sections', zh: '记录抽屉分区' },

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -28,7 +28,7 @@ export type WorkbenchLabelKey =
   | 'kbd.toggleHelp'
   // §3.5 static (non-interpolated) toast subset
   | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
-  | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted'
+  | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted' | 'toast.recordDuplicated'
   | 'toast.recordLocked' | 'toast.recordUnlocked' | 'toast.recordLockFailed'
   | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
   | 'toast.commentUpdated' | 'toast.commentAdded'
@@ -125,6 +125,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.datesUpdated': { en: 'Dates updated', zh: '日期已更新' },
   'toast.hierarchyUpdated': { en: 'Hierarchy updated', zh: '层级已更新' },
   'toast.recordDeleted': { en: 'Record deleted', zh: '记录已删除' },
+  'toast.recordDuplicated': { en: 'Record duplicated', zh: '记录已复制' },
   'toast.recordLocked': { en: 'Record locked', zh: '记录已锁定' },
   'toast.recordUnlocked': { en: 'Record unlocked', zh: '记录已解锁' },
   'toast.recordLockFailed': { en: 'Failed to update record lock', zh: '更新锁定状态失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -272,6 +272,7 @@
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @open-person-picker="onGridPersonPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
           @create-record="onAddRecord"
+          @duplicate-record="onDuplicateRecord"
           @set-frozen="onSetFrozen"
           @set-aggregation="onSetAggregation"
           @open-comments="onOpenRecordComments"
@@ -285,6 +286,7 @@
       <MetaRecordDrawer
         :visible="!!selectedRecordId" :record="selectedRecordResolved" :fields="scopedAllFields"
         :can-edit="effectiveRowActions.canEdit" :can-comment="effectiveRowActions.canComment" :can-delete="effectiveRowActions.canDelete"
+        :can-create="caps.canCreateRecord.value"
         :can-manage-automation="canOpenWorkflowDesigner"
         :field-permissions="effectiveFieldPermissions"
         :row-actions="effectiveRowActions"
@@ -298,7 +300,7 @@
         :ai-shortcut="aiShortcut.state"
         :button-run-pending="buttonRunPending"
         :mention-suggestions="commentMentionSuggestions"
-        @close="onCloseDrawer" @delete="onDeleteRecord" @patch="onDrawerPatch"
+        @close="onCloseDrawer" @delete="onDeleteRecord" @duplicate="onDuplicateRecord(selectedRecordId)" @patch="onDrawerPatch"
         @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker" @open-person-picker="openPersonPicker"
         @toggle-lock="onToggleRecordLock"
         @navigate="onDrawerNavigate"
@@ -1697,6 +1699,22 @@ async function onDeleteRecord() {
     showComments.value = false
     commentDraft.value = ''
     showSuccess(wb('toast.recordDeleted', isZh.value))
+    return
+  }
+  if (grid.error.value) showError(grid.error.value)
+}
+
+// Duplicate / clone record (design 2026-06-16). Both the drawer Duplicate button and the grid right-click
+// affordance route here. Gated on canCreateRecord (the server re-enforces it + the field-mask). On success
+// the new clone is opened in the drawer (Airtable/feishu staple) so the user lands on the copy to tweak it.
+async function onDuplicateRecord(recordId?: string | null) {
+  const sourceId = recordId ?? selectedRecordId.value
+  if (!sourceId) return
+  if (!ensureCanCreateRecord()) return
+  const newRecordId = await grid.duplicateRecord(sourceId)
+  if (newRecordId) {
+    showSuccess(wb('toast.recordDuplicated', isZh.value))
+    await selectRecord(newRecordId)
     return
   }
   if (grid.error.value) showError(grid.error.value)

--- a/apps/web/tests/meta-record-labels.spec.ts
+++ b/apps/web/tests/meta-record-labels.spec.ts
@@ -17,6 +17,13 @@ describe('meta-record-labels static keys', () => {
     expect(recordLabel('record.delete', true)).toBe('删除')
   })
 
+  it('duplicate button text is separate from its title key (button-suffix pattern)', () => {
+    expect(recordLabel('record.duplicate', true)).toBe('复制')
+    expect(recordLabel('record.duplicate', false)).toBe('Duplicate')
+    expect(recordLabel('record.duplicateTitle', true)).toBe('复制此记录')
+    expect(recordLabel('record.duplicateTitle', false)).toBe('Duplicate this record')
+  })
+
   it('distinguishes watch button text from watch/unwatch title (S1/T3A1 pattern)', () => {
     expect(recordLabel('record.watch', true)).toBe('关注')
     expect(recordLabel('record.watching', true)).toBe('已关注')

--- a/apps/web/tests/multitable-grid-duplicate-composable.spec.ts
+++ b/apps/web/tests/multitable-grid-duplicate-composable.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Duplicate / clone record (design 2026-06-16) — useMultitableGrid.duplicateRecord.
+ * The composable POSTs to /records/:id/duplicate, returns the NEW record id on success (so the workbench can
+ * open the clone), reloads the page, and sets a localized fallback error on failure. There is NO front-end
+ * permission mirror — the server owns the value-copy + field-mask.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import { useMultitableGrid } from '../src/multitable/composables/useMultitableGrid'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('useMultitableGrid.duplicateRecord', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+  afterEach(() => {
+    useLocale().setLocale('en')
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs to the duplicate endpoint, returns the new record id, and clears error', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/duplicate')) return jsonResponse({ ok: true, data: { record: { id: 'rec_clone', version: 1, data: {} } } })
+      return jsonResponse({ ok: true, data: { rows: [], page: { total: 0, offset: 0, limit: 50 } } })
+    })
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client: new MultitableApiClient({ fetchFn }) })
+
+    const newId = await grid.duplicateRecord('rec_source')
+
+    expect(newId).toBe('rec_clone')
+    expect(grid.error.value).toBeNull()
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/multitable/records/rec_source/duplicate',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    // body carries the sheet/view context so the server can resolve the source sheet
+    const body = JSON.parse((fetchFn.mock.calls.find((c) => String(c[0]).includes('/duplicate'))![1] as any).body)
+    expect(body.sheetId).toBe('s1')
+    expect(body.viewId).toBe('v1')
+  })
+
+  it('reloads the current page after a successful duplicate', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/duplicate')) return jsonResponse({ ok: true, data: { record: { id: 'rec_clone', version: 1, data: {} } } })
+      return jsonResponse({ ok: true, data: { rows: [], page: { total: 0, offset: 0, limit: 50 } } })
+    })
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client: new MultitableApiClient({ fetchFn }) })
+
+    await grid.duplicateRecord('rec_source')
+
+    // a view-data reload happened (a GET that is not the duplicate POST)
+    expect(fetchFn.mock.calls.some((c) => !String(c[0]).includes('/duplicate'))).toBe(true)
+  })
+
+  it('keeps a backend error message raw ahead of the localized fallback', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('/duplicate')) return jsonResponse({ ok: false, error: { code: 'FORBIDDEN', message: 'backend duplicate raw' } }, 403)
+      return jsonResponse({ ok: true, data: { rows: [], page: { total: 0, offset: 0, limit: 50 } } })
+    })
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client: new MultitableApiClient({ fetchFn }) })
+
+    const newId = await grid.duplicateRecord('rec_source')
+
+    expect(newId).toBeNull()
+    expect(grid.error.value).toBe('backend duplicate raw')
+  })
+
+  it('returns null and sets the localized fallback error when the failure carries no message', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = new MultitableApiClient({ fetchFn: vi.fn(async () => jsonResponse({ ok: true, data: { rows: [], page: { total: 0, offset: 0, limit: 50 } } })) })
+    // A message-less rejection (e.g. a non-Error throw) — the only path that reaches the FE fallback,
+    // since the client always sets `.message` on HTTP errors.
+    vi.spyOn(client, 'duplicateRecord').mockRejectedValue({})
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client })
+
+    const newId = await grid.duplicateRecord('rec_source')
+
+    expect(newId).toBeNull()
+    expect(grid.error.value).toBe('复制记录失败')
+  })
+})

--- a/apps/web/tests/multitable-grid-duplicate-context.spec.ts
+++ b/apps/web/tests/multitable-grid-duplicate-context.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Duplicate / clone record (design 2026-06-16) — grid right-click affordance.
+ * Right-clicking a row emits `duplicate-record` (the workbench owns the gated create + clone-open). The
+ * affordance is gated on `canCreate` and suppressed while a cell is being edited (so the native copy/paste
+ * menu still works inside the editor). NO front-end permission mirror — the server re-enforces canCreateRecord.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 'title', name: 'Title', type: 'string' }
+const ONE_ROW: MetaRecord[] = [{ id: 'r1', version: 1, data: { title: 'Alpha' } }]
+
+function mountGrid(props: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: ONE_ROW,
+        visibleFields: [TITLE_FIELD],
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        searchText: '',
+        rowDensity: 'normal',
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+function rightClickRow(root: HTMLElement): { event: MouseEvent; defaultPrevented: boolean } {
+  const row = root.querySelector('.meta-grid__row') as HTMLElement
+  const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+  row.dispatchEvent(event)
+  return { event, defaultPrevented: event.defaultPrevented }
+}
+
+describe('MetaGridTable duplicate context affordance', () => {
+  it('emits duplicate-record with the row id on right-click when canCreate', () => {
+    const onDuplicateRecord = vi.fn()
+    const root = mountGrid({ canCreate: true, rows: ONE_ROW, onDuplicateRecord })
+    const { defaultPrevented } = rightClickRow(root)
+    expect(onDuplicateRecord).toHaveBeenCalledTimes(1)
+    expect(onDuplicateRecord).toHaveBeenCalledWith('r1')
+    // suppresses the native menu so the row affordance is the menu
+    expect(defaultPrevented).toBe(true)
+  })
+
+  it('does NOT emit and does NOT suppress the native menu when canCreate is false (capability gate)', () => {
+    const onDuplicateRecord = vi.fn()
+    const root = mountGrid({ canCreate: false, rows: ONE_ROW, onDuplicateRecord })
+    const { defaultPrevented } = rightClickRow(root)
+    expect(onDuplicateRecord).not.toHaveBeenCalled()
+    expect(defaultPrevented).toBe(false)
+  })
+})

--- a/apps/web/tests/multitable-record-drawer-duplicate.spec.ts
+++ b/apps/web/tests/multitable-record-drawer-duplicate.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Duplicate / clone record (design 2026-06-16) — MetaRecordDrawer Duplicate button.
+ * The button is gated on `canCreate` (a duplicate is a create; the server re-enforces it) and emits
+ * `duplicate`. Hidden when canCreate is false or when there's no record to duplicate.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+const FIELDS = [{ id: 'fld_t', name: 'Title', type: 'string', property: {} }] as unknown as MetaField[]
+const RECORD = { id: 'rec_1', version: 1, data: { fld_t: 'v' } } as unknown as MetaRecord
+
+interface HarnessOptions {
+  canCreate?: boolean
+  record?: MetaRecord | null
+  onDuplicate?: () => void
+}
+
+function mountDrawer(options: HarnessOptions = {}): { container: HTMLElement; app: App } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaRecordDrawer, {
+        visible: true,
+        record: 'record' in options ? options.record : RECORD,
+        fields: FIELDS,
+        canEdit: true,
+        canComment: false,
+        canDelete: false,
+        canCreate: options.canCreate ?? false,
+        ...(options.onDuplicate ? { onDuplicate: options.onDuplicate } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+const dupBtn = (root: HTMLElement) => root.querySelector('.meta-record-drawer__btn--duplicate') as HTMLButtonElement | null
+
+describe('MetaRecordDrawer duplicate button', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    useLocale().setLocale('en')
+    vi.restoreAllMocks()
+  })
+
+  it('renders the Duplicate button when canCreate and a record is present', () => {
+    const { container } = mountDrawer({ canCreate: true })
+    const btn = dupBtn(container)
+    expect(btn).not.toBeNull()
+    expect((btn!.textContent ?? '').trim()).toBe('Duplicate')
+  })
+
+  it('localizes the Duplicate label in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mountDrawer({ canCreate: true })
+    expect((dupBtn(container)!.textContent ?? '').trim()).toBe('复制')
+  })
+
+  it('hides the Duplicate button when canCreate is false (capability gate)', () => {
+    const { container } = mountDrawer({ canCreate: false })
+    expect(dupBtn(container)).toBeNull()
+  })
+
+  it('hides the Duplicate button when there is no record (nothing to clone)', () => {
+    const { container } = mountDrawer({ canCreate: true, record: null })
+    expect(dupBtn(container)).toBeNull()
+  })
+
+  it('emits duplicate on click', () => {
+    const onDuplicate = vi.fn()
+    const { container } = mountDrawer({ canCreate: true, onDuplicate })
+    dupBtn(container)!.click()
+    expect(onDuplicate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
@@ -16,6 +16,7 @@ const showErrorSpy = vi.fn()
 const showSuccessSpy = vi.fn()
 
 let capturedDrawerAttrs: Record<string, unknown> | null = null
+let capturedGridAttrs: Record<string, unknown> | null = null
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
@@ -60,7 +61,17 @@ vi.mock('../src/multitable/import/bulk-import', () => ({ bulkImportRecords: vi.f
 
 vi.mock('../src/multitable/components/MetaViewTabBar.vue', () => ({ default: stubComponent('MetaViewTabBar') }))
 vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({ default: stubComponent('MetaToolbar') }))
-vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({ default: stubComponent('MetaGridTable') }))
+// Capturing stub for the grid — records the real listeners (for the duplicate-record wire-drift lock).
+vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({
+  default: defineComponent({
+    name: 'MetaGridTable',
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+      capturedGridAttrs = attrs as Record<string, unknown>
+      return () => h('div', { 'data-stub-MetaGridTable': 'true' })
+    },
+  }),
+}))
 vi.mock('../src/multitable/components/MetaFormView.vue', () => ({ default: stubComponent('MetaFormView') }))
 // Capturing stub for the component under wiring test — records the real listeners.
 vi.mock('../src/multitable/components/MetaRecordDrawer.vue', () => ({
@@ -146,7 +157,7 @@ function createGridMock() {
     toggleFieldVisibility: vi.fn(), addSortRule: vi.fn(), removeSortRule: vi.fn(), addFilterRule: vi.fn(),
     updateFilterRule: vi.fn(), removeFilterRule: vi.fn(), clearFilters: vi.fn(), applySortFilter: vi.fn(),
     undo: vi.fn(), redo: vi.fn(), setGroupField: vi.fn(), goToPage: vi.fn(), patchCell: vi.fn(),
-    createRecord: vi.fn(), deleteRecord: vi.fn(), resolveRowActions: vi.fn(() => null),
+    createRecord: vi.fn(), deleteRecord: vi.fn(), duplicateRecord: vi.fn().mockResolvedValue('rec_clone'), resolveRowActions: vi.fn(() => null),
     loadViewData: vi.fn().mockResolvedValue(true), reloadCurrentPage: vi.fn(), dismissConflict: vi.fn(),
     retryConflict: vi.fn(), setColumnWidth: vi.fn(), setSearchQuery: vi.fn(),
   }
@@ -162,6 +173,7 @@ describe('MultitableWorkbench drawer run-button handler wiring (B1-e)', () => {
     workbenchMock = createWorkbenchMock()
     gridMock = createGridMock()
     capturedDrawerAttrs = null
+    capturedGridAttrs = null
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -221,5 +233,83 @@ describe('MultitableWorkbench drawer run-button handler wiring (B1-e)', () => {
     await onRunButton({ recordId: 'rec_42', field: { id: 'fld_btn' } })
     await flushUi()
     expect(workbenchMock.client.runButton).not.toHaveBeenCalled()
+  })
+})
+
+// Wire-drift lock for the duplicate / clone record affordance (design 2026-06-16). Both the drawer Duplicate
+// button (`@duplicate`) and the grid right-click (`@duplicate-record`) must be threaded by the workbench into
+// the SAME onDuplicateRecord handler → grid.duplicateRecord. A component-level test (drawer/grid emit) stays
+// green even if the workbench forgets the listener, shipping a dead feature — so capture the real listeners.
+describe('MultitableWorkbench duplicate-record handler wiring (2026-06-16)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    workbenchMock = createWorkbenchMock()
+    gridMock = createGridMock()
+    capturedDrawerAttrs = null
+    capturedGridAttrs = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null; container = null
+    showErrorSpy.mockReset(); showSuccessSpy.mockReset()
+    vi.unstubAllGlobals(); vi.clearAllMocks()
+  })
+
+  async function mountWorkbench(): Promise<void> {
+    const Host = defineComponent({ setup() { return () => h(MultitableWorkbench as Component) } })
+    app = createApp(Host)
+    app.mount(container!)
+    await flushUi()
+  }
+
+  it('threads the grid @duplicate-record emit into grid.duplicateRecord and shows the success toast', async () => {
+    await mountWorkbench()
+    expect(capturedGridAttrs).not.toBeNull()
+    const onDuplicateRecord = capturedGridAttrs!.onDuplicateRecord as (recordId: string) => Promise<void>
+    expect(typeof onDuplicateRecord).toBe('function')
+
+    await onDuplicateRecord('rec_source')
+    await flushUi()
+
+    expect(gridMock.duplicateRecord).toHaveBeenCalledTimes(1)
+    expect(gridMock.duplicateRecord).toHaveBeenCalledWith('rec_source')
+    expect(showSuccessSpy).toHaveBeenCalledTimes(1)
+    expect(showErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('threads the drawer @duplicate emit into grid.duplicateRecord with the selected record id', async () => {
+    await mountWorkbench()
+    expect(capturedDrawerAttrs).not.toBeNull()
+    // The workbench wires `@duplicate="onDuplicateRecord(selectedRecordId)"`. Drive a selection first so the
+    // handler has a source id to duplicate (mirrors a user opening a record then clicking Duplicate).
+    const onSelectRecord = capturedGridAttrs!.onSelectRecord as (id: string) => void
+    onSelectRecord('rec_open')
+    await flushUi()
+
+    const onDuplicate = capturedDrawerAttrs!.onDuplicate as () => Promise<void>
+    expect(typeof onDuplicate).toBe('function')
+    await onDuplicate()
+    await flushUi()
+
+    expect(gridMock.duplicateRecord).toHaveBeenCalledWith('rec_open')
+  })
+
+  it('surfaces grid.error on a failed duplicate (null id) instead of a success toast', async () => {
+    gridMock.duplicateRecord.mockResolvedValueOnce(null)
+    gridMock.error.value = 'Failed to duplicate record'
+    await mountWorkbench()
+    const onDuplicateRecord = capturedGridAttrs!.onDuplicateRecord as (recordId: string) => Promise<void>
+
+    await onDuplicateRecord('rec_source')
+    await flushUi()
+
+    expect(showSuccessSpy).not.toHaveBeenCalled()
+    expect(showErrorSpy).toHaveBeenCalledWith('Failed to duplicate record')
   })
 })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -10573,6 +10573,166 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  // Duplicate / clone a record (design 2026-06-16). A duplicate is a value-seeded CREATE: the source row's
+  // values are read SERVER-SIDE (so field-masked values the actor can't read are visible to the strip step,
+  // not silently dropped client-side) and a NEW row is created from the masked subset via the SAME
+  // RecordService.createRecord write chokepoint as POST /records. Capability gate = canCreateRecord (a
+  // duplicate is a create), read off the SAME capabilities object that authorizes reading the source row.
+  //
+  // Field-mask discipline (the security spine): a field is copied IFF the actor can BOTH read AND write it.
+  // `deriveFieldPermissions(..., { allowCreateOnly: true, fieldScopeMap })` folds all three exclusions into
+  // one decision —
+  //   - visible === false   → read-denied (field_permissions.visible / property.hidden)            ⇒ NOT copied
+  //   - readOnly === true    → write-denied (field_permissions.read_only) OR isFieldAlwaysReadOnly
+  //                            (formula/lookup/rollup/system/mirror) OR !canCreateRecord              ⇒ NOT copied
+  // createRecord consults NEITHER field_permissions case (only isFieldAlwaysReadOnly + canCreateRecord — see
+  // the F4 create-echo note above), so THIS route is the only thing stripping read/write-denied fields. Link
+  // ids are copied verbatim (createRecord re-validates foreign existence); attachment ids are copied verbatim
+  // (shared blob reference — the lightweight clone semantics, NOT a deep file copy). Auto-number / formula /
+  // mirror fields are stripped here and re-derived by the server, matching Airtable/feishu behavior.
+  router.post('/records/:recordId/duplicate', async (req: Request, res: Response) => {
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
+    }
+    const schema = z.object({
+      sheetId: z.string().min(1).optional(),
+      viewId: z.string().min(1).optional(),
+    })
+    const parsed = schema.safeParse(req.body ?? {})
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      let sheetId = parsed.data.sheetId
+      if (parsed.data.sheetId || parsed.data.viewId) {
+        const resolved = await resolveMetaSheetId(pool as unknown as { query: QueryFn }, {
+          sheetId: parsed.data.sheetId,
+          viewId: parsed.data.viewId,
+        })
+        sheetId = resolved.sheetId
+      }
+
+      // Source row, raw + UNMASKED. `data` may carry stale link ids (link state is authoritative in
+      // meta_links, not meta_records.data), so the forward-link values are overlaid below.
+      const sourceLookup = sheetId
+        ? await pool.query('SELECT id, sheet_id, data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+        : await pool.query('SELECT id, sheet_id, data FROM meta_records WHERE id = $1', [recordId])
+      const sourceRow: any = sourceLookup.rows[0]
+      if (!sourceRow) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+      sheetId = String(sourceRow.sheet_id)
+
+      // Source-read authorization (canRead + record-level perms + 401/404). The returned `capabilities` is
+      // the SINGLE source for the create gate below — no second resolveSheetCapabilities call (which could
+      // diverge from the read gate).
+      const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+      if ('status' in readable) return res.status(readable.status).json(readable.body)
+      const { access, capabilities } = readable
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+
+      const fields = await loadSheetFields(pool as unknown as { query: QueryFn }, sheetId)
+
+      // Overlay forward-link values from meta_links onto a working copy of the source data (mirror/derived
+      // link fields are isFieldAlwaysReadOnly → stripped below regardless, so only forward links matter).
+      const sourceData: Record<string, unknown> = { ...normalizeJson(sourceRow.data) }
+      const relationalLinkFields = fields
+        .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: parseLinkFieldConfig(field.property) } : null))
+        .filter((value): value is RelationalLinkField => !!value && !!value.cfg)
+      if (relationalLinkFields.length > 0) {
+        const linkValuesByRecord = await loadLinkValuesByRecord(pool.query.bind(pool), [recordId], relationalLinkFields)
+        for (const { fieldId } of relationalLinkFields) {
+          sourceData[fieldId] = linkValuesByRecord.get(recordId)?.get(fieldId) ?? []
+        }
+      }
+
+      // Build the copy payload: copy a field IFF (readable ∧ writable) for THIS actor. The allowCreateOnly
+      // derive folds read-deny (visible=false), write-deny (read_only=true), isFieldAlwaysReadOnly, and
+      // !canCreateRecord. NB: this is intentionally a DIFFERENT derive than the create echo below (the echo
+      // omits allowCreateOnly and only reads `.visible`) — the echo decides what to RETURN, this decides what
+      // to COPY.
+      const visiblePropertyFields = filterVisiblePropertyFields(fields)
+      const copyFieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const copyFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, {
+        allowCreateOnly: true,
+        fieldScopeMap: copyFieldScopeMap,
+      })
+      const copyData: Record<string, unknown> = {}
+      for (const field of visiblePropertyFields) {
+        const perm = copyFieldPermissions[field.id]
+        if (!perm || perm.visible === false || perm.readOnly === true) continue
+        if (!(field.id in sourceData)) continue
+        copyData[field.id] = sourceData[field.id]
+      }
+
+      const recordService = new RecordService(pool, eventBus)
+      // A-min-create (#2255): compute the new record's same-record formula-over-lookup on create (parity
+      // with POST /records).
+      recordService.setFormulaRecalcHook((q, sid, ids) => recalcNewRecordFormulas(req, q, sid, ids))
+      const result = await recordService.createRecord({
+        sheetId,
+        capabilities,
+        actorId: getRequestActorId(req),
+        data: copyData,
+      })
+
+      // Create-echo mask — identical to POST /records (F4): the echo applies the layer-2 ∧ layer-3 READ
+      // mask so a denied field (whether copied or server-assigned) is omitted from the response.
+      const echoFieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap: echoFieldScopeMap })
+      const allowedFieldIds = await maskStoredRecordFieldIds(
+        req,
+        pool.query.bind(pool),
+        sheetId,
+        visiblePropertyFields,
+        new Set(visiblePropertyFields.filter((field) => securityFieldPermissions[field.id]?.visible !== false).map((field) => field.id)),
+      )
+
+      return res.json({
+        ok: true,
+        data: {
+          record: {
+            id: result.recordId,
+            version: result.version,
+            data: filterRecordDataByFieldIds(result.data, allowedFieldIds),
+          },
+        },
+      })
+    } catch (err) {
+      if (isRecordCreateValidationError(err)) {
+        const fieldErrors = normalizeRecordCreateFieldErrors(err.fieldErrors)
+        return res.status(422).json({
+          ok: false,
+          error: { code: 'VALIDATION_ERROR', message: 'Record validation failed', fieldErrors },
+        })
+      }
+      if (err instanceof RecordServiceFieldForbiddenError) {
+        return res.status(403).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
+      if (err instanceof RecordServiceValidationError || err instanceof ServiceValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code || 'VALIDATION_ERROR', message: err.message } })
+      }
+      if (err instanceof ValidationError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
+      }
+      if (err instanceof RecordServiceNotFoundError || err instanceof ServiceNotFoundError) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      if (err instanceof RecordServicePermissionError) {
+        return sendForbidden(res, err.message)
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] duplicate record failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to duplicate meta record' } })
+    }
+  })
+
   router.delete('/records/:recordId', async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId : ''
     if (!recordId) {

--- a/packages/core-backend/tests/integration/multitable-record-duplicate.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-duplicate.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Real-DB integration test for the duplicate / clone record route (design 2026-06-16).
+ *
+ * `POST /records/:recordId/duplicate` reads the source row SERVER-SIDE and creates a NEW row from the
+ * subset of fields the actor can BOTH read AND write, then echoes the clone through the SAME layer-2 ∧
+ * layer-3 read mask as POST /records. The security spine:
+ *   - read-denied  (field_permissions.visible=false)            → value NOT copied into the clone
+ *   - write-denied (field_permissions.read_only=true, visible)  → value NOT copied into the clone
+ *   - isFieldAlwaysReadOnly (formula/autoNumber)                → stripped + re-derived by the server
+ *   - link ids / attachment ids                                → copied verbatim (validated on create)
+ *   - capability gate                                           → 403 when canCreateRecord is false
+ *
+ * createRecord enforces NEITHER field_permissions case (only isFieldAlwaysReadOnly + canCreateRecord — see
+ * the F4 create-echo note in univer-meta.ts), so THIS route is the only thing stripping read/write-denied
+ * fields. The assertions therefore read the NEW row's UNMASKED stored `meta_records.data` (via `dbField`) —
+ * NOT the masked echo, which would hide a leak even if the value had been written.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_dup_${TS}`
+const SHEET_ID = `sheet_dup_${TS}`
+const FSHEET_ID = `sheet_dup_foreign_${TS}`
+
+const FLD_VISIBLE = `fld_dup_vis_${TS}` // string, readable+writable — positive control (copied)
+const FLD_SECRET = `fld_dup_secret_${TS}` // string, read-denied (visible=false) — NOT copied
+const FLD_RO = `fld_dup_ro_${TS}` // string, write-denied (read_only=true, visible) — NOT copied
+const FLD_SELECT = `fld_dup_sel_${TS}` // select — copied
+const FLD_MULTI = `fld_dup_multi_${TS}` // multiSelect — copied
+const FLD_FORMULA = `fld_dup_formula_${TS}` // formula (isFieldAlwaysReadOnly) — stripped + recomputed
+const FLD_AUTONUM = `fld_dup_auto_${TS}` // autoNumber (isFieldAlwaysReadOnly) — fresh server value
+const FLD_LINK = `fld_dup_link_${TS}` // link → FSHEET — ids copied verbatim
+const FLD_ATT = `fld_dup_att_${TS}` // attachment — ids copied verbatim
+
+const FOREIGN_REC = `rec_dup_foreign_${TS}`
+const SOURCE_REC = `rec_dup_source_${TS}`
+const ATT_ID = `att_dup_${TS}`
+
+const USER_OK = `u_dup_ok_${TS}` // write user, FLD_SECRET + FLD_RO denied — the duplicating actor
+const USER_RO = `u_dup_readonly_${TS}` // read-only user — canCreateRecord=false (403 path)
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const dupReq = (recordId: string, body: Record<string, unknown> = { sheetId: SHEET_ID }) =>
+  request(app).post(`/api/multitable/records/${recordId}/duplicate`).send(body)
+const dbData = async (recordId: string): Promise<Record<string, unknown>> => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  return (r.rows[0]?.data ?? {}) as Record<string, unknown>
+}
+
+describeIfDatabase('duplicate / clone record route (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Dup Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Dup Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FSHEET_ID, BASE_ID, 'Dup Foreign'])
+
+    const mkField = (id: string, name: string, type: string, property: Record<string, unknown>, order: number) =>
+      q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [id, SHEET_ID, name, type, JSON.stringify(property), order])
+
+    await mkField(FLD_VISIBLE, 'Visible', 'string', {}, 1)
+    await mkField(FLD_SECRET, 'Secret', 'string', {}, 2)
+    await mkField(FLD_RO, 'ReadOnlyForActor', 'string', {}, 3)
+    await mkField(FLD_SELECT, 'Sel', 'select', { options: [{ value: 'A' }, { value: 'B' }] }, 4)
+    await mkField(FLD_MULTI, 'Multi', 'multiSelect', { options: [{ value: 'x' }, { value: 'y' }, { value: 'z' }] }, 5)
+    await mkField(FLD_FORMULA, 'Formula', 'formula', { expression: '=1+1' }, 6)
+    await mkField(FLD_AUTONUM, 'Auto', 'autoNumber', {}, 7)
+    await mkField(FLD_LINK, 'Link', 'link', { foreignSheetId: FSHEET_ID }, 8)
+    await mkField(FLD_ATT, 'Att', 'attachment', {}, 9)
+
+    // Foreign sheet needs at least one field for the foreign record to be valid; the link only validates
+    // foreign-record existence.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [`fld_dup_fkey_${TS}`, FSHEET_ID, 'FKey', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, version, data) VALUES ($1,$2,$3,$4::jsonb)',
+      [FOREIGN_REC, FSHEET_ID, 1, JSON.stringify({})])
+
+    // layer-3 field permissions for USER_OK: FLD_SECRET read-denied, FLD_RO write-denied (still readable).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [SHEET_ID, FLD_SECRET, 'user', USER_OK, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [SHEET_ID, FLD_RO, 'user', USER_OK, true, true])
+
+    // Source record. Includes raw denied values (FLD_SECRET / FLD_RO) the duplicate MUST NOT carry over.
+    // Inserted BEFORE the attachment row (which FK-references it).
+    await q('INSERT INTO meta_records (id, sheet_id, version, data) VALUES ($1,$2,$3,$4::jsonb)', [
+      SOURCE_REC, SHEET_ID, 1,
+      JSON.stringify({
+        [FLD_VISIBLE]: 'hello-clone',
+        [FLD_SECRET]: 'TOP-SECRET-do-not-clone',
+        [FLD_RO]: 'readonly-do-not-clone',
+        [FLD_SELECT]: 'B',
+        [FLD_MULTI]: ['x', 'z'],
+        [FLD_FORMULA]: 'stale-formula',
+        [FLD_AUTONUM]: 9999,
+        [FLD_LINK]: [FOREIGN_REC],
+        [FLD_ATT]: [ATT_ID],
+      }),
+    ])
+    // Link state is authoritative in meta_links — seed the forward edge so the overlay reads it.
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_LINK, SOURCE_REC, FOREIGN_REC])
+
+    // Attachment blob owned by SOURCE_REC + FLD_ATT (the same-field check passes for the clone since the
+    // clone shares FLD_ATT; the copy is a shared reference, not a deep file copy).
+    await q(
+      `INSERT INTO multitable_attachments
+         (id, sheet_id, record_id, field_id, storage_file_id, filename, original_name, mime_type, size, storage_path, storage_provider, metadata, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13)`,
+      [ATT_ID, SHEET_ID, SOURCE_REC, FLD_ATT, `sf_${ATT_ID}`, 'f.txt', 'f.txt', 'text/plain', 3, `/tmp/${ATT_ID}`, 'local', '{}', USER_OK],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_field_auto_number_sequences WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE record_id IN (SELECT id FROM meta_records WHERE sheet_id = $1)', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM multitable_attachments WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('happy path: writable scalar/select/multiSelect + link + attachment values are copied into a NEW row', async () => {
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(200)
+    const newId = res.body.data.record.id
+    expect(typeof newId).toBe('string')
+    expect(newId).not.toBe(SOURCE_REC) // a NEW row, not the source
+
+    const stored = await dbData(newId)
+    expect(stored[FLD_VISIBLE]).toBe('hello-clone')
+    expect(stored[FLD_SELECT]).toBe('B')
+    expect(stored[FLD_MULTI]).toEqual(['x', 'z'])
+    expect(stored[FLD_LINK]).toEqual([FOREIGN_REC]) // link ids copied verbatim
+    expect(stored[FLD_ATT]).toEqual([ATT_ID]) // attachment ids copied (shared reference)
+
+    // The link edge is materialized for the clone (createRecord syncs meta_links).
+    const edge = await q('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2', [FLD_LINK, newId])
+    expect((edge.rows[0] as { foreign_record_id: string } | undefined)?.foreign_record_id).toBe(FOREIGN_REC)
+  })
+
+  test('SECURITY (read-denied): a field the actor CANNOT READ (visible=false) is NOT copied into the clone', async () => {
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(200)
+    const newId = res.body.data.record.id
+    const stored = await dbData(newId) // UNMASKED — proves the value never reached storage
+    expect(stored[FLD_SECRET]).toBeUndefined()
+    // ...and obviously not in the (masked) echo either.
+    expect(JSON.stringify(res.body)).not.toContain('TOP-SECRET-do-not-clone')
+  })
+
+  test('SECURITY (write-denied): a field the actor can READ but CANNOT WRITE (read_only=true) is NOT copied', async () => {
+    // This is the case createRecord does NOT catch (it never consults field_permissions.read_only). The
+    // route is the only guard; this asserts against the NEW row's stored data, so it fails loudly if the
+    // write-mask regresses.
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(200)
+    const newId = res.body.data.record.id
+    const stored = await dbData(newId)
+    expect(stored[FLD_RO]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain('readonly-do-not-clone')
+  })
+
+  test('derived fields: formula stripped+recomputed (not the stale source) and auto-number gets a FRESH value', async () => {
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(200)
+    const newId = res.body.data.record.id
+    const stored = await dbData(newId)
+    expect(stored[FLD_FORMULA]).not.toBe('stale-formula') // the stale source string was NOT carried over
+    expect(stored[FLD_AUTONUM]).toBeDefined()
+    expect(stored[FLD_AUTONUM]).not.toBe(9999) // server-reallocated, not the source's
+  })
+
+  test('SECURITY (capability gate): a read-only actor (canCreateRecord=false) gets 403', async () => {
+    currentUser = { id: USER_RO, roles: ['member'], perms: ['multitable:read'] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(403)
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+  })
+
+  test('404: duplicating a missing source record', async () => {
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+    const res = await dupReq(`rec_dup_missing_${TS}`)
+    expect(res.status).toBe(404)
+  })
+
+  test('401: unauthenticated request', async () => {
+    currentUser = { id: '', roles: [], perms: [] }
+    const res = await dupReq(SOURCE_REC)
+    expect(res.status).toBe(401)
+    currentUser = { id: USER_OK, roles: ['member'], perms: ['multitable:write'] }
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -49,7 +49,14 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     filterRecordFieldSummaryMap: 2,
   },
   'routes/univer-meta.ts': {
-    filterRecordDataByFieldIds: 13,
+    // 14 = +1 for the duplicate / clone record create-echo (design 2026-06-16): POST
+    // /records/:recordId/duplicate. The echo is routed through the SAME layer-2 ∧ layer-3 `allowedFieldIds`
+    // composite as POST /records (securityFieldPermissions.visible ∧ maskStoredRecordFieldIds →
+    // filterRecordDataByFieldIds). The COPY decision additionally applies a write-mask
+    // (deriveFieldPermissions allowCreateOnly) so read/write-denied fields never reach storage; the real-DB
+    // locking test is tests/integration/multitable-record-duplicate.test.ts (denied-field canary absent from
+    // the NEW row's unmasked stored data).
+    filterRecordDataByFieldIds: 14,
     loadRecordSummaries: 3,
     buildLinkSummaries: 4,
     serializeLinkSummaryMap: 1,


### PR DESCRIPTION
## Duplicate / clone record
`POST /records/:recordId/duplicate` reads the source server-side and creates a new row via the existing `RecordService.createRecord` chokepoint, **copying only fields the actor can both read AND write** (one `deriveFieldPermissions(..., {allowCreateOnly:true})` folding read-deny + write-deny + always-read-only formula/lookup/system). Gated on `canCreateRecord`. Link/attachment ids copied by reference; auto-number/formula re-derived. FE: row right-click + drawer Duplicate button (gated), clone opens in the drawer.

**Security**: copy is field-mask intersected (read∧write); the real-DB test asserts a write-denied field is NOT copied **against the new row's unmasked stored data** (not the echo). Backend integration 8/8 (happy/read-denied/write-denied/formula/auto-number/403/404/401), unit 3391/3391 (egress GOLDEN 13→14 for the create-echo channel), vue-tsc + tsc clean.

**Owner-deferred**: two-way link fan-out not run on single-record create (clone's reverse link updates on next edit); attachment copy is a shared-blob reference (not deep file copy); contextmenu-only grid affordance (drawer button is the accessible path). Verdict: ship.

Built + adversarially reviewed by subagents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)