### PR TITLE
feat(multitable): 2b-S4 conditional-rule parse cache (content-keyed, staleness-free)

### DIFF
--- a/packages/core-backend/src/multitable/permission-rule-evaluator.ts
+++ b/packages/core-backend/src/multitable/permission-rule-evaluator.ts
@@ -161,6 +161,44 @@ export function parseConditionalRules(raw: unknown): ParsedRulesResult {
   return { rules, rejected }
 }
 
+// ── 2b-S4: content-keyed parse cache ────────────────────────────────────────
+// parseConditionalRules is PURE over `raw`, so memoizing by the raw JSON is staleness-free: a rule
+// change yields a different key (automatic miss → re-parse), and field changes don't affect parsing
+// (fields are evaluated separately). This saves re-parsing identical rule sets across the many read
+// surfaces WITHOUT caching DB reads — caching the rules/fields query results would risk stale =
+// wrong access, which is unacceptable for a permission feature. Bounded LRU; the freshness guarantee
+// stays with the per-read DB load of the rules.
+const RULE_PARSE_CACHE = new Map<string, ParsedRulesResult>()
+const RULE_PARSE_CACHE_MAX = 256
+
+export function parseConditionalRulesCached(raw: unknown): ParsedRulesResult {
+  let key: string | null
+  try {
+    key = JSON.stringify(raw ?? null)
+  } catch {
+    key = null // unstringifiable (cycles) → bypass the cache, never throw
+  }
+  if (key === null) return parseConditionalRules(raw)
+  const hit = RULE_PARSE_CACHE.get(key)
+  if (hit) {
+    RULE_PARSE_CACHE.delete(key)
+    RULE_PARSE_CACHE.set(key, hit) // LRU bump
+    return hit
+  }
+  const parsed = parseConditionalRules(raw)
+  RULE_PARSE_CACHE.set(key, parsed)
+  if (RULE_PARSE_CACHE.size > RULE_PARSE_CACHE_MAX) {
+    const oldest = RULE_PARSE_CACHE.keys().next().value
+    if (oldest !== undefined) RULE_PARSE_CACHE.delete(oldest)
+  }
+  return parsed
+}
+
+/** Test hook: clear the 2b-S4 parse cache. */
+export function _clearConditionalRuleParseCache(): void {
+  RULE_PARSE_CACHE.clear()
+}
+
 function isEmptyValue(v: unknown): boolean {
   if (v === null || v === undefined) return true
   if (typeof v === 'string') return v.trim().length === 0

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -46,6 +46,7 @@ import {
 import { filterPermissionCodesByNamespaceAdmission } from '../rbac/namespace-admission'
 import {
   parseConditionalRules,
+  parseConditionalRulesCached,
   evaluateRecordDenied,
   type FieldMeta as RuleFieldMeta,
 } from './permission-rule-evaluator'
@@ -1078,7 +1079,7 @@ export async function loadRuleDeniedRecordIds(
     if (isUndefinedColumnError(err, 'conditional_read_rules')) return new Set<string>() // pre-migration → inert
     throw err // a real load failure → propagate (fail-closed: the surface errors, never grants read)
   }
-  const { rules } = parseConditionalRules(rawRules)
+  const { rules } = parseConditionalRulesCached(rawRules) // 2b-S4: content-keyed parse cache (staleness-free; the per-read DB load above is the freshness guarantee)
   if (rules.length === 0) return new Set<string>() // no valid rules → inert
   const fieldsById: Record<string, RuleFieldMeta | undefined> = {}
   const fr = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])

--- a/packages/core-backend/tests/unit/multitable-permission-rule-evaluator.test.ts
+++ b/packages/core-backend/tests/unit/multitable-permission-rule-evaluator.test.ts
@@ -5,11 +5,13 @@
  * the FAIL-CLOSED paths (missing field, deleted field, operator-not-allowed-for-type, malformed value,
  * thrown predicate -> DENIED); OR-combination; and the no-value-leak reason invariant.
  */
-import { describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test } from 'vitest'
 
 import {
   evaluateRecordDenied,
   parseConditionalRules,
+  parseConditionalRulesCached,
+  _clearConditionalRuleParseCache,
   type ConditionalRule,
   type FieldMeta,
 } from '../../src/multitable/permission-rule-evaluator'
@@ -165,5 +167,47 @@ describe('OR-combination + no-leak reason', () => {
   })
   test('empty rule set -> not denied', () => {
     expect(evaluateRecordDenied(rec({ a: 'x' }), [], fields(['a', 'select'])).denied).toBe(false)
+  })
+})
+
+describe('2b-S4 conditional-rule parse cache (content-keyed, staleness-free)', () => {
+  beforeEach(() => _clearConditionalRuleParseCache())
+  const raw = [{ id: 'r1', fieldId: 'f1', operator: 'eq', value: 'x', effect: 'deny_read' }]
+
+  test('identical raw → SAME cached reference (hit)', () => {
+    const a = parseConditionalRulesCached(raw)
+    const b = parseConditionalRulesCached([{ id: 'r1', fieldId: 'f1', operator: 'eq', value: 'x', effect: 'deny_read' }])
+    expect(b).toBe(a) // content-keyed hit, no re-parse
+  })
+
+  test('cached result equals the direct parse (correctness preserved)', () => {
+    expect(parseConditionalRulesCached(raw)).toEqual(parseConditionalRules(raw))
+  })
+
+  test('changed rules → re-parsed (auto-invalidation by content; no stale permissions)', () => {
+    const a = parseConditionalRulesCached(raw)
+    const b = parseConditionalRulesCached([{ id: 'r2', fieldId: 'f1', operator: 'eq', value: 'y', effect: 'deny_read' }])
+    expect(b).not.toBe(a)
+    expect(b.rules[0]?.id).toBe('r2')
+  })
+
+  test('clear hook forces a fresh parse (new ref, identical content)', () => {
+    const a = parseConditionalRulesCached(raw)
+    _clearConditionalRuleParseCache()
+    const b = parseConditionalRulesCached(raw)
+    expect(b).not.toBe(a)
+    expect(b).toEqual(a)
+  })
+
+  test('perf: a large identical rule set parses once across many reads', () => {
+    const big = Array.from({ length: 200 }, (_, i) => ({ id: `r${i}`, fieldId: 'f1', operator: 'eq', value: i, effect: 'deny_read' }))
+    const first = parseConditionalRulesCached(big)
+    for (let i = 0; i < 50; i++) expect(parseConditionalRulesCached(big)).toBe(first) // 50 reads → 1 parse
+  })
+
+  test('unstringifiable input bypasses the cache without throwing', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    expect(() => parseConditionalRulesCached([cyclic])).not.toThrow()
   })
 })


### PR DESCRIPTION
Closes the last **2b** slice (S4 performance/caching). The conditional read-deny enforcement re-parsed the sheet's rule JSON on every read surface; `parseConditionalRulesCached` memoizes `parseConditionalRules` by the raw JSON.

**Staleness-free by design** (it's a permission feature): content-keyed → a rule change is a different key (auto miss → re-parse); field changes don't affect parsing; and DB reads are **not** cached (that would risk stale = wrong access — the per-read rules load stays the freshness guarantee). Bounded LRU(256); enforcement uses the cached parse, authoring keeps the direct parser.

Tests: +6 cache cases (hit / equals-direct / content-change re-parse / clear hook / 200-rule set parsed once across 50 reads / cyclic-input bypass). Evaluator suite **43/43**; tsc clean. Real-DB enforcement goldens unaffected (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)