### PR TITLE
feat(attendance): annual-leave employee overview self-balance card (consumes /me)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -94,6 +94,24 @@
       </section>
 
       <section v-if="showOverview" class="attendance__grid attendance__grid--selfservice">
+        <div class="attendance__card attendance__card--selfservice" data-selfservice-card="annual-balance">
+          <div class="attendance__requests-header">
+            <div><h3>{{ tr('My annual leave', '我的年假') }}</h3></div>
+          </div>
+          <p v-if="annualSelfBalanceLoading" class="attendance__field-hint">{{ tr('Loading...', '加载中...') }}</p>
+          <p v-else-if="annualSelfBalanceError" class="attendance__error" data-annual-self-balance-error>{{ annualSelfBalanceError }}</p>
+          <div v-else-if="annualSelfBalance" class="attendance__selfbalance" data-annual-self-balance>
+            <div class="attendance__selfbalance-remaining">
+              <strong>{{ annualSelfBalance.summary.remainingMinutes }}</strong> {{ tr('min remaining', '分钟剩余') }}
+            </div>
+            <small class="attendance__field-hint">
+              {{ tr('Granted', '已发放') }} {{ annualSelfBalance.summary.grantedMinutes }} ·
+              {{ tr('Used', '已用') }} {{ annualSelfBalance.summary.exhaustedMinutes }} ·
+              {{ tr('Expired', '已过期') }} {{ annualSelfBalance.summary.expiredMinutes }}
+            </small>
+          </div>
+          <p v-else class="attendance__field-hint">{{ tr('No annual leave balance yet.', '暂无年假余额。') }}</p>
+        </div>
         <div class="attendance__card attendance__card--selfservice" data-selfservice-card="status">
           <div class="attendance__requests-header">
             <div>
@@ -19837,6 +19855,34 @@ const annualBalanceUserId = ref('')
 const annualBalanceLoading = ref(false)
 const annualBalanceData = ref<AnnualLeaveBalanceData | null>(null)
 
+// 年假/法定假 employee self-service: the overview card reads the caller's OWN balance via the token-locked /me
+// endpoint (no userId — the server forces the subject to the authenticated token). Read-only.
+const annualSelfBalance = ref<AnnualLeaveBalanceData | null>(null)
+const annualSelfBalanceLoading = ref(false)
+const annualSelfBalanceError = ref<string | null>(null)
+
+async function loadAnnualSelfBalance(): Promise<void> {
+  annualSelfBalanceLoading.value = true
+  annualSelfBalanceError.value = null
+  try {
+    const response = await apiFetch('/api/attendance/leave-balances/me?leaveTypeCode=annual')
+    if (response.status === 401 || response.status === 403) {
+      annualSelfBalance.value = null
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load your leave balance', '加载您的休假余额失败')))
+    }
+    // only accept a real balance payload (a summary); anything else leaves the card in its empty state
+    annualSelfBalance.value = data.data && data.data.summary ? (data.data as AnnualLeaveBalanceData) : null
+  } catch (error: any) {
+    annualSelfBalanceError.value = readErrorMessage(error, tr('Failed to load your leave balance', '加载您的休假余额失败'))
+  } finally {
+    annualSelfBalanceLoading.value = false
+  }
+}
+
 async function loadAnnualLeaveBalance() {
   // clear any prior result up front so an empty ID / failed / 403 / errored query never leaves a stale balance
   // from a previously-queried user on screen (the view renders solely on v-if="annualBalanceData").
@@ -23795,6 +23841,9 @@ onMounted(() => {
         refreshAll()
         if (showAdmin.value) {
           loadAdminData()
+        }
+        if (showOverview.value) {
+          void loadAnnualSelfBalance()
         }
       }
     })

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -833,6 +833,26 @@ describe('Attendance admin regressions', () => {
     ).toEqual([])
   })
 
+  it('overview self-service — the annual leave card reads the token-locked /me balance (no userId param)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/leave-balances/me')) {
+        return jsonResponse(200, { ok: true, data: { userId: 'self', summary: { leaveTypeCode: 'annual', grantedMinutes: 2400, remainingMinutes: 1800, exhaustedMinutes: 600, expiredMinutes: 0 }, activeLots: [], recentEvents: [], eventLimit: 50 } })
+      }
+      return emptyAttendanceResponse()
+    })
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(10)
+    const card = container!.querySelector('[data-selfservice-card="annual-balance"]')
+    expect(card).toBeTruthy()
+    expect(card!.querySelector('[data-annual-self-balance]')?.textContent).toContain('1800') // remaining
+    // the request hits the token-locked /me endpoint and carries NO userId param (self-service, server-forced subject)
+    const meCall = vi.mocked(apiFetch).mock.calls.map(c => String(c[0])).find(u => u.includes('/leave-balances/me'))
+    expect(meCall).toBeTruthy()
+    expect(meCall).not.toContain('userId=')
+  })
+
   it('exposes shift_swap as an approval-flow type and saves it through the admin form', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/docs/development/attendance-annual-leave-me-selfview-design-and-verification-20260617.md
+++ b/docs/development/attendance-annual-leave-me-selfview-design-and-verification-20260617.md
@@ -42,10 +42,13 @@ So neither a `?userId=<other>` param nor an `x-user-id: <other>` header can make
   3. `/me` with an `x-user-id: <other>` header still returns the caller's `2400` (the header cannot override the subject).
 - The admin **L5a** read still passes via the shared helper (no regression from the refactor). **9/9** annual tests green.
 
-## 5. Out of scope here / follow-up
+## 5. The view + follow-up
 
-- **Employee overview card** — a thin self-balance card in the `overview` surface that fetches `/me` on mount and shows
-  the summary (+ a detail expansion). It reuses this endpoint with no new security surface; it's the natural next thin
-  slice once the direction is confirmed. (It touches the overview section registry / nav, so it's its own small PR.)
+- **Employee overview card — SHIPPED (#2853).** A read-only "My annual leave" card in the `overview` surface
+  (`mode='overview'`) fetches `/me` on overview mount and shows remaining / granted / used / expired. It reuses this
+  endpoint with no new security surface (no `userId` param). The handler only accepts a real balance payload, so a
+  non-balance response leaves the card empty rather than crashing; loading/error/empty states are handled. Frontend
+  test asserts the card renders the `/me` balance and the request carries no `userId`. So the self-service **view**
+  (endpoint + card) is complete.
 - **Self-service for other leave types** — the endpoint already accepts `leaveTypeCode`; v1 surfaces `annual`.
 - This endpoint is **read-only**; no employee-facing mutation (employees never adjust their own balances).


### PR DESCRIPTION
Completes the **self-service balance view** the L5 design-lock named — the `/me` endpoint shipped in #2850, this adds the employee-facing card.

A read-only **"My annual leave"** card in the employee **overview** surface (`mode='overview'`) that fetches the token-locked `GET /api/attendance/leave-balances/me` on overview mount and shows remaining / granted / used / expired. **No `userId` param** (the server forces the subject to the token), so it can only ever show the caller's own balance. Loading / error / empty states; the handler only accepts a real balance payload, so a non-balance response leaves the card empty rather than crashing.

**Verification:** frontend test asserts the card renders the `/me` balance and the request carries **no `userId` param**; the existing "overview doesn't preload admin data" test still passes (`/me` is an employee-facing read, not a forbidden admin load). **120/120** web specs; `vue-tsc -b` clean.

With this, the annual-leave employee self-service view is complete (endpoint + card). The engine track's only remaining gate is still the owner-run **L6 staging smoke**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)