### PR TITLE
docs(multitable): add gated remainder plan and todo

### DIFF
--- a/docs/development/multitable-current-development-plan-20260617.md
+++ b/docs/development/multitable-current-development-plan-20260617.md
@@ -1,6 +1,10 @@
 # 多维表当前开发计划 — 2026-06-17
 
-> Status: **CURRENT ROUTING PLAN**.
+> Status: **SUPERSEDED / HISTORICAL ROUTING SNAPSHOT**.
+> Superseded by: `multitable-gated-remainder-development-plan-20260618.md` and `multitable-gated-remainder-todo-20260618.md`.
+> Reason: after this file was written, `#18` row-level read-deny completed, scalar CRDT reached the six product-wired types, and the D2 perf verdict was re-applied to move grid virtualization out of active remainder. Use the 2026-06-18 gated remainder docs for current next-work routing.
+
+> Former status: **CURRENT ROUTING PLAN**.
 > Grounding: `origin/main@4c5244532` (`docs+chore(multitable): correct recycle-bin contract for #2794 + untrack node_modules`).
 > Purpose: replace the stale "what next?" routing in the 2026-06-10/2026-06-15 ledgers. This file does **not** rewrite historical design-locks; it is the current source of truth for choosing the next multitable development slice.
 

--- a/docs/development/multitable-current-development-todo-20260617.md
+++ b/docs/development/multitable-current-development-todo-20260617.md
@@ -1,6 +1,10 @@
 # 多维表当前开发 TODO — 2026-06-17
 
-> Status: **CURRENT TODO**.
+> Status: **SUPERSEDED / HISTORICAL TODO SNAPSHOT**.
+> Superseded by: `multitable-gated-remainder-development-plan-20260618.md` and `multitable-gated-remainder-todo-20260618.md`.
+> Reason: after this file was written, `#18` row-level read-deny completed, scalar CRDT reached the six product-wired types, and the D2 perf verdict was re-applied to move grid virtualization out of active remainder. Use the 2026-06-18 gated remainder docs for current next-work routing.
+>
+> Former status: **CURRENT TODO**.
 > Pair: `multitable-current-development-plan-20260617.md`.
 > Grounding: `origin/main@4c5244532`.
 > Markers: `[x]` closed · `[ ]` open · `[~]` optional/demand-gated · `[!]` owner/ops/PM gate.

--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -1,0 +1,247 @@
+# 多维表剩余门控开发计划 — 2026-06-18
+
+> Status: **CURRENT GATED REMAINDER PLAN**.
+> Grounding: `origin/main@31a5efe05` (`feat(attendance): annual-leave L5c — admin operations UI (manual-adjust / backfill / accrual) + closeout MD (#2830)`). The multitable boundary in this document is grounded on `#18` through `#2819`, scalar CRDT through `#2821`, and comment hygiene through `#2823`. `#2825` is open with green checks and closes the final CRDT comment tails; update this line to `#2825` after it merges.
+> Supersedes: `multitable-current-development-plan-20260617.md` and `multitable-current-development-todo-20260617.md` for current multitable remainder routing.
+> Pair: `multitable-gated-remainder-todo-20260618.md`.
+> Rule: this is a closure ledger for the current multitable mainline. Every item below is gated. Do not start runtime work from this document without an explicit opt-in for that gate.
+
+## 0. Precise Boundary
+
+The current multitable mainline has no non-gated residual runtime work.
+
+Closed and removed from the active remainder:
+
+- `#18` row-level read-deny: foundation, all-surface enforcement, authoring UI, and flag endpoint tests are complete. The flag endpoint includes positive and negative GET authz locks.
+- Live scalar CRDT user-usable edit path: `number`, `currency`, `percent`, `boolean`, `rating`, and `multiSelect` are live.
+- CRDT comment hygiene: the repository documents that the backend bridge is a generic plain-value collector, which is not the same as a field type being product-open in the editor.
+
+The remaining development is exactly:
+
+1. **2a · Live CRDT remaining field types**: `select`, `date`, `dateTime`, and `duration`.
+2. **2b · #18 phase-2**: conditional / dynamic field-predicate permission rules.
+3. **2c · Gated arc not started**: `#16` Person field as a true org-member directory.
+
+Everything else belongs to a future roadmap pool, not to this closure ledger. See Appendix A.
+
+## 1. 2a · Live CRDT Remaining Field Types
+
+### 1.1 Current Contract
+
+`YjsSyncService` seeds a fresh record doc from `meta_records.data` by stored value shape:
+
+- string values seed as `Y.Text`;
+- non-string atomic values seed as plain values under the `fields` Y.Map;
+- `null` / `undefined` stay absent.
+
+The product editor only enables scalar Yjs binding for:
+
+`number`, `currency`, `percent`, `boolean`, `rating`, `multiSelect`.
+
+The backend bridge can collect generic plain values, but that does not open the remaining field types in the product path. The seed shape and frontend binding are the product boundary.
+
+### 1.2 `select` / `date` / `dateTime` Gate
+
+**Gate:** persisted-doc migration.
+
+These fields are string-stored atomics today. Existing Yjs docs can already hold their field keys as `Y.Text`. Flipping the seed or frontend binding directly to plain-value LWW would make old docs expose a `Y.Text` object where the product expects a string, which is a corruption risk.
+
+Required owner/design decisions before implementation:
+
+1. **Migration strategy**
+   - Lazy migration when a record doc opens.
+   - Offline / admin migration over persisted snapshots and updates.
+   - Dual-reader compatibility layer that accepts old `Y.Text` and new plain values for a defined window.
+   - Or a different explicit strategy.
+2. **Rollout compatibility**
+   - How mixed old/new clients behave during deployment.
+   - Whether old persisted docs are rewritten before any frontend scalar binding ships.
+   - Whether rollback must preserve old `Y.Text` docs or can tolerate already-migrated plain values.
+3. **Date semantics**
+   - `date` must preserve the canonical stored date string.
+   - `dateTime` must preserve the existing local-input conversion contract and avoid timezone drift.
+4. **Corruption golden**
+   - Real Postgres fixture with persisted Yjs state containing `Y.Text` for `select`, `date`, and `dateTime`.
+   - After migration + edit, `meta_records.data` must still contain the same native stored shapes: string select value, date string, dateTime string.
+   - The golden must fail if a `Y.Text` object, stringified object, `[object Object]`, or incompatible nested Yjs type reaches `patchRecords`.
+
+Recommended implementation slices after the gate opens:
+
+| Slice | Scope | Verification |
+|---|---|---|
+| 2a-S1 | Design-lock the migration strategy and corruption model. | Design review only; no runtime. |
+| 2a-S2 | Build migration / dual-reader helper behind tests. Do not enable frontend scalar binding yet. | Unit tests for old/new doc shapes; real-DB persisted-doc corruption golden. |
+| 2a-S3 | Flip seed / activation for one pilot string-stored type, likely `select`. | Real-DB seed + flush + old-doc migration; frontend active/inactive path tests; browser edit smoke. |
+| 2a-S4 | Extend to `date` and `dateTime` once date semantics are proven. | Date/dateTime round-trip, timezone edge, persisted-doc migration golden. |
+
+Non-goals:
+
+- Do not change stored cell data shapes.
+- Do not opportunistically rewrite unrelated `string` fields.
+- Do not infer migration success from mocked Yjs-only tests; persisted-doc corruption must be proven against the real DB path.
+
+### 1.3 `duration` Gate
+
+**Gate:** local-buffer UX.
+
+`duration` is not blocked by the same `Y.Text` migration problem. It is blocked because the editor has an intentional local text buffer for `h:mm` input. Live re-derivation from a remote plain value can interrupt typing, cursor position, and partially valid input.
+
+Required owner/design decisions before implementation:
+
+1. **Editing semantics**
+   - Keep REST-only for active duration editing.
+   - Commit-on-confirm LWW: local buffer stays local while typing; Yjs only updates on confirm.
+   - Live collaborative draft channel separate from the persisted `fields` value.
+2. **Conflict behavior**
+   - What happens when a remote duration change arrives while the user has an unconfirmed local buffer.
+   - Whether to show a conflict affordance, defer remote display, or overwrite on blur.
+3. **Input validity**
+   - How partially valid buffers such as `1:`, `:30`, or localized formats behave under live updates.
+
+Recommended implementation slices after the gate opens:
+
+| Slice | Scope | Verification |
+|---|---|---|
+| 2a-D1 | Duration UX design-lock with explicit conflict behavior. | Browser interaction plan; no runtime. |
+| 2a-D2 | Implement chosen duration binding strategy. | jsdom component tests + real-browser typing/cursor smoke. |
+| 2a-D3 | Real-DB no-corruption proof. | Flush path preserves numeric/stored duration shape and rejects invalid values through existing validation. |
+
+Non-goals:
+
+- Do not make live duration collaboration by silently removing the local buffer.
+- Do not accept a test that only clicks a valid final value; the risk is interruption during typing.
+
+## 2. 2b · #18 Phase-2 Permission Rule Engine
+
+### 2.1 Current Contract
+
+The shipped `#18` line is static row-level read-deny:
+
+- foundation and feature flag;
+- all-surface enforcement;
+- authoring UI;
+- flag endpoint positive and negative authz;
+- real-DB coverage.
+
+Phase-2 is not "finish #18"; it is a new security model: conditional / dynamic field-predicate permission rules.
+
+### 2.2 Gate
+
+**Gate:** owner-approved rule model and threat model.
+
+Required decisions before implementation:
+
+1. **Rule language**
+   - Which fields can participate in predicates.
+   - Which operators are allowed per field type.
+   - Whether predicates can reference dynamic user attributes, member groups, roles, current time, or related records.
+2. **Default behavior**
+   - Fail-closed vs fail-open on malformed rules, missing fields, deleted fields, or unsupported operators.
+   - Admin / owner bypass semantics.
+3. **Scope**
+   - Read-only rules first, or read + write + admin together.
+   - Record-level only, or field-level visibility/editability as well.
+4. **Evaluation timing**
+   - Query-time SQL pushdown.
+   - Post-query filtering.
+   - Cached materialization.
+   - Hybrid strategy.
+5. **Auditability**
+   - Whether denied rows need explainability in the UI.
+   - Whether permission rule changes require audit events.
+
+Recommended implementation slices after the gate opens:
+
+| Slice | Scope | Verification |
+|---|---|---|
+| 2b-S0 | Security design-lock and adversarial threat model. | Owner sign-off; no runtime. |
+| 2b-S1 | Pure evaluator + parser, no route wiring. | Unit matrix per field type/operator; malformed rule fail-closed. |
+| 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. | Real-DB golden over list, single record, view, summaries, export, aggregate/dashboard, search/filter, link picker, trash list/restore. |
+| 2b-S3 | Authoring UI for conditional rules. | Frontend tests + browser evidence; no silent rule loss on edit. |
+| 2b-S4 | Performance and caching pass. | Large fixture query evidence; invalidation tests for rule and field changes. |
+
+Security invariants:
+
+- Permission checks must not leak whether a hidden field exists or changed.
+- Rule evaluation must not expose hidden predicate field values through error messages, counts, ordering, or timing-sensitive "this field exists" responses.
+- Every new read path added after static #18 must be included in the phase-2 surface sweep before merge.
+
+Non-goals:
+
+- Do not fold phase-2 into a small patch on the static read-deny line.
+- Do not introduce a rule DSL without a parser/evaluator golden and a real-DB route golden.
+- Do not assume the current grant/additive row-permission model can express these rules without a new contract.
+
+## 3. 2c · Gated Arc Not Started
+
+### 3.1 `#16` Person Field → True Org-Member Directory
+
+Current state:
+
+- Native `person` fields exist as first-class fields.
+- `restrictToMemberGroupIds` is sanitized and persisted as optional configuration.
+- A true org-member directory product arc is not yet started.
+
+Gate:
+
+Owner decision on the org directory source of truth and product semantics.
+
+Required decisions:
+
+1. **Directory source**
+   - Internal `users` table only.
+   - Directory sync member groups.
+   - Hybrid directory with external identity provider metadata.
+2. **Assignability**
+   - Whether `restrictToMemberGroupIds` becomes a hard validation rule.
+   - How inactive/deleted users behave in existing records.
+   - Whether historical values outside the restriction remain readable but not newly assignable.
+3. **Picker UX**
+   - Filtering, empty states, disabled users, group labels.
+   - Whether the picker explains why a user is unavailable.
+4. **API / import / automation parity**
+   - REST writes, bulk edit, import, form submit, automation actions, and Yjs writes must share the same validator.
+
+Recommended slices after the gate opens:
+
+| Slice | Scope | Verification |
+|---|---|---|
+| 16-S0 | Design-lock person directory source and assignability semantics. | Owner sign-off; no runtime. |
+| 16-S1 | Backend directory resolver + person value validator shared by all write paths. | Real-DB positive/negative assignment tests; legacy value read parity. |
+| 16-S2 | Frontend picker filtering and explanation. | Component tests + browser picker smoke. |
+| 16-S3 | API/import/automation/Yjs parity locks. | Route tests and integration tests through each write path. |
+
+Non-goals:
+
+- Do not change stored person value shape without a migration design.
+- Do not make picker-only filtering the enforcement mechanism.
+- Do not reinterpret legacy link-backed person fields as native person fields.
+
+## 4. Recommended Planning Sequence
+
+Because every remaining item is gated, the default action is **hold**.
+
+If the product wants the fastest precise next design-lock:
+
+1. **2a select/date/dateTime migration design-lock** if the goal is CRDT completeness.
+2. **#16 person directory design-lock** if the goal is a user-visible product slice.
+3. **2b rule-engine threat model** only if the product explicitly wants dynamic permission semantics.
+4. **D2 high-scale re-baseline harness work** only if the product wants to revisit large-table performance after the existing D2 verdict; this is not a grid-virtualization slice.
+
+Do not open more than one security-sensitive runtime arc at the same time. `2b` should get an adversarial review lane before implementation, not after.
+
+## Appendix A. Roadmap Pool, Not Current Remainder
+
+The following are future candidates or reopen-only lines. They are not remaining work in the current closure ledger:
+
+- server-side all-dataset export;
+- form `required-if` validation;
+- dashboard linked filters / drill-down;
+- dashboard missing-date buckets and series-count caps;
+- grid virtualization / row-windowing: `docs/development/multitable-perf-gate-d2-baseline-verdict-20260525.md` already excludes `B_frontend_dom_memory_bound`; DOM and heap were flat across 1k -> 10k, the grid already windows the DOM, and the verdict says not to open a grid-virtualization PR. Only a future D2 high-scale re-baseline that flips this verdict should reopen the idea;
+- AI rings beyond the shipped base;
+- native synced / external-source tables;
+- FOL deep follow-ups such as multi-hop propagation, formula-to-formula, materialization, Yjs recompute, and automation triggers;
+- automation A6 remainder.
+
+Each requires a separate opt-in and should get its own plan/TODO when selected.

--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -1,0 +1,170 @@
+# 多维表剩余门控开发 TODO — 2026-06-18
+
+> Status: **CURRENT GATED TODO**.
+> Pair: `multitable-gated-remainder-development-plan-20260618.md`.
+> Grounding: `origin/main@31a5efe05`; multitable closure through `#2823`. `#2825` is open with green checks and closes the final CRDT comment tails; update this line to `#2825` after it merges.
+> Supersedes: `multitable-current-development-plan-20260617.md` and `multitable-current-development-todo-20260617.md` for current multitable remainder routing.
+> Legend: `[x]` closed · `[ ]` todo after opt-in · `[!]` gate requiring owner/design decision · `[~]` roadmap pool, not current remainder.
+
+## 0. Closed Lines That Must Not Re-Enter The Backlog
+
+- [x] `#18` static row-level read-deny foundation.
+- [x] `#18` all-surface enforcement.
+- [x] `#18` authoring UI.
+- [x] `#18` flag endpoint positive and negative GET authz tests (`#2819`).
+- [x] Live scalar CRDT for `number`, `currency`, `percent`, `boolean`.
+- [x] Live scalar CRDT for `rating`, `multiSelect` (`#2821`).
+- [x] CRDT comment hygiene documenting the real seed/bridge/frontend boundary (`#2823`; `#2825` PR head closes the final internal JSDoc/dateTime comment tails, pending merge).
+- [x] Runtime conclusion: no non-gated multitable remainder is open.
+
+## 1. 2a · Live CRDT Remaining Field Types
+
+### 1.1 `select` / `date` / `dateTime`
+
+- [!] Gate: choose a persisted-doc migration strategy before any seed flip or frontend scalar binding.
+  - [ ] Decide migration style: lazy, offline/admin, dual-reader, or another explicit strategy.
+  - [ ] Define rollback compatibility for old `Y.Text` docs and new plain-value docs.
+  - [ ] Define mixed-client behavior during deployment.
+  - [ ] Lock `date` and `dateTime` canonical stored string semantics, including timezone expectations.
+
+- [ ] 2a-S1 Design-lock.
+  - [ ] Inventory current seed and persisted-doc shapes.
+  - [ ] Write corruption model: what values must never reach `patchRecords`.
+  - [ ] Define the exact corruption golden fixtures.
+  - [ ] Define whether `select` pilots before `date` / `dateTime`.
+
+- [ ] 2a-S2 Migration / dual-reader helper.
+  - [ ] Unit test old `Y.Text` doc -> safe read/migration.
+  - [ ] Unit test new plain-value doc -> no migration.
+  - [ ] Real-DB persisted-doc fixture for all three types.
+  - [ ] Assert no `Y.Text` object, nested Yjs type, `[object Object]`, or stringified object reaches `meta_records.data`.
+
+- [ ] 2a-S3 Product binding pilot.
+  - [ ] Enable one pilot type only after corruption golden is green.
+  - [ ] Add FE active/inactive binding tests.
+  - [ ] Add real-browser edit smoke.
+  - [ ] Add plugin-tests / web-guard allowlist entries where needed.
+
+- [ ] 2a-S4 Extend to remaining string-stored atomics.
+  - [ ] Repeat seed + flush + persisted-doc migration tests for `date`.
+  - [ ] Repeat seed + flush + persisted-doc migration tests for `dateTime`.
+  - [ ] Add timezone / local-input conversion regression.
+
+### 1.2 `duration`
+
+- [!] Gate: choose the local-buffer UX semantics.
+  - [ ] Decide between REST-only, commit-on-confirm LWW, or a separate collaborative draft channel.
+  - [ ] Define remote-update behavior while local buffer is dirty.
+  - [ ] Define cursor/selection preservation expectations.
+  - [ ] Define partially valid input behavior.
+
+- [ ] 2a-D1 Duration UX design-lock.
+  - [ ] Document local-buffer invariants.
+  - [ ] Document conflict behavior.
+  - [ ] Define browser typing evidence.
+
+- [ ] 2a-D2 Runtime implementation after UX lock.
+  - [ ] Preserve local text buffer while typing.
+  - [ ] Add component tests for partially valid input.
+  - [ ] Add browser evidence for typing without interruption.
+
+- [ ] 2a-D3 Real-DB no-corruption proof.
+  - [ ] Flush valid duration through the real path.
+  - [ ] Assert stored shape is unchanged.
+  - [ ] Assert invalid values fail through existing validation.
+
+## 2. 2b · #18 Phase-2 Conditional Permission Rules
+
+- [!] Gate: owner-approved rule model and threat model.
+  - [ ] Decide rule language and field/operator matrix.
+  - [ ] Decide whether predicates can reference current user, groups, roles, time, or related records.
+  - [ ] Decide fail-closed behavior for malformed/deleted/unsupported fields.
+  - [ ] Decide admin/owner bypass.
+  - [ ] Decide read-only vs read/write/admin scope.
+  - [ ] Decide evaluation timing: SQL pushdown, post-filter, materialized, or hybrid.
+  - [ ] Decide audit/explainability requirements.
+
+- [ ] 2b-S0 Security design-lock.
+  - [ ] Enumerate every read surface inherited from static `#18`.
+  - [ ] Include trash list/restore in the surface sweep.
+  - [ ] Include summaries, export, aggregate/dashboard, search/filter, link picker, and single-record GET.
+  - [ ] Define side-channel rules: no hidden-field existence/change leaks.
+
+- [ ] 2b-S1 Parser/evaluator.
+  - [ ] Pure evaluator with no DB side effects.
+  - [ ] Per-field-type operator compatibility tests.
+  - [ ] Malformed rule fail-closed tests.
+  - [ ] Deleted/hidden predicate field tests.
+
+- [ ] 2b-S2 Backend enforcement.
+  - [ ] Real-DB list/view/single-record tests.
+  - [ ] Real-DB summary subset tests.
+  - [ ] Real-DB export and aggregate/dashboard tests.
+  - [ ] Real-DB link picker and trash tests.
+  - [ ] CI allowlist confirmation; do not infer from green jobs.
+
+- [ ] 2b-S3 Authoring UI.
+  - [ ] Rule builder preserves aliases/case/unsupported fields without silent loss.
+  - [ ] Browser evidence for create/edit/delete rule flows.
+  - [ ] i18n labels through typed modules.
+
+- [ ] 2b-S4 Performance/caching.
+  - [ ] Large fixture query evidence.
+  - [ ] Rule-change invalidation tests.
+  - [ ] Field-change invalidation tests.
+
+## 3. 2c · Gated Arc Not Started
+
+### 3.1 `#16` Person Field → True Org-Member Directory
+
+- [!] Gate: owner decision on directory source of truth and assignability semantics.
+  - [ ] Decide source: internal users, directory sync member groups, external identity metadata, or hybrid.
+  - [ ] Decide whether `restrictToMemberGroupIds` is a hard validator.
+  - [ ] Decide inactive/deleted user behavior.
+  - [ ] Decide historical out-of-scope values: readable-only vs forced cleanup.
+  - [ ] Decide picker explanation UX.
+
+- [ ] 16-S0 Design-lock.
+  - [ ] Lock stored value shape as unchanged unless a migration is explicitly designed.
+  - [ ] Lock legacy link-backed person coexistence.
+  - [ ] Lock API/import/automation/Yjs parity requirements.
+
+- [ ] 16-S1 Backend validator and resolver.
+  - [ ] Shared person validator for REST, bulk edit, import, form, automation, and Yjs write paths.
+  - [ ] Real-DB positive assignment test.
+  - [ ] Real-DB negative restricted-group assignment test.
+  - [ ] Real-DB inactive/deleted user characterization.
+
+- [ ] 16-S2 Frontend picker.
+  - [ ] Filter to assignable members.
+  - [ ] Explain empty/disabled states.
+  - [ ] Browser picker evidence.
+
+- [ ] 16-S3 Parity hardening.
+  - [ ] API route tests.
+  - [ ] Import/bulk tests.
+  - [ ] Automation/form/Yjs tests.
+
+## 4. Roadmap Pool — Not Current Remainder
+
+These are future candidates or reopen-only lines. They are not open work in the current closure ledger:
+
+- [~] Server-side all-dataset export.
+- [~] Form `required-if` validation.
+- [~] Dashboard linked filters / drill-down.
+- [~] Dashboard missing-date buckets / series-count cap.
+- [~] Grid virtualization / row-windowing: D2 baseline verdict already excludes the frontend DOM/memory bottleneck and says not to open a grid-virtualization PR. Reopen only if a future D2 high-scale re-baseline flips that verdict.
+- [~] AI rings beyond the shipped base.
+- [~] Native synced / external-source tables.
+- [~] FOL deep follow-ups: multi-hop, formula-to-formula, materialization, Yjs recompute, automation trigger.
+- [~] Automation A6 remainder.
+
+## 5. Owner Unlock Prompts
+
+Use one of these when opening the next arc:
+
+- **Unlock 2a select/date/dateTime:** choose migration strategy + rollback compatibility + whether `select` pilots first.
+- **Unlock 2a duration:** choose REST-only, commit-on-confirm LWW, or collaborative draft channel.
+- **Unlock 2b:** approve rule language, fail-closed behavior, scope, and evaluation timing.
+- **Unlock #16:** choose directory source of truth and assignability semantics.
+- **Revisit grid performance:** opt into D2 high-scale harness/re-baseline work first; row virtualization stays closed unless the verdict flips.


### PR DESCRIPTION
## Summary
- add the current gated multitable remainder plan and paired TODO
- keep the active remainder limited to 2a CRDT remaining types, 2b #18 phase-2 rule engine, and 2c #16 person directory
- move #17 grid virtualization out of active remainder because the D2 baseline verdict already excludes the frontend DOM/memory bottleneck and says not to open a grid-virtualization PR
- mark the just-merged 2026-06-17 current plan/TODO as superseded historical snapshots, so the new gated remainder docs are the current routing source
- keep roadmap-pool items separate from current remainder, including grid re-baseline as reopen-only

## Notes
- docs-only; no runtime changes
- grounding is current `origin/main@7c802c804`; #2825 is still open/green, so the docs mention it as pending rather than claiming it is on main

## Verification
- git diff --cached --check
- git diff --check
