### PR TITLE
feat(approval): Lane B — P1-C node field permissions (HIDDEN facet, server-side echo-redaction)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -243,8 +243,8 @@ jobs:
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints — rbac 403/200 + minimal-exposure shape + ?q + limit clamp + least-privilege source pin)
-        # Lane A (P1-static-picker) directory endpoints. Wired as a WHOLE FILE run so the
+      - name: Run approval real-DB integration (directory endpoints rbac/shape/limit + P1-C node field-permission HIDDEN redaction across viewers/detail/list)
+        # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
         # default test job, so this is its real CI lane.
@@ -255,6 +255,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for approval real-DB integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
             tests/integration/approval-directory-endpoints.api.test.ts \
+            tests/integration/approval-p1c-field-permissions.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -285,6 +285,38 @@ describe('approval template authoring helpers', () => {
     expect(reason).toContain('暂不支持编辑的审批节点')
   })
 
+  it('fails closed on a node carrying fieldPermissions (no node-field editor yet)', () => {
+    // P1-C: fieldPermissions is NOT in the FE allowlist until a node-field
+    // permission editor ships. A template carrying it must render read-only in
+    // the MVP editor (never silently flattened) so the hidden-field config is
+    // preserved on the round-trip.
+    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: '审批人 1',
+            config: {
+              assigneeSources: [{ kind: 'form_field_user', fieldId: 'reviewer' }],
+              approvalMode: 'single',
+              emptyAssigneePolicy: 'error',
+              fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+            } as never,
+          },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    }))
+
+    expect(reason).toContain('暂不支持的配置')
+  })
+
   it('blocks existing attachment fields because the MVP has no upload runtime', () => {
     const reason = unsupportedTemplateAuthoringReason(buildTemplate({
       formSchema: {

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -23,6 +23,11 @@ import type {
   UnifiedApprovalHistoryDTO,
 } from './approval-bridge-types'
 import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
+import {
+  collectActiveNodeKeys,
+  redactHiddenFormFields,
+  type RedactableRuntimeGraph,
+} from './approval-form-redaction'
 
 const logger = new Logger('ApprovalBridgeService')
 const PLM_SYNC_CONCURRENCY = 5
@@ -124,7 +129,17 @@ function plmBridgeUnavailableError(): ServiceError {
 function toUnifiedDTO(
   row: ApprovalInstanceRow,
   assignments: ApprovalAssignmentRow[] = [],
+  runtimeGraph: RedactableRuntimeGraph | null = null,
 ): UnifiedApprovalDTO {
+  // P1-C: redact form fields the instance's currently-active node(s) mark
+  // `hidden`. Keyed on the instance-active node, NOT the viewer — so observers /
+  // admins / the requester are all redacted alike. `runtimeGraph` is null for
+  // bridged/external instances (no node config) → snapshot unchanged.
+  const formSnapshot = redactHiddenFormFields(
+    row.form_snapshot || null,
+    runtimeGraph,
+    collectActiveNodeKeys(row.current_node_key, row.metadata),
+  )
   return {
     id: row.id,
     sourceSystem: row.source_system,
@@ -142,7 +157,7 @@ function toUnifiedDTO(
     templateVersionId: row.template_version_id,
     publishedDefinitionId: row.published_definition_id,
     requestNo: row.request_no,
-    formSnapshot: row.form_snapshot || null,
+    formSnapshot,
     currentNodeKey: row.current_node_key,
     assignments: assignments.map((assignment) => ({
       id: assignment.id,
@@ -463,9 +478,16 @@ export class ApprovalBridgeService {
     )
 
     const assignmentsByInstance = await this.loadAssignments(instancesResult.rows.map((row) => row.id))
+    const runtimeGraphsByDefinition = await this.loadRuntimeGraphs(
+      instancesResult.rows.map((row) => row.published_definition_id),
+    )
 
     return {
-      data: instancesResult.rows.map((row) => toUnifiedDTO(row, assignmentsByInstance.get(row.id) || [])),
+      data: instancesResult.rows.map((row) => toUnifiedDTO(
+        row,
+        assignmentsByInstance.get(row.id) || [],
+        row.published_definition_id ? runtimeGraphsByDefinition.get(row.published_definition_id) ?? null : null,
+      )),
       total,
     }
   }
@@ -488,7 +510,12 @@ export class ApprovalBridgeService {
     if (!row) return null
 
     const assignmentsByInstance = await this.loadAssignments([id])
-    return toUnifiedDTO(row, assignmentsByInstance.get(id) || [])
+    const runtimeGraphsByDefinition = await this.loadRuntimeGraphs([row.published_definition_id])
+    return toUnifiedDTO(
+      row,
+      assignmentsByInstance.get(id) || [],
+      row.published_definition_id ? runtimeGraphsByDefinition.get(row.published_definition_id) ?? null : null,
+    )
   }
 
   async getApprovalHistory(id: string): Promise<UnifiedApprovalHistoryDTO[]> {
@@ -726,6 +753,36 @@ export class ApprovalBridgeService {
     )
 
     return result.rows[0] || null
+  }
+
+  /**
+   * P1-C: batch-load the stored `runtime_graph` for the given published
+   * definition ids so each row's `formSnapshot` can be redacted by its
+   * instance-active node. Returns a map keyed by `published_definition_id`.
+   * Bridged/external instances have a null `published_definition_id` and are
+   * absent from the map (no redaction — they carry no node config). The raw
+   * JSONB blob is returned as-is (no `asRuntimeGraph` re-validation needed on
+   * the read path: redaction only reads `nodes[].key` + `config.fieldPermissions`).
+   */
+  private async loadRuntimeGraphs(
+    publishedDefinitionIds: Array<string | null>,
+  ): Promise<Map<string, RedactableRuntimeGraph>> {
+    const byDefinitionId = new Map<string, RedactableRuntimeGraph>()
+    const distinctIds = [...new Set(publishedDefinitionIds.filter((id): id is string => typeof id === 'string'))]
+    if (!pool || distinctIds.length === 0) {
+      return byDefinitionId
+    }
+
+    const result = await pool.query<{ id: string; runtime_graph: RedactableRuntimeGraph | null }>(
+      `SELECT id, runtime_graph FROM approval_published_definitions WHERE id = ANY($1)`,
+      [distinctIds],
+    )
+    for (const row of result.rows) {
+      if (row.runtime_graph) {
+        byDefinitionId.set(row.id, row.runtime_graph)
+      }
+    }
+    return byDefinitionId
   }
 
   private async loadAssignments(instanceIds: string[]): Promise<Map<string, ApprovalAssignmentRow[]>> {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -20,6 +20,8 @@ import type {
   FormSchema,
   FormFieldVisibilityOperator,
   FormFieldVisibilityRule,
+  NodeFieldAccess,
+  NodeFieldPermission,
   PublishApprovalTemplateRequest,
   RuntimeGraph,
   RuntimePolicy,
@@ -276,6 +278,7 @@ const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any'])
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
 const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
+const NODE_FIELD_ACCESS_VALUES = new Set<NodeFieldAccess>(['editable', 'readonly', 'hidden'])
 const APPROVAL_MAX_AUTO_STEPS = 50
 
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
@@ -638,6 +641,86 @@ function validateFormFieldVisibilityRules(
   fields.forEach((field) => visit(field.id, []))
 }
 
+/**
+ * P1-C: normalize a node's `fieldPermissions` array (shape only).
+ *
+ * Enforces shape invariants here (no formSchema needed): each entry must be an
+ * object with a non-empty-string `fieldId` and an `access` in the strict enum;
+ * `fieldId`s are trimmed and must be unique within the node (no last-write-wins
+ * ambiguity). Invalid `access`, missing `fieldId`, or a duplicate `fieldId`
+ * → `failValidation(400)`, never a coerced default (no silent flatten).
+ *
+ * `editable` entries are kept through (inert but round-trip byte-stable). An
+ * empty/absent array returns `undefined` so the caller omits the key entirely
+ * (consistent with the `assigneeSources`/`approvalMode` omit-empty pattern).
+ *
+ * The cross-reference check (every `fieldId` must exist in the version's
+ * formSchema) is NOT done here — `normalizeApprovalGraph` does not see the
+ * formSchema. It is done post-normalize in
+ * `validateNodeFieldPermissionsAgainstFormSchema`, mirroring how
+ * `validateApprovalAssigneeSourcesAgainstFormSchema` cross-validates
+ * `form_field_user` sources. This keeps `normalizeApprovalGraph`'s signature
+ * unchanged (hot-file collision discipline) while still failing closed on a
+ * dangling `fieldId`.
+ */
+function normalizeNodeFieldPermissions(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): NodeFieldPermission[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    failValidation(context, `${path} must be an array`)
+  }
+  if (value.length === 0) return undefined
+
+  const seen = new Set<string>()
+  const normalized = value.map((entry, entryIndex) => {
+    const entryPath = `${path}[${entryIndex}]`
+    if (!isRecord(entry) || !isNonEmptyString(entry.fieldId)) {
+      failValidation(context, `${entryPath}.fieldId is required`)
+    }
+    if (typeof entry.access !== 'string' || !NODE_FIELD_ACCESS_VALUES.has(entry.access as NodeFieldAccess)) {
+      failValidation(context, `${entryPath}.access must be editable, readonly, or hidden`)
+    }
+    const fieldId = entry.fieldId.trim()
+    if (seen.has(fieldId)) {
+      failValidation(context, `${entryPath}.fieldId is duplicated`)
+    }
+    seen.add(fieldId)
+    return { fieldId, access: entry.access as NodeFieldAccess }
+  })
+
+  return normalized
+}
+
+/**
+ * P1-C cross-reference: every `fieldPermissions[].fieldId` on an approval node
+ * must reference a field that exists in the version's formSchema. Runs after
+ * both graph and formSchema are normalized (mirrors
+ * `validateApprovalAssigneeSourcesAgainstFormSchema`). Unknown `fieldId`
+ * → `failValidation(400)` (no silent drop).
+ */
+function validateNodeFieldPermissionsAgainstFormSchema(
+  approvalGraph: ApprovalGraph,
+  formSchema: FormSchema,
+  context: ValidationContext,
+): void {
+  const fieldIds = new Set(formSchema.fields.map((field) => field.id))
+  approvalGraph.nodes.forEach((node) => {
+    if (node.type !== 'approval') return
+    const config = node.config as { fieldPermissions?: NodeFieldPermission[] }
+    for (const permission of config.fieldPermissions ?? []) {
+      if (!fieldIds.has(permission.fieldId)) {
+        failValidation(
+          context,
+          `approvalGraph node ${node.key} fieldPermissions references unknown field ${permission.fieldId}`,
+        )
+      }
+    }
+  })
+}
+
 function normalizeApprovalGraph(
   value: unknown,
   context: ValidationContext,
@@ -700,6 +783,11 @@ function normalizeApprovalGraph(
             context,
             `approvalGraph.nodes[${index}].config.autoApprovalPolicy`,
           )
+          const fieldPermissions = normalizeNodeFieldPermissions(
+            node.config.fieldPermissions,
+            context,
+            `approvalGraph.nodes[${index}].config.fieldPermissions`,
+          )
           normalizedNode.config = {
             ...(hasLegacyAssignees
               ? {
@@ -711,6 +799,7 @@ function normalizeApprovalGraph(
             ...(approvalMode ? { approvalMode } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
+            ...(fieldPermissions ? { fieldPermissions } : {}),
           }
         }
         break
@@ -2002,6 +2091,7 @@ export class ApprovalProductService {
     const formSchema = assertFormSchema(request.formSchema)
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
     validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -2155,6 +2245,7 @@ export class ApprovalProductService {
         const nextFormSchema = formSchema ?? asFormSchema(latestVersion.form_schema)
         const nextApprovalGraph = approvalGraph ?? asApprovalGraph(latestVersion.approval_graph)
         validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
+        validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
 
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
@@ -2241,6 +2332,7 @@ export class ApprovalProductService {
       const formSchema = asFormSchema(version.form_schema)
       const approvalGraph = asApprovalGraph(version.approval_graph)
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       const runtimeGraph = buildRuntimeGraph(approvalGraph, policy)
 
       const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(

--- a/packages/core-backend/src/services/approval-form-redaction.ts
+++ b/packages/core-backend/src/services/approval-form-redaction.ts
@@ -1,0 +1,115 @@
+import type { NodeFieldPermission } from '../types/approval-product'
+
+/**
+ * Structurally-minimal view of a stored runtime graph for redaction purposes.
+ * Only the node `key` and `config.fieldPermissions` are read, so this accepts a
+ * raw JSONB blob (`Record<string, unknown>`) without forcing a `asRuntimeGraph`
+ * re-validation on the read path (and without a circular import on the bridge).
+ */
+export interface RedactableRuntimeGraph {
+  nodes?: Array<{ key?: unknown; config?: unknown } | null | undefined> | null
+}
+
+/**
+ * P1-C HIDDEN field redaction (shared, pure).
+ *
+ * Enforces node-level `fieldPermissions` with `access === 'hidden'` by stripping
+ * the hidden fields from the `formSnapshot` echoed in read DTOs. Redaction is
+ * keyed on the INSTANCE's currently-active node(s) — NOT the viewer's assignment
+ * set — so a viewer with no active assignment (observer / admin / requester-only)
+ * is ALSO redacted. There is no per-viewer logic: every reader sees the same
+ * redacted snapshot while the instance is AT a hiding node.
+ *
+ * This module is imported by both the detail/list read path (ApprovalBridgeService)
+ * and may be reused by any other read surface, so the two seams cannot drift
+ * (wire-vs-fixture discipline).
+ *
+ * Safety / no-throw contract:
+ * - null/empty `formSnapshot` → returned as-is (no clone, no throw).
+ * - null `runtimeGraph` (bridged/external instance with no node config) → snapshot
+ *   returned unchanged.
+ * - empty/absent `activeNodeKeys` → snapshot returned unchanged.
+ * - a node without `fieldPermissions`, or with only `editable`/`readonly`
+ *   entries, hides nothing → snapshot returned unchanged.
+ * - in a parallel region the instance is active at multiple nodes; the UNION of
+ *   every active node's hidden fields is removed.
+ *
+ * The snapshot is shallow-cloned only when at least one field is actually
+ * removed, so the default/no-hidden path stays allocation-free and byte-stable.
+ */
+export function redactHiddenFormFields(
+  formSnapshot: Record<string, unknown> | null,
+  runtimeGraph: RedactableRuntimeGraph | null,
+  activeNodeKeys: ReadonlyArray<string | null | undefined>,
+): Record<string, unknown> | null {
+  if (!formSnapshot || !runtimeGraph) return formSnapshot
+  if (!Array.isArray(runtimeGraph.nodes) || runtimeGraph.nodes.length === 0) return formSnapshot
+
+  const activeKeys = new Set(
+    activeNodeKeys.filter((key): key is string => typeof key === 'string' && key.length > 0),
+  )
+  if (activeKeys.size === 0) return formSnapshot
+
+  const hiddenFieldIds = new Set<string>()
+  for (const node of runtimeGraph.nodes) {
+    if (!node || typeof node.key !== 'string' || !activeKeys.has(node.key)) continue
+    const permissions = (node.config as { fieldPermissions?: NodeFieldPermission[] } | undefined)?.fieldPermissions
+    if (!Array.isArray(permissions)) continue
+    for (const permission of permissions) {
+      if (permission && permission.access === 'hidden' && typeof permission.fieldId === 'string') {
+        hiddenFieldIds.add(permission.fieldId)
+      }
+    }
+  }
+
+  if (hiddenFieldIds.size === 0) return formSnapshot
+
+  // Only clone when at least one hidden field is actually present in the snapshot.
+  let redacted: Record<string, unknown> | null = null
+  for (const fieldId of hiddenFieldIds) {
+    if (Object.prototype.hasOwnProperty.call(formSnapshot, fieldId)) {
+      if (!redacted) redacted = { ...formSnapshot }
+      delete redacted[fieldId]
+    }
+  }
+
+  return redacted ?? formSnapshot
+}
+
+/**
+ * Derives the instance's currently-active node key(s) from the stored
+ * `current_node_key` plus, when the instance is inside a parallel region, the
+ * per-branch active node keys recorded in instance metadata.
+ *
+ * The metadata shape is the same one `readParallelBranchStates` validates; this
+ * helper is intentionally tolerant (best-effort) so a malformed metadata blob
+ * degrades to "use current_node_key only" rather than throwing on a read path.
+ */
+export function collectActiveNodeKeys(
+  currentNodeKey: string | null,
+  metadata: Record<string, unknown> | null | undefined,
+): string[] {
+  const keys = new Set<string>()
+  if (typeof currentNodeKey === 'string' && currentNodeKey.length > 0) {
+    keys.add(currentNodeKey)
+  }
+
+  const states = metadata && typeof metadata === 'object'
+    ? (metadata as { parallelBranchStates?: unknown }).parallelBranchStates
+    : undefined
+  if (states && typeof states === 'object') {
+    const branches = (states as { branches?: unknown }).branches
+    if (branches && typeof branches === 'object') {
+      for (const entry of Object.values(branches as Record<string, unknown>)) {
+        if (!entry || typeof entry !== 'object') continue
+        const branch = entry as { currentNodeKey?: unknown; complete?: unknown }
+        if (branch.complete === true) continue
+        if (typeof branch.currentNodeKey === 'string' && branch.currentNodeKey.length > 0) {
+          keys.add(branch.currentNodeKey)
+        }
+      }
+    }
+  }
+
+  return [...keys]
+}

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -20,6 +20,29 @@ export type ApprovalTerminalStatus = typeof APPROVAL_TERMINAL_STATUSES[number]
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
 export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
 export type FormFieldVisibilityOperator = 'eq' | 'neq' | 'in' | 'isEmpty' | 'notEmpty'
+
+/**
+ * P1-C node-level field permissions (HIDDEN subset).
+ *
+ * `editable` (the absent default) === current behavior — a node without
+ * `fieldPermissions` leaves every form field fully visible/editable, so every
+ * pre-existing template and instance is byte-for-byte unchanged.
+ *
+ * Only `hidden` is enforced at runtime (server-side echo-redaction: a hidden
+ * field is stripped from the `formSnapshot` echoed in read DTOs while the
+ * instance is AT the hiding node). `readonly`/`editable` are part of the
+ * contract enum (default-preserving, normalized-through) but have NO runtime
+ * effect yet — they are blocked on the edit-form-at-node prerequisite (form
+ * snapshots are written once at create and no dispatch branch edits them, so
+ * `readonly` is indistinguishable from plain display today). The enum members
+ * are declared now so the contract is forward-stable; do not wire them.
+ */
+export type NodeFieldAccess = 'editable' | 'readonly' | 'hidden'
+
+export interface NodeFieldPermission {
+  fieldId: string
+  access: NodeFieldAccess
+}
 export type FormFieldType =
   | 'text'
   | 'textarea'
@@ -50,6 +73,11 @@ export interface ApprovalNodeConfig {
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
+  // P1-C node-level field permissions. Default-absent === editable === current
+  // behavior. `hidden` entries are enforced server-side; `readonly`/`editable`
+  // are inert (forward-stable contract only). Orthogonal to FormFieldVisibilityRule
+  // (data-value-keyed); fieldPermissions is node-keyed.
+  fieldPermissions?: NodeFieldPermission[]
 }
 
 export type ApprovalAssigneeSource =

--- a/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
@@ -4,6 +4,10 @@ import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
 
+// Real-DB spec: runs only with a Postgres DATABASE_URL (DB-backed CI step in
+// plugin-tests.yml + local); excluded from the no-DB default test job, skipped here.
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
 type JsonRecord = Record<string, unknown>
 
 async function canListenOnEphemeralPort(): Promise<boolean> {
@@ -163,7 +167,7 @@ async function authorPublishStart(
   return created
 }
 
-describe('Approval P1-C node field permissions (hidden subset) API', () => {
+describeIfDatabase('Approval P1-C node field permissions (hidden subset) API', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
   const bookkeeping = { templates: new Set<string>(), approvals: new Set<string>() }
@@ -198,6 +202,10 @@ describe('Approval P1-C node field permissions (hidden subset) API', () => {
       // ignore cleanup failures
     }
     if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
   it('redacts a hidden field for every viewer while AT the hiding node, on detail AND list, and restores it after advancing', async () => {

--- a/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-p1c-field-permissions.api.test.ts
@@ -1,0 +1,318 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+type JsonRecord = Record<string, unknown>
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+) {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+// Two-field form. `secret` is hidden at approval_1 (and via visibilityRule for the
+// orthogonality node); `reason` is always visible. `attendanceRequestId`-style
+// non-hidden keys (here `reason`) prove list rows keep their non-hidden fields.
+function buildFormSchema() {
+  return {
+    fields: [
+      { id: 'reason', type: 'text', label: '事由', required: true },
+      { id: 'secret', type: 'text', label: '机密' },
+    ],
+  }
+}
+
+// approval_1 hides `secret`; approval_2 hides nothing → after advancing past
+// approval_1, `secret` reappears.
+function buildHidingGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['p1c-manager-1'],
+          fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }],
+        },
+      },
+      {
+        key: 'approval_2',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['p1c-manager-2'] },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+      { key: 'edge-1-2', source: 'approval_1', target: 'approval_2' },
+      { key: 'edge-2-end', source: 'approval_2', target: 'end' },
+    ],
+  }
+}
+
+// Legacy graph carrying no fieldPermissions — proves default-absent === unchanged.
+function buildLegacyGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['p1c-manager-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+      { key: 'edge-1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+// Orthogonality: `secret` is hidden by node-permission AND by a visibilityRule
+// that would otherwise SHOW it; `extra` is hidden only by visibilityRule.
+function buildOrthogonalSchema() {
+  return {
+    fields: [
+      { id: 'reason', type: 'text', label: '事由', required: true },
+      { id: 'secret', type: 'text', label: '机密', visibilityRule: { fieldId: 'reason', operator: 'notEmpty' } },
+    ],
+  }
+}
+
+function buildOrthogonalGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_1',
+        type: 'approval',
+        config: {
+          assigneeType: 'user',
+          assigneeIds: ['p1c-manager-1'],
+          fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }],
+        },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+      { key: 'edge-1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+}
+
+async function authorPublishStart(
+  baseUrl: string,
+  adminToken: string,
+  requesterToken: string,
+  templateKey: string,
+  formSchema: JsonRecord,
+  approvalGraph: JsonRecord,
+  formData: JsonRecord,
+  bookkeeping: { templates: Set<string>; approvals: Set<string> },
+): Promise<{ id: string; currentNodeKey: string | null }> {
+  const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+    method: 'POST',
+    body: { key: templateKey, name: templateKey, formSchema, approvalGraph },
+  })
+  expect(templateResponse.status).toBe(201)
+  const template = await templateResponse.json() as { id: string }
+  bookkeeping.templates.add(template.id)
+
+  const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+    method: 'POST',
+    body: { policy: { allowRevoke: true } },
+  })
+  expect(publishResponse.status).toBe(200)
+
+  const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+    method: 'POST',
+    body: { templateId: template.id, formData },
+  })
+  expect(createResponse.status).toBe(201)
+  const created = await createResponse.json() as { id: string; currentNodeKey: string | null }
+  bookkeeping.approvals.add(created.id)
+  return created
+}
+
+describe('Approval P1-C node field permissions (hidden subset) API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const bookkeeping = { templates: new Set<string>(), approvals: new Set<string>() }
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...bookkeeping.approvals]
+      const templateIds = [...bookkeeping.templates]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+    if (server) await server.stop()
+  })
+
+  it('redacts a hidden field for every viewer while AT the hiding node, on detail AND list, and restores it after advancing', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+    const manager1Token = await authToken(baseUrl, 'p1c-manager-1')
+    const observerToken = await authToken(baseUrl, 'p1c-observer')
+
+    const created = await authorPublishStart(
+      baseUrl,
+      adminToken,
+      requesterToken,
+      `p1c-hidden-${Date.now()}`,
+      buildFormSchema(),
+      buildHidingGraph(),
+      { reason: 'trip', secret: 'classified' },
+      bookkeeping,
+    )
+    expect(created.currentNodeKey).toBe('approval_1')
+
+    // DETAIL: while AT approval_1 the hidden field is absent for active approver,
+    // requester, AND an observer/admin with no assignment — but `reason` stays.
+    for (const token of [manager1Token, requesterToken, observerToken, adminToken]) {
+      const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, token)
+      expect(detail.status).toBe(200)
+      const body = await detail.json() as { formSnapshot: JsonRecord | null }
+      expect(body.formSnapshot).not.toHaveProperty('secret')
+      expect(body.formSnapshot).toHaveProperty('reason', 'trip')
+    }
+
+    // LIST: same redaction keyed on instance-active node; non-hidden field kept.
+    // Query the active approver's pending queue (manager-1 is the active assignee
+    // at approval_1) — the list row's formSnapshot must be redacted identically.
+    const listAtHiding = await jsonRequest(baseUrl, '/api/approvals?sourceSystem=all&tab=pending&limit=200', manager1Token)
+    expect(listAtHiding.status).toBe(200)
+    const listBody = await listAtHiding.json() as { data: Array<{ id: string; formSnapshot: JsonRecord | null }> }
+    const listRow = listBody.data.find((row) => row.id === created.id)
+    expect(listRow).toBeTruthy()
+    expect(listRow?.formSnapshot).not.toHaveProperty('secret')
+    expect(listRow?.formSnapshot).toHaveProperty('reason', 'trip')
+
+    // The DB form_snapshot is intact (redaction is echo-only, not a write).
+    const pool = poolManager.get()
+    const stored = await pool.query<{ form_snapshot: JsonRecord }>(
+      'SELECT form_snapshot FROM approval_instances WHERE id = $1',
+      [created.id],
+    )
+    expect(stored.rows[0]?.form_snapshot).toMatchObject({ reason: 'trip', secret: 'classified' })
+
+    // Advance past approval_1 to approval_2 (which hides nothing) → secret returns.
+    const approveResponse = await jsonRequest(baseUrl, `/api/approvals/${created.id}/actions`, manager1Token, {
+      method: 'POST',
+      body: { action: 'approve', comment: 'm1 ok' },
+    })
+    expect(approveResponse.status).toBe(200)
+    const advanced = await approveResponse.json() as { currentNodeKey: string | null }
+    expect(advanced.currentNodeKey).toBe('approval_2')
+
+    const detailAfter = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    const detailAfterBody = await detailAfter.json() as { formSnapshot: JsonRecord | null }
+    expect(detailAfterBody.formSnapshot).toHaveProperty('secret', 'classified')
+    expect(detailAfterBody.formSnapshot).toHaveProperty('reason', 'trip')
+
+    // History/timeline rows are not altered by redaction (assert directly on the
+    // records table — redaction is a read-time echo transform, never a write).
+    const records = await pool.query<{ action: string }>(
+      'SELECT action FROM approval_records WHERE instance_id = $1 ORDER BY id ASC',
+      [created.id],
+    )
+    expect(records.rows.length).toBeGreaterThan(0)
+    expect(records.rows.some((row) => row.action === 'approve')).toBe(true)
+  })
+
+  it('leaves a legacy instance with no fieldPermissions unchanged', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+
+    const created = await authorPublishStart(
+      baseUrl,
+      adminToken,
+      requesterToken,
+      `p1c-legacy-${Date.now()}`,
+      buildFormSchema(),
+      buildLegacyGraph(),
+      { reason: 'legacy', secret: 'still-here' },
+      bookkeeping,
+    )
+
+    const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    expect(detail.status).toBe(200)
+    const body = await detail.json() as { formSnapshot: JsonRecord | null }
+    expect(body.formSnapshot).toMatchObject({ reason: 'legacy', secret: 'still-here' })
+  })
+
+  it('applies node redaction orthogonally to visibilityRule', async () => {
+    const adminToken = await authToken(baseUrl, 'p1c-admin')
+    const requesterToken = await authToken(baseUrl, 'p1c-requester')
+
+    const created = await authorPublishStart(
+      baseUrl,
+      adminToken,
+      requesterToken,
+      `p1c-ortho-${Date.now()}`,
+      buildOrthogonalSchema(),
+      buildOrthogonalGraph(),
+      // reason is non-empty → visibilityRule for `secret` would SHOW it; node
+      // permission still hides it. Proves the two axes are independent.
+      { reason: 'present', secret: 'double-guarded' },
+      bookkeeping,
+    )
+
+    const detail = await jsonRequest(baseUrl, `/api/approvals/${created.id}`, requesterToken)
+    expect(detail.status).toBe(200)
+    const body = await detail.json() as { formSnapshot: JsonRecord | null }
+    expect(body.formSnapshot).not.toHaveProperty('secret')
+    expect(body.formSnapshot).toHaveProperty('reason', 'present')
+  })
+})

--- a/packages/core-backend/tests/unit/approval-form-redaction.test.ts
+++ b/packages/core-backend/tests/unit/approval-form-redaction.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectActiveNodeKeys,
+  redactHiddenFormFields,
+  type RedactableRuntimeGraph,
+} from '../../src/services/approval-form-redaction'
+
+function graphHiding(nodeKey: string, fieldIds: string[]): RedactableRuntimeGraph {
+  return {
+    nodes: [
+      { key: 'start', config: {} },
+      {
+        key: nodeKey,
+        config: { fieldPermissions: fieldIds.map((fieldId) => ({ fieldId, access: 'hidden' })) },
+      },
+      { key: 'end', config: {} },
+    ],
+  }
+}
+
+describe('redactHiddenFormFields', () => {
+  const snapshot = { fld_reason: 'trip', fld_amount: 5000, fld_secret: 'ssn' }
+
+  it('removes a hidden field when the instance is AT the hiding node', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_secret']), ['approval_1'])
+    expect(result).toEqual({ fld_reason: 'trip', fld_amount: 5000 })
+    expect(result).not.toBe(snapshot)
+  })
+
+  it('retains non-hidden fields', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_secret']), ['approval_1'])
+    expect(result).toHaveProperty('fld_reason')
+    expect(result).toHaveProperty('fld_amount')
+    expect(result).not.toHaveProperty('fld_secret')
+  })
+
+  it('leaves the snapshot byte-identical (same reference) when nothing is hidden', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', []), ['approval_1'])
+    expect(result).toBe(snapshot)
+  })
+
+  it('does not redact when the instance is at a non-hiding node', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_secret']), ['approval_2'])
+    expect(result).toBe(snapshot)
+    expect(result).toHaveProperty('fld_secret')
+  })
+
+  it('only redacts editable/readonly entries do not hide anything', () => {
+    const graph: RedactableRuntimeGraph = {
+      nodes: [
+        {
+          key: 'approval_1',
+          config: {
+            fieldPermissions: [
+              { fieldId: 'fld_reason', access: 'readonly' },
+              { fieldId: 'fld_amount', access: 'editable' },
+            ],
+          },
+        },
+      ],
+    }
+    const result = redactHiddenFormFields(snapshot, graph, ['approval_1'])
+    expect(result).toBe(snapshot)
+  })
+
+  it('unions hidden fields across all active nodes in a parallel region', () => {
+    const graph: RedactableRuntimeGraph = {
+      nodes: [
+        { key: 'branch_a', config: { fieldPermissions: [{ fieldId: 'fld_reason', access: 'hidden' }] } },
+        { key: 'branch_b', config: { fieldPermissions: [{ fieldId: 'fld_amount', access: 'hidden' }] } },
+      ],
+    }
+    const result = redactHiddenFormFields(snapshot, graph, ['branch_a', 'branch_b'])
+    expect(result).toEqual({ fld_secret: 'ssn' })
+  })
+
+  it('is safe with a null snapshot', () => {
+    expect(redactHiddenFormFields(null, graphHiding('approval_1', ['fld_secret']), ['approval_1'])).toBeNull()
+  })
+
+  it('is safe with a null runtime graph (bridged/external instance)', () => {
+    expect(redactHiddenFormFields(snapshot, null, ['approval_1'])).toBe(snapshot)
+  })
+
+  it('is safe with empty active node keys', () => {
+    expect(redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_secret']), [])).toBe(snapshot)
+  })
+
+  it('is safe with null/undefined active node keys mixed in', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_secret']), [null, undefined, 'approval_1'])
+    expect(result).not.toHaveProperty('fld_secret')
+  })
+
+  it('does not throw when a hidden field is absent from the snapshot', () => {
+    const result = redactHiddenFormFields(snapshot, graphHiding('approval_1', ['fld_not_present']), ['approval_1'])
+    expect(result).toBe(snapshot)
+  })
+
+  it('is safe with an empty-nodes runtime graph', () => {
+    expect(redactHiddenFormFields(snapshot, { nodes: [] }, ['approval_1'])).toBe(snapshot)
+  })
+})
+
+describe('collectActiveNodeKeys', () => {
+  it('returns the single current node key when there is no parallel state', () => {
+    expect(collectActiveNodeKeys('approval_1', null)).toEqual(['approval_1'])
+  })
+
+  it('returns empty when current node key is null and no parallel state', () => {
+    expect(collectActiveNodeKeys(null, {})).toEqual([])
+  })
+
+  it('unions current node key with non-complete parallel branch node keys', () => {
+    const metadata = {
+      parallelBranchStates: {
+        parallelNodeKey: 'p',
+        joinNodeKey: 'j',
+        joinMode: 'all',
+        branches: {
+          a: { edgeKey: 'a', currentNodeKey: 'branch_a', complete: false },
+          b: { edgeKey: 'b', currentNodeKey: 'branch_b', complete: false },
+        },
+      },
+    }
+    const result = collectActiveNodeKeys('p', metadata)
+    expect(result.sort()).toEqual(['branch_a', 'branch_b', 'p'])
+  })
+
+  it('skips completed branches', () => {
+    const metadata = {
+      parallelBranchStates: {
+        branches: {
+          a: { edgeKey: 'a', currentNodeKey: 'branch_a', complete: true },
+          b: { edgeKey: 'b', currentNodeKey: 'branch_b', complete: false },
+        },
+      },
+    }
+    expect(collectActiveNodeKeys(null, metadata).sort()).toEqual(['branch_b'])
+  })
+
+  it('degrades to current node key on malformed metadata', () => {
+    expect(collectActiveNodeKeys('approval_1', { parallelBranchStates: 'bad' } as never)).toEqual(['approval_1'])
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1333,6 +1333,180 @@ describe('ApprovalProductService', () => {
     expect(pgState.pool.connect).not.toHaveBeenCalled()
   })
 
+  describe('P1-C node field permissions (hidden subset)', () => {
+    function fieldPermRequest(fieldPermissions: unknown) {
+      return {
+        key: 'fieldperm-tpl',
+        name: 'Field Perm Template',
+        formSchema: {
+          fields: [
+            { id: 'amount', type: 'number', label: 'Amount' },
+            { id: 'secret', type: 'text', label: 'Secret' },
+          ],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            {
+              key: 'approval_1',
+              type: 'approval',
+              config: { assigneeType: 'user', assigneeIds: ['manager-1'], fieldPermissions },
+            },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+            { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+          ],
+        },
+      }
+    }
+
+    function mockTemplateInsert() {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-fieldperm',
+              key: String(params?.[0]),
+              name: String(params?.[1]),
+              description: null,
+              category: null,
+              visibility_scope: JSON.parse(String(params?.[4])),
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: null,
+              created_at: new Date('2026-06-17T00:00:00.000Z'),
+              updated_at: new Date('2026-06-17T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return {
+            rows: [{
+              id: 'ver-fieldperm',
+              template_id: 'tpl-fieldperm',
+              version: 1,
+              status: 'draft',
+              form_schema: JSON.parse(String(params?.[1])),
+              approval_graph: JSON.parse(String(params?.[2])),
+              created_at: new Date('2026-06-17T00:00:00.000Z'),
+              updated_at: new Date('2026-06-17T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return {
+            rows: [{
+              id: 'tpl-fieldperm',
+              key: 'fieldperm-tpl',
+              name: 'Field Perm Template',
+              description: null,
+              category: null,
+              visibility_scope: { type: 'all', ids: [] },
+              sla_hours: null,
+              status: 'draft',
+              active_version_id: null,
+              latest_version_id: 'ver-fieldperm',
+              created_at: new Date('2026-06-17T00:00:00.000Z'),
+              updated_at: new Date('2026-06-17T00:00:00.000Z'),
+            }],
+            rowCount: 1,
+          }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+    }
+
+    it('rejects an invalid access enum before hitting the database (no silent default)', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        fieldPermRequest([{ fieldId: 'secret', access: 'invisible' }]) as never,
+      )).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.fieldPermissions[0].access must be editable, readonly, or hidden',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('rejects a missing fieldId before hitting the database', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        fieldPermRequest([{ access: 'hidden' }]) as never,
+      )).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.fieldPermissions[0].fieldId is required',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('rejects a duplicate fieldId within one node', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        fieldPermRequest([
+          { fieldId: 'secret', access: 'hidden' },
+          { fieldId: 'secret', access: 'readonly' },
+        ]) as never,
+      )).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.fieldPermissions[1].fieldId is duplicated',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown fieldId not present in the form schema', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate(
+        fieldPermRequest([{ fieldId: 'ghost', access: 'hidden' }]) as never,
+      )).rejects.toMatchObject({
+        message: 'approvalGraph node approval_1 fieldPermissions references unknown field ghost',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+
+    it('accepts a valid hidden permission, trims fieldId, and round-trips byte-stably', async () => {
+      mockTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(
+        fieldPermRequest([
+          { fieldId: '  secret  ', access: 'hidden' },
+          { fieldId: 'amount', access: 'editable' },
+        ]) as never,
+      )
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')
+      expect((node?.config as Record<string, unknown>).fieldPermissions).toEqual([
+        { fieldId: 'secret', access: 'hidden' },
+        { fieldId: 'amount', access: 'editable' },
+      ])
+    })
+
+    it('omits an empty fieldPermissions array (does not emit [])', async () => {
+      mockTemplateInsert()
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      const result = await service.createTemplate(fieldPermRequest([]) as never)
+      const node = result.approvalGraph.nodes.find((n) => n.key === 'approval_1')
+      expect((node?.config as Record<string, unknown>).fieldPermissions).toBeUndefined()
+    })
+  })
+
   it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'tests/integration/after-sales-plugin.install.test.ts',
       'tests/integration/after-sales-registry-backfill.test.ts',
       'tests/integration/approval-directory-endpoints.api.test.ts',
+      'tests/integration/approval-p1c-field-permissions.api.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
POST-GATE approval **Lane B** (P1-C node-level field permissions, **HIDDEN facet only**) — first baton of the hot-file serial chain on `types/approval-product.ts`.

## Change (additive, default-preserving)
- Types: `NodeFieldAccess = 'editable'|'readonly'|'hidden'`, `NodeFieldPermission {fieldId, access}`, optional `fieldPermissions?` on `ApprovalNodeConfig`. **Default-absent === editable === current behavior** — every pre-existing template/instance is byte-unchanged. `readonly`/`editable` are declared (forward-stable) but **NOT wired** (blocked on the edit-form-at-node prerequisite).
- Enforcement: **HIDDEN only**, via a shared pure helper `approval-form-redaction.ts` — strips hidden fields from the `formSnapshot` echoed in read DTOs, keyed on the instance's **currently-active node(s), not the viewer**, so observer/admin/requester are all redacted alike. No-throw, allocation-free on the no-hidden path (clones only when actually removing). Parallel region = union of active nodes' hidden fields.
- Wiring: `ApprovalBridgeService.toUnifiedDTO` (covers detail + list in one seam), runtime graphs batch-loaded by `published_definition_id`; bridged instances (null def) → no redaction, no throw.
- FE stays **fail-closed**: `fieldPermissions` is deliberately NOT in the authoring allowlist (node renders read-only until a node-field editor ships).

## Gates
- backend `tsc` 0; **unit 62/62** (`approval-form-redaction` + `approval-product-service`); FE fail-closed **15/15**; `vue-tsc -b` 0.
- **Real-DB integration 4/4**: hidden field absent for active-approver + requester + observer + admin on **detail AND list** while at the hiding node; DB `form_snapshot` byte-intact; field present again after advancing; orthogonal to `visibilityRule`. CI-lane: `describeIfDatabase` + sentinel + excluded from default job + Postgres step in `plugin-tests.yml`.

## Governance
POST-GATE: P0-A/C (PASS) + lane GO. **Hot-file serial chain** — Lane D (`ApprovalActionType`) rebases after this lands to avoid a `types/approval-product.ts` contract collision. Pure read-time redaction — no cross-runtime writes, no BPMN. W7 stays locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)