### PR TITLE
fix(data-source): harden /test endpoint — bounded connect-timeout + audit trail

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -556,7 +556,22 @@ export class DataSourceManager extends EventEmitter {
       // Mirror addDataSourceInternal's wording; the route maps this to a 400 (client error).
       throw new Error(`Unsupported data source type: ${config.type}`)
     }
-    const adapter = new AdapterClass(config)
+    // Bound the connect attempt (follow-up m3): a hanging / black-hole host otherwise ties up the
+    // request to the driver default (pg = 30s). Inject a short connect-timeout via each driver's own
+    // knob — pg `poolConfig.acquireTimeout`, mysql2 `options.connectTimeout`, mssql
+    // `connection.connectionTimeoutMs` — defaulting ONLY when the caller didn't set one (each driver
+    // ignores the others' keys). Scrub below still reads the original `config` (same host/username).
+    const TEST_CONNECT_TIMEOUT_MS = 10000
+    const conn = (config.connection ?? {}) as Record<string, unknown>
+    const opts = (config.options ?? {}) as Record<string, unknown>
+    const pool = (config.poolConfig ?? {}) as Record<string, unknown>
+    const boundedConfig = {
+      ...config,
+      connection: { ...conn, connectionTimeoutMs: conn.connectionTimeoutMs ?? TEST_CONNECT_TIMEOUT_MS },
+      options: { ...opts, connectTimeout: opts.connectTimeout ?? TEST_CONNECT_TIMEOUT_MS },
+      poolConfig: { ...pool, acquireTimeout: pool.acquireTimeout ?? TEST_CONNECT_TIMEOUT_MS },
+    } as unknown as DataSourceConfig
+    const adapter = new AdapterClass(boundedConfig)
     adapter.on('error', () => { /* ephemeral: cause captured via connectionError; no emit/persist */ })
     // No-echo (design-lock 钉子②): the adapter redacts secret VALUES, but a driver diagnostic can still
     // reflect the caller's submitted host/username (e.g. `password authentication failed for user "x"`,

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -388,6 +388,16 @@ export function dataSourcesRouter(): Router {
       const manager = getManager()
       const config = parse.data as DataSourceConfig
       const result = await manager.testEphemeralConnection(config)
+      // Audit the dial-out attempt (values-free: id/name/type + outcome only — never connection/creds).
+      // This is a write-tier capability that connects to an arbitrary host, so it leaves a probe trail.
+      await auditLog({
+        actorId: req.user?.id?.toString(),
+        actorType: 'user',
+        action: 'test',
+        resourceType: 'data_source',
+        resourceId: config.id,
+        meta: { name: config.name, type: config.type, success: result.success },
+      })
       // RESULT-ONLY surface (design-lock 钉子②): success / latency / redacted error — NEVER echo the
       // submitted config, connection, or credentials back to the caller.
       return res.json({

--- a/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
@@ -16,6 +16,7 @@ import type {
   DbValue,
 } from '../../src/data-adapters/BaseAdapter'
 import { dataSourcesRouter, getDataSourceManager } from '../../src/routes/data-sources'
+import { auditLog } from '../../src/audit/audit'
 
 const SECRET = 'EphemeralSecretPw!2026'
 
@@ -69,6 +70,16 @@ class FailAdapter extends FakeBase {
   async disconnect(): Promise<void> { disconnectCalls.push(this.config.id); this.connected = false }
   isConnected(): boolean { return this.connected }
   async testConnection(): Promise<boolean> { return false }
+}
+
+// Records the config it was constructed with, so we can assert the helper injected bounded timeouts.
+let capturedConfig: DataSourceConfig | null = null
+class CapturingAdapter extends FakeBase {
+  constructor(c: DataSourceConfig) { super(c); capturedConfig = c }
+  async connect(): Promise<void> { this.connected = true; await this.onConnect() }
+  async disconnect(): Promise<void> { this.connected = false; await this.onDisconnect() }
+  isConnected(): boolean { return this.connected }
+  async testConnection(): Promise<boolean> { return true }
 }
 
 function appAs(userId: string) {
@@ -204,5 +215,46 @@ describe('POST /api/data-sources/test (route)', () => {
     expect(ids).not.toContain('eph_nopersist')
     const got = await request(appAs('tester')).get('/api/data-sources/eph_nopersist')
     expect(got.status).toBe(404)
+  })
+
+  it('injects a bounded connect-timeout per driver knob (defaults only when caller omits)', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', CapturingAdapter as never)
+    capturedConfig = null
+    await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_timeout', name: 'x', type: 'postgres', connection: { host: 'h' },
+    }).expect(200)
+    // pg reads poolConfig.acquireTimeout; mysql2 options.connectTimeout; mssql connection.connectionTimeoutMs.
+    expect(capturedConfig?.poolConfig?.acquireTimeout).toBe(10000)
+    expect((capturedConfig?.options as Record<string, unknown>)?.connectTimeout).toBe(10000)
+    expect((capturedConfig?.connection as Record<string, unknown>)?.connectionTimeoutMs).toBe(10000)
+  })
+
+  it('does not override a caller-supplied connect-timeout', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', CapturingAdapter as never)
+    capturedConfig = null
+    await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_timeout2', name: 'x', type: 'postgres',
+      connection: { host: 'h' }, poolConfig: { acquireTimeout: 3000 },
+    }).expect(200)
+    expect(capturedConfig?.poolConfig?.acquireTimeout).toBe(3000)
+  })
+
+  it('audits the test attempt (action=test) without leaking connection / credentials', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', OkAdapter as never)
+    ;(auditLog as unknown as { mockClear?: () => void }).mockClear?.()
+    await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_audit', name: 'Audit Probe', type: 'postgres',
+      connection: { host: 'secret-host.internal' }, credentials: { username: 'admin_user', password: SECRET },
+    }).expect(200)
+    expect(auditLog).toHaveBeenCalled()
+    const arg = (auditLog as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]
+    expect(arg).toMatchObject({ action: 'test', resourceType: 'data_source', resourceId: 'eph_audit' })
+    const wire = JSON.stringify(arg)
+    for (const leak of [SECRET, 'secret-host.internal', 'admin_user']) {
+      expect(wire).not.toContain(leak)
+    }
   })
 })

--- a/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-ephemeral.test.ts
@@ -230,15 +230,21 @@ describe('POST /api/data-sources/test (route)', () => {
     expect((capturedConfig?.connection as Record<string, unknown>)?.connectionTimeoutMs).toBe(10000)
   })
 
-  it('does not override a caller-supplied connect-timeout', async () => {
+  it('does not override caller-supplied connect-timeouts (all three driver knobs)', async () => {
     const manager = getDataSourceManager()
     manager.registerAdapterType('postgres', CapturingAdapter as never)
     capturedConfig = null
-    await request(appAs('tester')).post('/api/data-sources/test').send({
-      id: 'eph_timeout2', name: 'x', type: 'postgres',
-      connection: { host: 'h' }, poolConfig: { acquireTimeout: 3000 },
-    }).expect(200)
-    expect(capturedConfig?.poolConfig?.acquireTimeout).toBe(3000)
+    // Call the helper directly: the route's create-schema would strip options.connectTimeout, so a
+    // route request can't exercise that knob's caller-supplied case — the helper preserves all three.
+    await manager.testEphemeralConnection({
+      id: 'eph_t3', name: 'x', type: 'postgres',
+      connection: { host: 'h', connectionTimeoutMs: 1111 },
+      options: { connectTimeout: 2222 },
+      poolConfig: { acquireTimeout: 3333 },
+    } as never)
+    expect(capturedConfig?.poolConfig?.acquireTimeout).toBe(3333)
+    expect((capturedConfig?.options as Record<string, unknown>)?.connectTimeout).toBe(2222)
+    expect((capturedConfig?.connection as Record<string, unknown>)?.connectionTimeoutMs).toBe(1111)
   })
 
   it('audits the test attempt (action=test) without leaking connection / credentials', async () => {
@@ -252,9 +258,25 @@ describe('POST /api/data-sources/test (route)', () => {
     expect(auditLog).toHaveBeenCalled()
     const arg = (auditLog as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]
     expect(arg).toMatchObject({ action: 'test', resourceType: 'data_source', resourceId: 'eph_audit' })
+    // meta is constrained to exactly name/success/type — a future connection-derived field can't slip in.
+    expect(Object.keys((arg as { meta: Record<string, unknown> }).meta).sort()).toEqual(['name', 'success', 'type'])
     const wire = JSON.stringify(arg)
     for (const leak of [SECRET, 'secret-host.internal', 'admin_user']) {
       expect(wire).not.toContain(leak)
     }
+  })
+
+  it('audits a FAILED probe too (meta.success === false), still leaking nothing', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('postgres', FailAdapter as never)
+    ;(auditLog as unknown as { mockClear?: () => void }).mockClear?.()
+    await request(appAs('tester')).post('/api/data-sources/test').send({
+      id: 'eph_audit_fail', name: 'x', type: 'postgres',
+      connection: { host: 'secret-host.internal' }, credentials: { username: 'admin_user', password: SECRET },
+    }).expect(200)
+    expect(auditLog).toHaveBeenCalled()
+    const arg = (auditLog as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0]
+    expect(arg).toMatchObject({ action: 'test', resourceId: 'eph_audit_fail', meta: { success: false } })
+    expect(JSON.stringify(arg)).not.toContain(SECRET)
   })
 })


### PR DESCRIPTION
Follow-up hardening on the ephemeral **test-before-save** endpoint (`POST /api/data-sources/test`), addressing the two MINORs the BE reviews recorded (m3 timeout, m4 audit). No new surface — it tightens the dial-out capability that shipped in #2822.

## Changes
- **Bounded connect-timeout** — `testEphemeralConnection` injects a 10s connect-timeout via each driver's own knob: pg `poolConfig.acquireTimeout` (was the **30s** default), mysql2 `options.connectTimeout`, mssql `connection.connectionTimeoutMs`. Defaults **only** when the caller didn't set one; each driver ignores the others' keys. A hanging / black-hole host now returns a clean failure fast (and frees the pool via the existing catch path) instead of tying up the request ~30s.
- **Audit trail** — the route now writes an audit record (`action=test`, `id`/`name`/`type` + `success` outcome). **values-free** — never connection/credentials/host. Gives the write-tier "dial arbitrary host" capability an SSRF-probe trail, matching create/update/rotate.

## Tests (unit, +3)
- timeout injected by default (`acquireTimeout`/`connectTimeout`/`connectionTimeoutMs` = 10000 via a `CapturingAdapter`);
- a caller-supplied timeout is preserved (not overridden);
- audit called with `action=test` and **no** host/username/secret in the record.

Local: `tsc` build clean · eslint clean · data-source unit suite 98 passed (ephemeral 11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)