### PR TITLE
fix(data-source): scrub draft-test endpoint echoes

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -574,16 +574,45 @@ export class DataSourceManager extends EventEmitter {
     const adapter = new AdapterClass(boundedConfig)
     adapter.on('error', () => { /* ephemeral: cause captured via connectionError; no emit/persist */ })
     // No-echo (design-lock 钉子②): the adapter redacts secret VALUES, but a driver diagnostic can still
-    // reflect the caller's submitted host/username (e.g. `password authentication failed for user "x"`,
-    // `getaddrinfo ENOTFOUND <host>`). Strip those submitted identifiers too so the ephemeral test never
-    // echoes connection input back. Scoped here — shared redactSecrets stays intact for /:id/test.
+    // reflect the caller's submitted host/username/endpoint (e.g. `password authentication failed for
+    // user "x"`, `getaddrinfo ENOTFOUND <host>`, or an HTTP client echoing a submitted baseURL).
+    // Strip those submitted identifiers too so the ephemeral test never echoes connection input back.
+    // Scoped here — shared redactSecrets stays intact for /:id/test.
+    const submittedEndpointFragments = (): string[] => {
+      const conn = config.connection ?? {}
+      const fragments = new Set<string>()
+      const add = (value: unknown): void => {
+        if (typeof value !== 'string') return
+        const trimmed = value.trim()
+        if (trimmed.length < 3) return
+        fragments.add(trimmed)
+        fragments.add(trimmed.replace(/\/+$/, ''))
+        try {
+          const parsed = new URL(trimmed)
+          for (const part of [parsed.origin, parsed.host, parsed.hostname]) {
+            if (part.length >= 3) fragments.add(part)
+          }
+        } catch {
+          // Not every connection field is a URL; host/database/username are handled as plain strings.
+        }
+      }
+      for (const value of [
+        conn.host,
+        conn.server,
+        conn.database,
+        conn.baseURL,
+        conn.baseUrl,
+        conn.url,
+        config.credentials?.username,
+      ]) {
+        add(value)
+      }
+      return [...fragments].sort((a, b) => b.length - a.length)
+    }
     const scrubInput = (msg: string | undefined): string | undefined => {
       if (!msg) return msg
-      const conn = config.connection ?? {}
-      const ids = [conn.host, conn.server, conn.database, config.credentials?.username]
-        .filter((v): v is string => typeof v === 'string' && v.trim().length >= 3)
       let out = msg
-      for (const id of ids) out = out.split(id).join('***')
+      for (const id of submittedEndpointFragments()) out = out.split(id).join('***')
       return out
     }
     const start = Date.now()

--- a/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
@@ -82,6 +82,19 @@ class CapturingAdapter extends FakeBase {
   async testConnection(): Promise<boolean> { return true }
 }
 
+// HTTP-style failure that echoes the submitted endpoint rather than just a host.
+class UrlFailAdapter extends FakeBase {
+  async connect(): Promise<void> {
+    const endpoint = String(this.config.connection?.baseURL ?? this.config.connection?.url)
+    const err = new Error(`request to ${endpoint} failed: getaddrinfo ENOTFOUND ${new URL(endpoint).hostname}`)
+    await this.onError(err)
+    throw err
+  }
+  async disconnect(): Promise<void> { disconnectCalls.push(this.config.id); this.connected = false }
+  isConnected(): boolean { return this.connected }
+  async testConnection(): Promise<boolean> { return false }
+}
+
 function appAs(userId: string) {
   const a = express()
   a.use(express.json())
@@ -137,6 +150,24 @@ describe('DataSourceManager.testEphemeralConnection (helper)', () => {
     }
     expect(manager.getScope(id)).toBeUndefined() // still nothing registered on failure
     expect(removeAllListenerCalls).toContain(id) // disposed even on failure
+  })
+
+  it('scrubs submitted HTTP endpoint values from failure summaries', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('urlfaileph', UrlFailAdapter as never)
+    const submittedUrl = 'https://submitted-endpoint.example/internal/probe'
+
+    const result = await manager.testEphemeralConnection(cfg('eph_url_fail', 'urlfaileph', {
+      connection: { baseURL: `${submittedUrl}/` },
+    }))
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('***')
+    const wire = JSON.stringify(result)
+    for (const leak of [submittedUrl, 'submitted-endpoint.example']) {
+      expect(wire).not.toContain(leak)
+    }
+    expect(removeAllListenerCalls).toContain('eph_url_fail')
   })
 
   it('throws Unsupported data source type for an unknown adapter type', async () => {
@@ -196,6 +227,28 @@ describe('POST /api/data-sources/test (route)', () => {
     expect(res.body.data.error.message).toContain('***')  // submitted identifiers scrubbed
     const wire = JSON.stringify(res.body)
     for (const leak of [SECRET, 'secret-host.internal', 'admin_user', 'connection', 'credentials']) {
+      expect(wire).not.toContain(leak)
+    }
+  })
+
+  it('failure body echoes back NO submitted HTTP endpoint URL', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('http', UrlFailAdapter as never)
+    const submittedUrl = 'https://submitted-endpoint.example/internal/probe'
+    const res = await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_http_fail',
+      name: 'x',
+      type: 'http',
+      connection: { baseURL: `${submittedUrl}/` },
+      credentials: { apiKey: SECRET },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data.success).toBe(false)
+    expect(res.body.data.error.message).toBeTruthy()
+    expect(res.body.data.error.message).toContain('***')
+    const wire = JSON.stringify(res.body)
+    for (const leak of [SECRET, submittedUrl, 'submitted-endpoint.example', 'connection', 'credentials']) {
       expect(wire).not.toContain(leak)
     }
   })


### PR DESCRIPTION
## Summary

Fixes the #2769 entity-machine HOLD where `POST /api/data-sources/test` returned a failure summary that still echoed the submitted HTTP endpoint/baseURL.

## What changed

- Extends the test-before-save `DataSourceManager.testEphemeralConnection` no-echo scrubber from SQL-ish fields (`host/server/database/username`) to HTTP endpoint fields:
  - `connection.baseURL`
  - `connection.baseUrl`
  - `connection.url`
  - full trimmed value
  - trailing-slash-normalized value
  - parsed `origin` / `host` / `hostname`
- Keeps the scope local to the draft-test endpoint helper; shared `redactSecrets` and row-level `/:id/test` diagnostics are unchanged.
- Adds permanent helper + route tests proving the failure body does not contain the submitted endpoint URL or hostname.

## Verification

```text
pnpm install --frozen-lockfile
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-test-ephemeral.test.ts --watch=false
# 1 file / 10 tests pass

pnpm --filter @metasheet/core-backend build
# pass

git diff --check
# pass
```

I also accidentally ran the broader core-backend vitest invocation first; it completed PASS before entering watch mode:

```text
Test Files 342 passed | 87 skipped
Tests      4483 passed | 663 skipped
```

## Boundary

```text
frontend.inlineErrorUsesRedactedSummary=true
noSubmittedEndpointEcho=true
saveHardGate=unchanged_false
rowLevelExistingDataSourceTest=unchanged
productionWrite=false
batchWrite=false
k3Save=false
k3Submit=false
k3Audit=false
k3BomWrite=false
```
