### PR TITLE
feat(multitable): realtime live cell-cursors (remote collaborators' active cell)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -29,6 +29,11 @@ on:
       - 'apps/web/src/multitable/utils/view-config.ts'
       - 'apps/web/src/multitable/utils/meta-view-render-labels.ts'
       - 'apps/web/tests/multitable-kanban-view.spec.ts'
+      - 'apps/web/src/multitable/composables/useMultitableSheetPresence.ts'
+      - 'apps/web/src/multitable/utils/sheet-cursor-state.ts'
+      - 'apps/web/src/multitable/components/MetaGridTable.vue'
+      - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
+      - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -46,6 +51,11 @@ on:
       - 'apps/web/src/multitable/utils/view-config.ts'
       - 'apps/web/src/multitable/utils/meta-view-render-labels.ts'
       - 'apps/web/tests/multitable-kanban-view.spec.ts'
+      - 'apps/web/src/multitable/composables/useMultitableSheetPresence.ts'
+      - 'apps/web/src/multitable/utils/sheet-cursor-state.ts'
+      - 'apps/web/src/multitable/components/MetaGridTable.vue'
+      - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
+      - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -88,4 +98,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state --reporter=dot

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -76,7 +76,7 @@
                 v-for="(field, ci) in visibleFields"
                 :key="field.id"
                 class="meta-grid__cell"
-                :class="{ 'meta-grid__cell--editing': isEditing(item.row.id, field.id), 'meta-grid__cell--readonly': !isEditable(item.row.id, field), 'meta-grid__cell--focused': focusRow === item.navIndex && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(item.row.id, field.id) }"
+                :class="{ 'meta-grid__cell--editing': isEditing(item.row.id, field.id), 'meta-grid__cell--readonly': !isEditable(item.row.id, field), 'meta-grid__cell--focused': focusRow === item.navIndex && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(item.row.id, field.id), 'meta-grid__cell--remote-cursor': hasRemoteCursor(item.row.id, field.id) }"
                 :style="cellStyle(item.row.id, field.id, ci)"
                 @dblclick="startEdit(item.row, field)"
                 @click.stop="onCellClick(item.navIndex, ci, item.row.id)"
@@ -208,7 +208,7 @@
                 role="gridcell"
                 :aria-label="field.name"
                 class="meta-grid__cell"
-                :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(row.id, field.id) }"
+                :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci, 'meta-grid__cell--scale-fill': cellHasScaleFill(row.id, field.id), 'meta-grid__cell--remote-cursor': hasRemoteCursor(row.id, field.id) }"
                 :style="cellStyle(row.id, field.id, ci)"
                 @dblclick="startEdit(row, field)"
                 @click.stop="onCellClick(ri, ci, row.id)"
@@ -468,6 +468,9 @@ const props = defineProps<{
   // B5: people-mention candidates for rich-`longText` in-cell editing. Forwarded to
   // MetaCellEditor; the workbench feeds its already-loaded commentMentionSuggestions.
   mentionSuggestions?: MetaCommentMentionSuggestion[]
+  // Live cell-cursors: cellKey (`${recordId}:${fieldId}`) → remote collaborator userIds on that cell.
+  // Presentational highlight only; absent/empty → no cursors rendered.
+  remoteCursorsByCell?: Map<string, string[]>
 }>()
 
 const emit = defineEmits<{
@@ -497,6 +500,8 @@ const emit = defineEmits<{
   (e: 'ai-run', recordId: string, field: MetaField): void
   // B1-b: a button-field cell was clicked (run its configured action).
   (e: 'run-button', payload: { recordId: string; field: MetaField }): void
+  // Live cell-cursors: the local user focused a cell → parent broadcasts it as the active cursor.
+  (e: 'cursor-focus', payload: { recordId: string; fieldId: string }): void
 }>()
 
 const { isZh } = useLocale()
@@ -929,6 +934,13 @@ function onFieldCommentKeydown(event: KeyboardEvent, recordId: string, fieldId: 
 
 function onCellClick(ri: number, ci: number, rid: string) {
   focusRow.value = ri; focusCol.value = ci; emit('select-record', rid)
+  const fieldId = props.visibleFields[ci]?.id
+  if (fieldId) emit('cursor-focus', { recordId: rid, fieldId })
+}
+
+// Live cell-cursors: remote collaborators currently occupying a given cell (presentational highlight).
+function hasRemoteCursor(recordId: string, fieldId: string): boolean {
+  return (props.remoteCursorsByCell?.get(`${recordId}:${fieldId}`)?.length ?? 0) > 0
 }
 
 function startEdit(row: MetaRecord, field: MetaField) {
@@ -1046,6 +1058,8 @@ function onKeydown(e: KeyboardEvent) {
 .meta-grid__cell--editing { padding: 2px 4px; background: #fff; }
 .meta-grid__cell--readonly { color: #666; }
 .meta-grid__cell--focused { outline: 2px solid #409eff; outline-offset: -2px; }
+/* Live cell-cursor: a remote collaborator is on this cell (presentational, no interaction change). */
+.meta-grid__cell--remote-cursor { outline: 2px dashed #e6a23c; outline-offset: -2px; position: relative; }
 .meta-grid__cell-scale-icon { display: inline-block; margin-right: 4px; font-weight: 700; vertical-align: middle; }
 /* Over a data-bar / color-scale fill, force the cell-renderer's number sign-colors
    (green/red, set on an inner span that out-specifies the cell) to a luminance-

--- a/apps/web/src/multitable/composables/useMultitableSheetPresence.ts
+++ b/apps/web/src/multitable/composables/useMultitableSheetPresence.ts
@@ -3,6 +3,13 @@ import { io, type Socket } from 'socket.io-client'
 import { useAuth } from '../../composables/useAuth'
 import { getApiBase } from '../../utils/api'
 import type { MultitableSheetPresence } from '../types'
+import {
+  applyCursorEvent,
+  cursorsByCell,
+  pruneCursors,
+  type RemoteCellCursor,
+  type SheetCursorEvent,
+} from '../utils/sheet-cursor-state'
 
 type MaybeReactive<T> = T | { value: T } | (() => T)
 
@@ -52,6 +59,12 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
   let disconnected = false
   let connectionPromise: Promise<Socket | null> | null = null
 
+  // Live cell-cursors: remote collaborators' active cells (keyed by userId, self excluded). `byCell`
+  // indexes them for O(1) per-cell lookup in the grid render.
+  const remoteCursors = ref<Map<string, RemoteCellCursor>>(new Map())
+  const remoteCursorsByCell = computed(() => cursorsByCell(remoteCursors.value))
+  let localCursorKey: string | null = null
+
   const activeUsers = computed(() => presence.value?.users ?? [])
   const activeCollaborators = computed(() => {
     const selfId = currentUserId.value
@@ -66,6 +79,22 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
     }
   }
 
+  function clearRemoteCursors() {
+    if (remoteCursors.value.size > 0) remoteCursors.value = new Map()
+    localCursorKey = null
+  }
+
+  // Emit the local active cell to the sheet room (deduped — only on actual change). null/null clears it
+  // (blur). Presentational only: the server relays it; no data is mutated.
+  function setLocalCursor(recordId: string | null, fieldId: string | null) {
+    const key = recordId && fieldId ? `${recordId}:${fieldId}` : null
+    if (key === localCursorKey) return
+    localCursorKey = key
+    if (socket && activeSheetId) {
+      socket.emit('sheet:cursor', { sheetId: activeSheetId, recordId: recordId ?? null, fieldId: fieldId ?? null })
+    }
+  }
+
   function cleanupSocket() {
     if (socket) {
       if (activeSheetId) {
@@ -77,6 +106,7 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
     activeSheetId = null
     connectionPromise = null
     clearPresence()
+    clearRemoteCursors()
   }
 
   async function ensureSocket(): Promise<Socket | null> {
@@ -100,6 +130,11 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
           const nextPresence = normalizeSheetPresence(payload)
           if (!nextPresence || nextPresence.sheetId !== activeSheetId) return
           presence.value = nextPresence
+        })
+
+        nextSocket.on('sheet:cursor', (payload: SheetCursorEvent & { sheetId?: unknown }) => {
+          if (typeof payload?.sheetId === 'string' && payload.sheetId.trim() !== activeSheetId) return
+          remoteCursors.value = applyCursorEvent(remoteCursors.value, payload, currentUserId.value)
         })
 
         socket = nextSocket
@@ -126,6 +161,7 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
     if (activeSheetId && activeSheetId !== nextSheetId) {
       currentSocket.emit('leave-sheet', activeSheetId)
       clearPresence(activeSheetId)
+      clearRemoteCursors()
     }
     if (activeSheetId !== nextSheetId) {
       currentSocket.emit('join-sheet', nextSheetId)
@@ -141,6 +177,16 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
     { immediate: true },
   )
 
+  // Backstop prune: a collaborator who dropped out of presence can't keep a live cursor (the server also
+  // broadcasts a clear on disconnect/leave; this covers a missed clear). Safe because join-presence
+  // always precedes that user's first cursor event.
+  watch(
+    () => presence.value?.users?.map((user) => user.id).join(',') ?? '',
+    () => {
+      remoteCursors.value = pruneCursors(remoteCursors.value, presence.value?.users?.map((user) => user.id) ?? [])
+    },
+  )
+
   onBeforeUnmount(() => {
     disconnected = true
     cleanupSocket()
@@ -151,6 +197,9 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
     activeUsers,
     activeCollaborators,
     activeCollaboratorCount,
+    remoteCursors,
+    remoteCursorsByCell,
+    setLocalCursor,
     reconnect: syncSheetRoom,
     disconnect: cleanupSocket,
   }

--- a/apps/web/src/multitable/utils/sheet-cursor-state.ts
+++ b/apps/web/src/multitable/utils/sheet-cursor-state.ts
@@ -1,0 +1,89 @@
+/**
+ * Live cell-cursor state — pure reducers over remote collaborators' active cells.
+ *
+ * The sheet socket relays `sheet:cursor` events ({ userId, recordId, fieldId }; recordId/fieldId null =
+ * the user blurred/left). These pure functions fold those events into a Map keyed by userId, excluding
+ * self, so the grid can render one highlight per remote collaborator. Kept pure (no socket/Vue) so the
+ * tracking + self-exclusion + prune rules are unit-testable in isolation.
+ */
+
+export type RemoteCellCursor = { recordId: string; fieldId: string }
+
+export type SheetCursorEvent = {
+  userId?: unknown
+  recordId?: unknown
+  fieldId?: unknown
+}
+
+function asTrimmed(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Fold one `sheet:cursor` event into the cursor map. Returns a NEW Map (so Vue reactivity sees a change).
+ * - self events (userId === selfId) are ignored — you never render your own cursor as "remote";
+ * - a complete cell (recordId AND fieldId) sets/replaces that user's cursor;
+ * - an incomplete cell (either missing → blur/clear) removes that user's cursor.
+ */
+export function applyCursorEvent(
+  cursors: Map<string, RemoteCellCursor>,
+  event: SheetCursorEvent,
+  selfId: string | null,
+): Map<string, RemoteCellCursor> {
+  const userId = asTrimmed(event.userId)
+  if (!userId) return cursors
+  if (selfId && userId === selfId) return cursors
+
+  const recordId = asTrimmed(event.recordId)
+  const fieldId = asTrimmed(event.fieldId)
+  const next = new Map(cursors)
+  if (recordId && fieldId) {
+    next.set(userId, { recordId, fieldId })
+  } else {
+    next.delete(userId)
+  }
+  return next
+}
+
+/**
+ * Drop cursors for users no longer present in the sheet (presence is the source of truth for "who's
+ * here"; a disconnect also broadcasts a clear, but presence-prune is the backstop). Returns the SAME map
+ * reference when nothing changed, else a new pruned Map.
+ */
+export function pruneCursors(
+  cursors: Map<string, RemoteCellCursor>,
+  activeUserIds: Iterable<string>,
+): Map<string, RemoteCellCursor> {
+  const allowed = new Set<string>()
+  for (const id of activeUserIds) {
+    const trimmed = asTrimmed(id)
+    if (trimmed) allowed.add(trimmed)
+  }
+  let changed = false
+  const next = new Map<string, RemoteCellCursor>()
+  for (const [userId, cell] of cursors) {
+    if (allowed.has(userId)) next.set(userId, cell)
+    else changed = true
+  }
+  return changed ? next : cursors
+}
+
+/** Stable key for matching a remote cursor to a rendered grid cell. */
+export function cursorCellKey(recordId: string, fieldId: string): string {
+  return `${recordId}:${fieldId}`
+}
+
+/**
+ * Index cursors by cell key → list of userIds, for O(1) per-cell lookup in the grid render. A cell can
+ * carry more than one remote collaborator.
+ */
+export function cursorsByCell(cursors: Map<string, RemoteCellCursor>): Map<string, string[]> {
+  const byCell = new Map<string, string[]>()
+  for (const [userId, cell] of cursors) {
+    const key = cursorCellKey(cell.recordId, cell.fieldId)
+    const list = byCell.get(key)
+    if (list) list.push(userId)
+    else byCell.set(key, [userId])
+  }
+  return byCell
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -269,6 +269,8 @@
           :button-run-pending="buttonRunPending"
           :fetch-record="fetchLinkedRecordFn"
           :mention-suggestions="commentMentionSuggestions"
+          :remote-cursors-by-cell="sheetPresenceState.remoteCursorsByCell.value"
+          @cursor-focus="onCellCursorFocus"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @open-person-picker="onGridPersonPicker" @resize-column="onSetColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
@@ -1636,6 +1638,11 @@ async function selectRecord(recordId: string, opts?: { openComments?: boolean; h
 
 function onSelectRecord(recordId: string) {
   void selectRecord(recordId)
+}
+
+// Live cell-cursors: broadcast the local user's active cell to other collaborators on this sheet.
+function onCellCursorFocus(payload: { recordId: string; fieldId: string }) {
+  sheetPresenceState.setLocalCursor(payload.recordId, payload.fieldId)
 }
 
 function onMentionChipClick() {

--- a/apps/web/tests/multitable-sheet-cursor-state.spec.ts
+++ b/apps/web/tests/multitable-sheet-cursor-state.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyCursorEvent,
+  pruneCursors,
+  cursorsByCell,
+  cursorCellKey,
+  type RemoteCellCursor,
+} from '../src/multitable/utils/sheet-cursor-state'
+
+const empty = () => new Map<string, RemoteCellCursor>()
+
+describe('sheet-cursor-state — live cell-cursor reducers', () => {
+  it('applyCursorEvent tracks a remote collaborator\'s active cell', () => {
+    const next = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'rec_1', fieldId: 'fld_x' }, 'user_a')
+    expect(next.get('user_b')).toEqual({ recordId: 'rec_1', fieldId: 'fld_x' })
+  })
+
+  it('applyCursorEvent EXCLUDES self (never renders your own cursor as remote)', () => {
+    const next = applyCursorEvent(empty(), { userId: 'user_a', recordId: 'rec_1', fieldId: 'fld_x' }, 'user_a')
+    expect(next.has('user_a')).toBe(false)
+    expect(next.size).toBe(0)
+  })
+
+  it('applyCursorEvent replaces a user\'s cursor on move + returns a NEW map (reactivity)', () => {
+    const first = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'rec_1', fieldId: 'fld_x' }, 'user_a')
+    const moved = applyCursorEvent(first, { userId: 'user_b', recordId: 'rec_2', fieldId: 'fld_y' }, 'user_a')
+    expect(moved).not.toBe(first)
+    expect(moved.get('user_b')).toEqual({ recordId: 'rec_2', fieldId: 'fld_y' })
+    expect(moved.size).toBe(1)
+  })
+
+  it('applyCursorEvent removes a cursor on a cleared (blur) event — recordId/fieldId missing', () => {
+    const present = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'rec_1', fieldId: 'fld_x' }, 'user_a')
+    const cleared = applyCursorEvent(present, { userId: 'user_b', recordId: null, fieldId: null }, 'user_a')
+    expect(cleared.has('user_b')).toBe(false)
+  })
+
+  it('applyCursorEvent ignores an event with no userId', () => {
+    const next = applyCursorEvent(empty(), { recordId: 'rec_1', fieldId: 'fld_x' }, 'user_a')
+    expect(next.size).toBe(0)
+  })
+
+  it('pruneCursors drops cursors for users no longer present', () => {
+    let cursors = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'r1', fieldId: 'f1' }, 'me')
+    cursors = applyCursorEvent(cursors, { userId: 'user_c', recordId: 'r2', fieldId: 'f2' }, 'me')
+    const pruned = pruneCursors(cursors, ['user_b']) // user_c left
+    expect(pruned.has('user_b')).toBe(true)
+    expect(pruned.has('user_c')).toBe(false)
+  })
+
+  it('pruneCursors returns the SAME ref when nothing changed (avoids needless re-render)', () => {
+    const cursors = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'r1', fieldId: 'f1' }, 'me')
+    expect(pruneCursors(cursors, ['user_b', 'user_c'])).toBe(cursors)
+  })
+
+  it('cursorsByCell indexes by cell key and supports multiple collaborators on one cell', () => {
+    let cursors = applyCursorEvent(empty(), { userId: 'user_b', recordId: 'r1', fieldId: 'f1' }, 'me')
+    cursors = applyCursorEvent(cursors, { userId: 'user_c', recordId: 'r1', fieldId: 'f1' }, 'me')
+    const byCell = cursorsByCell(cursors)
+    expect(byCell.get(cursorCellKey('r1', 'f1'))?.sort()).toEqual(['user_b', 'user_c'])
+  })
+})

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -147,6 +147,31 @@ export class CollabService {
     return `sheet:${sheetId}`
   }
 
+  // Live cell-cursor payload: {sheetId, recordId, fieldId}; recordId/fieldId null = cleared (blur).
+  private normalizeCursorPayload(
+    payload: unknown,
+  ): { sheetId: string; recordId: string | null; fieldId: string | null } | null {
+    if (!payload || typeof payload !== 'object') return null
+    const p = payload as Record<string, unknown>
+    const sheetId = typeof p.sheetId === 'string' ? p.sheetId.trim() : ''
+    if (!sheetId) return null
+    const recordId = typeof p.recordId === 'string' && p.recordId.trim() ? p.recordId.trim() : null
+    const fieldId = typeof p.fieldId === 'string' && p.fieldId.trim() ? p.fieldId.trim() : null
+    return { sheetId, recordId, fieldId }
+  }
+
+  // Broadcast a user's active cell to the rest of the sheet room (sender excluded via socket.to). The
+  // userId is the trusted server-side identity; recordId/fieldId null clears that user's remote cursor.
+  private broadcastCursor(
+    socket: Socket,
+    sheetId: string,
+    userId: string,
+    recordId: string | null,
+    fieldId: string | null,
+  ): void {
+    socket.to(this.buildSheetRoom(sheetId)).emit('sheet:cursor', { sheetId, userId, recordId, fieldId })
+  }
+
   private trackSocketSheetMembership(socketId: string, sheetId: string) {
     const current = this.sheetMembershipBySocket.get(socketId) ?? new Set<string>()
     current.add(sheetId)
@@ -259,6 +284,8 @@ export class CollabService {
         const userId = this.getTrustedUserId(socket)
         const sheetIds = [...(this.sheetMembershipBySocket.get(socket.id) ?? [])]
         for (const sheetId of sheetIds) {
+          // Clear this socket's live cell-cursor for the rest of the room before dropping presence.
+          if (userId) this.broadcastCursor(socket, sheetId, userId, null, null)
           if (userId) this.removeSheetPresence(sheetId, userId, socket.id)
           this.untrackSocketSheetMembership(socket.id, sheetId)
           this.emitSheetPresence(sheetId)
@@ -275,11 +302,23 @@ export class CollabService {
         if (!sheetId) return
         const room = this.buildSheetRoom(sheetId)
         const userId = this.getTrustedUserId(socket)
+        if (userId) this.broadcastCursor(socket, sheetId, userId, null, null)
         socket.leave(room)
         if (userId) this.removeSheetPresence(sheetId, userId, socket.id)
         this.untrackSocketSheetMembership(socket.id, sheetId)
         this.logger.info(`Client ${socket.id} left ${room}`)
         this.emitSheetPresence(sheetId)
+      })
+
+      // Live cell-cursor relay (presentational, no persistence): a sheet member broadcasts its active
+      // cell to the rest of the room (sender excluded). Membership-gated; userId is the trusted identity.
+      socket.on('sheet:cursor', (payload: unknown) => {
+        const data = this.normalizeCursorPayload(payload)
+        if (!data) return
+        if (!this.sheetMembershipBySocket.get(socket.id)?.has(data.sheetId)) return
+        const userId = this.getTrustedUserId(socket)
+        if (!userId) return
+        this.broadcastCursor(socket, data.sheetId, userId, data.recordId, data.fieldId)
       })
 
       socket.on('join-comment-record', (payload: unknown) => {


### PR DESCRIPTION
Shows each remote collaborator's active cell as a dashed highlight in the grid (Feishu 多维表格 live-cursor parity). The contained realtime advance; the XL remainder (non-string-field CRDT binding) is a separate owner-prioritize arc.

**Premise corrected during design-lock:** FE Yjs is per-RECORD doc sync (no sheet-level Y.Awareness); sheet presence is socket.io (CollabService, online-users only, no per-cell state). So cursors extend the socket.io presence channel via a new BE relay (not FE-only).

**BE (CollabService):** membership-gated `sheet:cursor` relay — `if (!sheetMembershipBySocket.get(socket.id)?.has(sheetId)) return` (only a sheet member broadcasts), `userId` = server-trusted identity (never the spoofable query value), `socket.to(room)` excludes sender, clears on disconnect + leave-sheet. Presentational (cell coords + userId only, no record data).

**FE:** pure reducers `sheet-cursor-state.ts` (self-excluded set/clear/prune, 8/8 tested); `useMultitableSheetPresence` extended (reuses the sheet socket) with `remoteCursorsByCell` + `setLocalCursor`; `MetaGridTable` renders the dashed remote-cursor outline on both grouped + flat paths + emits `cursor-focus` on cell click; workbench wires both directions.

Verified: BE tsc 0, full BE suite 4426/0, vue-tsc clean, reducer spec 8/8; spec in the web-guard lane. **Follow-ups:** emit on click (not keyboard-nav); multi-tab disconnect-clear self-corrects on next focus; round-trip is reducer-tested (presentational socket.io, not a DB path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)