### PR TITLE
feat(multitable): rollup aggregation expansion — countall + unique (slice 2a)

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -230,6 +230,8 @@
             <span>{{ ml('field.aggregation') }}</span>
             <select v-model="rollupDraft.aggregation" class="meta-field-mgr__select">
               <option value="count">{{ aggregationLabel('count', isZh) }}</option>
+              <option value="countall">{{ aggregationLabel('countall', isZh) }}</option>
+              <option value="unique">{{ aggregationLabel('unique', isZh) }}</option>
               <option value="sum">{{ aggregationLabel('sum', isZh) }}</option>
               <option value="avg">{{ aggregationLabel('avg', isZh) }}</option>
               <option value="min">{{ aggregationLabel('min', isZh) }}</option>
@@ -739,6 +741,7 @@ import {
   resolveRatingFieldProperty,
   resolveRollupFieldProperty,
   resolveSelectFieldOptions,
+  type RollupAggregation,
 } from '../utils/field-config'
 import {
   SYSTEM_FIELD_TYPES,
@@ -976,7 +979,7 @@ const lookupDraft = reactive<{ linkFieldId: string; targetFieldId: string; forei
   targetFieldId: '',
   foreignSheetId: '',
 })
-const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: 'count' | 'sum' | 'avg' | 'min' | 'max' }>({
+const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation }>({
   linkFieldId: '',
   targetFieldId: '',
   foreignSheetId: '',

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -24,11 +24,23 @@ export type NormalizedLookupFieldProperty = {
   foreignSheetId: string | null
 }
 
+export type RollupAggregation = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+
 export type NormalizedRollupFieldProperty = {
   linkFieldId: string | null
   targetFieldId: string | null
   foreignSheetId: string | null
-  aggregation: 'count' | 'sum' | 'avg' | 'min' | 'max'
+  aggregation: RollupAggregation
+}
+
+// Keep in lockstep with parseRollupAggregation in core-backend (routes/univer-meta.ts + field-codecs.ts):
+// an aggregation this rejects gets silently shown/saved as 'count', corrupting a stored countall/unique.
+const ROLLUP_AGGREGATIONS: readonly RollupAggregation[] = ['count', 'sum', 'avg', 'min', 'max', 'countall', 'unique']
+export function normalizeRollupAggregation(value: string | null | undefined): RollupAggregation {
+  const a = (value ?? '').trim().toLowerCase()
+  if (a === 'counta') return 'count'
+  if (a === 'distinct' || a === 'uniquecount') return 'unique'
+  return (ROLLUP_AGGREGATIONS as readonly string[]).includes(a) ? (a as RollupAggregation) : 'count'
 }
 
 export type NormalizedFormulaFieldProperty = {
@@ -148,9 +160,7 @@ export function resolveRollupFieldProperty(value: unknown): NormalizedRollupFiel
     linkFieldId: stringOrNull(property.linkFieldId ?? property.linkedFieldId ?? property.relatedLinkFieldId ?? property.sourceFieldId),
     targetFieldId: stringOrNull(property.targetFieldId ?? property.lookUpTargetFieldId ?? property.lookupTargetFieldId ?? property.lookupFieldId),
     foreignSheetId: stringOrNull(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId),
-    aggregation: aggregation === 'sum' || aggregation === 'avg' || aggregation === 'min' || aggregation === 'max'
-      ? aggregation
-      : 'count',
+    aggregation: normalizeRollupAggregation(aggregation),
   }
 }
 

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -585,12 +585,18 @@ export function autoLinkFieldLabel(isZh: boolean): string {
 }
 
 export function aggregationLabel(value: string, isZh: boolean): string {
-  if (!isZh) return value
-  if (value === 'count') return '计数'
-  if (value === 'sum') return '求和'
-  if (value === 'avg') return '平均值'
-  if (value === 'min') return '最小值'
-  if (value === 'max') return '最大值'
+  if (isZh) {
+    if (value === 'count') return '计数'
+    if (value === 'sum') return '求和'
+    if (value === 'avg') return '平均值'
+    if (value === 'min') return '最小值'
+    if (value === 'max') return '最大值'
+    if (value === 'countall') return '记录数'
+    if (value === 'unique') return '去重计数'
+    return value
+  }
+  if (value === 'countall') return 'Count all'
+  if (value === 'unique') return 'Unique'
   return value
 }
 

--- a/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
+++ b/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeRollupAggregation, resolveRollupFieldProperty } from '../src/multitable/utils/field-config'
+import { aggregationLabel } from '../src/multitable/utils/meta-manager-labels'
+
+// Rollup aggregation expansion (slice 2a) — FE round-trip lock.
+//
+// Backend gained two numeric reducers (countall, unique). The FE normalizer is the read-back path:
+// before this change `resolveRollupFieldProperty` only recognized count/sum/avg/min/max and silently
+// collapsed a stored countall/unique to 'count' — so loading then re-saving the field corrupted the
+// aggregation. These tests lock the normalizer + label so the round-trip stays faithful (the #1781
+// wire-vs-fixture trap, normalizer-only, no component mount).
+describe('rollup aggregation — FE normalizer round-trip', () => {
+  it('normalizeRollupAggregation preserves the new numeric reducers', () => {
+    expect(normalizeRollupAggregation('countall')).toBe('countall')
+    expect(normalizeRollupAggregation('unique')).toBe('unique')
+    for (const a of ['count', 'sum', 'avg', 'min', 'max'] as const) {
+      expect(normalizeRollupAggregation(a)).toBe(a)
+    }
+  })
+
+  it('normalizeRollupAggregation honors backend aliases + case/whitespace', () => {
+    expect(normalizeRollupAggregation('counta')).toBe('count')
+    expect(normalizeRollupAggregation('distinct')).toBe('unique')
+    expect(normalizeRollupAggregation('uniquecount')).toBe('unique')
+    expect(normalizeRollupAggregation(' CountAll ')).toBe('countall')
+  })
+
+  it('unknown / empty aggregation falls back to count', () => {
+    expect(normalizeRollupAggregation('concatenate')).toBe('count') // deferred to slice 2b — not yet valid
+    expect(normalizeRollupAggregation('bogus')).toBe('count')
+    expect(normalizeRollupAggregation('')).toBe('count')
+    expect(normalizeRollupAggregation(null)).toBe('count')
+  })
+
+  it('resolveRollupFieldProperty does NOT collapse a stored countall/unique to count', () => {
+    const countall = resolveRollupFieldProperty({ linkFieldId: 'l', targetFieldId: 't', foreignSheetId: 's', aggregation: 'countall' })
+    expect(countall.aggregation).toBe('countall')
+    const unique = resolveRollupFieldProperty({ linkFieldId: 'l', targetFieldId: 't', foreignSheetId: 's', aggregation: 'unique' })
+    expect(unique.aggregation).toBe('unique')
+  })
+
+  it('aggregationLabel returns a distinct label for the new reducers (zh + en)', () => {
+    expect(aggregationLabel('countall', true)).toBe('记录数')
+    expect(aggregationLabel('unique', true)).toBe('去重计数')
+    expect(aggregationLabel('countall', false)).toBe('Count all')
+    expect(aggregationLabel('unique', false)).toBe('Unique')
+  })
+})

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -193,18 +193,25 @@ function sanitizeStringArray(value: unknown): string[] {
     .filter((item) => item.length > 0)
 }
 
-function parseRollupAggregation(value: unknown): 'count' | 'sum' | 'avg' | 'min' | 'max' | null {
+// Keep this enum in lockstep with parseRollupAggregation in routes/univer-meta.ts — this codec runs on the
+// provisioning / template-install / SDK-fixture write paths, and a value it rejects gets silently
+// corrupted to 'count' by the caller's `?? 'count'` fallback. Slice 2a added countall + unique (numeric).
+type RollupAggregationCodec = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+function parseRollupAggregation(value: unknown): RollupAggregationCodec | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
   if (normalized === 'counta') return 'count'
+  if (normalized === 'distinct' || normalized === 'uniquecount') return 'unique'
   if (
     normalized === 'count' ||
     normalized === 'sum' ||
     normalized === 'avg' ||
     normalized === 'min' ||
-    normalized === 'max'
+    normalized === 'max' ||
+    normalized === 'countall' ||
+    normalized === 'unique'
   ) {
-    return normalized as 'count' | 'sum' | 'avg' | 'min' | 'max'
+    return normalized as RollupAggregationCodec
   }
   return null
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -920,7 +920,11 @@ type LookupFieldConfig = {
   skipForeignFieldMasking?: boolean
 }
 
-type RollupAggregation = 'count' | 'sum' | 'avg' | 'min' | 'max'
+type RollupAggregation =
+  | 'count' | 'sum' | 'avg' | 'min' | 'max'
+  // Expansion: countall (resolved linked records incl. null-target), unique (distinct values), and the
+  // non-numeric reducers concatenate / and / or / xor.
+  | 'countall' | 'unique' | 'concatenate' | 'and' | 'or' | 'xor'
 
 type RollupFieldConfig = {
   linkFieldId: string
@@ -1012,10 +1016,51 @@ function parseLookupFieldConfig(property: unknown): LookupFieldConfig | null {
 function parseRollupAggregation(value: unknown): RollupAggregation | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
+  // counta ≡ count here: resolveLookupValues already drops null/empty targets, so `count` (values.length)
+  // is the count of non-empty values. Use `countall` for the all-records-incl-empty count.
   if (normalized === 'counta') return 'count'
-  if (normalized === 'count' || normalized === 'sum' || normalized === 'avg' || normalized === 'min' || normalized === 'max') {
+  if (normalized === 'concat') return 'concatenate'
+  if (normalized === 'distinct' || normalized === 'uniquecount') return 'unique'
+  if (
+    normalized === 'count' || normalized === 'sum' || normalized === 'avg' || normalized === 'min' || normalized === 'max'
+    || normalized === 'countall' || normalized === 'unique' || normalized === 'concatenate'
+    || normalized === 'and' || normalized === 'or' || normalized === 'xor'
+  ) {
     return normalized as RollupAggregation
   }
+  return null
+}
+
+/**
+ * Pure rollup reducer (exported for unit tests).
+ * - `values`: non-empty target values of foreign records the actor may read (post sheet-read + field-mask).
+ * - `count`: resolved linked records incl. empty target — the only signal `countall` needs.
+ * Numeric reducers (sum/avg/min/max) return null when no numeric values exist; non-numeric reducers
+ * (concatenate→string, and/or/xor→boolean) always return a concrete value. Record-level read is NON-GATING
+ * here by design (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
+ */
+export function aggregateRollup(
+  values: unknown[],
+  count: number,
+  aggregation: RollupAggregation,
+): number | string | boolean | null {
+  if (aggregation === 'count') return values.length // non-empty target values (≡ COUNTA)
+  if (aggregation === 'countall') return count // all resolved linked records, incl. empty target
+  if (aggregation === 'unique') {
+    return new Set(values.map((v) => (v !== null && typeof v === 'object' ? JSON.stringify(v) : v))).size
+  }
+  if (aggregation === 'concatenate') return values.map((v) => String(v)).join(', ')
+  if (aggregation === 'and') return values.length > 0 && values.every((v) => !!v)
+  if (aggregation === 'or') return values.some((v) => !!v)
+  if (aggregation === 'xor') return values.filter((v) => !!v).length % 2 === 1
+  const nums = values
+    .map((v) => toComparableNumber(v))
+    .filter((v): v is number => v !== null && Number.isFinite(v))
+  if (nums.length === 0) return null
+  if (aggregation === 'sum') return nums.reduce((sum, v) => sum + v, 0)
+  if (aggregation === 'avg') return nums.reduce((sum, v) => sum + v, 0) / nums.length
+  if (aggregation === 'min') return Math.min(...nums)
+  if (aggregation === 'max') return Math.max(...nums)
   return null
 }
 
@@ -2546,43 +2591,35 @@ async function applyLookupRollup(
   const resolveLookupValues = (
     record: UniverMetaRecord,
     cfg: LookupFieldConfig | RollupFieldConfig,
-  ): { values: unknown[]; masked: boolean } => {
+  ): { values: unknown[]; count: number; masked: boolean } => {
     const foreignSheetId = cfg.foreignSheetId ?? linkConfigById.get(cfg.linkFieldId)?.foreignSheetId
-    if (!foreignSheetId) return { values: [], masked: false }
+    if (!foreignSheetId) return { values: [], count: 0, masked: false }
     const linkIds = getLinkIds(record, cfg.linkFieldId)
-    if (linkIds.length === 0) return { values: [], masked: false }
-    if (!readableForeignSheetIds.has(foreignSheetId)) return { values: [], masked: true }
+    if (linkIds.length === 0) return { values: [], count: 0, masked: false }
+    if (!readableForeignSheetIds.has(foreignSheetId)) return { values: [], count: 0, masked: true }
     // §2a.3: fail-closed foreign-FIELD mask — if the actor can't read the foreign target field,
     // mask it (cross-base unconditional / same-base default unless opt-out). Same gate for
-    // lookup AND rollup (both read data[targetFieldId]).
+    // lookup AND rollup (both read data[targetFieldId]). Applied uniformly incl. countall — a record
+    // count over a field the actor can't read stays masked, no COUNTALL bypass of the field gate.
     if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cfg.targetFieldId, cfg.skipForeignFieldMasking)) {
-      return { values: [], masked: true }
+      return { values: [], count: 0, masked: true }
     }
     const foreignMap = foreignRecordsBySheet.get(foreignSheetId)
-    if (!foreignMap) return { values: [], masked: true }
+    if (!foreignMap) return { values: [], count: 0, masked: true }
     const values: unknown[] = []
+    let count = 0
     for (const id of linkIds) {
       const data = foreignMap.get(id)
       if (!data) continue
+      count += 1 // a RESOLVED linked record, regardless of whether its target value is empty
       const value = data[cfg.targetFieldId]
       if (value === null || value === undefined) continue
       values.push(value)
     }
-    return { values, masked: false }
+    return { values, count, masked: false }
   }
 
-  const aggregateRollup = (values: unknown[], aggregation: RollupAggregation): number | null => {
-    if (aggregation === 'count') return values.length
-    const nums = values
-      .map((v) => toComparableNumber(v))
-      .filter((v): v is number => v !== null && Number.isFinite(v))
-    if (nums.length === 0) return null
-    if (aggregation === 'sum') return nums.reduce((sum, v) => sum + v, 0)
-    if (aggregation === 'avg') return nums.reduce((sum, v) => sum + v, 0) / nums.length
-    if (aggregation === 'min') return Math.min(...nums)
-    if (aggregation === 'max') return Math.max(...nums)
-    return null
-  }
+  // aggregateRollup is module-level + exported (unit-tested) — defined near parseRollupAggregation.
 
   for (const row of rows) {
     for (const [fieldId, cfg] of lookupConfigs.entries()) {
@@ -2598,8 +2635,8 @@ async function applyLookupRollup(
         row.data[fieldId] = null
         continue
       }
-      const { values, masked } = resolveLookupValues(row, cfg)
-      row.data[fieldId] = masked ? null : aggregateRollup(values, cfg.aggregation)
+      const { values, count, masked } = resolveLookupValues(row, cfg)
+      row.data[fieldId] = masked ? null : aggregateRollup(values, count, cfg.aggregation)
     }
   }
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1032,13 +1032,26 @@ function parseRollupAggregation(value: unknown): RollupAggregation | null {
 }
 
 /**
+ * A target value that contributes NOTHING to a rollup: null/undefined, an empty/whitespace-only string,
+ * or an empty array. This is the boundary that makes `count` (≡ COUNTA, non-empty) genuinely differ from
+ * `countall` (every resolved linked record): a linked row whose target is blank counts toward countall but
+ * NOT count/unique. Falsy-but-present scalars (0, false) are NOT blank — they are real values.
+ */
+function isBlankRollupValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true
+  if (typeof value === 'string') return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+  return false
+}
+
+/**
  * Pure rollup reducer (exported for unit tests). Every reducer here returns number|null, so a rollup's
  * computed value stays NUMERIC — keeping the `rollup → number` assumption in filter/sort/dashboard correct.
  * (The string/boolean reducers concatenate/and/or/xor are deferred to slice 2b, which must also teach those
  * consumers the rollup's non-numeric result type before they can ship.)
- * - `values`: non-null/non-undefined target values of foreign records the actor may read (post sheet-read
- *   + field-mask). null/undefined are dropped upstream; other falsy scalars (0, "", false) are kept.
- * - `count`: resolved linked records incl. empty target — the only signal `countall` needs.
+ * - `values`: target values of foreign records the actor may read (post sheet-read + field-mask). null/
+ *   undefined are dropped upstream; count/unique additionally drop blank values (see isBlankRollupValue).
+ * - `count`: resolved linked records incl. empty/blank target — the only signal `countall` needs.
  * Numeric reducers (sum/avg/min/max) return null when no numeric values exist. Record-level read is
  * NON-GATING here by design (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
  */
@@ -1047,10 +1060,14 @@ export function aggregateRollup(
   count: number,
   aggregation: RollupAggregation,
 ): number | null {
-  if (aggregation === 'count') return values.length // non-null target values (≡ COUNTA)
-  if (aggregation === 'countall') return count // all resolved linked records, incl. empty target
+  if (aggregation === 'count') return values.filter((v) => !isBlankRollupValue(v)).length // ≡ COUNTA
+  if (aggregation === 'countall') return count // all resolved linked records, incl. blank/empty target
   if (aggregation === 'unique') {
-    return new Set(values.map((v) => (v !== null && typeof v === 'object' ? JSON.stringify(v) : v))).size
+    return new Set(
+      values
+        .filter((v) => !isBlankRollupValue(v))
+        .map((v) => (typeof v === 'object' ? JSON.stringify(v) : v)),
+    ).size
   }
   const nums = values
     .map((v) => toComparableNumber(v))

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -922,9 +922,11 @@ type LookupFieldConfig = {
 
 type RollupAggregation =
   | 'count' | 'sum' | 'avg' | 'min' | 'max'
-  // Expansion: countall (resolved linked records incl. null-target), unique (distinct values), and the
-  // non-numeric reducers concatenate / and / or / xor.
-  | 'countall' | 'unique' | 'concatenate' | 'and' | 'or' | 'xor'
+  // Expansion slice 2a — both NUMERIC, so a rollup's value stays number|null and the `rollup → number`
+  // assumption baked into filter/sort/dashboard stays correct. countall = resolved linked records incl.
+  // empty target; unique = distinct-value count. The string/boolean reducers (concatenate/and/or/xor) are
+  // deferred to slice 2b, which must first teach those consumers the rollup's non-numeric result type.
+  | 'countall' | 'unique'
 
 type RollupFieldConfig = {
   linkFieldId: string
@@ -1019,12 +1021,10 @@ function parseRollupAggregation(value: unknown): RollupAggregation | null {
   // counta ≡ count here: resolveLookupValues already drops null/empty targets, so `count` (values.length)
   // is the count of non-empty values. Use `countall` for the all-records-incl-empty count.
   if (normalized === 'counta') return 'count'
-  if (normalized === 'concat') return 'concatenate'
   if (normalized === 'distinct' || normalized === 'uniquecount') return 'unique'
   if (
     normalized === 'count' || normalized === 'sum' || normalized === 'avg' || normalized === 'min' || normalized === 'max'
-    || normalized === 'countall' || normalized === 'unique' || normalized === 'concatenate'
-    || normalized === 'and' || normalized === 'or' || normalized === 'xor'
+    || normalized === 'countall' || normalized === 'unique'
   ) {
     return normalized as RollupAggregation
   }
@@ -1032,27 +1032,26 @@ function parseRollupAggregation(value: unknown): RollupAggregation | null {
 }
 
 /**
- * Pure rollup reducer (exported for unit tests).
- * - `values`: non-empty target values of foreign records the actor may read (post sheet-read + field-mask).
+ * Pure rollup reducer (exported for unit tests). Every reducer here returns number|null, so a rollup's
+ * computed value stays NUMERIC — keeping the `rollup → number` assumption in filter/sort/dashboard correct.
+ * (The string/boolean reducers concatenate/and/or/xor are deferred to slice 2b, which must also teach those
+ * consumers the rollup's non-numeric result type before they can ship.)
+ * - `values`: non-null/non-undefined target values of foreign records the actor may read (post sheet-read
+ *   + field-mask). null/undefined are dropped upstream; other falsy scalars (0, "", false) are kept.
  * - `count`: resolved linked records incl. empty target — the only signal `countall` needs.
- * Numeric reducers (sum/avg/min/max) return null when no numeric values exist; non-numeric reducers
- * (concatenate→string, and/or/xor→boolean) always return a concrete value. Record-level read is NON-GATING
- * here by design (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
+ * Numeric reducers (sum/avg/min/max) return null when no numeric values exist. Record-level read is
+ * NON-GATING here by design (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
  */
 export function aggregateRollup(
   values: unknown[],
   count: number,
   aggregation: RollupAggregation,
-): number | string | boolean | null {
-  if (aggregation === 'count') return values.length // non-empty target values (≡ COUNTA)
+): number | null {
+  if (aggregation === 'count') return values.length // non-null target values (≡ COUNTA)
   if (aggregation === 'countall') return count // all resolved linked records, incl. empty target
   if (aggregation === 'unique') {
     return new Set(values.map((v) => (v !== null && typeof v === 'object' ? JSON.stringify(v) : v))).size
   }
-  if (aggregation === 'concatenate') return values.map((v) => String(v)).join(', ')
-  if (aggregation === 'and') return values.length > 0 && values.every((v) => !!v)
-  if (aggregation === 'or') return values.some((v) => !!v)
-  if (aggregation === 'xor') return values.filter((v) => !!v).length % 2 === 1
   const nums = values
     .map((v) => toComparableNumber(v))
     .filter((v): v is number => v !== null && Number.isFinite(v))

--- a/packages/core-backend/tests/integration/multitable-rollup-countall-nongating.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-countall-nongating.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Rollup COUNTALL — non-gating characterization (real DB).
+ *
+ * Owner-mandated regression lock for the #20 contract decision (B′): record-level read is NON-GATING.
+ * record_permissions in this codebase is a write/admin ELEVATION mechanism, not read-deny — so a
+ * record_permission pointing at OTHER subjects must NOT change a sheet-readable actor's COUNTALL. This
+ * test pins that behavior so a future change can't silently reintroduce record-level row filtering into
+ * lookup/rollup (which a past review mistook for a "leak") without turning this red.
+ *
+ * It also pins the REAL gate that DOES apply: when the foreign TARGET FIELD is masked for the actor
+ * (field_permissions), the rollup (incl. countall) returns null — no field-gate bypass.
+ *
+ * Trigger: GET /records/:recordId computes applyLookupRollup unconditionally for the single record and
+ * returns the computed value at res.body.data.record.data[rollupFieldId].
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const ALLOW_USER = `u_ca_allow_${TS}` // sheet-read on both sheets; no field denial
+const DENY_USER = `u_ca_deny_${TS}` // denied on the foreign target field (field-mask real gate)
+const OTHER_USER = `u_ca_other_${TS}` // the unrelated subject a record_permission points at
+
+const BASE = `base_ca_${TS}` // same base — keeps the cross-base base-read gate out of scope
+const FS = `sheet_ca_fs_${TS}` // foreign sheet (linked-to)
+const MS = `sheet_ca_main_${TS}` // source sheet (holds the link + rollups)
+
+const FLD_TARGET = `fld_ca_tgt_${TS}` // foreign target value (number)
+const FLD_LINK = `fld_ca_lk_${TS}`
+const FLD_COUNTALL = `fld_ca_all_${TS}` // rollup aggregation=countall
+const FLD_COUNT = `fld_ca_cnt_${TS}` // rollup aggregation=count (non-empty) — contrast vs countall
+
+// 3 foreign records: two with a non-empty target, one with an EMPTY target → countall=3, count=2.
+const FR1 = `rec_ca_f1_${TS}`
+const FR2 = `rec_ca_f2_${TS}`
+const FR3 = `rec_ca_f3_${TS}` // empty target
+const REC = `rec_ca_src_${TS}` // the source record linking all three
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = {
+      id: userId,
+      roles: ['member'],
+      perms: ['multitable:read'],
+      permissions: ['multitable:read'],
+    }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+
+async function readRollup(userId: string, fieldId: string): Promise<unknown> {
+  const res = await request(buildApp(userId)).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return res.body?.data?.record?.data?.[fieldId]
+}
+
+describeIfDatabase('multitable rollup countall — record-read non-gating characterization (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE, 'CA Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FS, BASE, 'CA Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [MS, BASE, 'CA Main'])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_TARGET, FS, 'Target', 'number', '{}', 1])
+
+    // FR1/FR2 have a non-empty target; FR3 has an EMPTY target (no FLD_TARGET key).
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR1, FS, JSON.stringify({ [FLD_TARGET]: 10 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR2, FS, JSON.stringify({ [FLD_TARGET]: 20 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR3, FS, JSON.stringify({})])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_COUNTALL, MS, 'CountAll', 'rollup',
+        JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_TARGET, foreignSheetId: FS, aggregation: 'countall' }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_COUNT, MS, 'CountNonEmpty', 'rollup',
+        JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_TARGET, foreignSheetId: FS, aggregation: 'count' }), 3])
+
+    // Source record links all three foreign records (data + meta_links, mirroring the read path).
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
+    for (const fr of [FR1, FR2, FR3]) {
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
+        [`lnk_ca_${fr}`, FLD_LINK, REC, fr])
+    }
+
+    // DENY_USER cannot read the foreign target field → the rollup must mask to null for them.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [FS, FLD_TARGET, 'user', DENY_USER, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS]]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('baseline: sheet-reader sees countall=3 (incl. empty-target row) and count=2 (non-empty only)', async () => {
+    expect(await readRollup(ALLOW_USER, FLD_COUNTALL)).toBe(3)
+    expect(await readRollup(ALLOW_USER, FLD_COUNT)).toBe(2)
+  })
+
+  test('CHARACTERIZATION: a record_permission on a linked row for ANOTHER subject does NOT change the sheet-reader\'s countall', async () => {
+    // Grant OTHER_USER an explicit record permission on ONE linked foreign record. Under the non-gating
+    // contract this must NOT remove that row from ALLOW_USER's rollup — record_permissions only ELEVATE
+    // (write/admin) for the named subject; they never deny read to a sheet-reader.
+    await q(
+      'INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)',
+      [FS, FR1, 'user', OTHER_USER, 'read'],
+    )
+    expect(await readRollup(ALLOW_USER, FLD_COUNTALL)).toBe(3) // unchanged — non-gating
+    expect(await readRollup(ALLOW_USER, FLD_COUNT)).toBe(2)
+
+    // And the actor the grant points at also reads the full count (the grant is additive, not exclusive).
+    expect(await readRollup(OTHER_USER, FLD_COUNTALL)).toBe(3)
+  })
+
+  test('REAL gate: a field-masked foreign target makes the rollup (incl. countall) null — no field-gate bypass', async () => {
+    expect(await readRollup(DENY_USER, FLD_COUNTALL) ?? null).toBeNull()
+    expect(await readRollup(DENY_USER, FLD_COUNT) ?? null).toBeNull()
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
+++ b/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Rollup aggregation expansion slice 2a (numeric reducers only) — pure-reducer unit tests.
+ *
+ * Locks the exported pure fn `aggregateRollup(values, count, aggregation)`. Every reducer returns
+ * number|null (the string/boolean reducers concatenate/and/or/xor are deferred to slice 2b):
+ *   - count       -> values.length (non-null target values, ≡ COUNTA)
+ *   - countall    -> the `count` arg (resolved linked records incl. empty target — INDEPENDENT of
+ *                    values.length)
+ *   - unique      -> distinct count (primitives by identity; 1 vs "1" distinct; objects keyed by
+ *                    JSON.stringify so structurally-equal duplicates collapse; null stays null)
+ *   - sum/avg/min/max -> over numeric values (toComparableNumber); null when no numeric values;
+ *                        numeric-string coercion; non-numerics filtered out
+ *
+ * `aggregateRollup` is the masked-safe caller's reducer: the route passes null instead of calling it
+ * when the foreign sheet/field is masked, so these tests exercise the un-masked numeric/value paths.
+ */
+import { describe, test, expect } from 'vitest'
+import { aggregateRollup } from '../../src/routes/univer-meta'
+
+describe('aggregateRollup — rollup reducer expansion', () => {
+  describe('count (≡ COUNTA: non-empty target values)', () => {
+    test('returns values.length', () => {
+      expect(aggregateRollup([1, 2, 3], 3, 'count')).toBe(3)
+      expect(aggregateRollup(['a', 'b'], 5, 'count')).toBe(2)
+    })
+    test('empty values -> 0 (independent of count arg)', () => {
+      expect(aggregateRollup([], 0, 'count')).toBe(0)
+      expect(aggregateRollup([], 4, 'count')).toBe(0)
+    })
+  })
+
+  describe('countall (resolved linked records incl. empty target)', () => {
+    test('uses the count arg, INDEPENDENT of values.length', () => {
+      // 3 records resolved, only 1 had a non-empty target value.
+      expect(aggregateRollup([1], 3, 'countall')).toBe(3)
+      expect(aggregateRollup([1], 1, 'count')).toBe(1) // sibling count over the same data
+    })
+    test('empty values still reports the resolved-record count', () => {
+      expect(aggregateRollup([], 4, 'countall')).toBe(4)
+      expect(aggregateRollup([], 0, 'countall')).toBe(0)
+    })
+    test('more values than count is still driven purely by count', () => {
+      expect(aggregateRollup([1, 2, 3, 4], 2, 'countall')).toBe(2)
+    })
+  })
+
+  describe('unique (distinct count)', () => {
+    test('distinct primitives', () => {
+      expect(aggregateRollup([1, 1, 2, 3, 3, 3], 6, 'unique')).toBe(3)
+      expect(aggregateRollup(['a', 'b', 'a'], 3, 'unique')).toBe(2)
+    })
+    test('1 (number) and "1" (string) are distinct', () => {
+      expect(aggregateRollup([1, '1'], 2, 'unique')).toBe(2)
+    })
+    test('structurally-equal objects collapse via JSON.stringify', () => {
+      expect(aggregateRollup([{ a: 1 }, { a: 1 }, { a: 2 }], 3, 'unique')).toBe(2)
+    })
+    test('null is preserved as a single distinct bucket', () => {
+      expect(aggregateRollup([null, null], 2, 'unique')).toBe(1)
+      expect(aggregateRollup([null, 1, null], 3, 'unique')).toBe(2)
+    })
+    test('empty values -> 0', () => {
+      expect(aggregateRollup([], 0, 'unique')).toBe(0)
+    })
+  })
+
+  describe('sum (numeric)', () => {
+    test('sums numeric values', () => {
+      expect(aggregateRollup([1, 2, 3], 3, 'sum')).toBe(6)
+    })
+    test('coerces numeric strings', () => {
+      expect(aggregateRollup(['1', '2', 3], 3, 'sum')).toBe(6)
+    })
+    test('mixed string+number filters non-numeric strings', () => {
+      expect(aggregateRollup([1, 'x', 2, 'nope', 3], 5, 'sum')).toBe(6)
+    })
+    test('null when no numeric values', () => {
+      expect(aggregateRollup(['x', 'y'], 2, 'sum')).toBeNull()
+      expect(aggregateRollup([], 0, 'sum')).toBeNull()
+    })
+  })
+
+  describe('avg (numeric)', () => {
+    test('averages numeric values (divides by numeric count only)', () => {
+      expect(aggregateRollup([2, 4, 6], 3, 'avg')).toBe(4)
+      expect(aggregateRollup([1, 'x', 3], 3, 'avg')).toBe(2) // mean of [1,3], non-numeric excluded
+    })
+    test('null when no numeric values', () => {
+      expect(aggregateRollup(['a'], 1, 'avg')).toBeNull()
+      expect(aggregateRollup([], 0, 'avg')).toBeNull()
+    })
+  })
+
+  describe('min / max (numeric)', () => {
+    test('min returns the smallest numeric value', () => {
+      expect(aggregateRollup([3, 1, 2], 3, 'min')).toBe(1)
+      expect(aggregateRollup([5, 'x', '2'], 3, 'min')).toBe(2) // numeric-string coercion
+    })
+    test('max returns the largest numeric value', () => {
+      expect(aggregateRollup([3, 1, 2], 3, 'max')).toBe(3)
+      expect(aggregateRollup([5, 'x', '20'], 3, 'max')).toBe(20)
+    })
+    test('null when no numeric values', () => {
+      expect(aggregateRollup(['x'], 1, 'min')).toBeNull()
+      expect(aggregateRollup(['x'], 1, 'max')).toBeNull()
+      expect(aggregateRollup([], 0, 'min')).toBeNull()
+      expect(aggregateRollup([], 0, 'max')).toBeNull()
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
+++ b/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
@@ -18,10 +18,19 @@ import { describe, test, expect } from 'vitest'
 import { aggregateRollup } from '../../src/routes/univer-meta'
 
 describe('aggregateRollup — rollup reducer expansion', () => {
-  describe('count (≡ COUNTA: non-empty target values)', () => {
-    test('returns values.length', () => {
+  describe('count (≡ COUNTA: non-blank target values)', () => {
+    test('counts present, non-blank values', () => {
       expect(aggregateRollup([1, 2, 3], 3, 'count')).toBe(3)
       expect(aggregateRollup(['a', 'b'], 5, 'count')).toBe(2)
+    })
+    test('drops blank targets — null/undefined/""/"   "/[] — THIS is the count-vs-countall boundary', () => {
+      expect(aggregateRollup(['x', '', '   ', [], 'y'], 5, 'count')).toBe(2) // only 'x','y'
+      expect(aggregateRollup([null, undefined, ''], 3, 'count')).toBe(0)
+      // countall over the SAME data counts every resolved row — the distinction the reviewer flagged:
+      expect(aggregateRollup(['x', '', '   ', [], 'y'], 5, 'countall')).toBe(5)
+    })
+    test('keeps falsy-but-present scalars 0 and false (NOT blank)', () => {
+      expect(aggregateRollup([0, false, 1], 3, 'count')).toBe(3)
     })
     test('empty values -> 0 (independent of count arg)', () => {
       expect(aggregateRollup([], 0, 'count')).toBe(0)
@@ -55,9 +64,10 @@ describe('aggregateRollup — rollup reducer expansion', () => {
     test('structurally-equal objects collapse via JSON.stringify', () => {
       expect(aggregateRollup([{ a: 1 }, { a: 1 }, { a: 2 }], 3, 'unique')).toBe(2)
     })
-    test('null is preserved as a single distinct bucket', () => {
-      expect(aggregateRollup([null, null], 2, 'unique')).toBe(1)
-      expect(aggregateRollup([null, 1, null], 3, 'unique')).toBe(2)
+    test('blank values (null / "" / "   " / []) are excluded, consistent with count', () => {
+      expect(aggregateRollup([null, null], 2, 'unique')).toBe(0)
+      expect(aggregateRollup([null, 1, null], 3, 'unique')).toBe(1) // just {1}
+      expect(aggregateRollup(['', '   ', 'a', 'a'], 4, 'unique')).toBe(1) // just {a}
     })
     test('empty values -> 0', () => {
       expect(aggregateRollup([], 0, 'unique')).toBe(0)


### PR DESCRIPTION
## What

Expands rollup aggregations beyond `count/sum/avg/min/max` with two **numeric** reducers:
- **countall** — count of resolved linked records *including* empty-target rows (vs `count`, which counts non-empty target values). Plumbs a resolved-record `count` out of `resolveLookupValues`.
- **unique** — distinct-value count (objects keyed by `JSON.stringify`).

Also extracts `aggregateRollup` to a **module-level exported pure fn** for unit coverage.

## Scope decision (slice 2a, numeric-only)

An adversarial review (4 lenses) found that the string/boolean reducers (`concatenate`→string, `and/or/xor`→boolean) **widen a rollup's value type** and break 3 consumers that hardcode `rollup → number`:
- filter eval (`evaluateMetaFilterCondition`)
- sort (`compareMetaSortValue`)
- dashboard grouping (`buildDashboardWidgetResult`)

Each receives only the field *type*, not the aggregation — so handling non-numeric rollups is a signature change across 4+ call sites. **Deferred to slice 2b.** This slice keeps only the numeric reducers, so a rollup's value stays `number|null` and **no downstream consumer changes are needed**.

## Security / contract (#20 decision B′)

Record-level read is **non-gating** — `record_permissions` is a write/admin *elevation* mechanism, not read-deny. So COUNTALL over sheet-readable foreign rows is **not** a leak. The real gates are foreign **sheet-read** + foreign **field-mask** (countall stays masked when the target field is masked — no bypass).

## Fixes (from review)

- **P1**: the *duplicate* `parseRollupAggregation` in `field-codecs.ts` (provisioning / template-install / SDK write path) still enumerated only the old 5 types and silently corrupted `countall`/`unique` to `count` via the caller's `?? 'count'` fallback — now in lockstep with the route parser.

## Tests

- **Unit** (19): every numeric reducer, incl. the countall-vs-count distinction, unique object/primitive keying, numeric-string coercion, null-when-no-numerics.
- **Integration — COUNTALL characterization** (owner-mandated regression lock): a `record_permission` on a linked row for *another* subject does **not** change a sheet-reader's countall; plus the real field-mask gate → null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)