### PR TITLE
feat(multitable): kanban swimlanes (optional row×column grouping)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -24,6 +24,11 @@ on:
       - 'apps/web/src/multitable/components/TrashModal.vue'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
       - 'apps/web/tests/multitable-trash-fe.spec.ts'
+      - 'apps/web/src/multitable/components/MetaKanbanView.vue'
+      - 'apps/web/src/multitable/components/MetaViewManager.vue'
+      - 'apps/web/src/multitable/utils/view-config.ts'
+      - 'apps/web/src/multitable/utils/meta-view-render-labels.ts'
+      - 'apps/web/tests/multitable-kanban-view.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -36,6 +41,11 @@ on:
       - 'apps/web/src/multitable/components/TrashModal.vue'
       - 'apps/web/tests/multitable-rollup-aggregation-fe.spec.ts'
       - 'apps/web/tests/multitable-trash-fe.spec.ts'
+      - 'apps/web/src/multitable/components/MetaKanbanView.vue'
+      - 'apps/web/src/multitable/components/MetaViewManager.vue'
+      - 'apps/web/src/multitable/utils/view-config.ts'
+      - 'apps/web/src/multitable/utils/meta-view-render-labels.ts'
+      - 'apps/web/tests/multitable-kanban-view.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -78,4 +88,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view --reporter=dot

--- a/apps/web/src/multitable/components/MetaKanbanView.vue
+++ b/apps/web/src/multitable/components/MetaKanbanView.vue
@@ -20,6 +20,13 @@
             <option v-for="field in selectFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
+        <label v-if="swimlaneFieldCandidates.length" class="meta-kanban__header-field">
+          <span>{{ viewRenderLabel('kanban.swimlane', isZh) }}</span>
+          <select class="meta-kanban__field-select" :value="kanbanDraft.swimlaneFieldId ?? ''" @change="onPickSwimlaneField($event)">
+            <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
+            <option v-for="field in swimlaneFieldCandidates" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
         <span class="meta-kanban__group-label">{{ viewRenderLabel('kanban.groupedBy', isZh) }} <strong>{{ groupField.name }}</strong></span>
         <details class="meta-kanban__field-picker">
           <summary>{{ cardFieldsSummary(previewFields.length, isZh) }}</summary>
@@ -38,123 +45,82 @@
         <button class="meta-kanban__change-btn" @click="onClearGroupField">{{ viewRenderLabel('kanban.clear', isZh) }}</button>
       </div>
 
-      <div class="meta-kanban__board">
-        <div class="meta-kanban__column">
-          <div class="meta-kanban__column-header meta-kanban__column-header--uncategorized">
-            <span>{{ viewRenderLabel('kanban.uncategorized', isZh) }}</span>
-            <span class="meta-kanban__count">{{ uncategorized.length }}</span>
+      <div class="meta-kanban__board" :class="{ 'meta-kanban__board--swimlaned': !!swimlaneField }">
+        <div v-for="lane in swimlaneRows" :key="lane.key ?? '__lane__'" class="meta-kanban__swimlane">
+          <div v-if="lane.label !== null" class="meta-kanban__swimlane-header" :style="lane.color ? { borderLeftColor: lane.color } : {}">
+            <span class="meta-kanban__swimlane-label">{{ lane.label }}</span>
+            <span class="meta-kanban__count">{{ lane.count }}</span>
           </div>
-          <div class="meta-kanban__cards" :class="{ 'meta-kanban__cards--drag-over': dragOverColumn === '__uncategorized__' }" @dragover.prevent="dragOverColumn = '__uncategorized__'" @dragleave="dragOverColumn = null" @drop="dragOverColumn = null; onDrop(null, $event)">
-            <div
-              v-for="row in uncategorized"
-              :key="row.id"
-              class="meta-kanban__card"
-              role="article"
-              tabindex="0"
-              :aria-label="cardTitle(row)"
-              draggable="true"
-              @dragstart="onDragStart(row, $event)"
-              @click="emit('select-record', row.id)"
-              @keydown="onCardKeydown($event, row.id)"
-            >
-              <div class="meta-kanban__card-header">
-                <div class="meta-kanban__card-title">{{ cardTitle(row) }}</div>
-                <button
-                  v-if="canComment"
-                  class="meta-kanban__comment-btn"
-                  :class="rowCommentButtonClass(row.id)"
-                  type="button"
-                  :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
-                  @click.stop="emit('open-comments', row.id)"
-                  @keydown="onRowCommentKeydown($event, row.id)"
-                >
-                  <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
-                </button>
+          <div class="meta-kanban__swimlane-columns">
+            <div v-for="col in lane.columns" :key="dropKey(lane.key, col.value)" class="meta-kanban__column">
+              <div
+                class="meta-kanban__column-header"
+                :class="{ 'meta-kanban__column-header--uncategorized': col.isUncategorized }"
+                :style="!col.isUncategorized ? { borderTopColor: col.color ?? '#409eff' } : {}"
+              >
+                <span>{{ col.label }}</span>
+                <span class="meta-kanban__count">{{ col.rows.length }}</span>
               </div>
-              <div class="meta-kanban__card-fields">
-                <div v-for="f in previewFields" :key="f.id" class="meta-kanban__card-field">
-                  <span class="meta-kanban__card-field-copy">
-                    <span class="meta-kanban__card-field-label">{{ f.name }}:</span>
-                    {{ formatValue(row, f) }}
-                  </span>
-                  <button
-                    v-if="canComment"
-                    type="button"
-                    class="meta-kanban__field-comment-btn"
-                    :class="fieldCommentButtonClass(row.id, f.id)"
-                    :aria-label="openFieldCommentsForRecordAria(f.name, cardTitle(row), isZh)"
-                    @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: f.id })"
-                    @keydown="onFieldCommentKeydown($event, row.id, f.id)"
-                  >
-                    <MetaCommentAffordance :state="fieldCommentAffordance(row.id, f.id)" />
-                  </button>
+              <div
+                class="meta-kanban__cards"
+                :class="{ 'meta-kanban__cards--drag-over': dragOverColumn === dropKey(lane.key, col.value) }"
+                @dragover.prevent="dragOverColumn = dropKey(lane.key, col.value)"
+                @dragleave="dragOverColumn = null"
+                @drop="dragOverColumn = null; onDrop(col.value, $event)"
+              >
+                <div
+                  v-for="row in col.rows"
+                  :key="row.id"
+                  class="meta-kanban__card"
+                  role="article"
+                  tabindex="0"
+                  :aria-label="cardTitle(row)"
+                  draggable="true"
+                  @dragstart="onDragStart(row, $event)"
+                  @click="emit('select-record', row.id)"
+                  @keydown="onCardKeydown($event, row.id)"
+                >
+                  <div class="meta-kanban__card-header">
+                    <div class="meta-kanban__card-title">{{ cardTitle(row) }}</div>
+                    <button
+                      v-if="canComment"
+                      class="meta-kanban__comment-btn"
+                      :class="rowCommentButtonClass(row.id)"
+                      type="button"
+                      :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
+                      @click.stop="emit('open-comments', row.id)"
+                      @keydown="onRowCommentKeydown($event, row.id)"
+                    >
+                      <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
+                    </button>
+                  </div>
+                  <div class="meta-kanban__card-fields">
+                    <div v-for="f in previewFields" :key="f.id" class="meta-kanban__card-field">
+                      <span class="meta-kanban__card-field-copy">
+                        <span class="meta-kanban__card-field-label">{{ f.name }}:</span>
+                        {{ formatValue(row, f) }}
+                      </span>
+                      <button
+                        v-if="canComment"
+                        type="button"
+                        class="meta-kanban__field-comment-btn"
+                        :class="fieldCommentButtonClass(row.id, f.id)"
+                        :aria-label="openFieldCommentsForRecordAria(f.name, cardTitle(row), isZh)"
+                        @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: f.id })"
+                        @keydown="onFieldCommentKeydown($event, row.id, f.id)"
+                      >
+                        <MetaCommentAffordance :state="fieldCommentAffordance(row.id, f.id)" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div v-if="!col.rows.length" class="meta-kanban__drop-hint">
+                  {{ canEdit ? (col.isUncategorized ? viewRenderLabel('kanban.dropOrAdd', isZh) : viewRenderLabel('kanban.dropToUpdate', isZh)) : viewRenderLabel('kanban.noCards', isZh) }}
                 </div>
               </div>
-            </div>
-            <div v-if="!uncategorized.length" class="meta-kanban__drop-hint">
-              {{ canEdit ? viewRenderLabel('kanban.dropOrAdd', isZh) : viewRenderLabel('kanban.noCards', isZh) }}
+              <button v-if="canCreate" class="meta-kanban__add-btn" @click="onCreateInCell(lane.key, col.value)">{{ viewRenderLabel('common.add', isZh) }}</button>
             </div>
           </div>
-          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', {})">{{ viewRenderLabel('common.add', isZh) }}</button>
-        </div>
-
-        <div v-for="opt in groupOptions" :key="opt.value" class="meta-kanban__column">
-          <div class="meta-kanban__column-header" :style="{ borderTopColor: opt.color ?? '#409eff' }">
-            <span>{{ opt.value }}</span>
-            <span class="meta-kanban__count">{{ columnRows(opt.value).length }}</span>
-          </div>
-          <div class="meta-kanban__cards" :class="{ 'meta-kanban__cards--drag-over': dragOverColumn === opt.value }" @dragover.prevent="dragOverColumn = opt.value" @dragleave="dragOverColumn = null" @drop="dragOverColumn = null; onDrop(opt.value, $event)">
-            <div
-              v-for="row in columnRows(opt.value)"
-              :key="row.id"
-              class="meta-kanban__card"
-              role="article"
-              tabindex="0"
-              :aria-label="cardTitle(row)"
-              draggable="true"
-              @dragstart="onDragStart(row, $event)"
-              @click="emit('select-record', row.id)"
-              @keydown="onCardKeydown($event, row.id)"
-            >
-              <div class="meta-kanban__card-header">
-                <div class="meta-kanban__card-title">{{ cardTitle(row) }}</div>
-                <button
-                  v-if="canComment"
-                  class="meta-kanban__comment-btn"
-                  :class="rowCommentButtonClass(row.id)"
-                  type="button"
-                  :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
-                  @click.stop="emit('open-comments', row.id)"
-                  @keydown="onRowCommentKeydown($event, row.id)"
-                >
-                  <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
-                </button>
-              </div>
-              <div class="meta-kanban__card-fields">
-                <div v-for="f in previewFields" :key="f.id" class="meta-kanban__card-field">
-                  <span class="meta-kanban__card-field-copy">
-                    <span class="meta-kanban__card-field-label">{{ f.name }}:</span>
-                    {{ formatValue(row, f) }}
-                  </span>
-                  <button
-                    v-if="canComment"
-                    type="button"
-                    class="meta-kanban__field-comment-btn"
-                    :class="fieldCommentButtonClass(row.id, f.id)"
-                    :aria-label="openFieldCommentsForRecordAria(f.name, cardTitle(row), isZh)"
-                    @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: f.id })"
-                    @keydown="onFieldCommentKeydown($event, row.id, f.id)"
-                  >
-                    <MetaCommentAffordance :state="fieldCommentAffordance(row.id, f.id)" />
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div v-if="!columnRows(opt.value).length" class="meta-kanban__drop-hint">
-              {{ canEdit ? viewRenderLabel('kanban.dropToUpdate', isZh) : viewRenderLabel('kanban.noCards', isZh) }}
-            </div>
-          </div>
-          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', { [groupField!.id]: opt.value })">{{ viewRenderLabel('common.add', isZh) }}</button>
         </div>
       </div>
     </template>
@@ -212,6 +178,7 @@ const emit = defineEmits<{
 const pendingConfigKey = ref<string | null>(null)
 const kanbanDraft = reactive<Required<MetaKanbanViewConfig>>({
   groupFieldId: null,
+  swimlaneFieldId: null,
   cardFieldIds: [],
 })
 let dragRecordId: string | null = null
@@ -225,8 +192,12 @@ const kanbanConfig = computed<Required<MetaKanbanViewConfig>>(() =>
 )
 
 function normalizeKanbanConfig(config?: Partial<Required<MetaKanbanViewConfig>>) {
+  const groupFieldId = config?.groupFieldId ?? null
+  // A field can't be both axes: drop the swimlane if it equals the column group field.
+  const rawSwimlane = config?.swimlaneFieldId ?? null
   return {
-    groupFieldId: config?.groupFieldId ?? null,
+    groupFieldId,
+    swimlaneFieldId: rawSwimlane && rawSwimlane !== groupFieldId ? rawSwimlane : null,
     cardFieldIds: [...(config?.cardFieldIds ?? [])],
   }
 }
@@ -238,6 +209,7 @@ watch(
     const configKey = JSON.stringify(normalized)
     if (pendingConfigKey.value && pendingConfigKey.value !== configKey) return
     kanbanDraft.groupFieldId = normalized.groupFieldId
+    kanbanDraft.swimlaneFieldId = normalized.swimlaneFieldId
     kanbanDraft.cardFieldIds = normalized.cardFieldIds
     if (pendingConfigKey.value === configKey) pendingConfigKey.value = null
   },
@@ -252,6 +224,18 @@ const groupField = computed(() =>
 
 const groupOptions = computed<Array<{ value: string; color?: string }>>(() =>
   groupField.value?.options ?? [],
+)
+
+// Swimlanes (optional row dimension). Unset → single implicit headerless lane = legacy 1D board.
+const swimlaneField = computed(() =>
+  kanbanDraft.swimlaneFieldId ? props.fields.find((f) => f.id === kanbanDraft.swimlaneFieldId) ?? null : null,
+)
+const swimlaneOptions = computed<Array<{ value: string; color?: string }>>(() =>
+  swimlaneField.value?.options ?? [],
+)
+// Candidates for the swimlane picker: select fields except the column group field (no field on both axes).
+const swimlaneFieldCandidates = computed(() =>
+  selectFields.value.filter((f) => f.id !== kanbanDraft.groupFieldId),
 )
 
 const titleField = computed(() =>
@@ -271,18 +255,65 @@ const previewFieldCandidates = computed(() =>
   props.fields.filter((field) => field.id !== kanbanDraft.groupFieldId && field.id !== titleField.value?.id),
 )
 
-const uncategorized = computed(() => {
+type KanbanColumn = { value: string | null; label: string; color?: string; isUncategorized: boolean; rows: MetaRecord[] }
+type KanbanSwimlane = { key: string | null; label: string | null; color?: string; count: number; columns: KanbanColumn[] }
+
+// Bucket a row set into [uncategorized, ...one per group option]. Shared by 1D + every swimlane row.
+function bucketColumns(rows: MetaRecord[]): KanbanColumn[] {
   if (!groupField.value) return []
+  const gid = groupField.value.id
   const optValues = new Set(groupOptions.value.map((o) => o.value))
-  return props.rows.filter((r) => {
-    const v = r.data[groupField.value!.id]
-    return !v || !optValues.has(String(v))
+  const uncategorized: KanbanColumn = {
+    value: null,
+    label: viewRenderLabel('kanban.uncategorized', isZh.value),
+    isUncategorized: true,
+    rows: rows.filter((r) => { const v = r.data[gid]; return !v || !optValues.has(String(v)) }),
+  }
+  const columns = groupOptions.value.map((opt): KanbanColumn => ({
+    value: opt.value,
+    label: opt.value,
+    color: opt.color,
+    isUncategorized: false,
+    rows: rows.filter((r) => String(r.data[gid] ?? '') === opt.value),
+  }))
+  return [uncategorized, ...columns]
+}
+
+// Unified board model: 1D = one headerless lane over all rows; 2D = one lane per swimlane option (+ an
+// uncategorized lane when needed), each lane bucketed into columns. Card template renders once over this.
+const swimlaneRows = computed<KanbanSwimlane[]>(() => {
+  if (!groupField.value) return []
+  if (!swimlaneField.value) {
+    return [{ key: null, label: null, count: props.rows.length, columns: bucketColumns(props.rows) }]
+  }
+  const sid = swimlaneField.value.id
+  const laneValues = new Set(swimlaneOptions.value.map((o) => o.value))
+  const lanes: KanbanSwimlane[] = swimlaneOptions.value.map((opt): KanbanSwimlane => {
+    const laneRows = props.rows.filter((r) => String(r.data[sid] ?? '') === opt.value)
+    return { key: opt.value, label: opt.value, color: opt.color, count: laneRows.length, columns: bucketColumns(laneRows) }
   })
+  const uncatLaneRows = props.rows.filter((r) => { const v = r.data[sid]; return !v || !laneValues.has(String(v)) })
+  if (uncatLaneRows.length) {
+    lanes.push({ key: null, label: viewRenderLabel('kanban.uncategorized', isZh.value), count: uncatLaneRows.length, columns: bucketColumns(uncatLaneRows) })
+  }
+  return lanes
 })
 
-function columnRows(optionValue: string): MetaRecord[] {
-  if (!groupField.value) return []
-  return props.rows.filter((r) => String(r.data[groupField.value!.id] ?? '') === optionValue)
+// Per-cell drag-over key (swimlane × column) so highlighting is scoped to one cell, not a whole column.
+function dropKey(laneKey: string | null, columnValue: string | null): string {
+  return (laneKey ?? '__lane__') + '::' + (columnValue ?? '__uncat__')
+}
+
+// Create in a cell: prefill the column (status) field AND, in swimlane mode, the swimlane field.
+function onCreateInCell(laneKey: string | null, columnValue: string | null) {
+  const data: Record<string, unknown> = {}
+  if (groupField.value && columnValue !== null) data[groupField.value.id] = columnValue
+  if (swimlaneField.value && laneKey !== null) data[swimlaneField.value.id] = laneKey
+  emit('create-record', data)
+}
+
+function onPickSwimlaneField(e: Event) {
+  emitConfigUpdate({ swimlaneFieldId: (e.target as HTMLSelectElement).value || null })
 }
 
 function cardTitle(row: MetaRecord): string {
@@ -338,14 +369,23 @@ function onClearGroupField() {
 function emitConfigUpdate(next: Partial<Required<MetaKanbanViewConfig>>) {
   const normalized = normalizeKanbanConfig({
     groupFieldId: kanbanDraft.groupFieldId,
+    swimlaneFieldId: kanbanDraft.swimlaneFieldId,
     cardFieldIds: kanbanDraft.cardFieldIds,
     ...next,
   })
   kanbanDraft.groupFieldId = normalized.groupFieldId
+  kanbanDraft.swimlaneFieldId = normalized.swimlaneFieldId
   kanbanDraft.cardFieldIds = normalized.cardFieldIds
   pendingConfigKey.value = JSON.stringify(normalized)
+  // Byte-identical wire for legacy (no-swimlane) configs: only persist the swimlane key when it's set, so
+  // existing kanban views serialize exactly as before and don't churn.
+  const config: Record<string, unknown> = {
+    groupFieldId: normalized.groupFieldId,
+    cardFieldIds: normalized.cardFieldIds,
+  }
+  if (normalized.swimlaneFieldId) config.swimlaneFieldId = normalized.swimlaneFieldId
   emit('update-view-config', {
-    config: normalized,
+    config,
     groupInfo: normalized.groupFieldId ? { fieldId: normalized.groupFieldId } : {},
   })
 }
@@ -373,9 +413,9 @@ function onDrop(targetValue: string | null, _e: DragEvent) {
 const focusedCardId = ref<string | null>(null)
 
 function allCards(): string[] {
-  const ids: string[] = uncategorized.value.map((r) => r.id)
-  for (const opt of groupOptions.value) {
-    ids.push(...columnRows(opt.value).map((r) => r.id))
+  const ids: string[] = []
+  for (const lane of swimlaneRows.value) {
+    for (const col of lane.columns) ids.push(...col.rows.map((r) => r.id))
   }
   return ids
 }
@@ -422,7 +462,15 @@ function onCardKeydown(e: KeyboardEvent, cardId: string) {
 .meta-kanban__field-picker summary::-webkit-details-marker { display: none; }
 .meta-kanban__field-picker-list { display: flex; flex-wrap: wrap; gap: 8px 12px; margin-top: 8px; padding: 10px 12px; border: 1px solid #d8e1ee; border-radius: 8px; background: #fff; box-shadow: 0 8px 20px rgba(15,23,42,.08); max-width: 360px; }
 .meta-kanban__field-picker-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #475569; }
-.meta-kanban__board { display: flex; flex: 1; overflow-x: auto; padding: 12px 8px; gap: 12px; }
+.meta-kanban__board { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow-y: auto; padding: 12px 8px; gap: 14px; }
+/* 1D (no swimlane): single lane fills height so columns scroll internally — identical to the legacy board. */
+.meta-kanban__board:not(.meta-kanban__board--swimlaned) .meta-kanban__swimlane { flex: 1; }
+.meta-kanban__swimlane { display: flex; flex-direction: column; gap: 6px; min-height: 0; }
+.meta-kanban__swimlane-header { display: flex; align-items: center; gap: 8px; padding: 5px 12px; font-size: 13px; font-weight: 600; color: #334155; background: #eef2f7; border-left: 3px solid #409eff; border-radius: 4px; position: sticky; left: 0; }
+.meta-kanban__swimlane-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The horizontal column strip (the legacy board's role). 2D caps each lane's height so the board scrolls vertically. */
+.meta-kanban__swimlane-columns { display: flex; flex: 1; min-height: 0; gap: 12px; overflow-x: auto; align-items: flex-start; padding-bottom: 4px; }
+.meta-kanban__board--swimlaned .meta-kanban__swimlane-columns { max-height: 440px; align-items: stretch; }
 .meta-kanban__column { min-width: 240px; width: 280px; flex-shrink: 0; background: #f5f7fa; border-radius: 8px; display: flex; flex-direction: column; max-height: 100%; }
 .meta-kanban__column-header { padding: 10px 12px; font-size: 13px; font-weight: 600; color: #333; display: flex; justify-content: space-between; align-items: center; border-top: 3px solid #409eff; border-radius: 8px 8px 0 0; }
 .meta-kanban__column-header--uncategorized { border-top-color: #999; color: #999; }

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -556,6 +556,7 @@ const calendarDraft = reactive<Required<MetaCalendarViewConfig>>({
 })
 const kanbanDraft = reactive<Required<MetaKanbanViewConfig>>({
   groupFieldId: null,
+  swimlaneFieldId: null,
   cardFieldIds: [],
 })
 const timelineDraft = reactive<Required<MetaTimelineViewConfig>>({
@@ -747,6 +748,7 @@ function resetConfigDrafts() {
   } satisfies Required<MetaCalendarViewConfig>)
   Object.assign(kanbanDraft, {
     groupFieldId: null,
+    swimlaneFieldId: null,
     cardFieldIds: [],
   } satisfies Required<MetaKanbanViewConfig>)
   Object.assign(timelineDraft, {
@@ -944,11 +946,16 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
     })
   }
   if (type === 'kanban') {
-    return JSON.stringify({
+    const kanbanConfig: Record<string, unknown> = {
       groupFieldId: kanbanDraft.groupFieldId,
       cardFieldIds: [...kanbanDraft.cardFieldIds],
       ...serializeCommonViewDraft(type),
-    })
+    }
+    // Preserve the swimlane (row) dimension set on the board — the manager has no swimlane picker, so
+    // omitting it would silently strip a configured swimlane when other kanban settings are saved. Only
+    // when set, for byte-identical wire on legacy no-swimlane views.
+    if (kanbanDraft.swimlaneFieldId) kanbanConfig.swimlaneFieldId = kanbanDraft.swimlaneFieldId
+    return JSON.stringify(kanbanConfig)
   }
   if (type === 'hierarchy') {
     return JSON.stringify({

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -861,6 +861,8 @@ export interface MetaCalendarViewConfig {
 
 export interface MetaKanbanViewConfig {
   groupFieldId?: string | null
+  // Optional second (row) grouping dimension — swimlanes. Unset → single-dimension board (legacy).
+  swimlaneFieldId?: string | null
   cardFieldIds?: string[]
 }
 

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -73,6 +73,7 @@ export type MetaViewRenderLabelKey =
   | 'kanban.noSelectFields'
   | 'kanban.groupedBy'
   | 'kanban.cardFields'
+  | 'kanban.swimlane'
   | 'kanban.clear'
   | 'kanban.uncategorized'
   | 'kanban.dropOrAdd'
@@ -217,6 +218,7 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'kanban.noSelectFields',
   'kanban.groupedBy',
   'kanban.cardFields',
+  'kanban.swimlane',
   'kanban.clear',
   'kanban.uncategorized',
   'kanban.dropOrAdd',
@@ -365,6 +367,7 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'kanban.noSelectFields': { en: 'No select-type fields found. Add a select field first.', zh: '未找到单选字段。请先添加一个单选字段。' },
   'kanban.groupedBy': { en: 'Grouped by:', zh: '分组依据：' },
   'kanban.cardFields': { en: 'Card fields', zh: '卡片字段' },
+  'kanban.swimlane': { en: 'Swimlane', zh: '泳道' },
   'kanban.clear': { en: 'Clear', zh: '清除' },
   'kanban.uncategorized': { en: 'Uncategorized', zh: '未分类' },
   'kanban.dropOrAdd': { en: 'Drop a card here or add a new record', zh: '将卡片拖到此处，或添加新记录' },

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -118,8 +118,17 @@ export function resolveKanbanViewConfig(
     .map((field) => field.id)
   const hasConfiguredCardFieldIds = hasOwnKey(raw, 'cardFieldIds')
   const configuredFieldIds = stringArray(raw?.cardFieldIds).filter((fieldId) => fields.some((field) => field.id === fieldId))
+  // Swimlane (row dimension) is opt-in: default null, no auto-pick. Must be a real field, must NOT be the
+  // column group field (a field can't be both axes), and is dropped if its field no longer exists.
+  const rawSwimlaneFieldId = stringOrNull(raw?.swimlaneFieldId)
+  const swimlaneFieldId = rawSwimlaneFieldId
+    && rawSwimlaneFieldId !== groupFieldId
+    && fields.some((field) => field.id === rawSwimlaneFieldId)
+    ? rawSwimlaneFieldId
+    : null
   return {
     groupFieldId,
+    swimlaneFieldId,
     cardFieldIds: hasConfiguredCardFieldIds ? configuredFieldIds : fallbackCardFieldIds,
   }
 }

--- a/apps/web/tests/multitable-kanban-view.spec.ts
+++ b/apps/web/tests/multitable-kanban-view.spec.ts
@@ -180,4 +180,70 @@ describe('MetaKanbanView', () => {
 
     app.unmount()
   })
+
+  const swimlaneFields = [
+    { id: 'fld_title', name: 'Title', type: 'string' },
+    { id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'Todo', color: '#aaa' }, { value: 'Doing', color: '#409eff' }] },
+    { id: 'fld_priority', name: 'Priority', type: 'select', options: [{ value: 'P1', color: '#f56c6c' }, { value: 'P2', color: '#67c23a' }] },
+  ]
+  const swimlaneRows = [
+    { id: 'rec_1', version: 1, data: { fld_title: 'A', fld_status: 'Doing', fld_priority: 'P1' } },
+    { id: 'rec_2', version: 1, data: { fld_title: 'B', fld_status: 'Todo', fld_priority: 'P2' } },
+  ]
+
+  function mountKanban(props: Record<string, unknown>) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({ render() { return h(MetaKanbanView, props) } })
+    app.mount(container)
+    return { container, app }
+  }
+
+  it('backward-compat: no swimlaneFieldId renders a single-dimension board (no swimlane headers)', async () => {
+    const { container, app } = mountKanban({
+      rows: swimlaneRows, fields: swimlaneFields, loading: false,
+      viewConfig: { groupFieldId: 'fld_status', cardFieldIds: [] },
+    })
+    await nextTick()
+    expect(container.querySelector('.meta-kanban__board--swimlaned')).toBeNull()
+    expect(container.querySelectorAll('.meta-kanban__swimlane-header')).toHaveLength(0)
+    // one implicit lane → one strip of columns (uncategorized + Todo + Doing)
+    expect(container.querySelectorAll('.meta-kanban__swimlane')).toHaveLength(1)
+    expect(container.querySelectorAll('.meta-kanban__column')).toHaveLength(3)
+    app.unmount(); container.remove()
+  })
+
+  it('swimlane mode renders a row per swimlane option, each with the column layout', async () => {
+    const { container, app } = mountKanban({
+      rows: swimlaneRows, fields: swimlaneFields, loading: false,
+      viewConfig: { groupFieldId: 'fld_status', swimlaneFieldId: 'fld_priority', cardFieldIds: [] },
+    })
+    await nextTick()
+    expect(container.querySelector('.meta-kanban__board--swimlaned')).not.toBeNull()
+    const headers = Array.from(container.querySelectorAll('.meta-kanban__swimlane-label')).map((el) => el.textContent)
+    expect(headers).toEqual(['P1', 'P2'])
+    // 2 swimlanes × 3 columns (uncategorized + Todo + Doing) each
+    expect(container.querySelectorAll('.meta-kanban__swimlane')).toHaveLength(2)
+    expect(container.querySelectorAll('.meta-kanban__column')).toHaveLength(6)
+    expect(container.textContent).toContain('A')
+    expect(container.textContent).toContain('B')
+    app.unmount(); container.remove()
+  })
+
+  it('create-in-cell prefills BOTH the column field and the swimlane field', async () => {
+    const createSpy = vi.fn()
+    const { container, app } = mountKanban({
+      rows: swimlaneRows, fields: swimlaneFields, loading: false, canCreate: true,
+      viewConfig: { groupFieldId: 'fld_status', swimlaneFieldId: 'fld_priority', cardFieldIds: [] },
+      onCreateRecord: createSpy,
+    })
+    await nextTick()
+    // swimlane[0] = P1; its columns = [uncategorized, Todo, Doing]; the last add button = the Doing cell.
+    const lane0 = container.querySelectorAll('.meta-kanban__swimlane')[0]
+    const addButtons = lane0.querySelectorAll('.meta-kanban__add-btn')
+    ;(addButtons[addButtons.length - 1] as HTMLButtonElement).click()
+    await nextTick()
+    expect(createSpy).toHaveBeenCalledWith({ fld_status: 'Doing', fld_priority: 'P1' })
+    app.unmount(); container.remove()
+  })
 })

--- a/apps/web/tests/multitable-kanban-view.spec.ts
+++ b/apps/web/tests/multitable-kanban-view.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaKanbanView from '../src/multitable/components/MetaKanbanView.vue'
 import { useLocale } from '../src/composables/useLocale'
+import { resolveKanbanViewConfig } from '../src/multitable/utils/view-config'
 
 describe('MetaKanbanView', () => {
   afterEach(() => {
@@ -245,5 +246,29 @@ describe('MetaKanbanView', () => {
     await nextTick()
     expect(createSpy).toHaveBeenCalledWith({ fld_status: 'Doing', fld_priority: 'P1' })
     app.unmount(); container.remove()
+  })
+})
+
+// Wire-drift regression lock: swimlaneFieldId is added to the kanban view config and serialized
+// field-by-field in MetaViewManager (which has no swimlane picker). resolveKanbanViewConfig is the
+// load/resolve half of that round-trip; lock its preserve + drop rules so a refactor can't silently
+// strip a board-set swimlane or admit an invalid one.
+describe('resolveKanbanViewConfig — swimlaneFieldId resolve/drop', () => {
+  const fields = [
+    { id: 'fld_status', name: 'Status', type: 'select' },
+    { id: 'fld_priority', name: 'Priority', type: 'select' },
+  ] as any
+
+  it('preserves a valid swimlaneFieldId distinct from the column group field', () => {
+    expect(resolveKanbanViewConfig(fields, { groupFieldId: 'fld_status', swimlaneFieldId: 'fld_priority' }).swimlaneFieldId).toBe('fld_priority')
+  })
+  it('drops swimlaneFieldId equal to the group field (a field cannot be on both axes)', () => {
+    expect(resolveKanbanViewConfig(fields, { groupFieldId: 'fld_status', swimlaneFieldId: 'fld_status' }).swimlaneFieldId).toBeNull()
+  })
+  it('drops swimlaneFieldId whose field no longer exists', () => {
+    expect(resolveKanbanViewConfig(fields, { groupFieldId: 'fld_status', swimlaneFieldId: 'fld_gone' }).swimlaneFieldId).toBeNull()
+  })
+  it('is null when unset (legacy single-dimension board)', () => {
+    expect(resolveKanbanViewConfig(fields, { groupFieldId: 'fld_status' }).swimlaneFieldId).toBeNull()
   })
 })


### PR DESCRIPTION
Adds an optional second (row/swimlane) grouping dimension to the kanban board (Feishu 多维表格 parity). `swimlaneFieldId` unset → byte-identical legacy single-dimension board; set → swimlane rows × status columns, cards bucketed by both, create-in-cell prefills both fields.

**FE-only** (kanban grouping is client-side; view config is opaque — no BE/contract change). Back-compat: the key is persisted only when set; MetaViewManager (which has no swimlane picker) **preserves** a board-set swimlaneFieldId on save (load resolves via resolveKanbanViewConfig at :1004, serialize at :957) — and a unit test locks that resolve/drop round-trip (valid kept / ==group dropped / missing dropped / unset null). Drag stays column-only (cross-swimlane via editor — documented v1 limit).

Verified: vue-tsc clean, kanban specs **10/10** (legacy back-compat unchanged + swimlane render + create-prefills-both + resolver round-trip); spec added to the multitable-web-guard lane filter (it was excluded). 3 pre-existing unrelated workbench-view failures fail identically on base — not from this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)