### PR TITLE
feat(integration-core): S1b-2 — multitable raw write-source + profile (rides C6 lifecycle, own-sheet only)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
@@ -8,8 +8,25 @@ const {
 } = require(path.join(__dirname, '..', 'lib', 'contracts.cjs'))
 const {
   createMetaSheetMultitableTargetAdapter,
+  createMetaSheetMultitableWriteSource,
+  MULTITABLE_WRITE_PROFILE,
   __internals,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'metasheet-multitable-target-adapter.cjs'))
+const {
+  dryRunExternalWrite,
+  applyExternalWrite,
+} = require(path.join(__dirname, '..', 'lib', 'external-write-dry-run.cjs'))
+
+function memoryStore() {
+  const map = new Map()
+  return {
+    map,
+    async get(key) { return map.get(key) || null },
+    async set(key, value) { map.set(key, JSON.parse(JSON.stringify(value))) },
+    async consume(key) { const v = map.get(key) || null; map.delete(key); return v },
+    async delete(key) { map.delete(key) },
+  }
+}
 
 function createContext({ existing = [], resolveFieldIds } = {}) {
   const rows = [...existing]
@@ -85,6 +102,111 @@ function createSystem(config = {}) {
       ...config,
     },
   }
+}
+
+// S1b-2: the multitable write-source rides the C6 dry-run->apply lifecycle (via the S1b-1
+// seam), writing ONLY to own sheets, idempotent on re-pull, values-free. Non-identity
+// fieldIdMap proves the logical<->physical round-trip.
+async function testMultitableWriteSourceRidesC6Lifecycle() {
+  const fieldIdMap = { code: 'f_code', name: 'f_name', quantity: 'f_qty' }
+  const { context, rows } = createContext({
+    existing: [
+      { id: 'rec_mat_002', sheetId: 'sheet_approved_materials', version: 1, data: { f_code: 'MAT-002', f_name: 'Gadget', f_qty: 5 } },
+    ],
+  })
+  const multitableSystem = createSystem({
+    objects: {
+      approved_materials: {
+        name: 'Approved Materials',
+        sheetId: 'sheet_approved_materials',
+        keyFields: ['code'],
+        fieldDetails: [
+          { id: 'code', name: 'Code', type: 'string' },
+          { id: 'name', name: 'Name', type: 'string' },
+          { id: 'quantity', name: 'Quantity', type: 'number' },
+        ],
+        fieldIdMap,
+      },
+    },
+  })
+  const writeSource = createMetaSheetMultitableWriteSource({ system: multitableSystem, context })
+
+  // capability test reports a REAL own-sheet-scoped safe state (not a rubber stamp)
+  const cap = await writeSource.test('mt', 'owner-1')
+  assert.deepEqual(MULTITABLE_WRITE_PROFILE.normalizeCapabilityState(cap), { success: true, ownSheetTarget: true, externalWrite: false })
+
+  const sourceRows = [
+    { code: 'MAT-001', name: 'Bolt', quantity: 2 },     // new -> add
+    { code: 'MAT-002', name: 'Gadget', quantity: 9 },   // exists with qty 5 -> update
+  ]
+  const baseInput = () => ({
+    pipeline: {
+      id: 'pipe_mt', tenantId: 't1', workspaceId: 'w1',
+      sourceSystemId: 'src', sourceObject: 'items',
+      targetSystemId: multitableSystem.id, targetObject: 'approved_materials',
+      createdBy: 'owner-1',
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'name' },
+        { sourceField: 'quantity', targetField: 'quantity' },
+      ],
+    },
+    sourceSystem: { id: 'src', kind: 'data-source:sql-readonly' },
+    // flat planner target config (what the S1b-3 route derives from the multitable system)
+    targetSystem: {
+      id: multitableSystem.id,
+      kind: 'metasheet:multitable',
+      config: { dataSourceId: 'mt', object: 'approved_materials', keyFields: ['code'], writableFields: ['name', 'quantity'] },
+    },
+    sourceAdapter: { async read() { return { records: sourceRows, done: true, nextCursor: null } } },
+    dataSourceWrites: writeSource,
+    targetWriteProfile: MULTITABLE_WRITE_PROFILE,
+    tokenStore: memoryStore(),
+    dryRunUser: 'owner-1',
+    dataSourceOwnerPrincipal: 'owner-1',
+    maxRows: 100,
+  })
+
+  // Run 1: add + update through the full C6 lifecycle.
+  const input1 = baseInput()
+  const dry1 = await dryRunExternalWrite(input1)
+  assert.equal(dry1.status, 'ready')
+  assert.equal(dry1.canApply, true)
+  assert.equal(dry1.counts.add, 1, 'MAT-001 classified add')
+  assert.equal(dry1.counts.update, 1, 'MAT-002 (qty 5->9) classified update via logical<->physical round-trip')
+  assert.equal(dry1.evidence.targetKind, 'metasheet:multitable', 'evidence carries the multitable kind via the S1b-1 seam')
+  assert.equal(JSON.stringify(dry1.evidence).includes('MAT-001'), false, 'dry-run evidence stays values-free')
+  assert.equal(JSON.stringify(dry1.evidence).includes('Bolt'), false, 'dry-run evidence stays values-free')
+
+  const apply1 = await applyExternalWrite({ ...input1, dryRunToken: dry1.dryRunToken, applyUser: 'owner-1', runId: 'run_mt_1' })
+  assert.equal(apply1.status, 'succeeded')
+  assert.equal(apply1.counts.add, 1)
+  assert.equal(apply1.counts.update, 1)
+  assert.equal(apply1.counts.written, 2)
+  assert.equal(rows.length, 2, 'exactly one new record created on own sheet (MAT-001), MAT-002 patched in place')
+  const created = rows.find((r) => r.data.f_code === 'MAT-001')
+  assert.ok(created && created.sheetId === 'sheet_approved_materials', 'write landed on OWN sheet')
+  assert.deepEqual(created.data, { f_code: 'MAT-001', f_name: 'Bolt', f_qty: 2 }, 'logical->physical map applied on write')
+  const patched = rows.find((r) => r.data.f_code === 'MAT-002')
+  assert.equal(patched.data.f_qty, 9, 'update patched the changed field')
+  assert.equal(JSON.stringify(apply1).includes('MAT-001'), false, 'apply response stays values-free')
+
+  // Run 2 (re-pull): same source, now everything matches -> idempotent skip, no new writes.
+  const input2 = baseInput()
+  const dry2 = await dryRunExternalWrite(input2)
+  assert.equal(dry2.counts.add, 0, 're-pull adds nothing')
+  assert.equal(dry2.counts.update, 0, 're-pull updates nothing')
+  assert.equal(dry2.counts.skip, 2, 're-pull classifies both as skip (idempotent)')
+  const apply2 = await applyExternalWrite({ ...input2, dryRunToken: dry2.dryRunToken, applyUser: 'owner-1', runId: 'run_mt_2' })
+  assert.equal(apply2.counts.written, 0, 're-pull writes nothing')
+  assert.equal(rows.length, 2, 're-pull created no duplicate records')
+
+  // Profile fails closed on an unsafe (non-own-sheet) capability state.
+  assert.throws(
+    () => MULTITABLE_WRITE_PROFILE.assertSafeCapabilityState({ ownSheetTarget: false, externalWrite: true }),
+    /own-sheet scoped/,
+    'unsafe capability state rejected',
+  )
 }
 
 async function main() {
@@ -301,6 +423,8 @@ async function main() {
     fld_sourceSystemId: 'bridge_source_1',
     fld_objectType: 'material',
   })
+
+  await testMultitableWriteSourceRidesC6Lifecycle()
 
   console.log('✓ metasheet-multitable-target-adapter: write-only multitable target tests passed')
 }

--- a/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/metasheet-multitable-target-adapter.test.cjs
@@ -209,6 +209,93 @@ async function testMultitableWriteSourceRidesC6Lifecycle() {
   )
 }
 
+// S1b-2 (review P2): MetaSheet sheets don't enforce key uniqueness, so a DUPLICATE key must
+// surface as ambiguous -> the C6 planner HOLDS (no write), not silently updates one row.
+async function testMultitableAmbiguousKeyHolds() {
+  const fieldIdMap = { code: 'f_code', name: 'f_name', quantity: 'f_qty' }
+  const { context, rows } = createContext({
+    existing: [
+      { id: 'rec_a', sheetId: 'sheet_approved_materials', version: 1, data: { f_code: 'DUP-1', f_name: 'A', f_qty: 1 } },
+      { id: 'rec_b', sheetId: 'sheet_approved_materials', version: 1, data: { f_code: 'DUP-1', f_name: 'B', f_qty: 2 } },
+    ],
+  })
+  const system = createSystem({
+    objects: {
+      approved_materials: {
+        name: 'Approved Materials', sheetId: 'sheet_approved_materials', keyFields: ['code'],
+        fieldDetails: [{ id: 'code' }, { id: 'name' }, { id: 'quantity' }], fieldIdMap,
+      },
+    },
+  })
+  const writeSource = createMetaSheetMultitableWriteSource({ system, context })
+  const dry = await dryRunExternalWrite({
+    pipeline: {
+      id: 'pipe_dup', tenantId: 't1', workspaceId: 'w1', sourceSystemId: 'src', sourceObject: 'items',
+      targetSystemId: system.id, targetObject: 'approved_materials', createdBy: 'owner-1',
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'name' },
+        { sourceField: 'quantity', targetField: 'quantity' },
+      ],
+    },
+    sourceSystem: { id: 'src', kind: 'data-source:sql-readonly' },
+    targetSystem: { id: system.id, kind: 'metasheet:multitable', config: { dataSourceId: 'mt', object: 'approved_materials', keyFields: ['code'], writableFields: ['name', 'quantity'] } },
+    sourceAdapter: { async read() { return { records: [{ code: 'DUP-1', name: 'C', quantity: 3 }], done: true, nextCursor: null } } },
+    dataSourceWrites: writeSource,
+    targetWriteProfile: MULTITABLE_WRITE_PROFILE,
+    tokenStore: memoryStore(),
+    dryRunUser: 'owner-1', dataSourceOwnerPrincipal: 'owner-1', maxRows: 100,
+  })
+  assert.equal(dry.counts.held, 1, 'duplicate key HOLDS (ambiguous), not silently updated')
+  assert.equal(dry.canApply, false, 'a held row blocks apply')
+  assert.equal(dry.dryRunToken, null, 'no token issued when a row is held')
+  assert.ok(dry.evidence.rowErrorTypes.includes('ambiguous_target_key'), 'ambiguity surfaced values-free')
+  assert.equal(rows.length, 2, 'no write attempted on an ambiguous key')
+}
+
+// S1b-2 (review P3): a writable field NOT in fieldIdMap must round-trip identity on BOTH write
+// and read-back (else re-pull would never be idempotent for unmapped fields).
+async function testMultitableUnmappedFieldRoundTrips() {
+  const fieldIdMap = { code: 'f_code' } // 'name' deliberately unmapped -> identity
+  const { context, rows } = createContext({ existing: [] })
+  const system = createSystem({
+    objects: {
+      approved_materials: {
+        name: 'Approved Materials', sheetId: 'sheet_approved_materials', keyFields: ['code'],
+        fieldDetails: [{ id: 'code' }, { id: 'name' }], fieldIdMap,
+      },
+    },
+  })
+  const writeSource = createMetaSheetMultitableWriteSource({ system, context })
+  const baseInput = () => ({
+    pipeline: {
+      id: 'pipe_unmapped', tenantId: 't1', workspaceId: 'w1', sourceSystemId: 'src', sourceObject: 'items',
+      targetSystemId: system.id, targetObject: 'approved_materials', createdBy: 'owner-1',
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'code', validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'name' },
+      ],
+    },
+    sourceSystem: { id: 'src', kind: 'data-source:sql-readonly' },
+    targetSystem: { id: system.id, kind: 'metasheet:multitable', config: { dataSourceId: 'mt', object: 'approved_materials', keyFields: ['code'], writableFields: ['name'] } },
+    sourceAdapter: { async read() { return { records: [{ code: 'U-1', name: 'Hello' }], done: true, nextCursor: null } } },
+    dataSourceWrites: writeSource,
+    targetWriteProfile: MULTITABLE_WRITE_PROFILE,
+    tokenStore: memoryStore(),
+    dryRunUser: 'owner-1', dataSourceOwnerPrincipal: 'owner-1', maxRows: 100,
+  })
+  const input1 = baseInput()
+  const dry1 = await dryRunExternalWrite(input1)
+  assert.equal(dry1.counts.add, 1)
+  await applyExternalWrite({ ...input1, dryRunToken: dry1.dryRunToken, applyUser: 'owner-1' })
+  const created = rows.find((r) => r.data.f_code === 'U-1')
+  assert.deepEqual(created.data, { f_code: 'U-1', name: 'Hello' }, 'mapped field uses physical id; unmapped field stays identity')
+  // re-pull: read-back of the unmapped field must equal -> skip (idempotent)
+  const dry2 = await dryRunExternalWrite(baseInput())
+  assert.equal(dry2.counts.skip, 1, 'unmapped field round-trips so re-pull is idempotent')
+  assert.equal(dry2.counts.update, 0)
+}
+
 async function main() {
   const { context, calls, rows } = createContext({
     existing: [
@@ -425,6 +512,8 @@ async function main() {
   })
 
   await testMultitableWriteSourceRidesC6Lifecycle()
+  await testMultitableAmbiguousKeyHolds()
+  await testMultitableUnmappedFieldRoundTrips()
 
   console.log('✓ metasheet-multitable-target-adapter: write-only multitable target tests passed')
 }

--- a/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
@@ -428,7 +428,156 @@ function createMetaSheetMultitableTargetAdapterFactory({ context } = {}) {
   return ({ system }) => createMetaSheetMultitableTargetAdapter({ system, context })
 }
 
+// ---------------------------------------------------------------------------
+// S1b-2: raw inward write-source + profile for the C6 safe-write lifecycle
+//
+// The C6 planner (external-write-dry-run.cjs) drives the FULL dry-run -> apply ->
+// token -> revision-fence -> per-row -> dead-letter lifecycle and consumes a raw
+// write-source (test/lookupByKey/insertRows/updateRows) + a target-write profile
+// (the S1b-1 seam). This lets the OWN metasheet:multitable target ride the SAME
+// safe lifecycle as data-source:sql-write-gated, writing ONLY to own plugin-scoped
+// sheets (zero external write).
+//
+// NOTE (design follow-up): this write-source + profile supersedes S1a's adapter-level
+// `targetWriteLifecycle` method surface for the write path — the S1b-1 seam consumes
+// the profile + raw source, never `targetWriteLifecycle`, so that S1a surface is now
+// orphaned. See the S1b-2 PR body / design-lock follow-up (owner to ratify retire vs
+// reposition). This file intentionally does NOT expose `targetWriteLifecycle`: a
+// write-performing apply outside the C6 lifecycle would be an ungated bypass.
+// ---------------------------------------------------------------------------
+const MULTITABLE_WRITE_TARGET_KIND = 'metasheet:multitable'
+
+const MULTITABLE_WRITE_PROFILE = {
+  kind: MULTITABLE_WRITE_TARGET_KIND,
+  normalizeCapabilityState(result) {
+    const state = result && result.capabilityState
+    if (
+      !state || typeof state !== 'object' ||
+      typeof state.ownSheetTarget !== 'boolean' ||
+      typeof state.externalWrite !== 'boolean'
+    ) {
+      throw new AdapterValidationError('metasheet:multitable write target capability state is unavailable', {
+        field: 'capabilityState',
+      })
+    }
+    return {
+      success: result.success === true,
+      ownSheetTarget: state.ownSheetTarget,
+      externalWrite: state.externalWrite,
+    }
+  },
+  assertSafeCapabilityState(state) {
+    // Real safety property (not a rubber stamp): writes are scoped to OWN plugin sheets and
+    // never reach an external system. A misconfigured target fails closed.
+    if (state.ownSheetTarget !== true || state.externalWrite !== false) {
+      throw new AdapterValidationError('metasheet:multitable write target is not own-sheet scoped', {
+        field: 'capabilityState',
+      })
+    }
+  },
+}
+
+function invertFieldMap(logicalToPhysical) {
+  const out = {}
+  for (const [logical, physical] of Object.entries(logicalToPhysical || {})) out[physical] = logical
+  return out
+}
+
+function mapRecordFieldsToLogical(data, physicalToLogical) {
+  const mapped = {}
+  for (const [field, value] of Object.entries(data || {})) {
+    mapped[physicalToLogical[field] || field] = value
+  }
+  return mapped
+}
+
+// Builds the raw inward write-source the C6 planner consumes (same shape as the host
+// context.api.dataSourceWrites facade), backed by context.api.multitable.records over our
+// own plugin sheets. Field names are mapped logical<->physical so the planner's value-diff
+// classifier (logical) and the record store (physical) agree.
+function createMetaSheetMultitableWriteSource({ system, context } = {}) {
+  const normalizedSystem = normalizeExternalSystemForAdapter(system)
+  const objects = normalizeObjects(normalizedSystem.config)
+  const fieldMapCache = new Map()
+
+  async function fieldMapForObject(objectConfig) {
+    if (fieldMapCache.has(objectConfig.objectId)) return fieldMapCache.get(objectConfig.objectId)
+    const resolved = {
+      ...objectConfig.fieldIdMap,
+      ...await resolveProvisionedFieldIdMap(context, objectConfig),
+    }
+    fieldMapCache.set(objectConfig.objectId, resolved)
+    return resolved
+  }
+
+  return {
+    async test() {
+      const recordsApi = context && context.api && context.api.multitable && context.api.multitable.records
+      const ready = Boolean(
+        recordsApi &&
+        typeof recordsApi.createRecord === 'function' &&
+        typeof recordsApi.queryRecords === 'function' &&
+        typeof recordsApi.patchRecord === 'function' &&
+        Object.keys(objects).length > 0,
+      )
+      // fail closed: a missing/partial records API or no configured objects -> success:false
+      // -> the planner raises C6_WRITE_TARGET_TEST_FAILED before any write.
+      return {
+        success: ready,
+        capabilityState: { ownSheetTarget: true, externalWrite: false },
+      }
+    },
+    async lookupByKey(dataSourceId, object, key, policy, principal) {
+      const recordsApi = getRecordsApi(context)
+      const objectConfig = getObjectConfig(objects, object)
+      const logicalToPhysical = await fieldMapForObject(objectConfig)
+      const physicalToLogical = invertFieldMap(logicalToPhysical)
+      const physicalKeyData = mapRecordFieldsForWrite(key || {}, logicalToPhysical)
+      const physicalKeyFields = Object.keys(key || {}).map((field) => mapLogicalFieldName(field, logicalToPhysical))
+      const existing = await findExistingRecord(recordsApi, objectConfig, physicalKeyData, physicalKeyFields)
+      if (!existing) return { data: [], metadata: {} }
+      // map the stored physical record back to logical so the planner's writableFields
+      // value-diff compares like-for-like.
+      return { data: [mapRecordFieldsToLogical(existing.data || {}, physicalToLogical)], metadata: {} }
+    },
+    async insertRows(dataSourceId, object, rows, policy, principal) {
+      const recordsApi = getRecordsApi(context)
+      const objectConfig = getObjectConfig(objects, object)
+      const logicalToPhysical = await fieldMapForObject(objectConfig)
+      const created = []
+      for (const row of rows) {
+        const data = mapRecordFieldsForWrite(projectRecordForWrite(row, objectConfig), logicalToPhysical)
+        created.push(await recordsApi.createRecord({ sheetId: objectConfig.sheetId, data }))
+      }
+      return { data: created, metadata: {} }
+    },
+    async updateRows(dataSourceId, object, rows, policy, principal) {
+      const recordsApi = getRecordsApi(context)
+      const objectConfig = getObjectConfig(objects, object)
+      const logicalToPhysical = await fieldMapForObject(objectConfig)
+      const keyFields = policy && Array.isArray(policy.keyFields) && policy.keyFields.length > 0
+        ? policy.keyFields
+        : objectConfig.keyFields
+      let rowCount = 0
+      for (const row of rows) {
+        const physicalRow = mapRecordFieldsForWrite(projectRecordForWrite(row, objectConfig), logicalToPhysical)
+        const physicalKeyFields = keyFields.map((field) => mapLogicalFieldName(field, logicalToPhysical))
+        const existing = await findExistingRecord(recordsApi, objectConfig, physicalRow, physicalKeyFields)
+        if (!existing || !existing.id) {
+          throw new AdapterValidationError('metasheet:multitable update target row not found for key', { object })
+        }
+        await recordsApi.patchRecord({ sheetId: objectConfig.sheetId, recordId: existing.id, changes: physicalRow })
+        rowCount += 1
+      }
+      return { rowCount, results: [] }
+    },
+  }
+}
+
 module.exports = {
+  MULTITABLE_WRITE_TARGET_KIND,
+  MULTITABLE_WRITE_PROFILE,
+  createMetaSheetMultitableWriteSource,
   createMetaSheetMultitableTargetAdapter,
   createMetaSheetMultitableTargetAdapterFactory,
   __internals: {

--- a/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
@@ -534,11 +534,21 @@ function createMetaSheetMultitableWriteSource({ system, context } = {}) {
       const physicalToLogical = invertFieldMap(logicalToPhysical)
       const physicalKeyData = mapRecordFieldsForWrite(key || {}, logicalToPhysical)
       const physicalKeyFields = Object.keys(key || {}).map((field) => mapLogicalFieldName(field, logicalToPhysical))
-      const existing = await findExistingRecord(recordsApi, objectConfig, physicalKeyData, physicalKeyFields)
-      if (!existing) return { data: [], metadata: {} }
-      // map the stored physical record back to logical so the planner's writableFields
+      if (physicalKeyFields.length === 0 || typeof recordsApi.queryRecords !== 'function') {
+        return { data: [], metadata: {} }
+      }
+      // IMPORTANT: fetch >1 (NOT the upsert helper's limit:1 findExistingRecord). MetaSheet
+      // sheets do NOT enforce uniqueness on a logical key, so duplicate-key rows must surface
+      // as multiple rows — that is what lets the C6 planner's ambiguity guard
+      // (existingRows.length > 1 -> 'held'/ambiguous_target_key) fire instead of silently
+      // updating one. Mirrors the SQL facade's deliberate limit:2.
+      const filters = {}
+      for (const field of physicalKeyFields) filters[field] = physicalKeyData[field]
+      const matches = await recordsApi.queryRecords({ sheetId: objectConfig.sheetId, filters, limit: 2, offset: 0 })
+      const list = Array.isArray(matches) ? matches : []
+      // map each stored physical record back to logical so the planner's writableFields
       // value-diff compares like-for-like.
-      return { data: [mapRecordFieldsToLogical(existing.data || {}, physicalToLogical)], metadata: {} }
+      return { data: list.map((record) => mapRecordFieldsToLogical(record.data || {}, physicalToLogical)), metadata: {} }
     },
     async insertRows(dataSourceId, object, rows, policy, principal) {
       const recordsApi = getRecordsApi(context)


### PR DESCRIPTION
## What (S1b-2)

Lets the **own** `metasheet:multitable` target ride the **same** C6 `dry-run→apply→token→revision-fence→per-row→dead-letter` lifecycle as `data-source:sql-write-gated`, via the S1b-1 seam. Adds to the multitable adapter:
- `createMetaSheetMultitableWriteSource({system, context})` — the raw inward write-source the planner consumes (`test`/`lookupByKey`/`insertRows`/`updateRows`) over `context.api.multitable.records`, mapping field names **logical↔physical** so the planner's value-diff classifier (logical) and the record store (physical) agree.
- `MULTITABLE_WRITE_PROFILE` — kind + capability normalize/assert. `assertSafeCapabilityState` encodes a **real** property (writes scoped to own plugin sheets, never an external system); a missing/partial records API or non-own-sheet state **fails closed** (`success:false` → `C6_WRITE_TARGET_TEST_FAILED` before any write).

**Zero external write** — all writes land on own plugin sheets. The C6 planner is the only write path; no route in this slice (that's S1b-3).

## Test
The write-source rides the planner end-to-end with a **non-identity `fieldIdMap`** (proves the logical↔physical round-trip): run 1 = add + update; run 2 (re-pull) = all **skip** (idempotent, no duplicate records); writes land on the own sheet; evidence/response values-free; profile rejects an unsafe capability state. Existing `external-write-dry-run` / `adapter-contracts` / `pipeline-runner` / `http-routes` green.

## ⚠️ Design follow-up — owner to ratify

The S1b-1 seam consumes the **profile + raw write-source**, never the adapter-level `targetWriteLifecycle` (lookup/apply) defined in S1a — so that S1a method surface is now **orphaned** (zero consumers outside `contracts.cjs` + its test, verified). This slice intentionally does **not** expose `targetWriteLifecycle` on the multitable adapter: a write-performing `apply` outside the C6 lifecycle would be an **ungated bypass**.

The signed S1b design-lock §3-A/§5 lists "+ `targetWriteLifecycle` (values-free) evidence projection" for S1b-2 — **this PR deviates from that line**, deliberately. Recommend repositioning S1a's capability as "the write-source + profile contract" (or formally retiring the lookup/apply method surface) in a follow-up. Flagged for your sign-off.

## Boundary
`REQUIRED_ADAPTER_METHODS` untouched. No K3, no external write. Auto-merge **not** armed — awaiting adversarial sub-agent review (write/safety PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)