### PR TITLE
feat(data-source): test-before-save Slice 1 (BE) — ephemeral connection test

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -247,6 +247,7 @@ jobs:
             tests/integration/multitable-ai-ledger-retention.test.ts \
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \
+            tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
       - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign 会签/或签/reduce/guards)

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -540,6 +540,46 @@ export class DataSourceManager extends EventEmitter {
     return ok ? { success: true } : { success: false, error: adapter.connectionError ?? undefined }
   }
 
+  // test-before-save (design-lock 2026-06-17): validate connection PARAMS before a source exists,
+  // so the create / credential-rotation form can surface a bad host/credential WITHOUT first
+  // persisting a broken source. Fully EPHEMERAL — builds a transient adapter via the same
+  // `adapterTypes` factory, then connects/probes/disposes. It deliberately does NOT go through
+  // addDataSourceInternal: it never writes `adapters`/`scopes`/`connectionPool`, never persists,
+  // and wires NO manager event forwarding (no `this.emit` / `updateStatus`). The only listener is a
+  // local no-op `error` swallow so BaseDataAdapter.onError()'s `emit('error')` can't throw on an
+  // unhandled emitter error; the redacted cause is still read from `adapter.connectionError`.
+  async testEphemeralConnection(
+    config: DataSourceConfig
+  ): Promise<{ success: boolean; latency?: number; error?: string }> {
+    const AdapterClass = this.adapterTypes.get(config.type.toLowerCase())
+    if (!AdapterClass) {
+      // Mirror addDataSourceInternal's wording; the route maps this to a 400 (client error).
+      throw new Error(`Unsupported data source type: ${config.type}`)
+    }
+    const adapter = new AdapterClass(config)
+    adapter.on('error', () => { /* ephemeral: cause captured via connectionError; no emit/persist */ })
+    const start = Date.now()
+    try {
+      if (!adapter.isConnected()) {
+        await adapter.connect() // throws on failure; onError records the redacted cause
+      }
+      const ok = await adapter.testConnection()
+      const latency = Date.now() - start
+      return ok
+        ? { success: true, latency }
+        : { success: false, latency, error: adapter.connectionError ?? undefined }
+    } catch {
+      return { success: false, latency: Date.now() - start, error: adapter.connectionError ?? undefined }
+    } finally {
+      try {
+        if (adapter.isConnected()) await adapter.disconnect()
+      } catch {
+        // best-effort teardown of the transient adapter
+      }
+      adapter.removeAllListeners()
+    }
+  }
+
   // Query routing methods
   async query<T = Record<string, DbValue>>(
     dataSourceId: string,

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -558,6 +558,19 @@ export class DataSourceManager extends EventEmitter {
     }
     const adapter = new AdapterClass(config)
     adapter.on('error', () => { /* ephemeral: cause captured via connectionError; no emit/persist */ })
+    // No-echo (design-lock 钉子②): the adapter redacts secret VALUES, but a driver diagnostic can still
+    // reflect the caller's submitted host/username (e.g. `password authentication failed for user "x"`,
+    // `getaddrinfo ENOTFOUND <host>`). Strip those submitted identifiers too so the ephemeral test never
+    // echoes connection input back. Scoped here — shared redactSecrets stays intact for /:id/test.
+    const scrubInput = (msg: string | undefined): string | undefined => {
+      if (!msg) return msg
+      const conn = config.connection ?? {}
+      const ids = [conn.host, conn.server, conn.database, config.credentials?.username]
+        .filter((v): v is string => typeof v === 'string' && v.trim().length >= 3)
+      let out = msg
+      for (const id of ids) out = out.split(id).join('***')
+      return out
+    }
     const start = Date.now()
     try {
       if (!adapter.isConnected()) {
@@ -567,9 +580,9 @@ export class DataSourceManager extends EventEmitter {
       const latency = Date.now() - start
       return ok
         ? { success: true, latency }
-        : { success: false, latency, error: adapter.connectionError ?? undefined }
+        : { success: false, latency, error: scrubInput(adapter.connectionError ?? undefined) }
     } catch {
-      return { success: false, latency: Date.now() - start, error: adapter.connectionError ?? undefined }
+      return { success: false, latency: Date.now() - start, error: scrubInput(adapter.connectionError ?? undefined) }
     } finally {
       try {
         if (adapter.isConnected()) await adapter.disconnect()

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -222,6 +222,8 @@ export class MSSQLAdapter extends BaseDataAdapter {
       this.connected = true
       await this.onConnect()
     } catch (error) {
+      // Close (not just drop) the pool so a failed connect leaks no open ConnectionPool.
+      try { await this.pool?.close() } catch { /* pool may be partially constructed */ }
       this.pool = null
       await this.onError(error as Error)
       throw new Error(`Failed to connect to SQL Server: ${error}`)

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -220,6 +220,10 @@ export class MySQLAdapter extends BaseDataAdapter {
       await this.onConnect()
     } catch (error) {
       await this.onError(error as Error)
+      // A failed connect must not leak the pool (see PostgresAdapter): end + null so the ephemeral
+      // test-before-save path and any failed reconnect leave no open pool.
+      try { await this.pool?.end() } catch { /* pool may be partially constructed */ }
+      this.pool = null
       throw new Error(`Failed to connect to MySQL: ${error}`)
     }
   }

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -95,6 +95,11 @@ export class PostgresAdapter extends BaseDataAdapter {
       await this.onConnect()
     } catch (error) {
       await this.onError(error as Error)
+      // A failed connect must not leak the pool created above. The ephemeral test-before-save helper
+      // gates teardown on isConnected() (false here) and disconnect() self-guards on `connected`, so
+      // neither would end it — close it here. connect() always recreates the pool, so nulling is safe.
+      try { await this.pool?.end() } catch { /* pool may be partially constructed */ }
+      this.pool = null
       throw new Error(`Failed to connect to PostgreSQL: ${error}`)
     }
   }

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -355,6 +355,68 @@ export function dataSourcesRouter(): Router {
   })
 
   /**
+   * POST /api/data-sources/test
+   * test-before-save (design-lock 2026-06-17): ephemeral connection test for the create /
+   * credential-rotation form. Accepts the create-payload shape, runs a transient connection test
+   * via DataSourceManager.testEphemeralConnection (persists nothing, registers nothing), and returns
+   * a RESULT-ONLY body — it never echoes back the submitted config / connection / credentials.
+   * rbac `write`: supplying arbitrary connection params + actively dialing out is a write-tier
+   * capability (matches create, and narrows the caller set vs `read`).
+   * NOTE: must precede the `/:id/*` routes is unnecessary (single-segment `/test` cannot match a
+   * two-segment `/:id/test`), but it is grouped with create for clarity.
+   */
+  router.post('/api/data-sources/test', rbacGuard('data_sources', 'write'), async (req: Request, res: Response) => {
+    const parse = DataSourceCreateSchema.safeParse(req.body)
+    if (!parse.success) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: parse.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ')
+        }
+      })
+    }
+
+    try {
+      const userId = resolveUserId(req)
+      if (!userId) {
+        return res.status(401).json({
+          ok: false,
+          error: { code: 'UNAUTHENTICATED', message: 'Authentication required' }
+        })
+      }
+      const manager = getManager()
+      const config = parse.data as DataSourceConfig
+      const result = await manager.testEphemeralConnection(config)
+      // RESULT-ONLY surface (design-lock 钉子②): success / latency / redacted error — NEVER echo the
+      // submitted config, connection, or credentials back to the caller.
+      return res.json({
+        ok: true,
+        data: {
+          success: result.success,
+          ...(typeof result.latency === 'number' ? { latency: `${result.latency}ms` } : {}),
+          ...(result.error ? { error: { message: result.error } } : {})
+        }
+      })
+    } catch (error) {
+      // Unsupported type is a client error (mirror create's allowlist semantics), not a 500.
+      if (error instanceof Error && error.message.toLowerCase().includes('unsupported data source type')) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'VALIDATION_ERROR', message: error.message }
+        })
+      }
+      return res.status(500).json({
+        ok: false,
+        error: {
+          code: 'TEST_FAILED',
+          message: error instanceof Error ? error.message : 'Connection test failed'
+        }
+      })
+    }
+  })
+
+  /**
    * PUT /api/data-sources/:id
    * Update data source configuration (requires reconnect)
    */

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -362,8 +362,8 @@ export function dataSourcesRouter(): Router {
    * a RESULT-ONLY body — it never echoes back the submitted config / connection / credentials.
    * rbac `write`: supplying arbitrary connection params + actively dialing out is a write-tier
    * capability (matches create, and narrows the caller set vs `read`).
-   * NOTE: must precede the `/:id/*` routes is unnecessary (single-segment `/test` cannot match a
-   * two-segment `/:id/test`), but it is grouped with create for clarity.
+   * Route placement: `/test` is single-segment and there is no bare `POST /:id`, so it cannot collide
+   * with the two-segment `/:id/*` routes; it is grouped with create for clarity.
    */
   router.post('/api/data-sources/test', rbacGuard('data_sources', 'write'), async (req: Request, res: Response) => {
     const parse = DataSourceCreateSchema.safeParse(req.body)
@@ -399,7 +399,8 @@ export function dataSourcesRouter(): Router {
         }
       })
     } catch (error) {
-      // Unsupported type is a client error (mirror create's allowlist semantics), not a 500.
+      // Defensive: the Zod enum rejects unknown types with a 400 before the helper runs; this maps the
+      // helper's "unsupported type" throw (a registered type with no adapter) to 400 too, not a 500.
       if (error instanceof Error && error.message.toLowerCase().includes('unsupported data source type')) {
         return res.status(400).json({
           ok: false,

--- a/packages/core-backend/tests/integration/data-source-test-ephemeral-realdb.test.ts
+++ b/packages/core-backend/tests/integration/data-source-test-ephemeral-realdb.test.ts
@@ -1,0 +1,90 @@
+import express from 'express'
+import { Pool } from 'pg'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { dataSourcesRouter, getDataSourceManager } from '../../src/routes/data-sources'
+
+// Real-DB gate: runs only where DATABASE_URL is configured (CI plugin-tests.yml). The enumerated
+// runner asserts DATABASE_URL is present, so this suite cannot silently skip in CI.
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const OWNER = 'eph-realdb-owner'
+const BAD_SECRET = 'definitely-not-the-real-password-2026'
+
+function appAs(userId: string) {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => { req.user = { id: userId, role: 'admin' } as never; next() })
+  a.use(dataSourcesRouter())
+  return a
+}
+
+function liveConnection(databaseUrl: string): { connection: Record<string, unknown>; credentials: Record<string, string> } {
+  const parsed = new URL(databaseUrl)
+  const credentials: Record<string, string> = {}
+  if (parsed.username) credentials.username = decodeURIComponent(parsed.username)
+  if (parsed.password) credentials.password = decodeURIComponent(parsed.password)
+  return {
+    connection: {
+      host: parsed.hostname || 'localhost',
+      port: parsed.port ? Number(parsed.port) : 5432,
+      database: parsed.pathname.replace(/^\//, ''),
+    },
+    credentials,
+  }
+}
+
+describeIfDatabase('POST /api/data-sources/test — ephemeral connection test (real Postgres)', () => {
+  let pool: Pool
+
+  beforeAll(() => { pool = new Pool({ connectionString: process.env.DATABASE_URL }) })
+  afterAll(async () => { if (pool) await pool.end() })
+
+  it('returns success + latency against the live database', async () => {
+    const live = liveConnection(process.env.DATABASE_URL!)
+    const res = await request(appAs(OWNER)).post('/api/data-sources/test').send({
+      id: 'eph_live_ok', name: 'Live OK', type: 'postgresql', ...live,
+      options: { readOnly: true },
+    })
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.success).toBe(true)
+    expect(res.body.data.latency).toMatch(/ms$/)
+    expect(res.body.data.error).toBeUndefined()
+  })
+
+  it('returns success:false with a cause for an unreachable target, leaking no secret', async () => {
+    const res = await request(appAs(OWNER)).post('/api/data-sources/test').send({
+      id: 'eph_live_fail', name: 'Live Fail', type: 'postgresql',
+      connection: { host: '127.0.0.1', port: 1, database: 'nope' }, // ECONNREFUSED, deterministic
+      credentials: { username: 'u', password: BAD_SECRET },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)            // request completed
+    expect(res.body.data.success).toBe(false) // connection failed
+    expect(res.body.data.error?.message).toBeTruthy()
+    expect(JSON.stringify(res.body)).not.toContain(BAD_SECRET) // no credential echo / leak
+  })
+
+  it('persists nothing — data_sources row count unchanged, source never registered (404)', async () => {
+    const before = (await pool.query('SELECT count(*)::int AS n FROM data_sources')).rows[0].n as number
+
+    const live = liveConnection(process.env.DATABASE_URL!)
+    await request(appAs(OWNER)).post('/api/data-sources/test').send({
+      id: 'eph_nopersist_live', name: 'No Persist', type: 'postgresql', ...live,
+      options: { readOnly: true },
+    }).expect(200)
+
+    const after = (await pool.query('SELECT count(*)::int AS n FROM data_sources')).rows[0].n as number
+    expect(after).toBe(before) // zero persistence: no row written
+
+    // Definitive no-persist proof: addDataSource is the ONLY path that writes data_sources and it
+    // ALWAYS registers the adapter/scope in memory first — so an absent in-memory registration proves
+    // the route never persisted.
+    const manager = getDataSourceManager()
+    expect(manager.listDataSources({ ownerId: OWNER }).some(s => s.id === 'eph_nopersist_live')).toBe(false)
+    const got = await request(appAs(OWNER)).get('/api/data-sources/eph_nopersist_live')
+    expect(got.status).toBe(404)
+  })
+})

--- a/packages/core-backend/tests/unit/data-source-connect-failure-cleanup.test.ts
+++ b/packages/core-backend/tests/unit/data-source-connect-failure-cleanup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
+import { MySQLAdapter } from '../../src/data-adapters/MySQLAdapter'
+import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
+
+// M1 regression: a FAILED connect() must not leak the driver Pool. The ephemeral test-before-save
+// helper gates teardown on isConnected() (false after a failed connect) and disconnect() self-guards
+// on `connected`, so the adapter's own connect() catch must end + null the pool. 127.0.0.1:1 gives a
+// deterministic, fast ECONNREFUSED with no DB required.
+function badCfg(type: string): DataSourceConfig {
+  return {
+    id: `bad_${type}`, name: 'bad', type,
+    connection: { host: '127.0.0.1', port: 1, database: 'nope' },
+    credentials: { username: 'u', password: 'p' },
+    poolConfig: { min: 0, max: 1, idleTimeout: 500, acquireTimeout: 1500 },
+  } as DataSourceConfig
+}
+
+function poolOf(adapter: unknown): unknown {
+  return (adapter as { pool: unknown }).pool
+}
+
+describe('SQL adapter connect() failure cleans up the pool (M1 — no leak)', () => {
+  it('PostgresAdapter: failed connect rejects, stays disconnected, and nulls the pool', async () => {
+    const adapter = new PostgresAdapter(badCfg('postgres'))
+    adapter.on('error', () => { /* swallow onError emit */ })
+    await expect(adapter.connect()).rejects.toThrow()
+    expect(adapter.isConnected()).toBe(false)
+    expect(poolOf(adapter)).toBeNull()
+  })
+
+  it('MySQLAdapter: failed connect rejects, stays disconnected, and nulls the pool', async () => {
+    const adapter = new MySQLAdapter(badCfg('mysql'))
+    adapter.on('error', () => { /* swallow onError emit */ })
+    await expect(adapter.connect()).rejects.toThrow()
+    expect(adapter.isConnected()).toBe(false)
+    expect(poolOf(adapter)).toBeNull()
+  })
+})

--- a/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
@@ -1,0 +1,195 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// auditLog hits the DB; no-op it for these in-memory tests.
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import { BaseDataAdapter } from '../../src/data-adapters/BaseAdapter'
+import type {
+  DataSourceConfig,
+  QueryResult,
+  SchemaInfo,
+  TableInfo,
+  ColumnInfo,
+  Transaction,
+  DbValue,
+} from '../../src/data-adapters/BaseAdapter'
+import { dataSourcesRouter, getDataSourceManager } from '../../src/routes/data-sources'
+
+const SECRET = 'EphemeralSecretPw!2026'
+
+// Module-level cleanup ledgers so we can prove the ephemeral helper's `finally` ran
+// (disconnect + removeAllListeners) even though it never hands us the adapter instance.
+const disconnectCalls: string[] = []
+const removeAllListenerCalls: string[] = []
+
+// All-no-op concrete base so each fake only overrides the lifecycle bits it cares about.
+abstract class FakeBase extends BaseDataAdapter {
+  async query<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async select<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async insert<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async update<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async delete<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async getSchema(): Promise<SchemaInfo> { return { tables: [] } }
+  async getTableInfo(): Promise<TableInfo> { return { name: '', columns: [] } }
+  async getColumns(): Promise<ColumnInfo[]> { return [] }
+  async tableExists(): Promise<boolean> { return false }
+  async beginTransaction(): Promise<Transaction> { return {} as Transaction }
+  async commit(): Promise<void> {}
+  async rollback(): Promise<void> {}
+  async inTransaction<R = unknown>(_t: Transaction, cb: () => Promise<R>): Promise<R> { return cb() }
+  async *stream<T = Record<string, DbValue>>(): AsyncIterableIterator<T> { /* no rows */ }
+  removeAllListeners(event?: string | symbol): this {
+    removeAllListenerCalls.push(this.config.id)
+    return super.removeAllListeners(event)
+  }
+}
+
+// Connects fine; testConnection passes.
+class OkAdapter extends FakeBase {
+  async connect(): Promise<void> { this.connected = true; await this.onConnect() }
+  async disconnect(): Promise<void> { disconnectCalls.push(this.config.id); this.connected = false; await this.onDisconnect() }
+  isConnected(): boolean { return this.connected }
+  async testConnection(): Promise<boolean> { return true }
+}
+
+// connect() fails with an error embedding the configured password (proves redaction + no echo).
+class FailAdapter extends FakeBase {
+  async connect(): Promise<void> {
+    const err = new Error(`ECONNREFUSED 127.0.0.1: login failed (password=${this.config.credentials?.password})`)
+    await this.onError(err) // records redactSecrets(err.message) into lastConnectionError, emits 'error'
+    throw err
+  }
+  async disconnect(): Promise<void> { disconnectCalls.push(this.config.id); this.connected = false }
+  isConnected(): boolean { return this.connected }
+  async testConnection(): Promise<boolean> { return false }
+}
+
+function appAs(userId: string) {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => { req.user = { id: userId, role: 'admin' } as never; next() })
+  a.use(dataSourcesRouter())
+  return a
+}
+
+function cfg(id: string, type: string, extra?: Partial<DataSourceConfig>): DataSourceConfig {
+  return {
+    id, name: id, type,
+    connection: { host: 'unreachable.example' },
+    credentials: { username: 'u', password: SECRET },
+    options: { autoConnect: false },
+    ...extra,
+  } as DataSourceConfig
+}
+
+beforeEach(() => { disconnectCalls.length = 0; removeAllListenerCalls.length = 0 })
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('DataSourceManager.testEphemeralConnection (helper)', () => {
+  it('returns success + latency, registers nothing, and disposes the transient adapter', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('okeph', OkAdapter as never)
+    const id = `eph_ok_${Date.now()}`
+
+    const result = await manager.testEphemeralConnection(cfg(id, 'okeph'))
+
+    expect(result.success).toBe(true)
+    expect(typeof result.latency).toBe('number')
+    // EPHEMERAL: no in-memory registration (the sole persist path, addDataSource, also registers here).
+    expect(manager.getScope(id)).toBeUndefined()
+    expect(() => manager.assertAccess(id, 'tester')).toThrow(/not found/)
+    expect(manager.listDataSources({ ownerId: 'tester' }).some(s => s.id === id)).toBe(false)
+    // CLEANUP: finally ran disconnect + removeAllListeners.
+    expect(disconnectCalls).toContain(id)
+    expect(removeAllListenerCalls).toContain(id)
+  })
+
+  it('returns success:false with a REDACTED cause on connect failure, leaking no secret', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('faileph', FailAdapter as never)
+    const id = `eph_fail_${Date.now()}`
+
+    const result = await manager.testEphemeralConnection(cfg(id, 'faileph'))
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('***')
+    expect(JSON.stringify(result)).not.toContain(SECRET)
+    expect(manager.getScope(id)).toBeUndefined() // still nothing registered on failure
+    expect(removeAllListenerCalls).toContain(id) // disposed even on failure
+  })
+
+  it('throws Unsupported data source type for an unknown adapter type', async () => {
+    const manager = getDataSourceManager()
+    await expect(manager.testEphemeralConnection(cfg('eph_x', 'no-such-type')))
+      .rejects.toThrow(/Unsupported data source type/)
+  })
+})
+
+describe('POST /api/data-sources/test (route)', () => {
+  it('400s on an unsupported type (create allowlist)', async () => {
+    const res = await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'x', name: 'x', type: 'mongodb', connection: { host: 'h' },
+    })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('400s on a malformed payload (missing required fields)', async () => {
+    const res = await request(appAs('tester')).post('/api/data-sources/test').send({ type: 'postgres' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns a RESULT-ONLY success body — never echoes config / connection / credentials', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', OkAdapter as never) // override real PG with a fake for this unit
+    const res = await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_echo', name: 'Echo Probe', type: 'postgres',
+      connection: { host: 'secret-host.internal' },
+      credentials: { username: 'admin_user', password: SECRET },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.success).toBe(true)
+    expect(res.body.data.latency).toMatch(/ms$/)
+    // NO ECHO: none of the submitted config/connection/credentials may appear in the response.
+    expect(Object.keys(res.body.data).sort()).toEqual(['latency', 'success'])
+    const wire = JSON.stringify(res.body)
+    for (const leak of [SECRET, 'secret-host.internal', 'admin_user', 'connection', 'credentials', 'Echo Probe']) {
+      expect(wire).not.toContain(leak)
+    }
+  })
+
+  it('returns a RESULT-ONLY failure body with a redacted error and no secret', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', FailAdapter as never)
+    const res = await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_echo_fail', name: 'x', type: 'postgres',
+      connection: { host: 'h' }, credentials: { username: 'u', password: SECRET },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.success).toBe(false)
+    expect(res.body.data.error.message).toContain('***')
+    expect(JSON.stringify(res.body)).not.toContain(SECRET)
+  })
+
+  it('persists nothing: a /test call adds no source to the list and the id stays 404', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', OkAdapter as never)
+    // control source so the list is non-empty — proves the absence below is real, not vacuous.
+    await manager.addDataSource(cfg('ctrl_keep', 'postgres'), { ownerId: 'tester', persist: false })
+
+    await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_nopersist', name: 'x', type: 'postgres', connection: { host: 'h' },
+    }).expect(200)
+
+    const ids = manager.listDataSources({ ownerId: 'tester' }).map(s => s.id)
+    expect(ids).toContain('ctrl_keep')
+    expect(ids).not.toContain('eph_nopersist')
+    const got = await request(appAs('tester')).get('/api/data-sources/eph_nopersist')
+    expect(got.status).toBe(404)
+  })
+})

--- a/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
@@ -54,10 +54,15 @@ class OkAdapter extends FakeBase {
   async testConnection(): Promise<boolean> { return true }
 }
 
-// connect() fails with an error embedding the configured password (proves redaction + no echo).
+// connect() fails with an error embedding the configured host + username + password — proves the
+// adapter redacts the secret AND the helper's scrubInput strips the submitted host/username (no echo).
 class FailAdapter extends FakeBase {
   async connect(): Promise<void> {
-    const err = new Error(`ECONNREFUSED 127.0.0.1: login failed (password=${this.config.credentials?.password})`)
+    const c = this.config
+    const err = new Error(
+      `connect to ${String(c.connection?.host)} failed: password authentication failed for user ` +
+        `"${c.credentials?.username}" (password=${c.credentials?.password})`,
+    )
     await this.onError(err) // records redactSecrets(err.message) into lastConnectionError, emits 'error'
     throw err
   }
@@ -78,7 +83,7 @@ function cfg(id: string, type: string, extra?: Partial<DataSourceConfig>): DataS
   return {
     id, name: id, type,
     connection: { host: 'unreachable.example' },
-    credentials: { username: 'u', password: SECRET },
+    credentials: { username: 'svc_user', password: SECRET },
     options: { autoConnect: false },
     ...extra,
   } as DataSourceConfig
@@ -115,7 +120,10 @@ describe('DataSourceManager.testEphemeralConnection (helper)', () => {
 
     expect(result.success).toBe(false)
     expect(result.error).toContain('***')
-    expect(JSON.stringify(result)).not.toContain(SECRET)
+    // no-echo: neither the password, the submitted host, nor the username survive in the cause
+    for (const leak of [SECRET, 'unreachable.example', 'svc_user']) {
+      expect(JSON.stringify(result)).not.toContain(leak)
+    }
     expect(manager.getScope(id)).toBeUndefined() // still nothing registered on failure
     expect(removeAllListenerCalls).toContain(id) // disposed even on failure
   })
@@ -162,18 +170,23 @@ describe('POST /api/data-sources/test (route)', () => {
     }
   })
 
-  it('returns a RESULT-ONLY failure body with a redacted error and no secret', async () => {
+  it('failure body is result-only and echoes back NO submitted host / username / password', async () => {
     const manager = getDataSourceManager()
     manager.registerAdapterType('postgres', FailAdapter as never)
     const res = await request(appAs('tester')).post('/api/data-sources/test').send({
       id: 'eph_echo_fail', name: 'x', type: 'postgres',
-      connection: { host: 'h' }, credentials: { username: 'u', password: SECRET },
+      connection: { host: 'secret-host.internal' },
+      credentials: { username: 'admin_user', password: SECRET },
     })
     expect(res.status).toBe(200)
     expect(res.body.ok).toBe(true)
     expect(res.body.data.success).toBe(false)
-    expect(res.body.data.error.message).toContain('***')
-    expect(JSON.stringify(res.body)).not.toContain(SECRET)
+    expect(res.body.data.error.message).toBeTruthy()      // category survives (e.g. "authentication failed")
+    expect(res.body.data.error.message).toContain('***')  // submitted identifiers scrubbed
+    const wire = JSON.stringify(res.body)
+    for (const leak of [SECRET, 'secret-host.internal', 'admin_user', 'connection', 'credentials']) {
+      expect(wire).not.toContain(leak)
+    }
   })
 
   it('persists nothing: a /test call adds no source to the list and the id stays 404', async () => {


### PR DESCRIPTION
Implements **Slice 1 (BE)** of the test-before-save design-lock (`docs/development/data-source-connection-test-before-save-design-lock-20260617.md`, landed in #2818).

## What
`POST /api/data-sources/test` validates connection params **before** a source is persisted, so the create / credential-rotation form can surface a bad host/credential without first creating a broken source. Today testing only works on a saved source (`GET /:id/test`).

## Contract (matches design-lock)
- **`DataSourceManager.testEphemeralConnection(config)`** — encapsulated helper. Builds the adapter via the `adapterTypes` factory + `new AdapterClass(config)`; **never** goes through `addDataSourceInternal`; **never** touches `adapters` / `scopes` / `connectionPool`; wires **no** manager event-forwarding (only a local no-op `error` swallow so `BaseDataAdapter.onError()`'s `emit('error')` can't throw on an unhandled emitter error — the redacted cause is read from `connectionError`); `finally disconnect() + removeAllListeners()`. (`BaseDataAdapter` has no `dispose()`; `addDataSource(persist=false)` still registers → not ephemeral, hence the dedicated helper.) — **钉子①**
- **Route** — `rbac data_sources:write`; reuses `DataSourceCreateSchema` (type allowlist); **RESULT-ONLY** response `{ success, latency, error.message(redacted) }`, **never echoes** the submitted config/connection/credentials — **钉子②**; unsupported type → 400.
- **Scope** — create + credential-rotation (FE wiring is Slice 2); edit excluded (v1); credential trust boundary unchanged (no new storage).

## Tests
- **Unit** (`data-source-test-ephemeral.test.ts`, 8 cases): helper success (+latency, no registration, disconnect+removeAllListeners ran) / failure (redacted, no secret) / unsupported-type throw; route 400 allowlist / 400 malformed / **result-only success (no echo of host·user·secret·connection·credentials)** / result-only failure redacted / **persists nothing** (control source present, test id absent + 404).
- **Real-DB integration** (`data-source-test-ephemeral-realdb.test.ts`): live success (+latency), unreachable-target failure (redacted, no secret), **zero-persistence** (`data_sources` count unchanged + no in-memory registration + 404). Enumerated in `plugin-tests.yml` with the hard `${DATABASE_URL:?...}` guard so it can't silently skip.

## Local verification
- `tsc` build clean · eslint clean (source) · unit 8/8 · all data-source unit tests 93 passed (integration correctly skipped without DATABASE_URL).

## Notes
- Docs design-lock self-reviewed + owner-approved (#2818). BE slice gets adversarial sub-agent review per the design-lock before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)