### PR TITLE
feat(multitable): 2c-S2 person org-directory resolver (source = B member-group directory)

### DIFF
--- a/packages/core-backend/src/multitable/person-field-restriction.ts
+++ b/packages/core-backend/src/multitable/person-field-restriction.ts
@@ -69,3 +69,44 @@ export function createPersonMemberResolver(
     return restricted
   }
 }
+
+export interface PersonDirectoryEntry {
+  userId: string
+  name: string | null
+  email: string | null
+}
+
+/**
+ * 2c-S2 (source of truth = B: member-group directory) — the READ counterpart of
+ * createPersonMemberResolver. Returns the assignable directory of a person field: the SAME allowed
+ * set the write-validator accepts (sheet members ∩ active group members; unrestricted ⇒ sheet
+ * members), hydrated with display info and filtered to ACTIVE users. Inactive/deleted users are
+ * excluded here (not assignable) — they remain READ-only via the stored value / buildPersonSummaries,
+ * never surfaced as assignable. The picker (2c-S3) consumes this so what it offers === what the
+ * validator will accept (display parity). Ordered by name for stable display. Read-only; sits behind
+ * the existing restriction seam (reuses createPersonMemberResolver — single source of truth).
+ */
+export async function resolvePersonAssignableDirectory(
+  query: QueryFn,
+  sheetId: string,
+  restrictGroupIds: string[],
+  /** Injectable allowed-set resolver (defaults to the canonical write-validator resolver) — lets unit
+   *  tests exercise hydration without the full candidate-resolution query chain. */
+  resolveAllowed: (groupIds: string[]) => Promise<Set<string>> = createPersonMemberResolver(query, sheetId),
+): Promise<PersonDirectoryEntry[]> {
+  const allowed = await resolveAllowed(restrictGroupIds)
+  if (allowed.size === 0) return []
+  const res = await query(
+    `SELECT id::text AS uid, name, email
+       FROM users
+      WHERE id::text = ANY($1::text[])
+        AND is_active = TRUE
+      ORDER BY name NULLS LAST, id`,
+    [Array.from(allowed)],
+  )
+  return (res.rows as Array<Record<string, unknown>>).map((row) => ({
+    userId: String(row.uid),
+    name: typeof row.name === 'string' ? row.name : null,
+    email: typeof row.email === 'string' ? row.email : null,
+  }))
+}

--- a/packages/core-backend/tests/integration/multitable-person-member-group-restrict.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-member-group-restrict.test.ts
@@ -24,6 +24,7 @@ import { poolManager } from '../../src/integration/db/connection-pool'
 import { RecordWriteService, RecordValidationError, type RecordPatchInput } from '../../src/multitable/record-write-service'
 import { createRecordWriteHelpers } from '../../src/routes/univer-meta'
 import { deriveCapabilities } from '../../src/multitable/sheet-capabilities'
+import { resolvePersonAssignableDirectory } from '../../src/multitable/person-field-restriction'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
@@ -38,6 +39,7 @@ const G_ALLOW = '11111111-1111-4111-8111-111111111111'
 const G_OTHER = '22222222-2222-4222-8222-222222222222'
 const U_IN = `u_pmg_in_${TS}`
 const U_OUT = `u_pmg_out_${TS}`
+const U_INACTIVE = `u_pmg_inactive_${TS}` // 2c-S2: in G_ALLOW but is_active=FALSE → excluded from the assignable directory
 
 const F_PERSON = 'fld_person_restricted'
 const F_PERSON_FREE = 'fld_person_free'
@@ -104,6 +106,11 @@ describeIfDatabase('#16 person restrictToMemberGroupIds enforcement (real DB)', 
     await q('INSERT INTO platform_member_groups (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [G_OTHER, 'Other'])
     await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_ALLOW, U_IN])
     await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_OTHER, U_OUT])
+    // 2c-S2 fixture: an INACTIVE user in the allowed group — must be excluded from the assignable directory
+    // (not assignable) while remaining readable via stored values elsewhere.
+    await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin) VALUES ($1,$2,$3,'x','user','[]'::jsonb,FALSE,FALSE) ON CONFLICT (id) DO NOTHING`, [U_INACTIVE, `${U_INACTIVE}@t.local`, U_INACTIVE])
+    await q(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1,'multitable:read') ON CONFLICT DO NOTHING`, [U_INACTIVE])
+    await q('INSERT INTO platform_member_group_members (group_id, user_id) VALUES ($1,$2) ON CONFLICT DO NOTHING', [G_ALLOW, U_INACTIVE])
   })
   beforeEach(async () => {
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, version = 1', [REC_ID, SHEET_ID, JSON.stringify({})])
@@ -155,5 +162,33 @@ describeIfDatabase('#16 person restrictToMemberGroupIds enforcement (real DB)', 
     const svc = makeService()
     await expect(svc.patchRecords(await buildInput(REC_ID, { [F_PERSON]: [U_OUT] }, 'yjs-bridge'))).rejects.toBeInstanceOf(RecordValidationError)
     expect((await readData(REC_ID))[F_PERSON]).toBeUndefined()
+  })
+
+  // ── 2c-S2: member-group directory READ model (resolvePersonAssignableDirectory) ──────────────
+  test('2c-S2 directory: restricted field → only in-group ACTIVE members, with display info', async () => {
+    const dir = await resolvePersonAssignableDirectory(q, SHEET_ID, [G_ALLOW])
+    const ids = dir.map((e) => e.userId)
+    expect(ids).toContain(U_IN) // in G_ALLOW, active, sheet member → assignable
+    expect(ids).not.toContain(U_OUT) // sheet member but not in G_ALLOW
+    expect(ids).not.toContain(ACTOR) // sheet member but not in G_ALLOW
+    expect(ids).not.toContain(U_INACTIVE) // in G_ALLOW but inactive → NOT assignable
+    const inEntry = dir.find((e) => e.userId === U_IN)
+    expect(inEntry?.email).toBe(`${U_IN}@t.local`) // hydrated display info
+    expect(inEntry?.name).toBe(U_IN)
+  })
+
+  test('2c-S2 directory: == the write-validator allowed set (display parity — offers exactly what patchRecords accepts)', async () => {
+    // The existing POSITIVE/NEGATIVE tests prove patchRecords accepts U_IN and rejects U_OUT for
+    // [G_ALLOW]; the directory must list exactly that allowed set so the picker never offers a value
+    // the validator would reject.
+    const dir = await resolvePersonAssignableDirectory(q, SHEET_ID, [G_ALLOW])
+    expect(dir.map((e) => e.userId).sort()).toEqual([U_IN])
+  })
+
+  test('2c-S2 directory: unrestricted field → all active sheet members (inactive excluded)', async () => {
+    const dir = await resolvePersonAssignableDirectory(q, SHEET_ID, [])
+    const ids = dir.map((e) => e.userId)
+    expect(ids).toEqual(expect.arrayContaining([ACTOR, U_IN, U_OUT])) // all active sheet members
+    expect(ids).not.toContain(U_INACTIVE) // inactive → not a sheet member, not in the directory
   })
 })

--- a/packages/core-backend/tests/unit/multitable-person-directory-resolver.test.ts
+++ b/packages/core-backend/tests/unit/multitable-person-directory-resolver.test.ts
@@ -1,0 +1,57 @@
+/**
+ * 2c-S2 — resolvePersonAssignableDirectory (source = B: member-group directory) unit coverage.
+ *
+ * The allowed-set resolver is INJECTED here (the canonical createPersonMemberResolver is exercised
+ * end-to-end by the real-DB person-member-group-restrict suite). These tests pin the read-model's
+ * own behavior: hydration → display mapping, stable ordering + active-only SQL, the empty-set
+ * short-circuit (fail-closed parity), the exact id params, and non-string field coercion.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { resolvePersonAssignableDirectory } from '../../src/multitable/person-field-restriction'
+import type { QueryFn } from '../../src/multitable/permission-service'
+
+describe('2c-S2 resolvePersonAssignableDirectory (member-group directory read model)', () => {
+  test('hydrates the allowed set into display entries (id/name/email); active-only + ordered SQL', async () => {
+    const calls: string[] = []
+    const query: QueryFn = async (sql) => {
+      calls.push(sql)
+      return { rows: [{ uid: 'u1', name: 'Alice', email: 'a@x.io' }, { uid: 'u2', name: 'Bob', email: null }] }
+    }
+    const out = await resolvePersonAssignableDirectory(query, 'sheet1', ['g1'], async () => new Set(['u1', 'u2']))
+    expect(out).toEqual([
+      { userId: 'u1', name: 'Alice', email: 'a@x.io' },
+      { userId: 'u2', name: 'Bob', email: null },
+    ])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatch(/is_active = TRUE/) // inactive/deleted excluded from the assignable directory
+    expect(calls[0]).toMatch(/ORDER BY name/) // stable display order
+  })
+
+  test('empty allowed set short-circuits — no hydration query (fail-closed parity with the validator)', async () => {
+    let called = false
+    const query: QueryFn = async () => {
+      called = true
+      return { rows: [] }
+    }
+    const out = await resolvePersonAssignableDirectory(query, 'sheet1', ['g1'], async () => new Set())
+    expect(out).toEqual([])
+    expect(called).toBe(false)
+  })
+
+  test('passes exactly the allowed ids as the hydration params', async () => {
+    let params: unknown[] | undefined
+    const query: QueryFn = async (_sql, p) => {
+      params = p
+      return { rows: [] }
+    }
+    await resolvePersonAssignableDirectory(query, 'sheet1', [], async () => new Set(['u9']))
+    expect(params?.[0]).toEqual(['u9'])
+  })
+
+  test('non-string name/email coerced to null (no numeric/object leakage into display)', async () => {
+    const query: QueryFn = async () => ({ rows: [{ uid: 'u1', name: undefined, email: 123 }] })
+    const out = await resolvePersonAssignableDirectory(query, 's', [], async () => new Set(['u1']))
+    expect(out).toEqual([{ userId: 'u1', name: null, email: null }])
+  })
+})


### PR DESCRIPTION
**Owner picked source B** (member-group directory) via the design-lock #2860 decision. This is **2c-S2: the directory read-model resolver**.

`resolvePersonAssignableDirectory` is the READ counterpart of the shipped write-validator (`createPersonMemberResolver`): same allowed set (sheet members ∩ active group members; unrestricted ⇒ sheet members), hydrated with display info, **active users only**, ordered by name. **Display parity** — the picker (2c-S3) offers exactly what `patchRecords` accepts; inactive/deleted users are excluded from assignment (still readable via stored values). Reuses the restriction seam (single source of truth); injectable allowed-resolver for unit testability. **Read-only — no behavior change until 2c-S3 wires the picker.**

Tests: unit **4/4**; real-DB **+3** in the allowlisted `person-member-group-restrict` suite (restricted → in-group active only; == validator allowed set; unrestricted → all active sheet members; inactive in-group excluded). tsc clean.

Next: 2c-S3 (picker UX) → 2c-S4 (inactive/historical display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)