### PR TITLE
feat(attendance): annual-leave L5b — annualLeavePolicy config UI

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6223,10 +6223,11 @@
                 </table>
               </div>
               <div class="attendance__admin-actions">
-                <button class="attendance__btn" @click="() => addAnnualPolicyTier()">{{ tr('Add tier', '新增阶梯') }}</button>
-                <button class="attendance__btn attendance__btn--primary" :disabled="annualPolicySaving" @click="() => saveAnnualPolicy()">
+                <button class="attendance__btn" :disabled="!annualPolicyLoaded" @click="() => addAnnualPolicyTier()">{{ tr('Add tier', '新增阶梯') }}</button>
+                <button class="attendance__btn attendance__btn--primary" :disabled="annualPolicySaving || !annualPolicyLoaded" @click="() => saveAnnualPolicy()">
                   {{ annualPolicySaving ? tr('Saving...', '保存中...') : tr('Save policy', '保存策略') }}
                 </button>
+                <span v-if="!annualPolicyLoaded" class="attendance__hint">{{ tr('Load the current policy before editing', '编辑前请先加载当前策略') }}</span>
               </div>
             </div>
 
@@ -8739,6 +8740,16 @@ interface AttendanceSettings {
       internalWinsOnIn?: boolean
       externalWinsOnOut?: boolean
     }
+  }
+  // 年假/法定假 L5b — the annual-leave engine policy (backend L0-L4). The admin card reads/writes it via
+  // PUT { annualLeavePolicy: ... } (per-key merge leaves sibling settings intact).
+  annualLeavePolicy?: {
+    enabled?: boolean
+    tenureMode?: string
+    standardDayMinutes?: number
+    tiers?: Array<{ minYears?: number; maxYears?: number | null; days?: number }>
+    carryover?: { enabled?: boolean }
+    timezone?: string | null
   }
 }
 
@@ -18640,6 +18651,7 @@ async function loadSettings() {
     applyInOutMergeToForm(data.data || {})
     applyAutoShiftMatchingToForm(data.data || {})
     applyAutoShiftAutoWriteToForm(data.data || {})
+    applyAnnualPolicyToForm(data.data || {})
   } catch (error: any) {
     attendanceSettings.value = null
     setStatusFromError(error, tr('Failed to load settings', '加载设置失败'), 'admin')
@@ -19762,6 +19774,7 @@ async function loadAnnualLeaveBalance() {
 interface AnnualLeaveTierRow { minYears: number; maxYears: number | null; days: number }
 const annualPolicyLoading = ref(false)
 const annualPolicySaving = ref(false)
+const annualPolicyLoaded = ref(false)
 const annualPolicyForm = reactive<{
   enabled: boolean
   tenureMode: string
@@ -19782,6 +19795,29 @@ const annualPolicyForm = reactive<{
   timezone: '',
 })
 
+// Hydrate the policy form from a settings object — the idiomatic apply…ToForm pattern, called from loadSettings()
+// on admin init AND after a successful save, so the form ALWAYS reflects the persisted policy, never the
+// clobber-able local defaults. tiers is hydrated whenever it is an array — INCLUDING an explicit empty ladder
+// (the backend allows [] = org disables tiers); only a MISSING tiers key keeps the current/default ladder.
+function applyAnnualPolicyToForm(settings: AttendanceSettings): void {
+  const p = settings.annualLeavePolicy
+  if (p) {
+    annualPolicyForm.enabled = !!p.enabled
+    annualPolicyForm.tenureMode = p.tenureMode || 'cumulative_service'
+    annualPolicyForm.standardDayMinutes = Number(p.standardDayMinutes) || 480
+    if (Array.isArray(p.tiers)) {
+      annualPolicyForm.tiers = p.tiers.map(t => ({
+        minYears: Number(t.minYears) || 0,
+        maxYears: t.maxYears === null || t.maxYears === undefined ? null : Number(t.maxYears),
+        days: Number(t.days) || 0,
+      }))
+    }
+    annualPolicyForm.carryoverEnabled = !!p.carryover?.enabled
+    annualPolicyForm.timezone = p.timezone || ''
+  }
+  annualPolicyLoaded.value = true
+}
+
 async function loadAnnualPolicy() {
   annualPolicyLoading.value = true
   try {
@@ -19795,21 +19831,7 @@ async function loadAnnualPolicy() {
       throw new Error(readErrorMessage(data, tr('Failed to load annual leave policy', '加载年假策略失败')))
     }
     adminForbidden.value = false
-    const p = data.data?.annualLeavePolicy
-    if (p) {
-      annualPolicyForm.enabled = !!p.enabled
-      annualPolicyForm.tenureMode = p.tenureMode || 'cumulative_service'
-      annualPolicyForm.standardDayMinutes = Number(p.standardDayMinutes) || 480
-      annualPolicyForm.tiers = Array.isArray(p.tiers) && p.tiers.length > 0
-        ? p.tiers.map((t: any) => ({
-            minYears: Number(t.minYears) || 0,
-            maxYears: t.maxYears === null || t.maxYears === undefined ? null : Number(t.maxYears),
-            days: Number(t.days) || 0,
-          }))
-        : annualPolicyForm.tiers
-      annualPolicyForm.carryoverEnabled = !!p.carryover?.enabled
-      annualPolicyForm.timezone = p.timezone || ''
-    }
+    applyAnnualPolicyToForm((data.data || {}) as AttendanceSettings)
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load annual leave policy', '加载年假策略失败')), 'error')
   } finally {
@@ -19827,10 +19849,40 @@ function onAnnualPolicyTierMaxInput(tier: AnnualLeaveTierRow, value: string): vo
   // maxYears is nullable ("and above"); an empty field means null, not 0 (v-model.number can't express this).
   tier.maxYears = value.trim() === '' ? null : Number(value)
 }
+// Mirror the backend ladder rules (normalizeAnnualLeaveTiers) so a malformed ladder is rejected here with a clear
+// message — otherwise the backend silently reverts the WHOLE list to the statutory preset and still returns 200,
+// discarding the admin's intent. An empty list is allowed (org disables tiers).
+function annualPolicyTierError(): string | null {
+  const tiers = annualPolicyForm.tiers
+  if (tiers.length === 0) return null
+  for (const t of tiers) {
+    if (!Number.isFinite(t.minYears) || t.minYears < 0) return tr('Each tier needs min years ≥ 0', '每个阶梯的起始年须 ≥ 0')
+    if (!Number.isFinite(t.days) || t.days < 0) return tr('Each tier needs days ≥ 0', '每个阶梯的天数须 ≥ 0')
+    if (t.maxYears !== null && (!Number.isFinite(t.maxYears) || t.maxYears <= t.minYears)) {
+      return tr('Tier max years must exceed min years, or be blank for open-ended', '阶梯截止年须大于起始年，或留空表示开放上限')
+    }
+  }
+  for (let i = 1; i < tiers.length; i++) {
+    if (tiers[i - 1].maxYears === null) return tr('Only the last tier may be open-ended (blank max years)', '仅最后一个阶梯可为开放上限(截止年留空)')
+    if (tiers[i].minYears !== tiers[i - 1].maxYears) return tr('Tiers must be contiguous — each starts where the previous ends', '阶梯须连续——每段起始年等于上一段截止年')
+  }
+  if (tiers[tiers.length - 1].maxYears !== null) return tr('The last tier must be open-ended (leave max years blank)', '最后一个阶梯须为开放上限(截止年留空)')
+  return null
+}
 
 async function saveAnnualPolicy() {
+  // Never let the hardcoded form defaults be PUT over a real policy the admin hasn't loaded yet.
+  if (!annualPolicyLoaded.value) {
+    setStatus(tr('Load the current policy before saving', '请先加载当前策略再保存'), 'error')
+    return
+  }
   if (annualPolicyForm.enabled && !annualPolicyForm.timezone.trim()) {
     setStatus(tr('Timezone is required when the annual leave engine is enabled', '启用年假引擎时必须填写时区'), 'error')
+    return
+  }
+  const tierError = annualPolicyTierError()
+  if (tierError) {
+    setStatus(tierError, 'error')
     return
   }
   annualPolicySaving.value = true
@@ -19855,8 +19907,10 @@ async function saveAnnualPolicy() {
       throw new Error(readErrorMessage(data, tr('Failed to save annual leave policy', '保存年假策略失败')))
     }
     adminForbidden.value = false
+    // Backfill from the server's normalized response (falling back to the payload), mirroring the other policy
+    // cards — so the form reflects exactly what persisted (e.g. a malformed ladder the backend reverted).
+    applyAnnualPolicyToForm((data.data || payload) as AttendanceSettings)
     setStatus(tr('Annual leave policy saved', '年假策略已保存'), 'info')
-    await loadAnnualPolicy()
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to save annual leave policy', '保存年假策略失败')), 'error')
   } finally {

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6166,6 +6166,71 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy)"
+            >
+              <div class="attendance__admin-section-header">
+                <h4>{{ tr('Annual leave policy', '年假策略') }}</h4>
+                <button class="attendance__btn" :disabled="annualPolicyLoading" @click="() => loadAnnualPolicy()">
+                  {{ annualPolicyLoading ? tr('Loading...', '加载中...') : tr('Reload policy', '重载策略') }}
+                </button>
+              </div>
+              <div class="attendance__admin-grid">
+                <label class="attendance__field">
+                  <span>{{ tr('Enabled', '启用') }}</span>
+                  <input type="checkbox" v-model="annualPolicyForm.enabled" />
+                </label>
+                <label class="attendance__field" for="attendance-annual-policy-tenure">
+                  <span>{{ tr('Tenure mode', '工龄口径') }}</span>
+                  <select id="attendance-annual-policy-tenure" v-model="annualPolicyForm.tenureMode">
+                    <option value="cumulative_service">{{ tr('Cumulative service', '累计工龄') }}</option>
+                    <option value="company_tenure">{{ tr('Company tenure', '本单位工龄') }}</option>
+                  </select>
+                </label>
+                <label class="attendance__field" for="attendance-annual-policy-stdday">
+                  <span>{{ tr('Standard day (min)', '标准工作日(分钟)') }}</span>
+                  <input id="attendance-annual-policy-stdday" type="number" v-model.number="annualPolicyForm.standardDayMinutes" />
+                </label>
+                <label class="attendance__field" for="attendance-annual-policy-tz">
+                  <span>{{ tr('Timezone (IANA)', '时区 (IANA)') }}</span>
+                  <input id="attendance-annual-policy-tz" type="text" v-model="annualPolicyForm.timezone" placeholder="Asia/Shanghai" />
+                </label>
+                <label class="attendance__field">
+                  <span>{{ tr('Carryover', '跨年结转') }}</span>
+                  <input type="checkbox" v-model="annualPolicyForm.carryoverEnabled" />
+                </label>
+              </div>
+              <h5>{{ tr('Tier ladder (cumulative years → days)', '工龄阶梯 (累计工龄 → 天数)') }}</h5>
+              <div class="attendance__table-wrapper">
+                <table class="attendance__table">
+                  <thead>
+                    <tr>
+                      <th>{{ tr('Min years', '起始年') }}</th>
+                      <th>{{ tr('Max years (blank = and above)', '截止年(空=及以上)') }}</th>
+                      <th>{{ tr('Days', '天数') }}</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(tier, index) in annualPolicyForm.tiers" :key="`annual-tier-${index}`">
+                      <td><input type="number" v-model.number="tier.minYears" /></td>
+                      <td><input type="number" :value="tier.maxYears ?? ''" @input="onAnnualPolicyTierMaxInput(tier, ($event.target as HTMLInputElement).value)" /></td>
+                      <td><input type="number" v-model.number="tier.days" /></td>
+                      <td><button class="attendance__btn" @click="() => removeAnnualPolicyTier(index)">{{ tr('Remove', '删除') }}</button></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div class="attendance__admin-actions">
+                <button class="attendance__btn" @click="() => addAnnualPolicyTier()">{{ tr('Add tier', '新增阶梯') }}</button>
+                <button class="attendance__btn attendance__btn--primary" :disabled="annualPolicySaving" @click="() => saveAnnualPolicy()">
+                  {{ annualPolicySaving ? tr('Saving...', '保存中...') : tr('Save policy', '保存策略') }}
+                </button>
+              </div>
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
@@ -19688,6 +19753,114 @@ async function loadAnnualLeaveBalance() {
     setStatus(readErrorMessage(error, tr('Failed to load annual leave balance', '加载年假余额失败')), 'error')
   } finally {
     annualBalanceLoading.value = false
+  }
+}
+
+// 年假/法定假 L5b: annualLeavePolicy config (admin console). Loads the policy from settings, edits it, and PUTs it
+// back. Client guards mirror the backend (an enabled policy needs a timezone; the backend additionally validates
+// IANA validity + the tier ladder and returns a clear error we surface).
+interface AnnualLeaveTierRow { minYears: number; maxYears: number | null; days: number }
+const annualPolicyLoading = ref(false)
+const annualPolicySaving = ref(false)
+const annualPolicyForm = reactive<{
+  enabled: boolean
+  tenureMode: string
+  standardDayMinutes: number
+  tiers: AnnualLeaveTierRow[]
+  carryoverEnabled: boolean
+  timezone: string
+}>({
+  enabled: false,
+  tenureMode: 'cumulative_service',
+  standardDayMinutes: 480,
+  tiers: [
+    { minYears: 1, maxYears: 10, days: 5 },
+    { minYears: 10, maxYears: 20, days: 10 },
+    { minYears: 20, maxYears: null, days: 15 },
+  ],
+  carryoverEnabled: false,
+  timezone: '',
+})
+
+async function loadAnnualPolicy() {
+  annualPolicyLoading.value = true
+  try {
+    const response = await apiFetch(`/api/attendance/settings?${buildQuery({ orgId: normalizedOrgId() }).toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load annual leave policy', '加载年假策略失败')))
+    }
+    adminForbidden.value = false
+    const p = data.data?.annualLeavePolicy
+    if (p) {
+      annualPolicyForm.enabled = !!p.enabled
+      annualPolicyForm.tenureMode = p.tenureMode || 'cumulative_service'
+      annualPolicyForm.standardDayMinutes = Number(p.standardDayMinutes) || 480
+      annualPolicyForm.tiers = Array.isArray(p.tiers) && p.tiers.length > 0
+        ? p.tiers.map((t: any) => ({
+            minYears: Number(t.minYears) || 0,
+            maxYears: t.maxYears === null || t.maxYears === undefined ? null : Number(t.maxYears),
+            days: Number(t.days) || 0,
+          }))
+        : annualPolicyForm.tiers
+      annualPolicyForm.carryoverEnabled = !!p.carryover?.enabled
+      annualPolicyForm.timezone = p.timezone || ''
+    }
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to load annual leave policy', '加载年假策略失败')), 'error')
+  } finally {
+    annualPolicyLoading.value = false
+  }
+}
+
+function addAnnualPolicyTier(): void {
+  annualPolicyForm.tiers.push({ minYears: 0, maxYears: null, days: 0 })
+}
+function removeAnnualPolicyTier(index: number): void {
+  annualPolicyForm.tiers.splice(index, 1)
+}
+function onAnnualPolicyTierMaxInput(tier: AnnualLeaveTierRow, value: string): void {
+  // maxYears is nullable ("and above"); an empty field means null, not 0 (v-model.number can't express this).
+  tier.maxYears = value.trim() === '' ? null : Number(value)
+}
+
+async function saveAnnualPolicy() {
+  if (annualPolicyForm.enabled && !annualPolicyForm.timezone.trim()) {
+    setStatus(tr('Timezone is required when the annual leave engine is enabled', '启用年假引擎时必须填写时区'), 'error')
+    return
+  }
+  annualPolicySaving.value = true
+  try {
+    const payload = {
+      annualLeavePolicy: {
+        enabled: annualPolicyForm.enabled,
+        tenureMode: annualPolicyForm.tenureMode,
+        standardDayMinutes: annualPolicyForm.standardDayMinutes,
+        tiers: annualPolicyForm.tiers.map(t => ({ minYears: t.minYears, maxYears: t.maxYears, days: t.days })),
+        carryover: { enabled: annualPolicyForm.carryoverEnabled },
+        timezone: annualPolicyForm.timezone.trim() || null,
+      },
+    }
+    const response = await apiFetch('/api/attendance/settings', { method: 'PUT', body: JSON.stringify(payload) })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to save annual leave policy', '保存年假策略失败')))
+    }
+    adminForbidden.value = false
+    setStatus(tr('Annual leave policy saved', '年假策略已保存'), 'info')
+    await loadAnnualPolicy()
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to save annual leave policy', '保存年假策略失败')), 'error')
+  } finally {
+    annualPolicySaving.value = false
   }
 }
 

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -38,6 +38,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   schedulerScopes: 'attendance-admin-scheduler-scopes',
   holidays: 'attendance-admin-holidays',
   annualLeaveBalance: 'attendance-admin-annual-leave-balance',
+  annualLeavePolicy: 'attendance-admin-annual-leave-policy',
 } as const
 
 export type AdminSectionNavItem = {
@@ -189,6 +190,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.schedulerScopes, label: tr('Scheduler scope mgmt', '排班管理范围') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.holidays, label: tr('Holidays', '节假日') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance, label: tr('Annual leave balance', '年假余额') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy, label: tr('Annual leave policy', '年假策略') },
   ])
   const adminSectionItemMap = computed(() => new Map(adminSectionNavItems.value.map(item => [item.id, item])))
   const adminSectionNavGroups = computed<AdminSectionNavGroupDefinition[]>(() => [
@@ -243,6 +245,7 @@ export function useAttendanceAdminRail({
       label: tr('Annual leave', '年假/法定假'),
       itemIds: [
         ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance,
+        ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy,
       ],
     },
     {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,10 +124,11 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Annual leave', 'Data & Payroll'])
-    expect(labels).toHaveLength(28)
+    expect(labels).toHaveLength(29)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Annual leave balance',
+        'Annual leave policy',
         'Settings',
         'User Access',
         'Notification deliveries',
@@ -828,7 +829,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(28)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(29)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -988,7 +988,7 @@ describe('Attendance admin regressions', () => {
     expect(section!.querySelector('.attendance__annual-balance')).toBeNull()
   })
 
-  it('loads the annual-leave policy, blocks save when enabled without a timezone, then saves', async () => {
+  it('annual-leave policy: hydrates from first-screen settings; first save (no Reload) keeps the real policy; blocks malformed ladder', async () => {
     let savedPayload: any = null
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = String(input)
@@ -1007,37 +1007,78 @@ describe('Attendance admin regressions', () => {
 
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)
-    await flushUi(8)
+    await flushUi(8) // loadSettings() on admin init must hydrate the policy form (no manual Reload)
 
     container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-policy"]')!.click()
     await flushUi(4)
     const section = container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-policy')
     expect(section).toBeTruthy()
-
-    // load → form populates from settings.
-    section!.querySelector<HTMLButtonElement>('.attendance__admin-section-header button')!.click()
-    await flushUi(4)
-    const tzInput = section!.querySelector<HTMLInputElement>('#attendance-annual-policy-tz')
-    expect(tzInput?.value).toBe('Asia/Shanghai')
+    const tzInput = section!.querySelector<HTMLInputElement>('#attendance-annual-policy-tz')!
+    expect(tzInput.value).toBe('Asia/Shanghai') // hydrated on first screen via loadSettings, NOT a Reload click
     const saveBtn = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Save policy'))!
 
-    // enabled + empty timezone → blocked client-side (no PUT).
-    tzInput!.value = ''
-    tzInput!.dispatchEvent(new Event('input'))
-    await flushUi(2)
-    saveBtn.click()
-    await flushUi(4)
-    expect(savedPayload).toBeNull()
-
-    // restore a timezone → save PUTs the policy.
-    tzInput!.value = 'Asia/Shanghai'
-    tzInput!.dispatchEvent(new Event('input'))
-    await flushUi(2)
+    // FIRST save WITHOUT ever clicking Reload → must PUT the real (hydrated) policy, never the local defaults.
     saveBtn.click()
     await flushUi(4)
     expect(savedPayload?.annualLeavePolicy?.enabled).toBe(true)
     expect(savedPayload?.annualLeavePolicy?.timezone).toBe('Asia/Shanghai')
     expect(savedPayload?.annualLeavePolicy?.carryover?.enabled).toBe(true)
+    expect(savedPayload?.annualLeavePolicy?.tiers).toEqual([{ minYears: 1, maxYears: null, days: 5 }])
+
+    // enabled + empty timezone → blocked client-side (no PUT).
+    savedPayload = null
+    tzInput.value = ''
+    tzInput.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    saveBtn.click()
+    await flushUi(4)
+    expect(savedPayload).toBeNull()
+
+    // restore timezone but make the ladder malformed (a closed last band) → blocked client-side, surfacing what the
+    // backend would otherwise silently revert to the statutory preset with a 200 "saved".
+    tzInput.value = 'Asia/Shanghai'
+    tzInput.dispatchEvent(new Event('input'))
+    const maxYearsInput = section!.querySelector<HTMLInputElement>('tbody tr td:nth-child(2) input')!
+    maxYearsInput.value = '10'
+    maxYearsInput.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    saveBtn.click()
+    await flushUi(4)
+    expect(savedPayload).toBeNull()
+  })
+
+  it('annual-leave policy: an explicit empty tier ladder round-trips (not reverted to the default ladder)', async () => {
+    let savedPayload: any = null
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/settings') && (init?.method ?? 'GET') === 'PUT') {
+        savedPayload = JSON.parse(String(init!.body))
+        return jsonResponse(200, { ok: true, data: {} })
+      }
+      if (url.includes('/api/attendance/settings')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: { annualLeavePolicy: { enabled: false, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [], carryover: { enabled: false }, timezone: null } },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-policy"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-policy')!
+    // the explicit empty ladder must hydrate as [] (no tier rows), NOT fall back to the 3-band default.
+    expect(section.querySelectorAll('tbody tr').length).toBe(0)
+    const saveBtn = Array.from(section.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Save policy'))!
+
+    // save (disabled engine, no edits) → PUT must keep tiers: [], not re-inject defaults.
+    saveBtn.click()
+    await flushUi(4)
+    expect(savedPayload?.annualLeavePolicy?.tiers).toEqual([])
   })
 
   it('warns when the attendance-group picker source is capped (no silent caps)', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -988,6 +988,58 @@ describe('Attendance admin regressions', () => {
     expect(section!.querySelector('.attendance__annual-balance')).toBeNull()
   })
 
+  it('loads the annual-leave policy, blocks save when enabled without a timezone, then saves', async () => {
+    let savedPayload: any = null
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/settings') && (init?.method ?? 'GET') === 'PUT') {
+        savedPayload = JSON.parse(String(init!.body))
+        return jsonResponse(200, { ok: true, data: {} })
+      }
+      if (url.includes('/api/attendance/settings')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: { annualLeavePolicy: { enabled: true, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [{ minYears: 1, maxYears: null, days: 5 }], carryover: { enabled: true }, timezone: 'Asia/Shanghai' } },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-policy"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-policy')
+    expect(section).toBeTruthy()
+
+    // load → form populates from settings.
+    section!.querySelector<HTMLButtonElement>('.attendance__admin-section-header button')!.click()
+    await flushUi(4)
+    const tzInput = section!.querySelector<HTMLInputElement>('#attendance-annual-policy-tz')
+    expect(tzInput?.value).toBe('Asia/Shanghai')
+    const saveBtn = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Save policy'))!
+
+    // enabled + empty timezone → blocked client-side (no PUT).
+    tzInput!.value = ''
+    tzInput!.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    saveBtn.click()
+    await flushUi(4)
+    expect(savedPayload).toBeNull()
+
+    // restore a timezone → save PUTs the policy.
+    tzInput!.value = 'Asia/Shanghai'
+    tzInput!.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    saveBtn.click()
+    await flushUi(4)
+    expect(savedPayload?.annualLeavePolicy?.enabled).toBe(true)
+    expect(savedPayload?.annualLeavePolicy?.timezone).toBe('Asia/Shanghai')
+    expect(savedPayload?.annualLeavePolicy?.carryover?.enabled).toBe(true)
+  })
+
   it('warns when the attendance-group picker source is capped (no silent caps)', async () => {
     vi.mocked(apiFetch).mockImplementation(async (input) => {
       const url = String(input)


### PR DESCRIPTION
Implements **L5b** per the design-lock (#2764): the admin **config** half of the annual-leave UI, stacked on the now-merged L5a read view (#2779).

## What
A **年假策略 / Annual leave policy** section in the existing 年假/法定假 admin nav group (the Policy sub-block beside L5a's Balance view) in `AttendanceView.vue`:
- Loads the policy from `GET /api/attendance/settings`; saves via `PUT { annualLeavePolicy }` (partial merge).
- Fields: `enabled` toggle, `tenureMode`, `standardDayMinutes`, `timezone` (IANA), `carryover.enabled`, and an **add/remove tier ladder** (`minYears` / nullable `maxYears` / `days`).
- **Client guard mirrors the backend**: an enabled policy requires a timezone; the backend additionally validates IANA validity + the tier ladder and we surface its error verbatim.
- Read + config only — mutating accrual / manual-adjustment / expiry-backfill **triggers (L5c) stay deferred** per the design-lock.

## Tests
- `attendance-admin-anchor-nav.spec.ts` → 29 links/options + `Annual leave policy` asserted (web-guard stays green; updated **in this PR**).
- `attendance-admin-regressions.spec.ts` → a new test loads the policy (form populates from settings), asserts **enabled-without-timezone blocks the save** (no PUT fired), then restores the timezone and asserts the **PUT payload** (`annualLeavePolicy.enabled/timezone/carryover`).
- **112/112** web specs pass; `vue-tsc -b` 0 errors.

## Maps to backend (already on main)
PUTs the same `annualLeavePolicy` shape the L0–L4 engine reads (`enabled / tenureMode / standardDayMinutes / tiers[] / carryover.enabled / timezone`); the nullable `maxYears` "and above" tier is handled explicitly (v-model.number can't express null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)