### PR TITLE
docs(data-source): record C6 bad-row hold

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -430,10 +430,19 @@ TODO:
     `POST /api/integration/pipelines/:id/external-write/dry-run` (`200`) while
     `POST /api/integration/pipelines/:id/external-write/apply` remains blocked (`403`) with
     no target write request accepted.
-  - remaining HOLD: controlled bad-row smoke has not run yet; it must prove row-level failure
-    evidence is values-free and clean sibling rows are not silently swallowed. The bad row must be
-    a write-time target constraint failure; target lookup / plan-decision drift after dry-run is
-    a revision-fence check (`C6_WRITE_DRY_RUN_TOKEN_MISMATCH`), not this row-level failure gate.
+  - #2720 controlled bad-row attempt HOLD: fresh dedicated dry-run returned `HTTP 200`,
+    `canApply=true`, `add=2`, but the entity-machine target principal lacked PostgreSQL
+    DDL/TRIGGER privilege for the planned reversible one-shot write-time failure injection
+    (`42501` / `HOLD_TARGET_DDL_UNAVAILABLE`). Apply was not run, no target rows were written,
+    and cleanup was values-free.
+  - remaining HOLD: controlled bad-row still needs a true write-time target constraint failure that
+    proves row-level failure evidence is values-free and clean sibling rows are not silently
+    swallowed. Target lookup / plan-decision drift after dry-run is a revision-fence check
+    (`C6_WRITE_DRY_RUN_TOKEN_MISMATCH`), not this row-level failure gate.
+  - next options, in order: provide a DDL-capable sandbox/reset principal for this sandbox-only,
+    operator-local maintenance check; use a seeded naturally failing row that can be reset
+    values-free; only if neither exists, open a separate design-first test-only failure-injection
+    slice. Do not add a broad production runtime failure hook inside C6-5.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -353,6 +353,22 @@ If the only available failure shape changes the target lookup result or plan
 decision after dry-run, skip this step and keep C6-5 at HOLD until a true
 write-time bad-row shape is available.
 
+Current #2720 attempt note: the first entity-machine bad-row setup stopped
+before Apply because the sandbox target principal could connect but lacked the
+DDL/TRIGGER privilege needed to install a temporary one-shot failure trigger.
+That is `HOLD_TARGET_DDL_UNAVAILABLE`, not a C6 route/runtime defect. Do not
+rerun Apply until one of these safe write-time failure shapes is available:
+
+- a DDL-capable sandbox/reset principal for the sandbox-only temporary trigger;
+- a seeded naturally failing row that can be reset values-free;
+- a separately reviewed test-only failure-injection slice. This must be
+  design-first and must not become a broad production failure hook.
+
+Any DDL/trigger setup for this check is operator-local sandbox maintenance
+outside MetaSheet product/runtime paths. It must never run against production,
+must never become evidence-bearing, and does not relax the forbidden product
+raw SQL / query / stored procedure / trigger paths above.
+
 Expected:
 
 - one controlled bad row creates row-level failure evidence;
@@ -365,8 +381,9 @@ Evidence:
 
 ```text
 badRow:
-  status=<partial|failed|not_run>
-  failureShape=write_time_constraint|not_available
+  status=<partial|failed|hold|not_run>
+  failureShape=write_time_constraint|ddl_unavailable|not_available
+  stopReason=none|target_ddl_unavailable|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
   deadLetters.count=<count>
@@ -506,8 +523,9 @@ readOnlyUser:
   applyRequestSent=false
 
 badRow:
-  status=<partial|failed|not_run>
-  failureShape=write_time_constraint|not_available
+  status=<partial|failed|hold|not_run>
+  failureShape=write_time_constraint|ddl_unavailable|not_available
+  stopReason=none|target_ddl_unavailable|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
   deadLetters.count=<count>

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -227,7 +227,8 @@ c6Sandbox:
   repullIdempotence=pass|fail|not_run
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
-  controlledBadRow=pass|fail|not_run
+  controlledBadRow=pass|fail|hold|not_run
+  controlledBadRowStopReason=none|target_ddl_unavailable|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
   productRawSqlUsed=false
@@ -243,7 +244,8 @@ Current #2720 checkpoint as of 2026-06-16:
 - dedicated read-only route subgate: passed
   (`/external-write/dry-run` allowed for `integration:read`; `/external-write/apply`
   blocked for the same read-only user);
-- controlled bad-row: pending.
+- controlled bad-row: attempted, HOLD on target DDL/TRIGGER privilege unavailable;
+  no Apply ran for that attempt, no target rows were written.
 
 ## Stop Rules
 
@@ -337,7 +339,8 @@ c6Sandbox:
   repullIdempotence=pass|fail|not_run
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
-  controlledBadRow=pass|fail|not_run
+  controlledBadRow=pass|fail|hold|not_run
+  controlledBadRowStopReason=none|target_ddl_unavailable|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
   productRawSqlUsed=false


### PR DESCRIPTION
## Summary

- record the latest #2720 controlled bad-row attempt as `HOLD_TARGET_DDL_UNAVAILABLE`, not a C6 route/runtime defect
- update C6 sandbox and release smoke templates so the bad-row state can be `hold` with `target_ddl_unavailable`
- clarify that any temporary DDL/trigger setup is operator-local sandbox maintenance only, outside MetaSheet product/runtime paths, never production, and not evidence-bearing

## Verification

- `git diff --check`
- `node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- subagent review: state-accuracy re-review approved after fixing the `hold` state template
- subagent review: boundary/values-free re-review approved after clarifying operator-local sandbox maintenance

## Boundaries

Docs-only. No runtime/UI/package change, no production/batch authorization, no K3, no raw SQL product path, and no broad failure-injection hook.
