### PR TITLE
test(approval): lock authoring route-permission guard (NOW-lane item 2)

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -14,6 +14,7 @@ import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { resolveAdminRouteRedirect } from './router/adminAccess'
 import { appRoutes } from './router/appRoutes'
+import { isRoutePermitted } from './router/routeAccess'
 import { ROUTE_PATHS } from './router/types'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
 import { useFeatureFlags } from './stores/featureFlags'
@@ -127,8 +128,7 @@ router.beforeEach(async (to, _from, next) => {
       return next(flags.resolveHomePath())
     }
 
-    const requiredPermissions = Array.isArray(to.meta?.permissions) ? to.meta.permissions : []
-    if (requiredPermissions.length > 0 && !requiredPermissions.every((permission) => auth.hasPermission(permission))) {
+    if (!isRoutePermitted(to.meta, (permission) => auth.hasPermission(permission))) {
       return next(flags.resolveHomePath())
     }
 

--- a/apps/web/src/router/routeAccess.ts
+++ b/apps/web/src/router/routeAccess.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure route permission gate, extracted from the router `beforeEach` guard
+ * (`main.ts`) so the "non-manager is redirected away from manage-gated routes"
+ * invariant can be unit-tested against the REAL `appRoutes` meta. Previously the
+ * check lived only inline in the guard with no test, so a drift between a FE
+ * route's `meta.permissions` and the backend `rbacGuard` string (e.g. the
+ * approval-template authoring routes) would pass CI silently.
+ *
+ * Behaviour matches the original inline check byte-for-byte: a route with no
+ * declared `permissions` is always permitted; otherwise the user must hold
+ * EVERY declared permission.
+ */
+
+/** The `permissions` array declared on a route's meta, or `[]` if none/!array. */
+export function routeMetaPermissions(meta: unknown): string[] {
+  const permissions = (meta as { permissions?: unknown } | null | undefined)?.permissions
+  return Array.isArray(permissions) ? (permissions as string[]) : []
+}
+
+/**
+ * Whether a route is permitted given a permission probe. Mirrors the guard:
+ * `permitted = required.length === 0 || required.every(hasPermission)`, so
+ * `!isRoutePermitted(...)` === the original `length > 0 && !every(...)` redirect
+ * condition.
+ */
+export function isRoutePermitted(
+  meta: unknown,
+  hasPermission: (permission: string) => boolean,
+): boolean {
+  const required = routeMetaPermissions(meta)
+  return required.length === 0 || required.every((permission) => hasPermission(permission))
+}

--- a/apps/web/tests/approvalTemplateRouteGuard.spec.ts
+++ b/apps/web/tests/approvalTemplateRouteGuard.spec.ts
@@ -41,8 +41,11 @@ describe('routeAccess gate (extracted from the router beforeEach)', () => {
 describe('approval-template authoring routes require approval-templates:manage (drift pin)', () => {
   const SRC = readFileSync(join(__dirname, '../src/router/appRoutes.ts'), 'utf8')
 
-  function routeBlock(name: string): string | null {
-    const i = SRC.indexOf(`name: '${name}'`)
+  // Find a route's source block by its PATH so the block includes — and the test
+  // asserts — the path value the title claims, plus the path→name binding (the
+  // earlier name-anchored slice started after the path line and never checked it).
+  function routeBlockByPath(path: string): string | null {
+    const i = SRC.indexOf(`path: '${path}'`)
     if (i === -1) return null
     const end = SRC.indexOf('\n  },', i)
     return end === -1 ? SRC.slice(i) : SRC.slice(i, end)
@@ -53,16 +56,19 @@ describe('approval-template authoring routes require approval-templates:manage (
     ['approval-template-edit', '/approval-templates/:id/edit'],
   ] as const) {
     it(`${name} (${path}) is auth-gated to exactly approval-templates:manage`, () => {
-      const block = routeBlock(name)
-      expect(block, `route ${name} must exist in appRoutes.ts`).toBeTruthy()
+      const block = routeBlockByPath(path)
+      expect(block, `route ${path} must exist in appRoutes.ts`).toBeTruthy()
+      // path → name → fence all asserted on the same route object
+      expect(block).toContain(`name: '${name}'`)
       expect(block).toMatch(/requiresAuth:\s*true/)
       expect(block).toMatch(/permissions:\s*\[\s*'approval-templates:manage'\s*\]/)
     })
   }
 
-  it('the public template-list route stays unguarded (no false-positive fence)', () => {
-    const block = routeBlock('approval-template-list')
+  it('the public template-list route (/approval-templates) stays unguarded (no false-positive fence)', () => {
+    const block = routeBlockByPath('/approval-templates')
     expect(block).toBeTruthy()
+    expect(block).toContain("name: 'approval-template-list'")
     expect(block).not.toMatch(/permissions:/)
   })
 })

--- a/apps/web/tests/approvalTemplateRouteGuard.spec.ts
+++ b/apps/web/tests/approvalTemplateRouteGuard.spec.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { isRoutePermitted, routeMetaPermissions } from '../src/router/routeAccess'
+
+/**
+ * Locks the router permission gate that protects the approval-template authoring
+ * routes. Two complementary checks:
+ *   1. The pure `routeAccess` gate (extracted from main.ts beforeEach) — the
+ *      "non-manager is redirected away" invariant, previously untested.
+ *   2. A source-level drift pin on appRoutes.ts — the authoring routes must keep
+ *      `permissions: ['approval-templates:manage']` so the FE fence can't drift
+ *      out of sync with the backend rbacGuard. (Read at the source level on
+ *      purpose: importing appRoutes eagerly pulls every view + element-plus CSS
+ *      into the jsdom test, matching the repo's existing `.guard.test.ts` idiom.)
+ */
+describe('routeAccess gate (extracted from the router beforeEach)', () => {
+  it('blocks when a required permission is missing, allows when all are held', () => {
+    const manageMeta = { permissions: ['approval-templates:manage'] }
+    expect(isRoutePermitted(manageMeta, () => false)).toBe(false)
+    expect(isRoutePermitted(manageMeta, (p) => p === 'approval-templates:manage')).toBe(true)
+    // every() semantics: ALL declared permissions are required
+    expect(isRoutePermitted({ permissions: ['a', 'b'] }, (p) => p === 'a')).toBe(false)
+    expect(isRoutePermitted({ permissions: ['a', 'b'] }, () => true)).toBe(true)
+  })
+
+  it('permits routes that declare no permissions (byte-identical baseline)', () => {
+    expect(isRoutePermitted({ permissions: [] }, () => false)).toBe(true)
+    expect(isRoutePermitted({}, () => false)).toBe(true)
+    expect(isRoutePermitted(undefined, () => false)).toBe(true)
+  })
+
+  it('routeMetaPermissions normalizes missing / non-array meta to []', () => {
+    expect(routeMetaPermissions(undefined)).toEqual([])
+    expect(routeMetaPermissions({})).toEqual([])
+    expect(routeMetaPermissions({ permissions: 'x' })).toEqual([])
+    expect(routeMetaPermissions({ permissions: ['x'] })).toEqual(['x'])
+  })
+})
+
+describe('approval-template authoring routes require approval-templates:manage (drift pin)', () => {
+  const SRC = readFileSync(join(__dirname, '../src/router/appRoutes.ts'), 'utf8')
+
+  function routeBlock(name: string): string | null {
+    const i = SRC.indexOf(`name: '${name}'`)
+    if (i === -1) return null
+    const end = SRC.indexOf('\n  },', i)
+    return end === -1 ? SRC.slice(i) : SRC.slice(i, end)
+  }
+
+  for (const [name, path] of [
+    ['approval-template-create', '/approval-templates/new'],
+    ['approval-template-edit', '/approval-templates/:id/edit'],
+  ] as const) {
+    it(`${name} (${path}) is auth-gated to exactly approval-templates:manage`, () => {
+      const block = routeBlock(name)
+      expect(block, `route ${name} must exist in appRoutes.ts`).toBeTruthy()
+      expect(block).toMatch(/requiresAuth:\s*true/)
+      expect(block).toMatch(/permissions:\s*\[\s*'approval-templates:manage'\s*\]/)
+    })
+  }
+
+  it('the public template-list route stays unguarded (no false-positive fence)', () => {
+    const block = routeBlock('approval-template-list')
+    expect(block).toBeTruthy()
+    expect(block).not.toMatch(/permissions:/)
+  })
+})


### PR DESCRIPTION
NOW-lane item 2 of 3 (the P0-C code-side increment, split out of the owner-gated deployed smoke). Zero-gate, no capability change, doesn't touch the hot authoring files.

**Problem:** the router `beforeEach` permission check that fences `/approval-templates/new` + `/:id/edit` behind `approval-templates:manage` lived inline in `main.ts` with **no test** — a refactor or a route-meta typo could quietly drop the fence, and nothing would catch it.

**Change:**
- Extract the inline check into a pure `src/router/routeAccess.ts` (`isRoutePermitted` / `routeMetaPermissions`). `main.ts` delegates — **byte-identical** behavior (`!isRoutePermitted(...)` === the original `length > 0 && !every(...)` redirect).
- Spec `approvalTemplateRouteGuard.spec.ts`: covers the pure gate (non-manager blocked, manager allowed, every-permission semantics, no-perm baseline) **and** source-level drift-pins the two authoring routes to `permissions: ['approval-templates:manage']` (matches the backend `rbacGuard`).

**Why source-read for the route meta:** importing `appRoutes` eagerly pulls every view + `element-plus` base CSS into the jsdom test (`ERR_UNKNOWN_FILE_EXTENSION .css`). The source-level pin matches the repo's existing `.guard.test.ts` idiom and stays dependency-light.

**Verification:** `vue-tsc -b` clean (exit 0); spec **6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)