### PR TITLE
fix(multitable): forward personSummaries in popover + realtime merge (audit #3)

### DIFF
--- a/apps/web/src/multitable/components/MetaLinkedRecordPopover.vue
+++ b/apps/web/src/multitable/components/MetaLinkedRecordPopover.vue
@@ -24,6 +24,7 @@
                 :field="field"
                 :value="context.record.data[field.id]"
                 :link-summaries="context.linkSummaries?.[field.id]"
+                :person-summaries="context.personSummaries?.[field.id]"
                 :attachment-summaries="context.attachmentSummaries?.[field.id]"
               />
             </span>

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -60,6 +60,7 @@ export interface GridConflictState {
 
 type RemoteRecordMergeOptions = {
   linkSummaries?: Record<string, LinkedRecordSummary[]>
+  personSummaries?: Record<string, PersonSummary[]>
   attachmentSummaries?: Record<string, MetaAttachment[]>
 }
 
@@ -972,6 +973,20 @@ export function useMultitableGrid(opts: {
     }
   }
 
+  function replaceRecordPersonSummaries(recordId: string, summaries?: Record<string, PersonSummary[]>) {
+    const normalized = summaries && Object.keys(summaries).length > 0 ? summaries : null
+    if (!normalized) {
+      const next = { ...personSummaries.value }
+      delete next[recordId]
+      personSummaries.value = next
+      return
+    }
+    personSummaries.value = {
+      ...personSummaries.value,
+      [recordId]: normalized,
+    }
+  }
+
   function replaceRecordAttachmentSummaries(recordId: string, summaries?: Record<string, MetaAttachment[]>) {
     const normalized = summaries && Object.keys(summaries).length > 0 ? summaries : null
     if (!normalized) {
@@ -997,6 +1012,7 @@ export function useMultitableGrid(opts: {
     }
     rows.value = nextRows
     replaceRecordLinkSummaries(record.id, options?.linkSummaries)
+    replaceRecordPersonSummaries(record.id, options?.personSummaries)
     replaceRecordAttachmentSummaries(record.id, options?.attachmentSummaries)
     return true
   }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3275,6 +3275,7 @@ async function mergeRemoteRecordContext(recordId: string): Promise<boolean> {
     })
     const mergedInPage = grid.mergeRemoteRecord(ctx.record, {
       linkSummaries: ctx.linkSummaries,
+      personSummaries: ctx.personSummaries,
       attachmentSummaries: ctx.attachmentSummaries,
     })
     if (selectedRecordId.value === recordId) {

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -930,6 +930,28 @@ describe('useMultitableGrid', () => {
     expect(grid.conflict.value).toBeNull()
     expect(grid.rows.value[0]).toEqual({ id: 'r1', version: 9, data: { f1: 'patched again' } })
   })
+
+  it('mergeRemoteRecord preserves personSummaries from a realtime refetch', () => {
+    // Regression (#3): the realtime full-context refetch merge must carry
+    // personSummaries (alongside link/attachment) so native person fields keep
+    // showing the resolved display instead of dropping back to the raw userId.
+    const grid = useMultitableGrid({ sheetId: ref('s1'), viewId: ref('v1'), client })
+    grid.rows.value = [{ id: 'r1', version: 1, data: { fld_owner: ['u1'] } }]
+
+    const merged = grid.mergeRemoteRecord(
+      { id: 'r1', version: 2, data: { fld_owner: ['u2'] } },
+      {
+        linkSummaries: {},
+        personSummaries: { fld_owner: [{ id: 'u2', display: 'Bob' }] },
+        attachmentSummaries: {},
+      },
+    )
+
+    expect(merged).toBe(true)
+    expect(grid.rows.value[0]).toEqual({ id: 'r1', version: 2, data: { fld_owner: ['u2'] } })
+    // The merged person summary is stored under the record, keyed by field id.
+    expect(grid.personSummaries.value.r1).toEqual({ fld_owner: [{ id: 'u2', display: 'Bob' }] })
+  })
 })
 
 describe('buildSortInfo', () => {

--- a/apps/web/tests/multitable-linked-record-popover.spec.ts
+++ b/apps/web/tests/multitable-linked-record-popover.spec.ts
@@ -141,6 +141,37 @@ describe('MetaLinkedRecordPopover (A3)', () => {
     container.remove()
   })
 
+  it('renders a native person chip from personSummaries (display, not raw userId)', async () => {
+    // Regression (#3): the popover must forward ctx.personSummaries to the inner
+    // renderer. A native person field (type='person', value=userId[]) has NO
+    // linkSummaries — personSummaries is its sole display source — so without the
+    // prop the chip would show the raw userId.
+    const fetchRecord = vi.fn(async () =>
+      baseContext({
+        fields: [{ id: 'fld_owner', name: 'Owner', type: 'person' }],
+        record: { id: 'vendor_1', data: { fld_owner: ['u1'] } } as MetaRecordContext['record'],
+        personSummaries: { fld_owner: [{ id: 'u1', display: 'Alice' }] },
+      }),
+    )
+    const { container, app } = mountPopover({
+      visible: true,
+      recordId: 'vendor_1',
+      fetchRecord,
+    })
+    await flushPromises()
+
+    const name = container.querySelector('.meta-cell-renderer__person-name')
+    expect(name).not.toBeNull()
+    // Resolved display is shown…
+    expect(name!.textContent).toContain('Alice')
+    // …and the raw userId never leaks into the rendered cell.
+    const value = container.querySelector('.meta-linked-record-popover__value')
+    expect(value!.textContent).not.toContain('u1')
+
+    app.unmount()
+    container.remove()
+  })
+
   it('does not fetch while hidden, and fetches once shown', async () => {
     const fetchRecord = vi.fn(async () => baseContext())
     const { container, app } = mountPopover({


### PR DESCRIPTION
## Audit #3 (Low/P2) — native person summaries dropped in two FE paths

Native person fields (`type='person'`, value `userId[]`) carry **no** `linkSummaries` — `personSummaries` is their sole display source in `MetaCellRenderer`. Two paths forwarded only link/attachment summaries, so person fields rendered the raw `userId`:
1. `MetaLinkedRecordPopover.vue` — now passes `:person-summaries="context.personSummaries?.[field.id]"` to the inner `MetaCellRenderer` (mirrors `linkSummaries`), so the linked-record peek resolves foreign person fields.
2. Realtime full-context refetch merge — added `personSummaries` to `RemoteRecordMergeOptions` + a `replaceRecordPersonSummaries` helper (mirroring `replaceRecordLinkSummaries`) in `grid.mergeRemoteRecord` (`useMultitableGrid.ts`), threaded `ctx.personSummaries` from `MultitableWorkbench.vue`.

Display-only (backend already masks `personSummaries` by `allowedFieldIds` — no new egress). **Tests:** 53 specs, both new tests revert-proven (chip rendered `u1` not `Alice`; merge left `personSummaries` undefined). vue-tsc clean. Verdict: ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)