### PR TITLE
feat(multitable): 2b-S1 conditional-rule parser/evaluator — pure, fail-closed, unwired

### DIFF
--- a/packages/core-backend/src/multitable/permission-rule-evaluator.ts
+++ b/packages/core-backend/src/multitable/permission-rule-evaluator.ts
@@ -1,0 +1,254 @@
+/**
+ * #18 phase-2 — conditional permission rules: PURE parser + evaluator (slice 2b-S1).
+ *
+ * UNWIRED ON PURPOSE. This module has no DB, no IO, and is NOT yet called by any route or by the
+ * #18 read-deny enforcement seam. A later slice (2b-S2) integrates `evaluateRecordDenied` into the
+ * existing per-record read-deny set under adversarial review. Keeping the evaluator pure + exhaustively
+ * unit-tested first is the safety discipline for this security arc.
+ *
+ * Model: a conditional read-deny rule DENIES READ of any record whose field value satisfies the
+ * predicate. Rules combine with OR — a record matched by ANY active deny_read rule is denied.
+ *
+ * FAIL-CLOSED invariant (the core security property): a rule that cannot be evaluated safely —
+ * missing/deleted field, operator not allowed for the field type, malformed rule value, or a predicate
+ * that throws — DENIES. For a deny-read rule, "when in doubt, hide" is the safe direction. The evaluator
+ * NEVER fails open (never lets a broken rule silently grant read).
+ *
+ * No side-channel leak: the returned `reason` names only the rule id — never the record's predicate
+ * field VALUE — so an error/telemetry surface cannot exfiltrate a hidden value.
+ */
+
+export type RuleEffect = 'deny_read'
+
+export type RuleOperator =
+  | 'eq'
+  | 'neq'
+  | 'isEmpty'
+  | 'isNotEmpty'
+  | 'contains'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'before'
+  | 'after'
+  | 'hasAny'
+  | 'hasNone'
+
+export interface ConditionalRule {
+  id: string
+  fieldId: string
+  operator: RuleOperator
+  value?: unknown
+  effect: RuleEffect
+}
+
+export interface FieldMeta {
+  id: string
+  type: string
+  /** A field flagged deleted is treated as missing (fail-closed). */
+  deleted?: boolean
+}
+
+export interface EvalRecord {
+  data: Record<string, unknown>
+}
+
+export interface EvalResult {
+  denied: boolean
+  /** Only ever a rule id (`rule:<id>`); never the record's field value. */
+  reason?: string
+}
+
+// ── field type → allowed operators (allowlist; a type/op pair not listed fails closed) ──
+const TEXT_OPS: RuleOperator[] = ['eq', 'neq', 'isEmpty', 'isNotEmpty', 'contains']
+const NUM_OPS: RuleOperator[] = ['eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'isEmpty', 'isNotEmpty']
+const BOOL_OPS: RuleOperator[] = ['eq', 'neq']
+const DATE_OPS: RuleOperator[] = ['eq', 'neq', 'before', 'after', 'isEmpty', 'isNotEmpty']
+const ARRAY_OPS: RuleOperator[] = ['hasAny', 'hasNone', 'isEmpty', 'isNotEmpty']
+
+const OPS_BY_TYPE: Record<string, RuleOperator[]> = {
+  text: TEXT_OPS,
+  singleLineText: TEXT_OPS,
+  longText: TEXT_OPS,
+  select: TEXT_OPS,
+  number: NUM_OPS,
+  currency: NUM_OPS,
+  percent: NUM_OPS,
+  rating: NUM_OPS,
+  duration: NUM_OPS,
+  boolean: BOOL_OPS,
+  checkbox: BOOL_OPS,
+  date: DATE_OPS,
+  dateTime: DATE_OPS,
+  multiSelect: ARRAY_OPS,
+  person: ARRAY_OPS,
+  user: ARRAY_OPS,
+}
+
+const ALL_OPERATORS: ReadonlySet<RuleOperator> = new Set<RuleOperator>([
+  ...TEXT_OPS,
+  ...NUM_OPS,
+  ...DATE_OPS,
+  ...ARRAY_OPS,
+])
+
+export interface ParsedRulesResult {
+  rules: ConditionalRule[]
+  rejected: Array<{ raw: unknown; reason: string }>
+}
+
+/**
+ * Parse + validate raw rule JSON into typed rules. Structurally-invalid rules are REJECTED here (at
+ * author time) and never reach the evaluator. Author-time rejection (bad shape / unknown operator /
+ * unsupported effect) is distinct from runtime fail-closed: a structurally-valid rule whose field is
+ * later deleted parses fine here and denies at evaluation.
+ */
+export function parseConditionalRules(raw: unknown): ParsedRulesResult {
+  const rules: ConditionalRule[] = []
+  const rejected: Array<{ raw: unknown; reason: string }> = []
+  if (!Array.isArray(raw)) {
+    return { rules, rejected: raw == null ? [] : [{ raw, reason: 'rules payload is not an array' }] }
+  }
+  for (const r of raw) {
+    if (r == null || typeof r !== 'object' || Array.isArray(r)) {
+      rejected.push({ raw: r, reason: 'rule is not an object' })
+      continue
+    }
+    const obj = r as Record<string, unknown>
+    const id = typeof obj.id === 'string' && obj.id.trim().length > 0 ? obj.id.trim() : null
+    const fieldId = typeof obj.fieldId === 'string' && obj.fieldId.trim().length > 0 ? obj.fieldId.trim() : null
+    if (!id) {
+      rejected.push({ raw: r, reason: 'missing id' })
+      continue
+    }
+    if (!fieldId) {
+      rejected.push({ raw: r, reason: 'missing fieldId' })
+      continue
+    }
+    if (obj.effect !== 'deny_read') {
+      rejected.push({ raw: r, reason: 'unsupported effect (only deny_read in 2b-S1)' })
+      continue
+    }
+    if (typeof obj.operator !== 'string' || !ALL_OPERATORS.has(obj.operator as RuleOperator)) {
+      rejected.push({ raw: r, reason: 'unknown operator' })
+      continue
+    }
+    rules.push({ id, fieldId, operator: obj.operator as RuleOperator, value: obj.value, effect: 'deny_read' })
+  }
+  return { rules, rejected }
+}
+
+function isEmptyValue(v: unknown): boolean {
+  if (v === null || v === undefined) return true
+  if (typeof v === 'string') return v.trim().length === 0
+  if (Array.isArray(v)) return v.length === 0
+  return false
+}
+
+function asNumberOrThrow(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  throw new Error('not a finite number')
+}
+
+function asStringOrThrow(v: unknown): string {
+  if (typeof v === 'string') return v
+  throw new Error('not a string')
+}
+
+function asArrayOrThrow(v: unknown): unknown[] {
+  if (Array.isArray(v)) return v
+  throw new Error('not an array')
+}
+
+/** Date comparison on canonical strings via Date.parse; throws on an unparseable side. */
+function dateMs(v: unknown): number {
+  const s = asStringOrThrow(v)
+  const ms = Date.parse(s)
+  if (Number.isNaN(ms)) throw new Error('unparseable date')
+  return ms
+}
+
+/**
+ * Returns true if the predicate MATCHES (⇒ this rule denies the record). Throws on a genuinely
+ * un-evaluable predicate (wrong-typed record value or rule value for the operator); the caller catches
+ * and fails closed (denies). Empty checks never throw — an absent value is a well-defined empty.
+ */
+function predicateMatches(op: RuleOperator, recordValue: unknown, ruleValue: unknown): boolean {
+  switch (op) {
+    case 'isEmpty':
+      return isEmptyValue(recordValue)
+    case 'isNotEmpty':
+      return !isEmptyValue(recordValue)
+    case 'eq':
+      // String/number/boolean equality with a type-matched rule value; mismatched types throw → deny.
+      if (typeof ruleValue === 'number') return asNumberOrThrow(recordValue) === ruleValue
+      if (typeof ruleValue === 'boolean') {
+        if (typeof recordValue !== 'boolean') throw new Error('not a boolean')
+        return recordValue === ruleValue
+      }
+      return asStringOrThrow(recordValue) === asStringOrThrow(ruleValue)
+    case 'neq':
+      return !predicateMatches('eq', recordValue, ruleValue)
+    case 'contains':
+      return asStringOrThrow(recordValue).includes(asStringOrThrow(ruleValue))
+    case 'gt':
+      return asNumberOrThrow(recordValue) > asNumberOrThrow(ruleValue)
+    case 'lt':
+      return asNumberOrThrow(recordValue) < asNumberOrThrow(ruleValue)
+    case 'gte':
+      return asNumberOrThrow(recordValue) >= asNumberOrThrow(ruleValue)
+    case 'lte':
+      return asNumberOrThrow(recordValue) <= asNumberOrThrow(ruleValue)
+    case 'before':
+      return dateMs(recordValue) < dateMs(ruleValue)
+    case 'after':
+      return dateMs(recordValue) > dateMs(ruleValue)
+    case 'hasAny': {
+      const rec = asArrayOrThrow(recordValue)
+      const want = asArrayOrThrow(ruleValue)
+      return rec.some((x) => want.includes(x))
+    }
+    case 'hasNone': {
+      const rec = asArrayOrThrow(recordValue)
+      const want = asArrayOrThrow(ruleValue)
+      return !rec.some((x) => want.includes(x))
+    }
+    default:
+      // Unreachable for a parsed rule, but fail closed if it ever happens.
+      throw new Error('unhandled operator')
+  }
+}
+
+/**
+ * Evaluate whether a record is read-denied by ANY conditional rule. PURE — no DB/IO. Fail-closed:
+ * a rule referencing a missing/deleted field, an operator not allowed for the field type, or a
+ * predicate that throws on a malformed value DENIES. Returns `{ denied:true, reason:'rule:<id>' }`
+ * on the first denying rule (reason carries no record value).
+ */
+export function evaluateRecordDenied(
+  record: EvalRecord,
+  rules: ConditionalRule[],
+  fieldsById: Record<string, FieldMeta | undefined>,
+): EvalResult {
+  for (const rule of rules) {
+    let denied: boolean
+    try {
+      const field = fieldsById[rule.fieldId]
+      if (!field || field.deleted === true) {
+        denied = true // fail-closed: missing / deleted field
+      } else {
+        const allowed = OPS_BY_TYPE[field.type]
+        if (!allowed || !allowed.includes(rule.operator)) {
+          denied = true // fail-closed: operator not allowed for this field type
+        } else {
+          denied = predicateMatches(rule.operator, record.data[rule.fieldId], rule.value)
+        }
+      }
+    } catch {
+      denied = true // fail-closed: any thrown predicate (malformed value) denies
+    }
+    if (denied) return { denied: true, reason: `rule:${rule.id}` }
+  }
+  return { denied: false }
+}

--- a/packages/core-backend/tests/unit/multitable-permission-rule-evaluator.test.ts
+++ b/packages/core-backend/tests/unit/multitable-permission-rule-evaluator.test.ts
@@ -1,0 +1,169 @@
+/**
+ * 2b-S1 — pure conditional-rule parser/evaluator unit matrix.
+ *
+ * Covers: parser author-time rejection; every (field type x allowed operator) positive + negative;
+ * the FAIL-CLOSED paths (missing field, deleted field, operator-not-allowed-for-type, malformed value,
+ * thrown predicate -> DENIED); OR-combination; and the no-value-leak reason invariant.
+ */
+import { describe, expect, test } from 'vitest'
+
+import {
+  evaluateRecordDenied,
+  parseConditionalRules,
+  type ConditionalRule,
+  type FieldMeta,
+} from '../../src/multitable/permission-rule-evaluator'
+
+const fields = (...defs: Array<[string, string]>): Record<string, FieldMeta> =>
+  Object.fromEntries(defs.map(([id, type]) => [id, { id, type }]))
+
+const rule = (over: Partial<ConditionalRule> & Pick<ConditionalRule, 'fieldId' | 'operator'>): ConditionalRule => ({
+  id: over.id ?? 'r1',
+  effect: 'deny_read',
+  value: over.value,
+  ...over,
+})
+
+const rec = (data: Record<string, unknown>) => ({ data })
+
+describe('parseConditionalRules — author-time rejection', () => {
+  test('valid rule parses', () => {
+    const { rules, rejected } = parseConditionalRules([{ id: 'a', fieldId: 'f1', operator: 'eq', value: 'x', effect: 'deny_read' }])
+    expect(rules).toHaveLength(1)
+    expect(rejected).toHaveLength(0)
+    expect(rules[0]).toMatchObject({ id: 'a', fieldId: 'f1', operator: 'eq', effect: 'deny_read' })
+  })
+
+  test.each([
+    ['not an object', 5],
+    ['null entry', null],
+    ['array entry', []],
+    ['missing id', { fieldId: 'f1', operator: 'eq', effect: 'deny_read' }],
+    ['missing fieldId', { id: 'a', operator: 'eq', effect: 'deny_read' }],
+    ['unsupported effect', { id: 'a', fieldId: 'f1', operator: 'eq', effect: 'allow_read' }],
+    ['unknown operator', { id: 'a', fieldId: 'f1', operator: 'regex', effect: 'deny_read' }],
+  ])('rejects %s', (_label, bad) => {
+    const { rules, rejected } = parseConditionalRules([bad])
+    expect(rules).toHaveLength(0)
+    expect(rejected).toHaveLength(1)
+  })
+
+  test('non-array payload rejected (null is a no-op, not an error)', () => {
+    expect(parseConditionalRules(null).rejected).toHaveLength(0)
+    expect(parseConditionalRules({ id: 'a' }).rejected).toHaveLength(1)
+  })
+
+  test('id and fieldId are trimmed', () => {
+    const { rules } = parseConditionalRules([{ id: '  a  ', fieldId: '  f1 ', operator: 'eq', value: 1, effect: 'deny_read' }])
+    expect(rules[0]).toMatchObject({ id: 'a', fieldId: 'f1' })
+  })
+})
+
+describe('evaluator — text/select operators', () => {
+  const f = fields(['f1', 'select'])
+  test('eq matches -> denied', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'secret' }), [rule({ fieldId: 'f1', operator: 'eq', value: 'secret' })], f).denied).toBe(true)
+  })
+  test('eq no match -> not denied', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'public' }), [rule({ fieldId: 'f1', operator: 'eq', value: 'secret' })], f).denied).toBe(false)
+  })
+  test('neq matches -> denied', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'public' }), [rule({ fieldId: 'f1', operator: 'neq', value: 'secret' })], f).denied).toBe(true)
+  })
+  test('contains', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'top secret memo' }), [rule({ fieldId: 'f1', operator: 'contains', value: 'secret' })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ f1: 'public memo' }), [rule({ fieldId: 'f1', operator: 'contains', value: 'secret' })], f).denied).toBe(false)
+  })
+  test('isEmpty / isNotEmpty', () => {
+    expect(evaluateRecordDenied(rec({ f1: '' }), [rule({ fieldId: 'f1', operator: 'isEmpty' })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({}), [rule({ fieldId: 'f1', operator: 'isEmpty' })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ f1: 'x' }), [rule({ fieldId: 'f1', operator: 'isNotEmpty' })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ f1: 'x' }), [rule({ fieldId: 'f1', operator: 'isEmpty' })], f).denied).toBe(false)
+  })
+})
+
+describe('evaluator — number operators', () => {
+  const f = fields(['n', 'number'])
+  test.each([
+    ['gt', 5, 3, true],
+    ['gt', 2, 3, false],
+    ['lt', 2, 3, true],
+    ['gte', 3, 3, true],
+    ['lte', 3, 3, true],
+    ['eq', 3, 3, true],
+    ['neq', 4, 3, true],
+  ] as Array<[string, number, number, boolean]>)('%s(%d,%d) -> %s', (op, recVal, ruleVal, expected) => {
+    expect(evaluateRecordDenied(rec({ n: recVal }), [rule({ fieldId: 'n', operator: op as ConditionalRule['operator'], value: ruleVal })], f).denied).toBe(expected)
+  })
+})
+
+describe('evaluator — boolean / date / array operators', () => {
+  test('boolean eq', () => {
+    const f = fields(['b', 'boolean'])
+    expect(evaluateRecordDenied(rec({ b: true }), [rule({ fieldId: 'b', operator: 'eq', value: true })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ b: false }), [rule({ fieldId: 'b', operator: 'eq', value: true })], f).denied).toBe(false)
+  })
+  test('date before / after', () => {
+    const f = fields(['d', 'date'])
+    expect(evaluateRecordDenied(rec({ d: '2026-01-01' }), [rule({ fieldId: 'd', operator: 'before', value: '2026-06-01' })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ d: '2026-12-01' }), [rule({ fieldId: 'd', operator: 'before', value: '2026-06-01' })], f).denied).toBe(false)
+    expect(evaluateRecordDenied(rec({ d: '2026-12-01' }), [rule({ fieldId: 'd', operator: 'after', value: '2026-06-01' })], f).denied).toBe(true)
+  })
+  test('multiSelect / person hasAny / hasNone', () => {
+    const f = fields(['m', 'multiSelect'], ['p', 'person'])
+    expect(evaluateRecordDenied(rec({ m: ['a', 'b'] }), [rule({ fieldId: 'm', operator: 'hasAny', value: ['b', 'c'] })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ m: ['a'] }), [rule({ fieldId: 'm', operator: 'hasAny', value: ['b', 'c'] })], f).denied).toBe(false)
+    expect(evaluateRecordDenied(rec({ p: ['u1'] }), [rule({ fieldId: 'p', operator: 'hasNone', value: ['u2'] })], f).denied).toBe(true)
+    expect(evaluateRecordDenied(rec({ p: ['u2'] }), [rule({ fieldId: 'p', operator: 'hasNone', value: ['u2'] })], f).denied).toBe(false)
+  })
+})
+
+describe('FAIL-CLOSED — un-evaluable rules DENY (never fail open)', () => {
+  test('missing field -> denied', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'x' }), [rule({ fieldId: 'GONE', operator: 'eq', value: 'x' })], fields(['f1', 'select'])).denied).toBe(true)
+  })
+  test('deleted field -> denied', () => {
+    const f: Record<string, FieldMeta> = { f1: { id: 'f1', type: 'select', deleted: true } }
+    expect(evaluateRecordDenied(rec({ f1: 'public' }), [rule({ fieldId: 'f1', operator: 'eq', value: 'secret' })], f).denied).toBe(true)
+  })
+  test('operator not allowed for field type -> denied (gt on a select)', () => {
+    expect(evaluateRecordDenied(rec({ f1: 'x' }), [rule({ fieldId: 'f1', operator: 'gt', value: 1 })], fields(['f1', 'select'])).denied).toBe(true)
+  })
+  test('malformed value: gt with a non-number record value -> denied', () => {
+    expect(evaluateRecordDenied(rec({ n: 'not-a-number' }), [rule({ fieldId: 'n', operator: 'gt', value: 1 })], fields(['n', 'number'])).denied).toBe(true)
+  })
+  test('malformed value: contains where record value is not a string -> denied', () => {
+    expect(evaluateRecordDenied(rec({ f1: 123 }), [rule({ fieldId: 'f1', operator: 'contains', value: 'x' })], fields(['f1', 'select'])).denied).toBe(true)
+  })
+  test('malformed value: hasAny where rule value is not an array -> denied', () => {
+    expect(evaluateRecordDenied(rec({ m: ['a'] }), [rule({ fieldId: 'm', operator: 'hasAny', value: 'a' })], fields(['m', 'multiSelect'])).denied).toBe(true)
+  })
+  test('malformed value: before with an unparseable date -> denied', () => {
+    expect(evaluateRecordDenied(rec({ d: 'garbage' }), [rule({ fieldId: 'd', operator: 'before', value: '2026-06-01' })], fields(['d', 'date'])).denied).toBe(true)
+  })
+  test('unknown field type (no operators) -> denied', () => {
+    expect(evaluateRecordDenied(rec({ x: 'v' }), [rule({ fieldId: 'x', operator: 'eq', value: 'v' })], fields(['x', 'formula'])).denied).toBe(true)
+  })
+})
+
+describe('OR-combination + no-leak reason', () => {
+  test('any matching rule denies (OR)', () => {
+    const f = fields(['a', 'select'], ['b', 'number'])
+    const rules = [rule({ id: 'r-a', fieldId: 'a', operator: 'eq', value: 'no' }), rule({ id: 'r-b', fieldId: 'b', operator: 'gt', value: 10 })]
+    expect(evaluateRecordDenied(rec({ a: 'yes', b: 99 }), rules, f).denied).toBe(true) // second rule matches
+  })
+  test('no rule matches -> not denied', () => {
+    const f = fields(['a', 'select'])
+    expect(evaluateRecordDenied(rec({ a: 'yes' }), [rule({ id: 'r-a', fieldId: 'a', operator: 'eq', value: 'no' })], f).denied).toBe(false)
+  })
+  test('reason carries only the rule id, never the record value', () => {
+    const f = fields(['a', 'select'])
+    const res = evaluateRecordDenied(rec({ a: 'SUPER_SECRET_VALUE' }), [rule({ id: 'r-leak', fieldId: 'a', operator: 'isNotEmpty' })], f)
+    expect(res.denied).toBe(true)
+    expect(res.reason).toBe('rule:r-leak')
+    expect(res.reason).not.toContain('SUPER_SECRET_VALUE')
+  })
+  test('empty rule set -> not denied', () => {
+    expect(evaluateRecordDenied(rec({ a: 'x' }), [], fields(['a', 'select'])).denied).toBe(false)
+  })
+})


### PR DESCRIPTION
#18 phase-2 foundation (gated arc 2b, slice S1). PURE evaluator — no DB/IO, NOT wired to any route or the #18 deny seam; S2 integrates it under adversarial review. A conditional deny_read rule denies read of any record matching the predicate (OR semantics). Operator allowlist per field type; **fail-closed** (missing/deleted field, wrong-type operator, malformed value, thrown predicate → DENIES — never fails open); reason carries only rule:<id>, never the predicate value. 37-case matrix (type×operator + all fail-closed paths + OR + no-leak); tsc clean; full unit 4481/0. 🤖 Generated with Claude Code