### PR TITLE
docs(multitable): close last CRDT comment tails (bridge class JSDoc + dateTime example)

### DIFF
--- a/packages/core-backend/src/collab/yjs-record-bridge.ts
+++ b/packages/core-backend/src/collab/yjs-record-bridge.ts
@@ -43,9 +43,10 @@ interface PendingWrite {
 /**
  * Bridges Y.Doc field changes → RecordWriteService.patchRecords().
  *
- * Each record doc has a Y.Map "fields". When a Y.Text field inside that
- * map changes (from a remote Yjs client, NOT from 'rest' origin), the
- * bridge debounces the change and flushes it as a patch.
+ * Each record doc has a Y.Map "fields". When a field inside that map changes
+ * — a Y.Text string edit OR a plain scalar value set under the key (from a
+ * remote Yjs client, NOT from 'rest' origin) — the bridge debounces the change
+ * and flushes it as a patch.
  */
 export class YjsRecordBridge {
   private pendingWrites = new Map<string, PendingWrite>()

--- a/packages/core-backend/src/collab/yjs-sync-service.ts
+++ b/packages/core-backend/src/collab/yjs-sync-service.ts
@@ -7,7 +7,7 @@ import type { YjsPersistenceAdapter } from './yjs-persistence-adapter'
  * yet (no snapshot, no incremental updates).
  *
  * Seeding rule (see the loop below for the authoritative logic):
- *   - String values (free-text AND string-stored atomics like select/date) → a
+ *   - String values (free-text AND string-stored atomics like select/date/dateTime) → a
  *     Y.Text pre-populated with the string, under the fieldId key (char-level merge).
  *   - Non-string ATOMIC values (number/currency/percent/rating/duration/boolean,
  *     multiSelect arrays) → a PLAIN value under the fieldId key, synced LWW per key
@@ -79,8 +79,8 @@ export class YjsSyncService {
           // multiSelect arrays, etc.): seed as a PLAIN value so they sync LWW per key
           // via the Y.Map (char-merge is meaningless for atomic values). The bridge
           // persists whatever's here through the validated patchRecords path, so the
-          // stored shape is unchanged. (string-stored atomics like select/date stay
-          // Y.Text for now — flipping their representation is a separate, gated decision.)
+          // stored shape is unchanged. (string-stored atomics like select/date/dateTime
+          // stay Y.Text for now — flipping their representation is a separate, gated decision.)
           fields.set(fieldId, value as never)
         }
         // null/undefined: leave absent (a delete; nothing to seed).


### PR DESCRIPTION
Follow-up to #2823 (reviewer P3). Comment-only: yjs-record-bridge class JSDoc reworded from 'When a Y.Text field changes' → 'a field inside that map changes — Y.Text edit OR plain scalar value' (it collects both); yjs-sync-service head + body examples gain `dateTime` to fully match the stated boundary. Diff is comments only; tsc clean. 🤖 Generated with Claude Code