### PR TITLE
fix(multitable): trash list/restore authz — write-own row policy + field-read mask (P1 on #15)

### DIFF
--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -46,7 +46,7 @@ import {
   notifyRecordSubscribersBestEffort,
   type NotifyRecordSubscribersInput,
 } from './record-subscription-service'
-import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
+import { ensureRecordWriteAllowed, requiresOwnWriteRowPolicy, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
 import { ensureRecordNotLocked } from './record-lock'
 
 export type QueryFn = (
@@ -863,20 +863,29 @@ export class RecordService {
     records: Array<{ recordId: string; sheetId: string; data: Record<string, unknown>; originalVersion: number; createdBy: string | null; deletedBy: string | null; deletedAt: string }>
     total: number
   }> {
-    const { sheetId, resolveSheetAccess } = input
-    const { capabilities } = await resolveSheetAccess(sheetId)
+    const { sheetId, access, resolveSheetAccess } = input
+    const { capabilities, sheetScope } = await resolveSheetAccess(sheetId)
     if (!capabilities.canDeleteRecord) {
       throw new RecordPermissionError('Insufficient permissions to view deleted records')
     }
     const limit = Math.min(Math.max(input.limit ?? 50, 1), 200)
     const offset = Math.max(input.offset ?? 0, 0)
+    // Row policy: under sheet write-own (may delete only own rows) the trash must likewise expose only the
+    // actor's OWN deletions — canDeleteRecord alone is true for write-own and would otherwise leak (and
+    // allow restore of) rows created by other users. Apply the own-only filter in SQL so total+pagination
+    // stay exact. Full-write / admin scopes see all trash for the sheet (no extra filter).
+    const ownOnly = requiresOwnWriteRowPolicy(sheetScope, access.isAdminRole)
+    const ownSql = ownOnly ? ' AND created_by = $OWN' : ''
     try {
-      const totalRes = await this.pool.query('SELECT COUNT(*)::int AS n FROM meta_records_trash WHERE sheet_id = $1', [sheetId])
+      const totalRes = await this.pool.query(
+        `SELECT COUNT(*)::int AS n FROM meta_records_trash WHERE sheet_id = $1${ownSql.replace('$OWN', '$2')}`,
+        ownOnly ? [sheetId, access.userId] : [sheetId],
+      )
       const total = Number((totalRes.rows[0] as { n?: number } | undefined)?.n ?? 0)
       const rowsRes = await this.pool.query(
         `SELECT record_id, sheet_id, data, original_version, created_by, deleted_by, deleted_at
-         FROM meta_records_trash WHERE sheet_id = $1 ORDER BY deleted_at DESC LIMIT $2 OFFSET $3`,
-        [sheetId, limit, offset],
+         FROM meta_records_trash WHERE sheet_id = $1${ownSql.replace('$OWN', '$4')} ORDER BY deleted_at DESC LIMIT $2 OFFSET $3`,
+        ownOnly ? [sheetId, limit, offset, access.userId] : [sheetId, limit, offset],
       )
       const records = (rowsRes.rows as Array<Record<string, unknown>>).map((r) => ({
         recordId: String(r.record_id),
@@ -902,7 +911,7 @@ export class RecordService {
     access: AccessInfo
     resolveSheetAccess: RecordDeleteInput['resolveSheetAccess']
   }): Promise<{ recordId: string; sheetId: string }> {
-    const { recordId, actorId, resolveSheetAccess } = input
+    const { recordId, actorId, access, resolveSheetAccess } = input
     const trashRes = await this.pool
       .query(
         `SELECT id, record_id, sheet_id, data, created_by, original_created_at, original_updated_at
@@ -918,13 +927,18 @@ export class RecordService {
     }
     const trashRow = trashRes.rows[0] as Record<string, unknown>
     const sheetId = String(trashRow.sheet_id)
-    const { capabilities } = await resolveSheetAccess(sheetId)
+    const { capabilities, sheetScope } = await resolveSheetAccess(sheetId)
     if (!capabilities.canDeleteRecord) {
       throw new RecordPermissionError('Insufficient permissions to restore records')
     }
     const trashPk = String(trashRow.id)
     const snapshot = normalizeJson(trashRow.data)
     const createdBy = typeof trashRow.created_by === 'string' ? trashRow.created_by : null
+    // Row policy: under write-own, deleteRecord only allowed deleting own rows, so restore must match —
+    // a write-own user must not resurrect another user's trash row (canDeleteRecord alone is true for them).
+    if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) {
+      throw new RecordPermissionError('Insufficient permissions to restore this record')
+    }
     const originalCreatedAt = (trashRow.original_created_at as Date | string | null) ?? null
     const originalUpdatedAt = (trashRow.original_updated_at as Date | string | null) ?? null
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -11101,7 +11101,16 @@ export function univerMetaRouter(): Router {
           return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
         },
       })
-      return res.json({ ok: true, data: result })
+      // Field-read mask: listDeletedRecords returns raw stored data, so mirror the live read/history path
+      // here — project each trashed record's data through the actor's visible field set so a
+      // field_permissions.visible=false (or taint-masked formula) value can't leak through the trash API.
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      const visibleFields = filterVisiblePropertyFields(await loadFieldsForSheetShared(pool.query.bind(pool), sheetId))
+      const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const allowedFieldIds = computeAllowedFieldIds(visibleFields, capabilities, fieldScopeMap)
+      const visibleFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, visibleFields, allowedFieldIds)
+      const maskedRecords = result.records.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
+      return res.json({ ok: true, data: { records: maskedRecords, total: result.total } })
     } catch (err) {
       if (err instanceof RecordServicePermissionError) {
         return sendForbidden(res, err.message)

--- a/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-recycle-bin.test.ts
@@ -156,3 +156,78 @@ describeIfDatabase('multitable recycle bin — delete/trash/restore (real DB)', 
     }
   })
 })
+
+// P1 authz: trash list/restore must honor the same write-own row policy as deleteRecord (a write-own user
+// sees/restores only OWN trash) and the same field-read mask as live read (field_permissions.visible=false
+// must not leak through the trash API).
+describeIfDatabase('multitable recycle bin — authz: write-own row policy + field-read mask (real DB)', () => {
+  const A_BASE = `base_rba_${TS}`
+  const A_SHEET = `sheet_rba_${TS}`
+  const A_FLD = `fld_rba_${TS}`
+  const A_SECRET = `fld_rbas_${TS}`
+  const A_FULL = `u_rba_full_${TS}` // global multitable:write (does setup deletes; field-mask subject)
+  const OWNER = `u_rba_own_${TS}` // sheet-scoped write-own, NO global write
+  const OTHER = `u_rba_oth_${TS}`
+  const REC_OWN = `rec_rba_own_${TS}`
+  const REC_OTHER = `rec_rba_oth_${TS}`
+  const fullApp = () => buildApp(A_FULL, ['multitable:read', 'multitable:write'])
+  const ownApp = () => buildApp(OWNER, ['multitable:read'])
+
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [A_BASE, 'RBA Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [A_SHEET, A_BASE, 'RBA Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_FLD, A_SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_SECRET, A_SHEET, 'Secret', 'string', '{}', 2])
+    // OWNER: sheet-scoped write-own grant with no global write → requiresOwnWriteRowPolicy true.
+    await q('INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4)', [A_SHEET, 'user', OWNER, 'spreadsheet:write-own'])
+  })
+  beforeEach(async () => {
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [A_SHEET])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OWN, A_SHEET, JSON.stringify({ [A_FLD]: 'mine', [A_SECRET]: 'shh' }), OWNER])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OTHER, A_SHEET, JSON.stringify({ [A_FLD]: 'theirs', [A_SECRET]: 'shh' }), OTHER])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [A_SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [A_BASE]).catch(() => {})
+  })
+
+  test('write-own: trash list shows only the actor\'s own deletions; full writer sees both', async () => {
+    expect((await request(fullApp()).delete(`/api/multitable/records/${REC_OWN}`)).status).toBe(200)
+    expect((await request(fullApp()).delete(`/api/multitable/records/${REC_OTHER}`)).status).toBe(200)
+    const own = await request(ownApp()).get(`/api/multitable/sheets/${A_SHEET}/trash`)
+    expect(own.status).toBe(200)
+    expect(trashIds(own)).toEqual([REC_OWN]) // NOT REC_OTHER
+    const full = await request(fullApp()).get(`/api/multitable/sheets/${A_SHEET}/trash`)
+    expect(trashIds(full).slice().sort()).toEqual([REC_OTHER, REC_OWN].slice().sort())
+    expect(full.body.data.total).toBe(2)
+    expect(own.body.data.total).toBe(1) // own filter applies to total too
+  })
+
+  test('write-own: cannot restore another user\'s trashed record (403), but can restore own', async () => {
+    expect((await request(fullApp()).delete(`/api/multitable/records/${REC_OTHER}`)).status).toBe(200)
+    expect((await request(ownApp()).post(`/api/multitable/records/${REC_OTHER}/restore`)).status).toBe(403)
+    expect((await request(fullApp()).delete(`/api/multitable/records/${REC_OWN}`)).status).toBe(200)
+    expect((await request(ownApp()).post(`/api/multitable/records/${REC_OWN}/restore`)).status).toBe(200)
+  })
+
+  test('field mask: a field_permissions.visible=false field is redacted from the trash list data', async () => {
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [A_SHEET, A_SECRET, 'user', A_FULL, false, false])
+    try {
+      expect((await request(fullApp()).delete(`/api/multitable/records/${REC_OWN}`)).status).toBe(200)
+      const res = await request(fullApp()).get(`/api/multitable/sheets/${A_SHEET}/trash`)
+      expect(res.status).toBe(200)
+      const rec = (res.body?.data?.records ?? []).find((r: { recordId: string }) => r.recordId === REC_OWN) as { data: Record<string, unknown> } | undefined
+      expect(rec).toBeTruthy()
+      expect(rec?.data[A_FLD]).toBe('mine') // visible field still present
+      expect(A_SECRET in (rec?.data ?? {})).toBe(false) // hidden field redacted, not leaked
+    } finally {
+      await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2', [A_SHEET, A_SECRET]).catch(() => {})
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -56,7 +56,12 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     // (deriveFieldPermissions allowCreateOnly) so read/write-denied fields never reach storage; the real-DB
     // locking test is tests/integration/multitable-record-duplicate.test.ts (denied-field canary absent from
     // the NEW row's unmasked stored data).
-    filterRecordDataByFieldIds: 14,
+    // 15 = +1 for the #15 recycle-bin trash list (GET /sheets/:sheetId/trash). listDeletedRecords returns
+    // raw stored data, so the handler re-derives the actor's allowed set (computeAllowedFieldIds layer-2∧3 →
+    // maskStoredRecordFieldIds) and masks each trashed record via filterRecordDataByFieldIds — mirroring the
+    // live read/history path. Real-DB canary: the field-mask redaction case in
+    // tests/integration/multitable-record-recycle-bin.test.ts (field_permissions.visible=false absent from trash data).
+    filterRecordDataByFieldIds: 15,
     loadRecordSummaries: 3,
     buildLinkSummaries: 4,
     serializeLinkSummaryMap: 1,

--- a/packages/core-backend/tests/unit/multitable-stored-data-taint-chokepoint.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-stored-data-taint-chokepoint.guard.test.ts
@@ -128,6 +128,10 @@ const ALLOWLIST: Record<string, Record<string, { disposition: 'CHOKEPOINT' | 'SA
       disposition: 'CHOKEPOINT',
       reason: 'POST /records create echo: allowedFieldIds from maskStoredRecordFieldIds (defense-in-depth; recompute also taint-skips)',
     },
+    'rec.data|visibleFieldIds': {
+      disposition: 'CHOKEPOINT',
+      reason: 'GET /sheets/:sheetId/trash list (#15 recycle bin): visibleFieldIds from maskStoredRecordFieldIds masks each trashed record data so field_permissions-denied / taint values do not leak through the trash API',
+    },
   },
   'multitable/record-write-service.ts': {
     'row.data|visiblePropertyFieldIds': {

--- a/plugins/plugin-audit-logger/node_modules/.bin/tsc
+++ b/plugins/plugin-audit-logger/node_modules/.bin/tsc
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/plugins/plugin-audit-logger/node_modules/.bin/tsserver
+++ b/plugins/plugin-audit-logger/node_modules/.bin/tsserver
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/plugins/plugin-audit-logger/node_modules/.bin/vite
+++ b/plugins/plugin-audit-logger/node_modules/.bin/vite
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"

--- a/plugins/plugin-audit-logger/node_modules/vite
+++ b/plugins/plugin-audit-logger/node_modules/vite
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vite@7.2.2_@types+node@20.19.25_less@4.4.2_tsx@4.20.6/node_modules/vite
+../../../node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite

--- a/plugins/plugin-intelligent-restore/node_modules/.bin/tsc
+++ b/plugins/plugin-intelligent-restore/node_modules/.bin/tsc
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/plugins/plugin-intelligent-restore/node_modules/.bin/tsserver
+++ b/plugins/plugin-intelligent-restore/node_modules/.bin/tsserver
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/plugins/plugin-intelligent-restore/node_modules/.bin/vite
+++ b/plugins/plugin-intelligent-restore/node_modules/.bin/vite
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"

--- a/plugins/plugin-intelligent-restore/node_modules/@vitejs/plugin-vue
+++ b/plugins/plugin-intelligent-restore/node_modules/@vitejs/plugin-vue
@@ -1,1 +1,1 @@
-../../../../node_modules/.pnpm/@vitejs+plugin-vue@6.0.1_vite@7.2.2_@types+node@20.19.25_less@4.4.2_tsx@4.20.6__vue@3.5.24_typescript@5.8.3_/node_modules/@vitejs/plugin-vue
+../../../../node_modules/.pnpm/@vitejs+plugin-vue@6.0.1_vite@5.4.21_@types+node@20.19.25_less@4.4.2__vue@3.5.24_typescript@5.8.3_/node_modules/@vitejs/plugin-vue

--- a/plugins/plugin-intelligent-restore/node_modules/vite
+++ b/plugins/plugin-intelligent-restore/node_modules/vite
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vite@7.2.2_@types+node@20.19.25_less@4.4.2_tsx@4.20.6/node_modules/vite
+../../../node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite

--- a/plugins/plugin-telemetry-otel/node_modules/.bin/tsc
+++ b/plugins/plugin-telemetry-otel/node_modules/.bin/tsc
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/plugins/plugin-telemetry-otel/node_modules/.bin/tsserver
+++ b/plugins/plugin-telemetry-otel/node_modules/.bin/tsserver
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/plugins/plugin-telemetry-otel/node_modules/.bin/vite
+++ b/plugins/plugin-telemetry-otel/node_modules/.bin/vite
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"

--- a/plugins/plugin-telemetry-otel/node_modules/.bin/vitest
+++ b/plugins/plugin-telemetry-otel/node_modules/.bin/vitest
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vitest/vitest.mjs" "$@"

--- a/plugins/plugin-telemetry-otel/node_modules/vite
+++ b/plugins/plugin-telemetry-otel/node_modules/vite
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vite@7.2.2_@types+node@20.19.25_less@4.4.2_tsx@4.20.6/node_modules/vite
+../../../node_modules/.pnpm/vite@5.4.21_@types+node@20.19.25_less@4.4.2/node_modules/vite

--- a/plugins/plugin-telemetry-otel/node_modules/vitest
+++ b/plugins/plugin-telemetry-otel/node_modules/vitest
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2_tsx@4.20.6/node_modules/vitest
+../../../node_modules/.pnpm/vitest@2.1.9_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest

--- a/plugins/plugin-view-gantt/node_modules/.bin/tsc
+++ b/plugins/plugin-view-gantt/node_modules/.bin/tsc
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/plugins/plugin-view-gantt/node_modules/.bin/tsserver
+++ b/plugins/plugin-view-gantt/node_modules/.bin/tsserver
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/plugins/plugin-view-gantt/node_modules/.bin/vitest
+++ b/plugins/plugin-view-gantt/node_modules/.bin/vitest
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vitest/vitest.mjs" "$@"

--- a/plugins/plugin-view-gantt/node_modules/vitest
+++ b/plugins/plugin-view-gantt/node_modules/vitest
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2_tsx@4.20.6/node_modules/vitest
+../../../node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest

--- a/tools/cli/node_modules/.bin/tsc
+++ b/tools/cli/node_modules/.bin/tsc
@@ -2,13 +2,17 @@
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
 
 case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/tools/cli/node_modules/.bin/tsserver
+++ b/tools/cli/node_modules/.bin/tsserver
@@ -2,13 +2,17 @@
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
 
 case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/bin/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/typescript@5.8.3/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/tools/cli/node_modules/.bin/vitest
+++ b/tools/cli/node_modules/.bin/vitest
@@ -2,13 +2,17 @@
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
 
 case `uname` in
-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.16/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.16/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.16/node_modules/vitest/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.16/node_modules:/Users/huazhou/Insync/hua.chau@outlook.com/OneDrive/应用/GitHub/smartsheet/metasheet-v2/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules:/Users/chouhua/Downloads/Github/metasheet2-trash-authz-20260617/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../vitest/vitest.mjs" "$@"

--- a/tools/cli/node_modules/@types/node
+++ b/tools/cli/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../node_modules/.pnpm/@types+node@20.19.16/node_modules/@types/node
+../../../../node_modules/.pnpm/@types+node@20.19.25/node_modules/@types/node

--- a/tools/cli/node_modules/fs-extra
+++ b/tools/cli/node_modules/fs-extra
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/fs-extra@11.3.2/node_modules/fs-extra
+../../../node_modules/.pnpm/fs-extra@11.3.4/node_modules/fs-extra

--- a/tools/cli/node_modules/inquirer
+++ b/tools/cli/node_modules/inquirer
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/inquirer@12.10.0_@types+node@20.19.16/node_modules/inquirer
+../../../node_modules/.pnpm/inquirer@12.11.1_@types+node@20.19.25/node_modules/inquirer

--- a/tools/cli/node_modules/vitest
+++ b/tools/cli/node_modules/vitest
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.16/node_modules/vitest
+../../../node_modules/.pnpm/vitest@1.6.1_@types+node@20.19.25_jsdom@27.2.0_less@4.4.2/node_modules/vitest


### PR DESCRIPTION
P1 review follow-up on #15 (#2791). Two bypasses in the recycle-bin API:

1. **Row policy** — `listDeletedRecords`/`restoreRecord` only checked `canDeleteRecord`, which is **true under sheet write-own**, so a write-own user could list/restore trash rows created by *other* users (while `deleteRecord` correctly gates per-row via `ensureRecordWriteAllowed`).
2. **Field mask** — the list returned raw `data`, leaking `field_permissions.visible=false` values.

## Fix
- **list**: `requiresOwnWriteRowPolicy(sheetScope, isAdminRole)` → inject `AND created_by = $actor` into **both** the COUNT and rows SQL (pagination + total stay exact); full-write/admin unfiltered.
- **restore**: `ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')` → reject (write-own can't resurrect another user's row).
- **mask**: trash GET handler now mirrors the live `/records` read — `computeAllowedFieldIds` → `maskStoredRecordFieldIds` → `filterRecordDataByFieldIds` per row. Registered the new `rec.data|visibleFieldIds` site in the taint-chokepoint guard + bumped the egress-coverage guard (14→15) — the structural guards caught the new egress.

## Tests
Real-DB (allowlisted): write-own sees only own trash (records+total), 403 restoring another's row / 200 own; `field_permissions.visible=false` field absent from trash data.

## Verification
`tsc` clean; **full** `vitest run` = 4388 passed / 0 failed; integration compiles+skips locally; `vue-tsc` PASS. The 3 new real-DB cases first run in CI `test (20.x)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)