### PR TITLE
docs(data-source): close release evidence gate

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -8,8 +8,9 @@
 
 - 只读数据库接入 Data Factory 源系统: 已经基本可用。
 - 可交付定义: C6 sandbox 外部写能力通过实体机验收后，才称为 sandbox
-  交付链路闭合；完整 release 签收仍要按 release runbook 汇总最终 values-free
-  evidence package。production/batch 写入始终是独立显式 gate。
+  交付链路闭合；完整 release 签收要按 release runbook 汇总最终 values-free
+  evidence package。#2769 已关闭为 scoped release evidence PASS。production/batch
+  写入始终是独立显式 gate。
 - 下一步建议: C2-close 已通过实体机 smoke；C3 core runtime + CI real-DB wire lock 已落地；
   C4 配置体验和已知 polish 已落地（source/object/schema picker、source-field picker、watermark config、
   read-only/source-only 边界提示、SQL bridge values-free 错误提示）。
@@ -18,7 +19,7 @@
   C5 K3/MSSQL smoke gate #2670 已在 `dea391a1` 包上通过并关闭：operator scope-adjusted rerun
   中 generic SQL Server smoke 和 K3 SQL Server executor smoke 均 PASS，且 evidence values-free、无 K3
   Save/Submit/Audit/BOM、无外部 DB 写、无 raw SQL。#2700 已补 C5 runbook 的 SQL auth/scope triage。
-- 下一门: release evidence package 收口。C6 是最大风险刀；C6-0 只锁 design contract，
+- 当前收口: release evidence package 已关闭。C6 是最大风险刀；C6-0 只锁 design contract，
   C6-1 只落地 backend latent writer helper 和 write-gated target adapter 的关闭态合同；
   C6-2 只增加 read-only dry-run route + dry-run token，不授权 apply runtime 或 external write。
   C6-3 增加 token-bound apply route；C6-4 UI dry-run -> review -> apply 已合并并发出实体机
@@ -31,8 +32,10 @@
   #2761 已修复 on-prem package 不应携带 `node_modules` 的打包/校验缺口，并已重发
   `d8244ee13` sandbox 包；实体机已部署该包并完成 C6-5c controlled bad-row PASS：
   one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE` + one clean sibling write，
-  dead-letter/provenance evidence values-free，注入配置已恢复关闭。production/batch 仍关闭；
-  Release 还需按 release runbook 汇总最终 values-free evidence package。
+  dead-letter/provenance evidence values-free，注入配置已恢复关闭。#2769 随后在
+  `79ab455e` release package 上完成 package/deploy/auth、C3 incremental/resume、
+  C4 UI exact-package evidence，并关闭为 scoped release evidence PASS。
+  production/batch 仍关闭；Windows 默认 temp path caveat 仍由 #2642 跟踪。
 
 ## 收口顺序
 
@@ -44,7 +47,7 @@
 | C4 | UI / 配置体验统一 | done (#2643/#2646/#2649/#2652/#2655); later UX polish demand-gated | 让用户不手写 JSON | 产品误导 / 凭据边界混乱 |
 | C5 | K3 generic MSSQL seam | done (#2670 PASS/CLOSED; #2700 runbook triage) | K3 SQL Server 通道复用 generic MSSQL 能力 | K3 红线被误开 |
 | C6 | external write | C6-0 design locked; C6-1 latent helper done; C6-2 dry-run route done; C6-3 apply route done; C6-4 UI done (#2719); C6-5 issue #2720 CLOSED as sandbox smoke PASS; C6-5a design done; C6-5b seam done (#2756); first C6-5c package `642560126` deploy blocked; package prune fix #2761 done; recut package `d8244ee13` entity-machine controlled bad-row PASS | 外部系统写回能力 | 权限、幂等、回滚、部分失败 |
-| Release | 总包 + 实体机验收 | #2769 opened for final release evidence package; release package `79ab455e` is published, package-preflight verified, and deployed healthy after short-temp rerun; migration/auth/startup PASS; #2720 C6 sandbox smoke PASS can be cited; C3/C4 exact-release evidence still HOLD unless owner explicitly narrows or defers those gates with downgraded wording | 交付签收 | 不得把 package preflight、deploy/auth PASS 或 sandbox C6 PASS 误写成 production/batch authorization |
+| Release | 总包 + 实体机验收 | done (#2769 CLOSED/PASS); release package `79ab455e` package-preflight, deploy/auth, C3 incremental/resume, C4 UI, C5 cite, and C6 sandbox cite all accepted; #2642 remains open for Windows default-temp workaround | 交付签收 | 不得把 scoped release PASS 误写成 production/batch authorization |
 
 ## P0 - ②b Arc 收口 Follow-Up
 
@@ -605,11 +608,26 @@ TODO:
   - boundary: evidence remained values-free; auth token was present but not
     printed; temporary auth user cleanup passed; production/batch writes remain
     closed.
-- [ ] 干净实体机 / 全新 DB smoke，用来暴露 migration 排序缺口。
+- [x] Entity-machine deploy/migration-ordering smoke for #2769.
+  - the release package reached dependency refresh, migration step, PM2 restart,
+    and healthcheck; pending migration diff was clean and `migrationPendingCount=0`.
+  - dedicated fresh-DB rebuild was not separately posted as #2769 evidence; the
+    owner-reviewed scoped release gate accepted the deploy/migration/auth
+    evidence above.
 - [x] 部署前/后 pending-migration diff + auth round-trip；静默 401 优先按 schema/migration 缺口排查，不先归咎 JWT secret。
-- [ ] C2 read-only smoke。
-- [ ] C3 incremental resume smoke。
-- [ ] C4 UI config smoke。
+- [x] C2 read-only smoke cited from #2600 for release signoff.
+- [x] C3 incremental resume smoke on exact package `79ab455e`.
+  - #2769 evidence: `mode=monotonic_id`, `pagesRead=2`,
+    `resumeReadDuplicateCount=0`, first/second/third run row counts recorded
+    values-free, `watermarkStableOnEmptyResume=true`, no dead letters, no
+    external DB write, no raw SQL, cursor values not printed, row values not
+    printed, payload JSON not printed.
+- [x] C4 UI config smoke on exact package `79ab455e`.
+  - #2769 evidence: Workbench page loaded, advanced connectors enabled,
+    bridge adapter option and picker visible, source/object/schema/source-field
+    picker and watermark UI passed, credentials input and credential JSON
+    textarea not visible, no credential copy, boundary text visible, no failed
+    API responses, token/password/values not printed.
 - [x] C5 K3 seam smoke。
 - [x] C6 core dry-run/apply/re-pull/rollback smoke（#2720）。
   - core sandbox smoke PASS; read-only dedicated dry-run subgate PASS.
@@ -623,12 +641,14 @@ TODO:
 - [x] issue 上贴 values-free 验收证据（#2720 entity-machine evidence + acceptance reply）。
 - [x] #2720 closed as C6 sandbox external-write smoke PASS after #2767 docs backfill.
 - [x] #2769 opened for the separate release evidence package gate.
+- [x] #2769 closed as scoped release evidence package PASS after exact-package
+  C3/C4 evidence and #2775 docs caveat backfill.
 
 交付判据:
 
 - C6 sandbox smoke 完成前: 只能称为“只读数据库接入可用”。
 - C6 sandbox smoke 已完成并通过实体机验收；现在可以称为“数据库及系统连接能力的 sandbox 交付链路已闭合”。
-- 完整 release 签收仍需 release runbook 的最终 values-free evidence package；production/batch 写入仍是独立显式 gate。
+- #2769 scoped release evidence package 已关闭为 PASS；production/batch 写入仍是独立显式 gate。
 
 ## 并行策略
 

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -7,7 +7,8 @@ release evidence package.
 
 Current evidence issue:
 
-- #2769 `[Data Source] Release evidence package gate`
+- #2769 `[Data Source] Release evidence package gate` — CLOSED/PASS for the
+  scoped release evidence package.
 
 Current release package anchor:
 
@@ -23,15 +24,15 @@ Current release package anchor:
   `deployApplyExit=0`, API/root health `200`, pending migration diff clean,
   `migrationPendingCount=0`, auth login/me `200`, backend online, and
   integration plugin present. The default-temp caveat is tracked by #2642.
+- C3/C4 exact-package checkpoint: #2769 accepted C3 monotonic-id
+  incremental/resume smoke and C4 Workbench UI configuration smoke on package
+  `79ab455e`; both evidence blocks are values-free.
 
-This package/deploy/auth checkpoint does not close the release gate by itself.
-C3 incremental/resume and C4 UI exact-package evidence are still HOLD unless
-the owner explicitly narrows or defers those gates with downgraded wording.
-
-This runbook does not authorize production rollout, batch writes, K3 Save /
-Submit / Audit / BOM, raw SQL, or broad writable database grants. C6 external
-write remains sandbox-only until the C6 smoke gate passes and a separate
-production/batch gate is explicitly approved and passes its own evidence/signoff.
+This closes the scoped release evidence package gate. It does not authorize
+production rollout, batch writes, K3 Save / Submit / Audit / BOM, raw SQL, or
+broad writable database grants.
+The C6 evidence cited here is sandbox-scoped; production/batch rollout still
+requires a separate explicit gate and evidence/signoff.
 
 ## Scope
 
@@ -66,8 +67,8 @@ the corresponding section below and post fresh values-free evidence.
 | Gate | Current anchor | Reuse rule for release signoff |
 | --- | --- | --- |
 | C2 read-only SQL source | issue #2600 closed PASS on package `f483bfdac`: PostgreSQL, MySQL/MariaDB, and SQL Server read-only paths all passed with `rowsWritten=0`, credentials stayed in `/data-sources`, and C3/C6/K3 writes were not run. | May be cited as prior entity-machine coverage for the read-only bridge. Rerun section 3 on the release package if C2 source/adapter/package surfaces changed or if exact-package evidence is required. |
-| C3 incremental/watermark | Runtime and CI real-DB wire locks are landed on main, but no release-package entity-machine incremental/resume smoke is recorded in this runbook. Large-BOM #2425 is related Data Factory C3/C4 evidence, not the SQL watermark/resume release gate. | Section 4 remains required for complete delivery unless an owner explicitly narrows the release scope and uses downgraded wording. Do not cite #2425 as C3 watermark/resume PASS. |
-| C4 UI configuration | Source/object/schema picker, source-field picker, watermark UI, and read-only/source-only boundary UX have landed, but this runbook has no final release-package UI smoke evidence yet. | Section 5 remains required for complete delivery unless exact UI smoke is explicitly deferred with downgraded wording. |
+| C3 incremental/watermark | issue #2769 closed PASS on package `79ab455e`: exact-package monotonic-id incremental/resume smoke passed with multi-run counts, `resumeReadDuplicateCount=0`, stable empty resume, no dead letters, no external DB write, no raw SQL, and no cursor/row/payload values printed. Large-BOM #2425 remains separate Data Factory evidence and is not the SQL watermark/resume gate. | Closed for the scoped release package. Future release packages should rerun section 4 if C3 source/adapter/package surfaces changed or if exact-package evidence is required again. |
+| C4 UI configuration | issue #2769 closed PASS on package `79ab455e`: Workbench page loaded, advanced connectors enabled, data-source bridge adapter option/picker visible, source/object/schema/source-field picker and watermark UI passed, credential inputs/textareas hidden, no credential copy, boundary text visible, and no token/password/values printed. | Closed for the scoped release package. Future release packages should rerun section 5 if C4 UI/source-picker/package surfaces changed or if exact-package evidence is required again. |
 | C5 K3/MSSQL read-only seam | issue #2670 closed PASS on package `dea391a1`: generic SQL Server smoke and K3 SQL Server executor smoke both passed after operator SQL scope adjustment; no K3 Save/Submit/Audit/BOM, external DB write, raw SQL, credentials, or row values were printed. | May be cited when no C5-relevant package/runtime surface changed after `dea391a1`; otherwise rerun the C5 runbook on the release package. |
 | C6 external write | issue #2720 is CLOSED/PASS: core sandbox dry-run/apply/re-pull/rollback PASS, read-only dedicated-route PASS, and C6-5c controlled bad-row PASS on package `d8244ee13`. The final pass used the reviewed C6-5b default-off, sandbox-only, server-owned failure-injection seam after real sandbox failure shapes were unavailable. Evidence showed one clean sibling write, one synthetic row-level failure `C6_TEST_INJECTED_ROW_FAILURE`, dead-letter/provenance counters, no request-body injection, and injection config restored/disabled after the check. | May be cited as C6 sandbox external-write smoke PASS for release evidence. Production/batch writes remain closed unless a separate production rollout gate is explicitly approved and passes its own evidence/signoff. |
 
@@ -209,6 +210,18 @@ c3Incremental:
   valuesFreeEvidence=true
 ```
 
+Current #2769 checkpoint:
+
+- `mode=monotonic_id`;
+- `pagesRead=2`;
+- `resumeReadDuplicateCount=0`;
+- first/second/third run row counts were posted as counts only;
+- `watermarkStableOnEmptyResume=true`;
+- `deadLetters=0`;
+- `externalDbWrite=false`;
+- `rawSqlExecuted=false`;
+- cursor values, row values, and payload JSON were not printed.
+
 ## 5. C4 UI Configuration Smoke
 
 Use the Workbench UI on the deployed package.
@@ -235,6 +248,18 @@ c4Ui:
   boundaryTextVisible=true|false
   valuesFreeEvidence=true
 ```
+
+Current #2769 checkpoint:
+
+- Workbench page loaded;
+- advanced connectors enabled;
+- data-source bridge adapter option and picker visible;
+- source/object/schema/source-field picker and watermark UI passed;
+- credential input and credential JSON textarea not visible;
+- credentials were not copied;
+- boundary text visible;
+- no failed API responses;
+- token/password/values were not printed.
 
 ## 6. C5 K3/MSSQL Read-Only Seam
 
@@ -478,12 +503,11 @@ Release signoff requires all of:
 
 The Evidence Reuse Ledger above may justify citing prior gates where explicitly
 allowed, but it does not change these pass criteria and does not turn a HOLD into
-PASS.
+PASS. #2769 is the owner-reviewed issue that closes these criteria for the
+scoped release package.
 
 Before C6 sandbox smoke passes, describe the product as "read-only database
-source integration available with external-write still gated". Only after C2,
-C3, C4, C5, and C6 all pass may the release discuss complete
-database/source-system integration delivery. If an owner explicitly removes C3
-from a narrower release scope, use downgraded wording that names the missing
-incremental/resume gate; do not call it complete delivery. Production/batch
-rollout still requires a separate explicit gate.
+source integration available with external-write still gated". After #2769, the
+scoped database/source-system integration release evidence package may be
+described as passed. Production/batch rollout still requires a separate explicit
+gate.


### PR DESCRIPTION
## Summary
- record #2769 as CLOSED/PASS for the scoped release evidence package
- add the exact-package C3 incremental/resume and C4 UI smoke evidence for package `79ab455e`
- keep #2642 open for the Windows default-temp workaround and keep production/batch writes as a separate explicit gate

## Verification
- `git diff --check`
- #2769 C3/C4 evidence: https://github.com/zensgit/metasheet2/issues/2769#issuecomment-4726713643
- #2769 acceptance: https://github.com/zensgit/metasheet2/issues/2769#issuecomment-4726998847

## Boundary
Docs-only. This closes the scoped release evidence package gate; it does not authorize production/batch rollout, K3 Save/Submit/Audit/BOM, raw SQL, or broad writable DB grants.