### PR TITLE
feat(integration-core): S1b-1 — pluggable C6 write-source profile (zero SQL drift)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-write-dry-run.test.cjs
@@ -691,8 +691,123 @@ async function testRejectsFailedTargetCapabilityCheck() {
   assert.equal(calls.lookupByKey.length, 0, 'failed target capability check fails before target lookup')
 }
 
+// --- S1b-1: the safe-write lifecycle generalizes off data-source:sql-write-gated ----------
+// A non-SQL target opts into the SAME C6 lifecycle via a write PROFILE + the injected write
+// source. The profile uses a DIFFERENT capability-state shape ({ ok }) to prove the planner
+// no longer hardcodes the SQL flags; the write primitives are the injected dataSourceWrites.
+function fakeWriteProfile() {
+  return {
+    kind: 'fake:write-target',
+    normalizeCapabilityState(result) {
+      const state = result && result.capabilityState
+      if (!state || typeof state.ok !== 'boolean') {
+        throw new Error('fake target capability state unavailable')
+      }
+      return { success: result.success === true, ok: state.ok }
+    },
+    assertSafeCapabilityState(state) {
+      if (state.ok !== true) throw new Error('fake target capability state is unsafe')
+    },
+  }
+}
+
+function fakeProfileInput(overrides = {}) {
+  return baseInput({
+    test: () => ({ success: true, capabilityState: { ok: true } }),
+    ...overrides,
+    input: {
+      dryRunUser: 'user_write',
+      targetWriteProfile: fakeWriteProfile(),
+      targetSystem: {
+        id: 'target_1',
+        kind: 'fake:write-target',
+        config: {
+          dataSourceId: 'fake-write-source',
+          object: 'own.target_items',
+          keyFields: ['externalId'],
+          writableFields: ['name', 'status'],
+        },
+      },
+      ...(overrides.input || {}),
+    },
+  })
+}
+
+async function testWriteSourceSeamGeneralizesLifecycleOffSqlProfile() {
+  const { input, calls } = fakeProfileInput()
+  const dryRun = await dryRunExternalWrite(input)
+  assert.equal(dryRun.status, 'ready')
+  assert.equal(dryRun.canApply, true)
+  assert.equal(dryRun.counts.add, 1, 'classification (add) works through the generalized profile')
+  assert.equal(dryRun.counts.update, 1, 'classification (update) works through the generalized profile')
+  assert.equal(dryRun.counts.failed, 0)
+  assert.equal(dryRun.evidence.targetKind, 'fake:write-target', 'evidence carries the generalized kind, not the SQL constant')
+  const dryText = JSON.stringify(dryRun.evidence)
+  assert.equal(dryText.includes('P-001'), false, 'generalized dry-run evidence stays values-free')
+  assert.equal(dryText.includes('Widget'), false, 'generalized dry-run evidence stays values-free')
+  assert.equal(dryText.includes('data-source:sql-write-gated'), false, 'generalized run is not mislabeled as the SQL profile')
+
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+    runId: 'run_fake_seam',
+  })
+  assert.equal(apply.status, 'succeeded')
+  assert.equal(apply.counts.written, 2)
+  assert.equal(apply.counts.add, 1)
+  assert.equal(apply.counts.update, 1)
+  assert.equal(calls.insertRows.length, 1, 'add routed to the injected (non-SQL) write source')
+  assert.equal(calls.updateRows.length, 1, 'update routed to the injected (non-SQL) write source')
+  assert.equal(apply.evidence.targetKind, 'fake:write-target')
+  assert.equal(input.tokenStore.map.size, 0, 'apply consumed the single-use token')
+  // Revision-fence / single-use still holds on the generalized path: the consumed token is dead.
+  await assert.rejects(
+    () => applyExternalWrite({ ...input, dryRunToken: dryRun.dryRunToken, applyUser: 'user_write' }),
+    (error) => error && error.code === 'C6_WRITE_DRY_RUN_TOKEN_INVALID',
+    'consumed token is single-use under the generalized profile',
+  )
+}
+
+async function testWriteSourceSeamIsolatesRowFailureValuesFree() {
+  const deadLetters = []
+  // The injected write source fails the add row with an error whose message embeds row
+  // values; the per-row failure must isolate, persist a values-free dead letter, and let the
+  // clean sibling (update) through — proving C6 safety holds on the generalized path.
+  const { input, calls } = fakeProfileInput({
+    insertRows: () => {
+      throw new Error('insert failed: (externalId)=(P-001) name=Widget')
+    },
+  })
+  const dryRun = await dryRunExternalWrite(input)
+  const apply = await applyExternalWrite({
+    ...input,
+    dryRunToken: dryRun.dryRunToken,
+    applyUser: 'user_write',
+    runId: 'run_fake_fail',
+    deadLetterStore: {
+      async createDeadLetter(entry) {
+        deadLetters.push(entry)
+        return { ...entry, id: `dl_${deadLetters.length}` }
+      },
+    },
+  })
+  assert.equal(apply.status, 'partial', 'add fails, update succeeds -> partial')
+  assert.equal(apply.counts.failed, 1)
+  assert.equal(apply.counts.update, 1)
+  assert.equal(apply.counts.written, 1)
+  assert.equal(calls.updateRows.length, 1, 'clean sibling still written through the injected source')
+  assert.deepEqual(apply.deadLetters, { attempted: 1, persisted: 1 })
+  const text = JSON.stringify(apply) + JSON.stringify(deadLetters)
+  for (const leak of ['P-001', 'P-002', 'Widget', 'Gadget']) {
+    assert.equal(text.includes(leak), false, `generalized row-failure path stays values-free (${leak})`)
+  }
+}
+
 async function main() {
   await testReadyDryRunIssuesTokenAndStaysValuesFree()
+  await testWriteSourceSeamGeneralizesLifecycleOffSqlProfile()
+  await testWriteSourceSeamIsolatesRowFailureValuesFree()
   await testAmbiguousTargetKeyHoldsAndDoesNotIssueToken()
   await testTruncatedSourceReadDoesNotIssueToken()
   await testRejectsNonC6Target()

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -244,6 +244,9 @@ function assertTargetWriteProfile(profile) {
 // Resolve the write profile for this run. Default = SQL write-gated, so the existing route
 // (which passes none) is unchanged; an opt-in target (S1b-2 multitable, S2 K3) supplies its
 // own profile via input.targetWriteProfile.
+// TRUST BOUNDARY: a profile IS the per-kind safety policy (its assertSafeCapabilityState is
+// the gate). targetWriteProfile is TRUSTED server-side planner wiring only — it must never be
+// sourced from request/user input. assertTargetWriteProfile validates shape, not strictness.
 function resolveTargetWriteProfile(input) {
   return assertTargetWriteProfile(input && input.targetWriteProfile ? input.targetWriteProfile : SQL_WRITE_GATED_PROFILE)
 }

--- a/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
+++ b/plugins/plugin-integration-core/lib/external-write-dry-run.cjs
@@ -195,15 +195,69 @@ function normalizeFieldList(value, field) {
   })
 }
 
-function normalizeTargetConfig(system) {
-  if (!system || system.kind !== TARGET_KIND) {
-    throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_REQUIRED', `C6 write dry-run requires target kind ${TARGET_KIND}`, {
-      expectedKind: TARGET_KIND,
+// --- Target-write PROFILE (S1b design-lock §3-A: two-interface split) -----------------
+// A profile abstracts the two places the C6 safe-write lifecycle was welded to
+// `data-source:sql-write-gated`: (1) which target KIND is an accepted write target, and
+// (2) what a SAFE capability state looks like. The write PRIMITIVES stay the injected
+// `dataSourceWrites` (test/lookupByKey/insertRows/updateRows) — the planner's proven
+// classification, token/fence, per-row isolation and dead-letter are UNCHANGED. The default
+// profile is the SQL one, so the existing path behaves byte-for-byte as before.
+const SQL_WRITE_GATED_PROFILE = {
+  kind: TARGET_KIND,
+  normalizeCapabilityState(result) {
+    const state = result && result.capabilityState
+    if (
+      !isPlainObject(state) ||
+      typeof state.readOnly !== 'boolean' ||
+      typeof state.c6WriteTarget !== 'boolean' ||
+      typeof state.genericQueryDisabled !== 'boolean'
+    ) {
+      throw new ExternalWriteDryRunError(501, 'C6_WRITE_CAPABILITY_STATE_UNAVAILABLE', 'C6 write dry-run requires target capability state from context.api.dataSourceWrites.test')
+    }
+    return {
+      success: result.success === true,
+      readOnly: state.readOnly,
+      c6WriteTarget: state.c6WriteTarget,
+      genericQueryDisabled: state.genericQueryDisabled,
+    }
+  },
+  assertSafeCapabilityState(state) {
+    if (state.readOnly !== false || state.c6WriteTarget !== true || state.genericQueryDisabled !== true) {
+      throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_CAPABILITY_UNSAFE', 'C6 write target capability state is unsafe')
+    }
+  },
+}
+
+function assertTargetWriteProfile(profile) {
+  if (
+    !profile ||
+    typeof profile.kind !== 'string' ||
+    profile.kind.length === 0 ||
+    typeof profile.normalizeCapabilityState !== 'function' ||
+    typeof profile.assertSafeCapabilityState !== 'function'
+  ) {
+    throw new ExternalWriteDryRunError(501, 'C6_WRITE_PROFILE_INVALID', 'C6 write requires a valid target-write profile (kind + normalizeCapabilityState + assertSafeCapabilityState)')
+  }
+  return profile
+}
+
+// Resolve the write profile for this run. Default = SQL write-gated, so the existing route
+// (which passes none) is unchanged; an opt-in target (S1b-2 multitable, S2 K3) supplies its
+// own profile via input.targetWriteProfile.
+function resolveTargetWriteProfile(input) {
+  return assertTargetWriteProfile(input && input.targetWriteProfile ? input.targetWriteProfile : SQL_WRITE_GATED_PROFILE)
+}
+
+function normalizeTargetConfig(system, profile = SQL_WRITE_GATED_PROFILE) {
+  if (!system || system.kind !== profile.kind) {
+    throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_REQUIRED', `C6 write dry-run requires target kind ${profile.kind}`, {
+      expectedKind: profile.kind,
       actualKind: system && system.kind,
     })
   }
   const config = isPlainObject(system.config) ? system.config : {}
   return {
+    kind: system.kind,
     dataSourceId: requiredString(config.dataSourceId, 'target.config.dataSourceId'),
     object: requiredString(config.object, 'target.config.object'),
     keyFields: normalizeFieldList(config.keyFields, 'target.config.keyFields'),
@@ -306,30 +360,6 @@ function requireDataSourceWritesApi(api) {
   return api
 }
 
-function normalizeTargetCapabilityState(result) {
-  const state = result && result.capabilityState
-  if (
-    !isPlainObject(state) ||
-    typeof state.readOnly !== 'boolean' ||
-    typeof state.c6WriteTarget !== 'boolean' ||
-    typeof state.genericQueryDisabled !== 'boolean'
-  ) {
-    throw new ExternalWriteDryRunError(501, 'C6_WRITE_CAPABILITY_STATE_UNAVAILABLE', 'C6 write dry-run requires target capability state from context.api.dataSourceWrites.test')
-  }
-  return {
-    success: result.success === true,
-    readOnly: state.readOnly,
-    c6WriteTarget: state.c6WriteTarget,
-    genericQueryDisabled: state.genericQueryDisabled,
-  }
-}
-
-function assertSafeTargetCapabilityState(state) {
-  if (state.readOnly !== false || state.c6WriteTarget !== true || state.genericQueryDisabled !== true) {
-    throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_CAPABILITY_UNSAFE', 'C6 write target capability state is unsafe')
-  }
-}
-
 function statusCounts() {
   return { add: 0, update: 0, skip: 0, held: 0, failed: 0 }
 }
@@ -423,7 +453,7 @@ function buildRevision(input) {
     },
     target: {
       systemId: input.pipeline.targetSystemId,
-      kind: TARGET_KIND,
+      kind: input.targetConfig.kind,
       dataSourceId: input.targetConfig.dataSourceId,
       object: input.targetConfig.object,
       keyFields: input.targetConfig.keyFields,
@@ -452,7 +482,7 @@ function publicRowErrorTypes(rowErrors) {
 function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, canApply, sourceRead, rowErrorTypes, dryRunToken, testFailureInjection }) {
   return {
     pipelineId: pipeline.id,
-    targetKind: TARGET_KIND,
+    targetKind: targetConfig.kind,
     sourceKind: sourceKind || null,
     operationMode: 'upsert',
     keyFields: targetConfig.keyFields.slice(),
@@ -474,7 +504,7 @@ function publicEvidence({ pipeline, targetConfig, sourceKind, counts, revision, 
 function publicApplyEvidence({ pipeline, targetConfig, sourceKind, status, counts, revision, sourceRead, rowErrors, provenanceEvents, testFailureInjection }) {
   return {
     pipelineId: pipeline.id,
-    targetKind: TARGET_KIND,
+    targetKind: targetConfig.kind,
     sourceKind: sourceKind || null,
     operationMode: 'upsert',
     keyFields: targetConfig.keyFields.slice(),
@@ -515,20 +545,21 @@ function validatePlannerInput(input = {}, phase = 'dry-run') {
 
 async function computeExternalWritePlan(input = {}) {
   const pipeline = validatePlannerInput(input, input.phase || 'dry-run')
-  const targetConfig = normalizeTargetConfig(input.targetSystem)
+  const profile = resolveTargetWriteProfile(input)
+  const targetConfig = normalizeTargetConfig(input.targetSystem, profile)
   const testFailureInjection = normalizeTestFailureInjectionConfig(input.testFailureInjection, {
     pipeline,
     targetSystem: input.targetSystem,
     targetConfig,
   })
   const dataSourceWrites = requireDataSourceWritesApi(input.dataSourceWrites)
-  const targetCapabilityState = normalizeTargetCapabilityState(
+  const targetCapabilityState = profile.normalizeCapabilityState(
     await dataSourceWrites.test(targetConfig.dataSourceId, input.dataSourceOwnerPrincipal),
   )
   if (targetCapabilityState.success !== true) {
     throw new ExternalWriteDryRunError(422, 'C6_WRITE_TARGET_TEST_FAILED', 'C6 write target test did not pass')
   }
-  assertSafeTargetCapabilityState(targetCapabilityState)
+  profile.assertSafeCapabilityState(targetCapabilityState)
   if (!input.sourceAdapter || typeof input.sourceAdapter.read !== 'function') {
     throw new ExternalWriteDryRunError(501, 'C6_WRITE_SOURCE_ADAPTER_UNAVAILABLE', 'source adapter read is required')
   }
@@ -693,14 +724,14 @@ function syntheticRunId(pipeline, revision) {
   return `c6-external-write:${pipeline.id}:${revision}`
 }
 
-function provenanceEvent({ pipeline, revision, runId, row, eventType, attrs = {} }) {
+function provenanceEvent({ pipeline, revision, runId, row, eventType, targetKind = TARGET_KIND, attrs = {} }) {
   return {
     runId: runId || syntheticRunId(pipeline, revision),
     rowId: row && row.keyFingerprint ? row.keyFingerprint : hashJson({ pipelineId: pipeline.id, eventType, attrs }),
     eventType,
     at: new Date().toISOString(),
     attrs: {
-      targetKind: TARGET_KIND,
+      targetKind,
       dryRunRevision: revision,
       ...attrs,
     },
@@ -790,6 +821,7 @@ async function applyExternalWrite(input = {}) {
         pipeline: plan.pipeline,
         revision: plan.revision,
         runId,
+        targetKind: plan.targetConfig.kind,
         row,
         eventType: 'target_write_succeeded',
         attrs: { decision: 'skip', writePerformed: false },
@@ -802,6 +834,7 @@ async function applyExternalWrite(input = {}) {
         pipeline: plan.pipeline,
         revision: plan.revision,
         runId,
+        targetKind: plan.targetConfig.kind,
         row,
         eventType: 'target_write_failed',
         attrs: { decision: 'held', errorCode: 'C6_WRITE_ROW_HELD' },
@@ -840,6 +873,7 @@ async function applyExternalWrite(input = {}) {
         pipeline: plan.pipeline,
         revision: plan.revision,
         runId,
+        targetKind: plan.targetConfig.kind,
         row,
         eventType: 'target_write_succeeded',
         attrs: { decision: row.decision, writePerformed: true },
@@ -852,6 +886,7 @@ async function applyExternalWrite(input = {}) {
         pipeline: plan.pipeline,
         revision: plan.revision,
         runId,
+        targetKind: plan.targetConfig.kind,
         row,
         eventType: 'target_write_failed',
         attrs: { decision: row.decision, errorCode },
@@ -904,6 +939,9 @@ module.exports = {
     C6_WRITE_DRY_RUN_TOKEN_PREFIX,
     C6_TEST_INJECTED_ROW_FAILURE,
     TARGET_KIND,
+    SQL_WRITE_GATED_PROFILE,
+    resolveTargetWriteProfile,
+    assertTargetWriteProfile,
     buildRevision,
     computeExternalWritePlan,
     consumeDryRunToken,


### PR DESCRIPTION
## What (S1b-1, per the S1b design-lock §3-A)

Generalizes the C6 `dry-run→apply` safe-write lifecycle off the hardwired `data-source:sql-write-gated` target onto a **target-write profile** — the **two-interface split** the owner signed off on. The planner's proven classification, token/revision-fence, per-row isolation, and dead-letter are **unchanged**; only the two welds become pluggable:
- kind acceptance (`normalizeTargetConfig`) → `profile.kind`
- safe capability-state (normalize + assert) → `profile` methods

The write **primitives** stay the injected `dataSourceWrites` (already a pluggable dependency). `buildRevision` / evidence / provenance now carry `targetConfig.kind` instead of the `TARGET_KIND` constant — **byte-identical for SQL**, so no revision drift.

Default profile = `SQL_WRITE_GATED_PROFILE`; the existing route passes none → behaves exactly as before. An opt-in target supplies `input.targetWriteProfile` (S1b-2 multitable, S2 K3).

## Zero-drift acceptance
The **entire existing `external-write-dry-run` suite passes unchanged**, including the exact `requires target kind data-source:sql-write-gated` message and `C6_WRITE_TARGET_CAPABILITY_UNSAFE`; plus `http-routes` / `pipeline-runner` / `data-source-sql-write-gated-target-adapter` / `adapter-contracts` green.

## New tests (prove generalization)
A fake **non-SQL** profile (different capability-state shape `{ ok }`) + injected write source runs `dry-run→apply` with correct add/update/skip classification, single-use token/fence, evidence carrying the **generalized** `targetKind` (not the SQL constant) and staying values-free; and a row-level write failure whose error message **embeds row values** isolates, persists a **values-free** dead letter, and lets the clean sibling through.

## Boundary
S1b-1 only. No route wiring (S1b-3), no multitable target (S1b-2), no external write, no K3 red lines. `REQUIRED_ADAPTER_METHODS` untouched. Auto-merge intentionally **not** armed — awaiting adversarial sub-agent review (write/safety PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)