### PR TITLE
fix(multitable): dashboard numeric-metric FE/BE parity (currency/percent/rating/duration) + rollup-fallback comment tightening

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -555,7 +555,9 @@ const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
   'rollup',
 ])
 // 'rollup' is NOT blanket-numeric (slice 2b): a rollup qualifies as a sum/avg value field only when its
-// aggregation yields a number — see isNumericMetricField. Mirrors the backend DASHBOARD_NUMERIC_FIELD_TYPES.
+// aggregation yields a number — see isNumericMetricField. This set is the SAME as the backend's
+// isNumericQueryFieldType (number/currency/percent/rating/duration), which /dashboard/query enforces, so a
+// metric offered here is never rejected there.
 const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'duration'])
 function isNumericMetricField(field: MetaField): boolean {
   if (field.type === 'rollup') {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1137,9 +1137,11 @@ const ROLLUP_FILTER_OPS_STRING = new Set(['is', 'equal', 'isnot', 'notequal', 'c
 export function isRollupFilterOperatorCompatible(fieldType: string, operator: string): boolean {
   const op = operator.trim().toLowerCase()
   if (op === 'isempty' || op === 'isnotempty') return true
-  // Mirror evaluateMetaFilterCondition's effectiveType EXACTLY: it coerces a rollup-typed field to
-  // 'number'. If this helper didn't, `rollupField contains x` would look string-compatible here, pass
-  // the guard, then hit the numeric catch-all (match-all) at eval — the same leak as `number contains`.
+  // LEGACY FALLBACK, not the main contract: callers now pass the already-resolved effective type
+  // (resolveEffectiveFieldType maps a rollup to its result kind — string/boolean/number — per its
+  // aggregation), so a raw 'rollup' should never reach here. This `rollup → number` only mirrors
+  // evaluateMetaFilterCondition's own fallback as a defensive backstop if an unresolved rollup ever slips
+  // through; it does NOT mean rollups are numeric-by-default. (See resolveEffectiveFieldType.)
   const effectiveType = fieldType === 'rollup' ? 'number' : fieldType
   if (isNumericQueryFieldType(effectiveType) || effectiveType === 'date') return ROLLUP_FILTER_OPS_NUMERIC.has(op)
   if (effectiveType === 'boolean') return ROLLUP_FILTER_OPS_BOOLEAN.has(op)
@@ -3066,6 +3068,9 @@ export function evaluateMetaFilterCondition(
   cellValue: unknown,
   condition: MetaFilterCondition,
 ): boolean {
+  // `rollup → number` here is a LEGACY FALLBACK only: every caller resolves the field through
+  // resolveEffectiveFieldType first (rollup → its result kind string/boolean/number), so a raw 'rollup'
+  // should not reach this function. Rollups are NOT numeric-by-default — see resolveEffectiveFieldType.
   const effectiveType = type === 'rollup' ? 'number' : type
   const op = condition.operator.trim()
   const opNorm = op.toLowerCase()
@@ -3135,13 +3140,9 @@ const DASHBOARD_GROUPABLE_FIELD_TYPES = new Set<UniverMetaField['type']>([
   'rollup',
 ])
 
-// 'rollup' is intentionally NOT a blanket member (slice 2b): a rollup is numeric ONLY when its
-// aggregation produces a number. The widget validation resolves the rollup's effective type via
-// resolveEffectiveFieldType before checking this set, so sum/avg over a concatenate/boolean rollup is
-// rejected while a numeric rollup (count/sum/avg/min/max/countall/unique) still passes.
-const DASHBOARD_NUMERIC_FIELD_TYPES = new Set<string>([
-  'number',
-])
+// (The dashboard numeric-metric gate uses isNumericQueryFieldType directly — the canonical numeric-field
+// predicate, kept in lockstep with the FE dashboard's numeric set — applied to resolveEffectiveFieldType
+// so a rollup is numeric only when its aggregation produces a number. See the widget validation.)
 
 const dashboardWidgetSchema = z.object({
   id: z.string().min(1).max(120).optional(),
@@ -6781,9 +6782,12 @@ export function univerMetaRouter(): Router {
           if (!valueField) {
             throw new ValidationError('valueFieldId is required for sum and avg dashboard metrics')
           }
-          // Resolve the rollup's effective type: sum/avg over a concatenate (string) or and/or/xor
-          // (boolean) rollup is rejected; a numeric rollup still passes. (Slice 2b.)
-          if (!DASHBOARD_NUMERIC_FIELD_TYPES.has(resolveEffectiveFieldType(valueField))) {
+          // Numeric-metric gate. isNumericQueryFieldType is the canonical "is this numeric" predicate
+          // (number/currency/percent/rating/duration) — the SAME set the FE dashboard offers, so a metric
+          // the UI shows is never rejected here (no FE/BE drift). resolveEffectiveFieldType first maps a
+          // rollup to its result kind, so sum/avg over a concatenate (string) or and/or/xor (boolean)
+          // rollup is rejected while a numeric rollup passes. (Slice 2b + dashboard parity.)
+          if (!isNumericQueryFieldType(resolveEffectiveFieldType(valueField))) {
             throw new ValidationError(`Field ${valueField.name} must be numeric for dashboard ${widget.metric}`)
           }
         }

--- a/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rollup-string-bool-reducers.test.ts
@@ -37,6 +37,7 @@ const FLD_AND = `fld_sb_and_${TS}` // and(flag) -> false (FR3 false)
 const FLD_OR = `fld_sb_or_${TS}` // or(flag) -> true
 const FLD_XOR = `fld_sb_xor_${TS}` // xor(flag) -> 2 truthy -> false
 const FLD_SUM = `fld_sb_sum_${TS}` // sum(num) -> 35 (numeric rollup control)
+const FLD_CURRENCY = `fld_sb_cur_${TS}` // MS currency field — FE offers it as a numeric metric; backend must too (parity)
 
 // Views that FILTER source records by a rollup CONDITION field — these lock the consumer threading: the
 // filter path must resolve the rollup to its effective kind (string/boolean), not the blind 'number'.
@@ -110,6 +111,8 @@ describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_GROUP, MS, 'Group', 'string', '{}', 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_CURRENCY, MS, 'Price', 'currency', '{}', 8])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 2])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_CONCAT, MS, 'Concat', 'rollup', rollup('concatenate', FLD_TAG), 3])
@@ -123,7 +126,7 @@ describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB
       [FLD_SUM, MS, 'Sum', 'rollup', rollup('sum', FLD_NUM), 7])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
-      [REC, MS, JSON.stringify({ [FLD_GROUP]: 'g1', [FLD_LINK]: [FR1, FR2, FR3] })])
+      [REC, MS, JSON.stringify({ [FLD_GROUP]: 'g1', [FLD_CURRENCY]: 100, [FLD_LINK]: [FR1, FR2, FR3] })])
     for (const fr of [FR1, FR2, FR3]) {
       await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)',
         [`lnk_sb_${fr}`, FLD_LINK, REC, fr])
@@ -187,6 +190,14 @@ describeIfDatabase('multitable rollup string/boolean reducers (slice 2b, real DB
 
   test('dashboard ACCEPTS sum over a numeric rollup (not rejected as non-numeric)', async () => {
     const res = await dashboardSum(FLD_SUM, 'sum')
+    expect(res.status).toBe(200)
+  })
+
+  test('FE/BE parity: dashboard ACCEPTS sum over a CURRENCY field (the FE offers it as numeric)', async () => {
+    // The FE dashboard offers number/currency/percent/rating/duration as numeric metrics; the backend gate
+    // (isNumericQueryFieldType) must accept the same set, or a UI-offered metric 400s. Pre-fix, the backend
+    // set was {number} only → this returned 400.
+    const res = await dashboardSum(FLD_CURRENCY, 'sum')
     expect(res.status).toBe(200)
   })
 })


### PR DESCRIPTION
Follow-up to #2785 review.

**[P2] Dashboard numeric-metric gate is now actually FE/BE lockstep.** FE offers number/currency/percent/rating/duration as metric fields, but the backend gate was `{number}` only — so a currency/percent/rating/duration metric the UI shows was rejected **400** by `/dashboard/query` (pre-existing; 2b's "Mirrors backend" comment made the divergence visible). Now the gate uses the canonical `isNumericQueryFieldType` (the exact set the FE uses) on `resolveEffectiveFieldType(valueField)`, so a numeric rollup still passes and a concatenate/boolean rollup is still rejected. Dropped the redundant `DASHBOARD_NUMERIC_FIELD_TYPES` set; fixed the FE comment. **Parity test added**: dashboard ACCEPTS a currency metric (200).

**[P3] Legacy fallback comments tightened.** `isRollupFilterOperatorCompatible` + `evaluateMetaFilterCondition` now state explicitly that callers resolve the effective type upstream and the `rollup → number` lines are defensive backstops, not a numeric-by-default contract — so the false positive the adversarial lens chased doesn't recur.

No behavior change beyond accepting the currency/percent/rating/duration metrics the FE already offers. tsc + vue-tsc clean; integration (9 cases incl. currency parity) in the real-DB allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)