### PR TITLE
test(approval): promote A/E/B/D/G cross-lane acceptance to a permanent CI guard

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -256,7 +256,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start)
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance)
         # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
@@ -271,6 +271,7 @@ jobs:
             tests/integration/approval-p1c-field-permissions.api.test.ts \
             tests/integration/approval-wp-add-reduce-sign.api.test.ts \
             tests/integration/approval-direct-manager.api.test.ts \
+            tests/integration/approval-postgate-acceptance.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/tests/integration/approval-postgate-acceptance.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-postgate-acceptance.api.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * POST-GATE integration acceptance (A/E/B/D/G combined) — the runbook, executed.
+ * ONE 3-node template: Node1 = static picker (A) + hidden field (B); Node2 = self-approver (E);
+ * Node3 = normal node for add/reduce-sign (D). Plus an old-template regression (G snapshot harmless).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `acc-req-${TS}`, A1 = `acc-n1-${TS}`, A3 = `acc-n3-${TS}`, COS = `acc-cosign-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => { const s = net.createServer(); s.once('error', () => r(false)); s.listen(0, '127.0.0.1', () => s.close(() => r(true))) })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, { method: opts.method || 'GET', headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) }, ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}) })
+}
+const node = (key: string, cfg: Record<string, unknown>) => ({ key, type: 'approval', name: key, config: cfg })
+
+describeIfDatabase('POST-GATE acceptance — A/E/B/D/G combined (real DB)', () => {
+  let server: MetaSheetServer | undefined, base = '', reqTok = '', a1Tok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ); a1Tok = await tok(base, A1)
+  })
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`acc-%-${TS}%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+    } catch { /* best effort */ }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('A+E+B coexist on one published template; start → B redaction at Node1; E self-resolves Node2; D add/reduce on Node3; G snapshot does not block', async () => {
+    // ---- author the 3-node multi-feature template (A assignee + B hidden on Node1; E on Node2; D node = Node3) ----
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 'start', config: {} },
+        node('approval_1', { assigneeSources: [{ kind: 'static_user', userIds: [A1] }], approvalMode: 'single', fieldPermissions: [{ fieldId: 'secret', access: 'hidden' }] }),
+        node('approval_2', { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', autoApprovalPolicy: { mergeWithRequester: true } }),
+        node('approval_3', { assigneeSources: [{ kind: 'static_user', userIds: [A3] }], approvalMode: 'single' }),
+        { key: 'end', type: 'end', name: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'approval_2' },
+        { key: 'e3', source: 'approval_2', target: 'approval_3' }, { key: 'e4', source: 'approval_3', target: 'end' },
+      ],
+    }
+    const form = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }, { id: 'secret', type: 'text', label: 's' }] }
+    const created = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key: `acc-multi-${TS}`, name: 'acc multi', formSchema: form, approvalGraph: graph } })
+    expect(created.status, await created.clone().text()).toBe(201) // A+E+B coexist + normalize accepts
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    // ---- start (G snapshot best-effort must not block) ----
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r', secret: 'TOP-SECRET' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const startedBody = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = startedBody.id ?? startedBody.data?.id
+
+    // ---- B: at Node1 (hiding node) the hidden field is redacted for every viewer; DB byte-intact ----
+    const detail = await (await req(base, `/api/approvals/${aid}`, a1Tok)).json() as any
+    const snap = detail.formSnapshot ?? detail.data?.formSnapshot ?? {}
+    expect(snap.reason).toBe('r')
+    expect('secret' in snap).toBe(false) // B redaction (approver view)
+    const dbRow = (await poolManager.get().query(`SELECT form_snapshot FROM approval_instances WHERE id=$1`, [aid])).rows[0]
+    expect((dbRow.form_snapshot as any).secret).toBe('TOP-SECRET') // DB byte-intact
+
+    // ---- approve Node1 → E self-resolves Node2 → pending at Node3; B field reappears ----
+    expect((await req(base, `/api/approvals/${aid}/actions`, a1Tok, { method: 'POST', body: { action: 'approve', comment: 'n1' } })).status).toBeLessThan(300)
+    const afterN1 = await (await req(base, `/api/approvals/${aid}`, reqTok)).json() as any
+    const cur = afterN1.currentNodeKey ?? afterN1.data?.currentNodeKey
+    expect(cur, JSON.stringify(afterN1).slice(0, 300)).toBe('approval_3') // E auto-resolved Node2, now at Node3
+    const snap3 = afterN1.formSnapshot ?? afterN1.data?.formSnapshot ?? {}
+    expect(snap3.secret).toBe('TOP-SECRET') // B: hidden field present again after leaving Node1
+
+    // ---- D: add_sign then reduce_sign on Node3 ----
+    const a3Tok = await tok(base, A3)
+    const addR = await req(base, `/api/approvals/${aid}/actions`, a3Tok, { method: 'POST', body: { action: 'add_sign', targetUserIds: [COS], addSignMode: 'parallel' } })
+    expect(addR.status, await addR.clone().text()).toBeLessThan(300)
+    const activeAfterAdd = (await poolManager.get().query(`SELECT count(*)::int n FROM approval_assignments WHERE instance_id=$1 AND node_key='approval_3' AND is_active=TRUE`, [aid])).rows[0].n
+    expect(activeAfterAdd).toBeGreaterThanOrEqual(2) // add_sign extended the node
+    const redR = await req(base, `/api/approvals/${aid}/actions`, a3Tok, { method: 'POST', body: { action: 'reduce_sign', targetAssignmentUserId: COS } })
+    expect(redR.status, await redR.clone().text()).toBeLessThan(300)
+    const cosActive = (await poolManager.get().query(`SELECT count(*)::int n FROM approval_assignments WHERE instance_id=$1 AND node_key='approval_3' AND assignee_id=$2 AND is_active=TRUE`, [aid, COS])).rows[0].n
+    expect(cosActive).toBe(0) // reduce_sign deactivated only the added co-signer
+  })
+
+  it('legacy template (no features): create/start/approve flow unchanged; G snapshot harmless (flow-equivalence, not a byte diff)', async () => {
+    const form = { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }
+    const graph = { nodes: [{ key: 'start', type: 'start', name: 's', config: {} }, node('approval_1', { assigneeSources: [{ kind: 'static_user', userIds: [A1] }], approvalMode: 'single' }), { key: 'end', type: 'end', name: 'e', config: {} }], edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }] }
+    const c = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key: `acc-legacy-${TS}`, name: 'legacy', formSchema: form, approvalGraph: graph } })
+    expect(c.status).toBe(201)
+    const tid = ((await c.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+    const s = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(s.status).toBeLessThan(300) // create succeeds; G snapshot bake never blocks
+    const sBody = (await s.json()) as { id?: string; data?: { id: string } }
+    const aid = sBody.id ?? sBody.data?.id
+    expect((await req(base, `/api/approvals/${aid}/actions`, a1Tok, { method: 'POST', body: { action: 'approve', comment: 'ok' } })).status).toBeLessThan(300)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'tests/integration/approval-p1c-field-permissions.api.test.ts',
       'tests/integration/approval-wp-add-reduce-sign.api.test.ts',
       'tests/integration/approval-direct-manager.api.test.ts',
+      'tests/integration/approval-postgate-acceptance.api.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
Promotes the POST-GATE integration acceptance — run locally throughout the cross-lane arc — into `tests/integration` as a **permanent DB-backed cross-lane regression guard**. No product code; test + CI wiring only.

## What it guards
One 3-node template exercising the lanes **together** (the seams no per-lane test covers):
- **Node 1** — static_user picker assignee (**A**) + hidden `fieldPermissions` (**B**): start redacts `secret` from the read DTO while the DB snapshot stays intact.
- **Node 2** — `autoApprovalPolicy.mergeWithRequester` (**E**): self-resolves, advancing to Node 3; the hidden field reappears after leaving Node 1.
- **Node 3** — `add_sign`/`reduce_sign` (**D**): add extends, reduce removes only the co-signer.
- **G** snapshot bake never blocks create; plus a legacy-template flow-equivalence check.

## Wiring (no new job)
Dropped into the **existing** approval real-DB step in `plugin-tests.yml` (alongside directory/P1-C/P1-B/direct_manager): `describeIfDatabase` + a `DATABASE_URL` sentinel + default-`vitest.config` exclude. **3/3** with a DB; cleanly skipped without one. Already CI-shaped: full FK-order cleanup + parse-once.

## Honesty fix (review catch)
Renamed the legacy test from *"old template byte-unchanged"* to *"legacy template: create/start/approve flow unchanged (flow-equivalence, not a byte diff)"* — it asserts the flow succeeds, not a byte-level diff, so the name shouldn't over-promise. (The internal runbook's stale "direct_manager not wired yet" line was also corrected — direct_manager shipped in #2852.)

## Governance
W7 stays locked; `dept_head` waits behind its sync-plumbing slice; `direct_manager` already shipped (#2852). This PR only makes the existing cross-lane verification permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)