### PR TITLE
fix(attendance): L5c — disable all three operation cards when policy is off (design-lock §6)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6253,7 +6253,7 @@
                 </div>
                 <div class="attendance__admin-actions">
                   <button class="attendance__btn" @click="() => previewAnnualAdjust()">{{ tr('Preview', '预览') }}</button>
-                  <button class="attendance__btn attendance__btn--primary" :disabled="annualAdjustSubmitting" @click="() => requestAnnualAdjust()">{{ annualAdjustSubmitting ? tr('Submitting...', '提交中...') : tr('Adjust balance', '调整余额') }}</button>
+                  <button class="attendance__btn attendance__btn--primary" :disabled="annualAdjustSubmitting || !annualOpsPolicyEnabled" @click="() => requestAnnualAdjust()">{{ annualAdjustSubmitting ? tr('Submitting...', '提交中...') : tr('Adjust balance', '调整余额') }}</button>
                 </div>
                 <p v-if="annualAdjustPreview" class="attendance__hint">{{ tr('Preview (client)', '预览(客户端)') }}: {{ annualAdjustPreview.before }} → {{ annualAdjustPreview.after }} {{ tr('min', '分钟') }} — <em>{{ tr('advisory; the server is the final authority', '仅供参考，以服务端为准') }}</em></p>
                 <p v-if="annualAdjustError" class="attendance__error" data-annual-ops-error-adjust>{{ annualAdjustError }}</p>
@@ -6268,8 +6268,8 @@
               <div class="attendance__admin-subsection" data-annual-ops-card="backfill">
                 <h5>{{ tr('Expiry backfill', '过期回填') }}</h5>
                 <div class="attendance__admin-actions">
-                  <button class="attendance__btn" :disabled="annualBackfillRunning" @click="() => runAnnualBackfillDryRun()">{{ tr('Dry-run', '预演') }}</button>
-                  <button class="attendance__btn attendance__btn--primary" :disabled="annualBackfillRunning || !annualBackfillDry" @click="() => requestAnnualBackfillCommit()">{{ tr('Commit backfill', '提交回填') }}</button>
+                  <button class="attendance__btn" :disabled="annualBackfillRunning || !annualOpsPolicyEnabled" @click="() => runAnnualBackfillDryRun()">{{ tr('Dry-run', '预演') }}</button>
+                  <button class="attendance__btn attendance__btn--primary" :disabled="annualBackfillRunning || !annualBackfillDry || !annualOpsPolicyEnabled" @click="() => requestAnnualBackfillCommit()">{{ tr('Commit backfill', '提交回填') }}</button>
                 </div>
                 <p v-if="annualBackfillError" class="attendance__error" data-annual-ops-error-backfill>{{ annualBackfillError }}</p>
                 <div v-if="annualBackfillDry" class="attendance__annual-ops-result" data-annual-ops-result-backfill>
@@ -6294,7 +6294,7 @@
                 </div>
                 <p v-if="annualAccrualOffYear" class="attendance__hint" data-annual-ops-accrual-offyear>⚠ {{ tr('Period is not the current or next year — committing requires an extra confirmation.', '年度非当前或次年——提交需要额外确认。') }}</p>
                 <div class="attendance__admin-actions">
-                  <button class="attendance__btn" :disabled="annualAccrualRunning" @click="() => runAnnualAccrualDryRun()">{{ tr('Dry-run', '预演') }}</button>
+                  <button class="attendance__btn" :disabled="annualAccrualRunning || !annualOpsPolicyEnabled" @click="() => runAnnualAccrualDryRun()">{{ tr('Dry-run', '预演') }}</button>
                   <button class="attendance__btn attendance__btn--primary" :disabled="annualAccrualRunning || !annualAccrualDry || !annualOpsPolicyEnabled" @click="() => requestAnnualAccrualCommit()">{{ tr('Commit accrual', '提交发放') }}</button>
                 </div>
                 <p v-if="annualAccrualError" class="attendance__error" data-annual-ops-error-accrual>{{ annualAccrualError }}</p>
@@ -20078,6 +20078,13 @@ function annualOpsErrorLine(code: string): string {
 
 // -- shared POST helper: pins orgId in the body so the write lands in the current org; surfaces structured codes --
 async function annualOpsPost(path: string, body: Record<string, unknown>, fallbackMsg: string): Promise<any | null> {
+  // design-lock §6: all three operation cards are blocked when the annual leave policy is disabled. The buttons are
+  // disabled in the template (proactive UX); this handler-level guard is the real gate — a keyboard / direct / test
+  // call cannot POST a mutation while the engine is off (accrual would 422 server-side anyway; adjust/backfill the
+  // backend still accepts, so this client guard is what enforces the consistency口径 the design-lock mandates).
+  if (!annualOpsPolicyEnabled.value) {
+    throw new Error(annualOpsErrorLine('ANNUAL_LEAVE_NOT_ENABLED'))
+  }
   const response = await apiFetch(path, { method: 'POST', body: JSON.stringify({ orgId: normalizedOrgId(), ...body }) })
   if (response.status === 403) {
     adminForbidden.value = true

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1198,9 +1198,14 @@ describe('Attendance admin regressions', () => {
     expect(bodies[1].period).toBe(2000)
   })
 
-  it('annual operations — accrual commit is disabled when the annual leave policy is off', async () => {
-    vi.mocked(apiFetch).mockImplementation(async (input) => {
+  it('annual operations — policy off: all three cards are disabled and none can POST a mutation (design-lock §6)', async () => {
+    const writePosts: string[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = String(input)
+      if ((url.includes('annual-leave-manual-adjustment') || url.includes('annual-leave-expiry-backfill') || url.includes('annual-leave-accrual/run')) && init?.method === 'POST') {
+        writePosts.push(url)
+        return jsonResponse(200, { ok: true, data: {} })
+      }
       if (url.includes('/api/attendance/settings')) {
         return jsonResponse(200, { ok: true, data: { annualLeavePolicy: { enabled: false, tenureMode: 'cumulative_service', standardDayMinutes: 480, tiers: [], carryover: { enabled: false }, timezone: null } } })
       }
@@ -1211,9 +1216,21 @@ describe('Attendance admin regressions', () => {
     await flushUi(8)
     const section = await openOpsSection()
     expect(section.querySelector('[data-annual-ops-policy-off]')).toBeTruthy()
-    const card = section.querySelector<HTMLElement>('[data-annual-ops-card="accrual"]')!
-    const commit = Array.from(card.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes('Commit accrual'))!
-    expect(commit.disabled).toBe(true) // load-bearing: accrual needs the engine enabled (backend 422s otherwise)
+    const btn = (cardSel: string, text: string) =>
+      Array.from(section.querySelector<HTMLElement>(cardSel)!.querySelectorAll<HTMLButtonElement>('button')).find(b => b.textContent?.includes(text))!
+    const actions = [
+      btn('[data-annual-ops-card="adjust"]', 'Adjust balance'),
+      btn('[data-annual-ops-card="backfill"]', 'Dry-run'),
+      btn('[data-annual-ops-card="backfill"]', 'Commit backfill'),
+      btn('[data-annual-ops-card="accrual"]', 'Dry-run'),
+      btn('[data-annual-ops-card="accrual"]', 'Commit accrual'),
+    ]
+    // every mutating action across all three cards is proactively disabled (accrual load-bearing; adjust/backfill consistency)
+    actions.forEach(b => expect(b.disabled).toBe(true))
+    // and no write can reach the backend (disabled buttons + the annualOpsPost handler guard)
+    actions.forEach(b => b.click())
+    await flushUi(4)
+    expect(writePosts).toEqual([])
   })
 
   it('annual operations — accrual: the submitted period is the snapshot at confirm time, not the live form (no TOCTOU)', async () => {


### PR DESCRIPTION
Follow-up to #2830 (merged). Your review caught a real **P2**: the build disabled only the accrual commit, but **design-lock §6** mandates **all three** operation cards proactively disable when `annualLeavePolicy.enabled=false` (accrual load-bearing — backend 422s; adjust/backfill for consistency + misoperation-prevention). I'd deviated to accrual-only during the build following my plan's R6 note; the design-lock is the authority.

**Fix:**
- Add `!annualOpsPolicyEnabled` to the **manual-adjust submit**, **backfill dry-run**, **backfill commit**, and **accrual dry-run** buttons (accrual commit already had it).
- A **handler-level guard** in `annualOpsPost` that throws `ANNUAL_LEAVE_NOT_ENABLED` when the policy is off — so no card can POST a mutation via a keyboard / direct / test call (your "avoid bypass" point). The read-only balance **preview** (a GET, via `apiFetch` directly) is unaffected.
- The policy-off regression test is expanded to assert **all three cards' actions are disabled AND no write POST reaches the backend**.

`vue-tsc -b` clean; **119/119** web specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)