### PR TITLE
fix(onprem): exclude node_modules from deploy packages

### DIFF
--- a/docs/development/onprem-package-node-modules-prune-verification-20260617.md
+++ b/docs/development/onprem-package-node-modules-prune-verification-20260617.md
@@ -1,0 +1,54 @@
+# On-Prem Package Node Modules Prune Verification (2026-06-17)
+
+## Context
+
+Issue #2720 reported that the C6-5c sandbox package published from `642560126`
+could not be applied on the Windows entity machine. The `.zip` failed during
+launcher staging extraction and the `.tgz` failed before dependency refresh with
+a missing staged path under `packages/mssql-readonly-utils/node_modules`.
+
+The package contract already said `nodeModulesBundled=false`, but the build
+script copied workspace package directories with `cp -R`. If a local workspace
+package had a pnpm `node_modules` directory or symlink, the archive could carry
+that content even though the deploy flow is supposed to refresh dependencies
+during apply.
+
+## Change
+
+- `scripts/ops/multitable-onprem-package-build.sh` now prunes copied
+  `node_modules` entries immediately after directory copies and sweeps the final
+  package root before archive creation.
+- `scripts/ops/multitable-onprem-package-verify.sh` now rejects any archive list
+  entry matching `(^|/)node_modules(/|$)`.
+- The verifier failure is intentionally before any package is considered valid:
+  the entity machine must not be the first place this contract is checked.
+
+## Verification
+
+Commands run:
+
+```bash
+node scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+node scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Results:
+
+- `multitable-onprem-package-no-node-modules.test.mjs`: 2 passed.
+- `multitable-onprem-package-verify-k3-helper-contract.test.mjs`: 1 passed.
+- Shell syntax checks passed.
+
+Negative control:
+
+- A synthesized archive list containing
+  `packages/mssql-readonly-utils/node_modules/typescript/package.json` fails
+  package verification with `Package must not contain node_modules entries`.
+
+## Boundary
+
+This is package/build verification only. It does not change C6 runtime,
+external-write behavior, K3 paths, database permissions, request bodies, or
+production/batch rollout state. C6-5c remains blocked until a recut package
+deploys cleanly and the entity machine posts the controlled bad-row evidence.

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -213,9 +213,21 @@ function copy_path() {
   mkdir -p "$(dirname "$dst")"
   if [[ -d "$src" ]]; then
     cp -R "$src" "$dst"
+    prune_node_modules "$dst"
   else
     cp "$src" "$dst"
   fi
+}
+
+function prune_node_modules() {
+  local root="$1"
+  [[ -e "$root" ]] || return 0
+  # On-prem packages intentionally refresh dependencies on apply. Bundling
+  # pnpm node_modules symlinks makes Windows extraction/copy fail on staged
+  # paths before the dependency refresh can run.
+  while IFS= read -r -d '' path; do
+    rm -rf "$path"
+  done < <(find "$root" -name node_modules -prune -print0)
 }
 
 function write_windows_entrypoints() {
@@ -475,6 +487,7 @@ command -v zip >/dev/null 2>&1 || die "zip command is required to build Windows 
 for rel in "${REQUIRED_PATHS[@]}"; do
   copy_path "$rel"
 done
+prune_node_modules "$PACKAGE_ROOT"
 
 stamp_packaged_version "package.json"
 stamp_packaged_version "packages/core-backend/package.json"

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const buildScriptPath = path.join(repoRoot, 'scripts/ops/multitable-onprem-package-build.sh')
+const verifyScriptPath = path.join(repoRoot, 'scripts/ops/multitable-onprem-package-verify.sh')
+const buildScript = fs.readFileSync(buildScriptPath, 'utf8')
+const verifyScript = fs.readFileSync(verifyScriptPath, 'utf8')
+
+function runVerifierListCheck(listEntries) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-package-list-'))
+  const listPath = path.join(dir, 'archive-list.txt')
+  fs.writeFileSync(listPath, `${listEntries.join('\n')}\n`)
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'source "$VERIFY"; verify_no_bundled_node_modules "$LIST"'],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        VERIFY: verifyScriptPath,
+        LIST: listPath,
+      },
+      encoding: 'utf8',
+    },
+  )
+  fs.rmSync(dir, { recursive: true, force: true })
+  return result
+}
+
+test('on-prem package build prunes copied workspace node_modules before archiving', () => {
+  assert.match(
+    buildScript,
+    /function prune_node_modules\(\)/,
+    'the build script must define an explicit node_modules pruning helper',
+  )
+  assert.match(
+    buildScript,
+    /find "\$root" -name node_modules -prune -print0/,
+    'the pruning helper must find directories or symlinks named node_modules without traversing them',
+  )
+  assert.match(
+    buildScript,
+    /prune_node_modules "\$dst"/,
+    'each copied directory should be pruned immediately',
+  )
+  assert.match(
+    buildScript,
+    /prune_node_modules "\$PACKAGE_ROOT"/,
+    'the final package root should be swept before archive creation',
+  )
+})
+
+test('on-prem verifier rejects archive lists that contain node_modules entries', () => {
+  const clean = runVerifierListCheck([
+    'package/package.json',
+    'package/packages/mssql-readonly-utils/package.json',
+    'package/packages/mssql-readonly-utils/index.cjs',
+  ])
+  assert.equal(clean.status, 0, clean.stderr)
+
+  const bad = runVerifierListCheck([
+    'package/package.json',
+    'package/packages/mssql-readonly-utils/node_modules/typescript/package.json',
+  ])
+  assert.notEqual(bad.status, 0, 'node_modules entries must fail package verification')
+  assert.match(
+    bad.stderr,
+    /Package must not contain node_modules entries/,
+    'failure should explain that dependencies are refreshed during apply',
+  )
+  assert.match(
+    bad.stderr,
+    /packages\/mssql-readonly-utils\/node_modules\/typescript/,
+    'failure should show a sample offending entry for diagnostics',
+  )
+})
+
+test('on-prem zip verifier fallback lists full archive depth', () => {
+  assert.match(
+    verifyScript,
+    /find "\$EXTRACT_ROOT" -mindepth 1 -print/,
+    'zip fallback must scan the full extracted package tree',
+  )
+  assert.doesNotMatch(
+    verifyScript,
+    /find "\$EXTRACT_ROOT" -mindepth 1 -maxdepth 3/,
+    'zip fallback must not stop before nested workspace node_modules paths',
+  )
+})

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -643,6 +643,19 @@ function verify_sha() {
   fi
 }
 
+function verify_no_bundled_node_modules() {
+  local archive_list_file="$1"
+  local matches
+  matches="$(mktemp)"
+  if grep -E '(^|/)node_modules(/|$)' "$archive_list_file" > "$matches"; then
+    local sample
+    sample="$(head -n 5 "$matches" | tr '\n' '; ')"
+    rm -f "$matches"
+    die "Package must not contain node_modules entries; deploy refreshes dependencies during apply. First entries: ${sample}"
+  fi
+  rm -f "$matches"
+}
+
 # When sourced (e.g. by the focused test), define functions only — do not run the
 # package verification main flow. Direct execution (BASH_SOURCE[0] == $0) runs normally.
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
@@ -683,7 +696,7 @@ case "$PACKAGE_FILE" in
     if command -v zipinfo >/dev/null 2>&1; then
       zipinfo -1 "$PACKAGE_FILE" > "$list_file"
     else
-      find "$EXTRACT_ROOT" -mindepth 1 -maxdepth 3 -print | sed "s#^${EXTRACT_ROOT}/##" > "$list_file"
+      find "$EXTRACT_ROOT" -mindepth 1 -print | sed "s#^${EXTRACT_ROOT}/##" > "$list_file"
     fi
     ;;
   *)
@@ -693,6 +706,7 @@ esac
 
 pkg_name="$(head -n 1 "$list_file" | cut -d/ -f1)"
 pkg_root="${EXTRACT_ROOT}/${pkg_name}"
+verify_no_bundled_node_modules "$list_file"
 
 required=(
   "DEPLOYMENT.txt"


### PR DESCRIPTION
## Summary

Fixes the C6-5c package/apply blocker reported on #2720 after the `642560126` sandbox package deploy attempt.

The package contract already says `nodeModulesBundled=false`, but the build script copied workspace package directories with `cp -R`. If a workspace package contains pnpm `node_modules` symlinks/directories, those entries can land in the archive and make Windows staging/apply fail before dependency refresh.

This PR makes the contract executable:

- prune copied `node_modules` entries during package build and sweep the final package root before archive creation;
- reject any `.tgz` / `.zip` archive list containing `node_modules` entries during package verification;
- add a focused negative-control test that feeds the verifier a synthetic offending archive list under `packages/mssql-readonly-utils/node_modules/typescript`.

## Verification

```bash
node scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
node scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs
bash -n scripts/ops/multitable-onprem-package-build.sh
bash -n scripts/ops/multitable-onprem-package-verify.sh
git diff --check
```

## Boundary

Package/build verification only. No C6 runtime change, no route/UI change, no database permission change, no K3 path, no request-body injection, and no production/batch authorization.

C6-5c remains blocked until this lands, a new package is cut, and the entity machine reruns the controlled bad-row evidence path values-free.
