### PR TITLE
feat(attendance): annual-leave L5a — admin balance/ledger read endpoint + read-only view

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6109,6 +6109,7 @@
                 </button>
               </div>
               <div v-if="annualBalanceData" class="attendance__annual-balance">
+                <h5>{{ tr('Balance for', '余额 ·') }} {{ annualBalanceData.userId }}</h5>
                 <div class="attendance__annual-balance-summary">
                   <span>{{ tr('Granted', '已发放') }}: {{ annualBalanceData.summary.grantedMinutes }} {{ tr('min', '分钟') }}</span>
                   <span>{{ tr('Remaining', '剩余') }}: {{ annualBalanceData.summary.remainingMinutes }} {{ tr('min', '分钟') }}</span>
@@ -19661,6 +19662,9 @@ const annualBalanceLoading = ref(false)
 const annualBalanceData = ref<AnnualLeaveBalanceData | null>(null)
 
 async function loadAnnualLeaveBalance() {
+  // clear any prior result up front so an empty ID / failed / 403 / errored query never leaves a stale balance
+  // from a previously-queried user on screen (the view renders solely on v-if="annualBalanceData").
+  annualBalanceData.value = null
   const targetUser = annualBalanceUserId.value.trim()
   if (!targetUser) {
     setStatus(tr('Enter a user ID to view the annual leave balance', '请输入用户 ID 查询年假余额'), 'error')

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6090,6 +6090,81 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance)"
+            >
+              <div class="attendance__admin-section-header">
+                <h4>{{ tr('Annual leave balance', '年假余额') }}</h4>
+              </div>
+              <div class="attendance__admin-grid">
+                <label class="attendance__field" for="attendance-annual-balance-user">
+                  <span>{{ tr('User ID', '用户 ID') }}</span>
+                  <input id="attendance-annual-balance-user" v-model="annualBalanceUserId" type="text" />
+                </label>
+              </div>
+              <div class="attendance__admin-actions">
+                <button class="attendance__btn attendance__btn--primary" :disabled="annualBalanceLoading" @click="() => loadAnnualLeaveBalance()">
+                  {{ annualBalanceLoading ? tr('Loading...', '加载中...') : tr('Load balance', '查询余额') }}
+                </button>
+              </div>
+              <div v-if="annualBalanceData" class="attendance__annual-balance">
+                <div class="attendance__annual-balance-summary">
+                  <span>{{ tr('Granted', '已发放') }}: {{ annualBalanceData.summary.grantedMinutes }} {{ tr('min', '分钟') }}</span>
+                  <span>{{ tr('Remaining', '剩余') }}: {{ annualBalanceData.summary.remainingMinutes }} {{ tr('min', '分钟') }}</span>
+                  <span>{{ tr('Used', '已用') }}: {{ annualBalanceData.summary.exhaustedMinutes }} {{ tr('min', '分钟') }}</span>
+                  <span>{{ tr('Expired', '已过期') }}: {{ annualBalanceData.summary.expiredMinutes }} {{ tr('min', '分钟') }}</span>
+                </div>
+                <h5>{{ tr('Active lots', '有效额度') }}</h5>
+                <div v-if="annualBalanceData.activeLots.length === 0" class="attendance__empty">{{ tr('No active lots.', '无有效额度。') }}</div>
+                <div v-else class="attendance__table-wrapper">
+                  <table class="attendance__table">
+                    <thead>
+                      <tr>
+                        <th>{{ tr('Source', '来源') }}</th>
+                        <th>{{ tr('Amount', '额度') }}</th>
+                        <th>{{ tr('Remaining', '剩余') }}</th>
+                        <th>{{ tr('Granted at', '发放日') }}</th>
+                        <th>{{ tr('Expires at', '过期时间') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="lot in annualBalanceData.activeLots" :key="lot.id">
+                        <td>{{ lot.source_type }}</td>
+                        <td>{{ lot.amount_minutes }}</td>
+                        <td>{{ lot.remaining_minutes }}</td>
+                        <td>{{ lot.granted_at }}</td>
+                        <td>{{ lot.expires_at ?? tr('Never', '永不') }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <h5>{{ tr('Recent events', '近期记录') }}</h5>
+                <div v-if="annualBalanceData.recentEvents.length === 0" class="attendance__empty">{{ tr('No events.', '无记录。') }}</div>
+                <div v-else class="attendance__table-wrapper">
+                  <table class="attendance__table">
+                    <thead>
+                      <tr>
+                        <th>{{ tr('Type', '类型') }}</th>
+                        <th>{{ tr('Delta', '变动') }}</th>
+                        <th>{{ tr('Source', '来源') }}</th>
+                        <th>{{ tr('Time', '时间') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(ev, i) in annualBalanceData.recentEvents" :key="i">
+                        <td>{{ ev.event_type }}</td>
+                        <td>{{ ev.delta_minutes }}</td>
+                        <td>{{ ev.source_type }}</td>
+                        <td>{{ ev.occurred_at }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
@@ -19550,6 +19625,65 @@ async function loadLeaveTypes(options: { activeOnly?: boolean } = {}) {
     setStatus(readErrorMessage(error, tr('Failed to load leave types', '加载请假类型失败')), 'error')
   } finally {
     leaveTypeLoading.value = false
+  }
+}
+
+// 年假/法定假 L5a: read-only annual-leave balance/ledger for one user (admin console). Calls the L5a read endpoint
+// and renders summary + active lots + recent events so a balance is explainable. Read-only; no mutation here.
+interface AnnualLeaveBalanceLot {
+  id: string
+  leave_type_code: string
+  amount_minutes: number
+  remaining_minutes: number
+  source_type: string
+  source_id: string | null
+  status: string
+  granted_at: string | null
+  expires_at: string | null
+}
+interface AnnualLeaveBalanceEvent {
+  event_type: string
+  delta_minutes: number
+  source_type: string
+  source_id: string | null
+  balance_id: string
+  occurred_at: string
+}
+interface AnnualLeaveBalanceData {
+  userId: string
+  summary: { leaveTypeCode: string; grantedMinutes: number; remainingMinutes: number; exhaustedMinutes: number; expiredMinutes: number }
+  activeLots: AnnualLeaveBalanceLot[]
+  recentEvents: AnnualLeaveBalanceEvent[]
+  eventLimit: number
+}
+const annualBalanceUserId = ref('')
+const annualBalanceLoading = ref(false)
+const annualBalanceData = ref<AnnualLeaveBalanceData | null>(null)
+
+async function loadAnnualLeaveBalance() {
+  const targetUser = annualBalanceUserId.value.trim()
+  if (!targetUser) {
+    setStatus(tr('Enter a user ID to view the annual leave balance', '请输入用户 ID 查询年假余额'), 'error')
+    return
+  }
+  annualBalanceLoading.value = true
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId(), userId: targetUser, leaveTypeCode: 'annual' })
+    const response = await apiFetch(`/api/attendance/leave-balances?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load annual leave balance', '加载年假余额失败')))
+    }
+    adminForbidden.value = false
+    annualBalanceData.value = data.data as AnnualLeaveBalanceData
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to load annual leave balance', '加载年假余额失败')), 'error')
+  } finally {
+    annualBalanceLoading.value = false
   }
 }
 

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -37,6 +37,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   assignments: 'attendance-admin-assignments',
   schedulerScopes: 'attendance-admin-scheduler-scopes',
   holidays: 'attendance-admin-holidays',
+  annualLeaveBalance: 'attendance-admin-annual-leave-balance',
 } as const
 
 export type AdminSectionNavItem = {
@@ -187,6 +188,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.assignments, label: tr('Assignments', '排班分配') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.schedulerScopes, label: tr('Scheduler scope mgmt', '排班管理范围') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.holidays, label: tr('Holidays', '节假日') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance, label: tr('Annual leave balance', '年假余额') },
   ])
   const adminSectionItemMap = computed(() => new Map(adminSectionNavItems.value.map(item => [item.id, item])))
   const adminSectionNavGroups = computed<AdminSectionNavGroupDefinition[]>(() => [
@@ -234,6 +236,13 @@ export function useAttendanceAdminRail({
         ATTENDANCE_ADMIN_SECTION_IDS.leaveTypes,
         ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules,
         ATTENDANCE_ADMIN_SECTION_IDS.approvalFlows,
+      ],
+    },
+    {
+      id: 'annual-leave',
+      label: tr('Annual leave', '年假/法定假'),
+      itemIds: [
+        ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance,
       ],
     },
     {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -123,10 +123,11 @@ describe('Attendance admin anchor navigation', () => {
       item => item.textContent?.trim() || '',
     )
 
-    expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
-    expect(labels).toHaveLength(27)
+    expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Annual leave', 'Data & Payroll'])
+    expect(labels).toHaveLength(28)
     expect(labels).toEqual(
       expect.arrayContaining([
+        'Annual leave balance',
         'Settings',
         'User Access',
         'Notification deliveries',
@@ -827,7 +828,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(27)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(28)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -934,6 +934,60 @@ describe('Attendance admin regressions', () => {
     expect(hint?.textContent || '').toContain('250')
   })
 
+  it('clears a prior annual-leave balance when a new query fails (no stale balance from another user)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/leave-balances')) {
+        if (url.includes('userId=userA')) {
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              userId: 'userA',
+              summary: { leaveTypeCode: 'annual', grantedMinutes: 4800, remainingMinutes: 3000, exhaustedMinutes: 1800, expiredMinutes: 0 },
+              activeLots: [],
+              recentEvents: [],
+              eventLimit: 50,
+            },
+          })
+        }
+        // userB → failure
+        return jsonResponse(500, { ok: false, error: { code: 'INTERNAL_ERROR', message: 'boom' } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-balance"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-balance')
+    expect(section).toBeTruthy()
+    const input = section!.querySelector<HTMLInputElement>('#attendance-annual-balance-user')
+    const loadBtn = section!.querySelector<HTMLButtonElement>('.attendance__admin-actions button')
+    expect(input).toBeTruthy()
+    expect(loadBtn).toBeTruthy()
+
+    // (A) query userA → success → A's balance renders, tied to userA.
+    input!.value = 'userA'
+    input!.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    loadBtn!.click()
+    await flushUi(4)
+    const shown = section!.querySelector('.attendance__annual-balance')
+    expect(shown).toBeTruthy()
+    expect(shown?.textContent || '').toContain('userA')
+
+    // (B) query userB → failure → A's balance MUST disappear (cleared up front; the view renders on v-if).
+    input!.value = 'userB'
+    input!.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    loadBtn!.click()
+    await flushUi(4)
+    expect(section!.querySelector('.attendance__annual-balance')).toBeNull()
+  })
+
   it('warns when the attendance-group picker source is capped (no silent caps)', async () => {
     vi.mocked(apiFetch).mockImplementation(async (input) => {
       const url = String(input)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5371,6 +5371,7 @@ attendanceIntegrationDescribe(
     const runSuffix = Date.now().toString(36)
     const adminId = `al-l5a-admin-${runSuffix}`
     const uid = `al-l5a-user-${runSuffix}`
+    const uOther = `al-l5a-other-${runSuffix}`
     const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${adminId}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
     const token = (tokenRes.body as { token?: string } | undefined)?.token
     if (!token) { await pool.end().catch(() => undefined); return }
@@ -5408,9 +5409,22 @@ attendanceIntegrationDescribe(
       // missing userId → 400.
       const bad = await requestJson(`${baseUrl}/api/attendance/leave-balances`, { headers })
       expect(bad.status).toBe(400)
+
+      // (reverse) an event whose org/user match the query but whose LOT belongs to a DIFFERENT user must be IGNORED —
+      // the read is org/user-consistent by construction (the FK only ties balance_id), not just by writer discipline.
+      // Without the `b.org_id=e.org_id AND b.user_id=e.user_id` join predicate this +9999 grant would inflate granted.
+      const otherLot = (await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at)
+         VALUES ('default',$1,'annual',9999,9999,'annual_accrual',$2,'active','2026-01-01') RETURNING id`, [uOther, `l5a:${runSuffix}:other`])).rows[0].id
+      await pool.query(
+        `INSERT INTO attendance_leave_balance_events (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+         VALUES ('default',$1,$2,'grant',9999,'annual_accrual',$3)`, [uid, otherLot, otherLot])
+      const after = await requestJson(`${baseUrl}/api/attendance/leave-balances?userId=${encodeURIComponent(uid)}`, { headers })
+      expect((after.body as { data?: { summary?: { grantedMinutes?: number } } } | undefined)?.data?.summary?.grantedMinutes).toBe(5280) // mismatched +9999 excluded
+      expect((after.body as { data?: { recentEvents?: unknown[] } } | undefined)?.data?.recentEvents?.length).toBe(4)
     } finally {
-      await pool.query(`DELETE FROM attendance_leave_balance_events WHERE user_id = $1`, [uid]).catch(() => undefined)
-      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = $1`, [uid]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])`, [[uid, uOther]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])`, [[uid, uOther]]).catch(() => undefined)
       await pool.end().catch(() => undefined)
     }
   })

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5363,6 +5363,58 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④/年假 L5a — admin balance/ledger read: summary (granted/remaining/exhausted/expired) + active lots + recent events', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const adminId = `al-l5a-admin-${runSuffix}`
+    const uid = `al-l5a-user-${runSuffix}`
+    const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${adminId}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) { await pool.end().catch(() => undefined); return }
+    const headers = { Authorization: `Bearer ${token}` }
+    // Build a known annual balance directly: an ACTIVE lot (4800 granted, 1800 deducted → 3000 remaining) + an
+    // EXPIRED lot (480 granted, 480 expired). So granted=5280, remaining=3000, exhausted=1800, expired=480
+    // (conservation: granted = remaining + exhausted + expired).
+    const mkLot = async (amount: number, remaining: number, status: string, expiresAt: string | null, tag: string) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, expires_at)
+       VALUES ('default',$1,'annual',$2,$3,'annual_accrual',$4,$5,'2026-01-01',$6) RETURNING id`,
+      [uid, amount, remaining, `l5a:${runSuffix}:${tag}`, status, expiresAt])).rows[0].id
+    const mkEvent = async (balanceId: string, type: string, delta: number) => { await pool.query(
+      `INSERT INTO attendance_leave_balance_events (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+       VALUES ('default',$1,$2,$3,$4,'annual_accrual',$5)`, [uid, balanceId, type, delta, balanceId]) }
+    try {
+      const lotActive = await mkLot(4800, 3000, 'active', '2026-12-31T16:00:00Z', 'active')
+      await mkEvent(lotActive, 'grant', 4800); await mkEvent(lotActive, 'deduct', -1800)
+      const lotExpired = await mkLot(480, 0, 'expired', '2025-12-31T16:00:00Z', 'expired')
+      await mkEvent(lotExpired, 'grant', 480); await mkEvent(lotExpired, 'expire', -480)
+
+      const res = await requestJson(`${baseUrl}/api/attendance/leave-balances?userId=${encodeURIComponent(uid)}`, { headers })
+      expect(res.status, JSON.stringify(res.body)).toBe(200)
+      const data = (res.body as { data?: { summary?: Record<string, unknown>; activeLots?: Array<Record<string, unknown>>; recentEvents?: Array<Record<string, unknown>> } } | undefined)?.data
+      expect(data?.summary).toMatchObject({ leaveTypeCode: 'annual', grantedMinutes: 5280, remainingMinutes: 3000, exhaustedMinutes: 1800, expiredMinutes: 480 })
+      // only the ACTIVE lot is returned in activeLots
+      expect(data?.activeLots?.length).toBe(1)
+      expect(Number((data!.activeLots![0] as { remaining_minutes: number }).remaining_minutes)).toBe(3000)
+      expect(data!.activeLots![0].status).toBe('active')
+      // all 4 ledger events are present (explains the balance), asserted by SET not order (occurred_at ties → uuid id).
+      expect(data?.recentEvents?.length).toBe(4)
+      expect((data!.recentEvents! as Array<{ event_type: string }>).map(e => e.event_type).sort()).toEqual(['deduct', 'expire', 'grant', 'grant'])
+      // eventLimit caps the ledger.
+      const limited = await requestJson(`${baseUrl}/api/attendance/leave-balances?userId=${encodeURIComponent(uid)}&eventLimit=2`, { headers })
+      expect((limited.body as { data?: { recentEvents?: unknown[] } } | undefined)?.data?.recentEvents?.length).toBe(2)
+      // missing userId → 400.
+      const bad = await requestJson(`${baseUrl}/api/attendance/leave-balances`, { headers })
+      expect(bad.status).toBe(400)
+    } finally {
+      await pool.query(`DELETE FROM attendance_leave_balance_events WHERE user_id = $1`, [uid]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = $1`, [uid]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('A2 auto-shift auto-write ledger — active-run claim and item invariants are DB-enforced (latent schema)', async () => {
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -37791,6 +37791,83 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'GET',
+      '/api/attendance/leave-balances',
+      withPermission('attendance:admin', async (req, res) => {
+        // 年假/法定假 L5a (design-lock 2026-06-16): admin-only, org-scoped balance/ledger READ. Query by userId
+        // (+ optional leaveTypeCode, default 'annual'). Returns summary (granted/remaining/exhausted/expired) +
+        // active lots + recent ledger events, so a balance is EXPLAINABLE (accrual/manual-adjust/deduction/expiry).
+        // Employee self-view (/me, token-subject-locked) is a SEPARATE future endpoint — never mixed into admin read.
+        const schema = z.object({
+          userId: z.string().min(1).max(255),
+          leaveTypeCode: z.string().min(1).max(64).optional(),
+          eventLimit: z.coerce.number().int().min(1).max(200).optional(),
+        })
+        const parsed = schema.safeParse(req.query ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const { userId } = parsed.data
+        const leaveTypeCode = parsed.data.leaveTypeCode ?? 'annual'
+        const eventLimit = parsed.data.eventLimit ?? 50
+        try {
+          // summary from the ledger (granted/exhausted/expired) + active-lot remaining. Conservation (no revoke in
+          // this chain): granted = remaining + exhausted + expired. Events are joined to lots only for the type filter.
+          const summaryRows = await db.query(
+            `SELECT
+               COALESCE(SUM(CASE WHEN e.event_type = 'grant'  THEN e.delta_minutes  ELSE 0 END), 0) AS granted,
+               COALESCE(SUM(CASE WHEN e.event_type = 'deduct' THEN -e.delta_minutes ELSE 0 END), 0) AS exhausted,
+               COALESCE(SUM(CASE WHEN e.event_type = 'expire' THEN -e.delta_minutes ELSE 0 END), 0) AS expired
+             FROM attendance_leave_balance_events e
+             JOIN attendance_leave_balances b ON b.id = e.balance_id
+             WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3`,
+            [orgId, userId, leaveTypeCode]
+          )
+          const remainingRows = await db.query(
+            `SELECT COALESCE(SUM(remaining_minutes), 0) AS remaining
+             FROM attendance_leave_balances
+             WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'`,
+            [orgId, userId, leaveTypeCode]
+          )
+          const activeLots = await db.query(
+            `SELECT id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, status, granted_at, expires_at
+             FROM attendance_leave_balances
+             WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'
+             ORDER BY expires_at ASC NULLS LAST, granted_at ASC, id ASC`,
+            [orgId, userId, leaveTypeCode]
+          )
+          const recentEvents = await db.query(
+            `SELECT e.event_type, e.delta_minutes, e.source_type, e.source_id, e.balance_id, e.occurred_at
+             FROM attendance_leave_balance_events e
+             JOIN attendance_leave_balances b ON b.id = e.balance_id
+             WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3
+             ORDER BY e.occurred_at DESC, e.id DESC
+             LIMIT $4`,
+            [orgId, userId, leaveTypeCode, eventLimit]
+          )
+          const s = summaryRows[0] || {}
+          const summary = {
+            leaveTypeCode,
+            grantedMinutes: Number(s.granted || 0),
+            remainingMinutes: Number(remainingRows[0]?.remaining || 0),
+            exhaustedMinutes: Number(s.exhausted || 0),
+            expiredMinutes: Number(s.expired || 0),
+          }
+          res.json({ ok: true, data: { userId, summary, activeLots, recentEvents, eventLimit } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Annual leave balance read failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
       'POST',
       '/api/attendance/annual-leave-manual-adjustment',
       withPermission('attendance:admin', async (req, res) => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -37821,7 +37821,7 @@ module.exports = {
                COALESCE(SUM(CASE WHEN e.event_type = 'deduct' THEN -e.delta_minutes ELSE 0 END), 0) AS exhausted,
                COALESCE(SUM(CASE WHEN e.event_type = 'expire' THEN -e.delta_minutes ELSE 0 END), 0) AS expired
              FROM attendance_leave_balance_events e
-             JOIN attendance_leave_balances b ON b.id = e.balance_id
+             JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
              WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3`,
             [orgId, userId, leaveTypeCode]
           )
@@ -37841,7 +37841,7 @@ module.exports = {
           const recentEvents = await db.query(
             `SELECT e.event_type, e.delta_minutes, e.source_type, e.source_id, e.balance_id, e.occurred_at
              FROM attendance_leave_balance_events e
-             JOIN attendance_leave_balances b ON b.id = e.balance_id
+             JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
              WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3
              ORDER BY e.occurred_at DESC, e.id DESC
              LIMIT $4`,


### PR DESCRIPTION
Implements **L5a** per the design-lock (#2764, merged): the admin **read** half of the annual-leave UI.

## Backend — `GET /api/attendance/leave-balances`
`attendance:admin`, **admin-only**, org-scoped. Query by `userId` (+ optional `leaveTypeCode`, default `annual`, `eventLimit` 1..200). Returns the *explainable* shape:
- **summary** — `granted` / `remaining` / `exhausted` / `expired` minutes (from the ledger + active-lot remaining; conservation `granted = remaining + exhausted + expired`).
- **active lots** (FIFO-ordered) and **recent events** (capped).

The ledger joins assert **event↔lot org/user consistency** (`ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id`) — the read is consistent by construction, not just by writer discipline (the FK only ties `balance_id`). Employee self-view (`/me`) is intentionally a separate future endpoint.

## Frontend — read-only Balance view
A new admin nav **group "年假/法定假"** with a **年假余额 / Annual leave balance** section in `AttendanceView.vue` (its own group, not folded into Settings, per the design-lock): user-ID input → loads the endpoint → renders summary + active-lots table + recent-events table. Read-only; mirrors the existing `.attendance__admin-section` / inline `tr(en,zh)` / `apiFetch` / `adminForbidden` conventions.

## Verification
- Backend integration test (real endpoint): known state (active lot 4800/−1800→3000 + expired lot 480/−480) → summary `5280/3000/1800/480`, one active lot, full 4-event ledger (by set), `eventLimit` cap, missing-`userId` → 400, **plus a reverse test** proving a mismatched event (a +9999 grant whose lot belongs to another user) is ignored.
- Frontend `vue-tsc -b`: 0 errors.

Out of scope (deferred per design-lock): L5b policy config (next), L5c mutating triggers (own design-lock), employee self-view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)