### PR TITLE
feat(multitable): form.submitted automation trigger

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -235,6 +235,7 @@ jobs:
             tests/integration/multitable-automation-jobs.test.ts \
             tests/integration/multitable-automation-suspend-resume.test.ts \
             tests/integration/multitable-automation-start-approval.test.ts \
+            tests/integration/multitable-form-submit-trigger.test.ts \
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -26,6 +26,7 @@
           <select v-model="draft.triggerType" class="meta-automation__select" data-automation-field="triggerType">
             <option value="record.created">{{ automationTriggerTypeLabel('record.created', isZh) }}</option>
             <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
+            <option value="form.submitted">{{ automationTriggerTypeLabel('form.submitted', isZh) }}</option>
             <option value="field.changed">{{ automationTriggerTypeLabel('field.changed', isZh) }}</option>
           </select>
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -917,6 +917,7 @@ export type AutomationTriggerType =
   | 'schedule.cron'
   | 'schedule.interval'
   | 'webhook.received'
+  | 'form.submitted'
   // Legacy aliases
   | 'field.changed'
 

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -880,6 +880,8 @@ export function automationTriggerTypeLabel(type: AutomationTriggerType | Unknown
       return isZh ? '定时计划（间隔）' : 'Schedule (interval)'
     case 'webhook.received':
       return isZh ? '收到 Webhook 时' : 'Webhook received'
+    case 'form.submitted':
+      return isZh ? '当表单提交时' : 'When form submitted'
     case 'field.changed':
       return isZh ? '当字段变化时' : 'When field changed'
     default:

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -82,6 +82,8 @@ describe('meta-automation-labels', () => {
   it('localizes trigger types, trigger conditions, and cron presets with raw fallbacks', () => {
     expect(automationTriggerTypeLabel('record.created', false)).toBe('When record created')
     expect(automationTriggerTypeLabel('record.created', true)).toBe('当记录创建时')
+    expect(automationTriggerTypeLabel('form.submitted', false)).toBe('When form submitted')
+    expect(automationTriggerTypeLabel('form.submitted', true)).toBe('当表单提交时')
     expect(automationTriggerTypeLabel('field.changed', true)).toBe('当字段变化时')
     expect(automationTriggerTypeLabel('future.trigger', true)).toBe('future.trigger')
 

--- a/packages/core-backend/src/db/migrations/zzzz20260617130000_add_form_submitted_trigger_type.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260617130000_add_form_submitted_trigger_type.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration: #22 form.submitted automation trigger — widen the trigger_type CHECK constraint.
+ *
+ * The `form.submitted` trigger was added to the application's VALID_TRIGGER_TYPES (automation-service +
+ * automation-triggers), but the DB CHECK constraint `chk_automation_trigger_type` on `automation_rules`
+ * predates it — so persisting a rule with trigger_type='form.submitted' was rejected by Postgres (23514).
+ * This adds 'form.submitted' to the allowed set, preserving every existing value. (Caught by the real-DB
+ * form-submit-trigger integration test — the unit tests don't hit the constraint.)
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval',
+      'webhook.received', 'form.submitted'
+    ))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_trigger_type`.execute(db)
+  await sql`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_trigger_type
+    CHECK (trigger_type IN (
+      'record.created', 'record.updated', 'record.deleted',
+      'field.changed', 'field.value_changed',
+      'schedule.cron', 'schedule.interval',
+      'webhook.received'
+    ))
+  `.execute(db)
+}

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -55,6 +55,7 @@ const VALID_TRIGGER_TYPES = new Set([
   'schedule.cron',
   'schedule.interval',
   'webhook.received',
+  'form.submitted',
 ])
 
 const LEGACY_ACTION_TYPES = [
@@ -617,6 +618,7 @@ export class AutomationService {
       'multitable.record.created',
       'multitable.record.updated',
       'multitable.record.deleted',
+      'multitable.form.submitted',
     ]
 
     for (const eventType of events) {

--- a/packages/core-backend/src/multitable/automation-triggers.ts
+++ b/packages/core-backend/src/multitable/automation-triggers.ts
@@ -11,6 +11,7 @@ export type AutomationTriggerType =
   | 'schedule.cron'
   | 'schedule.interval'
   | 'webhook.received'
+  | 'form.submitted'
 
 export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'record.created',
@@ -20,6 +21,7 @@ export const ALL_TRIGGER_TYPES: AutomationTriggerType[] = [
   'schedule.cron',
   'schedule.interval',
   'webhook.received',
+  'form.submitted',
 ]
 
 /** Config shape for field.value_changed */
@@ -58,6 +60,7 @@ export const TRIGGER_TYPE_BY_EVENT: Record<string, AutomationTriggerType> = {
   'multitable.record.created': 'record.created',
   'multitable.record.updated': 'record.updated',
   'multitable.record.deleted': 'record.deleted',
+  'multitable.form.submitted': 'form.submitted',
 }
 
 /**

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -9727,6 +9727,20 @@ export function univerMetaRouter(): Router {
         }],
       })
 
+      // #22 form.submitted automation trigger: a public/shared form submission emits this distinct,
+      // targetable event so automations can fire on form submits specifically. (Note: this raw-INSERT
+      // form-submit path does NOT emit multitable.record.created — form submits historically fired no
+      // automation event at all; this only adds the form.submitted event, leaving record.* behavior
+      // unchanged.) Payload is sheetId/recordId only (matchesTrigger + handleEvent key off those, and
+      // actions re-read the record) — no raw record.data egress. `mode` distinguishes a new submission
+      // ('create') from a form-link edit ('update').
+      eventBus.emit('multitable.form.submitted', {
+        sheetId: view.sheetId,
+        recordId: record.id,
+        actorId: getRequestActorId(req),
+        mode: recordId ? 'update' : 'create',
+      })
+
       return res.json({
         ok: true,
         data: {

--- a/packages/core-backend/tests/integration/multitable-form-submit-trigger.test.ts
+++ b/packages/core-backend/tests/integration/multitable-form-submit-trigger.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Real-event-chain integration test for the `form.submitted` automation trigger (#22).
+ *
+ * THE GAP this closes: the trigger is unit-covered (matchesTrigger, the event→type
+ * mapping, the subscription count) but no test proves the REAL endpoint→fire chain.
+ * This drives it end to end on real Postgres:
+ *
+ *   POST /views/:viewId/submit  (real route, real pool)
+ *     →  eventBus.emit('multitable.form.submitted')  (integration bus)
+ *       →  AutomationService subscription  →  matchesTrigger('form.submitted')
+ *         →  executeRule  →  durable row in multitable_automation_executions.
+ *
+ * The AutomationService is wired onto the SAME integration bus the submit route emits
+ * on (mirrors the webhook-event-bridge test). A NEGATIVE control proves the trigger is
+ * DISTINCT: a plain POST /records (which fires record.created, NOT form.submitted)
+ * produces no execution for the form.submitted rule.
+ *
+ * Runs only with DATABASE_URL (plugin-tests.yml multitable real-DB job).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { db } from '../../src/db/db'
+import { eventBus as integrationEventBus } from '../../src/integration/events/event-bus'
+import { AutomationService } from '../../src/multitable/automation-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_fst_${TS}`
+const SHEET_ID = `sheet_fst_${TS}`
+const VIEW_ID = `view_fst_${TS}`
+const FLD_VALUE = `fld_fst_value_${TS}`
+const USER_ID = `u_fst_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+// Real query fn for the executor's raw-SQL actions (not a mock — executeRule must run).
+const queryFn = ((sql: string, params?: unknown[]) => poolManager.get().query(sql, params)) as never
+
+let app: Express
+let svc: AutomationService
+let ruleId = ''
+
+async function executionsFor(rid: string): Promise<Array<Record<string, unknown>>> {
+  const r = await q('SELECT id, status FROM multitable_automation_executions WHERE rule_id = $1', [rid])
+  return r.rows as Array<Record<string, unknown>>
+}
+
+async function waitForExecution(rid: string, timeoutMs = 5000): Promise<Array<Record<string, unknown>>> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const rows = await executionsFor(rid)
+    if (rows.length > 0) return rows
+    if (Date.now() > deadline) return rows
+    await new Promise((r) => setTimeout(r, 50))
+  }
+}
+
+describeIfDatabase('form.submitted automation trigger real chain (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as unknown as { user: unknown }).user = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Form Trigger Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Form Trigger Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUE, SHEET_ID, 'Value', 'number', '{}', 1])
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb)', [VIEW_ID, SHEET_ID, 'Form', 'form', JSON.stringify({})])
+
+    // AutomationService wired onto the SAME integration bus the submit route emits on.
+    svc = new AutomationService(integrationEventBus, db as never, queryFn)
+    svc.init()
+    // Enabled rule whose ONLY trigger is form.submitted. The action lands an execution row
+    // regardless of action outcome (the log-service persists every run), so a fired rule is
+    // observable even if update_record no-ops.
+    const rule = await svc.createRule(SHEET_ID, {
+      name: 'on form submit',
+      triggerType: 'form.submitted',
+      triggerConfig: {},
+      actionType: 'update_record',
+      actionConfig: { fields: { [FLD_VALUE]: 99 } },
+    } as never)
+    ruleId = (rule as { id: string }).id
+  })
+
+  afterAll(async () => {
+    try { svc?.shutdown() } catch { /* noop */ }
+    await q('DELETE FROM multitable_automation_executions WHERE rule_id = $1', [ruleId]).catch(() => {})
+    await q('DELETE FROM automation_rules WHERE id = $1', [ruleId]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE id = $1', [VIEW_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('a real form submit emits form.submitted → AutomationService → durable execution row (keystone)', async () => {
+    const res = await request(app)
+      .post(`/api/multitable/views/${VIEW_ID}/submit`)
+      .send({ data: { [FLD_VALUE]: 5 } })
+    expect(res.status).toBe(200)
+
+    // The subscription fires synchronously on emit, but executeRule is async; poll the durable row.
+    const rows = await waitForExecution(ruleId)
+    expect(rows.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('negative: a plain record create (record.created, NOT form.submitted) does not fire the form.submitted rule', async () => {
+    const before = (await executionsFor(ruleId)).length
+    const res = await request(app)
+      .post('/api/multitable/records')
+      .send({ sheetId: SHEET_ID, data: { [FLD_VALUE]: 7 } })
+    expect(res.status).toBe(200)
+    // Give any (wrongly-wired) async fire a chance, then assert no new execution for the form rule.
+    await new Promise((r) => setTimeout(r, 300))
+    const after = (await executionsFor(ruleId)).length
+    expect(after).toBe(before)
+  })
+})

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { evaluateCondition, evaluateConditions, type AutomationCondition, type ConditionGroup } from '../../src/multitable/automation-conditions'
 import { AutomationExecutor, type AutomationRule, type AutomationDeps, type AutomationExecution } from '../../src/multitable/automation-executor'
 import { AutomationScheduler, parseCronToIntervalMs } from '../../src/multitable/automation-scheduler'
-import { matchesTrigger } from '../../src/multitable/automation-triggers'
+import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, ALL_TRIGGER_TYPES } from '../../src/multitable/automation-triggers'
 import type { AutomationTrigger, AutomationTriggerType } from '../../src/multitable/automation-triggers'
 import { EventBus } from '../../src/integration/events/event-bus'
 import { ALL_ACTION_TYPES, type AutomationAction } from '../../src/multitable/automation-actions'
@@ -277,6 +277,17 @@ describe('Trigger Matching', () => {
   it('matches record.deleted trigger', () => {
     const trigger: AutomationTrigger = { type: 'record.deleted', config: {} }
     expect(matchesTrigger(trigger, 'record.deleted', {})).toBe(true)
+  })
+
+  it('matches form.submitted trigger, and does not fire on record.created', () => {
+    const trigger: AutomationTrigger = { type: 'form.submitted', config: {} }
+    expect(matchesTrigger(trigger, 'form.submitted', {})).toBe(true)
+    expect(matchesTrigger(trigger, 'record.created', {})).toBe(false)
+  })
+
+  it('maps the multitable.form.submitted event to the form.submitted trigger', () => {
+    expect(TRIGGER_TYPE_BY_EVENT['multitable.form.submitted']).toBe('form.submitted')
+    expect(ALL_TRIGGER_TYPES).toContain('form.submitted')
   })
 
   it('field.value_changed fires only on record.updated', () => {

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -327,7 +327,7 @@ describe('AutomationService', () => {
       const unsubscribeSpy = vi.spyOn(bus, 'unsubscribe')
 
       service.init()
-      expect(subscribeSpy).toHaveBeenCalledTimes(7)
+      expect(subscribeSpy).toHaveBeenCalledTimes(8)
       expect(subscribeSpy).toHaveBeenCalledWith(
         'multitable.record.created',
         expect.any(Function),
@@ -338,6 +338,10 @@ describe('AutomationService', () => {
       )
       expect(subscribeSpy).toHaveBeenCalledWith(
         'multitable.record.deleted',
+        expect.any(Function),
+      )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'multitable.form.submitted',
         expect.any(Function),
       )
       expect(subscribeSpy).toHaveBeenCalledWith(
@@ -358,7 +362,7 @@ describe('AutomationService', () => {
       )
 
       service.shutdown()
-      expect(unsubscribeSpy).toHaveBeenCalledTimes(7)
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(8)
     })
   })
 })


### PR DESCRIPTION
Adds a `form.submitted` automation trigger so automations can fire specifically on public/shared form submissions (Feishu 多维表格 parity). The form-submit path historically emitted **no** automation event; this adds `multitable.form.submitted` (→ trigger type `form.submitted`) at the form-submit success, leaving `record.*` behavior unchanged (a form submit's raw INSERT never fired record.created either).

**BE:** trigger-type union + ALL_TRIGGER_TYPES + TRIGGER_TYPE_BY_EVENT + VALID_TRIGGER_TYPES + init subscription; emit `{sheetId, recordId, actorId, mode}` (no raw record.data — egress guard enforced). **FE:** trigger-type union, label (When form submitted / 当表单提交时), automation trigger dropdown. **Tests:** unit (matchesTrigger + mapping + subscription count) + **real-DB endpoint→fire integration** (POST form-submit → execution row via the real emit→subscription→executeRule chain; negative control: plain record create does NOT fire it), modeled on the proven webhook-event-bridge harness.

Verified: full unit suite 4416/0, tsc + vue-tsc clean, integration in plugin-tests allowlist (CI test 20.x = first real-DB run). Two structural guards (raw-data egress + subscription-count) fired during dev + were resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)