### PR TITLE
feat(multitable): useYjsScalarCell — FE scalar CRDT binding primitive (inert until grid wiring)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -34,6 +34,8 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
+      - 'apps/web/src/multitable/composables/useYjsScalarCell.ts'
+      - 'apps/web/tests/multitable-yjs-scalar-cell.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -56,6 +58,8 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
+      - 'apps/web/src/multitable/composables/useYjsScalarCell.ts'
+      - 'apps/web/tests/multitable-yjs-scalar-cell.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
 
 jobs:
@@ -98,4 +102,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-yjs-scalar-cell --reporter=dot

--- a/apps/web/src/multitable/composables/useYjsScalarCell.ts
+++ b/apps/web/src/multitable/composables/useYjsScalarCell.ts
@@ -1,0 +1,234 @@
+import { ref, shallowRef, watch, onUnmounted } from 'vue'
+import type { Ref } from 'vue'
+import * as Y from 'yjs'
+import { isYjsCollabEnabled } from './useYjsCellBinding'
+
+type UseYjsDocumentFn = typeof import('./useYjsDocument')['useYjsDocument']
+type YjsDocumentApi = ReturnType<UseYjsDocumentFn>
+
+/**
+ * Opt-in Yjs binding for a single NON-STRING (scalar) cell — the sibling of
+ * `useYjsCellBinding` (which handles `Y.Text` string cells).
+ *
+ * Scalars (number/currency/percent/rating/duration/select/boolean/...) are
+ * atomic values: character-level CRDT is meaningless, so the correct realtime
+ * semantic is **last-write-wins via the record `fields` Y.Map** (a Yjs Y.Map
+ * is a CRDT — LWW per key). This binds the cell to the plain value stored under
+ * the field key in that map.
+ *
+ * TYPE-AGNOSTIC BY DESIGN: it stores and returns whatever value the caller
+ * passes via `setValue`. It does NOT coerce or guess a per-type representation
+ * — the caller (the grid editor) is responsible for passing EXACTLY the value
+ * shape the REST patch would write for that field type, because the backend
+ * bridge persists whatever is in the Y.Map verbatim. Passing a wrong-typed
+ * value would persist corruption; that responsibility stays with the caller.
+ *
+ * Activation contract (mirrors `useYjsCellBinding`'s Y.Text-exists guard): we
+ * only flip `active` true once the sync handshake completes AND the field key
+ * already exists in the `fields` Y.Map. If the key is absent (e.g. the backend
+ * seed has not seeded scalar values yet) we stay inactive and the caller MUST
+ * keep its REST path — we never `set` into a missing key and risk clobbering a
+ * value the actor cannot see. The whole composable is inert when the
+ * `VITE_ENABLE_YJS_COLLAB` flag is off (same as `useYjsCellBinding`).
+ */
+
+const CONNECT_TIMEOUT_MS = 2500
+
+export interface UseYjsScalarCellOptions {
+  /** Record being edited. When null, binding is inert. */
+  recordId: Ref<string | null>
+  /** Field being edited. When null, binding is inert. */
+  fieldId: Ref<string | null>
+  /** Connect-timeout override (tests). */
+  connectTimeoutMs?: number
+  /** Soft-fallback notification; callers MUST continue with REST regardless. */
+  onFallback?: (reason: 'timeout' | 'error' | 'disabled') => void
+}
+
+export interface YjsScalarCellBinding<T = unknown> {
+  /** True once a live Y.Doc is attached AND the field key exists in `fields`. */
+  active: Ref<boolean>
+  /** Reactive plain value from the `fields` Y.Map (undefined when inactive). */
+  value: Ref<T | undefined>
+  /** Write the value into the `fields` Y.Map (LWW). No-op when inactive. */
+  setValue: (next: T) => void
+  /** Tear down the Yjs connection. */
+  release: () => void
+}
+
+/**
+ * Binds a scalar cell to its `fields` Y.Map value. Always returns a consistent
+ * API regardless of flag/active state; callers read `active.value` to decide
+ * whether to drive the cell from `value.value` or stick to their REST path.
+ */
+export function useYjsScalarCell<T = unknown>(options: UseYjsScalarCellOptions): YjsScalarCellBinding<T> {
+  const active = ref(false)
+  const value = ref<T | undefined>(undefined) as Ref<T | undefined>
+
+  if (!isYjsCollabEnabled()) {
+    options.onFallback?.('disabled')
+    return {
+      active,
+      value,
+      setValue: () => { /* inert: caller uses REST */ },
+      release: () => { /* nothing to release */ },
+    }
+  }
+
+  const timeoutMs = options.connectTimeoutMs ?? CONNECT_TIMEOUT_MS
+  const liveRecordId = shallowRef<string | null>(null)
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+  let released = false
+  let yjs: YjsDocumentApi | null = null
+  let runtimeReady = false
+  let fieldsObserver: (() => void) | null = null
+  let currentFieldId: string | null = null
+
+  let stopErrorWatch: (() => void) | null = null
+  let stopSyncedWatch: (() => void) | null = null
+  let stopConnectedWatch: (() => void) | null = null
+  let stopDocWatch: (() => void) | null = null
+
+  void loadRuntime()
+
+  function clearTimer() {
+    if (timeoutHandle) { clearTimeout(timeoutHandle); timeoutHandle = null }
+  }
+
+  function fieldsMap(): Y.Map<unknown> | null {
+    // `yjs.doc` is a ShallowRef<Doc | null> (created on connect). Read its
+    // current value; null until the doc exists. Matches the backend seed +
+    // useYjsTextField, which use doc.getMap('fields').
+    const d = yjs?.doc.value
+    if (!d) return null
+    try { return d.getMap('fields') } catch { return null }
+  }
+
+  // Re-read the value + recompute `active` from the current map state. Active
+  // requires synced AND the key present (an absent key = not seeded → REST).
+  function refresh() {
+    if (released || !yjs) return
+    const map = fieldsMap()
+    const fid = currentFieldId
+    const present = !!map && !!fid && map.has(fid)
+    if (yjs.synced.value && present) {
+      clearTimer()
+      value.value = map!.get(fid!) as T
+      active.value = true
+    } else if (!present && active.value) {
+      active.value = false
+      value.value = undefined
+    }
+  }
+
+  function detachObserver() {
+    if (fieldsObserver) { try { fieldsObserver() } catch { /* ignore */ } fieldsObserver = null }
+  }
+
+  function attachObserver() {
+    detachObserver()
+    const map = fieldsMap()
+    if (!map) return
+    const handler = (event: Y.YMapEvent<unknown>) => {
+      if (currentFieldId && event.keysChanged.has(currentFieldId)) refresh()
+    }
+    map.observe(handler)
+    fieldsObserver = () => map.unobserve(handler)
+  }
+
+  function fallback(reason: 'timeout' | 'error') {
+    if (released) return
+    clearTimer()
+    detachObserver()
+    active.value = false
+    value.value = undefined
+    liveRecordId.value = null // triggers useYjsDocument disconnect
+    options.onFallback?.(reason)
+  }
+
+  async function loadRuntime(): Promise<void> {
+    try {
+      const { useYjsDocument } = await import('./useYjsDocument')
+      if (released) return
+      yjs = useYjsDocument(liveRecordId, { registerUnmount: false })
+
+      stopErrorWatch = watch(() => yjs!.error.value, (err) => { if (err) fallback('error') })
+      stopSyncedWatch = watch(() => yjs!.synced.value, () => refresh())
+      stopConnectedWatch = watch(
+        () => yjs!.connected.value,
+        (isConnected) => { if (!isConnected && active.value) fallback('error') },
+      )
+      // The doc ref is null until useYjsDocument creates it on connect; (re)attach
+      // the observer + refresh when it arrives or changes on a record re-bind.
+      stopDocWatch = watch(
+        () => yjs!.doc.value,
+        () => { if (!released) { attachObserver(); refresh() } },
+      )
+
+      runtimeReady = true
+      startBinding(options.recordId.value, options.fieldId.value)
+    } catch (err) {
+      console.warn('[multitable] failed to load Yjs scalar cell runtime', err)
+      fallback('error')
+    }
+  }
+
+  function startBinding(newRecordId: string | null, newFieldId: string | null): void {
+    clearTimer()
+    detachObserver()
+    active.value = false
+    value.value = undefined
+    currentFieldId = newFieldId
+    if (!runtimeReady || !newRecordId || !newFieldId) {
+      liveRecordId.value = null
+      return
+    }
+    liveRecordId.value = newRecordId
+    // The doc/map exist synchronously once useYjsDocument wires the record;
+    // observe + an initial refresh (synced may already be true on re-bind).
+    attachObserver()
+    refresh()
+    timeoutHandle = setTimeout(() => { if (!active.value) fallback('timeout') }, timeoutMs)
+  }
+
+  const stopInputsWatch = watch(
+    [options.recordId, options.fieldId],
+    ([newRecordId, newFieldId]) => { if (!released) startBinding(newRecordId, newFieldId) },
+    { immediate: true },
+  )
+
+  function setValue(next: T) {
+    if (!active.value || !yjs) return
+    const map = fieldsMap()
+    if (!map || !currentFieldId) return
+    // A local (default-origin) Y.Map.set syncs to the server, which applies it
+    // with this client's socket.id as the transaction origin. The server-side
+    // bridge observer skips only 'rest'/'persistence' origins, so a synced
+    // client edit IS flushed via the validated patchRecords path, attributed
+    // to the resolved actor. (We never set into an absent key — see the
+    // `active`/`refresh` guard — so this can't clobber an unseeded value.)
+    map.set(currentFieldId, next as unknown)
+    value.value = next
+  }
+
+  function release() {
+    if (released) return
+    released = true
+    clearTimer()
+    detachObserver()
+    active.value = false
+    value.value = undefined
+    currentFieldId = null
+    liveRecordId.value = null
+    if (stopErrorWatch) try { stopErrorWatch() } catch { /* ignore */ }
+    if (stopSyncedWatch) try { stopSyncedWatch() } catch { /* ignore */ }
+    if (stopConnectedWatch) try { stopConnectedWatch() } catch { /* ignore */ }
+    if (stopDocWatch) try { stopDocWatch() } catch { /* ignore */ }
+    try { stopInputsWatch() } catch { /* ignore */ }
+    try { yjs?.dispose() } catch { /* ignore */ }
+  }
+
+  onUnmounted(release)
+
+  return { active, value, setValue, release }
+}

--- a/apps/web/tests/multitable-yjs-scalar-cell.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell.spec.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, shallowRef, type App, type Ref } from 'vue'
+import * as Y from 'yjs'
+
+// Mock useYjsDocument at its boundary: return a fake api wrapping a real Y.Doc
+// whose `synced`/`connected`/`error` we drive from the test. This exercises
+// useYjsScalarCell's read/write/active/fallback logic against a real `fields`
+// Y.Map without standing up Socket.IO.
+let sharedDoc: Y.Doc
+const docRef = shallowRef<Y.Doc | null>(null)
+let syncedRef: Ref<boolean>
+let connectedRef: Ref<boolean>
+let errorRef: Ref<string | null>
+const disposeMock = vi.fn()
+
+vi.mock('../src/multitable/composables/useYjsDocument', () => ({
+  useYjsDocument: vi.fn(() => ({
+    doc: docRef,
+    synced: syncedRef,
+    connected: connectedRef,
+    error: errorRef,
+    activeUsers: ref([]),
+    dispose: disposeMock,
+    setActiveField: vi.fn(),
+    getFieldCollaborators: vi.fn(() => []),
+  })),
+}))
+
+async function flush(cycles = 14): Promise<void> {
+  await vi.dynamicImportSettled()
+  for (let i = 0; i < cycles; i += 1) { await Promise.resolve(); await nextTick() }
+}
+
+async function loadScalar() {
+  return import('../src/multitable/composables/useYjsScalarCell')
+}
+
+// Mount a component that calls the composable, exposing the binding to the test.
+async function mountBinding(recordId: string | null, fieldId: string | null) {
+  const { useYjsScalarCell } = await loadScalar()
+  let binding!: ReturnType<typeof useYjsScalarCell>
+  const Comp = defineComponent({
+    setup() {
+      binding = useYjsScalarCell({ recordId: ref(recordId), fieldId: ref(fieldId), connectTimeoutMs: 200 })
+      return () => h('div')
+    },
+  })
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(Comp)
+  app.mount(container)
+  await flush()
+  return { binding, app, container }
+}
+
+describe('useYjsScalarCell', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    sharedDoc = new Y.Doc()
+    docRef.value = sharedDoc
+    syncedRef = ref(true)
+    connectedRef = ref(true)
+    errorRef = ref<string | null>(null)
+    disposeMock.mockReset()
+    vi.stubEnv('VITE_ENABLE_YJS_COLLAB', 'true')
+    // useYjsScalarCell reads isYjsCollabEnabled, which in test mode falls back
+    // to process.env — mirror what useYjsCellBinding's tests rely on.
+    process.env.VITE_ENABLE_YJS_COLLAB = 'true'
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    delete process.env.VITE_ENABLE_YJS_COLLAB
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('binds a seeded scalar: active + reads the typed value (number)', async () => {
+    sharedDoc.getMap('fields').set('fld_num', 42)
+    const m = await mountBinding('rec1', 'fld_num')
+    app = m.app; container = m.container
+    expect(m.binding.active.value).toBe(true)
+    expect(m.binding.value.value).toBe(42)
+  })
+
+  it('setValue writes the value (typed) into the fields Y.Map', async () => {
+    sharedDoc.getMap('fields').set('fld_num', 1)
+    const m = await mountBinding('rec1', 'fld_num')
+    app = m.app; container = m.container
+    m.binding.setValue(99)
+    expect(sharedDoc.getMap('fields').get('fld_num')).toBe(99)
+    // boolean + select preserve native type through the same path
+    sharedDoc.getMap('fields').set('fld_bool', false)
+    const m2 = await mountBinding('rec1', 'fld_bool')
+    m2.binding.setValue(true)
+    expect(sharedDoc.getMap('fields').get('fld_bool')).toBe(true)
+    m2.app.unmount(); m2.container.remove()
+  })
+
+  it('two-client sync: a scalar set on one doc applies to another via Y.Map LWW', async () => {
+    sharedDoc.getMap('fields').set('fld_sel', 'opt_a')
+    const m = await mountBinding('rec1', 'fld_sel')
+    app = m.app; container = m.container
+    m.binding.setValue('opt_b')
+    // Simulate a second connected client receiving the update.
+    const doc2 = new Y.Doc()
+    Y.applyUpdate(doc2, Y.encodeStateAsUpdate(sharedDoc))
+    expect(doc2.getMap('fields').get('fld_sel')).toBe('opt_b')
+  })
+
+  it('absent key (unseeded scalar) stays inactive → caller keeps REST', async () => {
+    // fields map has no 'fld_unseeded' key
+    const m = await mountBinding('rec1', 'fld_unseeded')
+    app = m.app; container = m.container
+    expect(m.binding.active.value).toBe(false)
+    expect(m.binding.value.value).toBeUndefined()
+    // setValue is a no-op when inactive (never clobbers an unseeded key)
+    m.binding.setValue(7)
+    expect(sharedDoc.getMap('fields').has('fld_unseeded')).toBe(false)
+  })
+
+  it('remote update to the bound key refreshes the reactive value', async () => {
+    sharedDoc.getMap('fields').set('fld_num', 5)
+    const m = await mountBinding('rec1', 'fld_num')
+    app = m.app; container = m.container
+    expect(m.binding.value.value).toBe(5)
+    sharedDoc.getMap('fields').set('fld_num', 8) // simulates an applied remote update
+    await flush(4)
+    expect(m.binding.value.value).toBe(8)
+  })
+
+  it('flag OFF → inert (no active, setValue no-op)', async () => {
+    delete process.env.VITE_ENABLE_YJS_COLLAB
+    vi.unstubAllEnvs()
+    sharedDoc.getMap('fields').set('fld_num', 1)
+    const m = await mountBinding('rec1', 'fld_num')
+    app = m.app; container = m.container
+    expect(m.binding.active.value).toBe(false)
+    m.binding.setValue(2)
+    expect(sharedDoc.getMap('fields').get('fld_num')).toBe(1) // unchanged
+  })
+})

--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -25,7 +25,7 @@ export interface YjsRecordBridgeConfig {
 export type ActorResolver = (socketId: string) => string | undefined
 
 interface PendingWrite {
-  fields: Record<string, string>
+  fields: Record<string, unknown>
   actorIds: Set<string>
   timer: NodeJS.Timeout
   firstSeen: number
@@ -99,8 +99,10 @@ export class YjsRecordBridge {
       const originSocketId = typeof transaction.origin === 'string' ? transaction.origin : undefined
       const actorId = originSocketId ? (this.actorResolver(originSocketId) ?? 'unknown') : 'unknown'
 
-      // Collect changed text field values
-      const changedFields: Record<string, string> = {}
+      // Collect changed field values: Y.Text (string fields, char-level merged) AND
+      // plain values (scalar fields — number/currency/select/boolean/date/etc. — synced
+      // last-write-wins via the Y.Map). Both flush through the same validated patch path.
+      const changedFields: Record<string, unknown> = {}
 
       for (const event of events) {
         if (event.target === fields && event instanceof Y.YMapEvent) {
@@ -108,6 +110,11 @@ export class YjsRecordBridge {
             const value = fields.get(key)
             if (value instanceof Y.Text) {
               changedFields[key] = value.toString()
+            } else if (value !== undefined && !(value instanceof Y.AbstractType)) {
+              // Scalar field: a plain value set under the Y.Map key (LWW). Skip Yjs
+              // shared types (Y.Text handled above; Y.Map/Y.Array out of scope) and
+              // deletes (undefined key). patchRecords validates the value downstream.
+              changedFields[key] = value
             }
           }
         }
@@ -151,7 +158,7 @@ export class YjsRecordBridge {
     this.flushNow(recordId)
   }
 
-  private scheduleFlush(recordId: string, changedFields: Record<string, string>, actorId: string): void {
+  private scheduleFlush(recordId: string, changedFields: Record<string, unknown>, actorId: string): void {
     const existing = this.pendingWrites.get(recordId)
 
     if (existing) {

--- a/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
+++ b/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
@@ -1,0 +1,118 @@
+/**
+ * YjsRecordBridge — scalar (non-text) field sync.
+ *
+ * String fields bind to Y.Text (char-level merge). Scalar fields (number/currency/
+ * percent/rating/duration/select/multiSelect/date/dateTime/boolean) are atomic, so
+ * the correct realtime semantic is last-write-wins via the Y.Map: a plain value set
+ * under the field key. This test locks that the bridge collects those plain values
+ * and flushes them through the SAME validated patch path as Y.Text — while still
+ * handling Y.Text strings and ignoring nested Yjs shared types (Y.Map/Y.Array).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import * as Y from 'yjs'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+import { YjsRecordBridge } from '../../src/collab/yjs-record-bridge'
+
+function makePersistence() {
+  const snapshots = new Map<string, Uint8Array>()
+  const updates = new Map<string, Uint8Array[]>()
+  return {
+    store: { snapshots, updates },
+    loadDoc: vi.fn(async (recordId: string): Promise<Uint8Array | null> => {
+      const snap = snapshots.get(recordId)
+      const ups = updates.get(recordId) ?? []
+      if (!snap && ups.length === 0) return null
+      const doc = new Y.Doc()
+      if (snap) Y.applyUpdate(doc, snap)
+      for (const u of ups) Y.applyUpdate(doc, u)
+      const out = Y.encodeStateAsUpdate(doc)
+      doc.destroy()
+      return out
+    }),
+    storeUpdate: vi.fn(async (recordId: string, update: Uint8Array) => {
+      const list = updates.get(recordId) ?? []
+      list.push(update)
+      updates.set(recordId, list)
+    }),
+    storeSnapshot: vi.fn(async () => {}),
+    compactDoc: vi.fn(async () => {}),
+    purgeRecords: vi.fn(async () => {}),
+  }
+}
+
+function makeBridge() {
+  const persistence = makePersistence()
+  const svc = new YjsSyncService(persistence as any, async () => ({}))
+  const captured: { patch: Record<string, unknown> | null } = { patch: null }
+  const recordWriteService = {
+    patchRecords: vi.fn().mockResolvedValue({ updated: [{ recordId: 'rec_1', version: 2 }] }),
+  }
+  const bridge = new YjsRecordBridge(
+    svc as any,
+    recordWriteService as any,
+    async (_recordId: string, patch: Record<string, unknown>) => {
+      captured.patch = patch
+      return {
+        sheetId: 'sh_1',
+        changesByRecord: new Map(),
+        actorId: 'user_1',
+        fields: [],
+        visiblePropertyFields: [],
+        visiblePropertyFieldIds: new Set(),
+        attachmentFields: [],
+        fieldById: new Map(),
+        capabilities: {} as any,
+        access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      }
+    },
+    { mergeWindowMs: 200, maxDelayMs: 500 },
+  )
+  return { svc, bridge, recordWriteService, captured }
+}
+
+describe('YjsRecordBridge — scalar (non-text) field sync', () => {
+  it('collects plain scalar Y.Map values (number/select/boolean) and flushes them via the patch path', async () => {
+    vi.useFakeTimers()
+    const { svc, bridge, recordWriteService, captured } = makeBridge()
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    const fields = doc.getMap('fields')
+    fields.set('fld_num', 42)
+    fields.set('fld_sel', 'optA')
+    fields.set('fld_bool', true)
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(recordWriteService.patchRecords).toHaveBeenCalledTimes(1)
+    // LWW: the plain values reach the validated patch path with their native types.
+    expect(captured.patch).toMatchObject({ fld_num: 42, fld_sel: 'optA', fld_bool: true })
+    vi.useRealTimers()
+  })
+
+  it('still collects Y.Text strings (regression) and ignores nested Yjs shared types', async () => {
+    vi.useFakeTimers()
+    const { svc, bridge, captured } = makeBridge()
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    const fields = doc.getMap('fields')
+    const title = new Y.Text()
+    fields.set('fld_title', title)
+    title.insert(0, 'hello')
+    fields.set('fld_num', 7) // scalar → collected
+    fields.set('fld_nested', new Y.Map()) // a nested shared type → must NOT be collected as a scalar
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(captured.patch).toMatchObject({ fld_title: 'hello', fld_num: 7 })
+    expect(captured.patch).not.toHaveProperty('fld_nested')
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
The reusable FE primitive for scalar realtime sync (pairs with the BE bridge core #2814). `useYjsScalarCell` — type-agnostic (caller passes the typed value; never coerces), mirrors useYjsCellBinding's flag-gate / synced-and-key-exists activation / REST-fallback / cleanup; reads/writes the record `fields` Y.Map key.

**Inert** until the grid calls it + the BE seeds scalars (deferred — see below). Tested 6/6 (seeded read native types; setValue writes typed number/boolean; two-client Y.Map LWW sync; unseeded key inactive + no-op; remote refresh; flag-off inert). vue-tsc clean.

**Deferred — the corruption-risky coupling (needs a dedicated pass + the field-type registry):** the BE seed of non-string scalars into the Y.Map (yjs-sync-service only seeds strings today), the per-field-type representation decision (Y.Text vs plain-value — esp. select/date, which are strings today), and the grid wiring. Guessing the representation wrong = persisted corruption (no flag-off safety here), so it's explicitly NOT rushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)