### PR TITLE
feat(multitable): rollup string/boolean reducers (slice 2b) via unified effective-field-type helper

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -19,6 +19,7 @@ on:
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
+      - 'apps/web/src/multitable/composables/useMultitableGrid.ts'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
@@ -27,6 +28,7 @@ on:
       - 'apps/web/src/multitable/utils/field-config.ts'
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
+      - 'apps/web/src/multitable/composables/useMultitableGrid.ts'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -213,6 +213,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts \
             tests/integration/multitable-rollup-countall-nongating.test.ts \
             tests/integration/multitable-rollup-filter-condition.test.ts \
+            tests/integration/multitable-rollup-string-bool-reducers.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts \
             tests/integration/multitable-dashboard-filterinfo-oracle.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-convergence.test.ts \

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -502,6 +502,7 @@ import { useLocale } from '../../composables/useLocale'
 import { dashboardDefaultName, viewRenderLabel, viewSizeLabel } from '../utils/meta-view-render-labels'
 import { fieldTypeLabel } from '../utils/meta-core-labels'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
+import { resolveRollupFieldProperty, rollupResultType } from '../utils/field-config'
 import MetaRichLongTextRender from './cells/MetaRichLongTextRender.vue'
 
 const props = defineProps<{
@@ -553,7 +554,15 @@ const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
   'lookup',
   'rollup',
 ])
-const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'duration', 'rollup'])
+// 'rollup' is NOT blanket-numeric (slice 2b): a rollup qualifies as a sum/avg value field only when its
+// aggregation yields a number — see isNumericMetricField. Mirrors the backend DASHBOARD_NUMERIC_FIELD_TYPES.
+const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'duration'])
+function isNumericMetricField(field: MetaField): boolean {
+  if (field.type === 'rollup') {
+    return rollupResultType(resolveRollupFieldProperty(field.property).aggregation) === 'number'
+  }
+  return NUMERIC_FIELD_TYPES.has(field.type)
+}
 const AGGREGATIONS_REQUIRING_VALUE = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max'])
 // v2-d: only additive aggregations make a stacked total meaningful (Σ segments == the single bar).
 const ADDITIVE_AGGREGATIONS = new Set<AggregationFunction>(['sum', 'count'])
@@ -599,7 +608,7 @@ const editingDateGrouped = computed(() => Boolean(editingChart.value?.dataSource
 
 const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? []))
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
-const numericFields = computed(() => chartFields.value.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
+const numericFields = computed(() => chartFields.value.filter((field) => isNumericMetricField(field)))
 // r12: scatter is the one non-grouped chart type — it hides groupBy/aggregation/value/series/bar-mode
 // and shows x/y/color/size pickers instead.
 const isScatter = computed(() => chartDraft.value.chartType === 'scatter')

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -236,6 +236,10 @@
               <option value="avg">{{ aggregationLabel('avg', isZh) }}</option>
               <option value="min">{{ aggregationLabel('min', isZh) }}</option>
               <option value="max">{{ aggregationLabel('max', isZh) }}</option>
+              <option value="concatenate">{{ aggregationLabel('concatenate', isZh) }}</option>
+              <option value="and">{{ aggregationLabel('and', isZh) }}</option>
+              <option value="or">{{ aggregationLabel('or', isZh) }}</option>
+              <option value="xor">{{ aggregationLabel('xor', isZh) }}</option>
             </select>
           </label>
         </template>

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -172,7 +172,7 @@
 import { ref, computed } from 'vue'
 import type { MetaField, RowDensity } from '../types'
 import type { SortRule, FilterRule, FilterConjunction } from '../composables/useMultitableGrid'
-import { FILTER_OPERATORS_BY_TYPE } from '../composables/useMultitableGrid'
+import { FILTER_OPERATORS_BY_TYPE, effectiveFilterTypeKey } from '../composables/useMultitableGrid'
 import { useLocale } from '../../composables/useLocale'
 import {
   metaCoreLabel,
@@ -311,7 +311,8 @@ const getOperatorsForField = (id: string) => {
   if (type === 'multiSelect') {
     return FILTER_OPERATORS_BY_TYPE.multiSelect ?? FILTER_OPERATORS_BY_TYPE.select
   }
-  return FILTER_OPERATORS_BY_TYPE[type] ?? FILTER_OPERATORS_BY_TYPE.string
+  // Slice 2b: rollup operators follow the aggregation's result kind (string/boolean/number).
+  return FILTER_OPERATORS_BY_TYPE[effectiveFilterTypeKey(getField(id))] ?? FILTER_OPERATORS_BY_TYPE.string
 }
 const applyButtonLabel = computed(() => props.sortFilterDirty
   ? metaCoreLabel('toolbar.applyFilterChanges', isZh.value)

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -461,6 +461,7 @@ import type {
 } from '../types'
 import {
   FILTER_OPERATORS_BY_TYPE,
+  effectiveFilterTypeKey,
   type FilterConjunction,
   type FilterRule,
   type SortRule,
@@ -1052,8 +1053,9 @@ function isPermissionHiddenFilterValue(rule: FilterRule): boolean {
 }
 
 function operatorsForField(fieldId: string) {
-  const fieldType = props.fields.find((field) => field.id === fieldId)?.type ?? 'string'
-  return FILTER_OPERATORS_BY_TYPE[fieldType] ?? FILTER_OPERATORS_BY_TYPE.string
+  // Slice 2b: a rollup field's operators follow its aggregation result kind, not a blanket numeric set.
+  const field = props.fields.find((f) => f.id === fieldId)
+  return FILTER_OPERATORS_BY_TYPE[effectiveFilterTypeKey(field)] ?? FILTER_OPERATORS_BY_TYPE.string
 }
 
 function inputTypeForField(fieldId: string): string {

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -16,6 +16,7 @@ import type {
 import { MultitableApiClient, multitableClient } from '../api/client'
 import { isPropertyHiddenField } from '../utils/field-permissions'
 import { metaCoreLabel } from '../utils/meta-core-labels'
+import { resolveRollupFieldProperty, rollupResultType } from '../utils/field-config'
 
 // --- Sort / Filter types ---
 
@@ -194,6 +195,8 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+  // Default rollup entry = numeric ops (a count/sum/avg/... rollup). For concatenate/and/or/xor rollups,
+  // effectiveFilterTypeKey resolves to string/boolean so the right ops are offered (slice 2b).
   rollup: [
     { value: 'is', label: '=' },
     { value: 'greater', label: '>' },
@@ -201,6 +204,15 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+}
+
+// Slice 2b — the map key to use for a field's filter operators. A rollup's operators depend on its
+// aggregation's result kind (concatenate → string, and/or/xor → boolean, else number), mirroring the
+// backend resolveEffectiveFieldType. Non-rollup fields key by their own type.
+export function effectiveFilterTypeKey(field: { type: string; property?: unknown } | null | undefined): string {
+  if (!field) return 'string'
+  if (field.type === 'rollup') return rollupResultType(resolveRollupFieldProperty(field.property).aggregation)
+  return field.type
 }
 
 // --- Main composable ---

--- a/apps/web/src/multitable/index.ts
+++ b/apps/web/src/multitable/index.ts
@@ -4,7 +4,7 @@ export { MultitableApiClient, multitableClient } from './api/client'
 
 // Composables
 export { useMultitableWorkbench } from './composables/useMultitableWorkbench'
-export { useMultitableGrid, buildSortInfo, buildFilterInfo, FILTER_OPERATORS_BY_TYPE } from './composables/useMultitableGrid'
+export { useMultitableGrid, buildSortInfo, buildFilterInfo, FILTER_OPERATORS_BY_TYPE, effectiveFilterTypeKey } from './composables/useMultitableGrid'
 export type { SortRule, FilterRule, FilterOperator, FilterConjunction, CellEdit } from './composables/useMultitableGrid'
 export { useMultitableCapabilities } from './composables/useMultitableCapabilities'
 export type { MultitableCapabilities, MultitableRole } from './composables/useMultitableCapabilities'

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -24,7 +24,17 @@ export type NormalizedLookupFieldProperty = {
   foreignSheetId: string | null
 }
 
-export type RollupAggregation = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+export type RollupAggregation =
+  | 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+  | 'concatenate' | 'and' | 'or' | 'xor'
+
+// The VALUE KIND a rollup aggregation produces (mirror of backend rollupResultType). Drives the FE
+// operator map + numeric-metric gating so the UI matches what the backend will actually compute.
+export function rollupResultType(aggregation: RollupAggregation): 'number' | 'string' | 'boolean' {
+  if (aggregation === 'concatenate') return 'string'
+  if (aggregation === 'and' || aggregation === 'or' || aggregation === 'xor') return 'boolean'
+  return 'number'
+}
 
 export type NormalizedRollupFieldProperty = {
   linkFieldId: string | null
@@ -39,11 +49,15 @@ export type NormalizedRollupFieldProperty = {
 
 // Keep in lockstep with parseRollupAggregation in core-backend (routes/univer-meta.ts + field-codecs.ts):
 // an aggregation this rejects gets silently shown/saved as 'count', corrupting a stored countall/unique.
-const ROLLUP_AGGREGATIONS: readonly RollupAggregation[] = ['count', 'sum', 'avg', 'min', 'max', 'countall', 'unique']
+const ROLLUP_AGGREGATIONS: readonly RollupAggregation[] = [
+  'count', 'sum', 'avg', 'min', 'max', 'countall', 'unique',
+  'concatenate', 'and', 'or', 'xor',
+]
 export function normalizeRollupAggregation(value: string | null | undefined): RollupAggregation {
   const a = (value ?? '').trim().toLowerCase()
   if (a === 'counta') return 'count'
   if (a === 'distinct' || a === 'uniquecount') return 'unique'
+  if (a === 'concat') return 'concatenate'
   return (ROLLUP_AGGREGATIONS as readonly string[]).includes(a) ? (a as RollupAggregation) : 'count'
 }
 

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -610,10 +610,18 @@ export function aggregationLabel(value: string, isZh: boolean): string {
     if (value === 'max') return '最大值'
     if (value === 'countall') return '记录数'
     if (value === 'unique') return '去重计数'
+    if (value === 'concatenate') return '拼接'
+    if (value === 'and') return '全部为真'
+    if (value === 'or') return '任一为真'
+    if (value === 'xor') return '奇数为真'
     return value
   }
   if (value === 'countall') return 'Count all'
   if (value === 'unique') return 'Unique'
+  if (value === 'concatenate') return 'Concatenate'
+  if (value === 'and') return 'All true (AND)'
+  if (value === 'or') return 'Any true (OR)'
+  if (value === 'xor') return 'Odd true (XOR)'
   return value
 }
 

--- a/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
+++ b/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeRollupAggregation, resolveRollupFieldProperty } from '../src/multitable/utils/field-config'
+import { normalizeRollupAggregation, resolveRollupFieldProperty, rollupResultType } from '../src/multitable/utils/field-config'
 import { aggregationLabel } from '../src/multitable/utils/meta-manager-labels'
+import { FILTER_OPERATORS_BY_TYPE, effectiveFilterTypeKey } from '../src/multitable/composables/useMultitableGrid'
 
 // Rollup aggregation expansion (slice 2a) — FE round-trip lock.
 //
@@ -26,7 +27,6 @@ describe('rollup aggregation — FE normalizer round-trip', () => {
   })
 
   it('unknown / empty aggregation falls back to count', () => {
-    expect(normalizeRollupAggregation('concatenate')).toBe('count') // deferred to slice 2b — not yet valid
     expect(normalizeRollupAggregation('bogus')).toBe('count')
     expect(normalizeRollupAggregation('')).toBe('count')
     expect(normalizeRollupAggregation(null)).toBe('count')
@@ -96,5 +96,52 @@ describe('rollup filter condition — opaque FE preservation (slice 3)', () => {
       filters: [{ fieldId: 'f', operator: 'is', value: 'x' }], filterConjunction: 'OR',
     })
     expect(upper.filterConjunction).toBe('or')
+  })
+})
+
+// Slice 2b — string/boolean reducers on the FE: enum/alias parity, result-type, labels, and the
+// operator map keyed by a rollup's result kind (so a concatenate rollup offers text ops, an and/or/xor
+// rollup equality-only) — matching the backend resolveEffectiveFieldType.
+describe('rollup string/boolean reducers (slice 2b) — FE', () => {
+  it('normalizeRollupAggregation preserves concatenate/and/or/xor + concat alias', () => {
+    for (const a of ['concatenate', 'and', 'or', 'xor'] as const) {
+      expect(normalizeRollupAggregation(a)).toBe(a)
+    }
+    expect(normalizeRollupAggregation('concat')).toBe('concatenate')
+  })
+
+  it('rollupResultType: concatenate→string, and/or/xor→boolean, numeric→number', () => {
+    expect(rollupResultType('concatenate')).toBe('string')
+    expect(rollupResultType('and')).toBe('boolean')
+    expect(rollupResultType('or')).toBe('boolean')
+    expect(rollupResultType('xor')).toBe('boolean')
+    expect(rollupResultType('sum')).toBe('number')
+    expect(rollupResultType('countall')).toBe('number')
+  })
+
+  it('aggregationLabel covers the 4 new reducers (zh + en)', () => {
+    expect(aggregationLabel('concatenate', true)).toBe('拼接')
+    expect(aggregationLabel('concatenate', false)).toBe('Concatenate')
+    expect(aggregationLabel('and', false)).toBe('All true (AND)')
+    expect(aggregationLabel('xor', true)).toBe('奇数为真')
+  })
+
+  it('effectiveFilterTypeKey resolves a rollup field by its aggregation result kind', () => {
+    const mk = (aggregation: string) => ({ type: 'rollup', property: { linkFieldId: 'l', targetFieldId: 't', aggregation } })
+    expect(effectiveFilterTypeKey(mk('concatenate'))).toBe('string')
+    expect(effectiveFilterTypeKey(mk('and'))).toBe('boolean')
+    expect(effectiveFilterTypeKey(mk('sum'))).toBe('number')
+    expect(effectiveFilterTypeKey({ type: 'string' })).toBe('string')
+  })
+
+  it('operator map: concatenate rollup offers TEXT ops; and/or/xor rollup offers equality only', () => {
+    const concatKey = effectiveFilterTypeKey({ type: 'rollup', property: { linkFieldId: 'l', targetFieldId: 't', aggregation: 'concatenate' } })
+    const concatOps = (FILTER_OPERATORS_BY_TYPE[concatKey] ?? []).map((o) => o.value)
+    expect(concatOps).toContain('contains')
+
+    const boolKey = effectiveFilterTypeKey({ type: 'rollup', property: { linkFieldId: 'l', targetFieldId: 't', aggregation: 'and' } })
+    const boolOps = (FILTER_OPERATORS_BY_TYPE[boolKey] ?? []).map((o) => o.value)
+    expect(boolOps).toContain('is')
+    expect(boolOps).not.toContain('greater')
   })
 })

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -195,13 +195,17 @@ function sanitizeStringArray(value: unknown): string[] {
 
 // Keep this enum in lockstep with parseRollupAggregation in routes/univer-meta.ts — this codec runs on the
 // provisioning / template-install / SDK-fixture write paths, and a value it rejects gets silently
-// corrupted to 'count' by the caller's `?? 'count'` fallback. Slice 2a added countall + unique (numeric).
-type RollupAggregationCodec = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+// corrupted to 'count' by the caller's `?? 'count'` fallback. Slice 2a added countall + unique (numeric);
+// slice 2b added the non-numeric reducers concatenate / and / or / xor.
+type RollupAggregationCodec =
+  | 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+  | 'concatenate' | 'and' | 'or' | 'xor'
 function parseRollupAggregation(value: unknown): RollupAggregationCodec | null {
   if (typeof value !== 'string') return null
   const normalized = value.trim().toLowerCase()
   if (normalized === 'counta') return 'count'
   if (normalized === 'distinct' || normalized === 'uniquecount') return 'unique'
+  if (normalized === 'concat') return 'concatenate'
   if (
     normalized === 'count' ||
     normalized === 'sum' ||
@@ -209,7 +213,11 @@ function parseRollupAggregation(value: unknown): RollupAggregationCodec | null {
     normalized === 'min' ||
     normalized === 'max' ||
     normalized === 'countall' ||
-    normalized === 'unique'
+    normalized === 'unique' ||
+    normalized === 'concatenate' ||
+    normalized === 'and' ||
+    normalized === 'or' ||
+    normalized === 'xor'
   ) {
     return normalized as RollupAggregationCodec
   }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -921,12 +921,21 @@ type LookupFieldConfig = {
 }
 
 type RollupAggregation =
-  | 'count' | 'sum' | 'avg' | 'min' | 'max'
-  // Expansion slice 2a — both NUMERIC, so a rollup's value stays number|null and the `rollup → number`
-  // assumption baked into filter/sort/dashboard stays correct. countall = resolved linked records incl.
-  // empty target; unique = distinct-value count. The string/boolean reducers (concatenate/and/or/xor) are
-  // deferred to slice 2b, which must first teach those consumers the rollup's non-numeric result type.
-  | 'countall' | 'unique'
+  // NUMERIC reducers (rollupResultType → 'number').
+  | 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countall' | 'unique'
+  // Slice 2b — NON-numeric reducers. concatenate → 'string'; and/or/xor → 'boolean'. A rollup's value is
+  // therefore no longer always numeric, so every filter/sort/dashboard/automation/rollup-filter consumer
+  // resolves the field through resolveEffectiveFieldType (which maps rollup → rollupResultType) instead of
+  // assuming 'number'.
+  | 'concatenate' | 'and' | 'or' | 'xor'
+
+// Slice 2b — the VALUE KIND a rollup aggregation produces. The single source of truth that lets every
+// rollup-aware consumer pick string/number/boolean comparators instead of hardcoding 'number'.
+export function rollupResultType(aggregation: RollupAggregation): 'number' | 'string' | 'boolean' {
+  if (aggregation === 'concatenate') return 'string'
+  if (aggregation === 'and' || aggregation === 'or' || aggregation === 'xor') return 'boolean'
+  return 'number' // count/countall/unique/sum/avg/min/max
+}
 
 type RollupFieldConfig = {
   linkFieldId: string
@@ -1027,9 +1036,12 @@ function parseRollupAggregation(value: unknown): RollupAggregation | null {
   // is the count of non-empty values. Use `countall` for the all-records-incl-empty count.
   if (normalized === 'counta') return 'count'
   if (normalized === 'distinct' || normalized === 'uniquecount') return 'unique'
+  if (normalized === 'concat') return 'concatenate'
   if (
     normalized === 'count' || normalized === 'sum' || normalized === 'avg' || normalized === 'min' || normalized === 'max'
     || normalized === 'countall' || normalized === 'unique'
+    // Slice 2b — non-numeric reducers.
+    || normalized === 'concatenate' || normalized === 'and' || normalized === 'or' || normalized === 'xor'
   ) {
     return normalized as RollupAggregation
   }
@@ -1064,7 +1076,7 @@ export function aggregateRollup(
   values: unknown[],
   count: number,
   aggregation: RollupAggregation,
-): number | null {
+): number | string | boolean | null {
   if (aggregation === 'count') return values.filter((v) => !isBlankRollupValue(v)).length // ≡ COUNTA
   if (aggregation === 'countall') return count // all resolved linked records, incl. blank/empty target
   if (aggregation === 'unique') {
@@ -1073,6 +1085,29 @@ export function aggregateRollup(
         .filter((v) => !isBlankRollupValue(v))
         .map((v) => (typeof v === 'object' ? JSON.stringify(v) : v)),
     ).size
+  }
+  // Slice 2b non-numeric reducers operate on the NON-BLANK values (false/0 are PRESENT; null/undefined/
+  // empty-or-whitespace string/empty array are blank). Empty (no non-blank value) → null, matching
+  // sum/avg/min/max — only the cardinality reducers (count/countall/unique) return 0 on empty.
+  if (aggregation === 'concatenate' || aggregation === 'and' || aggregation === 'or' || aggregation === 'xor') {
+    const present = values.filter((v) => !isBlankRollupValue(v))
+    if (present.length === 0) return null
+    if (aggregation === 'concatenate') {
+      return present
+        .map((v) => {
+          if (v !== null && typeof v === 'object') {
+            try { return JSON.stringify(v) } catch { return String(v) } // stable for plain data; fallback for cyclic
+          }
+          return String(v)
+        })
+        .join(', ')
+    }
+    // and/or/xor: truthiness via the canonical toComparableBoolean (so 'false'/'0'/'no'/0/false are falsy
+    // but present); a value counts as truthy ONLY when it coerces to exactly true.
+    const truthy = present.filter((v) => toComparableBoolean(v) === true).length
+    if (aggregation === 'and') return truthy === present.length
+    if (aggregation === 'or') return truthy > 0
+    return truthy % 2 === 1 // xor — odd number of truthy values
   }
   const nums = values
     .map((v) => toComparableNumber(v))
@@ -1157,6 +1192,19 @@ function parseRollupFieldConfig(property: unknown): RollupFieldConfig | null {
   }
 }
 
+/**
+ * Slice 2b — the SINGLE chokepoint for "what kind of value does this field compare as". For a rollup the
+ * answer depends on its aggregation (concatenate → string, and/or/xor → boolean, else number), so every
+ * filter/sort/dashboard/rollup-filter consumer must resolve through here instead of hardcoding
+ * `type === 'rollup' ? 'number'`. Non-rollup fields pass through unchanged. A rollup with an unparseable
+ * property defaults to 'count' → 'number' (the historical assumption), which is the safe fallback.
+ */
+export function resolveEffectiveFieldType(field: { type: string; property?: unknown }): UniverMetaField['type'] {
+  if (field.type !== 'rollup') return field.type as UniverMetaField['type']
+  const cfg = parseRollupFieldConfig(field.property)
+  return rollupResultType(cfg?.aggregation ?? 'count') // 'number' | 'string' | 'boolean' — all valid field types
+}
+
 async function validateLookupRollupConfig(
   req: Request,
   query: QueryFn,
@@ -1209,11 +1257,17 @@ async function validateLookupRollupConfig(
   const rollupConfig = type === 'rollup' ? (config as RollupFieldConfig) : null
   if (rollupConfig?.filters && rollupConfig.filters.length > 0) {
     const foreignFieldRes = await query(
-      'SELECT id, type FROM meta_fields WHERE sheet_id = $1',
+      'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1',
       [linkCfg.foreignSheetId],
     )
+    // Resolve the EFFECTIVE type per condition field. A foreign condition field that is itself a rollup
+    // must compare as its result kind (concatenate → string, and/or/xor → boolean), NOT blindly number —
+    // otherwise the per-type operator check below would mis-validate it. (Slice 2b chokepoint.)
     const foreignFieldTypeById = new Map<string, string>(
-      (foreignFieldRes as any).rows.map((r: any): [string, string] => [String(r.id), mapFieldType(String(r.type ?? ''))]),
+      (foreignFieldRes as any).rows.map((r: any): [string, string] => [
+        String(r.id),
+        resolveEffectiveFieldType({ type: mapFieldType(String(r.type ?? '')), property: r.property }),
+      ]),
     )
     for (const cond of rollupConfig.filters) {
       const condFieldType = foreignFieldTypeById.get(cond.fieldId)
@@ -2695,8 +2749,10 @@ async function applyLookupRollup(
   }
   const foreignFieldTypesBySheet = new Map<string, Map<string, string>>()
   for (const fsid of filteredRollupForeignSheetIds) {
-    const ffields = (await loadFieldsForSheetShared(query, fsid)) as Array<{ id: string; type: string }>
-    foreignFieldTypesBySheet.set(fsid, new Map(ffields.map((f) => [f.id, f.type])))
+    const ffields = (await loadFieldsForSheetShared(query, fsid)) as Array<{ id: string; type: string; property?: unknown }>
+    // EFFECTIVE type per field: a rollup-typed condition field resolves to its result kind (concatenate →
+    // string, and/or/xor → boolean), so the runtime operator guard + evaluator treat it correctly. (2b.)
+    foreignFieldTypesBySheet.set(fsid, new Map(ffields.map((f) => [f.id, resolveEffectiveFieldType(f)])))
   }
 
   const resolveLookupValues = (
@@ -3077,9 +3133,12 @@ const DASHBOARD_GROUPABLE_FIELD_TYPES = new Set<UniverMetaField['type']>([
   'rollup',
 ])
 
-const DASHBOARD_NUMERIC_FIELD_TYPES = new Set<UniverMetaField['type']>([
+// 'rollup' is intentionally NOT a blanket member (slice 2b): a rollup is numeric ONLY when its
+// aggregation produces a number. The widget validation resolves the rollup's effective type via
+// resolveEffectiveFieldType before checking this set, so sum/avg over a concatenate/boolean rollup is
+// rejected while a numeric rollup (count/sum/avg/min/max/countall/unique) still passes.
+const DASHBOARD_NUMERIC_FIELD_TYPES = new Set<string>([
   'number',
-  'rollup',
 ])
 
 const dashboardWidgetSchema = z.object({
@@ -3596,7 +3655,8 @@ async function loadDashboardSourceRows(args: {
     visibleFields,
     new Set(visibleFields.map((field) => field.id)),
   )
-  const fieldTypeById = new Map(visibleFields.map((field) => [field.id, field.type] as const))
+  // Effective type per field (slice 2b): a rollup compares as its result kind, not blindly number.
+  const fieldTypeById = new Map(visibleFields.map((field) => [field.id, resolveEffectiveFieldType(field)] as const))
   const rawFilterInfo = viewConfig ? parseMetaFilterInfo(viewConfig.filterInfo) : null
   // §2a.3 ANTI-ORACLE: prune saved filterInfo.conditions by the SAME post-chokepoint allow-set
   // (visibleFieldIds, masked by maskStoredRecordFieldIds above) that masks the per-row output at
@@ -3726,7 +3786,9 @@ function buildDashboardWidgetResult(args: {
         const rightEpoch = toEpoch(right.key)
         if (leftEpoch !== null && rightEpoch !== null && leftEpoch !== rightEpoch) return leftEpoch - rightEpoch
       }
-      if (groupField?.type === 'number' || groupField?.type === 'rollup') {
+      // Effective type (2b): a numeric rollup sorts numerically; a concatenate (string) / and-or-xor
+      // (boolean) rollup falls through to the locale string sort below.
+      if (groupField && resolveEffectiveFieldType(groupField) === 'number') {
         const leftNumber = toComparableNumber(left.key)
         const rightNumber = toComparableNumber(right.key)
         if (leftNumber !== null && rightNumber !== null && leftNumber !== rightNumber) return leftNumber - rightNumber
@@ -6717,7 +6779,9 @@ export function univerMetaRouter(): Router {
           if (!valueField) {
             throw new ValidationError('valueFieldId is required for sum and avg dashboard metrics')
           }
-          if (!DASHBOARD_NUMERIC_FIELD_TYPES.has(valueField.type)) {
+          // Resolve the rollup's effective type: sum/avg over a concatenate (string) or and/or/xor
+          // (boolean) rollup is rejected; a numeric rollup still passes. (Slice 2b.)
+          if (!DASHBOARD_NUMERIC_FIELD_TYPES.has(resolveEffectiveFieldType(valueField))) {
             throw new ValidationError(`Field ${valueField.name} must be numeric for dashboard ${widget.metric}`)
           }
         }
@@ -8269,7 +8333,7 @@ export function univerMetaRouter(): Router {
       // stays display-only for SELECTION (a readable-but-view-hidden field is still searchable/filterable on both).
       const viewHiddenFieldIds = view?.hiddenFieldIds ?? []
       const visibleFields = filterVisiblePropertyFields(await loadFieldsForSheetShared(pool.query.bind(pool), sheetId))
-      const filterFieldTypeById = new Map(visibleFields.map((field) => [field.id, field.type]))
+      const filterFieldTypeById = new Map(visibleFields.map((field) => [field.id, resolveEffectiveFieldType(field)]))
       const filterInfo = view ? parseMetaFilterInfo(view.filterInfo) : null
 
       const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
@@ -8585,7 +8649,7 @@ export function univerMetaRouter(): Router {
       // appears in the returned field list (parity with how a masked lookup keeps its column); only
       // the per-row materialized value is withheld.
       allowedFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, visiblePropertyFields, allowedFieldIds)
-      const fieldTypeById = new Map(visiblePropertyFields.map((f) => [f.id, f.type] as const))
+      const fieldTypeById = new Map(visiblePropertyFields.map((f) => [f.id, resolveEffectiveFieldType(f)] as const))
       // #2038 (a): search/sort/filter SELECTION is gated by allowedFieldIds (layer-3, the field-read gate) —
       // a field_permissions-denied field is treated as unavailable (not searchable/filterable/sortable),
       // exactly like a non-existent field. `allowedFieldIds` is layer-3-ONLY (hiddenFieldIds: [], :6161), so

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1062,15 +1062,17 @@ function isBlankRollupValue(value: unknown): boolean {
 }
 
 /**
- * Pure rollup reducer (exported for unit tests). Every reducer here returns number|null, so a rollup's
- * computed value stays NUMERIC — keeping the `rollup → number` assumption in filter/sort/dashboard correct.
- * (The string/boolean reducers concatenate/and/or/xor are deferred to slice 2b, which must also teach those
- * consumers the rollup's non-numeric result type before they can ship.)
+ * Pure rollup reducer (exported for unit tests). Returns number | string | boolean | null depending on the
+ * aggregation's result kind (see rollupResultType): count/countall/unique/sum/avg/min/max → number,
+ * concatenate → string, and/or/xor → boolean. Because a rollup is no longer always numeric, every
+ * filter/sort/dashboard/rollup-filter consumer resolves the field through resolveEffectiveFieldType.
  * - `values`: target values of foreign records the actor may read (post sheet-read + field-mask). null/
- *   undefined are dropped upstream; count/unique additionally drop blank values (see isBlankRollupValue).
+ *   undefined are dropped upstream; count/unique/concatenate/and/or/xor additionally drop blank values
+ *   (isBlankRollupValue: null/undefined/empty-or-whitespace string/empty array — `0` and `false` are NOT blank).
  * - `count`: resolved linked records incl. empty/blank target — the only signal `countall` needs.
- * Numeric reducers (sum/avg/min/max) return null when no numeric values exist. Record-level read is
- * NON-GATING here by design (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
+ * Empty input → null for the value reducers (sum/avg/min/max + concatenate/and/or/xor); only the cardinality
+ * reducers (count/countall/unique) return 0. Record-level read is NON-GATING here by design
+ * (record_permissions is write/admin elevation, not read-deny) — see #20 contract.
  */
 export function aggregateRollup(
   values: unknown[],

--- a/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
@@ -38,6 +38,13 @@ const FLD_OR = `fld_sb_or_${TS}` // or(flag) -> true
 const FLD_XOR = `fld_sb_xor_${TS}` // xor(flag) -> 2 truthy -> false
 const FLD_SUM = `fld_sb_sum_${TS}` // sum(num) -> 35 (numeric rollup control)
 
+// Views that FILTER source records by a rollup CONDITION field — these lock the consumer threading: the
+// filter path must resolve the rollup to its effective kind (string/boolean), not the blind 'number'.
+const VIEW_CONCAT_HIT = `view_sb_chit_${TS}` // concat contains 'a' → REC present (positive control)
+const VIEW_CONCAT_MISS = `view_sb_cmiss_${TS}` // concat contains 'zzz' → REC ABSENT (a numeric coercion would match-all → present)
+const VIEW_OR_TRUE = `view_sb_or_${TS}` // OR rollup is true → REC present (a numeric coercion of the bool → excluded)
+const VIEW_AND_TRUE = `view_sb_and_${TS}` // AND rollup is true → REC absent (and=false)
+
 const FR1 = `rec_sb_f1_${TS}` // tag a, flag true,  num 10
 const FR2 = `rec_sb_f2_${TS}` // tag b, flag true,  num 20
 const FR3 = `rec_sb_f3_${TS}` // tag c, flag false, num 5
@@ -64,6 +71,12 @@ async function readRollup(fieldId: string): Promise<unknown> {
 
 function rollup(aggregation: string, targetFieldId: string): string {
   return JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId, foreignSheetId: FS, aggregation })
+}
+
+async function viewRowIds(viewId: string): Promise<string[]> {
+  const res = await request(buildApp(USER)).get('/api/multitable/view').query({ sheetId: MS, viewId })
+  expect(res.status).toBe(200)
+  return (res.body?.data?.rows ?? []).map((r: { id: string }) => r.id)
 }
 
 async function dashboardSum(valueFieldId: string, metric: 'sum' | 'avg' = 'sum') {
@@ -115,9 +128,20 @@ describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB
       await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
         [`lnk_sb_${fr}`, FLD_LINK, REC, fr])
     }
+
+    // Views whose filter CONDITION is a rollup field — a filter on a computed field triggers
+    // applyLookupRollup, then the filter resolves the rollup's effective kind via resolveEffectiveFieldType.
+    const view = (id: string, conditions: unknown[]) =>
+      q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb)',
+        [id, MS, id, 'grid', '[]', JSON.stringify({ conjunction: 'and', conditions }), '{}'])
+    await view(VIEW_CONCAT_HIT, [{ fieldId: FLD_CONCAT, operator: 'contains', value: 'a' }])
+    await view(VIEW_CONCAT_MISS, [{ fieldId: FLD_CONCAT, operator: 'contains', value: 'zzz' }])
+    await view(VIEW_OR_TRUE, [{ fieldId: FLD_OR, operator: 'is', value: true }])
+    await view(VIEW_AND_TRUE, [{ fieldId: FLD_AND, operator: 'is', value: true }])
   })
 
   afterAll(async () => {
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [MS]).catch(() => {})
     await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
@@ -136,6 +160,19 @@ describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB
     expect(await readRollup(FLD_OR)).toBe(true)
     expect(await readRollup(FLD_XOR)).toBe(false) // 2 truthy (FR1,FR2) → even
     expect(await readRollup(FLD_SUM)).toBe(35) // numeric control unaffected
+  })
+
+  test('view FILTER on a STRING (concatenate) rollup uses string semantics, not numeric match-all', async () => {
+    expect(await viewRowIds(VIEW_CONCAT_HIT)).toEqual([REC]) // 'a, b, c' contains 'a' → present
+    // THE threading lock: if the rollup were coerced to number, `contains` hits the numeric catch-all
+    // (match-all) and REC would wrongly appear. Resolved-as-string → genuine no-match → empty.
+    expect(await viewRowIds(VIEW_CONCAT_MISS)).toEqual([])
+  })
+
+  test('view FILTER on a BOOLEAN (and/or/xor) rollup uses boolean semantics', async () => {
+    // OR rollup = true → present. A numeric coercion of the boolean would fail the equality and exclude it.
+    expect(await viewRowIds(VIEW_OR_TRUE)).toEqual([REC])
+    expect(await viewRowIds(VIEW_AND_TRUE)).toEqual([]) // AND rollup = false → excluded
   })
 
   test('dashboard REJECTS sum/avg over a concatenate (string) rollup', async () => {

--- a/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Rollup string/boolean reducers (slice 2b) — real DB.
+ *
+ * Pins the end-to-end behavior of the non-numeric reducers and the downstream consequences of a rollup
+ * no longer always being numeric:
+ *  1. VALUE: concatenate → string, and/or/xor → boolean, surfaced through GET /records/:recordId.
+ *  2. DASHBOARD: a sum/avg metric over a concatenate (string) or and/or/xor (boolean) rollup is REJECTED
+ *     (400), while a numeric rollup is still accepted — DASHBOARD_NUMERIC_FIELD_TYPES now resolves the
+ *     rollup's effective result type instead of treating every rollup as numeric.
+ *
+ * Trigger: GET /records/:recordId computes applyLookupRollup unconditionally and returns the value at
+ * res.body.data.record.data[rollupFieldId]; POST /dashboard/query runs widget validation.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER = `u_sb_${TS}`
+
+const BASE = `base_sb_${TS}`
+const FS = `sheet_sb_fs_${TS}`
+const MS = `sheet_sb_main_${TS}`
+
+const FLD_TAG = `fld_sb_tag_${TS}` // foreign string target (for concatenate)
+const FLD_FLAG = `fld_sb_flag_${TS}` // foreign boolean target (for and/or/xor)
+const FLD_NUM = `fld_sb_num_${TS}` // foreign number target (for the numeric-rollup control)
+const FLD_GROUP = `fld_sb_group_${TS}` // MS string field — dashboard group-by
+const FLD_LINK = `fld_sb_lk_${TS}`
+const FLD_CONCAT = `fld_sb_concat_${TS}` // concatenate(tag) -> 'a, b, c'
+const FLD_AND = `fld_sb_and_${TS}` // and(flag) -> false (FR3 false)
+const FLD_OR = `fld_sb_or_${TS}` // or(flag) -> true
+const FLD_XOR = `fld_sb_xor_${TS}` // xor(flag) -> 2 truthy -> false
+const FLD_SUM = `fld_sb_sum_${TS}` // sum(num) -> 35 (numeric rollup control)
+
+const FR1 = `rec_sb_f1_${TS}` // tag a, flag true,  num 10
+const FR2 = `rec_sb_f2_${TS}` // tag b, flag true,  num 20
+const FR3 = `rec_sb_f3_${TS}` // tag c, flag false, num 5
+const REC = `rec_sb_src_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read'], permissions: ['multitable:read'] }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+
+async function readRollup(fieldId: string): Promise<unknown> {
+  const res = await request(buildApp(USER)).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return res.body?.data?.record?.data?.[fieldId]
+}
+
+function rollup(aggregation: string, targetFieldId: string): string {
+  return JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId, foreignSheetId: FS, aggregation })
+}
+
+async function dashboardSum(valueFieldId: string, metric: 'sum' | 'avg' = 'sum') {
+  return request(buildApp(USER)).post('/api/multitable/dashboard/query').send({
+    sheetId: MS,
+    widgets: [{ title: 'W', chartType: 'bar', groupByFieldId: FLD_GROUP, metric, valueFieldId }],
+  })
+}
+
+describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE, 'SB Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FS, BASE, 'SB Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [MS, BASE, 'SB Main'])
+
+    for (const [fid, name, type, order] of [
+      [FLD_TAG, 'Tag', 'string', 1],
+      [FLD_FLAG, 'Flag', 'boolean', 2],
+      [FLD_NUM, 'Num', 'number', 3],
+    ] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+        [fid, FS, name, type, '{}', order])
+    }
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR1, FS, JSON.stringify({ [FLD_TAG]: 'a', [FLD_FLAG]: true, [FLD_NUM]: 10 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR2, FS, JSON.stringify({ [FLD_TAG]: 'b', [FLD_FLAG]: true, [FLD_NUM]: 20 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [FR3, FS, JSON.stringify({ [FLD_TAG]: 'c', [FLD_FLAG]: false, [FLD_NUM]: 5 })])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_GROUP, MS, 'Group', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_CONCAT, MS, 'Concat', 'rollup', rollup('concatenate', FLD_TAG), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_AND, MS, 'And', 'rollup', rollup('and', FLD_FLAG), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_OR, MS, 'Or', 'rollup', rollup('or', FLD_FLAG), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_XOR, MS, 'Xor', 'rollup', rollup('xor', FLD_FLAG), 6])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_SUM, MS, 'Sum', 'rollup', rollup('sum', FLD_NUM), 7])
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC, MS, JSON.stringify({ [FLD_GROUP]: 'g1', [FLD_LINK]: [FR1, FR2, FR3] })])
+    for (const fr of [FR1, FR2, FR3]) {
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
+        [`lnk_sb_${fr}`, FLD_LINK, REC, fr])
+    }
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('concatenate → string value end-to-end', async () => {
+    expect(await readRollup(FLD_CONCAT)).toBe('a, b, c')
+  })
+
+  test('and/or/xor → boolean values end-to-end', async () => {
+    expect(await readRollup(FLD_AND)).toBe(false) // FR3 flag=false
+    expect(await readRollup(FLD_OR)).toBe(true)
+    expect(await readRollup(FLD_XOR)).toBe(false) // 2 truthy (FR1,FR2) → even
+    expect(await readRollup(FLD_SUM)).toBe(35) // numeric control unaffected
+  })
+
+  test('dashboard REJECTS sum/avg over a concatenate (string) rollup', async () => {
+    const res = await dashboardSum(FLD_CONCAT, 'sum')
+    expect(res.status).toBe(400)
+  })
+
+  test('dashboard REJECTS avg over an and/or/xor (boolean) rollup', async () => {
+    const res = await dashboardSum(FLD_AND, 'avg')
+    expect(res.status).toBe(400)
+  })
+
+  test('dashboard ACCEPTS sum over a numeric rollup (not rejected as non-numeric)', async () => {
+    const res = await dashboardSum(FLD_SUM, 'sum')
+    expect(res.status).toBe(200)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
@@ -246,4 +246,20 @@ describe('multitable automation conditions', () => {
       ],
     }, fields)).not.toThrow()
   })
+
+  // NON-GOAL (slice 2b): automation has its OWN evaluator (not the shared evaluateMetaFilterCondition)
+  // and restricts rollup condition fields to equality operators for ALL result kinds — safe for
+  // string/number/boolean — so slice 2b deliberately does not upgrade automation. Lock it: equality on a
+  // rollup is accepted, a comparison operator is rejected.
+  it('rollup automation condition fields stay EQUALITY-ONLY (2b non-goal)', () => {
+    const fields = [{ id: 'roll', type: 'rollup' }]
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'roll', operator: 'equals', value: 'x' }],
+    }, fields)).not.toThrow()
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'roll', operator: 'greater_than', value: 1 }],
+    }, fields)).toThrow(/not supported for field type rollup/)
+  })
 })

--- a/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
+++ b/packages/core-backend/tests/unit/multitable-rollup-aggregation-expansion.test.ts
@@ -15,7 +15,7 @@
  * when the foreign sheet/field is masked, so these tests exercise the un-masked numeric/value paths.
  */
 import { describe, test, expect } from 'vitest'
-import { aggregateRollup } from '../../src/routes/univer-meta'
+import { aggregateRollup, rollupResultType, resolveEffectiveFieldType } from '../../src/routes/univer-meta'
 
 describe('aggregateRollup — rollup reducer expansion', () => {
   describe('count (≡ COUNTA: non-blank target values)', () => {
@@ -115,6 +115,81 @@ describe('aggregateRollup — rollup reducer expansion', () => {
       expect(aggregateRollup(['x'], 1, 'max')).toBeNull()
       expect(aggregateRollup([], 0, 'min')).toBeNull()
       expect(aggregateRollup([], 0, 'max')).toBeNull()
+    })
+  })
+
+  // ---- Slice 2b: non-numeric reducers (locked semantics) ----
+  describe('concatenate (slice 2b — string)', () => {
+    test('joins non-blank values with ", "', () => {
+      expect(aggregateRollup(['a', 'b', 'c'], 3, 'concatenate')).toBe('a, b, c')
+      expect(aggregateRollup([1, 2], 2, 'concatenate')).toBe('1, 2')
+    })
+    test('drops blanks; false/0 are PRESENT', () => {
+      expect(aggregateRollup(['a', '', '   ', [], 'b'], 5, 'concatenate')).toBe('a, b')
+      expect(aggregateRollup([0, false], 2, 'concatenate')).toBe('0, false')
+    })
+    test('empty (none / all-blank) → null, NOT ""', () => {
+      expect(aggregateRollup([], 0, 'concatenate')).toBeNull()
+      expect(aggregateRollup(['', '   ', []], 3, 'concatenate')).toBeNull()
+    })
+    test('objects/arrays use stable JSON', () => {
+      expect(aggregateRollup([{ a: 1 }, [1, 2]], 2, 'concatenate')).toBe('{"a":1}, [1,2]')
+    })
+  })
+
+  describe('and / or / xor (slice 2b — boolean, via toComparableBoolean)', () => {
+    test('and = all PRESENT values truthy', () => {
+      expect(aggregateRollup([true, 1, 'yes'], 3, 'and')).toBe(true)
+      expect(aggregateRollup([true, false], 2, 'and')).toBe(false)
+      expect(aggregateRollup([true, 0], 2, 'and')).toBe(false) // 0 present and falsy
+    })
+    test('or = any PRESENT value truthy', () => {
+      expect(aggregateRollup([false, 0, 'yes'], 3, 'or')).toBe(true)
+      expect(aggregateRollup([false, 0, 'no'], 3, 'or')).toBe(false)
+    })
+    test('xor = ODD number of truthy', () => {
+      expect(aggregateRollup([true], 1, 'xor')).toBe(true)
+      expect(aggregateRollup([true, true], 2, 'xor')).toBe(false)
+      expect(aggregateRollup([true, true, true], 3, 'xor')).toBe(true)
+    })
+    test("'false'/'0'/'no' strings are PRESENT-but-falsy", () => {
+      expect(aggregateRollup(['false', '0', 'no'], 3, 'or')).toBe(false)
+      expect(aggregateRollup(['false', 'true'], 2, 'xor')).toBe(true) // exactly 1 truthy
+    })
+    test('blanks excluded; empty → null', () => {
+      expect(aggregateRollup([null, '', []], 3, 'and')).toBeNull()
+      expect(aggregateRollup([], 0, 'or')).toBeNull()
+      expect(aggregateRollup([true, null, ''], 3, 'and')).toBe(true) // blanks dropped, only true remains
+    })
+  })
+
+  describe('rollupResultType', () => {
+    test('numeric reducers → number', () => {
+      for (const a of ['count', 'countall', 'unique', 'sum', 'avg', 'min', 'max'] as const) {
+        expect(rollupResultType(a)).toBe('number')
+      }
+    })
+    test('concatenate → string; and/or/xor → boolean', () => {
+      expect(rollupResultType('concatenate')).toBe('string')
+      expect(rollupResultType('and')).toBe('boolean')
+      expect(rollupResultType('or')).toBe('boolean')
+      expect(rollupResultType('xor')).toBe('boolean')
+    })
+  })
+
+  describe('resolveEffectiveFieldType', () => {
+    test('non-rollup field passes through', () => {
+      expect(resolveEffectiveFieldType({ type: 'string' })).toBe('string')
+      expect(resolveEffectiveFieldType({ type: 'number' })).toBe('number')
+    })
+    test('rollup resolves via its aggregation', () => {
+      const mk = (aggregation: string) => ({ type: 'rollup', property: { linkFieldId: 'l', targetFieldId: 't', aggregation } })
+      expect(resolveEffectiveFieldType(mk('sum'))).toBe('number')
+      expect(resolveEffectiveFieldType(mk('concatenate'))).toBe('string')
+      expect(resolveEffectiveFieldType(mk('and'))).toBe('boolean')
+    })
+    test('rollup with unparseable property defaults to number (count)', () => {
+      expect(resolveEffectiveFieldType({ type: 'rollup', property: {} })).toBe('number')
     })
   })
 })


### PR DESCRIPTION
## What

Adds the non-numeric rollup reducers — **concatenate** (→ string), **and/or/xor** (→ boolean) — completing the rollup aggregation set. Because a rollup's value is no longer always numeric, the core of this slice is a single chokepoint, `resolveEffectiveFieldType(field)`, that every filter/sort/dashboard/rollup-filter consumer resolves through instead of hardcoding `rollup → number`.

## Frozen semantics (locked in tests)

`aggregateRollup` → `number | string | boolean | null`. Blanks (`null`/`undefined`/empty-or-whitespace string/empty array) are excluded; **`0` and `false` are present**. Empty input → `null` for value reducers (sum/avg/min/max + concatenate/and/or/xor); only cardinality reducers (count/countall/unique) return `0`. concatenate uses `JSON.stringify` (String fallback) for objects; and/or/xor use `toComparableBoolean === true` truthiness; xor is odd-parity.

## Threading (the chokepoint)

`resolveEffectiveFieldType` is wired into: `compareMetaSortValue` + `evaluateMetaFilterCondition` callers, `foreignFieldTypesBySheet` (rollup-typed condition fields), the rollup-filter save validator + runtime guard, records-list `fieldTypeById`/`filterFieldTypeById`, dashboard grouping, and **dashboard numeric-metric validation** (so `sum`/`avg` over a concatenate/boolean rollup is rejected 400). Three-enum sync is a merge gate: `RollupAggregation` (univer-meta) + `RollupAggregationCodec` (field-codecs) + FE `field-config`, plus FE operator-map (`useMultitableGrid`), labels/select, and the dashboard FE numeric set.

## Non-goals (deliberate)

- **Automation conditions** stay equality-only for rollup (unchanged; locked by a test). Routing them through the helper is a future enhancement, not 2b.
- **`/records-summary`** already 422s on computed filter/group — untouched (assertion documents it).
- **View footer aggregation** reads materialized values only (never computes rollups), so a rollup contributes no footer value — pre-existing, out of scope.

## Verification

Built foundation + delegated mechanical threading to an isolated-worktree fork; then reviewed in two layers (semantics region vs threading) and ran a 3-lens adversarial pass. One lens flagged a P0 (sort/filter `rollup → number`) — **confirmed false positive**: every caller passes the resolved effective type, so the internal fallback is dead for those paths (verified by tracing all call sites). Acted on the valid residue: added the **filter-threading regression lock** (string `contains` → no-match, boolean `is true` → match — both fail closed if a blind `rollup → number` returns at a caller).

Tests: backend unit 54, FE 15, integration (string/boolean values + dashboard rejection + **view filter threading**) wired into the `plugin-tests.yml` real-DB allowlist + the `multitable-web-guard` spec. tsc + vue-tsc clean. (Integration's first real-DB run is CI `test (20.x)`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)