### PR TITLE
docs(approval): refresh stale org-derived assignee comments (dept_head/direct_manager live; sequential not QPS-throttled)

### DIFF
--- a/packages/core-backend/src/directory/department-manager-enrichment.ts
+++ b/packages/core-backend/src/directory/department-manager-enrichment.ts
@@ -64,7 +64,9 @@ export function resolveManagerListForDept(
 }
 
 /**
- * THE SEAM. Best-effort, sequential (QPS-throttled) per-department detail fetch.
+ * THE SEAM. Best-effort, sequential (concurrency=1; explicit min-interval throttle
+ * deferred — there is no real rate limiter yet, throughput is bounded only by
+ * per-call latency) per-department detail fetch.
  * On success sets `managerUserIds` (incl. `[]`); on failure LEAVES IT `undefined`
  * (so the composer carries the prior value forward) and reports via `onError` —
  * it must never throw or fail the whole sync.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -1879,8 +1879,9 @@ async function fetchAllDepartments(config: DirectoryIntegrationConfig, integrati
 
   // dept-head plumbing: enrich each department with its manager user ids from the
   // department-detail API (listsub does not return them). Best-effort + sequential
-  // (QPS-throttled): a per-dept failure leaves managerUserIds undefined so the upsert
-  // carries the prior dept_manager_userid_list forward instead of wiping it.
+  // (concurrency=1; explicit min-interval throttle deferred — no real rate limiter
+  // yet): a per-dept failure leaves managerUserIds undefined so the upsert carries
+  // the prior dept_manager_userid_list forward instead of wiping it.
   await enrichDepartmentsWithManagers(
     departments.values(),
     (deptId) => getDingTalkDepartmentDetail(accessToken, deptId, { baseUrl: config.baseUrl }),

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -16,11 +16,12 @@
  *     It writes nothing, and it touches no `approval_*` / `automation_*` table —
  *     so it is outside the convergence guard's write-boundary entirely and never
  *     crosses an automation boundary.
- *   - It is NOT a resolver kind. The new `direct_manager` / `dept_head` /
- *     `continuous_managers` assignee-source kinds (and their runtime in
- *     `ApprovalAssigneeResolver`) are DESIGN-ONLY for this slice and are NOT wired
- *     here. This module's sole job is to populate the snapshot fields those future
- *     kinds will read.
+ *   - It is NOT a resolver kind. The `direct_manager` / `dept_head` assignee-source
+ *     kinds are now LIVE in `ApprovalAssigneeResolver` and consume the snapshot
+ *     fields this module bakes (`managerId` / `deptHeadId`); `continuous_managers`
+ *     remains future/DESIGN-ONLY. Either way this module's sole job is unchanged:
+ *     snapshot plumbing — it populates those fields and does not resolve assignees
+ *     itself.
  *
  * Provider shape (DingTalk, the only synced provider today):
  *   - `directory_accounts.raw.leader_in_dept`: `Array<{ dept_id, leader: boolean }>`


### PR DESCRIPTION
## What

Pure **comment-drift** cleanup on the org-derived assignee chain that just landed (#2863 → #2871 → #2873). **Zero behavior change** — three comments only.

| File | Was | Now |
|---|---|---|
| `ApprovalDirectoryOrg.ts` | `direct_manager` / `dept_head` are `DESIGN-ONLY` and `NOT wired` | both are **LIVE** in `ApprovalAssigneeResolver`, consuming the `managerId` / `deptHeadId` snapshot fields this module bakes; only `continuous_managers` stays future. Module remains snapshot plumbing, not a resolver. |
| `department-manager-enrichment.ts` (the seam) | `sequential (QPS-throttled)` | `sequential (concurrency=1; explicit min-interval throttle deferred — no real rate limiter yet)` |
| `directory-sync.ts` (call site) | `(QPS-throttled)` | same reword as above |

## Why

The first two files are the freshly-shipped org-derived approval-assignee link. Drifted comments make the next reader misjudge **"live vs design-only"**, and `QPS-throttled` implies a rate limiter that does not exist (the pass is a plain serial `await` loop). Data-safety is unaffected either way: a per-dept `department/get` failure leaves `managerUserIds` undefined so the upsert carries the prior `dept_manager_userid_list` forward (last-known-good).

## Scope / not in scope

Comments only. The actual **min-interval/metrics throttle stays deferred** (a future gated slice), as does `continuous_managers`, C (detail/sub-form runtime), F (handler node), and **W7 (locked)**. No `.js` emitted; explicit-file-list commit; 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)