### PR TITLE
feat(multitable): dedicated send-notification permission (replace canEditRecord proxy)

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableCapabilities.ts
+++ b/apps/web/src/multitable/composables/useMultitableCapabilities.ts
@@ -14,16 +14,17 @@ export interface MultitableCapabilities {
   canComment: Ref<boolean>
   canManageAutomation: Ref<boolean>
   canExport: Ref<boolean>
+  canSendNotification: Ref<boolean>
 }
 
 const ROLE_CAPS: Record<MultitableRole, Record<string, boolean>> = {
   owner: {
     canRead: true, canCreateRecord: true, canEditRecord: true, canDeleteRecord: true,
-    canManageFields: true, canManageSheetAccess: true, canManageViews: true, canComment: true, canManageAutomation: true, canExport: true,
+    canManageFields: true, canManageSheetAccess: true, canManageViews: true, canComment: true, canManageAutomation: true, canExport: true, canSendNotification: true,
   },
   editor: {
     canRead: true, canCreateRecord: true, canEditRecord: true, canDeleteRecord: true,
-    canManageFields: false, canManageSheetAccess: false, canManageViews: false, canComment: true, canManageAutomation: false, canExport: true,
+    canManageFields: false, canManageSheetAccess: false, canManageViews: false, canComment: true, canManageAutomation: false, canExport: true, canSendNotification: true,
   },
   commenter: {
     canRead: true, canCreateRecord: false, canEditRecord: false, canDeleteRecord: false,
@@ -64,5 +65,8 @@ export function useMultitableCapabilities(
     canComment: caps('canComment'),
     canManageAutomation: caps('canManageAutomation'),
     canExport: caps('canExport', 'canRead'),
+    // Notify falls back to canEditRecord only for an OLD backend response that predates
+    // canSendNotification; current backends send it explicitly.
+    canSendNotification: caps('canSendNotification', 'canEditRecord'),
   }
 }

--- a/apps/web/src/multitable/composables/useMultitableWorkbench.ts
+++ b/apps/web/src/multitable/composables/useMultitableWorkbench.ts
@@ -24,6 +24,7 @@ const EMPTY_CAPABILITIES: MetaCapabilities = {
   canComment: false,
   canManageAutomation: false,
   canExport: false,
+  canSendNotification: false,
 }
 
 function filterVisibleSheets(sheets: MetaSheet[]): MetaSheet[] {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -381,6 +381,10 @@ export interface MetaCapabilities {
   canComment: boolean
   canManageAutomation: boolean
   canExport: boolean
+  // Sheet-level notify capability (B1-S1 send_notification button gate). Server-enforced
+  // (the route is authoritative); the FE mirror is OPTIONAL so existing capability fixtures
+  // need not set it — treat absent as false. Full sheet write/admin only (not write-own).
+  canSendNotification?: boolean
 }
 
 export interface YjsPresenceUser {

--- a/packages/core-backend/src/multitable/access.ts
+++ b/packages/core-backend/src/multitable/access.ts
@@ -13,6 +13,9 @@ export type MultitableCapabilities = {
   canComment: boolean
   canManageAutomation: boolean
   canExport: boolean
+  // Sheet-level "send notification" capability (B1-S1 button send_notification gate).
+  // Full sheet write/admin only — NOT write-own (notify is member fan-out, not record-scoped).
+  canSendNotification: boolean
 }
 
 export type MultitableFieldPermission = {
@@ -119,6 +122,7 @@ export function deriveCapabilities(
     canComment,
     canManageAutomation,
     canExport: canRead,
+    canSendNotification: canWrite,
   }
 }
 

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -198,6 +198,8 @@ export const PUBLIC_FORM_CAPABILITIES: MultitableCapabilities = {
   canComment: false,
   canManageAutomation: false,
   canExport: false,
+  // Anonymous public-form submitter must NEVER be able to send notifications.
+  canSendNotification: false,
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────────
@@ -1017,6 +1019,9 @@ export function applySheetPermissionScope(
     canComment: capabilities.canComment && scope.canRead,
     canManageAutomation: capabilities.canManageAutomation && scope.canWrite,
     canExport: scopedCanRead,
+    // Notify = full sheet write/admin only (scope.canWrite), NOT write-own: a
+    // record-scoped write must not imply notifying members from any row.
+    canSendNotification: capabilities.canSendNotification && scope.canWrite,
   }
 }
 

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1077,6 +1077,10 @@ export function applyContextSheetSchemaWriteGrant(
     ...scoped,
     canManageFields: true,
     canManageViews: true,
+    // Sheet-scoped FULL write (scope.canRead && scope.canWrite — NOT write-own) also grants
+    // the sheet-level notify capability, so a user with a sheet full-write grant but no global
+    // multitable:write can still send_notification (parity with canEditRecord/canManageViews).
+    canSendNotification: true,
     ...(scope.canAdmin ? { canManageSheetAccess: true } : {}),
   }
 }
@@ -1091,6 +1095,7 @@ const MULTITABLE_CAPABILITY_KEYS: Array<keyof MultitableCapabilities> = [
   'canManageViews',
   'canComment',
   'canManageAutomation',
+  'canSendNotification',
 ]
 
 export function deriveCapabilityOrigin(

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -41,6 +41,9 @@ export type MultitableCapabilities = {
   canComment: boolean
   canManageAutomation: boolean
   canExport: boolean
+  // Sheet-level "send notification" capability (B1-S1 button send_notification gate).
+  // Full sheet write/admin only — NOT write-own (notify is member fan-out, not record-scoped).
+  canSendNotification: boolean
 }
 
 export type SheetPermissionScope = {
@@ -91,6 +94,7 @@ export function deriveCapabilities(permissions: string[], isAdminRole: boolean):
     canComment,
     canManageAutomation,
     canExport: canRead,
+    canSendNotification: canWrite,
   }
 }
 

--- a/packages/core-backend/src/multitable/sheet-capabilities.ts
+++ b/packages/core-backend/src/multitable/sheet-capabilities.ts
@@ -148,6 +148,10 @@ export function applyContextSheetSchemaWriteGrant(
     ...scoped,
     canManageFields: true,
     canManageViews: true,
+    // Sheet-scoped FULL write (scope.canRead && scope.canWrite — NOT write-own) also grants
+    // the sheet-level notify capability, so a user with a sheet full-write grant but no global
+    // multitable:write can still send_notification (parity with canEditRecord/canManageViews).
+    canSendNotification: true,
     ...(scope.canAdmin ? { canManageSheetAccess: true } : {}),
   }
 }

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -58,7 +58,7 @@ const logger = new Logger('MultitableButton')
 
 // B1-S1 D0-A enabled actions. `record_click` = executor-owned INERT (read-gated,
 // requestId-optional, NO confirm). `send_notification` = first side-effecting
-// action (edit-gated proxy, durable + deduped + audited in one route transaction).
+// action (notify-gated via canSendNotification, durable + deduped + audited in one route transaction).
 // Every new action must declare its actor gate AND whether it is side-effecting —
 // a single `sideEffecting` flag drives BOTH the requestId requirement (§6 dedup)
 // AND the server-side confirm requirement (§4): a side-effecting action whose

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -63,7 +63,7 @@ const logger = new Logger('MultitableButton')
 // a single `sideEffecting` flag drives BOTH the requestId requirement (§6 dedup)
 // AND the server-side confirm requirement (§4): a side-effecting action whose
 // button declares confirm.enabled MUST be confirmed by the server, not just the FE.
-type ButtonActorGate = 'read' | 'edit'
+type ButtonActorGate = 'read' | 'edit' | 'notify'
 interface ButtonActionPolicy {
   /** Actor permission required to RUN this action (server-evaluated at dispatch). */
   gate: ButtonActorGate
@@ -80,7 +80,7 @@ interface ButtonActionPolicy {
 
 const BUTTON_ACTION_POLICIES: Record<string, ButtonActionPolicy> = {
   record_click: { gate: 'read', sideEffecting: false, dispatchType: 'record_click' },
-  send_notification: { gate: 'edit', sideEffecting: true, dispatchType: 'send_notification' },
+  send_notification: { gate: 'notify', sideEffecting: true, dispatchType: 'send_notification' },
 }
 
 export function createMultitableButtonRoutes(): Router {
@@ -159,10 +159,14 @@ export function createMultitableButtonRoutes(): Router {
       }
 
       // §3 ACTOR GATE (per-action). record_click = read (already passed above).
-      // send_notification = canEditRecord (PROVISIONAL proxy — a side-effecting
-      // button delivering a notification is gated as a record-edit-class action
-      // until a dedicated per-action permission exists; see design-lock §3).
+      // send_notification = canSendNotification — a DEDICATED sheet-level notify
+      // capability (full sheet write/admin, NOT write-own: notify is a fan-out to the
+      // sheet's configured members, not a record-scoped action). Replaces the earlier
+      // canEditRecord proxy. The 'edit' branch is retained for any future edit-gated action.
       if (policy.gate === 'edit' && !capabilities.canEditRecord) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+      }
+      if (policy.gate === 'notify' && !capabilities.canSendNotification) {
         return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
       }
 

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -171,6 +171,7 @@ describe('Multitable context API', () => {
       canComment: true,
       canManageAutomation: true,
       canExport: true,
+      canSendNotification: false,
     })
     expect(response.body.data.capabilityOrigin).toEqual({
       source: 'global-rbac',
@@ -353,6 +354,7 @@ describe('Multitable context API', () => {
       canComment: true,
       canManageAutomation: true,
       canExport: true,
+      canSendNotification: true,
     })
     expect(response.body.data.viewPermissions).toEqual({
       view_grid: {

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -206,6 +206,7 @@ describe('Multitable sheet-scoped permissions API', () => {
       canComment: true,
       canManageAutomation: false,
       canExport: true,
+      canSendNotification: false,
     })
     expect(contextResponse.body.data.viewPermissions).toEqual({
       view_grid: {

--- a/packages/core-backend/tests/unit/multitable-access.test.ts
+++ b/packages/core-backend/tests/unit/multitable-access.test.ts
@@ -94,6 +94,7 @@ describe('multitable access helper', () => {
       canComment: false,
       canManageAutomation: false,
       canExport: true,
+      canSendNotification: true,
     })
   })
 
@@ -115,6 +116,7 @@ describe('multitable access helper', () => {
       canComment: true,
       canManageAutomation: true,
       canExport: true,
+      canSendNotification: true,
     })
   })
 

--- a/packages/core-backend/tests/unit/multitable-button-routes.test.ts
+++ b/packages/core-backend/tests/unit/multitable-button-routes.test.ts
@@ -261,9 +261,19 @@ describe('B1-S1 D0-A send_notification button (mock pool)', () => {
     expect(state.dedupKeys.size).toBe(0)
   })
 
-  it('§3 actor gate: a non-editor (read-only) cannot run send_notification → 403 (no write)', async () => {
+  it('§3 actor gate: a read-only user lacks canSendNotification → 403, NOTHING written', async () => {
     notifyApp = await buildNotifyApp(reader)
     const res = await request(notifyApp).post(url).send({ requestId: 'req-1' })
+    expect(res.status).toBe(403)
+    expect(state.notificationInserts).toHaveLength(0)
+    expect(state.dedupKeys.size).toBe(0)
+  })
+
+  it('§3 actor gate: a WRITE-OWN user CANNOT send_notification → 403 (notify = full sheet write/admin, NOT record-scoped write-own)', async () => {
+    // canSendNotification derives from full multitable:write/admin only; write-own is
+    // record-scoped and must NOT imply notifying members from any row.
+    notifyApp = await buildNotifyApp({ id: 'u_writeown', roles: ['member'], perms: ['multitable:write-own'] })
+    const res = await request(notifyApp).post(url).send({ requestId: 'req-wo' })
     expect(res.status).toBe(403)
     expect(state.notificationInserts).toHaveLength(0)
     expect(state.dedupKeys.size).toBe(0)

--- a/packages/core-backend/tests/unit/multitable-permission-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-permission-service.test.ts
@@ -162,6 +162,23 @@ describe('permission-service: capability composition', () => {
     expect(expanded.canManageSheetAccess).toBe(true)
   })
 
+  it('grants canSendNotification via a sheet-scoped FULL-write grant (no global multitable:write needed)', () => {
+    // The button route resolves caps via resolveSheetCapabilities → applyContextSheetSchemaWriteGrant.
+    // A user with only global read but a sheet FULL-write grant must keep send_notification (option a).
+    const readerBase = deriveCapabilities(['multitable:read'], false)
+    expect(applyContextSheetSchemaWriteGrant(readerBase, editorScope, false).canSendNotification).toBe(true)
+    expect(applySheetPermissionScope(base, editorScope, false).canSendNotification).toBe(true)
+  })
+
+  it('does NOT grant canSendNotification to a sheet-scoped WRITE-OWN user (notify is full-write only)', () => {
+    const readerBase = deriveCapabilities(['multitable:read'], false)
+    // write-own through BOTH the context-grant path and the scope path → no notify.
+    expect(applyContextSheetSchemaWriteGrant(readerBase, writeOwnScope, false).canSendNotification).toBe(false)
+    expect(applySheetPermissionScope(base, writeOwnScope, false).canSendNotification).toBe(false)
+    // ...but the write-own user CAN still edit records — the capability we deliberately do NOT conflate with notify.
+    expect(applyContextSheetRecordWriteGrant(readerBase, writeOwnScope, false).canEditRecord).toBe(true)
+  })
+
   it('applyContextSheetReadGrant forces canRead only when scope grants read but base does not', () => {
     const noneBase = deriveCapabilities([], false)
     const expanded = applyContextSheetReadGrant(noneBase, viewerScope, false)


### PR DESCRIPTION
## Dedicated `canSendNotification` — replaces B1-S1's provisional `canEditRecord` gate

Per the approved design + the P1 correction (capabilities flow through the **access.ts + permission-service.ts** route seam, not `sheet-capabilities.ts` alone).

### Backend
- `canSendNotification` added to **both** `MultitableCapabilities` shapes (`access.ts` + `sheet-capabilities.ts`) and both base derivers (`admin || multitable:write`).
- **Scoped derivation** (`applySheetPermissionScope`) uses `scope.canWrite` only — **NOT** `canWriteAnyRecord` (which includes write-own). Notify is sheet-member fan-out, not record-scoped; write-own must not imply it. Mirrors `canManageViews`/`canManageFields`.
- `PUBLIC_FORM_CAPABILITIES.canSendNotification = false` (anonymous submitter can never notify).
- Button policy: `send_notification` gate `'edit' → 'notify'`, gated on `capabilities.canSendNotification`; comment updated from "PROVISIONAL proxy" to the explicit notify gate. `record_click` stays read-gated/inert.

### FE
`canSendNotification` mirrored on `MetaCapabilities` (**optional** — server is authoritative; existing fixtures need not set it) + the capability composable (interface/builder/ROLE_CAPS owner+editor) + the empty-capabilities default.

### Tests (per spec)
full writer can send; read-only cannot (403, nothing written); **write-own cannot (403 — the key nuance)**; `record_click` read-gated; existing dedup/confirm/audit unchanged. backend tsc clean; full core-backend unit **3473/3473**; FE button/notify specs **25/25**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)