### PR TITLE
feat(multitable): 2b-S2 trash-surface rule-deny — hide rule-denied trashed records + refuse restore (9/9)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -192,6 +192,7 @@ jobs:
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
             tests/integration/multitable-conditional-rule-enforce-realdb.test.ts \
+            tests/integration/multitable-conditional-rule-trash-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \
             tests/integration/multitable-rowlevel-readdeny-flag-endpoint.test.ts \

--- a/packages/core-backend/src/multitable/permission-service.ts
+++ b/packages/core-backend/src/multitable/permission-service.ts
@@ -1055,14 +1055,43 @@ export async function loadDeniedRecordIds(query: QueryFn, sheetId: string, userI
 }
 
 /**
+ * Shared loader for a sheet's conditional read-deny rule set + field-type map. Returns null when the
+ * surface is inert: a pre-migration sheet (no `conditional_read_rules` column) or an empty/invalid rule
+ * list. Used by BOTH the live (`loadRuleDeniedRecordIds`) and trash (`loadRuleDeniedTrashRecordIds`)
+ * evaluators so they share identical parse-cache (2b-S4) + fail-closed + inert semantics.
+ */
+async function loadConditionalRulesAndFields(
+  query: QueryFn,
+  sheetId: string,
+): Promise<{ rules: ReturnType<typeof parseConditionalRulesCached>['rules']; fieldsById: Record<string, RuleFieldMeta | undefined> } | null> {
+  let rawRules: unknown
+  try {
+    const r = await query('SELECT conditional_read_rules AS rules FROM meta_sheets WHERE id = $1', [sheetId])
+    rawRules = (r.rows[0] as { rules?: unknown } | undefined)?.rules
+  } catch (err) {
+    if (isUndefinedColumnError(err, 'conditional_read_rules')) return null // pre-migration → inert
+    throw err // a real load failure → propagate (fail-closed: the surface errors, never grants read)
+  }
+  const { rules } = parseConditionalRulesCached(rawRules) // 2b-S4: content-keyed parse cache (staleness-free; the per-read DB load above is the freshness guarantee)
+  if (rules.length === 0) return null // no valid rules → inert
+  const fieldsById: Record<string, RuleFieldMeta | undefined> = {}
+  const fr = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
+  for (const row of fr.rows as Array<{ id?: unknown; type?: unknown }>) {
+    if (typeof row.id === 'string' && row.id) {
+      fieldsById[row.id] = { id: row.id, type: typeof row.type === 'string' ? row.type : '' }
+    }
+  }
+  return { rules, fieldsById }
+}
+
+/**
  * #18 phase-2 (2b): the set of LIVE record ids in `sheetId` denied by a conditional read-deny rule
  * (predicate on the record's data), independent of the actor (a rule hides a record from every
  * non-admin reader). Fail-closed: a structurally-valid rule whose field is missing/deleted, or whose
  * operator/value is invalid for the field type, DENIES the record (see evaluateRecordDenied). A
  * pre-migration sheet (no `conditional_read_rules` column) or an empty rule list → empty set (inert).
  * Caller gates on `loadRowLevelReadDenyEnabled` + admin-bypass, exactly like the grant-deny set.
- * NOTE: evaluates live `meta_records` only — trash (meta_records_trash) is a separate surface not yet
- * covered (the flag-off default keeps everything inert until 2b is complete).
+ * Evaluates live `meta_records`; the trash surface is covered by the sibling `loadRuleDeniedTrashRecordIds`.
  */
 export async function loadRuleDeniedRecordIds(
   query: QueryFn,
@@ -1071,23 +1100,8 @@ export async function loadRuleDeniedRecordIds(
 ): Promise<Set<string>> {
   if (!sheetId) return new Set<string>()
   if (recordIds && recordIds.length === 0) return new Set<string>() // nothing to evaluate
-  let rawRules: unknown
-  try {
-    const r = await query('SELECT conditional_read_rules AS rules FROM meta_sheets WHERE id = $1', [sheetId])
-    rawRules = (r.rows[0] as { rules?: unknown } | undefined)?.rules
-  } catch (err) {
-    if (isUndefinedColumnError(err, 'conditional_read_rules')) return new Set<string>() // pre-migration → inert
-    throw err // a real load failure → propagate (fail-closed: the surface errors, never grants read)
-  }
-  const { rules } = parseConditionalRulesCached(rawRules) // 2b-S4: content-keyed parse cache (staleness-free; the per-read DB load above is the freshness guarantee)
-  if (rules.length === 0) return new Set<string>() // no valid rules → inert
-  const fieldsById: Record<string, RuleFieldMeta | undefined> = {}
-  const fr = await query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])
-  for (const row of fr.rows as Array<{ id?: unknown; type?: unknown }>) {
-    if (typeof row.id === 'string' && row.id) {
-      fieldsById[row.id] = { id: row.id, type: typeof row.type === 'string' ? row.type : '' }
-    }
-  }
+  const rf = await loadConditionalRulesAndFields(query, sheetId)
+  if (!rf) return new Set<string>() // pre-migration / no valid rules → inert
   const denied = new Set<string>()
   const rr = recordIds && recordIds.length > 0
     ? await query('SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])', [sheetId, recordIds])
@@ -1095,7 +1109,46 @@ export async function loadRuleDeniedRecordIds(
   for (const row of rr.rows as Array<{ id?: unknown; data?: unknown }>) {
     if (typeof row.id !== 'string' || !row.id) continue
     const data = row.data && typeof row.data === 'object' ? (row.data as Record<string, unknown>) : {}
-    if (evaluateRecordDenied({ data }, rules, fieldsById).denied) denied.add(row.id)
+    if (evaluateRecordDenied({ data }, rf.rules, rf.fieldsById).denied) denied.add(row.id)
+  }
+  return denied
+}
+
+/**
+ * 2b-S2 (trash surface): the set of TRASHED record ids in `sheetId` denied by a conditional read-deny
+ * rule, evaluated against each trashed record's stored data in `meta_records_trash` (keyed by the
+ * original `record_id`). Same fail-closed + inert semantics as the live `loadRuleDeniedRecordIds`, and
+ * the caller gates on `loadRowLevelReadDenyEnabled` + admin-bypass identically. Closes the trash gap so a
+ * rule-denied record stays hidden after deletion (trash list) and cannot be brought back via restore.
+ * A pre-migration trash table (absent `meta_records_trash`) → empty set (inert).
+ */
+export async function loadRuleDeniedTrashRecordIds(
+  query: QueryFn,
+  sheetId: string,
+  recordIds?: string[],
+): Promise<Set<string>> {
+  if (!sheetId) return new Set<string>()
+  if (recordIds && recordIds.length === 0) return new Set<string>()
+  const rf = await loadConditionalRulesAndFields(query, sheetId)
+  if (!rf) return new Set<string>() // pre-migration / no valid rules → inert
+  const denied = new Set<string>()
+  const useIds = Boolean(recordIds && recordIds.length > 0)
+  const sql = useIds
+    ? 'SELECT record_id AS id, data FROM meta_records_trash WHERE sheet_id = $1 AND record_id = ANY($2::text[])'
+    : 'SELECT record_id AS id, data FROM meta_records_trash WHERE sheet_id = $1'
+  const params = useIds ? [sheetId, recordIds] : [sheetId]
+  let rows: Array<{ id?: unknown; data?: unknown }>
+  try {
+    const rr = await query(sql, params)
+    rows = rr.rows as Array<{ id?: unknown; data?: unknown }>
+  } catch (err) {
+    if (isUndefinedTableError(err, 'meta_records_trash')) return new Set<string>() // pre-migration → inert
+    throw err // a real load failure → propagate (fail-closed: the surface errors, never grants read)
+  }
+  for (const row of rows) {
+    if (typeof row.id !== 'string' || !row.id) continue
+    const data = row.data && typeof row.data === 'object' ? (row.data as Record<string, unknown>) : {}
+    if (evaluateRecordDenied({ data }, rf.rules, rf.fieldsById).denied) denied.add(row.id)
   }
   return denied
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -52,6 +52,7 @@ import {
   loadRecordPermissionScopeMap,
   loadRowLevelReadDenyEnabled,
   loadDeniedRecordIds,
+  loadRuleDeniedTrashRecordIds,
   loadSheetMemberUserIdSet,
   loadSheetPermissionScopeMap,
   loadViewPermissionScopeMap,
@@ -11396,7 +11397,15 @@ export function univerMetaRouter(): Router {
       // canDeleteRecord-gated trash count may include a denied row; exact-count exclusion is a minor follow-up.)
       let trashRecords = result.records
       if (!access.isAdminRole && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
-        const deniedIds = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        // grant-deny (record_permissions, persists across delete) ∪ rule-deny evaluated against the
+        // TRASHED records' data (loadRuleDeniedRecordIds reads live meta_records only, so a rule-denied
+        // record would otherwise resurface here once deleted — 2b-S2 trash-surface close-out).
+        const trashedIds = result.records.map((rec) => rec.recordId)
+        const [deniedIds, ruleDeniedTrash] = await Promise.all([
+          loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId),
+          loadRuleDeniedTrashRecordIds(pool.query.bind(pool), sheetId, trashedIds),
+        ])
+        for (const id of ruleDeniedTrash) deniedIds.add(id)
         if (deniedIds.size > 0) trashRecords = result.records.filter((rec) => !deniedIds.has(rec.recordId))
       }
       const maskedRecords = trashRecords.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
@@ -11426,6 +11435,22 @@ export function univerMetaRouter(): Router {
       const access = await resolveRequestAccess(req)
       if (!access.userId) {
         return res.status(401).json({ error: 'Authentication required' })
+      }
+      // 2b-S2 trash-surface close-out: a record currently rule-denied for this actor must not be
+      // restorable — otherwise restore would reintroduce an unreadable record onto the live/operable
+      // path. Resolve the trashed record's sheet; if the flag is on, the actor is non-admin, and a
+      // conditional rule denies the trashed record's data, refuse (403). Admin-bypass + flag-off inert
+      // mirror the read surfaces exactly.
+      if (!access.isAdminRole) {
+        const trashRow = await pool.query('SELECT sheet_id FROM meta_records_trash WHERE record_id = $1 LIMIT 1', [recordId])
+        const trashSheetId = (trashRow.rows[0] as { sheet_id?: unknown } | undefined)?.sheet_id
+        if (typeof trashSheetId === 'string' && trashSheetId
+          && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), trashSheetId)) {
+          const ruleDenied = await loadRuleDeniedTrashRecordIds(pool.query.bind(pool), trashSheetId, [recordId])
+          if (ruleDenied.has(recordId)) {
+            return sendForbidden(res, 'Cannot restore a record you are not permitted to read')
+          }
+        }
       }
       const recordService = new RecordService(pool, eventBus)
       const result = await recordService.restoreRecord({

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -11436,11 +11436,12 @@ export function univerMetaRouter(): Router {
       if (!access.userId) {
         return res.status(401).json({ error: 'Authentication required' })
       }
-      // 2b-S2 trash-surface close-out: a record currently rule-denied for this actor must not be
-      // restorable — otherwise restore would reintroduce an unreadable record onto the live/operable
-      // path. Resolve the trashed record's sheet; if the flag is on, the actor is non-admin, and a
-      // conditional rule denies the trashed record's data, refuse (403). Admin-bypass + flag-off inert
-      // mirror the read surfaces exactly.
+      // 2b-S2 trash-surface close-out: a record currently denied by a CONDITIONAL READ-DENY RULE for
+      // this actor must not be restorable — otherwise restore would reintroduce a rule-denied record onto
+      // the live/operable path. Resolve the trashed record's sheet; if the flag is on, the actor is
+      // non-admin, and a conditional rule denies the trashed record's data, refuse (403). Admin-bypass +
+      // flag-off inert mirror the read surfaces. (Scope: conditional-rule deny only — grant-deny
+      // (record_permissions) on restore is pre-existing and out of this change's scope.)
       if (!access.isAdminRole) {
         const trashRow = await pool.query('SELECT sheet_id FROM meta_records_trash WHERE record_id = $1 LIMIT 1', [recordId])
         const trashSheetId = (trashRow.rows[0] as { sheet_id?: unknown } | undefined)?.sheet_id

--- a/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
@@ -11,6 +11,11 @@
  * Admin bypass + flag-off inertness mirror the live surfaces exactly. Each test re-seeds trash in
  * beforeEach so the (mutating) restore cases are independent.
  *
+ * SCOPE: this closes the CONDITIONAL-RULE deny on the trash surface. Grant-deny (record_permissions)
+ * on restore, and the unadjusted trash `total` COUNT (a pre-existing count caveat shared with grant-deny
+ * — the record's data is excluded, only the aggregate count is not), are deliberately out of scope here
+ * (a separate cross-cutting follow-up); the `total` behavior is pinned below so a future change is intentional.
+ *
  * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
  */
 import express, { type Express } from 'express'
@@ -33,7 +38,7 @@ const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, param
 let app: Express
 let testUserId = USER_ID
 let testPerms: string[] = ['multitable:read', 'multitable:write'] // full write → canDeleteRecord, non-admin
-let testRoles: string[] = []
+let testRoles: string[] = ['member'] // non-admin; full write (above) grants canDeleteRecord (gates the bin)
 
 const setFlag = (on: boolean) =>
   q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
@@ -87,7 +92,7 @@ describeIfDatabase('#18 phase-2 conditional read-deny — trash list + restore (
   beforeEach(async () => {
     testUserId = USER_ID
     testPerms = ['multitable:read', 'multitable:write']
-    testRoles = []
+    testRoles = ['member']
     await setFlag(false)
     await setRules([])
     await seedTrash()
@@ -108,9 +113,16 @@ describeIfDatabase('#18 phase-2 conditional read-deny — trash list + restore (
   test('enforce — flag ON + deny rule: trash list HIDES the rule-denied record, keeps the rest', async () => {
     await setFlag(true)
     await setRules(denySecretRule)
-    const ids = await trashIds()
-    expect(ids).not.toContain(REC_SECRET)
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/trash`).query({ limit: 100 })
+    expect(res.status).toBe(200)
+    const ids = (res.body?.data?.records ?? []).map((r: { recordId: string }) => r.recordId)
+    expect(ids).not.toContain(REC_SECRET) // the denied record's row + data are excluded
     expect(ids).toContain(REC_PUBLIC)
+    // KNOWN CAVEAT (pinned, out of this scope): `total` is a sheet-wide COUNT(*) in listDeletedRecords,
+    // NOT adjusted for the deny filter — it still counts the hidden row. Pre-existing count behavior also
+    // shared with grant-deny (route comments it a minor follow-up); the data is protected, only the count
+    // is unadjusted. Pinned so a future deny-aware counter is an intentional change, not a silent one.
+    expect(res.body?.data?.total).toBe(2)
   })
 
   test('enforce — flag ON + deny rule: restoring the rule-denied record is REFUSED (403); a non-denied record restores (200)', async () => {

--- a/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #18 phase-2 (2b) conditional read-deny rules — TRASH surface close-out (real DB).
+ *
+ * The live read surfaces feed the rule-deny via loadDeniedRecordIds → loadRuleDeniedRecordIds, which
+ * evaluates LIVE meta_records only. A deleted record lives in meta_records_trash, so the live evaluator
+ * can't see it — this golden proves the dedicated trash evaluator (loadRuleDeniedTrashRecordIds) closes
+ * that gap on the two trash-surface paths:
+ *   - trash list (GET /sheets/:id/trash): a rule-denied deleted record is hidden, just like live.
+ *   - restore (POST /records/:id/restore): restoring a currently-rule-denied record is REFUSED (403),
+ *     so restore can't reintroduce an unreadable record onto the live/operable path.
+ * Admin bypass + flag-off inertness mirror the live surfaces exactly. Each test re-seeds trash in
+ * beforeEach so the (mutating) restore cases are independent.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_crt_${TS}`
+const SHEET_ID = `sheet_crt_${TS}`
+const STATUS = `fld_crt_status_${TS}`
+const REC_SECRET = `rec_crt_secret_${TS}`
+const REC_PUBLIC = `rec_crt_public_${TS}`
+const USER_ID = `user_crt_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read', 'multitable:write'] // full write → canDeleteRecord, non-admin
+let testRoles: string[] = []
+
+const setFlag = (on: boolean) =>
+  q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) =>
+  q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
+const denySecretRule = [{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }]
+
+const trashIds = async (): Promise<string[]> => {
+  const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/trash`).query({ limit: 100 })
+  expect(res.status).toBe(200)
+  return (res.body?.data?.records ?? []).map((r: { recordId: string }) => r.recordId)
+}
+const restore = (recordId: string) => request(app).post(`/api/multitable/records/${recordId}/restore`)
+
+const seedTrash = async () => {
+  // start clean: nothing live, both records sitting in trash
+  await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID])
+  await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET_ID])
+  for (const [rid, status] of [[REC_SECRET, 'secret'], [REC_PUBLIC, 'public']] as const) {
+    await q(
+      `INSERT INTO meta_records_trash (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by)
+       VALUES ($1,$2,$3,$4::jsonb,1,$5,$5)`,
+      [rid, SHEET_ID, BASE_ID, JSON.stringify({ [STATUS]: status }), USER_ID],
+    )
+  }
+}
+
+describeIfDatabase('#18 phase-2 conditional read-deny — trash list + restore (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'CRT Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'CRT Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read', 'multitable:write']
+    testRoles = []
+    await setFlag(false)
+    await setRules([])
+    await seedTrash()
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('inert — flag OFF even with a deny rule: trash list shows the rule-denied record', async () => {
+    await setRules(denySecretRule)
+    await setFlag(false)
+    const ids = await trashIds()
+    expect(ids).toContain(REC_SECRET)
+    expect(ids).toContain(REC_PUBLIC)
+  })
+
+  test('enforce — flag ON + deny rule: trash list HIDES the rule-denied record, keeps the rest', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const ids = await trashIds()
+    expect(ids).not.toContain(REC_SECRET)
+    expect(ids).toContain(REC_PUBLIC)
+  })
+
+  test('enforce — flag ON + deny rule: restoring the rule-denied record is REFUSED (403); a non-denied record restores (200)', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const denied = await restore(REC_SECRET)
+    expect(denied.status).toBe(403)
+    // the refused record stays in trash (not resurrected onto the live path)
+    const trashRow = await q('SELECT 1 FROM meta_records_trash WHERE sheet_id = $1 AND record_id = $2', [SHEET_ID, REC_SECRET])
+    expect(trashRow.rows.length).toBe(1)
+    const live = await q('SELECT 1 FROM meta_records WHERE sheet_id = $1 AND id = $2', [SHEET_ID, REC_SECRET])
+    expect(live.rows.length).toBe(0)
+    // a non-denied trashed record restores normally
+    expect((await restore(REC_PUBLIC)).status).toBe(200)
+  })
+
+  test('inert — flag OFF: the same record restores normally (default-off changes nothing)', async () => {
+    await setRules(denySecretRule)
+    await setFlag(false)
+    expect((await restore(REC_SECRET)).status).toBe(200)
+  })
+
+  test('admin bypass — flag ON + deny rule: an admin sees the record in trash and can restore it', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    testRoles = ['admin']
+    expect(await trashIds()).toContain(REC_SECRET)
+    expect((await restore(REC_SECRET)).status).toBe(200)
+    testRoles = []
+  })
+})


### PR DESCRIPTION
## What

Owner-approved (选 Build) close-out of the **last 2b-S2 read surface** — trash list/restore — taking conditional read-deny coverage from 8/9 to **9/9** (records-excluded; see count caveat).

The live rule-deny path (`loadDeniedRecordIds` → `loadRuleDeniedRecordIds`) evaluates **live `meta_records` only**, so a conditional-rule-denied record would resurface in the trash list once deleted and could be restored back onto the live path.

## Changes (scoped exactly to the owner's boundary)

- **`permission-service.ts`** — extract `loadConditionalRulesAndFields` (rules + field-type map; parse-cache 2b-S4 + fail-closed + inert) shared by both evaluators; refactor `loadRuleDeniedRecordIds` onto it (**behavior-preserving**, guarded by the existing enforce-realdb golden); add **`loadRuleDeniedTrashRecordIds`** evaluating the same rules against `meta_records_trash` (keyed by original `record_id`), fail-closed, inert on absent column/table.
- **trash list** (`GET /sheets/:id/trash`) — union the trash rule-deny into the deny set → rule-denied deleted records' rows + data are hidden, consistent with live surfaces.
- **restore** (`POST /records/:id/restore`) — fail-closed gate: `!isAdmin` + flag-on + the trashed record currently **conditional-rule-denied** → **403**. Admin-bypass + flag-off inert mirror the read surfaces.
- **real-DB golden** (`multitable-conditional-rule-trash-realdb.test.ts`, registered in `plugin-tests.yml`): trash-list hide + restore-refuse (record stays in trash, absent from live) + non-denied record restores + **flag-OFF inert control** + admin bypass.

## Scope & known caveats (honest by design)

- **Conditional-rule deny only.** Grant-deny (`record_permissions`) on restore is **pre-existing and out of scope** — the gate checks `loadRuleDeniedTrashRecordIds`, not the grant set (honors "不扩展别的权限模型"). #2877 untouched; no roadmap items.
- **Count caveat (pinned, not fixed here).** The trash `total` is a sheet-wide `COUNT(*)` in `listDeletedRecords`, **not** adjusted for the deny filter — so it still counts the hidden row (the record's *data* is excluded; only the aggregate count is unadjusted). This is **pre-existing**, also true of grant-deny (route comments it a minor follow-up); a correct fix is a cross-cutting, pagination-aware counter for *both* deny types. Pinned with a test assertion + documented so the ledger says "records-excluded (count caveat)", not "no leak".

## Verification
`tsc --noEmit` clean; tests compile (DB-gated `describe` skips locally); evaluator unit suite green (43). Real-DB assertions run in `test (20.x)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)