### PR TITLE
feat(multitable): foreign-field picker for rollup/lookup config (3c)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -88,4 +88,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager --reporter=dot

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -203,7 +203,12 @@
             </label>
             <label class="meta-field-mgr__field">
               <span>{{ ml('field.targetFieldId') }}</span>
-              <input v-model="lookupDraft.targetFieldId" class="meta-field-mgr__input" placeholder="fld_target" />
+              <select v-if="foreignFieldsAvailable" v-model="lookupDraft.targetFieldId" class="meta-field-mgr__select">
+                <option value="">{{ ml('field.selectTargetField') }}</option>
+                <option v-if="lookupDraft.targetFieldId && !isForeignFieldKnown(lookupDraft.targetFieldId)" :value="lookupDraft.targetFieldId">{{ lookupDraft.targetFieldId }}</option>
+                <option v-for="f in foreignFields" :key="f.id" :value="f.id">{{ f.name }}</option>
+              </select>
+              <input v-else v-model="lookupDraft.targetFieldId" class="meta-field-mgr__input" placeholder="fld_target" />
             </label>
           </div>
         </template>
@@ -223,7 +228,12 @@
             </label>
             <label class="meta-field-mgr__field">
               <span>{{ ml('field.targetFieldId') }}</span>
-              <input v-model="rollupDraft.targetFieldId" class="meta-field-mgr__input" placeholder="fld_target" />
+              <select v-if="foreignFieldsAvailable" v-model="rollupDraft.targetFieldId" class="meta-field-mgr__select">
+                <option value="">{{ ml('field.selectTargetField') }}</option>
+                <option v-if="rollupDraft.targetFieldId && !isForeignFieldKnown(rollupDraft.targetFieldId)" :value="rollupDraft.targetFieldId">{{ rollupDraft.targetFieldId }}</option>
+                <option v-for="f in foreignFields" :key="f.id" :value="f.id">{{ f.name }}</option>
+              </select>
+              <input v-else v-model="rollupDraft.targetFieldId" class="meta-field-mgr__input" placeholder="fld_target" />
             </label>
           </div>
           <label class="meta-field-mgr__field">
@@ -253,9 +263,14 @@
               <label><input type="radio" value="or" v-model="rollupDraft.filterConjunction" /> {{ ml('field.rollupFilterAny') }}</label>
             </div>
             <div v-for="(cond, i) in rollupDraft.filters" :key="i" class="meta-field-mgr__rollup-cond">
-              <input v-model="cond.fieldId" class="meta-field-mgr__input" :placeholder="ml('field.rollupFilterFieldPlaceholder')" />
+              <select v-if="foreignFieldsAvailable" v-model="cond.fieldId" class="meta-field-mgr__select">
+                <option value="">{{ ml('field.selectTargetField') }}</option>
+                <option v-if="cond.fieldId && !isForeignFieldKnown(cond.fieldId)" :value="cond.fieldId">{{ cond.fieldId }}</option>
+                <option v-for="f in foreignFields" :key="f.id" :value="f.id">{{ f.name }}</option>
+              </select>
+              <input v-else v-model="cond.fieldId" class="meta-field-mgr__input" :placeholder="ml('field.rollupFilterFieldPlaceholder')" />
               <select v-model="cond.operator" class="meta-field-mgr__select">
-                <option v-for="op in ROLLUP_FILTER_OPERATOR_OPTIONS" :key="op.value" :value="op.value">{{ op.label }}</option>
+                <option v-for="op in operatorOptionsFor(cond.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
               </select>
               <input
                 v-if="!ROLLUP_FILTER_OPS_NO_VALUE.has(cond.operator)"
@@ -971,6 +986,12 @@ const props = defineProps<{
   // switchBase/loadBaseContext mutators (those would yank the user's active base).
   listBasesFn?: () => Promise<MetaBase[]>
   listForeignSheetsFn?: (baseId: string) => Promise<MetaSheet[]>
+  // 3c foreign-field picker: enumerate a sheet's fields so the lookup/rollup TARGET field and the
+  // rollup FILTER condition fields are PICKED (not hand-typed). The workbench wires this to
+  // client.listFields. Optional — absent / unresolvable foreign sheet / load failure → the inputs fall
+  // back to typed-id (cross-base + not-yet-loaded still work). NEVER computes its own readability; the
+  // callback (client.listFields) is the read-gated source of truth, mirroring listForeignSheetsFn.
+  listForeignFieldsFn?: (sheetId: string) => Promise<MetaField[]>
 }>()
 
 const emit = defineEmits<{
@@ -1308,6 +1329,50 @@ const configTargetType = computed(() => {
   if (configTarget.value) return configDraftType.value
   return newFieldConfigVisible.value && requiresConfig(newFieldType.value) ? newFieldType.value : null
 })
+
+// 3c foreign-field picker (defined AFTER configTargetType — activeForeignSheetId reads it, and watch
+// evaluates its source at registration). Foreign sheet = the active config's foreignSheetId override,
+// else the chosen link field's foreignSheetId (link fields live in props.fields). Loaded via
+// listForeignFieldsFn (workbench → client.listFields); empty when unavailable → target/filter inputs
+// fall back to typed-id (cross-base / not-yet-loaded still work).
+const foreignFields = ref<MetaField[]>([])
+function linkFieldForeignSheetId(linkFieldId: string): string {
+  const lf = props.fields.find((f) => f.id === linkFieldId)
+  const fsid = (lf?.property as Record<string, unknown> | undefined)?.foreignSheetId
+  return typeof fsid === 'string' ? fsid : ''
+}
+const activeForeignSheetId = computed<string>(() => {
+  if (configTargetType.value === 'lookup') return lookupDraft.foreignSheetId.trim() || linkFieldForeignSheetId(lookupDraft.linkFieldId)
+  if (configTargetType.value === 'rollup') return rollupDraft.foreignSheetId.trim() || linkFieldForeignSheetId(rollupDraft.linkFieldId)
+  return ''
+})
+watch(activeForeignSheetId, async (sheetId) => {
+  foreignFields.value = []
+  const fn = props.listForeignFieldsFn
+  if (!sheetId || !fn) return
+  try {
+    foreignFields.value = await fn(sheetId)
+  } catch {
+    foreignFields.value = [] // graceful: typed-id fallback
+  }
+}, { immediate: true })
+const foreignFieldsAvailable = computed(() => foreignFields.value.length > 0)
+function isForeignFieldKnown(fieldId: string): boolean {
+  return foreignFields.value.some((f) => f.id === fieldId)
+}
+// Operator options constrained by the picked field's type, mirroring backend isRollupFilterOperatorCompatible:
+// string → equality + contains; numeric/date → equality + comparison; boolean → equality only (+ universal
+// empty ops). Unknown / not-yet-loaded field → the full set (the backend still validates at save).
+const FOREIGN_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'date'])
+const FILTER_OPS_STRING = new Set(['is', 'isNot', 'contains', 'doesNotContain', 'isEmpty', 'isNotEmpty'])
+const FILTER_OPS_NUMERIC = new Set(['is', 'isNot', 'greater', 'greaterequal', 'less', 'lessequal', 'isEmpty', 'isNotEmpty'])
+const FILTER_OPS_BOOLEAN = new Set(['is', 'isNot', 'isEmpty', 'isNotEmpty'])
+function operatorOptionsFor(fieldId: string): Array<{ value: string; label: string }> {
+  const t = foreignFields.value.find((f) => f.id === fieldId)?.type
+  if (!t) return ROLLUP_FILTER_OPERATOR_OPTIONS
+  const allow = FOREIGN_NUMERIC_TYPES.has(t) ? FILTER_OPS_NUMERIC : t === 'boolean' ? FILTER_OPS_BOOLEAN : FILTER_OPS_STRING
+  return ROLLUP_FILTER_OPERATOR_OPTIONS.filter((o) => allow.has(o.value))
+}
 
 // ---- #5b formula dry-run (C1–C4 per design #1869) ----
 const DRY_RUN_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -48,7 +48,7 @@ export type MetaManagerLabelKey =
   | 'field.crossBaseBaseLocked' | 'field.crossBaseUnreadable'
   | 'field.personHint' | 'field.limitSinglePerson'
   | 'field.linkField' | 'field.selectLinkField'
-  | 'field.foreignSheetId' | 'field.targetFieldId'
+  | 'field.foreignSheetId' | 'field.targetFieldId' | 'field.selectTargetField'
   | 'field.optionalOverride' | 'field.aggregation'
   | 'field.rollupFilters' | 'field.rollupFilterAll' | 'field.rollupFilterAny'
   | 'field.rollupFilterFieldPlaceholder' | 'field.rollupFilterValuePlaceholder' | 'field.rollupFilterAdd'
@@ -277,6 +277,7 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.selectLinkField': { en: 'Select link field', zh: '选择关联字段' },
   'field.foreignSheetId': { en: 'Foreign sheet id', zh: '外部表 ID' },
   'field.targetFieldId': { en: 'Target field id', zh: '目标字段 ID' },
+  'field.selectTargetField': { en: 'Select field', zh: '选择字段' },
   'field.optionalOverride': { en: 'Optional override', zh: '可选覆盖' },
   'field.aggregation': { en: 'Aggregation', zh: '聚合' },
   'field.rollupFilters': { en: 'Filter conditions', zh: '筛选条件' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -411,6 +411,7 @@
       :formula-suggest-fn="formulaSuggestFn"
       :list-bases-fn="listBasesForFieldFn"
       :list-foreign-sheets-fn="listForeignSheetsForFieldFn"
+      :list-foreign-fields-fn="listForeignFieldsForFieldFn"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -2265,6 +2266,9 @@ const dryRunFormulaFn = (params: { sheetId: string; expression: string; sampleVa
 const listBasesForFieldFn = async () => (await workbench.client.listBases()).bases
 const listForeignSheetsForFieldFn = async (baseId: string) =>
   (await workbench.client.loadContext({ baseId })).sheets
+// 3c foreign-field picker: read-gated source for the lookup/rollup target + filter field pickers.
+const listForeignFieldsForFieldFn = async (sheetId: string) =>
+  (await workbench.client.listFields(sheetId)).fields
 const activeAggregationConfig = computed<Record<string, string>>(() => {
   const raw = workbench.activeView.value?.config?.aggregations
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -1045,3 +1045,51 @@ describe('MetaFieldManager', () => {
     app.unmount()
   })
 })
+
+describe('MetaFieldManager — foreign-field picker (3c)', () => {
+  const foreignFields = [
+    { id: 'fld_status', name: 'Status', type: 'select', property: {} },
+    { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
+  ]
+  // Rollup field FIRST so the first .meta-field-mgr__action[title="Configure"] opens ITS config; the link
+  // field is present so linkFieldForeignSheetId resolves the foreign sheet from property.foreignSheetId.
+  function rollupProps(extra: Record<string, unknown> = {}) {
+    return {
+      visible: true,
+      sheetId: 'sheet_1',
+      sheets: [],
+      fields: [
+        { id: 'fld_rollup', name: 'Roll', type: 'rollup', property: { linkFieldId: 'fld_link', targetFieldId: 'fld_status', aggregation: 'concatenate' } },
+        { id: 'fld_link', name: 'Link', type: 'link', property: { foreignSheetId: 'sheet_foreign' } },
+      ],
+      ...extra,
+    }
+  }
+  async function settle() { await nextTick(); await new Promise((r) => setTimeout(r)); await nextTick() }
+
+  it('renders the rollup target as a PICKER populated from listForeignFieldsFn (resolved foreign sheet)', async () => {
+    const container = document.createElement('div'); document.body.appendChild(container)
+    const listForeignFieldsFn = vi.fn(async () => foreignFields)
+    const app = createApp({ render() { return h(MetaFieldManager, rollupProps({ listForeignFieldsFn })) } })
+    app.mount(container); await nextTick()
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await settle()
+    expect(listForeignFieldsFn).toHaveBeenCalledWith('sheet_foreign')
+    const optionText = (Array.from(container.querySelectorAll('.meta-field-mgr__config select')) as HTMLSelectElement[])
+      .flatMap((s) => Array.from(s.options).map((o) => o.textContent))
+    expect(optionText).toContain('Status')
+    expect(optionText).toContain('Amount')
+    app.unmount(); container.remove()
+  })
+
+  it('falls back to a typed-id input when no listForeignFieldsFn is wired', async () => {
+    const container = document.createElement('div'); document.body.appendChild(container)
+    const app = createApp({ render() { return h(MetaFieldManager, rollupProps()) } })
+    app.mount(container); await nextTick()
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await settle()
+    const inputs = Array.from(container.querySelectorAll('.meta-field-mgr__config .meta-field-mgr__input')) as HTMLInputElement[]
+    expect(inputs.some((i) => i.getAttribute('placeholder') === 'fld_target')).toBe(true)
+    app.unmount(); container.remove()
+  })
+})


### PR DESCRIPTION
The 3c follow-up the merged slice-3b deferred. Replaces the typed-id `<input>`s for the lookup/rollup **target field** and rollup **filter condition field** with `<select>` pickers over the foreign sheet's fields, and constrains the rollup-filter operator dropdown by the picked field's type (mirroring backend `isRollupFilterOperatorCompatible`).

**FE-only.** Data flow: new `listForeignFieldsFn(sheetId)` prop wired in the workbench to `client.listFields`; foreign sheet resolved from the config override or the link field's `property.foreignSheetId`; a `watch` loads on link/override change (Option A, no caching). **Graceful fallback:** no fn / unresolvable sheet / load failure → original typed-id input (cross-base + not-yet-loaded still work); a stored id not in the loaded list is added as a selectable option (back-compat preserved).

Verified: vue-tsc clean, `multitable-field-manager` **23/23** (+2 new: picker populates, typed-id fallback); spec added to the web-guard run list. **Minor follow-ups (backend-gated, non-blocking):** a foreign field that is itself a rollup/formula/lookup uses raw `field.type` (not effective type) so its operator set falls to the string default — backend still validates at save; and no caching per Option A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)