### PR TITLE
docs(data-source): route C6 seeded-row hold

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -444,6 +444,10 @@ TODO:
     operator-local maintenance check; use a seeded naturally failing row that can be reset
     values-free; only if neither exists, open a separate design-first test-only failure-injection
     slice. Do not add a broad production runtime failure hook inside C6-5.
+  - before opening a test-only failure-injection design slice, the entity-machine operator must
+    explicitly report whether the seeded naturally failing row is possible. If both sandbox-safe
+    failure shapes are unavailable, report `HOLD_NO_SAFE_FAILURE_SHAPE`; this is a routing signal,
+    not runtime authorization.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -369,6 +369,13 @@ outside MetaSheet product/runtime paths. It must never run against production,
 must never become evidence-bearing, and does not relax the forbidden product
 raw SQL / query / stored procedure / trigger paths above.
 
+Before opening any test-only failure-injection design slice, the entity-machine
+operator must also explicitly confirm whether a seeded naturally failing
+sandbox row/constraint shape is possible. If neither the DDL-backed temporary
+failure nor the seeded naturally failing row can be run safely, report
+`HOLD_NO_SAFE_FAILURE_SHAPE` and keep C6-5 open. That report is a routing signal
+only; it does not authorize runtime failure-injection code by itself.
+
 Expected:
 
 - one controlled bad row creates row-level failure evidence;
@@ -382,8 +389,8 @@ Evidence:
 ```text
 badRow:
   status=<partial|failed|hold|not_run>
-  failureShape=write_time_constraint|ddl_unavailable|not_available
-  stopReason=none|target_ddl_unavailable|not_available
+  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  stopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
   deadLetters.count=<count>
@@ -524,8 +531,8 @@ readOnlyUser:
 
 badRow:
   status=<partial|failed|hold|not_run>
-  failureShape=write_time_constraint|ddl_unavailable|not_available
-  stopReason=none|target_ddl_unavailable|not_available
+  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  stopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
   deadLetters.count=<count>

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -228,7 +228,7 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
-  controlledBadRowStopReason=none|target_ddl_unavailable|not_available
+  controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
   productRawSqlUsed=false
@@ -340,7 +340,7 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
-  controlledBadRowStopReason=none|target_ddl_unavailable|not_available
+  controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
   productRawSqlUsed=false


### PR DESCRIPTION
## Summary

- add `HOLD_NO_SAFE_FAILURE_SHAPE` as the C6 controlled bad-row routing state when both safe sandbox failure shapes are unavailable
- require the entity-machine operator to explicitly check seeded naturally failing rows before opening any test-only failure-injection design slice
- extend bad-row/release evidence templates with `seeded_row_unavailable` / `no_safe_failure_shape` stop reasons

## Verification

- `git diff --check`
- `node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- subagent workflow/state review: no findings
- subagent boundary/values-free review: no findings

## Boundaries

Docs-only. This does not authorize runtime failure-injection code, production/batch, K3, raw SQL/product trigger paths, or C6-5 closure.
