### PR TITLE
fix(onprem): retire stale PM2 C6 env keys

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -505,6 +505,17 @@ TODO:
       `deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
       `provenance.target_write_failed=1`, request-body injection fields absent, and
       injection env/runtime config restored after the check.
+  - [ ] Post-C6 package reroll PM2 env hygiene hardening.
+    - trigger: #2769 found `app.env` no longer contained C6 failure-injection markers,
+      while the running PM2 process still reported marker presence.
+    - intended guard: when the two C6 test-only keys are absent from `app.env`,
+      the PM2 startup helper must clear them from the launch process and recreate
+      the PM2 app if an existing process definition still contains them.
+    - evidence must stay values-free:
+      `appEnvFailureInjectionMarkersPresent=false`,
+      `pm2RuntimeFailureInjectionMarkersPresent=false`,
+      `pm2StaleDefinitionFound=true|false`,
+      `pm2RecreatedFromCleanEnv=true|not_needed`, `health=200`; never print env values.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -368,6 +368,17 @@ Current #2720 checkpoint as of 2026-06-17:
   `apply.deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
   `provenance.target_write_failed=1`, request-body failure-injection fields
   absent, and injection env/runtime config restored/disabled after the check.
+- Post-C6 package rerolls must also prove PM2 runtime env hygiene before any
+  further Apply/write validation. The C6 test-only keys are retired when they
+  are absent from `app.env`; the PM2 helper recreates the app if a previous PM2
+  definition still contains those keys. Required values-free evidence:
+  `appEnvFailureInjectionMarkersPresent=false`,
+  `pm2RuntimeFailureInjectionMarkersPresent=false`,
+  `pm2StaleDefinitionFound=true|false`,
+  `pm2RecreatedFromCleanEnv=true|not_needed`, `health=200`. Do not print env
+  values. Collect and post only these booleans plus the helper log marker; do
+  not paste raw `app.env` contents or raw `pm2 jlist` JSON, because both can
+  include sensitive runtime values.
 
 ## Stop Rules
 
@@ -388,6 +399,8 @@ Stop and report HOLD if any of these occur:
 - C6 re-pull produces duplicate target rows or `add>0` after a successful
   apply;
 - C6 rollback/cleanup requires a MetaSheet product delete/raw SQL path;
+- C6 test-only failure-injection keys remain present in the running PM2 runtime
+  after they have been removed from `app.env`;
 - any evidence contains credentials, connection strings, raw SQL, row values,
   payload JSON, private ids, dry-run tokens, or value-bearing stack traces.
 
@@ -473,6 +486,13 @@ c6Sandbox:
   productionWrite=false
   batchWrite=false
 
+pm2EnvHygiene:
+  appEnvFailureInjectionMarkersPresent=false
+  pm2RuntimeFailureInjectionMarkersPresent=false
+  pm2StaleDefinitionFound=true|false
+  pm2RecreatedFromCleanEnv=true|not_needed
+  health=200|...
+
 boundaries:
   credentialsPrinted=false
   connectionStringPrinted=false
@@ -498,6 +518,8 @@ Release signoff requires all of:
 - C5 K3/MSSQL gate is either cited from #2670 or rerun cleanly on the current
   package;
 - C6 sandbox smoke passes through the dedicated C6 runbook;
+- post-C6 package rerolls prove PM2 runtime env hygiene with boolean-only
+  evidence and no raw `app.env` / PM2 JSON;
 - issue evidence is values-free;
 - no forbidden boundary is opened.
 

--- a/scripts/ops/attendance-onprem-start-pm2.ps1
+++ b/scripts/ops/attendance-onprem-start-pm2.ps1
@@ -5,6 +5,10 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+$RetiredSensitiveEnvKeys = @(
+  'METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED',
+  'INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON'
+)
 
 function Resolve-RootDirPath {
   param([string]$Candidate)
@@ -65,6 +69,43 @@ function Import-AppEnvFile {
     }
 
     Set-Item -Path ("Env:{0}" -f $name) -Value $value
+  }
+}
+
+function Get-AppEnvKeySet {
+  param([string]$EnvFile)
+
+  $keys = @{}
+  foreach ($rawLine in Get-Content -Path $EnvFile) {
+    $line = $rawLine.Trim()
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) {
+      continue
+    }
+
+    $parts = $line -split '=', 2
+    if ($parts.Length -ne 2) {
+      continue
+    }
+
+    $name = $parts[0].Trim()
+    if (-not [string]::IsNullOrWhiteSpace($name)) {
+      $keys[$name] = $true
+    }
+  }
+
+  return $keys
+}
+
+function Clear-RetiredSensitiveEnvKeysAbsentFromFile {
+  param(
+    [string[]]$KeyNames,
+    [hashtable]$EnvFileKeys
+  )
+
+  foreach ($key in $KeyNames) {
+    if (-not $EnvFileKeys.ContainsKey($key)) {
+      Remove-Item -Path ("Env:{0}" -f $key) -ErrorAction SilentlyContinue
+    }
   }
 }
 
@@ -254,6 +295,29 @@ function Test-Pm2AppMatchesTarget {
   return $actualScriptPath -eq $expectedScript -and $actualCwd -eq $expectedRoot
 }
 
+function Test-Pm2AppHasRetiredSensitiveEnvKey {
+  param(
+    [object]$App,
+    [string[]]$KeyNames,
+    [hashtable]$EnvFileKeys
+  )
+
+  if ($null -eq $App -or $null -eq $App.pm2_env) {
+    return $false
+  }
+
+  foreach ($key in $KeyNames) {
+    if ($EnvFileKeys.ContainsKey($key)) {
+      continue
+    }
+    if ($null -ne $App.pm2_env.PSObject.Properties[$key]) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
 function Start-Pm2App {
   param(
     [string]$Pm2Command,
@@ -269,7 +333,9 @@ function Start-Pm2App {
 }
 
 $envFile = Resolve-AppEnvFile -BaseDir $resolvedRoot
+$envFileKeys = Get-AppEnvKeySet -EnvFile $envFile
 Import-AppEnvFile -EnvFile $envFile
+Clear-RetiredSensitiveEnvKeysAbsentFromFile -KeyNames $RetiredSensitiveEnvKeys -EnvFileKeys $envFileKeys
 Initialize-WindowsSystemToolPath
 Initialize-WindowsSystemProfileEnv
 
@@ -285,7 +351,15 @@ $expectedScriptPath = Join-Path $resolvedRoot 'packages\core-backend\dist\src\in
 $existingApp = Get-Pm2AppProcess -Pm2Command $pm2Command -AppName $Pm2AppName
 
 if ($null -ne $existingApp) {
-  if (Test-Pm2AppMatchesTarget -App $existingApp -ExpectedScriptPath $expectedScriptPath -ExpectedCwd $resolvedRoot) {
+  if (Test-Pm2AppHasRetiredSensitiveEnvKey -App $existingApp -KeyNames $RetiredSensitiveEnvKeys -EnvFileKeys $envFileKeys) {
+    Write-Host "[attendance-onprem-start-pm2] deleting pm2 app definition for $Pm2AppName to retire sensitive/test-only env keys"
+    & $pm2Command delete $Pm2AppName
+    if ($LASTEXITCODE -ne 0) {
+      throw "pm2 delete failed while retiring env keys for $Pm2AppName"
+    }
+    Start-Pm2App -Pm2Command $pm2Command -ConfigPath $ecosystemConfig -AppName $Pm2AppName -EnvName $Pm2Env
+  }
+  elseif (Test-Pm2AppMatchesTarget -App $existingApp -ExpectedScriptPath $expectedScriptPath -ExpectedCwd $resolvedRoot) {
     & $pm2Command restart $Pm2AppName --update-env
     if ($LASTEXITCODE -ne 0) {
       throw "pm2 restart failed for $Pm2AppName"

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -50,3 +50,21 @@ test('PM2 startup helper replaces stale app definitions instead of restart-only 
   assert.match(script, /delete \$Pm2AppName/)
   assert.match(script, /--update-env/)
 })
+
+test('PM2 startup helper retires sensitive test-only env keys absent from app.env', () => {
+  const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
+
+  assert.match(script, /\$RetiredSensitiveEnvKeys = @\(/)
+  assert.match(script, /'METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED'/)
+  assert.match(script, /'INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON'/)
+  assert.match(script, /function Get-AppEnvKeySet/)
+  assert.match(script, /function Clear-RetiredSensitiveEnvKeysAbsentFromFile/)
+  assert.match(script, /Remove-Item -Path \("Env:\{0\}" -f \$key\) -ErrorAction SilentlyContinue/)
+  assert.match(script, /function Test-Pm2AppHasRetiredSensitiveEnvKey/)
+  assert.match(script, /if \(\$EnvFileKeys\.ContainsKey\(\$key\)\)/)
+  assert.match(script, /if \(\$null -ne \$App\.pm2_env\.PSObject\.Properties\[\$key\]\)/)
+  assert.match(script, /\$envFileKeys = Get-AppEnvKeySet -EnvFile \$envFile/)
+  assert.match(script, /Clear-RetiredSensitiveEnvKeysAbsentFromFile -KeyNames \$RetiredSensitiveEnvKeys -EnvFileKeys \$envFileKeys/)
+  assert.match(script, /deleting pm2 app definition for \$Pm2AppName to retire sensitive\/test-only env keys/)
+  assert.match(script, /pm2 delete failed while retiring env keys/)
+})


### PR DESCRIPTION
## Summary

Fixes the #2769 PM2 runtime-env hygiene caveat after C6 failure-injection validation.

- `attendance-onprem-start-pm2.ps1` now treats `docker/app.env` / `app.env` as the authority for retiring the two C6 test-only env keys:
  - `METASHEET_C6_TEST_FAILURE_INJECTION_ENABLED`
  - `INTEGRATION_CORE_C6_TEST_FAILURE_INJECTION_JSON`
- If those keys are absent from `app.env`, the helper clears them from the launch process env before PM2 start/restart.
- If an existing PM2 app definition still carries either retired key, the helper deletes the PM2 app definition and fresh-starts from the clean deploy root instead of restart-only reuse.
- If `app.env` intentionally contains either key, the normal path is preserved for the C6 sandbox package.
- Backfills the release smoke runbook/TODO with values-free evidence fields and HOLD rules.

## Verification

- `node --test scripts/ops/onprem-windows-system-hardening.test.mjs scripts/ops/ecosystem-env-loader.test.mjs scripts/ops/multitable-onprem-package-verify-k3-helper-contract.test.mjs scripts/ops/multitable-onprem-package-no-node-modules.test.mjs`
- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh scripts/ops/multitable-onprem-release-gate.sh`
- `pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw "scripts/ops/attendance-onprem-start-pm2.ps1")); "parse OK"'`
- `git diff --check`

## Boundaries

- No business runtime changes.
- No C6 route/adapter/write behavior change.
- No production/batch authorization.
- Evidence remains values-free: boolean presence/status only, no env values.

## Subagent review

- PowerShell/PM2 helper review: APPROVE.
- Runbook/TODO boundary review: P2 fixed (`pm2RecreatedFromCleanEnv=true|not_needed`), then APPROVE.
