### PR TITLE
docs(data-source): route release evidence gate

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -43,8 +43,8 @@
 | C3 | incremental / watermark runtime | core done through CI real-DB lock (#2609/#2619/#2625/#2628/#2631); bind-time/index hardening deferred | 避免每次全量读数据库 | 游标漏读 / 重读 / 过滤条件漂移 |
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
-| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 sandbox smoke PASS; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` entity-machine controlled bad-row PASS | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | #2720 core C6 sandbox smoke PASS, read-only subgate PASS, controlled bad-row PASS on package `d8244ee13`; final release evidence package still pending | 交付签收 | C2/C3/C4 exact-release evidence and clean-machine/migration/auth gate still need owner decision/rerun |
+| C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 CLOSED as sandbox smoke PASS; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` entity-machine controlled bad-row PASS | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
+| Release | 总包 + 实体机验收 | #2769 opened for final release evidence package; #2720 C6 sandbox smoke PASS can be cited; C2/C3/C4 exact-release evidence and clean-machine/migration/auth gate still need owner decision/rerun | 交付签收 | 不得把 sandbox C6 PASS 误写成 production/batch authorization |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -425,7 +425,8 @@ TODO:
   - apply is disabled for read-only users and requires an explicit review checkbox.
   - changing pipeline id or scope clears the pending dry-run token/review.
 - [x] C6-5 entity-machine smoke: apply、re-pull、rollback、controlled bad-row。
-  - issue: #2720 `[Data Source] C6 external-write entity-machine smoke gate`.
+  - issue: #2720 `[Data Source] C6 external-write entity-machine smoke gate`，已关闭为
+    C6 sandbox smoke PASS。
   - runbook: `docs/operations/data-source-system-integration-c6-sandbox-smoke-runbook-20260616.md`.
   - release: `multitable-onprem-datasource-c6-ui-20260616-9fb34fd91`.
   - package: `metasheet-multitable-onprem-v2.5.0-datasource-c6-ui-20260616-9fb34fd91`.
@@ -592,6 +593,8 @@ TODO:
     failure plus one clean sibling write, dead-letter/provenance evidence values-free,
     and restored the injection config after the check.
 - [x] issue 上贴 values-free 验收证据（#2720 entity-machine evidence + acceptance reply）。
+- [x] #2720 closed as C6 sandbox external-write smoke PASS after #2767 docs backfill.
+- [x] #2769 opened for the separate release evidence package gate.
 
 交付判据:
 

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -5,10 +5,14 @@ after the C2/C3/C4/C5/C6 implementation slices have landed. This runbook does
 not replace the slice-specific runbooks; it ties them into one values-free
 release evidence package.
 
+Current evidence issue:
+
+- #2769 `[Data Source] Release evidence package gate`
+
 This runbook does not authorize production rollout, batch writes, K3 Save /
 Submit / Audit / BOM, raw SQL, or broad writable database grants. C6 external
 write remains sandbox-only until the C6 smoke gate passes and a separate
-production/batch gate is explicitly opened.
+production/batch gate is explicitly approved and passes its own evidence/signoff.
 
 ## Scope
 
@@ -46,7 +50,7 @@ the corresponding section below and post fresh values-free evidence.
 | C3 incremental/watermark | Runtime and CI real-DB wire locks are landed on main, but no release-package entity-machine incremental/resume smoke is recorded in this runbook. Large-BOM #2425 is related Data Factory C3/C4 evidence, not the SQL watermark/resume release gate. | Section 4 remains required for complete delivery unless an owner explicitly narrows the release scope and uses downgraded wording. Do not cite #2425 as C3 watermark/resume PASS. |
 | C4 UI configuration | Source/object/schema picker, source-field picker, watermark UI, and read-only/source-only boundary UX have landed, but this runbook has no final release-package UI smoke evidence yet. | Section 5 remains required for complete delivery unless exact UI smoke is explicitly deferred with downgraded wording. |
 | C5 K3/MSSQL read-only seam | issue #2670 closed PASS on package `dea391a1`: generic SQL Server smoke and K3 SQL Server executor smoke both passed after operator SQL scope adjustment; no K3 Save/Submit/Audit/BOM, external DB write, raw SQL, credentials, or row values were printed. | May be cited when no C5-relevant package/runtime surface changed after `dea391a1`; otherwise rerun the C5 runbook on the release package. |
-| C6 external write | issue #2720 core sandbox dry-run/apply/re-pull/rollback PASS, read-only dedicated-route PASS, and C6-5c controlled bad-row PASS on package `d8244ee13`. The final pass used the reviewed C6-5b default-off, sandbox-only, server-owned failure-injection seam after real sandbox failure shapes were unavailable. Evidence showed one clean sibling write, one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter/provenance counters, no request-body injection, and injection config restored/disabled after the check. | May be cited as C6 sandbox external-write smoke PASS for release evidence. Production/batch writes remain closed unless a separate production rollout gate is explicitly opened. |
+| C6 external write | issue #2720 is CLOSED/PASS: core sandbox dry-run/apply/re-pull/rollback PASS, read-only dedicated-route PASS, and C6-5c controlled bad-row PASS on package `d8244ee13`. The final pass used the reviewed C6-5b default-off, sandbox-only, server-owned failure-injection seam after real sandbox failure shapes were unavailable. Evidence showed one clean sibling write, one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter/provenance counters, no request-body injection, and injection config restored/disabled after the check. | May be cited as C6 sandbox external-write smoke PASS for release evidence. Production/batch writes remain closed unless a separate production rollout gate is explicitly approved and passes its own evidence/signoff. |
 
 ## Required Inputs
 


### PR DESCRIPTION
## Summary

Docs-only follow-up after #2720 closed and #2769 was opened.

Updates:

- marks #2720 as CLOSED/PASS specifically for the C6 sandbox external-write smoke;
- records #2769 as the separate release evidence package gate;
- keeps C6 sandbox PASS separate from full release signoff;
- tightens production/batch wording so those writes remain closed unless a separate rollout gate is explicitly approved and passes its own evidence/signoff.

## Verification

- `git diff --check`
- GitHub state checked:
  - #2720 CLOSED;
  - #2767 MERGED (`6a359d790`);
  - #2769 OPEN.
- Subagent state/evidence review: no findings.
- Subagent boundary/safety review: findings fixed; re-review `resolved/no findings`.

## Boundaries

- Docs-only.
- No runtime, route, UI, package, migration, K3, production, or batch change.
- Does not authorize production/batch writes.

Closes no issue automatically; #2769 remains the release evidence collection gate.
