### PR TITLE
feat(data-source): test-before-save Slice 2 (FE) — in-form 测试连接 button

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -3,6 +3,7 @@ import { apiGet, apiFetch } from '../utils/api'
 import type {
   CreateDataSourcePayload,
   DataSourceDetail,
+  DataSourceDraftTestResult,
   DataSourceListItem,
   DataSourceSchemaInfo,
   DataSourceSelectPayload,
@@ -26,6 +27,11 @@ interface DetailEnvelope {
 interface TestEnvelope {
   ok: boolean
   data?: DataSourceTestResult
+}
+
+interface DraftTestEnvelope {
+  ok: boolean
+  data?: DataSourceDraftTestResult
 }
 
 interface SchemaEnvelope {
@@ -111,6 +117,24 @@ export async function testDataSourceConnection(id: string): Promise<DataSourceTe
   const body = await res.json() as TestEnvelope
   if (!body.data) {
     throw new Error('Failed to test data source: empty response')
+  }
+  return body.data
+}
+
+/**
+ * test-before-save: POST the create-shaped payload to the ephemeral connection-test endpoint. No
+ * source is persisted; the response is result-only (the backend never echoes the submitted config).
+ */
+export async function testDataSourceDraftConnection(
+  payload: CreateDataSourcePayload,
+): Promise<DataSourceDraftTestResult> {
+  const res = await apiFetch('/api/data-sources/test', { method: 'POST', body: JSON.stringify(payload) })
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to test connection'))
+  }
+  const body = await res.json() as DraftTestEnvelope
+  if (!body.data) {
+    throw new Error('Failed to test connection: empty response')
   }
   return body.data
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -39,6 +39,13 @@ export interface DataSourceTestResult {
   error?: { message?: string }
 }
 
+/** Result from `POST /api/data-sources/test` (ephemeral draft test). No `id` — nothing is persisted. */
+export interface DataSourceDraftTestResult {
+  success: boolean
+  latency?: string
+  error?: { message?: string }
+}
+
 export interface DataSourceColumnInfo {
   name: string
   type?: string

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -11,6 +11,7 @@ import {
   previewDataSourceRows,
   rotateDataSourceCredentials,
   testDataSourceConnection,
+  testDataSourceDraftConnection,
   updateDataSource,
 } from '../data-sources/api'
 import type {
@@ -20,6 +21,7 @@ import type {
   DataSourceSchemaInfo,
   DataSourceSelectPayload,
   DataSourceSelectResult,
+  DataSourceDraftTestResult,
   DataSourceTableInfo,
   DataSourceTestResult,
   RotateDataSourceCredentialsPayload,
@@ -150,6 +152,12 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     }
   }
 
+  // test-before-save: stateless proxy to the ephemeral connection-test endpoint. Returns the result
+  // for the caller to render form-locally; keeps NO store state (no source/id exists yet).
+  async function testDraftConnection(payload: CreateDataSourcePayload): Promise<DataSourceDraftTestResult> {
+    return testDataSourceDraftConnection(payload)
+  }
+
   function isSchemaLoading(id: string): boolean {
     return schemaLoading.value[id] === true
   }
@@ -250,6 +258,7 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     rotateCredentials,
     remove,
     testConnection,
+    testDraftConnection,
     loadSchema,
     loadTableInfo,
     previewRows,

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -96,10 +96,32 @@
       </label>
 
       <div class="data-sources__form-actions">
+        <button
+          v-if="canDraftTest"
+          type="button"
+          class="data-sources__btn"
+          data-testid="ds-test-draft"
+          :disabled="draftTest.status === 'testing'"
+          @click="runDraftTest"
+        >
+          {{ draftTest.status === 'testing' ? '测试中…' : '测试连接' }}
+        </button>
         <button type="submit" class="data-sources__btn data-sources__btn--primary" :disabled="submitDisabled" data-testid="ds-submit">
           {{ submitLabel }}
         </button>
       </div>
+      <p
+        v-if="draftTest.status === 'ok'"
+        class="data-sources__muted"
+        data-testid="ds-test-draft-ok"
+        role="status"
+      >连接成功{{ draftTest.latency ? ` · ${draftTest.latency}` : '' }}</p>
+      <p
+        v-else-if="draftTest.status === 'fail'"
+        class="data-sources__error"
+        data-testid="ds-test-draft-fail"
+        role="alert"
+      >连接失败{{ draftTest.message ? ` · ${draftTest.message}` : '' }}</p>
     </form>
 
     <div class="data-sources__list" data-testid="ds-list">
@@ -351,6 +373,7 @@ const activeSchemaId = ref<string | null>(null)
 const schemaTable = ref('')
 const activePreviewId = ref<string | null>(null)
 const previewTable = ref('')
+const draftTest = ref<{ status: 'idle' | 'testing' | 'ok' | 'fail'; latency?: string; message?: string }>({ status: 'idle' })
 
 interface TableChoice {
   value: string
@@ -394,6 +417,27 @@ const submitLabel = computed(() => {
   if (formMode.value === 'credentials') return '更新凭据'
   return formMode.value === 'edit' ? '保存' : '创建'
 })
+
+// test-before-save: offered for create, and for credential rotation ONLY when a new secret is entered
+// (a stateless /test can't reuse the stored secret — same limit as edit; see design-lock §4). Hidden
+// for edit (no secret available → would false-fail); the row-level GET /:id/test stays for saved sources.
+const canDraftTest = computed(() => {
+  if (formMode.value === 'edit') return false
+  if (formMode.value === 'credentials') return credentialFieldsFilled.value
+  return true
+})
+
+async function runDraftTest(): Promise<void> {
+  draftTest.value = { status: 'testing' }
+  try {
+    const result = await store.testDraftConnection(buildCreatePayload(form))
+    draftTest.value = result.success
+      ? { status: 'ok', latency: result.latency }
+      : { status: 'fail', message: result.error?.message }
+  } catch (e) {
+    draftTest.value = { status: 'fail', message: e instanceof Error ? e.message : '连接测试失败' }
+  }
+}
 
 // `server` is a SQL-Server-only concept; clear it when switching away so a stale value can't linger
 // (the builder + guard already ignore it for non-sqlserver — this keeps the form state clean).
@@ -528,6 +572,7 @@ function resetForm(): void {
     id: '', name: '', type: 'postgres', host: '', server: '', port: undefined, database: '',
     username: '', password: '', baseURL: '', apiKey: '', readOnly: true,
   })
+  draftTest.value = { status: 'idle' }
 }
 
 function fillFormFromDetail(detail: DataSourceDetail): void {

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -439,6 +439,14 @@ async function runDraftTest(): Promise<void> {
   }
 }
 
+// Drop a rendered draft result the moment the user edits any connection field — a stale
+// 连接成功/失败 next to changed params would be misleading (advisory, so no gate either way).
+watch(form, () => {
+  if (draftTest.value.status === 'ok' || draftTest.value.status === 'fail') {
+    draftTest.value = { status: 'idle' }
+  }
+}, { deep: true })
+
 // `server` is a SQL-Server-only concept; clear it when switching away so a stale value can't linger
 // (the builder + guard already ignore it for non-sqlserver — this keeps the form state clean).
 watch(() => form.type, (type) => {

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -17,6 +17,7 @@ const updateMock = vi.hoisted(() => vi.fn())
 const rotateCredentialsMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
 const testConnectionMock = vi.hoisted(() => vi.fn())
+const testDraftMock = vi.hoisted(() => vi.fn())
 const getSchemaMock = vi.hoisted(() => vi.fn())
 const getTableInfoMock = vi.hoisted(() => vi.fn())
 const previewRowsMock = vi.hoisted(() => vi.fn())
@@ -28,6 +29,7 @@ vi.mock('../src/data-sources/api', () => ({
   rotateDataSourceCredentials: rotateCredentialsMock,
   deleteDataSource: deleteMock,
   testDataSourceConnection: testConnectionMock,
+  testDataSourceDraftConnection: testDraftMock,
   getDataSourceSchema: getSchemaMock,
   getDataSourceTableInfo: getTableInfoMock,
   previewDataSourceRows: previewRowsMock,
@@ -732,5 +734,92 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     expect(previewRowsMock).not.toHaveBeenCalled()
     expect(store.previewErrors.pg).toBe('')
     expect(container.querySelector('[data-testid="ds-preview-empty-schema"]')?.textContent).toContain('没有可预览')
+  })
+
+  it('create form: 测试连接 posts the built payload and renders inline success with latency', async () => {
+    listMock.mockResolvedValue([])
+    testDraftMock.mockResolvedValue({ success: true, latency: '12ms' })
+
+    const container = await mountView()
+    ;(container.querySelector('[data-testid="ds-new-button"]') as HTMLButtonElement).click()
+    await flush()
+
+    const host = container.querySelector('[data-testid="ds-field-host"]') as HTMLInputElement
+    host.value = 'db.internal'; host.dispatchEvent(new Event('input'))
+    const db = container.querySelector('[data-testid="ds-field-database"]') as HTMLInputElement
+    db.value = 'erp'; db.dispatchEvent(new Event('input'))
+    await flush()
+
+    const testBtn = container.querySelector('[data-testid="ds-test-draft"]') as HTMLButtonElement
+    expect(testBtn).not.toBeNull()
+    testBtn.click()
+    await flush()
+    await flush()
+
+    expect(testDraftMock).toHaveBeenCalledTimes(1)
+    // wire check: the button posts the SAME create-payload builder used by submit (anti wire-drift).
+    expect(testDraftMock.mock.calls[0][0]).toMatchObject({
+      type: 'postgres',
+      connection: { host: 'db.internal', database: 'erp' },
+      options: { readOnly: true },
+    })
+    const ok = container.querySelector('[data-testid="ds-test-draft-ok"]')
+    expect(ok?.textContent).toContain('连接成功')
+    expect(ok?.textContent).toContain('12ms')
+    // a passing test must NOT auto-submit / create the source (no hard gate, advisory only)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('create form: a failed draft test renders inline failure with the (already redacted) message', async () => {
+    listMock.mockResolvedValue([])
+    testDraftMock.mockResolvedValue({ success: false, error: { message: 'authentication failed' } })
+
+    const container = await mountView()
+    ;(container.querySelector('[data-testid="ds-new-button"]') as HTMLButtonElement).click()
+    await flush()
+    const host = container.querySelector('[data-testid="ds-field-host"]') as HTMLInputElement
+    host.value = 'h'; host.dispatchEvent(new Event('input'))
+    await flush()
+    ;(container.querySelector('[data-testid="ds-test-draft"]') as HTMLButtonElement).click()
+    await flush()
+    await flush()
+
+    const fail = container.querySelector('[data-testid="ds-test-draft-fail"]')
+    expect(fail?.textContent).toContain('连接失败')
+    expect(fail?.textContent).toContain('authentication failed')
+    expect(container.querySelector('[data-testid="ds-test-draft-ok"]')).toBeNull()
+  })
+
+  it('edit mode hides the draft 测试连接 button (no secret available → would false-fail)', async () => {
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    getMock.mockResolvedValue({
+      id: 'a', name: 'A', type: 'postgres', connected: false, hasCredentials: true,
+      connection: { host: 'db.internal', port: 5432, database: 'erp' }, options: { readOnly: true },
+    })
+    const container = await mountView()
+    ;(container.querySelector('[data-testid="ds-edit"]') as HTMLButtonElement).click()
+    await flush()
+    await flush()
+    await flush()
+    expect(container.querySelector('[data-testid="ds-create-form"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ds-test-draft"]')).toBeNull()
+  })
+
+  it('credential mode shows the draft test only after a new secret is entered', async () => {
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    getMock.mockResolvedValue({
+      id: 'a', name: 'A', type: 'postgres', connected: false, hasCredentials: true,
+      connection: { host: 'db.internal', port: 5432, database: 'erp' }, options: { readOnly: true },
+    })
+    const container = await mountView()
+    ;(container.querySelector('[data-testid="ds-credentials"]') as HTMLButtonElement).click()
+    await flush()
+    await flush()
+    await flush()
+    expect(container.querySelector('[data-testid="ds-test-draft"]')).toBeNull() // no new secret yet
+    const pw = container.querySelector('[data-testid="ds-field-password"]') as HTMLInputElement
+    pw.value = 'newpw'; pw.dispatchEvent(new Event('input'))
+    await flush()
+    expect(container.querySelector('[data-testid="ds-test-draft"]')).not.toBeNull()
   })
 })

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -820,6 +820,19 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     const pw = container.querySelector('[data-testid="ds-field-password"]') as HTMLInputElement
     pw.value = 'newpw'; pw.dispatchEvent(new Event('input'))
     await flush()
-    expect(container.querySelector('[data-testid="ds-test-draft"]')).not.toBeNull()
+    const testBtn = container.querySelector('[data-testid="ds-test-draft"]') as HTMLButtonElement
+    expect(testBtn).not.toBeNull()
+
+    // wire: the credential-mode draft test posts the STORED connection params + the NEW secret.
+    testDraftMock.mockResolvedValue({ success: true, latency: '8ms' })
+    testBtn.click()
+    await flush()
+    await flush()
+    expect(testDraftMock).toHaveBeenCalledTimes(1)
+    expect(testDraftMock.mock.calls[0][0]).toMatchObject({
+      type: 'postgres',
+      connection: { host: 'db.internal', database: 'erp' },
+      credentials: { password: 'newpw' },
+    })
   })
 })


### PR DESCRIPTION
Implements **Slice 2 (FE)** of the test-before-save design-lock (landed in #2818; BE is Slice 1 #2822).

## What
Adds a **测试连接** button to the data-source **create** and **credential-rotation** forms (`DataSourcesView.vue`). It POSTs the current form payload to the ephemeral `POST /api/data-sources/test` (Slice 1) and renders the result **inline, form-local** — success `连接成功 · <latency>` / failure `连接失败 · <redacted message>` — not the global `store.error` banner.

## Scope (matches design-lock §4)
- **create**: button always offered.
- **credential rotation**: offered **only once a new secret is entered** (`credentialFieldsFilled`) — a stateless `/test` can't reuse the stored write-only secret.
- **edit**: button hidden — same stored-secret limitation would produce a false-fail; the per-row `GET /:id/test` remains for saved sources.
- **No hard save-gate** — a failed test warns; it does not block save (owner-confirmed advisory).

## Wiring
- `store.testDraftConnection(payload)` is a stateless proxy to `api.testDataSourceDraftConnection` — returns the result for form-local rendering, keeps **no** store state (no source/id exists yet).
- Reuses `buildCreatePayload(form)` — the exact payload builder `submit` uses.

## Tests (`data-sources-ui.spec.ts`, +4)
- success: renders latency **and** asserts the POSTed body equals `buildCreatePayload` output (anti wire-drift) **and** does not auto-create;
- failure: renders the redacted message;
- edit mode hides the button;
- credential mode reveals it only after a new secret is entered.

## Local verification
- `vitest` 39/39 (data-sources-ui) · `vue-tsc -b` type-check clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)