### PR TITLE
docs(data-source): record C6-5c sandbox package

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -23,8 +23,11 @@
   smoke 包；#2720 已完成 sandbox 配置和核心 dry-run/apply/re-pull/rollback smoke，
   且 #2737 后的 read-only dedicated-route 子门已 PASS。controlled bad-row 已尝试但
   HOLD 在 `HOLD_TARGET_DDL_UNAVAILABLE`，随后 seeded naturally failing row 也被实体机
-  回复确认为无安全 reset/cleanup 形态，路由为 `HOLD_NO_SAFE_FAILURE_SHAPE`。下一步只能
-  是独立的 C6-5a test-only failure-injection 设计/实现/复验链；production/batch 仍关闭。
+  回复确认为无安全 reset/cleanup 形态，路由为 `HOLD_NO_SAFE_FAILURE_SHAPE`。C6-5a
+  design 和 C6-5b sandbox-only failure-injection seam 已合并；首个 C6-5c sandbox 包
+  `642560126` 在实体机 package/apply 阶段 BLOCKED，尚未进入 controlled bad-row 复验。
+  #2761 已修复 on-prem package 不应携带 `node_modules` 的打包/校验缺口，并已重发
+  `d8244ee13` sandbox 包；下一步是实体机部署新包并重跑 C6-5c。production/batch 仍关闭。
 
 ## 收口顺序
 
@@ -35,8 +38,8 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open; C6-5a test-only injection design queued | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | C6-5 smoke package published; #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row HOLD_NO_SAFE_FAILURE_SHAPE | 交付签收 | 包内容/部署/证据不完整 |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` ready for entity-machine retry | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| Release | 总包 + 实体机验收 | #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row HOLD_NO_SAFE_FAILURE_SHAPE; old C6-5c deploy blocked, fixed package `d8244ee13` published and ready for rerun | 交付签收 | C6-5c controlled bad-row 证据未闭合 |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -456,9 +459,34 @@ TODO:
     pins `pipelineId`, `targetSystemId`, `targetDataSourceId`, `targetObject`, and
     `environment=sandbox`, so mutable external-system config cannot relabel a production target
     as sandbox.
-  - [ ] C6-5c package + entity-machine rerun: publish a sandbox package, rerun controlled bad-row
-    with one synthetic row failure plus at least one clean sibling write, prove values-free
-    dead-letter/provenance and re-pull idempotence, then disable the test-injection gate.
+  - [x] C6-5c package published:
+    `multitable-onprem-datasource-c6-failure-injection-20260617-642560126`
+    (`metasheet-multitable-onprem-v2.5.0-datasource-c6-failure-injection-20260617-642560126`).
+    Workflow `https://github.com/zensgit/metasheet2/actions/runs/27659564604`
+    passed; release asset set includes `.tgz`, `.zip`, both `.sha256`, `SHA256SUMS`,
+    metadata JSON, and tgz/zip verify JSON+MD reports.
+  - [x] C6-5c deploy blocker diagnosed and package fix merged:
+    #2761 / squash `d8244ee13`.
+    The build now prunes copied `node_modules` entries, sweeps the final package root,
+    and the verifier rejects any `.tgz` / `.zip` archive list containing `node_modules`.
+  - [x] C6-5c fixed sandbox package published:
+    `multitable-onprem-datasource-c6-package-prune-20260617-d8244ee13`
+    (`metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`).
+    Workflow `https://github.com/zensgit/metasheet2/actions/runs/27661650691`
+    passed; both package verifiers passed before publish; local downloaded asset verification
+    also passed for `.tgz` and `.zip`, and direct archive-list checks found no `node_modules`
+    entries.
+  - [x] C6-5c old deploy blocker recorded: entity-machine attempt of package `642560126`
+    returned `apply exit=1` before dependency refresh / migrations / PM2 restart / healthcheck.
+    The `.zip` path failed during launcher staging extraction with a missing staged `pnpm-lock.yaml`;
+    the `.tgz` path failed before dependency refresh with a missing staged path under
+    `packages/mssql-readonly-utils/node_modules/typescript`. Installed runtime did not contain the
+    failure-injection marker, so no C6-5c rerun was attempted.
+  - [ ] C6-5c entity-machine rerun: deploy package `d8244ee13`, confirm the
+    failure-injection marker is installed, enable the server-owned test-injection double gate,
+    rerun controlled bad-row with one synthetic row failure plus at least one clean sibling write,
+    prove values-free dead-letter/provenance and re-pull idempotence, then disable the
+    test-injection gate.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:
@@ -511,6 +539,22 @@ TODO:
 - [x] C6-5 package deploy preflight: #2720 reports `deploy.applyExit=0`, `health=200`, dry-run/apply
   route presence, token guard, and target-kind requirement present.
 - [x] C6-5 sandbox write-gated target + active C6 pipeline configured on entity machine.
+- [x] C6-5c test-injection sandbox package published after #2756.
+  - release: `multitable-onprem-datasource-c6-failure-injection-20260617-642560126`.
+  - package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-failure-injection-20260617-642560126`.
+  - workflow: `https://github.com/zensgit/metasheet2/actions/runs/27659564604`.
+  - asset set: `.tgz`, `.zip`, both `.sha256`, `SHA256SUMS`, metadata JSON,
+    and tgz/zip verify JSON+MD reports.
+- [x] C6-5c test-injection sandbox package deploy blocker fixed and recut.
+  - #2761 / `d8244ee13` makes `nodeModulesBundled=false` executable: build prunes
+    `node_modules`, verifier rejects package-contained `node_modules`, and the ZIP fallback scans
+    full extraction depth.
+  - fixed release: `multitable-onprem-datasource-c6-package-prune-20260617-d8244ee13`.
+  - fixed package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`.
+  - workflow: `https://github.com/zensgit/metasheet2/actions/runs/27661650691`.
+  - current routing: old package `642560126` -> `c6_5c_deploy=blocked`; new package
+    `d8244ee13` -> `c6_5c_deploy=ready_for_retry`; `c6_5c_rerun=not_started`.
+- [ ] C6-5c test-injection sandbox package deployed on entity machine and rerun.
 - [ ] 干净实体机 / 全新 DB smoke，用来暴露 migration 排序缺口。
 - [ ] 部署前跑 pending-migration diff + auth round-trip；静默 401 优先按 schema/migration 缺口排查，不先归咎 JWT secret。
 - [ ] C2 read-only smoke。

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -44,8 +44,12 @@ Forbidden:
 
 ## Preconditions
 
-- Deploy package `metasheet-multitable-onprem-v2.5.0-datasource-c6-ui-20260616-9fb34fd91`
-  or newer.
+- For the already-passed core C6 smoke, package
+  `metasheet-multitable-onprem-v2.5.0-datasource-c6-ui-20260616-9fb34fd91`
+  was sufficient.
+- For the C6-5c controlled bad-row rerun, deploy package
+  `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`
+  or a later package that includes #2756 and #2761.
 - Confirm health is `200`.
 - Confirm #2720 preflight already sees:
   - `dryRunRoutePresent=true`;
@@ -380,6 +384,47 @@ is a routing signal only, not runtime authorization. The next path is:
 1. C6-5a test-only failure-injection design;
 2. C6-5b default-off sandbox-only implementation;
 3. C6-5c new package + entity-machine rerun.
+
+C6-5a and C6-5b are now on `origin/main`. The first C6-5c sandbox package was
+published, but its entity-machine deploy attempt was blocked before rerun:
+
+- release tag:
+  `multitable-onprem-datasource-c6-failure-injection-20260617-642560126`;
+- package:
+  `metasheet-multitable-onprem-v2.5.0-datasource-c6-failure-injection-20260617-642560126`;
+- source commit: `6425601267264d256cbe0c2fa5e1f3c2fe5784a6`;
+- workflow:
+  `https://github.com/zensgit/metasheet2/actions/runs/27659564604`;
+- asset set: `.tgz`, `.zip`, both `.sha256`, `SHA256SUMS`, metadata JSON,
+  and tgz/zip verify JSON+MD reports.
+
+Current entity-machine result for that package:
+
+- `c6_5c_deploy=blocked`;
+- `c6_5c_rerun=not_started`;
+- `.zip` via `deploy.bat <zip>` failed during launcher staging extraction with
+  a missing staged `pnpm-lock.yaml`;
+- `.tgz` via `deploy.bat <tgz>` failed before dependency refresh / migrations /
+  PM2 restart / healthcheck with a missing staged path under
+  `packages/mssql-readonly-utils/node_modules/typescript`;
+- installed runtime did not contain the C6 failure-injection marker.
+
+#2761 is now merged and a fixed package is published:
+
+- release tag:
+  `multitable-onprem-datasource-c6-package-prune-20260617-d8244ee13`;
+- package:
+  `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`;
+- source commit: `d8244ee13e01368627d3a3aef4a5394db25708e2`;
+- workflow:
+  `https://github.com/zensgit/metasheet2/actions/runs/27661650691`;
+- package verification: workflow passed, both `.tgz` and `.zip` verifier reports
+  passed before publish, and downloaded archive-list checks found no
+  `node_modules` entries.
+
+Do not enable the failure-injection env until this fixed package deploys
+cleanly and the installed runtime contains the C6 failure-injection marker.
+The next step is to deploy the fixed package, then rerun this section.
 
 The C6-5b implementation is server-owned and deploy-gated. For the C6-5c
 sandbox package only, the deploy config must include both gates:

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -46,7 +46,7 @@ the corresponding section below and post fresh values-free evidence.
 | C3 incremental/watermark | Runtime and CI real-DB wire locks are landed on main, but no release-package entity-machine incremental/resume smoke is recorded in this runbook. Large-BOM #2425 is related Data Factory C3/C4 evidence, not the SQL watermark/resume release gate. | Section 4 remains required for complete delivery unless an owner explicitly narrows the release scope and uses downgraded wording. Do not cite #2425 as C3 watermark/resume PASS. |
 | C4 UI configuration | Source/object/schema picker, source-field picker, watermark UI, and read-only/source-only boundary UX have landed, but this runbook has no final release-package UI smoke evidence yet. | Section 5 remains required for complete delivery unless exact UI smoke is explicitly deferred with downgraded wording. |
 | C5 K3/MSSQL read-only seam | issue #2670 closed PASS on package `dea391a1`: generic SQL Server smoke and K3 SQL Server executor smoke both passed after operator SQL scope adjustment; no K3 Save/Submit/Audit/BOM, external DB write, raw SQL, credentials, or row values were printed. | May be cited when no C5-relevant package/runtime surface changed after `dea391a1`; otherwise rerun the C5 runbook on the release package. |
-| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS and read-only dedicated-route PASS; controlled bad-row remains HOLD after both `HOLD_TARGET_DDL_UNAVAILABLE` and `HOLD_NO_SAFE_FAILURE_SHAPE`. C6-5a now routes this to a separate test-only failure-injection design path. | C6-5 is not closed. Release signoff cannot claim complete database/source-system delivery until controlled bad-row row-level failure/dead-letter/provenance evidence passes values-free on a later sandbox package. |
+| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS and read-only dedicated-route PASS; controlled bad-row remains HOLD after both `HOLD_TARGET_DDL_UNAVAILABLE` and `HOLD_NO_SAFE_FAILURE_SHAPE`. C6-5a design and C6-5b seam are on main; first C6-5c package `642560126` was blocked during deploy, #2761 fixed package-contained `node_modules` handling, and recut package `d8244ee13` is published for entity-machine retry. | C6-5 is not closed. Release signoff cannot claim complete database/source-system delivery until package `d8244ee13` deploys and controlled bad-row row-level failure/dead-letter/provenance evidence passes values-free. |
 
 ## Required Inputs
 
@@ -276,6 +276,25 @@ Current #2720 checkpoint as of 2026-06-17:
   `environment=sandbox`. Mutable external-system config is not a sandbox proof.
   This runbook still does not authorize production, batch, raw SQL, DDL,
   trigger, or broad runtime failure hooks.
+- First C6-5c sandbox package was published but not validated on the entity
+  machine:
+  `multitable-onprem-datasource-c6-failure-injection-20260617-642560126`
+  / `metasheet-multitable-onprem-v2.5.0-datasource-c6-failure-injection-20260617-642560126`.
+  Workflow `https://github.com/zensgit/metasheet2/actions/runs/27659564604`
+  passed and published the full asset set plus tgz/zip verify reports.
+  The entity-machine deploy attempt was blocked before rerun:
+  `c6_5c_deploy=blocked`, `c6_5c_rerun=not_started`, with missing staged package
+  paths reported for `.zip` and `.tgz`.
+- #2761 fixed the package-contained `node_modules` gap and recut the C6-5c
+  package:
+  `multitable-onprem-datasource-c6-package-prune-20260617-d8244ee13`
+  / `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`.
+  Workflow `https://github.com/zensgit/metasheet2/actions/runs/27661650691`
+  passed; both verifier reports passed before publish, and downloaded
+  archive-list checks found no `node_modules` entries. Current routing is
+  `c6_5c_deploy=ready_for_retry`, `c6_5c_rerun=not_started`. This package
+  identity is not a C6 PASS claim; `controlledBadRow` remains `hold` until the
+  C6-5c entity-machine rerun proves the row-level failure evidence values-free.
 
 ## Stop Rules
 


### PR DESCRIPTION
## Summary
- record the published C6-5c sandbox failure-injection package in the delivery TODO and smoke runbooks
- distinguish the old C6 UI/core-smoke package from the new controlled bad-row rerun package
- keep #2720 controlled bad-row at HOLD and production/batch closed until entity-machine rerun evidence passes

## Verification
- git diff --check
- release verified: multitable-onprem-datasource-c6-failure-injection-20260617-642560126 has 10 assets and workflow 27659564604 succeeded

## Boundary
Docs-only state reconciliation. No runtime, route, UI, package build, production/batch authorization, raw SQL/DDL/trigger path, or C6 PASS claim.