### PR TITLE
feat(multitable): 2b-S2 conditional read-deny rule enforcement (wired into #18 seam, flag-off inert)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -191,6 +191,7 @@ jobs:
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
+            tests/integration/multitable-conditional-rule-enforce-realdb.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \
             tests/integration/multitable-rowlevel-readdeny-flag-endpoint.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260618120000_conditional_read_rules.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260618120000_conditional_read_rules.ts
@@ -1,0 +1,22 @@
+/**
+ * Migration: #18 phase-2 (2b) conditional read-deny rules — storage only (inert until rules are authored
+ * AND the per-sheet flag is on).
+ *
+ * Adds `meta_sheets.conditional_read_rules` jsonb, DEFAULT '[]'. A rule is
+ * `{ id, fieldId, operator, value?, effect:'deny_read' }`; a record whose data matches ANY rule is
+ * read-denied — fed into the SAME per-record deny set #18 already enforces on every read surface
+ * (loadDeniedRecordIds), so admin-bypass / no-cardinality-leak / masking all come from the #18 machinery.
+ *
+ * Double-inert + non-breaking: gated by the existing `row_level_read_permissions_enabled` flag (default
+ * false → no surface even computes the deny set) AND default-empty rules (flag on + no rules = no
+ * rule-deny). Byte-identical to today until an owner both enables the flag and authors a rule.
+ */
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_sheets ADD COLUMN IF NOT EXISTS conditional_read_rules jsonb NOT NULL DEFAULT '[]'::jsonb`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_sheets DROP COLUMN IF EXISTS conditional_read_rules`.execute(db)
+}

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -44,6 +44,11 @@ import {
   type ViewPermissionScope,
 } from './permission-derivation'
 import { filterPermissionCodesByNamespaceAdmission } from '../rbac/namespace-admission'
+import {
+  parseConditionalRules,
+  evaluateRecordDenied,
+  type FieldMeta as RuleFieldMeta,
+} from './permission-rule-evaluator'
 
 export { deriveRowActions, type MultitableRowActions } from './access'
 
@@ -209,6 +214,13 @@ function isUndefinedTableError(err: unknown, tableName: string): boolean {
   const msg = typeof (err as any)?.message === 'string' ? (err as any).message : ''
   if (code === '42P01') return msg.includes(tableName)
   return msg.includes(`relation "${tableName}" does not exist`)
+}
+
+function isUndefinedColumnError(err: unknown, columnName: string): boolean {
+  const code = typeof (err as any)?.code === 'string' ? (err as any).code : null
+  const msg = typeof (err as any)?.message === 'string' ? (err as any).message : ''
+  if (code === '42703') return msg.includes(columnName)
+  return msg.includes(`column "${columnName}" does not exist`)
 }
 
 export function isSheetPermissionSubjectType(
@@ -913,6 +925,9 @@ export async function loadRecordPermissionScopeMap(
   userId: string,
 ): Promise<Map<string, RecordPermissionScope>> {
   if (!userId || !sheetId || recordIds.length === 0) return new Map()
+  const scopes = new Map<string, RecordPermissionScope>()
+  const rank = { read: 0, write: 1, admin: 2, none: 3 } as const
+  // (a) grant scopes via the actor's subjects (user / member-group / role).
   try {
     const result = await query(
       `SELECT rp.record_id, rp.access_level
@@ -938,7 +953,6 @@ export async function loadRecordPermissionScopeMap(
          )`,
       [userId, sheetId, recordIds],
     )
-    const scopes = new Map<string, RecordPermissionScope>()
     for (const row of result.rows as Array<{ record_id: string; access_level: string }>) {
       const recordId = typeof row.record_id === 'string' ? row.record_id : ''
       if (!recordId) continue
@@ -950,7 +964,6 @@ export async function loadRecordPermissionScopeMap(
       if (existing) {
         // DENY-WINS: a 'none' read-deny is the most restrictive and overrides grants via other subjects
         // (a deny cannot be bypassed by group/role membership). Otherwise max of read<write<admin.
-        const rank = { read: 0, write: 1, admin: 2, none: 3 } as const
         if (rank[level] > rank[existing.accessLevel]) {
           existing.accessLevel = level
         }
@@ -958,15 +971,26 @@ export async function loadRecordPermissionScopeMap(
         scopes.set(recordId, { recordId, accessLevel: level })
       }
     }
-    return scopes
   } catch (err) {
     if (
-      isUndefinedTableError(err, 'record_permissions')
-      || isUndefinedTableError(err, 'user_roles')
-      || isUndefinedTableError(err, 'platform_member_group_members')
-    ) return new Map()
-    throw err
+      !isUndefinedTableError(err, 'record_permissions')
+      && !isUndefinedTableError(err, 'user_roles')
+      && !isUndefinedTableError(err, 'platform_member_group_members')
+    ) throw err
+    // else: grant tables absent (pre-feature) — no grant scopes, but rule-deny below still applies.
   }
+  // (b) 2b conditional rule-deny: a record matched by a predicate rule gets a synthetic 'none' scope
+  // (DENY-WINS), so the derive-based read paths (single GET / view / list) enforce predicate rules
+  // exactly like an explicit 'none' grant. Actor-independent; admins bypass at the call site (same as #18).
+  for (const rid of await loadRuleDeniedRecordIds(query, sheetId, recordIds)) {
+    const existing = scopes.get(rid)
+    if (existing) {
+      if (rank.none > rank[existing.accessLevel]) existing.accessLevel = 'none'
+    } else {
+      scopes.set(rid, { recordId: rid, accessLevel: 'none' })
+    }
+  }
+  return scopes
 }
 
 /**
@@ -979,6 +1003,8 @@ export async function loadRecordPermissionScopeMap(
  */
 export async function loadDeniedRecordIds(query: QueryFn, sheetId: string, userId: string): Promise<Set<string>> {
   if (!userId || !sheetId) return new Set<string>()
+  const denied = new Set<string>()
+  // (a) grant-deny: explicit 'none' record_permissions via any of the actor's subjects.
   try {
     const result = await query(
       `SELECT DISTINCT rp.record_id
@@ -1004,21 +1030,76 @@ export async function loadDeniedRecordIds(query: QueryFn, sheetId: string, userI
          )`,
       [userId, sheetId],
     )
-    const denied = new Set<string>()
     for (const row of result.rows as Array<{ record_id?: unknown }>) {
       if (typeof row.record_id === 'string' && row.record_id) denied.add(row.record_id)
     }
-    return denied
   } catch (err) {
     if (
-      isUndefinedTableError(err, 'record_permissions')
-      || isUndefinedTableError(err, 'user_roles')
-      || isUndefinedTableError(err, 'platform_member_group_members')
-    ) return new Set<string>()
-    throw err
+      !isUndefinedTableError(err, 'record_permissions')
+      && !isUndefinedTableError(err, 'user_roles')
+      && !isUndefinedTableError(err, 'platform_member_group_members')
+    ) throw err
+    // else: the grant tables are absent (pre-feature) — no grant-deny, but rule-deny below still applies.
   }
+  // (b) rule-deny (2b): predicate rules evaluated against each LIVE record's data. Unioned in — a
+  // rule-denied record is masked/excluded EXACTLY like a grant-denied one by every surface that
+  // consumes this set (admin-bypass + no-cardinality-leak inherited from #18). DENY-WINS by union.
+  for (const id of await loadRuleDeniedRecordIds(query, sheetId)) denied.add(id)
+  return denied
 }
 
+/**
+ * #18 phase-2 (2b): the set of LIVE record ids in `sheetId` denied by a conditional read-deny rule
+ * (predicate on the record's data), independent of the actor (a rule hides a record from every
+ * non-admin reader). Fail-closed: a structurally-valid rule whose field is missing/deleted, or whose
+ * operator/value is invalid for the field type, DENIES the record (see evaluateRecordDenied). A
+ * pre-migration sheet (no `conditional_read_rules` column) or an empty rule list → empty set (inert).
+ * Caller gates on `loadRowLevelReadDenyEnabled` + admin-bypass, exactly like the grant-deny set.
+ * NOTE: evaluates live `meta_records` only — trash (meta_records_trash) is a separate surface not yet
+ * covered (the flag-off default keeps everything inert until 2b is complete).
+ */
+export async function loadRuleDeniedRecordIds(
+  query: QueryFn,
+  sheetId: string,
+  recordIds?: string[],
+): Promise<Set<string>> {
+  if (!sheetId) return new Set<string>()
+  if (recordIds && recordIds.length === 0) return new Set<string>() // nothing to evaluate
+  let rawRules: unknown
+  try {
+    const r = await query('SELECT conditional_read_rules AS rules FROM meta_sheets WHERE id = $1', [sheetId])
+    rawRules = (r.rows[0] as { rules?: unknown } | undefined)?.rules
+  } catch (err) {
+    if (isUndefinedColumnError(err, 'conditional_read_rules')) return new Set<string>() // pre-migration → inert
+    throw err // a real load failure → propagate (fail-closed: the surface errors, never grants read)
+  }
+  const { rules } = parseConditionalRules(rawRules)
+  if (rules.length === 0) return new Set<string>() // no valid rules → inert
+  const fieldsById: Record<string, RuleFieldMeta | undefined> = {}
+  const fr = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  for (const row of fr.rows as Array<{ id?: unknown; type?: unknown }>) {
+    if (typeof row.id === 'string' && row.id) {
+      fieldsById[row.id] = { id: row.id, type: typeof row.type === 'string' ? row.type : '' }
+    }
+  }
+  const denied = new Set<string>()
+  const rr = recordIds && recordIds.length > 0
+    ? await query('SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])', [sheetId, recordIds])
+    : await query('SELECT id, data FROM meta_records WHERE sheet_id = $1', [sheetId])
+  for (const row of rr.rows as Array<{ id?: unknown; data?: unknown }>) {
+    if (typeof row.id !== 'string' || !row.id) continue
+    const data = row.data && typeof row.data === 'object' ? (row.data as Record<string, unknown>) : {}
+    if (evaluateRecordDenied({ data }, rules, fieldsById).denied) denied.add(row.id)
+  }
+  return denied
+}
+
+/**
+ * Whether `sheetId` carries any record-level read constraint that the derive-based read paths must
+ * consult: an explicit record_permission assignment OR (2b) a conditional read-deny rule. Used purely
+ * as the gate to skip the scope-map load on sheets with no constraints — a rules-bearing sheet must
+ * load the scope map so loadRecordPermissionScopeMap can contribute the rule-denied 'none' scopes.
+ */
 export async function hasRecordPermissionAssignments(
   query: QueryFn,
   sheetId: string,
@@ -1028,9 +1109,20 @@ export async function hasRecordPermissionAssignments(
       'SELECT 1 FROM record_permissions WHERE sheet_id = $1 LIMIT 1',
       [sheetId],
     )
-    return result.rows.length > 0
+    if (result.rows.length > 0) return true
   } catch (err) {
-    if (isUndefinedTableError(err, 'record_permissions')) return false
+    if (!isUndefinedTableError(err, 'record_permissions')) throw err
+    // record_permissions table absent — fall through to the conditional-rules check.
+  }
+  // 2b: a sheet with conditional read-deny rules also needs the derive-path scope check.
+  try {
+    const r = await query(
+      `SELECT 1 FROM meta_sheets WHERE id = $1 AND jsonb_array_length(COALESCE(conditional_read_rules, '[]'::jsonb)) > 0 LIMIT 1`,
+      [sheetId],
+    )
+    return r.rows.length > 0
+  } catch (err) {
+    if (isUndefinedColumnError(err, 'conditional_read_rules')) return false // pre-migration → inert
     throw err
   }
 }

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -982,12 +982,17 @@ export async function loadRecordPermissionScopeMap(
   // (b) 2b conditional rule-deny: a record matched by a predicate rule gets a synthetic 'none' scope
   // (DENY-WINS), so the derive-based read paths (single GET / view / list) enforce predicate rules
   // exactly like an explicit 'none' grant. Actor-independent; admins bypass at the call site (same as #18).
-  for (const rid of await loadRuleDeniedRecordIds(query, sheetId, recordIds)) {
-    const existing = scopes.get(rid)
-    if (existing) {
-      if (rank.none > rank[existing.accessLevel]) existing.accessLevel = 'none'
-    } else {
-      scopes.set(rid, { recordId: rid, accessLevel: 'none' })
+  // FLAG-GATED (matching #18): a flag-off sheet does ZERO rule work — no rule query is issued, so callers
+  // of the derive path on non-opted-in sheets are byte-identical to pre-2b (loadRowLevelReadDenyEnabled
+  // returns false on any error, so an absent column/flag is inert, never a 500).
+  if (await loadRowLevelReadDenyEnabled(query, sheetId)) {
+    for (const rid of await loadRuleDeniedRecordIds(query, sheetId, recordIds)) {
+      const existing = scopes.get(rid)
+      if (existing) {
+        if (rank.none > rank[existing.accessLevel]) existing.accessLevel = 'none'
+      } else {
+        scopes.set(rid, { recordId: rid, accessLevel: 'none' })
+      }
     }
   }
   return scopes
@@ -1114,7 +1119,13 @@ export async function hasRecordPermissionAssignments(
     if (!isUndefinedTableError(err, 'record_permissions')) throw err
     // record_permissions table absent — fall through to the conditional-rules check.
   }
-  // 2b: a sheet with conditional read-deny rules also needs the derive-path scope check.
+  // 2b: a sheet with conditional read-deny rules also needs the derive-path scope check — but ONLY when
+  // the read-deny flag is on (matching #18 + loadRecordPermissionScopeMap). Flag-off → the rules are inert,
+  // so we don't even issue the conditional_read_rules query: a non-opted-in sheet is byte-identical to
+  // pre-2b. loadRowLevelReadDenyEnabled returns false on any error, so an absent column/flag is inert
+  // (never a 500). record_permissions above stays unconditional (it is not flag-gated); only the 2b rule
+  // check is gated here.
+  if (!(await loadRowLevelReadDenyEnabled(query, sheetId))) return false
   try {
     const r = await query(
       `SELECT 1 FROM meta_sheets WHERE id = $1 AND jsonb_array_length(COALESCE(conditional_read_rules, '[]'::jsonb)) > 0 LIMIT 1`,

--- a/packages/core-backend/tests/integration/multitable-conditional-rule-enforce-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-conditional-rule-enforce-realdb.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #18 phase-2 (2b) conditional read-deny rules — CORE enforcement (real DB).
+ *
+ * A predicate rule `{ fieldId, operator:'eq', value:'secret', effect:'deny_read' }` hides every record
+ * whose data matches it, on every read surface — by feeding the SAME per-record deny set #18 already
+ * enforces (loadDeniedRecordIds, extended to union loadRuleDeniedRecordIds). So admin-bypass, masking,
+ * and no-cardinality-leak come from the #18 machinery; this golden proves the rule-deny reaches the
+ * surfaces (single GET + GET /records + /records-summary), bypasses for admins, fails closed on a
+ * missing-field rule, and is inert when the flag is off OR the rule list is empty.
+ *
+ * Reuses the existing `row_level_read_permissions_enabled` flag (every surface already gates on it).
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_crd_${TS}`
+const SHEET_ID = `sheet_crd_${TS}`
+const STATUS = `fld_crd_status_${TS}`
+const REC_SECRET = `rec_crd_secret_${TS}`
+const REC_PUBLIC = `rec_crd_public_${TS}`
+const USER_ID = `user_crd_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read']
+let testRoles: string[] = []
+
+const getRecord = (id: string) => request(app).get(`/api/multitable/records/${id}`)
+const setFlag = (on: boolean) =>
+  q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) =>
+  q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
+const denySecretRule = [{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }]
+const missingFieldRule = [{ id: 'r2', fieldId: 'fld_does_not_exist', operator: 'eq', value: 'x', effect: 'deny_read' }]
+
+const listIds = async (): Promise<string[]> => {
+  const res = await request(app).get('/api/multitable/records').query({ sheetId: SHEET_ID, limit: 100 })
+  expect(res.status).toBe(200)
+  return (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+}
+const summaryIds = async (): Promise<string[]> => {
+  const res = await request(app).get('/api/multitable/records-summary').query({ sheetId: SHEET_ID, limit: 100 })
+  expect(res.status).toBe(200)
+  return (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+}
+
+describeIfDatabase('#18 phase-2 conditional read-deny rule enforcement (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'CRD Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'CRD Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_SECRET, SHEET_ID, JSON.stringify({ [STATUS]: 'secret' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_PUBLIC, SHEET_ID, JSON.stringify({ [STATUS]: 'public' })])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    testRoles = []
+    await setFlag(false)
+    await setRules([])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('inert — flag OFF even with a deny rule: secret record is visible everywhere', async () => {
+    await setRules(denySecretRule)
+    await setFlag(false)
+    expect((await getRecord(REC_SECRET)).status).toBe(200)
+    expect(await listIds()).toContain(REC_SECRET)
+    expect(await summaryIds()).toContain(REC_SECRET)
+  })
+
+  test('inert — flag ON but EMPTY rules: secret record is visible everywhere', async () => {
+    await setFlag(true)
+    await setRules([])
+    expect((await getRecord(REC_SECRET)).status).toBe(200)
+    expect(await listIds()).toContain(REC_SECRET)
+  })
+
+  test('enforce — flag ON + deny rule: secret HIDDEN, public visible (single GET)', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const denied = await getRecord(REC_SECRET)
+    expect(denied.status).toBe(403)
+    expect(JSON.stringify(denied.body)).not.toContain('"data"')
+    expect((await getRecord(REC_PUBLIC)).status).toBe(200)
+  })
+
+  test('enforce — flag ON + deny rule: GET /records excludes secret, keeps public', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const ids = await listIds()
+    expect(ids).not.toContain(REC_SECRET)
+    expect(ids).toContain(REC_PUBLIC)
+  })
+
+  test('enforce — flag ON + deny rule: /records-summary excludes secret', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const ids = await summaryIds()
+    expect(ids).not.toContain(REC_SECRET)
+    expect(ids).toContain(REC_PUBLIC)
+  })
+
+  test('admin bypass — flag ON + deny rule: an admin sees the secret record', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    testRoles = ['admin']
+    expect((await getRecord(REC_SECRET)).status).toBe(200)
+    expect(await listIds()).toContain(REC_SECRET)
+    testPerms = ['multitable:read']
+  })
+
+  test('fail-closed — flag ON + rule on a MISSING field: even the public record is denied (never fail-open)', async () => {
+    await setFlag(true)
+    await setRules(missingFieldRule)
+    // a rule whose field is absent cannot be evaluated → the evaluator DENIES; so both records hide.
+    expect((await getRecord(REC_PUBLIC)).status).toBe(403)
+    expect(await listIds()).not.toContain(REC_PUBLIC)
+  })
+})


### PR DESCRIPTION
Gated arc 2b-S2 (security-critical). Predicate read-deny rules hide matching records on every read surface by reusing #18's machinery. Migration adds meta_sheets.conditional_read_rules jsonb DEFAULT '[]' — **double-inert**: gated by the existing row_level_read_permissions_enabled flag AND default-empty rules → byte-identical until opt-in. loadRuleDeniedRecordIds evaluates the pure S1 evaluator against each live record's data and **unions into loadDeniedRecordIds**, so a rule-denied record is masked/excluded exactly like a grant-denied one by every surface (derive paths get a synthetic 'none' scope, DENY-WINS). Fail-closed (missing/deleted field → denies); admin-bypass + cross-record no-cardinality-leak inherited from the seam. **Real-DB adversarial golden (allowlisted):** flag-off inert; flag-on+empty inert; deny rule hides secret on single GET + /records + /records-summary; admin bypass; missing-field rule denies even public (never fail-open). Surfaces beyond the 3 tested inherit via loadDeniedRecordIds (already #18-verified). 🤖 Generated with Claude Code