### PR TITLE
fix(deploy): support short Windows on-prem staging root

### DIFF
--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -28,6 +28,21 @@ the existing deploy root's apply entrypoint:
 deploy.bat <downloaded-package.zip>
 ```
 
+On Windows hosts with deep default `%TEMP%` paths, set a short local staging
+root before running the upgrade. The deploy launcher and the staged apply helper
+both honor the same variable, so zip extraction and package copy stay under the
+short path instead of falling back to the user profile temp directory:
+
+```bat
+mkdir C:\ms-tmp 2>NUL
+set "METASHEET_ONPREM_STAGING_ROOT=C:\ms-tmp"
+deploy.bat <downloaded-package.zip>
+```
+
+The setting only changes deploy staging/extraction. It does not change the
+installed root, app data paths, database connection, dependency store, or service
+configuration.
+
 Local build on the release machine:
 
 ```bash

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -12,6 +12,7 @@ param(
   [string]$BuildBackend = '0',
   [string]$RunMigrations = '1',
   [string]$RestartService = '1',
+  [string]$StagingRoot = '',
   [string]$DependencyRefreshTimeoutSec = '1800',
   [string]$DependencyRefreshHeartbeatSec = '60'
 )
@@ -78,13 +79,32 @@ function Write-Info {
   Write-Host "[multitable-onprem-apply-package] $Message"
 }
 
-function New-ShortTempDirectory {
-  param([string]$Prefix = 'mspa')
+function Resolve-StagingBase {
+  param([string]$Candidate)
 
-  $tempBase = [System.IO.Path]::GetTempPath()
-  if ([string]::IsNullOrWhiteSpace($tempBase) -or -not (Test-Path -LiteralPath $tempBase)) {
-    throw 'System temp directory is unavailable'
+  $tempBase = $Candidate
+  if ([string]::IsNullOrWhiteSpace($tempBase)) {
+    $tempBase = $env:METASHEET_ONPREM_STAGING_ROOT
   }
+  if ([string]::IsNullOrWhiteSpace($tempBase)) {
+    $tempBase = [System.IO.Path]::GetTempPath()
+  }
+  if ([string]::IsNullOrWhiteSpace($tempBase)) {
+    throw 'Staging root is unavailable. Set METASHEET_ONPREM_STAGING_ROOT to a short local path such as C:\ms-tmp.'
+  }
+
+  $tempBase = [System.IO.Path]::GetFullPath($tempBase.Trim().Trim('"'))
+  New-Item -ItemType Directory -Path $tempBase -Force | Out-Null
+  return (Resolve-Path -LiteralPath $tempBase).Path
+}
+
+function New-ShortTempDirectory {
+  param(
+    [string]$Prefix = 'mspa',
+    [string]$BaseRoot = ''
+  )
+
+  $tempBase = Resolve-StagingBase -Candidate $BaseRoot
 
   for ($index = 0; $index -lt 5; $index += 1) {
     $candidate = Join-Path $tempBase ($Prefix + '-' + [System.Guid]::NewGuid().ToString('N').Substring(0, 12))
@@ -527,7 +547,9 @@ Initialize-WindowsSystemToolPath
 
 $outputLogs = Join-Path $resolvedRoot 'output\logs'
 New-Item -ItemType Directory -Force -Path $outputLogs | Out-Null
-$extractRoot = New-ShortTempDirectory -Prefix 'mspa'
+$stagingBase = Resolve-StagingBase -Candidate $StagingRoot
+Write-Info "Staging base: $stagingBase"
+$extractRoot = New-ShortTempDirectory -Prefix 'mspa' -BaseRoot $stagingBase
 
 try {
   Write-Info "Package archive: $resolvedArchive"

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -1,7 +1,8 @@
 param(
   [Parameter(Mandatory = $true)]
   [string]$PackageArchive,
-  [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+  [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [string]$StagingRoot = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -47,8 +48,29 @@ function Resolve-LauncherPath {
   return (Resolve-Path -LiteralPath $trimmed).Path
 }
 
+function Resolve-StagingBase {
+  param([string]$Candidate)
+
+  $base = $Candidate
+  if ([string]::IsNullOrWhiteSpace($base)) {
+    $base = $env:METASHEET_ONPREM_STAGING_ROOT
+  }
+  if ([string]::IsNullOrWhiteSpace($base)) {
+    $base = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+  }
+  if ([string]::IsNullOrWhiteSpace($base)) {
+    throw 'No staging root is available. Set METASHEET_ONPREM_STAGING_ROOT to a short local path such as C:\ms-tmp.'
+  }
+
+  $base = [System.IO.Path]::GetFullPath($base.Trim().Trim('"'))
+  New-Item -ItemType Directory -Path $base -Force | Out-Null
+  return (Resolve-Path -LiteralPath $base).Path
+}
+
 function New-StagingDirectory {
-  $base = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+  param([string]$BaseRoot)
+
+  $base = Resolve-StagingBase -Candidate $BaseRoot
   $name = 'msdl-' + ([System.Guid]::NewGuid().ToString('N').Substring(0, 8))
   $path = Join-Path $base $name
   New-Item -ItemType Directory -Path $path -Force | Out-Null
@@ -101,7 +123,10 @@ $resolvedRoot = Resolve-LauncherPath -Candidate $RootDir -Label 'RootDir'
 Write-LauncherInfo "Package archive: $resolvedArchive"
 Write-LauncherInfo "Install root:    $resolvedRoot"
 
-$stage = New-StagingDirectory
+$stagingBase = Resolve-StagingBase -Candidate $StagingRoot
+Write-LauncherInfo "Staging base:    $stagingBase"
+
+$stage = New-StagingDirectory -BaseRoot $stagingBase
 $launcherExit = 1
 try {
   Write-LauncherInfo "Staging extraction root: $stage"
@@ -126,7 +151,7 @@ try {
   # complete" + health 200) reliably yields launcher exit 0 and a Last
   # Result of 0 in the outer scheduled task (#1526 follow-up).
   try {
-    & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
+    & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive -StagingRoot $stagingBase
     $launcherExit = 0
   }
   catch {

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -338,8 +338,14 @@ Upgrade / corrective reroll:
   deploy root, run:
     deploy.bat <downloaded-package.zip>
 
+  On Windows hosts whose default %TEMP% path is deep or redirected, pin staging
+  to a short local root before running deploy.bat:
+    mkdir C:\ms-tmp 2>NUL
+    set "METASHEET_ONPREM_STAGING_ROOT=C:\ms-tmp"
+    deploy.bat <downloaded-package.zip>
+
   Or run the PowerShell helper directly:
-    powershell -NoProfile -ExecutionPolicy Bypass -File scripts\ops\multitable-onprem-apply-package.ps1 -RootDir . -PackageArchive <downloaded-package.zip>
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts\ops\multitable-onprem-apply-package.ps1 -RootDir . -PackageArchive <downloaded-package.zip> -StagingRoot C:\ms-tmp
 
 Dependency policy:
   node_modules are intentionally not bundled. The apply helper defaults to
@@ -365,6 +371,7 @@ EOF
   "nodeModulesBundled": false,
   "dependencyInstallMode": "refresh-on-apply",
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+  "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
   "linuxEntryPoint": "scripts/ops/multitable-onprem-package-install.sh",
   "includedRuntimeRoots": [
     "apps/web/dist",
@@ -576,6 +583,14 @@ Runtime dependencies:
   node_modules from missing newly added workspace runtime dependencies. If
   applying files manually without deploy.bat, run pnpm install --frozen-lockfile
   from the package root before migrations/bootstrap.
+
+Windows staging root:
+  If the host's default %TEMP% path is deep, redirected, or fails package
+  staging, create a short local directory and set METASHEET_ONPREM_STAGING_ROOT
+  before running deploy.bat:
+    mkdir C:\ms-tmp 2>NUL
+    set "METASHEET_ONPREM_STAGING_ROOT=C:\ms-tmp"
+    deploy.bat <downloaded-package.zip>
 EOF
 
 run rm -f "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_TGZ_SHA_TMP_PATH" "$ARCHIVE_ZIP_SHA_TMP_PATH" "$METADATA_JSON_TMP_PATH"
@@ -603,6 +618,7 @@ cat > "${METADATA_JSON_TMP_PATH}" <<EOF
   "directReplaceSafe": false,
   "nodeModulesBundled": false,
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+  "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
   "attendanceOnly": false,
   "productMode": "platform",
   "includedPlugins": ["plugin-attendance", "plugin-integration-core"],

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -68,6 +68,8 @@ function verify_windows_entrypoints() {
   search_fixed_string '[multitable-onprem-deploy-launcher]' "$launcher_helper" || die "launcher must self-identify in its logs"
   search_fixed_string 'Expand-StagingArchive' "$launcher_helper" || die "launcher must extract the supplied package into a staging directory before invoking the apply helper"
   search_fixed_string 'Resolve-StagedPackageRoot' "$launcher_helper" || die "launcher must resolve the staged package root before invoking the apply helper"
+  search_fixed_string 'METASHEET_ONPREM_STAGING_ROOT' "$launcher_helper" || die "launcher must support METASHEET_ONPREM_STAGING_ROOT for short Windows staging paths"
+  search_fixed_string '-StagingRoot $stagingBase' "$launcher_helper" || die "launcher must pass its resolved staging base to the staged apply helper"
   search_fixed_string 'multitable-onprem-apply-package.ps1' "$launcher_helper" || die "launcher must invoke the staged apply helper from inside the extracted package"
   search_fixed_string 'Remove-Item -LiteralPath $stage' "$launcher_helper" || die "launcher must clean up staging extraction on exit"
   # #1526 follow-up (2026-05-20): launcher must use the apply.ps1
@@ -84,6 +86,8 @@ function verify_windows_entrypoints() {
   search_fixed_string 'Refresh dependencies (cmd.exe /c pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply through cmd.exe"
   search_fixed_string 'DependencyRefreshTimeoutSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh timeout"
   search_fixed_string 'DependencyRefreshHeartbeatSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh heartbeat"
+  search_fixed_string 'METASHEET_ONPREM_STAGING_ROOT' "$apply_helper" || die "PowerShell apply helper must support METASHEET_ONPREM_STAGING_ROOT for short Windows extraction paths"
+  search_fixed_string 'Staging base:' "$apply_helper" || die "PowerShell apply helper must log the resolved staging base"
   search_fixed_string 'dependency-refresh-' "$apply_helper" || die "PowerShell apply helper must write dependency refresh stdout/stderr logs"
   search_fixed_string 'pnpm path:' "$apply_helper" || die "PowerShell apply helper must log pnpm path before dependency refresh"
   search_fixed_string 'pnpm version:' "$apply_helper" || die "PowerShell apply helper must log pnpm version before dependency refresh"
@@ -207,6 +211,7 @@ function verify_deployable_artifact_contract() {
   search_fixed_string 'source-only archive' "$deployment_txt" || die "DEPLOYMENT.txt must explain that the workspace layout is not source-only"
   search_fixed_string 'not direct-replace-safe' "$deployment_txt" || die "DEPLOYMENT.txt must warn against direct replacement of a running install"
   search_fixed_string 'deploy.bat <downloaded-package.zip>' "$deployment_txt" || die "DEPLOYMENT.txt must show the Windows upgrade entrypoint"
+  search_fixed_string 'METASHEET_ONPREM_STAGING_ROOT' "$deployment_txt" || die "DEPLOYMENT.txt must document the short Windows staging root override"
   search_fixed_string 'node_modules are intentionally not bundled' "$deployment_txt" || die "DEPLOYMENT.txt must document node_modules policy"
 
   search_fixed_string 'DEPLOYMENT.txt' "$install_txt" || die "INSTALL.txt must point operators at DEPLOYMENT.txt"
@@ -219,6 +224,7 @@ function verify_deployable_artifact_contract() {
   search_fixed_string '"nodeModulesBundled": false' "$metadata_json" || die "PACKAGE-METADATA.json must document node_modules policy"
   search_fixed_string '"dependencyInstallMode": "refresh-on-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document dependency refresh policy"
   search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
+  search_fixed_string '"windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows staging root environment override"
 }
 
 function verify_build_provenance() {


### PR DESCRIPTION
## Summary

- add `METASHEET_ONPREM_STAGING_ROOT` / `-StagingRoot` support to the Windows on-prem deploy launcher and staged apply helper
- pass the launcher-resolved staging base into the staged apply helper so both extraction passes stay under the same short path
- document the short staging-root workflow in the Windows easy-start guide and generated `DEPLOYMENT.txt` / package metadata
- extend package verification markers so future packages cannot drop the short staging-root contract

## Issue

Progresses #2642. This PR does not close it by itself; closure still needs a rebuilt on-prem package and Windows entity-machine rerun proving the default-temp failure class is retired or the new staging-root path is accepted as the supported operator path.

## Verification

- `pwsh -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw 'scripts/ops/multitable-onprem-deploy-launcher.ps1')) | Out-Null; [scriptblock]::Create((Get-Content -Raw 'scripts/ops/multitable-onprem-apply-package.ps1')) | Out-Null; 'PowerShell parse OK'"`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh scripts/ops/multitable-onprem-package-build.sh`
- `node --test scripts/ops/multitable-onprem-release-gate.test.mjs`
- `git diff --check`
