### PR TITLE
fix(multitable): #16/#2b contract hardening — write-path parity + admin-bypass + person guard

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -207,6 +207,7 @@ jobs:
             tests/integration/multitable-view-summary-recordperm-leak.test.ts \
             tests/integration/multitable-person-summary-field-mask.test.ts \
             tests/integration/multitable-person-member-group-restrict.test.ts \
+            tests/integration/multitable-person-restrict-route-parity.test.ts \
             tests/integration/multitable-button-send-notification.test.ts \
             tests/integration/multitable-button-update-record.test.ts \
             tests/integration/multitable-form-context-submit-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/person-field-restriction.ts
+++ b/packages/core-backend/src/multitable/person-field-restriction.ts
@@ -1,0 +1,71 @@
+import { loadSheetMemberUserIdSet, type QueryFn } from './permission-service'
+
+/**
+ * #16 org-member directory — the member-group ids a person field restricts NEW assignment to.
+ * Empty ⇒ unrestricted. Sanitizes to trimmed, de-duped, non-empty strings.
+ */
+export function personRestrictGroupIds(field: { property?: unknown } | undefined | null): string[] {
+  const raw = (field?.property as Record<string, unknown> | undefined)?.restrictToMemberGroupIds
+  if (!Array.isArray(raw)) return []
+  return Array.from(
+    new Set(
+      raw
+        .filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+        .map((v) => v.trim()),
+    ),
+  )
+}
+
+/**
+ * #16 — SINGLE source of truth for the ALLOWED assignee set of a person field, shared by
+ * RecordService (REST create/patch + form submit) AND RecordWriteService (bulk / Yjs / automation),
+ * so every write path enforces identically (the route-parity fix).
+ *
+ * allowed = (sheet members) ∩ (active users in the field's restrictToMemberGroupIds); when the field
+ * is unrestricted ⇒ just the sheet members. FAIL-CLOSED: a restricted field whose groups contain no
+ * eligible member ⇒ empty set ⇒ every new assignment rejected. Read-back is unaffected (validation is
+ * write-only) so pre-existing out-of-scope values are grandfathered. Caches the sheet set + each
+ * restrict-key so a bulk op hits the DB once.
+ */
+export function createPersonMemberResolver(
+  query: QueryFn,
+  sheetId: string,
+  /** Injectable sheet-member loader (defaults to the canonical query); lets callers that already
+   *  inject a loader for testability keep their seam. */
+  loadSheetMembers: (q: QueryFn, sid: string) => Promise<Set<string>> = loadSheetMemberUserIdSet,
+): (restrictGroupIds: string[]) => Promise<Set<string>> {
+  let sheetMembers: Set<string> | null = null
+  const cache = new Map<string, Set<string>>()
+
+  const loadGroupUserIds = async (groupIds: string[]): Promise<Set<string>> => {
+    if (groupIds.length === 0) return new Set<string>()
+    const res = await query(
+      `SELECT DISTINCT gm.user_id::text AS uid
+         FROM platform_member_group_members gm
+         JOIN users u ON u.id = gm.user_id
+        WHERE gm.group_id::text = ANY($1::text[])
+          AND u.is_active = TRUE`,
+      [groupIds],
+    )
+    return new Set(
+      (res.rows as Array<Record<string, unknown>>)
+        .map((row) => (typeof row.uid === 'string' ? row.uid.trim() : ''))
+        .filter((v): v is string => v.length > 0),
+    )
+  }
+
+  return async (restrictGroupIds: string[]): Promise<Set<string>> => {
+    if (sheetMembers === null) sheetMembers = await loadSheetMembers(query, sheetId)
+    if (restrictGroupIds.length === 0) return sheetMembers
+    const key = Array.from(new Set(restrictGroupIds)).sort().join(',')
+    let restricted = cache.get(key)
+    if (!restricted) {
+      const groupSet = await loadGroupUserIds(restrictGroupIds)
+      // Intersect with the sheet member set: strictly narrows, never widens.
+      restricted = new Set<string>()
+      for (const id of sheetMembers) if (groupSet.has(id)) restricted.add(id)
+      cache.set(key, restricted)
+    }
+    return restricted
+  }
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -18,7 +18,7 @@ import {
   validatePersonValue,
   type MultitableField,
 } from './field-codecs'
-import { loadSheetMemberUserIdSet } from './permission-service'
+import { createPersonMemberResolver, personRestrictGroupIds } from './person-field-restriction'
 import {
   HierarchyCycleError,
   assertNoHierarchyParentCycle,
@@ -504,14 +504,16 @@ export class RecordService {
       const fieldById = buildCreateFieldGuardMap(fieldRes.rows)
       const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
-      // Native person (人员): resolve the sheet member set ONCE (lazily, only on the first person
-      // cell write) and reuse it for membership validation — parallel to the link-exists query.
-      let personMemberUserIds: Set<string> | null = null
-      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
-        if (personMemberUserIds === null) {
-          personMemberUserIds = await loadSheetMemberUserIdSet(query, sheetId)
-        }
-        return personMemberUserIds
+      // Native person (人员): #16 per-field allowed-assignee resolver (sheet members ∩ the field's
+      // restrictToMemberGroupIds) — shared with RecordWriteService so REST create enforces the group
+      // restriction identically (not sheet-member-only). Lazy + cached per restrict-key.
+      const resolvePersonAllowed = createPersonMemberResolver(query, sheetId)
+      const personRestrictByFieldId = new Map<string, string[]>()
+      for (const row of fieldRes.rows as Array<Record<string, unknown>>) {
+        if (row.type !== 'person') continue
+        const ids = personRestrictGroupIds({ property: row.property })
+        const fid = typeof row.id === 'string' ? row.id : ''
+        if (fid && ids.length > 0) personRestrictByFieldId.set(fid, ids)
       }
 
       for (const [fieldId, value] of Object.entries(data)) {
@@ -526,7 +528,7 @@ export class RecordService {
 
         if (field.type === 'person') {
           try {
-            const allowed = await resolvePersonMemberUserIds()
+            const allowed = await resolvePersonAllowed(personRestrictByFieldId.get(fieldId) ?? [])
             patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
           } catch (error) {
             throw new RecordValidationError(error instanceof Error ? error.message : String(error))
@@ -1032,14 +1034,15 @@ export class RecordService {
     const patch: Record<string, unknown> = {}
     const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
-    // Native person (人员): resolve the sheet member set ONCE (lazily on the first person cell)
-    // and reuse it for membership validation.
-    let personMemberUserIds: Set<string> | null = null
-    const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
-      if (personMemberUserIds === null) {
-        personMemberUserIds = await loadSheetMemberUserIdSet(this.pool.query.bind(this.pool), sheetId)
-      }
-      return personMemberUserIds
+    // Native person (人员): #16 per-field allowed-assignee resolver (sheet members ∩ the field's
+    // restrictToMemberGroupIds) — shared with RecordWriteService so REST patch enforces the group
+    // restriction identically (not sheet-member-only).
+    const resolvePersonAllowed = createPersonMemberResolver(this.pool.query.bind(this.pool), sheetId)
+    const personRestrictByFieldId = new Map<string, string[]>()
+    for (const f of fields) {
+      if (f.type !== 'person') continue
+      const ids = personRestrictGroupIds(f)
+      if (f.id && ids.length > 0) personRestrictByFieldId.set(f.id, ids)
     }
 
     for (const [fieldId, value] of Object.entries(data)) {
@@ -1058,7 +1061,7 @@ export class RecordService {
       }
       if (field.type === 'person') {
         try {
-          const allowed = await resolvePersonMemberUserIds()
+          const allowed = await resolvePersonAllowed(personRestrictByFieldId.get(fieldId) ?? [])
           patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
         } catch (error) {
           fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -23,6 +23,7 @@ import {
   type YjsInvalidator,
 } from './post-commit-hooks'
 import { BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, normalizeMultiSelectValue, validateLongTextValue, validatePersonValue } from './field-codecs'
+import { createPersonMemberResolver, personRestrictGroupIds } from './person-field-restriction'
 import {
   HierarchyCycleError,
   assertNoHierarchyParentCycle,
@@ -649,49 +650,17 @@ export class RecordWriteService {
       // sheet member AND in an allowed group (fail-closed). Unrestricted fields keep the sheet set.
       // Read-back is unaffected (validation is write-only), so pre-existing out-of-scope values are
       // grandfathered. Resolved sets are cached per restrict-key so a bulk patch hits the DB once.
-      let personMemberUserIds: Set<string> | null = null
-      const restrictedMemberSetCache = new Map<string, Set<string>>()
-      const loadMemberGroupUserIds = async (groupIds: string[]): Promise<Set<string>> => {
-        if (groupIds.length === 0) return new Set<string>()
-        const res = await query(
-          `SELECT DISTINCT gm.user_id::text AS uid
-             FROM platform_member_group_members gm
-             JOIN users u ON u.id = gm.user_id
-            WHERE gm.group_id::text = ANY($1::text[])
-              AND u.is_active = TRUE`,
-          [groupIds],
-        )
-        return new Set(
-          (res.rows as Array<Record<string, unknown>>)
-            .map((row) => (typeof row.uid === 'string' ? row.uid.trim() : ''))
-            .filter((v): v is string => v.length > 0),
-        )
-      }
-      const resolvePersonMemberUserIds = async (restrictGroupIds: string[]): Promise<Set<string>> => {
-        if (personMemberUserIds === null) {
-          personMemberUserIds = await h.loadSheetMemberUserIds(query, sheetId)
-        }
-        if (restrictGroupIds.length === 0) return personMemberUserIds
-        const key = Array.from(new Set(restrictGroupIds)).sort().join(',')
-        let restricted = restrictedMemberSetCache.get(key)
-        if (!restricted) {
-          const groupSet = await loadMemberGroupUserIds(restrictGroupIds)
-          // Intersect with the sheet member set: strictly narrows, never widens, the current contract.
-          restricted = new Set<string>()
-          for (const id of personMemberUserIds) if (groupSet.has(id)) restricted.add(id)
-          restrictedMemberSetCache.set(key, restricted)
-        }
-        return restricted
-      }
+      // Shared SINGLE source of truth (person-field-restriction.ts) — identical to the REST/form path
+      // in RecordService, so a restricted person field can't be bypassed via any write path. Keeps the
+      // injected sheet-member loader (h.loadSheetMemberUserIds) so the existing unit seam is preserved.
+      const resolvePersonMemberUserIds = createPersonMemberResolver(query, sheetId, h.loadSheetMemberUserIds)
 
       // #16: source each person field's restrictToMemberGroupIds from the property-bearing `fields`
       // list (the per-change `fieldById` guard does not carry property). Built once per patch op.
       const personRestrictByFieldId = new Map<string, string[]>()
       for (const f of fields as Array<{ id?: unknown; type?: unknown; property?: unknown }>) {
         if (!f || f.type !== 'person') continue
-        const raw = (f.property as Record<string, unknown> | undefined)?.restrictToMemberGroupIds
-        if (!Array.isArray(raw)) continue
-        const ids = Array.from(new Set(raw.filter((v): v is string => typeof v === 'string' && v.trim().length > 0).map((v) => v.trim())))
+        const ids = personRestrictGroupIds(f)
         const fid = typeof f.id === 'string' ? f.id : ''
         if (fid && ids.length > 0) personRestrictByFieldId.set(fid, ids)
       }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -68,6 +68,7 @@ import {
   type MultitableSheetPermissionSubjectType,
   type SheetPermissionScope,
 } from '../multitable/permission-service'
+import { createPersonMemberResolver, personRestrictGroupIds } from '../multitable/person-field-restriction'
 import {
   loadFieldsForSheet as loadFieldsForSheetShared,
   loadSheetRow as loadSheetRowShared,
@@ -3412,6 +3413,9 @@ function buildFieldMutationGuardMap(fields: UniverMetaField[]): Map<string, Fiel
         type: field.type,
         readOnly: isFieldAlwaysReadOnly(field),
         hidden: isFieldPermissionHidden(field),
+        // #16/P2: carry property so RecordWriteService.validateChanges' isPersonSingleRecord(property)
+        // sees limitSingleRecord — without it a multiSelect person is wrongly rejected as single.
+        property,
       }
       if (field.type === 'select' || field.type === 'multiSelect') {
         return [field.id, { ...base, options: field.options?.map((option) => option.value) ?? [] }] as const
@@ -9341,7 +9345,7 @@ export function univerMetaRouter(): Router {
         // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): a denied record reads as
         // not-found in the form prefill (404, NOT 403 — no existence oracle). Anonymous public forms have
         // no subject, so the deny never applies to them (only the authenticated actor is gated).
-        if (access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+        if (access.userId && !access.isAdminRole && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
           const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
           if (deniedIds.has(recordIdParam)) {
             return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordIdParam}` } })
@@ -9535,15 +9539,15 @@ export function univerMetaRouter(): Router {
       const patch: Record<string, unknown> = {}
       const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
 
-      // Native person (人员): resolve the sheet member set ONCE per request (lazily, only when a
-      // person field value is actually written) — parallel to the link-target-exists hot-path —
-      // and reuse it for every person cell's write-time membership validation (SECURITY boundary).
-      let personMemberUserIds: Set<string> | null = null
-      const resolvePersonMemberUserIds = async (): Promise<Set<string>> => {
-        if (personMemberUserIds === null) {
-          personMemberUserIds = await loadSheetMemberUserIdSet(pool.query.bind(pool), view.sheetId)
-        }
-        return personMemberUserIds
+      // Native person (人员): #16 per-field allowed-assignee resolver (sheet members ∩ the field's
+      // restrictToMemberGroupIds) — shared with RecordService/RecordWriteService so FORM SUBMIT
+      // enforces the member-group restriction identically (SECURITY boundary), not sheet-member-only.
+      const resolvePersonAllowed = createPersonMemberResolver(pool.query.bind(pool), view.sheetId)
+      const personRestrictByFieldId = new Map<string, string[]>()
+      for (const f of fields) {
+        if (f.type !== 'person') continue
+        const ids = personRestrictGroupIds(f)
+        if (f.id && ids.length > 0) personRestrictByFieldId.set(f.id, ids)
       }
 
       for (const [fieldId, value] of Object.entries(data)) {
@@ -9588,7 +9592,7 @@ export function univerMetaRouter(): Router {
 
         if (field.type === 'person') {
           try {
-            const allowed = await resolvePersonMemberUserIds()
+            const allowed = await resolvePersonAllowed(personRestrictByFieldId.get(fieldId) ?? [])
             patch[fieldId] = validatePersonValue(value, fieldId, allowed, isPersonSingleRecord(field.property))
           } catch (error) {
             fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
@@ -11348,7 +11352,7 @@ export function univerMetaRouter(): Router {
       // is denied so a denied record's data never surfaces via trash. (total left as-is — the
       // canDeleteRecord-gated trash count may include a denied row; exact-count exclusion is a minor follow-up.)
       let trashRecords = result.records
-      if (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+      if (!access.isAdminRole && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
         const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
         if (deniedIds.size > 0) trashRecords = result.records.filter((rec) => !deniedIds.has(rec.recordId))
       }

--- a/packages/core-backend/tests/integration/multitable-person-restrict-route-parity.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-restrict-route-parity.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #16/P1 ROUTE-LEVEL parity — the restrictToMemberGroupIds person guard must enforce on the REAL
+ * write routes, not just RecordWriteService. The prior #2833 test hit the service directly and missed
+ * that POST /records + PATCH /records/:id + POST /views/:viewId/submit go through RecordService.
+ * Also covers the two P2s: admin-bypass on GET /form-context + GET /sheets/:sheetId/trash, and the
+ * multiSelect-person /patch guard (property carried so it is not wrongly rejected as single).
+ * Real-DB only (sentinel skips without DATABASE_URL).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const TS = Date.now()
+const BASE_ID = `base_prp_${TS}`
+const SHEET_ID = `sheet_prp_${TS}`
+const VIEW_ID = `view_prp_${TS}`
+const REC_GF = `rec_prp_gf_${TS}`
+const REC_SECRET = `rec_prp_secret_${TS}`
+const ACTOR = `u_prp_actor_${TS}`
+const ADMIN = `u_prp_admin_${TS}`
+const G_ALLOW = '31111111-1111-4111-8111-111111111111'
+const G_OTHER = '32222222-2222-4222-8222-222222222222'
+const U_IN = `u_prp_in_${TS}`
+const U_OUT = `u_prp_out_${TS}`
+const F_PERSON = 'fld_prp_person'
+const F_PERSON_MULTI = 'fld_prp_person_multi'
+const F_STR = 'fld_prp_str'
+
+function buildApp(userId: string, perms: string[], roles: string[] = ['member']): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as Record<string, unknown>).user = { id: userId, roles, perms, permissions: perms }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const actorApp = () => buildApp(ACTOR, ['multitable:read', 'multitable:write'])
+const adminApp = () => buildApp(ADMIN, ['multitable:read', 'multitable:write'], ['admin'])
+
+const recData = async (recId: string): Promise<Record<string, unknown>> => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recId])
+  return (r.rows[0] as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+}
+
+describeIfDatabase('#16/P1 person restrict route parity + P2 admin-bypass/multiSelect (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'PRP Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'PRP Sheet'])
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, config) VALUES ($1,$2,$3,$4,$5::jsonb) ON CONFLICT (id) DO NOTHING',
+      [VIEW_ID, SHEET_ID, 'Form', 'form', JSON.stringify({})]).catch(() => {})
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_PERSON, SHEET_ID, 'Owner', 'person', JSON.stringify({ restrictToMemberGroupIds: [G_ALLOW] }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_PERSON_MULTI, SHEET_ID, 'Owners', 'person', JSON.stringify({ limitSingleRecord: false }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [F_STR, SHEET_ID, 'Note', 'string', '{}', 3])
+    for (const uid of [ACTOR, ADMIN, U_IN, U_OUT]) {
+      await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin) VALUES ($1,$2,$3,'x','user','[]'::jsonb,TRUE,FALSE) ON CONFLICT (id) DO NOTHING`, [uid, `${uid}@t.local`, uid])
+      await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:read') ON CONFLICT DO NOTHING`, [uid])
+    }
+    await q('INSERT INTO platform_member_groups (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [G_ALLOW, 'Allowed'])
+    await q('INSERT INTO platform_member_groups (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [G_OTHER, 'Other'])
+    await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_ALLOW, U_IN])
+    await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_OTHER, U_OUT])
+  })
+  beforeEach(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    // grandfather row: pre-existing OUT-of-scope person value, inserted directly (bypasses validation)
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_GF, SHEET_ID, JSON.stringify({ [F_PERSON]: [U_OUT], [F_STR]: 'orig' })])
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, '[]']).catch(() => {})
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM platform_member_group_members WHERE group_id = ANY($1)', [[G_ALLOW, G_OTHER]]).catch(() => {})
+    await q('DELETE FROM platform_member_groups WHERE id = ANY($1)', [[G_ALLOW, G_OTHER]]).catch(() => {})
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1)', [[ACTOR, ADMIN, U_IN, U_OUT]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1)', [[ACTOR, ADMIN, U_IN, U_OUT]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ---- P1: route-level enforcement ----
+  test('POST /records — in-group user accepted, out-of-group REJECTED', async () => {
+    const ok = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_PERSON]: [U_IN] } })
+    expect(ok.status).toBe(200)
+    const bad = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_PERSON]: [U_OUT] } })
+    expect(bad.status).toBeGreaterThanOrEqual(400)
+    expect(bad.status).toBeLessThan(500)
+  })
+
+  test('PATCH /records/:id — out-of-group REJECTED, in-group accepted', async () => {
+    const created = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_STR]: 'x' } })
+    const recId = (created.body?.data?.record?.id) as string
+    expect(recId).toBeTruthy()
+    const bad = await request(actorApp()).patch(`/api/multitable/records/${recId}`).send({ sheetId: SHEET_ID, data: { [F_PERSON]: [U_OUT] } })
+    expect(bad.status).toBeGreaterThanOrEqual(400)
+    expect(bad.status).toBeLessThan(500)
+    const ok = await request(actorApp()).patch(`/api/multitable/records/${recId}`).send({ sheetId: SHEET_ID, data: { [F_PERSON]: [U_IN] } })
+    expect(ok.status).toBe(200)
+  })
+
+  test('grandfather — pre-existing out-of-scope person value still reads back', async () => {
+    const data = await recData(REC_GF)
+    expect(data[F_PERSON]).toEqual([U_OUT])
+  })
+
+  test('POST /views/:viewId/submit — out-of-group person REJECTED (form path)', async () => {
+    const bad = await request(actorApp()).post(`/api/multitable/views/${VIEW_ID}/submit`).send({ data: { [F_PERSON]: [U_OUT], [F_STR]: 'viaform' } })
+    expect(bad.status).toBeGreaterThanOrEqual(400)
+    expect(bad.status).toBeLessThan(500)
+  })
+
+  // ---- P2: multiSelect person guard (property carried) ----
+  test('POST /patch — multiSelect person accepts an array (not rejected as single)', async () => {
+    const created = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_STR]: 'm' } })
+    const recId = (created.body?.data?.record?.id) as string
+    const res = await request(actorApp()).post('/api/multitable/patch').send({ sheetId: SHEET_ID, changes: [{ recordId: recId, fieldId: F_PERSON_MULTI, value: [U_IN, U_OUT] }] })
+    expect(res.status).toBe(200)
+    expect((await recData(recId))[F_PERSON_MULTI]).toEqual([U_IN, U_OUT])
+  })
+
+  // ---- P2: admin bypass on form-context + trash under a conditional deny rule ----
+  test('admin bypass — GET /form-context + GET /trash see a rule-denied record', async () => {
+    const created = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_STR]: 'secret' } })
+    const recId = (created.body?.data?.record?.id) as string
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1',
+      [SHEET_ID, JSON.stringify([{ id: 'r1', fieldId: F_STR, operator: 'eq', value: 'secret', effect: 'deny_read' }])])
+    // non-admin: denied at single GET
+    const nonAdmin = await request(actorApp()).get(`/api/multitable/records/${recId}`).query({ sheetId: SHEET_ID })
+    expect([403, 404]).toContain(nonAdmin.status)
+    // admin: form-context still resolves the record (bypass)
+    const fc = await request(adminApp()).get('/api/multitable/form-context').query({ sheetId: SHEET_ID, recordId: recId })
+    expect(fc.status).toBe(200)
+    // delete + admin trash list still shows it (bypass)
+    await request(adminApp()).delete(`/api/multitable/records/${recId}`).send({ sheetId: SHEET_ID })
+    const trash = await request(adminApp()).get(`/api/multitable/sheets/${SHEET_ID}/trash`)
+    expect(trash.status).toBe(200)
+    const ids = (trash.body?.data?.records ?? []).map((r: { recordId: string }) => r.recordId)
+    expect(ids).toContain(recId)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-person-restrict-route-parity.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-restrict-route-parity.test.ts
@@ -124,6 +124,16 @@ describeIfDatabase('#16/P1 person restrict route parity + P2 admin-bypass/multiS
     expect(bad.status).toBeLessThan(500)
   })
 
+  test('POST /views/:viewId/submit — in-group person accepted + stored (form path positive)', async () => {
+    // Positive half of the form-path parity: without this, a "form rejects ALL restricted person
+    // writes" regression would still pass. Assert the submit succeeds AND the created record stores [U_IN].
+    const ok = await request(actorApp()).post(`/api/multitable/views/${VIEW_ID}/submit`).send({ data: { [F_PERSON]: [U_IN], [F_STR]: 'viaform-in' } })
+    expect(ok.status).toBe(200)
+    const found = await q('SELECT data FROM meta_records WHERE sheet_id = $1 AND data ->> $2 = $3', [SHEET_ID, F_STR, 'viaform-in'])
+    expect(found.rows.length).toBe(1)
+    expect((found.rows[0].data as Record<string, unknown>)[F_PERSON]).toEqual([U_IN])
+  })
+
   // ---- P2: multiSelect person guard (property carried) ----
   test('POST /patch — multiSelect person accepts an array (not rejected as single)', async () => {
     const created = await request(actorApp()).post('/api/multitable/records').send({ sheetId: SHEET_ID, data: { [F_STR]: 'm' } })


### PR DESCRIPTION
Closes three reviewer-found contract holes, route-level real-PG verified.

**[P1 security] #16 was bypassed by the main REST/form write paths.** POST /records + PATCH /records/:id (RecordService) + POST /views/:viewId/submit (inline) all resolved allowed = sheet members only — no restrictToMemberGroupIds intersection (my prior #16 validator was in RecordWriteService, which these routes don't use). Fix: one shared `person-field-restriction.ts` (allowed = sheet members ∩ active users in the field's groups; unrestricted⇒sheet; fail-closed; grandfathered) called by **all four** sites — RecordService.createRecord + patchRecord, the form-submit handler, and RecordWriteService.patchRecords. Single source of truth.

**[P2 admin-bypass]** GET /form-context + GET /sheets/:sheetId/trash applied the deny set without `!isAdminRole` (rule-deny now unions into loadDeniedRecordIds → admins wrongly denied). Fixed both to `userId && !isAdminRole && flagEnabled`.

**[P2 person guard]** buildFieldMutationGuardMap now carries field.property → a limitSingleRecord:false (multiSelect) person via /patch is no longer rejected as single.

**Route-level real-PG gate** (multitable-person-restrict-route-parity.test.ts, allowlisted — real Express routes via supertest): POST /records in-group 200 / out-of-group reject; PATCH out-of-group reject / in-group accept; form-submit out-of-group reject; grandfather reads; /patch multiSelect person accepted; admin bypass on form-context + trash. 7/7. #2833 5/5 + conditional golden 8/8 no-regression; tsc clean; full unit 4485/0. 🤖 Generated with Claude Code