### PR TITLE
docs(multitable): correct stale 'UNWIRED' docstring on resolveBaseReadable (②b wired since #2582)

### DIFF
--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1360,9 +1360,11 @@ export async function resolveReadableSheetIds(
  *   3. base ownership (`meta_bases.owner_id` === actor) → that base.
  * A missing / soft-deleted base is NOT readable (no null-deref).
  *
- * This is the primitive ②b will consume when an opt-in cross-base READ path opens. It is deliberately
- * UNWIRED here: the §2a.2 wall compares two base_id strings and does not call this. It does NOT touch
- * central RBAC / auth — it is kernel-internal to multitable.
+ * This is the ②b cross-base READ primitive. It is WIRED (since #2582): the read paths call it via
+ * `resolveForeignFieldReadability` (univer-meta.ts) — a cross-base foreign field (foreignBaseId !=
+ * sourceBaseId) resolves only when the actor canReadBase(foreignBaseId), else its value is masked and
+ * dropped from lookup/rollup (no cardinality leak). The §2a.2 wall remains a separate same-base/base-id
+ * check; this is the per-actor base-read gate on top. Kernel-internal to multitable; no central RBAC/auth.
  */
 export async function resolveBaseReadable(
   req: Request,


### PR DESCRIPTION
Doc-only. The ②b cross-base READ primitive is wired (since #2582 — resolveForeignFieldReadability gates cross-base foreign reads via canReadBase, masking+dropping with no cardinality leak; real-DB-tested). The docstring still said 'deliberately UNWIRED', which misled a review into re-scoping already-built work. Corrected. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)