### PR TITLE
docs(integration): S1b keystone design-lock + data-source/system-integration plan & verification

### DIFF
--- a/docs/development/data-source-system-integration-plan-and-verification-20260618.md
+++ b/docs/development/data-source-system-integration-plan-and-verification-20260618.md
@@ -1,0 +1,103 @@
+# 数据库 / 系统对接 — 计划与验证汇总(2026-06-18)
+
+> 本文是"数据库连接 → 通用对接"业务线的**计划 + 验证**汇总(完成态交付物)。
+> 它索引各刀的设计/验证文档,不替代它们;每个 runtime 写能力仍是**独立 opt-in + 独立 PR + 独立验证**。
+> production / batch / 首笔外部写 = 始终独立显式 owner gate。
+
+## 0. 一页结论
+
+- **只读数据库接入(C2)+ 增量(C3)+ 配置体验(C4)+ K3 generic MSSQL seam(C5)+ 外部写 sandbox 链路(C6)**:全部已交付并实体机验收闭合(release evidence #2769 PASS)。
+- **通用对接收敛 S1a(合同层)**:可选写能力面 `targetWriteLifecycle`(#2872)+ values-free 加固(#2882,本轮)已落地。
+- **S1b(keystone)**:本轮**完成设计锁定**(`generic-integration-s1b-keystone-design-lock-20260618.md`);**实现 GATED**——它触及全系统风险最高的写路径,且暴露一个必须 owner 先签字的高度(altitude)问题。**这是相对"直接实现 S1b"请求的一次显式 scope 偏移,见 §3。**
+- **S2(K3)/ S3(模版对象)/ S4(自描述元数据)/ S5(PLM stock-prep 吸收)/ 首笔生产外部写**:均为后续 gated opt-in,各带自己的 gate(见 §5)。
+
+## 1. 状态阶梯
+
+| 阶段 | 内容 | 状态 | 锚点 |
+|---|---|---|---|
+| C2 | 只读 SQL 源链路 smoke | ✅ done | issue #2600 |
+| C3 | 增量 / watermark runtime | ✅ done(core+CI real-DB lock) | #2609/#2619/#2625/#2628/#2631 |
+| C4 | UI / 配置体验 | ✅ done | #2643/#2646/#2649/#2652/#2655 |
+| C5 | K3 generic MSSQL seam | ✅ done(红线不开) | #2670 PASS/CLOSED;#2700 runbook |
+| C6 | 外部写 sandbox 链路 | ✅ done(C6-0..C6-5c + 实体机 controlled bad-row) | #2720;package `d8244ee13`;#2761;PM2 #2820 |
+| Release | 总包 + 实体机验收(scoped) | ✅ done | #2769 PASS(package `79ab455e`) |
+| **S1a** | 通用可选写能力面(合同层) | ✅ done | #2868 设计锁;#2872 能力;**#2882 values-free 加固(本轮)** |
+| **S1b** | 自有 multitable target 走泛化安全写(keystone) | 🔒 **design-locked,impl GATED**(本轮) | `…s1b-keystone-design-lock-20260618.md` |
+| S2 | K3 WebAPI target opt-in 同一安全写(sandbox) | 🔒 gated(opt-in + 实体机) | 总锁 §6 |
+| S3 | first-class `integration-template` 对象 | 🔒 gated(opt-in) | 总锁 §6 |
+| S4 | adapter 自描述元数据 | 🔒 gated(opt-in) | 总锁 §6 |
+| S5 | 统一 field-mapping + PLM stock-prep 吸收 | 🔒 gated(低优先,短期不重写) | 总锁 §3/§6 |
+| 首笔生产外部写 | sandbox-first 序列后单独一刀 | 🔒 **owner 授权** | 总锁 §5/§6 |
+
+## 2. 本轮交付:S1a values-free 加固(#2882)
+
+**背景**:独立复审指出 S1a 的 keyHash 只堵了 key 一个 vector,result builder 仍原样放行 `error` / `revision` / `metadata` 自由串(P1);并指出总设计锁"OpenAPI parity"是过声明(P2)。
+
+**修复**(`plugins/plugin-integration-core/lib/contracts.cjs`):
+
+- 结构性 values-free(真保证):
+  - `revision` → opaque **`revisionHash`**(sha256;保留**相等性**,故 dry-run→apply revision-fence 仍判漂移);
+  - **drop free-text `error`**(DB 错误内嵌行值);人类可读原因改落 dead-letter(`sanitizeIntegrationPayload` + 32KB cap)= relocated, not lost;
+  - `metadata` → **number\|boolean\|null only**(拒绝字符串/嵌套)。
+- 纵深防御(非硬保证):`errorCode` → CODE charset `[A-Z0-9_]{1,64}`(允许全数字 SQLSTATE 如 `42501`);honestly 标注其非硬保证。
+- 文档(P2):总设计锁"OpenAPI parity"改为"plugin-local 内部合同,无公开 API surface,OpenAPI 不适用";新增 §6.1 验收 #3(values-free result 形态,逐 vector canary 锁)+ S1b 衔接(result=code-only 分流,dead-letter=sanitized detail)。
+
+**验证**:
+
+- 逐 vector canary(key/error/revision/metadata)+ revision-fence 相等性测试;`adapter-contracts.test.cjs` 绿。
+- **非空洞性经验证明**:逐一回退每个结构保证(error/revision),canary 即触发失败(`apply result must not carry alice@example.com`、`lookup result must not carry Acme Corp Ltd`),还原后转绿——证明 canary 落在被处理的输入字段上,不是自洽通过。
+- 独立子智能体复审 **APPROVE**:allow-list 投影(不 spread 输入行/匹配)、canary 非空洞、`REQUIRED_ADAPTER_METHODS` **未变**。
+- 受影响 pure-node 测试(含 `external-write-dry-run` / `metasheet-multitable-target-adapter` / `stock-preparation-table-actions` / `connector-action-contracts` / `provenance-contracts`)`pnpm install` 后全绿。
+- 基础 5-method 合同**未变**;**零 runtime 消费者**(S1a 未接线)。
+
+**PR**:#2882 — **MERGED**(squash `687271dd6`,2026-06-19T01:10:24Z)。已验证落 `origin/main`:`contracts.cjs` 含加固(`revisionHash`/`valuesFreeMetadata`/`assertErrorCode`/`CODE_PATTERN`),`REQUIRED_ADAPTER_METHODS` 未变。
+
+## 3. S1b:设计锁定(本轮)+ scope 偏移声明
+
+**显式声明(诚实优先)**:owner 的指令是"S1b 应继续做 metasheet:multitable sandbox keystone",期望是**实现**。本轮交付的是 **S1b 设计锁**,不是实现——这是一次**主动 scope 偏移**,理由如下,请 owner 知悉并裁决:
+
+- S1b 要把 C6 `dry-run→apply` 安全生命周期从 `data-source:sql-write-gated` 泛化到能力面。盘点 `external-write-dry-run.cjs`(914 行,**全系统风险最高写路径**)发现它与 sql-write-gated 焊死三处,且与 S1a 合同存在一个**高度问题**:`targetWriteLifecycle.lookup/apply` 到底是 planner *内部数据通路* 还是 *证据投影*?——`classifyExisting` 靠**原始行字段值比较**判 add/update/skip,而 S1a 加固后的 `lookup` 刻意 **values-free 无字段值**,二者**无法直接对接**。
+- 这是"design-lock first"纪律的典型场景:在安全写路径上,先由 owner 对高度问题签字,再动代码;否则实现极可能在复审被打回。
+- 因此本轮把 S1b 从"一刀"细化为**设计锁 + 可机械执行的实现计划**(`generic-integration-s1b-keystone-design-lock-20260618.md`)。
+
+**推荐解 A(双接口拆分)**:planner 已验证的判定 + 安全逻辑**原样不动**;只把写原语**来源**做成可插拔(adapter-backed 原始内向接口取代 host sql-write-gated facade);`targetWriteLifecycle.lookup/apply`(values-free)定位为 **evidence 投影**——这也使 #2882 加固**保持正确**(它就是 evidence 形态)。B(revision 制判定)= 幂等语义变更,需独立验证;C(另起生命周期)= 违反总锁"复用不重造"。
+
+**实现就绪计划**(签字后机械执行,各刀独立 PR + 子智能体审阅):
+
+- **S1b-1**:planner 写原语来源泛化为可插拔(kind 门 + capability-state 断言抽象);**SQL 路径行为零漂移(既有测试原样绿=硬验收)**;新增 capability 写源用 fake/in-memory 写源覆盖 add/update/skip/held/token/fence/per-row/dead-letter。
+- **S1b-2**:`metasheet:multitable` target 提供原始内向写源(自有 sheet lookup/insert/update)+ `targetWriteLifecycle`(values-free)evidence 投影。
+- **S1b-3**:sandbox pipeline + route + wire-vs-fixture 集成 smoke(dry-run→apply→re-pull 幂等),**零外部写**。
+
+> **裁决请求**:请 owner 对**高度问题(`lookup/apply`=evidence 投影,A 双接口)**签字。签字="go",我即按 S1b-1→2→3 实现。
+
+## 4. 安全红线(继承,逐字保留)
+
+- 凭据只经 credential store;UI 只引用 system/dataSourceId,不复制凭据。
+- 首笔真实外部写 = 独立 owner 授权;sandbox-first 序列不变。
+- 两阶段 dry-run→apply;per-row 隔离,不 batch-abort;无自动重试打爆;dead-letter 收口。
+- K3 Submit/Audit/BOM 红线不开。
+- issue / evidence values-free。
+
+## 5. 剩余 gated 项(各带 gate,均非本轮交付)
+
+| 项 | gate | 备注 |
+|---|---|---|
+| S1b-1/2/3 实现 | owner 对 §3 高度问题签字 | 计划已就绪 |
+| S2(K3 WebAPI opt-in) | opt-in + **实体机 smoke**(operator 执行) | 红线保留;仅 sandbox |
+| S3(template 对象) | opt-in | K3/PLM 各出一个参考模版 |
+| S4(自描述元数据) | opt-in | 替换 `ADAPTER_METADATA` 静态字面量 |
+| S5(PLM stock-prep 吸收) | opt-in | 低优先,短期不重写专用链路 |
+| 首笔生产外部写 | **owner 授权** | 多样本只读 dry-run→sandbox apply→re-pull 幂等+人工字段保留→生产 |
+
+## 6. 验证汇总
+
+| 维度 | 证据 |
+|---|---|
+| C2-C6 + Release | TODO 账本 `data-source-system-integration-delivery-todo-20260614.md` 全勾 + #2769 scoped release evidence PASS(package `79ab455e`) |
+| S1a 能力面 | #2872(opt-in 假 target 验证 / 非 opt-in 原样通过 / partial 拒绝 / enum-strict) |
+| S1a values-free 加固 | #2882:逐 vector canary + 经验回退证明非空洞 + 独立复审 APPROVE + 受影响 suite 绿 + `REQUIRED_ADAPTER_METHODS` 未变 |
+| S1b | 设计锁交付(高度问题裁明 + 推荐 A + S1b-1/2/3 就绪计划);实现 gated |
+
+---
+
+_校验脚注:#2882 合并态已核实——`gh pr view 2882` = MERGED(squash `687271dd6`),`git show origin/main:…/contracts.cjs` 含加固且 `REQUIRED_ADAPTER_METHODS` 未变。_

--- a/docs/development/generic-integration-s1b-keystone-design-lock-20260618.md
+++ b/docs/development/generic-integration-s1b-keystone-design-lock-20260618.md
@@ -1,0 +1,85 @@
+# 通用对接 S1b(keystone)设计锁定 — 2026-06-18
+
+> 状态:**DESIGN-LOCK 草案(待 owner 评审)**。不授权任何 runtime;首笔真实外部写仍是独立 owner gate。
+> 上游:`generic-integration-design-lock-20260618.md`(总设计锁,S1a→S5 切片序);S1a 合同层已落地(能力面 #2872 + values-free 加固 #2882)。
+> 目的:把总设计锁 §6 的 **S1b**(让自有 `metasheet:multitable` target 走 C6 `dry-run→apply` 安全生命周期,证明"安全写能脱离 `data-source:sql-write-gated` 泛化",零外部写)从"一刀"细化为**可评审的设计 + 可机械执行的实现计划**。
+
+## 0. 为什么 S1b 需要先设计锁(不是直接实现)
+
+总设计锁把 S1b 写成一刀 keystone。盘点 C6 planner(`external-write-dry-run.cjs`,914 行,**全系统风险最高的写路径**)后发现:它与 `data-source:sql-write-gated` 焊死在**三处**,且与 S1a 合同存在一个**高度(altitude)层级的冲突**,必须由 owner 先裁决,才能动这段安全代码。**本刀的核心交付就是把这个高度问题摆明、给出推荐解、并把实现拆成可逐刀 opt-in 的计划。**
+
+## 1. C6 planner 的三处焊死点(盘点结论)
+
+`plugins/plugin-integration-core/lib/external-write-dry-run.cjs`:
+
+1. **kind 硬门**:`normalizeTargetConfig(system)`(~L199)在 `system.kind !== 'data-source:sql-write-gated'` 时抛 `C6_WRITE_TARGET_REQUIRED`。
+2. **写原语来自 host facade**:`computeExternalWritePlan`(~L516)所有写原语走注入的 `input.dataSourceWrites`(`test/lookupByKey/insertRows/updateRows`,~L296 `requireDataSourceWritesApi`),**不来自 adapter**。
+3. **能力态是 SQL 专属**:`assertSafeTargetCapabilityState`(~L327)要求 `{readOnly:false, c6WriteTarget:true, genericQueryDisabled:true}`——这是 SQL 写目标的形态。
+
+好消息:`dataSourceWrites` 已是**注入依赖**(planner 不自己 new 它),所以"换写原语来源"在结构上是可行的 seam,不需要重写 planner 主体。
+
+## 2. 核心:一个高度问题(altitude question)
+
+> **`targetWriteLifecycle.lookup/apply`(S1a 合同)到底是 planner 的*内部数据通路*,还是坐落在另一套*原始内向接口*之上的*证据投影*?**
+
+这不是三个独立选项,而是一个高度问题——A/B 都从它推出。它**同时决定 S1a 刚合并的 values-free 加固是否落在对的方法上**:
+
+- S1a 总设计锁的措辞是"把 C6 planner 硬编码的 `dataSourceWrites.lookupByKey/insertRows/updateRows` **抽象成合同方法**"——读起来像要 `lookup/apply` **替换**内部原语。
+- 但 planner 的判定逻辑 `classifyExisting`(~L376)靠**原始既有行的字段值比较**决定 add/update/skip:`writableFields.every(f => valuesEqual(target[f], existing[f]))`,1 行且全等=`skip`,否则=`update`,0 行=`add`,>1 行=`held`。
+- 而 S1a 加固后 `createLookupResult` 刻意 **values-free**:只带 `keyHash`/`exists`/`revisionHash`,**不带任何字段值**。
+
+**结论:values-free 的 `lookup` 结果无法喂给 value-diff 的 `classifyExisting`。** 所以"capability 即内部通路"与"加固后的 values-free 合同"**直接矛盾**。本设计锁必须显式裁掉这个 conflation——这是它的核心职责。
+
+## 3. 三个解 + 推荐(owner 裁决项)
+
+| 解 | 高度定位 | 对 planner | 对 S1a 加固 | 风险 |
+|---|---|---|---|---|
+| **A(推荐)双接口拆分** | `lookup/apply` = **证据投影**;另有一套**原始内向写原语接口**(沿用 `dataSourceWrites` 形态)供 planner | 主体/判定/安全逻辑**不动**;只把写原语**来源**做成可插拔(adapter-backed 取代 host-facade-backed) | **保持正确**——values-free 正是证据形态 | 低 |
+| B 修判定为 revision 制 | `lookup`(values-free)即内部通路,用 `revisionHash` diff 取代字段值 diff 决定 update/skip | 改 `classifyExisting` 语义 | 正确,但语义变了 | 中(幂等语义变更,需独立验证) |
+| C 另起 capability 生命周期 | 自成一套,绕开 SQL planner | 不动 planner,但复制 token/fence/per-row/dead-letter | 正确 | 中-大(**违反总锁 §4"复用不重造"**) |
+
+**推荐 A——双接口拆分**:planner 已验证的判定 + 安全逻辑原样保留,只让写原语**来源**可插拔(adapter 提供原始内向 `lookupByKey/insertRows/updateRows`,而非 host `data-source:sql-write-gated` facade);S1a 的 `targetWriteLifecycle.lookup/apply`(values-free)定位为 **evidence 投影**,run/issue evidence 用它,planner 内部判定用原始内向接口。这样 **S1a 加固保持正确**(它就是 evidence 形态),且最贴合"复用不重造"。
+
+> **裁决请求**:请 owner 对**高度问题**签字(`lookup/apply` = evidence 投影,A 双接口),而不仅是选 A 这个字母。签字后,下方 S1b-1/2/3 即可机械执行。
+
+## 4. S1a 加固的归位说明(本锁顺带锁死)
+
+`targetWriteLifecycle.lookup/apply`(#2872 形态 + #2882 values-free)= **evidence 投影**,**不是** planner 内部数据通路。planner 内部继续用原始内向写原语接口(A)。故 #2882 把 result builder 做成 values-free(opaque keyHash/revisionHash、drop free-text error、metadata number\|boolean\|null、errorCode code-only)是**正确且就位**的——它服务于 evidence,不服务于 value-diff 判定。
+
+## 5. 实现计划(每刀:独立 opt-in + 独立 PR + 子智能体审阅;contracts/seam-first)
+
+> 前置:本设计锁经 owner 签字(§3 高度问题 + A)。S1a 已在 main。
+
+- **S1b-1(planner seam,最关键)**:把 `computeExternalWritePlan` / apply 的写原语**来源**从"硬绑 host `dataSourceWrites` facade + kind===sql-write-gated"泛化为**可插拔原始内向写源**。
+  - `normalizeTargetConfig` 的 kind 门:从"只接受 `data-source:sql-write-gated`"放宽为"接受 sql-write-gated **或** 一个声明了原始内向写能力的 target";SQL 路径**形态/行为零变更**。
+  - `assertSafeTargetCapabilityState`:抽象成"目标自报安全写态"的断言,SQL 目标仍返回原 `{readOnly,c6WriteTarget,genericQueryDisabled}`。
+  - 触点文件:`lib/external-write-dry-run.cjs`(seam)、可能新增 `lib/target-write-source.cjs`(把"原始内向写源"normalize 成 planner 期望形态)。
+  - **不变式**:既有 `data-source:sql-write-gated` 全部测试**原样绿**(零行为漂移),`external-write-dry-run.test.cjs` 不改判定;新增"capability 写源"路径用一个 **fake/in-memory 写源**单测覆盖 add/update/skip/held + token/fence/per-row/dead-letter,证明安全生命周期脱离 sql-write-gated 仍成立。
+  - 风险:中(动安全代码,但**加法式**——新增可插拔来源,不重写判定)。
+- **S1b-2(multitable 写源)**:让自有 `metasheet:multitable` target 提供 §3-A 的**原始内向写源**(对自有 sheet/record 的 lookup-by-key + insert + update),并实现 `targetWriteLifecycle.lookup/apply`(values-free)作为 evidence 投影。
+  - 触点:`lib/adapters/metasheet-multitable-target-adapter.cjs`(现仅 5-method;新增写源 + 能力面)、其单测。
+  - **不变式**:写仅落自有 sheet(零外部系统写);凭据/边界不变。
+- **S1b-3(sandbox pipeline + route + smoke)**:配一条 sandbox pipeline(source→multitable target),走 C6 `dry-run→apply` 走通用写源路径;wire-vs-fixture 集成测试断言真实 route body/response 的 per-row 结果与 evidence values-free。
+  - 触点:routes(`POST .../external-write/dry-run|apply` 已存在,确认其 kind/能力门同步放宽)、`http-routes*.test.cjs`、pipeline 装配。
+  - **零外部写**:multitable 写自有 sheet;首笔**外部**写仍是总锁 §6 的独立 owner gate(本刀不碰)。
+
+## 6. 红线 / 不变式(继承总锁 §5,逐字保留)
+
+- 凭据仍只经 credential store;UI 只引用 system / dataSourceId,**不复制凭据**。
+- **首笔真实外部写 = 独立 owner 授权**;sandbox-first 序列不变。S1b 全程**零外部写**(multitable 写自有 sheet)。
+- 两阶段 dry-run → apply;per-row 隔离,**不 batch-abort**;**无自动重试打爆**;dead-letter 收口。
+- **K3 Submit/Audit/BOM 红线不开**(S1b 不碰 K3;K3 是 S2)。
+- issue / evidence 上 **values-free**。
+- **SQL `data-source:sql-write-gated` 路径在 S1b-1 后行为零漂移**(既有测试原样绿是硬验收)。
+
+## 7. 验收(S1b 各刀必过)
+
+- S1b-1:既有 sql-write-gated 测试全绿(零漂移)+ fake 写源新路径覆盖 add/update/skip/held/token/fence/per-row/dead-letter。
+- S1b-2:multitable 写源单测 + `targetWriteLifecycle` evidence values-free(逐 vector canary,沿用 S1a §6.1 验收 #3)。
+- S1b-3:sandbox dry-run→apply→re-pull 幂等的 wire-vs-fixture 集成测试,断言真实 route body/response;evidence values-free;零外部写。
+
+## 8. 切片不做什么(防 scope 漂移)
+
+- 不改 `REQUIRED_ADAPTER_METHODS`(总锁 §6.1 逐字锁)。
+- 不动 K3(S2)、不动 template 对象(S3)、不动 adapter 自描述元数据(S4)、不吸收 PLM stock-prep(S5)。
+- 不开首笔生产外部写(owner gate)。


### PR DESCRIPTION
## What

Two docs closing out the current development cycle of the data-source / system-integration line.

### 1. `generic-integration-s1b-keystone-design-lock-20260618.md` — S1b design-lock
Mapping the C6 planner (`external-write-dry-run.cjs`, 914 lines, the system's highest-blast-radius write path) surfaced that generalizing the `dry-run→apply` safety lifecycle off `data-source:sql-write-gated` hits an **altitude question**: is `targetWriteLifecycle.lookup/apply` the planner's **internal data path** or an **evidence projection**? `classifyExisting` decides skip/update by comparing **raw row field values**; the S1a `lookup` result is **values-free by design** — they can't directly connect.

Recommends **A (two-interface split)**: planner keeps its proven classification + safety logic; the write-primitive **source** becomes pluggable (adapter-backed raw inward); the values-free builders are the **evidence projection** — which keeps the #2882 hardening correct. S1b-1/2/3 implementation plan is ready; **impl is GATED on owner sign-off of the altitude question.**

### 2. `data-source-system-integration-plan-and-verification-20260618.md` — plan + verification
C2–C6 + release (#2769) done; S1a capability (#2872) + values-free hardening (#2882, **MERGED** `687271dd6`) done & verified; S1b design-locked (impl gated); S2/S3/S4/S5 + first production write remain gated each with their gate.

**Scope-deviation note (explicit):** the request was to *implement* S1b; this delivers a *design-lock* instead, because S1b lands on the safety-critical write path with an unresolved altitude question that this repo's design-lock-first discipline requires the owner to resolve before code. Rationale is stated loudly in both the MD (§3) and the design-lock (§0/§2).

## Boundary
Docs-only. No runtime, no external write, no K3 red lines. `REQUIRED_ADAPTER_METHODS` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)