### PR TITLE
feat(multitable): 2a-DT-S2 live-CRDT dateTime (canonical UTC ISO invariant)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -17,9 +17,9 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="datetime-local"
-      :value="dateTimeInputValue(modelValue)"
-      @input="emit('update:modelValue', dateTimeValueFromLocalInput(($event.target as HTMLInputElement).value))"
-      @keydown.enter="emit('confirm')"
+      :value="dateTimeInputValue(scalarActive ? scalarValue : modelValue)"
+      @input="commitScalar(dateTimeValueFromLocalInput(($event.target as HTMLInputElement).value))"
+      @keydown.enter="scalarConfirm()"
       @keydown.escape="emit('cancel')"
     />
     <!-- string: date-like -->
@@ -503,12 +503,10 @@ const yjsCollaborators = computed(() => yjsBinding.collaborators.value)
 // convergence, no seed flip / migration needed; the value written is the exact
 // stored shape — select option value, date raw string — verified no-corruption
 // on real PG).
-// DEFERRED: `dateTime` — the backend codec normalizes it to canonical UTC ISO, so
-// the editor-written value diverges from the stored form (a tz round-trip/display
-// question; the real-DB golden surfaced it). It remains its own gate (see the
-// dateTime note below). (`duration` was once deferred for the same "local text buffer
-// fights the typist" reason, but now binds via the commit-on-confirm path — see 2a-2 /
-// DURATION_COMMIT_ON_CONFIRM_YJS_TYPES below; it is no longer a separate gate.)
+// `dateTime` (2a-DT-S2) and `duration` (2a-2) were once deferred but now bind: dateTime via
+// the string-stored-atomic path writing the CANONICAL UTC ISO value (see the
+// STRING_STORED_ATOMIC_YJS_TYPES note below), duration via commit-on-confirm
+// (DURATION_COMMIT_ON_CONFIRM_YJS_TYPES). No multitable scalar field type remains deferred.
 // Inactive → byte-identical REST path (setValue is a no-op; nothing changes).
 const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 'multiSelect']
 // 2a-1: string-stored ATOMIC types. Values are strings but atomic (LWW, not
@@ -516,12 +514,13 @@ const SCALAR_YJS_TYPES = ['number', 'currency', 'percent', 'boolean', 'rating', 
 // may exist in a persisted doc as Y.Text (the historical seed shape), so the
 // binding is constructed with coerceText (read Y.Text-or-plain) and writes a
 // plain string on edit — lazy convergence, no seed flip / migration needed.
-// dateTime is DEFERRED: the backend codec normalizes it to a canonical UTC ISO
-// string, so the value the editor writes diverges from the stored form — a tz
-// round-trip/display-consistency question that needs its own decision (the
-// real-DB corruption golden surfaced this). select + date have no such codec
-// conversion (exact string round-trip), so they ship here.
-const STRING_STORED_ATOMIC_YJS_TYPES = ['select', 'date']
+// 2a-DT-S2 (design-lock multitable-2a-datetime-live-crdt-designlock-20260618): dateTime
+// joins here. It is a string-stored atomic with the SAME Y.Text history (coerceText reads
+// old docs), but its editor handler writes the CANONICAL UTC ISO form — the dateTime
+// `@input` calls commitScalar(dateTimeValueFromLocalInput(localInput)), never the raw local
+// input — so cross-TZ collaborators converge on the canonical stored value and the flush
+// preserves the byte-identical REST shape. Display stays local via dateTimeInputValue.
+const STRING_STORED_ATOMIC_YJS_TYPES = ['select', 'date', 'dateTime']
 // 2a-2: duration is a plain number (seconds-backed) but commits ON CONFIRM, not per
 // keystroke — its editor's local h:mm buffer (durationText) owns the input while typing
 // (live re-derivation would reformat under the cursor). The binding is constructed so a

--- a/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App, type Ref } from 'vue'
+import { dateTimeInputValue, dateTimeValueFromLocalInput } from '../src/multitable/utils/field-display'
 
 // Controllable scalar-binding mock: tests flip `scalarActive`/`scalarVal` to
 // exercise the active (Yjs) vs inactive (REST) paths of MetaCellEditor's
@@ -329,5 +330,53 @@ describe('MetaCellEditor scalar Yjs wiring', () => {
     scalarVal.value = 9999 // a remote edit arrives mid-type
     await nextTick()
     expect(input.value).toBe('1:') // still the user's partial buffer, not remote-derived text
+  })
+
+  // ── 2a-DT-S2: dateTime live-CRDT (canonical UTC ISO value invariant) ──
+  it('constructs a dateTime scalar binding with coerceText (dual-reader for old Y.Text docs)', () => {
+    mountField({ id: 'fld_dt', name: 'When', type: 'dateTime' }, null)
+    expect(useYjsScalarCellMock).toHaveBeenCalled()
+    expect(useYjsScalarCellMock.mock.calls[0][0]).toMatchObject({ coerceText: true })
+  })
+
+  it('active dateTime: input writes the CANONICAL UTC ISO via setValue (never the raw local input)', async () => {
+    scalarActive.value = true
+    const onUpdate = vi.fn(); const onConfirm = vi.fn(); const onYjsCommit = vi.fn()
+    mountField({ id: 'fld_dt', name: 'When', type: 'dateTime' }, null, { 'onUpdate:modelValue': onUpdate, onConfirm, onYjsCommit })
+    const input = container!.querySelector('input[type="datetime-local"]') as HTMLInputElement
+    const local = '2026-06-18T14:30'
+    input.value = local
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    const canonical = dateTimeValueFromLocalInput(local)
+    expect(setValueMock).toHaveBeenCalledWith(canonical) // canonical UTC ISO, not the local input
+    expect(setValueMock).not.toHaveBeenCalledWith(local) // the raw local input is NEVER written
+    expect(onUpdate).toHaveBeenCalledWith(canonical)
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(onYjsCommit).toHaveBeenCalled()
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  it('active dateTime: displays the canonical scalar value in local form (read side)', () => {
+    scalarActive.value = true
+    const canonical = dateTimeValueFromLocalInput('2026-06-18T14:30')
+    scalarVal.value = canonical
+    mountField({ id: 'fld_dt', name: 'When', type: 'dateTime' }, null)
+    const input = container!.querySelector('input[type="datetime-local"]') as HTMLInputElement
+    expect(input.value).toBe(dateTimeInputValue(canonical))
+  })
+
+  it('inactive dateTime: REST path — setValue not called; input still emits canonical update:modelValue', async () => {
+    scalarActive.value = false
+    const onUpdate = vi.fn()
+    mountField({ id: 'fld_dt', name: 'When', type: 'dateTime' }, null, { 'onUpdate:modelValue': onUpdate })
+    const input = container!.querySelector('input[type="datetime-local"]') as HTMLInputElement
+    const local = '2026-06-18T09:00'
+    input.value = local
+    input.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(setValueMock).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledWith(dateTimeValueFromLocalInput(local))
   })
 })

--- a/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
+++ b/packages/core-backend/tests/integration/yjs-scalar-strdate-migration-realdb.test.ts
@@ -46,11 +46,11 @@ const F_DATETIME = 'fld_datetime'
 const SELECT_OPTS = [{ value: 'optA' }, { value: 'optB' }]
 
 // initial (seed) values — strings; the seed will store them as Y.Text.
-const SEED = { [F_SELECT]: 'optA', [F_DATE]: '2026-01-01', [F_DATETIME]: '2026-01-01T10:00' }
+const SEED = { [F_SELECT]: 'optA', [F_DATE]: '2026-01-01', [F_DATETIME]: '2026-01-01T10:00:00.000Z' }
 // edited values — what the client writes as PLAIN strings.
 const EDIT_SELECT = 'optB'
 const EDIT_DATE = '2026-02-02'
-const EDIT_DATETIME = '2026-02-02T12:30'
+const EDIT_DATETIME = '2026-02-02T12:30:00.000Z' // canonical UTC ISO — what the FE binding (dateTimeValueFromLocalInput) writes
 
 async function readData(): Promise<Record<string, unknown>> {
   const r = await q('SELECT data FROM meta_records WHERE id = $1', [REC_ID])
@@ -149,7 +149,7 @@ describeIfDatabase('Yjs string-stored atomic MIGRATION (real DB) — select/date
       // And they read back as the exact seed strings (what coerceText does on the FE).
       expect((fields.get(F_SELECT) as Y.Text).toString()).toBe('optA')
       expect((fields.get(F_DATE) as Y.Text).toString()).toBe('2026-01-01')
-      expect((fields.get(F_DATETIME) as Y.Text).toString()).toBe('2026-01-01T10:00')
+      expect((fields.get(F_DATETIME) as Y.Text).toString()).toBe('2026-01-01T10:00:00.000Z')
     } finally {
       await svc.destroy()
     }
@@ -204,15 +204,14 @@ describeIfDatabase('Yjs string-stored atomic MIGRATION (real DB) — select/date
         expect(data[k]).toBe(v)
         expect(data[k]).not.toBe('[object Object]')
       }
-      // dateTime is DEFERRED from live wiring precisely because its codec normalizes to canonical UTC
-      // ISO — a plain-string flush does NOT round-trip the raw input. Assert it is a valid normalized
-      // string (NOT corrupted: not a Y.Text object, not '[object Object]', not a nested Yjs type) but
-      // NOT the raw input — this is the evidence that dateTime must stay REST-only (not in
-      // STRING_STORED_ATOMIC_YJS_TYPES) until a tz-aware live-edit design exists.
+      // dateTime is WIRED (2a-DT-S2, design-lock multitable-2a-datetime-live-crdt-designlock-20260618):
+      // the FE binding writes the CANONICAL UTC ISO (dateTimeValueFromLocalInput) and the backend codec
+      // keeps it canonical, so the flush round-trips the SAME INSTANT with no tz drift — as an uncorrupted
+      // ISO string, never a Y.Text object, '[object Object]', or a nested Yjs type.
       expect(typeof data[F_DATETIME]).toBe('string')
       expect(data[F_DATETIME]).not.toBe('[object Object]')
-      expect(data[F_DATETIME]).not.toBe(EDIT_DATETIME) // normalized by the codec, not the raw input
       expect(data[F_DATETIME] as string).toMatch(/\dT\d.*Z$/) // canonical UTC ISO, a valid (uncorrupted) string
+      expect(new Date(data[F_DATETIME] as string).getTime()).toBe(new Date(EDIT_DATETIME).getTime()) // same instant — no tz drift (format-independent round-trip)
     } finally {
       bridge.unobserve(REC_ID)
       await svc.destroy()


### PR DESCRIPTION
Closes the **last 2a field type** per design-lock #2843. dateTime now binds to live CRDT.

- Joins `STRING_STORED_ATOMIC_YJS_TYPES` (→ `coerceText` dual-reader for old persisted `Y.Text` docs).
- Its `@input` writes the **canonical UTC ISO** via `commitScalar(dateTimeValueFromLocalInput(localInput))` — **never the raw local input** — so cross-TZ collaborators converge canonically and the flush keeps the byte-identical REST shape; display stays local via `dateTimeInputValue`.

**Tests:** FE unit (canonical write / no raw-local write / coerceText / active read / inactive REST) — **21/21**. Real-DB: the strdate migration golden now exercises dateTime end-to-end (old `Y.Text` → edit → flush → **same-instant** canonical ISO, no TZ drift, no corruption). Stale "dateTime DEFERRED" comments refreshed. backend tsc clean.

After this lands I'll refresh the gated-remainder plan/TODO to close 2a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)