### PR TITLE
docs(dev-completion): plan+verification MD + backfill 3 stale attendance ledgers

### DIFF
--- a/docs/development/attendance-annual-leave-admin-operations-dev-plan-20260617.md
+++ b/docs/development/attendance-annual-leave-admin-operations-dev-plan-20260617.md
@@ -1,6 +1,6 @@
 # L5c — Annual-leave admin operations UI · development plan (gated TODO-checklist)
 
-**Status:** ⬜ UNBLOCKED — build authorized. Design-lock `docs/development/attendance-annual-leave-admin-operations-design-lock-20260617.md` is MERGED on `origin/main` (at commit `619fab564`, #2795) and is the authority for every field, code, and 拍板 below. The L6 staging runbook `docs/development/attendance-annual-leave-l6-staging-smoke-runbook-20260617.md` is also merged (#2796) but is a **downstream owner-run gate** (§Dependencies), not part of this build.
+**Status:** ✅ **BUILT + MERGED — SUPERSEDED (2026-06-18 backfill).** This plan's build is complete on `origin/main`: impl **#2830** (the new `annualLeaveOperations` admin section + 3 operation cards + in-DOM confirm/result panels + failure-code mapper + 201-line regression suite + dev-verification MD `attendance-annual-leave-admin-operations-dev-verification-20260617.md`), policy-off fix **#2834** (all three cards disabled when policy off), closeout-MD corrections **#2835/#2844**. The design-lock (#2795) and L6 staging runbook (#2796) remain the authority / downstream gate. **The build-step boxes below were flipped to ✅ to reflect merged reality; only the L6 staging smoke (marked 🔒, §7 / G1) remains as an owner-run gate.** Retained as history.
 
 **One-line scope:** put the three existing **balance-mutating** annual-leave endpoints behind buttons inside **one** new admin nav section, in **one** PR, with the five locked dimensions (preview / confirm / idempotency / failure-code / permission-audit) instantiated three times — **without flattening the three different back-ends**.
 
@@ -52,38 +52,38 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 
 > **Anti-flatten rule (design-lock §1, the #1 codebase-fit trap):** the shared scaffold is the **interaction model** (preview → confirm → result) plus two helpers that do **NOT** apply uniformly. The three back-ends differ — keep the asymmetries explicit. A result panel that assumes all three return a `{code→count}` map is the flatten bug: **manual-adjust returns `{id,delta,applied,alreadyApplied}` with NO reasons map.**
 
-### 2.1 Section registration (rail) — ⬜
+### 2.1 Section registration (rail) — ✅
 - **`apps/web/src/views/attendance/useAttendanceAdminRail.ts`:**
   - Add `annualLeaveOperations: 'attendance-admin-annual-leave-operations'` to `ATTENDANCE_ADMIN_SECTION_IDS` (after `annualLeavePolicy`, line ~41).
   - Add nav-link label after line ~193: `{ id: ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations, label: tr('Annual leave operations', '年假操作') }`.
   - **Append** `ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations` to the existing `annual-leave` group `itemIds` (line ~248), after `annualLeavePolicy`. **Do NOT create a new group** — `groupLabels` must stay the 6 locked labels.
 
-### 2.2 Anchor-nav literal bump (the web-guard gate) — ⬜
+### 2.2 Anchor-nav literal bump (the web-guard gate) — ✅
 - **`apps/web/tests/attendance-admin-anchor-nav.spec.ts`:**
   - Line **127**: `expect(labels).toHaveLength(29)` → `30`.
   - Line **832**: `expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(29)` → `30`.
   - Add `'Annual leave operations'` to the line-130 `arrayContaining([...])` list (optional but recommended — proves the new label renders).
   - **Leave line-126 `groupLabels` `toEqual([...6 groups...])` untouched.**
 
-### 2.3 Section shell in the SFC — ⬜
+### 2.3 Section shell in the SFC — ✅
 - **`apps/web/src/views/AttendanceView.vue`**, insert a new `<section v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.annualLeaveOperations)" class="attendance__admin-section" v-bind="adminSectionBinding(...)">` immediately after the `annualLeavePolicy` section (ends ~line 6230). One `<h4>{{ tr('Annual leave operations', '年假操作') }}</h4>` header, then the three cards stacked.
 
-### 2.4 Shared confirm panel (in-DOM, NOT `window.confirm`) — ⬜
+### 2.4 Shared confirm panel (in-DOM, NOT `window.confirm`) — ✅
 - One reactive `annualOpsConfirm` ref: `{ open: boolean; card: 'adjust'|'backfill'|'accrual'; title: string; lines: Array<{label,value}>; extraConfirmRequired?: boolean; onConfirm: () => void }`.
 - Template: an in-DOM `role="dialog"` panel (mirror the line-4545 pattern) with a **restatement table** built from `lines` (target user / period / delta / `dryRun=false` / and, for accrual+backfill, the dry-run counts just seen — 拍板 dimension 2). Buttons: 取消 / 确认提交. Accrual off-year (拍板 C) adds a second explicit checkbox/confirm gated by `extraConfirmRequired`.
 - Helper `openAnnualOpsConfirm(payload)` / `closeAnnualOpsConfirm()`. **Stable selector** `[data-annual-ops-confirm]` for tests.
 
-### 2.5 Shared result panels — TWO shapes, NOT one — ⬜
+### 2.5 Shared result panels — TWO shapes, NOT one — ✅
 - **`renderReasonTable(map: Record<string,number>)`** — a `code → count` `<table>` fragment. Used by **backfill (`reasons`)** and **accrual (`skipReasons`)** ONLY. Renders unexpected keys gracefully (iterate `Object.entries`).
 - **Manual-adjust result is a DIFFERENT shape**: before/after numbers + `applied` / `alreadyApplied` badges + the returned adjustment **`id`**; **no reasons table**. Do not route it through `renderReasonTable`.
 - **Provenance IDs (design-lock §5 — traceability):** each result panel surfaces the returned identifier(s) so an action is auditable from the UI — manual-adjust's **`id`**, accrual's **`runId` + `periodKey`**, backfill's **`scanned/updated/skipped`** audit — rendered alongside the counts/badges, not hidden.
 - Stable selectors `[data-annual-ops-result-<card>]`.
 
-### 2.6 Shared failure-code mapper — ⬜
+### 2.6 Shared failure-code mapper — ✅
 - `annualOpsErrorLine(code: string, card): string` returning a `tr(en,zh)` human line. Shared function, **per-card code sets** (§3 lists). Accrual's map **must carry a default/fallback line** for the `UNKNOWN` skip bucket and any unlisted code — do NOT hardcode only the seven reason codes.
 - On `apiFetch` reject, read `error.code` (the routes return `{ ok:false, error:{ code, message } }`); render `annualOpsErrorLine(code)`, falling back to the raw code + message if unmapped.
 
-### 2.7 policy.enabled proactive gating (§6) — ⬜
+### 2.7 policy.enabled proactive gating (§6) — ✅
 - Computed `annualOpsPolicyEnabled = computed(() => annualPolicyForm.enabled === true)` (hydrated on first screen via `loadSettings → applyAnnualPolicyToForm`).
 - When `false`: **disable all three cards' commit buttons** + show an informational hint linking to the L5b Policy block (`#attendance-admin-annual-leave-policy`).
 - **Asymmetry to keep explicit:** the disable is **load-bearing for accrual** (backend hard-422s `ANNUAL_LEAVE_NOT_ENABLED`) but **UX-consistency-only for adjust/backfill** (backend stays callable). The hint is informational, not a hard client block layered on top of the server contract.
@@ -94,7 +94,7 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 
 > Each card = (state refs) + (handlers) + (template) + (regression test). Concrete `file:symbol` targets below. All POSTs via `apiFetch`. SFC hazards (§4) apply to every numeric input.
 
-### 3.1 Card 1 — Manual adjustment (client-preview) — ⬜
+### 3.1 Card 1 — Manual adjustment (client-preview) — ✅
 
 **Endpoint:** `POST /api/attendance/annual-leave-manual-adjustment`, body `{ userId, deltaMinutes:int32 nonzero, reason:1-500, idempotencyKey?:1-200, runId?:uuid }` → `{ id, delta, applied, alreadyApplied }`.
 
@@ -127,7 +127,7 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 - (e) disabled when `annualPolicyForm.enabled=false` (mock first-screen settings with `annualLeavePolicy.enabled:false`).
 - **Assert the request by type/URL match, never by call index** (§4 flake rule).
 
-### 3.2 Card 2 — Expiry backfill (server dry-run) — ⬜
+### 3.2 Card 2 — Expiry backfill (server dry-run) — ✅
 
 **Endpoint:** `POST /api/attendance/annual-leave-expiry-backfill`, body `{ dryRun?:bool }` (card sends only `dryRun`; `getOrgId` resolves org) → `{ scanned, updated, skipped, dryRun, reasons }` where `reasons` is an **object/map**.
 
@@ -152,7 +152,7 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 - (c) reasons-as-map: assert the result reads the map (not an array) — guards the flatten bug.
 - (d) disabled-when-policy-off.
 
-### 3.3 Card 3 — Accrual run (server dry-run + period guardrail) — ⬜
+### 3.3 Card 3 — Accrual run (server dry-run + period guardrail) — ✅
 
 **Endpoint:** `POST /api/attendance/annual-leave-accrual/run`, body `{ period:int 2000-2100, asOf?:'YYYY-MM-DD', dryRun?:bool }` → `{ runId, periodKey, asOf, dryRun, granted, skipped, grantedMinutes, lotsCreated, alreadyGranted, skipReasons }` (`skipReasons` an **object/map**).
 
@@ -181,7 +181,7 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 
 ---
 
-## 4. Cross-cutting engineering — ⬜
+## 4. Cross-cutting engineering — ✅
 
 - **Typecheck:** run `pnpm -C apps/web exec vue-tsc -b` (project-references build). **NOT `vue-tsc --noEmit`** — that false-greens cross-file union/ref errors (burned on a prior condition_branch FE union miss).
 - **Local vitest, NOT CI roulette:** debug in the worktree — `pnpm install` (warm store ≈3s) then `pnpm -C apps/web exec vitest run -t '<test name>'` and `vitest run apps/web/tests/attendance-admin-regressions.spec.ts apps/web/tests/attendance-admin-anchor-nav.spec.ts`. A 26k-line SFC test must be iterated locally, not by pushing and watching CI.
@@ -193,21 +193,21 @@ All inside one new section **年假操作 / Annual leave operations**, the 30th 
 
 ---
 
-## 5. Review loop — ⬜ (per-card, gated)
+## 5. Review loop — ✅ (per-card, gated)
 
 Per the L0–L4 precedent, **happy-path adversarial passes miss codebase-fit and RBAC issues** — the review must hunt those specifically, not just "does the button click."
 
-- **🔒 → ⬜ Adversarial sub-agent review, per card** (after each card is locally green; do not batch all three blind):
+- **🔒 → ✅ Adversarial sub-agent review, per card** (after each card is locally green; do not batch all three blind):
   - **Flatten check:** does the result panel route manual-adjust through the reasons-table? (must NOT). Does any card label a client preview as a "dry-run"? (must NOT for manual-adjust).
   - **RBAC / codebase-fit:** is every commit behind `adminForbidden` + the policy-enabled gate? Does the section use `shouldShowAdminSection`/`adminSectionBinding` (not a bespoke `v-if`)? Does `getOrgId` resolution stay server-side (card sends no `orgId`)?
   - **Failure-surface completeness:** every §3 code mapped; accrual fallback line present; `409`/`422`/`404` distinguished (not collapsed to "failed").
   - **Idempotency legibility:** `alreadyApplied` / `alreadyGranted` / `ALREADY_SET` each rendered as a no-op, not a zero-change blank.
   - **Test honesty:** assertions on real wire (body fields), by-type not by-index; not a vacuous mount.
-- **⬜ Owner-review-fix rounds:** fold owner comments per card; re-run local vitest + `vue-tsc -b` after each round. Do not declare a card done until its regression test + the anchor-nav guard are green locally.
+- **✅ Owner-review-fix rounds:** fold owner comments per card; re-run local vitest + `vue-tsc -b` after each round. Do not declare a card done until its regression test + the anchor-nav guard are green locally.
 
 ---
 
-## 6. L5c dev + verification closeout MD — ⬜ (final L5c deliverable, AFTER the build)
+## 6. L5c dev + verification closeout MD — ✅ (final L5c deliverable, AFTER the build)
 
 After all three cards land and CI is green, write an **L5c development + verification closeout** `docs/development/attendance-annual-leave-admin-operations-dev-verification-<date>.md` recording: the per-card 口径 as built, the exact state refs/handlers/selectors shipped, the local-vitest + `vue-tsc -b` evidence, the anchor-nav 29→30 diff, notes of each card's preview→confirm→result flow, and an explicit **L6-readiness handoff** (what the staging smoke can now drive). **Scope note:** this is the **L5c slice** closeout, **not** the whole annual-leave engine's final capstone — the engine track (§0.4) only flips to ✅ after the **L6 staging smoke** passes. This MD is described here but is **NOT produced by this planning step** — it is the closing checklist item of the build.
 
@@ -254,41 +254,41 @@ After all three cards land and CI is green, write an **L5c development + verific
 ## 10. Consolidated TODO-checklist
 
 **Shared scaffold (FIRST)**
-- ⬜ S1 — rail: add `annualLeaveOperations` to `ATTENDANCE_ADMIN_SECTION_IDS` + nav label + append to existing `annual-leave` group `itemIds` (no new group)
-- ⬜ S2 — anchor-nav spec: bump line 127 `toHaveLength(29)→30` AND line 832 `toBe(29)→30`; add label to `arrayContaining`; leave `groupLabels` `toEqual` untouched
-- ⬜ S3 — SFC section shell after `annualLeavePolicy` (`shouldShowAdminSection`/`adminSectionBinding`/`.attendance__admin-section`, `tr` header)
-- ⬜ S4 — shared in-DOM confirm panel (`role="dialog"`, restatement table, off-year extra-confirm slot, `[data-annual-ops-confirm]`) — NOT `window.confirm`
-- ⬜ S5 — TWO result shapes: `renderReasonTable(map)` (backfill+accrual only) + manual-adjust before/after+applied/alreadyApplied panel
-- ⬜ S6 — `annualOpsErrorLine(code,card)` shared mapper, per-card code sets, accrual default/fallback line
-- ⬜ S7 — `annualOpsPolicyEnabled` proactive gate (hydrated via `loadSettings→applyAnnualPolicyToForm`); load-bearing for accrual, UX-only hint for adjust/backfill
+- ✅ S1 — rail: add `annualLeaveOperations` to `ATTENDANCE_ADMIN_SECTION_IDS` + nav label + append to existing `annual-leave` group `itemIds` (no new group)
+- ✅ S2 — anchor-nav spec: bump line 127 `toHaveLength(29)→30` AND line 832 `toBe(29)→30`; add label to `arrayContaining`; leave `groupLabels` `toEqual` untouched
+- ✅ S3 — SFC section shell after `annualLeavePolicy` (`shouldShowAdminSection`/`adminSectionBinding`/`.attendance__admin-section`, `tr` header)
+- ✅ S4 — shared in-DOM confirm panel (`role="dialog"`, restatement table, off-year extra-confirm slot, `[data-annual-ops-confirm]`) — NOT `window.confirm`
+- ✅ S5 — TWO result shapes: `renderReasonTable(map)` (backfill+accrual only) + manual-adjust before/after+applied/alreadyApplied panel
+- ✅ S6 — `annualOpsErrorLine(code,card)` shared mapper, per-card code sets, accrual default/fallback line
+- ✅ S7 — `annualOpsPolicyEnabled` proactive gate (hydrated via `loadSettings→applyAnnualPolicyToForm`); load-bearing for accrual, UX-only hint for adjust/backfill
 
 **Card 1 — manual adjustment (client preview)**
-- ⬜ C1.1 — state refs + client-preview computed off L5a balance read
-- ⬜ C1.2 — preview/request/submit handlers; idempotencyKey surfacing; 422-final note
-- ⬜ C1.3 — template + 6 failure codes (runId/RUN_NOT_FOUND scoped out of v1) + alreadyApplied/409 wording + surface returned adjustment `id`
-- ⬜ C1.4 — regression tests (commit / replay / insufficient / 409 / disabled), assert-by-type
+- ✅ C1.1 — state refs + client-preview computed off L5a balance read
+- ✅ C1.2 — preview/request/submit handlers; idempotencyKey surfacing; 422-final note
+- ✅ C1.3 — template + 6 failure codes (runId/RUN_NOT_FOUND scoped out of v1) + alreadyApplied/409 wording + surface returned adjustment `id`
+- ✅ C1.4 — regression tests (commit / replay / insufficient / 409 / disabled), assert-by-type
 
 **Card 2 — expiry backfill (server dry-run)**
-- ⬜ C2.1 — state refs; dry-run-default + commit handlers
-- ⬜ C2.2 — reasons code→count table; ALREADY_SET-as-no-op framing
-- ⬜ C2.3 — regression tests (dry-run table / commit dryRun:false / reasons-as-map / disabled)
+- ✅ C2.1 — state refs; dry-run-default + commit handlers
+- ✅ C2.2 — reasons code→count table; ALREADY_SET-as-no-op framing
+- ✅ C2.3 — regression tests (dry-run table / commit dryRun:false / reasons-as-map / disabled)
 
 **Card 3 — accrual run (server dry-run + guardrail)**
-- ⬜ C3.1 — state refs incl off-year computed; dry-run + commit handlers
-- ⬜ C3.2 — period soft-warn + extra confirm (拍板 C, no hard block); alreadyGranted surface + link to Card 1
-- ⬜ C3.3 — skipReasons table incl UNKNOWN fallback; `ANNUAL_LEAVE_NOT_ENABLED` gate
-- ⬜ C3.4 — regression tests (dry-run+UNKNOWN row / commit / off-year extra-confirm / not-enabled)
+- ✅ C3.1 — state refs incl off-year computed; dry-run + commit handlers
+- ✅ C3.2 — period soft-warn + extra confirm (拍板 C, no hard block); alreadyGranted surface + link to Card 1
+- ✅ C3.3 — skipReasons table incl UNKNOWN fallback; `ANNUAL_LEAVE_NOT_ENABLED` gate
+- ✅ C3.4 — regression tests (dry-run+UNKNOWN row / commit / off-year extra-confirm / not-enabled)
 
 **Cross-cutting**
-- ⬜ X1 — `vue-tsc -b` green (not `--noEmit`)
-- ⬜ X2 — local vitest green: regressions + anchor-nav specs
-- ⬜ X3 — attendance-web-guard green; SFC hazards (numeric coercion, assert-by-type) hardened
-- ⬜ X4 — attendance-web-guard green on Node 20.x (the single pinned version); path-filter check (apps/web-only)
+- ✅ X1 — `vue-tsc -b` green (not `--noEmit`)
+- ✅ X2 — local vitest green: regressions + anchor-nav specs
+- ✅ X3 — attendance-web-guard green; SFC hazards (numeric coercion, assert-by-type) hardened
+- ✅ X4 — attendance-web-guard green on Node 20.x (the single pinned version); path-filter check (apps/web-only)
 
 **Review + close**
 - 🔒 R1 — adversarial sub-agent review per card (flatten / RBAC / failure-surface / idempotency-legibility / test-honesty) — gated on each card local-green
-- ⬜ R2 — owner-review-fix rounds folded, re-verified
-- ⬜ M1 — L5c dev+verification CLOSEOUT MD (built 口径 + evidence + L6-readiness handoff; NOT the whole-engine capstone — engine ✅ awaits L6)
+- ✅ R2 — owner-review-fix rounds folded, re-verified
+- ✅ M1 — L5c dev+verification CLOSEOUT MD (built 口径 + evidence + L6-readiness handoff; NOT the whole-engine capstone — engine ✅ awaits L6)
 
 **Dependencies**
 - ✅ G0 — upstream unblocked (design-lock merged, L5a/L5b on main, endpoints verified)

--- a/docs/development/attendance-annual-leave-balance-engine-design-lock-20260615.md
+++ b/docs/development/attendance-annual-leave-balance-engine-design-lock-20260615.md
@@ -1,6 +1,6 @@
 # 年假 / 法定假余额引擎 — 设计锁（design-lock）
 
-> **状态**：design-lock（owner 决策 2026-06-15 锁定）；**实现 gated**，子链 L0–L6 各自独立 opt-in，未开工。
+> **状态**：design-lock（owner 决策 2026-06-15 锁定）；**实现 L0–L5c 已全部 BUILT + MERGED 落 `origin/main`**（L0 #2627 · L1 #2633 · L2 #2638/#2678/#2687 · L3 #2713 · L4 #2717/#2718 · L5a/b/c #2779/#2782/#2830，L0–L4 capstone #2753）；**仅 L6 staging smoke 为 owner-run gate，尚未跑**。子链「各自独立 opt-in」纪律保留为历史。
 > **口径**：本文写 MetaSheet 自有设计口径；默认法定阶梯 preset 校准自**《职工带薪年休假条例》+《企业职工带薪年休假实施办法》**（法规来源，非竞品对标）。不引用任何竞品产品。
 > **基线**：代码实测 @ `origin/main`（plugin `index.cjs` 37.4k 行 + `packages/core-backend/src/services/AttendanceExpiryService.ts`/`AttendanceScheduler.ts`）。
 > **谱系**：复用 ④ 加班调休假期闭环建成的 leave-balance ledger（#2231）+ FIFO 扣减（#2261/C3）+ leader-elected `AttendanceScheduler` 过期基座（#2270/#2274/C4）。**这是该梯子的"下一主线"**（refresh 审计 v2 #2617 §2 档 A #1）。

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -112,12 +112,12 @@
 
 | 顺序 | 项 | 当前状态 | 完成口径 |
 |---|---|---|---|
-| L0 | latent config + `deductLeaveBalance` 抽取 | ⬜ | `annualLeavePolicy` 默认全关 + 抽参数化 deduct helper（`deductionBasis`），**comp_time C3 真 DB 逐字节不变** |
-| L1 | expiry `source_type` 泛化 | ⬜ | 按 `leave_type_code` 派生（`annual_leave_expiry`），**`comp_time_expiry` 不回归**（重跑 C4） |
-| L2 | accrual snapshot 引擎 + run provenance + manual adjustment | ⬜ | eligibility gate（连续满 12 个月，否则 `NOT_ELIGIBLE_UNDER_ONE_YEAR`）+ 累计工龄阶梯 + 满足条件新进员工首年折算 + `attendance_leave_accrual_runs(_run_items id PK)` + 缺工龄字段/时区 skip 可见 + **手工调整动 lot 非 event-only** |
-| L3 | 年假审批扣减 | ⬜ | final approval gated `annual` → `deductLeaveBalance(standard_day)`，不足 block 不预支 |
-| L4 | 结转 / 年末过期 | ⬜ | org 时区年末 `expires_at` + `annual_leave_expiry`，重复 tick 不重复 |
-| L5 | admin UI | ⬜ | 余额 / policy 配置 / 手工调整 / skip reasons |
+| L0 | latent config + `deductLeaveBalance` 抽取 | ✅ #2627 | `annualLeavePolicy` 默认全关 + 抽参数化 deduct helper（`deductionBasis`），**comp_time C3 真 DB 逐字节不变** |
+| L1 | expiry `source_type` 泛化 | ✅ #2633 | 按 `leave_type_code` 派生（`annual_leave_expiry`），**`comp_time_expiry` 不回归**（重跑 C4） |
+| L2 | accrual snapshot 引擎 + run provenance + manual adjustment | ✅ #2638/#2678/#2687 | eligibility gate（连续满 12 个月，否则 `NOT_ELIGIBLE_UNDER_ONE_YEAR`）+ 累计工龄阶梯 + 满足条件新进员工首年折算 + `attendance_leave_accrual_runs(_run_items id PK)` + 缺工龄字段/时区 skip 可见 + **手工调整动 lot 非 event-only** |
+| L3 | 年假审批扣减 | ✅ #2713 | final approval gated `annual` → `deductLeaveBalance(standard_day)`，不足 block 不预支 |
+| L4 | 结转 / 年末过期 | ✅ #2717/#2718 | org 时区年末 `expires_at` + `annual_leave_expiry`，重复 tick 不重复 |
+| L5 | admin UI | ✅ #2779/#2782/#2830 | 余额 / policy 配置 / 手工调整 / skip reasons |
 | L6 | staging smoke | ⬜ | 端到端 + residue=0 |
 
 ### Out of this target

--- a/docs/development/development-completion-plan-and-verification-20260618.md
+++ b/docs/development/development-completion-plan-and-verification-20260618.md
@@ -6,7 +6,7 @@
 
 ## 0. 一页结论 (headline)
 
-**所有"显式已授权"的开发都已完成并在 `origin/main` 实测验收闭合;没有可自主开工的已授权剩余开发。** "请并行开发...完成所有开发" 的诚实解析:唯一带 **"⬜ UNBLOCKED — build authorized"** 标记的刀(annual-leave **L5c**)早已由 **#2830** 落地并自带 dev-verification MD;其余每一项都是 **gated**(各自独立 owner opt-in + 具名 design 决策),通用的 "完成所有开发" **不构成**打开这些 gate 的授权(这正是 §6 "每 slice 独立 opt-in" 纪律,违反它在 #2831/#2177 烧过工)。
+**本轮深度验证的四条 track(多维表 · 数据库/系统对接 · 考勤 H2 · 考勤年假引擎)上,所有"显式已授权"的开发都已完成并在 `origin/main` 实测验收闭合;没有可自主开工的已授权剩余开发。** 另:对仓库内全部 plan/TODO MD 做了 authorization-marker(`UNBLOCKED`/`build authorized`/`可建`/`授权`)grep 普查,未发现任何其它带显式"可建"标记的刀 —— 但 approval/PLM/workflow 等 track 仅做此 marker 普查,**未逐一深度验证其完成度**(本 MD 的 COMPLETE 断言只覆盖上述四条 track)。"请并行开发...完成所有开发" 的诚实解析:唯一带 **"⬜ UNBLOCKED — build authorized"** 标记的刀(annual-leave **L5c**)早已由 **#2830** 落地并自带 dev-verification MD;其余每一项都是 **gated**(各自独立 owner opt-in + 具名 design 决策),通用的 "完成所有开发" **不构成**打开这些 gate 的授权(这正是 §6 "每 slice 独立 opt-in" 纪律,违反它在 #2831/#2177 烧过工)。
 
 因此本轮交付 = **验证 + 计划 MD + 两类 ledger hygiene**:(a) 回填三份 stale ledger(把已落地却仍标 ⬜ 的 checkbox 改成 ✅);(b) 本 MD 逐 track 列出 **已完成(带证据锚点)** 与 **gated 剩余(带每项所需的具名 opt-in/决策)**,让 owner 一次性挑选下一批授权。**未自主打开任何 gated arc。**
 

--- a/docs/development/development-completion-plan-and-verification-20260618.md
+++ b/docs/development/development-completion-plan-and-verification-20260618.md
@@ -1,0 +1,86 @@
+# 开发完成度 — 计划与验证汇总(2026-06-18)
+
+> Status: **VERIFICATION + PLAN** for the `/goal` "请并行开发,根据计划及 TODO MD 完成所有开发,完成后给出计划及验证 MD".
+> Grounding: `origin/main @ 060d72635` (live-main, 2026-06-18). Every claim below was verified **against `origin/main` by live code/PR ancestry, not by checkbox** (stale-marker traps recur in this repo — see §5).
+> Method: **parallel read-only verification** — three concurrent agents (data-source/integration · attendance annual-leave engine · attendance H2 benchmark) cross-checked against the author's own exhaustive multitable verification this session. Each cited squash SHA was tested with `git merge-base --is-ancestor`; on-main symbols confirmed via `git show`/`git grep`.
+
+## 0. 一页结论 (headline)
+
+**所有"显式已授权"的开发都已完成并在 `origin/main` 实测验收闭合;没有可自主开工的已授权剩余开发。** "请并行开发...完成所有开发" 的诚实解析:唯一带 **"⬜ UNBLOCKED — build authorized"** 标记的刀(annual-leave **L5c**)早已由 **#2830** 落地并自带 dev-verification MD;其余每一项都是 **gated**(各自独立 owner opt-in + 具名 design 决策),通用的 "完成所有开发" **不构成**打开这些 gate 的授权(这正是 §6 "每 slice 独立 opt-in" 纪律,违反它在 #2831/#2177 烧过工)。
+
+因此本轮交付 = **验证 + 计划 MD + 两类 ledger hygiene**:(a) 回填三份 stale ledger(把已落地却仍标 ⬜ 的 checkbox 改成 ✅);(b) 本 MD 逐 track 列出 **已完成(带证据锚点)** 与 **gated 剩余(带每项所需的具名 opt-in/决策)**,让 owner 一次性挑选下一批授权。**未自主打开任何 gated arc。**
+
+> ⚠️ Live note:主干在本轮进行中仍在快速移动 — **S1b-1(#2887)** 在验证期间刚落 `origin/main`,说明 S1b altitude 问题已由 owner 签字、一条并行 effort 正在执行 S1b。S1b 因此从 "design-locked, impl gated" 进入 "**impl in-progress(并行 effort 拥有)**";本会话不触碰它(全系统风险最高写路径)。
+
+## 1. 状态阶梯 — 四条 track 总览
+
+| Track | 已完成 (on main) | gated 剩余 | 权威 ledger |
+|---|---|---|---|
+| **多维表 (multitable)** | 2a 全标量 CRDT · 2b 条件读权限 S1–S4 · 2c 人员目录 S2–S4 · #18 行级读拒 | roadmap pool(导出/required-if/仪表盘联动/网格虚拟化 reopen-only/AI rings/原生同步表/FOL 深链/A6 余项) | `multitable-gated-remainder-development-plan/todo-20260618.md` |
+| **数据库/系统对接 (data-source)** | C2–C6 · Release · S1a(合同层) | **S1b(impl 进行中 #2887)** · S2 · S3 · S4 · S5 · 首笔生产外部写 | `data-source-system-integration-plan-and-verification-20260618.md` |
+| **考勤 H2 (attendance core)** | 一天多班次 · 排班发布/草稿 · 临时班次 · 加班三段 · 自动对班 A2 · C5 通知 · **排班合规引擎(block-on-save runtime)** · **打卡策略组** | §1 OUT 红线(算薪/防作弊/AI/人脸/原生 app/插件市场,🚫) · H3 高级(调度/换班/多门店,gated;3a 可建) | `attendance-dingtalk-benchmark-target-and-tracker-20260601.md` |
+| **考勤年假引擎 (annual-leave)** | 引擎 L0–L5c(含 L5a/b/c admin)+ 员工自助 surfaces | **L6 staging smoke(owner-run gate,非自主构建)** | `attendance-annual-leave-admin-operations-dev-plan-20260617.md` |
+
+## 2. 已完成 — 逐 track 证据 (COMPLETE, evidence-anchored)
+
+### 2.1 多维表 (multitable) — 全部完成
+- **2a 实时标量 CRDT(全标量集)**:select/date **#2832**、duration **#2838**、dateTime **#2849**(canonical-UTC-ISO 不变量);number/currency/percent/boolean/rating/multiSelect 此前已落。无标量类型仍是 REST-only。
+- **2b #18 条件读权限规则 S1–S4**:evaluator **#2836** · enforcement(接入 #18 seam,flag-off inert)**#2841** · authoring UI/API **#2847** · content-keyed parse cache(staleness-free)**#2861**。
+- **2c 人员字段 → 组织成员目录 S2–S4**:source = B 设计锁 **#2860** · resolver **#2866** · `canEditRecord`-gated directory endpoint **#2867** · `MetaPersonPicker` 接线 **#2869** · S4 inactive/historical 显示线索(read-only cell/summary cue)**#2874**;fail-closed 写校验 **#2833 + #2854**。
+- **closeout/ledger 一致性**:**#2878**(2c COMPLETE closeout)· **#2881**(P1/P2/P3 reconciliation + #2877 carve-out)· **#2883**(grounding-line 2c)· **#2885**(`MetaPersonPicker` 注释对齐)。**#2877**(2c-S4 picker-chip)= **CLOSED not-landed**(S4 口径由 #2874 cell/summary cue 满足;picker chip 为不同 surface 的补充打磨,非正确性缺口)。
+
+### 2.2 数据库/系统对接 (data-source) — C2–C6 + Release + S1a 完成
+- **C2** 只读 SQL 源 — #2600;**C3** 增量/watermark — #2609/#2619/#2625/#2628/#2631;**C4** UI/配置 — #2643/#2646/#2649/#2652/#2655;**C5** K3 generic MSSQL seam — #2670 PASS + #2700 runbook(K3 红线 `SQLSERVER_WRITE_EXECUTOR_DISABLED` 保留);**C6** 外部写 sandbox 链路 — #2719/#2720/#2761/#2820(实体机 controlled bad-row PASS,values-free dead-letter/provenance)。
+- **Release** 总包 scoped 验收 — #2769 PASS,package `79ab455e`。
+- **S1a** 可选写能力合同层 — #2872 + opaque-keyHash #2876 + values-free 加固 #2882(`contracts.cjs` 含 `revisionHash`/`valuesFreeMetadata`/`assertErrorCode`/`CODE_PATTERN`;`REQUIRED_ADAPTER_METHODS` 5 法未变;零 runtime 消费者)。
+- 设计文档:S1b keystone design-lock + 本汇总 plan/verification — docs-only #2884。
+
+### 2.3 考勤 H2 (attendance core) — 全部 MUST/SHOULD/OPTIONAL 完成(含此前误判为 gated 的两项)
+- **一天多班次** M0–M5 — #2426/#2427/#2428/#2429/#2445/#2446(staging `multi-shift-m5-*`)。
+- **排班发布/草稿** — #2430→#2436(`ATTENDANCE_SCHEDULE_PUBLISH_STATUSES = {draft,pending,published}`;staging `publish-p4-*`)。
+- **临时班次** — #2437→#2443(`assignment_kind='temporary'` replace-only overlay;staging `temp-shift-t6-*`)。
+- **加班三段引擎** O1–O6 — design-lock + O1–O6(`overtimeSegmentation`;staging `overtime-o6-*`)。
+- **自动对班 A2 自动写入** — A2-1/A2-2 runtime + A2-3 admin UI #2471(staging 35/35 `autoshift-a2-smoke-*`);grey-gate **已满足**(双 env flag + 三 org 条件),非待办。
+- **C5 外发通知 / fan-out** — #2487→#2498→#2502→#2504→#2507→#2515(真实 DingTalk staging 27/27 `c5-delivery-*`)。
+- **排班合规引擎(block-on-save)** — **runtime 已建,非 design-lock-only**:`enforceShiftComplianceCap` → 422 `SHIFT_COMPLIANCE_CAP_EXCEEDED`,日/周/月三粒度 × 全 save 路径事务内投影;链 #2213→#2214→#2218→#2221(staging 13/13);#2242 是其上的 settings 卡。默认 `enforcement` off(config 默认,非未建)。
+- **打卡策略组** — 已建:`punchPolicy.{merge, outdoor, unscheduled}`;链 #2204→#2209→#2304/#2308→#2329/#2333/#2336/#2344。
+
+### 2.4 考勤年假引擎 (annual-leave) — L0–L5c 完成,仅 L6 owner-run 剩余
+- **L0** latent config + `deductLeaveBalance` helper — #2627;**L1** expiry `source_type` 泛化(`annual_leave_expiry`)— #2633;**L2** accrual 引擎 + provenance + dry-run + manual adjust — #2638/#2678/#2687(`NOT_ELIGIBLE_UNDER_ONE_YEAR` gate · `attendance_leave_accrual_runs` provenance);**L3** 审批扣减 — #2713;**L4** 结转/年末过期 — #2717/#2718;**L0–L4 capstone** — #2753。
+- **L5a** admin 余额/台账读 — #2779;**L5b** policy 配置 UI — #2782;**L5c** admin 操作 UI(手工调整/回填/计提,in-DOM 两步确认 + 失败码 + policy-off 全禁用)— design #2795 / impl **#2830** / policy-off fix #2834 / closeout #2835/#2844;自带 dev-verification MD。
+- 员工自助(超出 L0–L6 范围的 bonus,已落)— /me 余额读 #2850 + overview 卡 #2853。
+
+## 3. Gated 剩余 — 每项所需 owner opt-in / 决策 (next-batch menu)
+
+> 以下 **均不可自主开工**;每项需 owner 显式 opt-in + 列出的具名决策。本会话不打开任何一项。
+
+### 3.1 数据库/系统对接
+- **S1b(自有 multitable target 走泛化安全写,keystone)** — **impl 进行中(#2887 S1b-1 已落,并行 effort 拥有)**。altitude 问题(`targetWriteLifecycle.lookup/apply` = planner 内部数据通路 vs 证据投影)已由 owner 倾向 A(双接口拆分)签字;S1b-2/S1b-3 续接。**本会话不触碰**(最高风险写路径,已有并行 lander)。
+- **S2(K3 WebAPI target 走同一安全写)** — opt-in + 实体机 smoke(operator 执行);红线保留;仅 sandbox。当前 K3 WebAPI 仅 read-only smoke,未接入 C6 写。
+- **S3(first-class `integration-template` 对象)** — opt-in;K3/PLM 各出一个参考模版。
+- **S4(adapter 自描述元数据)** — opt-in;替换 `ADAPTER_METADATA` 静态字面量(现仍为静态 literal)。
+- **S5(统一 field-mapping + PLM stock-prep 吸收)** — opt-in(低优先,短期不重写专用链路)。
+- **首笔生产外部写** — owner 授权;序列 = 多样本只读 dry-run → sandbox apply → re-pull 幂等+人工字段保留 → 生产。
+
+### 3.2 考勤
+- **年假 L6 staging smoke** — **owner-run gate(非自主构建)**:需 staging-realm `attendance:admin` JWT(prod token 在 staging 401)+ 一次性单成员 org,经 UI 驱动三个 L5c endpoint + L1 年末 reaper(`AttendanceExpiryService`),断言 residue=0。跑通后年假引擎 §0.4 总目标方翻 ✅。
+- **H3 钉钉级高级**(调度/换班/多门店/设备围栏/人脸/算薪)— gated,不一口吞;**3a 可建**(多门店挂部门,约 1–2 周)单点 opt-in;3b 不自研。
+- **§1 OUT 红线**(算薪 SaaS/防作弊/AI/人脸/原生 app/插件市场)— 🚫 明确不做。
+
+### 3.3 多维表 roadmap pool(reopen-only / 未来候选)
+服务端全量导出 · 表单 `required-if` · 仪表盘联动筛选/下钻 · 仪表盘缺失日期桶/系列数上限 · **网格虚拟化(D2 verdict 判定不需要,reopen-only)** · AI rings 进阶 · 原生同步/外源表 · FOL 深链(多跳/公式套公式/物化/Yjs 重算/automation 触发)· automation A6 余项。各为独立 gated opt-in。
+
+## 4. 本轮 ledger hygiene(已做,非 gated)
+
+把"已落地却仍标 ⬜"的 stale checkbox 回填为 ✅,防止下个会话把已发货的工作误读为未开工(#2831 浪费的根因):
+- **`attendance-annual-leave-admin-operations-dev-plan-20260617.md`** — Status 行翻 ✅ BUILT+MERGED(#2830/#2834/#2835/#2844)+ 39 个 build-step ⬜ → ✅;唯一保留的 🔒 是 L6 owner-run gate(§7/G1)。
+- **`attendance-dingtalk-benchmark-target-and-tracker-20260601.md` §0.4** — L0–L5 行 ⬜ → ✅(带 PR 锚点);**L6 行保持 ⬜(正确 — owner-run staging gate 未跑,不可翻)**。
+- **`attendance-annual-leave-balance-engine-design-lock-20260615.md`** — 状态行从 "实现 gated…未开工" 改为 "L0–L5c 已 BUILT+MERGED;仅 L6 owner-run 剩余"。
+
+## 5. 本轮经验 (lessons)
+- **验证按代码、不按 checkbox。** 一个并行 agent 因信任 §0.4 的 stale ⬜,误报年假引擎 "runtime unbuilt";按 `origin/main` 实测纠正为 L0–L5c 已建。账本 marker 滞后于 main 是本仓库的常态陷阱。
+- **"完成所有开发" ≠ 打开 gated arc。** 唯一带显式授权标记的刀(L5c)早已发货;通用 goal 不授权打开 S1b/S2–S5/H3/年假 L-series 重开等 gated 项。诚实路径 = 验证 + 计划 + opt-in 菜单,而非制造并行去开 gate。
+- **主干快速移动 + 并行 lander。** 验证期间 #2887(S1b-1)落地,说明 S1b 已被并行 effort 开工;交付前以最新 `origin/main` 重新校准,避免把旧快照当最终树。
+
+## 6. 结论 + 建议
+**所有已授权开发已建、已验、在 `origin/main`。** 四条 track 的主体链路全部闭合(多维表 2a/2b/2c + closeout;data-source C2–C6/Release/S1a;考勤 H2 全 MUST/SHOULD/OPTIONAL;年假引擎 L0–L5c)。**没有可自主开工的已授权剩余开发** — 剩余项全部 gated,每项需 owner 显式 opt-in + §3 所列具名决策。S1b 已由并行 effort 开工(#2887),本会话不触碰。**建议**:owner 从 §3 菜单挑选下一批授权(最近的自然候选 = 年假 L6 owner-run staging smoke;以及 S1b-2/3 由现有并行 lander 续接)。在拿到具名 opt-in 前,本会话不开任何 gated arc。


### PR DESCRIPTION
## What

Deliverable for `/goal` "请并行开发,根据计划及 TODO MD 完成所有开发,完成后给出计划及验证 MD".

**Finding (verified against `origin/main` by code/PR-ancestry, NOT by checkbox — via 3 parallel read-only verification agents + own multitable verification):** ALL explicitly-authorized development is already complete on `origin/main` across four tracks. The one slice carrying an explicit "⬜ UNBLOCKED — build authorized" marker (annual-leave **L5c**) already shipped via **#2830**. Every remaining item is **gated** per the per-slice opt-in discipline; a generic "complete all development" does not authorize opening them, so **none were opened**.

## Tracks (all authorized work COMPLETE on main)
- **多维表**: 2a/2b/2c + closeout (#2832/#2838/#2849 · #2836/#2841/#2847/#2861 · #2866/#2867/#2869/#2874 · #2878/#2881/#2883/#2885; #2877 CLOSED not-landed)
- **data-source**: C2–C6 · Release (#2769) · S1a (#2872/#2876/#2882)
- **考勤 H2**: all MUST/SHOULD/OPTIONAL incl. shift-compliance block-on-save engine (#2213→#2221) + punch-policy (#2204→#2344) — both were mis-carried as gated; verified built
- **年假引擎**: L0–L5c (#2627/#2633/#2638/#2678/#2687/#2713/#2717/#2718/#2753/#2779/#2782/#2830); **L6 = owner-run staging gate**

## Changes
1. **NEW** `development-completion-plan-and-verification-20260618.md` — per-track COMPLETE (evidence-anchored) + gated remainder (each with the specific owner opt-in/decision it needs) + ledger hygiene + lessons. Notes **S1b-1 (#2887)** landed mid-task (parallel effort now executing S1b — untouched here).
2. **Backfill 3 stale ledgers** (work shipped, checkbox still ⬜):
   - L5c admin-ops dev-plan → BUILT+MERGED; 39 build-step ⬜→✅; L6 🔒 preserved
   - benchmark tracker §0.4 → L0–L5 ⬜→✅ (PR refs); L6 stays ⬜
   - annual-leave engine design-lock status line → built+merged

Docs-only. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)