### PR TITLE
feat(approval): Lane A — static assignee directory picker (P1-static-picker, full-stack read-only)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -243,6 +243,20 @@ jobs:
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             --reporter=dot
 
+      - name: Run approval real-DB integration (directory endpoints — rbac 403/200 + minimal-exposure shape + ?q + limit clamp + least-privilege source pin)
+        # Lane A (P1-static-picker) directory endpoints. Wired as a WHOLE FILE run so the
+        # gate is robust (a name filter that matches zero tests would exit green and hide
+        # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
+        # default test job, so this is its real CI lane.
+        if: matrix.node-version == '20.x'
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+        run: |
+          : "${DATABASE_URL:?DATABASE_URL is required for approval real-DB integration}"
+          pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+            tests/integration/approval-directory-endpoints.api.test.ts \
+            --reporter=dot
+
       - name: Run comment-reaction keystone (real wire, real PG)
         # B6 emoji-reaction keystone (#2673 follow-up). Wired as a WHOLE FILE (not a
         # `-t` name filter) so the gate is robust: a name filter that matches zero

--- a/apps/web/src/approvals/useApprovalDirectory.ts
+++ b/apps/web/src/approvals/useApprovalDirectory.ts
@@ -1,0 +1,177 @@
+import { ref, type Ref } from 'vue'
+import { apiFetch as defaultApiFetch } from '../utils/api'
+
+/**
+ * Read-only directory lookups for the approval-authoring assignee picker (POST-GATE Lane A,
+ * P1-static-picker). Mirrors the STRUCTURE of useAttendanceAdminUsers (apiFetch DI default,
+ * loading/status refs, ensure*Visible placeholder synthesis) but targets the two
+ * approval-templates:manage-scoped endpoints landed alongside it:
+ *   GET /api/approval-templates/directory/users?q=&limit=
+ *   GET /api/approval-templates/directory/roles
+ *
+ * IMPORTANT shape difference vs the attendance endpoint: these return a BARE object
+ * ({ users } / { roles }), NOT the { ok, data: { items } } envelope. This composable parses
+ * the bare shape directly — it must NOT copy useAttendanceAdminUsers's data.data.items path.
+ *
+ * The picker never owns the carrier: the View derives selected[] from step.idsText via
+ * parseIdsText and writes back via .join(', '). ensure*OptionVisible synthesizes a placeholder
+ * option for any id that is in idsText but absent from the fetched page, so a pre-existing or
+ * free-text/unknown id stays a selectable chip and is never silently dropped.
+ */
+
+type ApiFetchFn = (path: string, options?: RequestInit) => Promise<Response>
+
+export interface DirectoryUserOption {
+  id: string
+  name: string
+  email: string
+}
+
+export interface DirectoryRoleOption {
+  id: string
+  name: string
+}
+
+export interface UseApprovalDirectoryOptions {
+  apiFetch?: ApiFetchFn
+}
+
+const FORBIDDEN_MESSAGE = '需要 approval-templates:manage 权限'
+const USERS_FAILED_MESSAGE = '加载用户目录失败'
+const ROLES_FAILED_MESSAGE = '加载角色目录失败'
+
+async function readJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    return (await response.json()) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function asUserOptions(value: unknown): DirectoryUserOption[] {
+  if (!Array.isArray(value)) return []
+  const options: DirectoryUserOption[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const id = typeof record.id === 'string' ? record.id : ''
+    if (!id) continue
+    options.push({
+      id,
+      name: typeof record.name === 'string' ? record.name : '',
+      email: typeof record.email === 'string' ? record.email : '',
+    })
+  }
+  return options
+}
+
+function asRoleOptions(value: unknown): DirectoryRoleOption[] {
+  if (!Array.isArray(value)) return []
+  const options: DirectoryRoleOption[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+    const id = typeof record.id === 'string' ? record.id : ''
+    if (!id) continue
+    options.push({ id, name: typeof record.name === 'string' ? record.name : '' })
+  }
+  return options
+}
+
+export function useApprovalDirectory({ apiFetch = defaultApiFetch }: UseApprovalDirectoryOptions = {}) {
+  const users = ref<DirectoryUserOption[]>([])
+  const roles = ref<DirectoryRoleOption[]>([])
+  const usersLoading = ref(false)
+  const rolesLoading = ref(false)
+  const statusMessage = ref('')
+
+  async function searchUsers(q: string): Promise<void> {
+    usersLoading.value = true
+    statusMessage.value = ''
+    try {
+      const params = new URLSearchParams()
+      const normalizedQuery = q.trim()
+      if (normalizedQuery) {
+        params.set('q', normalizedQuery)
+      }
+      params.set('limit', '20')
+      const response = await apiFetch(`/api/approval-templates/directory/users?${params.toString()}`)
+      if (response.status === 403) {
+        users.value = []
+        statusMessage.value = FORBIDDEN_MESSAGE
+        return
+      }
+      const data = await readJson(response)
+      if (!response.ok || !data) {
+        throw new Error(USERS_FAILED_MESSAGE)
+      }
+      users.value = asUserOptions(data.users)
+    } catch (error: unknown) {
+      statusMessage.value = error instanceof Error && error.message ? error.message : USERS_FAILED_MESSAGE
+    } finally {
+      usersLoading.value = false
+    }
+  }
+
+  async function loadRoles(): Promise<void> {
+    rolesLoading.value = true
+    statusMessage.value = ''
+    try {
+      const response = await apiFetch('/api/approval-templates/directory/roles')
+      if (response.status === 403) {
+        roles.value = []
+        statusMessage.value = FORBIDDEN_MESSAGE
+        return
+      }
+      const data = await readJson(response)
+      if (!response.ok || !data) {
+        throw new Error(ROLES_FAILED_MESSAGE)
+      }
+      roles.value = asRoleOptions(data.roles)
+    } catch (error: unknown) {
+      statusMessage.value = error instanceof Error && error.message ? error.message : ROLES_FAILED_MESSAGE
+    } finally {
+      rolesLoading.value = false
+    }
+  }
+
+  // Synthesize a placeholder option so an id present in idsText but absent from the fetched
+  // page still renders as a selectable chip (no silent drop of pre-existing / free-text ids).
+  function ensureUserOptionVisible(id: string): void {
+    const normalized = id.trim()
+    if (!normalized) return
+    if (users.value.some((option) => option.id === normalized)) return
+    users.value = [{ id: normalized, name: '', email: '' }, ...users.value]
+  }
+
+  function ensureRoleOptionVisible(id: string): void {
+    const normalized = id.trim()
+    if (!normalized) return
+    if (roles.value.some((option) => option.id === normalized)) return
+    roles.value = [{ id: normalized, name: '' }, ...roles.value]
+  }
+
+  function formatUserLabel(user: DirectoryUserOption): string {
+    const primary = user.name.trim() || user.id
+    const email = user.email.trim()
+    return email ? `${primary} · ${email}` : primary
+  }
+
+  function formatRoleLabel(role: DirectoryRoleOption): string {
+    return role.name.trim() || role.id
+  }
+
+  return {
+    users,
+    roles,
+    usersLoading,
+    rolesLoading,
+    statusMessage,
+    searchUsers,
+    loadRoles,
+    ensureUserOptionVisible,
+    ensureRoleOptionVisible,
+    formatUserLabel,
+    formatRoleLabel,
+  }
+}

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -277,15 +277,57 @@
               <el-input v-model="step.name" :disabled="readOnly" />
             </el-form-item>
             <el-form-item label="审批人来源">
-              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%">
-                <el-option label="指定用户 ID" value="static_user" />
-                <el-option label="指定角色 ID" value="static_role" />
+              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%" @change="syncStepOptions(step)">
+                <el-option label="指定用户" value="static_user" />
+                <el-option label="指定角色" value="static_role" />
                 <el-option label="发起人" value="requester" />
                 <el-option label="表单用户字段" value="form_field_user" />
               </el-select>
             </el-form-item>
-            <el-form-item v-if="step.sourceKind === 'static_user' || step.sourceKind === 'static_role'" label="用户/角色 ID">
-              <el-input v-model="step.idsText" :disabled="readOnly" placeholder="逗号或换行分隔" />
+            <el-form-item v-if="step.sourceKind === 'static_user'" label="选择用户">
+              <el-select
+                :model-value="stepIds(step)"
+                multiple
+                filterable
+                remote
+                :remote-method="onUserSearch"
+                :loading="directory.usersLoading.value"
+                :disabled="readOnly"
+                style="width: 100%"
+                placeholder="搜索用户名 / 邮箱 / ID"
+                data-testid="approval-step-user-picker"
+                @update:model-value="(ids: string[]) => setStepIds(step, ids)"
+                @visible-change="(visible: boolean) => visible && onUserSearch('')"
+              >
+                <el-option
+                  v-for="user in directory.users.value"
+                  :key="user.id"
+                  :label="directory.formatUserLabel(user)"
+                  :value="user.id"
+                />
+              </el-select>
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'static_role'" label="选择角色">
+              <el-select
+                :model-value="stepIds(step)"
+                multiple
+                filterable
+                :disabled="readOnly"
+                style="width: 100%"
+                placeholder="选择角色"
+                data-testid="approval-step-role-picker"
+                @update:model-value="(ids: string[]) => setStepIds(step, ids)"
+              >
+                <el-option
+                  v-for="role in directory.roles.value"
+                  :key="role.id"
+                  :label="directory.formatRoleLabel(role)"
+                  :value="role.id"
+                />
+              </el-select>
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'static_user' || step.sourceKind === 'static_role'" label="手动输入 ID（高级）">
+              <el-input v-model="step.idsText" :disabled="readOnly" placeholder="逗号或换行分隔" data-testid="approval-step-ids-text" />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'form_field_user'" label="表单用户字段">
               <el-select v-model="step.fieldId" :disabled="readOnly" style="width: 100%">
@@ -352,11 +394,14 @@ import {
   createEmptyStepDraft,
   createEmptyTemplateDraft,
   draftFromTemplate,
+  parseIdsText,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  type ApprovalStepDraft,
   type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
+import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
 
 const route = useRoute()
 const router = useRouter()
@@ -377,6 +422,42 @@ const canSave = computed(() => canManageTemplates.value && !unsupportedReason.va
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
 const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
 const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
+
+// Directory typeahead for static_user / static_role assignee sources. The picker is purely
+// additive: it reads/writes the SAME step.idsText carrier (parseIdsText in, ', ' join out, the
+// exact separator formatIds uses), so sourceFromStep / buildApprovalGraph consume it unchanged.
+const directory = useApprovalDirectory()
+
+function stepIds(step: ApprovalStepDraft): string[] {
+  return parseIdsText(step.idsText)
+}
+
+function setStepIds(step: ApprovalStepDraft, ids: string[]): void {
+  step.idsText = ids.join(', ')
+}
+
+async function onUserSearch(query: string): Promise<void> {
+  await directory.searchUsers(query)
+  // Keep already-selected ids visible as chips even if the new search page omits them.
+  for (const step of draft.value.steps) {
+    if (step.sourceKind !== 'static_user') continue
+    for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
+  }
+}
+
+// On sourceKind change (and on hydrate) make every already-selected id render as a chip,
+// even pre-existing / unknown ids absent from the fetched directory page — no silent drop.
+function syncStepOptions(step: ApprovalStepDraft): void {
+  if (step.sourceKind === 'static_user') {
+    for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
+  } else if (step.sourceKind === 'static_role') {
+    for (const id of parseIdsText(step.idsText)) directory.ensureRoleOptionVisible(id)
+  }
+}
+
+function syncAllStepOptions(): void {
+  for (const step of draft.value.steps) syncStepOptions(step)
+}
 
 function clearErrors() {
   loadError.value = null
@@ -442,6 +523,7 @@ async function loadTemplateForEdit() {
     const template = await getTemplate(templateId.value)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
     draft.value = draftFromTemplate(template)
+    syncAllStepOptions()
   } catch (error: any) {
     loadError.value = error?.message ?? '加载审批模板失败'
   } finally {
@@ -516,6 +598,7 @@ async function handlePublish() {
 
 onMounted(() => {
   if (!canManageTemplates.value) return
+  void directory.loadRoles()
   void loadTemplateForEdit()
 })
 </script>

--- a/apps/web/tests/approvalStaticPicker.spec.ts
+++ b/apps/web/tests/approvalStaticPicker.spec.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
+import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  buildCreateTemplatePayload,
+  draftFromTemplate,
+} from '../src/approvals/templateAuthoring'
+
+// --- router / permissions / api / element-plus mocks (mirror approvalTemplateAuthoring.spec.ts) ---
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const replaceSpy = vi.fn().mockResolvedValue(undefined)
+let routeParams: Record<string, string> = {}
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy, replace: replaceSpy, back: vi.fn() }),
+    useRoute: () => ({
+      params: routeParams,
+      query: {},
+      path: routeParams.id ? `/approval-templates/${routeParams.id}/edit` : '/approval-templates/new',
+      meta: {},
+    }),
+  }
+})
+
+const canManageTemplates = ref(true)
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    canManageTemplates,
+    canRead: ref(true),
+    canWrite: ref(true),
+    canAct: ref(true),
+  }),
+}))
+
+const createTemplateSpy = vi.fn()
+const updateTemplateSpy = vi.fn()
+const publishTemplateSpy = vi.fn()
+const getTemplateSpy = vi.fn()
+vi.mock('../src/approvals/api', () => ({
+  createTemplate: (payload: unknown) => createTemplateSpy(payload),
+  updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
+  publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
+  getTemplate: (id: string) => getTemplateSpy(id),
+}))
+
+// Mock the directory composable so the picker renders without any network.
+const searchUsersSpy = vi.fn().mockResolvedValue(undefined)
+const loadRolesSpy = vi.fn().mockResolvedValue(undefined)
+const ensureUserOptionVisibleSpy = vi.fn()
+const ensureRoleOptionVisibleSpy = vi.fn()
+const directoryUsers = ref<{ id: string; name: string; email: string }[]>([])
+const directoryRoles = ref<{ id: string; name: string }[]>([])
+vi.mock('../src/approvals/useApprovalDirectory', () => ({
+  useApprovalDirectory: () => ({
+    users: directoryUsers,
+    roles: directoryRoles,
+    usersLoading: ref(false),
+    rolesLoading: ref(false),
+    statusMessage: ref(''),
+    searchUsers: searchUsersSpy,
+    loadRoles: loadRolesSpy,
+    ensureUserOptionVisible: ensureUserOptionVisibleSpy,
+    ensureRoleOptionVisible: ensureRoleOptionVisibleSpy,
+    formatUserLabel: (u: { id: string; name: string }) => u.name || u.id,
+    formatRoleLabel: (r: { id: string; name: string }) => r.name || r.id,
+  }),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  ElMessageBox: { confirm: vi.fn().mockResolvedValue(undefined) },
+}))
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).value),
+    })
+  },
+})
+
+// Single-value select (sourceKind, approvalMode, ...) and multi-value picker share one stub.
+// For `multiple`, render <select multiple>; on change collect selected option values into an
+// array and emit update:modelValue. For single, behave like the base spec's stub.
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: {
+    modelValue: { type: [String, Array], default: '' },
+    disabled: Boolean,
+    multiple: Boolean,
+    filterable: Boolean,
+    remote: Boolean,
+    loading: Boolean,
+    remoteMethod: { type: Function, default: undefined },
+    placeholder: String,
+  },
+  emits: ['update:modelValue', 'change', 'visible-change'],
+  render() {
+    const selected = this.modelValue
+    return h('select', {
+      multiple: this.multiple,
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onChange: (event: Event) => {
+        const el = event.target as HTMLSelectElement
+        if (this.multiple) {
+          const values = Array.from(el.selectedOptions).map((o) => o.value)
+          this.$emit('update:modelValue', values)
+        } else {
+          this.$emit('update:modelValue', el.value)
+          this.$emit('change', el.value)
+        }
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const passthrough = (name: string, tag = 'div') => defineComponent({
+  name,
+  render() {
+    return h(tag, { 'data-testid': (this.$attrs as any)?.['data-testid'] }, this.$slots.default?.())
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { disabled: Boolean, loading: Boolean, type: String, text: Boolean, size: String },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (event: Event) => this.$emit('click', event),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, description: String },
+  render() {
+    return h('div', { 'data-testid': (this.$attrs as any)?.['data-testid'] }, [
+      h('strong', this.title),
+      this.description ? h('p', this.description) : null,
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+function installStubs(app: VueApp<Element>) {
+  app.directive('loading', {})
+  app.component('ElButton', ElButton)
+  app.component('ElInput', ElInput)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElAlert', ElAlert)
+  app.component('ElCheckbox', passthrough('ElCheckbox', 'label'))
+  app.component('ElCard', passthrough('ElCard', 'section'))
+  app.component('ElForm', passthrough('ElForm', 'form'))
+  app.component('ElFormItem', passthrough('ElFormItem', 'label'))
+  app.component('ElIcon', passthrough('ElIcon', 'span'))
+  app.component('ElCollapse', passthrough('ElCollapse'))
+  app.component('ElCollapseItem', passthrough('ElCollapseItem'))
+}
+
+function buildTemplate(overrides: Partial<ApprovalTemplateDetailDTO> = {}): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-04T00:00:00Z',
+    updatedAt: '2026-06-04T00:00:00Z',
+    formSchema: { fields: [{ id: 'amount', type: 'number', label: '金额', required: true }] },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: '审批人 1',
+          config: {
+            assigneeSources: [{ kind: 'static_user', userIds: ['legacy-user-1'] }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+let container: HTMLDivElement | null = null
+let app: VueApp<Element> | null = null
+
+async function mountView() {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(TemplateAuthoringView)
+  installStubs(app)
+  app.mount(container)
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+async function flushUi() {
+  for (let i = 0; i < 6; i += 1) {
+    await nextTick()
+    await Promise.resolve()
+  }
+}
+
+function stepRow() {
+  return container!.querySelector('[data-testid="approval-template-step-row"]') as HTMLElement
+}
+
+function pick(testId: string): HTMLElement | null {
+  return stepRow().querySelector(`[data-testid="${testId}"]`)
+}
+
+describe('TemplateAuthoringView static assignee picker', () => {
+  beforeEach(() => {
+    routeParams = {}
+    canManageTemplates.value = true
+    createTemplateSpy.mockReset()
+    updateTemplateSpy.mockReset()
+    getTemplateSpy.mockReset()
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    searchUsersSpy.mockClear()
+    loadRolesSpy.mockClear()
+    ensureUserOptionVisibleSpy.mockClear()
+    ensureRoleOptionVisibleSpy.mockClear()
+    directoryUsers.value = []
+    directoryRoles.value = []
+    createTemplateSpy.mockImplementation(async (payload) => ({
+      ...buildTemplate({ id: 'tpl_created' }),
+      key: payload.key,
+      name: payload.name,
+      formSchema: payload.formSchema,
+      approvalGraph: payload.approvalGraph,
+    }))
+    updateTemplateSpy.mockImplementation(async (id, payload) => ({ ...buildTemplate({ id }), ...payload }))
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  it('loads roles on mount', async () => {
+    await mountView()
+    expect(loadRolesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the user picker for static_user, hides it for requester / form_field_user', async () => {
+    await mountView()
+    // default new-template step sourceKind is `requester` -> no picker.
+    expect(pick('approval-step-user-picker')).toBeNull()
+    expect(pick('approval-step-role-picker')).toBeNull()
+
+    // switch to static_user.
+    const sourceSelect = stepRow().querySelector('select') as HTMLSelectElement
+    sourceSelect.value = 'static_user'
+    sourceSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(pick('approval-step-user-picker')).not.toBeNull()
+    expect(pick('approval-step-role-picker')).toBeNull()
+    // free-text fallback stays available.
+    expect(pick('approval-step-ids-text')).not.toBeNull()
+  })
+
+  it('renders the role picker for static_role', async () => {
+    await mountView()
+    const sourceSelect = stepRow().querySelector('select') as HTMLSelectElement
+    sourceSelect.value = 'static_role'
+    sourceSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(pick('approval-step-role-picker')).not.toBeNull()
+    expect(pick('approval-step-user-picker')).toBeNull()
+    expect(pick('approval-step-ids-text')).not.toBeNull()
+  })
+
+  it('selecting users writes a comma-joined string into the SAME idsText carrier and flows through sourceFromStep', async () => {
+    directoryUsers.value = [
+      { id: 'u1', name: 'Alice', email: 'a@x.io' },
+      { id: 'u2', name: 'Bob', email: 'b@x.io' },
+    ]
+    await mountView()
+    setTopInput('approval-template-key', 'leave')
+    setTopInput('approval-template-name', '请假审批')
+
+    setInputValueOnSelect('static_user') // switch sourceKind
+    await flushUi()
+
+    const picker = pick('approval-step-user-picker') as HTMLSelectElement
+    // select both options (multiple).
+    for (const opt of Array.from(picker.options)) {
+      if (opt.value === 'u1' || opt.value === 'u2') opt.selected = true
+    }
+    picker.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    // the free-text carrier now shows the comma-joined ids.
+    const idsText = pick('approval-step-ids-text') as HTMLInputElement
+    expect(idsText.value).toBe('u1, u2')
+
+    // save -> create payload built through the UNCHANGED serialization path.
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.approvalGraph.nodes[1].config.assigneeSources).toEqual([
+      { kind: 'static_user', userIds: ['u1', 'u2'] },
+    ])
+  })
+
+  it('free-text input remains editable as a fallback and feeds the same carrier', async () => {
+    await mountView()
+    setTopInput('approval-template-key', 'leave')
+    setTopInput('approval-template-name', '请假审批')
+    setInputValueOnSelect('static_user')
+    await flushUi()
+
+    const idsText = pick('approval-step-ids-text') as HTMLInputElement
+    idsText.value = 'manual-a, manual-b'
+    idsText.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.approvalGraph.nodes[1].config.assigneeSources).toEqual([
+      { kind: 'static_user', userIds: ['manual-a', 'manual-b'] },
+    ])
+  })
+
+  it('hydrating an existing static_user template calls ensureUserOptionVisible for each stored id', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate()) // step assignee = static_user ['legacy-user-1']
+    await mountView()
+    await flushUi()
+
+    expect(ensureUserOptionVisibleSpy).toHaveBeenCalledWith('legacy-user-1')
+    // the free-text carrier hydrated with the stored id.
+    expect((pick('approval-step-ids-text') as HTMLInputElement).value).toBe('legacy-user-1')
+  })
+
+  // KEYSTONE: no silent drop of an unknown / pre-existing id, exercised through the REAL
+  // templateAuthoring serialization (not a hand-built array, not the mocked composable).
+  it('keystone: an unknown id absent from the directory survives the real parse->source->payload wire', () => {
+    const template = buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: '审批人 1',
+            config: {
+              assigneeSources: [{ kind: 'static_user', userIds: ['known-u1', 'ghost-id-not-in-directory'] }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+            },
+          },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    })
+    const draft = draftFromTemplate(template)
+    // real wire: idsText -> parseIdsText -> sourceFromStep -> buildApprovalGraph
+    const graph = buildApprovalGraph(draft)
+    expect((graph.nodes[1].config as any).assigneeSources).toEqual([
+      { kind: 'static_user', userIds: ['known-u1', 'ghost-id-not-in-directory'] },
+    ])
+    // and through the full create payload builder.
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1].config as any).assigneeSources[0].userIds).toContain('ghost-id-not-in-directory')
+  })
+})
+
+// Helper: switch the step sourceKind select (first <select> in the step row) to a value.
+function setInputValueOnSelect(value: string) {
+  const sourceSelect = stepRow().querySelector('select') as HTMLSelectElement
+  sourceSelect.value = value
+  sourceSelect.dispatchEvent(new Event('change'))
+}
+
+// Helper: set a top-level text input (key / name) by testid.
+function setTopInput(testId: string, value: string) {
+  const input = container!.querySelector(`[data-testid="${testId}"]`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+}

--- a/apps/web/tests/useApprovalDirectory.spec.ts
+++ b/apps/web/tests/useApprovalDirectory.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useApprovalDirectory } from '../src/approvals/useApprovalDirectory'
+
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean } = {}): Response {
+  const status = init.status ?? 200
+  return {
+    ok: init.ok ?? (status >= 200 && status < 300),
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+describe('useApprovalDirectory', () => {
+  it('searchUsers hits the approval directory endpoint with q + limit and parses the bare {users} shape', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(
+      jsonResponse({ users: [{ id: 'u1', name: 'Alice', email: 'alice@example.com' }] }),
+    )
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.searchUsers(' alice ')
+
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+    const calledPath = apiFetch.mock.calls[0]?.[0] as string
+    expect(calledPath).toContain('/api/approval-templates/directory/users?')
+    expect(calledPath).toContain('q=alice')
+    expect(calledPath).toContain('limit=20')
+    // bare {users}, NOT data.data.items — assert the unwrapping path is the bare one.
+    expect(dir.users.value).toEqual([{ id: 'u1', name: 'Alice', email: 'alice@example.com' }])
+    expect(dir.usersLoading.value).toBe(false)
+    expect(dir.statusMessage.value).toBe('')
+  })
+
+  it('searchUsers without a query omits q but still sends limit', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse({ users: [] }))
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.searchUsers('')
+
+    const calledPath = apiFetch.mock.calls[0]?.[0] as string
+    expect(calledPath).not.toContain('q=')
+    expect(calledPath).toContain('limit=20')
+  })
+
+  it('searchUsers drops malformed user entries (no id) and coerces missing fields', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(
+      jsonResponse({ users: [{ id: 'u1' }, { name: 'no-id' }, null, { id: 'u2', name: 'Bob', email: 'b@x.io' }] }),
+    )
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.searchUsers('x')
+
+    expect(dir.users.value).toEqual([
+      { id: 'u1', name: '', email: '' },
+      { id: 'u2', name: 'Bob', email: 'b@x.io' },
+    ])
+  })
+
+  it('loadRoles parses the bare {roles} shape', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(
+      jsonResponse({ roles: [{ id: 'r1', name: '审批员' }, { id: 'r2', name: '' }] }),
+    )
+    const dir = useApprovalDirectory({ apiFetch })
+
+    await dir.loadRoles()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/approval-templates/directory/roles')
+    expect(dir.roles.value).toEqual([{ id: 'r1', name: '审批员' }, { id: 'r2', name: '' }])
+    expect(dir.rolesLoading.value).toBe(false)
+  })
+
+  it('403 on searchUsers sets a permission status message and clears the array', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse({}, { status: 403, ok: false }))
+    const dir = useApprovalDirectory({ apiFetch })
+    dir.users.value = [{ id: 'stale', name: 'x', email: '' }]
+
+    await dir.searchUsers('x')
+
+    expect(dir.users.value).toEqual([])
+    expect(dir.statusMessage.value).toContain('approval-templates:manage')
+  })
+
+  it('403 on loadRoles sets a permission status message and clears the array', async () => {
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse({}, { status: 403, ok: false }))
+    const dir = useApprovalDirectory({ apiFetch })
+    dir.roles.value = [{ id: 'stale', name: 'x' }]
+
+    await dir.loadRoles()
+
+    expect(dir.roles.value).toEqual([])
+    expect(dir.statusMessage.value).toContain('approval-templates:manage')
+  })
+
+  it('ensureUserOptionVisible prepends a synthetic option for an id missing from the page, no-op when present', () => {
+    const apiFetch = vi.fn()
+    const dir = useApprovalDirectory({ apiFetch })
+    dir.users.value = [{ id: 'u1', name: 'Alice', email: 'a@x.io' }]
+
+    dir.ensureUserOptionVisible('unknown-id')
+    expect(dir.users.value[0]).toEqual({ id: 'unknown-id', name: '', email: '' })
+    expect(dir.users.value).toHaveLength(2)
+
+    // already present -> no duplicate
+    dir.ensureUserOptionVisible('u1')
+    expect(dir.users.value.filter((u) => u.id === 'u1')).toHaveLength(1)
+    // blank id -> no-op
+    dir.ensureUserOptionVisible('   ')
+    expect(dir.users.value).toHaveLength(2)
+  })
+
+  it('ensureRoleOptionVisible prepends a synthetic option for an id missing from the page, no-op when present', () => {
+    const apiFetch = vi.fn()
+    const dir = useApprovalDirectory({ apiFetch })
+    dir.roles.value = [{ id: 'r1', name: '审批员' }]
+
+    dir.ensureRoleOptionVisible('legacy-role')
+    expect(dir.roles.value[0]).toEqual({ id: 'legacy-role', name: '' })
+
+    dir.ensureRoleOptionVisible('r1')
+    expect(dir.roles.value.filter((r) => r.id === 'r1')).toHaveLength(1)
+  })
+
+  it('formatUserLabel falls back name -> id and appends email; formatRoleLabel name -> id', () => {
+    const apiFetch = vi.fn()
+    const dir = useApprovalDirectory({ apiFetch })
+
+    expect(dir.formatUserLabel({ id: 'u1', name: 'Alice', email: 'a@x.io' })).toBe('Alice · a@x.io')
+    expect(dir.formatUserLabel({ id: 'u2', name: '', email: '' })).toBe('u2')
+    expect(dir.formatUserLabel({ id: 'u3', name: 'Bob', email: '' })).toBe('Bob')
+    expect(dir.formatRoleLabel({ id: 'r1', name: '审批员' })).toBe('审批员')
+    expect(dir.formatRoleLabel({ id: 'r2', name: '' })).toBe('r2')
+  })
+})

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -25,6 +25,7 @@ import {
   type ApprovalBridgePlmAdapter,
 } from '../services/approval-bridge-types'
 import { publishApprovalCountsUpdate } from '../services/approval-realtime'
+import { searchDirectoryUsers, listDirectoryRoles } from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 
 const logger = new Logger('ApprovalsRouter')
@@ -329,6 +330,29 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         'APPROVAL_TEMPLATE_CATEGORY_LIST_FAILED',
         'Failed to list approval template categories',
       )
+    }
+  })
+
+  // Directory lookups for the authoring assignee picker. Registered BEFORE
+  // '/api/approval-templates/:id' so 'directory' is not matched as an :id.
+  // Gated by approval-templates:manage (same authoring permission as create/publish).
+  r.get('/api/approval-templates/directory/users', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const q = String(req.query.q || '').trim()
+      const limit = Number.parseInt(String(req.query.limit ?? '20'), 10)
+      const users = await searchDirectoryUsers(q, Number.isFinite(limit) ? limit : 20)
+      res.json({ users })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DIRECTORY_USERS_FAILED', 'Failed to search directory users')
+    }
+  })
+
+  r.get('/api/approval-templates/directory/roles', authenticate, rbacGuard('approval-templates:manage'), async (_req: Request, res: Response) => {
+    try {
+      const roles = await listDirectoryRoles()
+      res.json({ roles })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DIRECTORY_ROLES_FAILED', 'Failed to list directory roles')
     }
   })
 

--- a/packages/core-backend/src/services/approval-directory.ts
+++ b/packages/core-backend/src/services/approval-directory.ts
@@ -1,0 +1,63 @@
+import { query } from '../db/pg'
+
+/**
+ * Minimal-exposure directory lookups for the approval-authoring assignee picker.
+ *
+ * These deliberately return ONLY an identifier + label (and email for users) — far less
+ * than admin-users' ADMIN_USER_PROFILE_SELECT / fetchRoleCatalog. The picker needs to turn
+ * a free-text id into a human-pickable option, nothing more, and these endpoints are gated
+ * upstream by rbacGuard('approval-templates:manage'). Keeping the shape minimal is the
+ * least-privilege choice and avoids re-exposing the full admin user profile through a
+ * template-authoring surface.
+ */
+
+export interface DirectoryUserOption {
+  id: string
+  name: string
+  email: string
+}
+
+export interface DirectoryRoleOption {
+  id: string
+  name: string
+}
+
+const MAX_LIMIT = 50
+const DEFAULT_LIMIT = 20
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT)
+}
+
+/** Search active users by id/name/email/username. Returns id/name/email only. */
+export async function searchDirectoryUsers(q: string, limit: number): Promise<DirectoryUserOption[]> {
+  const safeLimit = clampLimit(limit)
+  const term = q ? `%${q}%` : null
+  const where = term
+    ? `WHERE is_active = TRUE AND (COALESCE(email, '') ILIKE $1 OR COALESCE(username, '') ILIKE $1 OR name ILIKE $1 OR id ILIKE $1)`
+    : `WHERE is_active = TRUE`
+  const sql = `
+    SELECT id, name, COALESCE(email, '') AS email
+    FROM users
+    ${where}
+    ORDER BY name ASC
+    LIMIT ${term ? '$2' : '$1'}
+  `
+  const result = await query<{ id: string; name: string; email: string }>(
+    sql,
+    term ? [term, safeLimit] : [safeLimit],
+  )
+  return result.rows.map((row) => ({ id: row.id, name: row.name ?? '', email: row.email ?? '' }))
+}
+
+/**
+ * List roles as id/name options. Deliberately leaner than admin-users' fetchRoleCatalog
+ * (which also computes permissions + member counts); the picker only needs id + label.
+ */
+export async function listDirectoryRoles(): Promise<DirectoryRoleOption[]> {
+  const result = await query<{ id: string; name: string }>(
+    `SELECT r.id, r.name FROM roles r ORDER BY r.id ASC`,
+  )
+  return result.rows.map((row) => ({ id: row.id, name: row.name ?? '' }))
+}

--- a/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-directory-endpoints.api.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+// Real-DB spec: only runs when a Postgres DATABASE_URL is provided (the DB-backed CI
+// step in plugin-tests.yml + local runs). The no-DB default `test (18.x)` job both
+// excludes this file (vitest.config.ts) and would skip it here.
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+/**
+ * Lane A (P1-static-picker) backend landing blocker: the two read-only directory
+ * endpoints used by the authoring assignee picker.
+ *   GET /api/approval-templates/directory/users?q=&limit=
+ *   GET /api/approval-templates/directory/roles
+ *
+ * Coverage: rejection (403 for a non-manager), functional success + minimal-exposure
+ * shape + ?q filter + limit (via an authorized caller), and a source-level assertion
+ * that the routes are gated by the least-privilege `approval-templates:manage` and NOT
+ * `ensurePlatformAdmin`. (The positive caller is an admin token because a non-admin
+ * "manager" additionally needs role-derived namespace admission — the platform's real
+ * RBAC layer — which is out of scope here; the least-privilege wiring is pinned by the
+ * source assertion + the 403 negative.)
+ */
+
+const PREFIX = `dirpick-${Date.now()}`
+const ADMIN = `${PREFIX}-admin`
+const NON = `${PREFIX}-non`
+const ALICE = `${PREFIX}-alice`
+const BOB = `${PREFIX}-bob`
+const CAROL = `${PREFIX}-carol`
+const ROLE = `${PREFIX}-role`
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function devToken(baseUrl: string, userId: string, roles: string, perms: string): Promise<string> {
+  const res = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`,
+  )
+  expect(res.status).toBe(200)
+  return ((await res.json()) as { token: string }).token
+}
+
+function get(baseUrl: string, p: string, token: string): Promise<Response> {
+  return fetch(`${baseUrl}${p}`, { headers: { Authorization: `Bearer ${token}` } })
+}
+
+describeIfDatabase('approval directory endpoints (P1-static-picker backend, real DB)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let adminToken = ''
+  let nonMgrToken = ''
+  let roleSeeded = false
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+
+    const seedUser = async (id: string, name: string) => {
+      await pool.query(
+        `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+         VALUES ($1, $2, $3, 'x', 'member', '[]'::jsonb, TRUE, FALSE)
+         ON CONFLICT (id) DO UPDATE SET is_active = TRUE, name = EXCLUDED.name`,
+        [id, `${id}@ex.test`, name],
+      )
+    }
+    await seedUser(ALICE, 'ZmarkerQ Alice')
+    await seedUser(BOB, 'ZmarkerQ Bob')
+    await seedUser(CAROL, 'Zzz Other Person')
+    try {
+      await pool.query(`INSERT INTO roles (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`, [ROLE, 'Dirpick Role'])
+      roleSeeded = true
+    } catch {
+      roleSeeded = false
+    }
+
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address!.port}`
+
+    adminToken = await devToken(baseUrl, ADMIN, 'admin', '*:*')
+    // roles=member keeps this NON-admin; empty perms → lacks approval-templates:manage.
+    nonMgrToken = await devToken(baseUrl, NON, 'member', '')
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[ADMIN, NON, ALICE, BOB, CAROL]])
+      if (roleSeeded) await pool.query(`DELETE FROM roles WHERE id = $1`, [ROLE])
+    } catch {
+      // ignore cleanup failures
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('rejects a non-manager on /directory/users (403)', async () => {
+    const res = await get(baseUrl, '/api/approval-templates/directory/users', nonMgrToken)
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects a non-manager on /directory/roles (403)', async () => {
+    const res = await get(baseUrl, '/api/approval-templates/directory/roles', nonMgrToken)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the minimal {id,name,email} shape on /directory/users for an authorized caller', async () => {
+    const res = await get(baseUrl, `/api/approval-templates/directory/users?q=ZmarkerQ`, adminToken)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { users: Array<Record<string, unknown>> }
+    expect(Array.isArray(body.users)).toBe(true)
+    const alice = body.users.find((u) => u.id === ALICE)
+    expect(alice).toBeTruthy()
+    // least-privilege exposure: ONLY id/name/email — NOT mobile/department/role/is_admin/etc.
+    expect(Object.keys(alice as Record<string, unknown>).sort()).toEqual(['email', 'id', 'name'])
+    expect((alice as { email: string }).email).toBe(`${ALICE}@ex.test`)
+  })
+
+  it('filters by ?q name marker (matches alice/bob, excludes the other)', async () => {
+    const res = await get(baseUrl, `/api/approval-templates/directory/users?q=ZmarkerQ`, adminToken)
+    const body = (await res.json()) as { users: Array<{ id: string }> }
+    const ids = body.users.map((u) => u.id)
+    expect(ids).toContain(ALICE)
+    expect(ids).toContain(BOB)
+    expect(ids).not.toContain(CAROL)
+  })
+
+  it('applies limit (limit=1 over 2 matches → 1), clamps 0 without erroring, and caps at 50', async () => {
+    const one = await get(baseUrl, `/api/approval-templates/directory/users?q=ZmarkerQ&limit=1`, adminToken)
+    expect(one.status).toBe(200)
+    expect(((await one.json()) as { users: unknown[] }).users.length).toBe(1)
+    const zero = await get(baseUrl, `/api/approval-templates/directory/users?q=ZmarkerQ&limit=0`, adminToken)
+    expect(zero.status).toBe(200)
+    expect(((await zero.json()) as { users: unknown[] }).users.length).toBeGreaterThanOrEqual(1)
+    const over = await get(baseUrl, `/api/approval-templates/directory/users?limit=999`, adminToken)
+    expect(((await over.json()) as { users: unknown[] }).users.length).toBeLessThanOrEqual(50)
+  })
+
+  it('returns the minimal {id,name} shape on /directory/roles', async () => {
+    const res = await get(baseUrl, '/api/approval-templates/directory/roles', adminToken)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { roles: Array<Record<string, unknown>> }
+    expect(Array.isArray(body.roles)).toBe(true)
+    if (roleSeeded) {
+      const seeded = body.roles.find((r) => r.id === ROLE)
+      expect(seeded).toBeTruthy()
+      expect(Object.keys(seeded as Record<string, unknown>).sort()).toEqual(['id', 'name'])
+    } else if (body.roles.length > 0) {
+      expect(Object.keys(body.roles[0]).sort()).toEqual(['id', 'name'])
+    }
+  })
+
+  it('routes are gated by least-privilege approval-templates:manage, NOT ensurePlatformAdmin', () => {
+    const src = readFileSync(path.resolve(__dirname, '../../src/routes/approvals.ts'), 'utf8')
+    const lines = src.split('\n')
+    const usersLine = lines.find((l) => l.includes("'/api/approval-templates/directory/users'"))
+    const rolesLine = lines.find((l) => l.includes("'/api/approval-templates/directory/roles'"))
+    expect(usersLine).toBeTruthy()
+    expect(rolesLine).toBeTruthy()
+    expect(usersLine).toContain("rbacGuard('approval-templates:manage')")
+    expect(rolesLine).toContain("rbacGuard('approval-templates:manage')")
+    expect(usersLine).not.toContain('ensurePlatformAdmin')
+    expect(rolesLine).not.toContain('ensurePlatformAdmin')
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       'tests/integration/admin-users.api.test.ts',
       'tests/integration/after-sales-plugin.install.test.ts',
       'tests/integration/after-sales-registry-backfill.test.ts',
+      'tests/integration/approval-directory-endpoints.api.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
POST-GATE approval **Lane A** (P1-static-picker). Turns the authoring assignee from a free-text user/role-id box into a directory-backed picker — directly fixes the approver-selection UX gap. **Full-stack but read-only.**

## Backend (read-only, least-privilege)
- `approval-directory.ts`: `searchDirectoryUsers(q,limit)` → `{id,name,email}` (active users; ILIKE on id/email/username/name; **limit clamped 1..50**) + `listDirectoryRoles()` → `{id,name}`. **Minimal exposure by design** — not the full admin profile.
- Two routes gated `rbacGuard('approval-templates:manage')`, registered **before** `/:id` (so `directory` isn't matched as an `:id`):
  `GET /api/approval-templates/directory/users?q=&limit=` and `…/directory/roles`.

## Frontend (additive)
- New `useApprovalDirectory.ts` composable (parses the bare `{users}`/`{roles}` envelope; `ensure*OptionVisible` so unknown/pre-existing ids never silently drop).
- Multi-select picker in `TemplateAuthoringView.vue` for `static_user`/`static_role`; **the free-text `idsText` input is kept as fallback** and `idsText` serialization is byte-unchanged.

## Tests / gates (post-rebase onto current `main`)
- **Backend integration `approval-directory-endpoints.api.test.ts` 7/7** (real DB): non-manager **403**; authorized **200** with minimal `{id,name,email}`/`{id,name}` shape; `?q` filter; limit applied + clamped; **source-pin that the routes use `rbacGuard('approval-templates:manage')`, NOT `ensurePlatformAdmin`** (the landing blocker).
- FE specs **30/30** (`useApprovalDirectory` 9 + `approvalStaticPicker` 7 + existing `approvalTemplateAuthoring` 14 — picker coexists with the merged #2771 visibility editor on the shared view).
- `vue-tsc -b` clean; core-backend `tsc` clean.

## Governance
POST-GATE lane: gated on P0-A (authoring) + P0-C (non-manager route block), both PASS, plus this lane's owner GO. Read-only — no cross-runtime table writes, no BPMN import. Rebased onto current `main`; gates re-run post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)