### PR TITLE
feat(multitable): 2c-S4 inactive/historical person assignee display cue

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -65,7 +65,9 @@
         v-for="item in personItems"
         :key="item.id"
         class="meta-cell-renderer__person-chip"
+        :class="{ 'meta-cell-renderer__person-chip--inactive': item.inactive }"
         :title="item.display"
+        :data-inactive="item.inactive ? 'true' : undefined"
       >
         <span class="meta-cell-renderer__person-avatar" aria-hidden="true">{{ item.initial }}</span>
         <span class="meta-cell-renderer__person-name">{{ item.display }}</span>
@@ -361,10 +363,12 @@ const personItems = computed(() => {
   // NATIVE person (type='person', userId[]) → personSummaries. It has NO linkSummaries, so this
   // is the load-bearing display source (an advisor-flagged hidden dependency).
   if (isNativePersonField(props.field)) {
-    const summaryById = new Map((props.personSummaries ?? []).map((s) => [s.id, s.display]))
+    const summaryById = new Map((props.personSummaries ?? []).map((s) => [s.id, s]))
     return nativePersonIds.value.map((id) => {
-      const display = summaryById.get(id) || id
-      return { id, display, initial: personInitial(display) }
+      const summary = summaryById.get(id)
+      const display = summary?.display || id
+      // 2c-S4: surface the deactivated state of a stored assignee (read-only; never re-assignable).
+      return { id, display, initial: personInitial(display), inactive: summary?.inactive === true }
     })
   }
   // LEGACY link-backed person (type='link'+refKind:user, recordId[]) → linkSummaries (unchanged).
@@ -372,6 +376,7 @@ const personItems = computed(() => {
     id: item.id,
     display: item.display,
     initial: personInitial(item.display),
+    inactive: false,
   }))
 })
 
@@ -543,6 +548,18 @@ button.meta-cell-renderer__link--clickable:hover { background: #d9ecff; }
   font-size: 11px;
   max-width: 100%;
   min-width: 0;
+}
+/* 2c-S4: deactivated stored assignee — muted, read-only cue (still shown, never re-assignable). */
+.meta-cell-renderer__person-chip--inactive {
+  background: #f2f3f5;
+  color: #8a9099;
+}
+.meta-cell-renderer__person-chip--inactive .meta-cell-renderer__person-avatar {
+  background: #b8bec7;
+}
+.meta-cell-renderer__person-chip--inactive .meta-cell-renderer__person-name {
+  text-decoration: line-through;
+  text-decoration-color: #b8bec7;
 }
 .meta-cell-renderer__person-avatar {
   display: inline-flex;

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -581,6 +581,8 @@ export interface LinkedRecordSummary {
 export interface PersonSummary {
   id: string
   display: string
+  /** 2c-S4: the stored assignee's user is deactivated (displayed read-only, not re-assignable). */
+  inactive?: boolean
 }
 
 export interface LinkFieldRef {

--- a/apps/web/tests/multitable-cell-renderer-person-inactive.spec.ts
+++ b/apps/web/tests/multitable-cell-renderer-person-inactive.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, nextTick } from 'vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+
+// 2c-S4 — a stored person assignee whose user is deactivated renders with the muted "inactive" cue
+// (read-only; the directory endpoint already excludes inactive users from being re-assignable). The
+// chip is still SHOWN (never silently dropped) — only visually marked.
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(defineComponent({ render: () => h(MetaCellRenderer, props) }))
+  app.mount(container)
+  return { container, app }
+}
+
+const personField = { id: 'f', name: 'Owner', type: 'person', property: {} }
+
+describe('MetaCellRenderer person inactive cue (2c-S4)', () => {
+  it('marks only the deactivated stored assignee, and still shows it', async () => {
+    const { container, app } = mount({
+      field: personField,
+      value: ['u_active', 'u_gone'],
+      personSummaries: [
+        { id: 'u_active', display: 'Alice' },
+        { id: 'u_gone', display: 'Ghost', inactive: true },
+      ],
+    })
+    await nextTick()
+    const chips = container.querySelectorAll('.meta-cell-renderer__person-chip')
+    expect(chips.length).toBe(2) // both shown — the inactive one is NOT dropped
+    const inactive = container.querySelectorAll('[data-inactive="true"]')
+    expect(inactive.length).toBe(1)
+    expect((inactive[0] as HTMLElement).textContent).toContain('Ghost')
+    expect(inactive[0].classList.contains('meta-cell-renderer__person-chip--inactive')).toBe(true)
+    app.unmount(); container.remove()
+  })
+
+  it('does not mark active assignees', async () => {
+    const { container, app } = mount({
+      field: personField,
+      value: ['u_active'],
+      personSummaries: [{ id: 'u_active', display: 'Alice' }],
+    })
+    await nextTick()
+    expect(container.querySelectorAll('.meta-cell-renderer__person-chip').length).toBe(1)
+    expect(container.querySelectorAll('[data-inactive="true"]').length).toBe(0)
+    app.unmount(); container.remove()
+  })
+})

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -419,6 +419,8 @@ type LinkedRecordSummary = {
 type PersonSummary = {
   id: string
   display: string
+  /** 2c-S4: the stored assignee's user is deactivated (still displayed read-only, not re-assignable). */
+  inactive?: boolean
 }
 
 type MultitableAttachment = SharedMultitableAttachment
@@ -4274,17 +4276,19 @@ async function buildPersonSummaries(
   if (userIds.size === 0) return result
 
   const displayByUserId = new Map<string, string>()
+  const inactiveUserIds = new Set<string>()
   try {
     const usersRes = await query(
-      'SELECT id, email, name FROM users WHERE id = ANY($1::text[])',
+      'SELECT id, email, name, is_active FROM users WHERE id = ANY($1::text[])',
       [Array.from(userIds)],
     )
-    for (const u of usersRes.rows as Array<{ id?: unknown; email?: unknown; name?: unknown }>) {
+    for (const u of usersRes.rows as Array<{ id?: unknown; email?: unknown; name?: unknown; is_active?: unknown }>) {
       const id = typeof u.id === 'string' ? u.id : String(u.id ?? '')
       if (!id) continue
       const name = typeof u.name === 'string' ? u.name.trim() : ''
       const email = typeof u.email === 'string' ? u.email.trim() : ''
       displayByUserId.set(id, name || email || id)
+      if (u.is_active === false) inactiveUserIds.add(id) // 2c-S4: mark deactivated stored assignees (read-only, not re-assignable)
     }
   } catch (err) {
     // users table absent (minimal test harness) — fall back to userId as display below.
@@ -4300,7 +4304,7 @@ async function buildPersonSummaries(
       for (const item of value) {
         if (typeof item !== 'string' || !item.trim()) continue
         const userId = item.trim()
-        summaries.push({ id: userId, display: displayByUserId.get(userId) ?? userId })
+        summaries.push({ id: userId, display: displayByUserId.get(userId) ?? userId, ...(inactiveUserIds.has(userId) ? { inactive: true } : {}) })
       }
       if (summaries.length > 0) fieldMap.set(fieldId, summaries)
     }

--- a/packages/core-backend/tests/integration/multitable-person-summary-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-person-summary-field-mask.test.ts
@@ -35,6 +35,8 @@ const PERSON_USER = `u_psm_target_${TS}` // the userId stored in the person cell
 const PERSON_DISPLAY = `Person Canary ${TS}` // the resolved display name — second canary (personSummaries[...].display)
 const USER_DENIED = `u_psm_denied_${TS}` // field_permissions-denied on FLD_PERSON
 const USER_GRANTED = `u_psm_granted_${TS}` // no deny → positive control
+const PERSON_USER_INACTIVE = `u_psm_inactive_${TS}` // 2c-S4: a DEACTIVATED stored assignee
+const REC_INACTIVE = `rec_psm_inactive_${TS}` // record holding the inactive assignee
 
 let app: Express
 let testUserId: string | null = null
@@ -67,6 +69,15 @@ describeIfDatabase('native person personSummaries by-value field mask (real DB)'
       [PERSON_USER, `${PERSON_USER}@example.test`, PERSON_DISPLAY],
     )
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: 'visible-val', [FLD_PERSON]: [PERSON_USER] })])
+    // 2c-S4: a deactivated user stored in a person cell — buildPersonSummaries must still resolve its
+    // display (read-only) AND flag it inactive.
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $3, 'x', 'user', '[]'::jsonb, FALSE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = FALSE`,
+      [PERSON_USER_INACTIVE, `${PERSON_USER_INACTIVE}@example.test`, `Inactive ${TS}`],
+    )
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_INACTIVE, SHEET_ID, JSON.stringify({ [FLD_PERSON]: [PERSON_USER_INACTIVE] })])
     // layer-3 read deny on FLD_PERSON for USER_DENIED only (USER_GRANTED = positive control)
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_PERSON, 'user', USER_DENIED, false, false])
   })
@@ -76,7 +87,7 @@ describeIfDatabase('native person personSummaries by-value field mask (real DB)'
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
-    await q('DELETE FROM users WHERE id = $1', [PERSON_USER]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[PERSON_USER, PERSON_USER_INACTIVE]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
   })
 
@@ -90,6 +101,18 @@ describeIfDatabase('native person personSummaries by-value field mask (real DB)'
     expect(rec?.data[FLD_PERSON]).toEqual([PERSON_USER]) // readable: the raw value present
     expect(res.body.data.personSummaries?.[REC_ID]?.[FLD_PERSON]?.[0]?.id).toBe(PERSON_USER)
     expect(res.body.data.personSummaries?.[REC_ID]?.[FLD_PERSON]?.[0]?.display).toBe(PERSON_DISPLAY)
+  })
+
+  test('2c-S4: a deactivated stored assignee is still resolved (display) AND flagged inactive', async () => {
+    testUserId = USER_GRANTED; testPerms = ['multitable:read']
+    const res = await viewReq()
+    expect(res.status).toBe(200)
+    const inactiveSummary = res.body.data.personSummaries?.[REC_INACTIVE]?.[FLD_PERSON]?.[0]
+    expect(inactiveSummary?.id).toBe(PERSON_USER_INACTIVE) // still displayed read-only, not dropped
+    expect(inactiveSummary?.inactive).toBe(true) // flagged → the muted cue
+    const activeSummary = res.body.data.personSummaries?.[REC_ID]?.[FLD_PERSON]?.[0]
+    expect(activeSummary?.id).toBe(PERSON_USER)
+    expect(activeSummary?.inactive).toBeFalsy() // active assignee is NOT flagged
   })
 
   test('GET /view (DENIED): person value is absent from record.data AND personSummaries; neither userId nor display leaks', async () => {


### PR DESCRIPTION
**Closes 2c.** The final slice: a read-only display cue for deactivated stored assignees.

- `buildPersonSummaries` selects `is_active` and flags `inactive: true` on a stored assignee whose user is deactivated; plumbed through `PersonSummary` (backend + FE types) to `MetaCellRenderer`, which renders the chip muted + struck-through with `data-inactive`.
- **Visual-only (no new i18n string)**; the assignee is still **shown** (never dropped — the 2c-S3 invariant), and inactive users are already excluded from re-assignment by the 2c-S2/S3 directory.

Tests: real-DB **+1** in the allowlisted person-summary-field-mask suite (deactivated assignee resolves display AND `inactive:true`; active assignee not flagged); FE cell-renderer spec **2/2**. backend tsc clean.

After this lands, 2c is complete → the last gated arc closes → the gated-remainder ledger goes to fully-done. I'll refresh it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)