### PR TITLE
feat(approval): Lane D — P1-B add_sign / reduce_sign (runtime + FE/BE union)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -243,8 +243,8 @@ jobs:
             tests/integration/data-source-c3-keyset-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints rbac/shape/limit + P1-C node field-permission HIDDEN redaction across viewers/detail/list)
-        # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction). Wired as WHOLE FILE runs so the
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign 会签/或签/reduce/guards)
+        # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
         # default test job, so this is its real CI lane.
@@ -256,6 +256,7 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
             tests/integration/approval-directory-endpoints.api.test.ts \
             tests/integration/approval-p1c-field-permissions.api.test.ts \
+            tests/integration/approval-wp-add-reduce-sign.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -13,7 +13,15 @@ export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'reques
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
-export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
+export type ApprovalActionType =
+  | 'approve'
+  | 'reject'
+  | 'transfer'
+  | 'revoke'
+  | 'comment'
+  | 'return'
+  | 'add_sign'
+  | 'reduce_sign'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
 export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
@@ -223,6 +231,12 @@ export interface ApprovalActionRequest {
   comment?: string
   targetUserId?: string
   targetNodeKey?: string
+  /** P1-B add_sign — approver user IDs to pull into the current node as co-signers. */
+  targetUserIds?: string[]
+  /** P1-B add_sign — `parallel` (default) or `before`. */
+  addSignMode?: 'before' | 'parallel'
+  /** P1-B reduce_sign — assignee_id of the add-signed row to remove. */
+  targetAssignmentUserId?: string
 }
 
 export interface ApprovalTemplateListItemDTO {

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -235,6 +235,29 @@
             >
               转交
             </el-button>
+            <!-- P1-B 加签: pull additional co-signer(s) into the current node. -->
+            <el-button
+              v-if="canAct"
+              type="primary"
+              plain
+              :loading="store.loading"
+              data-testid="approval-add-sign-button"
+              @click="openAddSignDialog"
+            >
+              加签
+            </el-button>
+            <!-- P1-B 减签: remove a previously add-signed co-signer at the
+                 current node. Only shown when at least one such row exists. -->
+            <el-button
+              v-if="canAct && reducibleAssignees.length > 0"
+              type="primary"
+              plain
+              :loading="store.loading"
+              data-testid="approval-reduce-sign-button"
+              @click="openReduceSignDialog"
+            >
+              减签
+            </el-button>
             <!-- Wave 2 WP3 slice 1: 催办. Visible only for the requester on
                  a pending instance; server-side rate-limits to once per hour
                  per user per instance (429 → surfaced as a friendly toast). -->
@@ -335,6 +358,102 @@
       </template>
     </el-dialog>
 
+    <!-- P1-B 加签 dialog -->
+    <el-dialog
+      v-model="addSignDialogVisible"
+      title="加签"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="加签人">
+          <el-select
+            v-model="addSignUserIds"
+            multiple
+            filterable
+            placeholder="选择加签审批人"
+            style="width: 100%"
+            data-testid="approval-add-sign-users"
+          >
+            <el-option label="李四 (部门经理)" value="user_2" />
+            <el-option label="王五 (总监)" value="user_3" />
+            <el-option label="赵六 (VP)" value="user_4" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="加签方式">
+          <el-radio-group v-model="addSignMode" data-testid="approval-add-sign-mode">
+            <el-radio value="parallel">并加签</el-radio>
+            <el-radio value="before">前加签</el-radio>
+          </el-radio-group>
+        </el-form-item>
+        <el-form-item label="加签说明">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="2"
+            placeholder="请输入加签说明"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="addSignDialogVisible = false">取消</el-button>
+        <el-button
+          type="primary"
+          :loading="store.loading"
+          :disabled="addSignUserIds.length === 0"
+          data-testid="approval-add-sign-submit"
+          @click="submitAddSign"
+        >
+          确认加签
+        </el-button>
+      </template>
+    </el-dialog>
+
+    <!-- P1-B 减签 dialog -->
+    <el-dialog
+      v-model="reduceSignDialogVisible"
+      title="减签"
+      width="480px"
+    >
+      <el-form>
+        <el-form-item label="减签人">
+          <el-select
+            v-model="reduceSignUserId"
+            filterable
+            placeholder="选择要移除的加签人"
+            style="width: 100%"
+            data-testid="approval-reduce-sign-user"
+          >
+            <el-option
+              v-for="assignee in reducibleAssignees"
+              :key="assignee.assigneeId"
+              :label="assignee.label"
+              :value="assignee.assigneeId"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="减签说明">
+          <el-input
+            v-model="actionComment"
+            type="textarea"
+            :rows="2"
+            placeholder="请输入减签说明"
+          />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="reduceSignDialogVisible = false">取消</el-button>
+        <el-button
+          type="primary"
+          :loading="store.loading"
+          :disabled="!reduceSignUserId"
+          data-testid="approval-reduce-sign-submit"
+          @click="submitReduceSign"
+        >
+          确认减签
+        </el-button>
+      </template>
+    </el-dialog>
+
     <!-- Comment dialog -->
     <el-dialog
       v-model="commentDialogVisible"
@@ -408,6 +527,8 @@ import {
   ChatDotSquare,
   Bell,
   RefreshLeft,
+  CirclePlus,
+  Remove,
 } from '@element-plus/icons-vue'
 import type { ApprovalActionType } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
@@ -478,6 +599,34 @@ const currentAction = ref<ApprovalActionType>('approve')
 const actionComment = ref('')
 const transferUserId = ref('')
 const returnTargetNodeKey = ref('')
+// P1-B 加签/减签 dialog state.
+const addSignDialogVisible = ref(false)
+const addSignUserIds = ref<string[]>([])
+const addSignMode = ref<'before' | 'parallel'>('parallel')
+const reduceSignDialogVisible = ref(false)
+const reduceSignUserId = ref('')
+
+// P1-B 减签 picker — only previously add-signed (`metadata.addSign === true`),
+// still-active, user-typed assignments at the CURRENT node are reducible.
+// Requester-original / template-resolved / role rows are never listed (mirrors
+// the backend `reduce_sign` `removable` predicate — INV-2).
+const reducibleAssignees = computed<Array<{ assigneeId: string; label: string }>>(() => {
+  if (!approval.value || approval.value.status !== 'pending') return []
+  const currentNodeKey = approval.value.currentNodeKey
+  if (!currentNodeKey) return []
+  const seen = new Set<string>()
+  const result: Array<{ assigneeId: string; label: string }> = []
+  for (const assignment of approval.value.assignments) {
+    if (!assignment.isActive) continue
+    if (assignment.type !== 'user') continue
+    if (assignment.nodeKey !== currentNodeKey) continue
+    if (assignment.metadata?.addSign !== true) continue
+    if (seen.has(assignment.assigneeId)) continue
+    seen.add(assignment.assigneeId)
+    result.push({ assigneeId: assignment.assigneeId, label: assignment.assigneeId })
+  }
+  return result
+})
 
 const returnableNodes = computed(() => {
   if (!approval.value || approval.value.status !== 'pending') return []
@@ -536,6 +685,8 @@ function actionLabel(action: string, metadata?: Record<string, unknown>) {
     comment: '评论',
     return: '退回',
     sign: '签字',
+    add_sign: '加签',
+    reduce_sign: '减签',
   }
   return map[action] ?? action
 }
@@ -566,6 +717,8 @@ function timelineIcon(action: string, metadata?: Record<string, unknown>) {
     comment: ChatDotSquare,
     cc: Bell,
     revoke: RefreshLeft,
+    add_sign: CirclePlus,
+    reduce_sign: Remove,
   }
   return map[action] ?? undefined
 }
@@ -684,6 +837,54 @@ async function submitTransfer() {
     await store.loadHistory(id)
   } catch {
     ElMessage.error('转交失败，请重试')
+  }
+}
+
+function openAddSignDialog() {
+  addSignUserIds.value = []
+  addSignMode.value = 'parallel'
+  actionComment.value = ''
+  addSignDialogVisible.value = true
+}
+
+async function submitAddSign() {
+  if (addSignUserIds.value.length === 0) return
+  const id = route.params.id as string
+  try {
+    await store.executeAction(id, {
+      action: 'add_sign',
+      comment: actionComment.value || undefined,
+      targetUserIds: addSignUserIds.value,
+      addSignMode: addSignMode.value,
+    })
+    ElMessage.success('已成功加签')
+    addSignDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('加签失败，请重试')
+  }
+}
+
+function openReduceSignDialog() {
+  reduceSignUserId.value = ''
+  actionComment.value = ''
+  reduceSignDialogVisible.value = true
+}
+
+async function submitReduceSign() {
+  if (!reduceSignUserId.value) return
+  const id = route.params.id as string
+  try {
+    await store.executeAction(id, {
+      action: 'reduce_sign',
+      comment: actionComment.value || undefined,
+      targetAssignmentUserId: reduceSignUserId.value,
+    })
+    ElMessage.success('已成功减签')
+    reduceSignDialogVisible.value = false
+    await store.loadHistory(id)
+  } catch {
+    ElMessage.error('减签失败，请重试')
   }
 }
 

--- a/apps/web/tests/approval-e2e-lifecycle.spec.ts
+++ b/apps/web/tests/approval-e2e-lifecycle.spec.ts
@@ -218,8 +218,22 @@ const ElSelect = defineComponent({
   render() {
     return h('select', {
       'data-el-select': 'true',
+      'data-el-select-multiple': this.multiple ? 'true' : 'false',
+      // Intentionally NOT a native `multiple` <select>: a real multi-select
+      // ignores `.value` assignment, which tests rely on. We keep a single-value
+      // DOM node and reconstruct the array in the change handler below.
       value: Array.isArray(this.modelValue) ? '' : this.modelValue ?? '',
       onChange: (e: Event) => {
+        // For a multiple select, the v-model is an array. The change event
+        // carries a comma-separated list of selected values (tests set
+        // `select.value`), so split it into the array shape the component binds.
+        if (this.multiple) {
+          const raw = (e.target as HTMLSelectElement).value
+          const val = raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : []
+          this.$emit('update:modelValue', val)
+          this.$emit('change', val)
+          return
+        }
         const val = (e.target as HTMLSelectElement).value
         this.$emit('update:modelValue', val)
         this.$emit('change', val)
@@ -232,6 +246,36 @@ const ElOption = defineComponent({
   name: 'ElOption',
   props: { label: String, value: String },
   render() { return h('option', { value: this.value }, this.label) },
+})
+
+// Minimal radio-group stub: each child <el-radio> renders a clickable element
+// that emits the group's update with its own value (mirrors Element Plus's
+// value-based radio group). Used by the P1-B 加签 mode picker.
+const ElRadioGroup = defineComponent({
+  name: 'ElRadioGroup',
+  props: { modelValue: String },
+  emits: ['update:modelValue'],
+  provide() {
+    return {
+      radioGroupSelect: (value: string) => this.$emit('update:modelValue', value),
+      radioGroupValue: () => this.modelValue,
+    }
+  },
+  render() { return h('div', { 'data-el-radio-group': this.modelValue ?? '' }, this.$slots.default?.()) },
+})
+
+const ElRadio = defineComponent({
+  name: 'ElRadio',
+  props: { value: String, label: String },
+  inject: { radioGroupSelect: { default: null } } as any,
+  render() {
+    const self = this as any
+    return h('button', {
+      type: 'button',
+      'data-el-radio-value': this.value,
+      onClick: () => self.radioGroupSelect?.(this.value),
+    }, this.$slots.default?.())
+  },
 })
 
 const ElButton = defineComponent({
@@ -409,6 +453,8 @@ function registerAllStubs(app: VueApp<Element>) {
   app.component('ElInputNumber', ElInputNumber)
   app.component('ElSelect', ElSelect)
   app.component('ElOption', ElOption)
+  app.component('ElRadioGroup', ElRadioGroup)
+  app.component('ElRadio', ElRadio)
   app.component('ElButton', ElButton)
   app.component('ElIcon', ElIcon)
   app.component('ElTooltip', ElTooltip)
@@ -1025,6 +1071,136 @@ describe('Approval E2E Lifecycle', () => {
       await flushUi()
 
       expect(loadHistorySpy).toHaveBeenCalledWith('apv_pending_1')
+    })
+  })
+
+  // =========================================================================
+  // 5b. P1-B 加签 / 减签 (add_sign / reduce_sign)
+  // =========================================================================
+  describe('Add-sign / reduce-sign flow', () => {
+    // An active assignment stamped addSign:true at the current node — the only
+    // shape the 减签 picker should ever surface (INV-2 mirror).
+    function addSignedAssignment() {
+      return {
+        id: 'asgn_added_1',
+        type: 'user',
+        assigneeId: 'manager-9',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: { addSign: true, addedBy: 'user_current' },
+      }
+    }
+
+    it('clicking "加签" opens the add-sign dialog with a mode radio', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      await mountDetailView()
+
+      const addBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '加签')
+      expect(addBtn).toBeTruthy()
+      addBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="加签"]')
+      expect(dialog).toBeTruthy()
+      // parallel + before mode radios present.
+      const radios = dialog!.querySelectorAll('[data-el-radio-value]')
+      expect(radios.length).toBe(2)
+    })
+
+    it('confirming 加签 calls executeAction with action=add_sign, targetUserIds (array) and addSignMode', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval()
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+      await mountDetailView()
+
+      const addBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '加签')
+      addBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="加签"]')!
+      // Multiple-select: selecting an option emits the array shape the v-model
+      // binds (the stub wraps the chosen value into a string[]). A single
+      // <select> can only hold one option value, so we pick one — enough to
+      // assert the array contract reaches the action.
+      const select = dialog.querySelector('[data-el-select-multiple="true"]') as HTMLSelectElement
+      select.value = 'user_2'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      // Pick the 前加签 (before) mode radio to assert it round-trips.
+      const beforeRadio = Array.from(dialog.querySelectorAll('[data-el-radio-value]'))
+        .find((r) => r.getAttribute('data-el-radio-value') === 'before') as HTMLButtonElement
+      beforeRadio.click()
+      await flushUi()
+
+      const confirmBtn = Array.from(dialog.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认加签'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'add_sign',
+        targetUserIds: ['user_2'],
+        addSignMode: 'before',
+      }))
+    })
+
+    it('hides "减签" when no add-signed rows exist at the current node', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval() // only a plain active assignment, no addSign
+      await mountDetailView()
+
+      const reduceBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '减签')
+      expect(reduceBtn).toBeUndefined()
+    })
+
+    it('减签 picker lists only add-signed active rows at the current node and emits reduce_sign', async () => {
+      routeParams = { id: 'apv_pending_1' }
+      mockActiveApproval.value = mockPendingApproval({
+        assignments: [
+          // requester-original (no addSign) — must NOT be listed.
+          { id: 'asgn_orig', type: 'user', assigneeId: 'user_current', sourceStep: 1, nodeKey: 'approval_1', isActive: true, metadata: {} },
+          // add-signed at the current node — IS listed.
+          addSignedAssignment(),
+          // add-signed but at a DIFFERENT node — must NOT be listed.
+          { id: 'asgn_other_node', type: 'user', assigneeId: 'manager-8', sourceStep: 2, nodeKey: 'approval_2', isActive: true, metadata: { addSign: true } },
+          // add-signed but inactive — must NOT be listed.
+          { id: 'asgn_inactive', type: 'user', assigneeId: 'manager-7', sourceStep: 1, nodeKey: 'approval_1', isActive: false, metadata: { addSign: true } },
+        ],
+      } as any)
+      executeActionSpy.mockResolvedValue(mockPendingApproval())
+      await mountDetailView()
+
+      const reduceBtn = Array.from(container!.querySelectorAll('.approval-detail__actions button'))
+        .find((b) => b.textContent?.trim() === '减签')
+      expect(reduceBtn).toBeTruthy()
+      reduceBtn!.click()
+      await flushUi()
+
+      const dialog = container!.querySelector('[data-dialog-visible="true"][data-el-dialog="减签"]')!
+      const options = Array.from(dialog.querySelectorAll('option'))
+      // Exactly one reducible assignee: manager-9.
+      expect(options.map((o) => o.getAttribute('value'))).toEqual(['manager-9'])
+
+      const select = dialog.querySelector('[data-el-select]') as HTMLSelectElement
+      select.value = 'manager-9'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi()
+
+      const confirmBtn = Array.from(dialog.querySelectorAll('button'))
+        .find((b) => b.textContent?.includes('确认减签'))
+      confirmBtn!.click()
+      await flushUi()
+
+      expect(executeActionSpy).toHaveBeenCalledWith('apv_pending_1', expect.objectContaining({
+        action: 'reduce_sign',
+        targetAssignmentUserId: 'manager-9',
+      }))
     })
   })
 

--- a/packages/core-backend/src/db/migrations/zzzz20260616130000_add_add_reduce_sign_actions_to_approval_records.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260616130000_add_add_reduce_sign_actions_to_approval_records.ts
@@ -1,0 +1,46 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+// P1-B 加签/减签 — add `add_sign` / `reduce_sign` to the
+// `approval_records_action_check` CHECK constraint. Without this the audit-row
+// INSERT for these actions fails at runtime (Postgres 23514). No new
+// permission rows are needed: add_sign/reduce_sign are gated by the existing
+// `approvals:act` RBAC + active-assignee check (see ApprovalProductService
+// `actorCanAct`), not a new permission (unlike the jump migration which added
+// `approvals:admin`).
+const ACTIONS_WITH_ADD_REDUCE_SIGN = [
+  'created',
+  'approve',
+  'reject',
+  'return',
+  'revoke',
+  'transfer',
+  'sign',
+  'comment',
+  'cc',
+  'remind',
+  'jump',
+  'add_sign',
+  'reduce_sign',
+]
+const ACTIONS_WITHOUT_ADD_REDUCE_SIGN = ACTIONS_WITH_ADD_REDUCE_SIGN.filter(
+  (action) => action !== 'add_sign' && action !== 'reduce_sign',
+)
+
+function actionCheck(actions: string[]): string {
+  return `action IN (${actions.map((action) => `'${action}'`).join(', ')})`
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITH_ADD_REDUCE_SIGN)})`).execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITHOUT_ADD_REDUCE_SIGN)}) NOT VALID`).execute(db)
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -1257,11 +1257,11 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       }
 
       const action = req.body?.action
-      if (!['approve', 'reject', 'transfer', 'revoke', 'comment', 'return'].includes(String(action))) {
+      if (!['approve', 'reject', 'transfer', 'revoke', 'comment', 'return', 'add_sign', 'reduce_sign'].includes(String(action))) {
         return res.status(400).json({
           error: {
             code: 'VALIDATION_ERROR',
-            message: 'action must be approve, reject, transfer, revoke, comment, or return',
+            message: 'action must be approve, reject, transfer, revoke, comment, return, add_sign, or reduce_sign',
           },
         })
       }
@@ -1269,6 +1269,23 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       const comment = typeof req.body?.comment === 'string' ? req.body.comment : undefined
       const targetUserId = typeof req.body?.targetUserId === 'string' ? req.body.targetUserId.trim() : undefined
       const targetNodeKey = typeof req.body?.targetNodeKey === 'string' ? req.body.targetNodeKey.trim() : undefined
+      // P1-B add_sign: approver user IDs to pull into the current node.
+      const targetUserIds = Array.isArray(req.body?.targetUserIds)
+        ? req.body.targetUserIds
+            .filter((value: unknown): value is string => typeof value === 'string')
+            .map((value: string) => value.trim())
+            .filter(Boolean)
+        : undefined
+      // INV-9 (no silent flatten): unknown addSignMode is normalized to the
+      // explicit default 'parallel' (the service applies that default), not
+      // accepted as an arbitrary string.
+      const addSignMode = req.body?.addSignMode === 'before' || req.body?.addSignMode === 'parallel'
+        ? req.body.addSignMode
+        : undefined
+      // P1-B reduce_sign: assignee_id of the add-signed row to remove.
+      const targetAssignmentUserId = typeof req.body?.targetAssignmentUserId === 'string'
+        ? req.body.targetAssignmentUserId.trim()
+        : undefined
       const actor = {
         userId,
         userName: resolveApprovalActorName(req, userId),
@@ -1321,6 +1338,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
               comment,
               targetUserId,
               targetNodeKey,
+              targetUserIds,
+              addSignMode,
+              targetAssignmentUserId,
             },
             actor,
           )

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -714,6 +714,44 @@ export class ApprovalGraphExecutor {
     }]
   }
 
+  /**
+   * P1-B add_sign (加签) — build active co-signer rows at the actor's current
+   * approval node. The returned rows are stamped `{ addedBy, addSign: true }`
+   * (and deliberately carry NO `resolvedFrom`), so:
+   *   - 会签/all-mode completion auto-extends from the LIVE active-assignment
+   *     count (no shadow counter; see `ApprovalProductService.dispatchAction`).
+   *   - `reduce_sign` can later identify exactly these rows for removal.
+   *   - `assertNoActiveAssignmentConflicts` treats them as static (no resolver
+   *     fan-out), skipping the dynamic-conflict SELECT — correct, since
+   *     targets are explicit user IDs.
+   *
+   * The metadata shape differs from `ApprovalAssigneeResolutionMetadata`, so the
+   * return type is a LOCAL shape (not `ApprovalGraphAssignment`) passed straight
+   * to `insertAssignments` (whose `metadata?: unknown` param accepts it). This
+   * keeps `ApprovalGraphAssignment.metadata` typed as resolution-only and the
+   * `isDynamicallyResolvedAssignment` guard intact.
+   */
+  buildAddSignAssignments(
+    currentNodeKey: string,
+    targetUserIds: string[],
+    addedBy: string,
+  ): Array<{
+    assignmentType: 'user'
+    assigneeId: string
+    nodeKey: string
+    sourceStep: number
+    metadata: { addedBy: string; addSign: true }
+  }> {
+    const currentStep = this.stepIndexForNode(currentNodeKey)
+    return targetUserIds.map((assigneeId) => ({
+      assignmentType: 'user' as const,
+      assigneeId,
+      nodeKey: currentNodeKey,
+      sourceStep: currentStep,
+      metadata: { addedBy, addSign: true as const },
+    }))
+  }
+
   private resolveFromNode(
     nodeKey: string,
     context: { aggregateMode: 'single' | 'all' | 'any' | null; aggregateComplete: boolean },

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -3082,6 +3082,125 @@ export class ApprovalProductService {
         return (await this.getApproval(id))!
       }
 
+      if (request.action === 'add_sign') {
+        // P1-B 加签 — pull additional active co-signer(s) into the actor's
+        // current approval node. Completion auto-extends from the LIVE
+        // active-assignment count (no shadow counter — see all-mode branch).
+        if (!currentNodeKey) {
+          throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+        }
+        const addSignMode: 'before' | 'parallel' = request.addSignMode === 'before' ? 'before' : 'parallel'
+        const targetUserIds = (request.targetUserIds ?? [])
+          .filter((value): value is string => typeof value === 'string')
+          .map((value) => value.trim())
+          .filter(Boolean)
+        if (targetUserIds.length === 0) {
+          throw new ServiceError('targetUserIds is required for add_sign', 400, 'VALIDATION_ERROR')
+        }
+        // INV-6 (parallel-region safety): `before`-mode add_sign has no
+        // node-internal ordered queue in v1, so refuse it inside a parallel
+        // region rather than silently misrouting the new approver to the wrong
+        // branch frontier. `parallel`-mode is scoped to the actor's resolved
+        // branch node (`currentNodeKey`) and is allowed.
+        if (isInParallelRegion && addSignMode === 'before') {
+          throw new ServiceError(
+            'before-mode add_sign is not supported inside a parallel branch',
+            409,
+            'APPROVAL_ADD_SIGN_IN_PARALLEL_UNSUPPORTED',
+          )
+        }
+        await this.insertAssignments(
+          client,
+          id,
+          executor.buildAddSignAssignments(currentNodeKey, targetUserIds, actor.userId),
+        )
+        await client.query(
+          `UPDATE approval_instances SET version = $2, updated_at = now() WHERE id = $1`,
+          [id, nextVersion],
+        )
+        await this.insertApprovalRecord(client, id, {
+          action: 'add_sign',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: instance.status,
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: { nodeKey: currentNodeKey, addSignMode, addedUserIds: targetUserIds },
+          targetUserId: targetUserIds[0],
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
+      if (request.action === 'reduce_sign') {
+        // P1-B 减签 — deactivate a single previously add-signed co-signer row at
+        // the actor's current node. Removal is `is_active=FALSE` (audit
+        // preserved), and the node auto-shrinks on the next approve because
+        // completion is derived, not counted.
+        if (!currentNodeKey) {
+          throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+        }
+        const targetAssignmentUserId = request.targetAssignmentUserId?.trim()
+        if (!targetAssignmentUserId) {
+          throw new ServiceError('targetAssignmentUserId is required for reduce_sign', 400, 'VALIDATION_ERROR')
+        }
+        // INV-2: only rows stamped `metadata.addSign === true` (and of type
+        // 'user') are removable. Requester-original / template-resolved / role
+        // assignments never carry that stamp, so they can never be reduced.
+        const removable = currentNodeAssignments.find((assignment) =>
+          assignment.is_active
+          && assignment.assignment_type === 'user'
+          && assignment.assignee_id === targetAssignmentUserId
+          && isRecord(assignment.metadata)
+          && assignment.metadata.addSign === true)
+        if (!removable) {
+          throw new ServiceError(
+            'Assignment was not added by add_sign and cannot be reduced',
+            409,
+            'APPROVAL_ASSIGNMENT_NOT_ADD_SIGNED',
+          )
+        }
+        // INV-3: never strip the last active approver at the node (would orphan
+        // the node / make 会签 permanently unsatisfiable).
+        const activeUserRows = currentNodeAssignments.filter((assignment) =>
+          assignment.is_active && assignment.assignment_type === 'user')
+        if (activeUserRows.length <= 1) {
+          throw new ServiceError(
+            'Cannot reduce the last active approver at this node',
+            409,
+            'APPROVAL_REDUCE_LAST_ASSIGNEE',
+          )
+        }
+        await client.query(
+          `UPDATE approval_assignments SET is_active = FALSE, updated_at = now() WHERE id = $1`,
+          [removable.id],
+        )
+        await client.query(
+          `UPDATE approval_instances SET version = $2, updated_at = now() WHERE id = $1`,
+          [id, nextVersion],
+        )
+        await this.insertApprovalRecord(client, id, {
+          action: 'reduce_sign',
+          actorId: actor.userId,
+          actorName,
+          comment: request.comment || null,
+          fromStatus: instance.status,
+          toStatus: instance.status,
+          fromVersion: instance.version,
+          toVersion: nextVersion,
+          metadata: {
+            nodeKey: currentNodeKey,
+            removedUserId: targetAssignmentUserId,
+            removedAssignmentId: removable.id,
+          },
+          targetUserId: targetAssignmentUserId,
+        }, actor)
+        await client.query('COMMIT')
+        return (await this.getApproval(id))!
+      }
+
       if (request.action === 'revoke') {
         if (!runtimeGraph.policy.allowRevoke) {
           throw new ServiceError('Approval cannot be revoked for this template', 409, 'APPROVAL_REVOKE_DISABLED')

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -13,7 +13,15 @@ export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'reques
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
-export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
+export type ApprovalActionType =
+  | 'approve'
+  | 'reject'
+  | 'transfer'
+  | 'revoke'
+  | 'comment'
+  | 'return'
+  | 'add_sign'
+  | 'reduce_sign'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export const APPROVAL_TERMINAL_STATUSES = ['approved', 'rejected', 'revoked', 'cancelled'] as const
 export type ApprovalTerminalStatus = typeof APPROVAL_TERMINAL_STATUSES[number]
@@ -274,6 +282,22 @@ export interface ApprovalActionRequest {
   comment?: string
   targetUserId?: string
   targetNodeKey?: string
+  /**
+   * P1-B add_sign — approver user IDs to pull into the current approval node
+   * as co-signers (`assignment_type='user'`). Required (non-empty) for add_sign.
+   */
+  targetUserIds?: string[]
+  /**
+   * P1-B add_sign — `parallel` (并加签, default) adds co-signers at the current
+   * node; `before` (前加签) is rejected inside a parallel region in v1
+   * (no node-internal ordered queue yet — see design §7).
+   */
+  addSignMode?: 'before' | 'parallel'
+  /**
+   * P1-B reduce_sign — assignee_id of the previously add-signed row to remove.
+   * Only rows stamped `metadata.addSign === true` are removable.
+   */
+  targetAssignmentUserId?: string
 }
 
 export interface ApprovalTemplateListItemDTO {

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,11 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260515-pr3-admin-jump-action'
+// Bumped for P1-B 加签/减签: the action CHECK constraint now also permits
+// 'add_sign' / 'reduce_sign' (mirrors migration
+// zzzz20260616130000_add_add_reduce_sign_actions_to_approval_records.ts). The
+// version marker re-runs the DDL on an already-bootstrapped test DB.
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260616-p1b-add-reduce-sign-action'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -177,7 +181,7 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`
       ALTER TABLE approval_records
       ADD CONSTRAINT approval_records_action_check
-      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind', 'jump'))
+      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind', 'jump', 'add_sign', 'reduce_sign'))
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance ON approval_records(instance_id)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance_action_time ON approval_records(instance_id, action, occurred_at DESC)`)

--- a/packages/core-backend/tests/integration/approval-wp-add-reduce-sign.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp-add-reduce-sign.api.test.ts
@@ -4,6 +4,10 @@ import { MetaSheetServer } from '../../src/index'
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
 
+// Real-DB spec: runs only with a Postgres DATABASE_URL (DB-backed CI step in
+// plugin-tests.yml + local); excluded from the no-DB default test job, skipped here.
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
 // P1-B 加签/减签 (add_sign / reduce_sign) — real-PG integration. The
 // wire-vs-fixture invariant (MEMORY: skip-when-unreachable blind spot) requires
 // asserting `approval_assignments.is_active` flips and the live-count derived
@@ -135,7 +139,7 @@ function buildParallelGraph() {
   }
 }
 
-describe('Approval P1-B add_sign / reduce_sign API', () => {
+describeIfDatabase('Approval P1-B add_sign / reduce_sign API', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
   const createdTemplateIds = new Set<string>()
@@ -204,6 +208,10 @@ describe('Approval P1-B add_sign / reduce_sign API', () => {
       // ignore cleanup failures
     }
     if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
   // (1) 会签 add_sign extends — live-count derivation auto-extends the node.

--- a/packages/core-backend/tests/integration/approval-wp-add-reduce-sign.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp-add-reduce-sign.api.test.ts
@@ -1,0 +1,506 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+// P1-B 加签/减签 (add_sign / reduce_sign) — real-PG integration. The
+// wire-vs-fixture invariant (MEMORY: skip-when-unreachable blind spot) requires
+// asserting `approval_assignments.is_active` flips and the live-count derived
+// 会签 completion against Postgres, not against hand-built fixtures.
+
+type JsonRecord = Record<string, unknown>
+
+type AssignmentDTO = {
+  id: string
+  type: string
+  assigneeId: string
+  nodeKey?: string | null
+  isActive: boolean
+  metadata: JsonRecord
+}
+
+type ApprovalDTO = {
+  id: string
+  status: string
+  currentNodeKey: string | null
+  assignments: AssignmentDTO[]
+}
+
+type ApprovalRecordRow = {
+  action: string
+  actor_id: string | null
+  to_status: string
+  to_version: number
+  metadata: JsonRecord
+}
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+) {
+  return await fetch(`${baseUrl}${path}`, {
+    method: options.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+function buildFormSchema() {
+  return {
+    fields: [{ id: 'reason', type: 'text', label: '事由', required: true }],
+  }
+}
+
+function buildAllModeGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_all',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['manager-1', 'manager-2'], approvalMode: 'all' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-all', source: 'start', target: 'approval_all' },
+      { key: 'edge-all-end', source: 'approval_all', target: 'end' },
+    ],
+  }
+}
+
+function buildAnyModeGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'approval_any',
+        type: 'approval',
+        config: { assigneeType: 'user', assigneeIds: ['manager-1', 'manager-2'], approvalMode: 'any' },
+      },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-any', source: 'start', target: 'approval_any' },
+      { key: 'edge-any-end', source: 'approval_any', target: 'end' },
+    ],
+  }
+}
+
+function buildParallelGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      {
+        key: 'parallel_fork',
+        type: 'parallel',
+        config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'finance-review' },
+      },
+      { key: 'legal-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['legal-1'] } },
+      { key: 'compliance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['compliance-1'] } },
+      { key: 'finance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['finance-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'edge-fork-a', source: 'parallel_fork', target: 'legal-review' },
+      { key: 'edge-fork-b', source: 'parallel_fork', target: 'compliance-review' },
+      { key: 'edge-a-join', source: 'legal-review', target: 'finance-review' },
+      { key: 'edge-b-join', source: 'compliance-review', target: 'finance-review' },
+      { key: 'edge-finance-end', source: 'finance-review', target: 'end' },
+    ],
+  }
+}
+
+describe('Approval P1-B add_sign / reduce_sign API', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const createdTemplateIds = new Set<string>()
+  const createdApprovalIds = new Set<string>()
+
+  async function publishTemplate(adminToken: string, key: string, name: string, graph: unknown): Promise<string> {
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key, name, description: name, formSchema: buildFormSchema(), approvalGraph: graph },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, {
+      method: 'POST',
+      body: { policy: { allowRevoke: true } },
+    })
+    expect(publishResponse.status).toBe(200)
+    return template.id
+  }
+
+  async function startApproval(requesterToken: string, templateId: string): Promise<ApprovalDTO> {
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId, formData: { reason: 'add/reduce sign request' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const approval = await createResponse.json() as ApprovalDTO
+    createdApprovalIds.add(approval.id)
+    return approval
+  }
+
+  function activeAssignees(approval: ApprovalDTO, nodeKey: string): string[] {
+    return approval.assignments
+      .filter((a) => a.isActive && a.nodeKey === nodeKey)
+      .map((a) => a.assigneeId)
+      .sort()
+  }
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      const approvalIds = [...createdApprovalIds]
+      const templateIds = [...createdTemplateIds]
+      if (approvalIds.length > 0) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [approvalIds])
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds])
+      }
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // ignore cleanup failures
+    }
+    if (server) await server.stop()
+  })
+
+  // (1) 会签 add_sign extends — live-count derivation auto-extends the node.
+  it('会签: add_sign inserts an active co-signer and the node only completes after all three approve', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-as-all')
+    const requesterToken = await authToken(baseUrl, 'requester-as-all')
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const m2 = await authToken(baseUrl, 'manager-2')
+    const m9 = await authToken(baseUrl, 'manager-9')
+    const templateId = await publishTemplate(adminToken, `as-all-${Date.now()}`, 'AddSign All', buildAllModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+    expect(approval.currentNodeKey).toBe('approval_all')
+    const pool = poolManager.get()
+    const startVersion = (await pool.query<{ version: number }>(
+      `SELECT version FROM approval_instances WHERE id = $1`, [approval.id])).rows[0]!.version
+
+    // manager-1 加签 manager-9 (parallel).
+    const addResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST',
+      body: { action: 'add_sign', targetUserIds: ['manager-9'], addSignMode: 'parallel', comment: '需要补充审批' },
+    })
+    expect(addResponse.status).toBe(200)
+    const afterAdd = await addResponse.json() as ApprovalDTO
+    expect(activeAssignees(afterAdd, 'approval_all')).toEqual(['manager-1', 'manager-2', 'manager-9'])
+    // INV-5: version bumped on add_sign (unlike transfer). Asserted against PG
+    // (the DTO does not surface `version`).
+    const addedVersion = (await pool.query<{ version: number }>(
+      `SELECT version FROM approval_instances WHERE id = $1`, [approval.id])).rows[0]!.version
+    expect(addedVersion).toBeGreaterThan(startVersion)
+
+    // The new row is stamped addSign:true.
+    const addedRow = afterAdd.assignments.find((a) => a.assigneeId === 'manager-9' && a.isActive)
+    expect(addedRow?.metadata.addSign).toBe(true)
+    expect(addedRow?.metadata.addedBy).toBe('manager-1')
+
+    // First two original assignees approve → still pending (3rd outstanding).
+    for (const token of [m1, m2]) {
+      const r = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, token, {
+        method: 'POST',
+        body: { action: 'approve' },
+      })
+      expect(r.status).toBe(200)
+    }
+    const midState = await (await jsonRequest(baseUrl, `/api/approvals/${approval.id}`, requesterToken)).json() as ApprovalDTO
+    expect(midState.status).toBe('pending')
+    expect(midState.currentNodeKey).toBe('approval_all')
+    expect(activeAssignees(midState, 'approval_all')).toEqual(['manager-9'])
+
+    // The add-signed approver completes the node.
+    const finalResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m9, {
+      method: 'POST',
+      body: { action: 'approve' },
+    })
+    expect(finalResponse.status).toBe(200)
+    const finalState = await finalResponse.json() as ApprovalDTO
+    expect(finalState.status).toBe('approved')
+    expect(finalState.currentNodeKey).toBeNull()
+
+    // Assert the is_active flips against PG directly (wire-vs-fixture).
+    const pgRows = await pool.query<{ assignee_id: string; is_active: boolean }>(
+      `SELECT assignee_id, is_active FROM approval_assignments WHERE instance_id = $1 ORDER BY assignee_id`,
+      [approval.id],
+    )
+    expect(pgRows.rows.every((r) => r.is_active === false)).toBe(true)
+
+    // Audit: exactly one add_sign record with precise metadata.
+    const addRecords = await pool.query<ApprovalRecordRow>(
+      `SELECT action, actor_id, to_status, to_version, metadata FROM approval_records WHERE instance_id = $1 AND action = 'add_sign'`,
+      [approval.id],
+    )
+    expect(addRecords.rows).toHaveLength(1)
+    expect(addRecords.rows[0]?.metadata).toMatchObject({
+      nodeKey: 'approval_all',
+      addSignMode: 'parallel',
+      addedUserIds: ['manager-9'],
+    })
+  })
+
+  // (2) 或签 add_sign — any-of-now-3 can win.
+  it('或签: an add-signed approver can win the node first-wins', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-as-any')
+    const requesterToken = await authToken(baseUrl, 'requester-as-any')
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const m9 = await authToken(baseUrl, 'manager-9')
+    const templateId = await publishTemplate(adminToken, `as-any-${Date.now()}`, 'AddSign Any', buildAnyModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+    expect(approval.currentNodeKey).toBe('approval_any')
+
+    const addResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST',
+      body: { action: 'add_sign', targetUserIds: ['manager-9'] },
+    })
+    expect(addResponse.status).toBe(200)
+    const afterAdd = await addResponse.json() as ApprovalDTO
+    expect(activeAssignees(afterAdd, 'approval_any')).toEqual(['manager-1', 'manager-2', 'manager-9'])
+
+    // The add-signed approver wins immediately (或签 first-wins).
+    const winResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m9, {
+      method: 'POST',
+      body: { action: 'approve' },
+    })
+    expect(winResponse.status).toBe(200)
+    const won = await winResponse.json() as ApprovalDTO
+    expect(won.status).toBe('approved')
+    expect(won.assignments.filter((a) => a.isActive)).toHaveLength(0)
+  })
+
+  // (3) reduce_sign happy path + (4) non-add-signed 409 + (5) last-assignee 409.
+  it('减签: removes only an add-signed row, refuses requester-original and last-assignee', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-rs')
+    const requesterToken = await authToken(baseUrl, 'requester-rs')
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const m2 = await authToken(baseUrl, 'manager-2')
+    const templateId = await publishTemplate(adminToken, `rs-${Date.now()}`, 'ReduceSign', buildAllModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+
+    // add_sign manager-9.
+    const addResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST',
+      body: { action: 'add_sign', targetUserIds: ['manager-9'] },
+    })
+    expect(addResponse.status).toBe(200)
+
+    // (4) reduce a requester-original assignee → 409 NOT_ADD_SIGNED.
+    const reduceOriginal = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST',
+      body: { action: 'reduce_sign', targetAssignmentUserId: 'manager-2' },
+    })
+    expect(reduceOriginal.status).toBe(409)
+    expect((await reduceOriginal.json() as { error: { code: string } }).error.code).toBe('APPROVAL_ASSIGNMENT_NOT_ADD_SIGNED')
+
+    // (3) reduce the add-signed manager-9 → is_active flips FALSE.
+    const reduceAdded = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST',
+      body: { action: 'reduce_sign', targetAssignmentUserId: 'manager-9' },
+    })
+    expect(reduceAdded.status).toBe(200)
+    const afterReduce = await reduceAdded.json() as ApprovalDTO
+    expect(activeAssignees(afterReduce, 'approval_all')).toEqual(['manager-1', 'manager-2'])
+
+    const pool = poolManager.get()
+    const m9Row = await pool.query<{ is_active: boolean }>(
+      `SELECT is_active FROM approval_assignments WHERE instance_id = $1 AND assignee_id = 'manager-9'`,
+      [approval.id],
+    )
+    expect(m9Row.rows.every((r) => r.is_active === false)).toBe(true)
+
+    // reduce_sign audit row present with exact metadata.
+    const reduceRecords = await pool.query<ApprovalRecordRow>(
+      `SELECT action, metadata FROM approval_records WHERE instance_id = $1 AND action = 'reduce_sign'`,
+      [approval.id],
+    )
+    expect(reduceRecords.rows).toHaveLength(1)
+    expect(reduceRecords.rows[0]?.metadata).toMatchObject({ nodeKey: 'approval_all', removedUserId: 'manager-9' })
+
+    // Node still completes from the two remaining (live count shrank).
+    expect((await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, { method: 'POST', body: { action: 'approve' } })).status).toBe(200)
+    const last = await (await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m2, { method: 'POST', body: { action: 'approve' } })).json() as ApprovalDTO
+    expect(last.status).toBe('approved')
+  })
+
+  // (5) reduce the LAST add-signed approver when it is the only active row → 409.
+  it('减签: refuses removing the last active approver at a node', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-rs-last')
+    const requesterToken = await authToken(baseUrl, 'requester-rs-last')
+    // Single-assignee node — manager-1 add_signs manager-9, then approves itself
+    // away, leaving manager-9 as the only active row. Reducing it must 409.
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_all', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'], approvalMode: 'all' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-all', source: 'start', target: 'approval_all' },
+        { key: 'edge-all-end', source: 'approval_all', target: 'end' },
+      ],
+    }
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const m9 = await authToken(baseUrl, 'manager-9')
+    const templateId = await publishTemplate(adminToken, `rs-last-${Date.now()}`, 'ReduceLast', graph)
+    const approval = await startApproval(requesterToken, templateId)
+
+    expect((await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: ['manager-9'] },
+    })).status).toBe(200)
+    // manager-1 approves → only manager-9 (add-signed) remains active.
+    expect((await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'approve' },
+    })).status).toBe(200)
+
+    const reduceLast = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m9, {
+      method: 'POST', body: { action: 'reduce_sign', targetAssignmentUserId: 'manager-9' },
+    })
+    expect(reduceLast.status).toBe(409)
+    expect((await reduceLast.json() as { error: { code: string } }).error.code).toBe('APPROVAL_REDUCE_LAST_ASSIGNEE')
+  })
+
+  // (6) non-assignee add_sign → 403 (actorCanAct gate).
+  it('non-assignee add_sign is rejected with 403', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-403')
+    const requesterToken = await authToken(baseUrl, 'requester-403')
+    const stranger = await authToken(baseUrl, 'stranger-1')
+    const templateId = await publishTemplate(adminToken, `as-403-${Date.now()}`, 'AddSign403', buildAllModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+    const r = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, stranger, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: ['manager-9'] },
+    })
+    expect(r.status).toBe(403)
+    expect((await r.json() as { error: { code: string } }).error.code).toBe('APPROVAL_ASSIGNMENT_REQUIRED')
+  })
+
+  // (7) parallel region: before-mode 409, parallel-mode scoped to the branch.
+  it('parallel region: before-mode add_sign is 409, parallel-mode is scoped to the branch node', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-par')
+    const requesterToken = await authToken(baseUrl, 'requester-par')
+    const legal = await authToken(baseUrl, 'legal-1')
+    const templateId = await publishTemplate(adminToken, `as-par-${Date.now()}`, 'AddSignParallel', buildParallelGraph())
+    const approval = await startApproval(requesterToken, templateId)
+
+    // before-mode inside a parallel region → 409.
+    const before = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, legal, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: ['legal-9'], addSignMode: 'before' },
+    })
+    expect(before.status).toBe(409)
+    expect((await before.json() as { error: { code: string } }).error.code).toBe('APPROVAL_ADD_SIGN_IN_PARALLEL_UNSUPPORTED')
+
+    // parallel-mode is allowed and scoped to the actor's branch node.
+    const parallel = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, legal, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: ['legal-9'], addSignMode: 'parallel' },
+    })
+    expect(parallel.status).toBe(200)
+    const after = await parallel.json() as ApprovalDTO
+    const added = after.assignments.find((a) => a.assigneeId === 'legal-9' && a.isActive)
+    expect(added?.nodeKey).toBe('legal-review')
+    expect(added?.metadata.addSign).toBe(true)
+  })
+
+  // (8) empty targetUserIds → 400; (route) unknown action → 400.
+  it('validation: empty targetUserIds is 400 and an unknown action is 400 at the route', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-val')
+    const requesterToken = await authToken(baseUrl, 'requester-val')
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const templateId = await publishTemplate(adminToken, `as-val-${Date.now()}`, 'AddSignVal', buildAllModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+
+    const empty = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: [] },
+    })
+    expect(empty.status).toBe(400)
+    expect((await empty.json() as { error: { code: string } }).error.code).toBe('VALIDATION_ERROR')
+
+    const unknown = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'frobnicate' },
+    })
+    expect(unknown.status).toBe(400)
+  })
+
+  // (9) version monotonic + history DTO carries the rows.
+  it('audit: add_sign and reduce_sign bump version monotonically and appear in history', async () => {
+    const adminToken = await authToken(baseUrl, 'admin-hist')
+    const requesterToken = await authToken(baseUrl, 'requester-hist')
+    const m1 = await authToken(baseUrl, 'manager-1')
+    const templateId = await publishTemplate(adminToken, `as-hist-${Date.now()}`, 'AddSignHist', buildAllModeGraph())
+    const approval = await startApproval(requesterToken, templateId)
+
+    const pool = poolManager.get()
+    const readVersion = async (): Promise<number> => (await pool.query<{ version: number }>(
+      `SELECT version FROM approval_instances WHERE id = $1`, [approval.id])).rows[0]!.version
+
+    const v0 = await readVersion()
+    expect((await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'add_sign', targetUserIds: ['manager-9'] },
+    })).status).toBe(200)
+    const v1 = await readVersion()
+    expect((await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, m1, {
+      method: 'POST', body: { action: 'reduce_sign', targetAssignmentUserId: 'manager-9' },
+    })).status).toBe(200)
+    const v2 = await readVersion()
+    // INV-5: monotonic version bump on both actions (asserted against PG).
+    expect(v1).toBeGreaterThan(v0)
+    expect(v2).toBeGreaterThan(v1)
+
+    const records = await pool.query<ApprovalRecordRow>(
+      `SELECT action, to_version FROM approval_records WHERE instance_id = $1 AND action IN ('add_sign','reduce_sign') ORDER BY to_version ASC`,
+      [approval.id],
+    )
+    expect(records.rows.map((r) => r.action)).toEqual(['add_sign', 'reduce_sign'])
+    expect(records.rows[0]!.to_version).toBe(v1)
+    expect(records.rows[1]!.to_version).toBe(v2)
+
+    // History DTO surfaces the rows (route returns { ok, data: { items } }).
+    const historyResponse = await jsonRequest(baseUrl, `/api/approvals/${approval.id}/history`, requesterToken)
+    expect(historyResponse.status).toBe(200)
+    const history = await historyResponse.json() as { data: { items: Array<{ action: string }> } }
+    const actions = history.data.items.map((h) => h.action)
+    expect(actions).toContain('add_sign')
+    expect(actions).toContain('reduce_sign')
+  })
+})

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -44,11 +44,13 @@ describe('approval admin jump migration and bootstrap sync', () => {
     expect(roleDeleteIndex).toBeLessThan(permissionDeleteIndex)
   })
 
-  it('T-bootstrap keeps approval_schema_bootstrap action check aligned with jump', async () => {
+  it('T-bootstrap keeps approval_schema_bootstrap action check aligned with add_sign/reduce_sign (P1-B)', async () => {
     const source = await fs.readFile(BOOTSTRAP_PATH, 'utf8')
 
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260515-pr3-admin-jump-action'")
-    expect(source).toContain("'remind', 'jump'")
+    // Lane D (P1-B 加签/减签) bumped the bootstrap: the action CHECK now also
+    // permits add_sign/reduce_sign, mirroring migration zzzz20260616130000.
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260616-p1b-add-reduce-sign-action'")
+    expect(source).toContain("'remind', 'jump', 'add_sign', 'reduce_sign'")
   })
 
   it('does not mutate immutable historical approval action migrations', async () => {

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -876,4 +876,66 @@ describe('validateApprovalFormData', () => {
       'requestedAt must be on or after 2026-04-10',
     ])
   })
+
+  // P1-B 加签 — buildAddSignAssignments returns one active user row per target
+  // id at the current node, stamped {addedBy, addSign:true} and deliberately
+  // carrying NO resolvedFrom (so it reads as a static, non-resolver assignment).
+  it('buildAddSignAssignments stamps add-signed co-signers at the current node', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'approval_2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-1-2', source: 'approval_1', target: 'approval_2' },
+        { key: 'edge-2-end', source: 'approval_2', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    const rows = executor.buildAddSignAssignments('approval_2', ['user-9', 'user-10'], 'user-2')
+
+    // approval_2 is the 2nd approval node → stepIndexForNode = index(1) + 1 = 2.
+    expect(rows).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'user-9',
+        nodeKey: 'approval_2',
+        sourceStep: 2,
+        metadata: { addedBy: 'user-2', addSign: true },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'user-10',
+        nodeKey: 'approval_2',
+        sourceStep: 2,
+        metadata: { addedBy: 'user-2', addSign: true },
+      },
+    ])
+    // No resolvedFrom — the dynamic-resolution discriminator stays absent.
+    for (const row of rows) {
+      expect('resolvedFrom' in row.metadata).toBe(false)
+    }
+  })
+
+  it('buildAddSignAssignments returns an empty array for no targets', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-1-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {})
+    expect(executor.buildAddSignAssignments('approval_1', [], 'user-1')).toEqual([])
+  })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'tests/integration/after-sales-registry-backfill.test.ts',
       'tests/integration/approval-directory-endpoints.api.test.ts',
       'tests/integration/approval-p1c-field-permissions.api.test.ts',
+      'tests/integration/approval-wp-add-reduce-sign.api.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
POST-GATE approval **Lane D** (P1-B 加签/减签) — second baton of the hot-file serial chain, rebased after Lane B landed.

## Change
- Types (FE/BE same commit, `vue-tsc -b` parity gate): `ApprovalActionType` += `add_sign`/`reduce_sign`; `ApprovalActionRequest` += `targetUserIds?`, `addSignMode?: 'before'|'parallel'` (default parallel), `targetAssignmentUserId?`.
- Runtime: `dispatchAction` add/reduce branches (mirroring `transfer`, before the status guard); new `executor.buildAddSignAssignments` stamps inserted rows `{addedBy, addSign:true}`. Route allowlist extended.
- Migration: `add_sign`/`reduce_sign` added to the `approval_records_action_check` CHECK constraint (up + down).

## Invariants (the load-bearing ones)
- **No shadow counter** — 会签/all-mode completion derives from the **live active-assignment count**, so add INSERTs auto-extend the node and reduce flips `is_active=FALSE` to auto-shrink.
- **reduce_sign removes ONLY `metadata.addSign === true` rows** (never requester-original/template-resolved/role rows) and **refuses to remove the last active approver** (409).
- Both ride the existing `actorCanAct` 403 gate (NOT admin-jump). before-mode add inside a parallel region is **refused** (409), not silently misrouted. Empty/unknown inputs → 400.

## Gates
- backend `tsc` 0; **convergence guard #2742 = 24/24** (no cross-runtime writes, no BPMN import — pure approval-owned writes); FE `vue-tsc -b` 0.
- **Real-PG integration 9/9**: 会签 extend (`is_active` asserted) / 或签 add-signed win / reduce happy+flip / reduce-non-add-signed → 409 / reduce-last → 409 / non-assignee → 403 / parallel before-mode → 409 / empty/unknown → 400 / version monotonic + history round-trip. **FE e2e 47/47**. CI-lane: `describeIfDatabase` + sentinel + excluded + Postgres step.

## Governance
POST-GATE: P0-A/C (PASS) + lane GO. Hot-file chain (after Lane B); **Lane G (`ApprovalRequesterSnapshot`) rebases after this**. The CHECK-constraint migration goes through migration-replay + the staging-drift gate. No cross-runtime writes; no BPMN. W7 stays locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)