### PR TITLE
feat(multitable): 2c-S4 historical/inactive person chip display affordance (last 2c slice)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -50,6 +50,9 @@ on:
       - 'apps/web/src/multitable/components/cells/MetaCellEditor.vue'
       - 'apps/web/tests/multitable-yjs-scalar-cell-editor.spec.ts'
       - 'apps/web/tests/multitable-yjs-cell-editor.spec.ts'
+      - 'apps/web/src/multitable/components/MetaPersonPicker.vue'
+      - 'apps/web/src/multitable/utils/meta-person-picker-labels.ts'
+      - 'apps/web/tests/multitable-person-picker.spec.ts'
       - '.github/workflows/multitable-web-guard.yml'
   push:
     branches: [main]
@@ -130,4 +133,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker --reporter=dot

--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -14,7 +14,14 @@
           <button class="meta-person-picker__clear" @click="clearSelection">{{ pp('personPicker.clear') }}</button>
         </div>
         <div class="meta-person-picker__chips">
-          <span v-for="item in selectedSummaries" :key="item.id" class="meta-person-picker__chip">
+          <span
+            v-for="item in selectedSummaries"
+            :key="item.id"
+            class="meta-person-picker__chip"
+            :class="{ 'meta-person-picker__chip--historical': isHistorical(item.id) }"
+            :title="isHistorical(item.id) ? pp('personPicker.historicalMember') : undefined"
+            :data-historical="isHistorical(item.id) ? 'true' : undefined"
+          >
             <span>{{ item.display || item.id }}</span>
             <button type="button" class="meta-person-picker__chip-remove" @click="removeSelected(item.id)">&times;</button>
           </span>
@@ -75,6 +82,12 @@ type PersonMember = { id: string; display: string; subtitle?: string | null }
 
 const search = ref('')
 const members = ref<PersonMember[]>([])
+// 2c-S4: the FULL assignable directory id set, captured on the empty-search load (NOT the
+// search-filtered `members`), + whether it has loaded for the current field. A stored chip whose id
+// is absent from this set is a historical / no-longer-assignable value (inactive or out-of-restriction)
+// — it is still rendered (never dropped, per 2c-S3b) but marked so the user knows it can't be re-added.
+const assignableIds = ref<Set<string>>(new Set())
+const directoryLoaded = ref(false)
 const loading = ref(false)
 const errorMessage = ref('')
 const selected = reactive(new Set<string>())
@@ -113,7 +126,11 @@ async function loadMembers() {
   // exactly what the write validator accepts. An unsaved field (no id) has no directory yet; stored
   // chips still render from `selected` / `summaryById`, so nothing already-set is dropped.
   if (!fieldId) {
+    // Unsaved field: no directory yet → we cannot know the assignable set, so do NOT mark any chip
+    // historical (the stored chips still render from `selected`/`summaryById`, unchanged).
     members.value = []
+    directoryLoaded.value = false
+    assignableIds.value = new Set()
     return
   }
   loading.value = true
@@ -132,7 +149,14 @@ async function loadMembers() {
         summaryById[member.id] = { id: member.id, display: member.display }
       }
     }
+    // 2c-S4: only the empty-search load is the FULL assignable set; capture it there. A searched load
+    // is a filtered subset — keep the previously-captured full set so chip marking doesn't flicker on search.
+    if (!search.value) {
+      assignableIds.value = new Set(members.value.map((m) => m.id))
+    }
+    directoryLoaded.value = true
   } catch (error: any) {
+    directoryLoaded.value = false
     members.value = []
     errorMessage.value = error?.message ?? pp('personPicker.errorLoad')
   } finally {
@@ -160,6 +184,13 @@ function toggleSelect(id: string) {
 const selectedSummaries = computed<PersonSummary[]>(() =>
   Array.from(selected).map((id) => summaryById[id] ?? { id, display: id }),
 )
+
+// 2c-S4: a stored chip is "historical" (no longer assignable — inactive or out-of-member-group) when the
+// field's assignable directory has loaded AND this id is absent from it. Display-only: the chip still
+// renders and stays removable; it just can't be re-added (the picker's offered list, 2c-S3b, excludes it).
+function isHistorical(id: string): boolean {
+  return directoryLoaded.value && !assignableIds.value.has(id)
+}
 
 function clearSelection() {
   selected.clear()
@@ -192,6 +223,8 @@ function onConfirm() {
 .meta-person-picker__clear { border: none; background: none; color: #909399; font-size: 12px; cursor: pointer; }
 .meta-person-picker__chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .meta-person-picker__chip { display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 999px; background: #ecf5ff; color: #409eff; font-size: 12px; }
+/* 2c-S4: historical / no-longer-assignable stored value — muted + dashed so it reads as kept-but-not-current; still removable. */
+.meta-person-picker__chip--historical { background: #f4f4f5; color: #909399; border: 1px dashed #c0c4cc; text-decoration: line-through; }
 .meta-person-picker__chip-remove { border: none; background: none; color: inherit; cursor: pointer; font-size: 14px; line-height: 1; padding: 0; }
 .meta-person-picker__body { flex: 1; overflow-y: auto; padding: 0 16px; max-height: 300px; }
 .meta-person-picker__item { display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 13px; cursor: pointer; }

--- a/apps/web/src/multitable/utils/meta-person-picker-labels.ts
+++ b/apps/web/src/multitable/utils/meta-person-picker-labels.ts
@@ -15,6 +15,7 @@ export type MetaPersonPickerLabelKey =
   | 'personPicker.confirm'
   | 'personPicker.close'
   | 'personPicker.errorLoad'
+  | 'personPicker.historicalMember'
 
 const META_PERSON_PICKER_LABELS: Record<MetaPersonPickerLabelKey, { en: string; zh: string }> = {
   'personPicker.title': { en: 'Select People', zh: '选择人员' },
@@ -27,6 +28,7 @@ const META_PERSON_PICKER_LABELS: Record<MetaPersonPickerLabelKey, { en: string; 
   'personPicker.confirm': { en: 'Confirm', zh: '确认' },
   'personPicker.close': { en: 'Close people picker', zh: '关闭人员选择器' },
   'personPicker.errorLoad': { en: 'Failed to load members', zh: '加载成员失败' },
+  'personPicker.historicalMember': { en: 'No longer assignable (kept from a previous value)', zh: '已不可分配（保留的历史值）' },
 }
 
 export function personPickerLabel(key: MetaPersonPickerLabelKey, isZh: boolean): string {

--- a/apps/web/tests/multitable-person-picker.spec.ts
+++ b/apps/web/tests/multitable-person-picker.spec.ts
@@ -122,4 +122,36 @@ describe('MetaPersonPicker (field member-group directory)', () => {
     })
     app.unmount(); container.remove()
   })
+
+  // 2c-S4: a preserved stored chip that's absent from the assignable directory is VISUALLY MARKED
+  // historical (muted + title) so the user sees it's kept-but-not-reassignable; an in-directory chip is not.
+  it('marks a stored chip absent from the directory as historical; leaves an in-directory chip unmarked', async () => {
+    mockListDirectory.mockResolvedValue(directory) // u1, u2 offered — u_gone is NOT
+    const { container, app, vm } = mount({ id: 'f', name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, ['u_gone', 'u1'], vi.fn())
+    vm.visible = true
+    await flush()
+    const chips = Array.from(container.querySelectorAll('.meta-person-picker__chip')) as HTMLElement[]
+    const historical = chips.filter((c) => c.getAttribute('data-historical') === 'true')
+    expect(historical).toHaveLength(1) // only u_gone
+    const hist = historical[0]
+    expect(hist.classList.contains('meta-person-picker__chip--historical')).toBe(true)
+    expect(hist.getAttribute('title')).toBeTruthy() // i18n personPicker.historicalMember resolves
+    expect(hist.textContent).toContain('u_gone') // still rendered — never dropped (2c-S3b invariant held)
+    const inDir = chips.find((c) => (c.textContent ?? '').includes('Alice'))
+    expect(inDir?.getAttribute('data-historical')).toBeNull() // u1 is assignable → not marked
+    app.unmount(); container.remove()
+  })
+
+  // Guard: with no directory loaded (unsaved field, no id) we cannot know the assignable set, so NO chip
+  // is marked historical (avoids false positives) — the stored chip still renders.
+  it('does not mark chips historical when the directory has not loaded (unsaved field)', async () => {
+    mockListDirectory.mockResolvedValue(directory)
+    const { container, app, vm } = mount({ name: 'Owner', type: 'person', property: { limitSingleRecord: false } }, ['u_gone'], vi.fn())
+    vm.visible = true
+    await flush()
+    const chips = Array.from(container.querySelectorAll('.meta-person-picker__chip')) as HTMLElement[]
+    expect(chips).toHaveLength(1)
+    expect(chips[0].getAttribute('data-historical')).toBeNull()
+    app.unmount(); container.remove()
+  })
 })


### PR DESCRIPTION
Final 2c slice. A stored person chip whose user is no longer in the field's assignable directory (inactive / out-of-member-group) now renders with a **historical affordance** (muted + dashed + line-through + `personPicker.historicalMember` title + `data-historical`), so a readable-but-not-reassignable value is visually distinct. **Determination:** `directoryLoaded && !assignableIds.has(id)` where `assignableIds` = the full empty-search directory set (not the search-filtered list → no false positives); a `directoryLoaded` guard means an unsaved field never false-marks. **Invariants held (2c-S3b):** display-only — the chip is never dropped + still removable; re-adding stays blocked by the offered list. **Scope:** picker only (read-only `MetaCellRenderer` cells carry no directory data — marking there would need a per-cell fetch, deliberately out of scope). Verify: vue-tsc clean; multitable-person-picker 7/7 (2 new); web-guard filter updated. (Note: pre-existing main breakage in multitable-workbench-view — 58 failures from #2869, not in any required lane — is unrelated to this change; flagged separately.) 🤖 Generated with Claude Code