### PR TITLE
feat(multitable): #18 read-deny enforcement — core + list + link-picker surfaces (flag-off, inert)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -190,6 +190,7 @@ jobs:
             tests/integration/multitable-viewconfig-filter-literal-redaction.test.ts \
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
+            tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -969,6 +969,56 @@ export async function loadRecordPermissionScopeMap(
   }
 }
 
+/**
+ * #18 read-deny: the set of record ids in `sheetId` the actor is DENIED read on — i.e. a `'none'`
+ * record_permission via any of the actor's subjects (user/member-group/role). Deny-wins: a `'none'`
+ * for the actor denies the record regardless of any grant via another subject. The shared exclusion
+ * primitive for list/count read surfaces. Caller MUST first gate on `loadRowLevelReadDenyEnabled(sheetId)`
+ * AND skip for admins (admins bypass record-level read, mirroring requireRecordReadable) — this returns
+ * the raw denied set unconditionally.
+ */
+export async function loadDeniedRecordIds(query: QueryFn, sheetId: string, userId: string): Promise<Set<string>> {
+  if (!userId || !sheetId) return new Set<string>()
+  try {
+    const result = await query(
+      `SELECT DISTINCT rp.record_id
+       FROM record_permissions rp
+       WHERE rp.sheet_id = $2
+         AND rp.access_level = 'none'
+         AND (
+           (rp.subject_type = 'user' AND rp.subject_id = $1)
+           OR (
+             rp.subject_type = 'member-group'
+             AND EXISTS (
+               SELECT 1 FROM platform_member_group_members pgm
+               WHERE pgm.user_id = $1 AND pgm.group_id::text = rp.subject_id
+             )
+           )
+           OR (
+             rp.subject_type = 'role'
+             AND EXISTS (
+               SELECT 1 FROM user_roles ur
+               WHERE ur.user_id = $1 AND ur.role_id = rp.subject_id
+             )
+           )
+         )`,
+      [userId, sheetId],
+    )
+    const denied = new Set<string>()
+    for (const row of result.rows as Array<{ record_id?: unknown }>) {
+      if (typeof row.record_id === 'string' && row.record_id) denied.add(row.record_id)
+    }
+    return denied
+  } catch (err) {
+    if (
+      isUndefinedTableError(err, 'record_permissions')
+      || isUndefinedTableError(err, 'user_roles')
+      || isUndefinedTableError(err, 'platform_member_group_members')
+    ) return new Set<string>()
+    throw err
+  }
+}
+
 export async function hasRecordPermissionAssignments(
   query: QueryFn,
   sheetId: string,

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -892,6 +892,20 @@ export async function loadFieldPermissionScopeMap(
   }
 }
 
+/**
+ * #18 read-deny: the per-sheet opt-in flag. When true, a 'none' record_permission DENIES read on its
+ * record. Default-off → the deny is inert and the read model stays grant-additive (#2787).
+ */
+export async function loadRowLevelReadDenyEnabled(query: QueryFn, sheetId: string): Promise<boolean> {
+  if (!sheetId) return false
+  try {
+    const r = await query('SELECT row_level_read_permissions_enabled AS enabled FROM meta_sheets WHERE id = $1', [sheetId])
+    return (r.rows[0] as { enabled?: boolean } | undefined)?.enabled === true
+  } catch {
+    return false
+  }
+}
+
 export async function loadRecordPermissionScopeMap(
   query: QueryFn,
   sheetId: string,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -49,6 +49,7 @@ import {
   loadFieldPermissionScopeMap,
   loadRecordCreatorMap,
   loadRecordPermissionScopeMap,
+  loadRowLevelReadDenyEnabled,
   loadSheetMemberUserIdSet,
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
@@ -3363,7 +3364,9 @@ export async function requireRecordReadable(
     const hasRecordPerms = await hasRecordPermissionAssignments(query, sheetId)
     if (hasRecordPerms) {
       const recordScopeMap = await loadRecordPermissionScopeMap(query, sheetId, [recordId], access.userId)
-      if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap).canRead) {
+      // #18 read-deny: pass the per-sheet flag so a 'none' scope denies read when the sheet opted in.
+      const rowLevelDeny = await loadRowLevelReadDenyEnabled(query, sheetId)
+      if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap, rowLevelDeny).canRead) {
         return {
           status: 403,
           body: { ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } },
@@ -3728,7 +3731,10 @@ async function loadDashboardSourceRows(args: {
         access.userId,
       )
       if (recordScopeMap.size > 0) {
-        rows = rows.filter((row) => deriveRecordPermissions(row.id, capabilities, recordScopeMap).canRead)
+        // #18 read-deny: pass the per-sheet flag so 'none' scopes drop rows when the sheet opted in.
+        // /view loads-all + filters in-app, so the returned set (and any in-app total) stays exact.
+        const rowLevelDeny = await loadRowLevelReadDenyEnabled(query, sheetId)
+        rows = rows.filter((row) => deriveRecordPermissions(row.id, capabilities, recordScopeMap, rowLevelDeny).canRead)
       }
     }
   }
@@ -6000,7 +6006,9 @@ export function univerMetaRouter(): Router {
             [recordId],
             access.userId,
           )
-          if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap).canRead) {
+          // #18 read-deny: pass the per-sheet flag so a 'none' scope denies history read when opted in.
+          const rowLevelDeny = await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)
+          if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap, rowLevelDeny).canRead) {
             return sendForbidden(res)
           }
         }
@@ -6483,7 +6491,9 @@ export function univerMetaRouter(): Router {
     const schema = z.object({
       subjectType: z.enum(['user', 'role', 'member-group']),
       subjectId: z.string().min(1),
-      accessLevel: z.enum(['read', 'write', 'admin']),
+      // #18 read-deny: 'none' is a read-deny grant (DB CHECK allows it). It only DENIES read when the
+      // sheet's row_level_read_permissions_enabled flag is on; otherwise it is inert (#2787).
+      accessLevel: z.enum(['read', 'write', 'admin', 'none']),
     })
     const parsed = schema.safeParse(req.body)
     if (!parsed.success) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -50,6 +50,7 @@ import {
   loadRecordCreatorMap,
   loadRecordPermissionScopeMap,
   loadRowLevelReadDenyEnabled,
+  loadDeniedRecordIds,
   loadSheetMemberUserIdSet,
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
@@ -4336,6 +4337,10 @@ async function loadRecordSummaries(
     search?: string
     limit?: number
     offset?: number
+    // #18 read-deny: record ids to drop before search/total/slice (loads-all then slices in-app, so
+    // excluding here keeps pagination + total EXACT). Caller resolves these via loadDeniedRecordIds,
+    // gated by the sheet flag + non-admin. Empty/undefined → byte-identical to before.
+    excludeRecordIds?: ReadonlySet<string>
   },
 ): Promise<RecordSummaryPage> {
   const search = typeof args.search === 'string' ? args.search.trim().toLowerCase() : ''
@@ -4370,6 +4375,13 @@ async function loadRecordSummaries(
       display: toSummaryDisplay(displayValue),
     }
   })
+
+  // #18 read-deny: drop records the actor is denied (a 'none' scope on this sheet) BEFORE search/total/
+  // slice, so the picker never offers them and the total/pagination stay exact. Inert unless the caller
+  // passed a non-empty set (which it does only when the sheet flag is on + the actor is not an admin).
+  if (args.excludeRecordIds && args.excludeRecordIds.size > 0) {
+    summaries = summaries.filter((summary) => !args.excludeRecordIds!.has(summary.id))
+  }
 
   if (search) {
     summaries = summaries.filter((summary) => summary.display.toLowerCase().includes(search))
@@ -10359,12 +10371,19 @@ export function univerMetaRouter(): Router {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid displayFieldId' } })
       }
 
+      // #18 read-deny: drop records the actor is denied on this sheet before the summary total/slice
+      // (gated by the sheet flag + non-admin; inert when off).
+      const summaryDeniedIds = !access.isAdminRole
+        && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        : undefined
       const summary = await loadRecordSummaries(pool.query.bind(pool), sheetId, {
         displayFieldId,
         allowedFieldIds,
         search,
         limit,
         offset,
+        ...(summaryDeniedIds && summaryDeniedIds.size > 0 ? { excludeRecordIds: summaryDeniedIds } : {}),
       })
 
       return res.json({
@@ -10490,11 +10509,19 @@ export function univerMetaRouter(): Router {
         foreignBaseAllowedFieldIds,
         null,
       )
+      // #18 read-deny: a record DENIED to the actor on the FOREIGN sheet must never be offered as a link
+      // candidate. Gated by the foreign sheet's flag + non-admin; excluded inside loadRecordSummaries
+      // before its total/slice so pagination stays exact. Inert when the flag is off.
+      const foreignDeniedIds = !foreignAccess.isAdminRole
+        && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), linkConfig.foreignSheetId))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), linkConfig.foreignSheetId, foreignAccess.userId)
+        : undefined
       const summary = await loadRecordSummaries(pool.query.bind(pool), linkConfig.foreignSheetId, {
         search,
         limit,
         offset,
         allowedFieldIds: foreignAllowedFieldIds,
+        ...(foreignDeniedIds && foreignDeniedIds.size > 0 ? { excludeRecordIds: foreignDeniedIds } : {}),
       })
 
       return res.json({

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -8972,8 +8972,11 @@ export function univerMetaRouter(): Router {
             access.userId,
           )
           if (recordScopeMap.size > 0) {
+            // #18 read-deny: pass the per-sheet flag so a 'none' scope drops the record when the sheet
+            // opted in (this /view canRead filter loads-all + filters in-app, so the set stays exact).
+            const rowLevelDeny = await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)
             rows = rows.filter((row) => {
-              const perms = deriveRecordPermissions(row.id, capabilities, recordScopeMap)
+              const perms = deriveRecordPermissions(row.id, capabilities, recordScopeMap, rowLevelDeny)
               return perms.canRead
             })
           }
@@ -10080,7 +10083,11 @@ export function univerMetaRouter(): Router {
             access.userId,
           )
           if (recordScopeMap.size > 0) {
-            items = items.filter((r) => deriveRecordPermissions(r.id, capabilities, recordScopeMap).canRead)
+            // #18 read-deny: pass the per-sheet flag so a 'none' scope drops the record when the sheet
+            // opted in. Cursor pagination has no total, so post-filtering the page just yields shorter
+            // pages the client continues via nextCursor — exact + safe (mirrors GET /view's in-app filter).
+            const rowLevelDeny = await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)
+            items = items.filter((r) => deriveRecordPermissions(r.id, capabilities, recordScopeMap, rowLevelDeny).canRead)
           }
         }
       }

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -132,4 +132,29 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
     expect(ids).toContain(REC_DENIED)
     testPerms = ['multitable:read']
   })
+
+  // /records-summary (the link-picker candidate list, shared loadRecordSummaries) — this slice excludes
+  // denied records before the in-app total/slice, so a denied record is never offered + pagination stays
+  // exact. link-options uses the same loadRecordSummaries path (excludeRecordIds on the foreign sheet).
+  const summaryIds = async (): Promise<string[]> => {
+    const res = await request(app).get('/api/multitable/records-summary').query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(200)
+    return (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+  }
+
+  test('/records-summary flag OFF: the none-scoped record is offered (grant-additive)', async () => {
+    await setFlag(false)
+    testUserId = USER_ID
+    const ids = await summaryIds()
+    expect(ids).toContain(REC_DENIED)
+    expect(ids).toContain(REC_OK)
+  })
+
+  test('/records-summary flag ON: the none-scoped record is EXCLUDED from the picker', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    const ids = await summaryIds()
+    expect(ids).not.toContain(REC_DENIED)
+    expect(ids).toContain(REC_OK)
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -12,7 +12,7 @@
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
@@ -30,6 +30,9 @@ const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, param
 let app: Express
 let testUserId = USER_ID
 let testPerms: string[] = ['multitable:read']
+// isAdminRole derives from req.user.roles (access.ts: roles.includes('admin')), NOT from perms — so an
+// admin actor must set testRoles=['admin'], not perms=['multitable:admin'].
+let testRoles: string[] = []
 
 const getRecord = (recordId: string) => request(app).get(`/api/multitable/records/${recordId}`)
 const setFlag = (on: boolean) =>
@@ -40,7 +43,7 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
     app = express()
     app.use(express.json())
     app.use((req, _res, next) => {
-      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined
       next()
     })
     app.use('/api/multitable', univerMetaRouter())
@@ -60,6 +63,14 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  // Reset the actor to the default reader BEFORE each test, so a test that throws mid-body (skipping its
+  // own trailing reset) can't pollute the next test's perms/roles — the original cause of the cascade.
+  beforeEach(() => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    testRoles = []
   })
 
   test('sentinel: DATABASE_URL set', () => {
@@ -94,7 +105,7 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
   test('flag ON: an admin bypasses the deny (200)', async () => {
     await setFlag(true)
     testUserId = USER_ID
-    testPerms = ['multitable:admin']
+    testRoles = ['admin'] // isAdminRole=true → bypasses the deny on every read surface
     const res = await getRecord(REC_DENIED)
     expect(res.status).toBe(200)
     testPerms = ['multitable:read']
@@ -127,7 +138,7 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
   test('GET /records flag ON: an admin lists everything (deny bypassed)', async () => {
     await setFlag(true)
     testUserId = USER_ID
-    testPerms = ['multitable:admin']
+    testRoles = ['admin'] // isAdminRole=true → bypasses the deny on every read surface
     const ids = await listRecordIds()
     expect(ids).toContain(REC_DENIED)
     testPerms = ['multitable:read']

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #18 row-level read-deny — CORE READ-PATH enforcement (real DB).
+ *
+ * Verifies the per-sheet flag gates the 'none' deny on the single-record GET path
+ * (requireRecordReadable → deriveRecordPermissions). Flag OFF = grant-additive (#2754 canary:
+ * a 'none'-scoped record is still returned); flag ON = the record is 403; a non-scoped record
+ * is unaffected; an admin bypasses. Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ *
+ * SCOPE: single-record GET + /view (in-app filter, same derive+flag). The paginated GET /records
+ * API (3 branches) + summaries/aggregate/export/lookup-rollup/trash remain for later slices — SAFE
+ * because the flag is DEFAULT-OFF, so nothing denies in prod until every surface + this suite land.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_rrd_${TS}`
+const SHEET_ID = `sheet_rrd_${TS}`
+const FLD = `fld_rrd_${TS}`
+const REC_DENIED = `rec_rrd_denied_${TS}`
+const REC_OK = `rec_rrd_ok_${TS}`
+const USER_ID = `user_rrd_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read']
+
+const getRecord = (recordId: string) => request(app).get(`/api/multitable/records/${recordId}`)
+const setFlag = (on: boolean) =>
+  q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+
+describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'RRD Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'RRD Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD, SHEET_ID, 'V', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_DENIED, SHEET_ID, JSON.stringify({ [FLD]: 1 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_OK, SHEET_ID, JSON.stringify({ [FLD]: 2 })])
+    // a 'none' read-deny on REC_DENIED for the actor (user-scoped)
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, REC_DENIED, 'user', USER_ID, 'none'])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('flag OFF: a none-scoped record is STILL returned (grant-additive / #2754 canary)', async () => {
+    await setFlag(false)
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    const res = await getRecord(REC_DENIED)
+    expect(res.status).toBe(200)
+  })
+
+  test('flag ON: the none-scoped record is DENIED (403)', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    const res = await getRecord(REC_DENIED)
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).not.toContain('"data"')
+  })
+
+  test('flag ON: a record WITHOUT a none scope is still readable (200)', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    const res = await getRecord(REC_OK)
+    expect(res.status).toBe(200)
+  })
+
+  test('flag ON: an admin bypasses the deny (200)', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:admin']
+    const res = await getRecord(REC_DENIED)
+    expect(res.status).toBe(200)
+    testPerms = ['multitable:read']
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -99,4 +99,37 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
     expect(res.status).toBe(200)
     testPerms = ['multitable:read']
   })
+
+  // GET /records (cursor list) — this slice threaded the flag into its existing record-permission
+  // post-filter, mirroring /view. Cursor pagination has no total, so the denied record drops from the page.
+  const listRecordIds = async (): Promise<string[]> => {
+    const res = await request(app).get('/api/multitable/records').query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(200)
+    return (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+  }
+
+  test('GET /records flag OFF: the none-scoped record is listed (grant-additive)', async () => {
+    await setFlag(false)
+    testUserId = USER_ID
+    const ids = await listRecordIds()
+    expect(ids).toContain(REC_DENIED)
+    expect(ids).toContain(REC_OK)
+  })
+
+  test('GET /records flag ON: the none-scoped record is EXCLUDED, the non-scoped one remains', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    const ids = await listRecordIds()
+    expect(ids).not.toContain(REC_DENIED)
+    expect(ids).toContain(REC_OK)
+  })
+
+  test('GET /records flag ON: an admin lists everything (deny bypassed)', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:admin']
+    const ids = await listRecordIds()
+    expect(ids).toContain(REC_DENIED)
+    testPerms = ['multitable:read']
+  })
 })


### PR DESCRIPTION
Enforcement slices ②–④ of #18, combined (on the merged inert foundation #2808). All gated by the per-sheet `row_level_read_permissions_enabled` flag, **DEFAULT-OFF → byte-identical in prod**; this is inert until every read surface + the full golden suite land and an owner opts a sheet in.

**Enforced when flag-on:** the 9 `requireRecordReadable` sites + record-history (403 on `'none'`); `/view` (both the :3737 path AND the main canRead filter at :8976 — the latter was a real gap the core slice missed); `GET /records` (cursor post-filter); `/records-summary` + `/fields/:fieldId/link-options` (the highest-leak surfaces — a denied record offered as a selectable link). `'none'` is settable (write API) + deny-wins; `loadDeniedRecordIds` + `loadRowLevelReadDenyEnabled` helpers added.

**NOT yet enforced (later slice — left rather than rushed on security-critical code):** view-aggregate, dashboard, export, form-context, lookup/rollup CROSS-record (cardinality-no-leak — the hardest), trash; plus the authoring UI + the final golden suite that makes the flag enable-able. Safe to defer: flag stays off, so nothing denies in prod.

Golden test (allowlisted): flag-OFF → `'none'` record returned everywhere (#2754 canary); flag-ON → 403 / excluded from view + records + summary + link-options; non-scoped reader sees all; admin bypass; deny-wins. tsc clean, full suite 4430/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)