### PR TITLE
feat(integration-core): S1b-3 — wire C6 route to own multitable write target (sandbox, own-sheet only)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -4622,6 +4622,139 @@ async function testTableActionUnconfiguredFailsClosed() {
   assert.equal(res.body.error.code, 'TABLE_ACTION_NOT_CONFIGURED')
 }
 
+// S1b-3: the C6 dry-run->apply ROUTE drives the OWN metasheet:multitable target through the
+// same safe lifecycle (server-side write-source + profile resolution, never request-sourced),
+// writing only to own sheets, idempotent on re-pull, values-free. Wire-vs-fixture: asserts the
+// real route request/response, not a hand-built fixture.
+async function testPipelineExternalWriteMultitableRoute() {
+  const calls = []
+  const storage = createMemoryStorage()
+  const rows = [
+    { id: 'rec_mat2', sheetId: 'sheet_am', version: 1, data: { code: 'MAT-2', name: 'Gadget', qty: 5 } },
+  ]
+  const recordCalls = []
+  const recordsApi = {
+    async queryRecords(input) {
+      recordCalls.push(['queryRecords', input])
+      return rows
+        .filter((r) => Object.entries(input.filters || {}).every(([f, v]) => r.data[f] === v))
+        .slice(0, input.limit || 1000)
+    },
+    async createRecord(input) {
+      recordCalls.push(['createRecord', input])
+      const row = { id: `rec_${rows.length + 1}`, sheetId: input.sheetId, version: 1, data: { ...input.data } }
+      rows.push(row)
+      return row
+    },
+    async patchRecord(input) {
+      recordCalls.push(['patchRecord', input])
+      const row = rows.find((r) => r.id === input.recordId && r.sheetId === input.sheetId)
+      if (!row) throw new Error(`record not found: ${input.recordId}`)
+      row.version += 1
+      row.data = { ...row.data, ...input.changes }
+      return row
+    },
+  }
+  const sourceSystem = {
+    id: 'source_mt', tenantId: 'tenant_1', workspaceId: 'workspace_1', name: 'Readonly source',
+    kind: 'data-source:sql-readonly', role: 'source', status: 'active',
+    config: { dataSourceId: 'readonly-ds', object: 'src_items' },
+  }
+  const targetSystem = {
+    id: 'target_mt', tenantId: 'tenant_1', workspaceId: 'workspace_1', name: 'Own multitable target',
+    kind: 'metasheet:multitable', role: 'target', status: 'active',
+    config: {
+      objects: {
+        approved_materials: {
+          name: 'Approved Materials', sheetId: 'sheet_am', keyFields: ['code'],
+          fieldDetails: [{ id: 'code' }, { id: 'name' }, { id: 'qty' }],
+        },
+      },
+    },
+  }
+  const pipeline = {
+    id: 'pipe_mt', tenantId: 'tenant_1', workspaceId: 'workspace_1', name: 'C6 multitable', status: 'active',
+    sourceSystemId: sourceSystem.id, sourceObject: 'src_items',
+    targetSystemId: targetSystem.id, targetObject: 'approved_materials', createdBy: 'owner-7',
+    fieldMappings: [
+      { sourceField: 'c', targetField: 'code' },
+      { sourceField: 'n', targetField: 'name' },
+      { sourceField: 'q', targetField: 'qty' },
+    ],
+  }
+  const sourceRows = [
+    { c: 'MAT-1', n: 'Bolt', q: 2 },   // new -> add
+    { c: 'MAT-2', n: 'Gadget', q: 9 }, // exists with qty 5 -> update
+  ]
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) { calls.push(['getExternalSystemForAdapter', input]); return input.id === sourceSystem.id ? { ...sourceSystem } : null },
+      async getExternalSystem(input) { calls.push(['getExternalSystem', input]); return input.id === targetSystem.id ? { ...targetSystem } : null },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', { system, deps }])
+        assert.equal(system.id, sourceSystem.id, 'external-write creates only the source adapter')
+        return { async read() { return { records: sourceRows, done: true, nextCursor: null } } }
+      },
+    },
+    pipelineRegistry: {
+      async getPipeline(input) { calls.push(['getPipeline', input]); return { ...pipeline, id: input.id } },
+    },
+  })
+  const { routes } = mountRoutes(services, { storage, recordsApi })
+
+  // read-only user may dry-run; route resolves the multitable write-source + profile server-side.
+  let res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: READ_USER, params: { id: pipeline.id }, body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.canApply, true)
+  assert.equal(res.body.data.counts.add, 1, 'MAT-1 -> add')
+  assert.equal(res.body.data.counts.update, 1, 'MAT-2 (qty 5->9) -> update')
+  assert.equal(res.body.data.evidence.targetKind, 'metasheet:multitable', 'route resolved the multitable target by kind')
+  const dryText = JSON.stringify(res.body)
+  assert.equal(dryText.includes('MAT-1'), false, 'route dry-run evidence stays values-free')
+  assert.equal(dryText.includes('Bolt'), false, 'route dry-run evidence stays values-free')
+  assert.equal(recordCalls.some((c) => c[0] === 'createRecord' || c[0] === 'patchRecord'), false, 'dry-run performs no writes')
+
+  // dry-run as the apply user (token is principal-bound), then apply.
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER, params: { id: pipeline.id }, body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  const token = res.body.data.dryRunToken
+  assert.equal(typeof token, 'string')
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: WRITE_USER, params: { id: pipeline.id }, body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.counts.written, 2)
+  assert.equal(recordCalls.filter((c) => c[0] === 'createRecord').length, 1, 'one add -> one own-sheet createRecord')
+  assert.equal(recordCalls.filter((c) => c[0] === 'patchRecord').length, 1, 'one update -> one own-sheet patchRecord')
+  assert.ok(recordCalls.filter((c) => c[0] === 'createRecord' || c[0] === 'patchRecord').every((c) => c[1].sheetId === 'sheet_am'), 'writes land on the OWN sheet')
+  assert.equal(rows.length, 2, 'MAT-1 created; MAT-2 patched in place (no duplicate)')
+  assert.equal(JSON.stringify(res.body).includes('MAT-1'), false, 'apply response stays values-free')
+
+  // re-pull: same source -> idempotent skip, no new writes.
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/dry-run', {
+    user: WRITE_USER, params: { id: pipeline.id }, body: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.counts.skip, 2, 're-pull is idempotent (both skip)')
+  assert.equal(res.body.data.counts.add, 0)
+  assert.equal(res.body.data.counts.update, 0)
+  assert.equal(rows.length, 2, 're-pull created no duplicate records')
+
+  // read-only user cannot apply (perm gate fires before token).
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/external-write/apply', {
+    user: READ_USER, params: { id: pipeline.id }, body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', confirm: { dryRunToken: token } },
+  })
+  assert.equal(res.statusCode, 403, 'read-only integration user cannot apply multitable C6 writes')
+  assert.equal(rows.length, 2, 'rejected apply wrote nothing')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testStockPreparationTargetProvisioningRoutes()
@@ -4651,6 +4784,7 @@ async function main() {
   await testPipelineRoutes()
   await testPipelineExternalWriteDryRunRoute()
   await testPipelineExternalWriteApplyRoute()
+  await testPipelineExternalWriteMultitableRoute()
   await testPipelineExternalWriteApplyTestFailureInjectionRoute()
   await testPipelineExternalWriteApplyPersistsDeadLetterAndProvenance()
   await testPipelineExternalWriteApplyDoesNotOverstateProvenancePersistence()

--- a/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/metasheet-multitable-target-adapter.cjs
@@ -584,10 +584,49 @@ function createMetaSheetMultitableWriteSource({ system, context } = {}) {
   }
 }
 
+// S1b-3: derive the FLAT planner target config (what the C6 planner's normalizeTargetConfig
+// expects) from the multitable object config + the pipeline's field mappings. object/keyFields
+// come from the object config; writableFields are the MAPPED non-key targetFields (the fields
+// actually present in the transformed record), intersected with the object's fields — so the
+// planner's value-diff classify is idempotent. (Deriving writableFields from ALL object fields
+// would compare an unmapped field as undefined-vs-stored and force perpetual 'update'.)
+function deriveMultitablePlannerTargetConfig({ system, object, fieldMappings = [] } = {}) {
+  const normalizedSystem = normalizeExternalSystemForAdapter(system)
+  const objects = normalizeObjects(normalizedSystem.config)
+  const objectId = requiredString(object, 'object')
+  const objectConfig = getObjectConfig(objects, objectId)
+  const keyFields = objectConfig.keyFields
+  if (keyFields.length === 0) {
+    throw new AdapterValidationError('metasheet:multitable C6 write requires keyFields on the target object', { object: objectId })
+  }
+  const keySet = new Set(keyFields)
+  const fieldNameSet = objectConfig.fieldNames
+  const seen = new Set()
+  const writableFields = []
+  for (const mapping of Array.isArray(fieldMappings) ? fieldMappings : []) {
+    const target = mapping && (mapping.targetField || mapping.target)
+    if (typeof target !== 'string' || target.length === 0) continue
+    if (keySet.has(target) || seen.has(target)) continue
+    if (fieldNameSet.size > 0 && !fieldNameSet.has(target)) continue // only real sheet fields
+    seen.add(target)
+    writableFields.push(target)
+  }
+  if (writableFields.length === 0) {
+    throw new AdapterValidationError('metasheet:multitable C6 write requires at least one mapped non-key writable field', { object: objectId })
+  }
+  return {
+    dataSourceId: normalizedSystem.id || objectId, // opaque to the multitable write-source (it resolves object -> sheetId)
+    object: objectId,
+    keyFields,
+    writableFields,
+  }
+}
+
 module.exports = {
   MULTITABLE_WRITE_TARGET_KIND,
   MULTITABLE_WRITE_PROFILE,
   createMetaSheetMultitableWriteSource,
+  deriveMultitablePlannerTargetConfig,
   createMetaSheetMultitableTargetAdapter,
   createMetaSheetMultitableTargetAdapterFactory,
   __internals: {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -75,6 +75,13 @@ const {
   applyExternalWrite,
   dryRunExternalWrite,
 } = require('./external-write-dry-run.cjs')
+// S1b-3: own metasheet:multitable C6 write target (raw write-source + profile + flat-config derive).
+const {
+  MULTITABLE_WRITE_TARGET_KIND,
+  MULTITABLE_WRITE_PROFILE,
+  createMetaSheetMultitableWriteSource,
+  deriveMultitablePlannerTargetConfig,
+} = require('./adapters/metasheet-multitable-target-adapter.cjs')
 const {
   PLM_STOCK_PREPARATION_ACTION_ID,
   StockPreparationTableActionError,
@@ -446,6 +453,33 @@ function normalizeC6WriteApplyBody(body = {}) {
     confirm: {
       dryRunToken,
     },
+  }
+}
+
+// S1b-3: resolve the C6 write-source + profile + flat planner target config SERVER-SIDE by
+// target kind. The profile is NEVER taken from the request — it IS the per-kind safety policy.
+// metasheet:multitable rides the same C6 dry-run->apply lifecycle via its own-sheet raw
+// write-source (zero external write); any other (default) target uses the host SQL write
+// facade unchanged. Used by BOTH the dry-run and apply handlers with identical inputs so the
+// apply recompute reproduces the same dry-run revision (the revision fence).
+function resolveC6WritePlanInputs({ targetSystem, pipeline, context }) {
+  if (targetSystem && targetSystem.kind === MULTITABLE_WRITE_TARGET_KIND) {
+    const flatConfig = deriveMultitablePlannerTargetConfig({
+      system: targetSystem,
+      object: pipeline.targetObject,
+      fieldMappings: pipeline.fieldMappings,
+    })
+    return {
+      planTargetSystem: { ...targetSystem, config: flatConfig },
+      dataSourceWrites: createMetaSheetMultitableWriteSource({ system: targetSystem, context }),
+      targetWriteProfile: MULTITABLE_WRITE_PROFILE,
+    }
+  }
+  // default (data-source:sql-write-gated): host SQL write facade, planner uses its SQL profile.
+  return {
+    planTargetSystem: targetSystem,
+    dataSourceWrites: context && context.api && context.api.dataSourceWrites,
+    targetWriteProfile: undefined,
   }
 }
 
@@ -1575,12 +1609,14 @@ function createHandlers(services, options = {}) {
         role: 'source',
         principal: ownerPrincipal,
       })
+      const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context })
       return sendOk(res, await dryRunExternalWrite({
         pipeline,
         sourceSystem,
-        targetSystem,
+        targetSystem: c6.planTargetSystem,
         sourceAdapter,
-        dataSourceWrites: context && context.api && context.api.dataSourceWrites,
+        dataSourceWrites: c6.dataSourceWrites,
+        targetWriteProfile: c6.targetWriteProfile,
         tokenStore: context.storage,
         dryRunUser: requestPrincipal(req),
         dataSourceOwnerPrincipal: ownerPrincipal,
@@ -1662,12 +1698,16 @@ function createHandlers(services, options = {}) {
         })
       }
       try {
+        // SAME resolution as dry-run (server-side, by target kind) so the apply recompute
+        // reproduces the dry-run revision; the multitable write-source writes own sheets only.
+        const c6 = resolveC6WritePlanInputs({ targetSystem, pipeline, context })
         const result = await applyExternalWrite({
           pipeline,
           sourceSystem,
-          targetSystem,
+          targetSystem: c6.planTargetSystem,
           sourceAdapter,
-          dataSourceWrites: context && context.api && context.api.dataSourceWrites,
+          dataSourceWrites: c6.dataSourceWrites,
+          targetWriteProfile: c6.targetWriteProfile,
           tokenStore: context.storage,
           deadLetterStore: deadLetters,
           dryRunToken: body.confirm.dryRunToken,


### PR DESCRIPTION
## What (completes the S1b sandbox arc)

The C6 external-write dry-run/apply **route** now drives the own `metasheet:multitable` target through the **same** safe lifecycle as `sql-write-gated`, via the S1b-1 seam + S1b-2 write-source. Writes land **only** on own plugin sheets — **zero external write**.

- `resolveC6WritePlanInputs({targetSystem, pipeline, context})` (http-routes) resolves the write-source + profile + flat planner `targetConfig` **server-side by target kind**. The profile is **never request-sourced** (it is the per-kind safety policy). `metasheet:multitable` → own-sheet write-source + `MULTITABLE_WRITE_PROFILE`; any other kind → host SQL facade, unchanged.
- **Both** dry-run and apply handlers use the **same** resolver, so the apply recompute reproduces the dry-run revision (the fence holds).
- `deriveMultitablePlannerTargetConfig` builds the flat config from the object config (object/keyFields) + the pipeline's **mapped non-key** targetFields (`writableFields`) — so the planner's value-diff classify is **idempotent** (deriving from all object fields would force perpetual `update`).

## Wire-vs-fixture smoke (real route request/response)
`metasheet:multitable` dry-run → apply → re-pull through the **actual handlers**: add+update classified, token/revision-fence, writes hit only `sheet_am` (`createRecord`×1 + `patchRecord`×1), re-pull idempotent (`skip`×2, no duplicate), evidence carries `targetKind=metasheet:multitable` and stays values-free, read-only user is **403** on apply. **Empirically non-vacuous**: disabling the route's multitable branch fails the test. SQL route path unchanged (existing route tests green).

## Boundary
Sandbox / own-sheet only. **First production external write remains a separate owner gate.** No K3. `REQUIRED_ADAPTER_METHODS` unchanged. Auto-merge not armed — adversarial review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)