### PR TITLE
feat(data-source): add C6 sandbox failure injection seam

### DIFF
--- a/docs/development/data-source-system-integration-c6-test-failure-injection-verification-20260617.md
+++ b/docs/development/data-source-system-integration-c6-test-failure-injection-verification-20260617.md
@@ -1,0 +1,98 @@
+# Data Source System Integration C6-5b Test Failure Injection Verification
+
+Date: 2026-06-17
+
+## Scope
+
+This verifies the C6-5b implementation of the default-off, sandbox-only,
+server-owned test failure-injection seam for #2720.
+
+The slice exists only because #2720 reached `HOLD_NO_SAFE_FAILURE_SHAPE` after
+both real sandbox failure shapes were unavailable. It does not authorize
+production, batch, K3, raw SQL, DDL, trigger, stored-procedure, generic query,
+or a broad runtime failure hook.
+
+## Implementation Summary
+
+- Runtime config:
+  - `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true` is the deploy/process
+    gate.
+  - `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON` is the server-owned
+    config gate.
+- The server config must pin:
+  - `enabled=true`;
+  - `pipelineId`;
+  - `targetSystemId`;
+  - `targetDataSourceId`;
+  - `targetObject`;
+  - `environment=sandbox`;
+  - optional `failWriteOrdinal` (default `1`).
+- The browser/request body cannot enable, disable, parameterize, or target the
+  injection.
+- The mutable external-system config is not trusted as sandbox proof.
+- The injected row failure occurs after token consumption and revision
+  recompute, inside the existing per-row write loop, and is handled by the
+  normal row-level failure/dead-letter/provenance path.
+
+## Verification Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-config.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false --project tsconfig.json
+pnpm --filter plugin-integration-core test
+git diff --check
+```
+
+All commands passed locally.
+
+## Test Locks
+
+- default-off: JSON config without the deploy flag does not inject.
+- server-config gate: deploy flag + non-targeted server config does not inject.
+- sandbox proof: `environment=sandbox` must come from server runtime config.
+- target pinning: `targetDataSourceId` and `targetObject` must match the loaded
+  target before capability checks or writes.
+- client rejection: dry-run/apply request bodies reject injection/scope fields
+  before loading the pipeline.
+- token/revision first: active-to-active `failWriteOrdinal` drift is a revision
+  mismatch before writes.
+- single-row failure: exactly one row receives
+  `C6_TEST_INJECTED_ROW_FAILURE`.
+- clean sibling write: at least one sibling reaches `insertRows` in the same
+  route-level apply.
+- partial token consumption: partial injected apply consumes the dry-run token;
+  reuse returns `C6_WRITE_DRY_RUN_TOKEN_INVALID` and performs no additional
+  write or dead-letter.
+- values-free evidence: public response, persisted run provenance, and
+  dead-letter evidence contain tokens/counts/fingerprints only, not source row
+  values.
+
+## Subagent Review
+
+Security/boundary review found one high-severity issue in the first draft:
+sandbox enforcement trusted `target.config.environment`, which is mutable
+external-system config. Fixed by moving sandbox proof and target binding to
+server runtime config (`environment`, `targetDataSourceId`, `targetObject`) and
+adding mismatch tests.
+
+State-machine/test review found three non-blocking coverage gaps:
+
+- `failWriteOrdinal` active-to-active drift was not explicitly revision-bound.
+- partial injected apply did not explicitly prove token consumption.
+- values-free assertions checked only the injected failed row, not the clean
+  sibling.
+
+All three were fixed with helper and route-level assertions.
+
+## Remaining Gate
+
+C6-5 is still not complete until C6-5c publishes a sandbox package and #2720
+passes entity-machine evidence:
+
+- injected row failure is observed values-free;
+- at least one clean sibling writes;
+- dead-letter/provenance are values-free;
+- re-pull proves no duplicate target rows;
+- the test-injection deploy flag is disabled after validation.

--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -449,8 +449,13 @@ TODO:
   - [x] C6-5a test-only failure-injection design:
     `docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md`.
     This is design-only and exists only because both real sandbox failure shapes are unavailable.
-  - [ ] C6-5b test-only failure-injection implementation: default-off, sandbox-only, server-owned
+  - [x] C6-5b test-only failure-injection implementation: default-off, sandbox-only, server-owned
     double gate; no client-controlled injection, no production hook, no raw SQL/DDL/trigger path.
+    The implementation is deploy-gated by `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true`
+    plus server runtime config `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON`; server config
+    pins `pipelineId`, `targetSystemId`, `targetDataSourceId`, `targetObject`, and
+    `environment=sandbox`, so mutable external-system config cannot relabel a production target
+    as sandbox.
   - [ ] C6-5c package + entity-machine rerun: publish a sandbox package, rerun controlled bad-row
     with one synthetic row failure plus at least one clean sibling write, prove values-free
     dead-letter/provenance and re-pull idempotence, then disable the test-injection gate.

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -381,7 +381,29 @@ is a routing signal only, not runtime authorization. The next path is:
 2. C6-5b default-off sandbox-only implementation;
 3. C6-5c new package + entity-machine rerun.
 
-Until C6-5b/C6-5c exist, leave this controlled bad-row step at HOLD.
+The C6-5b implementation is server-owned and deploy-gated. For the C6-5c
+sandbox package only, the deploy config must include both gates:
+
+```text
+METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true
+INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON={
+  "enabled": true,
+  "pipelineId": "<c6 sandbox pipeline id>",
+  "targetSystemId": "<c6 sandbox target external system id>",
+  "targetDataSourceId": "<sandbox write data-source id>",
+  "targetObject": "<sandbox target object>",
+  "environment": "sandbox",
+  "failWriteOrdinal": 2
+}
+```
+
+The `targetDataSourceId`, `targetObject`, and `environment=sandbox` proof must
+come from server runtime config, not from the mutable external-system config.
+If any pinned server value does not match the loaded target, the route must fail
+closed before target capability checks or writes. Disable the deploy flag after
+the C6-5c controlled bad-row rerun.
+
+Until C6-5c passes, leave this controlled bad-row step at HOLD.
 
 Expected:
 

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -269,8 +269,13 @@ Current #2720 checkpoint as of 2026-06-17:
   `controlledBadRowStopReason=no_safe_failure_shape`,
   `failureShape=no_safe_failure_shape`;
 - next eligible step is the separate C6-5a/C6-5b/C6-5c test-only
-  failure-injection path. This runbook still does not authorize production,
-  batch, raw SQL, DDL, trigger, or broad runtime failure hooks.
+  failure-injection path. C6-5b uses two server-owned gates:
+  `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true` plus
+  `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON` pinning the sandbox
+  `pipelineId`, `targetSystemId`, `targetDataSourceId`, `targetObject`, and
+  `environment=sandbox`. Mutable external-system config is not a sandbox proof.
+  This runbook still does not authorize production, batch, raw SQL, DDL,
+  trigger, or broad runtime failure hooks.
 
 ## Stop Rules
 

--- a/packages/core-backend/src/plugin-runtime-config.ts
+++ b/packages/core-backend/src/plugin-runtime-config.ts
@@ -1,6 +1,8 @@
 const INTEGRATION_CORE_PLUGIN_NAME = 'plugin-integration-core'
 const INTEGRATION_CORE_STOCK_ACTIONS_ENV = 'INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON'
 const INTEGRATION_CORE_TABLE_ACTIONS_ENV = 'INTEGRATION_CORE_TABLE_ACTIONS_JSON'
+const INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_ENV = 'INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON'
+const C6_TEST_FAILURE_INJECTION_ENABLED_ENV = 'METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED'
 
 function parsePluginJsonEnv(env: NodeJS.ProcessEnv, key: string): unknown {
   const raw = env[key]
@@ -19,6 +21,19 @@ function assertPluginActionConfigShape(value: unknown, key: string): unknown {
   throw new Error(`${key} must be a JSON array or object`)
 }
 
+function assertPluginObjectConfigShape(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (value === undefined) return undefined
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  throw new Error(`${key} must be a JSON object`)
+}
+
+function parseBooleanEnv(env: NodeJS.ProcessEnv, key: string): boolean {
+  const raw = env[key]
+  if (typeof raw !== 'string' || raw.trim().length === 0) return false
+  const normalized = raw.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1'
+}
+
 export function resolvePluginRuntimeConfig(
   manifestName: string,
   env: NodeJS.ProcessEnv = process.env
@@ -33,9 +48,22 @@ export function resolvePluginRuntimeConfig(
     parsePluginJsonEnv(env, INTEGRATION_CORE_TABLE_ACTIONS_ENV),
     INTEGRATION_CORE_TABLE_ACTIONS_ENV
   )
+  const c6TestFailureInjection = assertPluginObjectConfigShape(
+    parsePluginJsonEnv(env, INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_ENV),
+    INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_ENV
+  )
+  const c6TestFailureInjectionDeployEnabled = parseBooleanEnv(env, C6_TEST_FAILURE_INJECTION_ENABLED_ENV)
 
   return {
     ...(tableActions !== undefined ? { tableActions } : {}),
     ...(stockPreparationTableActions !== undefined ? { stockPreparationTableActions } : {}),
+    ...(c6TestFailureInjection !== undefined || c6TestFailureInjectionDeployEnabled
+      ? {
+          c6TestFailureInjection: {
+            ...(c6TestFailureInjection || {}),
+            deployEnabled: c6TestFailureInjectionDeployEnabled,
+          },
+        }
+      : {}),
   }
 }

--- a/packages/core-backend/tests/unit/plugin-runtime-config.test.ts
+++ b/packages/core-backend/tests/unit/plugin-runtime-config.test.ts
@@ -44,6 +44,59 @@ describe('plugin runtime config resolution', () => {
     })
   })
 
+  it('injects C6 test failure injection config only when explicitly deploy-enabled', () => {
+    const config = resolvePluginRuntimeConfig('plugin-integration-core', {
+      METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED: 'true',
+      INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON: JSON.stringify({
+        enabled: true,
+        pipelineId: 'pipe_c6',
+        targetSystemId: 'target_c6',
+        targetDataSourceId: 'writable-ds',
+        targetObject: 'public.target_items',
+        environment: 'sandbox',
+        failWriteOrdinal: 2,
+      }),
+    })
+
+    expect(config).toEqual({
+      c6TestFailureInjection: {
+        deployEnabled: true,
+        enabled: true,
+        pipelineId: 'pipe_c6',
+        targetSystemId: 'target_c6',
+        targetDataSourceId: 'writable-ds',
+        targetObject: 'public.target_items',
+        environment: 'sandbox',
+        failWriteOrdinal: 2,
+      },
+    })
+  })
+
+  it('keeps C6 test failure injection default-off without the deploy flag', () => {
+    const config = resolvePluginRuntimeConfig('plugin-integration-core', {
+      INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON: JSON.stringify({
+        enabled: true,
+        pipelineId: 'pipe_c6',
+        targetSystemId: 'target_c6',
+        targetDataSourceId: 'writable-ds',
+        targetObject: 'public.target_items',
+        environment: 'sandbox',
+      }),
+    })
+
+    expect(config).toEqual({
+      c6TestFailureInjection: {
+        deployEnabled: false,
+        enabled: true,
+        pipelineId: 'pipe_c6',
+        targetSystemId: 'target_c6',
+        targetDataSourceId: 'writable-ds',
+        targetObject: 'public.target_items',
+        environment: 'sandbox',
+      },
+    })
+  })
+
   it('fails closed on invalid JSON', () => {
     expect(() => resolvePluginRuntimeConfig('plugin-integration-core', {
       INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON: '{not-json',
@@ -54,5 +107,11 @@ describe('plugin runtime config resolution', () => {
     expect(() => resolvePluginRuntimeConfig('plugin-integration-core', {
       INTEGRATION_CORE_TABLE_ACTIONS_JSON: '"not-an-action-list"',
     })).toThrow('INTEGRATION_CORE_TABLE_ACTIONS_JSON must be a JSON array or object')
+  })
+
+  it('fails closed when C6 test failure injection config is not an object', () => {
+    expect(() => resolvePluginRuntimeConfig('plugin-integration-core', {
+      INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON: '["not-an-object"]',
+    })).toThrow('INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON must be a JSON object')
   })
 })

--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -3,7 +3,11 @@
 const assert = require('node:assert/strict')
 const path = require('node:path')
 
-const { applyExternalWrite, dryRunExternalWrite } = require(path.join(__dirname, '..', 'lib', 'external-write-dry-run.cjs'))
+const {
+  applyExternalWrite,
+  dryRunExternalWrite,
+  __internals,
+} = require(path.join(__dirname, '..', 'lib', 'external-write-dry-run.cjs'))
 
 function memoryStore() {
   const map = new Map()
@@ -23,6 +27,36 @@ function memoryStore() {
       return value
     },
     async delete(key) { map.delete(key) },
+  }
+}
+
+function sandboxTargetSystem(overrides = {}) {
+  const { config: configOverride, ...rest } = overrides
+  return {
+    id: 'target_1',
+    kind: 'data-source:sql-write-gated',
+    config: {
+      dataSourceId: 'writable-ds',
+      object: 'public.target_items',
+      keyFields: ['externalId'],
+      writableFields: ['name', 'status'],
+      ...(configOverride || {}),
+    },
+    ...rest,
+  }
+}
+
+function enabledTestFailureInjection(overrides = {}) {
+  return {
+    deployEnabled: true,
+    enabled: true,
+    pipelineId: 'pipe_c6',
+    targetSystemId: 'target_1',
+    targetDataSourceId: 'writable-ds',
+    targetObject: 'public.target_items',
+    environment: 'sandbox',
+    failWriteOrdinal: 2,
+    ...overrides,
   }
 }
 
@@ -289,6 +323,265 @@ async function testApplyIsolatesRowWriteFailuresAndStaysValuesFree() {
   assert.equal(responseText.includes('DUPLICATE_P-002_WIDGET'), false, 'unsafe error codes are not exposed')
 }
 
+async function testTestFailureInjectionStaysOffWithoutDeployGate() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection({ deployEnabled: false }),
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  assert.equal(dryRun.canApply, true)
+  assert.deepEqual(dryRun.evidence.testFailureInjection, {
+    deployEnabled: false,
+    serverConfigEnabled: true,
+    active: false,
+    reason: 'deploy_disabled',
+  })
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+  })
+  assert.equal(apply.status, 'succeeded')
+  assert.equal(apply.counts.failed, 0)
+  assert.equal(apply.counts.written, 2)
+  assert.deepEqual(apply.evidence.rowErrorTypes, [])
+  assert.equal(calls.insertRows.length, 1)
+  assert.equal(calls.updateRows.length, 1)
+}
+
+async function testTestFailureInjectionRequiresServerConfigTargetMatch() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection({ targetSystemId: 'other_target' }),
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  assert.equal(dryRun.canApply, true)
+  assert.deepEqual(dryRun.evidence.testFailureInjection, {
+    deployEnabled: true,
+    serverConfigEnabled: true,
+    active: false,
+    reason: 'not_targeted',
+  })
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+  })
+  assert.equal(apply.status, 'succeeded')
+  assert.equal(apply.counts.failed, 0)
+  assert.equal(apply.counts.written, 2)
+  assert.equal(calls.insertRows.length, 1)
+  assert.equal(calls.updateRows.length, 1)
+}
+
+async function testTestFailureInjectionRejectsNonSandboxServerConfigBeforeWrite() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem({
+        config: { environment: 'sandbox' },
+      }),
+      testFailureInjection: enabledTestFailureInjection({ environment: 'production' }),
+    },
+  })
+  await assert.rejects(
+    () => dryRunExternalWrite(input),
+    (error) => error && error.code === 'C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET',
+  )
+  assert.equal(calls.test.length, 0, 'unsafe test injection target fails before capability check')
+  assert.equal(calls.lookupByKey.length, 0, 'unsafe test injection target fails before lookup')
+  assert.equal(calls.insertRows.length, 0)
+  assert.equal(calls.updateRows.length, 0)
+}
+
+async function testTestFailureInjectionRejectsMutableTargetDriftBeforeWrite() {
+  const { input, calls } = baseInput({
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem({
+        config: {
+          dataSourceId: 'prod-ds',
+          environment: 'sandbox',
+        },
+      }),
+      testFailureInjection: enabledTestFailureInjection({ targetDataSourceId: 'writable-ds' }),
+    },
+  })
+  await assert.rejects(
+    () => dryRunExternalWrite(input),
+    (error) => error && error.code === 'C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET',
+  )
+  assert.equal(calls.test.length, 0, 'server target mismatch fails before capability check')
+  assert.equal(calls.lookupByKey.length, 0, 'server target mismatch fails before lookup')
+  assert.equal(calls.insertRows.length, 0)
+  assert.equal(calls.updateRows.length, 0)
+}
+
+async function testTestFailureInjectionRequiresWritableSiblingRows() {
+  const { input, calls } = baseInput({
+    sourceRows: [{ code: 'P-001', name: 'Widget', status: 'new' }],
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection(),
+    },
+    lookupByKey: () => ({ data: [], metadata: {} }),
+  })
+  await assert.rejects(
+    () => dryRunExternalWrite(input),
+    (error) => error && error.code === 'C6_TEST_FAILURE_INJECTION_CONFIG_INVALID',
+  )
+  assert.equal(calls.insertRows.length, 0)
+  assert.equal(calls.updateRows.length, 0)
+}
+
+async function testTestFailureInjectionRevisionBoundBeforeWrite() {
+  const { input, calls } = baseInput({
+    sourceRows: [
+      { code: 'P-001', name: 'Widget', status: 'new' },
+      { code: 'P-002', name: 'Gadget', status: 'new' },
+    ],
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection({ enabled: false }),
+    },
+    lookupByKey: () => ({ data: [], metadata: {} }),
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      testFailureInjection: enabledTestFailureInjection({ failWriteOrdinal: 1 }),
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: 'user_write',
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH',
+  )
+  assert.equal(calls.insertRows.length, 0, 'injection config drift fails before insert')
+  assert.equal(calls.updateRows.length, 0, 'injection config drift fails before update')
+}
+
+async function testTestFailureInjectionOrdinalIsRevisionBoundBeforeWrite() {
+  const { input, calls } = baseInput({
+    sourceRows: [
+      { code: 'P-001', name: 'Widget', status: 'new' },
+      { code: 'P-002', name: 'Gadget', status: 'new' },
+    ],
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection({ failWriteOrdinal: 2 }),
+    },
+    lookupByKey: () => ({ data: [], metadata: {} }),
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      testFailureInjection: enabledTestFailureInjection({ failWriteOrdinal: 1 }),
+      dryRunToken: dryRun.dryRunToken,
+      applyUser: 'user_write',
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_MISMATCH',
+  )
+  assert.equal(calls.insertRows.length, 0, 'failWriteOrdinal drift fails before insert')
+  assert.equal(calls.updateRows.length, 0, 'failWriteOrdinal drift fails before update')
+}
+
+async function testTestFailureInjectionInjectsExactlyOneRowAndKeepsSibling() {
+  const { input, calls } = baseInput({
+    sourceRows: [
+      { code: 'P-001', name: 'Widget', status: 'new' },
+      { code: 'P-002', name: 'Gadget', status: 'new' },
+    ],
+    input: {
+      dryRunUser: 'user_write',
+      targetSystem: sandboxTargetSystem(),
+      testFailureInjection: enabledTestFailureInjection({ failWriteOrdinal: 2 }),
+    },
+    lookupByKey: () => ({ data: [], metadata: {} }),
+  })
+  const deadLetters = []
+  const dryRun = await dryRunExternalWrite(input)
+  const dryRunToken = dryRun.dryRunToken
+  assert.equal(dryRun.status, 'ready')
+  assert.deepEqual(dryRun.evidence.testFailureInjection, {
+    deployEnabled: true,
+    serverConfigEnabled: true,
+    active: true,
+    reason: 'active',
+  })
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken,
+    applyUser: 'user_write',
+    runId: 'run_c6_injected_failure',
+    deadLetterStore: {
+      async createDeadLetter(entry) {
+        deadLetters.push(entry)
+        return { ...entry, id: `dl_${deadLetters.length}` }
+      },
+    },
+  })
+  assert.equal(apply.status, 'partial')
+  assert.equal(apply.counts.add, 1)
+  assert.equal(apply.counts.update, 0)
+  assert.equal(apply.counts.failed, 1)
+  assert.equal(apply.counts.written, 1)
+  assert.equal(calls.insertRows.length, 1, 'only the clean sibling reaches insertRows')
+  assert.deepEqual(
+    calls.insertRows[0].rows,
+    [{ externalId: 'P-001', name: 'Widget', status: 'new' }],
+    'failWriteOrdinal=2 leaves the first writable row as the clean sibling',
+  )
+  assert.equal(calls.updateRows.length, 0)
+  assert.equal(input.tokenStore.map.size, 0, 'partial test-injection apply still consumes the dry-run token')
+  assert.deepEqual(apply.evidence.rowErrorTypes, [__internals.C6_TEST_INJECTED_ROW_FAILURE])
+  assert.deepEqual(apply.deadLetters, { attempted: 1, persisted: 1 })
+  assert.equal(deadLetters[0].errorCode, __internals.C6_TEST_INJECTED_ROW_FAILURE)
+  assert.equal(deadLetters[0].errorMessage, __internals.C6_TEST_INJECTED_ROW_FAILURE)
+  assert.deepEqual(apply.evidence.testFailureInjection, {
+    deployEnabled: true,
+    serverConfigEnabled: true,
+    active: true,
+    reason: 'active',
+  })
+  const responseText = JSON.stringify(apply)
+  assert.equal(responseText.includes('P-001'), false, 'injected failure response does not include clean sibling key values')
+  assert.equal(responseText.includes('P-002'), false, 'injected failure response does not include row key values')
+  assert.equal(responseText.includes('Widget'), false, 'injected failure response does not include clean sibling row values')
+  assert.equal(responseText.includes('Gadget'), false, 'injected failure response does not include row values')
+  assert.ok(apply.provenanceEvents.some((event) => event.eventType === 'target_write_failed'), 'injected failure produces failure provenance')
+  assert.ok(apply.provenanceEvents.some((event) => event.eventType === 'target_write_succeeded'), 'clean sibling produces success provenance')
+
+  const insertCountAfterPartial = calls.insertRows.length
+  const deadLetterCountAfterPartial = deadLetters.length
+  await assert.rejects(
+    () => applyExternalWrite({
+      ...input,
+      dryRunToken,
+      applyUser: 'user_write',
+      runId: 'run_c6_injected_failure_reuse',
+      deadLetterStore: {
+        async createDeadLetter(entry) {
+          deadLetters.push(entry)
+          return { ...entry, id: `dl_${deadLetters.length}` }
+        },
+      },
+    }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_INVALID',
+  )
+  assert.equal(calls.insertRows.length, insertCountAfterPartial, 'reusing a consumed partial token cannot write again')
+  assert.equal(deadLetters.length, deadLetterCountAfterPartial, 'reusing a consumed partial token cannot create another dead letter')
+}
+
 async function testApplyTokenIsSingleUseUnderConcurrency() {
   const { input, calls } = baseInput({
     input: {
@@ -412,6 +705,14 @@ async function main() {
   await testApplyRequiresAuthenticatedApplyUser()
   await testApplyRejectsRevisionMismatchBeforeWrite()
   await testApplyIsolatesRowWriteFailuresAndStaysValuesFree()
+  await testTestFailureInjectionStaysOffWithoutDeployGate()
+  await testTestFailureInjectionRequiresServerConfigTargetMatch()
+  await testTestFailureInjectionRejectsNonSandboxServerConfigBeforeWrite()
+  await testTestFailureInjectionRejectsMutableTargetDriftBeforeWrite()
+  await testTestFailureInjectionRequiresWritableSiblingRows()
+  await testTestFailureInjectionRevisionBoundBeforeWrite()
+  await testTestFailureInjectionOrdinalIsRevisionBoundBeforeWrite()
+  await testTestFailureInjectionInjectsExactlyOneRowAndKeepsSibling()
   console.log('external-write-dry-run.test.cjs OK')
 }
 

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1579,6 +1579,20 @@ async function testPipelineExternalWriteDryRunRoute() {
   assert.equal(res.statusCode, 400)
   assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_REQUEST_INVALID')
   assert.equal(calls.length, callsBeforeInvalidBody, 'client-supplied target scope is rejected before loading the pipeline')
+
+  const callsBeforeClientInjection = calls.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: READ_USER,
+    params: { id: pipeline.id },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      failureInjection: { enabled: true, failWriteOrdinal: 1 },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_REQUEST_INVALID')
+  assert.equal(calls.length, callsBeforeClientInjection, 'client-supplied dry-run injection control is rejected before loading the pipeline')
 }
 
 async function testPipelineExternalWriteApplyRoute() {
@@ -1757,7 +1771,7 @@ async function testPipelineExternalWriteApplyRoute() {
   assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_TOKEN_INVALID')
   assert.equal(writeCalls.insertRows.length + writeCalls.updateRows.length, writesAfterSuccess, 'used token cannot trigger another write')
 
-  for (const key of ['target', 'source', 'plan', 'payload']) {
+  for (const key of ['target', 'source', 'plan', 'payload', 'failureInjection']) {
     const callsBeforeInvalidBody = calls.length
     res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
       user: WRITE_USER,
@@ -1787,6 +1801,243 @@ async function testPipelineExternalWriteApplyRoute() {
   assert.equal(res.statusCode, 400)
   assert.equal(res.body.error.code, 'C6_WRITE_APPLY_REQUEST_INVALID')
   assert.equal(calls.length, callsBeforeNestedConfirm, 'nested confirm scope is rejected before loading the pipeline')
+
+  const callsBeforeNestedInject = calls.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      confirm: { dryRunToken: 'ignored', injectFailure: true },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'C6_WRITE_APPLY_REQUEST_INVALID')
+  assert.equal(calls.length, callsBeforeNestedInject, 'client-supplied injection control is rejected before loading the pipeline')
+}
+
+async function testPipelineExternalWriteApplyTestFailureInjectionRoute() {
+  const storage = createMemoryStorage()
+  const runWrites = []
+  const deadLetterWrites = []
+  const sourceSystem = {
+    id: 'source_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-readonly',
+    role: 'source',
+    status: 'active',
+    config: { dataSourceId: 'readonly-ds', object: 'public.source_items' },
+  }
+  const targetSystem = {
+    id: 'target_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'data-source:sql-write-gated',
+    role: 'target',
+    status: 'active',
+    config: {
+      dataSourceId: 'writable-ds',
+      object: 'public.target_items',
+      keyFields: ['externalId'],
+      writableFields: ['name'],
+    },
+  }
+  const pipeline = {
+    id: 'pipe_c6',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'C6 test failure injection',
+    status: 'active',
+    sourceSystemId: sourceSystem.id,
+    sourceObject: 'public.source_items',
+    targetSystemId: targetSystem.id,
+    targetObject: 'public.target_items',
+    createdBy: 'owner-7',
+    fieldMappings: [
+      { sourceField: 'code', targetField: 'externalId' },
+      { sourceField: 'name', targetField: 'name' },
+    ],
+  }
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        if (input.id === sourceSystem.id) return { ...sourceSystem }
+        return null
+      },
+      async getExternalSystem(input) {
+        if (input.id === targetSystem.id) return { ...targetSystem }
+        return null
+      },
+    },
+    adapterRegistry: {
+      createAdapter() {
+        return {
+          async read() {
+            return {
+              records: [
+                { code: 'P-001', name: 'Widget' },
+                { code: 'P-002', name: 'Gadget' },
+              ],
+              done: true,
+              nextCursor: null,
+            }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      async getPipeline(input) {
+        return { ...pipeline, id: input.id }
+      },
+      async createPipelineRun(input) {
+        runWrites.push(['create', input])
+        return {
+          id: 'run_c6_test_injection',
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: input.pipelineId,
+          status: input.status,
+          mode: input.mode,
+          startedAt: input.startedAt,
+          details: input.details || {},
+        }
+      },
+      async updatePipelineRun(input) {
+        runWrites.push(['update', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId || null,
+          pipelineId: pipeline.id,
+          status: input.status,
+          provenanceEvents: input.provenanceEvents || [],
+          details: input.details || {},
+        }
+      },
+    },
+    deadLetterStore: {
+      async listDeadLetters() {
+        return []
+      },
+      async createDeadLetter(input) {
+        deadLetterWrites.push(input)
+        return { ...input, id: `dl_${deadLetterWrites.length}` }
+      },
+    },
+  })
+  const writeCalls = { insertRows: [], updateRows: [] }
+  const dataSourceWrites = {
+    async test() {
+      return {
+        success: true,
+        capabilityState: {
+          readOnly: false,
+          c6WriteTarget: true,
+          genericQueryDisabled: true,
+        },
+      }
+    },
+    async lookupByKey() {
+      return { data: [], metadata: {} }
+    },
+    async insertRows(dataSourceId, object, rows, policy, principal) {
+      writeCalls.insertRows.push({ dataSourceId, object, rows, policy, principal })
+      return { data: rows, metadata: {} }
+    },
+    async updateRows(dataSourceId, object, rows, policy, principal) {
+      writeCalls.updateRows.push({ dataSourceId, object, rows, policy, principal })
+      return { rowCount: rows.length, results: [] }
+    },
+  }
+  const { routes } = mountRoutes(services, {
+    storage,
+    dataSourceWrites,
+    config: {
+      c6TestFailureInjection: {
+        deployEnabled: true,
+        enabled: true,
+        pipelineId: pipeline.id,
+        targetSystemId: targetSystem.id,
+        targetDataSourceId: 'writable-ds',
+        targetObject: 'public.target_items',
+        environment: 'sandbox',
+        failWriteOrdinal: 2,
+      },
+    },
+  })
+
+  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.canApply, true)
+  assert.deepEqual(res.body.data.evidence.testFailureInjection, {
+    deployEnabled: true,
+    serverConfigEnabled: true,
+    active: true,
+    reason: 'active',
+  })
+  const dryRunToken = res.body.data.dryRunToken
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'partial')
+  assert.equal(res.body.data.counts.add, 1)
+  assert.equal(res.body.data.counts.failed, 1)
+  assert.equal(res.body.data.counts.written, 1)
+  assert.deepEqual(res.body.data.evidence.rowErrorTypes, ['C6_TEST_INJECTED_ROW_FAILURE'])
+  assert.deepEqual(res.body.data.evidence.testFailureInjection, {
+    deployEnabled: true,
+    serverConfigEnabled: true,
+    active: true,
+    reason: 'active',
+  })
+  assert.equal(writeCalls.insertRows.length, 1, 'the clean sibling writes through the real route')
+  assert.deepEqual(
+    writeCalls.insertRows[0].rows,
+    [{ externalId: 'P-001', name: 'Widget' }],
+    'route-level failWriteOrdinal=2 leaves the first writable row as the clean sibling',
+  )
+  assert.equal(writeCalls.updateRows.length, 0)
+  assert.deepEqual(res.body.data.deadLetters, { attempted: 1, persisted: 1 })
+  assert.equal(deadLetterWrites.length, 1)
+  assert.equal(deadLetterWrites[0].errorCode, 'C6_TEST_INJECTED_ROW_FAILURE')
+  const update = runWrites.find(([kind]) => kind === 'update')[1]
+  assert.equal(update.status, 'partial')
+  assert.equal(update.rowsWritten, 1)
+  assert.equal(update.rowsFailed, 1)
+  assert.equal(update.provenanceEvents.length, 2)
+  assert.equal(update.provenanceEvents.find((event) => event.eventType === 'target_write_failed').attrs.errorCode, 'C6_TEST_INJECTED_ROW_FAILURE')
+  const publicText = JSON.stringify(res.body.data)
+  assert.equal(publicText.includes('P-001'), false, 'route response does not leak clean sibling key values')
+  assert.equal(publicText.includes('P-002'), false, 'route response does not leak source key values')
+  assert.equal(publicText.includes('Widget'), false, 'route response does not leak clean sibling row values')
+  assert.equal(publicText.includes('Gadget'), false, 'route response does not leak row values')
+  const persistedText = JSON.stringify({ runWrites, deadLetterWrites })
+  assert.equal(persistedText.includes('P-001'), false, 'persisted test-injection evidence does not leak clean sibling key values')
+  assert.equal(persistedText.includes('P-002'), false, 'persisted test-injection evidence does not leak source key values')
+  assert.equal(persistedText.includes('Widget'), false, 'persisted test-injection evidence does not leak clean sibling row values')
+  assert.equal(persistedText.includes('Gadget'), false, 'persisted test-injection evidence does not leak row values')
+
+  const writesAfterPartial = writeCalls.insertRows.length + writeCalls.updateRows.length
+  const deadLettersAfterPartial = deadLetterWrites.length
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER,
+    params: { id: pipeline.id },
+    body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken } },
+  })
+  assert.equal(res.statusCode, 409)
+  assert.equal(res.body.error.code, 'C6_WRITE_DRY_RUN_TOKEN_INVALID')
+  assert.equal(writeCalls.insertRows.length + writeCalls.updateRows.length, writesAfterPartial, 'partial test-injection token reuse cannot write again')
+  assert.equal(deadLetterWrites.length, deadLettersAfterPartial, 'partial test-injection token reuse cannot create another dead letter')
 }
 
 async function testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance() {
@@ -4400,6 +4651,7 @@ async function main() {
   await testPipelineRoutes()
   await testPipelineExternalWriteDryRunRoute()
   await testPipelineExternalWriteApplyRoute()
+  await testPipelineExternalWriteApplyTestFailureInjectionRoute()
   await testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance()
   await testPipelineExternalWriteApplyDoesNotOverstateProvenancePersistence()
   await testPipelineExternalWriteDryRunPreflightFailsClosed()

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -16,9 +16,13 @@ const MAX_ROWS = 10000
 const DEFAULT_PAGE_SIZE = 100
 const MAX_PAGES = 100
 const TARGET_KIND = 'data-source:sql-write-gated'
+const C6_TEST_INJECTED_ROW_FAILURE = 'C6_TEST_INJECTED_ROW_FAILURE'
+const C6_TEST_FAILURE_INJECTION_CONFIG_INVALID = 'C6_TEST_FAILURE_INJECTION_CONFIG_INVALID'
+const C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET = 'C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET'
 const CONSUMING_TOKEN_KEYS = new Set()
 const SAFE_WRITE_ERROR_CODES = new Set([
   'AdapterValidationError',
+  C6_TEST_INJECTED_ROW_FAILURE,
   'DATA_SOURCE_BRIDGE_CONFIG_ERROR',
   'DATA_SOURCE_GENERIC_QUERY_DISABLED_REQUIRED',
   'DATA_SOURCE_NOT_C6_WRITE_TARGET',
@@ -68,6 +72,23 @@ function positiveInteger(value, field, fallback) {
     throw new ExternalWriteDryRunError(400, 'C6_WRITE_DRY_RUN_REQUEST_INVALID', `${field} must be a positive integer`, { field })
   }
   return Math.min(numeric, MAX_ROWS)
+}
+
+function positiveConfigInteger(value, field, fallback) {
+  if (value === undefined || value === null || value === '') return fallback
+  const numeric = Number(value)
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, `${field} must be a positive integer`, { field })
+  }
+  return numeric
+}
+
+function requiredTestFailureString(value, field) {
+  const normalized = optionalString(value)
+  if (!normalized) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, `${field} is required`, { field })
+  }
+  return normalized
 }
 
 function cloneJson(value) {
@@ -188,6 +209,88 @@ function normalizeTargetConfig(system) {
     keyFields: normalizeFieldList(config.keyFields, 'target.config.keyFields'),
     writableFields: normalizeFieldList(config.writableFields, 'target.config.writableFields'),
   }
+}
+
+function normalizeTestFailureInjectionConfig(input, { pipeline, targetSystem, targetConfig }) {
+  const raw = isPlainObject(input) ? input : {}
+  const deployEnabled = raw.deployEnabled === true
+  const serverConfigEnabled = raw.enabled === true
+  const base = {
+    deployEnabled,
+    serverConfigEnabled,
+    active: false,
+    reason: !deployEnabled
+      ? 'deploy_disabled'
+      : (!serverConfigEnabled ? 'server_config_disabled' : 'not_targeted'),
+  }
+
+  if (!deployEnabled || !serverConfigEnabled) return base
+
+  const pipelineId = optionalString(raw.pipelineId)
+  const targetSystemId = optionalString(raw.targetSystemId)
+  if (!pipelineId || !targetSystemId) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, 'C6 test failure injection requires pipelineId and targetSystemId')
+  }
+  if (pipelineId !== pipeline.id || targetSystemId !== pipeline.targetSystemId) return base
+  if (!targetSystem || targetSystem.id !== targetSystemId) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, 'C6 test failure injection target does not match the loaded target system')
+  }
+  if (optionalString(raw.environment) !== 'sandbox') {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET, 'C6 test failure injection requires server config environment=sandbox')
+  }
+  if (requiredTestFailureString(raw.targetDataSourceId, 'c6TestFailureInjection.targetDataSourceId') !== targetConfig.dataSourceId) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET, 'C6 test failure injection target data source does not match server config')
+  }
+  if (requiredTestFailureString(raw.targetObject, 'c6TestFailureInjection.targetObject') !== targetConfig.object) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_UNSAFE_TARGET, 'C6 test failure injection target object does not match server config')
+  }
+  return {
+    deployEnabled,
+    serverConfigEnabled,
+    active: true,
+    reason: 'active',
+    failWriteOrdinal: positiveConfigInteger(raw.failWriteOrdinal, 'c6TestFailureInjection.failWriteOrdinal', 1),
+  }
+}
+
+function publicTestFailureInjectionEvidence(config) {
+  return {
+    deployEnabled: config && config.deployEnabled === true,
+    serverConfigEnabled: config && config.serverConfigEnabled === true,
+    active: config && config.active === true,
+    reason: config && config.reason ? config.reason : 'disabled',
+  }
+}
+
+function revisionTestFailureInjection(config) {
+  return {
+    deployEnabled: config && config.deployEnabled === true,
+    serverConfigEnabled: config && config.serverConfigEnabled === true,
+    active: config && config.active === true,
+    reason: config && config.reason ? config.reason : 'disabled',
+    failWriteOrdinal: config && config.active === true ? config.failWriteOrdinal : null,
+  }
+}
+
+function isWriteDecision(decision) {
+  return decision === 'add' || decision === 'update'
+}
+
+function assertTestFailureInjectionPlanReady(config, planRows) {
+  if (!config || config.active !== true) return
+  const writableRows = planRows.filter((row) => isWriteDecision(row.decision))
+  if (writableRows.length < 2) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, 'C6 test failure injection requires at least two writable plan rows')
+  }
+  if (config.failWriteOrdinal > writableRows.length) {
+    throw new ExternalWriteDryRunError(422, C6_TEST_FAILURE_INJECTION_CONFIG_INVALID, 'C6 test failure injection failWriteOrdinal is outside the writable plan')
+  }
+}
+
+function createInjectedRowFailure() {
+  const error = new Error('C6 test injected row failure')
+  error.code = C6_TEST_INJECTED_ROW_FAILURE
+  return error
 }
 
 function requireDataSourceWritesApi(api) {
@@ -327,6 +430,7 @@ function buildRevision(input) {
       writableFields: input.targetConfig.writableFields,
       capabilityState: input.targetCapabilityState,
     },
+    testFailureInjection: revisionTestFailureInjection(input.testFailureInjection),
     fieldMappings: input.pipeline.fieldMappings || [],
     rowFingerprints: input.rowFingerprints,
     counts: input.counts,
@@ -345,7 +449,7 @@ function publicRowErrorTypes(rowErrors) {
   return Array.from(new Set(rowErrors.map((entry) => entry.errorCode || entry.reason || 'write_failed'))).sort()
 }
 
-function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, canApply, sourceRead, rowErrorTypes, dryRunToken }) {
+function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, canApply, sourceRead, rowErrorTypes, dryRunToken, testFailureInjection }) {
   return {
     pipelineId: pipeline.id,
     targetKind: TARGET_KIND,
@@ -363,10 +467,11 @@ function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, 
     dryRunRevision: revision,
     canApply: canApply === true,
     dryRunTokenPresent: typeof dryRunToken === 'string' && dryRunToken.length > 0,
+    testFailureInjection: publicTestFailureInjectionEvidence(testFailureInjection),
   }
 }
 
-function publicApplyEvidence({ pipeline, targetConfig, sourceKind, status, counts, revision, sourceRead, rowErrors, provenanceEvents }) {
+function publicApplyEvidence({ pipeline, targetConfig, sourceKind, status, counts, revision, sourceRead, rowErrors, provenanceEvents, testFailureInjection }) {
   return {
     pipelineId: pipeline.id,
     targetKind: TARGET_KIND,
@@ -385,6 +490,7 @@ function publicApplyEvidence({ pipeline, targetConfig, sourceKind, status, count
     },
     dryRunRevision: revision,
     dryRunTokenConsumed: true,
+    testFailureInjection: publicTestFailureInjectionEvidence(testFailureInjection),
     provenanceEventCounts: provenanceEvents.reduce((acc, event) => {
       acc[event.eventType] = (acc[event.eventType] || 0) + 1
       return acc
@@ -410,6 +516,11 @@ function validatePlannerInput(input = {}, phase = 'dry-run') {
 async function computeExternalWritePlan(input = {}) {
   const pipeline = validatePlannerInput(input, input.phase || 'dry-run')
   const targetConfig = normalizeTargetConfig(input.targetSystem)
+  const testFailureInjection = normalizeTestFailureInjectionConfig(input.testFailureInjection, {
+    pipeline,
+    targetSystem: input.targetSystem,
+    targetConfig,
+  })
   const dataSourceWrites = requireDataSourceWritesApi(input.dataSourceWrites)
   const targetCapabilityState = normalizeTargetCapabilityState(
     await dataSourceWrites.test(targetConfig.dataSourceId, input.dataSourceOwnerPrincipal),
@@ -501,11 +612,15 @@ async function computeExternalWritePlan(input = {}) {
     rowErrorTypes.push('source_read_truncated')
   }
   const canApply = sourceRead.complete === true && counts.failed === 0 && counts.held === 0
+  if (canApply) {
+    assertTestFailureInjectionPlanReady(testFailureInjection, planRows)
+  }
   const revision = buildRevision({
     pipeline,
     sourceKind: input.sourceSystem && input.sourceSystem.kind,
     targetConfig,
     targetCapabilityState,
+    testFailureInjection,
     dryRunUser: input.dryRunUser,
     dataSourceOwnerPrincipal: input.dataSourceOwnerPrincipal,
     rowFingerprints,
@@ -526,6 +641,7 @@ async function computeExternalWritePlan(input = {}) {
     policy,
     canApply,
     revision,
+    testFailureInjection,
     maxRows,
   }
 }
@@ -562,6 +678,7 @@ async function dryRunExternalWrite(input = {}) {
       sourceRead: plan.sourceRead,
       rowErrorTypes: plan.rowErrorTypes,
       dryRunToken,
+      testFailureInjection: plan.testFailureInjection,
     }),
   }
 }
@@ -665,6 +782,7 @@ async function applyExternalWrite(input = {}) {
   const rowErrors = []
   const provenanceEvents = []
   const runId = optionalString(input.runId) || syntheticRunId(plan.pipeline, plan.revision)
+  let writeOrdinal = 0
   for (const row of plan.planRows) {
     if (row.decision === 'skip') {
       counts.skip += 1
@@ -691,6 +809,10 @@ async function applyExternalWrite(input = {}) {
       continue
     }
     try {
+      writeOrdinal += 1
+      if (plan.testFailureInjection && plan.testFailureInjection.active === true && writeOrdinal === plan.testFailureInjection.failWriteOrdinal) {
+        throw createInjectedRowFailure()
+      }
       if (row.decision === 'add') {
         await plan.dataSourceWrites.insertRows(
           plan.targetConfig.dataSourceId,
@@ -769,6 +891,7 @@ async function applyExternalWrite(input = {}) {
       sourceRead: plan.sourceRead,
       rowErrors,
       provenanceEvents,
+      testFailureInjection: plan.testFailureInjection,
     }),
   }
 }
@@ -779,11 +902,13 @@ module.exports = {
   dryRunExternalWrite,
   __internals: {
     C6_WRITE_DRY_RUN_TOKEN_PREFIX,
+    C6_TEST_INJECTED_ROW_FAILURE,
     TARGET_KIND,
     buildRevision,
     computeExternalWritePlan,
     consumeDryRunToken,
     normalizeTargetConfig,
+    normalizeTestFailureInjectionConfig,
     valuesEqual,
   },
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1585,6 +1585,7 @@ function createHandlers(services, options = {}) {
         dryRunUser: requestPrincipal(req),
         dataSourceOwnerPrincipal: ownerPrincipal,
         maxRows: body.maxRows,
+        testFailureInjection: context && context.config && context.config.c6TestFailureInjection,
       }))
     },
 
@@ -1673,6 +1674,7 @@ function createHandlers(services, options = {}) {
           applyUser: requestPrincipal(req),
           dataSourceOwnerPrincipal: ownerPrincipal,
           runId: run && run.id,
+          testFailureInjection: context && context.config && context.config.c6TestFailureInjection,
         })
         if (runLogger && run) {
           run = await runLogger.finishRun(run, externalWriteApplyMetrics(result), externalWriteRunStatus(result.status), {


### PR DESCRIPTION
## Summary

Implements C6-5b: the default-off, sandbox-only, server-owned test failure-injection seam required after #2720 reached `HOLD_NO_SAFE_FAILURE_SHAPE`.

What changed:

- adds `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED` + `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON` runtime config for `plugin-integration-core` only;
- wires C6 dry-run/apply through the same server-owned config so the dry-run revision binds the injection state;
- injects exactly one synthetic row-level write failure (`C6_TEST_INJECTED_ROW_FAILURE`) only after token consumption and revision recompute;
- requires a clean sibling writable row so partial success is actually proven;
- keeps the request body unable to activate/parameterize injection;
- pins sandbox proof to server runtime config (`environment=sandbox`, `targetDataSourceId`, `targetObject`), not mutable external-system config;
- updates TODO/runbooks + adds a verification MD.

## Boundaries

- no package in this PR;
- no entity-machine PASS claim;
- no production/batch authorization;
- no K3 Save/Submit/Audit/BOM;
- no raw SQL / DDL / trigger / stored procedure / generic execute product path;
- no broad runtime failure hook.

C6-5 remains open until C6-5c publishes a sandbox package and #2720 proves the controlled bad-row evidence on the entity machine.

## Verification

- `node plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-config.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false --project tsconfig.json`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

Subagent review:

- security/boundary review found a first-draft High: sandbox proof trusted mutable target config. Fixed by moving sandbox proof and target binding to server runtime config; re-review no findings.
- state-machine/test review found coverage gaps around ordinal drift, partial token consumption, and clean sibling value assertions. Fixed; re-review no findings.
