### PR TITLE
feat(attendance): annual-leave employee /me self-service balance read (token-locked subject)

### DIFF
--- a/docs/development/attendance-annual-leave-me-selfview-design-and-verification-20260617.md
+++ b/docs/development/attendance-annual-leave-me-selfview-design-and-verification-20260617.md
@@ -1,0 +1,51 @@
+# Annual-leave employee `/me` self-service balance — design & verification
+
+**Status:** the endpoint slice is built + verified on this branch. This is the **deferred-future** piece the L5 admin-UI
+design-lock named ("Employee `/me` self-service balance view — a separate future endpoint, subject locked to the token,
+never mixed into the admin read"). v1 here is the **secure self-read endpoint**; the employee-facing overview card is
+the documented thin follow-up (§5).
+
+## 1. Why a separate endpoint (not the admin L5a read)
+
+The admin read (`GET /api/attendance/leave-balances`, `attendance:admin`) queries an **arbitrary `userId`** — correct
+for an administrator, wrong for self-service. An employee surface must guarantee a caller can read **only their own**
+balance. Mixing a self-mode into the admin route (a flag, an optional userId) is exactly the conflation the design-lock
+forbade. So `/me` is its own route with a different gate and a **subject that is not a parameter**.
+
+## 2. Contract (as built)
+
+`GET /api/attendance/leave-balances/me` — `withPermission('attendance:read')` (any authenticated employee, **not**
+admin). Optional query: `leaveTypeCode` (default `annual`), `eventLimit` (1–200, default 50). **No `userId` parameter.**
+Returns the same explainable shape as the admin read: `{ ok, data: { userId, summary, activeLots, recentEvents, eventLimit } }`.
+
+The query is the shared `readAnnualLeaveBalanceForUser(orgId, userId, leaveTypeCode, eventLimit)` helper — the admin L5a
+route was refactored to call it too, so there is **one** balance-read implementation, not two.
+
+## 3. The security property (the whole point)
+
+**The subject is always the authenticated requester; it cannot be set to anyone else.**
+
+- The subject is `getUserId(req)` — resolved from the authenticated token. Once `withPermission('attendance:read')`
+  passes, `req.user.id` is set, so `getUserId`'s last-resort `x-user-id` header fallback **never** overrides it.
+- There is **no `userId` query parameter** on the route, so the schema cannot carry another user's id.
+- If no authenticated subject resolves → `401 UNAUTHORIZED`.
+
+So neither a `?userId=<other>` param nor an `x-user-id: <other>` header can make `/me` return another user's balance.
+
+## 4. Verification
+
+- `node --check` on the plugin: clean.
+- Integration test (`attendance-plugin.test.ts`, real in-process server + Postgres): a caller with a `2400`-minute
+  balance and **another** user holding `9999` —
+  1. `/me` returns the caller's own balance (`userId` = the token, `granted/remaining = 2400`);
+  2. `/me?userId=<other>` still returns the caller's `2400`, never the other's `9999` (the param cannot override the subject);
+  3. `/me` with an `x-user-id: <other>` header still returns the caller's `2400` (the header cannot override the subject).
+- The admin **L5a** read still passes via the shared helper (no regression from the refactor). **9/9** annual tests green.
+
+## 5. Out of scope here / follow-up
+
+- **Employee overview card** — a thin self-balance card in the `overview` surface that fetches `/me` on mount and shows
+  the summary (+ a detail expansion). It reuses this endpoint with no new security surface; it's the natural next thin
+  slice once the direction is confirmed. (It touches the overview section registry / nav, so it's its own small PR.)
+- **Self-service for other leave types** — the endpoint already accepts `leaveTypeCode`; v1 surfaces `annual`.
+- This endpoint is **read-only**; no employee-facing mutation (employees never adjust their own balances).

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5429,6 +5429,59 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④/年假 /me — employee self-read: subject is the token; neither a userId param nor an x-user-id header can read another user', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const meId = `al-me-${runSuffix}`
+    const otherId = `al-me-other-${runSuffix}`
+    // an EMPLOYEE token (attendance:read, NOT admin)
+    const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${meId}&roles=employee&perms=attendance:read`)
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    if (!token) { await pool.end().catch(() => undefined); return }
+    const headers = { Authorization: `Bearer ${token}` }
+    const mkLot = async (uid: string, amount: number, remaining: number, tag: string) => (await pool.query<{ id: string }>(
+      `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at)
+       VALUES ('default',$1,'annual',$2,$3,'annual_accrual',$4,'active','2026-01-01') RETURNING id`,
+      [uid, amount, remaining, `me:${runSuffix}:${tag}`])).rows[0].id
+    const mkEvent = async (uid: string, balanceId: string, delta: number) => { await pool.query(
+      `INSERT INTO attendance_leave_balance_events (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+       VALUES ('default',$1,$2,'grant',$3,'annual_accrual',$4)`, [uid, balanceId, delta, balanceId]) }
+    try {
+      // the caller has 2400; ANOTHER user has 9999 the caller must NEVER be able to read
+      const myLot = await mkLot(meId, 2400, 2400, 'mine'); await mkEvent(meId, myLot, 2400)
+      const otherLot = await mkLot(otherId, 9999, 9999, 'other'); await mkEvent(otherId, otherLot, 9999)
+
+      // (1) /me returns the caller's OWN balance (subject from the token; no userId param exists on this route)
+      const mine = await requestJson(`${baseUrl}/api/attendance/leave-balances/me`, { headers })
+      expect(mine.status, JSON.stringify(mine.body)).toBe(200)
+      const d1 = (mine.body as { data?: { userId?: string; summary?: { grantedMinutes?: number; remainingMinutes?: number } } } | undefined)?.data
+      expect(d1?.userId).toBe(meId)
+      expect(d1?.summary?.grantedMinutes).toBe(2400)
+      expect(d1?.summary?.remainingMinutes).toBe(2400)
+
+      // (2) a userId QUERY PARAM cannot override the subject → still the caller's 2400, never the other's 9999
+      const spoofParam = await requestJson(`${baseUrl}/api/attendance/leave-balances/me?userId=${encodeURIComponent(otherId)}`, { headers })
+      expect(spoofParam.status).toBe(200)
+      const d2 = (spoofParam.body as { data?: { userId?: string; summary?: { grantedMinutes?: number } } } | undefined)?.data
+      expect(d2?.userId).toBe(meId)
+      expect(d2?.summary?.grantedMinutes).toBe(2400)
+
+      // (3) an x-user-id HEADER cannot override the authenticated subject either
+      const spoofHeader = await requestJson(`${baseUrl}/api/attendance/leave-balances/me`, { headers: { ...headers, 'x-user-id': otherId } })
+      expect(spoofHeader.status).toBe(200)
+      const d3 = (spoofHeader.body as { data?: { userId?: string; summary?: { grantedMinutes?: number } } } | undefined)?.data
+      expect(d3?.userId).toBe(meId)
+      expect(d3?.summary?.grantedMinutes).toBe(2400)
+    } finally {
+      await pool.query(`DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('A2 auto-shift auto-write ledger — active-run claim and item invariants are DB-enforced (latent schema)', async () => {
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -37790,6 +37790,59 @@ module.exports = {
       })
     )
 
+    // Shared annual-leave balance read — used by the admin L5a route (arbitrary userId) AND the employee /me
+    // self-read (subject forced to the token). org/user-scoped; returns the EXPLAINABLE shape: summary
+    // (granted/remaining/exhausted/expired) + active lots + recent ledger events. Conservation (no revoke in this
+    // chain): granted = remaining + exhausted + expired. Events are joined to lots only for the type filter.
+    async function readAnnualLeaveBalanceForUser(orgId, userId, leaveTypeCode, eventLimit) {
+      const summaryRows = await db.query(
+        `SELECT
+           COALESCE(SUM(CASE WHEN e.event_type = 'grant'  THEN e.delta_minutes  ELSE 0 END), 0) AS granted,
+           COALESCE(SUM(CASE WHEN e.event_type = 'deduct' THEN -e.delta_minutes ELSE 0 END), 0) AS exhausted,
+           COALESCE(SUM(CASE WHEN e.event_type = 'expire' THEN -e.delta_minutes ELSE 0 END), 0) AS expired
+         FROM attendance_leave_balance_events e
+         JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
+         WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3`,
+        [orgId, userId, leaveTypeCode]
+      )
+      const remainingRows = await db.query(
+        `SELECT COALESCE(SUM(remaining_minutes), 0) AS remaining
+         FROM attendance_leave_balances
+         WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'`,
+        [orgId, userId, leaveTypeCode]
+      )
+      const activeLots = await db.query(
+        `SELECT id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, status, granted_at, expires_at
+         FROM attendance_leave_balances
+         WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'
+         ORDER BY expires_at ASC NULLS LAST, granted_at ASC, id ASC`,
+        [orgId, userId, leaveTypeCode]
+      )
+      const recentEvents = await db.query(
+        `SELECT e.event_type, e.delta_minutes, e.source_type, e.source_id, e.balance_id, e.occurred_at
+         FROM attendance_leave_balance_events e
+         JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
+         WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3
+         ORDER BY e.occurred_at DESC, e.id DESC
+         LIMIT $4`,
+        [orgId, userId, leaveTypeCode, eventLimit]
+      )
+      const s = summaryRows[0] || {}
+      return {
+        userId,
+        summary: {
+          leaveTypeCode,
+          grantedMinutes: Number(s.granted || 0),
+          remainingMinutes: Number(remainingRows[0]?.remaining || 0),
+          exhaustedMinutes: Number(s.exhausted || 0),
+          expiredMinutes: Number(s.expired || 0),
+        },
+        activeLots,
+        recentEvents,
+        eventLimit,
+      }
+    }
+
     context.api.http.addRoute(
       'GET',
       '/api/attendance/leave-balances',
@@ -37813,55 +37866,53 @@ module.exports = {
         const leaveTypeCode = parsed.data.leaveTypeCode ?? 'annual'
         const eventLimit = parsed.data.eventLimit ?? 50
         try {
-          // summary from the ledger (granted/exhausted/expired) + active-lot remaining. Conservation (no revoke in
-          // this chain): granted = remaining + exhausted + expired. Events are joined to lots only for the type filter.
-          const summaryRows = await db.query(
-            `SELECT
-               COALESCE(SUM(CASE WHEN e.event_type = 'grant'  THEN e.delta_minutes  ELSE 0 END), 0) AS granted,
-               COALESCE(SUM(CASE WHEN e.event_type = 'deduct' THEN -e.delta_minutes ELSE 0 END), 0) AS exhausted,
-               COALESCE(SUM(CASE WHEN e.event_type = 'expire' THEN -e.delta_minutes ELSE 0 END), 0) AS expired
-             FROM attendance_leave_balance_events e
-             JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
-             WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3`,
-            [orgId, userId, leaveTypeCode]
-          )
-          const remainingRows = await db.query(
-            `SELECT COALESCE(SUM(remaining_minutes), 0) AS remaining
-             FROM attendance_leave_balances
-             WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'`,
-            [orgId, userId, leaveTypeCode]
-          )
-          const activeLots = await db.query(
-            `SELECT id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, status, granted_at, expires_at
-             FROM attendance_leave_balances
-             WHERE org_id = $1 AND user_id = $2 AND leave_type_code = $3 AND status = 'active'
-             ORDER BY expires_at ASC NULLS LAST, granted_at ASC, id ASC`,
-            [orgId, userId, leaveTypeCode]
-          )
-          const recentEvents = await db.query(
-            `SELECT e.event_type, e.delta_minutes, e.source_type, e.source_id, e.balance_id, e.occurred_at
-             FROM attendance_leave_balance_events e
-             JOIN attendance_leave_balances b ON b.id = e.balance_id AND b.org_id = e.org_id AND b.user_id = e.user_id
-             WHERE e.org_id = $1 AND e.user_id = $2 AND b.leave_type_code = $3
-             ORDER BY e.occurred_at DESC, e.id DESC
-             LIMIT $4`,
-            [orgId, userId, leaveTypeCode, eventLimit]
-          )
-          const s = summaryRows[0] || {}
-          const summary = {
-            leaveTypeCode,
-            grantedMinutes: Number(s.granted || 0),
-            remainingMinutes: Number(remainingRows[0]?.remaining || 0),
-            exhaustedMinutes: Number(s.exhausted || 0),
-            expiredMinutes: Number(s.expired || 0),
-          }
-          res.json({ ok: true, data: { userId, summary, activeLots, recentEvents, eventLimit } })
+          const data = await readAnnualLeaveBalanceForUser(orgId, userId, leaveTypeCode, eventLimit)
+          res.json({ ok: true, data })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
           }
           logger.error('Annual leave balance read failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/leave-balances/me',
+      withPermission('attendance:read', async (req, res) => {
+        // 年假/法定假 employee SELF-service balance read. The subject is ALWAYS the authenticated requester
+        // (getUserId — once attendance:read passes, req.user.id is set, so the spoofable x-user-id header never
+        // overrides it). There is NO userId parameter, so an employee can only ever read their OWN annual-leave
+        // balance, never another user's. Same explainable shape as the admin L5a read, scoped to self.
+        const schema = z.object({
+          leaveTypeCode: z.string().min(1).max(64).optional(),
+          eventLimit: z.coerce.number().int().min(1).max(200).optional(),
+        })
+        const parsed = schema.safeParse(req.query ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const userId = getUserId(req)
+        if (!userId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const leaveTypeCode = parsed.data.leaveTypeCode ?? 'annual'
+        const eventLimit = parsed.data.eventLimit ?? 50
+        try {
+          const data = await readAnnualLeaveBalanceForUser(orgId, userId, leaveTypeCode, eventLimit)
+          res.json({ ok: true, data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Annual leave self balance read failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
         }
       })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -37901,7 +37901,9 @@ module.exports = {
           res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
           return
         }
-        const orgId = getOrgId(req)
+        // Self-service reads the caller's OWN org, pinned from the authenticated token — a ?orgId param / header cannot
+        // point /me at another org (getOrgId is only a fallback for a token that carries no org).
+        const orgId = req.user?.orgId ?? req.user?.workspaceId ?? getOrgId(req)
         const leaveTypeCode = parsed.data.leaveTypeCode ?? 'annual'
         const eventLimit = parsed.data.eventLimit ?? 50
         try {


### PR DESCRIPTION
The deferred-future endpoint the L5 admin-UI design-lock named: **`GET /api/attendance/leave-balances/me`** — employee self-service annual-leave balance, **subject locked to the token**.

## Security property (the point)
- `withPermission('attendance:read')` (any employee, **not** admin).
- Subject = `getUserId(req)` from the authenticated token; **no `userId` parameter** on the route. Once the permission gate passes, `req.user.id` is set so the spoofable `x-user-id` header never overrides it.
- So **neither a `?userId=<other>` param nor an `x-user-id` header can return another user's balance.** No-subject → `401`.

## Reuse, not duplication
The query is the shared `readAnnualLeaveBalanceForUser` helper; the admin **L5a** route was refactored to call it too (one balance-read implementation).

## Verification
Integration test: caller has `2400`, another user has `9999` — `/me` returns the caller's `2400`; `?userId=<other>` still returns `2400` (param can't override); `x-user-id: <other>` still returns `2400` (header can't override); L5a admin read still green via the shared helper. **9/9 annual tests pass.** Design & verification MD included.

Scope: read-only endpoint. The thin employee **overview card** (consumes this endpoint) is the documented follow-up slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)