### PR TITLE
docs(attendance): L5c closeout MD — append #2834 policy-off §6 correction

### DIFF
--- a/docs/development/attendance-annual-leave-admin-operations-dev-verification-20260617.md
+++ b/docs/development/attendance-annual-leave-admin-operations-dev-verification-20260617.md
@@ -105,3 +105,27 @@ runbook's `user_orgs` single-member-org gate and residue=0 teardown remain the L
   design-lock first).
 - **A full audit-history viewer** — out of v1; each card surfaces its returned identifiers (adjustment `id`, run
   `runId`/`periodKey`) inline.
+
+## Addendum — #2834: policy-off gate corrected to all three cards (design-lock §6)
+
+This **supersedes** the policy-off statements above that describe the #2830 build — §3 (Accrual run: "commit disabled
+when the policy is off"), §4 (Shared scaffold: "load-bearing disable on the accrual commit, informational hint
+elsewhere"), and §6's verification list ("policy-off accrual disable"). At #2830 only the **accrual commit** was
+disabled when `annualLeavePolicy.enabled === false`; manual-adjustment and backfill stayed callable — inconsistent
+with **design-lock §6** ("all three cards are proactively disabled… the adjustment/backfill cards disable for
+consistency and to steer the operator to enable the policy first").
+
+**Fixed in #2834 (`ca7d3051c`), on `main`:**
+- Every mutating action across **all three cards** is gated on `!annualOpsPolicyEnabled` — manual-adjust submit,
+  backfill dry-run, backfill commit, accrual dry-run, and accrual commit. The read-only balance **preview** (a GET)
+  stays enabled.
+- A **handler-level guard** in `annualOpsPost` throws `ANNUAL_LEAVE_NOT_ENABLED` when the policy is off, so no card
+  can POST a mutation via a keyboard / direct / test call — not only via the disabled buttons. Accrual remains
+  load-bearing on the server (the backend `422`s); adjust/backfill disable for consistency + misoperation-prevention,
+  per §6.
+- The policy-off regression test is **expanded** to assert **all three cards' actions are disabled AND that no write
+  POST reaches the backend** (`writePosts === []`), not merely the accrual commit.
+
+`vue-tsc -b` clean; **119/119** web specs. Lesson: a locked design-lock口径 (§6) outranks a plan's internal note —
+the #2830 accrual-only choice had followed the dev-plan's R6 "don't over-disable" note, but the merged design-lock is
+the authority.


### PR DESCRIPTION
Follow-up to your #2830 review [P3]: the L5c closeout MD still recorded the #2830 policy-off口径 (accrual-commit-only disable), which **#2834** superseded by disabling all three cards + adding a handler guard.

**Append-only** addendum (the body keeps the honest #2830-era record; the addendum corrects it) stating:
- all three cards' mutating actions gated on `!annualOpsPolicyEnabled` (manual-adjust submit, backfill dry-run/commit, accrual dry-run/commit);
- the `annualOpsPost` handler guard (no write POST via keyboard/direct/test, not only via disabled buttons);
- the expanded regression — all three disabled **and** `writePosts === []`.

No code change. Closes the documentation-evidence drift you flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)