### PR TITLE
ci(multitable): run the rollup countall characterization + FE round-trip in CI

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -1,0 +1,73 @@
+# Multitable web guard (targeted gate).
+#
+# Why this exists: the main PR gate (plugin-tests.yml) runs core-backend tests and only
+# `pnpm --filter @metasheet/web build` for the web app — it does NOT run apps/web vitest
+# specs. So FE-only regressions on the multitable surface slip through green CI. The rollup
+# aggregation expansion (countall/unique) added a FE normalizer (resolveRollupFieldProperty /
+# normalizeRollupAggregation) whose whole job is to NOT silently collapse a stored countall/
+# unique back to 'count' on edit — exactly the kind of regression a build-only gate can't catch.
+#
+# Scope (deliberately TARGETED, like attendance-web-guard): run the green multitable FE
+# normalizer/round-trip specs. The full `@metasheet/web` vitest suite still has historical/flaky
+# failures, so wiring the whole suite as a required gate would be red on arrival. Expand the
+# `vitest run` filter as more multitable web specs are cleaned up.
+name: Multitable Web Guard
+
+on:
+  pull_request:
+    paths:
+      - 'apps/web/src/multitable/utils/field-config.ts'
+      - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
+      - 'apps/web/src/multitable/components/MetaFieldManager.vue'
+      - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
+      - '.github/workflows/multitable-web-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/src/multitable/utils/field-config.ts'
+      - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
+      - 'apps/web/src/multitable/components/MetaFieldManager.vue'
+      - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
+      - '.github/workflows/multitable-web-guard.yml'
+
+jobs:
+  multitable-web-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run multitable web guard specs (targeted)
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -210,6 +210,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-write.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-create.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts \
+            tests/integration/multitable-rollup-countall-nongating.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts \
             tests/integration/multitable-dashboard-filterinfo-oracle.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-convergence.test.ts \


### PR DESCRIPTION
## Why

Review of #2755 caught that the slice's two new tests were **not wired into CI** — so the "ran on real Postgres / FE 5/5" claim was overstated:

- The real-DB multitable step in `plugin-tests.yml` runs an **explicit file list**. `multitable-rollup-countall-nongating.test.ts` wasn't in it, so under the default (no-DB) `test` job it hit `describeIfDatabase` → `describe.skip` — it passed as *skipped*, not *run*.
- The main gate only `build`s the web app; it never runs `apps/web` vitest, so the FE round-trip spec was **local-only**.

## Fix

- **`plugin-tests.yml`**: add `multitable-rollup-countall-nongating.test.ts` to the real-DB list (next to its model, `multitable-lookup-foreign-field-mask-aggregate.test.ts`) + update the step name. The COUNTALL non-gating characterization now executes against real Postgres in CI — this is also its **first real run**, so a green here is the actual verification of the non-gating contract.
- **`multitable-web-guard.yml`** (new, mirrors `attendance-web-guard.yml`): a targeted, path-filtered job that runs `multitable-rollup-aggregation-fe` so a regression in `resolveRollupFieldProperty` / `normalizeRollupAggregation` (the silent countall→count fallback) turns CI red.

## Note

No production code changes — CI wiring + the previously-merged tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)