### PR TITLE
feat(multitable): send_notification button — first side-effecting action (B1-S1 D0-A)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -196,6 +196,7 @@ jobs:
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \
             tests/integration/multitable-view-summary-recordperm-leak.test.ts \
+            tests/integration/multitable-button-send-notification.test.ts \
             tests/integration/multitable-form-context-submit-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-dashboard-preview-data.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -771,7 +771,13 @@ function normalizeRecordSubscriptionNotification(
   const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
   const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
   const userId = typeof payload?.userId === 'string' ? payload.userId : ''
-  const eventType = payload?.eventType === 'comment.created' ? 'comment.created' : payload?.eventType === 'record.updated' ? 'record.updated' : null
+  // Admit ALL three known types — a missing notification.sent branch here would
+  // silently DROP every button-delivered notification (returns null → filtered out).
+  const eventType =
+    payload?.eventType === 'comment.created' ? 'comment.created'
+      : payload?.eventType === 'notification.sent' ? 'notification.sent'
+        : payload?.eventType === 'record.updated' ? 'record.updated'
+          : null
   if (!id || !sheetId || !recordId || !userId || !eventType) return null
   return {
     id,
@@ -782,6 +788,7 @@ function normalizeRecordSubscriptionNotification(
     actorId: typeof payload?.actorId === 'string' ? payload.actorId : null,
     revisionId: typeof payload?.revisionId === 'string' ? payload.revisionId : null,
     commentId: typeof payload?.commentId === 'string' ? payload.commentId : null,
+    message: typeof payload?.message === 'string' ? payload.message : null,
     createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
     readAt: typeof payload?.readAt === 'string' ? payload.readAt : null,
   }
@@ -1288,13 +1295,23 @@ export class MultitableApiClient {
   // IMPORTANT: an action that FAILS returns HTTP 200 with { status: 'failed' } —
   // this resolves (does not throw); the caller MUST branch on `data.status`.
   // Only contract/permission/server errors (400/403/404/500) throw MultitableApiError.
-  async runButton(sheetId: string, recordId: string, fieldId: string, requestId?: string): Promise<ButtonRunData> {
+  async runButton(
+    sheetId: string,
+    recordId: string,
+    fieldId: string,
+    options?: { requestId?: string; confirmed?: boolean },
+  ): Promise<ButtonRunData> {
+    // §4: `confirmed` is the server-confirm signal (the server is the gate; the FE
+    // confirm dialog sends confirmed:true). `requestId` scopes §6 at-most-once dedup.
+    const body: { requestId?: string; confirmed?: boolean } = {}
+    if (options?.requestId) body.requestId = options.requestId
+    if (options?.confirmed) body.confirmed = true
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/fields/${encodeURIComponent(fieldId)}/button/run`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestId ? { requestId } : {}),
+        body: JSON.stringify(body),
       },
     )
     return this.parseJson(res)

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -496,10 +496,33 @@
           </label>
           <label class="meta-field-mgr__field">
             <span>{{ ml('field.buttonActionType') }}</span>
-            <select v-model="buttonDraft.actionType" class="meta-field-mgr__input">
-              <option v-for="t in BUTTON_ACTION_TYPES" :key="t" :value="t">{{ ml('field.buttonActionRecordClick') }}</option>
+            <select v-model="buttonDraft.actionType" class="meta-field-mgr__input" data-test="button-action-type">
+              <option v-for="t in BUTTON_ACTION_TYPES" :key="t" :value="t">{{ buttonActionTypeLabel(t) }}</option>
             </select>
           </label>
+          <!-- B1-S1 D0-A: send_notification authoring (message + member-scoped recipients). -->
+          <template v-if="buttonDraft.actionType === 'send_notification'">
+            <label class="meta-field-mgr__field">
+              <span>{{ ml('field.buttonNotifyMessage') }}</span>
+              <textarea
+                v-model="buttonNotifyDraft.message"
+                class="meta-field-mgr__input"
+                rows="2"
+                data-test="button-notify-message"
+              ></textarea>
+              <span class="meta-field-mgr__hint">{{ ml('field.buttonNotifyMessageHint') }}</span>
+            </label>
+            <label class="meta-field-mgr__field">
+              <span>{{ ml('field.buttonNotifyRecipients') }}</span>
+              <input
+                v-model="buttonNotifyDraft.userIds"
+                class="meta-field-mgr__input"
+                type="text"
+                data-test="button-notify-recipients"
+              />
+              <span class="meta-field-mgr__hint">{{ ml('field.buttonNotifyRecipientsHint') }}</span>
+            </label>
+          </template>
           <label class="meta-field-mgr__toggle">
             <input v-model="buttonDraft.confirm.enabled" type="checkbox" />
             <span>{{ ml('field.buttonConfirmEnable') }}</span>
@@ -979,15 +1002,11 @@ const lookupDraft = reactive<{ linkFieldId: string; targetFieldId: string; forei
   targetFieldId: '',
   foreignSheetId: '',
 })
-// filters/filterConjunction are carried OPAQUELY (no builder UI yet) so an API/template-authored rollup
-// filter survives an unrelated edit instead of being silently dropped on save.
-const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation; filters?: unknown[]; filterConjunction?: string }>({
+const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation }>({
   linkFieldId: '',
   targetFieldId: '',
   foreignSheetId: '',
   aggregation: 'count',
-  filters: undefined,
-  filterConjunction: undefined,
 })
 const formulaDraft = reactive<{ expression: string }>({
   expression: '',
@@ -1034,9 +1053,31 @@ const buttonDraft = reactive<{
   confirm: { enabled: false, message: '' },
   actionConfig: null,
 })
-// Only record_click is runnable today (run route ENABLED_BUTTON_ACTIONS); the
-// picker offers exactly it so an authored button can't 400 on run.
-const BUTTON_ACTION_TYPES = ['record_click'] as const
+// B1-S1 D0-A: record_click (inert) + send_notification (first side-effecting
+// action) are runnable from a button. The picker offers exactly the run route's
+// enabled set so an authored button can't 400 on run.
+const BUTTON_ACTION_TYPES = ['record_click', 'send_notification'] as const
+
+function buttonActionTypeLabel(type: (typeof BUTTON_ACTION_TYPES)[number]): string {
+  return type === 'send_notification'
+    ? ml('field.buttonActionSendNotification')
+    : ml('field.buttonActionRecordClick')
+}
+
+// B1-S1 D0-A: send_notification authoring fields. Held in a SEPARATE draft (the
+// editable form view of buttonDraft.actionConfig) so the opaque-actionConfig
+// clobber guard still holds for OTHER action types — we only re-serialize the
+// notify shape into actionConfig when actionType === 'send_notification'.
+const buttonNotifyDraft = reactive<{ message: string; userIds: string }>({
+  message: '',
+  userIds: '',
+})
+
+function parseRecipientUserIds(raw: string): string[] {
+  return Array.from(new Set(
+    raw.split(',').map((id) => id.trim()).filter((id) => id.length > 0),
+  ))
+}
 const autoNumberDraft = reactive<{ prefix: string; digits: number; start: number }>({
   prefix: '',
   digits: 0,
@@ -1496,8 +1537,6 @@ function resetDrafts() {
   rollupDraft.targetFieldId = ''
   rollupDraft.foreignSheetId = ''
   rollupDraft.aggregation = 'count'
-  rollupDraft.filters = undefined
-  rollupDraft.filterConjunction = undefined
   formulaDraft.expression = ''
   formulaFunctionSearch.value = ''
   formulaFunctionCategory.value = 'all'
@@ -1521,6 +1560,8 @@ function resetDrafts() {
   buttonDraft.actionType = 'record_click'
   buttonDraft.confirm = { enabled: false, message: '' }
   buttonDraft.actionConfig = null
+  buttonNotifyDraft.message = ''
+  buttonNotifyDraft.userIds = ''
   validationDraft.value = []
   validationDraftTouched.value = false
   fieldConfigError.value = ''
@@ -1567,10 +1608,6 @@ function serializeFieldDraft(type: string | null): string {
       targetFieldId: rollupDraft.targetFieldId,
       foreignSheetId: rollupDraft.foreignSheetId,
       aggregation: rollupDraft.aggregation,
-      // Opaque filter carry — part of the signature so editing a filtered rollup isn't seen as "clean".
-      ...(rollupDraft.filters && rollupDraft.filters.length > 0
-        ? { filters: rollupDraft.filters, filterConjunction: rollupDraft.filterConjunction ?? 'and' }
-        : {}),
     })
   }
   if (type === 'formula') {
@@ -1603,12 +1640,19 @@ function serializeFieldDraft(type: string | null): string {
     return JSON.stringify({ durationFormat: durationDraft.durationFormat })
   }
   if (type === 'button') {
+    // B1-S1 D0-A: for send_notification, the actionConfig is the EDITABLE notify
+    // shape (message + recipient user ids). Other action types keep the opaque
+    // carried-through actionConfig (clobber guard).
+    const actionType = buttonDraft.actionType.trim()
+    const actionConfig = actionType === 'send_notification'
+      ? { message: buttonNotifyDraft.message.trim(), userIds: parseRecipientUserIds(buttonNotifyDraft.userIds) }
+      : buttonDraft.actionConfig
     return JSON.stringify({
       label: buttonDraft.label.trim(),
       variant: buttonDraft.variant,
-      actionType: buttonDraft.actionType.trim(),
+      actionType,
       confirm: { enabled: buttonDraft.confirm.enabled, message: buttonDraft.confirm.message.trim() },
-      actionConfig: buttonDraft.actionConfig,
+      actionConfig,
     })
   }
   if (type === 'autoNumber') {
@@ -1702,8 +1746,6 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     rollupDraft.targetFieldId = property.targetFieldId ?? ''
     rollupDraft.foreignSheetId = property.foreignSheetId ?? ''
     rollupDraft.aggregation = property.aggregation
-    rollupDraft.filters = property.filters
-    rollupDraft.filterConjunction = property.filterConjunction
   } else if (fieldType === 'formula') {
     formulaDraft.expression = resolveFormulaFieldProperty(field.property).expression
   } else if (fieldType === 'attachment') {
@@ -1743,6 +1785,13 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     buttonDraft.actionType = property.actionType
     buttonDraft.confirm = { enabled: property.confirm.enabled, message: property.confirm.message }
     buttonDraft.actionConfig = property.actionConfig
+    // B1-S1 D0-A: hydrate the editable notify draft from the persisted actionConfig
+    // so re-opening a send_notification button shows its message + recipients.
+    const cfg = property.actionConfig ?? {}
+    buttonNotifyDraft.message = typeof cfg.message === 'string' ? cfg.message : ''
+    buttonNotifyDraft.userIds = Array.isArray(cfg.userIds)
+      ? cfg.userIds.filter((id): id is string => typeof id === 'string').join(', ')
+      : ''
   } else if (fieldType === 'string' || fieldType === 'longText') {
     // A3 CLOBBER GUARD leg 1 (LOCKED §2.1): hydrate the persisted aiShortcut
     // into the draft so EVERY subsequent save re-emits it (see
@@ -2146,10 +2195,6 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       targetFieldId: rollupDraft.targetFieldId,
       aggregation: rollupDraft.aggregation,
       ...(rollupDraft.foreignSheetId ? { foreignSheetId: rollupDraft.foreignSheetId } : {}),
-      // Opaque filter carry (no builder UI yet) — re-emit a stored filter so it isn't dropped on save.
-      ...(rollupDraft.filters && rollupDraft.filters.length > 0
-        ? { filters: rollupDraft.filters, filterConjunction: rollupDraft.filterConjunction ?? 'and' }
-        : {}),
     }
   }
   if (normalizedType === 'formula') {
@@ -2223,6 +2268,24 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     if (!actionType) {
       fieldConfigError.value = ml('field.error.buttonActionType')
       return undefined
+    }
+    // B1-S1 D0-A: send_notification authors an EDITABLE actionConfig (message +
+    // recipient user ids). Require both; recipients are FILTERED to members
+    // server-side at run, but config-time must be non-empty.
+    if (actionType === 'send_notification') {
+      const message = buttonNotifyDraft.message.trim()
+      const userIds = parseRecipientUserIds(buttonNotifyDraft.userIds)
+      if (!message || userIds.length === 0) {
+        fieldConfigError.value = ml('field.error.buttonNotifyConfig')
+        return undefined
+      }
+      return {
+        label: buttonDraft.label.trim(),
+        variant: buttonDraft.variant,
+        actionType,
+        confirm: { enabled: buttonDraft.confirm.enabled, message: buttonDraft.confirm.message.trim() },
+        actionConfig: { message, userIds },
+      }
     }
     // KEYSTONE: re-emit actionConfig from the draft (hydrated on edit) so a
     // label/variant change never drops a server-authored config — update-field

--- a/apps/web/src/multitable/components/MetaNotificationBell.vue
+++ b/apps/web/src/multitable/components/MetaNotificationBell.vue
@@ -37,7 +37,15 @@
           @click="onItemClick(n)"
         >
           <span v-if="!n.readAt" class="meta-notif-bell__dot" data-test="notification-unread-dot" aria-hidden="true"></span>
-          <span class="meta-notif-bell__event">{{ eventLabel(n.eventType) }}</span>
+          <span class="meta-notif-bell__body">
+            <span class="meta-notif-bell__event">{{ eventLabel(n.eventType) }}</span>
+            <!-- B1-S1 D0-A: a notification.sent row carries a custom message body. -->
+            <span
+              v-if="n.eventType === 'notification.sent' && n.message"
+              class="meta-notif-bell__message"
+              data-test="notification-message"
+            >{{ n.message }}</span>
+          </span>
           <span class="meta-notif-bell__time">{{ formatTime(n.createdAt) }}</span>
         </li>
       </ul>
@@ -100,6 +108,8 @@ void refreshUnreadCount()
 .meta-notif-bell__item:hover { background: #f8fafc; }
 .meta-notif-bell__item--unread { background: #eff6ff; }
 .meta-notif-bell__dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: #2563eb; align-self: center; }
-.meta-notif-bell__event { flex: 1 1 auto; color: #0f172a; font-size: 13px; }
+.meta-notif-bell__body { flex: 1 1 auto; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.meta-notif-bell__event { color: #0f172a; font-size: 13px; }
+.meta-notif-bell__message { color: #475569; font-size: 12px; white-space: normal; word-break: break-word; }
 .meta-notif-bell__time { flex: 0 0 auto; color: #94a3b8; font-size: 11px; }
 </style>

--- a/apps/web/src/multitable/composables/useNotificationInbox.ts
+++ b/apps/web/src/multitable/composables/useNotificationInbox.ts
@@ -19,9 +19,9 @@ export function useNotificationInbox(client?: MultitableApiClient) {
   const hasUnread = computed(() => unreadCount.value > 0)
 
   function eventLabel(eventType: MetaRecordSubscriptionNotificationType): string {
-    return eventType === 'comment.created'
-      ? recordLabel('notification.eventCommentCreated', isZh.value)
-      : recordLabel('notification.eventRecordUpdated', isZh.value)
+    if (eventType === 'comment.created') return recordLabel('notification.eventCommentCreated', isZh.value)
+    if (eventType === 'notification.sent') return recordLabel('notification.eventNotificationSent', isZh.value)
+    return recordLabel('notification.eventRecordUpdated', isZh.value)
   }
 
   // UI-facing actions NEVER throw — they surface failure via `error` and resolve. The bell is ambient

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -328,7 +328,9 @@ export interface MetaRecordSubscriptionStatus {
   items?: MetaRecordSubscription[]
 }
 
-export type MetaRecordSubscriptionNotificationType = 'record.updated' | 'comment.created'
+// B1-S1 D0-A: `notification.sent` is the durable in-app notification from a
+// side-effecting send_notification button action (carries a custom `message`).
+export type MetaRecordSubscriptionNotificationType = 'record.updated' | 'comment.created' | 'notification.sent'
 
 export interface MetaRecordSubscriptionNotification {
   id: string
@@ -339,6 +341,8 @@ export interface MetaRecordSubscriptionNotification {
   actorId: string | null
   revisionId: string | null
   commentId: string | null
+  /** Custom message body — populated for `notification.sent`; null for watcher events. */
+  message: string | null
   createdAt: string
   readAt: string | null
 }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -69,6 +69,11 @@ export type MetaManagerLabelKey =
   | 'field.durationFormat' | 'field.durationFormatHmm' | 'field.durationFormatMmss'
   | 'field.buttonLabelText' | 'field.buttonVariant' | 'field.buttonVariantPrimary' | 'field.buttonVariantSecondary' | 'field.buttonVariantDanger'
   | 'field.buttonActionType' | 'field.buttonActionRecordClick' | 'field.buttonConfirmEnable' | 'field.buttonConfirmMessage' | 'field.buttonConfirmHint'
+  // B1-S1 D0-A: send_notification button action authoring.
+  | 'field.buttonActionSendNotification'
+  | 'field.buttonNotifyMessage' | 'field.buttonNotifyMessageHint'
+  | 'field.buttonNotifyRecipients' | 'field.buttonNotifyRecipientsHint'
+  | 'field.error.buttonNotifyConfig'
   | 'field.autoNumberHint' | 'field.saveSettings' | 'field.applyDefaults'
   | 'field.namePlaceholder' | 'field.addButton'
   | 'field.changedTypeBlocking' | 'field.changedWarning'
@@ -322,9 +327,21 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.buttonVariantDanger': { en: 'Danger', zh: '危险' },
   'field.buttonActionType': { en: 'Action', zh: '动作' },
   'field.buttonActionRecordClick': { en: 'Record click (audit only)', zh: '记录点击（仅审计）' },
+  'field.buttonActionSendNotification': { en: 'Send notification', zh: '发送通知' },
   'field.buttonConfirmEnable': { en: 'Confirm before running', zh: '运行前确认' },
   'field.buttonConfirmMessage': { en: 'Confirm message', zh: '确认提示' },
-  'field.buttonConfirmHint': { en: 'Takes effect when the button runs a side-effecting action (coming later).', zh: '在按钮执行有副作用的动作时生效（后续上线）。' },
+  'field.buttonConfirmHint': { en: 'Takes effect when the button runs a side-effecting action.', zh: '在按钮执行有副作用的动作时生效。' },
+  'field.buttonNotifyMessage': { en: 'Notification message', zh: '通知内容' },
+  'field.buttonNotifyMessageHint': { en: 'The message recipients see in their Notification Center.', zh: '收件人将在通知中心看到的内容。' },
+  'field.buttonNotifyRecipients': { en: 'Recipients (user IDs)', zh: '收件人（用户 ID）' },
+  'field.buttonNotifyRecipientsHint': {
+    en: 'Comma-separated user IDs. Non-members are dropped server-side at run time.',
+    zh: '逗号分隔的用户 ID。运行时服务端会剔除非成员。',
+  },
+  'field.error.buttonNotifyConfig': {
+    en: 'Send notification requires a message and at least one recipient.',
+    zh: '发送通知需要填写内容并至少一个收件人。',
+  },
   'field.prefix': { en: 'Prefix', zh: '前缀' },
   'field.digits': { en: 'Digits', zh: '位数' },
   'field.startAt': { en: 'Start at', zh: '起始值' },

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -59,6 +59,8 @@ export type MetaRecordLabelKey =
   | 'notification.bell' | 'notification.title' | 'notification.empty'
   | 'notification.markAllRead' | 'notification.loadError'
   | 'notification.eventRecordUpdated' | 'notification.eventCommentCreated'
+  // B1-S1 D0-A: durable button-delivered notification (custom message render).
+  | 'notification.eventNotificationSent'
   // --- MetaFormView multi-page nav chrome (A4) ---
   | 'form.previousPage' | 'form.nextPage'
 
@@ -70,6 +72,7 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'notification.loadError': { en: 'Failed to load notifications', zh: '加载通知失败' },
   'notification.eventRecordUpdated': { en: 'Record updated', zh: '记录有更新' },
   'notification.eventCommentCreated': { en: 'New comment', zh: '新增评论' },
+  'notification.eventNotificationSent': { en: 'Notification', zh: '通知' },
   'record.title': { en: 'Record Detail', zh: '记录详情' },
   'record.previous': { en: 'Previous record', zh: '上一条记录' },
   'record.next': { en: 'Next record', zh: '下一条记录' },

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -57,6 +57,9 @@ export type WorkbenchLabelKey =
   | 'toast.workbenchInitFailed'
   | 'confirm.discardContextChanges' | 'confirm.discardRecordChanges'
   | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
+  // B1-S1 D0-A: default confirm copy for a side-effecting button run (used when
+  // the button's own confirm.message is blank).
+  | 'confirm.buttonRun'
   // §3.6 MetaTemplateCard button (counts use the card* helpers below)
   | 'card.install' | 'card.installing'
   // S2 template detail + dry-run (design 20260611 §2.2)
@@ -205,6 +208,10 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'confirm.discardRecordChanges': {
     en: 'Discard unsaved record changes?',
     zh: '放弃未保存的记录更改吗？',
+  },
+  'confirm.buttonRun': {
+    en: 'Run this button action?',
+    zh: '确定执行此按钮操作吗？',
   },
   'confirm.pageLeaveBusy': {
     en: 'Leave the multitable while the current save or import is still running?',

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -492,6 +492,7 @@ import {
 } from '../utils/workbench-labels'
 import { commentLabel } from '../utils/meta-comment-labels'
 import { recordLabel } from '../utils/meta-record-labels'
+import { resolveButtonFieldProperty } from '../utils/field-config'
 import {
   bulkFailure as fmtBulkFailure,
   bulkPartialSuccess as fmtBulkPartialSuccess,
@@ -672,9 +673,24 @@ async function onRunButton({ recordId, field }: { recordId: string; field: MetaF
   if (!sheetId) return
   const key = `${recordId}:${field.id}`
   if (buttonRunPending.value.includes(key)) return
+
+  // B1-S1 D0-A: CONFIRM dialog (UX affordance — the SERVER is the gate). If the
+  // button declares confirm.enabled, prompt BEFORE the side-effecting call;
+  // cancelling writes NOTHING. On confirm we send confirmed:true so the server's
+  // §4 confirm gate passes (a direct POST without it is rejected server-side). A
+  // requestId scopes server-side at-most-once dedup for side effects.
+  const buttonProperty = resolveButtonFieldProperty(field.property)
+  let confirmed = false
+  if (buttonProperty.confirm.enabled) {
+    const prompt = buttonProperty.confirm.message || wb('confirm.buttonRun', isZh.value)
+    if (!window.confirm(prompt)) return
+    confirmed = true
+  }
+  const requestId = crypto.randomUUID()
+
   buttonRunPending.value = [...buttonRunPending.value, key]
   try {
-    const result = await workbench.client.runButton(sheetId, recordId, field.id)
+    const result = await workbench.client.runButton(sheetId, recordId, field.id, { requestId, confirmed })
     if (result.status === 'failed') {
       showError(result.message || wb('toast.buttonRunFailed', isZh.value))
     } else {

--- a/apps/web/tests/meta-notification-bell.spec.ts
+++ b/apps/web/tests/meta-notification-bell.spec.ts
@@ -9,7 +9,11 @@ import MetaNotificationBell from '../src/multitable/components/MetaNotificationB
 import type { MetaRecordSubscriptionNotification } from '../src/multitable/types'
 
 function notif(id: string, readAt: string | null = null): MetaRecordSubscriptionNotification {
-  return { id, sheetId: 's1', recordId: `rec_${id}`, userId: 'u1', eventType: 'record.updated', actorId: null, revisionId: null, commentId: null, createdAt: '2026-06-16T00:00:00Z', readAt }
+  return { id, sheetId: 's1', recordId: `rec_${id}`, userId: 'u1', eventType: 'record.updated', actorId: null, revisionId: null, commentId: null, message: null, createdAt: '2026-06-16T00:00:00Z', readAt }
+}
+// B1-S1 D0-A: a durable button-delivered notification carries a custom message body.
+function notifSent(id: string, message: string): MetaRecordSubscriptionNotification {
+  return { id, sheetId: 's1', recordId: `rec_${id}`, userId: 'u1', eventType: 'notification.sent', actorId: null, revisionId: null, commentId: null, message, createdAt: '2026-06-16T00:00:00Z', readAt: null }
 }
 const flush = async () => { await nextTick(); await Promise.resolve(); await Promise.resolve(); await nextTick() }
 
@@ -78,6 +82,20 @@ describe('MetaNotificationBell (S1b)', () => {
     expect(m.container.querySelector('.meta-notif-bell__state--error')?.textContent).toContain('mark fail')
     // the list is NOT replaced by the error — both render
     expect(m.container.querySelectorAll('[data-test="notification-item"]').length).toBe(2)
+  })
+
+  it('B1-S1 D0-A: renders the custom message for a notification.sent row', async () => {
+    const m = mount({
+      listRecordSubscriptionNotifications: vi.fn(async () => [notifSent('n1', 'Ship the release')]),
+      getRecordSubscriptionUnreadCount: vi.fn(async () => 1),
+    })
+    mounted = m
+    await flush()
+    m.container.querySelector<HTMLButtonElement>('[data-test="notification-bell-btn"]')!.click()
+    await flush()
+    const message = m.container.querySelector('[data-test="notification-message"]')
+    expect(message).not.toBeNull()
+    expect(message?.textContent).toContain('Ship the release')
   })
 
   it('does not crash when the client fails — renders the error state instead (P2-1)', async () => {

--- a/apps/web/tests/multitable-button-run-client.spec.ts
+++ b/apps/web/tests/multitable-button-run-client.spec.ts
@@ -32,8 +32,25 @@ describe('MultitableApiClient.runButton (B1-b)', () => {
   it('includes requestId in the body only when provided', async () => {
     const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'x' } }))
     const client = new MultitableApiClient({ fetchFn })
-    await client.runButton('s1', 'r1', 'f1', 'req-9')
+    await client.runButton('s1', 'r1', 'f1', { requestId: 'req-9' })
     expect(fetchFn).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ body: JSON.stringify({ requestId: 'req-9' }) }))
+  })
+
+  it('§4: includes confirmed:true in the body when confirmed (server-confirm signal)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'x' } }))
+    const client = new MultitableApiClient({ fetchFn })
+    await client.runButton('s1', 'r1', 'f1', { requestId: 'req-c', confirmed: true })
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: JSON.stringify({ requestId: 'req-c', confirmed: true }) }),
+    )
+  })
+
+  it('omits confirmed when not confirmed (no stray false in the body)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({ ok: true, data: { status: 'succeeded', executionId: 'x' } }))
+    const client = new MultitableApiClient({ fetchFn })
+    await client.runButton('s1', 'r1', 'f1', { requestId: 'req-d', confirmed: false })
+    expect(fetchFn).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ body: JSON.stringify({ requestId: 'req-d' }) }))
   })
 
   it('encodeURIComponents all three path segments', async () => {
@@ -50,5 +67,47 @@ describe('MultitableApiClient.runButton (B1-b)', () => {
     const fetchFn = vi.fn().mockResolvedValue(json({ ok: false, error: { code: 'FORBIDDEN', message: 'nope' } }, 403))
     const client = new MultitableApiClient({ fetchFn })
     await expect(client.runButton('s1', 'r1', 'f1')).rejects.toMatchObject({ name: 'MultitableApiError', status: 403 } as ApiErr)
+  })
+})
+
+// B1-S1 D0-A: the notification list normalizer is a field-by-field whitelist — a
+// missing notification.sent branch silently DROPS button-delivered rows (returns
+// null → filtered out). This is the wire-vs-fixture rule: a field added via a
+// whitelist normalizer MUST have a round-trip test.
+describe('MultitableApiClient.listRecordSubscriptionNotifications normalizer (B1-S1 D0-A)', () => {
+  it('admits a notification.sent row and maps its custom message', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({
+      items: [{
+        id: 'n1', sheetId: 's1', recordId: 'r1', userId: 'u1',
+        eventType: 'notification.sent', actorId: 'actor', revisionId: null, commentId: null,
+        message: 'Ship the release', createdAt: '2026-06-16T00:00:00Z', readAt: null,
+      }],
+    }))
+    const client = new MultitableApiClient({ fetchFn })
+    const rows = await client.listRecordSubscriptionNotifications({ sheetId: 's1' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ id: 'n1', eventType: 'notification.sent', message: 'Ship the release' })
+  })
+
+  it('still maps the two watcher types and leaves message null for them', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({
+      items: [
+        { id: 'a', sheetId: 's1', recordId: 'r1', userId: 'u1', eventType: 'record.updated', createdAt: 't', readAt: null },
+        { id: 'b', sheetId: 's1', recordId: 'r1', userId: 'u1', eventType: 'comment.created', createdAt: 't', readAt: null },
+      ],
+    }))
+    const client = new MultitableApiClient({ fetchFn })
+    const rows = await client.listRecordSubscriptionNotifications()
+    expect(rows.map((r) => r.eventType)).toEqual(['record.updated', 'comment.created'])
+    expect(rows.every((r) => r.message === null)).toBe(true)
+  })
+
+  it('drops a row with an unknown eventType (returns null → filtered)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(json({
+      items: [{ id: 'x', sheetId: 's1', recordId: 'r1', userId: 'u1', eventType: 'bogus.type', createdAt: 't', readAt: null }],
+    }))
+    const client = new MultitableApiClient({ fetchFn })
+    const rows = await client.listRecordSubscriptionNotifications()
+    expect(rows).toHaveLength(0)
   })
 })

--- a/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-drawer-button-wiring.spec.ts
@@ -204,8 +204,12 @@ describe('MultitableWorkbench drawer run-button handler wiring (B1-e)', () => {
     await flushUi()
     expect(workbenchMock.client.runButton).toHaveBeenCalledTimes(1)
     // Active sheet from the workbench + record + field id, in order — a reorder would silently
-    // run the wrong button; caught here.
-    expect(workbenchMock.client.runButton).toHaveBeenCalledWith('sheet_orders', 'rec_42', 'fld_btn')
+    // run the wrong button; caught here. B1-S1 D0-A passes an options 4th arg carrying a
+    // generated requestId. A non-confirm button does NOT set confirmed.
+    expect(workbenchMock.client.runButton).toHaveBeenCalledWith(
+      'sheet_orders', 'rec_42', 'fld_btn',
+      expect.objectContaining({ requestId: expect.any(String), confirmed: false }),
+    )
     expect(showSuccessSpy).toHaveBeenCalledTimes(1)
     expect(showErrorSpy).not.toHaveBeenCalled()
   })
@@ -233,6 +237,35 @@ describe('MultitableWorkbench drawer run-button handler wiring (B1-e)', () => {
     await onRunButton({ recordId: 'rec_42', field: { id: 'fld_btn' } })
     await flushUi()
     expect(workbenchMock.client.runButton).not.toHaveBeenCalled()
+  })
+
+  // B1-S1 D0-A confirm enforcement: a confirm.enabled button must NOT dispatch
+  // (no runButton call → no notification, no audit) when the user cancels the
+  // confirm; it MUST dispatch when confirmed.
+  const confirmField = { id: 'fld_btn', name: 'Notify', type: 'button', property: { label: 'Notify', actionType: 'send_notification', confirm: { enabled: true, message: 'Send it?' } } }
+
+  it('confirm.enabled + user CANCELS → runButton is NOT called (no side effect)', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const onRunButton = await mountAndGetRunButton()
+    await onRunButton({ recordId: 'rec_42', field: confirmField as any })
+    await flushUi()
+    expect(confirmSpy).toHaveBeenCalledWith('Send it?')
+    expect(workbenchMock.client.runButton).not.toHaveBeenCalled()
+    expect(showSuccessSpy).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('confirm.enabled + user CONFIRMS → runButton IS called with a requestId AND confirmed:true', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const onRunButton = await mountAndGetRunButton()
+    await onRunButton({ recordId: 'rec_42', field: confirmField as any })
+    await flushUi()
+    // §4: confirming sends confirmed:true so the server-confirm gate passes.
+    expect(workbenchMock.client.runButton).toHaveBeenCalledWith(
+      'sheet_orders', 'rec_42', 'fld_btn',
+      expect.objectContaining({ requestId: expect.any(String), confirmed: true }),
+    )
+    confirmSpy.mockRestore()
   })
 })
 

--- a/docs/development/multitable-button-side-effect-1-send-notification-designlock-20260616.md
+++ b/docs/development/multitable-button-side-effect-1-send-notification-designlock-20260616.md
@@ -1,0 +1,86 @@
+# 多维表 Button 副作用动作 #1 — send_notification — 设计锁 D0-A — 2026-06-16
+
+> Status: **DESIGN-LOCK → 已实现(IMPLEMENTED,经 owner 安全复审重做)**。承接 `multitable-button-field-b1s0-designlock-20260615.md`(B1-S0 inert `record_click` 已落地)。
+> 范围:button 字段的**第一个有副作用动作** `send_notification` —— 写入通知中心(durable in-app notification)。
+> 一句话:把"按钮点击"从"零副作用审计"升级为"对**经服务端硬校验**的收件人产生一条**可持久化**的站内通知",并把**服务端确认 / 持久化审计 / 幂等 / 收件人硬拒**一并锁死成**一个全成功或全失败的路由级副作用事务**。
+
+## 0. D0 决策(已定:**D0-A**)+ 复审重做的架构基线
+
+B1-S0 §0 标记了一处前提缺口(premise-break):`executeSendNotification` 当时**只 `eventBus.emit`**,没有任何持久化写,也没有生产侧订阅者 —— 即"看似能发通知,实则没有落地"。
+
+**D0 决策 = D0-A:第一个副作用动作就是 `send_notification`,且它必须把通知作为一条 durable 行写入通知中心 sink(`meta_record_subscription_notifications`),而不是仅 eventBus。** 半成品状态(能发但无审计 / 有 sink 但按钮不受控 / 收件人不校验)一律不可接受 —— 故迁移 + 写入 seam + Bell 渲染 + 派发/确认/审计/幂等/收件人鉴权**同一个 PR 落地**。
+
+**架构基线(复审重做,REQUEST CHANGES):durable 通知写**不**进 `AutomationExecutor`,而是 `routes/multitable-button.ts` 里一个**路由级专用副作用事务**(`pool.transaction` = 一个 client 的 BEGIN/COMMIT/ROLLBACK),严格按序、全成功或全失败:**服务端确认闸 → actor 编辑闸 → 收件人硬拒 → dedup → 通知行 → 审计行**。无副作用的校验(确认 / actor / 收件人)在**事务开启之前**完成,被拒的 run **不写任何东西**(无通知、无审计、无 dedup marker;requestId 不被消费,后续同 requestId 的合法重试仍发一次)。dedup + 通知 + 审计**在同一事务内**提交;**审计写入失败 = 整个 run 回滚(fail-closed,无"已发未审计"状态)**。
+
+> **规则触发路径不受本 PR 影响**:`executeSendNotification` 对规则路径恢复为**仅 `eventBus.emit`**(不加 durable 写 / 成员过滤 / dedup / button 审计 —— 那会扩大 automation 的行为面,超出 button slice 范围)。durable 路径只活在路由。watcher 通知(`record.updated` / `comment.created`)走的是 `notifyRecordSubscribers`,不受影响(回归测试守住)。§0 标记的前提缺口由**路由的 durable 写**修复,而非共享 executor。
+
+## 1. sink 复用(不另造通知表)
+
+复用既有通知中心 sink 表 `meta_record_subscription_notifications`(迁移 `zzzz20260505103000`)。本 PR 两处 schema 变更:
+
+- 新增可空列 `message text` —— 自定义通知正文;watcher 事件为 NULL。
+- 扩展 `event_type` CHECK 接纳 `notification.sent`(保留原有 `record.updated` / `comment.created`)。原 CHECK 为**内联无名约束**(Postgres 自动命名 `<table>_<column>_check`),迁移先 DROP 自动名 + 任何旧的具名约束(幂等),再以**具名约束** `chk_meta_record_subscription_notifications_event_type` 重建,后续扩展稳定。
+
+## 2. 写入 seam(单一 INSERT 之家,无旁路)
+
+把 `notifyRecordSubscribers` 的 INSERT 半边抽成导出函数
+`insertRecordSubscriptionNotifications(query, { userIds, sheetId, recordId?, eventType, message?, actorId?, revisionId?, commentId? }) → { inserted }`。
+
+- **忠实超集**:仍携带 `revisionId` / `commentId`,故 `notifyRecordSubscribers` 改指向它后**不回归**(`record.updated` 的 `revision_id` 必须 round-trip)。`message` 是唯一新增列(watcher 路径恒为 NULL)。
+- **收件人不在此处鉴权**:seam 只写"被交给它的内容";收件人策略归调用方(button 路由在派发前按成员集过滤)。
+
+## 3. 执行 + 派发(路由级副作用事务,durable 写不进 executor)
+
+- button 路由对 `send_notification`**自己拥有派发**:先做无副作用校验(确认 / actor / 收件人硬拒),再在 `pool.transaction` 内 dedup → 经写入 seam `insertRecordSubscriptionNotifications` 落 durable 行(`eventType='notification.sent'` + `message`)→ 写审计行。`eventBus.emit('automation.notification', …)` 仅在**提交后**触发(绝不在事务内,否则回滚会发幽灵通知;重放跳过)。
+- executor 的 `executeSendNotification`**恢复为仅 `eventBus.emit`**(规则路径不变;durable / dedup / 审计都是路由的事,不在共享 executor)。
+- 启用动作的"两改陷阱"已处理:`record_click` 的硬编码派发改为按**校验后的 actionType** 派发;`ENABLED_BUTTON_ACTIONS` 升级为 `BUTTON_ACTION_POLICIES`(每动作声明 actor 闸 + `sideEffecting` 标志 + 派发类型;`sideEffecting` 同时驱动 requestId 要求与服务端确认要求)。
+
+### 3.1 收件人鉴权(头号控制)=== 硬拒 ===
+
+`config.userIds` 必须**全部**是 sheet 成员,**服务端在事务开启前校验**,复用 `loadSheetMemberUserIdSet`(与 Person 字段写校验器同一成员集,单解析器无漂移)。**只要任一**配置收件人不是成员 → **硬拒整个 run**(400 `RECIPIENT_NOT_AUTHORIZED`,validation-failed),**什么都不写**(无静默部分投递)。零收件人 / 空 message 同样在事务前 400。硬拒发生在事务前,故被拒的 run **不消费 requestId**。
+
+### 3.2 actor 闸(临时代理)
+
+`send_notification` 以 `canEditRecord` 为闸(provisional proxy:有副作用、对外投递的按钮按"记录编辑类"动作把关,直到有专用 per-action 权限);`record_click` 仍是读闸。actor 闸在事务前,被拒 = 不写。
+
+## 4. 服务端确认 / 硬审计 / 幂等(同一事务,全成功或全失败)
+
+- **服务端确认强制(SERVER GATE)**:请求体新增 `confirmed?: boolean`。当字段 `property.confirm.enabled` **且**动作 side-effecting 时,路由**要求 `confirmed === true`**,否则 400 `CONFIRMATION_REQUIRED` 且**什么都不写**(无通知、无审计、无 dedup) —— "未确认 → 不写"现在是**服务端行为**,直 POST 绕不过去。FE 仍弹 `window.confirm`(确认后 `runButton` 带 `confirmed:true`),但 FE 只是 affordance,**服务端是闸**。
+- **硬持久化审计(同事务前置条件)**:路由经 `AutomationLogService.recordWithQuery(txClient, …)` 在**同一事务 client** 上写一条 redacted `multitable_automation_executions`,`triggered_by='button'`(显式,不依赖 executor 的 `'event'` 默认)。`recordWithQuery` 用**与 `record()` 同一组脱敏 helper**(`redactValue`/`redactString`)对 steps / trigger_event / rule_snapshot / error 四条秘密通道脱敏,杜绝脱敏回退;jsonb 列以**脱敏后的 PLAIN 值** `JSON.stringify(...)` + `$n::jsonb` 写入(**不**走 `toPersistedExecutionValues` —— 它把值包成 kysely `RawBuilder`,`JSON.stringify` 会序列化成空 `{}`,致审计内容为空)。**审计写失败 → 抛错 → 整个事务回滚**(通知 + dedup 一并撤销),run fail-closed 返回失败,**绝无"已发未审计"**。button 行**排除**出规则监控读(`listExecutions` + `getRecent` 加 `triggered_by != 'button'`),但 `getById` 仍可取回。审计 `steps` 内容(非仅 `triggered_by`)由 unit + 实库测试 round-trip 守住。
+  - INERT `record_click` 是 **logger-only,不写 durable 行**(与 §9 / AUDIT-1 一致):durable `multitable_automation_executions` 行**专属 side-effecting 动作**;把 inert 动作挡在审计表外也让 DF-N1 规则监控面保持干净。(单测断言 record_click run 不触发任何 `multitable_automation_executions` INSERT。)
+- **幂等(§6,at-most-once)**:side-effecting 动作**要求 requestId**(`record_click` 仍可选)。dedup key = `JSON.stringify([actor, sheet, record, field, requestId])`(**结构化数组**而非 `|` 拼接 —— requestId 是客户端输入,可能含分隔符,拼接会有 false-replay 风险),存入新表 `multitable_button_run_dedup`(`UNIQUE(dedup_key)`);dedup `INSERT ... ON CONFLICT DO NOTHING` 在**事务内**(通知 + 审计之前)。`rowCount===0` = 重放 → 成功形返回 + **不写第二条通知、不写第二条审计**(单一效果),且**返回原始已 COMMIT 的 executionId**(从 dedup 行的 `execution_id` 取回,可追溯到真实审计行;绝不返回本次新生成的不可追溯 id)。**dedup marker 在事务内**意味着:一个回滚的 run(如审计失败)**不消费 requestId** —— 重试仍发一次。replay 只在**真有一次先前 COMMIT 的效果**时短路。
+
+## 5. 配置 / 渲染(B1-c + Bell)
+
+- B1-c 配置:button 配置新增 `send_notification` 的 `actionConfig {userIds(逗号/成员), message}` 编写(`MetaFieldManager.vue`),保存校验要求 message + 至少一个收件人;其它 action type 的 opaque-actionConfig clobber guard 不变。
+- `MetaNotificationBell.vue` 新增 message 渲染路径(`notification.sent` 行展示自定义 message)。
+- i18n:typed en+zh,无 dead key;FE 不做权限镜像(服务端把关)。
+
+## 6. 已实现范围(IMPLEMENTED SCOPE)
+
+四块同 PR 落地:
+
+1. **迁移**:`..._add_meta_record_subscription_notification_message.ts`(message 列 + CHECK 扩展,幂等 up/down)+ `..._create_multitable_button_run_dedup.ts`(dedup 表)。
+2. **写入 seam**:`insertRecordSubscriptionNotifications`(接受任意 `QueryFn`,可传事务 client)+ `notifyRecordSubscribers` 改指(忠实超集,无回归);序列化 `normalizeEventType` 接纳三种类型 + map `message`;list SELECT 增 `message`。
+3. **Bell 渲染**:`notification.sent` 自定义 message 渲染 + typed i18n。
+4. **路由级副作用事务**:button 路由 `pool.transaction` 内 dedup → 通知 → 审计;`AutomationLogService.recordWithQuery`(事务版审计,复用 `record()` 脱敏);`executeSendNotification` 恢复 eventBus-only;`triggered_by='button'` 审计排除;at-most-once dedup;收件人**硬拒**;服务端确认闸;FE `confirmed:true` 信号。
+
+## 7. 测试
+
+unit(mock pool / mock query,含**带回滚语义**的 transaction mock):
+- **服务端确认**:confirm.enabled + side-effecting + `confirmed` 缺省或 `false` → 400 `CONFIRMATION_REQUIRED`,**无通知、无审计、requestId 不消费**(随后同 requestId + `confirmed:true` 仍发一次)。
+- 重复 requestId(同 dedup key,且有先前 COMMIT 效果)→ 通知只写一次 + 不写第二条审计。
+- **越界收件人(任一非成员)→ 硬拒整个 run(400 `RECIPIENT_NOT_AUTHORIZED`),什么都不写**。
+- **硬审计**:模拟审计 insert 失败 → 通知**不提交**(回滚),run 返回失败(fail-closed)。
+- 全成员收件人 → `notification.sent` + message 投递 + 同事务审计行 `triggered_by='button'`。
+- Bell 渲染 `notification.sent` 自定义 message;序列化不把它强转 `record.updated`。
+- 旧 watcher 通知(`record.updated` 经 `notifyRecordSubscribers`)不回归(seam 重构守住 revision_id round-trip)。
+- 持久化审计 `triggered_by='button'`,排除 `listExecutions`/`getRecent`,`getById` 可取回。
+- `record_click` 仍 inert(requestId 可选,无 durable 行)。
+- FE:`runButton` body 仅在 confirm 时带 `confirmed:true`;onRunButton 取消 = 不调 runButton,确认 = 带 `confirmed:true`。
+
+real-DB integration(`plugin-tests.yml` 实库白名单):全成员投递 + dedup 重放 + `notification.sent` round-trip 跑真实 `UNIQUE(dedup_key)` / `ON CONFLICT DO NOTHING` / 扩展后的 CHECK;**收件人硬拒(非成员)→ 什么都不写**;**§2 硬审计回滚 = 真实事务回滚**(审计抛错 → 通知行确实消失 → 唯有实库能证明,mock 无法回滚自身状态)。mock 无法验证错误列名 / 缺约束 / 被 CHECK 拒的行,实库测试是唯一兜底。
+
+## 8. 排除矩阵(沿用 B1-S0 §2)
+
+本 PR 不动 §2 value-field 排除矩阵 —— `send_notification` 仍是"无值字段 + 点击执行",所有消费字段值的路径继续显式排除 button。

--- a/packages/core-backend/src/db/migrations/zzzz20260616120000_add_meta_record_subscription_notification_message.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260616120000_add_meta_record_subscription_notification_message.ts
@@ -1,0 +1,76 @@
+/**
+ * Migration: B1-S1 D0-A — make the Notification Center sink carry a durable
+ * `send_notification` button delivery.
+ *
+ * Two changes to meta_record_subscription_notifications:
+ *  1) add a nullable `message text` column (the custom notification body; NULL on
+ *     the watcher events record.updated / comment.created).
+ *  2) widen the event_type CHECK to admit `notification.sent` alongside the two
+ *     existing watcher types.
+ *
+ * The original CHECK (zzzz20260505103000) was declared INLINE/unnamed, so Postgres
+ * auto-named it `<table>_<column>_check`. We drop that auto-name AND any prior run
+ * of our named constraint (idempotent), then re-add a NAMED constraint so future
+ * widenings are stable.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+const AUTO_CHECK_NAME = 'meta_record_subscription_notifications_event_type_check'
+const NAMED_CHECK_NAME = 'chk_meta_record_subscription_notifications_event_type'
+
+const EVENT_TYPES_WITH_NOTIFICATION_SENT = ['record.updated', 'comment.created', 'notification.sent'] as const
+const EVENT_TYPES_WATCHER_ONLY = ['record.updated', 'comment.created'] as const
+
+function quoted(values: readonly string[]): string {
+  return values.map((value) => `'${value}'`).join(', ')
+}
+
+async function replaceEventTypeCheck(db: Kysely<unknown>, values: readonly string[]): Promise<void> {
+  // Drop BOTH the auto-named (original inline) and our named constraint so up/down
+  // are idempotent regardless of which is currently present.
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications DROP CONSTRAINT IF EXISTS ${AUTO_CHECK_NAME}`,
+  ).execute(db)
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications DROP CONSTRAINT IF EXISTS ${NAMED_CHECK_NAME}`,
+  ).execute(db)
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications
+     ADD CONSTRAINT ${NAMED_CHECK_NAME}
+     CHECK (event_type IN (${quoted(values)}))`,
+  ).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE meta_record_subscription_notifications
+    ADD COLUMN IF NOT EXISTS message text
+  `.execute(db)
+  await replaceEventTypeCheck(db, EVENT_TYPES_WITH_NOTIFICATION_SENT)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Narrow the CHECK back to watcher-only. Rebuild under the original AUTO name so
+  // the schema matches the pre-migration shape. (Any notification.sent rows must
+  // be removed first or the ADD CONSTRAINT would fail — defensive cleanup.)
+  await sql`
+    DELETE FROM meta_record_subscription_notifications
+    WHERE event_type = 'notification.sent'
+  `.execute(db)
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications DROP CONSTRAINT IF EXISTS ${NAMED_CHECK_NAME}`,
+  ).execute(db)
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications DROP CONSTRAINT IF EXISTS ${AUTO_CHECK_NAME}`,
+  ).execute(db)
+  await sql.raw(
+    `ALTER TABLE meta_record_subscription_notifications
+     ADD CONSTRAINT ${AUTO_CHECK_NAME}
+     CHECK (event_type IN (${quoted(EVENT_TYPES_WATCHER_ONLY)}))`,
+  ).execute(db)
+  await sql`
+    ALTER TABLE meta_record_subscription_notifications
+    DROP COLUMN IF EXISTS message
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260616121000_create_multitable_button_run_dedup.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260616121000_create_multitable_button_run_dedup.ts
@@ -1,0 +1,43 @@
+/**
+ * Migration: B1-S1 D0-A §6 — at-most-once dedup marker for side-effecting button
+ * runs (send_notification).
+ *
+ * A side-effecting button REQUIRES a requestId. The dedup key
+ * (actor + sheet + record + field + requestId) is persisted BEFORE the
+ * notification write via `INSERT ... ON CONFLICT (dedup_key) DO NOTHING`; a
+ * replay collapses to a no-op (single effect). The UNIQUE constraint is the
+ * atomic guard (no read-then-write race).
+ *
+ * `record_click` (inert) does NOT require a requestId and is never recorded here.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS multitable_button_run_dedup (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      dedup_key text NOT NULL UNIQUE,
+      actor_id text NOT NULL,
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      field_id text NOT NULL,
+      request_id text NOT NULL,
+      execution_id text,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  // Retention sweep anchor (the cleanup job prunes old markers by age).
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_multitable_button_run_dedup_created
+    ON multitable_button_run_dedup(created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_multitable_button_run_dedup_created`.execute(db)
+  await sql`DROP TABLE IF EXISTS multitable_button_run_dedup`.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -2349,7 +2349,15 @@ export class AutomationExecutor {
     }
 
     try {
-      // Emit notification event — CollabService or other handler picks this up
+      // Emit notification event — CollabService or other handler picks this up.
+      //
+      // B1-S1 D0-A SCOPE NOTE: the DURABLE notification write does NOT live here. A
+      // button's durable Notification-Center delivery is a route-level dedicated
+      // side-effect transaction (see routes/multitable-button.ts) so it composes
+      // with the run's dedup + audit as one all-or-nothing unit. The automation-RULE
+      // path stays eventBus-only here — adding durable writes / member-filter / dedup
+      // to the shared executor would expand automation's behavior surface, which is
+      // out of scope for a button slice.
       this.deps.eventBus.emit('automation.notification', {
         userIds,
         message,

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -11,6 +11,12 @@ import { AUTOMATION_EXECUTION_SCHEMA_VERSION } from './automation-executor'
 import type { AutomationExecution, AutomationStepResult } from './automation-executor'
 import { redactString, redactValue } from './automation-log-redact'
 
+/** Minimal query surface a transaction client satisfies (pg `QueryResult` shape). */
+export type ExecutionLogQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
 export interface AutomationStats {
   total: number
   success: number
@@ -46,6 +52,55 @@ export class AutomationLogService {
         initiated_by: execution.initiatedBy ?? null,
       })
       .execute()
+  }
+
+  /**
+   * Record an execution log on a CALLER-SUPPLIED query client (B1-S1 D0-A).
+   *
+   * Same redaction as `record()` — it scrubs the SAME four secret channels (steps /
+   * trigger_event / rule_snapshot / error) via the SAME `redactValue`/`redactString`
+   * helpers, so the redaction CANNOT drift from the kysely path. The difference is
+   * ONLY the execution channel: the INSERT runs on the passed client (a transaction
+   * client) so the audit row commits or rolls back atomically WITH the side effect
+   * it audits. The button route uses this to make the audit a HARD precondition (a
+   * failed audit rolls back the notification write — no "sent but unaudited" state).
+   *
+   * NOTE: it does NOT route through `toPersistedExecutionValues` because that wraps
+   * the jsonb values in kysely `RawBuilder`s (for `.values()` interpolation), which
+   * `JSON.stringify` cannot serialize — it would persist empty `{}` content. Here
+   * the jsonb columns are the redacted PLAIN values passed as `JSON.stringify(...)`
+   * text + `$n::jsonb` casts (node-postgres would otherwise coerce a JS array to a
+   * PostgreSQL array literal).
+   */
+  async recordWithQuery(query: ExecutionLogQueryFn, execution: AutomationExecution): Promise<void> {
+    await query(
+      `INSERT INTO multitable_automation_executions (
+         id, rule_id, triggered_by, triggered_at, status, steps, error, duration,
+         sheet_id, trigger_event, rule_snapshot, finished_at, schema_version,
+         rerun_of_execution_id, initiated_by
+       ) VALUES (
+         $1, $2, $3, $4, $5, $6::jsonb, $7, $8,
+         $9, $10::jsonb, $11::jsonb, $12, $13,
+         $14, $15
+       )`,
+      [
+        execution.id,
+        execution.ruleId,
+        execution.triggeredBy,
+        execution.triggeredAt,
+        execution.status,
+        JSON.stringify(redactValue(execution.steps)),
+        execution.error != null ? redactString(execution.error) : null,
+        execution.duration ?? null,
+        execution.sheetId ?? null,
+        execution.triggerEvent == null ? null : JSON.stringify(redactValue(execution.triggerEvent)),
+        execution.ruleSnapshot == null ? null : JSON.stringify(redactValue(execution.ruleSnapshot)),
+        execution.finishedAt ?? null,
+        execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
+        execution.rerunOfExecutionId ?? null,
+        execution.initiatedBy ?? null,
+      ],
+    )
   }
 
   /**
@@ -91,11 +146,16 @@ export class AutomationLogService {
 
   /**
    * Get recent executions across all rules, newest first.
+   *
+   * EXCLUDES triggered_by='button' rows (B1-S1 D0-A §6): a button run is a
+   * record-scoped side effect, NOT a rule execution, so it must not pollute the
+   * DF-N1 rule-monitoring stream. It remains retrievable by getById for audit.
    */
   async getRecent(limit = 50): Promise<AutomationExecution[]> {
     const rows = await db
       .selectFrom('multitable_automation_executions')
       .selectAll()
+      .where('triggered_by', '!=', 'button')
       .orderBy('created_at', 'desc')
       .limit(limit)
       .execute()
@@ -113,6 +173,10 @@ export class AutomationLogService {
   ): Promise<AutomationExecution[]> {
     const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
     let q = db.selectFrom('multitable_automation_executions').selectAll()
+    // EXCLUDE triggered_by='button' (B1-S1 D0-A §6) — button runs are record-scoped
+    // side effects, not rule executions; they stay out of the rule-monitoring reads
+    // but remain retrievable by getById.
+    q = q.where('triggered_by', '!=', 'button')
     if (filters.sheetId) q = q.where('sheet_id', '=', filters.sheetId)
     if (filters.ruleId) q = q.where('rule_id', '=', filters.ruleId)
     if (filters.status) q = q.where('status', '=', filters.status)

--- a/packages/core-backend/src/multitable/record-subscription-service.ts
+++ b/packages/core-backend/src/multitable/record-subscription-service.ts
@@ -6,7 +6,11 @@ export type QueryFn = (
   params?: unknown[],
 ) => Promise<{ rows: unknown[]; rowCount?: number | null }>
 
-export type RecordSubscriptionEventType = 'record.updated' | 'comment.created'
+// B1-S1 D0-A: `notification.sent` joins the two watcher event types. It is the
+// durable in-app notification produced by a side-effecting `send_notification`
+// button action (recipient-validated server-side at dispatch). The two watcher
+// types stay untouched (no regression).
+export type RecordSubscriptionEventType = 'record.updated' | 'comment.created' | 'notification.sent'
 
 export interface RecordSubscription {
   id: string
@@ -26,6 +30,8 @@ export interface RecordSubscriptionNotification {
   actorId: string | null
   revisionId: string | null
   commentId: string | null
+  /** Custom message body — populated for `notification.sent`; NULL for watcher events. */
+  message: string | null
   createdAt: string
   readAt: string | null
 }
@@ -37,6 +43,95 @@ export interface NotifyRecordSubscribersInput {
   actorId?: string | null
   revisionId?: string | null
   commentId?: string | null
+}
+
+/**
+ * Explicit-recipient INSERT seam (B1-S1 D0-A). Extracted from
+ * `notifyRecordSubscribers` so the durable notification write has ONE home that
+ * both the watcher path (recipients derived from subscriptions) and the
+ * side-effecting button/rule path (recipients supplied + server-validated) share
+ * — no parallel INSERT.
+ *
+ * Faithful SUPERSET of the watcher INSERT: it still carries `revisionId`/
+ * `commentId` so re-pointing `notifyRecordSubscribers` to it does NOT regress the
+ * watcher rows (record.updated → revision_id; the comment.created path uses the
+ * Kysely variant, untouched). `message` is the only NEW column, NULL on the
+ * watcher path.
+ *
+ * RECIPIENTS ARE NOT AUTHORIZED HERE — the caller owns recipient policy (the
+ * button route member-filters before dispatch). This seam writes exactly what it
+ * is handed.
+ */
+export interface InsertRecordSubscriptionNotificationsInput {
+  userIds: string[]
+  sheetId: string
+  recordId?: string | null
+  eventType: RecordSubscriptionEventType
+  message?: string | null
+  actorId?: string | null
+  revisionId?: string | null
+  commentId?: string | null
+}
+
+export async function insertRecordSubscriptionNotifications(
+  query: QueryFn,
+  input: InsertRecordSubscriptionNotificationsInput,
+): Promise<{ inserted: number }> {
+  const userIds = input.userIds
+    .map((userId) => (typeof userId === 'string' ? userId.trim() : ''))
+    .filter((userId) => userId.length > 0)
+  if (userIds.length === 0) return { inserted: 0 }
+
+  const recordId = input.recordId ?? ''
+  const values = userIds.map((userId) => ({
+    id: randomUUID(),
+    sheet_id: input.sheetId,
+    record_id: recordId,
+    user_id: userId,
+    event_type: input.eventType,
+    actor_id: input.actorId ?? null,
+    revision_id: input.revisionId ?? null,
+    comment_id: input.commentId ?? null,
+    message: input.message ?? null,
+  }))
+
+  await query(
+    `INSERT INTO meta_record_subscription_notifications (
+       id,
+       sheet_id,
+       record_id,
+       user_id,
+       event_type,
+       actor_id,
+       revision_id,
+       comment_id,
+       message
+     )
+     SELECT
+       item.id::uuid,
+       item.sheet_id,
+       item.record_id,
+       item.user_id,
+       item.event_type,
+       item.actor_id,
+       item.revision_id::uuid,
+       item.comment_id,
+       item.message
+     FROM jsonb_to_recordset($1::jsonb) AS item(
+       id text,
+       sheet_id text,
+       record_id text,
+       user_id text,
+       event_type text,
+       actor_id text,
+       revision_id text,
+       comment_id text,
+       message text
+     )`,
+    [JSON.stringify(values)],
+  )
+
+  return { inserted: userIds.length }
 }
 
 export async function subscribeRecord(
@@ -115,60 +210,20 @@ export async function notifyRecordSubscribers(
 
   if (userIds.length === 0) return { inserted: 0, userIds: [] }
 
-  const values = userIds.map((userId) => ({
-    id: randomUUID(),
+  // Re-pointed onto the shared writer seam (B1-S1 D0-A). Watcher events never
+  // carry a `message`, so it stays NULL — revision_id/comment_id round-trip
+  // exactly as before (no regression).
+  const { inserted } = await insertRecordSubscriptionNotifications(query, {
+    userIds,
     sheetId: input.sheetId,
     recordId: input.recordId,
-    userId,
     eventType: input.eventType,
     actorId: input.actorId ?? null,
     revisionId: input.revisionId ?? null,
     commentId: input.commentId ?? null,
-  }))
+  })
 
-  await query(
-    `INSERT INTO meta_record_subscription_notifications (
-       id,
-       sheet_id,
-       record_id,
-       user_id,
-       event_type,
-       actor_id,
-       revision_id,
-       comment_id
-     )
-     SELECT
-       item.id::uuid,
-       item.sheet_id,
-       item.record_id,
-       item.user_id,
-       item.event_type,
-       item.actor_id,
-       item.revision_id::uuid,
-       item.comment_id
-     FROM jsonb_to_recordset($1::jsonb) AS item(
-       id text,
-       sheet_id text,
-       record_id text,
-       user_id text,
-       event_type text,
-       actor_id text,
-       revision_id text,
-       comment_id text
-     )`,
-    [JSON.stringify(values.map((item) => ({
-      id: item.id,
-      sheet_id: item.sheetId,
-      record_id: item.recordId,
-      user_id: item.userId,
-      event_type: item.eventType,
-      actor_id: item.actorId,
-      revision_id: item.revisionId,
-      comment_id: item.commentId,
-    })))],
-  )
-
-  return { inserted: userIds.length, userIds }
+  return { inserted, userIds }
 }
 
 export async function notifyRecordSubscribersBestEffort(
@@ -246,7 +301,7 @@ export async function listRecordSubscriptionNotifications(
     filters.push(`record_id = $${params.length}`)
   }
   const result = await query(
-    `SELECT id, sheet_id, record_id, user_id, event_type, actor_id, revision_id, comment_id, created_at, read_at
+    `SELECT id, sheet_id, record_id, user_id, event_type, actor_id, revision_id, comment_id, message, created_at, read_at
      FROM meta_record_subscription_notifications
      WHERE ${filters.join(' AND ')}
      ORDER BY created_at DESC, id DESC
@@ -321,13 +376,22 @@ function serializeNotification(row: Record<string, unknown>): RecordSubscription
     sheetId: String(row.sheet_id),
     recordId: String(row.record_id),
     userId: String(row.user_id),
-    eventType: row.event_type === 'comment.created' ? 'comment.created' : 'record.updated',
+    // Map ALL three known types — coercing an unknown value to record.updated
+    // would silently mislabel a notification.sent row and hide its message.
+    eventType: normalizeEventType(row.event_type),
     actorId: typeof row.actor_id === 'string' ? row.actor_id : null,
     revisionId: typeof row.revision_id === 'string' ? row.revision_id : null,
     commentId: typeof row.comment_id === 'string' ? row.comment_id : null,
+    message: typeof row.message === 'string' ? row.message : null,
     createdAt: serializeTime(row.created_at),
     readAt: row.read_at === null || row.read_at === undefined ? null : serializeTime(row.read_at),
   }
+}
+
+function normalizeEventType(value: unknown): RecordSubscriptionEventType {
+  if (value === 'comment.created') return 'comment.created'
+  if (value === 'notification.sent') return 'notification.sent'
+  return 'record.updated'
 }
 
 function serializeTime(value: unknown): string {

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -1,5 +1,5 @@
 /**
- * Multitable BUTTON field run route (B1-a1).
+ * Multitable BUTTON field run route (B1-a1 → B1-S1 D0-A).
  *
  * POST /sheets/:sheetId/records/:recordId/fields/:fieldId/button/run
  *
@@ -9,10 +9,27 @@
  *
  * Security (design-lock #2645): VISIBILITY != EXECUTABILITY. Seeing a button
  * requires the field to be visible; RUNNING it re-evaluates the action's own
- * gate server-side, as the actor, at dispatch. B1-a1 enables ONLY the
- * executor-owned INERT `record_click` action (gate = record-readable); real
- * actions (update_record / send_webhook / ...) are gated follow-ups, each of
- * which must add its own per-action actor gate before being enabled here.
+ * gate server-side, as the actor, at dispatch.
+ *
+ * B1-S1 D0-A enables the FIRST side-effecting action: `send_notification`. It
+ * writes a DURABLE in-app notification (Notification Center sink) to recipients
+ * that are SERVER-VALIDATED against the sheet member set at dispatch (§3.1, the
+ * #1 control). Side-effecting actions REQUIRE a requestId, REQUIRE server-side
+ * confirmation when the button declares confirm.enabled, and HARD-REJECT the
+ * whole run if ANY configured recipient is not a member.
+ *
+ * The durable delivery is a ROUTE-LEVEL DEDICATED SIDE-EFFECT TRANSACTION (it does
+ * NOT live in the shared AutomationExecutor). All-succeed-or-all-fail in ONE DB
+ * transaction, in this order:
+ *   server-confirm gate → actor edit gate → recipient hard-reject → dedup
+ *     → notification rows → audit row.
+ * The no-write validation (confirm / actor / recipient) runs BEFORE the
+ * transaction opens, so a rejected run writes NOTHING (no notification, no audit,
+ * no dedup marker — the requestId is NOT consumed and a later valid retry with the
+ * same requestId still sends once). dedup + notification + audit then commit
+ * together; if the audit insert fails, the WHOLE run rolls back (fail-closed — no
+ * "sent but unaudited" state). The inert `record_click` stays read-gated,
+ * requestId-optional, and OFF this transactional path.
  */
 
 import { Router, type Request, type Response } from 'express'
@@ -22,30 +39,72 @@ import { buildRecordPatchContext, requireRecordReadable } from './univer-meta'
 import { type ConnectionPool, type QueryFn } from '../multitable/record-write-service'
 import { poolManager } from '../integration/db/connection-pool'
 import { eventBus } from '../integration/events/event-bus'
-import { AutomationExecutor, type ExecutionContext } from '../multitable/automation-executor'
+import {
+  AutomationExecutor,
+  AUTOMATION_EXECUTION_SCHEMA_VERSION,
+  type AutomationExecution,
+  type AutomationStepResult,
+  type ExecutionContext,
+} from '../multitable/automation-executor'
+import type { AutomationActionType } from '../multitable/automation-actions'
+import { AutomationLogService } from '../multitable/automation-log-service'
+import { loadSheetMemberUserIdSet } from '../multitable/permission-service'
+import { insertRecordSubscriptionNotifications } from '../multitable/record-subscription-service'
 import { normalizeJson } from '../multitable/field-codecs'
 import { Logger } from '../core/logger'
 
 type PoolLike = ConnectionPool & { query: QueryFn }
 const logger = new Logger('MultitableButton')
 
-// B1-a1 enables ONLY the executor-owned INERT action from a button click. Real
-// actions are gated follow-ups: each needs its own actor-permission mapping at
-// dispatch (e.g. update_record -> canEditRecord) before it can be enabled here.
-const ENABLED_BUTTON_ACTIONS = new Set<string>(['record_click'])
+// B1-S1 D0-A enabled actions. `record_click` = executor-owned INERT (read-gated,
+// requestId-optional, NO confirm). `send_notification` = first side-effecting
+// action (edit-gated proxy, durable + deduped + audited in one route transaction).
+// Every new action must declare its actor gate AND whether it is side-effecting —
+// a single `sideEffecting` flag drives BOTH the requestId requirement (§6 dedup)
+// AND the server-side confirm requirement (§4): a side-effecting action whose
+// button declares confirm.enabled MUST be confirmed by the server, not just the FE.
+type ButtonActorGate = 'read' | 'edit'
+interface ButtonActionPolicy {
+  /** Actor permission required to RUN this action (server-evaluated at dispatch). */
+  gate: ButtonActorGate
+  /**
+   * Side-effecting actions REQUIRE a requestId (§6 at-most-once) AND, when the
+   * button declares confirm.enabled, REQUIRE `confirmed === true` from the server
+   * (§4 — the FE confirm dialog is an affordance, the server is the gate). Inert
+   * actions are neither.
+   */
+  sideEffecting: boolean
+  /** The executor action dispatched for this button click. */
+  dispatchType: AutomationActionType
+}
+
+const BUTTON_ACTION_POLICIES: Record<string, ButtonActionPolicy> = {
+  record_click: { gate: 'read', sideEffecting: false, dispatchType: 'record_click' },
+  send_notification: { gate: 'edit', sideEffecting: true, dispatchType: 'send_notification' },
+}
 
 export function createMultitableButtonRoutes(): Router {
   const router = Router()
+  const logService = new AutomationLogService()
 
   router.post('/sheets/:sheetId/records/:recordId/fields/:fieldId/button/run', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     const fieldId = typeof req.params.fieldId === 'string' ? req.params.fieldId.trim() : ''
-    const parsed = z.object({ requestId: z.string().min(1).max(100).optional() }).safeParse(req.body ?? {})
+    const parsed = z
+      .object({
+        requestId: z.string().min(1).max(100).optional(),
+        // §4 server-confirm: a side-effecting button with confirm.enabled requires
+        // confirmed===true. FE-only window.confirm is bypassable by a direct POST,
+        // so the server is the gate.
+        confirmed: z.boolean().optional(),
+      })
+      .safeParse(req.body ?? {})
     if (!sheetId || !recordId || !fieldId || !parsed.success) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, recordId, fieldId are required' } })
     }
     const requestId = parsed.data.requestId
+    const confirmed = parsed.data.confirmed === true
 
     try {
       const pool = poolManager.get() as unknown as PoolLike
@@ -82,13 +141,143 @@ export function createMultitableButtonRoutes(): Router {
       if (!actionType) {
         return res.status(400).json({ ok: false, error: { code: 'BUTTON_NOT_CONFIGURED', message: 'Button has no actionType configured' } })
       }
-      if (!ENABLED_BUTTON_ACTIONS.has(actionType)) {
-        // Real action types are not yet enabled from a button (B1-a1 ships the inert action only).
+      const policy = BUTTON_ACTION_POLICIES[actionType]
+      if (!policy) {
+        // Real action types are enabled one-by-one (each needs its own gate + policy).
         return res.status(400).json({ ok: false, error: { code: 'BUTTON_ACTION_NOT_ENABLED', message: `Button action not yet enabled: ${actionType}` } })
       }
 
-      // 3) Dispatch through the SAME executor path as a rule trigger (no parallel path).
+      // §4 SERVER-CONFIRM GATE (no-write). If the button declares confirm.enabled
+      // AND the action is side-effecting, the server REQUIRES confirmed===true.
+      // FE-only window.confirm is bypassable by a direct POST, so this is a SERVER
+      // behavior: no-confirm → no write (no notification, no audit, no dedup). The
+      // FE confirm dialog still runs (it sends confirmed:true), but is not the gate.
+      const confirmConfig = normalizeJson(property.confirm)
+      const confirmEnabled = confirmConfig.enabled === true
+      if (policy.sideEffecting && confirmEnabled && !confirmed) {
+        return res.status(400).json({ ok: false, error: { code: 'CONFIRMATION_REQUIRED', message: 'This action requires confirmation' } })
+      }
+
+      // §3 ACTOR GATE (per-action). record_click = read (already passed above).
+      // send_notification = canEditRecord (PROVISIONAL proxy — a side-effecting
+      // button delivering a notification is gated as a record-edit-class action
+      // until a dedicated per-action permission exists; see design-lock §3).
+      if (policy.gate === 'edit' && !capabilities.canEditRecord) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+      }
+
+      // §6 IDEMPOTENCY: side-effecting actions REQUIRE a requestId.
+      if (policy.sideEffecting && !requestId) {
+        return res.status(400).json({ ok: false, error: { code: 'REQUEST_ID_REQUIRED', message: 'requestId is required for this action' } })
+      }
+
       const executionId = `axe_btn_${randomUUID()}`
+
+      // ── send_notification dispatch (B1-S1 D0-A) ─────────────────────────────
+      // Route-level DEDICATED SIDE-EFFECT TRANSACTION. No-write validation first
+      // (recipient hard-reject), then one all-or-nothing DB transaction:
+      //   dedup → notification rows → audit row.
+      if (actionType === 'send_notification') {
+        const actorId = access.userId
+        const requestIdValue = requestId as string // §6 requestId already required above.
+
+        const actionConfig = normalizeJson(property.actionConfig)
+        const requestedUserIds = Array.from(new Set(
+          (Array.isArray(actionConfig.userIds) ? actionConfig.userIds : [])
+            .filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
+            .map((u) => u.trim()),
+        ))
+        const message = typeof actionConfig.message === 'string' ? actionConfig.message.trim() : ''
+
+        // §3.1 RECIPIENT HARD-REJECT (the #1 control, NO write). config.userIds MUST
+        // ALL be sheet members. If ANY configured recipient is not a member, REJECT
+        // the entire run (validation-failed) and write NOTHING — no silent partial
+        // delivery. Reuses the SAME member set the Person field write-validator uses
+        // (single resolver, no drift). This runs BEFORE the transaction so a rejected
+        // run never consumes the requestId.
+        if (requestedUserIds.length === 0) {
+          return res.status(400).json({ ok: false, error: { code: 'NO_RECIPIENTS', message: 'No recipients configured' } })
+        }
+        if (!message) {
+          return res.status(400).json({ ok: false, error: { code: 'MESSAGE_REQUIRED', message: 'Notification message is required' } })
+        }
+        const memberSet = await loadSheetMemberUserIdSet(query, sheetId)
+        const nonMembers = requestedUserIds.filter((u) => !memberSet.has(u))
+        if (nonMembers.length > 0) {
+          return res.status(400).json({
+            ok: false,
+            error: { code: 'RECIPIENT_NOT_AUTHORIZED', message: 'One or more recipients are not members of this sheet' },
+          })
+        }
+
+        // §6 + §4: dedup + notification + audit in ONE transaction (all-or-nothing).
+        // The dedup INSERT inside the transaction means a rolled-back run (e.g. a
+        // failed audit) does NOT consume the requestId — a later retry still sends.
+        // Structured (JSON array) key, NOT a '|'-joined string: requestId is client
+        // input and could contain the delimiter, which would risk a false replay.
+        const dedupKey = JSON.stringify([actorId, sheetId, recordId, fieldId, requestIdValue])
+        const txResult = await pool.transaction<{ deduplicated: boolean; executionId: string }>(async ({ query: txq }) => {
+          const dedup = await txq(
+            `INSERT INTO multitable_button_run_dedup
+               (id, dedup_key, actor_id, sheet_id, record_id, field_id, request_id, execution_id)
+             VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (dedup_key) DO NOTHING`,
+            [randomUUID(), dedupKey, actorId, sheetId, recordId, fieldId, requestIdValue, executionId],
+          )
+          if (Number(dedup.rowCount ?? 0) === 0) {
+            // Replay: a prior run already COMMITTED this effect. Short-circuit with no
+            // second notification and no second audit (single effect, §6). Return the
+            // ORIGINAL committed executionId (it maps to the real audit row) — never the
+            // fresh id generated this request, which would be untraceable.
+            const existing = await txq(
+              `SELECT execution_id FROM multitable_button_run_dedup WHERE dedup_key = $1`,
+              [dedupKey],
+            )
+            const originalExecutionId = (existing.rows[0] as { execution_id?: string } | undefined)?.execution_id ?? executionId
+            return { deduplicated: true, executionId: originalExecutionId }
+          }
+
+          // Durable notification write — the route owns recipient policy (already
+          // hard-rejected above); this seam writes exactly the validated recipients.
+          await insertRecordSubscriptionNotifications(txq, {
+            userIds: requestedUserIds,
+            sheetId,
+            recordId,
+            eventType: 'notification.sent',
+            message,
+            actorId,
+          })
+
+          // §2 HARD DURABLE AUDIT — the redacted triggered_by='button' row is written
+          // on the SAME transaction client. If it throws, the whole transaction rolls
+          // back (notification + dedup released): fail-closed, no "sent but unaudited".
+          const step: AutomationStepResult = {
+            actionType: 'send_notification',
+            status: 'success',
+            output: { notifiedUsers: requestedUserIds.length },
+          }
+          await writeButtonAudit(logService, txq, {
+            executionId, sheetId, fieldId, actorId, requestId: requestIdValue, step,
+          })
+          return { deduplicated: false, executionId }
+        })
+
+        // Post-commit: emit the legacy realtime event so any live in-memory subscriber
+        // still fires. Emitted AFTER commit (never inside the tx) so a rolled-back run
+        // can never emit a phantom notification. Skipped on a replay (no new effect).
+        if (!txResult.deduplicated) {
+          eventBus.emit('automation.notification', { userIds: requestedUserIds, message, sheetId, recordId, actorId })
+        }
+
+        logger.info('[multitable.button.run]', {
+          executionId, sheetId, recordId, fieldId, actionType,
+          actorId, status: 'success', requestId: requestIdValue,
+          recipients: requestedUserIds.length, deduplicated: txResult.deduplicated,
+        })
+        return res.json({ ok: true, data: { status: 'succeeded', executionId: txResult.executionId, ...(txResult.deduplicated ? { deduplicated: true } : {}) } })
+      }
+
+      // ── record_click dispatch (inert) ───────────────────────────────────────
       const context: ExecutionContext = {
         executionId,
         ruleId: `btn_${fieldId}`,
@@ -101,18 +290,20 @@ export function createMultitableButtonRoutes(): Router {
       }
       const executor = new AutomationExecutor({ eventBus, queryFn: query })
       const step = await executor.runSingleAction(
-        { type: 'record_click', config: normalizeJson(property.actionConfig) },
+        { type: policy.dispatchType, config: normalizeJson(property.actionConfig) },
         context,
       )
 
-      // 4) Audit — redacted by construction: only ids + actionType + status are
-      //    logged (never the action config values), so no secret-shaped value leaks.
+      // record_click is INERT: logger-only, NO durable automation-execution row
+      // (design-lock §7/§9, AUDIT-1). Durable audit rows are EXCLUSIVE to
+      // side-effecting actions (the in-transaction audit on the send_notification
+      // path above). Keeping an inert action out of multitable_automation_executions
+      // also keeps the DF-N1 rule-monitoring surface clean.
       logger.info('[multitable.button.run]', {
         executionId, sheetId, recordId, fieldId, actionType,
         actorId: access.userId, status: step.status, requestId,
       })
 
-      // 5) Settle. Errors are NOT swallowed: a failed step surfaces with its message.
       if (step.status === 'success') {
         return res.json({ ok: true, data: { status: 'succeeded', executionId } })
       }
@@ -125,4 +316,52 @@ export function createMultitableButtonRoutes(): Router {
   })
 
   return router
+}
+
+interface ButtonAuditInput {
+  executionId: string
+  sheetId: string
+  fieldId: string
+  actorId: string
+  requestId?: string
+  step: AutomationStepResult
+}
+
+function buildButtonExecution(input: ButtonAuditInput): AutomationExecution {
+  const now = new Date().toISOString()
+  return {
+    id: input.executionId,
+    ruleId: `btn_${input.fieldId}`,
+    triggeredBy: 'button',
+    triggeredAt: now,
+    status: input.step.status === 'success' ? 'success' : input.step.status === 'skipped' ? 'skipped' : 'failed',
+    steps: [input.step],
+    sheetId: input.sheetId,
+    initiatedBy: input.actorId,
+    // requestId is a plain identifier (the §6 idempotency key), kept in the
+    // redacted trigger_event so a run is traceable to its dedup marker.
+    triggerEvent: input.requestId ? { _trigger: 'button', fieldId: input.fieldId, requestId: input.requestId } : { _trigger: 'button', fieldId: input.fieldId },
+    finishedAt: now,
+    schemaVersion: AUTOMATION_EXECUTION_SCHEMA_VERSION,
+  }
+}
+
+/**
+ * §2 HARD DURABLE AUDIT — write a redacted multitable_automation_executions row
+ * with triggered_by='button' (EXPLICIT; never the executor's 'event' default) ON
+ * THE CALLER'S query client. For send_notification this is the SAME transaction
+ * client as the dedup + notification writes, so audit is a HARD precondition: if
+ * this insert fails it THROWS, the transaction rolls back, and the run fails
+ * fail-closed (no "sent but unaudited" state). The action config is NEVER
+ * persisted (only ids + actionType + status ride into the step), and the row is
+ * redacted via the SAME path record() uses (recordWithQuery delegates the value
+ * builder), so no secret-shaped value leaks. Button rows are EXCLUDED from the
+ * rule-monitoring reads (listExecutions/getRecent) but stay retrievable by getById.
+ */
+async function writeButtonAudit(
+  logService: AutomationLogService,
+  query: QueryFn,
+  input: ButtonAuditInput,
+): Promise<void> {
+  await logService.recordWithQuery(query, buildButtonExecution(input))
 }

--- a/packages/core-backend/tests/integration/multitable-button-send-notification.test.ts
+++ b/packages/core-backend/tests/integration/multitable-button-send-notification.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Real-DB integration for B1-S1 D0-A — send_notification button (first
+ * side-effecting button action). Design-lock:
+ * docs/development/multitable-button-side-effect-1-send-notification-designlock-20260616.md
+ *
+ * Exercises the parts a mock pool CANNOT verify (the wire-vs-fixture trap):
+ *  - the real `UNIQUE(dedup_key)` + `ON CONFLICT DO NOTHING` at-most-once guard
+ *  - the real recipient HARD-REJECT (loadSheetMemberUserIdSet against real users):
+ *    ANY non-member rejects the whole run, nothing written
+ *  - a `notification.sent` row surviving the widened event_type CHECK + round-tripping
+ *    its `message` back through the list serializer
+ *  - the durable, in-transaction `triggered_by='button'` audit row
+ *  - the §2 HARD-AUDIT rollback: a failing audit insert rolls back the notification
+ *    (true rollback only provable on a real DB — a mock can't roll back its own state)
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { createMultitableButtonRoutes } from '../../src/routes/multitable-button'
+import { listRecordSubscriptionNotifications } from '../../src/multitable/record-subscription-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_btnsn_${TS}`
+const SHEET_ID = `sheet_btnsn_${TS}`
+const REC_ID = `rec_btnsn_${TS}`
+const FLD_NOTIFY = `fld_btnsn_notify_${TS}` // recipients = members only (delivers)
+const FLD_NOTIFY_BAD = `fld_btnsn_notify_bad_${TS}` // recipients include a non-member (hard-reject)
+const USER_EDITOR = `u_btnsn_editor_${TS}`
+const USER_MEMBER = `u_btnsn_member_${TS}`
+const USER_OUTSIDER = `u_btnsn_outsider_${TS}`
+
+let app: Express
+let actorPerms: string[] = ['multitable:read', 'multitable:write']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const runUrl = `/api/multitable/sheets/${SHEET_ID}/records/${REC_ID}/fields/${FLD_NOTIFY}/button/run`
+const runBadUrl = `/api/multitable/sheets/${SHEET_ID}/records/${REC_ID}/fields/${FLD_NOTIFY_BAD}/button/run`
+
+describeIfDatabase('B1-S1 D0-A send_notification button (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = { id: USER_EDITOR, roles: [], perms: actorPerms }
+      next()
+    })
+    app.use('/api/multitable', createMultitableButtonRoutes())
+
+    // Users: editor + member are multitable-eligible (members); outsider is NOT.
+    const seedUser = (id: string, perms: string[]) =>
+      q(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active, permissions)
+         VALUES ($1,$2,'hash',$3,'user',true,$4::jsonb)
+         ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active, permissions = EXCLUDED.permissions`,
+        [id, `${id}@example.test`, id, JSON.stringify(perms)],
+      )
+    await seedUser(USER_EDITOR, ['multitable:read', 'multitable:write'])
+    await seedUser(USER_MEMBER, ['multitable:read'])
+    await seedUser(USER_OUTSIDER, []) // not multitable-eligible → excluded from member set
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'BtnSN Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'BtnSN Sheet'])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, '{}'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [
+        FLD_NOTIFY, SHEET_ID, 'Notify', 'button',
+        JSON.stringify({
+          actionType: 'send_notification',
+          label: 'Notify',
+          // members-only recipients → delivers.
+          actionConfig: { userIds: [USER_MEMBER], message: 'Ship the release' },
+        }),
+        1,
+      ],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [
+        FLD_NOTIFY_BAD, SHEET_ID, 'NotifyBad', 'button',
+        JSON.stringify({
+          actionType: 'send_notification',
+          label: 'NotifyBad',
+          // member + outsider authored; the outsider must HARD-REJECT the whole run.
+          actionConfig: { userIds: [USER_MEMBER, USER_OUTSIDER], message: 'Ship the release' },
+        }),
+        2,
+      ],
+    )
+  })
+
+  beforeEach(async () => {
+    actorPerms = ['multitable:read', 'multitable:write']
+    // Self-scope every test: clear prior notifications + dedup markers for this sheet so
+    // length/count assertions are exact regardless of test order.
+    await q('DELETE FROM meta_record_subscription_notifications WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM multitable_button_run_dedup WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM multitable_button_run_dedup WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_record_subscription_notifications WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM multitable_automation_executions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[USER_EDITOR, USER_MEMBER, USER_OUTSIDER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('members-only recipients + notification.sent round-trip: member delivered with message', async () => {
+    const res = await request(app).post(runUrl).send({ requestId: `req-deliver-${TS}` })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('succeeded')
+
+    // The member got a durable notification.sent row carrying the message (survives the
+    // widened CHECK + round-trips through the list serializer).
+    const memberInbox = await listRecordSubscriptionNotifications(
+      (sql, params) => poolManager.get().query(sql, params),
+      { userId: USER_MEMBER, sheetId: SHEET_ID },
+    )
+    expect(memberInbox).toHaveLength(1)
+    expect(memberInbox[0]).toMatchObject({ eventType: 'notification.sent', message: 'Ship the release' })
+  })
+
+  test('§3.1 recipient HARD-REJECT: a configured non-member rejects the whole run → 400, NOTHING written', async () => {
+    const requestId = `req-reject-${TS}`
+    const res = await request(app).post(runBadUrl).send({ requestId })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('RECIPIENT_NOT_AUTHORIZED')
+
+    // No notification for ANYONE (the member in the list is NOT delivered to).
+    const memberInbox = await listRecordSubscriptionNotifications(
+      (sql, params) => poolManager.get().query(sql, params),
+      { userId: USER_MEMBER, sheetId: SHEET_ID },
+    )
+    expect(memberInbox).toHaveLength(0)
+    // requestId NOT consumed: no dedup marker, no audit row.
+    const markers = await q('SELECT count(*)::int AS n FROM multitable_button_run_dedup WHERE request_id = $1', [requestId])
+    expect((markers.rows[0] as { n: number }).n).toBe(0)
+  })
+
+  test('§2 HARD AUDIT rollback (real DB): a failing audit insert rolls back the notification — fail-closed', async () => {
+    const { AutomationLogService } = await import('../../src/multitable/automation-log-service')
+    const spy = vi
+      .spyOn(AutomationLogService.prototype, 'recordWithQuery')
+      .mockRejectedValue(new Error('audit boom'))
+    try {
+      const requestId = `req-failclosed-${TS}`
+      const res = await request(app).post(runUrl).send({ requestId })
+      // Fail-closed: the run does NOT report success.
+      expect(res.status).toBe(500)
+      expect(res.body.ok).toBe(false)
+
+      // TRUE rollback: the notification the seam wrote inside the tx is GONE.
+      const memberInbox = await listRecordSubscriptionNotifications(
+        (sql, params) => poolManager.get().query(sql, params),
+        { userId: USER_MEMBER, sheetId: SHEET_ID },
+      )
+      expect(memberInbox).toHaveLength(0)
+      // dedup marker also rolled back → requestId NOT consumed.
+      const markers = await q('SELECT count(*)::int AS n FROM multitable_button_run_dedup WHERE request_id = $1', [requestId])
+      expect((markers.rows[0] as { n: number }).n).toBe(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  test('at-most-once: replaying the same requestId writes the notification only once', async () => {
+    const requestId = `req-dedup-${TS}`
+    const first = await request(app).post(runUrl).send({ requestId })
+    expect(first.status).toBe(200)
+    const replay = await request(app).post(runUrl).send({ requestId })
+    expect(replay.status).toBe(200)
+    expect(replay.body.data.deduplicated).toBe(true)
+
+    // Exactly ONE dedup marker AND exactly ONE notification — single effect despite two
+    // requests (beforeEach self-scopes the sheet, so the count is exact).
+    const markers = await q('SELECT count(*)::int AS n FROM multitable_button_run_dedup WHERE request_id = $1', [requestId])
+    expect((markers.rows[0] as { n: number }).n).toBe(1)
+    const notes = await q(
+      `SELECT count(*)::int AS n FROM meta_record_subscription_notifications
+       WHERE sheet_id = $1 AND user_id = $2 AND event_type = 'notification.sent'`,
+      [SHEET_ID, USER_MEMBER],
+    )
+    expect((notes.rows[0] as { n: number }).n).toBe(1)
+  })
+
+  test('durable audit: triggered_by=button row written, excluded from rule reads, retrievable by id', async () => {
+    const res = await request(app).post(runUrl).send({ requestId: `req-audit-${TS}` })
+    expect(res.status).toBe(200)
+    const executionId = res.body.data.executionId as string
+
+    const row = await q('SELECT triggered_by, status, steps FROM multitable_automation_executions WHERE id = $1', [executionId])
+    expect(row.rows).toHaveLength(1)
+    expect((row.rows[0] as { triggered_by: string }).triggered_by).toBe('button')
+    // The steps jsonb persists the REAL redacted step content — NOT empty {} (guards
+    // against a RawBuilder-stringify regression that would store empty audit content).
+    const persistedSteps = (row.rows[0] as { steps: unknown }).steps
+    const steps = typeof persistedSteps === 'string' ? JSON.parse(persistedSteps) : persistedSteps
+    expect(Array.isArray(steps)).toBe(true)
+    expect(steps[0]).toMatchObject({ actionType: 'send_notification', status: 'success' })
+
+    const { AutomationLogService } = await import('../../src/multitable/automation-log-service')
+    const logService = new AutomationLogService()
+    // getById retrievable; getRecent / listExecutions exclude triggered_by='button'.
+    expect(await logService.getById(executionId)).toBeTruthy()
+    const recent = await logService.getRecent(200)
+    expect(recent.find((e) => e.id === executionId)).toBeUndefined()
+    const listed = await logService.listExecutions({ sheetId: SHEET_ID, limit: 200 })
+    expect(listed.find((e) => e.id === executionId)).toBeUndefined()
+  })
+
+  test('side-effecting action requires a requestId', async () => {
+    const res = await request(app).post(runUrl).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('REQUEST_ID_REQUIRED')
+  })
+
+  test('actor gate: a read-only actor cannot run send_notification', async () => {
+    actorPerms = ['multitable:read']
+    const res = await request(app).post(runUrl).send({ requestId: `req-ro-${TS}` })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-button-routes.test.ts
+++ b/packages/core-backend/tests/unit/multitable-button-routes.test.ts
@@ -15,13 +15,25 @@ const FIELDS = [
   { id: 'fld_btn_webhook', name: 'Hook', type: 'button', property: { actionType: 'send_webhook', actionConfig: {} }, order: 2 },
   { id: 'fld_btn_unconf', name: 'Unconf', type: 'button', property: {}, order: 3 },
   { id: 'fld_text', name: 'Text', type: 'string', property: {}, order: 4 },
+  // B1-S1 D0-A: send_notification buttons. `u_member` / `u_editor` are members; `u_outsider` is NOT.
+  // All-members recipient set (delivers).
+  { id: 'fld_btn_notify', name: 'Notify', type: 'button', property: { actionType: 'send_notification', actionConfig: { userIds: ['u_member'], message: 'Hello team' } }, order: 5 },
+  // Mixed set with a non-member → §3.1 HARD-REJECT (write nothing).
+  { id: 'fld_btn_notify_bad', name: 'NotifyBad', type: 'button', property: { actionType: 'send_notification', actionConfig: { userIds: ['u_member', 'u_outsider'], message: 'Hello team' } }, order: 6 },
+  // confirm.enabled send_notification (server-confirm gate).
+  { id: 'fld_btn_notify_confirm', name: 'NotifyConfirm', type: 'button', property: { actionType: 'send_notification', confirm: { enabled: true, message: 'Send it?' }, actionConfig: { userIds: ['u_member'], message: 'Hello team' } }, order: 7 },
 ]
 
 let currentUser: { id: string; roles: string[]; perms: string[] } | undefined
 let noRecord = false
+let auditInserts = 0
 
 function createMockPool() {
   const query = vi.fn(async (sql: string): Promise<{ rows: any[]; rowCount?: number }> => {
+    if (/INSERT INTO multitable_automation_executions/i.test(sql)) {
+      auditInserts += 1
+      return { rows: [], rowCount: 1 }
+    }
     if (/FROM meta_records WHERE id/i.test(sql)) {
       return noRecord ? { rows: [] } : { rows: [{ id: RECORD_ID, sheet_id: SHEET_ID }] }
     }
@@ -57,7 +69,7 @@ const reader = { id: 'u_read', roles: ['member'], perms: ['multitable:read'] }
 const nonReader = { id: 'u_none', roles: ['member'], perms: ['multitable:comment'] }
 
 describe('B1-a1 button/run route (mock pool)', () => {
-  beforeEach(async () => { currentUser = reader; noRecord = false; app = await buildApp() })
+  beforeEach(async () => { currentUser = reader; noRecord = false; auditInserts = 0; app = await buildApp() })
   afterEach(() => { vi.restoreAllMocks(); currentUser = undefined; noRecord = false })
 
   it('runs an inert record_click button → 200 succeeded', async () => {
@@ -66,6 +78,9 @@ describe('B1-a1 button/run route (mock pool)', () => {
     expect(res.body.ok).toBe(true)
     expect(res.body.data.status).toBe('succeeded')
     expect(res.body.data.executionId).toMatch(/^axe_btn_/)
+    // record_click is INERT: logger-only, NO durable automation-execution row
+    // (design-lock §7/§9, AUDIT-1). Durable rows are exclusive to side-effecting actions.
+    expect(auditInserts).toBe(0)
   })
 
   it('SECURITY: a non-reader cannot execute (403) — visibility != executability', async () => {
@@ -104,5 +119,233 @@ describe('B1-a1 button/run route (mock pool)', () => {
   it('unknown field → 404', async () => {
     const res = await request(app).post(runUrl('fld_missing')).send({})
     expect(res.status).toBe(404)
+  })
+
+  it('record_click stays inert: requestId is OPTIONAL (no requestId → 200)', async () => {
+    const res = await request(app).post(runUrl('fld_btn')).send({})
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('succeeded')
+  })
+})
+
+// ── B1-S1 D0-A: send_notification (first side-effecting button action) ──────────
+// Stateful mock with REAL transaction semantics: the `transaction` wrapper snapshots
+// the in-memory side-effect state and ROLLS IT BACK if the handler throws — so the
+// hard-audit fail-closed assertion ("nothing written") is meaningful, not fake-green.
+// (The real-DB suite is the keystone for true rollback; this unit mirror prevents
+// the route's tx wiring from silently regressing.)
+const editor = { id: 'u_editor', roles: ['member'], perms: ['multitable:write'] }
+const MEMBER_IDS = new Set(['u_member', 'u_editor'])
+
+interface NotifyState {
+  dedupKeys: Set<string>
+  dedupExec: Map<string, string>
+  notificationInserts: any[]
+  auditInserts: any[]
+}
+
+function createNotifyMockPool(state: NotifyState) {
+  const query = vi.fn(async (sql: string, params?: any[]): Promise<{ rows: any[]; rowCount?: number }> => {
+    if (/FROM meta_records WHERE id/i.test(sql)) {
+      return { rows: [{ id: RECORD_ID, sheet_id: SHEET_ID }] }
+    }
+    if (/FROM meta_fields WHERE sheet_id/i.test(sql)) {
+      return { rows: FIELDS.map((f) => ({ ...f })) }
+    }
+    if (/FROM meta_sheets WHERE id/i.test(sql)) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    // Dedup marker insert (§6 at-most-once). UNIQUE(dedup_key): a repeat key inserts 0 rows.
+    if (/INSERT INTO multitable_button_run_dedup/i.test(sql)) {
+      const dedupKey = String(params?.[1] ?? '')
+      if (state.dedupKeys.has(dedupKey)) return { rows: [], rowCount: 0 }
+      state.dedupKeys.add(dedupKey)
+      state.dedupExec.set(dedupKey, String(params?.[7] ?? '')) // $8 = execution_id
+      return { rows: [], rowCount: 1 }
+    }
+    // Replay path resolves the ORIGINAL committed execution id from the dedup row.
+    if (/SELECT execution_id FROM multitable_button_run_dedup/i.test(sql)) {
+      const dedupKey = String(params?.[0] ?? '')
+      const ex = state.dedupExec.get(dedupKey)
+      return { rows: ex ? [{ execution_id: ex }] : [] }
+    }
+    // Member-set resolver (loadSheetMemberUserIdSet → listSheetPermissionCandidates).
+    if (/user_candidates/i.test(sql)) {
+      return {
+        rows: Array.from(MEMBER_IDS).map((id) => ({
+          subject_type: 'user', subject_id: id, user_name: id, user_email: `${id}@x`, user_is_active: true,
+          role_name: null, group_name: null, group_description: null, member_count: null, permission_codes: [],
+        })),
+      }
+    }
+    // Candidate eligibility (loadCandidateUserEligibilityMap): grant members multitable:read.
+    if (/FROM user_permissions/i.test(sql)) {
+      return { rows: Array.from(MEMBER_IDS).map((id) => ({ user_id: id, permission_code: 'multitable:read' })) }
+    }
+    // Durable notification write (the §3.1 effect).
+    if (/INSERT INTO meta_record_subscription_notifications/i.test(sql)) {
+      const payload = JSON.parse(String(params?.[0] ?? '[]'))
+      state.notificationInserts.push(...payload)
+      return { rows: [], rowCount: payload.length }
+    }
+    // Audit row (HARD, in-transaction) — recordWithQuery emits this raw INSERT.
+    // Capture the steps jsonb ($6) too: the row's content must be the REAL redacted
+    // step, not an empty {} (a RawBuilder-stringify bug would persist empty content).
+    if (/INSERT INTO multitable_automation_executions/i.test(sql)) {
+      state.auditInserts.push({
+        id: params?.[0],
+        triggered_by: params?.[2],
+        status: params?.[4],
+        steps: params?.[5],
+      })
+      return { rows: [], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 0 }
+  })
+  // Transaction wrapper with rollback: snapshot mutable state, restore on throw.
+  const transaction = vi.fn(async (fn: (c: { query: typeof query }) => Promise<unknown>) => {
+    const snapDedup = new Set(state.dedupKeys)
+    const snapExec = new Map(state.dedupExec)
+    const snapNotif = state.notificationInserts.length
+    const snapAudit = state.auditInserts.length
+    try {
+      return await fn({ query })
+    } catch (e) {
+      state.dedupKeys = snapDedup
+      state.dedupExec = snapExec
+      state.notificationInserts.length = snapNotif
+      state.auditInserts.length = snapAudit
+      throw e
+    }
+  })
+  return { query, transaction }
+}
+
+describe('B1-S1 D0-A send_notification button (mock pool)', () => {
+  let state: NotifyState
+  let recordWithQuerySpy: ReturnType<typeof vi.spyOn>
+  let notifyApp: Express
+  let createRoutes: () => import('express').Router
+
+  async function buildNotifyApp(asUser: typeof editor) {
+    const built = express()
+    built.use(express.json())
+    built.use((req, _res, next) => { (req as any).user = asUser; next() })
+    built.use('/api/multitable', createRoutes())
+    return built
+  }
+
+  beforeEach(async () => {
+    state = { dedupKeys: new Set(), dedupExec: new Map(), notificationInserts: [], auditInserts: [] }
+    const { poolManager } = await import('../../src/integration/db/connection-pool')
+    const { createMultitableButtonRoutes } = await import('../../src/routes/multitable-button')
+    createRoutes = createMultitableButtonRoutes
+    // recordWithQuery is the in-transaction audit writer — let it run the real raw
+    // INSERT against the mock query (so the §2 hard-audit wiring is exercised end to
+    // end); individual tests re-mock it to simulate an audit failure.
+    vi.spyOn(poolManager, 'get').mockReturnValue(createNotifyMockPool(state) as any)
+    notifyApp = await buildNotifyApp(editor)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  const url = `/api/multitable/sheets/${SHEET_ID}/records/${RECORD_ID}/fields/fld_btn_notify/button/run`
+  const badUrl = `/api/multitable/sheets/${SHEET_ID}/records/${RECORD_ID}/fields/fld_btn_notify_bad/button/run`
+  const confirmUrl = `/api/multitable/sheets/${SHEET_ID}/records/${RECORD_ID}/fields/fld_btn_notify_confirm/button/run`
+
+  it('side-effecting action REQUIRES a requestId → 400 without one (no write)', async () => {
+    const res = await request(notifyApp).post(url).send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('REQUEST_ID_REQUIRED')
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.auditInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+  })
+
+  it('§3 actor gate: a non-editor (read-only) cannot run send_notification → 403 (no write)', async () => {
+    notifyApp = await buildNotifyApp(reader)
+    const res = await request(notifyApp).post(url).send({ requestId: 'req-1' })
+    expect(res.status).toBe(403)
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+  })
+
+  it('§4 server-confirm: confirm.enabled + confirmed omitted → 400 CONFIRMATION_REQUIRED, NOTHING written, requestId NOT consumed', async () => {
+    const res = await request(notifyApp).post(confirmUrl).send({ requestId: 'req-confirm' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('CONFIRMATION_REQUIRED')
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.auditInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+
+    // The SAME requestId later WITH confirmed:true still sends once (not consumed).
+    const retry = await request(notifyApp).post(confirmUrl).send({ requestId: 'req-confirm', confirmed: true })
+    expect(retry.status).toBe(200)
+    expect(retry.body.data.status).toBe('succeeded')
+    expect(retry.body.data.deduplicated).toBeUndefined()
+    expect(state.notificationInserts.filter((r) => r.user_id === 'u_member')).toHaveLength(1)
+  })
+
+  it('§4 server-confirm: confirmed:false is treated as not-confirmed → 400', async () => {
+    const res = await request(notifyApp).post(confirmUrl).send({ requestId: 'req-confirm-f', confirmed: false })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('CONFIRMATION_REQUIRED')
+    expect(state.notificationInserts).toHaveLength(0)
+  })
+
+  it('§3.1 recipient HARD-REJECT: ANY non-member rejects the whole run → 400, NOTHING written', async () => {
+    const res = await request(notifyApp).post(badUrl).send({ requestId: 'req-bad' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('RECIPIENT_NOT_AUTHORIZED')
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.auditInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+  })
+
+  it('all-members recipient set delivers a notification.sent row with the message + writes an audit row', async () => {
+    const res = await request(notifyApp).post(url).send({ requestId: 'req-ok' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('succeeded')
+    expect(state.notificationInserts.map((r) => r.user_id)).toEqual(['u_member'])
+    expect(state.notificationInserts[0]).toEqual(expect.objectContaining({ event_type: 'notification.sent', message: 'Hello team' }))
+    // §2 audit row written in the SAME transaction, triggered_by='button'.
+    expect(state.auditInserts).toHaveLength(1)
+    expect(state.auditInserts[0]).toEqual(expect.objectContaining({ triggered_by: 'button', status: 'success' }))
+    // The steps jsonb persists the REAL redacted step content (NOT an empty {} — a
+    // RawBuilder-stringify bug would silently store empty content and defeat §2).
+    const steps = JSON.parse(String(state.auditInserts[0].steps))
+    expect(steps).toEqual([
+      expect.objectContaining({ actionType: 'send_notification', status: 'success', output: { notifiedUsers: 1 } }),
+    ])
+  })
+
+  it('§6 at-most-once: a duplicate requestId writes the notification ONCE + no second audit', async () => {
+    const first = await request(notifyApp).post(url).send({ requestId: 'req-dup' })
+    expect(first.status).toBe(200)
+    const replay = await request(notifyApp).post(url).send({ requestId: 'req-dup' })
+    expect(replay.status).toBe(200)
+    expect(replay.body.data.deduplicated).toBe(true)
+    expect(state.notificationInserts.filter((r) => r.user_id === 'u_member')).toHaveLength(1)
+    expect(state.auditInserts).toHaveLength(1)
+    // Replay returns the ORIGINAL committed executionId (maps to the real audit row),
+    // not a fresh untraceable one (review Low #3).
+    expect(replay.body.data.executionId).toBe(first.body.data.executionId)
+  })
+
+  it('§2 HARD AUDIT: an audit insert failure ROLLS BACK the notification → fail-closed, NOTHING committed', async () => {
+    const logServiceModule = await import('../../src/multitable/automation-log-service')
+    // Simulate the audit insert failing (recordWithQuery throws). Because audit runs in
+    // the SAME transaction as the notification write, the whole run must roll back.
+    recordWithQuerySpy = vi
+      .spyOn(logServiceModule.AutomationLogService.prototype, 'recordWithQuery')
+      .mockRejectedValue(new Error('audit boom'))
+
+    const res = await request(notifyApp).post(url).send({ requestId: 'req-failclosed' })
+    // Fail-closed: the run does NOT report success.
+    expect(res.status).toBe(500)
+    expect(res.body.ok).toBe(false)
+    // Notification + dedup rolled back (mock transaction restores the snapshot).
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+    expect(recordWithQuerySpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core-backend/tests/unit/record-subscription-service.test.ts
+++ b/packages/core-backend/tests/unit/record-subscription-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   getRecordSubscriptionStatus,
+  insertRecordSubscriptionNotifications,
   listRecordSubscriptionNotifications,
   listRecordSubscriptions,
   notifyRecordSubscribers,
@@ -100,6 +101,66 @@ describe('record-subscription-service', () => {
     expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO meta_record_subscription_notifications'), [
       expect.stringContaining('"event_type":"record.updated"'),
     ])
+    // NO-REGRESS (B1-S1 D0-A writer-seam refactor): the watcher INSERT must still
+    // carry revision_id round-trip AND a NULL message — a count-only assertion would
+    // green-light the regression where the new writer drops revision/comment columns.
+    const insertPayload = JSON.parse((query.mock.calls[1] as unknown[])[1] as string[][0] as unknown as string)
+    expect(insertPayload).toEqual([
+      expect.objectContaining({ user_id: 'watcher_1', event_type: 'record.updated', revision_id: '11111111-1111-1111-1111-111111111111', comment_id: null, message: null }),
+      expect.objectContaining({ user_id: 'watcher_2', event_type: 'record.updated', revision_id: '11111111-1111-1111-1111-111111111111', comment_id: null, message: null }),
+    ])
+  })
+
+  it('insertRecordSubscriptionNotifications writes notification.sent with a custom message', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 2 })
+    const result = await insertRecordSubscriptionNotifications(query, {
+      userIds: ['u1', 'u2'],
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      eventType: 'notification.sent',
+      message: 'Ship it',
+      actorId: 'actor_1',
+    })
+    expect(result).toEqual({ inserted: 2 })
+    const payload = JSON.parse((query.mock.calls[0] as unknown[])[1] as unknown as string[][0] as unknown as string)
+    expect(payload).toEqual([
+      expect.objectContaining({ user_id: 'u1', event_type: 'notification.sent', message: 'Ship it', revision_id: null, comment_id: null }),
+      expect.objectContaining({ user_id: 'u2', event_type: 'notification.sent', message: 'Ship it', revision_id: null, comment_id: null }),
+    ])
+  })
+
+  it('insertRecordSubscriptionNotifications is a no-op for an empty recipient set', async () => {
+    const query = vi.fn()
+    await expect(insertRecordSubscriptionNotifications(query, {
+      userIds: [],
+      sheetId: 'sheet_1',
+      eventType: 'notification.sent',
+      message: 'x',
+    })).resolves.toEqual({ inserted: 0 })
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('serializes a notification.sent row WITH its message (no coercion to record.updated)', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{
+        id: 'note_sent',
+        sheet_id: 'sheet_1',
+        record_id: 'rec_1',
+        user_id: 'user_1',
+        event_type: 'notification.sent',
+        actor_id: 'actor_1',
+        revision_id: null,
+        comment_id: null,
+        message: 'Custom body',
+        created_at: '2026-06-16T00:00:00.000Z',
+        read_at: null,
+      }],
+    })
+    await expect(listRecordSubscriptionNotifications(query, { userId: 'user_1' })).resolves.toEqual([
+      expect.objectContaining({ id: 'note_sent', eventType: 'notification.sent', message: 'Custom body' }),
+    ])
+    // The list SELECT must include the `message` column or the row's body is lost.
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('message'), expect.anything())
   })
 
   it('keeps watcher notification enqueue best-effort for write paths', async () => {


### PR DESCRIPTION
## B1-S1 D0-A — `send_notification` as the first side-effecting button action

Delivers a **durable** in-app notification to the Notification Center when a button with `actionType: send_notification` is clicked. Reworked per the owner security review (REQUEST CHANGES) into a **route-level all-or-nothing side-effect transaction**.

### Gate order (multitable-button.ts) — all no-write validation runs BEFORE the txn
1. **Server-enforced confirm** — `confirmed` in the body schema; a side-effecting action whose `confirm.enabled` is true REQUIRES `confirmed===true`, else `400 CONFIRMATION_REQUIRED` writing nothing (FE `window.confirm` is UX only, not the gate).
2. **Actor edit gate** — `send_notification` requires `canEditRecord` (provisional proxy, noted); `403` otherwise.
3. **Recipient hard-reject** — any configured `userId` not in `loadSheetMemberUserIdSet` → `400 RECIPIENT_NOT_AUTHORIZED`, writes nothing (no silent filter-and-send). §3.1 #1 control, server-side.
4. **requestId required** for side-effecting actions.
5. **`pool.transaction` (one client, BEGIN/COMMIT/ROLLBACK):** dedup `INSERT ... ON CONFLICT DO NOTHING` → notification rows → durable audit row, **commit together or roll back together**.

### The 6 review findings — closed
1. ✅ server-enforced confirm (was FE-only/bypassable)
2. ✅ hard audit — `recordWithQuery` on the same txn client; audit-write failure rolls back the notification (fail-closed; no "sent but unaudited"). Fixed an advisor-caught defect: audit `steps` jsonb was serializing to empty `{}` via kysely RawBuilders → now stringifies redacted plain values; tests assert the content round-trips.
3. ✅ executor reverted to eventBus-only for the rule path; durable write lives only in the route (no automation behavior-surface expansion; 224 automation tests green)
4. ✅ dedup moved inside the txn, after validation — a rejected/failed run does **not** consume the requestId
5. ✅ recipient hard-reject (was filter-and-send)
6. ✅ tests: server-confirm-no-write + requestId-not-consumed, dup-requestId-once, unauthorized-recipient-reject, **hard-audit-fail-closed rollback**, audit steps round-trip, record_click inert; FE confirm-cancel=no-dispatch / confirm=dispatch-with-requestId + Bell renders the custom message

### Schema
- migration: nullable `message` column + widened `event_type` CHECK (admits `notification.sent`) on `meta_record_subscription_notifications` (idempotent)
- migration: new `multitable_button_run_dedup` table, `UNIQUE(dedup_key)` for at-most-once

### Tests
Backend tsc 0 errors; full unit sweep 3465/3465 (incl. reworked button-route + audit-rollback + steps-content + executor-revert no-regress). FE 25/25, vue-tsc clean (2 pre-existing unrelated errors in untouched files). Real-DB integration (hard-reject nothing-written, **true audit-fail rollback**, audit steps content, dedup, requestId-required, actor gate) registered in the `plugin-tests.yml` real-DB allowlist (CI-gated; not locally run without DATABASE_URL).

### Notes
- `send_notification` actor gate is `canEditRecord` as a **provisional** proxy until a dedicated per-action permission exists (noted in code + design-lock §3.2).
- Recovery footnote: the first attempt's worktree was lost mid-session to a disk-cleanup mistake; the work was fully recovered + reworked on top. No other work affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)