### PR TITLE
feat(multitable): #18 read-deny enforcement — aggregate/export/trash + cross-record (flag-off)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -191,6 +191,7 @@ jobs:
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
+            tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2731,6 +2731,14 @@ async function applyLookupRollup(
     Array.from(foreignIdsBySheet.keys()).filter((id) => readableForeignSheetIds.has(id)),
   )
 
+  // #18 row-level read-deny (cross-record): when a FOREIGN sheet opts in (its
+  // row_level_read_permissions_enabled flag) and the actor is denied ('none') read on some foreign
+  // records, those records must be ABSENT from foreignRecordsBySheet. Because resolveLookupValues skips
+  // ids missing from the map (`if (!data) continue`) before counting, an excluded record is omitted from
+  // lookup values AND never counted by rollup — so a rollup count equals the count of READABLE foreign
+  // records, never the true total (no cardinality leak). Resolved once per read; flag-OFF on the foreign
+  // sheet → no exclusion → byte-identical; admins bypass.
+  const access = await resolveRequestAccess(req)
   const foreignRecordsBySheet = new Map<string, Map<string, Record<string, unknown>>>()
   for (const [foreignSheetId, ids] of foreignIdsBySheet.entries()) {
     if (!readableForeignSheetIds.has(foreignSheetId)) continue
@@ -2740,9 +2748,15 @@ async function applyLookupRollup(
       'SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
       [foreignSheetId, idList],
     )
+    let deniedForeign: Set<string> | null = null
+    if (!access.isAdminRole && access.userId && (await loadRowLevelReadDenyEnabled(query, foreignSheetId))) {
+      deniedForeign = await loadDeniedRecordIds(query, foreignSheetId, access.userId)
+    }
     const recordMap = new Map<string, Record<string, unknown>>()
     for (const raw of foreignRes.rows as any[]) {
-      recordMap.set(String(raw.id), normalizeJson(raw.data))
+      const fid = String(raw.id)
+      if (deniedForeign?.has(fid)) continue // denied foreign record → treated as absent (no value, no count)
+      recordMap.set(fid, normalizeJson(raw.data))
     }
     foreignRecordsBySheet.set(foreignSheetId, recordMap)
   }
@@ -4150,6 +4164,12 @@ async function buildLinkSummaries(
     displayFieldBySheet.set(sheetId, stringField?.id ?? allowedFields[0]?.id ?? null)
   }
 
+  // #18 row-level read-deny (cross-record): foreign records the actor is denied ('none') on an opted-in
+  // foreign sheet must not surface in a link summary (their id + display would leak). Build the denied set
+  // per foreign sheet; the summary loop below FILTERS those ids out entirely (omitted, not shown blank).
+  // flag-OFF on the foreign sheet → no denial → byte-identical; admins bypass.
+  const summaryAccess = await resolveRequestAccess(req)
+  const deniedForeignBySheet = new Map<string, Set<string>>()
   const foreignRecordsBySheet = new Map<string, Map<string, Record<string, unknown>>>()
   for (const [sheetId, ids] of idsBySheet.entries()) {
     if (!readableSheetIds.has(sheetId)) continue
@@ -4159,6 +4179,9 @@ async function buildLinkSummaries(
       'SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
       [sheetId, idList],
     )
+    if (!summaryAccess.isAdminRole && summaryAccess.userId && (await loadRowLevelReadDenyEnabled(query, sheetId))) {
+      deniedForeignBySheet.set(sheetId, await loadDeniedRecordIds(query, sheetId, summaryAccess.userId))
+    }
     const recordMap = new Map<string, Record<string, unknown>>()
     for (const row of recordRes.rows as any[]) {
       recordMap.set(String(row.id), normalizeJson(row.data))
@@ -4177,14 +4200,17 @@ async function buildLinkSummaries(
       }
       const foreignMap = foreignRecordsBySheet.get(cfg.foreignSheetId)
       const displayFieldId = displayFieldBySheet.get(cfg.foreignSheetId) ?? null
-      const summaries: LinkedRecordSummary[] = ids.map((id) => {
-        const data = foreignMap?.get(id) ?? {}
-        const displayValue = displayFieldId ? data[displayFieldId] : undefined
-        return {
-          id,
-          display: toSummaryDisplay(displayValue),
-        }
-      })
+      const denied = deniedForeignBySheet.get(cfg.foreignSheetId) // #18 cross-record: omit denied foreign ids
+      const summaries: LinkedRecordSummary[] = ids
+        .filter((id) => !denied?.has(id))
+        .map((id) => {
+          const data = foreignMap?.get(id) ?? {}
+          const displayValue = displayFieldId ? data[displayFieldId] : undefined
+          return {
+            id,
+            display: toSummaryDisplay(displayValue),
+          }
+        })
       byField.set(fieldId, summaries)
     }
     result.set(row.id, byField)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6913,7 +6913,7 @@ export function univerMetaRouter(): Router {
       // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop denied records so widget
       // counts/aggregates/group-buckets exclude them (no count leak). Inert until the per-sheet flag is on.
       let dashboardRows = rows
-      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+      if (!access.isAdminRole && access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
         const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
         if (deniedIds.size > 0) dashboardRows = rows.filter((r) => !deniedIds.has(r.id))
       }
@@ -8358,7 +8358,7 @@ export function univerMetaRouter(): Router {
 
       const rows: Array<Array<string | number | boolean | null | undefined>> = []
       // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): skip records the actor is denied.
-      const exportDeniedIds = (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))
+      const exportDeniedIds = (!access.isAdminRole && access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))
         ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
         : null
       let cursor: string | undefined
@@ -8508,7 +8508,7 @@ export function univerMetaRouter(): Router {
       // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop records the actor is
       // denied BEFORE search/filter/aggregate, so the returned total (rows.length), aggregate values, and
       // group buckets all exclude them (no count leak). Inert until the per-sheet flag is enabled.
-      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+      if (!access.isAdminRole && access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
         const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
         if (deniedIds.size > 0) rows = rows.filter((rec) => !deniedIds.has(rec.id))
       }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6884,9 +6884,16 @@ export function univerMetaRouter(): Router {
         capabilities,
       })
 
+      // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop denied records so widget
+      // counts/aggregates/group-buckets exclude them (no count leak). Inert until the per-sheet flag is on.
+      let dashboardRows = rows
+      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+        const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (deniedIds.size > 0) dashboardRows = rows.filter((r) => !deniedIds.has(r.id))
+      }
       const results = widgets.map((widget) => buildDashboardWidgetResult({
         widget,
-        rows,
+        rows: dashboardRows,
         fields: visibleFields,
       }))
 
@@ -8324,6 +8331,10 @@ export function univerMetaRouter(): Router {
       }
 
       const rows: Array<Array<string | number | boolean | null | undefined>> = []
+      // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): skip records the actor is denied.
+      const exportDeniedIds = (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        : null
       let cursor: string | undefined
       let truncated = false
       do {
@@ -8334,6 +8345,7 @@ export function univerMetaRouter(): Router {
           limit: Math.min(5000, XLSX_MAX_ROWS - rows.length),
         })
         for (const record of result.items) {
+          if (exportDeniedIds && exportDeniedIds.has(record.id)) continue
           const data = filterRecordDataByFieldIds(record.data, fieldIds)
           rows.push(fields.map((field) => {
             const cell = data[field.id]
@@ -8467,6 +8479,13 @@ export function univerMetaRouter(): Router {
         version: Number(r.version ?? 1),
         data: normalizeJson(r.data),
       }))
+      // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop records the actor is
+      // denied BEFORE search/filter/aggregate, so the returned total (rows.length), aggregate values, and
+      // group buckets all exclude them (no count leak). Inert until the per-sheet flag is enabled.
+      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+        const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (deniedIds.size > 0) rows = rows.filter((rec) => !deniedIds.has(rec.id))
+      }
       if (search) rows = rows.filter((rec) => recordMatchesSearch(rec, selectableFields, search))
       if (filterInfo) {
         const conditions = filterInfo.conditions.filter((c) => filterFieldTypeById.has(c.fieldId) && selectableFieldIds.has(c.fieldId))
@@ -9227,6 +9246,15 @@ export function univerMetaRouter(): Router {
         const row: any = recordRes.rows[0]
         if (!row) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordIdParam}` } })
+        }
+        // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): a denied record reads as
+        // not-found in the form prefill (404, NOT 403 — no existence oracle). Anonymous public forms have
+        // no subject, so the deny never applies to them (only the authenticated actor is gated).
+        if (access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+          const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+          if (deniedIds.has(recordIdParam)) {
+            return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordIdParam}` } })
+          }
         }
         record = {
           id: String(row.id),
@@ -11225,7 +11253,15 @@ export function univerMetaRouter(): Router {
       const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
       const allowedFieldIds = computeAllowedFieldIds(visibleFields, capabilities, fieldScopeMap)
       const visibleFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, visibleFields, allowedFieldIds)
-      const maskedRecords = result.records.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
+      // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop trashed records the actor
+      // is denied so a denied record's data never surfaces via trash. (total left as-is — the
+      // canDeleteRecord-gated trash count may include a denied row; exact-count exclusion is a minor follow-up.)
+      let trashRecords = result.records
+      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+        const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (deniedIds.size > 0) trashRecords = result.records.filter((rec) => !deniedIds.has(rec.recordId))
+      }
+      const maskedRecords = trashRecords.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
       return res.json({ ok: true, data: { records: maskedRecords, total: result.total } })
     } catch (err) {
       if (err instanceof RecordServicePermissionError) {

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -191,8 +191,7 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
   test('view-aggregate flag ON: an admin counts everything (deny bypassed)', async () => {
     await setFlag(true)
     testUserId = USER_ID
-    testPerms = ['multitable:admin']
+    testRoles = ['admin'] // isAdminRole derives from roles, not perms — bypasses the deny
     expect(await aggTotal()).toBe(2)
-    testPerms = ['multitable:read']
   })
 })

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-enforce.test.ts
@@ -168,4 +168,31 @@ describeIfDatabase('#18 row-level read-deny core enforcement (real DB)', () => {
     expect(ids).not.toContain(REC_DENIED)
     expect(ids).toContain(REC_OK)
   })
+
+  // view-aggregate — returned total is the filtered rows.length; denied records are dropped before
+  // aggregation, so the count excludes them (no count leak). (export / form-context / trash use the SAME
+  // loadDeniedRecordIds exclusion but need extra fixtures to assert here — final golden suite.)
+  const aggTotal = async (): Promise<number> => {
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate`)
+    return Number((res.body?.data?.total ?? -1))
+  }
+  test('view-aggregate flag OFF: the none-scoped record is counted (grant-additive)', async () => {
+    await setFlag(false)
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    expect(await aggTotal()).toBe(2)
+  })
+  test('view-aggregate flag ON: the none-scoped record is EXCLUDED from the total', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    expect(await aggTotal()).toBe(1)
+  })
+  test('view-aggregate flag ON: an admin counts everything (deny bypassed)', async () => {
+    await setFlag(true)
+    testUserId = USER_ID
+    testPerms = ['multitable:admin']
+    expect(await aggTotal()).toBe(2)
+    testPerms = ['multitable:read']
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-xrec.test.ts
+++ b/packages/core-backend/tests/integration/multitable-rowlevel-readdeny-xrec.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #18 row-level read-deny — CROSS-record enforcement (real DB).
+ *
+ * A lookup/rollup over a FOREIGN record the actor is denied ('none', with the FOREIGN sheet's
+ * row_level_read_permissions_enabled flag ON) must treat that record as ABSENT: the lookup omits its
+ * value, the rollup COUNT equals the readable-count (NEVER the true total → no cardinality leak), sum
+ * excludes it, and the link summary omits its id. Flag-OFF on the foreign sheet → full values (#2754
+ * canary). Admin bypasses. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_rrx_${TS}`
+const MS = `sheet_rrx_src_${TS}` // source sheet
+const FS = `sheet_rrx_for_${TS}` // foreign sheet
+const FLD_FNAME = `fld_rrx_fname_${TS}` // foreign display (string)
+const FLD_FVAL = `fld_rrx_fval_${TS}` // foreign value (number)
+const FLD_LINK = `fld_rrx_link_${TS}`
+const FLD_LOOKUP = `fld_rrx_lk_${TS}`
+const FLD_COUNT = `fld_rrx_cnt_${TS}` // rollup countall
+const FLD_SUM = `fld_rrx_sum_${TS}` // rollup sum
+const FR_OK = `rec_rrx_fok_${TS}` // val 10
+const FR_DENIED = `rec_rrx_fden_${TS}` // val 100, 'none' to USER
+const REC = `rec_rrx_src_${TS}`
+const USER_ID = `user_rrx_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let testRoles: string[] = ['member']
+function buildApp(): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: USER_ID, roles: testRoles, perms: ['multitable:read'], permissions: ['multitable:read'] }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const setForeignFlag = (on: boolean) =>
+  q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [FS, on])
+async function readSrc() {
+  const res = await request(buildApp()).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return res.body?.data
+}
+const rollupCfg = (aggregation: string) =>
+  JSON.stringify({ linkFieldId: FLD_LINK, foreignSheetId: FS, targetFieldId: FLD_FVAL, aggregation })
+const lookupCfg = () => JSON.stringify({ linkFieldId: FLD_LINK, foreignSheetId: FS, targetFieldId: FLD_FVAL })
+
+describeIfDatabase('#18 row-level read-deny cross-record (lookup/rollup/link-summary, real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'RRX Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS, BASE_ID, 'RRX Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_ID, 'RRX Source'])
+    // foreign fields + records
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FNAME, FS, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FVAL, FS, 'Val', 'number', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR_OK, FS, JSON.stringify({ [FLD_FNAME]: 'OK', [FLD_FVAL]: 10 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR_DENIED, FS, JSON.stringify({ [FLD_FNAME]: 'SECRET', [FLD_FVAL]: 100 })])
+    // source fields: link → lookup(val) → rollup countall + rollup sum(val)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP, MS, 'Lookup', 'lookup', lookupCfg(), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_COUNT, MS, 'Count', 'rollup', rollupCfg('countall'), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SUM, MS, 'Sum', 'rollup', rollupCfg('sum'), 4])
+    // source record links BOTH foreign records
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, MS, JSON.stringify({ [FLD_LINK]: [FR_OK, FR_DENIED] })])
+    for (const fr of [FR_OK, FR_DENIED]) {
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_rrx_${fr}`, FLD_LINK, REC, fr])
+    }
+    // a 'none' read-deny on FR_DENIED for the actor, on the FOREIGN sheet
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [FS, FR_DENIED, 'user', USER_ID, 'none'])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [FS]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('flag OFF (foreign): lookup + rollup include the would-be-denied record (#2754 canary)', async () => {
+    testRoles = ['member']
+    await setForeignFlag(false)
+    const d = await readSrc()
+    expect((d.record.data[FLD_LOOKUP] as number[]).slice().sort((a, b) => a - b)).toEqual([10, 100])
+    expect(d.record.data[FLD_COUNT]).toBe(2)
+    expect(d.record.data[FLD_SUM]).toBe(110)
+    const sum = (d.linkSummaries?.[FLD_LINK] ?? []) as Array<{ id: string }>
+    expect(sum.map((s) => s.id).slice().sort()).toEqual([FR_DENIED, FR_OK].slice().sort())
+  })
+
+  test('flag ON (foreign): denied record ABSENT — lookup omits, countall=readable (NO leak), sum excludes, summary omits', async () => {
+    testRoles = ['member']
+    await setForeignFlag(true)
+    const d = await readSrc()
+    expect(d.record.data[FLD_LOOKUP]).toEqual([10]) // denied 100 omitted
+    expect(d.record.data[FLD_COUNT]).toBe(1) // NOT 2 → no cardinality leak (the readable count, never the true total)
+    expect(d.record.data[FLD_SUM]).toBe(10) // denied 100 excluded
+    const sum = (d.linkSummaries?.[FLD_LINK] ?? []) as Array<{ id: string }>
+    expect(sum.map((s) => s.id)).toEqual([FR_OK]) // denied id omitted from the link summary
+  })
+
+  test('flag ON (foreign) + admin: bypasses the deny (countall=2)', async () => {
+    testRoles = ['admin']
+    await setForeignFlag(true)
+    const d = await readSrc()
+    expect(d.record.data[FLD_COUNT]).toBe(2)
+    expect((d.record.data[FLD_LOOKUP] as number[]).length).toBe(2)
+    testRoles = ['member']
+  })
+})


### PR DESCRIPTION
Completes the #18 read-surface enforcement (on #2810's core/list/link-picker). All flag-gated, **default-OFF → inert in prod**.

**Slice ⓢ (aggregate/export/trash):** view-aggregate (exact total, no count leak), dashboard, export-xlsx, form-context (404 not 403 = no existence oracle; anonymous forms gated out), trash — all via the shared `loadDeniedRecordIds` (deny-wins).

**Cross-record (the cardinality-no-leak surface):** `applyLookupRollup` + `buildLinkSummaries` exclude denied FOREIGN records (gated by the foreign sheet's flag) from the `foreignRecordsBySheet` map; since `resolveLookupValues` does `if (!data) continue` **before** `count += 1`, a denied foreign record is never counted → rollup count = readable-count, never the true total (no leak, by construction); link summaries omit denied ids.

**Real-PG verified** (the lesson from the prior CI failure): xrec golden 4/4 (countall=1 not 2 → no leak, lookup/sum exclude, summary omits, flag-off canary, admin bypass) + regression formula-over-lookup 3/3 / lookup-foreign-mask 8/8 / rollup-filter 10/10. enforce golden admin-signal fixed to match the verified pattern.

**Remaining for #18:** authoring UI (set `'none'` grants) + the final consolidated golden suite — then the per-sheet flag becomes enable-able.

🤖 Generated with [Claude Code](https://claude.com/claude-code)