### PR TITLE
feat(multitable): 2c-S3a person field directory endpoint (field-aware, canEditRecord-gated)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -221,6 +221,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-view.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-export.test.ts \
             tests/integration/multitable-export-permission-canary.test.ts \
+            tests/integration/multitable-person-directory-route.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-write.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-create.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -68,7 +68,7 @@ import {
   type MultitableSheetPermissionSubjectType,
   type SheetPermissionScope,
 } from '../multitable/permission-service'
-import { createPersonMemberResolver, personRestrictGroupIds } from '../multitable/person-field-restriction'
+import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssignableDirectory } from '../multitable/person-field-restriction'
 import {
   loadFieldsForSheet as loadFieldsForSheetShared,
   loadSheetRow as loadSheetRowShared,
@@ -5452,6 +5452,45 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list sheet permission candidates failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list sheet permission candidates' } })
+    }
+  })
+
+  // 2c-S3a: person field assignable directory (source = B member-group directory). Returns the
+  // resolvePersonAssignableDirectory read model for ONE person field — the same allowed set the write
+  // validator accepts, hydrated + active-only. Gated on canEditRecord (the picker is used while editing
+  // a record's person field), NOT canManageSheetAccess like /permission-candidates.
+  router.get('/sheets/:sheetId/person-fields/:fieldId/directory', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const fieldId = typeof req.params.fieldId === 'string' ? req.params.fieldId.trim() : ''
+    if (!sheetId || !fieldId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and fieldId are required' } })
+    }
+    const q = typeof req.query.q === 'string' ? req.query.q.trim().toLowerCase() : ''
+    try {
+      const pool = poolManager.get()
+      const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
+      if (!sheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!capabilities.canEditRecord) return sendForbidden(res)
+
+      const fields = await loadFieldsForSheet(pool.query.bind(pool), sheetId)
+      const field = fields.find((f) => f.id === fieldId)
+      if (!field || field.type !== 'person') {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Person field not found: ${fieldId}` } })
+      }
+
+      const directory = await resolvePersonAssignableDirectory(pool.query.bind(pool), sheetId, personRestrictGroupIds(field))
+      const items = q
+        ? directory.filter((e) => (e.name ?? '').toLowerCase().includes(q) || (e.email ?? '').toLowerCase().includes(q))
+        : directory
+      return res.json({ ok: true, data: { items, total: items.length, query: q } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list person field directory failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list person field directory' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-person-directory-route.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-directory-route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * 2c-S3a — GET /sheets/:sheetId/person-fields/:fieldId/directory route logic.
+ *
+ * Mock-pool route test (mirrors the export-permission-canary harness). The directory CONTENT is
+ * real-DB-tested at the resolver (2c-S2 / the person-member-group-restrict suite); here we pin the
+ * route's OWN gatekeeping: the canEditRecord auth gate (NOT the canManageSheetAccess gate that
+ * /permission-candidates uses), the person-field 404, and the success response shape.
+ */
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const SHEET_ID = 'sheet_pdir'
+const F_PERSON = 'fld_person'
+const F_STRING = 'fld_str'
+const FIELD_ROWS = [
+  { id: F_PERSON, name: 'Owner', type: 'person', property: {}, order: 1 },
+  { id: F_STRING, name: 'Note', type: 'string', property: {}, order: 2 },
+]
+
+function createMockPool() {
+  const handler = (sql: string) => {
+    if (sql.includes('FROM meta_sheets') && sql.includes('WHERE id = $1')) {
+      return { rows: [{ id: SHEET_ID, base_id: 'base_pdir', name: 'PDir', description: null }] }
+    }
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1')) return { rows: FIELD_ROWS }
+    // All permission / candidate tables empty → the directory resolver yields [] (content is tested
+    // for real elsewhere; this test only needs the route to reach + shape it).
+    return { rows: [], rowCount: 0 }
+  }
+  const query = vi.fn(async (sql: string) => handler(sql))
+  const transaction = vi.fn(async (fn: (c: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(isAdmin: boolean) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(isAdmin),
+    userHasPermission: vi.fn().mockResolvedValue(isAdmin),
+    listUserPermissions: vi.fn().mockResolvedValue(isAdmin ? ['multitable:write'] : ['multitable:read']),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  vi.spyOn(poolManager, 'get').mockReturnValue(createMockPool() as unknown as ReturnType<typeof poolManager.get>)
+  const app = express()
+  app.use(express.json())
+  const perms = isAdmin ? ['multitable:write'] : ['multitable:read']
+  app.use((req, _res, next) => {
+    ;(req as unknown as { user: unknown }).user = { id: 'u_pdir', roles: [], perms, permissions: perms }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return app
+}
+
+const url = (fieldId: string) => `/api/multitable/sheets/${SHEET_ID}/person-fields/${fieldId}/directory`
+
+describe('2c-S3a person field directory route', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  test('403 when the caller lacks canEditRecord (read-only — not the admin gate)', async () => {
+    const app = await createApp(false)
+    const res = await request(app).get(url(F_PERSON))
+    expect(res.status).toBe(403)
+  })
+
+  test('404 for a non-person field', async () => {
+    const app = await createApp(true)
+    const res = await request(app).get(url(F_STRING))
+    expect(res.status).toBe(404)
+  })
+
+  test('404 for an unknown field id', async () => {
+    const app = await createApp(true)
+    const res = await request(app).get(url('fld_nope'))
+    expect(res.status).toBe(404)
+  })
+
+  test('200 with the directory response shape for a person field', async () => {
+    const app = await createApp(true)
+    const res = await request(app).get(url(F_PERSON))
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.data).toMatchObject({ items: expect.any(Array), total: expect.any(Number), query: '' })
+  })
+})


### PR DESCRIPTION
Backend half of **2c-S3**. `GET /sheets/:sheetId/person-fields/:fieldId/directory` returns the 2c-S2 `resolvePersonAssignableDirectory` for one person field — the same allowed set the write validator accepts, active-only, hydrated, optional `q` filter.

- **Gated on `canEditRecord`** (the picker is used while editing a record's person field) — deliberately **not** `canManageSheetAccess` like `/permission-candidates`.
- 404s a non-person / unknown field.

**Invariant for 2c-S3b** (per review): the picker will offer exactly this directory, and historical inactive / out-of-restriction stored chips stay rendered (display polish = S4, never a silent drop).

Tests: mock-pool route test (allowlisted) **4/4** — 403 read-only gate, 404 non-person, 404 unknown, 200 shape. Directory content is real-DB-tested at the resolver (2c-S2). tsc clean.

Next: 2c-S3b wires `MetaPersonPicker` to this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)