### PR TITLE
fix(onprem): fresh-start PM2 when jlist cannot inspect env

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -505,17 +505,23 @@ TODO:
       `deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
       `provenance.target_write_failed=1`, request-body injection fields absent, and
       injection env/runtime config restored after the check.
-  - [ ] Post-C6 package reroll PM2 env hygiene hardening.
-    - trigger: #2769 found `app.env` no longer contained C6 failure-injection markers,
-      while the running PM2 process still reported marker presence.
-    - intended guard: when the two C6 test-only keys are absent from `app.env`,
-      the PM2 startup helper must clear them from the launch process and recreate
-      the PM2 app if an existing process definition still contains them.
-    - evidence must stay values-free:
-      `appEnvFailureInjectionMarkersPresent=false`,
-      `pm2RuntimeFailureInjectionMarkersPresent=false`,
-      `pm2StaleDefinitionFound=true|false`,
-      `pm2RecreatedFromCleanEnv=true|not_needed`, `health=200`; never print env values.
+- [ ] Post-C6 package reroll PM2 env hygiene hardening.
+  - trigger: #2769 found `app.env` no longer contained C6 failure-injection markers,
+    while the running PM2 process still reported marker presence.
+  - intended guard: when the two C6 test-only keys are absent from `app.env`,
+    the PM2 startup helper must clear them from the launch process and recreate
+    the PM2 app if an existing process definition still contains them.
+  - follow-up trigger: #2788 implemented the first guard, but #2769 entity-machine
+    validation showed a missed fallback path: `pm2 jlist` did not return the app,
+    while `pm2 describe` / restart could still find it. When the retired keys are
+    absent from `app.env`, that path must delete + fresh-start instead of
+    restart-only reuse because the helper cannot inspect the old definition's
+    runtime env.
+  - evidence must stay values-free:
+    `appEnvFailureInjectionMarkersPresent=false`,
+    `pm2RuntimeFailureInjectionMarkersPresent=false`,
+    `pm2StaleDefinitionFound=true|false|unknown_jlist_uninspectable`,
+    `pm2RecreatedFromCleanEnv=true|not_needed`, `health=200`; never print env values.
   - C6-5 remains sandbox/entity-machine validation only; no production/batch rollout.
 
 完成条件:

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -371,10 +371,13 @@ Current #2720 checkpoint as of 2026-06-17:
 - Post-C6 package rerolls must also prove PM2 runtime env hygiene before any
   further Apply/write validation. The C6 test-only keys are retired when they
   are absent from `app.env`; the PM2 helper recreates the app if a previous PM2
-  definition still contains those keys. Required values-free evidence:
+  definition still contains those keys, and it also recreates the app if PM2
+  `jlist` cannot inspect the app while `describe` still proves the app exists.
+  Restart-only reuse is not a valid cleanup path when the retired keys are
+  absent from `app.env`. Required values-free evidence:
   `appEnvFailureInjectionMarkersPresent=false`,
   `pm2RuntimeFailureInjectionMarkersPresent=false`,
-  `pm2StaleDefinitionFound=true|false`,
+  `pm2StaleDefinitionFound=true|false|unknown_jlist_uninspectable`,
   `pm2RecreatedFromCleanEnv=true|not_needed`, `health=200`. Do not print env
   values. Collect and post only these booleans plus the helper log marker; do
   not paste raw `app.env` contents or raw `pm2 jlist` JSON, because both can
@@ -489,7 +492,7 @@ c6Sandbox:
 pm2EnvHygiene:
   appEnvFailureInjectionMarkersPresent=false
   pm2RuntimeFailureInjectionMarkersPresent=false
-  pm2StaleDefinitionFound=true|false
+  pm2StaleDefinitionFound=true|false|unknown_jlist_uninspectable
   pm2RecreatedFromCleanEnv=true|not_needed
   health=200|...
 

--- a/scripts/ops/attendance-onprem-start-pm2.ps1
+++ b/scripts/ops/attendance-onprem-start-pm2.ps1
@@ -318,6 +318,21 @@ function Test-Pm2AppHasRetiredSensitiveEnvKey {
   return $false
 }
 
+function Test-RetiredSensitiveEnvKeyRetirementRequired {
+  param(
+    [string[]]$KeyNames,
+    [hashtable]$EnvFileKeys
+  )
+
+  foreach ($key in $KeyNames) {
+    if (-not $EnvFileKeys.ContainsKey($key)) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
 function Start-Pm2App {
   param(
     [string]$Pm2Command,
@@ -380,10 +395,20 @@ else {
     Start-Pm2App -Pm2Command $pm2Command -ConfigPath $ecosystemConfig -AppName $Pm2AppName -EnvName $Pm2Env
   }
   else {
-    Write-Host "[attendance-onprem-start-pm2] pm2 jlist did not return $Pm2AppName; falling back to restart"
-    & $pm2Command restart $Pm2AppName --update-env
-    if ($LASTEXITCODE -ne 0) {
-      throw "pm2 restart failed for $Pm2AppName"
+    if (Test-RetiredSensitiveEnvKeyRetirementRequired -KeyNames $RetiredSensitiveEnvKeys -EnvFileKeys $envFileKeys) {
+      Write-Host "[attendance-onprem-start-pm2] pm2 jlist did not return $Pm2AppName; deleting existing pm2 app definition to retire sensitive/test-only env keys"
+      & $pm2Command delete $Pm2AppName
+      if ($LASTEXITCODE -ne 0) {
+        throw "pm2 delete failed while retiring env keys for $Pm2AppName after jlist fallback"
+      }
+      Start-Pm2App -Pm2Command $pm2Command -ConfigPath $ecosystemConfig -AppName $Pm2AppName -EnvName $Pm2Env
+    }
+    else {
+      Write-Host "[attendance-onprem-start-pm2] pm2 jlist did not return $Pm2AppName; falling back to restart"
+      & $pm2Command restart $Pm2AppName --update-env
+      if ($LASTEXITCODE -ne 0) {
+        throw "pm2 restart failed for $Pm2AppName"
+      }
     }
   }
 }

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -68,3 +68,18 @@ test('PM2 startup helper retires sensitive test-only env keys absent from app.en
   assert.match(script, /deleting pm2 app definition for \$Pm2AppName to retire sensitive\/test-only env keys/)
   assert.match(script, /pm2 delete failed while retiring env keys/)
 })
+
+test('PM2 startup helper deletes existing app when jlist cannot inspect retired-key state', () => {
+  const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
+
+  assert.match(script, /function Test-RetiredSensitiveEnvKeyRetirementRequired/)
+  assert.match(script, /if \(-not \$EnvFileKeys\.ContainsKey\(\$key\)\) \{\s+return \$true\s+\}/)
+  assert.match(script, /Test-RetiredSensitiveEnvKeyRetirementRequired -KeyNames \$RetiredSensitiveEnvKeys -EnvFileKeys \$envFileKeys/)
+  assert.match(script, /pm2 jlist did not return \$Pm2AppName; deleting existing pm2 app definition to retire sensitive\/test-only env keys/)
+  assert.match(script, /pm2 delete failed while retiring env keys for \$Pm2AppName after jlist fallback/)
+
+  const fallbackBlockStart = script.indexOf('pm2 jlist did not return $Pm2AppName; deleting existing pm2 app definition')
+  const restartBlockStart = script.indexOf('pm2 jlist did not return $Pm2AppName; falling back to restart')
+  assert.ok(fallbackBlockStart > -1)
+  assert.ok(restartBlockStart > fallbackBlockStart)
+})


### PR DESCRIPTION
## Summary

Fixes the #2769 PM2 runtime-env hygiene fallback exposed by the entity-machine validation of the `331deb71d` package.

When `app.env` has retired the two C6 test-only failure-injection keys, the helper already clears them from the launch process and deletes a PM2 app if `pm2 jlist` shows those keys in the existing definition. The missed path was: `pm2 jlist` fails to return `metasheet-backend`, but `pm2 describe` / restart can still find an existing app. In that case the helper could not inspect the old definition, then reused restart-only and left stale PM2 runtime env behind.

This patch changes that fallback: if `jlist` cannot inspect the app, `describe` proves the app exists, and retired-key cleanup is required by `app.env`, the helper deletes the existing app definition and fresh-starts from the clean deploy root.

## Changes

- Add `Test-RetiredSensitiveEnvKeyRetirementRequired` to detect when any retired C6 test key is absent from `app.env`.
- In the `jlist`-miss / `describe`-hit fallback, use delete + fresh start when retirement is required.
- Keep restart-only fallback only when `app.env` intentionally still contains all retired keys.
- Extend the Windows hardening test lock for the jlist-uninspectable fallback.
- Update the release smoke runbook/TODO evidence wording, including `pm2StaleDefinitionFound=unknown_jlist_uninspectable` for this honest evidence shape.

## Verification

- `node --test scripts/ops/onprem-windows-system-hardening.test.mjs`
- `pwsh -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw "scripts/ops/attendance-onprem-start-pm2.ps1")); "PowerShell parse OK"'`
- `git diff --check`

Also attempted broader `node --test scripts/ops/*.test.mjs`; it is not a usable signal in this checkout because unrelated existing tests fail on missing `tsx`/`undici` and unrelated OpenAPI parity drift. The targeted PM2 helper suite above is green.

## Boundaries

- No C6 route/write behavior changes.
- No production/batch authorization.
- No K3 Save / Submit / Audit / BOM changes.
- Evidence remains values-free; no env values or raw PM2 JSON are requested.
