### PR TITLE
feat(multitable): rollup filter builder UI (slice 3b) — condition rows + AND/OR + round-trip

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -242,6 +242,31 @@
               <option value="xor">{{ aggregationLabel('xor', isZh) }}</option>
             </select>
           </label>
+
+          <!-- Slice 3b — rollup filter conditions builder. Conditions read FOREIGN-sheet fields; the
+               field id is typed (consistent with the target-field input above); operators are validated
+               per the resolved foreign-field type by the backend at save. -->
+          <div class="meta-field-mgr__field meta-field-mgr__rollup-filters">
+            <span>{{ ml('field.rollupFilters') }}</span>
+            <div v-if="rollupDraft.filters.length > 1" class="meta-field-mgr__rollup-conj">
+              <label><input type="radio" value="and" v-model="rollupDraft.filterConjunction" /> {{ ml('field.rollupFilterAll') }}</label>
+              <label><input type="radio" value="or" v-model="rollupDraft.filterConjunction" /> {{ ml('field.rollupFilterAny') }}</label>
+            </div>
+            <div v-for="(cond, i) in rollupDraft.filters" :key="i" class="meta-field-mgr__rollup-cond">
+              <input v-model="cond.fieldId" class="meta-field-mgr__input" :placeholder="ml('field.rollupFilterFieldPlaceholder')" />
+              <select v-model="cond.operator" class="meta-field-mgr__select">
+                <option v-for="op in ROLLUP_FILTER_OPERATOR_OPTIONS" :key="op.value" :value="op.value">{{ op.label }}</option>
+              </select>
+              <input
+                v-if="!ROLLUP_FILTER_OPS_NO_VALUE.has(cond.operator)"
+                v-model="cond.value"
+                class="meta-field-mgr__input"
+                :placeholder="ml('field.rollupFilterValuePlaceholder')"
+              />
+              <button type="button" class="meta-field-mgr__icon-btn" :aria-label="ml('action.remove')" @click="removeRollupFilter(i)">×</button>
+            </div>
+            <button type="button" class="meta-field-mgr__add-btn" @click="addRollupFilter">{{ ml('field.rollupFilterAdd') }}</button>
+          </div>
         </template>
 
         <template v-else-if="configTargetType === 'formula'">
@@ -769,6 +794,7 @@ import {
   resolveRollupFieldProperty,
   resolveSelectFieldOptions,
   type RollupAggregation,
+  type RollupFilterCondition,
 } from '../utils/field-config'
 import {
   SYSTEM_FIELD_TYPES,
@@ -1006,12 +1032,44 @@ const lookupDraft = reactive<{ linkFieldId: string; targetFieldId: string; forei
   targetFieldId: '',
   foreignSheetId: '',
 })
-const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation }>({
+// Slice 3b — filter conditions are edited as string-valued rows in the builder; mapped to/from the
+// typed RollupFilterCondition (value: unknown) on hydrate/save so the UI never binds v-model to unknown.
+type RollupFilterDraftRow = { fieldId: string; operator: string; value: string }
+const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; foreignSheetId: string; aggregation: RollupAggregation; filters: RollupFilterDraftRow[]; filterConjunction: 'and' | 'or' }>({
   linkFieldId: '',
   targetFieldId: '',
   foreignSheetId: '',
   aggregation: 'count',
+  filters: [],
+  filterConjunction: 'and',
 })
+// Operators offered in the builder. The backend (isRollupFilterOperatorCompatible) validates per the
+// resolved target-field type at SAVE and returns a clear error for an incompatible op — so the builder
+// offers the full set rather than constraining (constraining needs foreign-field type enumeration, a
+// follow-up data flow). Values lower-case to the backend's accepted operators.
+const ROLLUP_FILTER_OPERATOR_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'is', label: '=' }, { value: 'isNot', label: '≠' },
+  { value: 'contains', label: 'contains' }, { value: 'doesNotContain', label: 'does not contain' },
+  { value: 'greater', label: '>' }, { value: 'greaterequal', label: '≥' },
+  { value: 'less', label: '<' }, { value: 'lessequal', label: '≤' },
+  { value: 'isEmpty', label: 'is empty' }, { value: 'isNotEmpty', label: 'is not empty' },
+]
+const ROLLUP_FILTER_OPS_NO_VALUE = new Set(['isEmpty', 'isNotEmpty', 'isempty', 'isnotempty'])
+function addRollupFilter(): void {
+  rollupDraft.filters.push({ fieldId: '', operator: 'is', value: '' })
+}
+function removeRollupFilter(index: number): void {
+  rollupDraft.filters.splice(index, 1)
+}
+// Builder rows → typed conditions for save: drop incomplete rows (need fieldId+operator), omit `value`
+// for the no-value operators (isEmpty/isNotEmpty).
+function rollupFilterPayload(): RollupFilterCondition[] {
+  return rollupDraft.filters
+    .filter((c) => c.fieldId.trim() !== '' && c.operator.trim() !== '')
+    .map((c) => (ROLLUP_FILTER_OPS_NO_VALUE.has(c.operator.trim().toLowerCase())
+      ? { fieldId: c.fieldId.trim(), operator: c.operator }
+      : { fieldId: c.fieldId.trim(), operator: c.operator, value: c.value }))
+}
 const formulaDraft = reactive<{ expression: string }>({
   expression: '',
 })
@@ -1541,6 +1599,8 @@ function resetDrafts() {
   rollupDraft.targetFieldId = ''
   rollupDraft.foreignSheetId = ''
   rollupDraft.aggregation = 'count'
+  rollupDraft.filters = []
+  rollupDraft.filterConjunction = 'and'
   formulaDraft.expression = ''
   formulaFunctionSearch.value = ''
   formulaFunctionCategory.value = 'all'
@@ -1612,6 +1672,8 @@ function serializeFieldDraft(type: string | null): string {
       targetFieldId: rollupDraft.targetFieldId,
       foreignSheetId: rollupDraft.foreignSheetId,
       aggregation: rollupDraft.aggregation,
+      filters: rollupFilterPayload(),
+      filterConjunction: rollupDraft.filterConjunction,
     })
   }
   if (type === 'formula') {
@@ -1750,6 +1812,13 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     rollupDraft.targetFieldId = property.targetFieldId ?? ''
     rollupDraft.foreignSheetId = property.foreignSheetId ?? ''
     rollupDraft.aggregation = property.aggregation
+    // Hydrate the builder from the (typed, normalized) stored filters; value → string for the inputs.
+    rollupDraft.filters = (property.filters ?? []).map((c) => ({
+      fieldId: c.fieldId,
+      operator: c.operator,
+      value: c.value === null || c.value === undefined ? '' : String(c.value),
+    }))
+    rollupDraft.filterConjunction = property.filterConjunction ?? 'and'
   } else if (fieldType === 'formula') {
     formulaDraft.expression = resolveFormulaFieldProperty(field.property).expression
   } else if (fieldType === 'attachment') {
@@ -2194,11 +2263,15 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       fieldConfigError.value = ml('field.error.rollupNeedsValidTargetSheet')
       return undefined
     }
+    const rollupFilters = rollupFilterPayload()
     return {
       linkedFieldId: rollupDraft.linkFieldId,
       targetFieldId: rollupDraft.targetFieldId,
       aggregation: rollupDraft.aggregation,
       ...(rollupDraft.foreignSheetId ? { foreignSheetId: rollupDraft.foreignSheetId } : {}),
+      // Slice 3b — emit the authored filter conditions (omit entirely when none, so an unfiltered rollup's
+      // property is byte-identical to before this feature). Backend validates operators per resolved type.
+      ...(rollupFilters.length > 0 ? { filters: rollupFilters, filterConjunction: rollupDraft.filterConjunction } : {}),
     }
   }
   if (normalizedType === 'formula') {

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -36,15 +36,35 @@ export function rollupResultType(aggregation: RollupAggregation): 'number' | 'st
   return 'number'
 }
 
+// Slice 3b — a single rollup filter condition (field on the FOREIGN sheet, operator, optional value).
+// Matches the backend MetaFilterCondition shape; value is omitted for isEmpty/isNotEmpty.
+export type RollupFilterCondition = { fieldId: string; operator: string; value?: unknown }
+
 export type NormalizedRollupFieldProperty = {
   linkFieldId: string | null
   targetFieldId: string | null
   foreignSheetId: string | null
   aggregation: RollupAggregation
-  // Slice 3 rollup filter condition. The field manager has no builder UI yet, so these are carried
-  // OPAQUELY (load → re-save unchanged) to avoid clobbering an API/template-authored filter on edit.
-  filters?: unknown[]
-  filterConjunction?: string
+  // Slice 3b rollup filter condition — now editable via the builder UI (no longer opaque). Normalized to
+  // typed conditions so the field manager can hydrate/round-trip them; absent when no filter is set.
+  filters?: RollupFilterCondition[]
+  filterConjunction?: 'and' | 'or'
+}
+
+// Normalize raw stored filters (any of the backend aliases) into typed conditions, dropping malformed
+// entries (need a non-empty string fieldId + operator). `value` preserved only when present.
+export function normalizeRollupFilters(raw: unknown): RollupFilterCondition[] {
+  if (!Array.isArray(raw)) return []
+  const out: RollupFilterCondition[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const o = item as Record<string, unknown>
+    const fieldId = typeof o.fieldId === 'string' ? o.fieldId.trim() : ''
+    const operator = typeof o.operator === 'string' ? o.operator.trim() : ''
+    if (!fieldId || !operator) continue
+    out.push('value' in o ? { fieldId, operator, value: o.value } : { fieldId, operator })
+  }
+  return out
 }
 
 // Keep in lockstep with parseRollupAggregation in core-backend (routes/univer-meta.ts + field-codecs.ts):
@@ -178,21 +198,15 @@ export function resolveRollupFieldProperty(value: unknown): NormalizedRollupFiel
   // filterConditions aliases and a case-insensitive filterConjunction / conjunction. If the FE only
   // recognized a subset, an alias-authored rollup would lose its filter — or flip OR→AND — after an
   // unrelated Field Manager edit re-saved it in the FE's canonical shape.
-  const rawFilters = Array.isArray(property.filters)
-    ? property.filters
-    : Array.isArray(property.conditions)
-      ? property.conditions
-      : Array.isArray(property.filterConditions)
-        ? property.filterConditions
-        : null
+  const filters = normalizeRollupFilters(property.filters ?? property.conditions ?? property.filterConditions)
   const conjunction = String(property.filterConjunction ?? property.conjunction ?? '').trim().toLowerCase()
   return {
     linkFieldId: stringOrNull(property.linkFieldId ?? property.linkedFieldId ?? property.relatedLinkFieldId ?? property.sourceFieldId),
     targetFieldId: stringOrNull(property.targetFieldId ?? property.lookUpTargetFieldId ?? property.lookupTargetFieldId ?? property.lookupFieldId),
     foreignSheetId: stringOrNull(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId),
     aggregation: normalizeRollupAggregation(aggregation),
-    ...(rawFilters && rawFilters.length > 0
-      ? { filters: rawFilters, filterConjunction: conjunction === 'or' ? 'or' : 'and' }
+    ...(filters.length > 0
+      ? { filters, filterConjunction: conjunction === 'or' ? 'or' : 'and' }
       : {}),
   }
 }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -50,6 +50,8 @@ export type MetaManagerLabelKey =
   | 'field.linkField' | 'field.selectLinkField'
   | 'field.foreignSheetId' | 'field.targetFieldId'
   | 'field.optionalOverride' | 'field.aggregation'
+  | 'field.rollupFilters' | 'field.rollupFilterAll' | 'field.rollupFilterAny'
+  | 'field.rollupFilterFieldPlaceholder' | 'field.rollupFilterValuePlaceholder' | 'field.rollupFilterAdd'
   | 'field.expression' | 'field.insertFieldToken'
   | 'field.formulaReference' | 'field.formulaSearchPlaceholder'
   | 'field.formulaDryRun.test' | 'field.formulaDryRun.testWithRecord' | 'field.formulaDryRun.recordHint' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
@@ -277,6 +279,12 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.targetFieldId': { en: 'Target field id', zh: '目标字段 ID' },
   'field.optionalOverride': { en: 'Optional override', zh: '可选覆盖' },
   'field.aggregation': { en: 'Aggregation', zh: '聚合' },
+  'field.rollupFilters': { en: 'Filter conditions', zh: '筛选条件' },
+  'field.rollupFilterAll': { en: 'Match all', zh: '满足全部' },
+  'field.rollupFilterAny': { en: 'Match any', zh: '满足任一' },
+  'field.rollupFilterFieldPlaceholder': { en: 'foreign field id', zh: '外表字段 ID' },
+  'field.rollupFilterValuePlaceholder': { en: 'value', zh: '值' },
+  'field.rollupFilterAdd': { en: '+ Add condition', zh: '+ 添加条件' },
   'field.expression': { en: 'Expression', zh: '表达式' },
   'field.insertFieldToken': { en: 'Insert field token', zh: '插入字段令牌' },
   'field.formulaReference': { en: 'Formula reference', zh: '公式参考' },

--- a/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
+++ b/apps/web/tests/multitable-rollup-aggregation-fe.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeRollupAggregation, resolveRollupFieldProperty, rollupResultType } from '../src/multitable/utils/field-config'
+import { normalizeRollupAggregation, normalizeRollupFilters, resolveRollupFieldProperty, rollupResultType } from '../src/multitable/utils/field-config'
 import { aggregationLabel } from '../src/multitable/utils/meta-manager-labels'
 import { FILTER_OPERATORS_BY_TYPE, effectiveFilterTypeKey } from '../src/multitable/composables/useMultitableGrid'
 
@@ -143,5 +143,49 @@ describe('rollup string/boolean reducers (slice 2b) — FE', () => {
     const boolOps = (FILTER_OPERATORS_BY_TYPE[boolKey] ?? []).map((o) => o.value)
     expect(boolOps).toContain('is')
     expect(boolOps).not.toContain('greater')
+  })
+})
+
+// Slice 3b — rollup filter builder: normalization + round-trip. The builder edits string-valued rows;
+// these lock the field-config side (typed normalize + resolver round-trip) the field manager relies on.
+describe('rollup filter conditions — builder normalization + round-trip (slice 3b)', () => {
+  it('normalizeRollupFilters keeps well-formed, drops malformed, preserves value presence', () => {
+    expect(normalizeRollupFilters([
+      { fieldId: 'f1', operator: 'is', value: 'x' },
+      { fieldId: ' f2 ', operator: 'isEmpty' },   // trimmed; no value key
+      { fieldId: '', operator: 'is' },             // dropped — no fieldId
+      { fieldId: 'f3', operator: '' },             // dropped — no operator
+      { fieldId: '   ', operator: 'is', value: 1 },// dropped — whitespace fieldId
+      'nope', null, 42,                            // dropped — non-object
+    ])).toEqual([
+      { fieldId: 'f1', operator: 'is', value: 'x' },
+      { fieldId: 'f2', operator: 'isEmpty' },
+    ])
+    expect(normalizeRollupFilters(undefined)).toEqual([])
+    expect(normalizeRollupFilters('x')).toEqual([])
+  })
+
+  it('resolveRollupFieldProperty round-trips typed filters + conjunction (filters alias, case-insensitive OR)', () => {
+    const p = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'sum',
+      filters: [{ fieldId: 'f', operator: 'greater', value: 5 }], filterConjunction: 'OR',
+    })
+    expect(p.filters).toEqual([{ fieldId: 'f', operator: 'greater', value: 5 }])
+    expect(p.filterConjunction).toBe('or')
+  })
+
+  it('resolveRollupFieldProperty honors the filterConditions + conjunction aliases (backend parity)', () => {
+    const p = resolveRollupFieldProperty({
+      linkFieldId: 'l', targetFieldId: 't', aggregation: 'count',
+      filterConditions: [{ fieldId: 'f', operator: 'is', value: 'a' }], conjunction: 'and',
+    })
+    expect(p.filters).toEqual([{ fieldId: 'f', operator: 'is', value: 'a' }])
+    expect(p.filterConjunction).toBe('and')
+  })
+
+  it('no filters → filters/filterConjunction absent (unfiltered rollup property unchanged)', () => {
+    const p = resolveRollupFieldProperty({ linkFieldId: 'l', targetFieldId: 't', aggregation: 'count' })
+    expect(p.filters).toBeUndefined()
+    expect(p.filterConjunction).toBeUndefined()
   })
 })


### PR DESCRIPTION
Slice 3b — FE condition-builder for rollup filters (backend shipped + locked). Replaces the opaque filter carry with a real authoring panel.

## What
- `field-config.ts`: typed `RollupFilterCondition` + `normalizeRollupFilters` (drops malformed, preserves value-presence); `resolveRollupFieldProperty` returns typed filters, still honoring the `filters`/`conditions`/`filterConditions` + `filterConjunction`/`conjunction` aliases (case-insensitive).
- `MetaFieldManager.vue`: rollup config gains a filter-builder — condition rows (field-id input + operator + value, add/remove), AND/OR conjunction (shown at ≥2 rows), hydrate-from-stored + emit-on-save (genuine round-trip), reset clears. `rollupFilterPayload()` drops incomplete rows + omits `value` for isEmpty/isNotEmpty.
- 6 zh/en i18n labels; +4 FE spec cases (normalize keep/drop, resolver round-trip, alias + case-insensitive OR, no-filters-absent) in the `multitable-web-guard` spec.

## Design notes
- The condition **field is a typed id input**, consistent with the existing rollup TARGET field (also typed-id; only the local LINK field is a picker). A readable-foreign-field **picker** + **type-aware operator/value constraint** is a deliberate follow-up (**3c**) — it upgrades the target *and* filter fields together via one new foreign-field data flow (workbench → `client.listFields`), rather than making just the filter field inconsistent. Until then the backend validates operator/type at save with a clear error (the authoritative gate).

## Verification
`vue-tsc -b` PASS; `vitest run multitable-rollup-aggregation-fe` **19/19**; backend `tsc` PASS (untouched). FE-only; no real-DB change. Component mount isn't tested (repo FE-test style covers the field-config round-trip logic, which is where the correctness lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)