### PR TITLE
feat(multitable): non-string CRDT — rating + multiSelect live sync (real-PG no-corruption)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -197,6 +197,7 @@ jobs:
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
+            tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -164,8 +164,8 @@
       multiple
       :value="multiSelectValue"
       @change="onMultiSelectChange"
-      @keydown.meta.enter.prevent="emit('confirm')"
-      @keydown.ctrl.enter.prevent="emit('confirm')"
+      @keydown.meta.enter.prevent="scalarConfirm()"
+      @keydown.ctrl.enter.prevent="scalarConfirm()"
       @keydown.escape="emit('cancel')"
     >
       <option v-for="opt in field.options ?? []" :key="opt.value" :value="opt.value">
@@ -495,11 +495,15 @@ const yjsCollaborators = computed(() => yjsBinding.collaborators.value)
 // --- Yjs opt-in binding for ATOMIC (non-text) scalar cells (LWW via the
 // `fields` Y.Map). Same gating/fallback discipline as the text binding:
 // `scalarActive` flips true only once a live Y.Doc is attached AND the field
-// key exists in the Y.Map (the backend seeds atomic fields). Wired here only
-// for the unambiguous numeric/boolean types — select/date (string-stored
-// atomics) + multiSelect/rating/duration are deferred to a focused pass.
+// key exists in the Y.Map (the backend seeds atomic fields as plain LWW values).
+// Wired for the atomic types that read directly from modelValue (no local edit
+// buffer): numeric/boolean + rating (number) + multiSelect (string[]).
+// DEFERRED: `duration` has an intentional local text buffer decoupled from
+// modelValue (advisor B: live re-derivation fights the typist); `select`/`date`
+// are string-stored atomics seeded as Y.Text today — flipping them to plain-value
+// is a separate gated call (persisted docs hold them as Y.Text).
 // Inactive → byte-identical REST path (setValue is a no-op; nothing changes).
-const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean']
+const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 'multiSelect']
 const scalarFieldIdRef = computed<string | null>(() => {
   if (!props.field || !SCALAR_YJS_TYPES.includes(props.field.type)) return null
   if (!props.recordId) return null
@@ -562,14 +566,20 @@ function onTextConfirm() {
 
 const inputRef = ref<HTMLElement | null>(null)
 const multiSelectValue = computed(() => {
-  const raw = props.modelValue
+  // Read the synced Y.Map value (a plain string[]) when the scalar binding is
+  // live; otherwise the REST modelValue. Both normalize to string[] for <select>.
+  const raw = scalarActive.value ? scalarValue.value : props.modelValue
   if (!Array.isArray(raw)) return []
   return raw.map(String)
 })
 
 function onMultiSelectChange(event: Event) {
   const select = event.target as HTMLSelectElement
-  emit('update:modelValue', Array.from(select.selectedOptions).map((option) => option.value))
+  // multiSelect is a plain string[] scalar (LWW via the fields Y.Map). commitScalar
+  // drives the Y.Map when live (Y.Map.set stores a plain array — NOT a Y.Array — so
+  // the bridge flushes it verbatim through patchRecords) and always mirrors via
+  // update:modelValue. Inactive → byte-identical REST emit.
+  commitScalar(Array.from(select.selectedOptions).map((option) => option.value))
 }
 
 const linkButtonLabel = computed(() => {
@@ -730,15 +740,20 @@ const ratingMax = computed(() => {
 })
 
 const ratingValue = computed(() => {
-  const v = props.modelValue
+  const v = scalarActive.value ? scalarValue.value : props.modelValue
   const num = typeof v === 'number' ? v : Number(v)
   if (!Number.isFinite(num)) return 0
   return Math.max(0, Math.min(ratingMax.value, Math.round(num)))
 })
 
 function onRatingPick(value: number) {
-  emit('update:modelValue', value === 0 ? null : value)
-  emit('confirm')
+  // Rating is a plain-number scalar (seeded LWW in the fields Y.Map). When the
+  // scalar binding is live, commitScalar drives the Y.Map AND mirrors via
+  // update:modelValue; scalarConfirm signals yjs-commit so the host skips the
+  // redundant REST patch. Inactive → byte-identical to the old REST emit
+  // (commitScalar emits update:modelValue, scalarConfirm emits confirm).
+  commitScalar(value === 0 ? null : value)
+  scalarConfirm()
 }
 
 async function onRemoveAttachment(attachmentId: string) {

--- a/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
@@ -45,7 +45,7 @@ describe('MetaCellEditor scalar Yjs wiring', () => {
     container = null
   })
 
-  function mountField(field: { id: string; name: string; type: string }, modelValue: unknown, handlers: Record<string, unknown> = {}) {
+  function mountField(field: { id: string; name: string; type: string; options?: Array<{ value: string }> }, modelValue: unknown, handlers: Record<string, unknown> = {}) {
     app = createApp(defineComponent({
       render() {
         return h(loadedEditor, {
@@ -132,6 +132,83 @@ describe('MetaCellEditor scalar Yjs wiring', () => {
     await nextTick()
     expect(setValueMock).not.toHaveBeenCalled()
     expect(onUpdate).toHaveBeenCalledWith(true)
+    expect(onYjsCommit).not.toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('active rating: star pick writes the native Number via setValue + yjs-commit then confirm; clear writes null', async () => {
+    scalarActive.value = true
+    scalarVal.value = 2
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_score', name: 'Score', type: 'rating' }, 2, { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const stars = container!.querySelectorAll('.meta-cell-editor__rating-star')
+    expect(stars.length).toBe(5)
+    ;(stars[2] as HTMLButtonElement).click() // pick 3
+    await nextTick()
+    expect(setValueMock).toHaveBeenCalledWith(3) // native number, not '3'
+    expect(onUpdate).toHaveBeenCalledWith(3)
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+    // clear → null (the field-clear shape REST would write)
+    const clear = container!.querySelector('.meta-cell-editor__rating-clear') as HTMLButtonElement
+    expect(clear).toBeTruthy()
+    clear.click()
+    await nextTick()
+    expect(setValueMock).toHaveBeenLastCalledWith(null)
+    expect(onUpdate).toHaveBeenLastCalledWith(null)
+  })
+
+  it('inactive rating: REST path byte-identical — setValue not called, no yjs-commit', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_score', name: 'Score', type: 'rating' }, 2, { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const stars = container!.querySelectorAll('.meta-cell-editor__rating-star')
+    ;(stars[2] as HTMLButtonElement).click()
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith(3)
+    expect(onYjsCommit).not.toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('active multiSelect: change writes the plain string[] via setValue + emits update; meta+Enter emits yjs-commit then confirm', async () => {
+    scalarActive.value = true
+    scalarVal.value = ['a']
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField(
+      { id: 'fld_tags', name: 'Tags', type: 'multiSelect', options: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+      ['a'],
+      { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit },
+    )
+    const select = container!.querySelector('select.meta-cell-editor__select--multi') as HTMLSelectElement
+    expect(select).toBeTruthy()
+    Array.from(select.options).forEach((o) => { o.selected = o.value === 'a' || o.value === 'c' })
+    select.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(setValueMock).toHaveBeenCalledWith(['a', 'c']) // plain string[], not a Y.Array
+    expect(onUpdate).toHaveBeenCalledWith(['a', 'c'])
+    select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }))
+    await nextTick()
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('inactive multiSelect: REST path byte-identical — setValue not called, no yjs-commit', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField(
+      { id: 'fld_tags', name: 'Tags', type: 'multiSelect', options: [{ value: 'a' }, { value: 'b' }, { value: 'c' }] },
+      ['a'],
+      { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit },
+    )
+    const select = container!.querySelector('select.meta-cell-editor__select--multi') as HTMLSelectElement
+    Array.from(select.options).forEach((o) => { o.selected = o.value === 'b' })
+    select.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith(['b'])
+    select.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }))
+    await nextTick()
     expect(onYjsCommit).not.toHaveBeenCalled()
     expect(onConfirm).toHaveBeenCalled()
   })

--- a/packages/core-backend/tests/integration/yjs-scalar-flush-realdb.test.ts
+++ b/packages/core-backend/tests/integration/yjs-scalar-flush-realdb.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Real-DB no-corruption proof — the FLUSH side of non-string CRDT for the field types wired in
+ * this slice: rating (number) and multiSelect (string[]). A synced client edits the record
+ * `fields` Y.Map; the YjsRecordBridge flushes the change through the REAL
+ * RecordWriteService.patchRecords (real injected helpers + real Postgres). We then re-read
+ * meta_records.data and assert the values round-trip with native types:
+ *   - rating stays a JS number (not '4', not coerced)
+ *   - multiSelect stays a PLAIN JSON array (not a Y.Array, not a JSON-stringified blob)
+ *
+ * Companion to yjs-scalar-seed-realdb (the SEED side: data -> Y.Map) and
+ * yjs-bridge-scalar-fields (the COLLECTION side: Y.Map -> patch, mocked). This closes the loop
+ * on real Postgres. Capabilities come from deriveCapabilities(['multitable:write']) — the same
+ * MultitableCapabilities derivation the REST write path uses — so the only thing isolated here is
+ * value fidelity, not permission gating (covered elsewhere). The bridge's own flushNow swallows
+ * write errors, so a broken wiring shows up as a FAILED DB assertion below, never a false green.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI per the suite convention).
+ */
+import { EventEmitter } from 'events'
+import type { Request } from 'express'
+import * as Y from 'yjs'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+import { YjsRecordBridge } from '../../src/collab/yjs-record-bridge'
+import { RecordWriteService, type RecordPatchInput } from '../../src/multitable/record-write-service'
+import { createRecordWriteHelpers } from '../../src/routes/univer-meta'
+import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const TS = Date.now()
+const BASE_ID = `base_scalarflush_${TS}`
+const SHEET_ID = `sheet_scalarflush_${TS}`
+const REC_ID = `rec_scalarflush_${TS}`
+const ACTOR = `u_scalarflush_${TS}`
+const SOCKET = `socket_scalarflush_${TS}`
+
+const F_RATING = 'fld_rating'
+const F_TAGS = 'fld_tags'
+const TAG_OPTS = [{ value: 'x' }, { value: 'y' }, { value: 'z' }]
+
+async function readData(): Promise<Record<string, unknown>> {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [REC_ID])
+  return (r.rows[0]?.data as Record<string, unknown>) ?? {}
+}
+
+// Faithful resolver: builds RecordPatchInput from the REAL fields + REAL capability derivation,
+// mirroring the production wiring in src/index.ts. (No DB-backed RBAC lookup — we grant the
+// actor multitable:write directly, since this test isolates value fidelity, not permissions.)
+function makeGetWriteInput() {
+  return async (recordId: string, patch: Record<string, unknown>, actorId: string): Promise<RecordPatchInput | null> => {
+    const rec = await q('SELECT sheet_id FROM meta_records WHERE id = $1', [recordId])
+    if (rec.rows.length === 0) return null
+    const sheetId = String((rec.rows[0] as { sheet_id: string }).sheet_id)
+    const fr = await q(
+      'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
+      [sheetId],
+    )
+    const fields = (fr.rows as Array<Record<string, unknown>>).map((f) => {
+      const prop = f.property && typeof f.property === 'object' ? (f.property as Record<string, unknown>) : {}
+      return { id: String(f.id), name: String(f.name), type: f.type as string, property: prop, options: prop.options, order: Number(f.order ?? 0) }
+    })
+    const fieldById = new Map(
+      fields.map((f) => {
+        const prop = (f.property || {}) as Record<string, unknown>
+        const guard: Record<string, unknown> = { type: f.type, readOnly: false, hidden: false }
+        if ((f.type === 'select' || f.type === 'multiSelect') && Array.isArray(prop.options)) {
+          guard.options = (prop.options as unknown[]).map((o) => (typeof o === 'string' ? o : (o as { value?: string })?.value ?? ''))
+        }
+        return [f.id, guard] as const
+      }),
+    )
+    const changesByRecord = new Map([
+      [recordId, Object.entries(patch).map(([fieldId, value]) => ({ fieldId, value }))],
+    ])
+    const capabilities = deriveCapabilities(['multitable:read', 'multitable:write'], false)
+    return {
+      sheetId,
+      changesByRecord,
+      actorId,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fields: fields as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      visiblePropertyFields: fields as any,
+      visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+      attachmentFields: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fieldById: fieldById as any,
+      capabilities,
+      access: { userId: actorId, permissions: ['multitable:read', 'multitable:write'], isAdminRole: false },
+      source: 'yjs-bridge',
+    }
+  }
+}
+
+describeIfDatabase('Yjs scalar FLUSH (real DB) — rating/multiSelect round-trip through the bridge, no corruption', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'ScalarFlush Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'ScalarFlush Sheet'])
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_RATING, SHEET_ID, 'Score', 'rating', JSON.stringify({ max: 5 }), 1],
+    )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_TAGS, SHEET_ID, 'Tags', 'multiSelect', JSON.stringify({ options: TAG_OPTS }), 2],
+    )
+  })
+  beforeEach(async () => {
+    // Fresh starting state each run: rating=1, tags=['x'].
+    await q(
+      'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ' +
+        'ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1',
+      [REC_ID, SHEET_ID, JSON.stringify({ [F_RATING]: 1, [F_TAGS]: ['x'] })],
+    )
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE id = $1', [REC_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('Y.Map edit (rating=4, multiSelect=[x,y,z]) flushes via REAL patchRecords → DB keeps native number + plain array', async () => {
+    const pool = poolManager.get()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const eventBus = new EventEmitter() as any
+    const fakeReq = { user: { id: ACTOR, roles: [], perms: ['multitable:read', 'multitable:write'] } } as unknown as Request
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const helpers = createRecordWriteHelpers(fakeReq, pool as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const recordWriteService = new RecordWriteService(pool as any, eventBus, helpers)
+
+    const persistence = { loadDoc: async () => null, storeUpdate: async () => {}, storeSnapshot: async () => {}, destroy: async () => {} }
+    const recordSeed = async (recordId: string): Promise<Record<string, unknown> | null> => {
+      const res = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+      return (res.rows[0]?.data as Record<string, unknown>) ?? null
+    }
+    const svc = new YjsSyncService(persistence as never, recordSeed)
+
+    const bridge = new YjsRecordBridge(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc as any,
+      recordWriteService,
+      makeGetWriteInput(),
+      { mergeWindowMs: 50, maxDelayMs: 200 },
+      (socketId: string) => (socketId === SOCKET ? ACTOR : 'unknown'),
+    )
+
+    try {
+      const doc = await svc.getOrCreateDoc(REC_ID)
+      bridge.observe(REC_ID, doc)
+      const fields = doc.getMap('fields')
+
+      // A synced client edit: a non-rest/persistence transaction origin (the socket id) so the
+      // bridge attributes + flushes it through patchRecords, exactly like a real collaborator.
+      doc.transact(() => {
+        fields.set(F_RATING, 4)
+        fields.set(F_TAGS, ['x', 'y', 'z'])
+      }, SOCKET)
+
+      // Wait out the debounce + the async patchRecords landing in Postgres.
+      await new Promise((r) => setTimeout(r, 500))
+
+      const data = await readData()
+      expect(data[F_RATING]).toBe(4)
+      expect(typeof data[F_RATING]).toBe('number') // native number, not '4'
+      expect(data[F_TAGS]).toEqual(['x', 'y', 'z']) // plain JSON array, not a Y.Array, not stringified
+      expect(Array.isArray(data[F_TAGS])).toBe(true)
+    } finally {
+      bridge.unobserve(REC_ID)
+      await svc.destroy()
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
+++ b/packages/core-backend/tests/unit/yjs-bridge-scalar-fields.test.ts
@@ -115,4 +115,42 @@ describe('YjsRecordBridge — scalar (non-text) field sync', () => {
     expect(captured.patch).not.toHaveProperty('fld_nested')
     vi.useRealTimers()
   })
+
+  it('collects a plain string[] (multiSelect) and a number (rating) VERBATIM — Y.Map.set stores a plain array, not a Y.Array, so it is not dropped as a shared type', async () => {
+    vi.useFakeTimers()
+    const { svc, bridge, captured } = makeBridge()
+    const doc = await svc.getOrCreateDoc('rec_1')
+    bridge.observe('rec_1', doc)
+
+    const fields = doc.getMap('fields')
+    fields.set('fld_tags', ['x', 'y', 'z']) // multiSelect: a PLAIN JS array (NOT a Y.Array)
+    fields.set('fld_rating', 4) // rating: a plain number
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(200)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The array reaches the validated patch path deep-equal + still a real array (uncorrupted,
+    // not stringified, not a Yjs shared type that the `!(value instanceof Y.AbstractType)` guard drops).
+    expect(captured.patch).toMatchObject({ fld_tags: ['x', 'y', 'z'], fld_rating: 4 })
+    expect(Array.isArray((captured.patch as Record<string, unknown>).fld_tags)).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('two-client LWW: a multiSelect array + rating set on one doc sync to a peer via the Y.Map (plain array survives, not a Y.Array)', () => {
+    const docA = new Y.Doc()
+    const docB = new Y.Doc()
+    const fa = docA.getMap('fields')
+    const fb = docB.getMap('fields')
+    fa.set('fld_tags', ['a', 'b'])
+    fa.set('fld_rating', 5)
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA))
+    expect(fb.get('fld_tags')).toEqual(['a', 'b'])
+    expect(Array.isArray(fb.get('fld_tags'))).toBe(true) // plain array crosses the wire intact
+    expect(fb.get('fld_tags')).not.toBeInstanceOf(Y.AbstractType)
+    expect(fb.get('fld_rating')).toBe(5)
+    docA.destroy()
+    docB.destroy()
+  })
 })


### PR DESCRIPTION
Widens live realtime sync to **rating + multiSelect** (on top of the merged number/currency/percent/boolean). Grounded representation: rating → number; multiSelect → **plain JS array** in the Y.Map (not Y.Array, so the bridge's `!(value instanceof Y.AbstractType)` guard admits it). Surgical MetaCellEditor wiring; inactive/REST path byte-identical (test-locked).

**Real-PG corruption test (the gate):** rating=4 + multiSelect=[x,y,z] written via the binding → bridge → REAL patchRecords → DB keeps native number + plain array uncorrupted (asserted values differ from the seed, so a silent flush failure would fail the test). 3/3 on Postgres 15.

**Deferred with cause (separate gated decisions, NOT guessed):** select/date/dateTime — the seed commits strings as Y.Text and persisted docs already hold Y.Text; flipping to plain-value would strand those docs (the scalar binding would read a Y.Text object = corruption) → needs a persisted-doc migration story; they're FE-unbound (REST) today so the flip is pure-risk/inert-benefit. duration — a local h:mm buffer drives the input; live re-derivation would reformat under the cursor (UX conflict).

Verified: vue-tsc + tsc clean; BE suite 4434/0; FE web-guard 112/0; editor 10/10; bridge 4/4; real-PG 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)