### PR TITLE
docs(multitable): add omitted 2c to plan grounding line (post-#2881 consistency)

### DIFF
--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -1,7 +1,7 @@
 # 多维表剩余门控开发计划 — 2026-06-18
 
 > Status: **CURRENT GATED REMAINDER PLAN**.
-> Grounding: `origin/main` (live-main, 2026-06-18). Completed since the prior snapshot and now on `main`: **2a** scalar-type extensions (`#2832` / `#2838` / `#2849`) and **2b** dynamic rule-engine **complete through S4** (`#2836` / `#2841` / `#2847` / `#2861` parse cache). The earlier comment/ledger tail PRs `#2825` + `#2857` are closed as superseded by `#2859` (this reconciliation).
+> Grounding: `origin/main` (live-main, 2026-06-18). Completed since the prior snapshot and now on `main`: **2a** scalar-type extensions (`#2832` / `#2838` / `#2849`), **2b** dynamic rule-engine **complete through S4** (`#2836` / `#2841` / `#2847` / `#2861` parse cache), and **2c** `#16` person org-member directory **COMPLETE** (`#2866` / `#2867` / `#2869` / `#2874`, source = B). The earlier comment/ledger tail PRs `#2825` + `#2857` are closed as superseded by `#2859` (this reconciliation).
 > Supersedes: `multitable-current-development-plan-20260617.md` and `multitable-current-development-todo-20260617.md` for current multitable remainder routing.
 > Pair: `multitable-gated-remainder-todo-20260618.md`.
 > Rule: this is a closure ledger for the current multitable mainline. Every item below is gated. Do not start runtime work from this document without an explicit opt-in for that gate.


### PR DESCRIPTION
## What

**One-line** consistency fix. The plan doc's `> Grounding:` header (line 4) enumerated only **2a + 2b** as complete-on-main, omitting **2c** — even though the same doc's §0 ("active remainder EMPTY — 2a, 2b, 2c complete") and §3 ("2c · COMPLETE") already state 2c is done. Adds the omitted 2c entry so the reader-model-forming header matches the body.

## Context — why this is only one line

The original #2883 carried four ledger fixes, but a parallel PR **#2881** (`9dbc3f275`) landed first and reconciled **all three reviewer findings** — *more* accurately than #2883 (it additionally scoped the 2c-S4 claim to the shipped cell/summary surface and recorded #2877 closed-not-landed). Forcing #2883's original content would have **regressed** #2881. So #2883 was `reset --hard origin/main` and reduced to the single residual #2881 left untouched: the line-4 grounding omission.

Terse on purpose (no S4 sub-scoping) — matches how 2a/2b aren't surface-scoped on that line, and avoids re-broadening the S4 claim #2881 narrowed.

## Verification

Full residual sweep of **both** docs on post-#2881 main (`9dbc3f275`): every completion-enumeration and stale-phrase grep (`pending merge` / `Remaining: S` / `Continue 2c` / `In-Progress` / `through S2`) returns only accurate references — line-4 grounding was the sole straggler. Diff = 1 file, 1 line, text-only.

## Scope

No code, no gate opened; `continuous_managers` / C / F / W7 / §4 roadmap pool all stay gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
