### PR TITLE
feat(multitable): #18 row-level read-deny — inert foundation (flag-gated, non-breaking)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260617140000_rowlevel_read_deny_foundation.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260617140000_rowlevel_read_deny_foundation.ts
@@ -1,0 +1,37 @@
+/**
+ * Migration: #18 row-level record read-deny — FOUNDATION ONLY (inert until the enforcement slice).
+ *
+ * Adds the building blocks WITHOUT enforcing anything:
+ *  - `access_level='none'` (a read-deny grant) to the record_permissions CHECK constraint;
+ *  - `meta_sheets.row_level_read_permissions_enabled` boolean, DEFAULT false (the per-sheet opt-in).
+ *
+ * NON-BREAKING + zero partial-deny risk: no read path consults the flag yet, deriveRecordPermissions
+ * only denies 'none' when explicitly told the flag is on (no caller passes it), and the per-record
+ * write API still restricts access_level to read/write/admin — so 'none' cannot even be SET yet. With
+ * the flag off everywhere, behavior is byte-identical to today and the #2754 grant-additive canary
+ * stays green. The read-path enforcement (CTE on every surface) + write-API-allow-'none' + conflict
+ * semantics + golden suite are the next (XL) slice and MUST land before any sheet enables the flag.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE record_permissions DROP CONSTRAINT IF EXISTS record_permissions_access_level_check`.execute(db)
+  await sql`
+    ALTER TABLE record_permissions
+    ADD CONSTRAINT record_permissions_access_level_check
+    CHECK (access_level IN ('read', 'write', 'admin', 'none'))
+  `.execute(db)
+  await sql`ALTER TABLE meta_sheets ADD COLUMN IF NOT EXISTS row_level_read_permissions_enabled boolean NOT NULL DEFAULT false`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_sheets DROP COLUMN IF EXISTS row_level_read_permissions_enabled`.execute(db)
+  // 'none' rows would violate the narrowed constraint — remove them before re-adding it.
+  await sql`DELETE FROM record_permissions WHERE access_level = 'none'`.execute(db)
+  await sql`ALTER TABLE record_permissions DROP CONSTRAINT IF EXISTS record_permissions_access_level_check`.execute(db)
+  await sql`
+    ALTER TABLE record_permissions
+    ADD CONSTRAINT record_permissions_access_level_check
+    CHECK (access_level IN ('read', 'write', 'admin'))
+  `.execute(db)
+}

--- a/packages/core-backend/src/multitable/permission-derivation.ts
+++ b/packages/core-backend/src/multitable/permission-derivation.ts
@@ -39,7 +39,8 @@ export type FieldPermissionScope = {
 
 export type RecordPermissionScope = {
   recordId: string
-  accessLevel: 'read' | 'write' | 'admin'
+  // #18 read-deny FOUNDATION: 'none' is a read-deny grant (enforced only when the per-sheet flag is on).
+  accessLevel: 'read' | 'write' | 'admin' | 'none'
 }
 
 export type MultitableRecordPermission = {
@@ -131,6 +132,10 @@ export function deriveRecordPermissions(
   recordId: string,
   capabilities: Pick<MultitableCapabilities, 'canRead' | 'canEditRecord'>,
   recordScopeMap?: Map<string, RecordPermissionScope>,
+  // #18 read-deny FOUNDATION: when true (caller passes the sheet's row_level_read_permissions_enabled),
+  // a 'none' scope DENIES read. Default false → 'none' is inert (no read path passes this yet), so the
+  // model stays grant-ADDITIVE (#2787) and behavior is byte-identical to today.
+  rowLevelReadDenyEnabled = false,
 ): MultitableRecordPermission {
   const scope = recordScopeMap?.get(recordId)
   if (!scope) {
@@ -140,8 +145,11 @@ export function deriveRecordPermissions(
       canDelete: capabilities.canEditRecord,
     }
   }
+  // Read stays grant-additive: a read/write/admin grant never reduces the sheet-level canRead. ONLY an
+  // ACTIVE 'none' (flag on) subtracts read. Write/delete are unchanged (a 'none' grants neither).
+  const readDeniedByNone = scope.accessLevel === 'none' && rowLevelReadDenyEnabled
   return {
-    canRead: capabilities.canRead && (scope.accessLevel === 'read' || scope.accessLevel === 'write' || scope.accessLevel === 'admin'),
+    canRead: capabilities.canRead && !readDeniedByNone,
     canEdit: capabilities.canEditRecord && (scope.accessLevel === 'write' || scope.accessLevel === 'admin'),
     canDelete: capabilities.canEditRecord && scope.accessLevel === 'admin',
   }

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -929,9 +929,14 @@ export async function loadRecordPermissionScopeMap(
       const recordId = typeof row.record_id === 'string' ? row.record_id : ''
       if (!recordId) continue
       const existing = scopes.get(recordId)
-      const level = row.access_level as 'read' | 'write' | 'admin'
+      const raw = row.access_level
+      // #18 read-deny FOUNDATION: 'none' is now a valid level. Defensive narrow (DB-constrained anyway).
+      const level: 'read' | 'write' | 'admin' | 'none' =
+        raw === 'none' || raw === 'write' || raw === 'admin' ? raw : 'read'
       if (existing) {
-        const rank = { read: 0, write: 1, admin: 2 } as const
+        // DENY-WINS: a 'none' read-deny is the most restrictive and overrides grants via other subjects
+        // (a deny cannot be bypassed by group/role membership). Otherwise max of read<write<admin.
+        const rank = { read: 0, write: 1, admin: 2, none: 3 } as const
         if (rank[level] > rank[existing.accessLevel]) {
           existing.accessLevel = level
         }

--- a/packages/core-backend/tests/unit/multitable-record-permissions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-record-permissions.test.ts
@@ -113,3 +113,34 @@ describe('deriveRecordPermissions', () => {
     expect(result.canDelete).toBe(false)
   })
 })
+
+describe('deriveRecordPermissions — #18 read-deny foundation (flag-gated none)', () => {
+  const caps = { canRead: true, canEditRecord: true }
+  const noneScope = () => new Map([['r1', { recordId: 'r1', accessLevel: 'none' as const }]])
+
+  it('none scope is INERT when the flag is off (default) — grant-additive, reads per sheet', () => {
+    const r = deriveRecordPermissions('r1', caps, noneScope())
+    expect(r.canRead).toBe(true)
+    expect(r.canEdit).toBe(false)
+    expect(r.canDelete).toBe(false)
+  })
+
+  it('none scope DENIES read only when the flag is on', () => {
+    const r = deriveRecordPermissions('r1', caps, noneScope(), true)
+    expect(r.canRead).toBe(false)
+    expect(r.canEdit).toBe(false)
+    expect(r.canDelete).toBe(false)
+  })
+
+  it('read/write/admin scopes are grant-additive — flag never reduces their read', () => {
+    for (const lvl of ['read', 'write', 'admin'] as const) {
+      const m = new Map([['r1', { recordId: 'r1', accessLevel: lvl }]])
+      expect(deriveRecordPermissions('r1', caps, m, true).canRead).toBe(true)
+      expect(deriveRecordPermissions('r1', caps, m, false).canRead).toBe(true)
+    }
+  })
+
+  it('flag-on does not deny an UNMAPPED record (no scope) — #2754 canary stays additive', () => {
+    expect(deriveRecordPermissions('r2', caps, noneScope(), true).canRead).toBe(true)
+  })
+})


### PR DESCRIPTION
Step ① of the #18 row-level read-deny arc (per the #2787 staged plan). **Fully INERT + non-breaking** — the safe foundation the enforcement slices build on.

- Migration: `'none'` read-deny level added to the `record_permissions` access_level CHECK; per-sheet `meta_sheets.row_level_read_permissions_enabled` boolean **DEFAULT false** (the runtime opt-in).
- `deriveRecordPermissions(..., rowLevelReadDenyEnabled = false)`: a `'none'` scope subtracts read **only when the flag is passed true** — and **no caller passes it**; read stays grant-additive (#2787).
- `loadRecordPermissionScopeMap`: `'none'` deny-wins conflict semantics (a deny via one subject can't be bypassed by a grant via another) — consulted only under the (off) flag.
- The per-record write API is **unchanged** (`z.enum(['read','write','admin'])`) → `'none'` is **not settable yet**. Read paths **untouched** (univer-meta.ts diff empty).

Net: flag OFF on every sheet, `'none'` unsettable + consulted nowhere → byte-identical behavior, #2754 canary green. +4 derivation unit tests (flag-off inert / flag-on denies / grant-additive both states / flag-on doesn't deny an unmapped record). Full suite 4430/0.

**The deny does NOT function until the enforcement slices land** (CTE on every read surface + write-API-allow-'none' + golden suite). Do NOT enable the flag on any sheet until then. This PR is safe precisely because it changes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)