### PR TITLE
feat(data-factory): metadata-drive table action display

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1049,6 +1049,17 @@ export interface IntegrationTableActionMetadata {
   kind: string
   label: string
   configured: boolean
+  display?: {
+    genericActionKind?: string
+    commandLabel?: string
+    commandLabelZh?: string
+    targetLabel?: string
+    targetLabelZh?: string
+    presetLabel?: string
+    presetLabelZh?: string
+    policyLabel?: string
+    policyLabelZh?: string
+  }
   parameters: IntegrationTableActionParameter[]
   permissions?: {
     dryRun?: string

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -855,7 +855,7 @@
               <span>动作</span>
               <select v-model="selectedTableActionId" data-testid="table-action-id">
                 <option v-for="action in tableActions" :key="action.actionId" :value="action.actionId">
-                  {{ action.label }} · {{ action.configured ? '已配置' : '未配置' }}
+                  {{ tableActionOptionLabel(action) }} · {{ action.configured ? '已配置' : '未配置' }}
                 </option>
               </select>
             </label>
@@ -866,6 +866,9 @@
           </div>
           <p class="integration-workbench__hint" data-testid="table-action-boundary">
             不提供 raw SQL、source/object、sheetId、C3 plan 或 C4 payload 输入；apply 会用 dry-run token 触发服务端重新计算。
+          </p>
+          <p v-if="tableActionDisplayContextItems.length" class="integration-workbench__hint" data-testid="table-action-display-context">
+            {{ tableActionDisplayContextItems.join(' · ') }}
           </p>
           <div class="integration-workbench__actions">
             <button
@@ -884,7 +887,7 @@
               :disabled="!tableActionCanApply"
               @click="applyTableAction"
             >
-              {{ runningTableAction === 'apply' ? 'Apply 中' : 'Apply 到备料表' }}
+              {{ runningTableAction === 'apply' ? 'Apply 中' : tableActionApplyCommandLabel }}
             </button>
           </div>
           <div v-if="tableActionDryRunResult" class="integration-workbench__table-action-review" data-testid="table-action-review">
@@ -2338,6 +2341,65 @@ const dryRunBlockedSummary = computed(() => {
 })
 const configuredTableActions = computed(() => tableActions.value.filter((action) => action.configured === true))
 const selectedTableAction = computed(() => tableActions.value.find((action) => action.actionId === selectedTableActionId.value) || configuredTableActions.value[0] || tableActions.value[0] || null)
+type TableActionDisplayKey = keyof NonNullable<IntegrationTableActionMetadata['display']>
+type TableActionDisplay = NonNullable<IntegrationTableActionMetadata['display']>
+
+const GENERIC_TABLE_ACTION_KIND = 'apply_to_target_table'
+const TABLE_ACTION_GENERIC_APPLY_LABEL = 'Apply 到目标表'
+const DOMAIN_SPECIFIC_APPLY_LABEL_PATTERN = /备料表|stock[-\s]?preparation/i
+
+function safeTableActionDisplay(action: IntegrationTableActionMetadata | null | undefined): TableActionDisplay | null {
+  const display = action?.display
+  return display?.genericActionKind === GENERIC_TABLE_ACTION_KIND ? display : null
+}
+
+function safeTableActionCommandLabel(value: string, fallback: string): string {
+  return DOMAIN_SPECIFIC_APPLY_LABEL_PATTERN.test(value) ? fallback : value
+}
+
+function tableActionDisplayString(
+  action: IntegrationTableActionMetadata | null | undefined,
+  zhKey: TableActionDisplayKey,
+  key: TableActionDisplayKey,
+  fallback: string,
+): string {
+  const display = safeTableActionDisplay(action)
+  const localized = display?.[zhKey]
+  if (typeof localized === 'string' && localized.trim()) {
+    const value = localized.trim()
+    return key === 'commandLabel' ? safeTableActionCommandLabel(value, fallback) : value
+  }
+  const value = display?.[key]
+  if (typeof value === 'string' && value.trim()) {
+    const normalized = value.trim()
+    return key === 'commandLabel' ? safeTableActionCommandLabel(normalized, fallback) : normalized
+  }
+  return fallback
+}
+
+function tableActionOptionLabel(action: IntegrationTableActionMetadata): string {
+  const command = tableActionDisplayString(action, 'commandLabelZh', 'commandLabel', TABLE_ACTION_GENERIC_APPLY_LABEL)
+  const preset = tableActionDisplayString(action, 'presetLabelZh', 'presetLabel', '')
+  return preset ? `${command} · ${preset}` : command
+}
+
+const tableActionApplyCommandLabel = computed(() => tableActionDisplayString(
+  selectedTableAction.value,
+  'commandLabelZh',
+  'commandLabel',
+  TABLE_ACTION_GENERIC_APPLY_LABEL,
+))
+const tableActionDisplayContextItems = computed(() => {
+  const action = selectedTableAction.value
+  if (!action) return []
+  return [
+    ['预设', tableActionDisplayString(action, 'presetLabelZh', 'presetLabel', '')],
+    ['目标', tableActionDisplayString(action, 'targetLabelZh', 'targetLabel', '')],
+    ['策略', tableActionDisplayString(action, 'policyLabelZh', 'policyLabel', '')],
+  ]
+    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .map(([label, value]) => `${label}: ${value}`)
+})
 const tableActionCounts = computed(() => tableActionDryRunResult.value?.counts || {})
 const tableActionManualConfirmCount = computed(() => Number(tableActionCounts.value.manual_confirm || 0))
 const tableActionDryRunToken = computed(() => tableActionDryRunResult.value?.dryRunToken || '')
@@ -4342,7 +4404,7 @@ async function applyTableAction(): Promise<void> {
     return
   }
   if (!auth.hasPermission('integration:write')) {
-    setStatus('当前用户只有 dry-run 读取权限，不能 apply 到备料表。', 'error')
+    setStatus(`当前用户只有 dry-run 读取权限，不能 ${tableActionApplyCommandLabel.value}。`, 'error')
     return
   }
   if (!tableActionDryRunToken.value) {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -3499,7 +3499,10 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(12)
 
-    expect(container.querySelector('[data-testid="table-action-panel"]')?.textContent).toContain('PLM project BOM -> stock preparation')
+    const tableActionPanel = container.querySelector('[data-testid="table-action-panel"]')?.textContent || ''
+    expect(tableActionPanel).toContain('Apply 到目标表')
+    expect(tableActionPanel).not.toContain('PLM project BOM -> stock preparation')
+    expect(tableActionPanel).not.toContain('Apply 到备料表')
     expect(container.querySelector('[data-testid="table-action-boundary"]')?.textContent).toContain('不提供 raw SQL')
     expect((container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
 
@@ -3557,6 +3560,17 @@ describe('IntegrationWorkbenchView', () => {
       kind: 'parameterized_table_action',
       label: 'PLM project BOM -> stock preparation',
       configured: true,
+      display: {
+        genericActionKind: 'apply_to_target_table',
+        commandLabel: 'Apply to stock-preparation table',
+        commandLabelZh: 'Apply 到备料表',
+        targetLabel: 'configured target table',
+        targetLabelZh: '已配置目标表',
+        presetLabel: 'PLM stock-preparation preset',
+        presetLabelZh: 'PLM 备料预设',
+        policyLabel: 'fresh dry-run token + server recompute',
+        policyLabelZh: 'fresh dry-run token + 服务端重新计算',
+      },
       parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
       permissions: { dryRun: 'read', apply: 'write' },
       evidence: { valuesFreeIssueEvidence: true },
@@ -3597,6 +3611,11 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(12)
 
+    const tableActionPanel = container.querySelector('[data-testid="table-action-panel"]')?.textContent || ''
+    expect(tableActionPanel).toContain('Apply 到目标表')
+    expect(tableActionPanel).not.toContain('Apply 到备料表')
+    expect(tableActionPanel).not.toContain('Apply to stock-preparation table')
+
     const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
     projectInput.value = 'P-READ'
     projectInput.dispatchEvent(new Event('input', { bubbles: true }))
@@ -3622,6 +3641,17 @@ describe('IntegrationWorkbenchView', () => {
       kind: 'parameterized_table_action',
       label: 'PLM project BOM -> stock preparation',
       configured: true,
+      display: {
+        genericActionKind: 'apply_to_target_table',
+        commandLabel: 'Apply to target table',
+        commandLabelZh: 'Apply 到目标表',
+        targetLabel: 'configured target table',
+        targetLabelZh: '已配置目标表',
+        presetLabel: 'PLM stock-preparation preset',
+        presetLabelZh: 'PLM 备料预设',
+        policyLabel: 'fresh dry-run token + server recompute',
+        policyLabelZh: 'fresh dry-run token + 服务端重新计算',
+      },
       parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
       permissions: { dryRun: 'read', apply: 'write' },
       evidence: { valuesFreeIssueEvidence: true },
@@ -3736,6 +3766,18 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(12)
 
+    const tableActionPanel = container.querySelector('[data-testid="table-action-panel"]')?.textContent || ''
+    const actionSelect = container.querySelector('[data-testid="table-action-id"]')?.textContent || ''
+    const displayContext = container.querySelector('[data-testid="table-action-display-context"]')?.textContent || ''
+    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
+    expect(applyButton.textContent).toContain('Apply 到目标表')
+    expect(applyButton.textContent).not.toContain('备料表')
+    expect(actionSelect).toContain('Apply 到目标表')
+    expect(displayContext).toContain('预设: PLM 备料预设')
+    expect(displayContext).toContain('目标: 已配置目标表')
+    expect(displayContext).toContain('策略: fresh dry-run token + 服务端重新计算')
+    expect(tableActionPanel).not.toContain('Apply 到备料表')
+
     const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
     projectInput.value = 'P-DUP'
     projectInput.dispatchEvent(new Event('input', { bubbles: true }))
@@ -3776,7 +3818,6 @@ describe('IntegrationWorkbenchView', () => {
     expect(evidence).not.toContain('Secret Alloy')
     expect(evidence).not.toContain('DETAIL-A')
     expect(container.querySelector('[data-testid="table-action-panel"]')?.textContent).not.toContain('duplicate-dry-token')
-    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
     expect(applyButton.disabled).toBe(true)
     applyButton.click()
     await flushUi()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -181,12 +181,29 @@ function createRecordsApi({ existing = [], failCreateWith = null } = {}) {
 }
 
 async function testRegistryListsConfiguredMetadataWithoutTargetSecrets() {
-  const registry = createStockPreparationTableActionRegistry({ actions: [baseAction()] })
+  const registry = createStockPreparationTableActionRegistry({
+    actions: [baseAction({
+      label: 'sheet_stock private action label',
+      template: {
+        ...STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
+        label: 'sheet_stock private target label',
+      },
+    })],
+  })
   const actions = await registry.listTableActions()
   assert.equal(actions.length, 1)
   assert.equal(actions[0].actionId, PLM_STOCK_PREPARATION_ACTION_ID)
   assert.equal(actions[0].configured, true)
+  assert.equal(actions[0].label, 'Apply to target table')
+  assert.equal(actions[0].display.genericActionKind, 'apply_to_target_table')
+  assert.equal(actions[0].display.commandLabel, 'Apply to target table')
+  assert.equal(actions[0].display.commandLabelZh, 'Apply 到目标表')
+  assert.equal(actions[0].display.targetLabel, 'configured target table')
+  assert.equal(actions[0].display.targetLabelZh, '已配置目标表')
+  assert.equal(actions[0].display.presetLabel, 'PLM stock-preparation preset')
+  assert.equal(actions[0].display.policyLabel, 'fresh dry-run token + server recompute')
   assert.deepEqual(actions[0].parameters.map((param) => param.id), ['projectNo'])
+  assert.equal(actions[0].parameters[0].binding, undefined, 'public parameter metadata hides source binding details')
   const text = JSON.stringify(actions)
   assert.equal(text.includes('sheet_stock'), false, 'public action metadata does not expose target sheetId')
   assert.equal(text.includes('plm_source_1'), false, 'public action metadata does not expose source binding')

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -35,6 +35,7 @@ const {
 
 const PLM_STOCK_PREPARATION_ACTION_ID = 'plm.stock-preparation.pull-bom.v1'
 const TABLE_ACTION_KIND = 'parameterized_table_action'
+const GENERIC_TABLE_ACTION_KIND = 'apply_to_target_table'
 const DRY_RUN_TOKEN_PREFIX = 'integration:table-action:dry-run-token:'
 const DEFAULT_DRY_RUN_TOKEN_TTL_MS = 30 * 60 * 1000
 const DEFAULT_EXISTING_ROWS_PAGE_LIMIT = 1000
@@ -216,18 +217,25 @@ function publicActionMetadata(action) {
   return {
     actionId: PLM_STOCK_PREPARATION_ACTION_ID,
     kind: TABLE_ACTION_KIND,
-    label: configured && action.label ? action.label : 'PLM project BOM -> stock preparation',
+    label: 'Apply to target table',
     configured,
+    display: {
+      genericActionKind: GENERIC_TABLE_ACTION_KIND,
+      commandLabel: 'Apply to target table',
+      commandLabelZh: 'Apply 到目标表',
+      targetLabel: 'configured target table',
+      targetLabelZh: '已配置目标表',
+      presetLabel: 'PLM stock-preparation preset',
+      presetLabelZh: 'PLM 备料预设',
+      policyLabel: 'fresh dry-run token + server recompute',
+      policyLabelZh: 'fresh dry-run token + 服务端重新计算',
+    },
     parameters: [{
       id: 'projectNo',
       label: 'Project number',
       type: 'string',
       required: true,
       trim: true,
-      binding: {
-        type: 'equality_filter',
-        field: 'FileCode',
-      },
     }],
     permissions: {
       dryRun: 'read',
@@ -710,6 +718,7 @@ async function applyStockPreparationAction(input = {}) {
 
 module.exports = {
   DEFAULT_DRY_RUN_TOKEN_TTL_MS,
+  GENERIC_TABLE_ACTION_KIND,
   PLM_STOCK_PREPARATION_ACTION_ID,
   TABLE_ACTION_KIND,
   StockPreparationTableActionError,


### PR DESCRIPTION
## Summary

Closes the #2388 UI/action-model feedback for the parameterized table-action surface without changing runtime/write authorization.

- adds public table-action `display` metadata with generic `apply_to_target_table` command text, preset context, target context, and policy context
- renders the Workbench table-action select/apply button from metadata, so the generic action button no longer says `Apply 到备料表`
- keeps stock-preparation wording only as preset/context, not the generic action model
- hardens fallback behavior so stale/partial action metadata still renders the generic `Apply 到目标表` command instead of the legacy stock-preparation label
- keeps public target display fixed (`configured target table` / `已配置目标表`) so config-derived template labels cannot leak sheet/source/private ids

## Boundary

No route, auth, dry-run/apply token, target scoping, writer, K3, PLM/external DB write, raw SQL, production, or batch behavior changes. Client request bodies remain generic and metadata-bound.

## Verification

- `git diff --check`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue src/services/integration/workbench.ts --max-warnings=0`

Review notes from parallel subagents were folded in before opening:

- public `targetLabel` no longer derives from configurable template labels
- no-display/stale metadata fallback no longer renders the legacy stock-preparation action label
