### PR TITLE
feat(multitable): record recycle bin / undelete (#15) — trash table + list/restore + modal

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -20,7 +20,10 @@ on:
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
       - 'apps/web/src/multitable/composables/useMultitableGrid.ts'
+      - 'apps/web/src/multitable/composables/useTrash.ts'
+      - 'apps/web/src/multitable/components/TrashModal.vue'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
+      - 'apps/web/tests/multitable-trash-fe.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -29,7 +32,10 @@ on:
       - 'apps/web/src/multitable/utils/meta-manager-labels.ts'
       - 'apps/web/src/multitable/components/MetaFieldManager.vue'
       - 'apps/web/src/multitable/composables/useMultitableGrid.ts'
+      - 'apps/web/src/multitable/composables/useTrash.ts'
+      - 'apps/web/src/multitable/components/TrashModal.vue'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
+      - 'apps/web/tests/multitable-trash-fe.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -72,4 +78,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + record recycle-bin delete/restore)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -192,6 +192,7 @@ jobs:
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-record-restore.test.ts \
+            tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -70,6 +70,7 @@ import type {
   DingTalkGroupDelivery,
   DingTalkPersonDelivery,
   DingTalkGroupDestinationInput,
+  MetaDeletedRecord,
 } from '../types'
 import { apiFetch } from '../../utils/api'
 import { apiDefaultErrorMessage, apiFieldValidationFallback } from '../utils/meta-api-error-labels'
@@ -1026,6 +1027,29 @@ export class MultitableApiClient {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/permissions`)
     const data = await this.parseJson<{ items?: Array<Partial<MetaSheetPermissionEntry>> }>(res)
     return normalizeSheetPermissionEntries(data)
+  }
+
+  // #15 recycle bin — list a sheet's deleted records (newest first) and restore one.
+  async listDeletedRecords(sheetId: string, params?: { limit?: number; offset?: number }): Promise<{ records: MetaDeletedRecord[]; total: number }> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/trash${qs(params ?? {})}`)
+    const data = await this.parseJson<{ records?: MetaDeletedRecord[]; total?: number }>(res)
+    return {
+      records: Array.isArray(data?.records) ? data.records : [],
+      total: typeof data?.total === 'number' ? data.total : 0,
+    }
+  }
+
+  async restoreDeletedRecord(recordId: string): Promise<{ restored: string; sheetId: string }> {
+    const res = await this.fetch(`/api/multitable/records/${encodeURIComponent(recordId)}/restore`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    const data = await this.parseJson<{ restored?: string; sheetId?: string }>(res)
+    return {
+      restored: typeof data?.restored === 'string' ? data.restored : recordId,
+      sheetId: typeof data?.sheetId === 'string' ? data.sheetId : '',
+    }
   }
 
   async listSheetPermissionCandidates(

--- a/apps/web/src/multitable/components/TrashModal.vue
+++ b/apps/web/src/multitable/components/TrashModal.vue
@@ -1,0 +1,81 @@
+<!--
+  #15 recycle bin — a modal listing a sheet's deleted records with a per-row Restore action.
+  Visibility is the caller's concern (open it only for actors who can delete); the backend gates the
+  list/restore endpoints on canDeleteRecord regardless. Loads on open via useTrash; restore is
+  optimistic-on-success and surfaces 409 (id occupied) / 403 inline via the composable's `error`.
+-->
+<template>
+  <div v-if="open" class="meta-trash__overlay" @click.self="emit('close')">
+    <div class="meta-trash__modal" role="dialog" aria-modal="true" :aria-label="t('回收站', 'Recycle bin')">
+      <header class="meta-trash__header">
+        <h3 class="meta-trash__title">{{ t('回收站', 'Recycle bin') }}</h3>
+        <button class="meta-trash__close" type="button" :aria-label="t('关闭', 'Close')" @click="emit('close')">×</button>
+      </header>
+
+      <p v-if="error" class="meta-trash__error" role="alert">{{ error }}</p>
+
+      <div v-if="loading" class="meta-trash__hint">{{ t('加载中…', 'Loading…') }}</div>
+      <ul v-else-if="records.length" class="meta-trash__list">
+        <li v-for="rec in records" :key="rec.recordId" class="meta-trash__row">
+          <span class="meta-trash__id" :title="rec.recordId">{{ rec.recordId }}</span>
+          <span class="meta-trash__meta">{{ formatDeleted(rec.deletedAt) }}</span>
+          <button
+            class="meta-trash__restore"
+            type="button"
+            :disabled="restoringIds.includes(rec.recordId)"
+            @click="onRestore(rec.recordId)"
+          >{{ restoringIds.includes(rec.recordId) ? t('恢复中…', 'Restoring…') : t('恢复', 'Restore') }}</button>
+        </li>
+      </ul>
+      <p v-else class="meta-trash__hint">{{ t('回收站为空', 'The recycle bin is empty') }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import { useTrash } from '../composables/useTrash'
+
+const props = defineProps<{ open: boolean; sheetId: string }>()
+const emit = defineEmits<{ (e: 'close'): void; (e: 'restored', recordId: string): void }>()
+
+const { isZh } = useLocale()
+const t = (zh: string, en: string) => (isZh.value ? zh : en)
+const { records, loading, error, restoringIds, load, restore } = useTrash()
+
+watch(
+  () => [props.open, props.sheetId] as const,
+  ([open, sheetId]) => {
+    if (open && sheetId) void load(sheetId)
+  },
+  { immediate: true },
+)
+
+function formatDeleted(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+async function onRestore(recordId: string): Promise<void> {
+  const ok = await restore(recordId)
+  if (ok) emit('restored', recordId)
+}
+</script>
+
+<style scoped>
+.meta-trash__overlay { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.4); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.meta-trash__modal { background: var(--meta-surface, #fff); color: var(--meta-text, #1f2329); border-radius: 8px; min-width: 360px; max-width: 560px; max-height: 70vh; overflow: auto; padding: 16px; box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18); }
+.meta-trash__header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.meta-trash__title { margin: 0; font-size: 15px; }
+.meta-trash__close { background: none; border: none; font-size: 20px; line-height: 1; cursor: pointer; color: inherit; }
+.meta-trash__list { list-style: none; margin: 0; padding: 0; }
+.meta-trash__row { display: flex; align-items: center; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--meta-border, #eee); }
+.meta-trash__id { font-family: monospace; font-size: 12px; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-trash__meta { color: var(--meta-text-secondary, #888); font-size: 12px; white-space: nowrap; }
+.meta-trash__restore { cursor: pointer; }
+.meta-trash__restore:disabled { cursor: default; opacity: 0.6; }
+.meta-trash__error { color: var(--meta-danger, #c0392b); margin: 0 0 8px; }
+.meta-trash__hint { color: var(--meta-text-secondary, #888); padding: 12px 0; }
+</style>

--- a/apps/web/src/multitable/composables/useTrash.ts
+++ b/apps/web/src/multitable/composables/useTrash.ts
@@ -1,0 +1,57 @@
+// #15 recycle bin — deleted-records list + restore for a sheet. Mirrors useNotificationInbox: a list +
+// loading/error state + a per-record restore action. UI-facing actions NEVER throw — failure (e.g. a 409
+// id-occupied conflict or a 403) surfaces via `error` and resolves, so a click can't leak an unhandled
+// rejection. Locale-reactive labels via useLocale (inline zh/en for this module's own strings).
+import { ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type { MetaDeletedRecord } from '../types'
+import { MultitableApiClient, multitableClient } from '../api/client'
+
+export function useTrash(client?: MultitableApiClient) {
+  const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const records = ref<MetaDeletedRecord[]>([])
+  const total = ref(0)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const restoringIds = ref<string[]>([])
+
+  const t = (zh: string, en: string) => (isZh.value ? zh : en)
+
+  async function load(sheetId: string, params?: { limit?: number; offset?: number }): Promise<MetaDeletedRecord[]> {
+    if (!sheetId) return records.value
+    loading.value = true
+    error.value = null
+    try {
+      const res = await api.listDeletedRecords(sheetId, params)
+      records.value = res.records
+      total.value = res.total
+      return res.records
+    } catch (e: unknown) {
+      error.value = (e as { message?: string })?.message ?? t('加载回收站失败', 'Failed to load the recycle bin')
+      return records.value
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // Returns true on success. Never throws — a 409 (id occupied) / 403 surfaces via `error`.
+  async function restore(recordId: string): Promise<boolean> {
+    if (!recordId || restoringIds.value.includes(recordId)) return false
+    restoringIds.value = [...restoringIds.value, recordId]
+    error.value = null
+    try {
+      await api.restoreDeletedRecord(recordId)
+      records.value = records.value.filter((r) => r.recordId !== recordId)
+      total.value = Math.max(0, total.value - 1)
+      return true
+    } catch (e: unknown) {
+      error.value = (e as { message?: string })?.message ?? t('恢复记录失败', 'Failed to restore the record')
+      return false
+    } finally {
+      restoringIds.value = restoringIds.value.filter((id) => id !== recordId)
+    }
+  }
+
+  return { records, total, loading, error, restoringIds, load, restore }
+}

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -299,6 +299,17 @@ export interface MetaRecordContext {
 
 export type MetaRecordRevisionAction = 'create' | 'update' | 'delete'
 
+// #15 recycle bin — a deleted record sitting in the trash, restorable.
+export interface MetaDeletedRecord {
+  recordId: string
+  sheetId: string
+  data: Record<string, unknown>
+  originalVersion: number
+  createdBy: string | null
+  deletedBy: string | null
+  deletedAt: string
+}
+
 export interface MetaRecordRevision {
   id: string
   sheetId: string

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -18,7 +18,7 @@ export type WorkbenchLabelKey =
   // §3.2 toolbar
   | 'toolbar.commentInbox' | 'toolbar.fields' | 'toolbar.access' | 'toolbar.views'
   | 'toolbar.workflow' | 'toolbar.automations' | 'toolbar.templates'
-  | 'toolbar.dashboard' | 'toolbar.shareForm' | 'toolbar.apiWebhooks'
+  | 'toolbar.dashboard' | 'toolbar.shareForm' | 'toolbar.apiWebhooks' | 'toolbar.trash'
   | 'toolbar.mentions'
   // §3.3 template library modal
   | 'tpl.title' | 'tpl.subtitle' | 'tpl.loading' | 'tpl.more' | 'tpl.errorLoad'
@@ -91,6 +91,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toolbar.dashboard': { en: 'Dashboard', zh: '仪表盘' },
   'toolbar.shareForm': { en: 'Share Form', zh: '分享表单' },
   'toolbar.apiWebhooks': { en: 'API & Webhooks', zh: 'API 与 Webhook' },
+  'toolbar.trash': { en: 'Trash', zh: '回收站' },
   'toolbar.mentions': { en: 'Mentions', zh: '提及' },
 
   'tpl.title': { en: 'Template Library', zh: '模板库' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -61,6 +61,7 @@
       <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard">&#x1F4CA; {{ wb('toolbar.dashboard', isZh) }}</button>
       <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; {{ wb('toolbar.shareForm', isZh) }}</button>
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; {{ wb('toolbar.apiWebhooks', isZh) }}</button>
+      <button v-if="caps.canDeleteRecord.value" class="mt-workbench__mgr-btn" @click="showTrash = true">&#x1F5D1; {{ wb('toolbar.trash', isZh) }}</button>
     </div>
     <div v-if="showTemplateLibrary" class="mt-template-library" data-testid="multitable-template-library">
       <div class="mt-template-library__header">
@@ -456,6 +457,13 @@
       :can-manage-automation="caps.canManageAutomation.value"
       @close="showApiTokenManager = false"
     />
+
+    <TrashModal
+      :open="showTrash"
+      :sheet-id="workbench.activeSheetId.value"
+      @close="showTrash = false"
+      @restored="onTrashRestored"
+    />
   </div>
 </template>
 
@@ -547,6 +555,7 @@ import MetaPersonPicker from '../components/MetaPersonPicker.vue'
 import MetaTemplateCard from '../components/MetaTemplateCard.vue'
 import MetaFieldManager from '../components/MetaFieldManager.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
+import TrashModal from '../components/TrashModal.vue'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
 import MetaAutomationManager from '../components/MetaAutomationManager.vue'
 import MetaFormShareManager from '../components/MetaFormShareManager.vue'
@@ -741,6 +750,11 @@ const showTemplateLibrary = ref(false)
 const TemplateCenterRouteName = AppRouteNames.MULTITABLE_TEMPLATES
 const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
+const showTrash = ref(false)
+// After an undelete, the restored record is back in the sheet → refresh the current page so it appears.
+function onTrashRestored(): void {
+  void grid.reloadCurrentPage()
+}
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])
 const viewPermissionEntries = ref<MetaViewPermissionEntry[]>([])
 const showViewManager = ref(false)

--- a/apps/web/tests/multitable-trash-fe.spec.ts
+++ b/apps/web/tests/multitable-trash-fe.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useTrash } from '../src/multitable/composables/useTrash'
+import type { MetaDeletedRecord } from '../src/multitable/types'
+
+// #15 recycle bin — useTrash composable contract. Locks: load populates list+total; restore is
+// optimistic-on-success (removes row, decrements total) and NEVER throws — a 409 (id occupied) / 403
+// surfaces via `error` and leaves the list unchanged, so a click can't leak an unhandled rejection.
+
+function rec(id: string): MetaDeletedRecord {
+  return { recordId: id, sheetId: 's1', data: {}, originalVersion: 1, createdBy: null, deletedBy: 'u', deletedAt: '2026-06-17T00:00:00Z' }
+}
+function fakeClient(over: { list?: unknown; restore?: unknown } = {}) {
+  return {
+    listDeletedRecords: over.list ?? vi.fn().mockResolvedValue({ records: [rec('r1'), rec('r2')], total: 2 }),
+    restoreDeletedRecord: over.restore ?? vi.fn().mockResolvedValue({ restored: 'r1', sheetId: 's1' }),
+  } as never
+}
+
+describe('useTrash — recycle bin composable', () => {
+  it('load populates records + total', async () => {
+    const { records, total, load } = useTrash(fakeClient())
+    await load('s1')
+    expect(records.value.map((r) => r.recordId)).toEqual(['r1', 'r2'])
+    expect(total.value).toBe(2)
+  })
+
+  it('restore removes the record, decrements total, returns true', async () => {
+    const { records, total, load, restore } = useTrash(fakeClient())
+    await load('s1')
+    const ok = await restore('r1')
+    expect(ok).toBe(true)
+    expect(records.value.map((r) => r.recordId)).toEqual(['r2'])
+    expect(total.value).toBe(1)
+  })
+
+  it('restore NEVER throws — surfaces error, returns false, list unchanged (e.g. 409 id occupied)', async () => {
+    const c = fakeClient({ restore: vi.fn().mockRejectedValue(new Error('Record id is occupied, cannot restore: r1')) })
+    const { error, restore, records, load } = useTrash(c)
+    await load('s1')
+    const ok = await restore('r1')
+    expect(ok).toBe(false)
+    expect(error.value).toContain('occupied')
+    expect(records.value.map((r) => r.recordId)).toEqual(['r1', 'r2'])
+  })
+
+  it('load NEVER throws — surfaces error', async () => {
+    const c = fakeClient({ list: vi.fn().mockRejectedValue(new Error('boom')) })
+    const { error, load } = useTrash(c)
+    await load('s1')
+    expect(error.value).toBe('boom')
+  })
+
+  it('load is a no-op without a sheetId', async () => {
+    const c = fakeClient()
+    const { load } = useTrash(c)
+    await load('')
+    expect((c as { listDeletedRecords: { mock: { calls: unknown[] } } }).listDeletedRecords.mock.calls.length).toBe(0)
+  })
+})

--- a/docs/development/multitable-record-recycle-bin-arc-20260617.md
+++ b/docs/development/multitable-record-recycle-bin-arc-20260617.md
@@ -1,0 +1,40 @@
+# Multitable Record Recycle Bin (#15) — ARC note
+
+Record deletion is a hard delete from `meta_records`. This arc adds a recycle bin: on delete the row is
+copied into a dedicated `meta_records_trash` table in the **same transaction**, so it can be listed and
+restored.
+
+## Design decisions (conservative, reversible)
+
+- **Separate table, not a tombstone column.** Deleted rows land in `meta_records_trash` (surrogate uuid PK
+  + `record_id` of the original). Every existing read path is untouched — no `WHERE deleted_at IS NULL`
+  guards to add and no fail-open risk. The trash table is independent of the existing
+  `meta_record_revisions` delete snapshot.
+- **Retention is disabled by default.** Trashed rows are kept until an explicit purge; there is no
+  automatic aging. A retention/purge policy can be layered on later without changing this contract.
+- **Record-id reuse: reject on conflict.** Record ids are server-generated (`randomUUID`), so collisions
+  are essentially nil; if the original id is occupied by a live record at restore time, restore is rejected
+  with **409** rather than overwriting the live record.
+- **Cascade is best-effort.** Inbound links are not snapshotted (the hard delete already removes
+  `meta_links`); a restored record reappears without its former inbound link rows. Documented limitation.
+
+## Surface
+
+- `DELETE /records/:recordId` — unchanged contract; now also copies the row into the trash (txn-local,
+  guarded so a pre-migration DB still deletes cleanly).
+- `GET /sheets/:sheetId/trash` — list deleted records (newest first, paginated). Gated on
+  `canDeleteRecord` (whoever may delete may view + restore the trash).
+- `POST /records/:recordId/restore` — restore the most-recently-deleted trash row for that id. 409 if the
+  id is occupied; 403 for a non-deleter; 404 if there is nothing to restore.
+
+## Permissions
+
+`canDeleteRecord` (== `canWrite`) gates both list and restore. A read-only actor receives 403.
+
+## Verification
+
+Real-DB integration (`multitable-record-recycle-bin.test.ts`, in the `plugin-tests.yml` allowlist):
+delete→trash→restore round-trip; restore-into-occupied-id → 409 with the live record untouched;
+read-only actor denied (403) for both list and restore. FE composable contract (`multitable-trash-fe.spec.ts`,
+in the `multitable-web-guard` lane): load populates list+total; restore is optimistic-on-success and never
+throws (409/403 surface via `error`).

--- a/packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts
@@ -25,6 +25,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       original_version integer NOT NULL DEFAULT 1,
       created_by text,
       deleted_by text,
+      -- Original meta_records timestamps, captured at delete so restore preserves them (NOT reset to
+      -- restore-time) — keeps sort-by-created/audit order stable across a delete→restore cycle.
+      original_created_at timestamptz,
+      original_updated_at timestamptz,
       deleted_at timestamptz NOT NULL DEFAULT now()
     )
   `.execute(db)

--- a/packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260617120000_create_meta_records_trash.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration: #15 recycle bin — soft-delete landing table for deleted multitable records.
+ *
+ * Record DELETE is a hard delete from meta_records (record-service.deleteRecord). This table is the
+ * recycle bin: on delete the row is copied here in the SAME transaction, so it can be listed + restored.
+ *
+ * Design (ARC #15, conservative defaults): a SEPARATE table (NOT a tombstone column on meta_records) so
+ * every existing read path is untouched. Retention is DISABLED by default — rows live here until an
+ * explicit purge; no automatic aging. Surrogate uuid PK + record_id column so a delete→restore→delete
+ * cycle never collides on the original id; restore resolves the most-recent trash row per record_id.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_records_trash (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      record_id text NOT NULL,
+      sheet_id text NOT NULL,
+      base_id text,
+      data jsonb NOT NULL DEFAULT '{}'::jsonb,
+      original_version integer NOT NULL DEFAULT 1,
+      created_by text,
+      deleted_by text,
+      deleted_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  // Listing: deleted records per sheet, newest first.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_trash_sheet_deleted
+    ON meta_records_trash(sheet_id, deleted_at DESC)
+  `.execute(db)
+
+  // Restore lookup by original record id.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_trash_record
+    ON meta_records_trash(record_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_records_trash`.execute(db)
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -153,6 +153,18 @@ export class RecordValidationFailedError extends Error {
   }
 }
 
+// #15 recycle bin: undelete attempted on a record id that is currently occupied (id was reused by a new
+// CREATE after the delete). Maps to 409 at the route. Conservative default: reject rather than overwrite.
+export class RecordRestoreConflictError extends Error {
+  public readonly code = 'CONFLICT'
+  public readonly statusCode = 409
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'RecordRestoreConflictError'
+  }
+}
+
 export class RecordPatchFieldValidationError extends Error {
   public readonly code: string
   public readonly statusCode: number
@@ -789,6 +801,23 @@ export class RecordService {
         snapshot,
       })
 
+      // #15 recycle bin: copy the row into the trash table in the SAME txn before the hard delete, so it
+      // can be listed + restored. base_id is best-effort. Guarded by isUndefinedTableError so a DB that
+      // predates the migration still deletes cleanly (degrades to no-trash, the revision snapshot remains).
+      try {
+        const baseRow = (await query('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])).rows[0] as
+          | Record<string, unknown>
+          | undefined
+        const baseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
+        await query(
+          `INSERT INTO meta_records_trash (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by)
+           VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)`,
+          [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId],
+        )
+      } catch (err) {
+        if (!isUndefinedTableError(err, 'meta_records_trash')) throw err
+      }
+
       // lock-guarded: single DELETE — ensureRecordNotLocked enforced above (rejects before this txn).
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
     })
@@ -811,6 +840,120 @@ export class RecordService {
       recordId,
       sheetId,
     }
+  }
+
+  // #15 recycle bin — list the records deleted from a sheet (newest first). Gated on canDeleteRecord
+  // (whoever may delete may view/restore the trash). Returns empty if the trash table predates migration.
+  async listDeletedRecords(input: {
+    sheetId: string
+    access: AccessInfo
+    resolveSheetAccess: RecordDeleteInput['resolveSheetAccess']
+    limit?: number
+    offset?: number
+  }): Promise<{
+    records: Array<{ recordId: string; sheetId: string; data: Record<string, unknown>; originalVersion: number; createdBy: string | null; deletedBy: string | null; deletedAt: string }>
+    total: number
+  }> {
+    const { sheetId, resolveSheetAccess } = input
+    const { capabilities } = await resolveSheetAccess(sheetId)
+    if (!capabilities.canDeleteRecord) {
+      throw new RecordPermissionError('Insufficient permissions to view deleted records')
+    }
+    const limit = Math.min(Math.max(input.limit ?? 50, 1), 200)
+    const offset = Math.max(input.offset ?? 0, 0)
+    try {
+      const totalRes = await this.pool.query('SELECT COUNT(*)::int AS n FROM meta_records_trash WHERE sheet_id = $1', [sheetId])
+      const total = Number((totalRes.rows[0] as { n?: number } | undefined)?.n ?? 0)
+      const rowsRes = await this.pool.query(
+        `SELECT record_id, sheet_id, data, original_version, created_by, deleted_by, deleted_at
+         FROM meta_records_trash WHERE sheet_id = $1 ORDER BY deleted_at DESC LIMIT $2 OFFSET $3`,
+        [sheetId, limit, offset],
+      )
+      const records = (rowsRes.rows as Array<Record<string, unknown>>).map((r) => ({
+        recordId: String(r.record_id),
+        sheetId: String(r.sheet_id),
+        data: normalizeJson(r.data),
+        originalVersion: Number(r.original_version ?? 1),
+        createdBy: typeof r.created_by === 'string' ? r.created_by : null,
+        deletedBy: typeof r.deleted_by === 'string' ? r.deleted_by : null,
+        deletedAt: r.deleted_at instanceof Date ? r.deleted_at.toISOString() : String(r.deleted_at ?? ''),
+      }))
+      return { records, total }
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_records_trash')) return { records: [], total: 0 }
+      throw err
+    }
+  }
+
+  // #15 recycle bin — restore the most-recently-deleted trash row for a record id back into meta_records.
+  // Rejects (409) if the id is currently occupied (conservative default: never overwrite a live record).
+  async restoreRecord(input: {
+    recordId: string
+    actorId: string | null
+    access: AccessInfo
+    resolveSheetAccess: RecordDeleteInput['resolveSheetAccess']
+  }): Promise<{ recordId: string; sheetId: string }> {
+    const { recordId, actorId, resolveSheetAccess } = input
+    const trashRes = await this.pool
+      .query(
+        `SELECT id, record_id, sheet_id, data, created_by
+         FROM meta_records_trash WHERE record_id = $1 ORDER BY deleted_at DESC LIMIT 1`,
+        [recordId],
+      )
+      .catch((err: unknown) => {
+        if (isUndefinedTableError(err, 'meta_records_trash')) return { rows: [] as Array<Record<string, unknown>> }
+        throw err
+      })
+    if (trashRes.rows.length === 0) {
+      throw new RecordNotFoundError(`No deleted record to restore: ${recordId}`)
+    }
+    const trashRow = trashRes.rows[0] as Record<string, unknown>
+    const sheetId = String(trashRow.sheet_id)
+    const { capabilities } = await resolveSheetAccess(sheetId)
+    if (!capabilities.canDeleteRecord) {
+      throw new RecordPermissionError('Insufficient permissions to restore records')
+    }
+    const trashPk = String(trashRow.id)
+    const snapshot = normalizeJson(trashRow.data)
+    const createdBy = typeof trashRow.created_by === 'string' ? trashRow.created_by : null
+
+    await this.pool.transaction(async ({ query }) => {
+      const occupied = await query('SELECT 1 FROM meta_records WHERE id = $1 FOR UPDATE', [recordId])
+      if (occupied.rows.length > 0) {
+        throw new RecordRestoreConflictError(`Record id is occupied, cannot restore: ${recordId}`)
+      }
+      const inserted = await query(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
+         VALUES ($1, $2, $3::jsonb, 1, $4, $5)
+         RETURNING version`,
+        [recordId, sheetId, JSON.stringify(snapshot), createdBy, actorId],
+      )
+      const restoredVersion = Number((inserted.rows[0] as { version?: number } | undefined)?.version ?? 1)
+      await recordRecordRevision(query, {
+        sheetId,
+        recordId,
+        version: restoredVersion,
+        action: 'create',
+        source: 'rest',
+        actorId,
+        changedFieldIds: Object.keys(snapshot),
+        patch: snapshot,
+        snapshot,
+      })
+      await query('DELETE FROM meta_records_trash WHERE id = $1', [trashPk])
+    })
+
+    publishMultitableSheetRealtime({
+      spreadsheetId: sheetId,
+      actorId,
+      source: 'multitable',
+      kind: 'record-created',
+      recordId,
+      recordIds: [recordId],
+    })
+    this.eventBus.emit('multitable.record.created', { sheetId, recordId, actorId })
+
+    return { recordId, sheetId }
   }
 
   async patchRecord(input: RecordPatchInput): Promise<RecordPatchResult> {

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -234,6 +234,11 @@ function isUndefinedTableError(err: unknown, tableName: string): boolean {
   return message.includes(`relation \"${tableName}\" does not exist`)
 }
 
+// Postgres unique_violation (e.g. a primary-key collision from a TOCTOU race on restore).
+function isUniqueViolation(err: unknown): boolean {
+  return typeof (err as { code?: unknown })?.code === 'string' && (err as { code: string }).code === '23505'
+}
+
 function mapFieldType(type: string): UniverMetaField['type'] {
   const normalized = type.trim().toLowerCase()
   if (normalized === 'number') return 'number'
@@ -739,7 +744,7 @@ export class RecordService {
     const { recordId, expectedVersion, actorId, access, resolveSheetAccess } = input
 
     const recordRes = await this.pool.query(
-      'SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1',
+      'SELECT id, sheet_id, created_by, locked, locked_by, created_at, updated_at FROM meta_records WHERE id = $1',
       [recordId],
     )
     if (recordRes.rows.length === 0) {
@@ -749,6 +754,9 @@ export class RecordService {
     const recordRow = recordRes.rows[0] as Record<string, unknown>
     const sheetId = typeof recordRow.sheet_id === 'string' ? recordRow.sheet_id : ''
     const createdBy = typeof recordRow.created_by === 'string' ? recordRow.created_by : null
+    // Captured for the trash row so restore preserves original timestamps (pg returns Date|string).
+    const originalCreatedAt = (recordRow.created_at as Date | string | null) ?? null
+    const originalUpdatedAt = (recordRow.updated_at as Date | string | null) ?? null
     const { capabilities, sheetScope } = await resolveSheetAccess(sheetId)
 
     if (!capabilities.canDeleteRecord) {
@@ -810,9 +818,10 @@ export class RecordService {
           | undefined
         const baseId = baseRow && typeof baseRow.base_id === 'string' ? baseRow.base_id : null
         await query(
-          `INSERT INTO meta_records_trash (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by)
-           VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)`,
-          [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId],
+          `INSERT INTO meta_records_trash
+             (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
+           VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
+          [recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, originalCreatedAt, originalUpdatedAt],
         )
       } catch (err) {
         if (!isUndefinedTableError(err, 'meta_records_trash')) throw err
@@ -896,7 +905,7 @@ export class RecordService {
     const { recordId, actorId, resolveSheetAccess } = input
     const trashRes = await this.pool
       .query(
-        `SELECT id, record_id, sheet_id, data, created_by
+        `SELECT id, record_id, sheet_id, data, created_by, original_created_at, original_updated_at
          FROM meta_records_trash WHERE record_id = $1 ORDER BY deleted_at DESC LIMIT 1`,
         [recordId],
       )
@@ -916,18 +925,53 @@ export class RecordService {
     const trashPk = String(trashRow.id)
     const snapshot = normalizeJson(trashRow.data)
     const createdBy = typeof trashRow.created_by === 'string' ? trashRow.created_by : null
+    const originalCreatedAt = (trashRow.original_created_at as Date | string | null) ?? null
+    const originalUpdatedAt = (trashRow.original_updated_at as Date | string | null) ?? null
+
+    // Orphan guard: refuse to resurrect into a sheet that no longer exists. Sheet delete is a hard delete
+    // and meta_records_trash has no FK to meta_sheets, so a trash row can outlive its sheet's cascade.
+    const sheetAlive = await this.pool.query('SELECT 1 FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL', [sheetId])
+    if (sheetAlive.rows.length === 0) {
+      throw new RecordRestoreConflictError(`Cannot restore: sheet no longer exists: ${sheetId}`)
+    }
+
+    // Outbound links: deleteRecord dropped this record's meta_links rows, but the snapshot still carries the
+    // link-field arrays (createRecord writes them into data). Rebuild meta_links on restore so link values
+    // aren't silently empty on read (loadLinkValuesByRecord reads from meta_links, not data).
+    const sheetFields = await loadFieldsForSheet(this.pool.query.bind(this.pool), sheetId)
+    const linkFieldIds = sheetFields.filter((f) => f.type === 'link').map((f) => f.id)
 
     await this.pool.transaction(async ({ query }) => {
       const occupied = await query('SELECT 1 FROM meta_records WHERE id = $1 FOR UPDATE', [recordId])
       if (occupied.rows.length > 0) {
         throw new RecordRestoreConflictError(`Record id is occupied, cannot restore: ${recordId}`)
       }
-      const inserted = await query(
-        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
-         VALUES ($1, $2, $3::jsonb, 1, $4, $5)
-         RETURNING version`,
-        [recordId, sheetId, JSON.stringify(snapshot), createdBy, actorId],
-      )
+      let inserted: { rows: Array<{ version?: number }> }
+      try {
+        inserted = await query(
+          `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by, created_at, updated_at)
+           VALUES ($1, $2, $3::jsonb, 1, $4, $5, COALESCE($6, now()), COALESCE($7, now()))
+           RETURNING version`,
+          [recordId, sheetId, JSON.stringify(snapshot), createdBy, actorId, originalCreatedAt, originalUpdatedAt],
+        )
+      } catch (err) {
+        // TOCTOU: a concurrent create/restore can take the id between the FOR UPDATE check and this INSERT.
+        // The PK still blocks it; map unique_violation to a clean 409 instead of letting a raw 23505 → 500.
+        if (isUniqueViolation(err)) {
+          throw new RecordRestoreConflictError(`Record id is occupied, cannot restore: ${recordId}`)
+        }
+        throw err
+      }
+      // Rebuild outbound meta_links from the restored snapshot (same insert shape as create/patch).
+      for (const fieldId of linkFieldIds) {
+        for (const foreignId of normalizeLinkIds(snapshot[fieldId])) {
+          await query(
+            `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+             VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+            [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
+          )
+        }
+      }
       const restoredVersion = Number((inserted.rows[0] as { version?: number } | undefined)?.version ?? 1)
       await recordRecordRevision(query, {
         sheetId,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -143,6 +143,7 @@ import {
   RecordValidationError as RecordServiceValidationError,
   RecordFieldForbiddenError as RecordServiceFieldForbiddenError,
   RecordPermissionError as RecordServicePermissionError,
+  RecordRestoreConflictError as RecordServiceRestoreConflictError,
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
@@ -11071,6 +11072,86 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] delete record failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete record' } })
+    }
+  })
+
+  // #15 recycle bin — list records deleted from a sheet (newest first). Gated on canDeleteRecord (whoever
+  // may delete may view + restore the trash).
+  router.get('/sheets/:sheetId/trash', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    const limitRaw = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : Number.NaN
+    const offsetRaw = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : Number.NaN
+    try {
+      const pool = poolManager.get()
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      const recordService = new RecordService(pool, eventBus)
+      const result = await recordService.listDeletedRecords({
+        sheetId,
+        access,
+        ...(Number.isFinite(limitRaw) ? { limit: limitRaw } : {}),
+        ...(Number.isFinite(offsetRaw) ? { offset: offsetRaw } : {}),
+        resolveSheetAccess: async (sid) => {
+          const { capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sid)
+          return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
+        },
+      })
+      return res.json({ ok: true, data: result })
+    } catch (err) {
+      if (err instanceof RecordServicePermissionError) {
+        return sendForbidden(res, err.message)
+      }
+      if (err instanceof RecordServiceNotFoundError || err instanceof ServiceNotFoundError) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      throw err
+    }
+  })
+
+  // #15 recycle bin — restore a deleted record. 409 if the id is now occupied (conservative default:
+  // never overwrite a live record).
+  router.post('/records/:recordId/restore', async (req: Request, res: Response) => {
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      const recordService = new RecordService(pool, eventBus)
+      const result = await recordService.restoreRecord({
+        recordId,
+        actorId: getRequestActorId(req),
+        access,
+        resolveSheetAccess: async (sid) => {
+          const { capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sid)
+          return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
+        },
+      })
+      return res.json({ ok: true, data: { restored: result.recordId, sheetId: result.sheetId } })
+    } catch (err) {
+      if (err instanceof RecordServicePermissionError) {
+        return sendForbidden(res, err.message)
+      }
+      if (err instanceof RecordServiceNotFoundError || err instanceof ServiceNotFoundError) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      if (err instanceof RecordServiceRestoreConflictError) {
+        return res.status(409).json({ ok: false, error: { code: 'CONFLICT', message: err.message } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      throw err
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #15 recycle bin — real-DB integration. Pins the delete→trash→restore round-trip, the occupied-id
+ * conflict (409, never overwrite a live record), and permission denial (a non-deleter can neither view
+ * nor restore the trash). Triggers: DELETE /records/:id, GET /sheets/:sheetId/trash,
+ * POST /records/:recordId/restore. canDeleteRecord == canWrite, so multitable:write gates the bin.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_rb_${TS}`
+const SHEET = `sheet_rb_${TS}`
+const FLD = `fld_rb_${TS}`
+const REC = `rec_rb_${TS}`
+const WRITER = `u_rb_w_${TS}`
+const READER = `u_rb_ro_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string, perms: string[]): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms, permissions: perms }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const writerApp = () => buildApp(WRITER, ['multitable:read', 'multitable:write'])
+const readerApp = () => buildApp(READER, ['multitable:read'])
+const trashIds = (res: { body?: { data?: { records?: Array<{ recordId: string }> } } }) =>
+  (res.body?.data?.records ?? []).map((r) => r.recordId)
+
+describeIfDatabase('multitable recycle bin — delete/trash/restore (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RB Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RB Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD, SHEET, 'Name', 'string', '{}', 1])
+  })
+
+  beforeEach(async () => {
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC, SHEET, JSON.stringify({ [FLD]: 'hello' })])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('delete → record lands in trash → restore → back in records', async () => {
+    expect((await request(writerApp()).delete(`/api/multitable/records/${REC}`)).status).toBe(200)
+    // gone from the live table
+    expect((await request(writerApp()).get(`/api/multitable/records/${REC}`)).status).toBe(404)
+    // appears in the trash
+    const trash = await request(writerApp()).get(`/api/multitable/sheets/${SHEET}/trash`)
+    expect(trash.status).toBe(200)
+    expect(trashIds(trash)).toContain(REC)
+    // restore
+    expect((await request(writerApp()).post(`/api/multitable/records/${REC}/restore`)).status).toBe(200)
+    // back in the live table with its data
+    const back = await request(writerApp()).get(`/api/multitable/records/${REC}`)
+    expect(back.status).toBe(200)
+    expect(back.body?.data?.record?.data?.[FLD]).toBe('hello')
+    // and no longer in the trash
+    expect(trashIds(await request(writerApp()).get(`/api/multitable/sheets/${SHEET}/trash`))).not.toContain(REC)
+  })
+
+  test('restore into an OCCUPIED id → 409 conflict, live record untouched', async () => {
+    await request(writerApp()).delete(`/api/multitable/records/${REC}`)
+    // simulate id reuse: a live record now occupies the id
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC, SHEET, JSON.stringify({ [FLD]: 'new owner' })])
+    expect((await request(writerApp()).post(`/api/multitable/records/${REC}/restore`)).status).toBe(409)
+    const live = await request(writerApp()).get(`/api/multitable/records/${REC}`)
+    expect(live.body?.data?.record?.data?.[FLD]).toBe('new owner') // not overwritten by the trashed 'hello'
+  })
+
+  test('permission denial: a read-only (non-deleter) actor cannot view or restore the trash', async () => {
+    await request(writerApp()).delete(`/api/multitable/records/${REC}`)
+    expect((await request(readerApp()).get(`/api/multitable/sheets/${SHEET}/trash`)).status).toBe(403)
+    expect((await request(readerApp()).post(`/api/multitable/records/${REC}/restore`)).status).toBe(403)
+    // the writer can still restore it afterward (denial didn't consume the trash row)
+    expect((await request(writerApp()).post(`/api/multitable/records/${REC}/restore`)).status).toBe(200)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
@@ -98,4 +98,61 @@ describeIfDatabase('multitable recycle bin — delete/trash/restore (real DB)', 
     // the writer can still restore it afterward (denial didn't consume the trash row)
     expect((await request(writerApp()).post(`/api/multitable/records/${REC}/restore`)).status).toBe(200)
   })
+
+  test('restore REBUILDS outbound links — a link field is not silently emptied', async () => {
+    const fsheet = `sheet_rbl_${TS}`, ffld = `fld_rbl_t_${TS}`, frec = `rec_rbl_f_${TS}`
+    const lfld = `fld_rbl_link_${TS}`, srec = `rec_rbl_s_${TS}`
+    try {
+      await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [fsheet, BASE, 'RBL Foreign'])
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [ffld, fsheet, 'T', 'string', '{}', 1])
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [frec, fsheet, JSON.stringify({ [ffld]: 'x' })])
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [lfld, SHEET, 'Link', 'link', JSON.stringify({ foreignSheetId: fsheet }), 2])
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [srec, SHEET, JSON.stringify({ [FLD]: 'linked', [lfld]: [frec] })])
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_rbl_${TS}`, lfld, srec, frec])
+      expect((await request(writerApp()).delete(`/api/multitable/records/${srec}`)).status).toBe(200)
+      expect((await request(writerApp()).post(`/api/multitable/records/${srec}/restore`)).status).toBe(200)
+      const back = await request(writerApp()).get(`/api/multitable/records/${srec}`)
+      expect(back.status).toBe(200)
+      // The restored link field must carry the foreign id again (meta_links rebuilt), not be empty.
+      expect(JSON.stringify(back.body?.data?.record?.data?.[lfld] ?? null)).toContain(frec)
+    } finally {
+      await q('DELETE FROM meta_links WHERE field_id = $1', [lfld]).catch(() => {})
+      await q('DELETE FROM meta_records_trash WHERE sheet_id = ANY($1::text[])', [[SHEET, fsheet]]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE id = $1', [srec]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [fsheet]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE id = $1', [lfld]).catch(() => {})
+      await q('DELETE FROM meta_fields WHERE sheet_id = $1', [fsheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [fsheet]).catch(() => {})
+    }
+  })
+
+  test('restore into a DELETED sheet is rejected (orphan guard), not resurrected', async () => {
+    const tsheet = `sheet_rbo_${TS}`, trec = `rec_rbo_${TS}`
+    try {
+      await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [tsheet, BASE, 'RBO'])
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [trec, tsheet, JSON.stringify({})])
+      expect((await request(writerApp()).delete(`/api/multitable/records/${trec}`)).status).toBe(200)
+      await q('DELETE FROM meta_sheets WHERE id = $1', [tsheet]) // hard-delete the sheet; trash row survives
+      expect((await request(writerApp()).post(`/api/multitable/records/${trec}/restore`)).status).toBe(409)
+    } finally {
+      await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [tsheet]).catch(() => {})
+      await q('DELETE FROM meta_records WHERE sheet_id = $1', [tsheet]).catch(() => {})
+      await q('DELETE FROM meta_sheets WHERE id = $1', [tsheet]).catch(() => {})
+    }
+  })
+
+  test('restore PRESERVES the original created_at (not reset to restore-time)', async () => {
+    const crec = `rec_rbc_${TS}`
+    const old = '2020-01-02T03:04:05.000Z'
+    try {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version, created_at) VALUES ($1,$2,$3::jsonb,1,$4)', [crec, SHEET, JSON.stringify({ [FLD]: 'old' }), old])
+      expect((await request(writerApp()).delete(`/api/multitable/records/${crec}`)).status).toBe(200)
+      expect((await request(writerApp()).post(`/api/multitable/records/${crec}/restore`)).status).toBe(200)
+      const row = await q('SELECT created_at FROM meta_records WHERE id = $1', [crec])
+      expect(new Date(row.rows[0].created_at as string).toISOString()).toBe(old)
+    } finally {
+      await q('DELETE FROM meta_records WHERE id = $1', [crec]).catch(() => {})
+      await q('DELETE FROM meta_records_trash WHERE record_id = $1', [crec]).catch(() => {})
+    }
+  })
 })

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -101,9 +101,9 @@ function createMockPool(
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
     }
-    if (sql.includes('SELECT id, sheet_id, created_by, locked, locked_by FROM meta_records WHERE id = $1')) {
+    if (sql.includes('SELECT id, sheet_id, created_by, locked, locked_by') && sql.includes('FROM meta_records WHERE id = $1')) {
       return responses.SELECT_DELETE_RECORD ?? {
-        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1', locked: false, locked_by: null }],
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1', locked: false, locked_by: null, created_at: null, updated_at: null }],
       }
     }
     if (sql.includes('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE')) {
@@ -133,6 +133,14 @@ function createMockPool(
     }
     if (sql.includes('DELETE FROM meta_records WHERE id = $1')) {
       return responses.DELETE_RECORD ?? { rows: [], rowCount: 1 }
+    }
+    // #15 recycle bin: deleteRecord copies the row into meta_records_trash (base_id lookup + insert) in the
+    // delete txn before the hard delete; mock both so the delete-path unit tests don't hit Unhandled SQL.
+    if (sql.includes('SELECT base_id FROM meta_sheets WHERE id = $1')) {
+      return responses.SELECT_SHEET_BASE ?? { rows: [{ base_id: 'base_ops' }] }
+    }
+    if (sql.includes('INSERT INTO meta_records_trash')) {
+      return responses.INSERT_TRASH ?? { rows: [], rowCount: 1 }
     }
     throw new Error(`Unhandled SQL in test: ${sql}`)
   })


### PR DESCRIPTION
Arc #15 — recoverable deletes. Hard-delete copies the row into a new `meta_records_trash` table inside the SAME `pool.transaction` as the DELETE (atomic). New: `listDeletedRecords`+`restoreRecord` (record-service) + `GET /sheets/:sheetId/trash` + `POST /records/:recordId/restore` — both assert `canDeleteRecord`; restore 409s on id-occupied, double-restore→404. Distinct from the existing version-restore `/sheets/:sheetId/records/:recordId/restore`. FE: client + useTrash + TrashModal + spec. Defaults (reversible): retention OFF, id-reuse conflict-reject, cascade best-effort, restore→v1; isUndefinedTableError-guarded for pre-migration DBs. **Follow-up:** TrashModal not yet wired to a trigger (UX-placement call; ~10-line follow-up). Verified directly: atomic txn + canDeleteRecord + 409 + double-restore; adversarial pass running. tsc/vue-tsc PASS, FE 5/5, integration in plugin-tests allowlist (CI is first real-PG run). 🤖 Generated with Claude Code