### PR TITLE
feat(multitable): non-string-field realtime sync — Yjs bridge scalar core (inert until FE binding)

### DIFF
--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -25,7 +25,7 @@ export interface YjsRecordBridgeConfig {
 export type ActorResolver = (socketId: string) => string | undefined
 
 interface PendingWrite {
-  fields: Record<string, string>
+  fields: Record<string, unknown>
   actorIds: Set<string>
   timer: NodeJS.Timeout
   firstSeen: number
@@ -99,8 +99,10 @@ export class YjsRecordBridge {
       const originSocketId = typeof transaction.origin === 'string' ? transaction.origin : undefined
       const actorId = originSocketId ? (this.actorResolver(originSocketId) ?? 'unknown') : 'unknown'
 
-      // Collect changed text field values
-      const changedFields: Record<string, string> = {}
+      // Collect changed field values: Y.Text (string fields, char-level merged) AND
+      // plain values (scalar fields — number/currency/select/boolean/date/etc. — synced
+      // last-write-wins via the Y.Map). Both flush through the same validated patch path.
+      const changedFields: Record<string, unknown> = {}
 
       for (const event of events) {
         if (event.target === fields && event instanceof Y.YMapEvent) {
@@ -108,6 +110,11 @@ export class YjsRecordBridge {
             const value = fields.get(key)
             if (value instanceof Y.Text) {
               changedFields[key] = value.toString()
+            } else if (value !== undefined && !(value instanceof Y.AbstractType)) {
+              // Scalar field: a plain value set under the Y.Map key (LWW). Skip Yjs
+              // shared types (Y.Text handled above; Y.Map/Y.Array out of scope) and
+              // deletes (undefined key). patchRecords validates the value downstream.
+              changedFields[key] = value
             }
           }
         }
@@ -151,7 +158,7 @@ export class YjsRecordBridge {
     this.flushNow(recordId)
   }
 
-  private scheduleFlush(recordId: string, changedFields: Record<string, string>, actorId: string): void {
+  private scheduleFlush(recordId: string, changedFields: Record<string, unknown>, actorId: string): void {
     const existing = this.pendingWrites.get(recordId)
 
     if (existing) {

--- a/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
+++ b/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
@@ -1,0 +1,118 @@
+/**
+ * YjsRecordBridge — scalar (non-text) field sync.
+ *
+ * String fields bind to Y.Text (char-level merge). Scalar fields (number/currency/
+ * percent/rating/duration/select/multiSelect/date/dateTime/boolean) are atomic, so
+ * the correct realtime semantic is last-write-wins via the Y.Map: a plain value set
+ * under the field key. This test locks that the bridge collects those plain values
+ * and flushes them through the SAME validated patch path as Y.Text — while still
+ * handling Y.Text strings and ignoring nested Yjs shared types (Y.Map/Y.Array).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+import { YjsRecordBridge } from '../../src/collab/yjs-record-bridge'
+
+function makePersistence() {
+  const snapshots = new Map<string, Uint8Array>()
+  const updates = new Map<string, Uint8Array[]>()
+  return {
+    store: { snapshots, updates },
+    loadDoc: vi.fn(async (recordId: string): Promise<Uint8Array | null> => {
+      const snap = snapshots.get(recordId)
+      const ups = updates.get(recordId) ?? []
+      if (!snap && ups.length === 0) return null
+      const doc = new Y.Doc()
+      if (snap) Y.applyUpdate(doc, snap)
+      for (const u of ups) Y.applyUpdate(doc, u)
+      const out = Y.encodeStateAsUpdate(doc)
+      doc.destroy()
+      return out
+    }),
+    storeUpdate: vi.fn(async (recordId: string, update: Uint8Array) => {
+      const list = updates.get(recordId) ?? []
+      list.push(update)
+      updates.set(recordId, list)
+    }),
+    storeSnapshot: vi.fn(async () => {}),
+    compactDoc: vi.fn(async () => {}),
+    purgeRecords: vi.fn(async () => {}),
+  }
+}
+
+function makeBridge() {
+  const persistence = makePersistence()
+  const svc = new YjsSyncService(persistence as any, async () => ({}))
+  const captured: { patch: Record<string, unknown> | null } = { patch: null }
+  const recordWriteService = {
+    patchRecords: vi.fn().mockResolvedValue({ updated: [{ recordId: 'rec_1', version: 2 }] }),
+  }
+  const bridge = new YjsRecordBridge(
+    svc as any,
+    recordWriteService as any,
+    async (_recordId: string, patch: Record<string, unknown>) => {
+      captured.patch = patch
+      return {
+        sheetId: 'sh_1',
+        changesByRecord: new Map(),
+        actorId: 'user_1',
+        fields: [],
+        visiblePropertyFields: [],
+        visiblePropertyFieldIds: new Set(),
+        attachmentFields: [],
+        fieldById: new Map(),
+        capabilities: {} as any,
+        access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      }
+    },
+    { mergeWindowMs: 200, maxDelayMs: 500 },
+  )
+  return { svc, bridge, recordWriteService, captured }
+}
+
+describe('YjsRecordBridge — scalar (non-text) field sync', () => {
+  it('collects plain scalar Y.Map values (number/select/boolean) and flushes them via the patch path', async () => {
+    vi.useFakeTimers()
+    const { svc, bridge, recordWriteService, captured } = makeBridge()
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    const fields = doc.getMap('fields')
+    fields.set('fld_num', 42)
+    fields.set('fld_sel', 'optA')
+    fields.set('fld_bool', true)
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(recordWriteService.patchRecords).toHaveBeenCalledTimes(1)
+    // LWW: the plain values reach the validated patch path with their native types.
+    expect(captured.patch).toMatchObject({ fld_num: 42, fld_sel: 'optA', fld_bool: true })
+    vi.useRealTimers()
+  })
+
+  it('still collects Y.Text strings (regression) and ignores nested Yjs shared types', async () => {
+    vi.useFakeTimers()
+    const { svc, bridge, captured } = makeBridge()
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    const fields = doc.getMap('fields')
+    const title = new Y.Text()
+    fields.set('fld_title', title)
+    title.insert(0, 'hello')
+    fields.set('fld_num', 7) // scalar → collected
+    fields.set('fld_nested', new Y.Map()) // a nested shared type → must NOT be collected as a scalar
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(captured.patch).toMatchObject({ fld_title: 'hello', fld_num: 7 })
+    expect(captured.patch).not.toHaveProperty('fld_nested')
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
Realtime sync for SCALAR fields (number/currency/percent/rating/duration/select/multiSelect/date/dateTime/boolean) — the BE core. Today only string fields (Y.Text) sync; scalars don't. Correct semantic for atomic values = **LWW via the record `fields` Y.Map** (Yjs Y.Map is a CRDT, LWW per key).

`yjs-record-bridge` observer + `PendingWrite.fields` + `scheduleFlush` widened `string`→`unknown`; the observer now also collects plain Y.Map values (skipping Yjs shared types — Y.Text handled separately, Y.Map/Y.Array out of scope — and `undefined` deletes). Scalars flush through the **same validated `patchRecords` path** as Y.Text (no validation bypass), field-type-agnostic.

**Safe + inert:** nothing writes scalar values into the Y.Map until the FE scalar binding lands (forking now), so this changes no behavior. New unit test `yjs-bridge-scalar-fields.test.ts` 2/2 (scalar collection w/ native types; Y.Text regression; nested-shared-type exclusion); tsc clean; full suite 4432/0.

**Follow-up (forking now):** the FE scalar cell binding (read/write the Y.Map key as a typed plain value) + grid wiring — the user-facing half + a two-client e2e test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)