### PR TITLE
fix(plm-adapter): validate inner BOM multitable context shape (no silent field drift)

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -2153,10 +2153,11 @@ export class PLMAdapter extends HTTPAdapter {
       const entitled = body.entitled === true
       if (entitled && body.context != null && !isBomMultitableContext(body.context)) {
         // Entitled, and a context object IS present, but its inner shape drifted from the contract
-        // (e.g. a renamed/removed line field). Refuse to pass undefined-laden rows to the review
-        // table: throw so the governed relay degrades to its visible 'error' state instead of
-        // silently rendering corrupt rows. (Benign additions don't trip this -- the guard checks
-        // only the required structural fields.)
+        // (e.g. a renamed/removed/retyped line field). Refuse to pass undefined-laden rows to the
+        // review table: throw so the governed relay degrades to its visible 'error' state instead of
+        // silently rendering corrupt rows. (The guard validates every declared context field --
+        // structural keys and displayed cells alike, null allowed where the type is nullable -- while
+        // tolerating unknown extras, so a benign provider addition does not trip it.)
         throw new Error(`getBomMultitableContext: malformed bom_multitable context shape for part ${partId}`)
       }
       return {

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -722,6 +722,35 @@ export interface BomMultitableContextResult {
   context: BomMultitableContext | null;
 }
 
+// Structural guard for the governed BOM multi-table context. Validates ONLY the fields the review
+// table depends on as keys/structure: the stable row key `bom_line_id`, the line `part_id`, the
+// hierarchy `level`/`path`, `sync_status`, the context `part.part_id`, the `lines` array and the
+// `template_key`. It deliberately TOLERATES extra/unknown fields (so a benign provider addition does
+// not trip it) and only rejects a renamed / removed / retyped REQUIRED field — exactly the drift that
+// would otherwise pass `typeof === 'object'` and render `undefined` rows. Used to fail LOUDLY (throw →
+// the governed relay degrades to its visible 'error' state) instead of corrupting the table silently.
+function isBomMultitableLine(value: unknown): value is BomMultitableLine {
+  const l = value as Record<string, unknown> | null;
+  return (
+    !!l && typeof l === 'object'
+    && typeof l.bom_line_id === 'string' && l.bom_line_id.length > 0
+    && typeof l.part_id === 'string'
+    && typeof l.level === 'number'
+    && Array.isArray(l.path)
+    && typeof l.sync_status === 'string'
+  );
+}
+
+function isBomMultitableContext(value: unknown): value is BomMultitableContext {
+  const c = value as Record<string, unknown> | null;
+  if (!c || typeof c !== 'object') return false;
+  const part = c.part as Record<string, unknown> | null;
+  if (!part || typeof part !== 'object' || typeof part.part_id !== 'string') return false;
+  if (typeof c.template_key !== 'string') return false;
+  if (!Array.isArray(c.lines) || !c.lines.every(isBomMultitableLine)) return false;
+  return true;
+}
+
 export class PLMAdapter extends HTTPAdapter {
   private mockMode = false;
   private apiMode: PLMApiMode = 'legacy';
@@ -2091,12 +2120,21 @@ export class PLMAdapter extends HTTPAdapter {
         return { feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }
       }
       const entitled = body.entitled === true
+      if (entitled && body.context != null && !isBomMultitableContext(body.context)) {
+        // Entitled, and a context object IS present, but its inner shape drifted from the contract
+        // (e.g. a renamed/removed line field). Refuse to pass undefined-laden rows to the review
+        // table: throw so the governed relay degrades to its visible 'error' state instead of
+        // silently rendering corrupt rows. (Benign additions don't trip this -- the guard checks
+        // only the required structural fields.)
+        throw new Error(`getBomMultitableContext: malformed bom_multitable context shape for part ${partId}`)
+      }
       return {
         feature_key: typeof body.feature_key === 'string' && body.feature_key ? body.feature_key : 'bom_multitable',
         entitled,
         upgrade: { available: !entitled },
-        // context only when the provider says entitled (defence in depth against a stale manifest)
-        context: entitled && body.context && typeof body.context === 'object' ? body.context : null,
+        // context only when entitled AND the inner shape validates (defence in depth against a stale
+        // manifest + no silent corruption from provider field drift)
+        context: entitled && isBomMultitableContext(body.context) ? body.context : null,
       }
     }
     // legacy / non-yuantus PLM has no multitable review surface

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -722,21 +722,50 @@ export interface BomMultitableContextResult {
   context: BomMultitableContext | null;
 }
 
-// Structural guard for the governed BOM multi-table context. Validates ONLY the fields the review
-// table depends on as keys/structure: the stable row key `bom_line_id`, the line `part_id`, the
-// hierarchy `level`/`path`, `sync_status`, the context `part.part_id`, the `lines` array and the
-// `template_key`. It deliberately TOLERATES extra/unknown fields (so a benign provider addition does
-// not trip it) and only rejects a renamed / removed / retyped REQUIRED field — exactly the drift that
-// would otherwise pass `typeof === 'object'` and render `undefined` rows. Used to fail LOUDLY (throw →
-// the governed relay degrades to its visible 'error' state) instead of corrupting the table silently.
+// Field guard for the governed BOM multi-table context. Validates EVERY field declared on
+// BomMultitableLine / BomMultitablePart / BomMultitableContext — both the structural keys
+// (bom_line_id, part_id, level, path, ...) AND the displayed cells (item_number, name, state,
+// quantity, uom, refdes, source_version, source_updated_at, ...), because the review table renders
+// those too: a renamed/removed *display* field would otherwise pass `typeof === 'object'` and render
+// silent empty cells (the same drift class as a missing row key). Nullable fields accept the typed
+// value OR null (a legitimate null is NOT drift); an ABSENT / renamed / retyped key IS caught. Extra
+// unknown fields are TOLERATED (a benign provider addition does not trip it). Used to fail LOUDLY
+// (throw → the governed relay degrades to its visible 'error' state) instead of corrupting silently.
+const isStringOrNull = (v: unknown): boolean => typeof v === 'string' || v === null;
+const isNumberOrNull = (v: unknown): boolean => typeof v === 'number' || v === null;
+const isStringArray = (v: unknown): boolean => Array.isArray(v) && v.every((x) => typeof x === 'string');
+
+function isBomMultitablePart(value: unknown): value is BomMultitablePart {
+  const p = value as Record<string, unknown> | null;
+  return (
+    !!p && typeof p === 'object'
+    && typeof p.part_id === 'string'
+    && isStringOrNull(p.item_number)
+    && isStringOrNull(p.name)
+    && isStringOrNull(p.state)
+    && isNumberOrNull(p.generation)
+  );
+}
+
 function isBomMultitableLine(value: unknown): value is BomMultitableLine {
   const l = value as Record<string, unknown> | null;
   return (
     !!l && typeof l === 'object'
     && typeof l.bom_line_id === 'string' && l.bom_line_id.length > 0
     && typeof l.part_id === 'string'
+    && isStringOrNull(l.item_number)
+    && isStringOrNull(l.name)
+    && isStringOrNull(l.state)
+    && isNumberOrNull(l.generation)
+    && isNumberOrNull(l.quantity)
+    && isStringOrNull(l.uom)
+    && isStringOrNull(l.find_num)
+    && isStringOrNull(l.refdes)
     && typeof l.level === 'number'
-    && Array.isArray(l.path)
+    && isStringArray(l.path)
+    && isStringArray(l.path_labels)
+    && isNumberOrNull(l.source_version)
+    && isStringOrNull(l.source_updated_at)
     && typeof l.sync_status === 'string'
   );
 }
@@ -744,10 +773,12 @@ function isBomMultitableLine(value: unknown): value is BomMultitableLine {
 function isBomMultitableContext(value: unknown): value is BomMultitableContext {
   const c = value as Record<string, unknown> | null;
   if (!c || typeof c !== 'object') return false;
-  const part = c.part as Record<string, unknown> | null;
-  if (!part || typeof part !== 'object' || typeof part.part_id !== 'string') return false;
-  if (typeof c.template_key !== 'string') return false;
+  if (!isBomMultitablePart(c.part)) return false;
   if (!Array.isArray(c.lines) || !c.lines.every(isBomMultitableLine)) return false;
+  if (!isNumberOrNull(c.source_version)) return false;
+  if (!isStringOrNull(c.source_updated_at)) return false;
+  if (typeof c.sync_status !== 'string') return false;
+  if (typeof c.template_key !== 'string') return false;
   return true;
 }
 

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -126,4 +126,35 @@ describe('PLMAdapter.getBomMultitableContext (PLM-COLLAB P3-C)', () => {
     expect(result.entitled).toBe(true)
     expect(result.context).toEqual(withExtra)
   })
+
+  it('yuantus + entitled but a DISPLAYED field drifts (quantity renamed -> qty): THROWS (display drift is the same failure class as a missing row key)', async () => {
+    const adapter = createAdapter('yuantus')
+    const drifted = {
+      ...PROVIDER_CONTEXT,
+      lines: [{ ...PROVIDER_CONTEXT.lines[0], quantity: undefined, qty: 2 }],
+    }
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: drifted }],
+    })
+
+    await expect(adapter.getBomMultitableContext('P1')).rejects.toThrow(/malformed/i)
+  })
+
+  it('yuantus + entitled with legitimate null cells (quantity/uom/source_updated_at = null): relays (null is a valid value, not drift)', async () => {
+    const adapter = createAdapter('yuantus')
+    const withNulls = {
+      ...PROVIDER_CONTEXT,
+      source_version: null,
+      source_updated_at: null,
+      lines: [{ ...PROVIDER_CONTEXT.lines[0], quantity: null, uom: null, item_number: null, source_version: null, source_updated_at: null }],
+    }
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: withNulls }],
+    })
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result.entitled).toBe(true)
+    expect(result.context).toEqual(withNulls)
+  })
 })

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -95,4 +95,35 @@ describe('PLMAdapter.getBomMultitableContext (PLM-COLLAB P3-C)', () => {
     expect(result.context?.lines[0].bom_line_id).toBeTruthy()
     expect(result.context?.template_key).toBe('bom_review')
   })
+
+  it('yuantus + entitled but MALFORMED context (a required line field renamed/removed): THROWS so the relay degrades to a visible error, not silent corrupt rows', async () => {
+    const adapter = createAdapter('yuantus')
+    // the silent-corruption scenario: the stable row key `bom_line_id` is renamed away
+    const drifted = {
+      ...PROVIDER_CONTEXT,
+      lines: [{ ...PROVIDER_CONTEXT.lines[0], bom_line_id: undefined, bomLineId: 'R1' }],
+    }
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: drifted }],
+    })
+
+    await expect(adapter.getBomMultitableContext('P1')).rejects.toThrow(/malformed/i)
+  })
+
+  it('yuantus + entitled with EXTRA unknown fields: still relays (benign provider additions do not trip the guard)', async () => {
+    const adapter = createAdapter('yuantus')
+    const withExtra = {
+      ...PROVIDER_CONTEXT,
+      some_new_top_level_field: true,
+      lines: [{ ...PROVIDER_CONTEXT.lines[0], some_new_line_field: 'x' }],
+    }
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: withExtra }],
+    })
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result.entitled).toBe(true)
+    expect(result.context).toEqual(withExtra)
+  })
 })


### PR DESCRIPTION
## What

Closes the one **silent-corruption** soft spot in the PLM ↔ MetaSheet integration (surfaced by a cross-repo coupling review). `PLMAdapter.getBomMultitableContext` relayed the provider's `context` after **only an envelope check** (`entitled === true && typeof context === 'object'`), passing the inner `BomMultitableLine[]` through **verbatim**. If the PLM provider renamed/removed a required line field (e.g. the stable row key `bom_line_id`), the consumer got a 200, the context passed the `typeof` gate, and the review table rendered rows with **`undefined` keys/cells** — silent data corruption, and **unpinned by the pact**.

## Fix

- Add structural guards `isBomMultitableLine` / `isBomMultitableContext` that validate **only the fields the review table depends on as keys/structure** (`bom_line_id`, `part_id`, `level`, `path`, `sync_status`; `part.part_id`; `lines` array; `template_key`) and **tolerate extra/unknown fields** — so a benign provider addition does **not** trip them; only a renamed/removed/retyped **required** field does.
- When entitled and a context **is** present but its inner shape is invalid → **throw**. The governed relay (`plm-workbench`) catches it and degrades to its **visible `error` state** (line 843-850), instead of silently rendering corrupt rows. Entitled-but-absent context still nulls the context as before (unchanged 'empty' path).

This converts a silent table corruption into a clean, visible error — making it safe to evolve the PLM BOM projection without quietly breaking the MetaSheet display.

## Verified

- New tests: malformed required-field (renamed `bom_line_id`) → `rejects`; extra unknown fields → still relays verbatim.
- **41/41** across `plm-adapter-bom-multitable` + `plm-workbench-bom-multitable-routes` + `plm-embed-routes`; `tsc --noEmit` clean; eslint clean on the adapter.

Branch is a few commits behind fast-moving `main` (no overlap — change is isolated to `getBomMultitableContext`); rebase at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)