### PR TITLE
docs(multitable): sync gated-remainder ledger to 2b COMPLETE (S4 #2861) — 2c sole remaining

### DIFF
--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -1,7 +1,7 @@
 # 多维表剩余门控开发计划 — 2026-06-18
 
 > Status: **CURRENT GATED REMAINDER PLAN**.
-> Grounding: `origin/main` (live-main, 2026-06-18). Completed since the prior snapshot and now on `main`: **2a** scalar-type extensions (`#2832` / `#2838` / `#2849`) and **2b** dynamic rule-engine **through S3** (`#2836` / `#2841` / `#2847`). `#2825` (final CRDT comment tails) remains open with green checks — **comment-tail hygiene only**, not a main-grounding line to update here.
+> Grounding: `origin/main` (live-main, 2026-06-18). Completed since the prior snapshot and now on `main`: **2a** scalar-type extensions (`#2832` / `#2838` / `#2849`) and **2b** dynamic rule-engine **COMPLETE (S1–S4)** (`#2836` / `#2841` / `#2847` / `#2861`). **`2c` (#16 person directory) is the sole remaining gated arc.** `#2825` (final CRDT comment tails) remains open with green checks — **comment-tail hygiene only**, not a main-grounding line to update here.
 > Supersedes: `multitable-current-development-plan-20260617.md` and `multitable-current-development-todo-20260617.md` for current multitable remainder routing.
 > Pair: `multitable-gated-remainder-todo-20260618.md`.
 > Rule: this is a closure ledger for the current multitable mainline. Every item below is gated. Do not start runtime work from this document without an explicit opt-in for that gate.
@@ -224,11 +224,10 @@ Non-goals:
 
 Because every remaining item is gated, the default action is **hold**.
 
-**2a is complete and 2b is shipped through S3 — those gates are closed, not next options.** The remaining gated next options:
+**2a and 2b are both complete (2b S1–S4, S4 = `#2861`) — those gates are closed, not next options. `2c` is the sole remaining gated arc.** The next options:
 
-1. **2c / #16 person-directory source-of-truth design-lock** — the remaining user-visible product slice (owner-gated: directory source of truth + assignability semantics).
-2. **2b-S4 (rule-engine perf / caching)** — only on **large-rule-set demand**; `2b` is otherwise shipped through S3 (`#2836`/`#2841`/`#2847`), so this is a perf follow-up, not a fresh security gate.
-3. **D2 high-scale re-baseline harness work** — only if the product wants to revisit large-table performance after the existing D2 verdict; this is not a grid-virtualization slice.
+1. **2c / #16 person-directory source-of-truth design-lock** — the sole remaining gated arc (owner-gated: directory source of truth + assignability semantics).
+2. **D2 high-scale re-baseline harness work** — only if the product wants to revisit large-table performance after the existing D2 verdict; this is not a grid-virtualization slice and not part of the gated remainder.
 
 Do not open more than one security-sensitive runtime arc at the same time.
 

--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -2,7 +2,7 @@
 
 > Status: **CURRENT GATED TODO**.
 > Pair: `multitable-gated-remainder-development-plan-20260618.md`.
-> Grounding: `origin/main` (live-main, 2026-06-18). Completed + on `main`: **2a** (`#2832`/`#2838`/`#2849`), **2b through S3** (`#2836`/`#2841`/`#2847`). `#2825` remains open (final CRDT comment tails) — **comment-tail hygiene only**, not a main-grounding line to update here.
+> Grounding: `origin/main` (live-main, 2026-06-18). Completed + on `main`: **2a** (`#2832`/`#2838`/`#2849`), **2b COMPLETE S1–S4** (`#2836`/`#2841`/`#2847`/`#2861`). **`2c` (#16 person directory) is the sole remaining gated arc.** `#2825` remains open (final CRDT comment tails) — **comment-tail hygiene only**, not a main-grounding line to update here.
 > Supersedes: `multitable-current-development-plan-20260617.md` and `multitable-current-development-todo-20260617.md` for current multitable remainder routing.
 > Legend: `[x]` closed · `[ ]` todo after opt-in · `[!]` gate requiring owner/design decision · `[~]` roadmap pool, not current remainder.
 
@@ -166,8 +166,7 @@ These are future candidates or reopen-only lines. They are not open work in the 
 
 ## 5. Owner Unlock Prompts
 
-Use one of these when opening the next arc (2a is complete and 2b is shipped through S3 — those gates are closed, not next options):
+Use one of these when opening the next arc (2a and 2b are both complete — 2b S1–S4 — so those gates are closed; `2c` is the sole remaining gated arc):
 
-- **Unlock 2c / #16 person directory:** choose directory source of truth and assignability semantics.
-- **Unlock 2b-S4 (rule-engine perf / caching):** only on large-rule-set demand; `2b` is otherwise shipped through S3 — a perf follow-up, not a fresh security gate.
+- **Unlock 2c / #16 person directory:** choose directory source of truth and assignability semantics. (Sole remaining gated arc.)
 - **Revisit grid performance:** opt into D2 high-scale harness/re-baseline work first; row virtualization stays closed unless the verdict flips.


### PR DESCRIPTION
Follow-up self-catch while re-verifying the review of #2855/#2865.

#2865 refreshed the ledger grounding/prompts to **"2b through S3 / S4-on-demand"**, but **#2864** (which landed just before #2865) had already marked **2b COMPLETE (S1–S4, S4 = #2861)** and made **2c the sole remaining arc**. So the doc **body** said "2b complete" while my **header + unlock prompts** still lagged at "S3" — the same header-vs-body drift the review flagged, one state-step newer.

Synced both ledger docs: grounding + Recommended Planning Sequence + Owner Unlock Prompts now read **"2a + 2b complete, 2c is the sole remaining gated arc"** (dropped the stale 2b-S4-next-option). Verified: `through S3`=0, `2b-S4`-as-next-option=0, `sole remaining` present, body 2b-COMPLETE unchanged. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)