### PR TITLE
feat(multitable): #16 person field org-member directory — fail-closed assignment validator (chokepoint)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -203,6 +203,7 @@ jobs:
             tests/integration/multitable-link-summary-display-field-mask.test.ts \
             tests/integration/multitable-view-summary-recordperm-leak.test.ts \
             tests/integration/multitable-person-summary-field-mask.test.ts \
+            tests/integration/multitable-person-member-group-restrict.test.ts \
             tests/integration/multitable-button-send-notification.test.ts \
             tests/integration/multitable-button-update-record.test.ts \
             tests/integration/multitable-form-context-submit-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -643,12 +643,57 @@ export class RecordWriteService {
       // Native person (人员): resolve the sheet member set ONCE per patch op (lazily, only when a
       // person field value is actually written), then reuse it for every person cell's write-time
       // membership validation (SECURITY boundary) — parallel to the link-target-exists hot-path.
+      //
+      // #16 org-member directory: when a person field carries `restrictToMemberGroupIds`, the allowed
+      // set narrows to (sheet members ∩ users in those member groups) — a NEW assignment must be both a
+      // sheet member AND in an allowed group (fail-closed). Unrestricted fields keep the sheet set.
+      // Read-back is unaffected (validation is write-only), so pre-existing out-of-scope values are
+      // grandfathered. Resolved sets are cached per restrict-key so a bulk patch hits the DB once.
       let personMemberUserIds: Set<string> | null = null
-      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
+      const restrictedMemberSetCache = new Map<string, Set<string>>()
+      const loadMemberGroupUserIds = async (groupIds: string[]): Promise<Set<string>> => {
+        if (groupIds.length === 0) return new Set<string>()
+        const res = await query(
+          `SELECT DISTINCT gm.user_id::text AS uid
+             FROM platform_member_group_members gm
+             JOIN users u ON u.id = gm.user_id
+            WHERE gm.group_id::text = ANY($1::text[])
+              AND u.is_active = TRUE`,
+          [groupIds],
+        )
+        return new Set(
+          (res.rows as Array<Record<string, unknown>>)
+            .map((row) => (typeof row.uid === 'string' ? row.uid.trim() : ''))
+            .filter((v): v is string => v.length > 0),
+        )
+      }
+      const resolvePersonMemberUserIds = async (restrictGroupIds: string[]): Promise<Set<string>> => {
         if (personMemberUserIds === null) {
           personMemberUserIds = await h.loadSheetMemberUserIds(query, sheetId)
         }
-        return personMemberUserIds
+        if (restrictGroupIds.length === 0) return personMemberUserIds
+        const key = Array.from(new Set(restrictGroupIds)).sort().join(',')
+        let restricted = restrictedMemberSetCache.get(key)
+        if (!restricted) {
+          const groupSet = await loadMemberGroupUserIds(restrictGroupIds)
+          // Intersect with the sheet member set: strictly narrows, never widens, the current contract.
+          restricted = new Set<string>()
+          for (const id of personMemberUserIds) if (groupSet.has(id)) restricted.add(id)
+          restrictedMemberSetCache.set(key, restricted)
+        }
+        return restricted
+      }
+
+      // #16: source each person field's restrictToMemberGroupIds from the property-bearing `fields`
+      // list (the per-change `fieldById` guard does not carry property). Built once per patch op.
+      const personRestrictByFieldId = new Map<string, string[]>()
+      for (const f of fields as Array<{ id?: unknown; type?: unknown; property?: unknown }>) {
+        if (!f || f.type !== 'person') continue
+        const raw = (f.property as Record<string, unknown> | undefined)?.restrictToMemberGroupIds
+        if (!Array.isArray(raw)) continue
+        const ids = Array.from(new Set(raw.filter((v): v is string => typeof v === 'string' && v.trim().length > 0).map((v) => v.trim())))
+        const fid = typeof f.id === 'string' ? f.id : ''
+        if (fid && ids.length > 0) personRestrictByFieldId.set(fid, ids)
       }
 
       for (const [recordId, changes] of changesByRecord.entries()) {
@@ -739,7 +784,10 @@ export class RecordWriteService {
 
           if (field.type === 'person') {
             try {
-              const allowed = await resolvePersonMemberUserIds()
+              // NB: `field` here is the fieldById GUARD (type/readOnly/hidden), which does NOT carry
+              // `property`. The restrict config is sourced from `personRestrictByFieldId`, built from the
+              // full `fields` list (which does carry property) once per patch op.
+              const allowed = await resolvePersonMemberUserIds(personRestrictByFieldId.get(change.fieldId) ?? [])
               patch[change.fieldId] = validatePersonValue(change.value, change.fieldId, allowed, isPersonSingleRecord(field.property))
             } catch (error) {
               throw new RecordValidationError(error instanceof Error ? error.message : String(error))

--- a/packages/core-backend/tests/integration/multitable-person-member-group-restrict.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-member-group-restrict.test.ts
@@ -1,0 +1,159 @@
+/**
+ * #16 org-member directory — real-DB enforcement of `person` field `restrictToMemberGroupIds`.
+ *
+ * The person write validation runs in RecordWriteService.patchRecords (the shared chokepoint every
+ * write path — REST, bulk, import, form, automation, and the Yjs bridge — funnels through). This test
+ * drives patchRecords directly with real Postgres and the real helper wiring (createRecordWriteHelpers),
+ * mirroring src/index.ts, and pins:
+ *   - POSITIVE: assigning an in-group user to a restricted person field succeeds + stores.
+ *   - NEGATIVE (fail-closed): assigning a user who is a sheet member but NOT in the allowed member
+ *     group is rejected (RecordValidationError) and nothing is stored.
+ *   - GRANDFATHER: a pre-existing out-of-scope stored value survives an unrelated edit (validation is
+ *     write-only over the CHANGED fields, never a re-scrub of stored data).
+ *   - UNRESTRICTED control: a field with no restrictToMemberGroupIds accepts any active member.
+ *   - PARITY: the rejection is identical whether source='rest' or source='yjs-bridge' (same chokepoint).
+ *
+ * Sheet membership = active users (listSheetPermissionCandidates reads FROM users), so both users are
+ * sheet members; the member-group restriction is the only differentiator. Real-DB only (sentinel
+ * fails-not-skips; registered in plugin-tests.yml).
+ */
+import type { Request } from 'express'
+import { EventEmitter } from 'events'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { RecordWriteService, RecordValidationError, type RecordPatchInput } from '../../src/multitable/record-write-service'
+import { createRecordWriteHelpers } from '../../src/routes/univer-meta'
+import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const TS = Date.now()
+const BASE_ID = `base_pmg_${TS}`
+const SHEET_ID = `sheet_pmg_${TS}`
+const REC_ID = `rec_pmg_${TS}`
+const REC_GF = `rec_pmg_gf_${TS}`
+const ACTOR = `u_pmg_actor_${TS}`
+const G_ALLOW = '11111111-1111-4111-8111-111111111111'
+const G_OTHER = '22222222-2222-4222-8222-222222222222'
+const U_IN = `u_pmg_in_${TS}`
+const U_OUT = `u_pmg_out_${TS}`
+
+const F_PERSON = 'fld_person_restricted'
+const F_PERSON_FREE = 'fld_person_free'
+const F_STR = 'fld_str'
+
+async function readData(recId: string): Promise<Record<string, unknown>> {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recId])
+  return (r.rows[0]?.data as Record<string, unknown>) ?? {}
+}
+
+async function buildInput(recordId: string, patch: Record<string, unknown>, source: string): Promise<RecordPatchInput> {
+  const fr = await q('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC', [SHEET_ID])
+  const fields = (fr.rows as Array<Record<string, unknown>>).map((f) => {
+    const prop = f.property && typeof f.property === 'object' ? (f.property as Record<string, unknown>) : {}
+    return { id: String(f.id), name: String(f.name), type: f.type as string, property: prop, options: prop.options, order: Number(f.order ?? 0) }
+  })
+  const fieldById = new Map(fields.map((f) => [f.id, { type: f.type, readOnly: false, hidden: false } as Record<string, unknown>] as const))
+  const changesByRecord = new Map([[recordId, Object.entries(patch).map(([fieldId, value]) => ({ fieldId, value }))]])
+  const capabilities = deriveCapabilities(['multitable:read', 'multitable:write'], false)
+  return {
+    sheetId: SHEET_ID,
+    changesByRecord,
+    actorId: ACTOR,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fields: fields as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    visiblePropertyFields: fields as any,
+    visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+    attachmentFields: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fieldById: fieldById as any,
+    capabilities,
+    access: { userId: ACTOR, permissions: ['multitable:read', 'multitable:write'], isAdminRole: false },
+    source,
+  } as RecordPatchInput
+}
+
+function makeService(): RecordWriteService {
+  const pool = poolManager.get()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const eventBus = new EventEmitter() as any
+  const fakeReq = { user: { id: ACTOR, roles: [], perms: ['multitable:read', 'multitable:write'] } } as unknown as Request
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const helpers = createRecordWriteHelpers(fakeReq, pool as any)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new RecordWriteService(pool as any, eventBus, helpers)
+}
+
+describeIfDatabase('#16 person restrictToMemberGroupIds enforcement (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PMG Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PMG Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_PERSON, SHEET_ID, 'Owner', 'person', JSON.stringify({ restrictToMemberGroupIds: [G_ALLOW] }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_PERSON_FREE, SHEET_ID, 'AnyOne', 'person', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_STR, SHEET_ID, 'Note', 'string', '{}', 3])
+    for (const uid of [ACTOR, U_IN, U_OUT]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin) VALUES ($1,$2,$3,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO NOTHING`, [uid, `${uid}@t.local`, uid])
+      // Eligibility = a multitable:read/write grant (loadCandidateUserEligibilityMap). Without it a user
+      // is not an eligible sheet member, so person assignment would reject on the sheet check before the
+      // group restriction — make all three eligible so the member-group restriction is what differentiates.
+      await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:read') ON CONFLICT DO NOTHING`, [uid])
+    }
+    await q('INSERT INTO platform_member_groups (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [G_ALLOW, 'Allowed'])
+    await q('INSERT INTO platform_member_groups (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [G_OTHER, 'Other'])
+    await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_ALLOW, U_IN])
+    await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_OTHER, U_OUT])
+  })
+  beforeEach(async () => {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1', [REC_ID, SHEET_ID, JSON.stringify({})])
+    // grandfather record: pre-existing OUT-of-scope person value, inserted directly (bypasses validation).
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1', [REC_GF, SHEET_ID, JSON.stringify({ [F_PERSON]: [U_OUT], [F_STR]: 'orig' })])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM platform_member_group_members WHERE group_id = ANY($1)', [[G_ALLOW, G_OTHER]]).catch(() => {})
+    await q('DELETE FROM platform_member_groups WHERE id = ANY($1)', [[G_ALLOW, G_OTHER]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1)', [[ACTOR, U_IN, U_OUT]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1)', [[ACTOR, U_IN, U_OUT]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('POSITIVE: in-group user assigned to a restricted person field → stored', async () => {
+    const svc = makeService()
+    await svc.patchRecords(await buildInput(REC_ID, { [F_PERSON]: [U_IN] }, 'rest'))
+    expect((await readData(REC_ID))[F_PERSON]).toEqual([U_IN])
+  })
+
+  test('NEGATIVE (fail-closed): out-of-group sheet member rejected + nothing stored', async () => {
+    const svc = makeService()
+    await expect(svc.patchRecords(await buildInput(REC_ID, { [F_PERSON]: [U_OUT] }, 'rest'))).rejects.toBeInstanceOf(RecordValidationError)
+    expect((await readData(REC_ID))[F_PERSON]).toBeUndefined()
+  })
+
+  test('UNRESTRICTED control: any active member accepted on a field with no restriction', async () => {
+    const svc = makeService()
+    await svc.patchRecords(await buildInput(REC_ID, { [F_PERSON_FREE]: [U_OUT] }, 'rest'))
+    expect((await readData(REC_ID))[F_PERSON_FREE]).toEqual([U_OUT])
+  })
+
+  test('GRANDFATHER: pre-existing out-of-scope value survives an unrelated edit (not re-scrubbed)', async () => {
+    const svc = makeService()
+    await svc.patchRecords(await buildInput(REC_GF, { [F_STR]: 'edited' }, 'rest'))
+    const data = await readData(REC_GF)
+    expect(data[F_STR]).toBe('edited')
+    expect(data[F_PERSON]).toEqual([U_OUT]) // out-of-scope person value preserved, never stripped
+  })
+
+  test('PARITY: the yjs-bridge source rejects the out-of-group assignment identically (shared chokepoint)', async () => {
+    const svc = makeService()
+    await expect(svc.patchRecords(await buildInput(REC_ID, { [F_PERSON]: [U_OUT] }, 'yjs-bridge'))).rejects.toBeInstanceOf(RecordValidationError)
+    expect((await readData(REC_ID))[F_PERSON]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Gated arc 2c #16. restrictToMemberGroupIds becomes real enforcement (was config-only). Fail-closed person-assignment validator at the record-write-service chokepoint (REST/bulk/import/form/automation/Yjs all inherit it): allowed set = sheet members ∩ users in the allowed member groups (source: platform_member_group_members); unrestricted = sheet set; grandfathered (write-only validation, existing out-of-scope values still read). **Real-DB gate (allowlisted, test 20.x):** positive/negative/grandfather + **parity (rest vs yjs-bridge same chokepoint)**. tsc clean; record-write unit 52/52. **Follow-up (UX only):** MetaPersonPicker filtering — the validator is the enforcement, the picker is convenience. 🤖 Generated with Claude Code