### PR TITLE
docs(data-source): record PM2 env hygiene fallback pass

### DIFF
--- a/docs/development/data-source-system-integration-delivery-todo-20260614.md
+++ b/docs/development/data-source-system-integration-delivery-todo-20260614.md
@@ -505,7 +505,7 @@ TODO:
       `deadLetters.persisted=1`, `provenance.target_write_succeeded=1`,
       `provenance.target_write_failed=1`, request-body injection fields absent, and
       injection env/runtime config restored after the check.
-- [ ] Post-C6 package reroll PM2 env hygiene hardening.
+- [x] Post-C6 package reroll PM2 env hygiene hardening.
   - trigger: #2769 found `app.env` no longer contained C6 failure-injection markers,
     while the running PM2 process still reported marker presence.
   - intended guard: when the two C6 test-only keys are absent from `app.env`,
@@ -517,6 +517,15 @@ TODO:
     absent from `app.env`, that path must delete + fresh-start instead of
     restart-only reuse because the helper cannot inspect the old definition's
     runtime env.
+  - fix: #2820 (`58143a2ac`) makes the `jlist`-uninspectable / `describe`-found
+    fallback delete + fresh-start when the retired keys are absent from `app.env`.
+  - entity-machine PASS package:
+    `multitable-onprem-pm2-env-hygiene-fallback-20260618-58143a2a`.
+    Evidence: `deployApplyExit=0`, dependency refresh / migrations / PM2 restart /
+    healthcheck reached, `pm2StaleDefinitionFound=unknown_jlist_uninspectable`,
+    `pm2RecreatedFromCleanEnv=true`, `pm2RestartOnlyFallbackObserved=false`,
+    `pm2RuntimeFailureInjectionMarkersPresent=false`, root/API health `200`,
+    and `valuesFreeEvidence=true`.
   - evidence must stay values-free:
     `appEnvFailureInjectionMarkersPresent=false`,
     `pm2RuntimeFailureInjectionMarkersPresent=false`,

--- a/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
+++ b/docs/operations/data-source-system-integration-release-smoke-runbook-20260616.md
@@ -382,6 +382,13 @@ Current #2720 checkpoint as of 2026-06-17:
   values. Collect and post only these booleans plus the helper log marker; do
   not paste raw `app.env` contents or raw `pm2 jlist` JSON, because both can
   include sensitive runtime values.
+- PM2 env-hygiene fallback checkpoint passed on package
+  `multitable-onprem-pm2-env-hygiene-fallback-20260618-58143a2a` (#2820,
+  `58143a2ac`): the entity machine reproduced the `jlist`-uninspectable shape,
+  observed delete + fresh-start instead of restart-only reuse, and reported
+  `pm2RuntimeFailureInjectionMarkersPresent=false`, `pm2RecreatedFromCleanEnv=true`,
+  `pm2RestartOnlyFallbackObserved=false`, root/API health `200`, and
+  `valuesFreeEvidence=true`.
 
 ## Stop Rules
 


### PR DESCRIPTION
## Summary

Backfills the #2769 PM2 env-hygiene fallback PASS after the `58143a2a` package validation.

## What changed

- Marks the post-C6 package reroll PM2 env-hygiene hardening item as complete in the data-source/system-integration TODO.
- Records #2820 (`58143a2ac`) as the `jlist`-uninspectable / `describe`-found fallback fix.
- Records the entity-machine PASS evidence for package `multitable-onprem-pm2-env-hygiene-fallback-20260618-58143a2a`.
- Adds the same checkpoint to the release smoke runbook while preserving the future reroll evidence template.

## Boundary

Docs-only. No runtime behavior changes, no C6 route/write changes, no production/batch authorization, no K3 Save / Submit / Audit / BOM authorization.

## Verification

- `git diff --check`
