### PR TITLE
fix(multitable): close rollup-filter security/correctness gaps (skipMask bypass + per-type operators + FE aliases)

### DIFF
--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -160,18 +160,25 @@ export function resolveLookupFieldProperty(value: unknown): NormalizedLookupFiel
 export function resolveRollupFieldProperty(value: unknown): NormalizedRollupFieldProperty {
   const property = asRecord(value)
   const aggregation = stringOrNull(property.aggregation ?? property.agg ?? property.function ?? property.rollupFunction)
+  // Align with the backend parser (parseRollupFieldConfig): accept the filters / conditions /
+  // filterConditions aliases and a case-insensitive filterConjunction / conjunction. If the FE only
+  // recognized a subset, an alias-authored rollup would lose its filter — or flip OR→AND — after an
+  // unrelated Field Manager edit re-saved it in the FE's canonical shape.
   const rawFilters = Array.isArray(property.filters)
     ? property.filters
     : Array.isArray(property.conditions)
       ? property.conditions
-      : null
+      : Array.isArray(property.filterConditions)
+        ? property.filterConditions
+        : null
+  const conjunction = String(property.filterConjunction ?? property.conjunction ?? '').trim().toLowerCase()
   return {
     linkFieldId: stringOrNull(property.linkFieldId ?? property.linkedFieldId ?? property.relatedLinkFieldId ?? property.sourceFieldId),
     targetFieldId: stringOrNull(property.targetFieldId ?? property.lookUpTargetFieldId ?? property.lookupTargetFieldId ?? property.lookupFieldId),
     foreignSheetId: stringOrNull(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId),
     aggregation: normalizeRollupAggregation(aggregation),
     ...(rawFilters && rawFilters.length > 0
-      ? { filters: rawFilters, filterConjunction: property.filterConjunction === 'or' ? 'or' : 'and' }
+      ? { filters: rawFilters, filterConjunction: conjunction === 'or' ? 'or' : 'and' }
       : {}),
   }
 }

--- a/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
+++ b/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
@@ -73,4 +73,28 @@ describe('rollup filter condition — opaque FE preservation (slice 3)', () => {
     })
     expect(p.filterConjunction).toBe('and')
   })
+
+  // The backend parser accepts filters/conditions/filterConditions + filterConjunction/conjunction
+  // (case-insensitive). The FE resolver must match, or an alias-authored rollup loses its filter — or
+  // flips OR→AND — when the field manager re-saves in its canonical shape.
+  it('preserves the filterConditions alias (backend parity)', () => {
+    const p = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'count',
+      filterConditions: [{ fieldId: 'f', operator: 'is', value: 'x' }],
+    })
+    expect(p.filters).toEqual([{ fieldId: 'f', operator: 'is', value: 'x' }])
+  })
+
+  it('honors the conjunction alias and is case-insensitive (uppercase OR is not demoted to and)', () => {
+    const viaAlias = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'count',
+      filters: [{ fieldId: 'f', operator: 'is', value: 'x' }], conjunction: 'or',
+    })
+    expect(viaAlias.filterConjunction).toBe('or')
+    const upper = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'count',
+      filters: [{ fieldId: 'f', operator: 'is', value: 'x' }], filterConjunction: 'OR',
+    })
+    expect(upper.filterConjunction).toBe('or')
+  })
 })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1085,14 +1085,25 @@ export function aggregateRollup(
   return null
 }
 
-// Operators evaluateMetaFilterCondition recognizes (lowercased). Used to reject bogus operators on a
-// rollup filter at save time — the evaluator's catch-all returns match-all, which would silently hide a typo.
-const ROLLUP_FILTER_OPERATORS = new Set([
+// Operator compatibility by field type — mirrors the branches in evaluateMetaFilterCondition so a rollup
+// filter is validated AT SAVE the same way it will be EVALUATED. This is stricter than a flat allow-list:
+// the evaluator's per-type catch-all returns `true` (match-all) for an incompatible op (e.g. number
+// `contains`, boolean `greater`), so without a type-aware check such a filter would silently aggregate
+// ALL linked rows. isempty/isnotempty are universal.
+const ROLLUP_FILTER_OPS_NUMERIC = new Set([
   'is', 'equal', 'isnot', 'notequal',
   'greater', 'isgreater', 'greaterequal', 'isgreaterequal',
   'less', 'isless', 'lessequal', 'islessequal',
-  'contains', 'doesnotcontain', 'isempty', 'isnotempty',
 ])
+const ROLLUP_FILTER_OPS_BOOLEAN = new Set(['is', 'equal', 'isnot', 'notequal'])
+const ROLLUP_FILTER_OPS_STRING = new Set(['is', 'equal', 'isnot', 'notequal', 'contains', 'doesnotcontain'])
+export function isRollupFilterOperatorCompatible(fieldType: string, operator: string): boolean {
+  const op = operator.trim().toLowerCase()
+  if (op === 'isempty' || op === 'isnotempty') return true
+  if (isNumericQueryFieldType(fieldType) || fieldType === 'date') return ROLLUP_FILTER_OPS_NUMERIC.has(op)
+  if (fieldType === 'boolean') return ROLLUP_FILTER_OPS_BOOLEAN.has(op)
+  return ROLLUP_FILTER_OPS_STRING.has(op)
+}
 
 // Slice 3 — parse a rollup's optional filter conditions from stored property JSON. Each well-formed entry
 // needs a string fieldId + operator; `value` is preserved only when present (operators like isEmpty omit it).
@@ -1194,18 +1205,22 @@ async function validateLookupRollupConfig(
   const rollupConfig = type === 'rollup' ? (config as RollupFieldConfig) : null
   if (rollupConfig?.filters && rollupConfig.filters.length > 0) {
     const foreignFieldRes = await query(
-      'SELECT id FROM meta_fields WHERE sheet_id = $1',
+      'SELECT id, type FROM meta_fields WHERE sheet_id = $1',
       [linkCfg.foreignSheetId],
     )
-    const foreignFieldIds = new Set((foreignFieldRes as any).rows.map((r: any) => String(r.id)))
+    const foreignFieldTypeById = new Map<string, string>(
+      (foreignFieldRes as any).rows.map((r: any): [string, string] => [String(r.id), mapFieldType(String(r.type ?? ''))]),
+    )
     for (const cond of rollupConfig.filters) {
-      if (!foreignFieldIds.has(cond.fieldId)) {
+      const condFieldType = foreignFieldTypeById.get(cond.fieldId)
+      if (!condFieldType) {
         return `Rollup 过滤条件引用了不存在的外表字段：${cond.fieldId}（sheetId=${linkCfg.foreignSheetId}）`
       }
-      // Reject operators evaluateMetaFilterCondition doesn't recognize — its catch-all returns `true`
-      // (match-all), so a bogus operator would silently make the filter a no-op rather than erroring.
-      if (!ROLLUP_FILTER_OPERATORS.has(cond.operator.trim().toLowerCase())) {
-        return `Rollup 过滤条件使用了不支持的运算符：${cond.operator}`
+      // Per-TYPE operator check (not a flat allow-list): evaluateMetaFilterCondition's per-type catch-all
+      // returns match-all for an incompatible op (number `contains`, boolean `greater`), which would
+      // silently aggregate ALL linked rows. Reject at save so that can't be stored.
+      if (!isRollupFilterOperatorCompatible(condFieldType, cond.operator)) {
+        return `Rollup 过滤条件运算符 ${cond.operator} 与字段类型 ${condFieldType} 不兼容：${cond.fieldId}`
       }
     }
   }
@@ -2702,11 +2717,15 @@ async function applyLookupRollup(
     // Slice 3 — rollup filter (lookup configs carry no filters, so this is a no-op for them).
     // SECURITY (fail-closed): a condition that reads a foreign field the actor can't see is a
     // side-channel — the resulting match-count would leak the masked field's values — so mask the
-    // WHOLE rollup rather than evaluate it. Honors the same skipForeignFieldMasking opt-out as the target.
+    // WHOLE rollup rather than evaluate it.
+    // Condition fields IGNORE skipForeignFieldMasking (pass `false`, NOT cfg.skipForeignFieldMasking):
+    // that flag is a same-base PROJECTION opt-out for the TARGET value the author chose to surface.
+    // Using an unreadable field as a FILTER is a side-channel regardless of that opt-out, so a rollup
+    // with skipForeignFieldMasking:true must still fail closed when a CONDITION reads an unreadable field.
     const rollupCfg = 'aggregation' in cfg ? cfg : null
     const filters = rollupCfg?.filters ?? []
     for (const cond of filters) {
-      if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cond.fieldId, cfg.skipForeignFieldMasking)) {
+      if (shouldMaskForeignField(foreignFieldReadability, foreignSheetId, cond.fieldId, false)) {
         return { values: [], count: 0, masked: true }
       }
     }

--- a/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
@@ -38,6 +38,7 @@ const FLD_ALL = `fld_rf_all_${TS}` // countall, no filter -> 3
 const FLD_PAID_COUNT = `fld_rf_pc_${TS}` // countall where status = paid -> 2
 const FLD_PAID_SUM = `fld_rf_ps_${TS}` // sum amount where status = paid -> 30
 const FLD_BY_SECRET = `fld_rf_bs_${TS}` // countall where secret = yes -> 2 (masks to null for DENY_USER)
+const FLD_BY_SECRET_SKIP = `fld_rf_bsk_${TS}` // same + skipForeignFieldMasking:true — P1 bypass regression
 const FLD_OR_UNION = `fld_rf_or_${TS}` // countall where status=unpaid OR amount=10 -> union FR3+FR1 = 2
 const FLD_AND_EMPTY = `fld_rf_and_${TS}` // countall where status=unpaid AND amount=10 -> 0 (contrast for OR)
 const FLD_AMT_GT8 = `fld_rf_gt8_${TS}` // countall where amount greater 8 -> FR1(10),FR2(20) = 2
@@ -127,6 +128,10 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
     // isEmpty: note absent on FR2, FR3 → 2.
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_NOTE_EMPTY, MS, 'NoteEmpty', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_NOTE, operator: 'isEmpty' }] }), 10])
+    // P1 regression: skipForeignFieldMasking is a same-base TARGET-projection opt-out; it must NOT let a
+    // CONDITION read an unreadable field (side-channel). Same as FLD_BY_SECRET but with the opt-out set.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_BY_SECRET_SKIP, MS, 'BySecretSkip', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_SECRET, operator: 'is', value: 'yes' }], skipForeignFieldMasking: true }), 11])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
@@ -160,6 +165,13 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
 
   test('SECURITY fail-closed: a condition on a field the actor cannot read masks that rollup to null', async () => {
     expect(await readRollup(DENY_USER, FLD_BY_SECRET) ?? null).toBeNull() // condition reads denied FLD_SECRET
+  })
+
+  test('SECURITY: skipForeignFieldMasking does NOT bypass the condition fail-closed (it is a target-projection opt-out only)', async () => {
+    // ALLOW_USER (can read FLD_SECRET) still gets the real count even with the opt-out set.
+    expect(await readRollup(ALLOW_USER, FLD_BY_SECRET_SKIP)).toBe(2)
+    // DENY_USER: the same-base opt-out must NOT leak — a CONDITION on the unreadable field still masks to null.
+    expect(await readRollup(DENY_USER, FLD_BY_SECRET_SKIP) ?? null).toBeNull()
   })
 
   test('fail-closed is SCOPED: sibling rollups whose condition reads a readable field still work', async () => {

--- a/packages/core-backend/tests/unit/multitable-rollup-filter-operator-compat.test.ts
+++ b/packages/core-backend/tests/unit/multitable-rollup-filter-operator-compat.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Rollup filter operator/type compatibility (slice 3 hardening).
+ *
+ * evaluateMetaFilterCondition's per-type catch-all returns `true` (match-all) for an operator that
+ * doesn't fit the field type — e.g. a number field with `contains`, a boolean field with `greater`.
+ * Saving such a condition would silently aggregate ALL linked rows. isRollupFilterOperatorCompatible is
+ * the save-time gate that rejects those; this locks it per type so the validator stays in lockstep with
+ * the evaluator's branches.
+ */
+import { describe, test, expect } from 'vitest'
+import { isRollupFilterOperatorCompatible } from '../../src/routes/univer-meta'
+
+describe('isRollupFilterOperatorCompatible', () => {
+  test('numeric/date: comparison operators allowed, text operators rejected', () => {
+    for (const t of ['number', 'currency', 'percent', 'rating', 'duration', 'date']) {
+      expect(isRollupFilterOperatorCompatible(t, 'is')).toBe(true)
+      expect(isRollupFilterOperatorCompatible(t, 'greater')).toBe(true)
+      expect(isRollupFilterOperatorCompatible(t, 'lessequal')).toBe(true)
+      expect(isRollupFilterOperatorCompatible(t, 'contains')).toBe(false) // catch-all match-all otherwise
+      expect(isRollupFilterOperatorCompatible(t, 'doesnotcontain')).toBe(false)
+    }
+  })
+
+  test('boolean: equality only, comparison/text rejected', () => {
+    expect(isRollupFilterOperatorCompatible('boolean', 'is')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('boolean', 'isnot')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('boolean', 'greater')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('boolean', 'contains')).toBe(false)
+  })
+
+  test('string: equality + contains, comparison rejected', () => {
+    expect(isRollupFilterOperatorCompatible('string', 'is')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('string', 'contains')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('string', 'doesnotcontain')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('string', 'greater')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('string', 'lessequal')).toBe(false)
+  })
+
+  test('isempty/isnotempty are universal', () => {
+    for (const t of ['number', 'boolean', 'string', 'date']) {
+      expect(isRollupFilterOperatorCompatible(t, 'isempty')).toBe(true)
+      expect(isRollupFilterOperatorCompatible(t, 'isnotempty')).toBe(true)
+    }
+  })
+
+  test('unknown operator rejected for every type', () => {
+    expect(isRollupFilterOperatorCompatible('string', 'bogus')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('number', 'xyz')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('boolean', '')).toBe(false)
+  })
+
+  test('case-insensitive', () => {
+    expect(isRollupFilterOperatorCompatible('number', 'GREATER')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('string', 'Contains')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('number', ' is ')).toBe(true)
+  })
+})


### PR DESCRIPTION
Review hardening of the slice-3 rollup filter (#2765). CI wiring there was confirmed real (the test ran 7 cases on PG, FE 8); these are the **boundary cases that weren't tested**.

## [P1 security] `skipForeignFieldMasking` bypassed the condition fail-closed

The filter condition's mask check inherited `cfg.skipForeignFieldMasking`, but that flag is a same-base **target-projection** opt-out — it must not license using an unreadable field as a **filter** (the match-count is a side-channel regardless). With `skipForeignFieldMasking:true`, `countall where secret='yes'` returned the true count to an actor who can't read `secret`.

**Fix:** the condition mask check now passes `false`, so a same-base rollup with the opt-out still fails closed when a condition reads an unreadable field. **Regression test** (real-DB): same-base + `skip=true` + denied condition field → `null` (and `ALLOW_USER` still gets the real count).

## [P2] operator validation was type-agnostic

A flat allow-list let `amount contains '10'` through, but `evaluateMetaFilterCondition`'s per-type catch-all returns match-all for an incompatible op (number `contains`, boolean `greater`) → silently aggregates **all** linked rows. Now validated **per field type** at save via `isRollupFilterOperatorCompatible` (mirrors the evaluator's branches). Unit-tested.

## [P2] FE opaque preservation didn't cover backend aliases

Backend accepts `filters`/`conditions`/`filterConditions` + `filterConjunction`/`conjunction` (case-insensitive); the FE resolver only honored `filters`/`conditions` and exact-lowercase `'or'`. An alias-authored rollup could lose its filter or flip OR→AND on an unrelated Field Manager edit. FE resolver now matches the backend parser; web-guard spec covers `filterConditions` + `'OR'`.

## Tests (all CI-wired)

- Real-DB integration **skip-bypass** case (in the `plugin-tests.yml` list).
- `isRollupFilterOperatorCompatible` unit test (default test job).
- FE alias cases in the `multitable-web-guard` spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)