### PR TITLE
docs(multitable): tidy MetaPersonPicker comment — picker S4 polish closed not-landed (#2877)

### DIFF
--- a/apps/web/src/multitable/components/MetaPersonPicker.vue
+++ b/apps/web/src/multitable/components/MetaPersonPicker.vue
@@ -57,7 +57,9 @@ import {
 // Native person (人员) picker. The offered set is the field's assignable member-group DIRECTORY
 // (2c-S3, GET .../person-fields/:fieldId/directory) — the SAME active, member-group-scoped set the
 // write-time validator accepts (display parity). Stored chips render independently of this list, so
-// historical inactive / out-of-restriction values are never dropped (their display polish is 2c-S4).
+// historical inactive / out-of-restriction values are never dropped. (Dedicated picker-chip marking
+// of such no-longer-assignable values was 2c-S4 picker polish — closed not-landed as #2877; the
+// shipped S4 affordance is the read-only cell/summary inactive cue, #2874.)
 // Emits userId[] (NOT recordIds) + a personSummaries echo so the chip renders immediately.
 const props = defineProps<{
   visible: boolean


### PR DESCRIPTION
## What

One-line **comment-only** tidy (no behavior change). `MetaPersonPicker.vue` header still forward-referenced the historical-value "display polish is **2c-S4**" — which now points at **closed-not-landed #2877** and could mislead a developer reading the source into thinking picker-side 2c-S4 work is pending.

Reframed to the settled scope: dedicated picker-chip marking of no-longer-assignable values was 2c-S4 picker polish, **closed not-landed as #2877**; the shipped S4 affordance is the read-only **cell/summary** inactive cue (**#2874**).

## Why

Clears the last "old map in live code" the ledger reconciliation left behind. The analogous text in the plan doc's retained-history section is banner-suppressed history, but this is live source, so it's worth one line. Ledger口径 on main is already self-consistent (2a/2b/2c complete; #2877 not planned remainder); this just makes the code comment agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)