### PR TITLE
docs(multitable): correct stale CRDT head comments (sync-service / bridge / cell-editor)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -499,9 +499,10 @@ const yjsCollaborators = computed(() => yjsBinding.collaborators.value)
 // Wired for the atomic types that read directly from modelValue (no local edit
 // buffer): numeric/boolean + rating (number) + multiSelect (string[]).
 // DEFERRED: `duration` has an intentional local text buffer decoupled from
-// modelValue (advisor B: live re-derivation fights the typist); `select`/`date`
-// are string-stored atomics seeded as Y.Text today — flipping them to plain-value
-// is a separate gated call (persisted docs hold them as Y.Text).
+// modelValue (advisor B: live re-derivation fights the typist); `select`/`date`/
+// `dateTime` are string-stored atomics seeded as Y.Text today — flipping them to
+// plain-value is a separate gated call (persisted docs hold them as Y.Text, so it
+// needs a migration story, not just a seed flip).
 // Inactive → byte-identical REST path (setValue is a no-op; nothing changes).
 const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 'multiSelect']
 const scalarFieldIdRef = computed<string | null>(() => {

--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -1,13 +1,22 @@
 /**
- * Yjs → RecordWriteService bridge (POC scope: single text field only).
+ * Yjs → RecordWriteService bridge.
  *
- * Converts Y.Text changes on a record doc into a single-field patch
- * and writes via RecordWriteService.patchRecords() — the authoritative
- * write path shared with REST.
+ * Converts changes on a record doc's `fields` Y.Map into single-field patches
+ * and writes via RecordWriteService.patchRecords() — the authoritative write
+ * path shared with REST. Field-type-agnostic: collects both Y.Text values
+ * (string fields, char-level merged) AND any PLAIN value set directly under a
+ * Y.Map key (atomic scalars, LWW). Nested Yjs shared types (Y.Map/Y.Array) are
+ * skipped.
  *
- * NOT in scope: create/delete, non-text fields, field-level permissions,
- * webhook/automation (those are downstream of RecordWriteService and will
- * fire automatically once bridge calls patchRecords).
+ * NOTE: being a generic plain-value collector does NOT mean every scalar type is
+ * live in the product. Which fields actually reach the bridge is determined by the
+ * seed (yjs-sync-service) + the FE cell bindings, not here — e.g. string-stored
+ * select/date/dateTime currently seed as Y.Text and have no scalar binding, so they
+ * do not flow as plain values yet (a gated decision), even though this collector
+ * would accept them if they did.
+ *
+ * NOT in scope: create/delete, field-level permissions, webhook/automation
+ * (downstream of RecordWriteService; they fire once the bridge calls patchRecords).
  */
 
 import * as Y from 'yjs'

--- a/packages/core-backend/src/collab/yjs-sync-service.ts
+++ b/packages/core-backend/src/collab/yjs-sync-service.ts
@@ -6,17 +6,20 @@ import type { YjsPersistenceAdapter } from './yjs-persistence-adapter'
  * `meta_records.data`. Only invoked when there's no persisted Yjs state
  * yet (no snapshot, no incremental updates).
  *
- * Seeding rule:
- *   - For each field whose current value is a string, create a Y.Text
- *     pre-populated with that string and put it in the fields map under
- *     the fieldId key.
- *   - Non-string values are left out of the fields map. The frontend
- *     `useYjsTextField` only binds to Y.Text entries, so non-string
- *     fields continue to go through the existing REST edit path.
+ * Seeding rule (see the loop below for the authoritative logic):
+ *   - String values (free-text AND string-stored atomics like select/date) → a
+ *     Y.Text pre-populated with the string, under the fieldId key (char-level merge).
+ *   - Non-string ATOMIC values (number/currency/percent/rating/duration/boolean,
+ *     multiSelect arrays) → a PLAIN value under the fieldId key, synced LWW per key
+ *     via the Y.Map. The bridge persists these through the validated patchRecords
+ *     path, so the stored shape is unchanged.
+ *   - null/undefined → left absent (a delete; nothing to seed).
  *
- * Returning null (e.g. record was deleted) leaves the Y.Doc empty;
- * `useYjsTextField` will then decline to activate for that cell and the
- * caller falls back to REST.
+ * Frontend binding: `useYjsTextField`/`useYjsCellBinding` bind Y.Text string cells;
+ * `useYjsScalarCell` binds the plain-value scalar cells the grid has wired so far
+ * (number/currency/percent/boolean/rating/multiSelect). A cell with no active binding
+ * (incl. the not-yet-wired scalar types, and any field once the doc is empty) falls
+ * back to the existing REST edit path.
  */
 export type YjsRecordSeedFn = (
   recordId: string,


### PR DESCRIPTION
Comment-layer hygiene, no runtime change (reviewer P3). yjs-sync-service head said non-string → REST (it now seeds atomic non-string as plain LWW values); yjs-record-bridge head said 'single text field only / non-text out of scope' (it now collects plain scalars, with a note that the generic collector ≠ a type being live in the product — seed + FE decide that); MetaCellEditor deferred comment added the missing `dateTime`. Diff is comment-only; tsc clean. 🤖 Generated with Claude Code