### PR TITLE
docs(multitable): /goal closeout — 2b-S2 surface coverage 8/9 (#2890), 2c CI-wiring (#2891), trash deferral

### DIFF
--- a/docs/development/multitable-development-completion-verification-20260618.md
+++ b/docs/development/multitable-development-completion-verification-20260618.md
@@ -1,5 +1,31 @@
 # 多维表开发完成度核验 — 2026-06-18
 
+> ### ⟳ RE-VERIFIED 2026-06-18 — parallel acceptance-criteria sweep for the `/goal` (LATEST; supersedes the banners below)
+> Method: five parallel read-only verification agents against live `origin/main@33db39688`, each confirming one
+> arc's acceptance criteria against the shipped code + tests (with file:line evidence), then the gaps acted on.
+> - **2a · live-CRDT full scalar set — ALL COVERED.** All 10 scalar types bind via `useYjsScalarCell`
+>   (`SCALAR_YJS_TYPES` / `STRING_STORED_ATOMIC_YJS_TYPES` `coerceText` / `DURATION_COMMIT_ON_CONFIRM`); unit +
+>   real-DB seed/flush/migration goldens; dateTime canonical-UTC-ISO invariant proven by instant-equality.
+> - **2b-S1 evaluator · S3 authoring UI · S4 parse cache — ALL COVERED.** Operator matrix + fail-closed
+>   (malformed / deleted field); no-silent-loss rule preservation + CRUD + text-op allowlist FE↔BE parity +
+>   typed i18n; cache hit / equals-direct / content-invalidation / 200-rule perf / LRU+clear / staleness-free.
+> - **2b-S2 enforcement — GAP FOUND AND CLOSED.** Only 3/9 read surfaces had real-DB goldens; the rule-deny
+>   composes into the shared `loadDeniedRecordIds` set (DENY-WINS union) for every surface, so **#2890** added
+>   goldens for view/search-filter, aggregate/dashboard, export, and link-picker → **8/9** (green in
+>   `test (20.x)`). The 9th — **trash list/restore** — is a deliberate deferral (`loadRuleDeniedRecordIds`
+>   reads live `meta_records` only, code-acknowledged) → **explicit owner decision (TODO §5):** build trash
+>   rule-deny + restore gating, or record as a known deferral. NOT built autonomously (new access-control on a
+>   flag-off / inert feature — owner-named territory).
+> - **2c · #16 person org-directory — ALL COVERED.** Native `userId[]`; fail-closed validator across all write
+>   paths (incl. import via shared `createRecord`); active-only directory resolver; `canEditRecord`-gated
+>   endpoint; picker display-parity + no-silent-drop; inactive cue. **CI gap closed:** the two FE specs
+>   (`multitable-person-picker`, `multitable-cell-renderer-person-inactive`) were in no required gate → now in
+>   the web-guard gate (**#2891**).
+>
+> **Net for the `/goal`:** every planned arc (2a / 2b / 2c) is built + tested on main; verification surfaced and
+> closed two real test/CI gaps (#2890, #2891). The only remaining items are **owner decisions** — the trash-deny
+> build-vs-defer binary (TODO §5) and the closed-not-landed #2877 reopen — neither is autonomous planned remainder.
+>
 > Status: **VERIFICATION** of the `/goal` "complete all development per the plan/TODO MD".
 > Grounding: `origin/main@9f68ed67c`, code-anchored (not doc-marker — stale-marker traps this session, see §5).
 > Authoritative plan: **`multitable-gated-remainder-development-plan-20260618.md` (#2828)**, which **supersedes** `multitable-current-development-plan/todo-20260617.md` (#2801).

--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -113,7 +113,7 @@ Non-goals:
 
 ## 2. 2b · #18 Phase-2 Permission Rule Engine
 
-> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history.
+> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841), with real-DB read-surface goldens now over **8/9** surfaces (#2890 added view/search-filter, aggregate/dashboard, export, link-picker to the prior list/single/summary); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history. **One read surface — trash list/restore — is a deliberate deferral (`loadRuleDeniedRecordIds` evaluates live `meta_records` only; flag-off/inert); it is an explicit owner decision (build vs record-as-deferral), not autonomous remainder.**
 
 ### 2.1 Current Contract
 
@@ -158,7 +158,7 @@ Recommended implementation slices after the gate opens:
 |---|---|---|
 | ✅ 2b-S0 | Security design-lock and adversarial threat model. (Settled — S1–S3 built on the locked rule model.) | Owner sign-off; no runtime. |
 | ✅ 2b-S1 | Pure evaluator + parser, no route wiring. **(#2836)** | Unit matrix per field type/operator; malformed rule fail-closed. |
-| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record, view, summaries, export, aggregate/dashboard, search/filter, link picker, trash list/restore. |
+| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record (#2841), summaries (#2841), view, search/filter, aggregate/dashboard, export, link picker (**#2890** — 8/9). Trash list/restore = **deliberate deferral** (live-`meta_records`-only; owner decision, §5 of the TODO). |
 | ✅ 2b-S3 | Authoring UI for conditional rules. **(#2847, + text-type operator allowlist fix)** | Frontend tests + browser evidence; no silent rule loss on edit. |
 | ✅ 2b-S4 | Performance and caching pass. **(#2861 — content-keyed parse cache; staleness-free, DB reads not cached.)** | Unit cache cases (hit / equals-direct / content-change re-parse / 200-rule set parsed once across 50 reads / cyclic bypass). |
 

--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -58,12 +58,16 @@
   - [ ] Malformed rule fail-closed tests.
   - [ ] Deleted/hidden predicate field tests.
 
-- [x] 2b-S2 Backend enforcement (#2841 — wired into the #18 seam, flag-off inert).
-  - [ ] Real-DB list/view/single-record tests.
-  - [ ] Real-DB summary subset tests.
-  - [ ] Real-DB export and aggregate/dashboard tests.
-  - [ ] Real-DB link picker and trash tests.
-  - [ ] CI allowlist confirmation; do not infer from green jobs.
+- [x] 2b-S2 Backend enforcement (#2841 — wired into the #18 seam, flag-off inert). Real-DB read-surface
+  goldens extended to 8/9 surfaces (#2890); trash is the one deliberate deferral (see below).
+  - [x] Real-DB list / single-record / view tests (#2841 list+single; #2890 view-aggregate).
+  - [x] Real-DB summary subset tests (#2841).
+  - [x] Real-DB export and aggregate/dashboard tests (#2890 — export-xlsx parse + view-aggregate total).
+  - [x] Real-DB link-picker test (#2890 link-options) + search/filter deny-before-filter (#2890).
+  - [!] Real-DB **trash list/restore** — DEFERRED, owner-gated. `loadRuleDeniedRecordIds` evaluates live
+    `meta_records` only (code-acknowledged docstring); extending rule-deny to trashed records + gating
+    restore is new access-control on a flag-off feature → explicit owner decision (build vs record-as-deferral). See §5.
+  - [x] CI allowlist confirmation — `plugin-tests.yml:194` registers enforce-realdb (verified by reading the workflow, not inferred from green jobs); the goldens ran green in `test (20.x)` on #2890.
 
 - [x] 2b-S3 Authoring UI (#2847, + text-type operator allowlist fix).
   - [ ] Rule builder preserves aliases/case/unsupported fields without silent loss.
@@ -107,7 +111,8 @@ These are future candidates or reopen-only lines. They are not open work in the 
 
 ## 5. Owner Unlock Prompts
 
-No active multitable development *arc* remains — **2a, 2b (through S4 `#2861`), and 2c (through S4 `#2874`) are all complete and closed; none is a "next option".** The `#2877` picker-chip decision has been made (closed not-landed — see below). One pre-identified owner option remains (not active planned work):
+No active multitable development *arc* remains — **2a, 2b (through S4 `#2861`), and 2c (through S4 `#2874`) are all complete and closed; none is a "next option".** The `#2877` picker-chip decision has been made (closed not-landed — see below). Two pre-identified owner decisions remain (neither is active planned work):
 
+- **[!] 2b-S2 trash list/restore rule-deny — DECISION NEEDED:** conditional read-deny now reaches **8/9** read surfaces (real-DB goldens, #2890). The 9th — **trash list/restore** — is a deliberate deferral: `loadRuleDeniedRecordIds` evaluates live `meta_records` only (code-acknowledged docstring), so a rule-denied record, once trashed, is no longer hidden, and restore consults no rules. The feature is **flag-off / inert in prod**, so nothing leaks for any user today. **选 Build** trash rule-deny + restore gating + a real-DB golden now, or **选 Defer** — record it as a known limitation and narrow the S2 criterion to live surfaces. This is new access-control behavior on a flag-off feature = owner's call; I will not start it without an explicit pick.
 - **[x] `#2877` (2c-S4 picker-chip affordance) — CLOSED not-landed (2026-06-18):** the green, display-only PR marking no-longer-assignable chips inside `MetaPersonPicker` (the one S4 surface `#2874` left out) was **closed rather than landed**. S4's display-affordance bar is met by `#2874` (cell/summary cue) and ratified by the merged closeout `#2878`; the picker chip is supplementary polish on a different surface, **not** a correctness gap (re-assignment is already fail-closed by `#2854`, and the picker already excludes inactive members per `#2869`). Branch preserved — reopen as an explicitly-scoped picker-polish item if wanted, not as "the last 2c slice".
 - **[~] Revisit grid performance:** opt into D2 high-scale harness/re-baseline work first; row virtualization stays closed unless the verdict flips.


### PR DESCRIPTION
## What

The plan + verification MD deliverable for the `/goal` "complete all development per the plan/TODO," after a parallel acceptance-criteria sweep (5 read-only agents) found and closed two real test/CI gaps.

### Verification result (all evidence in the verification MD's new top banner)
- **2a** (full scalar live-CRDT) · **2b-S1** (evaluator) · **2b-S3** (authoring UI) · **2b-S4** (parse cache) · **2c** (#16 person org-directory) — **all built + tested on main**, with file:line evidence.
- **2b-S2** — gap found and closed: only **3/9** read surfaces had real-DB goldens; the rule-deny composes into the shared `loadDeniedRecordIds` set for every surface, so **#2890** added goldens for view/search-filter, aggregate/dashboard, export, link-picker → **8/9** (green in `test (20.x)`).
- **2c CI gap** — the two FE specs were in no required gate → wired into web-guard (**#2891**).

### The one remaining item is an owner decision (not autonomous work)
**Trash list/restore rule-deny** is the 9th surface, deliberately deferred: `loadRuleDeniedRecordIds` evaluates **live `meta_records` only** (code-acknowledged docstring), so a rule-denied record, once trashed, is no longer hidden, and restore consults no rules. The feature is **flag-off / inert in prod** — nothing leaks today. Extending rule-deny to trashed records + gating restore is **new access-control behavior**, which is owner-named territory. Surfaced as a binary in TODO §5:
- **选 Build** trash rule-deny + restore gating + a real-DB golden, or
- **选 Defer** — record as a known limitation and narrow the S2 criterion to live surfaces.

I will not start it without an explicit pick.

Docs-only; depends on the already-merged #2890 + #2891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)