### PR TITLE
docs(data-source): link release temp-path caveat

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -592,7 +592,8 @@ TODO:
 - [x] `79ab455e` release package deployed on entity machine and migration/auth
   preflight passed for #2769.
   - first Windows deploy attempt using the default temp path failed before a
-    healthy app start with `missing_staged_path_under_default_temp`.
+    healthy app start with `missing_staged_path_under_default_temp`; this
+    operational caveat is tracked by #2642.
   - rerun with a short operator temp path passed: `deployApplyExit=0`,
     dependency refresh reached, migrations step reached, PM2 restart reached,
     healthcheck reached, post-deploy API health `200`, and root health `200`.

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -22,7 +22,7 @@ Current release package anchor:
   `missing_staged_path_under_default_temp`, then short-temp rerun passed with
   `deployApplyExit=0`, API/root health `200`, pending migration diff clean,
   `migrationPendingCount=0`, auth login/me `200`, backend online, and
-  integration plugin present.
+  integration plugin present. The default-temp caveat is tracked by #2642.
 
 This package/deploy/auth checkpoint does not close the release gate by itself.
 C3 incremental/resume and C4 UI exact-package evidence are still HOLD unless
@@ -121,7 +121,8 @@ Current #2769 checkpoint:
   with a short operator temp path passed with `deployApplyExit=0` and health
   `200`;
 - boundary: the default-temp failure is an operational deploy caveat, not a
-  runtime release PASS blocker once the short-temp rerun succeeds.
+  runtime release PASS blocker once the short-temp rerun succeeds; #2642 tracks
+  retiring this workaround.
 
 ## 2. Migration / Auth Preflight
 


### PR DESCRIPTION
## Summary
- link the `79ab455e` default Windows temp-path deploy caveat to #2642 in the delivery TODO and release smoke runbook
- keep the short-temp rerun as the accepted deploy/auth checkpoint
- keep C3/C4 exact-package evidence and production/batch gates unchanged

## Verification
- `git diff --check`
- #2642 now carries the concrete `79ab455e` reproduction: https://github.com/zensgit/metasheet2/issues/2642#issuecomment-4726611175

## Boundary
Docs-only. This does not change release signoff, does not close #2769, and does not authorize production/batch writes.