### PR TITLE
feat(multitable): 2a-1 live CRDT for select + date (dual-reader migration; dateTime deferred w/ cause)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -198,6 +198,7 @@ jobs:
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
+            tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -6,9 +6,9 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="date"
-      :value="textControlValue(modelValue)"
-      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
-      @keydown.enter="emit('confirm')"
+      :value="textControlValue(scalarActive ? scalarValue : modelValue)"
+      @input="commitScalar(($event.target as HTMLInputElement).value)"
+      @keydown.enter="scalarConfirm()"
       @keydown.escape="emit('cancel')"
     />
     <!-- datetime field type -->
@@ -146,8 +146,8 @@
       v-else-if="field.type === 'select'"
       ref="inputRef"
       class="meta-cell-editor__select"
-      :value="modelValue ?? ''"
-      @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value); emit('confirm')"
+      :value="(scalarActive ? scalarValue : modelValue) ?? ''"
+      @change="commitScalar(($event.target as HTMLSelectElement).value); scalarConfirm()"
       @keydown.escape="emit('cancel')"
     >
       <option value="">—</option>
@@ -497,16 +497,33 @@ const yjsCollaborators = computed(() => yjsBinding.collaborators.value)
 // `scalarActive` flips true only once a live Y.Doc is attached AND the field
 // key exists in the Y.Map (the backend seeds atomic fields as plain LWW values).
 // Wired for the atomic types that read directly from modelValue (no local edit
-// buffer): numeric/boolean + rating (number) + multiSelect (string[]).
-// DEFERRED: `duration` has an intentional local text buffer decoupled from
-// modelValue (advisor B: live re-derivation fights the typist); `select`/`date`/
-// `dateTime` are string-stored atomics seeded as Y.Text today — flipping them to
-// plain-value is a separate gated call (persisted docs hold them as Y.Text, so it
-// needs a migration story, not just a seed flip).
+// buffer): numeric/boolean + rating (number) + multiSelect (string[]), and (2a-1)
+// the string-stored atomics select + date via the dual-reader (coerceText: a
+// persisted Y.Text reads as a string, an edit writes a plain string → lazy
+// convergence, no seed flip / migration needed; the value written is the exact
+// stored shape — select option value, date raw string — verified no-corruption
+// on real PG).
+// DEFERRED: `dateTime` — the backend codec normalizes it to canonical UTC ISO, so
+// the editor-written value diverges from the stored form (a tz round-trip/display
+// question; the real-DB golden surfaced it). `duration` — an intentional local text
+// buffer (advisor B: live re-derivation fights the typist). Both are separate gates.
 // Inactive → byte-identical REST path (setValue is a no-op; nothing changes).
 const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 'multiSelect']
+// 2a-1: string-stored ATOMIC types. Values are strings but atomic (LWW, not
+// char-merge), so they bind via useYjsScalarCell like the other scalars. They
+// may exist in a persisted doc as Y.Text (the historical seed shape), so the
+// binding is constructed with coerceText (read Y.Text-or-plain) and writes a
+// plain string on edit — lazy convergence, no seed flip / migration needed.
+// dateTime is DEFERRED: the backend codec normalizes it to a canonical UTC ISO
+// string, so the value the editor writes diverges from the stored form — a tz
+// round-trip/display-consistency question that needs its own decision (the
+// real-DB corruption golden surfaced this). select + date have no such codec
+// conversion (exact string round-trip), so they ship here.
+const STRING_STORED_ATOMIC_YJS_TYPES = ['select', 'date']
+const isScalarYjsType = (t: string | undefined): boolean =>
+  !!t && (SCALAR_YJS_TYPES.includes(t) || STRING_STORED_ATOMIC_YJS_TYPES.includes(t))
 const scalarFieldIdRef = computed<string | null>(() => {
-  if (!props.field || !SCALAR_YJS_TYPES.includes(props.field.type)) return null
+  if (!props.field || !isScalarYjsType(props.field.type)) return null
   if (!props.recordId) return null
   return props.field.id
 })
@@ -516,11 +533,13 @@ const inertScalarBinding: YjsScalarCellBinding = {
   setValue: () => { /* inactive: caller keeps using REST */ },
   release: () => { /* nothing to release */ },
 }
-const scalarEligibleAtSetup = !!props.field && SCALAR_YJS_TYPES.includes(props.field.type) && !!props.recordId
+const scalarEligibleAtSetup = !!props.field && isScalarYjsType(props.field.type) && !!props.recordId
 const scalarBinding = scalarEligibleAtSetup
   ? useYjsScalarCell({
       recordId: computed<string | null>(() => recordIdRef.value ?? null),
       fieldId: scalarFieldIdRef,
+      // Dual-reader for string-stored atomics so a persisted Y.Text reads as a string.
+      coerceText: !!props.field && STRING_STORED_ATOMIC_YJS_TYPES.includes(props.field.type),
       onFallback: (reason) => {
         if (reason === 'disabled') return
         // eslint-disable-next-line no-console

--- a/apps/web/src/multitable/composables/useYjsScalarCell.ts
+++ b/apps/web/src/multitable/composables/useYjsScalarCell.ts
@@ -41,6 +41,15 @@ export interface UseYjsScalarCellOptions {
   fieldId: Ref<string | null>
   /** Connect-timeout override (tests). */
   connectTimeoutMs?: number
+  /**
+   * Dual-reader for string-stored atomics (select/date/dateTime). When true, a
+   * `Y.Text` value read from the map is coerced to its string via `.toString()`.
+   * This lets a string-stored atomic cell bind even when an existing/persisted
+   * doc still holds the field as `Y.Text` (the historical seed shape); on the
+   * first `setValue` it converges to a plain string (LWW). Off by default so
+   * genuine non-string scalars (number/boolean/array) are returned verbatim.
+   */
+  coerceText?: boolean
   /** Soft-fallback notification; callers MUST continue with REST regardless. */
   onFallback?: (reason: 'timeout' | 'error' | 'disabled') => void
 }
@@ -113,7 +122,11 @@ export function useYjsScalarCell<T = unknown>(options: UseYjsScalarCellOptions):
     const present = !!map && !!fid && map.has(fid)
     if (yjs.synced.value && present) {
       clearTimer()
-      value.value = map!.get(fid!) as T
+      const raw = map!.get(fid!)
+      // Dual-reader: a string-stored atomic cell (coerceText) may find a
+      // persisted Y.Text under its key — coerce to the plain string. Genuine
+      // scalars are returned verbatim.
+      value.value = (options.coerceText === true && raw instanceof Y.Text ? raw.toString() : raw) as T
       active.value = true
     } else if (!present && active.value) {
       active.value = false

--- a/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
@@ -212,4 +212,69 @@ describe('MetaCellEditor scalar Yjs wiring', () => {
     expect(onYjsCommit).not.toHaveBeenCalled()
     expect(onConfirm).toHaveBeenCalled()
   })
+
+  // --- 2a-1: string-stored atomics select / date (dual-reader; value = exact stored shape) ---
+  it('active select: change writes the option-value string via setValue + emits yjs-commit then confirm', async () => {
+    scalarActive.value = true
+    scalarVal.value = 'optA'
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'optA' }, { value: 'optB' }] }, 'optA', { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const select = container!.querySelector('select') as HTMLSelectElement
+    expect(select).toBeTruthy()
+    select.value = 'optB'
+    select.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(setValueMock).toHaveBeenCalledWith('optB')
+    expect(onUpdate).toHaveBeenCalledWith('optB')
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('inactive select: REST byte-identical — setValue not called, no yjs-commit', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'optA' }, { value: 'optB' }] }, 'optA', { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const select = container!.querySelector('select') as HTMLSelectElement
+    select.value = 'optB'
+    select.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith('optB')
+    expect(onYjsCommit).not.toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('active date: input writes the date string via setValue; Enter emits yjs-commit then confirm', async () => {
+    scalarActive.value = true
+    scalarVal.value = '2026-01-01'
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_day', name: 'Day', type: 'date' }, '2026-01-01', { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const input = container!.querySelector('input[type="date"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    input.value = '2026-02-02'
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(setValueMock).toHaveBeenCalledWith('2026-02-02')
+    expect(onUpdate).toHaveBeenCalledWith('2026-02-02')
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('inactive date: REST byte-identical — setValue not called, no yjs-commit', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_day', name: 'Day', type: 'date' }, '2026-01-01', { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const input = container!.querySelector('input[type="date"]') as HTMLInputElement
+    input.value = '2026-02-02'
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith('2026-02-02')
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(onYjsCommit).not.toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
 })

--- a/apps/web/tests/multitable-yjs-scalar-cell.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell.spec.ts
@@ -144,4 +144,47 @@ describe('useYjsScalarCell', () => {
     m.binding.setValue(2)
     expect(sharedDoc.getMap('fields').get('fld_num')).toBe(1) // unchanged
   })
+
+  // --- 2a-1: dual-reader (coerceText) for string-stored atomics (select/date/dateTime) ---
+  async function mountCoerce(fieldId: string) {
+    const { useYjsScalarCell } = await loadScalar()
+    let binding!: ReturnType<typeof useYjsScalarCell>
+    const Comp = defineComponent({
+      setup() {
+        binding = useYjsScalarCell({ recordId: ref('rec1'), fieldId: ref(fieldId), connectTimeoutMs: 200, coerceText: true })
+        return () => h('div')
+      },
+    })
+    const c = document.createElement('div'); document.body.appendChild(c)
+    const a = createApp(Comp); a.mount(c); await flush()
+    return { binding, app: a, container: c }
+  }
+
+  it('coerceText reads a persisted Y.Text value as its plain string (dual-reader)', async () => {
+    const yt = new Y.Text(); yt.insert(0, 'optA')
+    sharedDoc.getMap('fields').set('fld_sel', yt)
+    const m = await mountCoerce('fld_sel')
+    app = m.app; container = m.container
+    expect(m.binding.active.value).toBe(true)
+    expect(m.binding.value.value).toBe('optA')
+    expect(typeof m.binding.value.value).toBe('string') // not a Y.Text object
+  })
+
+  it('coerceText reads a plain string verbatim (post-convergence)', async () => {
+    sharedDoc.getMap('fields').set('fld_date', '2026-01-01')
+    const m = await mountCoerce('fld_date')
+    app = m.app; container = m.container
+    expect(m.binding.value.value).toBe('2026-01-01')
+  })
+
+  it('coerceText setValue writes a PLAIN string, replacing the Y.Text (lazy convergence)', async () => {
+    const yt = new Y.Text(); yt.insert(0, 'optA')
+    sharedDoc.getMap('fields').set('fld_sel', yt)
+    const m = await mountCoerce('fld_sel')
+    app = m.app; container = m.container
+    m.binding.setValue('optB')
+    const stored = sharedDoc.getMap('fields').get('fld_sel')
+    expect(stored).toBe('optB')
+    expect(stored instanceof Y.Text).toBe(false)
+  })
 })

--- a/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
@@ -197,11 +197,22 @@ describeIfDatabase('Yjs string-stored atomic MIGRATION (real DB) — select/date
       await new Promise((r) => setTimeout(r, 500))
 
       const data = await readData()
-      for (const [k, v] of [[F_SELECT, EDIT_SELECT], [F_DATE, EDIT_DATE], [F_DATETIME, EDIT_DATETIME]] as const) {
+      // WIRED string-stored atomics (select + date): exact round-trip, no corruption. These have no
+      // normalizing codec, so the plain string the dual-reader writes is persisted verbatim.
+      for (const [k, v] of [[F_SELECT, EDIT_SELECT], [F_DATE, EDIT_DATE]] as const) {
         expect(typeof data[k]).toBe('string')
         expect(data[k]).toBe(v)
         expect(data[k]).not.toBe('[object Object]')
       }
+      // dateTime is DEFERRED from live wiring precisely because its codec normalizes to canonical UTC
+      // ISO — a plain-string flush does NOT round-trip the raw input. Assert it is a valid normalized
+      // string (NOT corrupted: not a Y.Text object, not '[object Object]', not a nested Yjs type) but
+      // NOT the raw input — this is the evidence that dateTime must stay REST-only (not in
+      // STRING_STORED_ATOMIC_YJS_TYPES) until a tz-aware live-edit design exists.
+      expect(typeof data[F_DATETIME]).toBe('string')
+      expect(data[F_DATETIME]).not.toBe('[object Object]')
+      expect(data[F_DATETIME]).not.toBe(EDIT_DATETIME) // normalized by the codec, not the raw input
+      expect(data[F_DATETIME] as string).toMatch(/\dT\d.*Z$/) // canonical UTC ISO, a valid (uncorrupted) string
     } finally {
       bridge.unobserve(REC_ID)
       await svc.destroy()

--- a/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Real-DB persisted-Y.Text CORRUPTION GOLDEN — the gate for 2a-1 (live CRDT for the string-stored
+ * atomics select / date / dateTime via the dual-reader migration).
+ *
+ * The migration story: these fields are stored as strings, and the historical seed shape puts ALL
+ * strings into the `fields` Y.Map as **Y.Text**. So an existing/persisted record doc holds
+ * select/date/dateTime as Y.Text. The new dual-reader binding (useYjsScalarCell coerceText) reads a
+ * Y.Text as its string, and on edit WRITES a PLAIN string (Y.Map.set), which replaces the Y.Text →
+ * lazy convergence. The backend bridge already collects both Y.Text->toString and plain values, so
+ * the stored shape stays a string either way.
+ *
+ * This golden proves there is NO corruption across that transition on REAL Postgres:
+ *   1. After the seed, the fields ARE Y.Text (asserts the old-doc scenario is real, not a strawman).
+ *   2. A synced client edits each with a PLAIN string (replacing the Y.Text), the bridge flushes
+ *      through the REAL RecordWriteService.patchRecords, and meta_records.data keeps the EXACT
+ *      native string — never a Y.Text object, never '[object Object]', never a nested Yjs type.
+ *
+ * Models yjs-scalar-flush-realdb (rating/multiSelect). Runs only with DATABASE_URL (sentinel
+ * fails-not-skips per the suite convention). The bridge's flushNow swallows write errors, so broken
+ * wiring shows up as a FAILED DB assertion below, never a false green.
+ */
+import { EventEmitter } from 'events'
+import type { Request } from 'express'
+import * as Y from 'yjs'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { YjsSyncService } from '../../src/collab/yjs-sync-service'
+import { YjsRecordBridge } from '../../src/collab/yjs-record-bridge'
+import { RecordWriteService, type RecordPatchInput } from '../../src/multitable/record-write-service'
+import { createRecordWriteHelpers } from '../../src/routes/univer-meta'
+import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const TS = Date.now()
+const BASE_ID = `base_strdate_${TS}`
+const SHEET_ID = `sheet_strdate_${TS}`
+const REC_ID = `rec_strdate_${TS}`
+const ACTOR = `u_strdate_${TS}`
+const SOCKET = `socket_strdate_${TS}`
+
+const F_SELECT = 'fld_select'
+const F_DATE = 'fld_date'
+const F_DATETIME = 'fld_datetime'
+const SELECT_OPTS = [{ value: 'optA' }, { value: 'optB' }]
+
+// initial (seed) values — strings; the seed will store them as Y.Text.
+const SEED = { [F_SELECT]: 'optA', [F_DATE]: '2026-01-01', [F_DATETIME]: '2026-01-01T10:00' }
+// edited values — what the client writes as PLAIN strings.
+const EDIT_SELECT = 'optB'
+const EDIT_DATE = '2026-02-02'
+const EDIT_DATETIME = '2026-02-02T12:30'
+
+async function readData(): Promise<Record<string, unknown>> {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [REC_ID])
+  return (r.rows[0]?.data as Record<string, unknown>) ?? {}
+}
+
+function makeGetWriteInput() {
+  return async (recordId: string, patch: Record<string, unknown>, actorId: string): Promise<RecordPatchInput | null> => {
+    const rec = await q('SELECT sheet_id FROM meta_records WHERE id = $1', [recordId])
+    if (rec.rows.length === 0) return null
+    const sheetId = String((rec.rows[0] as { sheet_id: string }).sheet_id)
+    const fr = await q(
+      'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
+      [sheetId],
+    )
+    const fields = (fr.rows as Array<Record<string, unknown>>).map((f) => {
+      const prop = f.property && typeof f.property === 'object' ? (f.property as Record<string, unknown>) : {}
+      return { id: String(f.id), name: String(f.name), type: f.type as string, property: prop, options: prop.options, order: Number(f.order ?? 0) }
+    })
+    const fieldById = new Map(
+      fields.map((f) => {
+        const prop = (f.property || {}) as Record<string, unknown>
+        const guard: Record<string, unknown> = { type: f.type, readOnly: false, hidden: false }
+        if (f.type === 'select' && Array.isArray(prop.options)) {
+          guard.options = (prop.options as unknown[]).map((o) => (typeof o === 'string' ? o : (o as { value?: string })?.value ?? ''))
+        }
+        return [f.id, guard] as const
+      }),
+    )
+    const changesByRecord = new Map([
+      [recordId, Object.entries(patch).map(([fieldId, value]) => ({ fieldId, value }))],
+    ])
+    const capabilities = deriveCapabilities(['multitable:read', 'multitable:write'], false)
+    return {
+      sheetId,
+      changesByRecord,
+      actorId,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fields: fields as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      visiblePropertyFields: fields as any,
+      visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+      attachmentFields: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fieldById: fieldById as any,
+      capabilities,
+      access: { userId: actorId, permissions: ['multitable:read', 'multitable:write'], isAdminRole: false },
+      source: 'yjs-bridge',
+    }
+  }
+}
+
+describeIfDatabase('Yjs string-stored atomic MIGRATION (real DB) — select/date/dateTime seeded as Y.Text, edited to plain, no corruption', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'StrDate Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'StrDate Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_SELECT, SHEET_ID, 'Status', 'select', JSON.stringify({ options: SELECT_OPTS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_DATE, SHEET_ID, 'Day', 'date', JSON.stringify({}), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_DATETIME, SHEET_ID, 'When', 'dateTime', JSON.stringify({}), 3])
+  })
+  beforeEach(async () => {
+    await q(
+      'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ' +
+        'ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1',
+      [REC_ID, SHEET_ID, JSON.stringify(SEED)],
+    )
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE id = $1', [REC_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('seed stores select/date/dateTime as Y.Text (the old-doc shape the dual-reader must tolerate)', async () => {
+    const persistence = { loadDoc: async () => null, storeUpdate: async () => {}, storeSnapshot: async () => {}, destroy: async () => {} }
+    const recordSeed = async (recordId: string): Promise<Record<string, unknown> | null> => {
+      const res = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+      return (res.rows[0]?.data as Record<string, unknown>) ?? null
+    }
+    const svc = new YjsSyncService(persistence as never, recordSeed)
+    try {
+      const doc = await svc.getOrCreateDoc(REC_ID)
+      const fields = doc.getMap('fields')
+      // The historical seed shape: all three string-stored atomics arrive as Y.Text.
+      expect(fields.get(F_SELECT) instanceof Y.Text).toBe(true)
+      expect(fields.get(F_DATE) instanceof Y.Text).toBe(true)
+      expect(fields.get(F_DATETIME) instanceof Y.Text).toBe(true)
+      // And they read back as the exact seed strings (what coerceText does on the FE).
+      expect((fields.get(F_SELECT) as Y.Text).toString()).toBe('optA')
+      expect((fields.get(F_DATE) as Y.Text).toString()).toBe('2026-01-01')
+      expect((fields.get(F_DATETIME) as Y.Text).toString()).toBe('2026-01-01T10:00')
+    } finally {
+      await svc.destroy()
+    }
+  })
+
+  test('plain-string edit over a seeded Y.Text → bridge → patchRecords → DB keeps EXACT strings (no Y.Text / [object Object])', async () => {
+    const pool = poolManager.get()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const eventBus = new EventEmitter() as any
+    const fakeReq = { user: { id: ACTOR, roles: [], perms: ['multitable:read', 'multitable:write'] } } as unknown as Request
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const helpers = createRecordWriteHelpers(fakeReq, pool as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const recordWriteService = new RecordWriteService(pool as any, eventBus, helpers)
+    const persistence = { loadDoc: async () => null, storeUpdate: async () => {}, storeSnapshot: async () => {}, destroy: async () => {} }
+    const recordSeed = async (recordId: string): Promise<Record<string, unknown> | null> => {
+      const res = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+      return (res.rows[0]?.data as Record<string, unknown>) ?? null
+    }
+    const svc = new YjsSyncService(persistence as never, recordSeed)
+    const bridge = new YjsRecordBridge(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc as any,
+      recordWriteService,
+      makeGetWriteInput(),
+      { mergeWindowMs: 50, maxDelayMs: 200 },
+      (socketId: string) => (socketId === SOCKET ? ACTOR : 'unknown'),
+    )
+    try {
+      const doc = await svc.getOrCreateDoc(REC_ID)
+      bridge.observe(REC_ID, doc)
+      const fields = doc.getMap('fields')
+      // Precondition: seeded as Y.Text.
+      expect(fields.get(F_SELECT) instanceof Y.Text).toBe(true)
+
+      // The dual-reader binding writes a PLAIN string on edit (Y.Map.set replaces the Y.Text).
+      doc.transact(() => {
+        fields.set(F_SELECT, EDIT_SELECT)
+        fields.set(F_DATE, EDIT_DATE)
+        fields.set(F_DATETIME, EDIT_DATETIME)
+      }, SOCKET)
+      // After the write the values are plain strings, not Y.Text.
+      expect(fields.get(F_SELECT) instanceof Y.Text).toBe(false)
+
+      await new Promise((r) => setTimeout(r, 500))
+
+      const data = await readData()
+      for (const [k, v] of [[F_SELECT, EDIT_SELECT], [F_DATE, EDIT_DATE], [F_DATETIME, EDIT_DATETIME]] as const) {
+        expect(typeof data[k]).toBe('string')
+        expect(data[k]).toBe(v)
+        expect(data[k]).not.toBe('[object Object]')
+      }
+    } finally {
+      bridge.unobserve(REC_ID)
+      await svc.destroy()
+    }
+  })
+})


### PR DESCRIPTION
Gated arc 2a-1. Live LWW sync for string-stored atomics select + date via a dual-reader (useYjsScalarCell coerceText): a persisted Y.Text is read as its string, and the first edit writes a plain string (Y.Map.set), lazily converging old docs — no big-bang migration, no seed flip, no old-client read break (these types had no FE Yjs binding before). **dateTime deferred with cause**: backend codec normalizes to canonical UTC ISO → naive plain write can drift (the corruption golden surfaced it). **Gate = real-DB persisted-Y.Text corruption golden** (allowlisted; runs in test (20.x)): seed→Y.Text real, edit→plain→real patchRecords→meta_records.data keeps the exact native string, never a Y.Text object/[object Object]/nested type. FE 23/23; vue-tsc+tsc clean. 🤖 Generated with Claude Code