### PR TITLE
fix(multitable): runtime operator/type guard on rollup filter (provisioning + legacy safety net)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2733,12 +2733,16 @@ async function applyLookupRollup(
     const filterConjunction = rollupCfg?.filterConjunction ?? 'and'
     const matchesFilters = (data: Record<string, unknown>): boolean => {
       if (filters.length === 0) return true
-      const test = (cond: MetaFilterCondition) =>
-        evaluateMetaFilterCondition(
-          (filterTypes?.get(cond.fieldId) ?? 'string') as UniverMetaField['type'],
-          data[cond.fieldId],
-          cond,
-        )
+      const test = (cond: MetaFilterCondition) => {
+        const condFieldType = filterTypes?.get(cond.fieldId) ?? 'string'
+        // RUNTIME guard (defense-in-depth, complements the save-time per-type check): an operator
+        // incompatible with the field type hits evaluateMetaFilterCondition's per-type catch-all, which
+        // returns match-all — for a rollup filter that's an over-count. Treat it as NO match instead.
+        // Covers provisioning/plugin writes that bypass validateLookupRollupConfig AND any config
+        // persisted before that save-time check existed.
+        if (!isRollupFilterOperatorCompatible(condFieldType, cond.operator)) return false
+        return evaluateMetaFilterCondition(condFieldType as UniverMetaField['type'], data[cond.fieldId], cond)
+      }
       return filterConjunction === 'or' ? filters.some(test) : filters.every(test)
     }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1100,8 +1100,12 @@ const ROLLUP_FILTER_OPS_STRING = new Set(['is', 'equal', 'isnot', 'notequal', 'c
 export function isRollupFilterOperatorCompatible(fieldType: string, operator: string): boolean {
   const op = operator.trim().toLowerCase()
   if (op === 'isempty' || op === 'isnotempty') return true
-  if (isNumericQueryFieldType(fieldType) || fieldType === 'date') return ROLLUP_FILTER_OPS_NUMERIC.has(op)
-  if (fieldType === 'boolean') return ROLLUP_FILTER_OPS_BOOLEAN.has(op)
+  // Mirror evaluateMetaFilterCondition's effectiveType EXACTLY: it coerces a rollup-typed field to
+  // 'number'. If this helper didn't, `rollupField contains x` would look string-compatible here, pass
+  // the guard, then hit the numeric catch-all (match-all) at eval — the same leak as `number contains`.
+  const effectiveType = fieldType === 'rollup' ? 'number' : fieldType
+  if (isNumericQueryFieldType(effectiveType) || effectiveType === 'date') return ROLLUP_FILTER_OPS_NUMERIC.has(op)
+  if (effectiveType === 'boolean') return ROLLUP_FILTER_OPS_BOOLEAN.has(op)
   return ROLLUP_FILTER_OPS_STRING.has(op)
 }
 

--- a/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
@@ -44,6 +44,7 @@ const FLD_AND_EMPTY = `fld_rf_and_${TS}` // countall where status=unpaid AND amo
 const FLD_AMT_GT8 = `fld_rf_gt8_${TS}` // countall where amount greater 8 -> FR1(10),FR2(20) = 2
 const FLD_NOTE_SET = `fld_rf_ns_${TS}` // countall where note isNotEmpty -> FR1 only = 1
 const FLD_NOTE_EMPTY = `fld_rf_ne_${TS}` // countall where note isEmpty -> FR2,FR3 = 2
+const FLD_BAD_OP = `fld_rf_badop_${TS}` // PERSISTED incompatible op (number `contains`) — runtime no-match -> 0
 
 const FR1 = `rec_rf_f1_${TS}` // amount 10, paid,   secret yes
 const FR2 = `rec_rf_f2_${TS}` // amount 20, paid,   secret no
@@ -132,6 +133,10 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
     // CONDITION read an unreadable field (side-channel). Same as FLD_BY_SECRET but with the opt-out set.
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_BY_SECRET_SKIP, MS, 'BySecretSkip', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_SECRET, operator: 'is', value: 'yes' }], skipForeignFieldMasking: true }), 11])
+    // Persisted INCOMPATIBLE operator (number field + `contains`) inserted directly, bypassing save-time
+    // validation — simulates a provisioning/plugin write or a config saved before the validator existed.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_BAD_OP, MS, 'BadOp', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_AMOUNT, operator: 'contains', value: '1' }] }), 12])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
@@ -188,6 +193,13 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
 
   test('numeric operator: amount greater 8 matches FR1(10), FR2(20) but not FR3(5)', async () => {
     expect(await readRollup(ALLOW_USER, FLD_AMT_GT8)).toBe(2)
+  })
+
+  test('runtime guard: a PERSISTED operator incompatible with the field type fails closed (no-match), not match-all', async () => {
+    // `amount contains '1'` is incompatible (number + text op). Without the runtime guard,
+    // evaluateMetaFilterCondition's numeric catch-all returns match-all → 3. The guard treats the
+    // bad condition as no-match → 0. Locks defense for provisioning/plugin writes + pre-validator configs.
+    expect(await readRollup(ALLOW_USER, FLD_BAD_OP)).toBe(0)
   })
 
   test('isNotEmpty / isEmpty on a foreign field set on a subset of linked records', async () => {

--- a/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-filter-condition.test.ts
@@ -45,6 +45,8 @@ const FLD_AMT_GT8 = `fld_rf_gt8_${TS}` // countall where amount greater 8 -> FR1
 const FLD_NOTE_SET = `fld_rf_ns_${TS}` // countall where note isNotEmpty -> FR1 only = 1
 const FLD_NOTE_EMPTY = `fld_rf_ne_${TS}` // countall where note isEmpty -> FR2,FR3 = 2
 const FLD_BAD_OP = `fld_rf_badop_${TS}` // PERSISTED incompatible op (number `contains`) — runtime no-match -> 0
+const FLD_FOREIGN_ROLLUP = `fld_rf_fro_${TS}` // a FOREIGN field whose TYPE is rollup (used as a condition field)
+const FLD_BAD_ROLLUP_OP = `fld_rf_badro_${TS}` // countall where foreignRollup CONTAINS '1' — rollup→numeric guard -> 0
 
 const FR1 = `rec_rf_f1_${TS}` // amount 10, paid,   secret yes
 const FR2 = `rec_rf_f2_${TS}` // amount 20, paid,   secret no
@@ -89,6 +91,10 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
       await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
         [fid, FS, name, type, '{}', order])
     }
+    // A foreign field whose TYPE is rollup — used below as a CONDITION field to prove the guard coerces
+    // rollup→numeric (matching the evaluator), so a text op on it is rejected rather than match-all.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FOREIGN_ROLLUP, FS, 'ForeignRollup', 'rollup', '{}', 5])
 
     // FLD_NOTE is set on FR1 only (absent key on FR2/FR3) → isNotEmpty matches 1, isEmpty matches 2.
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
@@ -137,6 +143,10 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
     // validation — simulates a provisioning/plugin write or a config saved before the validator existed.
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_BAD_OP, MS, 'BadOp', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_AMOUNT, operator: 'contains', value: '1' }] }), 12])
+    // Condition on a ROLLUP-typed foreign field with a text op — the evaluator coerces rollup→number, so
+    // the guard must too (else it passes and match-alls). Directly inserted (bypasses save validation).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_BAD_ROLLUP_OP, MS, 'BadRollupOp', 'rollup', rollup('countall', { filters: [{ fieldId: FLD_FOREIGN_ROLLUP, operator: 'contains', value: '1' }] }), 13])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3] })])
@@ -200,6 +210,12 @@ describeIfDatabase('multitable rollup filter condition + fail-closed field-reada
     // evaluateMetaFilterCondition's numeric catch-all returns match-all → 3. The guard treats the
     // bad condition as no-match → 0. Locks defense for provisioning/plugin writes + pre-validator configs.
     expect(await readRollup(ALLOW_USER, FLD_BAD_OP)).toBe(0)
+  })
+
+  test('runtime guard treats a ROLLUP-typed condition field as numeric (text op rejected, not match-all)', async () => {
+    // foreignRollup `contains` — the evaluator coerces rollup→number, so the guard must too. Without the
+    // rollup→number normalization the guard would pass it and the numeric catch-all would match-all (3).
+    expect(await readRollup(ALLOW_USER, FLD_BAD_ROLLUP_OP)).toBe(0)
   })
 
   test('isNotEmpty / isEmpty on a foreign field set on a subset of linked records', async () => {

--- a/packages/core-backend/tests/unit/multitable-rollup-filter-operator-compat.test.ts
+++ b/packages/core-backend/tests/unit/multitable-rollup-filter-operator-compat.test.ts
@@ -28,6 +28,16 @@ describe('isRollupFilterOperatorCompatible', () => {
     expect(isRollupFilterOperatorCompatible('boolean', 'contains')).toBe(false)
   })
 
+  test('rollup-typed condition field is coerced to NUMERIC (mirrors evaluateMetaFilterCondition)', () => {
+    // The evaluator does `effectiveType = type === 'rollup' ? 'number' : type`; the guard must match, or
+    // `rollupField contains x` looks string-compatible, passes, then match-alls via the numeric catch-all.
+    expect(isRollupFilterOperatorCompatible('rollup', 'greater')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('rollup', 'is')).toBe(true)
+    expect(isRollupFilterOperatorCompatible('rollup', 'contains')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('rollup', 'doesnotcontain')).toBe(false)
+    expect(isRollupFilterOperatorCompatible('rollup', 'isempty')).toBe(true) // universal
+  })
+
   test('string: equality + contains, comparison rejected', () => {
     expect(isRollupFilterOperatorCompatible('string', 'is')).toBe(true)
     expect(isRollupFilterOperatorCompatible('string', 'contains')).toBe(true)


### PR DESCRIPTION
Review follow-up to #2772. The per-type operator check there only runs on the **HTTP save path** (`validateLookupRollupConfig`). Three gaps remained:
- **Provisioning/plugin writes** — `ensureFields` writes `meta_fields.property` directly; `patchObjectFieldProperty` runs only `sanitizeFieldProperty`, which canonicalizes ids/aggregation but leaves `filters`/operators untouched.
- **Legacy configs** persisted in the #2765→#2772 window, before save-time validation existed.

On read, `resolveLookupValues` called `evaluateMetaFilterCondition` with no compatibility guard, so a persisted `number contains …` hit the numeric catch-all `return true` (match-all → over-count).

## Fix

`resolveLookupValues` now applies `isRollupFilterOperatorCompatible` **at evaluation time**: an operator incompatible with the field type is treated as **no match** (fail-closed) instead of match-all. This covers **every** write path and existing data in one place — the comprehensive option from the review.

## Test

Real-DB regression: a rollup with a directly-inserted `amount contains '1'` (number + text op, bypassing save-time validation) aggregates **0**, not all-linked — locking the runtime guard against provisioning/plugin/legacy configs. (In the existing `multitable-rollup-filter-condition.test.ts`, already in the real-DB allowlist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)