### PR TITLE
feat(multitable): button update_record action (no-elevation actor-permission gate)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -199,6 +199,7 @@ jobs:
             tests/integration/multitable-view-summary-recordperm-leak.test.ts \
             tests/integration/multitable-person-summary-field-mask.test.ts \
             tests/integration/multitable-button-send-notification.test.ts \
+            tests/integration/multitable-button-update-record.test.ts \
             tests/integration/multitable-form-context-submit-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-dashboard-preview-data.test.ts \

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -50,7 +50,7 @@ import type { AutomationActionType } from '../multitable/automation-actions'
 import { AutomationLogService } from '../multitable/automation-log-service'
 import { loadSheetMemberUserIdSet } from '../multitable/permission-service'
 import { insertRecordSubscriptionNotifications } from '../multitable/record-subscription-service'
-import { normalizeJson } from '../multitable/field-codecs'
+import { normalizeJson, normalizeMultiSelectValue } from '../multitable/field-codecs'
 import { ensureRecordWriteAllowed } from '../multitable/sheet-capabilities'
 import { ensureRecordNotLocked } from '../multitable/record-lock'
 import { Logger } from '../core/logger'
@@ -328,6 +328,47 @@ export function createMultitableButtonRoutes(): Router {
           return res.status(400).json({ ok: false, error: { code: 'NO_FIELDS', message: 'Button update_record has no fields configured' } })
         }
 
+        // §3.3 PER-FIELD WRITE GATE + per-type validation (no field-LEVEL elevation). The §3.1 row gate
+        // does not bound WHICH fields/values are written, and the executor does a raw `data || $jsonb`
+        // merge with NO field checks — so without this a button could write a field the clicker cannot
+        // write via a normal PATCH (field_permissions read-only / computed / system), corrupt a computed
+        // field, or store an unvalidated value. Enforce the SAME field-level contract as PATCH:
+        // `ctx.fieldPermissions[id].readOnly` folds the actor's field_permissions + isFieldAlwaysReadOnly
+        // (computed formula/lookup/rollup + system + mirror + intrinsic) — the same deriveFieldPermissions
+        // source the PATCH path uses, so a field not writable directly is not writable via a button. Then
+        // validate select/multiSelect values via the shared codecs. link/person/attachment need meta_links
+        // / membership / attachment writes the executor cannot do → rejected (deferred to a follow-up that
+        // routes through the full write path). Either failure → reject BEFORE the tx (no dedup consumed).
+        const fieldDefById = new Map(ctx.fields.map((f) => [f.id, f]))
+        const validatedFields: Record<string, unknown> = {}
+        for (const [fid, value] of Object.entries(fields)) {
+          const perm = ctx.fieldPermissions[fid]
+          const def = fieldDefById.get(fid)
+          if (!def || !perm || perm.readOnly !== false) {
+            return res.status(403).json({ ok: false, error: { code: 'FIELD_FORBIDDEN', message: `Field is not writable by this actor: ${fid}` } })
+          }
+          if (def.type === 'link' || def.type === 'person' || def.type === 'attachment') {
+            return res.status(400).json({ ok: false, error: { code: 'FIELD_UNSUPPORTED', message: `Button update_record does not support ${def.type} fields yet: ${fid}` } })
+          }
+          if (def.type === 'select') {
+            const options = def.options?.map((o) => o.value) ?? []
+            if (typeof value !== 'string' || (value !== '' && !options.includes(value))) {
+              return res.status(422).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid select option for ${fid}` } })
+            }
+            validatedFields[fid] = value
+            continue
+          }
+          if (def.type === 'multiSelect') {
+            try {
+              validatedFields[fid] = normalizeMultiSelectValue(value, fid, def.options?.map((o) => o.value) ?? [])
+            } catch (err) {
+              return res.status(422).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err instanceof Error ? err.message : `Invalid multiSelect value for ${fid}` } })
+            }
+            continue
+          }
+          validatedFields[fid] = value
+        }
+
         // §6 + §2: dedup → executor write (SAME tx client) → audit, all-or-nothing.
         // Mirrors the send_notification transaction; the executor performs the real
         // versioned write via the SAME path automations use (no parallel write path).
@@ -353,7 +394,7 @@ export function createMultitableButtonRoutes(): Router {
           // Same-base update of the clicked record (fields only). The executor write
           // runs on the tx client, so a failed audit rolls the write back (fail-closed).
           const executor = new AutomationExecutor({ eventBus, queryFn: txq })
-          const step = await executor.runSingleAction({ type: 'update_record', config: { fields } }, context)
+          const step = await executor.runSingleAction({ type: 'update_record', config: { fields: validatedFields } }, context)
           if (step.status !== 'success') {
             // Roll back the dedup + any partial write so a transient failure is retryable.
             throw new Error(step.error ?? 'update_record failed')

--- a/packages/core-backend/src/routes/multitable-button.ts
+++ b/packages/core-backend/src/routes/multitable-button.ts
@@ -51,6 +51,8 @@ import { AutomationLogService } from '../multitable/automation-log-service'
 import { loadSheetMemberUserIdSet } from '../multitable/permission-service'
 import { insertRecordSubscriptionNotifications } from '../multitable/record-subscription-service'
 import { normalizeJson } from '../multitable/field-codecs'
+import { ensureRecordWriteAllowed } from '../multitable/sheet-capabilities'
+import { ensureRecordNotLocked } from '../multitable/record-lock'
 import { Logger } from '../core/logger'
 
 type PoolLike = ConnectionPool & { query: QueryFn }
@@ -81,6 +83,10 @@ interface ButtonActionPolicy {
 const BUTTON_ACTION_POLICIES: Record<string, ButtonActionPolicy> = {
   record_click: { gate: 'read', sideEffecting: false, dispatchType: 'record_click' },
   send_notification: { gate: 'notify', sideEffecting: true, dispatchType: 'send_notification' },
+  // B1-S1 D0-B: first RECORD-MUTATING button action. `edit` gate is the sheet-level
+  // pre-filter; the dispatch branch re-gates the SPECIFIC row (write-own + lock) so a
+  // button can never mutate a row the clicker could not edit directly (no elevation).
+  update_record: { gate: 'edit', sideEffecting: true, dispatchType: 'update_record' },
 }
 
 export function createMultitableButtonRoutes(): Router {
@@ -117,7 +123,7 @@ export function createMultitableButtonRoutes(): Router {
       if ('status' in readable) {
         return res.status(readable.status).json(readable.body)
       }
-      const { access, capabilities } = readable
+      const { access, capabilities, sheetScope } = readable
 
       // 2) Load the field + its derived permissions for THIS actor.
       const ctx = await buildRecordPatchContext(req, query, sheetId, access, capabilities)
@@ -277,6 +283,88 @@ export function createMultitableButtonRoutes(): Router {
           executionId, sheetId, recordId, fieldId, actionType,
           actorId, status: 'success', requestId: requestIdValue,
           recipients: requestedUserIds.length, deduplicated: txResult.deduplicated,
+        })
+        return res.json({ ok: true, data: { status: 'succeeded', executionId: txResult.executionId, ...(txResult.deduplicated ? { deduplicated: true } : {}) } })
+      }
+
+      // ── update_record dispatch (B1-S1 D0-B) ─────────────────────────────────
+      // First RECORD-MUTATING button action. NO ELEVATION: the click performs the
+      // update as the CLICKING ACTOR through the SAME per-row gates a normal edit
+      // uses, so a button can never mutate a row the clicker could not edit directly.
+      if (actionType === 'update_record') {
+        const actorId = access.userId
+        const requestIdValue = requestId as string // §6 requestId already required (side-effecting).
+
+        // §3.1 PER-ROW WRITE GATE (no-elevation). The sheet-level `edit` policy gate
+        // (canEditRecord) above is NOT sufficient — under write-own it is true for
+        // EVERY row. Re-gate THIS record by created_by (write-own honored) + the lock
+        // guard, identically to the normal record-edit path. Either failure → 403,
+        // no write, no dedup consumed.
+        const recRes = await query(
+          'SELECT created_by, locked, locked_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+          [recordId, sheetId],
+        )
+        if (recRes.rows.length === 0) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+        }
+        const recRow = recRes.rows[0] as { created_by?: string | null; locked?: boolean | null; locked_by?: string | null }
+        const createdBy = typeof recRow.created_by === 'string' ? recRow.created_by : null
+        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'edit')) {
+          return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions to edit this record' } })
+        }
+        try {
+          ensureRecordNotLocked(actorId, { locked: recRow.locked === true, locked_by: recRow.locked_by ?? null }, () => new Error('locked'))
+        } catch {
+          return res.status(403).json({ ok: false, error: { code: 'RECORD_LOCKED', message: 'Record is locked' } })
+        }
+
+        // §3.2 CONFIG: same-base update of THE CLICKED record (fields only — a button
+        // does NOT do cross-base targeting). Empty → nothing to write.
+        const actionConfig = normalizeJson(property.actionConfig)
+        const fields = (actionConfig.fields && typeof actionConfig.fields === 'object' && !Array.isArray(actionConfig.fields))
+          ? (actionConfig.fields as Record<string, unknown>)
+          : null
+        if (!fields || Object.keys(fields).length === 0) {
+          return res.status(400).json({ ok: false, error: { code: 'NO_FIELDS', message: 'Button update_record has no fields configured' } })
+        }
+
+        // §6 + §2: dedup → executor write (SAME tx client) → audit, all-or-nothing.
+        // Mirrors the send_notification transaction; the executor performs the real
+        // versioned write via the SAME path automations use (no parallel write path).
+        const dedupKey = JSON.stringify([actorId, sheetId, recordId, fieldId, requestIdValue])
+        const context: ExecutionContext = {
+          executionId, ruleId: `btn_${fieldId}`, sheetId, recordId,
+          recordData: {}, ruleCreatedBy: '', actorId,
+          triggerEvent: { _trigger: 'button', fieldId, requestId: requestIdValue },
+        }
+        const txResult = await pool.transaction<{ deduplicated: boolean; executionId: string }>(async ({ query: txq }) => {
+          const dedup = await txq(
+            `INSERT INTO multitable_button_run_dedup
+               (id, dedup_key, actor_id, sheet_id, record_id, field_id, request_id, execution_id)
+             VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (dedup_key) DO NOTHING`,
+            [randomUUID(), dedupKey, actorId, sheetId, recordId, fieldId, requestIdValue, executionId],
+          )
+          if (Number(dedup.rowCount ?? 0) === 0) {
+            const existing = await txq(`SELECT execution_id FROM multitable_button_run_dedup WHERE dedup_key = $1`, [dedupKey])
+            const originalExecutionId = (existing.rows[0] as { execution_id?: string } | undefined)?.execution_id ?? executionId
+            return { deduplicated: true, executionId: originalExecutionId }
+          }
+          // Same-base update of the clicked record (fields only). The executor write
+          // runs on the tx client, so a failed audit rolls the write back (fail-closed).
+          const executor = new AutomationExecutor({ eventBus, queryFn: txq })
+          const step = await executor.runSingleAction({ type: 'update_record', config: { fields } }, context)
+          if (step.status !== 'success') {
+            // Roll back the dedup + any partial write so a transient failure is retryable.
+            throw new Error(step.error ?? 'update_record failed')
+          }
+          await writeButtonAudit(logService, txq, { executionId, sheetId, fieldId, actorId, requestId: requestIdValue, step })
+          return { deduplicated: false, executionId }
+        })
+
+        logger.info('[multitable.button.run]', {
+          executionId, sheetId, recordId, fieldId, actionType,
+          actorId, status: 'success', requestId: requestIdValue, deduplicated: txResult.deduplicated,
         })
         return res.json({ ok: true, data: { status: 'succeeded', executionId: txResult.executionId, ...(txResult.deduplicated ? { deduplicated: true } : {}) } })
       }

--- a/packages/core-backend/tests/integration/multitable-button-update-record.test.ts
+++ b/packages/core-backend/tests/integration/multitable-button-update-record.test.ts
@@ -23,6 +23,13 @@ const BASE_ID = `base_btnup_${TS}`
 const SHEET_ID = `sheet_btnup_${TS}`
 const FLD_TARGET = `fld_btnup_target_${TS}`
 const FLD_BTN = `fld_btnup_btn_${TS}`
+const FLD_RO = `fld_btnup_ro_${TS}` // field_permissions/intrinsic read-only
+const FLD_FORMULA = `fld_btnup_formula_${TS}` // computed (always read-only)
+const FLD_SELECT = `fld_btnup_select_${TS}` // select with options a/b
+const FLD_BTN_RO = `fld_btnup_btnro_${TS}`
+const FLD_BTN_FORMULA = `fld_btnup_btnformula_${TS}`
+const FLD_BTN_SEL_BAD = `fld_btnup_btnselbad_${TS}`
+const FLD_BTN_SEL_OK = `fld_btnup_btnselok_${TS}`
 const REC_OWN = `rec_btnup_own_${TS}` // created_by = OWNER
 const REC_OTHER = `rec_btnup_other_${TS}` // created_by = OTHER
 const USER_EDITOR = `u_btnup_editor_${TS}` // global multitable:write → can edit any row
@@ -31,6 +38,7 @@ const USER_OTHER = `u_btnup_other_${TS}`
 
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 const runUrl = (recId: string) => `/api/multitable/sheets/${SHEET_ID}/records/${recId}/fields/${FLD_BTN}/button/run`
+const runUrlBtn = (recId: string, btnId: string) => `/api/multitable/sheets/${SHEET_ID}/records/${recId}/fields/${btnId}/button/run`
 
 function buildApp(userId: string, perms: string[]): Express {
   const app = express()
@@ -68,6 +76,15 @@ describeIfDatabase('B1-S1 D0-B update_record button — per-row no-elevation gat
       'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_BTN, SHEET_ID, 'Mark', 'button', JSON.stringify({ actionType: 'update_record', label: 'Mark', actionConfig: { fields: { [FLD_TARGET]: 'updated' } } }), 2],
     )
+    // Field-level gate fixtures: a read-only field, a computed (formula) field, a select field, and a
+    // button per case (each targeting a field the field-gate must reject or validate).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_RO, SHEET_ID, 'ReadOnly', 'string', JSON.stringify({ readonly: true }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FORMULA, SHEET_ID, 'Calc', 'formula', JSON.stringify({ expression: '1+1' }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SELECT, SHEET_ID, 'Stage', 'select', JSON.stringify({ options: [{ value: 'a' }, { value: 'b' }] }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_BTN_RO, SHEET_ID, 'BtnRO', 'button', JSON.stringify({ actionType: 'update_record', actionConfig: { fields: { [FLD_RO]: 'x' } } }), 6])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_BTN_FORMULA, SHEET_ID, 'BtnF', 'button', JSON.stringify({ actionType: 'update_record', actionConfig: { fields: { [FLD_FORMULA]: 'x' } } }), 7])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_BTN_SEL_BAD, SHEET_ID, 'BtnSB', 'button', JSON.stringify({ actionType: 'update_record', actionConfig: { fields: { [FLD_SELECT]: 'nope' } } }), 8])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_BTN_SEL_OK, SHEET_ID, 'BtnSO', 'button', JSON.stringify({ actionType: 'update_record', actionConfig: { fields: { [FLD_SELECT]: 'a' } } }), 9])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OWN, SHEET_ID, JSON.stringify({ [FLD_TARGET]: 'orig' }), USER_OWNER])
     await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OTHER, SHEET_ID, JSON.stringify({ [FLD_TARGET]: 'orig' }), USER_OTHER])
   })
@@ -112,5 +129,33 @@ describeIfDatabase('B1-S1 D0-B update_record button — per-row no-elevation gat
     const res = await request(buildApp(USER_OWNER, ['multitable:read'])).post(runUrl(REC_OWN)).send({ requestId: `req-own-own-${TS}` })
     expect(res.status).toBe(200)
     expect(await fieldValue(REC_OWN)).toBe('updated')
+  })
+
+  // ── Field-level no-elevation: even a FULL writer (row gate passes) cannot write a field the normal
+  //    PATCH path would reject, nor store an unvalidated value. ────────────────────────────────────
+  test('NO FIELD ELEVATION: button targeting a READ-ONLY field → 403 FIELD_FORBIDDEN', async () => {
+    const res = await request(buildApp(USER_EDITOR, ['multitable:read', 'multitable:write'])).post(runUrlBtn(REC_OTHER, FLD_BTN_RO)).send({ requestId: `req-ro-${TS}` })
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('FIELD_FORBIDDEN')
+  })
+
+  test('NO COMPUTED CORRUPTION: button targeting a formula field → 403, the row untouched', async () => {
+    const res = await request(buildApp(USER_EDITOR, ['multitable:read', 'multitable:write'])).post(runUrlBtn(REC_OTHER, FLD_BTN_FORMULA)).send({ requestId: `req-f-${TS}` })
+    expect(res.status).toBe(403)
+    expect(await fieldValue(REC_OTHER)).toBe('orig')
+  })
+
+  test('VALUE VALIDATION: button writing an INVALID select option → 422, no mutation', async () => {
+    const res = await request(buildApp(USER_EDITOR, ['multitable:read', 'multitable:write'])).post(runUrlBtn(REC_OTHER, FLD_BTN_SEL_BAD)).send({ requestId: `req-sb-${TS}` })
+    expect(res.status).toBe(422)
+    const data = ((await q('SELECT data FROM meta_records WHERE id = $1', [REC_OTHER])).rows[0] as { data: Record<string, unknown> }).data
+    expect(data[FLD_SELECT]).toBeUndefined()
+  })
+
+  test('VALUE VALIDATION: button writing a VALID select option → 200, select updated', async () => {
+    const res = await request(buildApp(USER_EDITOR, ['multitable:read', 'multitable:write'])).post(runUrlBtn(REC_OTHER, FLD_BTN_SEL_OK)).send({ requestId: `req-so-${TS}` })
+    expect(res.status).toBe(200)
+    const data = ((await q('SELECT data FROM meta_records WHERE id = $1', [REC_OTHER])).rows[0] as { data: Record<string, unknown> }).data
+    expect(data[FLD_SELECT]).toBe('a')
   })
 })

--- a/packages/core-backend/tests/integration/multitable-button-update-record.test.ts
+++ b/packages/core-backend/tests/integration/multitable-button-update-record.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Real-DB integration for B1-S1 D0-B — update_record button (first RECORD-MUTATING
+ * button action). The decision: NO ELEVATION — a click performs the update as the
+ * CLICKING ACTOR through the same per-row gate a normal edit uses, so a button can
+ * never mutate a row the clicker could not edit directly.
+ *
+ * The keystone (the wire-vs-fixture trap a mock can't prove): under sheet write-own,
+ * the sheet-level `edit` capability is TRUE for every row, so only a real per-row
+ * gate (ensureRecordWriteAllowed by created_by) stops a write-own user from updating
+ * ANOTHER user's row via the button. Asserted against a real DB with real records.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { createMultitableButtonRoutes } from '../../src/routes/multitable-button'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_btnup_${TS}`
+const SHEET_ID = `sheet_btnup_${TS}`
+const FLD_TARGET = `fld_btnup_target_${TS}`
+const FLD_BTN = `fld_btnup_btn_${TS}`
+const REC_OWN = `rec_btnup_own_${TS}` // created_by = OWNER
+const REC_OTHER = `rec_btnup_other_${TS}` // created_by = OTHER
+const USER_EDITOR = `u_btnup_editor_${TS}` // global multitable:write → can edit any row
+const USER_OWNER = `u_btnup_owner_${TS}` // sheet write-own, no global write → own rows only
+const USER_OTHER = `u_btnup_other_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const runUrl = (recId: string) => `/api/multitable/sheets/${SHEET_ID}/records/${recId}/fields/${FLD_BTN}/button/run`
+
+function buildApp(userId: string, perms: string[]): Express {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms, permissions: perms }
+    next()
+  })
+  app.use('/api/multitable', createMultitableButtonRoutes())
+  return app
+}
+
+const fieldValue = async (recId: string) =>
+  ((await q('SELECT data FROM meta_records WHERE id = $1', [recId])).rows[0] as { data: Record<string, unknown> }).data[FLD_TARGET]
+
+describeIfDatabase('B1-S1 D0-B update_record button — per-row no-elevation gate (real DB)', () => {
+  beforeAll(async () => {
+    const seedUser = (id: string, perms: string[]) =>
+      q(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active, permissions)
+         VALUES ($1,$2,'hash',$3,'user',true,$4::jsonb)
+         ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active, permissions = EXCLUDED.permissions`,
+        [id, `${id}@example.test`, id, JSON.stringify(perms)],
+      )
+    await seedUser(USER_EDITOR, ['multitable:read', 'multitable:write'])
+    await seedUser(USER_OWNER, ['multitable:read'])
+    await seedUser(USER_OTHER, ['multitable:read'])
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'BtnUp Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'BtnUp Sheet'])
+    // OWNER: sheet-scoped write-own, no global write → requiresOwnWriteRowPolicy true.
+    await q('INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4)', [SHEET_ID, 'user', USER_OWNER, 'spreadsheet:write-own'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_TARGET, SHEET_ID, 'Status', 'string', '{}', 1])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_BTN, SHEET_ID, 'Mark', 'button', JSON.stringify({ actionType: 'update_record', label: 'Mark', actionConfig: { fields: { [FLD_TARGET]: 'updated' } } }), 2],
+    )
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OWN, SHEET_ID, JSON.stringify({ [FLD_TARGET]: 'orig' }), USER_OWNER])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [REC_OTHER, SHEET_ID, JSON.stringify({ [FLD_TARGET]: 'orig' }), USER_OTHER])
+  })
+
+  beforeEach(async () => {
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [REC_OWN, JSON.stringify({ [FLD_TARGET]: 'orig' })]).catch(() => {})
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [REC_OTHER, JSON.stringify({ [FLD_TARGET]: 'orig' })]).catch(() => {})
+    await q('DELETE FROM multitable_button_run_dedup WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM multitable_button_run_dedup WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM multitable_automation_executions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[USER_EDITOR, USER_OWNER, USER_OTHER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('full writer clicks → the clicked record is updated + a button audit row is written', async () => {
+    const res = await request(buildApp(USER_EDITOR, ['multitable:read', 'multitable:write'])).post(runUrl(REC_OTHER)).send({ requestId: `req-ed-${TS}` })
+    expect(res.status).toBe(200)
+    expect(res.body.data.status).toBe('succeeded')
+    expect(await fieldValue(REC_OTHER)).toBe('updated')
+    const audit = await q("SELECT count(*)::int AS n FROM multitable_automation_executions WHERE sheet_id = $1 AND triggered_by = 'button'", [SHEET_ID])
+    expect((audit.rows[0] as { n: number }).n).toBeGreaterThanOrEqual(1)
+  })
+
+  test('NO ELEVATION: a write-own user CANNOT update another user\'s row via the button → 403, no mutation', async () => {
+    const res = await request(buildApp(USER_OWNER, ['multitable:read'])).post(runUrl(REC_OTHER)).send({ requestId: `req-own-other-${TS}` })
+    expect(res.status).toBe(403)
+    expect(await fieldValue(REC_OTHER)).toBe('orig') // untouched
+  })
+
+  test('write-own user CAN update their OWN row via the button → 200, updated', async () => {
+    const res = await request(buildApp(USER_OWNER, ['multitable:read'])).post(runUrl(REC_OWN)).send({ requestId: `req-own-own-${TS}` })
+    expect(res.status).toBe(200)
+    expect(await fieldValue(REC_OWN)).toBe('updated')
+  })
+})


### PR DESCRIPTION
Makes a button click perform a real `update_record` (previously INERT/audit-only per B1, pending the gate decision). **Decision (conservative, documented for review): no elevation** — a click can never mutate a row the clicker couldn't edit directly.

`BUTTON_ACTION_POLICIES.update_record = {gate:'edit', sideEffecting:true}`; the dispatch branch re-gates THIS row (loads created_by/lock → `ensureRecordWriteAllowed(...,'edit')` write-own-honored + `ensureRecordNotLocked`) → 403/no-write/no-dedup-consumed on failure; then a tx mirroring send_notification (dedup ON CONFLICT → executor write on tx client → audit → commit). The configurer-elevation model is a deliberate FUTURE opt-in.

Verified: tsc 0, full suite 4426/0, real-DB integration (authorized→200 row updated; write-own on another's row→403 untouched; audit either way) in the allowlist. **Follow-ups noted:** realtime emits inline pre-commit (phantom-emit on rare audit-rollback, self-correcting); templated actionConfig.fields referencing record data don't resolve (static values work); send_webhook stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)