### PR TITLE
feat(approval): Lane E — self-approver authoring (expose autoApprovalPolicy, frontend-only)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -2,8 +2,10 @@ import type {
   ApprovalAssigneeSource,
   ApprovalGraph,
   ApprovalMode,
+  ApprovalNodeConfig,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateVisibilityScope,
+  AutoApprovalPolicy,
   EmptyAssigneePolicy,
   FormField,
   FormFieldType,
@@ -60,6 +62,13 @@ export interface ApprovalStepDraft {
   fieldId: string
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy
+  // Self-approver authoring: the editable toggle (merge the requester in as an
+  // auto-approval). `originalAutoApprovalPolicy` preserves the three non-merge
+  // sub-fields (mergeAdjacentApprover / dedupeHistoricalApprover / actorMode),
+  // which are out of UI scope but must survive hydrate→rebuild (no silent flatten),
+  // mirroring `FieldAuthoringDraft.original`.
+  mergeWithRequester: boolean
+  originalAutoApprovalPolicy?: AutoApprovalPolicy
 }
 
 export interface TemplateAuthoringDraft {
@@ -135,6 +144,7 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     fieldId: '',
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
+    mergeWithRequester: false,
   }
 }
 
@@ -246,6 +256,11 @@ function stepDraftFromApprovalNode(
     idsText = formatIds(legacyIds)
   }
 
+  // Hydrate the self-approver policy: surface `mergeWithRequester` as the editable
+  // toggle, and stash the full policy so non-merge sub-fields survive a rebuild.
+  const autoApprovalPolicy = config.autoApprovalPolicy as AutoApprovalPolicy | undefined
+  const mergeWithRequester = autoApprovalPolicy?.mergeWithRequester === true
+
   return {
     localId: nextLocalId('step'),
     name: node.name ?? `审批人 ${index}`,
@@ -254,6 +269,8 @@ function stepDraftFromApprovalNode(
     fieldId,
     approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
+    mergeWithRequester,
+    ...(autoApprovalPolicy ? { originalAutoApprovalPolicy: autoApprovalPolicy } : {}),
   }
 }
 
@@ -338,6 +355,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
       'assigneeSources',
       'approvalMode',
       'emptyAssigneePolicy',
+      'autoApprovalPolicy',
     ]
     if (Object.keys(config).some((key) => !allowedConfigKeys.includes(key))) return true
     const sources = config.assigneeSources
@@ -425,16 +443,38 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   return { kind: 'requester' }
 }
 
+/**
+ * Build the approval-node config for a step. The `mergeWithRequester` toggle is the
+ * only authored sub-field of `autoApprovalPolicy`; the three non-merge sub-fields are
+ * preserved verbatim from `originalAutoApprovalPolicy` (no silent flatten). The
+ * `autoApprovalPolicy` key is OMITTED entirely when the effective policy is empty —
+ * mirroring `buildFormSchema`'s `delete next.visibilityRule` omit-empty discipline so a
+ * bare `{}` is never persisted.
+ */
+function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
+  const autoApprovalPolicy: AutoApprovalPolicy = {
+    ...step.originalAutoApprovalPolicy,
+    ...(step.mergeWithRequester ? { mergeWithRequester: true } : {}),
+  }
+  // The toggle owns `mergeWithRequester`: when OFF, drop the flag but keep preserved
+  // siblings. (Spread-only would resurrect a `mergeWithRequester:true` carrier.)
+  if (!step.mergeWithRequester) {
+    delete autoApprovalPolicy.mergeWithRequester
+  }
+  return {
+    assigneeSources: [sourceFromStep(step)],
+    approvalMode: step.approvalMode,
+    emptyAssigneePolicy: step.emptyAssigneePolicy,
+    ...(Object.keys(autoApprovalPolicy).length > 0 ? { autoApprovalPolicy } : {}),
+  }
+}
+
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
     type: 'approval' as const,
     name: step.name.trim() || `审批人 ${index + 1}`,
-    config: {
-      assigneeSources: [sourceFromStep(step)],
-      approvalMode: step.approvalMode,
-      emptyAssigneePolicy: step.emptyAssigneePolicy,
-    },
+    config: buildStepConfig(step),
   }))
   const nodes: ApprovalGraph['nodes'] = [
     { key: 'start', type: 'start', name: '发起', config: {} },

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -47,7 +47,20 @@ export interface ApprovalNodeConfig {
   assigneeSources?: ApprovalAssigneeSource[]
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
+  autoApprovalPolicy?: AutoApprovalPolicy
 }
+
+// Byte-mirrors backend packages/core-backend/src/types/approval-product.ts:121-128.
+// The authoring UI only owns `mergeWithRequester` (self-approver / merge-with-requester);
+// the other three fields are carried for round-trip preservation (no silent flatten).
+export interface AutoApprovalPolicy {
+  mergeWithRequester?: boolean
+  mergeAdjacentApprover?: boolean
+  dedupeHistoricalApprover?: boolean
+  actorMode?: AutoApprovalActorMode
+}
+
+export type AutoApprovalActorMode = 'system' | 'original_approver'
 
 export type ApprovalAssigneeSource =
   | { kind: 'static_user'; userIds: string[] }

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -352,6 +352,15 @@
                 <el-option label="自动通过" value="auto-approve" />
               </el-select>
             </el-form-item>
+            <el-form-item label="自审策略">
+              <el-checkbox
+                v-model="step.mergeWithRequester"
+                :disabled="readOnly"
+                data-testid="approval-step-merge-with-requester"
+              >
+                发起人自动通过（自审合并）
+              </el-checkbox>
+            </el-form-item>
           </div>
         </div>
       </el-card>

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
-import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
+import type { ApprovalNodeConfig, ApprovalTemplateDetailDTO, AutoApprovalPolicy } from '../src/types/approval'
 import {
+  buildApprovalGraph,
   buildCreateTemplatePayload,
   buildFormSchema,
   createEmptyTemplateDraft,
@@ -122,6 +123,7 @@ const ElOption = defineComponent({
 
 const ElCheckbox = defineComponent({
   name: 'ElCheckbox',
+  inheritAttrs: false,
   props: { modelValue: Boolean, disabled: Boolean },
   emits: ['update:modelValue'],
   render() {
@@ -130,6 +132,7 @@ const ElCheckbox = defineComponent({
         type: 'checkbox',
         checked: this.modelValue,
         disabled: this.disabled,
+        'data-testid': (this.$attrs as any)?.['data-testid'],
         onChange: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).checked),
       }),
       this.$slots.default?.(),
@@ -387,6 +390,90 @@ describe('approval template authoring helpers', () => {
       { kind: 'form_field_user', fieldId: 'reviewer' },
     ])
   })
+
+  // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
+  function buildAutoApprovalTemplate(
+    policy: AutoApprovalPolicy,
+    extraConfig: Record<string, unknown> = {},
+  ): ApprovalTemplateDetailDTO {
+    return buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: '审批人 1',
+            config: {
+              assigneeSources: [{ kind: 'requester' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+              autoApprovalPolicy: policy,
+              ...extraConfig,
+            },
+          },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    })
+  }
+
+  it('T1: hydrates mergeWithRequester and captures the full policy carrier', () => {
+    const draft = draftFromTemplate(buildAutoApprovalTemplate({ mergeWithRequester: true }))
+    expect(draft.steps[0].mergeWithRequester).toBe(true)
+    expect(draft.steps[0].originalAutoApprovalPolicy).toEqual({ mergeWithRequester: true })
+  })
+
+  it('T2: round-trips merge-on through buildApprovalGraph', () => {
+    const draft = draftFromTemplate(buildAutoApprovalTemplate({ mergeWithRequester: true }))
+    const graph = buildApprovalGraph(draft)
+    const config = graph.nodes[1]?.config as ApprovalNodeConfig
+    expect(config.autoApprovalPolicy).toEqual({ mergeWithRequester: true })
+  })
+
+  it('T3: a node carrying only allowed keys + autoApprovalPolicy is editable (not read-only)', () => {
+    const reason = unsupportedTemplateAuthoringReason(buildAutoApprovalTemplate({ mergeWithRequester: true }))
+    expect(reason).toBeNull()
+  })
+
+  it('T4: omits autoApprovalPolicy entirely when off with no preserved policy (not {})', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.steps[0].mergeWithRequester = false
+    const config = buildApprovalGraph(draft).nodes[1]?.config as ApprovalNodeConfig
+    expect('autoApprovalPolicy' in config).toBe(false)
+  })
+
+  it('T5: preserves non-merge policy siblings across a toggle off-then-on', () => {
+    const draft = draftFromTemplate(buildAutoApprovalTemplate({
+      mergeWithRequester: true,
+      mergeAdjacentApprover: true,
+      actorMode: 'system',
+    }))
+    // toggle off: siblings survive, merge flag dropped
+    draft.steps[0].mergeWithRequester = false
+    const offConfig = buildApprovalGraph(draft).nodes[1]?.config as ApprovalNodeConfig
+    expect(offConfig.autoApprovalPolicy).toEqual({ mergeAdjacentApprover: true, actorMode: 'system' })
+    // toggle back on: merge flag returns, siblings still present
+    draft.steps[0].mergeWithRequester = true
+    const onConfig = buildApprovalGraph(draft).nodes[1]?.config as ApprovalNodeConfig
+    expect(onConfig.autoApprovalPolicy).toEqual({
+      mergeWithRequester: true,
+      mergeAdjacentApprover: true,
+      actorMode: 'system',
+    })
+  })
+
+  it('T6: keeps fail-closed read-only for any OTHER unsupported config key', () => {
+    const reason = unsupportedTemplateAuthoringReason(
+      buildAutoApprovalTemplate({ mergeWithRequester: true }, { bogusKey: 'x' }),
+    )
+    expect(reason).not.toBeNull()
+    expect(reason).toContain('暂不支持')
+  })
 })
 
 describe('TemplateAuthoringView', () => {
@@ -516,6 +603,24 @@ describe('TemplateAuthoringView', () => {
     expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
   })
 
+  it('T7: wires the self-approver toggle through the mounted view into the saved payload', async () => {
+    await mountView()
+
+    setInput('approval-template-key', 'leave')
+    setInput('approval-template-name', '请假审批')
+    const mergeToggle = container!.querySelector('[data-testid="approval-step-merge-with-requester"]') as HTMLInputElement
+    mergeToggle.checked = true
+    mergeToggle.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.approvalGraph.nodes[1].config.autoApprovalPolicy).toEqual({ mergeWithRequester: true })
+  })
+
   it('opens unsupported existing graphs read-only and refuses to save them', async () => {
     routeParams = { id: 'tpl_parallel' }
     getTemplateSpy.mockResolvedValue(buildTemplate({
@@ -543,5 +648,41 @@ describe('TemplateAuthoringView', () => {
     await flushUi()
 
     expect(updateTemplateSpy).not.toHaveBeenCalled()
+  })
+
+  it('T8: disables the self-approver toggle when the template opens read-only', async () => {
+    routeParams = { id: 'tpl_locked' }
+    // A bogus config key forces fail-closed read-only while the approval step row
+    // (and its merge checkbox) still renders.
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      id: 'tpl_locked',
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: '审批人 1',
+            config: {
+              assigneeSources: [{ kind: 'requester' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+              bogusKey: 'x',
+            },
+          },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    }))
+
+    await mountView()
+
+    const mergeToggle = container!.querySelector('[data-testid="approval-step-merge-with-requester"]') as HTMLInputElement
+    expect(mergeToggle).not.toBeNull()
+    expect(mergeToggle.disabled).toBe(true)
   })
 })


### PR DESCRIPTION
POST-GATE approval **Lane E** (P2 self-approver authoring). **Frontend-only** — the engine already accepts/persists/evaluates `autoApprovalPolicy.mergeWithRequester` (`evaluateAutoApprovalAssignment`); this lane just authors it.

## Change
- Adds `'autoApprovalPolicy'` to the authoring allowlist, so a node carrying it becomes **editable** instead of fail-closed read-only. **Fail-closed preserved** for any *other* unsupported config key.
- `ApprovalStepDraft` gains `mergeWithRequester` (the editable toggle) + `originalAutoApprovalPolicy?` (carrier preserving the 3 non-merge sub-fields — `mergeAdjacentApprover`/`dedupeHistoricalApprover`/`actorMode`).
- `buildStepConfig`: the toggle owns `mergeWithRequester` (explicit `delete` when off so a stale `true` can't resurrect), siblings preserved verbatim, and the `autoApprovalPolicy` key is **omitted entirely when empty** (no bare `{}`) — mirroring the visibility-editor's omit-empty discipline. FE types `AutoApprovalPolicy`/`AutoApprovalActorMode` byte-mirror the backend.

## Gates
- **`approvalTemplateAuthoring.spec.ts` 22/22** (14 existing + 8 new T1–T8; the MD's source-mutation review confirmed each invariant is non-vacuous — dropping the carrier spread, the delete-guard, or the allowlist entry each breaks the corresponding test). `vue-tsc -b` clean. **Zero `core-backend` diff.**

## Governance
POST-GATE: gated on P0-A/C (PASS) + this lane's owner GO. Rebased onto current `main` (clean — coexists with Lane A's picker on the shared `TemplateAuthoringView`). No engine/backend change; no cross-runtime writes. W7 stays locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)