### PR TITLE
docs(data-source): design C6 test failure injection

### DIFF
--- a/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
+++ b/docs/development/data-source-system-integration-c6-external-write-design-20260616.md
@@ -442,6 +442,20 @@ Run sandbox-first validation:
 
 Only after C6-5 passes can the Release gate discuss production/batch.
 
+### C6-5a - test-only failure-injection design
+
+If the entity-machine sandbox cannot provide either a reversible DDL/trigger
+failure shape or a seeded naturally failing row that can be reset values-free,
+the controlled bad-row check remains HOLD and must route through a separate
+test-only design slice:
+
+- `docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md`
+
+That design is docs-only. It does not add runtime, routes, UI, package, raw SQL,
+production write, batch write, K3 write, or a broad failure hook. C6-5 remains
+open until a later C6-5b implementation and C6-5c entity-machine rerun produce
+values-free row-level failure / dead-letter / provenance evidence.
+
 ## Acceptance Checklist
 
 - [x] C6-0 design merged before runtime.

--- a/docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md
+++ b/docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md
@@ -1,0 +1,219 @@
+# Data Source System Integration C6 - Test Failure Injection Design
+
+Status: C6-5a design only; no runtime, no route, no UI, no package
+Date: 2026-06-17
+
+## Purpose
+
+C6 external write still needs one entity-machine proof before the database/source
+system integration line can close: a controlled write-time row failure must
+produce values-free row-level evidence while clean sibling rows are not silently
+swallowed.
+
+Issue #2720 already proved the core C6 path on the entity machine:
+
+- sandbox dry-run/apply/re-pull/rollback passed;
+- the dedicated read-only route subgate passed;
+- the controlled bad-row path could not use a reversible DDL/trigger shape
+  because the target principal lacks the needed PostgreSQL privilege;
+- the operator also reported that a seeded naturally failing row/constraint
+  shape cannot be reset safely values-free in the current sandbox.
+
+That leaves `HOLD_NO_SAFE_FAILURE_SHAPE`. This document defines the only
+acceptable next direction: a separate, test-only, sandbox-only failure-injection
+slice. It is a design contract, not implementation authorization.
+
+## Non-Goals
+
+This slice does not:
+
+- add a production runtime hook;
+- add a broad write-path fault-injection mechanism;
+- allow the browser or API request body to choose failing rows;
+- add raw SQL, DDL, trigger, stored procedure, CTE, or generic execute support;
+- change C6 dry-run/apply authorization;
+- relax dry-run token, revision fence, or single-use token rules;
+- touch K3 Save / Submit / Audit / BOM;
+- authorize production or batch writes;
+- produce a new on-prem package;
+- mark C6-5 as passed.
+
+## Trigger And Routing
+
+The test-only injection path may be opened only after all of these are true:
+
+1. C6 core sandbox dry-run/apply/re-pull/rollback has passed on the entity
+   machine.
+2. The dedicated read-only route subgate has passed.
+3. A reversible DDL/trigger-backed write-time failure shape is unavailable.
+4. A seeded naturally failing row/constraint shape is unavailable or unsafe to
+   reset values-free.
+5. The issue evidence reports:
+
+```text
+controlledBadRow=hold
+controlledBadRowStopReason=no_safe_failure_shape
+failureShape=no_safe_failure_shape
+```
+
+If a real sandbox write-time failure shape becomes available later, prefer that
+real target failure over this test-only mechanism.
+
+## Trust Boundary
+
+The failure injection must be server-owned and double-gated:
+
+- process/deploy gate: disabled by default, enabled only by an explicit
+  test-only environment flag such as
+  `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true`;
+- server config gate: enabled only for an admin-reviewed sandbox C6 target or
+  pipeline configuration;
+- target kind gate: target external system must be
+  `data-source:sql-write-gated`;
+- sandbox gate: target config must declare `environment=sandbox`;
+- raw-query gate: target data source must still have
+  `genericQueryDisabled=true`;
+- auth gate: C6 apply still requires write/admin permission;
+- review gate: C6 apply still requires a fresh single-use dry-run token and an
+  explicit operator confirmation;
+- revision gate: apply must still recompute the plan and reject revision drift
+  before any injected or real write.
+
+The request body must never enable, disable, parameterize, or target the
+injection. If a client sends fields such as `failureInjection`, `injectFailure`,
+`failRow`, `rowIndex`, `rowFingerprint`, `targetObject`, `plan`, or `payload`,
+the route must reject or ignore them according to the existing C6 scope-rejection
+contract, and tests must prove the injected path is not activated.
+
+No missing gate may fall back to tenant, workspace, admin, service, default, or
+system identity.
+
+## Injection Semantics
+
+The future implementation may inject exactly one row-level write failure in a
+sandbox C6 apply.
+
+Required behavior:
+
+- select the failing row deterministically from the server-recomputed dry-run
+  plan using a values-free stable row fingerprint or ordinal;
+- require at least one clean sibling row in the same apply so the test proves
+  partial success, not only total failure;
+- inject after dry-run token validation, token consumption, and revision
+  recompute, so the gate exercises the real apply path;
+- inject at the structured write boundary, before or at the same layer that
+  calls `insertRows` / `updateRows`;
+- return a synthetic values-free row error token such as
+  `C6_TEST_INJECTED_ROW_FAILURE`;
+- keep clean sibling writes eligible and observable;
+- emit values-free row result, dead-letter, and provenance evidence for the
+  failed row when the normal C6 stores are available;
+- preserve re-pull idempotence: a post-apply dry-run must show no duplicate
+  target rows and no silent retry of the failed injected row without another
+  explicit review/apply.
+
+The injection must not mutate source rows, target rows outside the reviewed plan,
+target schema, credentials, or pipeline configuration.
+
+## Evidence Contract
+
+Allowed evidence:
+
+- package fingerprint;
+- route names;
+- target kind;
+- sandbox/test-injection enabled flags as booleans;
+- counts: planned, written, failed, dead-lettered;
+- error code tokens;
+- row fingerprints or opaque hashes;
+- whether at least one clean sibling wrote;
+- whether production/batch/K3/raw-SQL boundaries stayed closed.
+
+Forbidden evidence:
+
+- credentials;
+- connection strings;
+- host/database names unless already approved as names-only metadata;
+- data-source ids;
+- row values;
+- target payload JSON;
+- raw SQL;
+- dry-run tokens;
+- private sheet/field ids;
+- value-bearing stack traces.
+
+Example values-free result:
+
+```text
+c6TestFailureInjection:
+  enabledByDeploy=true
+  enabledByServerConfig=true
+  clientControlled=false
+  targetKind=data-source:sql-write-gated
+  environment=sandbox
+  dryRunTokenRequired=true
+  revisionMatched=true
+  injectedRows=1
+  cleanSiblingWritten=true
+  apply.status=partial
+  deadLetters.count=1
+  rowErrorTypes=C6_TEST_INJECTED_ROW_FAILURE
+  productionWrite=false
+  batchWrite=false
+  rawSql=false
+  k3Write=false
+  valuesFreeEvidence=true
+```
+
+## Implementation Acceptance For C6-5b
+
+A future implementation PR must include all of these tests:
+
+- default-off: with the env flag absent or false, no injected failure can occur;
+- server-config gate: env true but no admin-reviewed sandbox config still does
+  not inject;
+- sandbox-only: non-sandbox target fails closed before write when injection is
+  requested by server config;
+- target-kind guard: only `data-source:sql-write-gated` can use the test path;
+- raw-query guard: target must remain `genericQueryDisabled=true`;
+- client cannot activate injection: request body fields cannot select or enable
+  the failed row;
+- token/revision first: missing, stale, used, or mismatched tokens block before
+  any injected write;
+- single-row failure: exactly one row receives the synthetic error token;
+- clean sibling writes: at least one valid sibling row writes in the same apply;
+- values-free dead-letter/provenance: no row values, payload JSON, SQL text,
+  data-source ids, credentials, tokens, or value-bearing messages;
+- ordinary C6 apply remains unchanged when the test gates are off.
+
+At least one integration-style test must drive the real C6 apply route with a
+fake structured write facade; a helper-only fixture is not enough.
+
+## Entity-Machine Acceptance For C6-5c
+
+After C6-5b lands and a new sandbox package is published, #2720 may continue
+with this ordered sequence:
+
+1. deploy package and confirm checksum/health;
+2. confirm the test-injection deploy flag is enabled only for the sandbox
+   package/environment;
+3. dry-run through the dedicated C6 route;
+4. apply with the fresh token and explicit review confirmation;
+5. verify `apply.status=partial`, one synthetic row error, and at least one clean
+   sibling write;
+6. verify dead-letter/provenance are values-free;
+7. re-pull and verify idempotence/no duplicate target rows;
+8. clean up with operator-local sandbox controls;
+9. disable the test-injection flag after validation.
+
+If any evidence contains values or any boundary opens, stop and report HOLD.
+
+## Sequencing
+
+- C6-5a: this design and tracker/runbook updates. Docs only.
+- C6-5b: implement the default-off test-only injection seam and tests. Separate
+  opt-in.
+- C6-5c: publish a sandbox package and rerun #2720 controlled bad-row evidence.
+  Separate opt-in.
+
+C6-5 remains open until C6-5c passes. Production and batch rollout remain closed.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -1,6 +1,6 @@
 # 数据库连接与系统对接交付收尾 TODO
 
-状态日期: 2026-06-16
+状态日期: 2026-06-17
 
 本文只跟踪“数据库连接能力接入系统并最终可交付”的剩余开发量。它不替代各功能线自己的设计文档/验证文档；每个 runtime 写能力仍然必须单独 opt-in、单独 PR、单独实体机验证。
 
@@ -22,8 +22,9 @@
   C6-3 增加 token-bound apply route；C6-4 UI dry-run -> review -> apply 已合并并发出实体机
   smoke 包；#2720 已完成 sandbox 配置和核心 dry-run/apply/re-pull/rollback smoke，
   且 #2737 后的 read-only dedicated-route 子门已 PASS。controlled bad-row 已尝试但
-  HOLD 在 `HOLD_TARGET_DDL_UNAVAILABLE`；下一步需要 DDL-capable sandbox/reset principal
-  或 seeded naturally failing sandbox row。production/batch 仍关闭。
+  HOLD 在 `HOLD_TARGET_DDL_UNAVAILABLE`，随后 seeded naturally failing row 也被实体机
+  回复确认为无安全 reset/cleanup 形态，路由为 `HOLD_NO_SAFE_FAILURE_SHAPE`。下一步只能
+  是独立的 C6-5a test-only failure-injection 设计/实现/复验链；production/batch 仍关闭。
 
 ## 收口顺序
 
@@ -34,8 +35,8 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | C6-5 smoke package published; #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row HOLD_TARGET_DDL_UNAVAILABLE | 交付签收 | 包内容/部署/证据不完整 |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open; C6-5a test-only injection design queued | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| Release | 总包 + 实体机验收 | C6-5 smoke package published; #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row HOLD_NO_SAFE_FAILURE_SHAPE | 交付签收 | 包内容/部署/证据不完整 |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -436,18 +437,23 @@ TODO:
     DDL/TRIGGER privilege for the planned reversible one-shot write-time failure injection
     (`42501` / `HOLD_TARGET_DDL_UNAVAILABLE`). Apply was not run, no target rows were written,
     and cleanup was values-free.
-  - remaining HOLD: controlled bad-row still needs a true write-time target constraint failure that
-    proves row-level failure evidence is values-free and clean sibling rows are not silently
-    swallowed. Target lookup / plan-decision drift after dry-run is a revision-fence check
+  - #2720 follow-up HOLD: the target data source connects and can be inspected, but the same
+    principal cannot perform the values-free reset/cleanup needed after a sandbox Apply. A seeded
+    naturally failing row/constraint shape is therefore unavailable; no fresh Apply was run and no
+    target rows were written. Routing tokens: `controlledBadRow=hold`,
+    `controlledBadRowStopReason=no_safe_failure_shape`, `failureShape=no_safe_failure_shape`.
+  - remaining HOLD: controlled bad-row still needs a true write-time row failure that proves
+    row-level failure evidence is values-free and clean sibling rows are not silently swallowed.
+    Target lookup / plan-decision drift after dry-run is a revision-fence check
     (`C6_WRITE_DRY_RUN_TOKEN_MISMATCH`), not this row-level failure gate.
-  - next options, in order: provide a DDL-capable sandbox/reset principal for this sandbox-only,
-    operator-local maintenance check; use a seeded naturally failing row that can be reset
-    values-free; only if neither exists, open a separate design-first test-only failure-injection
-    slice. Do not add a broad production runtime failure hook inside C6-5.
-  - before opening a test-only failure-injection design slice, the entity-machine operator must
-    explicitly report whether the seeded naturally failing row is possible. If both sandbox-safe
-    failure shapes are unavailable, report `HOLD_NO_SAFE_FAILURE_SHAPE`; this is a routing signal,
-    not runtime authorization.
+  - [x] C6-5a test-only failure-injection design:
+    `docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md`.
+    This is design-only and exists only because both real sandbox failure shapes are unavailable.
+  - [ ] C6-5b test-only failure-injection implementation: default-off, sandbox-only, server-owned
+    double gate; no client-controlled injection, no production hook, no raw SQL/DDL/trigger path.
+  - [ ] C6-5c package + entity-machine rerun: publish a sandbox package, rerun controlled bad-row
+    with one synthetic row failure plus at least one clean sibling write, prove values-free
+    dead-letter/provenance and re-pull idempotence, then disable the test-injection gate.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:
@@ -509,8 +515,9 @@ TODO:
 - [x] C6 core dry-run/apply/re-pull/rollback smoke（#2720）。
   - core sandbox smoke PASS; read-only dedicated dry-run subgate PASS.
 - [ ] C6 controlled bad-row row-level failure smoke（#2720）。
-  - attempted but HOLD on `HOLD_TARGET_DDL_UNAVAILABLE`; Apply was not run for that attempt and
-    no target rows were written.
+  - attempted but HOLD on `HOLD_TARGET_DDL_UNAVAILABLE`; seeded naturally failing row also
+    HOLD on `HOLD_NO_SAFE_FAILURE_SHAPE`. Apply was not run for either failed controlled
+    bad-row setup and no target rows were written.
   - C6-5 cannot close until true row-level write-time failure / dead-letter / provenance evidence
     is produced values-free.
 - [ ] issue 上贴 values-free 验收证据。

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -2,14 +2,16 @@
 
 Purpose: run or continue #2720's sandbox-only C6 external-write smoke.
 
-Current #2720 status as of 2026-06-16: the sandbox write target, write-gated
+Current #2720 status as of 2026-06-17: the sandbox write target, write-gated
 external system, active C6 pipeline, core dry-run/apply/re-pull/rollback path
 have already passed on the entity machine. After #2737, the read-only subgate
 also passed on the dedicated C6 route: an `integration:read` user can call
 `/external-write/dry-run`, while `/external-write/apply` remains blocked. The
-remaining HOLD is the controlled bad-row check. If continuing that run, do not
-recreate the sandbox or rerun write/admin Apply just to repeat already-passed
-checks.
+remaining HOLD is the controlled bad-row check. The DDL-backed failure shape is
+unavailable, and the seeded naturally failing row/constraint shape is also
+unavailable because the target principal cannot safely reset/cleanup values-free
+after sandbox Apply. If continuing that run, do not recreate the sandbox or rerun
+write/admin Apply just to repeat already-passed checks.
 
 This runbook sets up the minimum sandbox-only shape needed to run the C6
 dry-run -> apply -> re-pull -> rollback/cleanup smoke. It does not authorize
@@ -356,8 +358,11 @@ write-time bad-row shape is available.
 Current #2720 attempt note: the first entity-machine bad-row setup stopped
 before Apply because the sandbox target principal could connect but lacked the
 DDL/TRIGGER privilege needed to install a temporary one-shot failure trigger.
-That is `HOLD_TARGET_DDL_UNAVAILABLE`, not a C6 route/runtime defect. Do not
-rerun Apply until one of these safe write-time failure shapes is available:
+That is `HOLD_TARGET_DDL_UNAVAILABLE`, not a C6 route/runtime defect. The
+operator then checked the seeded naturally failing row path and reported
+`HOLD_NO_SAFE_FAILURE_SHAPE`: the target principal can inspect/connect but cannot
+perform the values-free reset/cleanup required after sandbox Apply. Do not rerun
+Apply until one of these safe write-time failure paths is available:
 
 - a DDL-capable sandbox/reset principal for the sandbox-only temporary trigger;
 - a seeded naturally failing row that can be reset values-free;
@@ -369,12 +374,14 @@ outside MetaSheet product/runtime paths. It must never run against production,
 must never become evidence-bearing, and does not relax the forbidden product
 raw SQL / query / stored procedure / trigger paths above.
 
-Before opening any test-only failure-injection design slice, the entity-machine
-operator must also explicitly confirm whether a seeded naturally failing
-sandbox row/constraint shape is possible. If neither the DDL-backed temporary
-failure nor the seeded naturally failing row can be run safely, report
-`HOLD_NO_SAFE_FAILURE_SHAPE` and keep C6-5 open. That report is a routing signal
-only; it does not authorize runtime failure-injection code by itself.
+The entity-machine operator has now reported `HOLD_NO_SAFE_FAILURE_SHAPE`; that
+is a routing signal only, not runtime authorization. The next path is:
+
+1. C6-5a test-only failure-injection design;
+2. C6-5b default-off sandbox-only implementation;
+3. C6-5c new package + entity-machine rerun.
+
+Until C6-5b/C6-5c exist, leave this controlled bad-row step at HOLD.
 
 Expected:
 

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -46,7 +46,7 @@ the corresponding section below and post fresh values-free evidence.
 | C3 incremental/watermark | Runtime and CI real-DB wire locks are landed on main, but no release-package entity-machine incremental/resume smoke is recorded in this runbook. Large-BOM #2425 is related Data Factory C3/C4 evidence, not the SQL watermark/resume release gate. | Section 4 remains required for complete delivery unless an owner explicitly narrows the release scope and uses downgraded wording. Do not cite #2425 as C3 watermark/resume PASS. |
 | C4 UI configuration | Source/object/schema picker, source-field picker, watermark UI, and read-only/source-only boundary UX have landed, but this runbook has no final release-package UI smoke evidence yet. | Section 5 remains required for complete delivery unless exact UI smoke is explicitly deferred with downgraded wording. |
 | C5 K3/MSSQL read-only seam | issue #2670 closed PASS on package `dea391a1`: generic SQL Server smoke and K3 SQL Server executor smoke both passed after operator SQL scope adjustment; no K3 Save/Submit/Audit/BOM, external DB write, raw SQL, credentials, or row values were printed. | May be cited when no C5-relevant package/runtime surface changed after `dea391a1`; otherwise rerun the C5 runbook on the release package. |
-| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS and read-only dedicated-route PASS; controlled bad-row remains HOLD on `HOLD_TARGET_DDL_UNAVAILABLE` until a safe seeded-row/DDL-backed write-time failure shape is available. | C6-5 is not closed. Release signoff cannot claim complete database/source-system delivery until controlled bad-row row-level failure/dead-letter/provenance evidence passes values-free. |
+| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS and read-only dedicated-route PASS; controlled bad-row remains HOLD after both `HOLD_TARGET_DDL_UNAVAILABLE` and `HOLD_NO_SAFE_FAILURE_SHAPE`. C6-5a now routes this to a separate test-only failure-injection design path. | C6-5 is not closed. Release signoff cannot claim complete database/source-system delivery until controlled bad-row row-level failure/dead-letter/provenance evidence passes values-free on a later sandbox package. |
 
 ## Required Inputs
 
@@ -243,6 +243,7 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
+  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
@@ -253,14 +254,23 @@ c6Sandbox:
   valuesFreeEvidence=true
 ```
 
-Current #2720 checkpoint as of 2026-06-16:
+Current #2720 checkpoint as of 2026-06-17:
 
 - core sandbox dry-run/apply/re-pull/rollback: passed;
 - dedicated read-only route subgate: passed
   (`/external-write/dry-run` allowed for `integration:read`; `/external-write/apply`
   blocked for the same read-only user);
 - controlled bad-row: attempted, HOLD on target DDL/TRIGGER privilege unavailable;
-  no Apply ran for that attempt, no target rows were written.
+  no Apply ran for that attempt, no target rows were written;
+- seeded naturally failing row: also HOLD because the target principal cannot
+  perform the values-free reset/cleanup needed after sandbox Apply;
+- current controlled bad-row routing:
+  `controlledBadRow=hold`,
+  `controlledBadRowStopReason=no_safe_failure_shape`,
+  `failureShape=no_safe_failure_shape`;
+- next eligible step is the separate C6-5a/C6-5b/C6-5c test-only
+  failure-injection path. This runbook still does not authorize production,
+  batch, raw SQL, DDL, trigger, or broad runtime failure hooks.
 
 ## Stop Rules
 
@@ -355,6 +365,7 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
+  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false


### PR DESCRIPTION
## Summary
- record #2720's `HOLD_NO_SAFE_FAILURE_SHAPE` routing after both DDL-backed and seeded-row controlled bad-row shapes proved unavailable
- add a C6-5a design contract for a default-off, sandbox-only, server-owned test failure-injection path
- update C6/release runbooks and the delivery TODO while keeping C6-5 open and production/batch closed

## Verification
- `git diff --check`
- `node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- subagent state/evidence review: P2 fixed (`failureShape` added to both release templates), then resolved
- subagent security/boundary review: no findings

## Boundaries
Docs-only. No runtime hook, no route/UI/package, no production/batch authorization, no K3, no raw SQL/DDL/stored-procedure/trigger product path, and no C6-5 PASS claim.
