### PR TITLE
fix(multitable): stop anon form-context leaking view.config.publicForm secrets (#2730)

### DIFF
--- a/packages/core-backend/src/multitable/form-context-view-projection.ts
+++ b/packages/core-backend/src/multitable/form-context-view-projection.ts
@@ -1,0 +1,28 @@
+/**
+ * #2730 — form-context view projection.
+ *
+ * `GET /api/multitable/form-context` echoes the view to callers that include ANONYMOUS
+ * public-form submitters. `view.config` is freeform (`Record<string, unknown>`) and carries
+ * `publicForm` secrets (`publicToken` / `allowedUserIds` / `allowedMemberGroupIds`), so echoing
+ * it leaks those to anonymous callers.
+ *
+ * A key blacklist (strip only `publicForm`) is forward-UNSAFE: any future secret-bearing
+ * config key would silently leak. Instead this projects to a top-level whitelist and DROPS
+ * `config` entirely.
+ *
+ * This is safe because NO form-context consumer reads `view.config`:
+ *  - the public form (`PublicMultitableFormView`) reads only `view.name` + `view.id`;
+ *  - the authenticated standalone form (`MultitableWorkbench.loadStandaloneForm`) reads only
+ *    `fields` / `fieldPermissions` / `viewPermissions` / `rowActions` / `record` / etc.;
+ *  - the DingTalk public-form link-warnings read `publicForm` from the views LIST
+ *    (`/views`), NOT from form-context.
+ *
+ * Scope: applied ONLY to the form-context echo. The `/views`, `/view`, create, and update
+ * routes intentionally keep echoing `config` — that is where admins (and the link-warnings)
+ * legitimately read `publicForm`.
+ */
+export function projectFormContextView<T extends { config?: unknown }>(view: T): Omit<T, 'config'> {
+  // Drop `config` wholesale (whitelist of config keys needed by form-context consumers = none).
+  const { config: _omittedConfig, ...rest } = view
+  return rest
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -18,6 +18,7 @@ import {
 import { validateAiShortcutFieldProperty } from '../multitable/ai-shortcut-config'
 import { withFieldVisibilityRule } from '../multitable/field-visibility-rule'
 import { withFormLayout, projectPublicFormLayout, sanitizeFormRedirectUrl } from '../multitable/form-layout'
+import { projectFormContextView } from '../multitable/form-context-view-projection'
 import { rbacGuard, rbacGuardAny } from '../rbac/rbac'
 import {
   deriveCapabilities,
@@ -9217,11 +9218,13 @@ export function univerMetaRouter(): Router {
               : `/api/multitable/views/${resolved.view.id}/submit`)
             : '/api/multitable/records',
           sheet,
-          // Requester-aware view echo (unchanged from pre-A4): redactViewConfigFilterLiterals keeps
-          // filter literals the requester may read and redacts denied ones (#2052 / R5b). NOTE: this still
-          // echoes view.config.publicForm to anonymous callers — a PRE-EXISTING leak (NOT introduced by A4),
-          // tracked separately so it gets its own one-concern fix rather than riding this feature PR.
-          ...(resolved.view ? { view: redactViewConfigFilterLiterals(resolved.view, await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)) } : {}),
+          // Requester-aware view echo: redactViewConfigFilterLiterals keeps filter literals the requester
+          // may read and redacts denied ones (#2052 / R5b). #2730: projectFormContextView DROPS view.config
+          // entirely first — view.config carries publicForm secrets (publicToken / allowedUserIds /
+          // allowedMemberGroupIds) and is freeform, so echoing it leaked those to anonymous callers. No
+          // form-context consumer reads view.config (A4 presentational features come via the SAFE top-level
+          // formLayout below; the public form reads only view.name/id); admins read publicForm from /views.
+          ...(resolved.view ? { view: redactViewConfigFilterLiterals(projectFormContextView(resolved.view), await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)) } : {}),
           // A4 SAFE form-logic projection: ONLY the presentational layout sub-objects (pages / prefill
           // allowlist / validated redirect / confirmation text), normalized by sanitizeFormLayout. Built
           // from view.config.formLayout via a whitelist — never carries publicForm or other config keys.

--- a/packages/core-backend/tests/integration/multitable-form-context-submit-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-form-context-submit-field-mask.test.ts
@@ -154,11 +154,9 @@ describeIfDatabase('D1 form-context / form-submit echo field mask (real DB)', ()
     // A4 feature scope ONLY: the anonymous form-context echo carries the A4
     // presentational layout (pages/prefill/redirect/confirmation), projected via
     // projectPublicFormLayout from view.config.formLayout.
-    // NOTE: the broader anonymous publicForm-secret leak (publicToken/allowedUserIds
-    // still echoed via the requester-aware view.config) is PRE-EXISTING (not an A4
-    // regression) and is intentionally OUT OF SCOPE here — tracked as its own
-    // one-concern fix so it doesn't ride this feature PR. Do NOT re-add the
-    // secret-exclusion assertions to this test; they belong with that fix.
+    // NOTE: this test is A4-feature-scoped (formLayout only). The anonymous publicForm-secret
+    // exclusion (publicToken / allowedUserIds via the dropped view.config) is asserted by the
+    // dedicated '#2730' test below.
     testUserId = null
     const res = await request(app)
       .get('/api/multitable/form-context')
@@ -172,6 +170,31 @@ describeIfDatabase('D1 form-context / form-submit echo field mask (real DB)', ()
       redirect: { url: '/thanks' },
       confirmation: { title: 'Thanks!', body: 'We got it.' },
     })
+
+    testUserId = USER_ID
+  })
+
+  test('#2730 (anonymous form-context): view.config secrets are NOT echoed (config dropped, allowlist absent everywhere)', async () => {
+    // Pre-existing leak: the requester-aware view echo serialized the WHOLE view.config to
+    // anonymous callers, exposing publicForm.publicToken / .allowedUserIds / .allowedMemberGroupIds.
+    // projectFormContextView now drops view.config from the form-context echo.
+    testUserId = null
+    const res = await request(app)
+      .get('/api/multitable/form-context')
+      .query({ sheetId: SHEET_ID, viewId: VIEW_ID, publicToken: PUBLIC_TOKEN })
+    expect(res.status).toBe(200)
+
+    // The echoed VIEW carries no config (and thus no publicForm token/allowlist).
+    expect(res.body.data.view).toBeDefined()
+    expect(res.body.data.view.config).toBeUndefined()
+    const viewJson = JSON.stringify(res.body.data.view)
+    expect(viewJson).not.toContain(PUBLIC_TOKEN) // token scoped to the view echo (submitPath legitimately carries the caller's OWN token)
+    expect(viewJson).not.toContain('publicForm')
+    // The allowlist is purely secret — it must not appear ANYWHERE in the response (submitPath carries only the token, never the allowlist).
+    expect(JSON.stringify(res.body)).not.toContain('_allow_canary')
+    // Positive controls: presentational view metadata kept; the SAFE A4 formLayout (separate top-level projection) unaffected.
+    expect(res.body.data.view.name).toBe('D1 Form')
+    expect(res.body.data.formLayout?.pages?.length).toBe(1)
 
     testUserId = USER_ID
   })

--- a/packages/core-backend/tests/unit/form-context-view-projection.test.ts
+++ b/packages/core-backend/tests/unit/form-context-view-projection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { projectFormContextView } from '../../src/multitable/form-context-view-projection'
+
+describe('#2730 projectFormContextView — form-context view echo must not leak view.config', () => {
+  const fullView = {
+    id: 'view_1',
+    sheetId: 'sheet_1',
+    name: 'Intake form',
+    type: 'form',
+    filterInfo: { conditions: [{ fieldId: 'f1', operator: 'eq', value: 'x' }] },
+    sortInfo: { rules: [] },
+    groupInfo: { rules: [] },
+    hiddenFieldIds: ['f9'],
+    config: {
+      parentFieldId: 'f2',
+      frozenLeftColumnIds: ['f3'],
+      formLayout: { pages: [], redirect: { url: 'https://example.com' } },
+      publicForm: {
+        enabled: true,
+        publicToken: 'SECRET_TOKEN_abc123',
+        allowedUserIds: ['user_secret_1', 'user_secret_2'],
+        allowedMemberGroupIds: ['grp_secret_1'],
+        accessMode: 'dingtalk',
+      },
+    },
+  }
+
+  it('DROPS config entirely (no publicForm token / allowlists / any config key survives)', () => {
+    const projected = projectFormContextView(fullView)
+    expect('config' in projected).toBe(false)
+    // Belt-and-suspenders: the serialized projection contains none of the secrets.
+    const serialized = JSON.stringify(projected)
+    expect(serialized).not.toContain('SECRET_TOKEN_abc123')
+    expect(serialized).not.toContain('user_secret_1')
+    expect(serialized).not.toContain('grp_secret_1')
+    expect(serialized).not.toContain('publicForm')
+    // Forward-safe: even a hypothetical future config secret is gone (whole config dropped).
+    expect(serialized).not.toContain('frozenLeftColumnIds')
+    expect(serialized).not.toContain('formLayout')
+  })
+
+  it('KEEPS the presentational top-level keys the form-context render needs', () => {
+    const projected = projectFormContextView(fullView)
+    expect(projected).toEqual({
+      id: 'view_1',
+      sheetId: 'sheet_1',
+      name: 'Intake form',
+      type: 'form',
+      filterInfo: { conditions: [{ fieldId: 'f1', operator: 'eq', value: 'x' }] },
+      sortInfo: { rules: [] },
+      groupInfo: { rules: [] },
+      hiddenFieldIds: ['f9'],
+    })
+  })
+
+  it('is a no-op shape when there is no config (idempotent on already-safe views)', () => {
+    const noConfig = { id: 'v', sheetId: 's', name: 'n', type: 'grid' }
+    expect(projectFormContextView(noConfig)).toEqual(noConfig)
+  })
+})


### PR DESCRIPTION
## #2730 — anonymous form-context leaked `view.config.publicForm` secrets

`GET /api/multitable/form-context` echoed the entire `resolved.view` (only `filterInfo` literals redacted) to anonymous public-form callers, serializing `view.config.publicForm.{publicToken,allowedUserIds,allowedMemberGroupIds}`. Pre-existing (not an A4 regression); de-scoped from A4 (#2727) and filed as its own one-concern fix.

### Fix
`projectFormContextView` — a **forward-safe top-level whitelist** that **drops `view.config` entirely** from the form-context echo (a `publicForm`-only blacklist would leak any *future* config secret, e.g. a new allowlist key).

**Safe because no form-context consumer reads `view.config`** (verified):
- public form (`PublicMultitableFormView`) reads only `view.name` / `view.id`;
- A4 presentational features come via the **safe top-level `formLayout`** (`projectPublicFormLayout`), read by the FE as `context.formLayout.*` (confirmation/redirect/prefill) — never raw config;
- the authenticated standalone form (`MultitableWorkbench`) reads `fields`/permissions/`record`;
- DingTalk link-warnings read `publicForm` from **`/views`**, not form-context.

**Surgical**: only the form-context echo. `/views`, `/view`, create, update still echo `config` (where admins legitimately read `publicForm`).

### Tests
- **Pure unit** `form-context-view-projection.test.ts` (local verification of the security core): drops `config`/`publicForm`/allowlists, keeps presentational top-level keys, idempotent on config-less views.
- **Real-DB** anon-exclusion case in `multitable-form-context-submit-field-mask.test.ts`: `view.config` undefined, no `publicToken` in the view echo, allowlist canary absent **everywhere**, `formLayout` + `view.name` preserved. (`submitPath` echoing the caller's *own* token is not a disclosure → token assertions scoped to the view echo.)
- R5b (authed filter-literal redaction) untouched.

core-backend `tsc` clean; full unit **3493/3493**. Real-DB integration runs in CI `test (20.x)`.

Closes #2730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)