### PR TITLE
feat(attendance): annual-leave L5c — admin operations UI (manual-adjust / backfill / accrual) + closeout MD

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6232,6 +6232,105 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations)"
+            >
+              <div class="attendance__admin-section-header">
+                <h4>{{ tr('Annual leave operations', '年假操作') }}</h4>
+              </div>
+              <p v-if="!annualOpsPolicyEnabled" class="attendance__hint" data-annual-ops-policy-off>
+                {{ tr('The annual leave engine is disabled — accrual is blocked until you enable it in', '年假引擎未启用——发放将被拦截，请先在') }}
+                <a href="#attendance-admin-annual-leave-policy" @click.prevent="selectAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy)">{{ tr('Annual leave policy', '年假策略') }}</a>.
+              </p>
+
+              <div class="attendance__admin-subsection" data-annual-ops-card="adjust">
+                <h5>{{ tr('Manual adjustment', '手工调整') }}</h5>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field"><span>{{ tr('User ID', '用户 ID') }}</span><input v-model="annualAdjustForm.userId" type="text" /></label>
+                  <label class="attendance__field"><span>{{ tr('Delta (minutes, ±)', '变动(分钟,±)') }}</span><input v-model.number="annualAdjustForm.deltaMinutes" type="number" /></label>
+                  <label class="attendance__field"><span>{{ tr('Reason', '原因') }}</span><input v-model="annualAdjustForm.reason" type="text" maxlength="500" /></label>
+                </div>
+                <div class="attendance__admin-actions">
+                  <button class="attendance__btn" @click="() => previewAnnualAdjust()">{{ tr('Preview', '预览') }}</button>
+                  <button class="attendance__btn attendance__btn--primary" :disabled="annualAdjustSubmitting" @click="() => requestAnnualAdjust()">{{ annualAdjustSubmitting ? tr('Submitting...', '提交中...') : tr('Adjust balance', '调整余额') }}</button>
+                </div>
+                <p v-if="annualAdjustPreview" class="attendance__hint">{{ tr('Preview (client)', '预览(客户端)') }}: {{ annualAdjustPreview.before }} → {{ annualAdjustPreview.after }} {{ tr('min', '分钟') }} — <em>{{ tr('advisory; the server is the final authority', '仅供参考，以服务端为准') }}</em></p>
+                <p v-if="annualAdjustError" class="attendance__error" data-annual-ops-error-adjust>{{ annualAdjustError }}</p>
+                <div v-if="annualAdjustResult" class="attendance__annual-ops-result" data-annual-ops-result-adjust>
+                  <span v-if="annualAdjustResult.applied">✅ {{ tr('Applied', '已应用') }}</span>
+                  <span v-else-if="annualAdjustResult.alreadyApplied">↻ {{ tr('Already applied (no change)', '已应用(无变化)') }}</span>
+                  <span>{{ tr('Delta', '变动') }}: {{ annualAdjustResult.delta }} {{ tr('min', '分钟') }}</span>
+                  <span>{{ tr('Adjustment id', '调整 id') }}: {{ annualAdjustResult.id }}</span>
+                </div>
+              </div>
+
+              <div class="attendance__admin-subsection" data-annual-ops-card="backfill">
+                <h5>{{ tr('Expiry backfill', '过期回填') }}</h5>
+                <div class="attendance__admin-actions">
+                  <button class="attendance__btn" :disabled="annualBackfillRunning" @click="() => runAnnualBackfillDryRun()">{{ tr('Dry-run', '预演') }}</button>
+                  <button class="attendance__btn attendance__btn--primary" :disabled="annualBackfillRunning || !annualBackfillDry" @click="() => requestAnnualBackfillCommit()">{{ tr('Commit backfill', '提交回填') }}</button>
+                </div>
+                <p v-if="annualBackfillError" class="attendance__error" data-annual-ops-error-backfill>{{ annualBackfillError }}</p>
+                <div v-if="annualBackfillDry" class="attendance__annual-ops-result" data-annual-ops-result-backfill>
+                  <h6>{{ tr('Dry-run', '预演') }}</h6>
+                  <span>{{ tr('Scanned', '扫描') }}: {{ annualBackfillDry.scanned }} · {{ tr('Updated', '更新') }}: {{ annualBackfillDry.updated }} · {{ tr('Skipped', '跳过') }}: {{ annualBackfillDry.skipped }}</span>
+                  <table v-if="Object.keys(annualBackfillDry.reasons || {}).length" class="attendance__table">
+                    <thead><tr><th>{{ tr('Reason', '原因') }}</th><th>{{ tr('Count', '数量') }}</th></tr></thead>
+                    <tbody><tr v-for="(count, code) in annualBackfillDry.reasons" :key="code"><td>{{ code }}</td><td>{{ count }}</td></tr></tbody>
+                  </table>
+                </div>
+                <div v-if="annualBackfillCommitted" class="attendance__annual-ops-result" data-annual-ops-committed-backfill>
+                  <h6>{{ tr('Committed', '已提交') }}</h6>
+                  <span>{{ tr('Updated', '更新') }}: {{ annualBackfillCommitted.updated }} / {{ annualBackfillCommitted.scanned }}</span>
+                </div>
+              </div>
+
+              <div class="attendance__admin-subsection" data-annual-ops-card="accrual">
+                <h5>{{ tr('Accrual run', '发放') }}</h5>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field"><span>{{ tr('Period (year)', '年度') }}</span><input v-model.number="annualAccrualForm.period" type="number" /></label>
+                  <label class="attendance__field"><span>{{ tr('As-of (optional)', 'as-of(可选)') }}</span><input v-model="annualAccrualForm.asOf" type="date" /></label>
+                </div>
+                <p v-if="annualAccrualOffYear" class="attendance__hint" data-annual-ops-accrual-offyear>⚠ {{ tr('Period is not the current or next year — committing requires an extra confirmation.', '年度非当前或次年——提交需要额外确认。') }}</p>
+                <div class="attendance__admin-actions">
+                  <button class="attendance__btn" :disabled="annualAccrualRunning" @click="() => runAnnualAccrualDryRun()">{{ tr('Dry-run', '预演') }}</button>
+                  <button class="attendance__btn attendance__btn--primary" :disabled="annualAccrualRunning || !annualAccrualDry || !annualOpsPolicyEnabled" @click="() => requestAnnualAccrualCommit()">{{ tr('Commit accrual', '提交发放') }}</button>
+                </div>
+                <p v-if="annualAccrualError" class="attendance__error" data-annual-ops-error-accrual>{{ annualAccrualError }}</p>
+                <div v-if="annualAccrualDry" class="attendance__annual-ops-result" data-annual-ops-result-accrual>
+                  <h6>{{ tr('Dry-run', '预演') }}</h6>
+                  <span>{{ tr('Granted', '发放') }}: {{ annualAccrualDry.granted }} · {{ tr('Minutes', '分钟') }}: {{ annualAccrualDry.grantedMinutes }} · {{ tr('Skipped', '跳过') }}: {{ annualAccrualDry.skipped }}</span>
+                  <table v-if="Object.keys(annualAccrualDry.skipReasons || {}).length" class="attendance__table">
+                    <thead><tr><th>{{ tr('Skip reason', '跳过原因') }}</th><th>{{ tr('Count', '数量') }}</th></tr></thead>
+                    <tbody><tr v-for="(count, code) in annualAccrualDry.skipReasons" :key="code"><td>{{ code }}</td><td>{{ count }}</td></tr></tbody>
+                  </table>
+                </div>
+                <div v-if="annualAccrualCommitted" class="attendance__annual-ops-result" data-annual-ops-committed-accrual>
+                  <h6>{{ tr('Committed', '已提交') }}</h6>
+                  <span>{{ tr('Lots created', '创建额度') }}: {{ annualAccrualCommitted.lotsCreated }} · {{ tr('Already granted', '已发放') }}: {{ annualAccrualCommitted.alreadyGranted }}</span>
+                  <span>{{ tr('Run id', '运行 id') }}: {{ annualAccrualCommitted.runId }} · {{ tr('Period', '年度') }}: {{ annualAccrualCommitted.periodKey }}</span>
+                </div>
+              </div>
+
+              <div v-if="annualOpsConfirm.open" class="attendance__modal" role="dialog" aria-modal="true" data-annual-ops-confirm>
+                <div class="attendance__modal-body">
+                  <h5>{{ annualOpsConfirm.title }}</h5>
+                  <table class="attendance__table">
+                    <tbody><tr v-for="(line, i) in annualOpsConfirm.lines" :key="i"><th>{{ line.label }}</th><td>{{ line.value }}</td></tr></tbody>
+                  </table>
+                  <label v-if="annualOpsConfirm.extraConfirmRequired" class="attendance__field" data-annual-ops-extra-confirm>
+                    <input type="checkbox" v-model="annualOpsConfirm.extraConfirmChecked" /> <span>{{ annualOpsConfirm.extraConfirmLabel }}</span>
+                  </label>
+                  <div class="attendance__admin-actions">
+                    <button class="attendance__btn" @click="() => closeAnnualOpsConfirm()">{{ tr('Cancel', '取消') }}</button>
+                    <button class="attendance__btn attendance__btn--primary" :disabled="annualOpsConfirm.extraConfirmRequired && !annualOpsConfirm.extraConfirmChecked" @click="() => confirmAnnualOps()" data-annual-ops-confirm-submit>{{ tr('Confirm', '确认') }}</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules)"
@@ -19915,6 +20014,301 @@ async function saveAnnualPolicy() {
     setStatus(readErrorMessage(error, tr('Failed to save annual leave policy', '保存年假策略失败')), 'error')
   } finally {
     annualPolicySaving.value = false
+  }
+}
+
+// ===== 年假/法定假 L5c: admin operations (the three balance-mutating actions) =====
+// Three cards (manual adjustment / expiry backfill / accrual run) behind one in-DOM two-step confirm. The three
+// back-ends DIFFER and are kept distinct: manual-adjust has NO server dry-run (client preview only; backend 422
+// is final) and returns {id,delta,applied,alreadyApplied} — NOT a reasons map; backfill + accrual have a server
+// dry-run and return a {code→count} reasons/skipReasons map. Cards are proactively disabled when the policy is
+// off (load-bearing for accrual; UX-only hint for the others).
+
+// -- shared in-DOM confirm panel (mirrors the role="dialog" pattern; window.confirm can't restate a request) --
+interface AnnualOpsConfirmLine { label: string; value: string }
+const annualOpsConfirm = reactive<{
+  open: boolean
+  title: string
+  lines: AnnualOpsConfirmLine[]
+  extraConfirmRequired: boolean
+  extraConfirmChecked: boolean
+  extraConfirmLabel: string
+  onConfirm: (() => void) | null
+}>({ open: false, title: '', lines: [], extraConfirmRequired: false, extraConfirmChecked: false, extraConfirmLabel: '', onConfirm: null })
+
+function openAnnualOpsConfirm(payload: { title: string; lines: AnnualOpsConfirmLine[]; extraConfirmRequired?: boolean; extraConfirmLabel?: string; onConfirm: () => void }): void {
+  annualOpsConfirm.open = true
+  annualOpsConfirm.title = payload.title
+  annualOpsConfirm.lines = payload.lines
+  annualOpsConfirm.extraConfirmRequired = payload.extraConfirmRequired === true
+  annualOpsConfirm.extraConfirmChecked = false
+  annualOpsConfirm.extraConfirmLabel = payload.extraConfirmLabel || ''
+  annualOpsConfirm.onConfirm = payload.onConfirm
+}
+function closeAnnualOpsConfirm(): void {
+  annualOpsConfirm.open = false
+  annualOpsConfirm.onConfirm = null
+}
+function confirmAnnualOps(): void {
+  if (annualOpsConfirm.extraConfirmRequired && !annualOpsConfirm.extraConfirmChecked) return
+  const cb = annualOpsConfirm.onConfirm
+  closeAnnualOpsConfirm()
+  if (cb) cb()
+}
+
+// -- the policy.enabled gate (hydrated first-screen via loadSettings → applyAnnualPolicyToForm) --
+const annualOpsPolicyEnabled = computed(() => annualPolicyForm.enabled === true)
+
+// -- shared failure-code → human line mapper (per-card code sets live in §3; this carries them all + a fallback) --
+function annualOpsErrorLine(code: string): string {
+  switch (code) {
+    case 'ANNUAL_LEAVE_NOT_ENABLED': return tr('The annual leave engine is disabled — enable it in Annual leave policy first.', '年假引擎未启用——请先在「年假策略」中启用。')
+    case 'ANNUAL_LEAVE_TIMEZONE_REQUIRED': return tr('The policy is missing a timezone.', '策略缺少时区。')
+    case 'ANNUAL_LEAVE_TIMEZONE_INVALID': return tr('The policy timezone is not a valid IANA zone.', '策略时区不是有效的 IANA 时区。')
+    case 'ANNUAL_LEAVE_INVALID_ASOF': return tr('The as-of date is invalid.', 'as-of 日期无效。')
+    case 'ANNUAL_LEAVE_MULTI_DAY_UNSUPPORTED': return tr('Multi-day standard-day conversion is not supported.', '不支持多天标准工作日折算。')
+    case 'USER_NOT_IN_ORG': return tr('That user is not an active member of this org.', '该用户不是本组织的有效成员。')
+    case 'ANNUAL_LEAVE_ADJUST_DELTA_INVALID': return tr('The adjustment amount must be non-zero.', '调整数值必须非零。')
+    case 'ANNUAL_LEAVE_BALANCE_INSUFFICIENT': return tr('Insufficient balance — the negative adjustment exceeds the available active lots.', '余额不足——负向调整超过可用额度。')
+    case 'ANNUAL_LEAVE_ADJUST_IDEMPOTENCY_CONFLICT': return tr('This idempotency key already names a different adjustment.', '该幂等键已对应另一笔不同的调整。')
+    case 'DB_NOT_READY': return tr('Attendance tables are not ready on this environment.', '本环境的考勤表尚未就绪。')
+    case 'VALIDATION_ERROR': return tr('The request was rejected as invalid.', '请求校验失败。')
+    default: return tr('The operation failed', '操作失败') + (code ? ` (${code})` : '')
+  }
+}
+
+// -- shared POST helper: pins orgId in the body so the write lands in the current org; surfaces structured codes --
+async function annualOpsPost(path: string, body: Record<string, unknown>, fallbackMsg: string): Promise<any | null> {
+  const response = await apiFetch(path, { method: 'POST', body: JSON.stringify({ orgId: normalizedOrgId(), ...body }) })
+  if (response.status === 403) {
+    adminForbidden.value = true
+    return null
+  }
+  const data = await response.json()
+  if (!response.ok || !data.ok) {
+    const code = data?.error?.code
+    throw new Error(code ? annualOpsErrorLine(code) : readErrorMessage(data, fallbackMsg))
+  }
+  adminForbidden.value = false
+  return data.data
+}
+function annualOpsIdempotencyKey(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  } catch { /* fall through */ }
+  return `annual-adjust-${Date.now()}-${Math.floor(Math.random() * 1e9)}`
+}
+
+// -- Card 1: manual adjustment (client preview; backend 422 final; returns {id,delta,applied,alreadyApplied}) --
+interface AnnualAdjustResult { id: string; delta: number; applied: boolean; alreadyApplied: boolean }
+const annualAdjustForm = reactive<{ userId: string; deltaMinutes: number; reason: string }>({ userId: '', deltaMinutes: 0, reason: '' })
+const annualAdjustSubmitting = ref(false)
+const annualAdjustResult = ref<AnnualAdjustResult | null>(null)
+const annualAdjustError = ref<string | null>(null)
+const annualAdjustPreview = ref<{ user: string; before: number; after: number } | null>(null)
+const annualAdjustIdemKey = ref('')
+
+async function previewAnnualAdjust(): Promise<void> {
+  const userId = annualAdjustForm.userId.trim()
+  annualAdjustError.value = null
+  annualAdjustPreview.value = null
+  if (!userId) {
+    annualAdjustError.value = tr('Enter a user ID first', '请先输入用户 ID')
+    return
+  }
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId(), userId, leaveTypeCode: 'annual' })
+    const response = await apiFetch(`/api/attendance/leave-balances?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to read balance', '读取余额失败')))
+    }
+    adminForbidden.value = false
+    // client preview ONLY — advisory; the backend 422 (FIFO-insufficient) is the final authority on a save.
+    const before = Number(data.data?.summary?.remainingMinutes) || 0
+    annualAdjustPreview.value = { user: userId, before, after: before + (Number(annualAdjustForm.deltaMinutes) || 0) }
+  } catch (error: any) {
+    annualAdjustError.value = readErrorMessage(error, tr('Failed to read balance', '读取余额失败'))
+  }
+}
+
+function requestAnnualAdjust(): void {
+  annualAdjustError.value = null
+  const userId = annualAdjustForm.userId.trim()
+  const delta = Number(annualAdjustForm.deltaMinutes)
+  const reason = annualAdjustForm.reason.trim()
+  if (!userId) {
+    annualAdjustError.value = tr('Enter a user ID', '请输入用户 ID')
+    return
+  }
+  if (!Number.isInteger(delta) || delta === 0) {
+    annualAdjustError.value = tr('The adjustment must be a non-zero whole number of minutes', '调整必须是非零整数分钟')
+    return
+  }
+  if (!reason) {
+    annualAdjustError.value = tr('A reason is required', '必须填写原因')
+    return
+  }
+  annualAdjustIdemKey.value = annualOpsIdempotencyKey()
+  const preview = annualAdjustPreview.value
+  openAnnualOpsConfirm({
+    title: tr('Confirm manual adjustment', '确认手工调整'),
+    lines: [
+      { label: tr('User', '用户'), value: userId },
+      { label: tr('Delta (min)', '变动(分钟)'), value: (delta > 0 ? '+' : '') + delta },
+      ...(preview && preview.user === userId ? [{ label: tr('Remaining (preview)', '剩余(预览)'), value: `${preview.before} → ${preview.after}` }] : []),
+      { label: tr('Reason', '原因'), value: reason },
+      { label: tr('Idempotency key', '幂等键'), value: annualAdjustIdemKey.value },
+    ],
+    onConfirm: () => { void submitAnnualAdjust() },
+  })
+}
+
+async function submitAnnualAdjust(): Promise<void> {
+  annualAdjustSubmitting.value = true
+  annualAdjustError.value = null
+  annualAdjustResult.value = null
+  try {
+    const data = await annualOpsPost('/api/attendance/annual-leave-manual-adjustment', {
+      userId: annualAdjustForm.userId.trim(),
+      deltaMinutes: Number(annualAdjustForm.deltaMinutes),
+      reason: annualAdjustForm.reason.trim(),
+      idempotencyKey: annualAdjustIdemKey.value,
+    }, tr('Failed to adjust balance', '调整余额失败'))
+    if (data) annualAdjustResult.value = data as AnnualAdjustResult
+  } catch (error: any) {
+    annualAdjustError.value = readErrorMessage(error, tr('Failed to adjust balance', '调整余额失败'))
+  } finally {
+    annualAdjustSubmitting.value = false
+  }
+}
+
+// -- Card 2: expiry backfill (server dry-run; returns {scanned,updated,skipped,reasons{code→count}}) --
+interface AnnualBackfillSummary { scanned: number; updated: number; skipped: number; reasons: Record<string, number> }
+const annualBackfillRunning = ref(false)
+const annualBackfillDry = ref<AnnualBackfillSummary | null>(null)
+const annualBackfillCommitted = ref<AnnualBackfillSummary | null>(null)
+const annualBackfillError = ref<string | null>(null)
+
+async function runAnnualBackfillDryRun(): Promise<void> {
+  annualBackfillRunning.value = true
+  annualBackfillError.value = null
+  annualBackfillCommitted.value = null
+  try {
+    const data = await annualOpsPost('/api/attendance/annual-leave-expiry-backfill', { dryRun: true }, tr('Backfill dry-run failed', '回填预演失败'))
+    if (data) annualBackfillDry.value = data as AnnualBackfillSummary
+  } catch (error: any) {
+    annualBackfillError.value = readErrorMessage(error, tr('Backfill dry-run failed', '回填预演失败'))
+  } finally {
+    annualBackfillRunning.value = false
+  }
+}
+
+function requestAnnualBackfillCommit(): void {
+  annualBackfillError.value = null
+  const dry = annualBackfillDry.value
+  if (!dry) {
+    annualBackfillError.value = tr('Run a dry-run first', '请先执行预演')
+    return
+  }
+  openAnnualOpsConfirm({
+    title: tr('Commit expiry backfill', '提交过期回填'),
+    lines: [
+      { label: tr('Scanned', '扫描'), value: String(dry.scanned) },
+      { label: tr('To update', '将更新'), value: String(dry.updated) },
+      { label: tr('Skipped', '跳过'), value: String(dry.skipped) },
+    ],
+    onConfirm: () => { void submitAnnualBackfillCommit() },
+  })
+}
+
+async function submitAnnualBackfillCommit(): Promise<void> {
+  annualBackfillRunning.value = true
+  annualBackfillError.value = null
+  try {
+    const data = await annualOpsPost('/api/attendance/annual-leave-expiry-backfill', { dryRun: false }, tr('Backfill failed', '回填失败'))
+    if (data) annualBackfillCommitted.value = data as AnnualBackfillSummary
+  } catch (error: any) {
+    annualBackfillError.value = readErrorMessage(error, tr('Backfill failed', '回填失败'))
+  } finally {
+    annualBackfillRunning.value = false
+  }
+}
+
+// -- Card 3: accrual run (server dry-run + period guardrail; returns full summary incl skipReasons{code→count}) --
+interface AnnualAccrualSummary { runId: string; periodKey: string; asOf: string; dryRun: boolean; granted: number; skipped: number; grantedMinutes: number; lotsCreated: number; alreadyGranted: number; skipReasons: Record<string, number> }
+const annualOpsCurrentYear = new Date().getFullYear()
+const annualAccrualForm = reactive<{ period: number; asOf: string }>({ period: annualOpsCurrentYear, asOf: '' })
+const annualAccrualRunning = ref(false)
+const annualAccrualDry = ref<AnnualAccrualSummary | null>(null)
+const annualAccrualCommitted = ref<AnnualAccrualSummary | null>(null)
+const annualAccrualError = ref<string | null>(null)
+const annualAccrualOffYear = computed(() => {
+  const p = Number(annualAccrualForm.period)
+  return p !== annualOpsCurrentYear && p !== annualOpsCurrentYear + 1
+})
+
+async function runAnnualAccrualDryRun(): Promise<void> {
+  annualAccrualRunning.value = true
+  annualAccrualError.value = null
+  annualAccrualCommitted.value = null
+  try {
+    const asOf = annualAccrualForm.asOf.trim()
+    const data = await annualOpsPost('/api/attendance/annual-leave-accrual/run', {
+      period: Number(annualAccrualForm.period),
+      ...(asOf ? { asOf } : {}),
+      dryRun: true,
+    }, tr('Accrual dry-run failed', '发放预演失败'))
+    if (data) annualAccrualDry.value = data as AnnualAccrualSummary
+  } catch (error: any) {
+    annualAccrualError.value = readErrorMessage(error, tr('Accrual dry-run failed', '发放预演失败'))
+  } finally {
+    annualAccrualRunning.value = false
+  }
+}
+
+function requestAnnualAccrualCommit(): void {
+  annualAccrualError.value = null
+  const dry = annualAccrualDry.value
+  if (!dry) {
+    annualAccrualError.value = tr('Run a dry-run first', '请先执行预演')
+    return
+  }
+  openAnnualOpsConfirm({
+    title: tr('Commit accrual run', '提交发放'),
+    lines: [
+      { label: tr('Period', '年度'), value: String(annualAccrualForm.period) },
+      { label: tr('Granted', '发放'), value: String(dry.granted) },
+      { label: tr('Granted (min)', '发放(分钟)'), value: String(dry.grantedMinutes) },
+      { label: tr('Skipped', '跳过'), value: String(dry.skipped) },
+    ],
+    extraConfirmRequired: annualAccrualOffYear.value,
+    extraConfirmLabel: annualAccrualOffYear.value
+      ? tr(`I confirm granting for the off-year period ${annualAccrualForm.period}`, `我确认为非当前/次年年度 ${annualAccrualForm.period} 发放`)
+      : '',
+    onConfirm: () => { void submitAnnualAccrualCommit() },
+  })
+}
+
+async function submitAnnualAccrualCommit(): Promise<void> {
+  annualAccrualRunning.value = true
+  annualAccrualError.value = null
+  try {
+    const asOf = annualAccrualForm.asOf.trim()
+    const data = await annualOpsPost('/api/attendance/annual-leave-accrual/run', {
+      period: Number(annualAccrualForm.period),
+      ...(asOf ? { asOf } : {}),
+      dryRun: false,
+    }, tr('Accrual run failed', '发放失败'))
+    if (data) annualAccrualCommitted.value = data as AnnualAccrualSummary
+  } catch (error: any) {
+    annualAccrualError.value = readErrorMessage(error, tr('Accrual run failed', '发放失败'))
+  } finally {
+    annualAccrualRunning.value = false
   }
 }
 

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -20066,7 +20066,6 @@ function annualOpsErrorLine(code: string): string {
     case 'ANNUAL_LEAVE_TIMEZONE_REQUIRED': return tr('The policy is missing a timezone.', '策略缺少时区。')
     case 'ANNUAL_LEAVE_TIMEZONE_INVALID': return tr('The policy timezone is not a valid IANA zone.', '策略时区不是有效的 IANA 时区。')
     case 'ANNUAL_LEAVE_INVALID_ASOF': return tr('The as-of date is invalid.', 'as-of 日期无效。')
-    case 'ANNUAL_LEAVE_MULTI_DAY_UNSUPPORTED': return tr('Multi-day standard-day conversion is not supported.', '不支持多天标准工作日折算。')
     case 'USER_NOT_IN_ORG': return tr('That user is not an active member of this org.', '该用户不是本组织的有效成员。')
     case 'ANNUAL_LEAVE_ADJUST_DELTA_INVALID': return tr('The adjustment amount must be non-zero.', '调整数值必须非零。')
     case 'ANNUAL_LEAVE_BALANCE_INSUFFICIENT': return tr('Insufficient balance — the negative adjustment exceeds the available active lots.', '余额不足——负向调整超过可用额度。')
@@ -20154,6 +20153,9 @@ function requestAnnualAdjust(): void {
     return
   }
   annualAdjustIdemKey.value = annualOpsIdempotencyKey()
+  // Snapshot the resolved request NOW; the confirm consumes this snapshot, NOT the live form — so editing an input
+  // while the panel is open cannot change what is actually submitted (confirm-is-authoritative, no TOCTOU).
+  const snapshot = { userId, deltaMinutes: delta, reason, idempotencyKey: annualAdjustIdemKey.value }
   const preview = annualAdjustPreview.value
   openAnnualOpsConfirm({
     title: tr('Confirm manual adjustment', '确认手工调整'),
@@ -20164,20 +20166,20 @@ function requestAnnualAdjust(): void {
       { label: tr('Reason', '原因'), value: reason },
       { label: tr('Idempotency key', '幂等键'), value: annualAdjustIdemKey.value },
     ],
-    onConfirm: () => { void submitAnnualAdjust() },
+    onConfirm: () => { void submitAnnualAdjust(snapshot) },
   })
 }
 
-async function submitAnnualAdjust(): Promise<void> {
+async function submitAnnualAdjust(snapshot: { userId: string; deltaMinutes: number; reason: string; idempotencyKey: string }): Promise<void> {
   annualAdjustSubmitting.value = true
   annualAdjustError.value = null
   annualAdjustResult.value = null
   try {
     const data = await annualOpsPost('/api/attendance/annual-leave-manual-adjustment', {
-      userId: annualAdjustForm.userId.trim(),
-      deltaMinutes: Number(annualAdjustForm.deltaMinutes),
-      reason: annualAdjustForm.reason.trim(),
-      idempotencyKey: annualAdjustIdemKey.value,
+      userId: snapshot.userId,
+      deltaMinutes: snapshot.deltaMinutes,
+      reason: snapshot.reason,
+      idempotencyKey: snapshot.idempotencyKey,
     }, tr('Failed to adjust balance', '调整余额失败'))
     if (data) annualAdjustResult.value = data as AnnualAdjustResult
   } catch (error: any) {
@@ -20197,6 +20199,7 @@ const annualBackfillError = ref<string | null>(null)
 async function runAnnualBackfillDryRun(): Promise<void> {
   annualBackfillRunning.value = true
   annualBackfillError.value = null
+  annualBackfillDry.value = null // drop any prior dry-run so a failed re-run can't leave Commit enabled on stale data
   annualBackfillCommitted.value = null
   try {
     const data = await annualOpsPost('/api/attendance/annual-leave-expiry-backfill', { dryRun: true }, tr('Backfill dry-run failed', '回填预演失败'))
@@ -20251,10 +20254,14 @@ const annualAccrualOffYear = computed(() => {
   const p = Number(annualAccrualForm.period)
   return p !== annualOpsCurrentYear && p !== annualOpsCurrentYear + 1
 })
+// Editing the period/asOf invalidates a prior dry-run, so Commit (disabled on !annualAccrualDry) cannot fire against
+// a period that was never previewed — the highest-stakes safety on this card.
+watch(() => [annualAccrualForm.period, annualAccrualForm.asOf], () => { annualAccrualDry.value = null })
 
 async function runAnnualAccrualDryRun(): Promise<void> {
   annualAccrualRunning.value = true
   annualAccrualError.value = null
+  annualAccrualDry.value = null // never keep a stale dry-run from a prior period
   annualAccrualCommitted.value = null
   try {
     const asOf = annualAccrualForm.asOf.trim()
@@ -20278,29 +20285,34 @@ function requestAnnualAccrualCommit(): void {
     annualAccrualError.value = tr('Run a dry-run first', '请先执行预演')
     return
   }
+  // Snapshot the resolved request (period/asOf/off-year) NOW; the dry-run was for THIS period (the watch clears it on
+  // any edit). submitAnnualAccrualCommit consumes the snapshot, never the live form — a never-previewed period or a
+  // bypassed off-year guard cannot be submitted by editing the field while the panel is open.
+  const offYear = annualAccrualOffYear.value
+  const snapshot = { period: Number(annualAccrualForm.period), asOf: annualAccrualForm.asOf.trim() }
   openAnnualOpsConfirm({
     title: tr('Commit accrual run', '提交发放'),
     lines: [
-      { label: tr('Period', '年度'), value: String(annualAccrualForm.period) },
+      { label: tr('Period', '年度'), value: String(snapshot.period) },
       { label: tr('Granted', '发放'), value: String(dry.granted) },
       { label: tr('Granted (min)', '发放(分钟)'), value: String(dry.grantedMinutes) },
       { label: tr('Skipped', '跳过'), value: String(dry.skipped) },
     ],
-    extraConfirmRequired: annualAccrualOffYear.value,
-    extraConfirmLabel: annualAccrualOffYear.value
-      ? tr(`I confirm granting for the off-year period ${annualAccrualForm.period}`, `我确认为非当前/次年年度 ${annualAccrualForm.period} 发放`)
+    extraConfirmRequired: offYear,
+    extraConfirmLabel: offYear
+      ? tr(`I confirm granting for the off-year period ${snapshot.period}`, `我确认为非当前/次年年度 ${snapshot.period} 发放`)
       : '',
-    onConfirm: () => { void submitAnnualAccrualCommit() },
+    onConfirm: () => { void submitAnnualAccrualCommit(snapshot) },
   })
 }
 
-async function submitAnnualAccrualCommit(): Promise<void> {
+async function submitAnnualAccrualCommit(snapshot: { period: number; asOf: string }): Promise<void> {
   annualAccrualRunning.value = true
   annualAccrualError.value = null
   try {
-    const asOf = annualAccrualForm.asOf.trim()
+    const asOf = snapshot.asOf
     const data = await annualOpsPost('/api/attendance/annual-leave-accrual/run', {
-      period: Number(annualAccrualForm.period),
+      period: snapshot.period,
       ...(asOf ? { asOf } : {}),
       dryRun: false,
     }, tr('Accrual run failed', '发放失败'))
@@ -26474,5 +26486,39 @@ const holidaySectionBindings = {
   display: flex;
   gap: 8px;
   margin-top: 4px;
+}
+
+/* 年假/法定假 L5c: the balance-mutating confirm is a real overlay (backdrop + centered panel) so the form
+   underneath is not interactive while a two-step confirm is open. */
+.attendance__modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+.attendance__modal-body {
+  background: var(--surface, #fff);
+  color: inherit;
+  border-radius: 8px;
+  padding: 20px;
+  max-width: 480px;
+  width: calc(100% - 32px);
+  max-height: calc(100% - 32px);
+  overflow: auto;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+}
+.attendance__admin-subsection {
+  border-top: 1px solid var(--border, #e5e7eb);
+  padding-top: 12px;
+  margin-top: 12px;
+}
+.attendance__annual-ops-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
 }
 </style>

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -39,6 +39,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   holidays: 'attendance-admin-holidays',
   annualLeaveBalance: 'attendance-admin-annual-leave-balance',
   annualLeavePolicy: 'attendance-admin-annual-leave-policy',
+  annualLeaveOperations: 'attendance-admin-annual-leave-operations',
 } as const
 
 export type AdminSectionNavItem = {
@@ -191,6 +192,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.holidays, label: tr('Holidays', '节假日') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance, label: tr('Annual leave balance', '年假余额') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy, label: tr('Annual leave policy', '年假策略') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations, label: tr('Annual leave operations', '年假操作') },
   ])
   const adminSectionItemMap = computed(() => new Map(adminSectionNavItems.value.map(item => [item.id, item])))
   const adminSectionNavGroups = computed<AdminSectionNavGroupDefinition[]>(() => [
@@ -246,6 +248,7 @@ export function useAttendanceAdminRail({
       itemIds: [
         ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveBalance,
         ATTENDANCE_ADMIN_SECTION_IDS.annualLeavePolicy,
+        ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations,
       ],
     },
     {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,11 +124,12 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Annual leave', 'Data & Payroll'])
-    expect(labels).toHaveLength(29)
+    expect(labels).toHaveLength(30)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Annual leave balance',
         'Annual leave policy',
+        'Annual leave operations',
         'Settings',
         'User Access',
         'Notification deliveries',
@@ -829,7 +830,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(29)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(30)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1182,6 +1182,8 @@ describe('Attendance admin regressions', () => {
     await flushUi(4)
     expect(bodies[0].dryRun).toBe(true)
     expect(bodies[0].period).toBe(2000)
+    // accrual skipReasons render as a code→count table (object map, not an array)
+    expect(card.querySelector('[data-annual-ops-result-accrual]')?.textContent).toContain('NOT_YET_HIRED')
     Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!.click()
     await flushUi(2)
     const confirmSubmit = section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!
@@ -1212,6 +1214,72 @@ describe('Attendance admin regressions', () => {
     const card = section.querySelector<HTMLElement>('[data-annual-ops-card="accrual"]')!
     const commit = Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!
     expect(commit.disabled).toBe(true) // load-bearing: accrual needs the engine enabled (backend 422s otherwise)
+  })
+
+  it('annual operations — accrual: the submitted period is the snapshot at confirm time, not the live form (no TOCTOU)', async () => {
+    const bodies: any[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/annual-leave-accrual/run')) {
+        const b = JSON.parse(String(init!.body)); bodies.push(b)
+        return jsonResponse(200, { ok: true, data: { runId: 'run-1', periodKey: `annual:${b.period}`, asOf: '', dryRun: b.dryRun, granted: 1, skipped: 0, grantedMinutes: 2400, lotsCreated: b.dryRun ? 0 : 1, alreadyGranted: 0, skipReasons: {} } })
+      }
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="accrual"]')!
+    const periodInput = card.querySelector<HTMLInputElement>('input[type="number"]')!
+    const currentYear = new Date().getFullYear()
+    // dry-run a SAFE (current-year) period → confirm opens with no off-year extra-confirm
+    periodInput.value = String(currentYear); periodInput.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Dry-run'))!.click()
+    await flushUi(4)
+    expect(bodies[0].period).toBe(currentYear)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!.click()
+    await flushUi(2)
+    expect(section.querySelector('[data-annual-ops-confirm]')).toBeTruthy()
+    // tamper the period to an off-year WHILE the confirm panel is open
+    periodInput.value = '2000'; periodInput.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!.click()
+    await flushUi(4)
+    expect(bodies[1].dryRun).toBe(false)
+    expect(bodies[1].period).toBe(currentYear) // the snapshot wins — the tampered off-year is NOT submitted
+  })
+
+  it('annual operations — manual adjustment maps a backend error code to a human line', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/annual-leave-manual-adjustment')) {
+        return jsonResponse(404, { ok: false, error: { code: 'USER_NOT_IN_ORG', message: 'raw' } })
+      }
+      if (url.includes('/api/attendance/leave-balances')) {
+        return jsonResponse(200, { ok: true, data: { userId: 'u9', summary: { grantedMinutes: 0, remainingMinutes: 0, exhaustedMinutes: 0, expiredMinutes: 0 }, activeLots: [], recentEvents: [], eventLimit: 50 } })
+      }
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="adjust"]')!
+    const inputs = card.querySelectorAll<HTMLInputElement>('input')
+    inputs[0].value = 'u9'; inputs[0].dispatchEvent(new Event('input'))
+    inputs[1].value = '60'; inputs[1].dispatchEvent(new Event('input'))
+    inputs[2].value = 'x'; inputs[2].dispatchEvent(new Event('input'))
+    await flushUi(2)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Adjust balance'))!.click()
+    await flushUi(2)
+    section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!.click()
+    await flushUi(4)
+    // the structured code maps to its human line, not a raw "raw"/generic failure
+    expect(card.querySelector('[data-annual-ops-error-adjust]')?.textContent || '').toContain('not an active member')
   })
 
   it('warns when the attendance-group picker source is capped (no silent caps)', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1081,6 +1081,139 @@ describe('Attendance admin regressions', () => {
     expect(savedPayload?.annualLeavePolicy?.tiers).toEqual([])
   })
 
+  // ===== L5c admin operations =====
+  const enabledPolicySettings = () => jsonResponse(200, {
+    ok: true,
+    data: { annualLeavePolicy: { enabled: true, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [{ minYears: 1, maxYears: null, days: 5 }], carryover: { enabled: false }, timezone: 'Asia/Shanghai' } },
+  })
+  const openOpsSection = async () => {
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-annual-leave-operations"]')!.click()
+    await flushUi(4)
+    return container!.querySelector<HTMLElement>('#attendance-admin-annual-leave-operations')!
+  }
+
+  it('annual operations — manual adjustment: preview, in-DOM confirm, POST with idempotency key, result shows id', async () => {
+    let adjustBody: any = null
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/annual-leave-manual-adjustment')) {
+        adjustBody = JSON.parse(String(init!.body))
+        return jsonResponse(200, { ok: true, data: { id: 'adj-1', delta: 240, applied: true, alreadyApplied: false } })
+      }
+      if (url.includes('/api/attendance/leave-balances')) {
+        return jsonResponse(200, { ok: true, data: { userId: 'u1', summary: { grantedMinutes: 1000, remainingMinutes: 1000, exhaustedMinutes: 0, expiredMinutes: 0 }, activeLots: [], recentEvents: [], eventLimit: 50 } })
+      }
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="adjust"]')!
+    const inputs = card.querySelectorAll<HTMLInputElement>('input')
+    inputs[0].value = 'u1'; inputs[0].dispatchEvent(new Event('input'))
+    inputs[1].value = '240'; inputs[1].dispatchEvent(new Event('input'))
+    inputs[2].value = 'comp grant'; inputs[2].dispatchEvent(new Event('input'))
+    await flushUi(2)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Adjust balance'))!.click()
+    await flushUi(2)
+    expect(section.querySelector('[data-annual-ops-confirm]')).toBeTruthy() // in-DOM confirm, not window.confirm
+    section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!.click()
+    await flushUi(4)
+    expect(adjustBody?.userId).toBe('u1')
+    expect(adjustBody?.deltaMinutes).toBe(240)
+    expect(adjustBody?.reason).toBe('comp grant')
+    expect(typeof adjustBody?.idempotencyKey).toBe('string')
+    expect(adjustBody.idempotencyKey.length).toBeGreaterThan(0)
+    expect(card.querySelector('[data-annual-ops-result-adjust]')?.textContent).toContain('adj-1')
+  })
+
+  it('annual operations — expiry backfill: dry-run renders the code→count table, commit sends dryRun:false', async () => {
+    const bodies: any[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/annual-leave-expiry-backfill')) {
+        const b = JSON.parse(String(init!.body)); bodies.push(b)
+        return jsonResponse(200, { ok: true, data: { scanned: 10, updated: 7, skipped: 3, dryRun: b.dryRun, reasons: { ALREADY_SET: 2, NON_ACCRUAL_SOURCE: 1 } } })
+      }
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="backfill"]')!
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Dry-run'))!.click()
+    await flushUi(4)
+    const result = card.querySelector('[data-annual-ops-result-backfill]')
+    expect(result?.textContent).toContain('ALREADY_SET')
+    expect(result?.textContent).toContain('NON_ACCRUAL_SOURCE') // reasons rendered as a code→count table (object, not array)
+    expect(bodies[0].dryRun).toBe(true)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit backfill'))!.click()
+    await flushUi(2)
+    section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!.click()
+    await flushUi(4)
+    expect(bodies[1].dryRun).toBe(false)
+  })
+
+  it('annual operations — accrual run: an off-year period requires the extra confirm before committing', async () => {
+    const bodies: any[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/annual-leave-accrual/run')) {
+        const b = JSON.parse(String(init!.body)); bodies.push(b)
+        return jsonResponse(200, { ok: true, data: { runId: 'run-1', periodKey: `annual:${b.period}`, asOf: '2026-01-01', dryRun: b.dryRun, granted: 3, skipped: 1, grantedMinutes: 7200, lotsCreated: b.dryRun ? 0 : 3, alreadyGranted: 0, skipReasons: { NOT_YET_HIRED: 1 } } })
+      }
+      if (url.includes('/api/attendance/settings')) return enabledPolicySettings()
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="accrual"]')!
+    const periodInput = card.querySelector<HTMLInputElement>('input[type="number"]')!
+    periodInput.value = '2000'; periodInput.dispatchEvent(new Event('input')) // an off-year (not current/next)
+    await flushUi(2)
+    expect(card.querySelector('[data-annual-ops-accrual-offyear]')).toBeTruthy()
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Dry-run'))!.click()
+    await flushUi(4)
+    expect(bodies[0].dryRun).toBe(true)
+    expect(bodies[0].period).toBe(2000)
+    Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!.click()
+    await flushUi(2)
+    const confirmSubmit = section.querySelector<HTMLButtonElement>('[data-annual-ops-confirm-submit]')!
+    expect(section.querySelector('[data-annual-ops-extra-confirm]')).toBeTruthy()
+    expect(confirmSubmit.disabled).toBe(true) // blocked until the off-year box is checked
+    const extra = section.querySelector<HTMLInputElement>('[data-annual-ops-extra-confirm] input[type="checkbox"]')!
+    extra.checked = true; extra.dispatchEvent(new Event('change'))
+    await flushUi(2)
+    confirmSubmit.click()
+    await flushUi(4)
+    expect(bodies[1].dryRun).toBe(false)
+    expect(bodies[1].period).toBe(2000)
+  })
+
+  it('annual operations — accrual commit is disabled when the annual leave policy is off', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/settings')) {
+        return jsonResponse(200, { ok: true, data: { annualLeavePolicy: { enabled: false, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [], carryover: { enabled: false }, timezone: null } } })
+      }
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    const section = await openOpsSection()
+    expect(section.querySelector('[data-annual-ops-policy-off]')).toBeTruthy()
+    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="accrual"]')!
+    const commit = Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!
+    expect(commit.disabled).toBe(true) // load-bearing: accrual needs the engine enabled (backend 422s otherwise)
+  })
+
   it('warns when the attendance-group picker source is capped (no silent caps)', async () => {
     vi.mocked(apiFetch).mockImplementation(async (input) => {
       const url = String(input)

--- a/docs/development/attendance-annual-leave-admin-operations-dev-verification-20260617.md
+++ b/docs/development/attendance-annual-leave-admin-operations-dev-verification-20260617.md
@@ -1,0 +1,107 @@
+# Annual-leave admin operations (L5c) — development + verification closeout
+
+**Status:** L5c **slice** closeout. This records the L5c admin-operations UI as built and verified. It is **not** the
+whole annual-leave engine's final capstone — the engine track flips to ✅ only after the **L6 staging smoke** passes
+on a live stack (see the merged L6 runbook). Authority: the merged L5c design-lock
+(`attendance-annual-leave-admin-operations-design-lock-20260617.md`, #2795) + the dev-plan (#2826).
+
+## 1. What shipped (one PR)
+
+One new admin nav section — **年假操作 / Annual leave operations** — the 3rd item in the existing 年假/法定假 group
+(no new group; anchor-nav `29 → 30`). It puts the three already-existing, `attendance:admin`-gated, balance-mutating
+endpoints behind buttons, each satisfying the five locked dimensions (preview / confirm / idempotency / failure-code
+/ permission-audit) — **without flattening the three different back-ends**:
+
+- **Manual adjustment** — `POST /api/attendance/annual-leave-manual-adjustment`.
+- **Expiry backfill** — `POST /api/attendance/annual-leave-expiry-backfill`.
+- **Accrual run** — `POST /api/attendance/annual-leave-accrual/run`.
+
+Read+config (L5a/L5b) already shipped; this is the mutating-operations layer the L5 design-lock deferred.
+
+## 2. The load-bearing distinction, as built
+
+**Dry-run is not one capability.** Accrual and backfill have a **server dry-run** (the backend returns an
+authoritative preview without mutating). Manual adjustment has **no server dry-run** — its "preview" is a
+**client-side** computation of `current → resulting` from the L5a balance read, explicitly labelled advisory, with
+the **backend `422 ANNUAL_LEAVE_BALANCE_INSUFFICIENT` as the final authority** on a save. The two are kept in
+separate code paths and separate UI copy; the client preview is never labelled a "dry-run".
+
+Likewise the **result shapes differ and are never flattened**: accrual `skipReasons` and backfill `reasons` render as
+a **code → count table** (they are object maps); manual adjustment returns `{ id, delta, applied, alreadyApplied }`
+and is rendered as discrete fields + badges, never routed through the reasons table.
+
+## 3. Per-card 口径 as built
+
+**Manual adjustment (client preview).** Inputs userId / deltaMinutes (±) / reason; a **Preview** computes
+before→after from the L5a read; **Adjust balance** opens the in-DOM confirm restating the request; on confirm the POST
+carries a per-attempt **idempotency key** (so a double-submit is a server no-op). The result surfaces the returned
+**adjustment `id`** and an `Applied` / `Already applied (no change)` badge. `runId` is **scoped out of v1** (standalone
+adjustments), so `ANNUAL_LEAVE_ADJUST_RUN_NOT_FOUND` is unreachable from the card and is not in its rendered codes.
+
+**Expiry backfill (server dry-run).** **Dry-run** posts `{dryRun:true}` and renders the `{scanned, updated, skipped}`
+counts + the **reasons code→count table** (`ALREADY_SET` framed as a concurrent-write no-op, not a failure);
+**Commit backfill** opens the confirm restating the dry-run counts, then posts `{dryRun:false}`.
+
+**Accrual run (server dry-run + period guardrail).** Inputs period (year) / optional as-of; **Dry-run** posts
+`{period, dryRun:true}` → summary + `skipReasons` table; **Commit accrual** opens the confirm restating the dry-run
+numbers. When the period is **not the current or next year**, the confirm requires an **extra explicit checkbox**
+(拍板 C — soft-warn, *not* a hard block). The committed result surfaces `runId` + `periodKey` (provenance). The
+commit is **disabled when the policy is off** (load-bearing — the backend `422`s `ANNUAL_LEAVE_NOT_ENABLED`).
+
+## 4. Shared scaffold
+
+- **In-DOM confirm panel** (`role="dialog"`, real overlay) that restates the resolved request as a table — *not*
+  `window.confirm` (which cannot show a structured restatement). The confirm is **authoritative**: it consumes a
+  **snapshot** of the request captured when it opened, so editing an input while the panel is open cannot change what
+  is submitted (see §6 review trail — this was hardened after review).
+- **`annualOpsErrorLine(code)`** — one mapper from the real per-endpoint error codes to human lines, with a fallback.
+- **`annualOpsPost(path, body, fallback)`** — shared POST that pins `orgId` in the body (so the write lands in the
+  current org via `getOrgId` precedence) and surfaces structured `error.code`s; routes `403 → adminForbidden`.
+- **`annualOpsPolicyEnabled`** — computed off `annualPolicyForm.enabled`, hydrated first-screen via
+  `loadSettings → applyAnnualPolicyToForm`; load-bearing disable on the accrual commit, informational hint elsewhere.
+
+## 5. Symbols + stable selectors (for L6 + future reference)
+
+Section id `attendance-admin-annual-leave-operations` (rail: `ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations`).
+Cards: `[data-annual-ops-card="adjust|backfill|accrual"]`; results `[data-annual-ops-result-*]`; errors
+`[data-annual-ops-error-*]`; confirm panel `[data-annual-ops-confirm]` + submit `[data-annual-ops-confirm-submit]`;
+off-year extra confirm `[data-annual-ops-extra-confirm]`; policy-off hint `[data-annual-ops-policy-off]`.
+
+## 6. Verification
+
+- **`vue-tsc -b`** (project-references build, not `--noEmit`): **0 errors**.
+- **Local vitest**: `attendance-admin-regressions` + `attendance-admin-anchor-nav` → **119 passed**. New tests:
+  manual-adjust (preview → in-DOM confirm → POST body incl. idempotency key → result id); backfill (dry-run code→count
+  table → commit `dryRun:false`); accrual off-year (extra-confirm gating + `skipReasons` table); policy-off accrual
+  disable; **TOCTOU snapshot** (tamper the period while the confirm is open → the POST carries the snapshot, not the
+  tampered value); error-code → human-line mapping.
+- **attendance-web-guard**: anchor-nav `29 → 30` on both literals (`groupLabels` unchanged at 6).
+
+### Adversarial review trail (honest)
+
+Two independent adversarial reviewers checked the build against the backend on `main`. The five named classes
+(contract accuracy, anti-flatten, `orgId` routing, failure-surface, idempotency legibility) and RBAC / gate
+placement / two-step structure / numeric+idempotency safety / test wire-honesty were all **clean**. Both reviewers
+independently caught one real **P2** on the highest-stakes card: the confirm re-read the **live form** on submit and
+the modal had **no CSS** (rendered inline, the form still interactive underneath) — so editing the period after the
+panel opened could fire a **never-previewed** accrual with the off-year guard bypassed. **Fixed:** `submit*` now
+consumes a snapshot taken at confirm-open time; a watch invalidates a stale dry-run on any period/as-of edit; the
+modal is a real fixed overlay. P3s (a dead error-code mapper entry; an untested mapper) were also fixed. The passing
+tests had missed the P2 because they dry-ran and committed the same period — the lesson logged is that the build's own
+tests can pass against a real safety hole, so the adversarial pass + the new TOCTOU test were necessary.
+
+## 7. L6-readiness handoff
+
+The L6 staging smoke (owner-run, per the merged runbook) can now drive these buttons end-to-end: enable the policy
+(L5b) → accrual **Dry-run** then **Commit accrual** (server dry-run residue + real grant + idempotent re-run) →
+**Manual adjustment** (write + idempotency replay) → backfill **Dry-run** → and the L1 reaper via the scheduler. The
+runbook's `user_orgs` single-member-org gate and residue=0 teardown remain the L6 owner's responsibility.
+
+## 8. Out of scope / deferred
+
+- **Employee `/me` self-service balance view** — a separate future endpoint (subject locked to the token), per the L5
+  design-lock; never mixed into this admin surface.
+- **`runId`-linked corrections** in the adjust card — API-only for now; a small additive input later (re-open the
+  design-lock first).
+- **A full audit-history viewer** — out of v1; each card surfaces its returned identifiers (adjustment `id`, run
+  `runId`/`periodKey`) inline.


### PR DESCRIPTION
Implements **L5c** per the merged design-lock (#2795) and dev-plan (#2826): the admin UI for the three balance-mutating annual-leave endpoints, in **one** 年假操作 / Annual leave operations section (3rd item in the existing 年假/法定假 nav group; anchor-nav **29→30**), one PR.

## Cards
- **Manual adjustment** — client preview (current→resulting from the L5a read; backend 422 is final), per-attempt idempotency key, surfaces the returned adjustment `id`. `runId` scoped out of v1.
- **Expiry backfill** — server dry-run → `{scanned,updated,skipped}` + a **code→count reasons table** → commit.
- **Accrual run** — server dry-run, **off-current/next-year → extra-confirm** (拍板 C, soft-warn not hard-block), surfaces `runId`/`periodKey`; commit disabled when the policy is off (load-bearing).

## Discipline
The three back-ends are **not flattened**: server-dry-run (accrual/backfill) vs client-preview (manual-adjust) are distinct paths/copy; `reasons`/`skipReasons` render as object→table, manual-adjust as discrete fields. The confirm is an **in-DOM overlay** (not `window.confirm`) and is **authoritative** — it consumes a snapshot taken when it opens, so editing a field while it's open can't change what's submitted. Policy gate hydrated first-screen; writes pin `orgId` in the body; every write routes `403→adminForbidden`.

## Verification
`vue-tsc -b` 0 errors; **119/119** web specs (regressions + anchor-nav). Two adversarial reviewers verified contract/anti-flatten/RBAC/etc. clean and caught one real **P2** (confirm re-read the live form + unstyled modal → a never-previewed accrual was reachable) — **fixed** (snapshot + clear-on-change + real overlay) and locked by a **TOCTOU test**. Full trail + L6-readiness handoff in the included **dev+verification closeout MD** (`docs/development/attendance-annual-leave-admin-operations-dev-verification-20260617.md`).

Out of scope (deferred): employee `/me` self-view, `runId`-linked corrections, a full audit-history viewer. **L6 staging smoke** is the downstream owner-run gate; the whole-engine ✅ awaits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)