### PR TITLE
feat(multitable): rollup filter condition with fail-closed field-readability (slice 3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -211,6 +211,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-create.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts \
             tests/integration/multitable-rollup-countall-nongating.test.ts \
+            tests/integration/multitable-rollup-filter-condition.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts \
             tests/integration/multitable-dashboard-filterinfo-oracle.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-convergence.test.ts \

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -979,11 +979,15 @@ const lookupDraft = reactive<{ linkFieldId: string; targetFieldId: string; forei
   targetFieldId: '',
   foreignSheetId: '',
 })
-const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation }>({
+// filters/filterConjunction are carried OPAQUELY (no builder UI yet) so an API/template-authored rollup
+// filter survives an unrelated edit instead of being silently dropped on save.
+const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation; filters?: unknown[]; filterConjunction?: string }>({
   linkFieldId: '',
   targetFieldId: '',
   foreignSheetId: '',
   aggregation: 'count',
+  filters: undefined,
+  filterConjunction: undefined,
 })
 const formulaDraft = reactive<{ expression: string }>({
   expression: '',
@@ -1492,6 +1496,8 @@ function resetDrafts() {
   rollupDraft.targetFieldId = ''
   rollupDraft.foreignSheetId = ''
   rollupDraft.aggregation = 'count'
+  rollupDraft.filters = undefined
+  rollupDraft.filterConjunction = undefined
   formulaDraft.expression = ''
   formulaFunctionSearch.value = ''
   formulaFunctionCategory.value = 'all'
@@ -1561,6 +1567,10 @@ function serializeFieldDraft(type: string | null): string {
       targetFieldId: rollupDraft.targetFieldId,
       foreignSheetId: rollupDraft.foreignSheetId,
       aggregation: rollupDraft.aggregation,
+      // Opaque filter carry — part of the signature so editing a filtered rollup isn't seen as "clean".
+      ...(rollupDraft.filters && rollupDraft.filters.length > 0
+        ? { filters: rollupDraft.filters, filterConjunction: rollupDraft.filterConjunction ?? 'and' }
+        : {}),
     })
   }
   if (type === 'formula') {
@@ -1692,6 +1702,8 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     rollupDraft.targetFieldId = property.targetFieldId ?? ''
     rollupDraft.foreignSheetId = property.foreignSheetId ?? ''
     rollupDraft.aggregation = property.aggregation
+    rollupDraft.filters = property.filters
+    rollupDraft.filterConjunction = property.filterConjunction
   } else if (fieldType === 'formula') {
     formulaDraft.expression = resolveFormulaFieldProperty(field.property).expression
   } else if (fieldType === 'attachment') {
@@ -2134,6 +2146,10 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       targetFieldId: rollupDraft.targetFieldId,
       aggregation: rollupDraft.aggregation,
       ...(rollupDraft.foreignSheetId ? { foreignSheetId: rollupDraft.foreignSheetId } : {}),
+      // Opaque filter carry (no builder UI yet) — re-emit a stored filter so it isn't dropped on save.
+      ...(rollupDraft.filters && rollupDraft.filters.length > 0
+        ? { filters: rollupDraft.filters, filterConjunction: rollupDraft.filterConjunction ?? 'and' }
+        : {}),
     }
   }
   if (normalizedType === 'formula') {

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -31,6 +31,10 @@ export type NormalizedRollupFieldProperty = {
   targetFieldId: string | null
   foreignSheetId: string | null
   aggregation: RollupAggregation
+  // Slice 3 rollup filter condition. The field manager has no builder UI yet, so these are carried
+  // OPAQUELY (load → re-save unchanged) to avoid clobbering an API/template-authored filter on edit.
+  filters?: unknown[]
+  filterConjunction?: string
 }
 
 // Keep in lockstep with parseRollupAggregation in core-backend (routes/univer-meta.ts + field-codecs.ts):
@@ -156,11 +160,19 @@ export function resolveLookupFieldProperty(value: unknown): NormalizedLookupFiel
 export function resolveRollupFieldProperty(value: unknown): NormalizedRollupFieldProperty {
   const property = asRecord(value)
   const aggregation = stringOrNull(property.aggregation ?? property.agg ?? property.function ?? property.rollupFunction)
+  const rawFilters = Array.isArray(property.filters)
+    ? property.filters
+    : Array.isArray(property.conditions)
+      ? property.conditions
+      : null
   return {
     linkFieldId: stringOrNull(property.linkFieldId ?? property.linkedFieldId ?? property.relatedLinkFieldId ?? property.sourceFieldId),
     targetFieldId: stringOrNull(property.targetFieldId ?? property.lookUpTargetFieldId ?? property.lookupTargetFieldId ?? property.lookupFieldId),
     foreignSheetId: stringOrNull(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId),
     aggregation: normalizeRollupAggregation(aggregation),
+    ...(rawFilters && rawFilters.length > 0
+      ? { filters: rawFilters, filterConjunction: property.filterConjunction === 'or' ? 'or' : 'and' }
+      : {}),
   }
 }
 

--- a/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
+++ b/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
@@ -46,3 +46,31 @@ describe('rollup aggregation — FE normalizer round-trip', () => {
     expect(aggregationLabel('unique', false)).toBe('Unique')
   })
 })
+
+// Slice 3 — the rollup filter condition has no builder UI yet, so the field manager carries it OPAQUELY.
+// resolveRollupFieldProperty is the load side of that round-trip; if it dropped filters, an unrelated edit
+// would clobber an API/template-authored filter on save (the same silent-data-loss class as #1781).
+describe('rollup filter condition — opaque FE preservation (slice 3)', () => {
+  it('preserves filters + filterConjunction so an edit does not silently drop them', () => {
+    const p = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', foreignSheetId: 's', aggregation: 'countall',
+      filters: [{ fieldId: 'f1', operator: 'is', value: 'paid' }], filterConjunction: 'or',
+    })
+    expect(p.filters).toEqual([{ fieldId: 'f1', operator: 'is', value: 'paid' }])
+    expect(p.filterConjunction).toBe('or')
+  })
+
+  it('no filters → filters/filterConjunction stay absent (clean config, no spurious dirty)', () => {
+    const p = resolveRollupFieldProperty({ linkFieldId: 'l', targetFieldId: 't', aggregation: 'count' })
+    expect(p.filters).toBeUndefined()
+    expect(p.filterConjunction).toBeUndefined()
+  })
+
+  it('filters present without explicit conjunction defaults to and', () => {
+    const p = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'count',
+      filters: [{ fieldId: 'f', operator: 'is', value: 'x' }],
+    })
+    expect(p.filterConjunction).toBe('and')
+  })
+})

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -935,6 +935,11 @@ type RollupFieldConfig = {
   foreignSheetId?: string
   // §2a.3: see LookupFieldConfig.skipForeignFieldMasking — same semantics for rollup configs.
   skipForeignFieldMasking?: boolean
+  // Slice 3 — optional condition: aggregate ONLY the linked foreign records that match. Each condition
+  // reads a foreign field; if the actor can't read that field it is a side-channel, so resolveLookupValues
+  // fails CLOSED (masks the whole rollup) rather than evaluating it. Empty/absent = aggregate all linked.
+  filters?: MetaFilterCondition[]
+  filterConjunction?: MetaFilterConjunction
 }
 
 function parseLinkFieldConfig(property: unknown): LinkFieldConfig | null {
@@ -1080,6 +1085,22 @@ export function aggregateRollup(
   return null
 }
 
+// Slice 3 — parse a rollup's optional filter conditions from stored property JSON. Each well-formed entry
+// needs a string fieldId + operator; `value` is preserved only when present (operators like isEmpty omit it).
+function parseRollupFilterConditions(raw: unknown): MetaFilterCondition[] {
+  if (!Array.isArray(raw)) return []
+  const out: MetaFilterCondition[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const o = item as Record<string, unknown>
+    const fieldId = typeof o.fieldId === 'string' ? o.fieldId.trim() : ''
+    const operator = typeof o.operator === 'string' ? o.operator.trim() : ''
+    if (!fieldId || !operator) continue
+    out.push('value' in o ? { fieldId, operator, value: o.value } : { fieldId, operator })
+  }
+  return out
+}
+
 function parseRollupFieldConfig(property: unknown): RollupFieldConfig | null {
   const obj = normalizeJson(property)
   const linkFieldId = obj.linkedFieldId ?? obj.linkFieldId ?? obj.relatedLinkFieldId ?? obj.sourceFieldId
@@ -1093,12 +1114,17 @@ function parseRollupFieldConfig(property: unknown): RollupFieldConfig | null {
   const foreign = obj.datasheetId ?? obj.foreignDatasheetId ?? obj.foreignSheetId
   const foreignSheetId = typeof foreign === 'string' && foreign.trim().length > 0 ? foreign.trim() : undefined
 
+  const filters = parseRollupFilterConditions(obj.filters ?? obj.conditions ?? obj.filterConditions)
+  const filterConjunction: MetaFilterConjunction =
+    obj.filterConjunction === 'or' || obj.conjunction === 'or' ? 'or' : 'and'
+
   return {
     linkFieldId: linkFieldId.trim(),
     targetFieldId: targetFieldId.trim(),
     aggregation,
     ...(foreignSheetId ? { foreignSheetId } : {}),
     ...(obj.skipForeignFieldMasking === true ? { skipForeignFieldMasking: true } : {}),
+    ...(filters.length > 0 ? { filters, filterConjunction } : {}),
   }
 }
 
@@ -1146,6 +1172,23 @@ async function validateLookupRollupConfig(
   )
   if ((targetRes as any).rows.length === 0) {
     return `外表字段不存在：${config.targetFieldId}（sheetId=${linkCfg.foreignSheetId}）`
+  }
+
+  // Slice 3 — rollup filter conditions must reference real foreign fields (a typo'd condition would
+  // otherwise silently never-match at read time). Field-READABILITY is a per-actor read-time gate
+  // (fail-closed in resolveLookupValues), not a save-time check, so it's deliberately not enforced here.
+  const rollupConfig = type === 'rollup' ? (config as RollupFieldConfig) : null
+  if (rollupConfig?.filters && rollupConfig.filters.length > 0) {
+    const foreignFieldRes = await query(
+      'SELECT id FROM meta_fields WHERE sheet_id = $1',
+      [linkCfg.foreignSheetId],
+    )
+    const foreignFieldIds = new Set((foreignFieldRes as any).rows.map((r: any) => String(r.id)))
+    for (const cond of rollupConfig.filters) {
+      if (!foreignFieldIds.has(cond.fieldId)) {
+        return `Rollup 过滤条件引用了不存在的外表字段：${cond.fieldId}（sheetId=${linkCfg.foreignSheetId}）`
+      }
+    }
   }
 
   const { capabilities } = await resolveSheetCapabilities(req, query, linkCfg.foreignSheetId)
@@ -2604,6 +2647,20 @@ async function applyLookupRollup(
     foreignRecordsBySheet.set(foreignSheetId, recordMap)
   }
 
+  // Slice 3 — foreign field TYPES, loaded ONLY for sheets a FILTERED rollup targets (keeps the extra
+  // read off the common unfiltered path). Needed so each filter condition compares with the right type.
+  const filteredRollupForeignSheetIds = new Set<string>()
+  for (const cfg of rollupConfigs.values()) {
+    if (!cfg?.filters || cfg.filters.length === 0) continue
+    const fsid = cfg.foreignSheetId ?? linkConfigById.get(cfg.linkFieldId)?.foreignSheetId
+    if (fsid && readableForeignSheetIds.has(fsid)) filteredRollupForeignSheetIds.add(fsid)
+  }
+  const foreignFieldTypesBySheet = new Map<string, Map<string, string>>()
+  for (const fsid of filteredRollupForeignSheetIds) {
+    const ffields = (await loadFieldsForSheetShared(query, fsid)) as Array<{ id: string; type: string }>
+    foreignFieldTypesBySheet.set(fsid, new Map(ffields.map((f) => [f.id, f.type])))
+  }
+
   const resolveLookupValues = (
     record: UniverMetaRecord,
     cfg: LookupFieldConfig | RollupFieldConfig,
@@ -2622,12 +2679,38 @@ async function applyLookupRollup(
     }
     const foreignMap = foreignRecordsBySheet.get(foreignSheetId)
     if (!foreignMap) return { values: [], count: 0, masked: true }
+
+    // Slice 3 — rollup filter (lookup configs carry no filters, so this is a no-op for them).
+    // SECURITY (fail-closed): a condition that reads a foreign field the actor can't see is a
+    // side-channel — the resulting match-count would leak the masked field's values — so mask the
+    // WHOLE rollup rather than evaluate it. Honors the same skipForeignFieldMasking opt-out as the target.
+    const rollupCfg = 'aggregation' in cfg ? cfg : null
+    const filters = rollupCfg?.filters ?? []
+    for (const cond of filters) {
+      if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cond.fieldId, cfg.skipForeignFieldMasking)) {
+        return { values: [], count: 0, masked: true }
+      }
+    }
+    const filterTypes = filters.length > 0 ? foreignFieldTypesBySheet.get(foreignSheetId) : undefined
+    const filterConjunction = rollupCfg?.filterConjunction ?? 'and'
+    const matchesFilters = (data: Record<string, unknown>): boolean => {
+      if (filters.length === 0) return true
+      const test = (cond: MetaFilterCondition) =>
+        evaluateMetaFilterCondition(
+          (filterTypes?.get(cond.fieldId) ?? 'string') as UniverMetaField['type'],
+          data[cond.fieldId],
+          cond,
+        )
+      return filterConjunction === 'or' ? filters.some(test) : filters.every(test)
+    }
+
     const values: unknown[] = []
     let count = 0
     for (const id of linkIds) {
       const data = foreignMap.get(id)
       if (!data) continue
-      count += 1 // a RESOLVED linked record, regardless of whether its target value is empty
+      if (!matchesFilters(data)) continue // slice 3: only linked records matching the condition participate
+      count += 1 // a RESOLVED, matched linked record, regardless of whether its target value is empty
       const value = data[cfg.targetFieldId]
       if (value === null || value === undefined) continue
       values.push(value)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1085,6 +1085,15 @@ export function aggregateRollup(
   return null
 }
 
+// Operators evaluateMetaFilterCondition recognizes (lowercased). Used to reject bogus operators on a
+// rollup filter at save time — the evaluator's catch-all returns match-all, which would silently hide a typo.
+const ROLLUP_FILTER_OPERATORS = new Set([
+  'is', 'equal', 'isnot', 'notequal',
+  'greater', 'isgreater', 'greaterequal', 'isgreaterequal',
+  'less', 'isless', 'lessequal', 'islessequal',
+  'contains', 'doesnotcontain', 'isempty', 'isnotempty',
+])
+
 // Slice 3 — parse a rollup's optional filter conditions from stored property JSON. Each well-formed entry
 // needs a string fieldId + operator; `value` is preserved only when present (operators like isEmpty omit it).
 function parseRollupFilterConditions(raw: unknown): MetaFilterCondition[] {
@@ -1115,8 +1124,13 @@ function parseRollupFieldConfig(property: unknown): RollupFieldConfig | null {
   const foreignSheetId = typeof foreign === 'string' && foreign.trim().length > 0 ? foreign.trim() : undefined
 
   const filters = parseRollupFilterConditions(obj.filters ?? obj.conditions ?? obj.filterConditions)
-  const filterConjunction: MetaFilterConjunction =
-    obj.filterConjunction === 'or' || obj.conjunction === 'or' ? 'or' : 'and'
+  // Case-insensitive (parity with parseMetaFilterInfo) so a stored 'OR'/'Or' isn't silently demoted to 'and'.
+  const conjRaw = (typeof obj.filterConjunction === 'string'
+    ? obj.filterConjunction
+    : typeof obj.conjunction === 'string'
+      ? obj.conjunction
+      : '').trim().toLowerCase()
+  const filterConjunction: MetaFilterConjunction = conjRaw === 'or' ? 'or' : 'and'
 
   return {
     linkFieldId: linkFieldId.trim(),
@@ -1187,6 +1201,11 @@ async function validateLookupRollupConfig(
     for (const cond of rollupConfig.filters) {
       if (!foreignFieldIds.has(cond.fieldId)) {
         return `Rollup 过滤条件引用了不存在的外表字段：${cond.fieldId}（sheetId=${linkCfg.foreignSheetId}）`
+      }
+      // Reject operators evaluateMetaFilterCondition doesn't recognize — its catch-all returns `true`
+      // (match-all), so a bogus operator would silently make the filter a no-op rather than erroring.
+      if (!ROLLUP_FILTER_OPERATORS.has(cond.operator.trim().toLowerCase())) {
+        return `Rollup 过滤条件使用了不支持的运算符：${cond.operator}`
       }
     }
   }

--- a/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Rollup filter condition (slice 3) — real DB.
+ *
+ * A rollup may carry an optional condition so it aggregates ONLY the linked foreign records that match
+ * (e.g. SUM(amount) where status = "paid"). Two things are pinned:
+ *  1. Behavior: the filter narrows count/countall/sum to the matched subset; no filter = aggregate all.
+ *  2. SECURITY (owner gate): a condition that reads a foreign field the actor CANNOT read is a
+ *     side-channel — the match-count would leak the masked field — so resolveLookupValues fails CLOSED
+ *     and masks the WHOLE rollup to null. Crucially the fail-closed is SCOPED to the offending rollup:
+ *     a sibling rollup whose condition reads a readable field still works for the same actor.
+ *
+ * Trigger: GET /records/:recordId computes applyLookupRollup unconditionally and returns the value at
+ * res.body.data.record.data[rollupFieldId].
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const ALLOW_USER = `u_rf_allow_${TS}` // reads everything
+const DENY_USER = `u_rf_deny_${TS}` // denied on the foreign SECRET field
+
+const BASE = `base_rf_${TS}`
+const FS = `sheet_rf_fs_${TS}`
+const MS = `sheet_rf_main_${TS}`
+
+const FLD_AMOUNT = `fld_rf_amt_${TS}` // number target
+const FLD_STATUS = `fld_rf_status_${TS}` // string filter field (readable by all)
+const FLD_SECRET = `fld_rf_secret_${TS}` // string filter field (DENIED for DENY_USER)
+const FLD_LINK = `fld_rf_lk_${TS}`
+const FLD_ALL = `fld_rf_all_${TS}` // countall, no filter -> 3
+const FLD_PAID_COUNT = `fld_rf_pc_${TS}` // countall where status = paid -> 2
+const FLD_PAID_SUM = `fld_rf_ps_${TS}` // sum amount where status = paid -> 30
+const FLD_BY_SECRET = `fld_rf_bs_${TS}` // countall where secret = yes -> 2 (masks to null for DENY_USER)
+
+const FR1 = `rec_rf_f1_${TS}` // amount 10, paid,   secret yes
+const FR2 = `rec_rf_f2_${TS}` // amount 20, paid,   secret no
+const FR3 = `rec_rf_f3_${TS}` // amount  5, unpaid, secret yes
+const REC = `rec_rf_src_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read'], permissions: ['multitable:read'] }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+
+async function readRollup(userId: string, fieldId: string): Promise<unknown> {
+  const res = await request(buildApp(userId)).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return res.body?.data?.record?.data?.[fieldId]
+}
+
+function rollup(aggregation: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_AMOUNT, foreignSheetId: FS, aggregation, ...extra })
+}
+
+describeIfDatabase('multitable rollup filter condition + fail-closed field-readability (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE, 'RF Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FS, BASE, 'RF Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [MS, BASE, 'RF Main'])
+
+    for (const [fid, name, type, order] of [
+      [FLD_AMOUNT, 'Amount', 'number', 1],
+      [FLD_STATUS, 'Status', 'string', 2],
+      [FLD_SECRET, 'Secret', 'string', 3],
+    ] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [fid, FS, name, type, '{}', order])
+    }
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR1, FS, JSON.stringify({ [FLD_AMOUNT]: 10, [FLD_STATUS]: 'paid', [FLD_SECRET]: 'yes' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR2, FS, JSON.stringify({ [FLD_AMOUNT]: 20, [FLD_STATUS]: 'paid', [FLD_SECRET]: 'no' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR3, FS, JSON.stringify({ [FLD_AMOUNT]: 5, [FLD_STATUS]: 'unpaid', [FLD_SECRET]: 'yes' })])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_ALL, MS, 'All', 'rollup', rollup('countall'), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_PAID_COUNT, MS, 'PaidCount', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_STATUS, operator: 'is', value: 'paid' }] }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_PAID_SUM, MS, 'PaidSum', 'rollup', rollup('sum', { filters: [{ fieldId: FLD_STATUS, operator: 'is', value: 'paid' }] }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_BY_SECRET, MS, 'BySecret', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_SECRET, operator: 'is', value: 'yes' }] }), 5])
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
+    for (const fr of [FR1, FR2, FR3]) {
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
+        [`lnk_rf_${fr}`, FLD_LINK, REC, fr])
+    }
+
+    // DENY_USER cannot read the foreign SECRET field → any rollup whose CONDITION reads it must fail closed.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [FS, FLD_SECRET, 'user', DENY_USER, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('filter narrows the aggregate to matched linked records (countall/sum); no filter = all', async () => {
+    expect(await readRollup(ALLOW_USER, FLD_ALL)).toBe(3) // no filter
+    expect(await readRollup(ALLOW_USER, FLD_PAID_COUNT)).toBe(2) // status = paid -> FR1, FR2
+    expect(await readRollup(ALLOW_USER, FLD_PAID_SUM)).toBe(30) // amount of paid -> 10 + 20
+    expect(await readRollup(ALLOW_USER, FLD_BY_SECRET)).toBe(2) // secret = yes -> FR1, FR3
+  })
+
+  test('SECURITY fail-closed: a condition on a field the actor cannot read masks that rollup to null', async () => {
+    expect(await readRollup(DENY_USER, FLD_BY_SECRET) ?? null).toBeNull() // condition reads denied FLD_SECRET
+  })
+
+  test('fail-closed is SCOPED: sibling rollups whose condition reads a readable field still work', async () => {
+    expect(await readRollup(DENY_USER, FLD_ALL)).toBe(3) // no filter
+    expect(await readRollup(DENY_USER, FLD_PAID_COUNT)).toBe(2) // condition reads FLD_STATUS (readable)
+    expect(await readRollup(DENY_USER, FLD_PAID_SUM)).toBe(30)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
@@ -32,11 +32,17 @@ const MS = `sheet_rf_main_${TS}`
 const FLD_AMOUNT = `fld_rf_amt_${TS}` // number target
 const FLD_STATUS = `fld_rf_status_${TS}` // string filter field (readable by all)
 const FLD_SECRET = `fld_rf_secret_${TS}` // string filter field (DENIED for DENY_USER)
+const FLD_NOTE = `fld_rf_note_${TS}` // string filter field, set on FR1 only (readable by all)
 const FLD_LINK = `fld_rf_lk_${TS}`
 const FLD_ALL = `fld_rf_all_${TS}` // countall, no filter -> 3
 const FLD_PAID_COUNT = `fld_rf_pc_${TS}` // countall where status = paid -> 2
 const FLD_PAID_SUM = `fld_rf_ps_${TS}` // sum amount where status = paid -> 30
 const FLD_BY_SECRET = `fld_rf_bs_${TS}` // countall where secret = yes -> 2 (masks to null for DENY_USER)
+const FLD_OR_UNION = `fld_rf_or_${TS}` // countall where status=unpaid OR amount=10 -> union FR3+FR1 = 2
+const FLD_AND_EMPTY = `fld_rf_and_${TS}` // countall where status=unpaid AND amount=10 -> 0 (contrast for OR)
+const FLD_AMT_GT8 = `fld_rf_gt8_${TS}` // countall where amount greater 8 -> FR1(10),FR2(20) = 2
+const FLD_NOTE_SET = `fld_rf_ns_${TS}` // countall where note isNotEmpty -> FR1 only = 1
+const FLD_NOTE_EMPTY = `fld_rf_ne_${TS}` // countall where note isEmpty -> FR2,FR3 = 2
 
 const FR1 = `rec_rf_f1_${TS}` // amount 10, paid,   secret yes
 const FR2 = `rec_rf_f2_${TS}` // amount 20, paid,   secret no
@@ -76,13 +82,15 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
       [FLD_AMOUNT, 'Amount', 'number', 1],
       [FLD_STATUS, 'Status', 'string', 2],
       [FLD_SECRET, 'Secret', 'string', 3],
+      [FLD_NOTE, 'Note', 'string', 4],
     ] as const) {
       await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
         [fid, FS, name, type, '{}', order])
     }
 
+    // FLD_NOTE is set on FR1 only (absent key on FR2/FR3) → isNotEmpty matches 1, isEmpty matches 2.
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
-      [FR1, FS, JSON.stringify({ [FLD_AMOUNT]: 10, [FLD_STATUS]: 'paid', [FLD_SECRET]: 'yes' })])
+      [FR1, FS, JSON.stringify({ [FLD_AMOUNT]: 10, [FLD_STATUS]: 'paid', [FLD_SECRET]: 'yes', [FLD_NOTE]: 'hi' })])
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [FR2, FS, JSON.stringify({ [FLD_AMOUNT]: 20, [FLD_STATUS]: 'paid', [FLD_SECRET]: 'no' })])
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
@@ -98,6 +106,27 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
       [FLD_PAID_SUM, MS, 'PaidSum', 'rollup', rollup('sum', { filters: [{ fieldId: FLD_STATUS, operator: 'is', value: 'paid' }] }), 4])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_BY_SECRET, MS, 'BySecret', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_SECRET, operator: 'is', value: 'yes' }] }), 5])
+
+    // OR over two disjoint singletons: status=unpaid (FR3) OR amount=10 (FR1) → union = 2.
+    // Their AND is empty (no record is both) so OR=2 genuinely proves union, not coincidental all-3.
+    const orConds = [
+      { fieldId: FLD_STATUS, operator: 'is', value: 'unpaid' },
+      { fieldId: FLD_AMOUNT, operator: 'is', value: 10 },
+    ]
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_OR_UNION, MS, 'OrUnion', 'rollup', rollup('countall', { filters: orConds, filterConjunction: 'or' }), 6])
+    // Same two conditions with default conjunction (and) → 0: proves conjunction is honored, not ignored.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_AND_EMPTY, MS, 'AndEmpty', 'rollup', rollup('countall', { filters: orConds }), 7])
+    // Numeric operator: amount greater 8 → FR1(10), FR2(20) match, FR3(5) does not → 2.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_AMT_GT8, MS, 'AmtGt8', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_AMOUNT, operator: 'greater', value: 8 }] }), 8])
+    // isNotEmpty: note set on FR1 only → 1.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_NOTE_SET, MS, 'NoteSet', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_NOTE, operator: 'isNotEmpty' }] }), 9])
+    // isEmpty: note absent on FR2, FR3 → 2.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_NOTE_EMPTY, MS, 'NoteEmpty', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_NOTE, operator: 'isEmpty' }] }), 10])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
@@ -137,5 +166,20 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
     expect(await readRollup(DENY_USER, FLD_ALL)).toBe(3) // no filter
     expect(await readRollup(DENY_USER, FLD_PAID_COUNT)).toBe(2) // condition reads FLD_STATUS (readable)
     expect(await readRollup(DENY_USER, FLD_PAID_SUM)).toBe(30)
+  })
+
+  test("conjunction 'or' returns the UNION of two disjoint conditions; default 'and' returns the intersection", async () => {
+    // status=unpaid (FR3) OR amount=10 (FR1) → union of 2; AND of the same is empty.
+    expect(await readRollup(ALLOW_USER, FLD_OR_UNION)).toBe(2)
+    expect(await readRollup(ALLOW_USER, FLD_AND_EMPTY)).toBe(0)
+  })
+
+  test('numeric operator: amount greater 8 matches FR1(10), FR2(20) but not FR3(5)', async () => {
+    expect(await readRollup(ALLOW_USER, FLD_AMT_GT8)).toBe(2)
+  })
+
+  test('isNotEmpty / isEmpty on a foreign field set on a subset of linked records', async () => {
+    expect(await readRollup(ALLOW_USER, FLD_NOTE_SET)).toBe(1) // note set on FR1 only
+    expect(await readRollup(ALLOW_USER, FLD_NOTE_EMPTY)).toBe(2) // note absent on FR2, FR3
   })
 })


### PR DESCRIPTION
## What

A rollup may carry an optional **filter condition** so it aggregates only the linked foreign records that match — e.g. `SUM(amount) where status = "paid"`. Narrows count/countall/unique/sum/avg/min/max to the matched subset; absent/empty filter = aggregate all.

- `RollupFieldConfig` gains `filters: MetaFilterCondition[]` + `filterConjunction` (`and`/`or`); parsed via `parseRollupFilterConditions` (aliases `conditions`/`filterConditions`/`conjunction`, case-insensitive).
- `applyLookupRollup` loads foreign field **types** only for sheets a *filtered* rollup targets (off the common path), so conditions compare with the right type via the existing `evaluateMetaFilterCondition`.

## Security (owner gate)

A condition that reads a foreign field the actor **cannot read** is a side-channel — the match-count would leak the masked value — so `resolveLookupValues` **fails closed** and masks the whole rollup to `null`. Reuses `shouldMaskForeignField`; honors `skipForeignFieldMasking`. The fail-closed is **scoped per-rollup**: a sibling rollup whose condition reads a readable field still works for the same actor. Adversarial review (4 lenses) found **no bypass**.

## Review fixes folded in

- **FE silent data loss (P1):** the field manager omitted `filters` when rebuilding the rollup property, so editing an API/template-authored filtered rollup dropped the filter. Now carried **opaquely** (no builder UI yet) through `resolveRollupFieldProperty` → draft → both save paths. FE round-trip test locks it.
- Operator validation at save (reject unknown operators — the evaluator's catch-all is match-all).
- Case-insensitive conjunction parsing.
- Verified non-issues: `dateTime` isn't a field type here; the foreign-field loader is once-per-filtered-sheet.

## Tests (wired into CI from the start)

- Real-DB integration in the explicit `plugin-tests.yml` list: filter narrows the aggregate; OR-union vs AND-empty; numeric `greater`; isEmpty/isNotEmpty; **condition-on-denied-field masks to null**; fail-closed is **scoped** (sibling rollup on a readable field still works).
- FE round-trip preservation in the `multitable-web-guard` spec.

## Deferred

Rollup filter **builder UI** (condition rows / field+operator+value pickers) → slice 3b. Until then filters are authorable via API/template and preserved through FE edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)