### PR TITLE
feat(multitable): 2c-S3b wire MetaPersonPicker to the field directory endpoint

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1062,6 +1062,28 @@ export class MultitableApiClient {
     return normalizeSheetPermissionCandidates(data)
   }
 
+  /**
+   * 2c-S3 — the assignable directory for ONE person field (source = B member-group directory).
+   * Returns the same allowed set the write validator accepts (active-only, member-group-scoped),
+   * so the picker offers exactly what a save will accept. Gated server-side on canEditRecord.
+   */
+  async listPersonFieldDirectory(
+    sheetId: string,
+    fieldId: string,
+    params?: { q?: string },
+  ): Promise<{ items: Array<{ userId: string; name: string | null; email: string | null }>; total: number; query: string }> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/person-fields/${encodeURIComponent(fieldId)}/directory${qs(params ?? {})}`)
+    const data = await this.parseJson<{ items?: Array<{ userId?: unknown; name?: unknown; email?: unknown }>; total?: number; query?: string }>(res)
+    const items = (data.items ?? [])
+      .map((it) => ({
+        userId: String(it.userId ?? ''),
+        name: typeof it.name === 'string' ? it.name : null,
+        email: typeof it.email === 'string' ? it.email : null,
+      }))
+      .filter((it) => it.userId.length > 0)
+    return { items, total: typeof data.total === 'number' ? data.total : items.length, query: typeof data.query === 'string' ? data.query : '' }
+  }
+
   async updateSheetPermission(
     sheetId: string,
     subjectType: 'user' | 'role' | 'member-group',

--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -54,8 +54,10 @@ import {
   type MetaPersonPickerLabelKey,
 } from '../utils/meta-person-picker-labels'
 
-// Native person (人员) picker. Member-scoped by construction: candidates come from the SHEET's
-// permission-candidates (the SAME set the write-time validator accepts) — NO global org directory.
+// Native person (人员) picker. The offered set is the field's assignable member-group DIRECTORY
+// (2c-S3, GET .../person-fields/:fieldId/directory) — the SAME active, member-group-scoped set the
+// write-time validator accepts (display parity). Stored chips render independently of this list, so
+// historical inactive / out-of-restriction values are never dropped (their display polish is 2c-S4).
 // Emits userId[] (NOT recordIds) + a personSummaries echo so the chip renders immediately.
 const props = defineProps<{
   visible: boolean
@@ -106,16 +108,25 @@ watch(() => props.visible, async (visible) => {
 
 async function loadMembers() {
   if (!props.sheetId) return
+  const fieldId = props.field?.id
+  // Field-aware directory (2c-S3): the offered set is the field's assignable member-group directory —
+  // exactly what the write validator accepts. An unsaved field (no id) has no directory yet; stored
+  // chips still render from `selected` / `summaryById`, so nothing already-set is dropped.
+  if (!fieldId) {
+    members.value = []
+    return
+  }
   loading.value = true
   errorMessage.value = ''
   try {
-    const data = await multitableClient.listSheetPermissionCandidates(props.sheetId, {
+    const data = await multitableClient.listPersonFieldDirectory(props.sheetId, fieldId, {
       q: search.value || undefined,
-      limit: 100,
     })
-    members.value = (data.items ?? [])
-      .filter((item) => item.subjectType === 'user' && item.isActive)
-      .map((item) => ({ id: item.subjectId, display: item.label || item.subjectId, subtitle: item.subtitle ?? null }))
+    members.value = (data.items ?? []).map((item) => ({
+      id: item.userId,
+      display: item.name || item.email || item.userId,
+      subtitle: item.email ?? null,
+    }))
     for (const member of members.value) {
       if (selected.has(member.id) || summaryById[member.id]) {
         summaryById[member.id] = { id: member.id, display: member.display }

--- a/apps/web/tests/multitable-person-picker.spec.ts
+++ b/apps/web/tests/multitable-person-picker.spec.ts
@@ -2,25 +2,24 @@ import { describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import MetaPersonPicker from '../src/multitable/components/MetaPersonPicker.vue'
 
-// Native person (人员) picker — MEMBER-SCOPED by construction (sources from
-// listSheetPermissionCandidates, NOT a global org directory) and emits userId[] (NOT recordIds).
+// Native person (人员) picker — sources the field's assignable member-group DIRECTORY
+// (listPersonFieldDirectory, 2c-S3) = exactly the active, member-group-scoped set the write validator
+// accepts (display parity). Emits userId[] (NOT recordIds). Stored chips render independently of the
+// offered list, so a stored value missing from the directory is never silently dropped (2c-S3 invariant).
 
-const { mockListCandidates } = vi.hoisted(() => ({ mockListCandidates: vi.fn() }))
+const { mockListDirectory } = vi.hoisted(() => ({ mockListDirectory: vi.fn() }))
 
 vi.mock('../src/multitable/api/client', () => ({
-  multitableClient: { listSheetPermissionCandidates: mockListCandidates },
+  multitableClient: { listPersonFieldDirectory: mockListDirectory },
 }))
 
-const candidates = {
+// The endpoint already returns ACTIVE, member-group-scoped users only — the picker no longer filters.
+const directory = {
   items: [
-    { subjectType: 'user', subjectId: 'u1', label: 'Alice', subtitle: 'alice@x.test', isActive: true },
-    { subjectType: 'user', subjectId: 'u2', label: 'Bob', subtitle: 'bob@x.test', isActive: true },
-    // non-user + inactive entries must be filtered out of the member roster
-    { subjectType: 'role', subjectId: 'role_x', label: 'Editor', subtitle: null, isActive: true },
-    { subjectType: 'user', subjectId: 'u_inactive', label: 'Ghost', subtitle: null, isActive: false },
+    { userId: 'u1', name: 'Alice', email: 'alice@x.test' },
+    { userId: 'u2', name: 'Bob', email: 'bob@x.test' },
   ],
-  total: 4,
-  limit: 100,
+  total: 2,
   query: '',
 }
 
@@ -48,27 +47,34 @@ function mount(field: Record<string, unknown>, currentValue: unknown, onConfirm 
     },
   })
   const app = createApp(Harness)
-  const vm = app.mount(container) as any
+  const vm = app.mount(container) as unknown as { visible: boolean }
   return { container, app, vm, onConfirm }
 }
 
-describe('MetaPersonPicker (member-scoped)', () => {
-  it('lists ONLY active user candidates (member-scoped; roles + inactive filtered out)', async () => {
-    mockListCandidates.mockResolvedValue(candidates)
+describe('MetaPersonPicker (field member-group directory)', () => {
+  it('lists the field directory members (pre-filtered active + member-group-scoped by the endpoint)', async () => {
+    mockListDirectory.mockResolvedValue(directory)
     const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, [])
     vm.visible = true
     await flush()
     const rows = container.querySelectorAll('[data-test="person-picker-member"]')
-    expect(rows.length).toBe(2) // u1 + u2 only
+    expect(rows.length).toBe(2)
     expect(container.textContent).toContain('Alice')
     expect(container.textContent).toContain('Bob')
-    expect(container.textContent).not.toContain('Editor')
-    expect(container.textContent).not.toContain('Ghost')
+    app.unmount(); container.remove()
+  })
+
+  it('calls the field-aware directory endpoint with sheetId + the field id', async () => {
+    mockListDirectory.mockResolvedValue(directory)
+    const { container, app, vm } = mount({ id: 'fld_owner', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, [])
+    vm.visible = true
+    await flush()
+    expect(mockListDirectory).toHaveBeenCalledWith('sheet_1', 'fld_owner', expect.anything())
     app.unmount(); container.remove()
   })
 
   it('emits userId[] (NOT recordIds) on confirm — multi when limitSingleRecord:false', async () => {
-    mockListCandidates.mockResolvedValue(candidates)
+    mockListDirectory.mockResolvedValue(directory)
     const onConfirm = vi.fn()
     const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, [], onConfirm)
     vm.visible = true
@@ -85,20 +91,34 @@ describe('MetaPersonPicker (member-scoped)', () => {
   })
 
   it('single-select replaces the prior pick when limitSingleRecord is true (default)', async () => {
-    mockListCandidates.mockResolvedValue(candidates)
+    mockListDirectory.mockResolvedValue(directory)
     const onConfirm = vi.fn()
-    // limitSingleRecord omitted → defaults to TRUE (single person)
     const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person' }, ['u1'], onConfirm)
     vm.visible = true
     await flush()
     const boxes = Array.from(container.querySelectorAll('[data-test="person-picker-member"] input[type="checkbox"]')) as HTMLInputElement[]
-    // pick u2 → should REPLACE u1 (single select)
-    boxes[1]?.click()
+    boxes[1]?.click() // pick u2 → REPLACE u1
     await nextTick()
     ;(container.querySelector('[data-test="person-picker-confirm"]') as HTMLButtonElement)?.click()
     expect(onConfirm).toHaveBeenCalledWith({
       userIds: ['u2'],
       summaries: [{ id: 'u2', display: 'Bob' }],
+    })
+    app.unmount(); container.remove()
+  })
+
+  // 2c-S3 invariant: a stored value NOT in the current directory (inactive / out-of-restriction) is
+  // preserved — kept as a selected chip and emitted on confirm, never silently dropped (display = S4).
+  it('preserves a stored value missing from the directory (no silent drop)', async () => {
+    mockListDirectory.mockResolvedValue(directory) // directory = u1, u2 only — u_gone is NOT offered
+    const onConfirm = vi.fn()
+    const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, ['u_gone'], onConfirm)
+    vm.visible = true
+    await flush()
+    ;(container.querySelector('[data-test="person-picker-confirm"]') as HTMLButtonElement)?.click()
+    expect(onConfirm).toHaveBeenCalledWith({
+      userIds: ['u_gone'],
+      summaries: [{ id: 'u_gone', display: 'u_gone' }],
     })
     app.unmount(); container.remove()
   })

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -970,6 +970,7 @@ function createWorkbenchMock() {
       deleteView: vi.fn(),
       listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
       listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      listPersonFieldDirectory: vi.fn().mockResolvedValue({ items: [], total: 0, query: '' }),
       updateSheetPermission: vi.fn().mockResolvedValue({}),
       patchRecords: vi.fn(),
       submitForm: vi.fn(),


### PR DESCRIPTION
FE half of **2c-S3**. `MetaPersonPicker` now sources its offered set from `listPersonFieldDirectory` (2c-S3a) — the field's assignable member-group directory = **exactly what the write validator accepts** (display parity); active + member-group-scoped server-side (the FE no longer hand-filters roles/inactive).

**Invariant held (per review):** stored chips render from `selected`/`summaryById` (seeded from `currentValue`), **independent of the offered list** — so a stored value missing from the directory (inactive / out-of-restriction) is **never silently dropped**; its display polish is **2c-S4**. Unsaved field (no id) → empty offer, chips still shown.

Tests: picker spec rewired to the directory mock + **new invariant test** (stored value missing from the directory is preserved on confirm) + endpoint-call assertion — **5/5**. workbench-view client mock gains `listPersonFieldDirectory`.

Next: 2c-S4 (inactive/historical display polish — the "(inactive)" affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)