### PR TITLE
feat(multitable): #18 read-deny authoring UI — deny grant + per-sheet flag toggle

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -34,6 +34,13 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
+      - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
+      - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
+      - 'apps/web/src/multitable/utils/meta-permission-labels.ts'
+      - 'apps/web/src/multitable/api/client.ts'
+      - 'apps/web/src/multitable/types.ts'
+      - 'apps/web/tests/multitable-record-permission-manager.spec.ts'
+      - 'apps/web/tests/multitable-sheet-permission-manager.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -56,6 +63,13 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
+      - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
+      - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
+      - 'apps/web/src/multitable/utils/meta-permission-labels.ts'
+      - 'apps/web/src/multitable/api/client.ts'
+      - 'apps/web/src/multitable/types.ts'
+      - 'apps/web/tests/multitable-record-permission-manager.spec.ts'
+      - 'apps/web/tests/multitable-sheet-permission-manager.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -98,4 +112,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager --reporter=dot

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -668,7 +668,7 @@ function normalizeRecordPermissionEntry(
   const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
   const subjectId = typeof payload?.subjectId === 'string' ? payload.subjectId : ''
   const accessLevel =
-    payload?.accessLevel === 'read' || payload?.accessLevel === 'write' || payload?.accessLevel === 'admin'
+    payload?.accessLevel === 'read' || payload?.accessLevel === 'write' || payload?.accessLevel === 'admin' || payload?.accessLevel === 'none'
       ? payload.accessLevel
       : null
   if (!id || !sheetId || !recordId || !subjectType || !subjectId || !accessLevel) return null
@@ -1601,6 +1601,27 @@ export class MultitableApiClient {
       { method: 'DELETE' },
     )
     await this.parseJson(res)
+  }
+
+  // #18 row-level read-deny: per-sheet flag (default-off). When ON, record_permissions access_level='none'
+  // denies read across every read surface; OFF → inert.
+  async getRowLevelReadDeny(sheetId: string): Promise<boolean> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/row-level-read-deny`)
+    const data = await this.parseJson<{ enabled?: boolean }>(res)
+    return data?.enabled === true
+  }
+
+  async setRowLevelReadDeny(sheetId: string, enabled: boolean): Promise<boolean> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/row-level-read-deny`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      },
+    )
+    const data = await this.parseJson<{ enabled?: boolean }>(res)
+    return data?.enabled === true
   }
 
   // --- Automation rules ---

--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -5,6 +5,7 @@
         <div>
           <h4 class="meta-record-perm__title">{{ p('record.title') }}</h4>
           <p class="meta-record-perm__subtitle">{{ p('record.subtitle') }}</p>
+          <p class="meta-record-perm__hint">{{ p('rowDeny.noneHint') }}</p>
         </div>
         <button class="meta-record-perm__close" type="button" @click="requestClose">&times;</button>
       </div>
@@ -266,7 +267,7 @@ const candidateDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
 let candidateLoadVersion = 0
 
 const { isZh } = useLocale()
-const recordAccessLevels: RecordPermissionAccessLevel[] = ['read', 'write', 'admin']
+const recordAccessLevels: RecordPermissionAccessLevel[] = ['read', 'write', 'admin', 'none']
 const recordAccessOptions = computed(() =>
   recordAccessLevels.map((value) => ({
     value,

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -281,6 +281,22 @@
               </div>
             </template>
           </section>
+
+          <!-- #18 row-level read-deny: per-sheet flag -->
+          <section class="meta-sheet-perm__section meta-sheet-perm__rowdeny">
+            <h4 class="meta-sheet-perm__section-title">{{ p('rowDeny.title') }}</h4>
+            <label class="meta-sheet-perm__rowdeny-toggle">
+              <input
+                type="checkbox"
+                :checked="rowDenyEnabled"
+                :disabled="rowDenyBusy"
+                @change="toggleRowDeny(($event.target as HTMLInputElement).checked)"
+              />
+              <span>{{ p('rowDeny.toggle') }}</span>
+            </label>
+            <p class="meta-sheet-perm__rowdeny-warning" role="note">{{ p('rowDeny.warning') }}</p>
+            <p v-if="rowDenyEnabled" class="meta-sheet-perm__rowdeny-note">{{ p('rowDeny.enabledNote') }}</p>
+          </section>
         </template>
 
         <!-- Field Permissions tab -->
@@ -1342,7 +1358,36 @@ async function refreshAll(query?: string) {
   await Promise.all([
     loadEntries(),
     loadCandidates(query ?? search.value),
+    loadRowDeny(),
   ])
+}
+
+// #18 row-level read-deny per-sheet flag
+const rowDenyEnabled = ref(false)
+const rowDenyBusy = ref(false)
+
+async function loadRowDeny() {
+  try {
+    rowDenyEnabled.value = await props.client.getRowLevelReadDeny(props.sheetId)
+  } catch {
+    // non-fatal: leave the toggle at its last-known state (the section still renders)
+  }
+}
+
+async function toggleRowDeny(next: boolean) {
+  if (rowDenyBusy.value) return
+  rowDenyBusy.value = true
+  clearMessages()
+  try {
+    rowDenyEnabled.value = await props.client.setRowLevelReadDeny(props.sheetId, next)
+    emit('updated')
+  } catch (err) {
+    // revert the optimistic checkbox; surface the error (e.g. 403 for non-managers)
+    rowDenyEnabled.value = !next
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    rowDenyBusy.value = false
+  }
 }
 
 function scheduleCandidateRefresh() {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -891,7 +891,9 @@ export interface MetaHierarchyViewConfig {
 }
 
 // --- Record-level permissions ---
-export type RecordPermissionAccessLevel = 'read' | 'write' | 'admin'
+// 'none' = a row-level read-deny grant (#18); only effective when the sheet's
+// row_level_read_permissions_enabled flag is on, otherwise inert (#2787 contract).
+export type RecordPermissionAccessLevel = 'read' | 'write' | 'admin' | 'none'
 export type RecordPermissionSubjectType = 'user' | 'role' | 'member-group'
 
 export interface RecordPermissionEntry {

--- a/apps/web/src/multitable/utils/meta-permission-labels.ts
+++ b/apps/web/src/multitable/utils/meta-permission-labels.ts
@@ -10,9 +10,15 @@ export type MetaPermissionLabelKey =
   | 'action.copyFieldViewAcl'
   | 'action.grant'
   | 'access.admin'
+  | 'access.none'
   | 'access.read'
   | 'access.write'
   | 'access.writeOwn'
+  | 'rowDeny.title'
+  | 'rowDeny.toggle'
+  | 'rowDeny.warning'
+  | 'rowDeny.noneHint'
+  | 'rowDeny.enabledNote'
   | 'field.applyAll'
   | 'field.bulkApply'
   | 'field.error.applyTemplate'
@@ -111,9 +117,15 @@ const LABELS: Record<MetaPermissionLabelKey, { en: string; zh: string }> = {
   'action.copyFieldViewAcl': { en: 'Copy field+view ACL', zh: '复制字段+视图 ACL' },
   'action.grant': { en: 'Grant', zh: '授权' },
   'access.admin': { en: 'Admin', zh: '管理员' },
+  'access.none': { en: 'No access (deny read)', zh: '无权限（拒绝读取）' },
   'access.read': { en: 'Read', zh: '读取' },
   'access.write': { en: 'Write', zh: '写入' },
   'access.writeOwn': { en: 'Write own', zh: '仅写入自己' },
+  'rowDeny.title': { en: 'Row-level read permissions', zh: '行级读取权限' },
+  'rowDeny.toggle': { en: 'Enable per-record read-deny for this sheet', zh: '为此表启用按记录的读取拒绝' },
+  'rowDeny.warning': { en: 'When enabled, records with a “No access” grant become invisible to non-granted readers across every view, list, summary, aggregate, and export — a real visibility change.', zh: '启用后，带有“无权限”授权的记录将对未被授权的读者在所有视图、列表、汇总、聚合和导出中不可见——这是真实的可见性变更。' },
+  'rowDeny.noneHint': { en: 'Only effective when row-level read permissions are enabled for this sheet.', zh: '仅当此表启用了行级读取权限时生效。' },
+  'rowDeny.enabledNote': { en: 'Row-level read-deny is ON for this sheet.', zh: '此表已开启行级读取拒绝。' },
   'field.applyAll': { en: 'Apply to all fields', zh: '应用到所有字段' },
   'field.bulkApply': { en: 'Bulk apply to all fields', zh: '批量应用到所有字段' },
   'field.error.applyTemplate': { en: 'Failed to apply field permission template', zh: '应用字段权限模板失败' },
@@ -225,6 +237,7 @@ export function recordAccessText(level: string, isZh: boolean): string {
   if (level === 'read') return permissionLabel('access.read', isZh)
   if (level === 'write') return permissionLabel('access.write', isZh)
   if (level === 'admin') return permissionLabel('access.admin', isZh)
+  if (level === 'none') return permissionLabel('access.none', isZh)
   return level
 }
 

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -125,7 +125,7 @@ describe('MetaRecordPermissionManager', () => {
     const entry = container!.querySelector('[data-record-permission-entry="perm_zh"]')!
     expect(entry.querySelector('.meta-record-perm__badge')?.getAttribute('data-access-level')).toBe('write')
     const candidateSelect = container!.querySelector('[data-record-permission-candidate="member-group:group_north"] select') as HTMLSelectElement
-    expect(Array.from(candidateSelect.options).map((option) => option.value)).toEqual(['read', 'write', 'admin'])
+    expect(Array.from(candidateSelect.options).map((option) => option.value)).toEqual(['read', 'write', 'admin', 'none'])
   })
 
   it('renders permission list when visible', async () => {
@@ -422,5 +422,33 @@ describe('MetaRecordPermissionManager', () => {
     await flushUi()
 
     expect(container!.querySelector('.meta-record-perm__overlay')).toBeNull()
+  })
+
+  it('offers the #18 "No access (deny read)" option in the access-level selector', async () => {
+    useLocale().setLocale('en')
+    mountManager({
+      client: makeClient({
+        listRecordPermissions: vi.fn().mockResolvedValue([
+          {
+            id: 'perm_1',
+            sheetId: 'sheet_1',
+            recordId: 'record_1',
+            subjectType: 'user',
+            subjectId: 'user_a',
+            accessLevel: 'read',
+            label: 'A',
+            subtitle: null,
+            isActive: true,
+          },
+        ]),
+      }),
+    })
+    await flushUi()
+    const select = container!.querySelector('.meta-record-perm__select') as HTMLSelectElement | null
+    expect(select).not.toBeNull()
+    const values = Array.from(select!.options).map((o) => o.value)
+    expect(values).toContain('none')
+    const noneOption = Array.from(select!.options).find((o) => o.value === 'none')
+    expect(noneOption?.textContent).toContain('No access')
   })
 })

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -1202,4 +1202,31 @@ describe('MetaSheetPermissionManager', () => {
     expect(viewOrphanRow.textContent).toContain('Inactive user')
     expect(viewOrphanRow.textContent).toContain('No current sheet access')
   })
+
+  it('renders the #18 row-level read-deny toggle (with warning) and persists via setRowLevelReadDeny', async () => {
+    useLocale().setLocale('en')
+    const setRowLevelReadDeny = vi.fn().mockResolvedValue(true)
+    mountManager({
+      client: {
+        listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+        listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+        updateSheetPermission: vi.fn().mockResolvedValue({}),
+        updateFieldPermission: vi.fn().mockResolvedValue({}),
+        updateViewPermission: vi.fn().mockResolvedValue({}),
+        getRowLevelReadDeny: vi.fn().mockResolvedValue(false),
+        setRowLevelReadDeny,
+      } as never,
+    })
+    await flushUi()
+
+    const toggle = container!.querySelector('.meta-sheet-perm__rowdeny-toggle input[type="checkbox"]') as HTMLInputElement | null
+    expect(toggle).not.toBeNull()
+    expect(toggle!.checked).toBe(false)
+    expect(container!.querySelector('.meta-sheet-perm__rowdeny-warning')?.textContent).toContain('invisible')
+
+    toggle!.checked = true
+    toggle!.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(setRowLevelReadDeny).toHaveBeenCalledWith('sheet_orders', true)
+  })
 })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5522,6 +5522,61 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  // ── #18 row-level read-deny: per-sheet flag (default-off) ──
+  // GET reports the flag (any sheet reader, so the authoring UI can show state); PUT sets it
+  // (manage-gated). When ON, record_permissions access_level='none' denies read across every
+  // read surface; OFF → inert (#2787 contract). The 'none' grant is set via the record-permission
+  // write API (PUT /sheets/:sheetId/records/:recordId/permissions).
+  router.get('/sheets/:sheetId/row-level-read-deny', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
+      if (!sheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canRead) return sendForbidden(res)
+      const r = await pool.query('SELECT row_level_read_permissions_enabled AS enabled FROM meta_sheets WHERE id = $1', [sheetId])
+      return res.json({ ok: true, data: { enabled: (r.rows[0] as { enabled?: boolean } | undefined)?.enabled === true } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] read row-level-read-deny flag failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to read row-level read-deny flag' } })
+    }
+  })
+
+  router.put('/sheets/:sheetId/row-level-read-deny', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    const parsed = z.object({ enabled: z.boolean() }).safeParse(req.body)
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+    try {
+      const pool = poolManager.get()
+      const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
+      if (!sheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res)
+      await pool.query('UPDATE meta_sheets SET row_level_read_permissions_enabled = $1 WHERE id = $2', [parsed.data.enabled, sheetId])
+      return res.json({ ok: true, data: { enabled: parsed.data.enabled } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] set row-level-read-deny flag failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to set row-level read-deny flag' } })
+    }
+  })
+
   // ── View permission authoring ──
 
   router.get('/views/:viewId/permissions', async (req: Request, res: Response) => {


### PR DESCRIPTION
The final #18 piece (per #2787's staged design). The BE (enforcement across all read surfaces + the flag + settable 'none') is merged + real-PG-verified; this adds the authoring UI.

- **'none' (No access / deny read)** option in every record access-level selector (MetaRecordPermissionManager) + a hint it's only effective with the sheet flag on. `RecordPermissionAccessLevel += 'none'`; client normalizer + labels.
- **Per-sheet flag toggle** in MetaSheetPermissionManager (load via GET, set via PUT) with a clear visibility-change warning + revert-on-error (e.g. 403 for non-managers).
- New BE `GET/PUT /sheets/:sheetId/row-level-read-deny` — GET `canRead`-gated; **PUT `canManageSheetAccess`-gated** (verbatim reuse of the tested sheet-permission PUT pattern), `z.boolean()`-validated.

Verified: vue-tsc + tsc clean; record + sheet permission-manager specs **29/29** (+2: 'none' option appears; toggle renders w/ warning + persists); full unit suite 4430/0. **Follow-up:** a focused real-DB test for the GET/PUT flag endpoints (gating is verbatim-reuse-verified; regression-lock recommended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)