### PR TITLE
feat(approval): continuous_managers snapshot plumbing — bake-time manager-chain walk (latent, PR-1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -258,7 +258,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward)
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk)
         # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
@@ -275,6 +275,7 @@ jobs:
             tests/integration/approval-direct-manager.api.test.ts \
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
+            tests/integration/approval-manager-chain.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -49,12 +49,17 @@ export interface ApprovalRequesterOrgRelations {
   deptHeadId?: string
   /**
    * Ordered local user ids of the requester's management chain, level 1 first
-   * (`[0]` is the direct manager, equal to `managerId`). Only populated when the
-   * caller opts in via `includeManagerChain` (i.e. a published graph actually uses
-   * the `continuous_managers` source). Cycle-guarded and capped at
-   * `MAX_MANAGER_CHAIN_LEVELS`; unlinked hops are walked through but not included.
-   * Read by the `continuous_managers` assignee-source kind (which slices it to its
-   * own `levels`). Omitted when the chain resolves empty.
+   * (`[0]` is the direct manager **when that manager is distinct from the
+   * requester**). It usually equals `managerId`, but can differ in one edge case:
+   * this chain self-excludes on the requester's LOCAL id, whereas `managerId`
+   * (step 2) excludes only the requester's external id — so if an alt-account of
+   * the requester is flagged leader of their own dept, `managerId` may be the
+   * requester (harmless; the resolver drops it) while this chain skips past it.
+   * Only populated when the caller opts in via `includeManagerChain` (i.e. a
+   * published graph actually uses the `continuous_managers` source). Cycle-guarded
+   * and capped at `MAX_MANAGER_CHAIN_LEVELS`; unlinked hops are walked through but
+   * not included. Read by the `continuous_managers` assignee-source kind (which
+   * slices it to its own `levels`). Omitted when the chain resolves empty.
    */
   managerChainIds?: string[]
 }

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -47,7 +47,21 @@ export interface ApprovalRequesterOrgRelations {
   managerId?: string
   /** Local user id of the head of the requester's primary department, if resolvable. */
   deptHeadId?: string
+  /**
+   * Ordered local user ids of the requester's management chain, level 1 first
+   * (`[0]` is the direct manager, equal to `managerId`). Only populated when the
+   * caller opts in via `includeManagerChain` (i.e. a published graph actually uses
+   * the `continuous_managers` source). Cycle-guarded and capped at
+   * `MAX_MANAGER_CHAIN_LEVELS`; unlinked hops are walked through but not included.
+   * Read by the `continuous_managers` assignee-source kind (which slices it to its
+   * own `levels`). Omitted when the chain resolves empty.
+   */
+  managerChainIds?: string[]
 }
+
+/** Hard ceiling on how far up the org tree the bake-time walk climbs. The per-source
+ * `levels` slices this; the cap only bounds the walk cost + a pathological deep tree. */
+export const MAX_MANAGER_CHAIN_LEVELS = 10
 
 interface LeaderInDeptEntry {
   dept_id?: unknown
@@ -115,6 +129,7 @@ interface RequesterDirectoryRow {
 export async function resolveApprovalRequesterOrgRelations(
   localUserId: string,
   query: QueryFn,
+  options: { includeManagerChain?: boolean; maxLevels?: number } = {},
 ): Promise<ApprovalRequesterOrgRelations> {
   const userId = localUserId.trim()
   if (!userId) return {}
@@ -188,7 +203,134 @@ export async function resolveApprovalRequesterOrgRelations(
   const relations: ApprovalRequesterOrgRelations = {}
   if (managerId) relations.managerId = managerId
   if (deptHeadId) relations.deptHeadId = deptHeadId
+
+  // 4) Manager chain (opt-in): walk leader_in_dept hop-by-hop up the org tree,
+  //    starting from the requester. Only runs when the caller opts in — i.e. a
+  //    published graph actually uses `continuous_managers` — so the per-hop
+  //    queries are NOT added to every approval. Same point-in-time + self-exclusion
+  //    posture as the direct manager above.
+  if (options.includeManagerChain) {
+    const chain = await resolveManagerChain(
+      integrationId,
+      requester.external_user_id,
+      userId,
+      requesterDeptId,
+      clampChainLevels(options.maxLevels),
+      query,
+    )
+    if (chain.length > 0) relations.managerChainIds = chain
+  }
+
   return relations
+}
+
+function clampChainLevels(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) return MAX_MANAGER_CHAIN_LEVELS
+  return Math.min(value, MAX_MANAGER_CHAIN_LEVELS)
+}
+
+interface DeptLeaderHop {
+  accountId: string
+  externalUserId: string
+  primaryDeptExternalId: string | null
+}
+
+/**
+ * One hop up the tree: the active account flagged leader for `deptExternalId` in
+ * its own `leader_in_dept` (excluding `excludeExternalId` so a node is never its
+ * own manager), returned with the identity needed to continue the walk — the
+ * leader's external id and *their* primary department.
+ */
+async function findDeptLeaderHop(
+  integrationId: string,
+  deptExternalId: string,
+  excludeExternalId: string,
+  query: QueryFn,
+): Promise<DeptLeaderHop | undefined> {
+  const rows = await query<{
+    account_id: string
+    external_user_id: string
+    raw: unknown
+    primary_dept_external_id: string | null
+  }>(
+    `SELECT a.id::text                  AS account_id,
+            a.external_user_id          AS external_user_id,
+            a.raw                       AS raw,
+            pd.external_department_id   AS primary_dept_external_id
+       FROM directory_accounts a
+       JOIN directory_account_departments ad
+         ON ad.directory_account_id = a.id
+       JOIN directory_departments d
+         ON d.id = ad.directory_department_id
+       LEFT JOIN directory_account_departments pad
+         ON pad.directory_account_id = a.id
+        AND pad.is_primary = true
+       LEFT JOIN directory_departments pd
+         ON pd.id = pad.directory_department_id
+      WHERE a.integration_id = $1::uuid
+        AND a.is_active = true
+        AND d.external_department_id = $2
+        AND a.external_user_id <> $3`,
+    [integrationId, deptExternalId, excludeExternalId],
+  )
+  const leader = rows.rows.find((row) => parseLeaderDeptIds(asRecord(row.raw)).includes(deptExternalId))
+  if (!leader) return undefined
+  return {
+    accountId: leader.account_id,
+    externalUserId: leader.external_user_id,
+    primaryDeptExternalId: normalizeExternalId(leader.primary_dept_external_id),
+  }
+}
+
+/**
+ * Walk the management chain up from the requester, collecting linked LOCAL user
+ * ids in order (level 1 = direct manager). Termination is bounded three ways so a
+ * malformed org graph can never loop or run away:
+ *   - a visited-set of external ids stops cycles (A leads B's dept, B leads A's);
+ *   - a hop with no leader stops the walk (top of tree reached);
+ *   - at most `maxLevels` hops are taken.
+ * Unlinked managers are walked *through* (their own manager can still resolve) but
+ * not added to the chain; duplicates are collapsed.
+ *
+ * Self-exclusion is enforced on the requester's LOCAL id, not just their starting
+ * external id: a person can own multiple directory accounts (distinct external ids)
+ * that all link back to the same local user, and any of those alt-accounts could be
+ * flagged leader of the requester's department. Excluding only the starting external
+ * id would let such an alt-account resolve to the requester's own local id and land
+ * the requester in their own management chain. So a hop that resolves to
+ * `requesterLocalId` is walked *through* (we still climb past it to find the real
+ * next manager) but never added to the chain.
+ */
+async function resolveManagerChain(
+  integrationId: string,
+  requesterExternalId: string,
+  requesterLocalId: string,
+  requesterDeptExternalId: string | null,
+  maxLevels: number,
+  query: QueryFn,
+): Promise<string[]> {
+  const chain: string[] = []
+  const visited = new Set<string>([requesterExternalId])
+  let currentExternalId = requesterExternalId
+  let currentDeptExternalId = requesterDeptExternalId
+
+  for (let level = 0; level < maxLevels; level += 1) {
+    if (!currentDeptExternalId) break
+    const hop = await findDeptLeaderHop(integrationId, currentDeptExternalId, currentExternalId, query)
+    if (!hop) break
+    if (visited.has(hop.externalUserId)) break
+    visited.add(hop.externalUserId)
+
+    const localId = await resolveLinkedLocalUserId(hop.accountId, query)
+    // Self-exclusion on the LOCAL id: an alt-account of the requester (different
+    // external id, same local user) must not enter the chain. Walk through it.
+    if (localId && localId !== requesterLocalId && !chain.includes(localId)) chain.push(localId)
+
+    currentExternalId = hop.externalUserId
+    currentDeptExternalId = hop.primaryDeptExternalId
+  }
+
+  return chain
 }
 
 async function resolveLinkedLocalUserId(accountId: string, query: QueryFn): Promise<string | undefined> {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1513,6 +1513,23 @@ function getApprovalNodeConfig(runtimeGraph: RuntimeGraph, nodeKey: string): App
   return node?.type === 'approval' ? node.config : null
 }
 
+/**
+ * True when any approval node's assignee sources include a `continuous_managers`
+ * source. Used at create time to decide whether to walk the (more expensive)
+ * management chain into the requester snapshot — keeping the extra per-hop
+ * directory queries off every approval that does not use the source. `kind` is
+ * read structurally so this works before the kind is added to the typed union.
+ */
+export function runtimeGraphUsesContinuousManagers(runtimeGraph: RuntimeGraph): boolean {
+  return runtimeGraph.nodes.some((node) => {
+    if (node.type !== 'approval') return false
+    const config: unknown = node.config
+    const sources = isRecord(config) ? config.assigneeSources : undefined
+    if (!Array.isArray(sources)) return false
+    return sources.some((source) => isRecord(source) && source.kind === 'continuous_managers')
+  })
+}
+
 function getEffectiveAutoApprovalPolicy(
   runtimeGraph: RuntimeGraph,
   nodeKey: string,
@@ -2589,15 +2606,21 @@ export class ApprovalProductService {
       )
     }
 
-    // Lane G (P1-A) plumbing — freeze the requester's org relations (direct
-    // manager / dept head, as LOCAL user ids) from the directory `raw` payload.
-    // READ-ONLY (directory_* SELECTs only) and best-effort: a directory read
-    // failure must never block create, so an unresolved lookup just omits the
-    // fields. The future direct_manager / dept_head assignee-source kinds read
-    // these; absence falls through to the node's emptyAssigneePolicy.
+    // Org-relation plumbing — freeze the requester's org relations (direct manager
+    // / dept head / management chain, as LOCAL user ids) from the directory `raw`
+    // payload. READ-ONLY (directory_* SELECTs only) and best-effort: a directory
+    // read failure must never block create, so an unresolved lookup just omits the
+    // fields. direct_manager / dept_head read managerId / deptHeadId; the chain is
+    // walked only when the published graph uses continuous_managers (so the extra
+    // per-hop queries stay off every approval). Absence falls through to the node's
+    // emptyAssigneePolicy.
+    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
+    const needsManagerChain = runtimeGraphUsesContinuousManagers(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
     try {
-      orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool))
+      orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool), {
+        includeManagerChain: needsManagerChain,
+      })
     } catch (error) {
       metricsLogger.warn(
         `Failed to resolve requester org relations for ${actor.userId}: ${
@@ -2615,8 +2638,8 @@ export class ApprovalProductService {
       permissions: actor.permissions || [],
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
       ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
+      ...(orgRelations.managerChainIds ? { managerChainIds: orgRelations.managerChainIds } : {}),
     }
-    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {
       assignmentResolver: buildApprovalAssignmentResolver({
         formSchema,

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -222,6 +222,15 @@ export interface ApprovalRequesterSnapshot {
    * unresolvable. Read by the future `dept_head` assignee-source kind.
    */
   deptHeadId?: string
+  /**
+   * Org-relation plumbing — ordered local user ids of the requester's management
+   * chain, level 1 first (`[0]` equals `managerId`). Frozen at create time only
+   * when the published graph uses the `continuous_managers` source (so it is not
+   * baked for every approval). Cycle-guarded + capped; absent when unresolvable or
+   * unused. Read by the `continuous_managers` assignee-source kind, which slices it
+   * to its own `levels`. Purely additive; existing snapshots omit it.
+   */
+  managerChainIds?: string[]
   [key: string]: unknown
 }
 

--- a/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { query } from '../../src/db/pg'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+
+/**
+ * continuous_managers chain walk — REAL DB. The unit test
+ * (approval-manager-chain.test.ts) drives the walk logic against a fake query, so
+ * it cannot catch a malformed SQL string. This proves the actual `findDeptLeaderHop`
+ * SQL (the dept-membership joins + the primary-dept LEFT JOIN) executes against
+ * Postgres and resolves a real one-level chain — which also exercises the
+ * top-of-tree short-chain stop (only one level is seeded, so level 2 finds no
+ * leader and the walk terminates at length 1). The design-lock (#2886 §4) asks for
+ * this real-DB case alongside the unit coverage.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const DEPT = `cmd-${TS}`
+const U_R = `cm-ur-${TS}`
+const U_M = `cm-um-${TS}`
+
+// Adapt the QueryResultRow-constrained `query` to the resolver's unconstrained QueryFn.
+const queryFn = <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> =>
+  query(text, params).then((r) => ({ rows: r.rows as Row[] }))
+
+describeIfDatabase('continuous_managers chain walk (real DB)', () => {
+  let integrationId = ''
+
+  beforeAll(async () => {
+    integrationId = (await query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`cmchain-${TS}`, `cmchain-corp-${TS}`],
+    )).rows[0].id
+
+    const deptId = (await query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+       VALUES ($1, $2, 'Eng', true, '{}'::jsonb) RETURNING id`,
+      [integrationId, DEPT],
+    )).rows[0].id
+
+    await query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x'), ($3, $4, 'x')`, [
+      U_R, `${U_R}@example.test`, U_M, `${U_M}@example.test`,
+    ])
+
+    // Requester account R (member of DEPT, primary), linked to U_R.
+    const accR = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'R', '{}'::jsonb) RETURNING id`,
+      [integrationId, `extR-${TS}`, `keyR-${TS}`],
+    )).rows[0].id
+    // Manager account M: member of DEPT and flagged leader of DEPT in its own leader_in_dept.
+    const accM = (await query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'M', $4::jsonb) RETURNING id`,
+      [integrationId, `extM-${TS}`, `keyM-${TS}`, JSON.stringify({ leader_in_dept: [{ dept_id: DEPT, leader: true }] })],
+    )).rows[0].id
+
+    await query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual'), ($3, $4, 'linked', 'manual')`,
+      [accR, U_R, accM, U_M],
+    )
+    await query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true), ($3, $2, true)`,
+      [accR, deptId, accM],
+    )
+  })
+
+  afterAll(async () => {
+    if (integrationId) {
+      // account_departments + links cascade on directory_accounts delete.
+      await query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+      await query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+      await query(`DELETE FROM users WHERE id = ANY($1)`, [[U_R, U_M]])
+    }
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('resolves a real one-level chain and stops at the top of the tree (SQL validity + short-chain)', async () => {
+    const rel = await resolveApprovalRequesterOrgRelations(U_R, queryFn, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual([U_M]) // exactly one level; level-2 finds no leader → stops
+    expect(rel.managerId).toBe(U_M) // chain[0] agrees with the shipped direct-manager resolution
+  })
+
+  it('does not bake the chain when includeManagerChain is off (only the direct manager)', async () => {
+    const rel = await resolveApprovalRequesterOrgRelations(U_R, queryFn)
+    expect(rel.managerChainIds).toBeUndefined()
+    expect(rel.managerId).toBe(U_M)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+import { runtimeGraphUsesContinuousManagers } from '../../src/services/ApprovalProductService'
+import type { RuntimeGraph } from '../../src/types/approval-product'
+
+/**
+ * PR-1 (continuous_managers snapshot plumbing) unit test. Drives the management-
+ * chain walk through the public `resolveApprovalRequesterOrgRelations` seam with
+ * `includeManagerChain`, against an in-memory org graph (no DB). The fake serves
+ * the five SELECT shapes the resolver issues — recognizing the new hop query by
+ * its `primary_dept_external_id` projection BEFORE the legacy single-hop manager
+ * scan so the two don't collide — and models the org as {leader-of-dept,
+ * primary-dept-of-person, local-id-of-account} so termination (cycle / top /
+ * cap), self-exclusion, unlinked-passthrough, and dedup are all exercised on the
+ * real walk, not a stub.
+ */
+
+interface OrgModel {
+  integrationId: string
+  requesterLocalId: string
+  requesterExternalId: string
+  requesterDeptExternalId: string | null
+  leaderOfDept: Record<string, string | undefined>
+  primaryDeptOf: Record<string, string | null>
+  localByAccountId: Record<string, string | null>
+  onHop?: (deptId: string) => void
+}
+
+function makeOrgQuery(org: OrgModel) {
+  return async <Row>(text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+    // 1) requester lookup by local user id
+    if (text.includes('FROM directory_account_links l') && text.includes('LEFT JOIN directory_account_departments')) {
+      if (String(params?.[0]) !== org.requesterLocalId) return { rows: [] }
+      return {
+        rows: [{
+          integration_id: org.integrationId,
+          account_id: `acc-${org.requesterExternalId}`,
+          external_user_id: org.requesterExternalId,
+          raw: {},
+          primary_external_department_id: org.requesterDeptExternalId,
+          primary_department_raw: {},
+        }] as Row[],
+      }
+    }
+    // 2) chain hop query (find dept leader + their primary dept) — recognized by
+    //    `primary_dept_external_id`; MUST precede the legacy scan below.
+    if (text.includes('primary_dept_external_id') && text.includes('d.external_department_id = $2')) {
+      const deptId = String(params?.[1])
+      const excludeExternal = String(params?.[2])
+      org.onHop?.(deptId)
+      const leaderExt = org.leaderOfDept[deptId]
+      if (!leaderExt || leaderExt === excludeExternal) return { rows: [] }
+      return {
+        rows: [{
+          account_id: `acc-${leaderExt}`,
+          external_user_id: leaderExt,
+          raw: { leader_in_dept: [{ dept_id: deptId, leader: true }] },
+          primary_dept_external_id: org.primaryDeptOf[leaderExt] ?? null,
+        }] as Row[],
+      }
+    }
+    // 3) legacy single-hop manager scan (no primary-dept projection) — empty here;
+    //    the direct-manager path is covered by approval-directory-org.test.ts.
+    if (text.includes('JOIN directory_account_departments ad') && text.includes('d.external_department_id = $2')) {
+      return { rows: [] }
+    }
+    // 4) local user id by account id
+    if (text.includes('FROM directory_account_links') && text.includes('WHERE directory_account_id = $1::uuid')) {
+      return { rows: [{ local_user_id: org.localByAccountId[String(params?.[0])] ?? null }] as Row[] }
+    }
+    // 5) dept-head by-external — empty here (covered elsewhere)
+    if (text.includes('JOIN directory_account_links l') && text.includes('a.external_user_id = $2')) {
+      return { rows: [] }
+    }
+    throw new Error(`unexpected query: ${text.slice(0, 80)}`)
+  }
+}
+
+const BASE = {
+  integrationId: 'int-1',
+  requesterLocalId: 'u-r',
+  requesterExternalId: 'e-r',
+  requesterDeptExternalId: 'd-r',
+}
+
+describe('manager-chain walk (resolveApprovalRequesterOrgRelations + includeManagerChain)', () => {
+  it('walks multiple levels in order, stopping at the top of the tree', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-m1', 'd-m1': 'e-m2', 'd-m2': 'e-m3', 'd-m3': undefined },
+      primaryDeptOf: { 'e-m1': 'd-m1', 'e-m2': 'd-m2', 'e-m3': 'd-m3' },
+      localByAccountId: { 'acc-e-m1': 'u-m1', 'acc-e-m2': 'u-m2', 'acc-e-m3': 'u-m3' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual(['u-m1', 'u-m2', 'u-m3'])
+  })
+
+  it('stops on a cycle (visited-set guard) without looping', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-a', 'd-a': 'e-b', 'd-b': 'e-a' }, // b's dept points back to a
+      primaryDeptOf: { 'e-a': 'd-a', 'e-b': 'd-b' },
+      localByAccountId: { 'acc-e-a': 'u-a', 'acc-e-b': 'u-b' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual(['u-a', 'u-b'])
+  })
+
+  it('excludes the requester themselves (self-led department → empty chain)', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-r' }, // requester leads their own department
+      primaryDeptOf: {},
+      localByAccountId: {},
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toBeUndefined()
+  })
+
+  it('walks THROUGH an unlinked manager but does not include it', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-m1', 'd-m1': 'e-m2', 'd-m2': undefined },
+      primaryDeptOf: { 'e-m1': 'd-m1', 'e-m2': 'd-m2' },
+      localByAccountId: { 'acc-e-m1': null, 'acc-e-m2': 'u-m2' }, // m1 unlinked
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual(['u-m2'])
+  })
+
+  it('caps the walk at the requested maxLevels', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-m1', 'd-m1': 'e-m2', 'd-m2': 'e-m3', 'd-m3': 'e-m4' },
+      primaryDeptOf: { 'e-m1': 'd-m1', 'e-m2': 'd-m2', 'e-m3': 'd-m3', 'e-m4': 'd-m4' },
+      localByAccountId: { 'acc-e-m1': 'u-m1', 'acc-e-m2': 'u-m2', 'acc-e-m3': 'u-m3', 'acc-e-m4': 'u-m4' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true, maxLevels: 2 })
+    expect(rel.managerChainIds).toEqual(['u-m1', 'u-m2'])
+  })
+
+  it('dedups a person who appears at two levels', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-a', 'd-a': 'e-b', 'd-b': undefined },
+      primaryDeptOf: { 'e-a': 'd-a', 'e-b': 'd-b' },
+      localByAccountId: { 'acc-e-a': 'u-x', 'acc-e-b': 'u-x' }, // both map to same local id
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual(['u-x'])
+  })
+
+  it('excludes the requester via an ALT directory account linking to the same local id (self-exclusion on local id, not just external id)', async () => {
+    const query = makeOrgQuery({
+      ...BASE,
+      // d-r's leader is an ALTERNATE account of the requester: a different external id
+      // (e-r-alt) that links back to the requester's OWN local id (u-r). Excluding only
+      // the starting external id e-r would let this resolve u-r into the chain. The walk
+      // must climb THROUGH it to the real next manager (u-m2) and never include u-r.
+      leaderOfDept: { 'd-r': 'e-r-alt', 'd-r-alt': 'e-m2', 'd-m2': undefined },
+      primaryDeptOf: { 'e-r-alt': 'd-r-alt', 'e-m2': 'd-m2' },
+      localByAccountId: { 'acc-e-r-alt': 'u-r', 'acc-e-m2': 'u-m2' },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual(['u-m2'])
+  })
+
+  it('does NOT walk the chain when includeManagerChain is not set (gating)', async () => {
+    let hopIssued = false
+    const query = makeOrgQuery({
+      ...BASE,
+      leaderOfDept: { 'd-r': 'e-m1' },
+      primaryDeptOf: { 'e-m1': 'd-m1' },
+      localByAccountId: { 'acc-e-m1': 'u-m1' },
+      onHop: () => { hopIssued = true },
+    })
+    const rel = await resolveApprovalRequesterOrgRelations('u-r', query)
+    expect(rel.managerChainIds).toBeUndefined()
+    expect(hopIssued).toBe(false)
+  })
+})
+
+describe('runtimeGraphUsesContinuousManagers (conditional-bake scanner)', () => {
+  const graph = (sources: unknown): RuntimeGraph =>
+    ({ nodes: [{ key: 'n1', type: 'approval', config: { assigneeSources: sources } }] }) as unknown as RuntimeGraph
+
+  it('detects a continuous_managers source on an approval node', () => {
+    expect(runtimeGraphUsesContinuousManagers(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(true)
+  })
+
+  it('returns false when only other source kinds are present', () => {
+    expect(runtimeGraphUsesContinuousManagers(graph([{ kind: 'direct_manager' }, { kind: 'static_user', userIds: ['x'] }]))).toBe(false)
+  })
+
+  it('returns false for nodes without assignee sources or non-approval nodes', () => {
+    expect(runtimeGraphUsesContinuousManagers({ nodes: [{ key: 'c', type: 'condition', config: {} }] } as unknown as RuntimeGraph)).toBe(false)
+    expect(runtimeGraphUsesContinuousManagers({ nodes: [] } as unknown as RuntimeGraph)).toBe(false)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'tests/integration/approval-direct-manager.api.test.ts',
       'tests/integration/approval-postgate-acceptance.api.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
+      'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
## What

**PR-1 of the `continuous_managers` arc** (design-lock #2886, reading **A** = manager-chain-as-approver-set). Bakes the requester's management chain into the snapshot so PR-2's resolver can consume it. **Ships fully inert:** no kind/normalizer/resolver/authoring yet, so no published graph can carry a `continuous_managers` source — the conditional walk therefore never fires in production.

## Changes

- **`ApprovalDirectoryOrg.ts`** — generalize the org resolver with an opt-in `includeManagerChain`: a hop-by-hop `leader_in_dept` walk producing ordered `managerChainIds` (local user ids, level 1 = direct manager = existing `managerId`). Bounded three ways: **visited-set cycle guard**, **stop at top-of-tree**, **cap at `MAX_MANAGER_CHAIN_LEVELS = 10`**. Unlinked managers are walked **through** but not included; duplicates collapsed; requester **self-excluded** (pre-seeded visited). The shipped single-hop `direct_manager`/`dept_head` resolution is **untouched**.
- **`approval-product.ts`** — additive `managerChainIds?: string[]` on `ApprovalRequesterSnapshot`.
- **`ApprovalProductService.ts`** — **conditional baking**: scan the published runtime graph for a `continuous_managers` source (`runtimeGraphUsesContinuousManagers`, exported for unit test) and only then pass `includeManagerChain`, keeping the extra per-hop directory queries **off every approval** that doesn't use the source. `runtimeGraph` hoisted above the org resolve (behavior-preserving — verified the graph is in hand at the bake site).

## Tests

New `approval-manager-chain.test.ts` (10): multi-level / cycle / top-reached / self-exclusion / unlinked-passthrough / level-cap / dedup / **opt-in gating** (no hop query issued when the flag is off) + the conditional-bake scanner. Pure-unit (in-memory org fixture, no DB) so it runs in the default `test (20.x)` job. Existing `approval-directory-org` (8) + `approval-assignee-resolver` (12) + `approval-direct-manager` real-DB create/start (5) all still green; `tsc` clean; no `.js` emitted.

## Scope / gating

- **End-to-end "chain baked when graph uses the source" is a PR-2 test** — the kind isn't authorable until PR-2 adds it to the union/normalizer.
- **W7 stays locked.** Reading **B** (true sequential escalation = graph expansion) stays carved out per the design-lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
