### PR TITLE
docs(approval): align two stale comments with code (NOW-lane hygiene)

### DIFF
--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -24,7 +24,8 @@ export interface ApprovalSlaSchedulerOptions {
   runtime?: ApprovalSlaSchedulerRuntimeOptions
   /**
    * Optional hook invoked once per breach cycle with the newly-breached
-   * instance ids. Main caller wires it to approval audit + notifications.
+   * instance ids. Main caller (index.ts) wires it to the SLA breach notifier
+   * (notifications only); audit-event emission on breach is not yet wired.
    */
   onBreach?: (instanceIds: string[]) => Promise<void> | void
   logger?: Logger

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -91,8 +91,9 @@ export interface CcNodeConfig {
 /**
  * Parallel gateway (并行分支) — fans into N branches from `branches` (edgeKeys)
  * and re-joins at `joinNodeKey`. `joinMode === 'all'` ("和") waits for every
- * branch to reach the join node before advancing. `'any'` is reserved for
- * a future wave and is not wired into the executor in v1.
+ * branch to reach the join node before advancing. `'any'` advances as soon as
+ * the first branch reaches the join node — wired in the executor
+ * (`resolveFromNode` fan-out + `resolveAfterApproveInParallel`).
  */
 export interface ParallelNodeConfig {
   branches: string[]


### PR DESCRIPTION
NOW-lane item 1 of 3 (zero-gate hygiene from the approval dev plan). Two comments contradicted the code and were re-deriving wrong conclusions downstream (the dev-plan workflow itself tripped on both):

- **`ParallelNodeConfig`** (`types/approval-product.ts`): claimed `joinMode: 'any'` is *"reserved for a future wave and is not wired into the executor in v1"*. It **is** wired — `resolveFromNode` fan-out + `resolveAfterApproveInParallel` both handle join-any (advance on first branch to reach the join). Comment now reflects that.
- **`ApprovalSlaScheduler.onBreach`**: claimed the main caller wires it to *"approval audit + notifications"*. `index.ts:2056` wires it to `breachNotifier.notifyBreaches` **only** (notifications); there is no audit-event emission on breach. Comment now says notifications-only + flags the audit gap as not-yet-wired.

Comment-only — no behavior, type, or API change. Zero-gate (doesn't expand capability, doesn't touch the hot authoring files), so it's safe ahead of the P0 trial gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)