### PR TITLE
ci(multitable): run the two 2c person-field FE specs in the web-guard gate

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -130,4 +130,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive --reporter=dot


### PR DESCRIPTION
## What

A verification sweep found the two 2c person-field FE specs — `multitable-person-picker.spec.ts` (directory-offered set + display parity, no silent drop of stored values) and `multitable-cell-renderer-person-inactive.spec.ts` (inactive/historical chip cue) — **exist and pass, but run in NO required CI gate**:
- `multitable-web-guard.yml` runs an explicit spec allowlist that excluded both.
- `multitable-browser-verify.yml` is a path-triggered Playwright job that doesn't execute these vitest unit specs.

So the 2c FE behavior had tests that nothing executed on PRs — a real CI gap (the kind that lets a future regression land green). This adds both to the web-guard allowlist.

Both pass locally (7 tests). Pure CI-config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)