### PR TITLE
feat(approval): dept_head assignee source (resolver + authoring)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -250,6 +250,8 @@ function stepDraftFromApprovalNode(
     fieldId = source.fieldId
   } else if (source?.kind === 'direct_manager') {
     sourceKind = 'direct_manager'
+  } else if (source?.kind === 'dept_head') {
+    sourceKind = 'dept_head'
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -364,7 +366,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head'].includes(source?.kind)) return true
     }
     return false
   })
@@ -444,6 +446,9 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   }
   if (step.sourceKind === 'direct_manager') {
     return { kind: 'direct_manager' }
+  }
+  if (step.sourceKind === 'dept_head') {
+    return { kind: 'dept_head' }
   }
   return { kind: 'requester' }
 }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -76,6 +76,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'requester' }
   | { kind: 'form_field_user'; fieldId: string }
   | { kind: 'direct_manager' }
+  | { kind: 'dept_head' }
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -282,6 +282,7 @@
                 <el-option label="指定角色" value="static_role" />
                 <el-option label="发起人" value="requester" />
                 <el-option label="直属上级" value="direct_manager" />
+                <el-option label="部门主管" value="dept_head" />
                 <el-option label="表单用户字段" value="form_field_user" />
               </el-select>
             </el-form-item>

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -436,6 +436,19 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].sourceKind).toBe('direct_manager')
   })
 
+  it('round-trips a dept_head assignee source (save emits {kind} + hydrate restores sourceKind)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'dh'
+    draft.name = '部门主管审批'
+    draft.steps[0].sourceKind = 'dept_head'
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'dept_head' }])
+
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('dept_head')
+  })
+
   // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
   function buildAutoApprovalTemplate(
     policy: AutoApprovalPolicy,
@@ -621,6 +634,19 @@ describe('TemplateAuthoringView', () => {
     expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('direct_manager') // hydrated back
+  })
+
+  it('dept_head reads back editable: a saved dept_head template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {
+    routeParams = { id: 'tpl_dh' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('dept_head') // hydrated back
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -134,6 +134,18 @@ export function resolveApprovalAssignees(
         }
         break
       }
+      case 'dept_head': {
+        // Resolve to the requester's department head, frozen in the requester snapshot at
+        // approval start (no live directory re-query). Self-exclusion: a dept head that
+        // resolves to the requester is not a valid approver, so we return empty and let the
+        // node's emptyAssigneePolicy decide.
+        const deptHeadId = normalizeId(options.requesterSnapshot?.deptHeadId)
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        if (deptHeadId && deptHeadId !== requesterId) {
+          pushResolved('user', deptHeadId, source, sourceIndex)
+        }
+        break
+      }
       case 'form_field_user': {
         assertFormUserSource(source, options.formSchema, options.nodeKey)
         const assigneeId = resolveFormUserValue(options.formSnapshot[source.fieldId])

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -411,6 +411,8 @@ function normalizeApprovalAssigneeSources(
         return { kind: 'requester' }
       case 'direct_manager':
         return { kind: 'direct_manager' }
+      case 'dept_head':
+        return { kind: 'dept_head' }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -94,6 +94,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'requester' }
   | { kind: 'form_field_user'; fieldId: string }
   | { kind: 'direct_manager' }
+  | { kind: 'dept_head' }
 
 export interface ApprovalAssigneeResolutionMetadata {
   resolvedFrom: {

--- a/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
@@ -30,18 +30,18 @@ async function tok(base: string, userId: string): Promise<string> {
 async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
   return fetch(`${base}${path}`, { method: opts.method || 'GET', headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) }, ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}) })
 }
-function graph(emptyAssigneePolicy: 'auto-approve' | 'error') {
+function graph(emptyAssigneePolicy: 'auto-approve' | 'error', kind: 'direct_manager' | 'dept_head' = 'direct_manager') {
   return {
     nodes: [
       { key: 'start', type: 'start', name: 's', config: {} },
-      { key: 'approval_1', type: 'approval', name: '直属上级', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy } },
+      { key: 'approval_1', type: 'approval', name: '上级', config: { assigneeSources: [{ kind }], approvalMode: 'single', emptyAssigneePolicy } },
       { key: 'end', type: 'end', name: 'e', config: {} },
     ],
     edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
   }
 }
 
-describeIfDatabase('direct_manager assignee source — real-DB create/start', () => {
+describeIfDatabase('direct_manager + dept_head assignee sources — real-DB create/start', () => {
   let server: MetaSheetServer | undefined, base = '', reqTok = ''
 
   beforeAll(async () => {
@@ -74,9 +74,9 @@ describeIfDatabase('direct_manager assignee source — real-DB create/start', ()
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  async function publish(key: string, emptyAssigneePolicy: 'auto-approve' | 'error'): Promise<string> {
-    const created = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph(emptyAssigneePolicy) } })
-    expect(created.status, await created.clone().text()).toBe(201) // normalizer accepts direct_manager
+  async function publish(key: string, emptyAssigneePolicy: 'auto-approve' | 'error', kind: 'direct_manager' | 'dept_head' = 'direct_manager'): Promise<string> {
+    const created = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph(emptyAssigneePolicy, kind) } })
+    expect(created.status, await created.clone().text()).toBe(201) // normalizer accepts the org-derived source kind
     const tid = ((await created.json()) as { id: string }).id
     expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
     return tid
@@ -98,5 +98,21 @@ describeIfDatabase('direct_manager assignee source — real-DB create/start', ()
     const tid = await publish(`dm-err-${TS}`, 'error')
     const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
     expect(started.status).toBeGreaterThanOrEqual(400) // empty assignee under 'error' policy rejects at start
+  })
+
+  it('dept_head auto-approve branch: a requester with no department head auto-resolves the dept_head node', async () => {
+    const tid = await publish(`dh-auto-${TS}`, 'auto-approve', 'dept_head')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+    const status = (await (await req(base, `/api/approvals/${aid}`, reqTok)).json()) as any
+    expect(['approved', 'completed', 'auto_approved']).toContain(String(status.status ?? status.data?.status))
+  })
+
+  it('dept_head error branch: a requester with no department head makes the dept_head node fail-create', async () => {
+    const tid = await publish(`dh-err-${TS}`, 'error', 'dept_head')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status).toBeGreaterThanOrEqual(400)
   })
 })

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -58,6 +58,32 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveDirectManager({ id: 'requester-1', managerId: 'requester-1' })).toEqual([])
   })
 
+  // dept_head — resolves to requesterSnapshot.deptHeadId (frozen at start), mirroring direct_manager.
+  function resolveDeptHead(requesterSnapshot: Record<string, unknown> | null) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'dept_head' }] },
+      formSnapshot: {},
+      requesterSnapshot,
+    })
+  }
+
+  it('resolves dept_head to the requester snapshot deptHeadId, with resolvedFrom metadata', () => {
+    expect(resolveDeptHead({ id: 'requester-1', deptHeadId: 'head-7' })).toEqual([
+      { assignmentType: 'user', assigneeId: 'head-7', nodeKey: 'review', sourceStep: 2, metadata: { resolvedFrom: { kind: 'dept_head', sourceIndex: 0 } } },
+    ])
+  })
+
+  it('resolves dept_head to empty when the requester has no department head (falls to emptyAssigneePolicy)', () => {
+    expect(resolveDeptHead({ id: 'requester-1' })).toEqual([])
+    expect(resolveDeptHead(null)).toEqual([])
+  })
+
+  it('excludes self: a dept_head that resolves to the requester is not a valid approver (empty)', () => {
+    expect(resolveDeptHead({ id: 'requester-1', deptHeadId: 'requester-1' })).toEqual([])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [


### PR DESCRIPTION
Second of the dept_head two-PR shape (design-lock #2863); the sync-plumbing #2871 provides the data. A `dept_head` assignee kind resolves a node's approver to the requester's **department head** from `requesterSnapshot.deptHeadId` (baked by the org-relation plumbing at approval start).

## Change — mirrors `direct_manager` exactly
- Backend: `ApprovalAssigneeSourceKind` + union (`{ kind: 'dept_head' }`); normalizer case; resolver case (reads `deptHeadId`, **self-exclusion** — dept head == requester → empty → `emptyAssigneePolicy`; point-in-time snapshot, no live re-query); `resolvedFrom.kind` automatic.
- Frontend: mirrored type, `draftFromTemplate` hydrate, `sourceFromStep`, the `unsupportedTemplateAuthoringReason` **allowlist** (else a saved dept_head template reads back fail-closed), and the authoring source option (部门主管).

## Tests
- **Resolver unit** (3): resolve + `resolvedFrom` metadata / unresolvable→empty (incl. null snapshot) / self-exclusion→empty.
- **Authoring** round-trip + **mounted read-back** (saved dept_head template is not fail-closed, save enabled, sourceKind hydrated).
- **Real-DB create/start** both `emptyAssigneePolicy` branches, added to the org-derived-source integration (renamed to cover both direct_manager + dept_head).
- backend `tsc` 0, `vue-tsc -b` 0, full core-backend unit suite **4507/0**.

## Governance
Live dept_head data depends on #2871 + a real DingTalk-synced tenant (resolver returns empty → `emptyAssigneePolicy` until then — same honest path as direct_manager). `continuous_managers` deferred; **W7 locked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)