### PR TITLE
feat(approval/directory): dept_head sync-plumbing (department-detail enrichment + carry-forward)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -257,7 +257,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance)
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward)
         # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
@@ -273,6 +273,7 @@ jobs:
             tests/integration/approval-wp-add-reduce-sign.api.test.ts \
             tests/integration/approval-direct-manager.api.test.ts \
             tests/integration/approval-postgate-acceptance.api.test.ts \
+            tests/integration/dept-head-sync-plumbing.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/directory/department-manager-enrichment.ts
+++ b/packages/core-backend/src/directory/department-manager-enrichment.ts
@@ -1,0 +1,108 @@
+/**
+ * dept_head data plumbing — directory_departments.raw `dept_manager_userid_list` enrichment.
+ *
+ * Design-lock: docs/design/approval-dept-head-sync-plumbing-design-20260618.md.
+ *
+ * The DingTalk department-detail API (`/topapi/v2/department/get`) returns the
+ * department's manager user ids, which `/topapi/v2/department/listsub` does NOT.
+ * We enrich each department's stored raw with a normalized `dept_manager_userid_list`
+ * (string[]) — the shape `ApprovalDirectoryOrg.parseDeptManagerExternalIds` reads.
+ *
+ * Failure semantics (last-known-good, the load-bearing invariant): a detail-fetch
+ * SUCCESS — including a genuinely empty manager list — is authoritative; a detail-fetch
+ * FAILURE must NOT be confused with success-empty, or a transient API blip would wipe a
+ * previously-synced manager list and silently flip dept_head to empty. So at the
+ * enrichment boundary the two are DISTINCT values:
+ *   - success           → `managerUserIds = [...]` (possibly `[]`)
+ *   - fetch failed       → `managerUserIds` stays `undefined`
+ * and the upsert composer carries the prior value forward only on `undefined`.
+ */
+
+import type { DingTalkDepartment } from '../integrations/dingtalk/client'
+
+type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
+
+/** A department carrying its (optional) freshly-fetched manager list. */
+export type EnrichableDepartment = DingTalkDepartment & { managerUserIds?: string[] }
+
+/** Normalize a `dept_manager_userid_list` value (DingTalk comma-string OR array) to string[]. */
+export function normalizeDeptManagerList(value: unknown): string[] {
+  const out: string[] = []
+  const push = (v: unknown): void => {
+    const s = typeof v === 'string' ? v.trim() : typeof v === 'number' ? String(v) : ''
+    if (s) out.push(s)
+  }
+  if (Array.isArray(value)) value.forEach(push)
+  else if (typeof value === 'string') value.split(',').forEach(push)
+  return out
+}
+
+/**
+ * Compose the raw the dept upsert writes: listsub raw + `dept_manager_userid_list`.
+ * NEVER overwrites listsub keys.
+ * - `managerList === undefined` (detail failed AND no prior) → listsub-only (field absent).
+ * - `managerList === []` (success-empty) → the field is written as `[]` (authoritative empty).
+ */
+export function mergeDeptManagerIntoRaw(
+  listsubRaw: Record<string, unknown>,
+  managerList: string[] | undefined,
+): Record<string, unknown> {
+  if (managerList === undefined) return listsubRaw
+  return { ...listsubRaw, dept_manager_userid_list: managerList }
+}
+
+/**
+ * Last-known-good carry-forward for one department.
+ * - fresh DEFINED (success, incl. `[]`) → fresh (authoritative).
+ * - fresh UNDEFINED (fetch failed)       → prior (carry forward; `undefined` if none → field omitted).
+ */
+export function resolveManagerListForDept(
+  fresh: string[] | undefined,
+  prior: string[] | undefined,
+): string[] | undefined {
+  return fresh !== undefined ? fresh : prior
+}
+
+/**
+ * THE SEAM. Best-effort, sequential (QPS-throttled) per-department detail fetch.
+ * On success sets `managerUserIds` (incl. `[]`); on failure LEAVES IT `undefined`
+ * (so the composer carries the prior value forward) and reports via `onError` —
+ * it must never throw or fail the whole sync.
+ */
+export async function enrichDepartmentsWithManagers(
+  departments: Iterable<EnrichableDepartment>,
+  fetchDetail: (deptId: string) => Promise<{ deptManagerUserIdList: string[] }>,
+  onError?: (deptId: string, error: unknown) => void,
+): Promise<void> {
+  for (const department of departments) {
+    try {
+      const detail = await fetchDetail(department.id)
+      // success — authoritative, INCLUDING an empty list (distinct from failure below)
+      department.managerUserIds = detail.deptManagerUserIdList
+    } catch (error) {
+      // failure — leave managerUserIds undefined so the composer carries prior forward
+      onError?.(department.id, error)
+    }
+  }
+}
+
+/**
+ * Capture the last-known-good `dept_manager_userid_list` per external department id,
+ * BEFORE the whole-column upsert (`raw = EXCLUDED.raw`) overwrites the raw.
+ */
+export async function capturePriorDeptManagers(
+  integrationId: string,
+  query: QueryFn,
+): Promise<Map<string, string[]>> {
+  const result = await query<{ external_department_id: string; mgr: unknown }>(
+    `SELECT external_department_id, raw->'dept_manager_userid_list' AS mgr
+       FROM directory_departments
+      WHERE integration_id = $1 AND raw ? 'dept_manager_userid_list'`,
+    [integrationId],
+  )
+  const map = new Map<string, string[]>()
+  for (const row of result.rows) {
+    map.set(String(row.external_department_id), normalizeDeptManagerList(row.mgr))
+  }
+  return map
+}

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -8,12 +8,19 @@ import { Logger } from '../core/logger'
 import { query, transaction } from '../db/pg'
 import {
   fetchDingTalkAppAccessToken,
+  getDingTalkDepartmentDetail,
   getDingTalkUserDetail,
   listDingTalkDepartments,
   listDingTalkDepartmentUsers,
   type DingTalkDepartment,
   type DingTalkDirectoryUser,
 } from '../integrations/dingtalk/client'
+import {
+  capturePriorDeptManagers,
+  enrichDepartmentsWithManagers,
+  mergeDeptManagerIntoRaw,
+  resolveManagerListForDept,
+} from './department-manager-enrichment'
 import { assertDingTalkCorpAllowed } from '../integrations/dingtalk/runtime-policy'
 import {
   deriveDelegatedAdminNamespace,
@@ -1870,6 +1877,19 @@ async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrati
     }
   }
 
+  // dept-head plumbing: enrich each department with its manager user ids from the
+  // department-detail API (listsub does not return them). Best-effort + sequential
+  // (QPS-throttled): a per-dept failure leaves managerUserIds undefined so the upsert
+  // carries the prior dept_manager_userid_list forward instead of wiping it.
+  await enrichDepartmentsWithManagers(
+    departments.values(),
+    (deptId) => getDingTalkDepartmentDetail(accessToken, deptId, { baseUrl: config.baseUrl }),
+    (deptId, error) =>
+      logger.warn(
+        `dept-head: department/get failed for dept ${deptId} (integration ${integrationName}); carrying prior forward: ${readErrorMessage(error, 'unknown error')}`,
+      ),
+  )
+
   return departments
 }
 
@@ -2115,6 +2135,10 @@ export async function syncDirectoryIntegration(
   try {
     const departments = await fetchAllDepartments(config, integration.name)
     const departmentPathMap = buildDepartmentPathMap(departments)
+    // dept-head plumbing: capture last-known-good dept_manager_userid_list BEFORE the
+    // whole-column upsert (raw = EXCLUDED.raw) overwrites raw, so a failed department/get
+    // (managerUserIds left undefined) carries the prior value forward instead of wiping it.
+    const priorDeptManagers = await capturePriorDeptManagers(integrationId, query)
     const users = await fetchAllUsers(config, departments)
 
     let directoryDiagnosticStats: JsonRecord = {}
@@ -2173,7 +2197,12 @@ export async function syncDirectoryIntegration(
             department.name,
             departmentPathMap.get(department.id) ?? department.name,
             department.order,
-            JSON.stringify(department.source),
+            JSON.stringify(
+              mergeDeptManagerIntoRaw(
+                department.source,
+                resolveManagerListForDept(department.managerUserIds, priorDeptManagers.get(department.id)),
+              ),
+            ),
             syncTimestamp,
           ],
         )

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -81,6 +81,11 @@ export interface DingTalkDepartment {
   name: string
   order: number
   source: Record<string, unknown>
+  /**
+   * Filled by the dept-head enrichment pass (department-detail fetch).
+   * `undefined` = not fetched / fetch failed (carry prior forward); `[]` = success-empty.
+   */
+  managerUserIds?: string[]
 }
 
 export interface DingTalkDepartmentUserSummary {
@@ -493,6 +498,36 @@ export async function listDingTalkDepartments(
       source: entry,
     }))
     .filter((entry) => entry.id.length > 0 && entry.name.length > 0)
+}
+
+export async function getDingTalkDepartmentDetail(
+  accessToken: string,
+  departmentId: string,
+  config?: { baseUrl?: string },
+): Promise<{ deptManagerUserIdList: string[] }> {
+  const payload = await requestDingTalkDirectoryJson(
+    `/topapi/v2/department/get?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dept_id: Number.isNaN(Number(departmentId)) ? departmentId : Number(departmentId),
+      }),
+    },
+    'Failed to read DingTalk department detail',
+    config?.baseUrl,
+  )
+
+  const result = readNestedPayload(payload)
+  // DingTalk `/topapi/v2/department/get` returns `dept_manager_userid_list` as a
+  // comma-separated string of userids; tolerate an array too for forward-compat.
+  const rawManagers = result.dept_manager_userid_list ?? result.deptManagerUseridList
+  const deptManagerUserIdList = Array.isArray(rawManagers)
+    ? rawManagers.map((item) => String(item ?? '').trim()).filter(Boolean)
+    : typeof rawManagers === 'string'
+      ? rawManagers.split(',').map((item) => item.trim()).filter(Boolean)
+      : []
+  return { deptManagerUserIdList }
 }
 
 export async function listDingTalkDepartmentUsers(

--- a/packages/core-backend/tests/integration/dept-head-sync-plumbing.test.ts
+++ b/packages/core-backend/tests/integration/dept-head-sync-plumbing.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import {
+  capturePriorDeptManagers,
+  enrichDepartmentsWithManagers,
+  mergeDeptManagerIntoRaw,
+  resolveManagerListForDept,
+} from '../../src/directory/department-manager-enrichment'
+import type { DingTalkDepartment } from '../../src/integrations/dingtalk/client'
+
+/**
+ * dept-head sync-plumbing — real-DB proof that the last-known-good carry-forward
+ * survives the whole-column upsert (`raw = EXCLUDED.raw`). Drives the actual seam
+ * (`enrichDepartmentsWithManagers` with a throwing `getDetail`) + capture-prior +
+ * compose + upsert, end to end.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+
+async function upsertDept(integrationId: string, externalId: string, name: string, raw: Record<string, unknown>): Promise<void> {
+  await query(
+    `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw, last_seen_at, created_at, updated_at)
+     VALUES ($1, $2, $3, true, $4::jsonb, NOW(), NOW(), NOW())
+     ON CONFLICT (integration_id, external_department_id)
+     DO UPDATE SET name = EXCLUDED.name, raw = EXCLUDED.raw, updated_at = NOW()`,
+    [integrationId, externalId, name, JSON.stringify(raw)],
+  )
+}
+async function readRaw(integrationId: string, externalId: string): Promise<Record<string, unknown>> {
+  const r = await query<{ raw: Record<string, unknown> }>(
+    `SELECT raw FROM directory_departments WHERE integration_id = $1 AND external_department_id = $2`,
+    [integrationId, externalId],
+  )
+  return r.rows[0].raw
+}
+
+describeIfDatabase('dept-head sync-plumbing (real DB)', () => {
+  let integrationId = ''
+
+  beforeAll(async () => {
+    const r = await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`dhsync-${TS}`, `dhsync-corp-${TS}`],
+    )
+    integrationId = r.rows[0].id
+    // D1: a department that already has a previously-synced manager list.
+    await upsertDept(integrationId, 'D1', 'Eng', { name: 'Eng', dept_manager_userid_list: ['mgr-x'] })
+    // D2: a department with no prior manager data.
+    await upsertDept(integrationId, 'D2', 'Sales', { name: 'Sales' })
+  })
+  afterAll(async () => {
+    if (integrationId) {
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('a department/get FAILURE on re-sync preserves the prior dept_manager_userid_list (carried forward, not wiped)', async () => {
+    // capture prior BEFORE the re-sync upsert overwrites the whole raw column
+    const prior = await capturePriorDeptManagers(integrationId, query)
+    expect(prior.get('D1')).toEqual(['mgr-x'])
+
+    // the seam: department/get throws → managerUserIds stays undefined (NOT [])
+    const d1: DingTalkDepartment = { id: 'D1', parentId: null, name: 'Eng v2', order: 0, source: { name: 'Eng v2' } }
+    await enrichDepartmentsWithManagers([d1], async () => { throw new Error('429 rate limited') })
+    expect(d1.managerUserIds).toBeUndefined()
+
+    // compose (carry forward) + whole-column upsert
+    await upsertDept(integrationId, 'D1', 'Eng v2', mergeDeptManagerIntoRaw(d1.source, resolveManagerListForDept(d1.managerUserIds, prior.get('D1'))))
+
+    const raw = await readRaw(integrationId, 'D1')
+    expect(raw.dept_manager_userid_list).toEqual(['mgr-x']) // PRESERVED — the bug would have wiped this
+    expect(raw.name).toBe('Eng v2') // listsub field still refreshed
+  })
+
+  it('a department/get SUCCESS writes the fresh manager list into raw (data lands)', async () => {
+    const prior = await capturePriorDeptManagers(integrationId, query)
+    const d2: DingTalkDepartment = { id: 'D2', parentId: null, name: 'Sales', order: 0, source: { name: 'Sales' } }
+    await enrichDepartmentsWithManagers([d2], async () => ({ deptManagerUserIdList: ['mgr-y'] }))
+    expect(d2.managerUserIds).toEqual(['mgr-y'])
+
+    await upsertDept(integrationId, 'D2', 'Sales', mergeDeptManagerIntoRaw(d2.source, resolveManagerListForDept(d2.managerUserIds, prior.get('D2'))))
+
+    const raw = await readRaw(integrationId, 'D2')
+    expect(raw.dept_manager_userid_list).toEqual(['mgr-y']) // fresh data landed
+  })
+})

--- a/packages/core-backend/tests/unit/department-manager-enrichment.test.ts
+++ b/packages/core-backend/tests/unit/department-manager-enrichment.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  normalizeDeptManagerList,
+  mergeDeptManagerIntoRaw,
+  resolveManagerListForDept,
+  enrichDepartmentsWithManagers,
+} from '../../src/directory/department-manager-enrichment'
+import type { DingTalkDepartment } from '../../src/integrations/dingtalk/client'
+
+const dept = (id: string, source: Record<string, unknown> = {}): DingTalkDepartment =>
+  ({ id, parentId: null, name: id, order: 0, source })
+
+describe('department-manager-enrichment', () => {
+  describe('normalizeDeptManagerList', () => {
+    it('parses DingTalk comma-string and array, dropping blanks', () => {
+      expect(normalizeDeptManagerList('u1,u2 , ,u3')).toEqual(['u1', 'u2', 'u3'])
+      expect(normalizeDeptManagerList(['u1', '', 'u2'])).toEqual(['u1', 'u2'])
+      expect(normalizeDeptManagerList(null)).toEqual([])
+      expect(normalizeDeptManagerList(undefined)).toEqual([])
+    })
+  })
+
+  describe('mergeDeptManagerIntoRaw', () => {
+    it('adds dept_manager_userid_list without overwriting listsub keys', () => {
+      expect(mergeDeptManagerIntoRaw({ name: 'Eng', dept_id: 5 }, ['m1'])).toEqual({
+        name: 'Eng', dept_id: 5, dept_manager_userid_list: ['m1'],
+      })
+    })
+    it('writes [] for success-empty (authoritative)', () => {
+      expect(mergeDeptManagerIntoRaw({ name: 'Eng' }, [])).toEqual({ name: 'Eng', dept_manager_userid_list: [] })
+    })
+    it('leaves listsub-only when managerList is undefined (failure + no prior)', () => {
+      expect(mergeDeptManagerIntoRaw({ name: 'Eng' }, undefined)).toEqual({ name: 'Eng' })
+    })
+  })
+
+  describe('resolveManagerListForDept (carry-forward)', () => {
+    it('uses fresh when defined — and success-empty is authoritative, NOT carried over', () => {
+      expect(resolveManagerListForDept(['m1'], ['prior'])).toEqual(['m1'])
+      expect(resolveManagerListForDept([], ['prior'])).toEqual([])
+    })
+    it('carries the prior forward when fresh is undefined (failure); omits when no prior', () => {
+      expect(resolveManagerListForDept(undefined, ['prior'])).toEqual(['prior'])
+      expect(resolveManagerListForDept(undefined, undefined)).toBeUndefined()
+    })
+  })
+
+  // THE SEAM — the catch-block correctness the whole carry-forward depends on.
+  describe('enrichDepartmentsWithManagers', () => {
+    it('success sets managerUserIds (incl. an empty list); a FAILURE leaves it undefined (distinct from success-empty)', async () => {
+      const ok = dept('d-ok')
+      const empty = dept('d-empty')
+      const failed = dept('d-failed')
+      const onError = vi.fn()
+      const fetchDetail = async (id: string) => {
+        if (id === 'd-ok') return { deptManagerUserIdList: ['m1', 'm2'] }
+        if (id === 'd-empty') return { deptManagerUserIdList: [] }
+        throw new Error('429 rate limited')
+      }
+
+      await enrichDepartmentsWithManagers([ok, empty, failed], fetchDetail, onError)
+
+      expect(ok.managerUserIds).toEqual(['m1', 'm2'])
+      expect(empty.managerUserIds).toEqual([]) // success-empty → [] (authoritative)
+      expect(failed.managerUserIds).toBeUndefined() // failure → undefined, NOT [] — so prior carries forward
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(onError).toHaveBeenCalledWith('d-failed', expect.any(Error))
+    })
+
+    it('a per-department failure never throws and never aborts the remaining departments', async () => {
+      const a = dept('a')
+      const b = dept('b')
+      const fetchDetail = async (id: string) => {
+        if (id === 'a') throw new Error('boom')
+        return { deptManagerUserIdList: ['mb'] }
+      }
+
+      await expect(enrichDepartmentsWithManagers([a, b], fetchDetail)).resolves.toBeUndefined()
+      expect(a.managerUserIds).toBeUndefined()
+      expect(b.managerUserIds).toEqual(['mb']) // b still processed after a failed
+    })
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       'tests/integration/approval-wp-add-reduce-sign.api.test.ts',
       'tests/integration/approval-direct-manager.api.test.ts',
       'tests/integration/approval-postgate-acceptance.api.test.ts',
+      'tests/integration/dept-head-sync-plumbing.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
First of the dept_head two-PR shape (design-lock #2863). **Data only** — no approval surface, no resolver. Captures `dept_manager_userid_list` into `directory_departments.raw` so `dept_head` becomes data-backed.

## Change
- **DingTalk client** — `getDingTalkDepartmentDetail` (`/topapi/v2/department/get`), the per-entity detail call mirroring `getDingTalkUserDetail`. Returns the dept's manager user ids (which `listsub` does not), normalizing DingTalk's comma-string-or-array to `string[]` (the shape `ApprovalDirectoryOrg.parseDeptManagerExternalIds` reads).
- **`department-manager-enrichment` module** (pure + injectable) — `enrichDepartmentsWithManagers` (**THE SEAM**), `mergeDeptManagerIntoRaw` (never overwrites listsub keys), `resolveManagerListForDept` (last-known-good), `capturePriorDeptManagers`.
- **`directory-sync`** — `fetchAllDepartments` enriches each dept; `syncDirectoryIntegration` **captures the prior manager list BEFORE the whole-column upsert** (`raw = EXCLUDED.raw`) and composes the written raw with carry-forward.

## The load-bearing invariant (design-lock §2/§4)
The upsert overwrites the whole `raw`, so a `department/get` failure that wrote a detail-less raw would **wipe** a previously-synced manager list and silently flip dept_head to empty. Prevented by making **success-empty (`[]`) and fetch-failure (`undefined`) distinct at the seam** — success is authoritative (incl. empty), failure carries the prior value forward.

## Tests
- **Unit 8/8** incl. the seam: a throwing `getDetail` leaves `managerUserIds` **undefined** (not `[]`), so prior carries forward; success-empty sets `[]`; per-dept failure never aborts the rest.
- **Real-DB 3/3**: drives the **actual seam + the whole-column upsert** — a re-sync where `department/get` fails **preserves** the prior `dept_manager_userid_list` (the bug would have wiped it) while still refreshing listsub fields; a success lands fresh data. `describeIfDatabase` + sentinel + default-exclude + plugin-tests step.
- Full core-backend unit suite **4512/0**.

## Honesty / scope
Live dept_head data still requires a **real DingTalk-synced tenant** (the staging directory has only a synthetic root dept). This PR makes the sync *capture* the field correctly; the **dept_head resolver/authoring is the next PR** (mirrors `direct_manager`). `continuous_managers` + incremental detail-sync deferred; **W7 locked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)