### PR TITLE
docs(data-source): record C6-5c controlled bad-row pass

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -7,7 +7,9 @@
 ## 当前结论
 
 - 只读数据库接入 Data Factory 源系统: 已经基本可用。
-- 可交付定义: C6 外部写能力完成并通过实体机验收后，才称为完整交付。
+- 可交付定义: C6 sandbox 外部写能力通过实体机验收后，才称为 sandbox
+  交付链路闭合；完整 release 签收仍要按 release runbook 汇总最终 values-free
+  evidence package。production/batch 写入始终是独立显式 gate。
 - 下一步建议: C2-close 已通过实体机 smoke；C3 core runtime + CI real-DB wire lock 已落地；
   C4 配置体验和已知 polish 已落地（source/object/schema picker、source-field picker、watermark config、
   read-only/source-only 边界提示、SQL bridge values-free 错误提示）。
@@ -16,7 +18,7 @@
   C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
   中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
   Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
-- 下一门: C6-5 entity-machine smoke。C6 是最大风险刀；C6-0 只锁 design contract，
+- 下一门: release evidence package 收口。C6 是最大风险刀；C6-0 只锁 design contract，
   C6-1 只落地 backend latent writer helper 和 write-gated target adapter 的关闭态合同；
   C6-2 只增加 read-only dry-run route + dry-run token，不授权 apply runtime 或 external write。
   C6-3 增加 token-bound apply route；C6-4 UI dry-run -> review -> apply 已合并并发出实体机
@@ -25,9 +27,12 @@
   HOLD 在 `HOLD_TARGET_DDL_UNAVAILABLE`，随后 seeded naturally failing row 也被实体机
   回复确认为无安全 reset/cleanup 形态，路由为 `HOLD_NO_SAFE_FAILURE_SHAPE`。C6-5a
   design 和 C6-5b sandbox-only failure-injection seam 已合并；首个 C6-5c sandbox 包
-  `642560126` 在实体机 package/apply 阶段 BLOCKED，尚未进入 controlled bad-row 复验。
+  `642560126` 在实体机 package/apply 阶段 BLOCKED，未进入 controlled bad-row 复验。
   #2761 已修复 on-prem package 不应携带 `node_modules` 的打包/校验缺口，并已重发
-  `d8244ee13` sandbox 包；下一步是实体机部署新包并重跑 C6-5c。production/batch 仍关闭。
+  `d8244ee13` sandbox 包；实体机已部署该包并完成 C6-5c controlled bad-row PASS：
+  one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE` + one clean sibling write，
+  dead-letter/provenance evidence values-free，注入配置已恢复关闭。production/batch 仍关闭；
+  Release 还需按 release runbook 汇总最终 values-free evidence package。
 
 ## 收口顺序
 
@@ -38,8 +43,8 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 open; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` ready for entity-machine retry | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row HOLD_NO_SAFE_FAILURE_SHAPE; old C6-5c deploy blocked, fixed package `d8244ee13` published and ready for rerun | 交付签收 | C6-5c controlled bad-row 证据未闭合 |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 sandbox smoke PASS; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` entity-machine controlled bad-row PASS | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| Release | 总包 + 实体机验收 | #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row PASS on package `d8244ee13`; final release evidence package still pending | 交付签收 | C2/C3/C4 exact-release evidence and clean-machine/migration/auth gate still need owner decision/rerun |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -419,7 +424,7 @@ TODO:
     into the values-free evidence panel.
   - apply is disabled for read-only users and requires an explicit review checkbox.
   - changing pipeline id or scope clears the pending dry-run token/review.
-- [ ] C6-5 entity-machine smoke: apply、re-pull、rollback。
+- [x] C6-5 entity-machine smoke: apply、re-pull、rollback、controlled bad-row。
   - issue: #2720 `[Data Source] C6 external-write entity-machine smoke gate`.
   - runbook: `docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md`.
   - release: `multitable-onprem-datasource-c6-ui-20260616-9fb34fd91`.
@@ -445,10 +450,11 @@ TODO:
     naturally failing row/constraint shape is therefore unavailable; no fresh Apply was run and no
     target rows were written. Routing tokens: `controlledBadRow=hold`,
     `controlledBadRowStopReason=no_safe_failure_shape`, `failureShape=no_safe_failure_shape`.
-  - remaining HOLD: controlled bad-row still needs a true write-time row failure that proves
-    row-level failure evidence is values-free and clean sibling rows are not silently swallowed.
-    Target lookup / plan-decision drift after dry-run is a revision-fence check
-    (`C6_WRITE_DRY_RUN_TOKEN_MISMATCH`), not this row-level failure gate.
+  - that HOLD is superseded by the C6-5a/C6-5b/C6-5c test-only path below. The
+    row-level failure gate still required a write-time failure proving values-free
+    dead-letter/provenance and a clean sibling write. Target lookup / plan-decision
+    drift after dry-run is a revision-fence check (`C6_WRITE_DRY_RUN_TOKEN_MISMATCH`),
+    not this row-level failure gate.
   - [x] C6-5a test-only failure-injection design:
     `docs/development/data-source-system-integration-c6-test-failure-injection-design-20260617.md`.
     This is design-only and exists only because both real sandbox failure shapes are unavailable.
@@ -482,11 +488,19 @@ TODO:
     the `.tgz` path failed before dependency refresh with a missing staged path under
     `packages/mssql-readonly-utils/node_modules/typescript`. Installed runtime did not contain the
     failure-injection marker, so no C6-5c rerun was attempted.
-  - [ ] C6-5c entity-machine rerun: deploy package `d8244ee13`, confirm the
+  - [x] C6-5c entity-machine rerun: deploy package `d8244ee13`, confirm the
     failure-injection marker is installed, enable the server-owned test-injection double gate,
     rerun controlled bad-row with one synthetic row failure plus at least one clean sibling write,
-    prove values-free dead-letter/provenance and re-pull idempotence, then disable the
+    prove values-free dead-letter/provenance for the row-level failure, then disable the
     test-injection gate.
+    - entity-machine PASS evidence: `releaseAssetCheck=pass`, `archiveNodeModulesEntries=0`,
+      `deploy.applyExit=0`, `healthAfterDeploy=200`, `failureInjectionMarkerFound=true`,
+      `freshDryRun.status=ready`, `freshDryRun.canApply=true`, `apply.status=partial`,
+      `apply.counts.written=1`, `apply.counts.failed=1`,
+      `apply.rowErrorCodes=C6_TEST_INJECTED_ROW_FAILURE`,
+      `deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
+      `provenance.target_write_failed=1`, request-body injection fields absent, and
+      injection env/runtime config restored after the check.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:
@@ -535,7 +549,8 @@ TODO:
   - package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-ui-20260616-9fb34fd91`.
   - `.tgz` SHA256: `8659e9bfbad0c51efe55238108dc7b84a72a19478bf0f841cfa26d76e2cd784f`.
   - `.zip` SHA256: `9b771902fca4c607422d6ac30e63bf3fe95b576537fc7b9f6c2f767a25d6ab3c`.
-- [x] C6-5 smoke package deployed on entity machine for preflight; full smoke still HOLD.
+- [x] C6-5 smoke package deployed on entity machine for preflight; initial full smoke was
+  HOLD until sandbox target setup, read-only subgate, and controlled bad-row follow-up closed.
 - [x] C6-5 package deploy preflight: #2720 reports `deploy.applyExit=0`, `health=200`, dry-run/apply
   route presence, token guard, and target-kind requirement present.
 - [x] C6-5 sandbox write-gated target + active C6 pipeline configured on entity machine.
@@ -552,9 +567,15 @@ TODO:
   - fixed release: `multitable-onprem-datasource-c6-package-prune-20260617-d8244ee13`.
   - fixed package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`.
   - workflow: `https://github.com/zensgit/metasheet2/actions/runs/27661650691`.
-  - current routing: old package `642560126` -> `c6_5c_deploy=blocked`; new package
+  - previous routing: old package `642560126` -> `c6_5c_deploy=blocked`; new package
     `d8244ee13` -> `c6_5c_deploy=ready_for_retry`; `c6_5c_rerun=not_started`.
-- [ ] C6-5c test-injection sandbox package deployed on entity machine and rerun.
+- [x] C6-5c test-injection sandbox package deployed on entity machine and rerun.
+  - package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`.
+  - result: `c6_5c_deploy=pass`, `controlledBadRow=pass`.
+  - controlled row-level failure evidence: `apply.status=partial`, one clean sibling write,
+    one synthetic row failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter persisted,
+    target-write provenance success/failure counters both present, request-body injection absent,
+    and test injection disabled/restored after the check.
 - [ ] 干净实体机 / 全新 DB smoke，用来暴露 migration 排序缺口。
 - [ ] 部署前跑 pending-migration diff + auth round-trip；静默 401 优先按 schema/migration 缺口排查，不先归咎 JWT secret。
 - [ ] C2 read-only smoke。
@@ -563,18 +584,20 @@ TODO:
 - [x] C5 K3 seam smoke。
 - [x] C6 core dry-run/apply/re-pull/rollback smoke（#2720）。
   - core sandbox smoke PASS; read-only dedicated dry-run subgate PASS.
-- [ ] C6 controlled bad-row row-level failure smoke（#2720）。
-  - attempted but HOLD on `HOLD_TARGET_DDL_UNAVAILABLE`; seeded naturally failing row also
-    HOLD on `HOLD_NO_SAFE_FAILURE_SHAPE`. Apply was not run for either failed controlled
-    bad-row setup and no target rows were written.
-  - C6-5 cannot close until true row-level write-time failure / dead-letter / provenance evidence
-    is produced values-free.
-- [ ] issue 上贴 values-free 验收证据。
+- [x] C6 controlled bad-row row-level failure smoke（#2720）。
+  - earlier real failure shapes HOLD on `HOLD_TARGET_DDL_UNAVAILABLE` and
+    `HOLD_NO_SAFE_FAILURE_SHAPE`; the final accepted path uses the reviewed C6-5b
+    sandbox-only, server-owned failure-injection seam.
+  - C6-5c entity-machine rerun on package `d8244ee13` produced one synthetic row-level
+    failure plus one clean sibling write, dead-letter/provenance evidence values-free,
+    and restored the injection config after the check.
+- [x] issue 上贴 values-free 验收证据（#2720 entity-machine evidence + acceptance reply）。
 
 交付判据:
 
-- C6 未完成前: 只能称为“只读数据库接入可用”。
-- C6 完成并通过实体机验收后: 才称为“数据库及系统连接能力可交付”。
+- C6 sandbox smoke 完成前: 只能称为“只读数据库接入可用”。
+- C6 sandbox smoke 已完成并通过实体机验收；现在可以称为“数据库及系统连接能力的 sandbox 交付链路已闭合”。
+- 完整 release 签收仍需 release runbook 的最终 values-free evidence package；production/batch 写入仍是独立显式 gate。
 
 ## 并行策略
 

--- a/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md
@@ -3,15 +3,13 @@
 Purpose: run or continue #2720's sandbox-only C6 external-write smoke.
 
 Current #2720 status as of 2026-06-17: the sandbox write target, write-gated
-external system, active C6 pipeline, core dry-run/apply/re-pull/rollback path
-have already passed on the entity machine. After #2737, the read-only subgate
-also passed on the dedicated C6 route: an `integration:read` user can call
-`/external-write/dry-run`, while `/external-write/apply` remains blocked. The
-remaining HOLD is the controlled bad-row check. The DDL-backed failure shape is
-unavailable, and the seeded naturally failing row/constraint shape is also
-unavailable because the target principal cannot safely reset/cleanup values-free
-after sandbox Apply. If continuing that run, do not recreate the sandbox or rerun
-write/admin Apply just to repeat already-passed checks.
+external system, active C6 pipeline, core dry-run/apply/re-pull/rollback path,
+read-only dedicated-route subgate, and C6-5c controlled bad-row check have
+passed on the entity machine. The accepted C6-5c path used the reviewed,
+default-off, sandbox-only, server-owned failure-injection seam after both real
+sandbox failure shapes were unavailable (`HOLD_TARGET_DDL_UNAVAILABLE` and
+`HOLD_NO_SAFE_FAILURE_SHAPE`). If continuing that run, do not recreate the
+sandbox or rerun write/admin Apply just to repeat already-passed checks.
 
 This runbook sets up the minimum sandbox-only shape needed to run the C6
 dry-run -> apply -> re-pull -> rollback/cleanup smoke. It does not authorize
@@ -49,7 +47,8 @@ Forbidden:
   was sufficient.
 - For the C6-5c controlled bad-row rerun, deploy package
   `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`
-  or a later package that includes #2756 and #2761.
+  or a later package that includes #2756 and #2761. This package has already
+  passed the C6-5c entity-machine rerun for #2720.
 - Confirm health is `200`.
 - Confirm #2720 preflight already sees:
   - `dryRunRoutePresent=true`;
@@ -330,7 +329,13 @@ Expected:
 
 ### 5. Controlled bad-row check
 
-Only run this if the sandbox target can be safely reset.
+The #2720 controlled bad-row gate is now passed for package `d8244ee13`. Rerun
+this section if an owner explicitly asks for fresh evidence, if the relevant
+C6 package/runtime surface changes, if exact-artifact release evidence is
+required, or if the sandbox target/config has materially changed.
+
+Only run this if the sandbox target can be safely reset, or if the reviewed
+C6-5b test-only failure-injection seam is enabled for the sandbox package.
 
 The controlled bad row must be a write-time row failure, not target lookup or
 plan-decision drift between dry-run and apply. The dry-run revision is
@@ -378,8 +383,8 @@ outside MetaSheet product/runtime paths. It must never run against production,
 must never become evidence-bearing, and does not relax the forbidden product
 raw SQL / query / stored procedure / trigger paths above.
 
-The entity-machine operator has now reported `HOLD_NO_SAFE_FAILURE_SHAPE`; that
-is a routing signal only, not runtime authorization. The next path is:
+The entity-machine operator reported `HOLD_NO_SAFE_FAILURE_SHAPE`; that was a
+routing signal only, not runtime authorization. The accepted path was:
 
 1. C6-5a test-only failure-injection design;
 2. C6-5b default-off sandbox-only implementation;
@@ -422,9 +427,14 @@ Current entity-machine result for that package:
   passed before publish, and downloaded archive-list checks found no
   `node_modules` entries.
 
-Do not enable the failure-injection env until this fixed package deploys
-cleanly and the installed runtime contains the C6 failure-injection marker.
-The next step is to deploy the fixed package, then rerun this section.
+The fixed package deployed successfully on the entity machine and the installed
+runtime contained the C6 failure-injection marker:
+
+- `releaseAssetCheck=pass`;
+- `archiveNodeModulesEntries=0`;
+- `deploy.applyExit=0`;
+- `healthAfterDeploy=200`;
+- `failureInjectionMarkerFound=true`.
 
 The C6-5b implementation is server-owned and deploy-gated. For the C6-5c
 sandbox package only, the deploy config must include both gates:
@@ -448,7 +458,19 @@ If any pinned server value does not match the loaded target, the route must fail
 closed before target capability checks or writes. Disable the deploy flag after
 the C6-5c controlled bad-row rerun.
 
-Until C6-5c passes, leave this controlled bad-row step at HOLD.
+The accepted #2720 C6-5c evidence:
+
+- `freshDryRun.httpStatus=200`, `freshDryRun.status=ready`, `freshDryRun.canApply=true`;
+- token was present but not printed;
+- apply returned `HTTP 200` with `status=partial`;
+- one clean sibling row wrote successfully;
+- one row failed with `C6_TEST_INJECTED_ROW_FAILURE`;
+- one dead-letter was persisted;
+- provenance included one target-write success and one target-write failure;
+- request bodies contained no failure-injection fields;
+- injection env/runtime config was restored/disabled after the check.
+
+C6-5c is therefore PASS for #2720. Production and batch remain closed.
 
 Expected:
 
@@ -463,7 +485,7 @@ Evidence:
 ```text
 badRow:
   status=<partial|failed|hold|not_run>
-  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  failureShape=test_failure_injection|write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   stopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
@@ -605,12 +627,14 @@ readOnlyUser:
 
 badRow:
   status=<partial|failed|hold|not_run>
-  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  failureShape=test_failure_injection|write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   stopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   revisionMismatchObserved=false
   cleanSiblingWritten=true|false
   deadLetters.count=<count>
   rowErrorTypes=<tokens only>
+  requestBodyFailureInjectionFields=false
+  injectionEnvRestored=true|false|not_applicable
   valuesLeaked=false
 
 rollback:

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -46,7 +46,7 @@ the corresponding section below and post fresh values-free evidence.
 | C3 incremental/watermark | Runtime and CI real-DB wire locks are landed on main, but no release-package entity-machine incremental/resume smoke is recorded in this runbook. Large-BOM #2425 is related Data Factory C3/C4 evidence, not the SQL watermark/resume release gate. | Section 4 remains required for complete delivery unless an owner explicitly narrows the release scope and uses downgraded wording. Do not cite #2425 as C3 watermark/resume PASS. |
 | C4 UI configuration | Source/object/schema picker, source-field picker, watermark UI, and read-only/source-only boundary UX have landed, but this runbook has no final release-package UI smoke evidence yet. | Section 5 remains required for complete delivery unless exact UI smoke is explicitly deferred with downgraded wording. |
 | C5 K3/MSSQL read-only seam | issue #2670 closed PASS on package `dea391a1`: generic SQL Server smoke and K3 SQL Server executor smoke both passed after operator SQL scope adjustment; no K3 Save/Submit/Audit/BOM, external DB write, raw SQL, credentials, or row values were printed. | May be cited when no C5-relevant package/runtime surface changed after `dea391a1`; otherwise rerun the C5 runbook on the release package. |
-| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS and read-only dedicated-route PASS; controlled bad-row remains HOLD after both `HOLD_TARGET_DDL_UNAVAILABLE` and `HOLD_NO_SAFE_FAILURE_SHAPE`. C6-5a design and C6-5b seam are on main; first C6-5c package `642560126` was blocked during deploy, #2761 fixed package-contained `node_modules` handling, and recut package `d8244ee13` is published for entity-machine retry. | C6-5 is not closed. Release signoff cannot claim complete database/source-system delivery until package `d8244ee13` deploys and controlled bad-row row-level failure/dead-letter/provenance evidence passes values-free. |
+| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS, read-only dedicated-route PASS, and C6-5c controlled bad-row PASS on package `d8244ee13`. The final pass used the reviewed C6-5b default-off, sandbox-only, server-owned failure-injection seam after real sandbox failure shapes were unavailable. Evidence showed one clean sibling write, one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter/provenance counters, no request-body injection, and injection config restored/disabled after the check. | May be cited as C6 sandbox external-write smoke PASS for release evidence. Production/batch writes remain closed unless a separate production rollout gate is explicitly opened. |
 
 ## Required Inputs
 
@@ -243,7 +243,7 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
-  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  failureShape=test_failure_injection|write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
@@ -265,11 +265,11 @@ Current #2720 checkpoint as of 2026-06-17:
 - seeded naturally failing row: also HOLD because the target principal cannot
   perform the values-free reset/cleanup needed after sandbox Apply;
 - current controlled bad-row routing:
-  `controlledBadRow=hold`,
-  `controlledBadRowStopReason=no_safe_failure_shape`,
-  `failureShape=no_safe_failure_shape`;
-- next eligible step is the separate C6-5a/C6-5b/C6-5c test-only
-  failure-injection path. C6-5b uses two server-owned gates:
+  `controlledBadRow=pass`,
+  `controlledBadRowStopReason=none`,
+  `failureShape=test_failure_injection`;
+- C6-5a/C6-5b/C6-5c test-only failure-injection path is complete for #2720.
+  C6-5b uses two server-owned gates:
   `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED=true` plus
   `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON` pinning the sandbox
   `pipelineId`, `targetSystemId`, `targetDataSourceId`, `targetObject`, and
@@ -291,10 +291,16 @@ Current #2720 checkpoint as of 2026-06-17:
   / `metasheet-multitable-onprem-v2.5.0-datasource-c6-package-prune-d8244ee13`.
   Workflow `https://github.com/zensgit/metasheet2/actions/runs/27661650691`
   passed; both verifier reports passed before publish, and downloaded
-  archive-list checks found no `node_modules` entries. Current routing is
-  `c6_5c_deploy=ready_for_retry`, `c6_5c_rerun=not_started`. This package
-  identity is not a C6 PASS claim; `controlledBadRow` remains `hold` until the
-  C6-5c entity-machine rerun proves the row-level failure evidence values-free.
+  archive-list checks found no `node_modules` entries.
+- The `d8244ee13` package then passed the C6-5c entity-machine rerun:
+  `releaseAssetCheck=pass`, `archiveNodeModulesEntries=0`, `deploy.applyExit=0`,
+  `healthAfterDeploy=200`, `failureInjectionMarkerFound=true`,
+  `freshDryRun.status=ready`, `freshDryRun.canApply=true`, `apply.status=partial`,
+  `apply.counts.written=1`, `apply.counts.failed=1`,
+  `apply.rowErrorCodes=C6_TEST_INJECTED_ROW_FAILURE`,
+  `apply.deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
+  `provenance.target_write_failed=1`, request-body failure-injection fields
+  absent, and injection env/runtime config restored/disabled after the check.
 
 ## Stop Rules
 
@@ -389,8 +395,10 @@ c6Sandbox:
   readOnlyUserExternalWriteDryRunAllowed=true|false
   readOnlyUserApplyBlocked=true|false
   controlledBadRow=pass|fail|hold|not_run
-  failureShape=write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
+  failureShape=test_failure_injection|write_time_constraint|ddl_unavailable|no_safe_failure_shape|not_available
   controlledBadRowStopReason=none|target_ddl_unavailable|seeded_row_unavailable|no_safe_failure_shape|not_available
+  requestBodyFailureInjectionFields=false
+  injectionEnvRestored=true|false|not_applicable
   rollbackCleanup=pass|fail|not_run
   productDeleteRouteUsed=false
   productRawSqlUsed=false


### PR DESCRIPTION
## Summary

Docs-only status backfill for #2720 after the entity-machine C6-5c controlled bad-row rerun passed on package `d8244ee13`.

Updates:

- marks C6-5 / C6-5c as sandbox entity-machine PASS in the delivery TODO;
- records the accepted evidence shape: package deploy success, failure-injection marker present, dry-run ready, token-confirmed partial apply, one clean sibling write, one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter/provenance counters, no request-body injection, and injection config restored/disabled;
- updates the C6 sandbox smoke runbook and release smoke runbook so `test_failure_injection` is a valid failureShape token;
- keeps the boundary explicit: this is sandbox C6 smoke closure, not production/batch authorization, and final release signoff still needs the release evidence package.

## Verification

- `git diff --check`
- Subagent state/evidence review: initial findings fixed; re-review `resolved/no findings`.
- Subagent safety/boundary review: initial findings fixed; re-review `resolved/no findings`.

## Boundaries

- Docs-only.
- No runtime, route, UI, package, migration, K3, production, or batch change.
- Does not authorize production/batch writes.

Closes no issue automatically; this records the #2720 C6-5c PASS and leaves release signoff gates explicit.
