### PR TITLE
feat(approval): Lane G — read-only directory→approval org-relation plumbing (P1-A prereq)

### DIFF
--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -1,0 +1,227 @@
+/**
+ * Approval ↔ Directory org-relation plumbing (READ-ONLY).
+ *
+ * Lane G (P1-A) prerequisite slice. The directory-sync subsystem already stores
+ * the full provider payload for every synced account/department in the `raw`
+ * JSONB column (`directory_accounts.raw`, `directory_departments.raw`), but the
+ * org-hierarchy signals inside it — the requester's direct manager and their
+ * department head — are NOT extracted into queryable columns. This module is the
+ * single read-only seam that lifts those two relations out of `raw` and maps
+ * them back to LOCAL user ids, so the approval bake step
+ * (`ApprovalProductService.createApproval`) can freeze `managerId` / `deptHeadId`
+ * into the requester snapshot.
+ *
+ * BOUNDARY / DOCTRINE (#2738/#2740, CI-enforced by #2742):
+ *   - This module ONLY issues SELECTs against `directory_*` + `directory_account_links`.
+ *     It writes nothing, and it touches no `approval_*` / `automation_*` table —
+ *     so it is outside the convergence guard's write-boundary entirely and never
+ *     crosses an automation boundary.
+ *   - It is NOT a resolver kind. The new `direct_manager` / `dept_head` /
+ *     `continuous_managers` assignee-source kinds (and their runtime in
+ *     `ApprovalAssigneeResolver`) are DESIGN-ONLY for this slice and are NOT wired
+ *     here. This module's sole job is to populate the snapshot fields those future
+ *     kinds will read.
+ *
+ * Provider shape (DingTalk, the only synced provider today):
+ *   - `directory_accounts.raw.leader_in_dept`: `Array<{ dept_id, leader: boolean }>`
+ *     — the account's manager flag *per department*. The manager USER is not on
+ *     this row; DingTalk models "leader of dept D" as a flag on the leader's own
+ *     account. So the direct manager of user U is the account in U's primary
+ *     department whose `leader_in_dept` marks it leader for that department.
+ *   - `directory_departments.raw.dept_manager_userid_list`: `string[]` of the
+ *     department's manager external user ids (dept head).
+ *
+ * Both lookups resolve a directory account → LOCAL user id via
+ * `directory_account_links` (link_status = 'linked'), mirroring the join already
+ * used by `AttendanceNotificationDeliveryWorker.resolveRecipient`. When a relation
+ * is absent (no manager, top-of-tree, unlinked, or pre-extraction legacy rows),
+ * the field is simply omitted — never throws — so the empty-assignee policy
+ * downstream stays in control.
+ */
+
+type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
+
+export interface ApprovalRequesterOrgRelations {
+  /** Local user id of the requester's direct manager, if resolvable. */
+  managerId?: string
+  /** Local user id of the head of the requester's primary department, if resolvable. */
+  deptHeadId?: string
+}
+
+interface LeaderInDeptEntry {
+  dept_id?: unknown
+  deptId?: unknown
+  leader?: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function normalizeExternalId(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return null
+}
+
+function parseLeaderDeptIds(raw: Record<string, unknown> | null): string[] {
+  if (!raw) return []
+  const entries = raw.leader_in_dept ?? raw.leaderInDept
+  if (!Array.isArray(entries)) return []
+  const deptIds: string[] = []
+  for (const entry of entries as LeaderInDeptEntry[]) {
+    if (entry?.leader !== true) continue
+    const deptId = normalizeExternalId(entry.dept_id ?? entry.deptId)
+    if (deptId) deptIds.push(deptId)
+  }
+  return deptIds
+}
+
+function parseDeptManagerExternalIds(raw: Record<string, unknown> | null): string[] {
+  if (!raw) return []
+  const list = raw.dept_manager_userid_list ?? raw.deptManagerUseridList
+  if (!Array.isArray(list)) return []
+  const ids: string[] = []
+  for (const item of list) {
+    const id = normalizeExternalId(item)
+    if (id) ids.push(id)
+  }
+  return ids
+}
+
+interface RequesterDirectoryRow {
+  integration_id: string
+  account_id: string
+  external_user_id: string
+  raw: unknown
+  primary_external_department_id: string | null
+  primary_department_raw: unknown
+}
+
+/**
+ * Read-only resolution of the requester's direct manager + department head as
+ * LOCAL user ids. Returns `{}` when the requester has no linked directory account
+ * (e.g. a purely-local user) so callers can bake an unchanged snapshot.
+ *
+ * `query` is injected (defaults to the shared pool) so the unit path can drive it
+ * against an in-memory fixture without a database.
+ */
+export async function resolveApprovalRequesterOrgRelations(
+  localUserId: string,
+  query: QueryFn,
+): Promise<ApprovalRequesterOrgRelations> {
+  const userId = localUserId.trim()
+  if (!userId) return {}
+
+  // 1) Requester's linked directory account + its primary department's raw.
+  const requesterRows = await query<RequesterDirectoryRow>(
+    `SELECT a.integration_id::text       AS integration_id,
+            a.id::text                   AS account_id,
+            a.external_user_id           AS external_user_id,
+            a.raw                        AS raw,
+            d.external_department_id     AS primary_external_department_id,
+            d.raw                        AS primary_department_raw
+       FROM directory_account_links l
+       JOIN directory_accounts a
+         ON a.id = l.directory_account_id
+        AND a.is_active = true
+       LEFT JOIN directory_account_departments ad
+         ON ad.directory_account_id = a.id
+        AND ad.is_primary = true
+       LEFT JOIN directory_departments d
+         ON d.id = ad.directory_department_id
+      WHERE l.local_user_id = $1
+        AND l.link_status = 'linked'
+      ORDER BY a.updated_at DESC, a.id ASC
+      LIMIT 1`,
+    [userId],
+  )
+  const requester = requesterRows.rows[0]
+  if (!requester) return {}
+
+  const integrationId = requester.integration_id
+  const requesterDeptId = normalizeExternalId(requester.primary_external_department_id)
+
+  // 2) Direct manager: the account flagged leader for the requester's primary
+  //    department in its own `leader_in_dept`. Exclude the requester themselves.
+  let managerId: string | undefined
+  if (requesterDeptId) {
+    const candidateRows = await query<{ account_id: string; raw: unknown }>(
+      `SELECT a.id::text AS account_id, a.raw AS raw
+         FROM directory_accounts a
+         JOIN directory_account_departments ad
+           ON ad.directory_account_id = a.id
+         JOIN directory_departments d
+           ON d.id = ad.directory_department_id
+        WHERE a.integration_id = $1::uuid
+          AND a.is_active = true
+          AND d.external_department_id = $2
+          AND a.external_user_id <> $3`,
+      [integrationId, requesterDeptId, requester.external_user_id],
+    )
+    const managerAccountId = candidateRows.rows.find((row) =>
+      parseLeaderDeptIds(asRecord(row.raw)).includes(requesterDeptId))?.account_id
+    if (managerAccountId) {
+      managerId = await resolveLinkedLocalUserId(managerAccountId, query)
+    }
+  }
+
+  // 3) Department head: first manager external id on the primary department's raw
+  //    that resolves to a linked local user (and is not the requester).
+  let deptHeadId: string | undefined
+  const deptManagerExternalIds = parseDeptManagerExternalIds(asRecord(requester.primary_department_raw))
+    .filter((external) => external !== requester.external_user_id)
+  for (const external of deptManagerExternalIds) {
+    const localId = await resolveLinkedLocalUserIdByExternal(integrationId, external, query)
+    if (localId) {
+      deptHeadId = localId
+      break
+    }
+  }
+
+  const relations: ApprovalRequesterOrgRelations = {}
+  if (managerId) relations.managerId = managerId
+  if (deptHeadId) relations.deptHeadId = deptHeadId
+  return relations
+}
+
+async function resolveLinkedLocalUserId(accountId: string, query: QueryFn): Promise<string | undefined> {
+  const rows = await query<{ local_user_id: string | null }>(
+    `SELECT local_user_id
+       FROM directory_account_links
+      WHERE directory_account_id = $1::uuid
+        AND link_status = 'linked'
+        AND local_user_id IS NOT NULL
+      LIMIT 1`,
+    [accountId],
+  )
+  const localId = rows.rows[0]?.local_user_id
+  return localId ? localId : undefined
+}
+
+async function resolveLinkedLocalUserIdByExternal(
+  integrationId: string,
+  externalUserId: string,
+  query: QueryFn,
+): Promise<string | undefined> {
+  const rows = await query<{ local_user_id: string | null }>(
+    `SELECT l.local_user_id AS local_user_id
+       FROM directory_accounts a
+       JOIN directory_account_links l
+         ON l.directory_account_id = a.id
+        AND l.link_status = 'linked'
+        AND l.local_user_id IS NOT NULL
+      WHERE a.integration_id = $1::uuid
+        AND a.external_user_id = $2
+        AND a.is_active = true
+      LIMIT 1`,
+    [integrationId, externalUserId],
+  )
+  const localId = rows.rows[0]?.local_user_id
+  return localId ? localId : undefined
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -14,6 +14,7 @@ import type {
   ApprovalTemplateVersionDetailDTO,
   ApprovalGraph,
   ApprovalMode,
+  ApprovalRequesterSnapshot,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
   EmptyAssigneePolicy,
@@ -39,6 +40,7 @@ import {
   validateApprovalFormData,
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
+import { resolveApprovalRequesterOrgRelations, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import type {
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
@@ -2583,13 +2585,32 @@ export class ApprovalProductService {
       )
     }
 
-    const requesterSnapshot = {
+    // Lane G (P1-A) plumbing — freeze the requester's org relations (direct
+    // manager / dept head, as LOCAL user ids) from the directory `raw` payload.
+    // READ-ONLY (directory_* SELECTs only) and best-effort: a directory read
+    // failure must never block create, so an unresolved lookup just omits the
+    // fields. The future direct_manager / dept_head assignee-source kinds read
+    // these; absence falls through to the node's emptyAssigneePolicy.
+    let orgRelations: ApprovalRequesterOrgRelations = {}
+    try {
+      orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool))
+    } catch (error) {
+      metricsLogger.warn(
+        `Failed to resolve requester org relations for ${actor.userId}: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`,
+      )
+    }
+
+    const requesterSnapshot: ApprovalRequesterSnapshot = {
       id: actor.userId,
       name: actor.userName || actor.userId,
       email: actor.email,
       department: actor.department,
       roles: actor.roles || [],
       permissions: actor.permissions || [],
+      ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
+      ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
     }
     const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -206,6 +206,20 @@ export interface ApprovalRequesterSnapshot {
   name?: string
   department?: string
   title?: string
+  /**
+   * Lane G (P1-A) org-relation plumbing — local user id of the requester's
+   * direct manager, frozen at create time from the directory `raw` payload.
+   * Absent when unresolvable (no linked directory account, top-of-tree, or
+   * pre-extraction legacy rows). The future `direct_manager` assignee-source
+   * kind reads this; it is purely additive and existing snapshots omit it.
+   */
+  managerId?: string
+  /**
+   * Lane G (P1-A) org-relation plumbing — local user id of the head of the
+   * requester's primary department, frozen at create time. Absent when
+   * unresolvable. Read by the future `dept_head` assignee-source kind.
+   */
+  deptHeadId?: string
   [key: string]: unknown
 }
 

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -20,7 +20,7 @@ interface FakeDb {
     primary_department_raw: unknown
   } | null
   // candidate accounts in the requester's primary department (for manager scan)
-  deptCandidates?: Array<{ account_id: string; raw: unknown }>
+  deptCandidates?: Array<{ account_id: string; raw: unknown; external_user_id?: string }>
   // directory_account_id -> linked local user id
   localByAccountId?: Record<string, string | null>
   // external_user_id -> linked local user id
@@ -33,7 +33,13 @@ function makeQuery(db: FakeDb) {
       return { rows: (db.requester ? [db.requester] : []) as Row[] }
     }
     if (text.includes('JOIN directory_account_departments ad') && text.includes('d.external_department_id = $2')) {
-      return { rows: (db.deptCandidates ?? []) as Row[] }
+      // Mirror the production self-exclusion `AND a.external_user_id <> $3` so a
+      // leader-requester is never a candidate for their own manager.
+      const selfExternal = params?.[2]
+      const candidates = (db.deptCandidates ?? []).filter(
+        (c) => c.external_user_id === undefined || c.external_user_id !== selfExternal,
+      )
+      return { rows: candidates as Row[] }
     }
     if (text.includes('FROM directory_account_links') && text.includes('WHERE directory_account_id = $1::uuid')) {
       const accountId = String(params?.[0])
@@ -69,6 +75,27 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     }
     const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
     expect(result).toEqual({ managerId: 'local-mgr', deptHeadId: 'local-head' })
+  })
+
+  it('excludes the requester from their own dept leaders (self-exclusion <> $3): a leader requester is not their own manager', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] }, // the requester IS a leader of D1
+        primary_external_department_id: 'D1',
+        primary_department_raw: {},
+      },
+      // Production SQL excludes ext-req via $3; the fake mirrors it. The requester is the
+      // only leader, so after self-exclusion there is no other leader to resolve.
+      deptCandidates: [
+        { account_id: 'acc-req', external_user_id: 'ext-req', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } },
+      ],
+      localByAccountId: { 'acc-req': 'local-req' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result.managerId).toBeUndefined() // not 'local-req' — self is excluded
   })
 
   it('omits managerId when the dept leader is unlinked, but still resolves deptHead', async () => {

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+
+/**
+ * Lane G (P1-A) plumbing unit test — drives the read-only org resolver against an
+ * in-memory fake `query` (no database). The fake recognizes the three SELECT
+ * shapes the resolver issues by stable fragments and serves fixture rows, so the
+ * extraction logic (leader_in_dept → manager, dept_manager_userid_list → head,
+ * reverse-link → local user id) is locked without a PG dependency.
+ */
+
+interface FakeDb {
+  // requester local id -> linked directory row (account + primary dept raw)
+  requester?: {
+    integration_id: string
+    account_id: string
+    external_user_id: string
+    raw: unknown
+    primary_external_department_id: string | null
+    primary_department_raw: unknown
+  } | null
+  // candidate accounts in the requester's primary department (for manager scan)
+  deptCandidates?: Array<{ account_id: string; raw: unknown }>
+  // directory_account_id -> linked local user id
+  localByAccountId?: Record<string, string | null>
+  // external_user_id -> linked local user id
+  localByExternalId?: Record<string, string | null>
+}
+
+function makeQuery(db: FakeDb) {
+  return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+    if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
+      return { rows: (db.requester ? [db.requester] : []) as Row[] }
+    }
+    if (text.includes('JOIN directory_account_departments ad') && text.includes('d.external_department_id = $2')) {
+      return { rows: (db.deptCandidates ?? []) as Row[] }
+    }
+    if (text.includes('FROM directory_account_links') && text.includes('WHERE directory_account_id = $1::uuid')) {
+      const accountId = String(params?.[0])
+      const localId = db.localByAccountId?.[accountId] ?? null
+      return { rows: [{ local_user_id: localId }] as Row[] }
+    }
+    if (text.includes('JOIN directory_account_links l') && text.includes('a.external_user_id = $2')) {
+      const external = String(params?.[1])
+      const localId = db.localByExternalId?.[external] ?? null
+      return { rows: (localId !== null ? [{ local_user_id: localId }] : []) as Row[] }
+    }
+    throw new Error(`unexpected query: ${text.slice(0, 60)}`)
+  }
+}
+
+describe('resolveApprovalRequesterOrgRelations', () => {
+  it('resolves direct manager (leader_in_dept) and dept head (dept_manager_userid_list) to local ids', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: { leader_in_dept: [{ dept_id: 'D1', leader: false }] },
+        primary_external_department_id: 'D1',
+        primary_department_raw: { dept_manager_userid_list: ['ext-head'] },
+      },
+      deptCandidates: [
+        { account_id: 'acc-req', raw: { leader_in_dept: [{ dept_id: 'D1', leader: false }] } },
+        { account_id: 'acc-mgr', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } },
+      ],
+      localByAccountId: { 'acc-mgr': 'local-mgr' },
+      localByExternalId: { 'ext-head': 'local-head' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({ managerId: 'local-mgr', deptHeadId: 'local-head' })
+  })
+
+  it('omits managerId when the dept leader is unlinked, but still resolves deptHead', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: { dept_manager_userid_list: ['ext-head'] },
+      },
+      deptCandidates: [{ account_id: 'acc-mgr', raw: { leader_in_dept: [{ dept_id: 'D1', leader: true }] } }],
+      localByAccountId: { 'acc-mgr': null },
+      localByExternalId: { 'ext-head': 'local-head' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({ deptHeadId: 'local-head' })
+  })
+
+  it('returns {} when the requester has no linked directory account', async () => {
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery({ requester: null }))
+    expect(result).toEqual({})
+  })
+
+  it('returns {} for a blank user id without touching the db', async () => {
+    let called = false
+    const result = await resolveApprovalRequesterOrgRelations('   ', async () => {
+      called = true
+      return { rows: [] }
+    })
+    expect(result).toEqual({})
+    expect(called).toBe(false)
+  })
+
+  it('never picks the requester as their own dept head (self excluded)', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: 'D1',
+        primary_department_raw: { dept_manager_userid_list: ['ext-req', 'ext-head'] },
+      },
+      deptCandidates: [],
+      localByExternalId: { 'ext-head': 'local-head' },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({ deptHeadId: 'local-head' })
+  })
+
+  it('tolerates legacy raw without leader/manager keys (no throw, empty result)', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: { name: 'Requester' },
+        primary_external_department_id: 'D1',
+        primary_department_raw: { name: 'Dept One' },
+      },
+      deptCandidates: [{ account_id: 'acc-x', raw: { name: 'Someone' } }],
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({})
+  })
+
+  it('skips the manager scan entirely when the requester has no primary department', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1',
+        account_id: 'acc-req',
+        external_user_id: 'ext-req',
+        raw: {},
+        primary_external_department_id: null,
+        primary_department_raw: null,
+      },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result).toEqual({})
+  })
+})


### PR DESCRIPTION
POST-GATE approval **Lane G** — the **read-only directory→approval org-relation plumbing** prerequisite that flips `direct_manager`/`dept_head` from blocked→buildable. Third baton of the hot-file chain (rebased after Lane D).

## Change (READ-ONLY)
- New `ApprovalDirectoryOrg.ts`: `resolveApprovalRequesterOrgRelations(localUserId, query)` — **`directory_*` SELECTs only**, with an injectable `QueryFn`. Extracts direct-manager from `directory_accounts.raw.leader_in_dept` (**self-excluded** `<> $3`) + dept-head from `directory_departments.raw.dept_manager_userid_list`, mapped to LOCAL ids via `directory_account_links` (`link_status='linked'`).
- `ApprovalRequesterSnapshot` += `managerId?`/`deptHeadId?` (additive, rides the existing `requester_snapshot` JSONB — **no DB migration, no staging-drift gate**).
- `createApproval` bakes via a **best-effort try/catch** — warn-logs, never blocks create; unresolved relations simply omit the field.

## Data-assumption validation (done on real staging data, per the goal)
- **`direct_manager` (`leader_in_dept`): VALIDATED.** The staging accounts are real DingTalk payloads and `leader_in_dept` is present + structured (`[{"leader":…,"dept_id":…}]`) in **4/4**. `managerId` is data-backed.
- **`dept_head` (`dept_manager_userid_list`): UNVALIDATED.** Staging has only a **synthetic** department (no real DingTalk dept raw), so the key's absence is a staging-data limitation, *not* a proven sync gap. `deptHeadId` may be omitted until real department data confirms the key. **The future `dept_head` resolver (design-only) is gated on a real-DingTalk-dept integration test before it can be relied on.**

## Scope + gates
- **`buildScope = plumbing-only`**: the resolver kinds (`direct_manager`/`dept_head`/`continuous_managers`) + union/normalize/FE authoring are **DESIGN-ONLY** (not built). user-group sources are hard-blocked on an absent user-group entity.
- backend `tsc` 0; **unit 8/8** (incl. the new self-exclusion case — a leader-requester is NOT their own manager, closing the prior fake-ignores-`$3` gap); **convergence guard 4/4** (read-only `directory_*` SELECTs; no automation/approval-table writes; no BPMN import).

## Governance
POST-GATE: P0-A/C (PASS) + lane GO. Hot-file chain (after Lane D). Read-only — no automation-boundary touch, no migration. W7 stays locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)