### PR TITLE
feat(approval): G direct_manager assignee source (resolver + authoring)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -255,7 +255,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign 会签/或签/reduce/guards)
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start)
         # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
@@ -269,6 +269,7 @@ jobs:
             tests/integration/approval-directory-endpoints.api.test.ts \
             tests/integration/approval-p1c-field-permissions.api.test.ts \
             tests/integration/approval-wp-add-reduce-sign.api.test.ts \
+            tests/integration/approval-direct-manager.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ output/releases/
 
 # multitable browser-verification lane outputs (screenshots, traces)
 apps/web/verification-output/
+
+# vue-tsc -b (the `type-check` script) emits .js/.vue.js next to TS/Vue source; never commit them
+apps/web/src/**/*.js

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -248,6 +248,8 @@ function stepDraftFromApprovalNode(
   } else if (source?.kind === 'form_field_user') {
     sourceKind = 'form_field_user'
     fieldId = source.fieldId
+  } else if (source?.kind === 'direct_manager') {
+    sourceKind = 'direct_manager'
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -362,7 +364,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager'].includes(source?.kind)) return true
     }
     return false
   })
@@ -439,6 +441,9 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   }
   if (step.sourceKind === 'form_field_user') {
     return { kind: 'form_field_user', fieldId: step.fieldId.trim() }
+  }
+  if (step.sourceKind === 'direct_manager') {
+    return { kind: 'direct_manager' }
   }
   return { kind: 'requester' }
 }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -75,6 +75,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'static_role'; roleIds: string[] }
   | { kind: 'requester' }
   | { kind: 'form_field_user'; fieldId: string }
+  | { kind: 'direct_manager' }
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -277,10 +277,11 @@
               <el-input v-model="step.name" :disabled="readOnly" />
             </el-form-item>
             <el-form-item label="审批人来源">
-              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%" @change="syncStepOptions(step)">
+              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%" data-testid="approval-step-source-kind" @change="syncStepOptions(step)">
                 <el-option label="指定用户" value="static_user" />
                 <el-option label="指定角色" value="static_role" />
                 <el-option label="发起人" value="requester" />
+                <el-option label="直属上级" value="direct_manager" />
                 <el-option label="表单用户字段" value="form_field_user" />
               </el-select>
             </el-form-item>

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -423,6 +423,19 @@ describe('approval template authoring helpers', () => {
     ])
   })
 
+  it('round-trips a direct_manager assignee source (save emits {kind} + hydrate restores sourceKind)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'mgr'
+    draft.name = '经理审批'
+    draft.steps[0].sourceKind = 'direct_manager'
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'direct_manager' }])
+
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('direct_manager')
+  })
+
   // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
   function buildAutoApprovalTemplate(
     policy: AutoApprovalPolicy,
@@ -595,6 +608,19 @@ describe('TemplateAuthoringView', () => {
 
     expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).not.toBeNull() // B fail-closed
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(true) // save disabled
+  })
+
+  it('direct_manager reads back editable: a saved direct_manager template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {
+    routeParams = { id: 'tpl_dm' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('direct_manager') // hydrated back
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/docs/design/approval-direct-manager-assignee-source-design-20260618.md
+++ b/docs/design/approval-direct-manager-assignee-source-design-20260618.md
@@ -1,0 +1,27 @@
+# Approval — `direct_manager` assignee source (design-lock)
+
+**Status:** design-lock → implemented in the same PR (decisions pre-approved by the owner).
+**Builds on:** the landed read-only org-relation plumbing that bakes `requesterSnapshot.managerId` (derived from the directory `leader_in_dept` of the requester's primary department, self-excluded) at approval creation. This lane turns that snapshot field into an authorable **assignee source**.
+
+## What it is
+A new assignee-source kind `direct_manager` that resolves a node's approver to the requester's direct manager. It carries **no extra config** — it is requester-relative, like `requester`.
+
+## Locked decisions
+1. **Unresolvable manager → empty result → existing `emptyAssigneePolicy`.** When `requesterSnapshot.managerId` is absent (e.g. the requester is the org head, or no leader was synced), the resolver returns **no assignment** for that source. The node then follows its configured `emptyAssigneePolicy` (`error` / `auto-approve`) through `ApprovalGraphExecutor` — exactly the existing semantics for any source that resolves empty. No special-casing in the resolver.
+2. **Manager == requester → exclude self → empty result.** If the resolved `managerId` equals the requester's own id, the resolver treats it as **no valid manager** and returns empty (falling to `emptyAssigneePolicy`). This mirrors the directory resolver's own self-exclusion. We deliberately do **not** defer this to the self-approver (`autoApprovalPolicy`) path: `direct_manager` semantically means "someone *above* the requester," so a self-resolution is invalid by definition, not an auto-approval opportunity.
+3. **Point-in-time snapshot.** The resolver reads `requesterSnapshot.managerId` **frozen at approval start**. There is no live directory re-query during dispatch / admin-jump / return — consistent with the frozen runtime-graph + snapshot model every other runtime path already follows.
+
+## In scope (this PR)
+Backend type (`ApprovalAssigneeSourceKind` + `ApprovalAssigneeSource` union) · normalizer (accept `{ kind: 'direct_manager' }`, no extra fields) · resolver (`ApprovalAssigneeResolver`, read `managerId`, self-exclusion, push when present) · metadata (`resolvedFrom.kind = 'direct_manager'`, automatic via `metadataFor`) · FE type/draft/source-picker/`sourceFromStep` · tests (normal resolve, unresolvable→empty-policy, self-exclusion→empty, metadata, hydrate/save UI, real-DB create/start).
+
+## Out of scope (stay gated)
+`dept_head` (waits on a sync-plumbing slice — `dept_manager_userid_list` is not captured by the current department-list sync) · `continuous_managers` (multi-level escalation, later) · any live re-resolution · W7 result write-back (locked).
+
+## Implementation checklist
+- [ ] `ApprovalAssigneeSourceKind` += `'direct_manager'`; union += `{ kind: 'direct_manager' }`.
+- [ ] `normalizeApprovalAssigneeSources`: `case 'direct_manager': return { kind: 'direct_manager' }`.
+- [ ] `resolveApprovalAssignees`: `case 'direct_manager'` → read `requesterSnapshot.managerId`, push `user` assignment iff present **and** `!== requester id`.
+- [ ] Metadata: `resolvedFrom.kind = 'direct_manager'` (no change needed — `metadataFor` keys off `source.kind`).
+- [x] FE: `ApprovalStepSourceKind` (auto via `ApprovalAssigneeSource['kind']`), `draftFromTemplate` kind→sourceKind map, `sourceFromStep`, the source-picker option, **and the `unsupportedTemplateAuthoringReason` source-kind allowlist** — without it a saved `direct_manager` template reads back fail-closed/read-only (write-out / can't-read-back). FE `ApprovalAssigneeSource` type is mirrored separately from the backend, so both are updated.
+- [x] Tests: resolver (resolve+`resolvedFrom` metadata / unresolvable→empty incl. null snapshot / self-exclusion→empty), authoring (hydrate + save round-trip), and a **mounted-view read-back** regression (a saved `direct_manager` template is NOT fail-closed: no unsupported alert, save enabled, sourceKind hydrated).
+- [x] Real-DB integration is **scoped to create/start + the unresolvable→`emptyAssigneePolicy` decision on BOTH branches** (auto-approve cascades past the empty node; `error` rejects at start). The **resolved-manager assignment** (managerId present → manager assigned) is covered by the resolver unit (resolution logic + metadata) + the `ApprovalDirectoryOrg` plumbing tests (directory→`managerId` bake); it is intentionally **not** re-seeded here as a 5-table directory fixture (`directory_accounts.integration_id` FKs to `directory_integrations`).

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -122,6 +122,18 @@ export function resolveApprovalAssignees(
         if (requesterId) pushResolved('user', requesterId, source, sourceIndex)
         break
       }
+      case 'direct_manager': {
+        // Resolve to the requester's direct manager, frozen in the requester snapshot at
+        // approval start (no live directory re-query during dispatch/admin-jump/return).
+        // Self-exclusion: a manager that resolves to the requester is not a valid manager,
+        // so we return empty here and let the node's emptyAssigneePolicy decide.
+        const managerId = normalizeId(options.requesterSnapshot?.managerId)
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        if (managerId && managerId !== requesterId) {
+          pushResolved('user', managerId, source, sourceIndex)
+        }
+        break
+      }
       case 'form_field_user': {
         assertFormUserSource(source, options.formSchema, options.nodeKey)
         const assigneeId = resolveFormUserValue(options.formSnapshot[source.fieldId])

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -409,6 +409,8 @@ function normalizeApprovalAssigneeSources(
         }
       case 'requester':
         return { kind: 'requester' }
+      case 'direct_manager':
+        return { kind: 'direct_manager' }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -93,6 +93,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'static_role'; roleIds: string[] }
   | { kind: 'requester' }
   | { kind: 'form_field_user'; fieldId: string }
+  | { kind: 'direct_manager' }
 
 export interface ApprovalAssigneeResolutionMetadata {
   resolvedFrom: {

--- a/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * direct_manager assignee source — real-DB create/start.
+ *
+ * SCOPE: this exercises the create/start WIRING (normalizer accepts `direct_manager`;
+ * the resolver runs in the real createApproval→dispatch path) and the locked
+ * "unresolvable manager → emptyAssigneePolicy" decision on BOTH branches. The requester
+ * has NO directory manager, so `requesterSnapshot.managerId` is absent and the node
+ * resolves empty. The RESOLVED-manager assignment (managerId present) is covered by the
+ * resolver unit test (resolution logic + metadata) and the ApprovalDirectoryOrg plumbing
+ * tests (directory → managerId snapshot bake); it is intentionally NOT re-seeded here as a
+ * 5-table directory fixture.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `dm-req-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => { const s = net.createServer(); s.once('error', () => r(false)); s.listen(0, '127.0.0.1', () => s.close(() => r(true))) })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, { method: opts.method || 'GET', headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) }, ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}) })
+}
+function graph(emptyAssigneePolicy: 'auto-approve' | 'error') {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: 's', config: {} },
+      { key: 'approval_1', type: 'approval', name: '直属上级', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy } },
+      { key: 'end', type: 'end', name: 'e', config: {} },
+    ],
+    edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
+  }
+}
+
+describeIfDatabase('direct_manager assignee source — real-DB create/start', () => {
+  let server: MetaSheetServer | undefined, base = '', reqTok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+  })
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`dm-%-${TS}%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+    } catch { /* best effort */ }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  async function publish(key: string, emptyAssigneePolicy: 'auto-approve' | 'error'): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph(emptyAssigneePolicy) } })
+    expect(created.status, await created.clone().text()).toBe(201) // normalizer accepts direct_manager
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+    return tid
+  }
+
+  it('auto-approve branch: a requester with no manager auto-resolves the direct_manager node (does not block)', async () => {
+    const tid = await publish(`dm-auto-${TS}`, 'auto-approve')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const body = (await started.json()) as { id?: string; status?: string; data?: { id: string; status?: string } }
+    const aid = body.id ?? body.data?.id
+    const status = (await (await req(base, `/api/approvals/${aid}`, reqTok)).json() as any)
+    const s = status.status ?? status.data?.status
+    // empty direct_manager + auto-approve cascades past approval_1 → terminal approved/completed
+    expect(['approved', 'completed', 'auto_approved']).toContain(String(s))
+  })
+
+  it('error branch: a requester with no manager makes the direct_manager node fail-create (empty assignee)', async () => {
+    const tid = await publish(`dm-err-${TS}`, 'error')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status).toBeGreaterThanOrEqual(400) // empty assignee under 'error' policy rejects at start
+  })
+})

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -32,6 +32,32 @@ describe('ApprovalAssigneeResolver', () => {
     ])
   })
 
+  // direct_manager — resolves to requesterSnapshot.managerId (frozen at start).
+  function resolveDirectManager(requesterSnapshot: Record<string, unknown> | null) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'direct_manager' }] },
+      formSnapshot: {},
+      requesterSnapshot,
+    })
+  }
+
+  it('resolves direct_manager to the requester snapshot managerId, with resolvedFrom metadata', () => {
+    expect(resolveDirectManager({ id: 'requester-1', managerId: 'manager-9' })).toEqual([
+      { assignmentType: 'user', assigneeId: 'manager-9', nodeKey: 'review', sourceStep: 2, metadata: { resolvedFrom: { kind: 'direct_manager', sourceIndex: 0 } } },
+    ])
+  })
+
+  it('resolves direct_manager to empty when the requester has no manager (falls to emptyAssigneePolicy)', () => {
+    expect(resolveDirectManager({ id: 'requester-1' })).toEqual([])
+    expect(resolveDirectManager(null)).toEqual([])
+  })
+
+  it('excludes self: a direct_manager that resolves to the requester is not a valid manager (empty)', () => {
+    expect(resolveDirectManager({ id: 'requester-1', managerId: 'requester-1' })).toEqual([])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'tests/integration/approval-directory-endpoints.api.test.ts',
       'tests/integration/approval-p1c-field-permissions.api.test.ts',
       'tests/integration/approval-wp-add-reduce-sign.api.test.ts',
+      'tests/integration/approval-direct-manager.api.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
The first **new capability** on top of the landed org-relation plumbing: a `direct_manager` assignee source that resolves a node's approver to the requester's direct manager (from `requesterSnapshot.managerId`, baked from `leader_in_dept` at approval start). Opened with a **design-lock** (commit 1) settling three decisions, then implemented (commit 2).

## Locked decisions
1. **Unresolvable manager → empty → `emptyAssigneePolicy`.** No special-casing; the node follows its configured `error`/`auto-approve` policy, exactly like any source that resolves empty.
2. **Manager == requester → exclude self → empty.** `direct_manager` means "someone *above* the requester," so a self-resolution is invalid by definition (mirrors the plumbing's own self-exclusion) — **not** deferred to the self-approver path.
3. **Point-in-time snapshot.** Reads `requesterSnapshot.managerId` frozen at start; no live directory re-query during dispatch / admin-jump / return.

## Change
- **Backend** — `ApprovalAssigneeSourceKind` + union (`{ kind: 'direct_manager' }`); `normalizeApprovalAssigneeSources` case (no extra fields); `resolveApprovalAssignees` case (read `managerId`, push iff present **and** `!== requester id`); `resolvedFrom.kind` is automatic via `metadataFor`.
- **Frontend** — mirrored type, `draftFromTemplate` hydrate, `sourceFromStep`, and the authoring source-picker option (直属上级).

## Tests / gates
- backend `tsc` 0, `vue-tsc -b` 0, **full core-backend unit suite 4484/0**.
- **Resolver unit** (3): resolve+`resolvedFrom` metadata / unresolvable→empty (incl. null snapshot) / self-exclusion→empty.
- **Authoring** round-trip (save emits `{kind}` + hydrate restores `sourceKind`).
- **Real-DB create/start** (3): normalizer accepts `direct_manager`; both `emptyAssigneePolicy` branches end-to-end (auto-approve cascades past the empty node; `error` rejects at start). CI-lane: `describeIfDatabase` + sentinel + default-exclude + plugin-tests step.

## Scope note (honest)
The integration verifies the **create/start wiring + the unresolvable→`emptyAssigneePolicy` decision** on a real DB. The **resolved-manager assignment** (managerId present → manager assigned) is covered by the resolver unit test (resolution logic + metadata) and the `ApprovalDirectoryOrg` plumbing tests (directory→`managerId` snapshot bake); it is intentionally **not** re-seeded here as a 5-table directory fixture (`integration_id` FKs to `directory_integrations`).

## Governance
`dept_head` stays behind its sync-plumbing slice (`dept_manager_userid_list` not captured by the current department-list sync); `continuous_managers` later; **W7 locked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)