### PR TITLE
feat(multitable): 2a-2 live CRDT for duration (commit-on-confirm LWW, defer-remote-while-dirty)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -215,7 +215,7 @@
       :placeholder="durationFormat"
       :value="durationText"
       @input="onDurationInput"
-      @keydown.enter="emit('confirm')"
+      @keydown.enter="durationConfirm()"
       @keydown.escape="emit('cancel')"
     />
 
@@ -520,8 +520,18 @@ const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 
 // real-DB corruption golden surfaced this). select + date have no such codec
 // conversion (exact string round-trip), so they ship here.
 const STRING_STORED_ATOMIC_YJS_TYPES = ['select', 'date']
+// 2a-2: duration is a plain number (seconds-backed) but commits ON CONFIRM, not per
+// keystroke — its editor's local h:mm buffer (durationText) owns the input while typing
+// (live re-derivation would reformat under the cursor). The binding is constructed so a
+// confirmed edit syncs LWW, but the read defers to the local buffer (the editor is only
+// mounted while editing, so it never drives off the remote value) and the Y.Map write
+// happens only in durationConfirm() — never on @input.
+const DURATION_COMMIT_ON_CONFIRM_YJS_TYPES = ['duration']
 const isScalarYjsType = (t: string | undefined): boolean =>
-  !!t && (SCALAR_YJS_TYPES.includes(t) || STRING_STORED_ATOMIC_YJS_TYPES.includes(t))
+  !!t &&
+  (SCALAR_YJS_TYPES.includes(t) ||
+    STRING_STORED_ATOMIC_YJS_TYPES.includes(t) ||
+    DURATION_COMMIT_ON_CONFIRM_YJS_TYPES.includes(t))
 const scalarFieldIdRef = computed<string | null>(() => {
   if (!props.field || !isScalarYjsType(props.field.type)) return null
   if (!props.recordId) return null
@@ -561,6 +571,18 @@ function commitScalar(next: unknown) {
 // patch (the server bridge persists the Y.Map change), then confirm.
 function scalarConfirm() {
   if (scalarActive.value) emit('yjs-commit')
+  emit('confirm')
+}
+// 2a-2 duration: commit-on-confirm LWW. onDurationInput only updates the local buffer +
+// REST emit (never the Y.Map), so the remote value never reformats the field mid-type
+// (defer-remote-while-dirty). Only on confirm do we write the parsed seconds (a plain
+// number) to the Y.Map when live, then signal yjs-commit so the host skips the redundant
+// REST patch; inactive → just emit('confirm'), byte-identical to before.
+function durationConfirm() {
+  if (scalarActive.value) {
+    scalarBinding.setValue(durationSecondsFromInput(durationText.value, durationFormat.value))
+    emit('yjs-commit')
+  }
   emit('confirm')
 }
 function onBooleanChange(event: Event) {

--- a/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
@@ -277,4 +277,57 @@ describe('MetaCellEditor scalar Yjs wiring', () => {
     expect(onYjsCommit).not.toHaveBeenCalled()
     expect(onConfirm).toHaveBeenCalled()
   })
+
+  // 2a-2 duration: commit-on-confirm LWW. Typing must NOT drive the Y.Map (the local
+  // h:mm buffer owns the input); only Enter commits the parsed seconds.
+  it('active duration: @input does NOT write Y.Map (buffer owns the input); Enter commits parsed seconds + yjs-commit then confirm', async () => {
+    scalarActive.value = true
+    scalarVal.value = 60
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_dur', name: 'Dur', type: 'duration' }, 60, { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const input = container!.querySelector('input[inputmode="numeric"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    input.value = '1:30'
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    // typing must NOT reformat under the cursor: no Y.Map write on input.
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith(5400) // h:mm → seconds, REST emit only
+    // Enter commits the parsed seconds (native number) to the Y.Map (LWW) + yjs-commit.
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(setValueMock).toHaveBeenCalledWith(5400)
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('inactive duration: REST byte-identical — setValue never called, no yjs-commit on Enter', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_dur', name: 'Dur', type: 'duration' }, 60, { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const input = container!.querySelector('input[inputmode="numeric"]') as HTMLInputElement
+    input.value = '2:00'
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith(7200)
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onYjsCommit).not.toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('defer-remote-while-dirty: a remote duration change does NOT reformat the input the user is mid-typing', async () => {
+    scalarActive.value = true
+    scalarVal.value = 60
+    mountField({ id: 'fld_dur', name: 'Dur', type: 'duration' }, 60, {})
+    const input = container!.querySelector('input[inputmode="numeric"]') as HTMLInputElement
+    input.value = '1:'
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    scalarVal.value = 9999 // a remote edit arrives mid-type
+    await nextTick()
+    expect(input.value).toBe('1:') // still the user's partial buffer, not remote-derived text
+  })
 })

--- a/packages/core-backend/tests/integration/yjs-scalar-flush-realdb.test.ts
+++ b/packages/core-backend/tests/integration/yjs-scalar-flush-realdb.test.ts
@@ -39,6 +39,7 @@ const SOCKET = `socket_scalarflush_${TS}`
 
 const F_RATING = 'fld_rating'
 const F_TAGS = 'fld_tags'
+const F_DURATION = 'fld_dur'
 const TAG_OPTS = [{ value: 'x' }, { value: 'y' }, { value: 'z' }]
 
 async function readData(): Promise<Record<string, unknown>> {
@@ -107,13 +108,17 @@ describeIfDatabase('Yjs scalar FLUSH (real DB) — rating/multiSelect round-trip
       'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [F_TAGS, SHEET_ID, 'Tags', 'multiSelect', JSON.stringify({ options: TAG_OPTS }), 2],
     )
+    await q(
+      'INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_DURATION, SHEET_ID, 'Dur', 'duration', JSON.stringify({ durationFormat: 'h:mm' }), 3],
+    )
   })
   beforeEach(async () => {
     // Fresh starting state each run: rating=1, tags=['x'].
     await q(
       'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ' +
         'ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1',
-      [REC_ID, SHEET_ID, JSON.stringify({ [F_RATING]: 1, [F_TAGS]: ['x'] })],
+      [REC_ID, SHEET_ID, JSON.stringify({ [F_RATING]: 1, [F_TAGS]: ['x'], [F_DURATION]: 60 })],
     )
   })
   afterAll(async () => {
@@ -163,6 +168,9 @@ describeIfDatabase('Yjs scalar FLUSH (real DB) — rating/multiSelect round-trip
       doc.transact(() => {
         fields.set(F_RATING, 4)
         fields.set(F_TAGS, ['x', 'y', 'z'])
+        // 2a-2 duration: commit-on-confirm writes the parsed seconds (a plain number) to the
+        // Y.Map; the bridge must persist a native number (not '5400', not [object Object]).
+        fields.set(F_DURATION, 5400)
       }, SOCKET)
 
       // Wait out the debounce + the async patchRecords landing in Postgres.
@@ -173,6 +181,8 @@ describeIfDatabase('Yjs scalar FLUSH (real DB) — rating/multiSelect round-trip
       expect(typeof data[F_RATING]).toBe('number') // native number, not '4'
       expect(data[F_TAGS]).toEqual(['x', 'y', 'z']) // plain JSON array, not a Y.Array, not stringified
       expect(Array.isArray(data[F_TAGS])).toBe(true)
+      expect(data[F_DURATION]).toBe(5400) // duration seconds — native number
+      expect(typeof data[F_DURATION]).toBe('number') // not '5400', not [object Object]
     } finally {
       bridge.unobserve(REC_ID)
       await svc.destroy()


### PR DESCRIPTION
Gated arc 2a-2 (local-buffer UX gate). duration syncs live via commit-on-confirm LWW: the local h:mm buffer stays source-of-truth WHILE typing (onDurationInput never writes the Y.Map → no reformat under the cursor); durationConfirm() writes the parsed seconds (native number) to the Y.Map on Enter/blur + yjs-commit; a remote value never reformats an in-progress edit (defer-remote-while-dirty). Inactive → REST byte-identical. **Real-PG no-corruption (gate):** duration=5400 flushes through real patchRecords → meta_records.data keeps native number 5400. FE 17/17 (incl mid-type `1:` buffer untouched by remote); vue-tsc+tsc clean; FE multitable 61/61 no-regression. 🤖 Generated with Claude Code