### PR TITLE
fix(integration): S1a values-free — opaque keyHash, not raw key (follow-up to #2872)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
@@ -171,18 +171,42 @@ async function main() {
   assert.equal(okApply.rows.length, 2)
   assert.equal(okApply.rows[0].index, 0, 'row index defaults to position')
 
-  // --- 10. lookup/apply results are VALUES-FREE (no submitted row data) -----
+  // --- 10. VALUES-FREE incl. inside key{} + metadata{} (the real leak vectors) -
+  // Plant PII/secret canaries INSIDE the key (a natural key can BE PII) and a nested
+  // metadata value — the result must carry only an opaque keyHash + scalar metadata.
   const apply = createApplyResult({
-    rows: [{ key: { id: 'a' }, status: 'failed', errorCode: 'CONFLICT', error: 'revision drift', secretValue: 'p@ss', data: { col: 'submitted' } }],
+    keyFields: ['id'],
+    rows: [{ key: { id: 'a', ssn: '123-45-6789', password: 'p@ss' }, status: 'failed', errorCode: 'CONFLICT', error: 'revision drift' }],
     failed: 1,
   })
   const applyWire = JSON.stringify(apply)
-  assert.ok(!applyWire.includes('p@ss') && !applyWire.includes('submitted'), 'apply result is values-free (drops non-allow-listed fields)')
+  for (const leak of ['123-45-6789', 'p@ss', '"ssn"', '"key"']) {
+    assert.ok(!applyWire.includes(leak), `apply result must not carry ${leak} (values-free)`)
+  }
+  assert.match(apply.rows[0].keyHash, /^[a-f0-9]{64}$/, 'apply row carries an opaque keyHash, not the raw key')
   assert.equal(apply.rows[0].errorCode, 'CONFLICT')
   assert.equal(apply.rows[0].status, 'failed')
-  const lookup = createLookupResult({ matches: [{ key: { id: 'a' }, exists: true, revision: 7, data: { col: 'x' } }] })
-  assert.ok(!JSON.stringify(lookup).includes('"col"'), 'lookup result is values-free')
+  assert.throws(
+    () => createApplyResult({ rows: [], metadata: { mode: 'append', leak: { col: 'submitted' } } }),
+    /scalar \(values-free\)/,
+    'nested apply metadata rejected',
+  )
+
+  const lookup = createLookupResult({
+    keyFields: ['id'],
+    matches: [{ key: { id: 'a', email: 'pii@example.test' }, exists: true, revision: 7 }],
+  })
+  const lookupWire = JSON.stringify(lookup)
+  for (const leak of ['pii@example.test', '"email"', '"key"']) {
+    assert.ok(!lookupWire.includes(leak), `lookup result must not carry ${leak} (values-free)`)
+  }
+  assert.match(lookup.matches[0].keyHash, /^[a-f0-9]{64}$/, 'lookup match carries an opaque keyHash')
   assert.equal(lookup.matches[0].revision, '7', 'revision normalized to string')
+  assert.throws(
+    () => createLookupResult({ matches: [], metadata: { nested: { x: 1 } } }),
+    /scalar \(values-free\)/,
+    'nested lookup metadata rejected',
+  )
 
   console.log('✓ adapter-contracts: registry + normalizer + optional target-write lifecycle tests passed')
 }

--- a/plugins/plugin-integration-core/lib/contracts.cjs
+++ b/plugins/plugin-integration-core/lib/contracts.cjs
@@ -1,5 +1,7 @@
 'use strict'
 
+const crypto = require('node:crypto')
+
 // ---------------------------------------------------------------------------
 // Adapter contracts - plugin-integration-core
 //
@@ -246,7 +248,37 @@ function normalizeLookupRequest(input = {}) {
   }
 }
 
-function createLookupResult({ matches = [], metadata = {} } = {}) {
+// VALUES-FREE helpers for the two lifecycle builders. A natural key can itself be PII
+// (email/phone) and metadata can hide row data, so these builders never carry a raw key or a
+// nested metadata value: they emit an OPAQUE keyHash (projected to declared keyFields, then
+// sha256'd — mirroring external-write-dry-run.cjs's keyFromRecord + hashJson) and accept only
+// SCALAR metadata. This is the values-free LOCK at the contract layer (design-lock §5/§6.1).
+function hashKey(key, keyFields) {
+  const source = Array.isArray(keyFields) && keyFields.length > 0
+    ? keyFields.reduce((acc, field) => {
+        if (isPlainObject(key) && Object.prototype.hasOwnProperty.call(key, field)) acc[field] = key[field]
+        return acc
+      }, {})
+    : (isPlainObject(key) ? key : {})
+  return crypto.createHash('sha256').update(JSON.stringify(source)).digest('hex')
+}
+
+function scalarMetadata(value, field) {
+  if (value === undefined || value === null) return {}
+  if (!isPlainObject(value)) {
+    throw new AdapterContractError(`${field} must be an object`, { field })
+  }
+  const out = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry !== null && typeof entry === 'object') {
+      throw new AdapterContractError(`${field}.${key} must be a scalar (values-free)`, { field, key })
+    }
+    out[key] = entry
+  }
+  return out
+}
+
+function createLookupResult({ matches = [], keyFields = [], metadata = {} } = {}) {
   if (!Array.isArray(matches)) {
     throw new AdapterContractError('lookup result matches must be an array', { field: 'matches' })
   }
@@ -255,14 +287,15 @@ function createLookupResult({ matches = [], metadata = {} } = {}) {
       if (!isPlainObject(match)) {
         throw new AdapterContractError(`matches[${index}] must be an object`, { field: 'matches' })
       }
-      // allow-list projection — key/exists/revision only (no row values)
+      // VALUES-FREE: index + opaque keyHash + existence/revision only — never the raw key.
       return {
-        key: objectOrEmpty(match.key, `matches[${index}].key`),
+        index: normalizeResultCount(match.index === undefined ? index : match.index, `matches[${index}].index`),
+        keyHash: hashKey(match.key, keyFields),
         exists: Boolean(match.exists),
         revision: match.revision === undefined || match.revision === null ? null : String(match.revision),
       }
     }),
-    metadata: objectOrEmpty(metadata, 'metadata'),
+    metadata: scalarMetadata(metadata, 'metadata'),
   }
 }
 
@@ -293,7 +326,7 @@ function normalizeApplyRequest(input = {}) {
 
 // Per-row apply result: ENUM-STRICT status + VALUES-FREE (allow-list projection of
 // index/key/status/errorCode/error — the submitted row values are never carried).
-function createApplyResult({ rows = [], written = 0, updated = 0, skipped = 0, failed = 0, held = 0, metadata = {} } = {}) {
+function createApplyResult({ rows = [], keyFields = [], written = 0, updated = 0, skipped = 0, failed = 0, held = 0, metadata = {} } = {}) {
   if (!Array.isArray(rows)) {
     throw new AdapterContractError('apply result rows must be an array', { field: 'rows' })
   }
@@ -308,9 +341,10 @@ function createApplyResult({ rows = [], written = 0, updated = 0, skipped = 0, f
         { field: 'rows', index, value: row.status, allowed: APPLY_ROW_STATUSES },
       )
     }
+    // VALUES-FREE: index + opaque keyHash + status + redacted errorCode/error only — never the raw key.
     return {
       index: normalizeResultCount(row.index === undefined ? index : row.index, `rows[${index}].index`),
-      key: objectOrEmpty(row.key, `rows[${index}].key`),
+      keyHash: hashKey(row.key, keyFields),
       status,
       ...(row.errorCode ? { errorCode: requiredString(row.errorCode, `rows[${index}].errorCode`) } : {}),
       ...(row.error ? { error: requiredString(row.error, `rows[${index}].error`) } : {}),
@@ -323,7 +357,7 @@ function createApplyResult({ rows = [], written = 0, updated = 0, skipped = 0, f
     skipped: normalizeResultCount(skipped, 'skipped'),
     failed: normalizeResultCount(failed, 'failed'),
     held: normalizeResultCount(held, 'held'),
-    metadata: objectOrEmpty(metadata, 'metadata'),
+    metadata: scalarMetadata(metadata, 'metadata'),
   }
 }
 


### PR DESCRIPTION
Follow-up to **#2872** (S1a optional `targetWriteLifecycle` capability), which auto-merged in a quiet CI window **before** the sub-agent review's values-free fix could land. This lands that fix.

**Defect (review BLOCKER-1):** `createLookupResult`/`createApplyResult` raw-spread `key` and `metadata`, so a PII/secret-bearing natural key (or nested metadata) leaked into the result — a regression from the C6 path it abstracts (`external-write-dry-run.cjs` projects keyFields + `hashJson`). The §10 test only canaried *dropped* top-level fields, so it couldn't catch the real vector.

**Fix:** both builders emit an opaque **`keyHash`** (projected to declared `keyFields`, sha256'd) + `index` — never the raw key; **metadata restricted to scalars** (nested rejected). §10 re-canaried **inside** `key{}` (ssn/email/password) and `metadata{}` — fails on the old raw-spread, passes now.

Contract-only, **no runtime consumer** (the leak never manifested in practice). Contract items 1/2/3/5/6 (base-contract preservation, opt-in detection, all-or-nothing, enum-strict, no-runtime-wire) unchanged. `test:adapter-contracts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)