### PR TITLE
feat(approval): editable field visibility-rule editor (NOW-lane item 3)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -7,6 +7,8 @@ import type {
   EmptyAssigneePolicy,
   FormField,
   FormFieldType,
+  FormFieldVisibilityOperator,
+  FormFieldVisibilityRule,
   FormOption,
   FormSchema,
   CreateApprovalTemplateRequest,
@@ -27,6 +29,17 @@ export const AUTHORABLE_FIELD_TYPES: AuthorableFieldType[] = [
   'user',
 ]
 
+/**
+ * Editable representation of a `FormFieldVisibilityRule`. `dependsOnFieldId === ''`
+ * means "no rule". `valueText` holds the eq/neq single value, or — for `in` —
+ * newline-separated values; it is unused for isEmpty/notEmpty.
+ */
+export interface FieldVisibilityDraft {
+  dependsOnFieldId: string
+  operator: FormFieldVisibilityOperator
+  valueText: string
+}
+
 export interface FieldAuthoringDraft {
   localId: string
   id: string
@@ -35,6 +48,7 @@ export interface FieldAuthoringDraft {
   required: boolean
   placeholder: string
   optionsText: string
+  visibility: FieldVisibilityDraft
   original?: FormField
 }
 
@@ -77,7 +91,39 @@ export function createEmptyFieldDraft(index = 1): FieldAuthoringDraft {
     required: false,
     placeholder: '',
     optionsText: '',
+    visibility: emptyVisibilityDraft(),
   }
+}
+
+export function emptyVisibilityDraft(): FieldVisibilityDraft {
+  return { dependsOnFieldId: '', operator: 'eq', valueText: '' }
+}
+
+/** Hydrate an editable visibility draft from a stored rule (or blank for none). */
+function visibilityDraftFromRule(rule: FormFieldVisibilityRule | undefined): FieldVisibilityDraft {
+  if (!rule) return emptyVisibilityDraft()
+  const valueText = rule.operator === 'in'
+    ? (rule.values ?? []).map((value) => String(value)).join('\n')
+    : (rule.value === undefined || rule.value === null ? '' : String(rule.value))
+  return { dependsOnFieldId: rule.fieldId, operator: rule.operator, valueText }
+}
+
+/**
+ * Build the emitted `visibilityRule` from the draft, or `undefined` for "no rule".
+ * The editor is authoritative: callers MUST delete a missing rule rather than let
+ * a stale one survive via the `original` spread (see buildFormSchema).
+ */
+function buildVisibilityRule(visibility: FieldVisibilityDraft): FormFieldVisibilityRule | undefined {
+  const fieldId = visibility.dependsOnFieldId.trim()
+  if (!fieldId) return undefined
+  if (visibility.operator === 'in') {
+    const values = visibility.valueText.split('\n').map((line) => line.trim()).filter(Boolean)
+    return { fieldId, operator: 'in', values }
+  }
+  if (visibility.operator === 'isEmpty' || visibility.operator === 'notEmpty') {
+    return { fieldId, operator: visibility.operator }
+  }
+  return { fieldId, operator: visibility.operator, value: visibility.valueText.trim() }
 }
 
 export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
@@ -159,6 +205,7 @@ function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
     required: field.required === true,
     placeholder: field.placeholder ?? '',
     optionsText: formatOptionsText(field.options),
+    visibility: visibilityDraftFromRule(field.visibilityRule),
     original: field,
   }
 }
@@ -352,6 +399,14 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
       } else {
         delete next.options
       }
+      // Editor is authoritative for visibilityRule: emit the built rule, or
+      // delete it so a cleared rule is not resurrected from the `original` spread.
+      const visibilityRule = buildVisibilityRule(field.visibility)
+      if (visibilityRule) {
+        next.visibilityRule = visibilityRule
+      } else {
+        delete next.visibilityRule
+      }
       return next
     }),
   }
@@ -436,6 +491,48 @@ export function validateTemplateDraft(
       }
     }
   })
+  // Mirror the server visibility-rule reject-set (normalizeFormFieldVisibilityRule +
+  // validateFormFieldVisibilityRules): dependency must reference an existing field,
+  // not itself; `in` needs >=1 value; and the dependency graph must be acyclic.
+  const fieldIdSet = new Set(draft.fields.map((field) => field.id.trim()).filter(Boolean))
+  const visibilityDeps = new Map<string, string>()
+  draft.fields.forEach((field) => {
+    const dependsOn = field.visibility.dependsOnFieldId.trim()
+    if (!dependsOn) return
+    const fieldId = field.id.trim()
+    const label = field.label.trim() || fieldId || '(未命名)'
+    if (!fieldIdSet.has(dependsOn)) {
+      errors.push(`字段 ${label} 的显隐依赖字段不存在`)
+      return
+    }
+    if (dependsOn === fieldId) {
+      errors.push(`字段 ${label} 的显隐规则不能依赖自身`)
+      return
+    }
+    if (field.visibility.operator === 'in'
+      && field.visibility.valueText.split('\n').map((line) => line.trim()).filter(Boolean).length === 0) {
+      errors.push(`字段 ${label} 的显隐"包含"规则需要至少一个值`)
+    }
+    if (fieldId) visibilityDeps.set(fieldId, dependsOn)
+  })
+  const cycleState = new Map<string, 0 | 1 | 2>()
+  let cycleReported = false
+  const visitVisibility = (fieldId: string): void => {
+    const state = cycleState.get(fieldId) ?? 0
+    if (state === 1) {
+      if (!cycleReported) {
+        errors.push('字段显隐规则存在循环依赖')
+        cycleReported = true
+      }
+      return
+    }
+    if (state === 2) return
+    cycleState.set(fieldId, 1)
+    const dependsOn = visibilityDeps.get(fieldId)
+    if (dependsOn) visitVisibility(dependsOn)
+    cycleState.set(fieldId, 2)
+  }
+  visibilityDeps.forEach((_dependsOn, fieldId) => visitVisibility(fieldId))
   if (draft.steps.length === 0) errors.push('至少需要一个审批步骤')
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -182,6 +182,62 @@
                 placeholder="每行一个选项，格式：显示名:值"
               />
             </el-form-item>
+            <el-form-item label="显隐规则" class="template-authoring__wide">
+              <div class="template-authoring__visibility">
+                <el-select
+                  v-model="field.visibility.dependsOnFieldId"
+                  :disabled="readOnly"
+                  style="width: 200px"
+                  data-testid="approval-field-visibility-depends"
+                >
+                  <el-option label="无（始终显示）" value="" />
+                  <el-option
+                    v-for="dep in visibilityFieldOptions(field)"
+                    :key="dep.localId"
+                    :label="dep.label"
+                    :value="dep.id"
+                  />
+                </el-select>
+                <template v-if="field.visibility.dependsOnFieldId">
+                  <el-select
+                    v-model="field.visibility.operator"
+                    :disabled="readOnly"
+                    style="width: 130px"
+                    data-testid="approval-field-visibility-operator"
+                  >
+                    <el-option label="等于" value="eq" />
+                    <el-option label="不等于" value="neq" />
+                    <el-option label="包含" value="in" />
+                    <el-option label="为空" value="isEmpty" />
+                    <el-option label="不为空" value="notEmpty" />
+                  </el-select>
+                  <el-input
+                    v-if="field.visibility.operator === 'in'"
+                    v-model="field.visibility.valueText"
+                    :disabled="readOnly"
+                    type="textarea"
+                    :rows="2"
+                    placeholder="每行一个值"
+                    style="width: 240px"
+                    data-testid="approval-field-visibility-values"
+                  />
+                  <el-input
+                    v-else-if="field.visibility.operator === 'eq' || field.visibility.operator === 'neq'"
+                    v-model="field.visibility.valueText"
+                    :disabled="readOnly"
+                    placeholder="比较值"
+                    style="width: 240px"
+                    data-testid="approval-field-visibility-value"
+                  />
+                </template>
+              </div>
+              <div v-if="field.visibility.dependsOnFieldId" class="template-authoring__hint">
+                仅当依赖字段满足条件时才显示本字段。
+                <template v-if="field.visibility.operator === 'eq' || field.visibility.operator === 'neq'">
+                  比较值留空表示「{{ field.visibility.operator === 'eq' ? '等于' : '不等于' }}空值」；要取消规则请把依赖字段设为「无」。
+                </template>
+              </div>
+            </el-form-item>
           </div>
         </div>
       </el-card>
@@ -298,6 +354,7 @@ import {
   draftFromTemplate,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
 
@@ -351,6 +408,13 @@ function removeField(index: number) {
 
 function moveField(index: number, delta: -1 | 1) {
   draft.value.fields = swap(draft.value.fields, index, delta) ?? draft.value.fields
+}
+
+// Visibility-rule depends-on options: other fields that have an id (excludes self).
+function visibilityFieldOptions(current: FieldAuthoringDraft) {
+  return draft.value.fields
+    .filter((field) => field.localId !== current.localId && field.id.trim().length > 0)
+    .map((field) => ({ localId: field.localId, id: field.id.trim(), label: field.label.trim() || field.id.trim() }))
 }
 
 function addStep() {
@@ -522,6 +586,20 @@ onMounted(() => {
 
 .template-authoring__wide {
   grid-column: 1 / -1;
+}
+
+.template-authoring__visibility {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.template-authoring__hint {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary, #909399);
 }
 
 .template-authoring__inline > .el-input {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -311,6 +311,64 @@ describe('approval template authoring helpers', () => {
     expect(errors.some((error) => error.includes('表单用户字段无效'))).toBe(true)
   })
 
+  it('emits an editable visibility rule (eq / in / isEmpty) from the draft', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.fields = [
+      { ...draft.fields[0], id: 'kind', label: '类型', type: 'select', optionsText: 'A:a\nB:b' },
+      { ...draft.fields[0], localId: 'field_2', id: 'reason', label: '原因', type: 'text',
+        visibility: { dependsOnFieldId: 'kind', operator: 'eq', valueText: 'a' } },
+    ]
+    expect(buildFormSchema(draft).fields[1]?.visibilityRule).toEqual({ fieldId: 'kind', operator: 'eq', value: 'a' })
+
+    draft.fields[1].visibility = { dependsOnFieldId: 'kind', operator: 'in', valueText: 'a\nb\n' }
+    expect(buildFormSchema(draft).fields[1]?.visibilityRule).toEqual({ fieldId: 'kind', operator: 'in', values: ['a', 'b'] })
+
+    draft.fields[1].visibility = { dependsOnFieldId: 'kind', operator: 'isEmpty', valueText: 'ignored' }
+    expect(buildFormSchema(draft).fields[1]?.visibilityRule).toEqual({ fieldId: 'kind', operator: 'isEmpty' })
+  })
+
+  it('is authoritative: clearing the rule removes it instead of leaking the original', () => {
+    // buildTemplate's `reviewer` field carries visibilityRule { amount, notEmpty }.
+    const draft = draftFromTemplate(buildTemplate())
+    expect(draft.fields[1].visibility.dependsOnFieldId).toBe('amount')
+    draft.fields[1].visibility = { dependsOnFieldId: '', operator: 'eq', valueText: '' }
+    expect(buildFormSchema(draft).fields[1]?.visibilityRule).toBeUndefined()
+  })
+
+  it('mirrors the server visibility reject-set (existing / self / in-empty / cycle)', () => {
+    const base = () => {
+      const draft = createEmptyTemplateDraft()
+      draft.key = 'k'
+      draft.name = 'n'
+      draft.fields = [
+        { ...draft.fields[0], id: 'a', label: 'A', type: 'text' },
+        { ...draft.fields[0], localId: 'field_2', id: 'b', label: 'B', type: 'text' },
+      ]
+      return draft
+    }
+
+    const missing = base()
+    missing.fields[1].visibility = { dependsOnFieldId: 'nope', operator: 'eq', valueText: 'x' }
+    expect(validateTemplateDraft(missing).some((e) => e.includes('显隐依赖字段不存在'))).toBe(true)
+
+    const self = base()
+    self.fields[1].visibility = { dependsOnFieldId: 'b', operator: 'eq', valueText: 'x' }
+    expect(validateTemplateDraft(self).some((e) => e.includes('不能依赖自身'))).toBe(true)
+
+    const inEmpty = base()
+    inEmpty.fields[1].visibility = { dependsOnFieldId: 'a', operator: 'in', valueText: '  \n ' }
+    expect(validateTemplateDraft(inEmpty).some((e) => e.includes('需要至少一个值'))).toBe(true)
+
+    const cycle = base()
+    cycle.fields[0].visibility = { dependsOnFieldId: 'b', operator: 'eq', valueText: 'x' }
+    cycle.fields[1].visibility = { dependsOnFieldId: 'a', operator: 'eq', valueText: 'y' }
+    expect(validateTemplateDraft(cycle).some((e) => e.includes('循环依赖'))).toBe(true)
+
+    const valid = base()
+    valid.fields[1].visibility = { dependsOnFieldId: 'a', operator: 'eq', valueText: 'x' }
+    expect(validateTemplateDraft(valid).some((e) => e.includes('显隐'))).toBe(false)
+  })
+
   it('builds a create payload with C1 assigneeSources and a deterministic linear graph', () => {
     const draft = createEmptyTemplateDraft()
     draft.key = 'leave'

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -102,6 +102,7 @@ const ElSelect = defineComponent({
     return h('select', {
       value: this.modelValue ?? '',
       disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
       onChange: (event: Event) => {
         const value = (event.target as HTMLSelectElement).value
         this.$emit('update:modelValue', value)
@@ -448,6 +449,58 @@ describe('TemplateAuthoringView', () => {
     expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
     expect(updateTemplateSpy.mock.calls[0]?.[0]).toBe('tpl_1')
     expect((updateTemplateSpy.mock.calls[0]?.[1] as any).name).toBe('费用审批 v2')
+  })
+
+  it('wires the visibility subform through the mounted view into the saved payload', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate()) // fields[1] reviewer depends on `amount` (notEmpty)
+    await mountView()
+    await flushUi()
+
+    const reviewerRow = () => container!.querySelectorAll('[data-testid="approval-template-field-row"]')[1] as HTMLElement
+    const inRow = (testId: string) => reviewerRow().querySelector(`[data-testid="${testId}"]`)
+
+    // hydrated wiring: the depends-on select reflects the stored rule.
+    expect((inRow('approval-field-visibility-depends') as HTMLSelectElement).value).toBe('amount')
+    // there is no value input yet because the stored operator is notEmpty.
+    expect(inRow('approval-field-visibility-value')).toBeNull()
+
+    // switch operator notEmpty -> eq (reveals the value input), then enter a value.
+    const operatorSelect = inRow('approval-field-visibility-operator') as HTMLSelectElement
+    operatorSelect.value = 'eq'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    const valueInput = inRow('approval-field-visibility-value') as HTMLInputElement
+    valueInput.value = '1000'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    expect(payload.formSchema.fields[1].visibilityRule).toEqual({ fieldId: 'amount', operator: 'eq', value: '1000' })
+  })
+
+  it('clearing the dependency in the mounted view drops the rule from the saved payload', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+    await mountView()
+    await flushUi()
+
+    const reviewerRow = container!.querySelectorAll('[data-testid="approval-template-field-row"]')[1] as HTMLElement
+    const dependsSelect = reviewerRow.querySelector('[data-testid="approval-field-visibility-depends"]') as HTMLSelectElement
+    dependsSelect.value = ''
+    dependsSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    expect(payload.formSchema.fields[1].visibilityRule).toBeUndefined()
   })
 
   it('publishes with an explicit allowRevoke policy after saving', async () => {


### PR DESCRIPTION
NOW-lane item 3 of 3 — the one genuine feature (items 1 & 2 were hygiene/tests). **Zero-gate**: it completes the authoring UI over an engine/validation capability that already ships (server-side `FormFieldVisibilityRule` normalize/validate incl. cycle detection is live); no new capability, no backend change.

## Two commits
1. **Data + validation layer** (`b777cf259`)
   - `FieldAuthoringDraft.visibility` editable model (dependsOn / operator / valueText), hydrated from + emitted back to the stored rule.
   - **Anti-leak**: `buildFormSchema` is now *authoritative* for `visibilityRule` — a rule cleared in the editor is deleted, not resurrected from the `original` spread (other unsupported original fields stay preserved).
   - `validateTemplateDraft` mirrors the **server reject-set** exactly: dependency must reference an existing field, not itself; `in` needs ≥1 value; dependency graph must be acyclic.
2. **Authoring subform (UI)**
   - Depends-on `<el-select>` (excludes self; `无（始终显示）` = no rule), operator select, value input shown only for eq/neq + `in`, hidden for isEmpty/notEmpty.
   - Pure presentation; `data-testid`s for future interaction tests.

## Review note addressed
Empty eq/neq value emits `value: ''` (server accepts it). The subform shows a hint making this an explicit "equals empty value" — distinct from clearing the depends-on (which removes the rule).

## Verification
`vue-tsc -b` clean; `approvalTemplateAuthoring.spec.ts` **12/12** — the pre-existing line-255 round-trip stays green (hydrate→emit regression) + new editable-emit / authoritative-clear / server-parity cases; the view mounts with the subform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)