### PR TITLE
feat(multitable): 2b-S3 conditional-rule authoring UI + API (+ fix text-type operator allowlist)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -37,6 +37,10 @@ on:
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
       - 'apps/web/src/multitable/utils/meta-permission-labels.ts'
+      - 'apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue'
+      - 'apps/web/src/multitable/utils/conditional-rule-ops.ts'
+      - 'apps/web/tests/multitable-conditional-rule-builder.spec.ts'
+      - 'apps/web/tests/multitable-conditional-rule-ops.spec.ts'
       - 'apps/web/src/multitable/api/client.ts'
       - 'apps/web/src/multitable/types.ts'
       - 'apps/web/tests/multitable-record-permission-manager.spec.ts'
@@ -71,6 +75,10 @@ on:
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
       - 'apps/web/src/multitable/utils/meta-permission-labels.ts'
+      - 'apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue'
+      - 'apps/web/src/multitable/utils/conditional-rule-ops.ts'
+      - 'apps/web/tests/multitable-conditional-rule-builder.spec.ts'
+      - 'apps/web/tests/multitable-conditional-rule-ops.spec.ts'
       - 'apps/web/src/multitable/api/client.ts'
       - 'apps/web/src/multitable/types.ts'
       - 'apps/web/tests/multitable-record-permission-manager.spec.ts'
@@ -122,4 +130,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -192,6 +192,7 @@ jobs:
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
             tests/integration/multitable-conditional-rule-enforce-realdb.test.ts \
+            tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \
             tests/integration/multitable-rowlevel-readdeny-flag-endpoint.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -74,6 +74,7 @@ import type {
 } from '../types'
 import { apiFetch } from '../../utils/api'
 import { apiDefaultErrorMessage, apiFieldValidationFallback } from '../utils/meta-api-error-labels'
+import type { ConditionalRuleDTO } from '../utils/conditional-rule-ops'
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
 type ApiErrorLocaleResolver = () => boolean
@@ -1622,6 +1623,27 @@ export class MultitableApiClient {
     )
     const data = await this.parseJson<{ enabled?: boolean }>(res)
     return data?.enabled === true
+  }
+
+  // #18 phase-2 (2b): conditional read-deny rules. Stored per-sheet; only enforce when the
+  // row-level-read-deny flag is on. PUT re-validates server-side (throws on a structurally-invalid rule).
+  async getConditionalRules(sheetId: string): Promise<{ rules: ConditionalRuleDTO[]; rejected: unknown[] }> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/conditional-rules`)
+    const data = await this.parseJson<{ rules?: ConditionalRuleDTO[]; rejected?: unknown[] }>(res)
+    return { rules: Array.isArray(data?.rules) ? data!.rules : [], rejected: Array.isArray(data?.rejected) ? data!.rejected : [] }
+  }
+
+  async setConditionalRules(sheetId: string, rules: ConditionalRuleDTO[]): Promise<ConditionalRuleDTO[]> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/conditional-rules`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rules }),
+      },
+    )
+    const data = await this.parseJson<{ rules?: ConditionalRuleDTO[] }>(res)
+    return Array.isArray(data?.rules) ? data!.rules : []
   }
 
   // --- Automation rules ---

--- a/apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue
+++ b/apps/web/src/multitable/components/MetaConditionalRuleBuilder.vue
@@ -1,0 +1,202 @@
+<template>
+  <section class="meta-cond-rule" data-testid="conditional-rule-builder">
+    <h4 class="meta-cond-rule__title">{{ p('condRule.title') }}</h4>
+    <p class="meta-cond-rule__desc">{{ p('condRule.desc') }}</p>
+    <p v-if="!flagEnabled" class="meta-cond-rule__hint" data-testid="cond-rule-flag-hint">{{ p('condRule.disabledHint') }}</p>
+
+    <ul v-if="rules.length" class="meta-cond-rule__list">
+      <li
+        v-for="(rule, idx) in rules"
+        :key="rule.id"
+        class="meta-cond-rule__row"
+        :class="{ 'meta-cond-rule__row--unknown': !fieldName(rule.fieldId) }"
+        :data-testid="`cond-rule-row-${idx}`"
+      >
+        <span class="meta-cond-rule__field">
+          {{ fieldName(rule.fieldId) ?? rule.fieldId }}
+          <em v-if="!fieldName(rule.fieldId)" class="meta-cond-rule__unknown">{{ p('condRule.unknownField') }}</em>
+        </span>
+        <span class="meta-cond-rule__op">{{ opLabel(rule.operator) }}</span>
+        <span v-if="!takesNoValue(rule.operator)" class="meta-cond-rule__val">{{ displayValue(rule.value) }}</span>
+        <span class="meta-cond-rule__deny">→ {{ p('condRule.deny') }}</span>
+        <button type="button" class="meta-cond-rule__remove" :data-testid="`cond-rule-remove-${idx}`" @click="removeRule(idx)">
+          {{ p('condRule.delete') }}
+        </button>
+      </li>
+    </ul>
+    <p v-else class="meta-cond-rule__empty">{{ p('condRule.empty') }}</p>
+
+    <div class="meta-cond-rule__add">
+      <select v-model="draftFieldId" class="meta-cond-rule__select" data-testid="cond-rule-field" :aria-label="p('condRule.field')">
+        <option value="">{{ p('condRule.field') }}</option>
+        <option v-for="f in fieldsWithRules" :key="f.id" :value="f.id">{{ f.name }}</option>
+      </select>
+      <select
+        v-model="draftOperator"
+        class="meta-cond-rule__select"
+        data-testid="cond-rule-operator"
+        :aria-label="p('condRule.operator')"
+        :disabled="!draftFieldId"
+      >
+        <option v-for="op in draftOperators" :key="op" :value="op">{{ opLabel(op) }}</option>
+      </select>
+      <input
+        v-if="draftNeedsValue"
+        v-model="draftValue"
+        class="meta-cond-rule__input"
+        data-testid="cond-rule-value"
+        :placeholder="p('condRule.value')"
+        :aria-label="p('condRule.value')"
+      />
+      <button type="button" class="meta-cond-rule__add-btn" data-testid="cond-rule-add" :disabled="!canAdd" @click="addRule">
+        {{ p('condRule.add') }}
+      </button>
+    </div>
+
+    <div class="meta-cond-rule__actions">
+      <button type="button" class="meta-cond-rule__save" data-testid="cond-rule-save" :disabled="saving" @click="save">
+        {{ p('condRule.save') }}
+      </button>
+      <span v-if="savedFlash" class="meta-cond-rule__saved" data-testid="cond-rule-saved">{{ p('condRule.saved') }}</span>
+      <span v-if="error" class="meta-cond-rule__error" role="alert" data-testid="cond-rule-error">{{ error }}</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
+import type { MultitableApiClient } from '../api/client'
+import type { MetaField } from '../types'
+import { permissionLabel, type MetaPermissionLabelKey } from '../utils/meta-permission-labels'
+import {
+  coerceRuleValue,
+  fieldTypeSupportsRule,
+  operatorTakesNoValue,
+  operatorsForFieldType,
+  type ConditionalRuleDTO,
+  type RuleOperator,
+} from '../utils/conditional-rule-ops'
+
+const props = withDefaults(
+  defineProps<{
+    sheetId: string
+    client: MultitableApiClient
+    fields?: MetaField[]
+    flagEnabled?: boolean
+  }>(),
+  { fields: () => [], flagEnabled: false },
+)
+
+const { isZh } = useLocale()
+function p(key: MetaPermissionLabelKey): string {
+  return permissionLabel(key, isZh.value)
+}
+
+const rules = ref<ConditionalRuleDTO[]>([])
+const saving = ref(false)
+const savedFlash = ref(false)
+const error = ref('')
+let idSeq = 0
+
+const draftFieldId = ref('')
+const draftOperator = ref<RuleOperator | ''>('')
+const draftValue = ref('')
+
+const fieldsWithRules = computed(() => props.fields.filter((f) => fieldTypeSupportsRule(f.type)))
+const draftField = computed(() => props.fields.find((f) => f.id === draftFieldId.value))
+const draftOperators = computed<RuleOperator[]>(() => operatorsForFieldType(draftField.value?.type))
+const draftNeedsValue = computed(() => !!draftOperator.value && !operatorTakesNoValue(draftOperator.value))
+const canAdd = computed(
+  () => !!draftFieldId.value && !!draftOperator.value && (!draftNeedsValue.value || draftValue.value.trim() !== ''),
+)
+
+function fieldName(fieldId: string): string | null {
+  return props.fields.find((f) => f.id === fieldId)?.name ?? null
+}
+function opLabel(op: RuleOperator): string {
+  return p(`condRule.op.${op}` as MetaPermissionLabelKey)
+}
+function takesNoValue(op: RuleOperator): boolean {
+  return operatorTakesNoValue(op)
+}
+function displayValue(value: unknown): string {
+  if (Array.isArray(value)) return value.join(', ')
+  return value == null ? '' : String(value)
+}
+
+// keep draftOperator valid for the chosen field
+watch(draftFieldId, () => {
+  const ops = draftOperators.value
+  draftOperator.value = ops.length ? ops[0] : ''
+  draftValue.value = ''
+})
+
+async function load(): Promise<void> {
+  error.value = ''
+  try {
+    const res = await props.client.getConditionalRules(props.sheetId)
+    rules.value = res.rules
+  } catch {
+    error.value = p('condRule.error.load')
+  }
+}
+
+function addRule(): void {
+  if (!canAdd.value || !draftOperator.value) return
+  rules.value.push({
+    id: `cr_${Date.now()}_${idSeq++}`,
+    fieldId: draftFieldId.value,
+    operator: draftOperator.value,
+    value: coerceRuleValue(draftField.value?.type, draftOperator.value, draftValue.value),
+    effect: 'deny_read',
+  })
+  draftFieldId.value = ''
+  draftOperator.value = ''
+  draftValue.value = ''
+}
+
+function removeRule(idx: number): void {
+  rules.value.splice(idx, 1)
+}
+
+async function save(): Promise<void> {
+  saving.value = true
+  error.value = ''
+  savedFlash.value = false
+  try {
+    // send the full list (incl preserved unknown-field rules) so nothing is silently dropped
+    rules.value = await props.client.setConditionalRules(props.sheetId, [...rules.value])
+    savedFlash.value = true
+  } catch {
+    error.value = p('condRule.error.save')
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(load)
+watch(() => props.sheetId, load)
+</script>
+
+<style scoped>
+.meta-cond-rule { margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--meta-border, #e5e7eb); }
+.meta-cond-rule__title { margin: 0 0 4px; font-size: 13px; font-weight: 600; }
+.meta-cond-rule__desc { margin: 0 0 8px; font-size: 12px; color: var(--meta-text-muted, #6b7280); }
+.meta-cond-rule__hint { margin: 0 0 8px; font-size: 12px; color: var(--meta-warning, #b45309); }
+.meta-cond-rule__list { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.meta-cond-rule__row { display: flex; align-items: center; gap: 8px; font-size: 12px; padding: 4px 8px; background: var(--meta-surface-2, #f9fafb); border-radius: 6px; }
+.meta-cond-rule__row--unknown { opacity: 0.7; }
+.meta-cond-rule__field { font-weight: 600; }
+.meta-cond-rule__unknown { font-weight: 400; font-style: italic; color: var(--meta-text-muted, #9ca3af); margin-left: 4px; }
+.meta-cond-rule__op { color: var(--meta-text-muted, #6b7280); }
+.meta-cond-rule__deny { color: var(--meta-danger, #dc2626); margin-left: auto; }
+.meta-cond-rule__remove { border: none; background: none; color: var(--meta-danger, #dc2626); cursor: pointer; font-size: 12px; }
+.meta-cond-rule__add { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-bottom: 8px; }
+.meta-cond-rule__select, .meta-cond-rule__input { font-size: 12px; padding: 4px 6px; border: 1px solid var(--meta-border, #d1d5db); border-radius: 6px; }
+.meta-cond-rule__add-btn, .meta-cond-rule__save { font-size: 12px; padding: 4px 10px; border: 1px solid var(--meta-border, #d1d5db); border-radius: 6px; cursor: pointer; background: var(--meta-surface, #fff); }
+.meta-cond-rule__add-btn:disabled, .meta-cond-rule__save:disabled { opacity: 0.5; cursor: not-allowed; }
+.meta-cond-rule__actions { display: flex; align-items: center; gap: 12px; }
+.meta-cond-rule__saved { font-size: 12px; color: var(--meta-success, #059669); }
+.meta-cond-rule__error { font-size: 12px; color: var(--meta-danger, #dc2626); }
+</style>

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -296,6 +296,12 @@
             </label>
             <p class="meta-sheet-perm__rowdeny-warning" role="note">{{ p('rowDeny.warning') }}</p>
             <p v-if="rowDenyEnabled" class="meta-sheet-perm__rowdeny-note">{{ p('rowDeny.enabledNote') }}</p>
+            <MetaConditionalRuleBuilder
+              :sheet-id="sheetId"
+              :client="client"
+              :fields="fields"
+              :flag-enabled="rowDenyEnabled"
+            />
           </section>
         </template>
 
@@ -690,6 +696,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
+import MetaConditionalRuleBuilder from './MetaConditionalRuleBuilder.vue'
 import type { MultitableApiClient } from '../api/client'
 import type {
   MetaField,

--- a/apps/web/src/multitable/utils/conditional-rule-ops.ts
+++ b/apps/web/src/multitable/utils/conditional-rule-ops.ts
@@ -1,0 +1,96 @@
+// Conditional read-deny rule types + the operator-per-field-type allowlist for the authoring UI.
+//
+// This MIRRORS the backend evaluator `permission-rule-evaluator.ts` (OPS_BY_TYPE / RuleOperator). The
+// backend is authoritative — it re-validates every PUT through parseConditionalRules and evaluates
+// per-type at read time. This copy exists only so the authoring UI can filter the operator picker to
+// the operators the backend will actually honor for a field type (offering an unsupported operator
+// would author a rule that fails closed at evaluation). Keep the two in sync; a unit test asserts the
+// shapes match the backend allowlist.
+
+export type RuleOperator =
+  | 'eq'
+  | 'neq'
+  | 'isEmpty'
+  | 'isNotEmpty'
+  | 'contains'
+  | 'gt'
+  | 'lt'
+  | 'gte'
+  | 'lte'
+  | 'before'
+  | 'after'
+  | 'hasAny'
+  | 'hasNone'
+
+export interface ConditionalRuleDTO {
+  id: string
+  fieldId: string
+  operator: RuleOperator
+  value?: unknown
+  effect: 'deny_read'
+}
+
+const TEXT_OPS: RuleOperator[] = ['eq', 'neq', 'isEmpty', 'isNotEmpty', 'contains']
+const NUM_OPS: RuleOperator[] = ['eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'isEmpty', 'isNotEmpty']
+const BOOL_OPS: RuleOperator[] = ['eq', 'neq']
+const DATE_OPS: RuleOperator[] = ['eq', 'neq', 'before', 'after', 'isEmpty', 'isNotEmpty']
+const ARRAY_OPS: RuleOperator[] = ['hasAny', 'hasNone', 'isEmpty', 'isNotEmpty']
+
+// Keyed by the FE MetaFieldType. Types absent here cannot carry a rule (the field picker hides them).
+const OPS_BY_FE_TYPE: Record<string, RuleOperator[]> = {
+  string: TEXT_OPS,
+  longText: TEXT_OPS,
+  select: TEXT_OPS,
+  url: TEXT_OPS,
+  email: TEXT_OPS,
+  phone: TEXT_OPS,
+  number: NUM_OPS,
+  currency: NUM_OPS,
+  percent: NUM_OPS,
+  rating: NUM_OPS,
+  duration: NUM_OPS,
+  autoNumber: NUM_OPS,
+  boolean: BOOL_OPS,
+  date: DATE_OPS,
+  dateTime: DATE_OPS,
+  createdTime: DATE_OPS,
+  modifiedTime: DATE_OPS,
+  multiSelect: ARRAY_OPS,
+  person: ARRAY_OPS,
+}
+
+/** Operators the backend will honor for this FE field type; empty (= rule not authorable) for unknowns. */
+export function operatorsForFieldType(type: string | undefined): RuleOperator[] {
+  return type ? [...(OPS_BY_FE_TYPE[type] ?? [])] : []
+}
+
+/** Whether a field type can carry a conditional rule (has at least one valid operator). */
+export function fieldTypeSupportsRule(type: string | undefined): boolean {
+  return operatorsForFieldType(type).length > 0
+}
+
+/** Operators that take no value input (the value box is hidden for these). */
+export function operatorTakesNoValue(op: RuleOperator): boolean {
+  return op === 'isEmpty' || op === 'isNotEmpty'
+}
+
+const NUMERIC_FE_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
+const ARRAY_FE_TYPES = new Set(['multiSelect', 'person'])
+
+/**
+ * Coerce the raw text the author typed into the value shape the evaluator compares against:
+ * empty-operators carry no value; numeric fields → a number (NaN guarded back to the raw string so the
+ * rule still round-trips and the user can fix it); array fields with hasAny/hasNone → a string[] split on
+ * commas; everything else stays a string.
+ */
+export function coerceRuleValue(fieldType: string | undefined, op: RuleOperator, raw: string): unknown {
+  if (operatorTakesNoValue(op)) return undefined
+  if (fieldType && NUMERIC_FE_TYPES.has(fieldType)) {
+    const n = Number(raw)
+    return raw.trim() !== '' && Number.isFinite(n) ? n : raw
+  }
+  if (fieldType && ARRAY_FE_TYPES.has(fieldType) && (op === 'hasAny' || op === 'hasNone')) {
+    return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+  }
+  return raw
+}

--- a/apps/web/src/multitable/utils/meta-permission-labels.ts
+++ b/apps/web/src/multitable/utils/meta-permission-labels.ts
@@ -110,6 +110,34 @@ export type MetaPermissionLabelKey =
   | 'view.status.copyTemplateNoop'
   | 'view.status.updated'
   | 'view.title'
+  | 'condRule.title'
+  | 'condRule.desc'
+  | 'condRule.empty'
+  | 'condRule.field'
+  | 'condRule.operator'
+  | 'condRule.value'
+  | 'condRule.add'
+  | 'condRule.delete'
+  | 'condRule.save'
+  | 'condRule.saved'
+  | 'condRule.unknownField'
+  | 'condRule.disabledHint'
+  | 'condRule.error.load'
+  | 'condRule.error.save'
+  | 'condRule.deny'
+  | 'condRule.op.eq'
+  | 'condRule.op.neq'
+  | 'condRule.op.contains'
+  | 'condRule.op.isEmpty'
+  | 'condRule.op.isNotEmpty'
+  | 'condRule.op.gt'
+  | 'condRule.op.lt'
+  | 'condRule.op.gte'
+  | 'condRule.op.lte'
+  | 'condRule.op.before'
+  | 'condRule.op.after'
+  | 'condRule.op.hasAny'
+  | 'condRule.op.hasNone'
 
 const LABELS: Record<MetaPermissionLabelKey, { en: string; zh: string }> = {
   'action.clearOverrides': { en: 'Clear overrides', zh: '清除覆盖' },
@@ -226,6 +254,34 @@ const LABELS: Record<MetaPermissionLabelKey, { en: string; zh: string }> = {
   'view.status.copyTemplateNoop': { en: 'View ACL template already matches source member group', zh: '视图 ACL 模板已与源成员组一致' },
   'view.status.updated': { en: 'View permission updated', zh: '视图权限已更新' },
   'view.title': { en: 'View-level permissions', zh: '视图级权限' },
+  'condRule.title': { en: 'Conditional read-deny rules', zh: '条件读取拒绝规则' },
+  'condRule.desc': { en: 'A record matched by any rule below is hidden from non-admin readers on every surface. Rules only take effect when row-level read permissions are enabled above.', zh: '被下列任一规则匹配的记录，将在所有界面对非管理员读者隐藏。仅当上方启用了行级读取权限时，规则才生效。' },
+  'condRule.empty': { en: 'No conditional rules.', zh: '暂无条件规则。' },
+  'condRule.field': { en: 'Field', zh: '字段' },
+  'condRule.operator': { en: 'Condition', zh: '条件' },
+  'condRule.value': { en: 'Value', zh: '值' },
+  'condRule.add': { en: 'Add rule', zh: '添加规则' },
+  'condRule.delete': { en: 'Remove', zh: '移除' },
+  'condRule.save': { en: 'Save rules', zh: '保存规则' },
+  'condRule.saved': { en: 'Rules saved', zh: '规则已保存' },
+  'condRule.unknownField': { en: '(field not found — preserved)', zh: '（字段不存在——已保留）' },
+  'condRule.disabledHint': { en: 'Rules are stored but only enforce when row-level read permissions are enabled.', zh: '规则已保存，但仅在启用行级读取权限后才会强制执行。' },
+  'condRule.error.load': { en: 'Failed to load conditional rules', zh: '加载条件规则失败' },
+  'condRule.error.save': { en: 'Failed to save conditional rules', zh: '保存条件规则失败' },
+  'condRule.deny': { en: 'deny read', zh: '拒绝读取' },
+  'condRule.op.eq': { en: 'equals', zh: '等于' },
+  'condRule.op.neq': { en: 'not equals', zh: '不等于' },
+  'condRule.op.contains': { en: 'contains', zh: '包含' },
+  'condRule.op.isEmpty': { en: 'is empty', zh: '为空' },
+  'condRule.op.isNotEmpty': { en: 'is not empty', zh: '不为空' },
+  'condRule.op.gt': { en: 'greater than', zh: '大于' },
+  'condRule.op.lt': { en: 'less than', zh: '小于' },
+  'condRule.op.gte': { en: 'at least', zh: '大于等于' },
+  'condRule.op.lte': { en: 'at most', zh: '小于等于' },
+  'condRule.op.before': { en: 'before', zh: '早于' },
+  'condRule.op.after': { en: 'after', zh: '晚于' },
+  'condRule.op.hasAny': { en: 'has any of', zh: '包含任一' },
+  'condRule.op.hasNone': { en: 'has none of', zh: '不包含任一' },
 }
 
 export function permissionLabel(key: MetaPermissionLabelKey, isZh: boolean): string {

--- a/apps/web/tests/multitable-conditional-rule-builder.spec.ts
+++ b/apps/web/tests/multitable-conditional-rule-builder.spec.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+import MetaConditionalRuleBuilder from '../src/multitable/components/MetaConditionalRuleBuilder.vue'
+
+let app: VueApp | null = null
+let container: HTMLDivElement | null = null
+
+async function flush(cycles = 5) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+const FIELDS = [
+  { id: 'fld_status', name: 'Status', type: 'select' },
+  { id: 'fld_amount', name: 'Amount', type: 'number' },
+  { id: 'fld_link', name: 'Linked', type: 'link' }, // unsupported → hidden from picker
+]
+
+function mount(opts: {
+  getConditionalRules: ReturnType<typeof vi.fn>
+  setConditionalRules: ReturnType<typeof vi.fn>
+  flagEnabled?: boolean
+}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(MetaConditionalRuleBuilder, {
+    sheetId: 'sheet_x',
+    client: { getConditionalRules: opts.getConditionalRules, setConditionalRules: opts.setConditionalRules } as any,
+    fields: FIELDS,
+    flagEnabled: opts.flagEnabled ?? true,
+  })
+  app.mount(container)
+}
+
+const q = (sel: string) => container!.querySelector(sel) as HTMLElement | null
+const qa = (sel: string) => Array.from(container!.querySelectorAll(sel)) as HTMLElement[]
+function setSelect(sel: string, value: string) {
+  const el = q(sel) as HTMLSelectElement
+  el.value = value
+  el.dispatchEvent(new Event('change'))
+}
+function setInput(sel: string, value: string) {
+  const el = q(sel) as HTMLInputElement
+  el.value = value
+  el.dispatchEvent(new Event('input'))
+}
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+describe('MetaConditionalRuleBuilder', () => {
+  it('builds a rule and saves it with the correct PUT payload (coerced value)', async () => {
+    const get = vi.fn().mockResolvedValue({ rules: [], rejected: [] })
+    const set = vi.fn().mockImplementation((_s: string, rules: unknown[]) => Promise.resolve(rules))
+    mount({ getConditionalRules: get, setConditionalRules: set })
+    await flush()
+
+    setSelect('[data-testid="cond-rule-field"]', 'fld_amount') // number field
+    await flush()
+    setSelect('[data-testid="cond-rule-operator"]', 'gt')
+    await flush()
+    setInput('[data-testid="cond-rule-value"]', '100')
+    await flush()
+    ;(q('[data-testid="cond-rule-add"]') as HTMLButtonElement).click()
+    await flush()
+    ;(q('[data-testid="cond-rule-save"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(set).toHaveBeenCalledTimes(1)
+    const payload = set.mock.calls[0][1] as any[]
+    expect(payload).toHaveLength(1)
+    expect(payload[0]).toMatchObject({ fieldId: 'fld_amount', operator: 'gt', value: 100, effect: 'deny_read' })
+    expect(typeof payload[0].value).toBe('number') // numeric coercion
+  })
+
+  it('filters the operator list per field type', async () => {
+    const get = vi.fn().mockResolvedValue({ rules: [], rejected: [] })
+    mount({ getConditionalRules: get, setConditionalRules: vi.fn() })
+    await flush()
+
+    setSelect('[data-testid="cond-rule-field"]', 'fld_amount') // number
+    await flush()
+    let ops = qa('[data-testid="cond-rule-operator"] option').map((o) => (o as HTMLOptionElement).value)
+    expect(ops).toContain('gt')
+    expect(ops).not.toContain('contains')
+
+    setSelect('[data-testid="cond-rule-field"]', 'fld_status') // select
+    await flush()
+    ops = qa('[data-testid="cond-rule-operator"] option').map((o) => (o as HTMLOptionElement).value)
+    expect(ops).toContain('contains')
+    expect(ops).not.toContain('gt')
+  })
+
+  it('hides unsupported field types from the picker', async () => {
+    mount({ getConditionalRules: vi.fn().mockResolvedValue({ rules: [], rejected: [] }), setConditionalRules: vi.fn() })
+    await flush()
+    const fieldOpts = qa('[data-testid="cond-rule-field"] option').map((o) => (o as HTMLOptionElement).value)
+    expect(fieldOpts).toContain('fld_status')
+    expect(fieldOpts).toContain('fld_amount')
+    expect(fieldOpts).not.toContain('fld_link') // 'link' is unsupported
+  })
+
+  it('preserves an unknown-field rule on save (no silent loss)', async () => {
+    const unknownRule = { id: 'r_old', fieldId: 'fld_deleted', operator: 'eq', value: 'x', effect: 'deny_read' }
+    const get = vi.fn().mockResolvedValue({ rules: [unknownRule], rejected: [] })
+    const set = vi.fn().mockImplementation((_s: string, rules: unknown[]) => Promise.resolve(rules))
+    mount({ getConditionalRules: get, setConditionalRules: set })
+    await flush()
+
+    // it renders, flagged as unknown
+    expect(q('[data-testid="cond-rule-row-0"]')).toBeTruthy()
+    expect(container!.textContent).toContain('fld_deleted')
+
+    ;(q('[data-testid="cond-rule-save"]') as HTMLButtonElement).click()
+    await flush()
+    const payload = set.mock.calls[0][1] as any[]
+    expect(payload.find((r) => r.id === 'r_old')).toBeTruthy() // preserved
+  })
+
+  it('deletes a rule', async () => {
+    const get = vi.fn().mockResolvedValue({
+      rules: [{ id: 'r1', fieldId: 'fld_status', operator: 'eq', value: 'secret', effect: 'deny_read' }],
+      rejected: [],
+    })
+    mount({ getConditionalRules: get, setConditionalRules: vi.fn() })
+    await flush()
+    expect(q('[data-testid="cond-rule-row-0"]')).toBeTruthy()
+    ;(q('[data-testid="cond-rule-remove-0"]') as HTMLButtonElement).click()
+    await flush()
+    expect(q('[data-testid="cond-rule-row-0"]')).toBeNull()
+  })
+})

--- a/apps/web/tests/multitable-conditional-rule-ops.spec.ts
+++ b/apps/web/tests/multitable-conditional-rule-ops.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  coerceRuleValue,
+  fieldTypeSupportsRule,
+  operatorTakesNoValue,
+  operatorsForFieldType,
+} from '../src/multitable/utils/conditional-rule-ops'
+
+describe('conditional-rule-ops (FE mirror of the backend allowlist)', () => {
+  it('returns the operators allowed per field type; empty for unsupported', () => {
+    expect(operatorsForFieldType('select')).toContain('contains')
+    expect(operatorsForFieldType('number')).toEqual(expect.arrayContaining(['gt', 'lt', 'gte', 'lte']))
+    expect(operatorsForFieldType('boolean')).toEqual(['eq', 'neq'])
+    expect(operatorsForFieldType('multiSelect')).toEqual(expect.arrayContaining(['hasAny', 'hasNone']))
+    expect(operatorsForFieldType('string')).toContain('contains') // basic text supported (alias of BE 'text')
+    expect(operatorsForFieldType('link')).toEqual([]) // unsupported
+    expect(operatorsForFieldType(undefined)).toEqual([])
+    expect(fieldTypeSupportsRule('select')).toBe(true)
+    expect(fieldTypeSupportsRule('link')).toBe(false)
+  })
+
+  it('coerces values to the evaluator shape', () => {
+    expect(coerceRuleValue('number', 'gt', '100')).toBe(100)
+    expect(typeof coerceRuleValue('currency', 'gte', '5')).toBe('number')
+    expect(coerceRuleValue('number', 'gt', 'abc')).toBe('abc') // non-numeric kept raw so it round-trips/fixable
+    expect(coerceRuleValue('multiSelect', 'hasAny', 'a, b ,c')).toEqual(['a', 'b', 'c'])
+    expect(coerceRuleValue('select', 'eq', 'secret')).toBe('secret')
+    expect(coerceRuleValue('select', 'isEmpty', 'ignored')).toBeUndefined() // empty-ops carry no value
+    expect(operatorTakesNoValue('isNotEmpty')).toBe(true)
+    expect(operatorTakesNoValue('eq')).toBe(false)
+  })
+})

--- a/packages/core-backend/src/multitable/permission-rule-evaluator.ts
+++ b/packages/core-backend/src/multitable/permission-rule-evaluator.ts
@@ -68,22 +68,44 @@ const DATE_OPS: RuleOperator[] = ['eq', 'neq', 'before', 'after', 'isEmpty', 'is
 const ARRAY_OPS: RuleOperator[] = ['hasAny', 'hasNone', 'isEmpty', 'isNotEmpty']
 
 const OPS_BY_TYPE: Record<string, RuleOperator[]> = {
+  // text-like (the FE field type for plain single-line text is `string`; `text`/`singleLineText` are
+  // accepted aliases so a rule authored against either naming evaluates rather than failing closed)
   text: TEXT_OPS,
+  string: TEXT_OPS,
   singleLineText: TEXT_OPS,
   longText: TEXT_OPS,
   select: TEXT_OPS,
+  url: TEXT_OPS,
+  email: TEXT_OPS,
+  phone: TEXT_OPS,
+  // numeric
   number: NUM_OPS,
   currency: NUM_OPS,
   percent: NUM_OPS,
   rating: NUM_OPS,
   duration: NUM_OPS,
+  autoNumber: NUM_OPS,
+  // boolean
   boolean: BOOL_OPS,
   checkbox: BOOL_OPS,
+  // date-like
   date: DATE_OPS,
   dateTime: DATE_OPS,
+  createdTime: DATE_OPS,
+  modifiedTime: DATE_OPS,
+  // array-like
   multiSelect: ARRAY_OPS,
   person: ARRAY_OPS,
   user: ARRAY_OPS,
+}
+
+/**
+ * The canonical operator allowlist for a field type (the authoring UI mirrors this to filter the
+ * operator picker). An unknown field type → empty list (no operator is valid → any rule on it would
+ * fail closed at evaluation). Returned as a fresh array so callers can't mutate the internal map.
+ */
+export function operatorsForFieldType(type: string): RuleOperator[] {
+  return [...(OPS_BY_TYPE[type] ?? [])]
 }
 
 const ALL_OPERATORS: ReadonlySet<RuleOperator> = new Set<RuleOperator>([

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -17,6 +17,7 @@ import {
 } from '../multitable/permission-derivation'
 import { validateAiShortcutFieldProperty } from '../multitable/ai-shortcut-config'
 import { withFieldVisibilityRule } from '../multitable/field-visibility-rule'
+import { parseConditionalRules } from '../multitable/permission-rule-evaluator'
 import { withFormLayout, projectPublicFormLayout, sanitizeFormRedirectUrl } from '../multitable/form-layout'
 import { projectFormContextView } from '../multitable/form-context-view-projection'
 import { rbacGuard, rbacGuardAny } from '../rbac/rbac'
@@ -5600,6 +5601,70 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] set row-level-read-deny flag failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to set row-level read-deny flag' } })
+    }
+  })
+
+  // #18 phase-2 (2b): conditional read-deny rules authoring. Rules live in meta_sheets.conditional_read_rules
+  // and only ENFORCE when the row-level-read-deny flag is on (see permission-service). GET is canRead-gated;
+  // PUT replaces the list, canManageSheetAccess-gated, validated through parseConditionalRules — a
+  // structurally-invalid rule is REJECTED (400) and nothing is written (no silent drop).
+  router.get('/sheets/:sheetId/conditional-rules', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    try {
+      const pool = poolManager.get()
+      const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
+      if (!sheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canRead) return sendForbidden(res)
+      const r = await pool.query('SELECT conditional_read_rules AS rules FROM meta_sheets WHERE id = $1', [sheetId])
+      const raw = (r.rows[0] as { rules?: unknown } | undefined)?.rules
+      // parseConditionalRules round-trips the stored rules; `rejected` surfaces any legacy/unknown rows so
+      // the editor can show them disabled rather than silently dropping them.
+      const { rules, rejected } = parseConditionalRules(raw)
+      return res.json({ ok: true, data: { rules, rejected } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] read conditional-rules failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to read conditional rules' } })
+    }
+  })
+
+  router.put('/sheets/:sheetId/conditional-rules', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    }
+    const body = req.body as { rules?: unknown } | undefined
+    if (!body || !Array.isArray(body.rules)) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'rules must be an array' } })
+    }
+    // Validate at author time: any structurally-invalid rule rejects the whole PUT (never store a bad rule,
+    // never silently drop one).
+    const { rules, rejected } = parseConditionalRules(body.rules)
+    if (rejected.length > 0) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `invalid rule(s): ${rejected.map((x) => x.reason).join('; ')}` } })
+    }
+    try {
+      const pool = poolManager.get()
+      const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
+      if (!sheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res)
+      await pool.query('UPDATE meta_sheets SET conditional_read_rules = $1::jsonb WHERE id = $2', [JSON.stringify(rules), sheetId])
+      return res.json({ ok: true, data: { rules } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] set conditional-rules failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to set conditional rules' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-conditional-rules-api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-conditional-rules-api.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #18 phase-2 (2b-S3) conditional-rules authoring API — real-DB. Pins GET/PUT
+ * /sheets/:sheetId/conditional-rules: PUT is canManageSheetAccess-gated (multitable:share) and validates
+ * every rule through parseConditionalRules (a structurally-invalid rule rejects the whole PUT, 400, no
+ * write); GET is canRead-gated. Rules persist in meta_sheets.conditional_read_rules.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_cr_${TS}`
+const SHEET = `sheet_cr_${TS}`
+const MANAGER = `u_cr_mgr_${TS}`
+const READER = `u_cr_ro_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+function buildApp(userId: string, perms: string[]): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms, permissions: perms }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+// manager: multitable:share → canManageSheetAccess; reader: read-only; no-read: no multitable perms.
+const managerApp = () => buildApp(MANAGER, ['multitable:read', 'multitable:share'])
+const readerApp = () => buildApp(READER, ['multitable:read'])
+const noReadApp = () => buildApp(`u_cr_nr_${TS}`, [])
+const URL = `/api/multitable/sheets/${SHEET}/conditional-rules`
+
+const VALID = [{ id: 'r1', fieldId: 'fld_status', operator: 'eq', value: 'secret', effect: 'deny_read' }]
+const dbRules = async (): Promise<unknown> => {
+  const r = await q('SELECT conditional_read_rules AS rules FROM meta_sheets WHERE id = $1', [SHEET])
+  return (r.rows[0] as { rules?: unknown } | undefined)?.rules
+}
+
+describeIfDatabase('#18 phase-2 conditional-rules API (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CR Sheet'])
+  })
+  beforeEach(async () => {
+    await q(`UPDATE meta_sheets SET conditional_read_rules = '[]'::jsonb WHERE id = $1`, [SHEET])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('manager PUT valid rules → 200 + GET returns them + DB persists', async () => {
+    const put = await request(managerApp()).put(URL).send({ rules: VALID })
+    expect(put.status).toBe(200)
+    expect(put.body.data.rules).toHaveLength(1)
+    const get = await request(managerApp()).get(URL)
+    expect(get.status).toBe(200)
+    expect(get.body.data.rules[0]).toMatchObject({ id: 'r1', fieldId: 'fld_status', operator: 'eq', effect: 'deny_read' })
+    expect(Array.isArray(await dbRules())).toBe(true)
+  })
+
+  test('PUT invalid rule (bad operator) → 400, nothing written', async () => {
+    const bad = [{ id: 'r1', fieldId: 'fld_status', operator: 'bogus', effect: 'deny_read' }]
+    const put = await request(managerApp()).put(URL).send({ rules: bad })
+    expect(put.status).toBe(400)
+    expect(await dbRules()).toEqual([])
+  })
+
+  test('PUT invalid rule (unknown effect) → 400, nothing written', async () => {
+    const bad = [{ id: 'r1', fieldId: 'fld_status', operator: 'eq', effect: 'deny_write' }]
+    expect((await request(managerApp()).put(URL).send({ rules: bad })).status).toBe(400)
+    expect(await dbRules()).toEqual([])
+  })
+
+  test('PUT non-array body → 400', async () => {
+    expect((await request(managerApp()).put(URL).send({ rules: 'nope' })).status).toBe(400)
+    expect((await request(managerApp()).put(URL).send({})).status).toBe(400)
+  })
+
+  test('non-manager (read-only) PUT → 403, rules unchanged', async () => {
+    const put = await request(readerApp()).put(URL).send({ rules: VALID })
+    expect(put.status).toBe(403)
+    expect(await dbRules()).toEqual([])
+  })
+
+  test('reader GET → 200 (canRead-gated)', async () => {
+    const get = await request(readerApp()).get(URL)
+    expect(get.status).toBe(200)
+    expect(get.body.data.rules).toEqual([])
+  })
+
+  test('no-read user GET → 403', async () => {
+    expect((await request(noReadApp()).get(URL)).status).toBe(403)
+  })
+
+  test('PUT on a missing sheet → 404', async () => {
+    const put = await request(managerApp())
+      .put(`/api/multitable/sheets/sheet_cr_missing_${TS}/conditional-rules`)
+      .send({ rules: VALID })
+    expect(put.status).toBe(404)
+  })
+})


### PR DESCRIPTION
Gated arc 2b-S3 (final slice). **API:** GET /sheets/:sheetId/conditional-rules (canRead) + PUT (canManageSheetAccess, 404 missing) — PUT validates the whole list through parseConditionalRules, invalid→400 writing nothing (no silent drop); gating mirrors the row-level-read-deny flag endpoints. **UI:** MetaConditionalRuleBuilder.vue in MetaSheetPermissionManager beside the row-deny flag — field picker hides rule-incapable types, **operator picker filtered per field type**, value coerced to the evaluator shape, **unknown/deleted-field rule shown disabled + preserved on save (no silent loss)**, i18n via typed labels. **Bug fixed:** OPS_BY_TYPE was keyed by text/singleLineText but the real FE type is `string` → text/url/email/phone rules would have failed closed at evaluation; added the FE type names + exported operatorsForFieldType as the canonical allowlist (select/number/date/array were already correct). **Verify:** real-DB API test (allowlisted, CI 20.x): valid→200+GET; invalid op/effect/non-array→400 unchanged; non-manager→403; no-read GET→403; missing→404. FE 7/7; evaluator 37/37; vue-tsc+tsc clean; full unit 4481/0. 🤖 Generated with Claude Code