### PR TITLE
docs(integration): refresh verification MD to completed S1b arc + S3 design-lock

### DIFF
--- a/docs/development/data-source-system-integration-plan-and-verification-20260618.md
+++ b/docs/development/data-source-system-integration-plan-and-verification-20260618.md
@@ -1,103 +1,77 @@
-# 数据库 / 系统对接 — 计划与验证汇总(2026-06-18)
+# 数据库 / 系统对接 — 计划与验证汇总(2026-06-19 刷新)
 
-> 本文是"数据库连接 → 通用对接"业务线的**计划 + 验证**汇总(完成态交付物)。
-> 它索引各刀的设计/验证文档,不替代它们;每个 runtime 写能力仍是**独立 opt-in + 独立 PR + 独立验证**。
-> production / batch / 首笔外部写 = 始终独立显式 owner gate。
+> 本文是"数据库连接 → 通用对接"业务线的**计划 + 验证**汇总(完成态交付物)。它索引各刀的设计/验证文档,不替代它们。
+> production / batch / **首笔真实外部写 = 始终独立显式 owner gate**。
 
 ## 0. 一页结论
 
-- **只读数据库接入(C2)+ 增量(C3)+ 配置体验(C4)+ K3 generic MSSQL seam(C5)+ 外部写 sandbox 链路(C6)**:全部已交付并实体机验收闭合(release evidence #2769 PASS)。
-- **通用对接收敛 S1a(合同层)**:可选写能力面 `targetWriteLifecycle`(#2872)+ values-free 加固(#2882,本轮)已落地。
-- **S1b(keystone)**:本轮**完成设计锁定**(`generic-integration-s1b-keystone-design-lock-20260618.md`);**实现 GATED**——它触及全系统风险最高的写路径,且暴露一个必须 owner 先签字的高度(altitude)问题。**这是相对"直接实现 S1b"请求的一次显式 scope 偏移,见 §3。**
-- **S2(K3)/ S3(模版对象)/ S4(自描述元数据)/ S5(PLM stock-prep 吸收)/ 首笔生产外部写**:均为后续 gated opt-in,各带自己的 gate(见 §5)。
+- **只读数据库接入(C2)+ 增量(C3)+ 配置体验(C4)+ K3 generic MSSQL seam(C5)+ 外部写 sandbox 链路(C6)**:已交付并实体机验收闭合(release evidence #2769 PASS)。
+- **通用对接收敛(S1a + S1b sandbox 弧)= 本轮全部落地**:C6 `dry-run→apply` 安全写生命周期**已从 `data-source:sql-write-gated` 泛化**到一个 **target write profile + 注入式 raw write-source 合同**;自有 `metasheet:multitable` target 已经骑上同一生命周期(**sandbox、零外部写**)。S1a 早期的 `targetWriteLifecycle`(lookup/apply)方法面在实现中被证明 orphaned 且有"绕过 C6 gate 直接写"误用风险,**已退役**;S1a 合同**重定义为 profile + raw write-source**。
+- **S2(K3)/ S3(模版对象)/ S4(自描述元数据)/ S5(PLM stock-prep 吸收)/ 首笔生产外部写**:后续 gated opt-in,各带自己的 gate(见 §5)。**S3 已出设计锁**(`generic-integration-s3-template-object-design-lock-20260619.md`);**S2 因实体机 gate + K3 红线**不在本轮自动构建;**S5 按计划短期不重写**。
 
 ## 1. 状态阶梯
 
-| 阶段 | 内容 | 状态 | 锚点 |
+| 阶段 | 内容 | 状态 | 锚点(SHA = squash 合并) |
 |---|---|---|---|
-| C2 | 只读 SQL 源链路 smoke | ✅ done | issue #2600 |
-| C3 | 增量 / watermark runtime | ✅ done(core+CI real-DB lock) | #2609/#2619/#2625/#2628/#2631 |
+| C2 | 只读 SQL 源链路 smoke | ✅ done | #2600 |
+| C3 | 增量 / watermark runtime | ✅ done | #2609/#2619/#2625/#2628/#2631 |
 | C4 | UI / 配置体验 | ✅ done | #2643/#2646/#2649/#2652/#2655 |
-| C5 | K3 generic MSSQL seam | ✅ done(红线不开) | #2670 PASS/CLOSED;#2700 runbook |
-| C6 | 外部写 sandbox 链路 | ✅ done(C6-0..C6-5c + 实体机 controlled bad-row) | #2720;package `d8244ee13`;#2761;PM2 #2820 |
-| Release | 总包 + 实体机验收(scoped) | ✅ done | #2769 PASS(package `79ab455e`) |
-| **S1a** | 通用可选写能力面(合同层) | ✅ done | #2868 设计锁;#2872 能力;**#2882 values-free 加固(本轮)** |
-| **S1b** | 自有 multitable target 走泛化安全写(keystone) | 🔒 **design-locked,impl GATED**(本轮) | `…s1b-keystone-design-lock-20260618.md` |
-| S2 | K3 WebAPI target opt-in 同一安全写(sandbox) | 🔒 gated(opt-in + 实体机) | 总锁 §6 |
-| S3 | first-class `integration-template` 对象 | 🔒 gated(opt-in) | 总锁 §6 |
-| S4 | adapter 自描述元数据 | 🔒 gated(opt-in) | 总锁 §6 |
-| S5 | 统一 field-mapping + PLM stock-prep 吸收 | 🔒 gated(低优先,短期不重写) | 总锁 §3/§6 |
+| C5 | K3 generic MSSQL seam(红线不开) | ✅ done | #2670;#2700 |
+| C6 | 外部写 sandbox 链路 | ✅ done | #2720;#2761;#2820 |
+| Release | 总包 + 实体机验收(scoped) | ✅ done | #2769(package `79ab455e`) |
+| **S1a** 合同 | 通用可选写能力(合同层) | ✅ done | #2868 设计锁;#2872 能力;#2882 values-free 加固(`687271dd6`) |
+| **S1a-retire** | 退役 orphaned `targetWriteLifecycle`,S1a 重定义为 profile + raw write-source | ✅ done | #2894(`14ffaf10b`) |
+| **S1b-1** | C6 planner 写原语来源可插拔(profile seam,SQL 零漂移) | ✅ done | #2887(`060d72635`) |
+| **S1b-2** | `metasheet:multitable` raw write-source + profile(rides C6,自有 sheet) | ✅ done | #2892(`e5dc7cf9f`) |
+| **S1b-3** | C6 route 接入 multitable target(server-side 解析,sandbox 零外部写)+ wire-vs-fixture smoke | ✅ done | #2898(`5e65a4add`) |
+| S2 | K3 WebAPI target opt-in 同一安全写(sandbox) | 🔒 gated(opt-in + **实体机** + K3 红线保留) | 总锁 §6 |
+| S3 | first-class `integration-template` 对象 | 🔒 **design-locked**,impl gated | `…s3-template-object-design-lock-20260619.md` |
+| S4 | adapter 自描述元数据(替换 `ADAPTER_METADATA` 静态字面量) | 🔒 gated(opt-in;已 scope:~13 文件,机械) | 总锁 §6 |
+| S5 | 统一 field-mapping + PLM stock-prep 吸收 | 🔒 gated(**低优先,短期不重写**) | 总锁 §3/§6 |
 | 首笔生产外部写 | sandbox-first 序列后单独一刀 | 🔒 **owner 授权** | 总锁 §5/§6 |
 
-## 2. 本轮交付:S1a values-free 加固(#2882)
+## 2. 本轮交付:通用对接收敛(S1a 重定义 + S1b sandbox 弧)
 
-**背景**:独立复审指出 S1a 的 keyHash 只堵了 key 一个 vector,result builder 仍原样放行 `error` / `revision` / `metadata` 自由串(P1);并指出总设计锁"OpenAPI parity"是过声明(P2)。
+**最终架构**:C6 的 `dry-run → revision-fence → token-apply → per-row → dead-letter` 安全写生命周期不再焊死在 `data-source:sql-write-gated`。它由两件解耦的东西驱动:**(a) target write profile**(`kind` + capability `normalize`/`assert`,**per-kind 安全策略**,server-side 装配,绝不来自 request),**(b) 注入式 raw write-source**(`test/lookupByKey/insertRows/updateRows`)。planner 已验证的判定(value-diff classify)+ 安全原语**原样不动**,自产 values-free evidence。
 
-**修复**(`plugins/plugin-integration-core/lib/contracts.cjs`):
+逐刀:
 
-- 结构性 values-free(真保证):
-  - `revision` → opaque **`revisionHash`**(sha256;保留**相等性**,故 dry-run→apply revision-fence 仍判漂移);
-  - **drop free-text `error`**(DB 错误内嵌行值);人类可读原因改落 dead-letter(`sanitizeIntegrationPayload` + 32KB cap)= relocated, not lost;
-  - `metadata` → **number\|boolean\|null only**(拒绝字符串/嵌套)。
-- 纵深防御(非硬保证):`errorCode` → CODE charset `[A-Z0-9_]{1,64}`(允许全数字 SQLSTATE 如 `42501`);honestly 标注其非硬保证。
-- 文档(P2):总设计锁"OpenAPI parity"改为"plugin-local 内部合同,无公开 API surface,OpenAPI 不适用";新增 §6.1 验收 #3(values-free result 形态,逐 vector canary 锁)+ S1b 衔接(result=code-only 分流,dead-letter=sanitized detail)。
+- **S1a values-free 加固(#2882)**:result builder 的 error/revision/metadata 自由串收口(revision→opaque `revisionHash` 保相等性用于 fence;drop free-text error→落 dead-letter;metadata→number\|boolean\|null;errorCode→CODE charset 纵深防御)。逐 vector canary + **经验回退证明非空洞** + 独立复审 APPROVE + `REQUIRED_ADAPTER_METHODS` 未变。
+- **S1a-retire(#2894)**:S1b 实现证明 `targetWriteLifecycle`(lookup/apply)零 runtime 消费者(seam 用 profile + raw source,planner 自产 evidence),且 adapter 上留 `apply()` = 绕过 C6 gate 直接写的误用风险。退役该方法面(含其专用 values-free helpers + crypto),`REQUIRED_ADAPTER_METHODS` 未变;文档把 S1a 重定义为 profile + raw write-source 合同。复审 APPROVE(无 over-deletion / 无 missed consumer)。
+- **S1b-1 planner seam(#2887)**:`normalizeTargetConfig` kind 门 + capability-state 断言抽象为 profile;写原语来源 = 注入 `dataSourceWrites`(已可插拔)。**SQL 路径零漂移(既有套件原样绿 + revision hash 字节级一致,经验证)**;新增 capability 路径用 fake profile + fake 写源覆盖 add/update/skip/held/token/fence/per-row/dead-letter。复审 APPROVE。
+- **S1b-2 multitable 写源 + profile(#2892)**:`createMetaSheetMultitableWriteSource`(自有 sheet,logical↔physical 字段映射)+ `MULTITABLE_WRITE_PROFILE`(**真安全属性**:own-sheet scoped、external-write=false,fail-closed)。**零外部写**。复审 REQUEST-CHANGES→修(P2:`lookupByKey` 取 `limit:2` 让重复键命中 planner 的 ambiguous→held,而非静默改一条)→**经验回退证非空洞**→re-review APPROVE。
+- **S1b-3 route + smoke(#2898)**:C6 dry-run/apply route 由 `resolveC6WritePlanInputs` **server-side 按 target kind** 解析 write-source + profile + 派生 flat targetConfig(`writableFields` = 已映射非键字段,保 re-pull 幂等);dry-run 与 apply **同一解析**(故 apply recompute 复现 dry-run revision,fence 成立)。wire-vs-fixture 集成 smoke 跑**真实 route**:dry-run→apply→re-pull 幂等、只写自有 sheet、evidence values-free、read-only 403。**经验回退证非空洞**(关掉 multitable 分支即 fail)。复审 APPROVE(server-side-only / dry-run-apply parity / own-sheet / SQL 零漂移 全确认)。
 
-**验证**:
+## 3. 红线 / 不变式(继承,逐字保留)
 
-- 逐 vector canary(key/error/revision/metadata)+ revision-fence 相等性测试;`adapter-contracts.test.cjs` 绿。
-- **非空洞性经验证明**:逐一回退每个结构保证(error/revision),canary 即触发失败(`apply result must not carry alice@example.com`、`lookup result must not carry Acme Corp Ltd`),还原后转绿——证明 canary 落在被处理的输入字段上,不是自洽通过。
-- 独立子智能体复审 **APPROVE**:allow-list 投影(不 spread 输入行/匹配)、canary 非空洞、`REQUIRED_ADAPTER_METHODS` **未变**。
-- 受影响 pure-node 测试(含 `external-write-dry-run` / `metasheet-multitable-target-adapter` / `stock-preparation-table-actions` / `connector-action-contracts` / `provenance-contracts`)`pnpm install` 后全绿。
-- 基础 5-method 合同**未变**;**零 runtime 消费者**(S1a 未接线)。
+- 凭据只经 credential store;UI / request 只引用 system / dataSourceId,**不复制凭据**;**write profile 绝不来自 request**(它是 per-kind 安全策略,server-side 装配)。
+- **首笔真实外部写 = 独立 owner 授权**;sandbox-first 序列不变。S1b 全程**零外部写**(multitable 写自有 sheet)。
+- 两阶段 dry-run→apply;per-row 隔离,不 batch-abort;无自动重试打爆;dead-letter 收口;revision fence 硬围栏。
+- **K3 Submit/Audit/BOM 红线不开**(S1b 不碰 K3;K3 = S2,另门)。
+- issue / evidence **values-free**。
+- **SQL `data-source:sql-write-gated` 路径在整条 S1b 后行为零漂移**(既有套件原样绿 = 硬验收,已多刀确认)。
 
-**PR**:#2882 — **MERGED**(squash `687271dd6`,2026-06-19T01:10:24Z)。已验证落 `origin/main`:`contracts.cjs` 含加固(`revisionHash`/`valuesFreeMetadata`/`assertErrorCode`/`CODE_PATTERN`),`REQUIRED_ADAPTER_METHODS` 未变。
-
-## 3. S1b:设计锁定(本轮)+ scope 偏移声明
-
-**显式声明(诚实优先)**:owner 的指令是"S1b 应继续做 metasheet:multitable sandbox keystone",期望是**实现**。本轮交付的是 **S1b 设计锁**,不是实现——这是一次**主动 scope 偏移**,理由如下,请 owner 知悉并裁决:
-
-- S1b 要把 C6 `dry-run→apply` 安全生命周期从 `data-source:sql-write-gated` 泛化到能力面。盘点 `external-write-dry-run.cjs`(914 行,**全系统风险最高写路径**)发现它与 sql-write-gated 焊死三处,且与 S1a 合同存在一个**高度问题**:`targetWriteLifecycle.lookup/apply` 到底是 planner *内部数据通路* 还是 *证据投影*?——`classifyExisting` 靠**原始行字段值比较**判 add/update/skip,而 S1a 加固后的 `lookup` 刻意 **values-free 无字段值**,二者**无法直接对接**。
-- 这是"design-lock first"纪律的典型场景:在安全写路径上,先由 owner 对高度问题签字,再动代码;否则实现极可能在复审被打回。
-- 因此本轮把 S1b 从"一刀"细化为**设计锁 + 可机械执行的实现计划**(`generic-integration-s1b-keystone-design-lock-20260618.md`)。
-
-**推荐解 A(双接口拆分)**:planner 已验证的判定 + 安全逻辑**原样不动**;只把写原语**来源**做成可插拔(adapter-backed 原始内向接口取代 host sql-write-gated facade);`targetWriteLifecycle.lookup/apply`(values-free)定位为 **evidence 投影**——这也使 #2882 加固**保持正确**(它就是 evidence 形态)。B(revision 制判定)= 幂等语义变更,需独立验证;C(另起生命周期)= 违反总锁"复用不重造"。
-
-**实现就绪计划**(签字后机械执行,各刀独立 PR + 子智能体审阅):
-
-- **S1b-1**:planner 写原语来源泛化为可插拔(kind 门 + capability-state 断言抽象);**SQL 路径行为零漂移(既有测试原样绿=硬验收)**;新增 capability 写源用 fake/in-memory 写源覆盖 add/update/skip/held/token/fence/per-row/dead-letter。
-- **S1b-2**:`metasheet:multitable` target 提供原始内向写源(自有 sheet lookup/insert/update)+ `targetWriteLifecycle`(values-free)evidence 投影。
-- **S1b-3**:sandbox pipeline + route + wire-vs-fixture 集成 smoke(dry-run→apply→re-pull 幂等),**零外部写**。
-
-> **裁决请求**:请 owner 对**高度问题(`lookup/apply`=evidence 投影,A 双接口)**签字。签字="go",我即按 S1b-1→2→3 实现。
-
-## 4. 安全红线(继承,逐字保留)
-
-- 凭据只经 credential store;UI 只引用 system/dataSourceId,不复制凭据。
-- 首笔真实外部写 = 独立 owner 授权;sandbox-first 序列不变。
-- 两阶段 dry-run→apply;per-row 隔离,不 batch-abort;无自动重试打爆;dead-letter 收口。
-- K3 Submit/Audit/BOM 红线不开。
-- issue / evidence values-free。
-
-## 5. 剩余 gated 项(各带 gate,均非本轮交付)
-
-| 项 | gate | 备注 |
-|---|---|---|
-| S1b-1/2/3 实现 | owner 对 §3 高度问题签字 | 计划已就绪 |
-| S2(K3 WebAPI opt-in) | opt-in + **实体机 smoke**(operator 执行) | 红线保留;仅 sandbox |
-| S3(template 对象) | opt-in | K3/PLM 各出一个参考模版 |
-| S4(自描述元数据) | opt-in | 替换 `ADAPTER_METADATA` 静态字面量 |
-| S5(PLM stock-prep 吸收) | opt-in | 低优先,短期不重写专用链路 |
-| 首笔生产外部写 | **owner 授权** | 多样本只读 dry-run→sandbox apply→re-pull 幂等+人工字段保留→生产 |
-
-## 6. 验证汇总
+## 4. 验证汇总
 
 | 维度 | 证据 |
 |---|---|
-| C2-C6 + Release | TODO 账本 `data-source-system-integration-delivery-todo-20260614.md` 全勾 + #2769 scoped release evidence PASS(package `79ab455e`) |
-| S1a 能力面 | #2872(opt-in 假 target 验证 / 非 opt-in 原样通过 / partial 拒绝 / enum-strict) |
-| S1a values-free 加固 | #2882:逐 vector canary + 经验回退证明非空洞 + 独立复审 APPROVE + 受影响 suite 绿 + `REQUIRED_ADAPTER_METHODS` 未变 |
-| S1b | 设计锁交付(高度问题裁明 + 推荐 A + S1b-1/2/3 就绪计划);实现 gated |
+| C2-C6 + Release | TODO 账本 `…delivery-todo-20260614.md` 全勾 + #2769 scoped release evidence PASS |
+| S1a 加固 #2882 | 逐 vector canary + 经验回退非空洞 + 独立复审 APPROVE + suite 绿 + REQUIRED 未变 |
+| S1a-retire #2894 | grep 零 runtime 消费者 + 无 over-deletion + adapter-contracts/S1b-1/S1b-2 绿 + REQUIRED 未变 + 复审 APPROVE |
+| S1b-1 #2887 | SQL revision hash 字节级一致(经验) + 既有 C6 套件原样绿 + fake-profile 新路径覆盖 + 复审 APPROVE |
+| S1b-2 #2892 | 非身份 fieldIdMap 往返 + re-pull 幂等 + 重复键→held(limit:2,经验非空洞) + own-sheet + values-free + 复审 APPROVE |
+| S1b-3 #2898 | 真实 route dry-run→apply→re-pull 幂等 + own-sheet + values-free + read-only 403 + dry-run/apply parity + SQL 零漂移 + 经验非空洞 + 复审 APPROVE |
+
+## 5. 剩余 gated 项(各带 gate,均非本轮自动构建)
+
+| 项 | gate | 备注 |
+|---|---|---|
+| **S2(K3 WebAPI opt-in)** | opt-in + **实体机 smoke**(operator 执行,无法在此完成)+ **K3 Submit/Audit/BOM 红线保留** | 全系统最受控红线面;需 eyes-open 单独 opt-in;不自动构建 |
+| **S3(template 对象)** | opt-in;已出**设计锁** | `…s3-template-object-design-lock-20260619.md`:新 `integration_templates` 表 + migration 058 + 实例化(原子性 / 模版版本 vs 已实例化 live pipeline / 参考模版注册 = 开放裁决项) |
+| **S4(自描述元数据)** | opt-in | 已 scope:~13 文件(`ADAPTER_METADATA`→各 adapter 自声明 + registry 收集 + route 取 registry),机械,route 输出形态不变(既有 adapters 元数据测试 = 安全网) |
+| **S5(PLM stock-prep 吸收)** | opt-in | 计划:**低优先、短期不重写**专用链路;泛化到通用 table-action seam 是后续 |
+| **首笔生产外部写** | **owner 授权** | 多样本只读 dry-run→sandbox apply→re-pull 幂等+人工字段保留→生产 |
 
 ---
 
-_校验脚注:#2882 合并态已核实——`gh pr view 2882` = MERGED(squash `687271dd6`),`git show origin/main:…/contracts.cjs` 含加固且 `REQUIRED_ADAPTER_METHODS` 未变。_
+_校验脚注(2026-06-19):S1b 全弧合并态已核实——#2882/#2894/#2887/#2892/#2898 均 MERGED;`origin/main` 上 `external-write-dry-run.cjs` 含 profile seam、`metasheet-multitable-target-adapter.cjs` 含 write-source + profile、`http-routes.cjs` 含 `resolveC6WritePlanInputs`、`contracts.cjs` 已无 `targetWriteLifecycle`、`REQUIRED_ADAPTER_METHODS` 未变。_

--- a/docs/development/generic-integration-s3-template-object-design-lock-20260619.md
+++ b/docs/development/generic-integration-s3-template-object-design-lock-20260619.md
@@ -1,0 +1,51 @@
+# 通用对接 S3 — first-class integration-template 对象 设计锁定(2026-06-19)
+
+> 状态:**DESIGN-LOCK 草案(待 owner 评审)**。不授权任何 runtime / migration;impl 是后续独立 opt-in。
+> 上游:`generic-integration-design-lock-20260618.md` §6 S3。基础 = 已落地的 S1b 收敛(C6 安全写经 target write profile + raw write-source 泛化;见 `…plan-and-verification-20260618.md`)。
+> 目的:把 §6 的 S3(first-class `integration-template` 对象 + 实例化)从"一刀"细化为**可评审设计 + 开放裁决项 + 分刀计划**。S3 是 中-大 弧,**设计锁先行**(同 S1a/S1b)。
+
+## 1. 现状(盘点结论)
+
+- **de-facto 模版 = 三件分布式拼装**:`integration_pipelines`(migration 057)+ `integration_field_mappings`(057)+ `integration_external_systems.config` JSONB(057);各有 registry CRUD(`pipelines.cjs` / `external-systems.cjs`)+ routes(`http-routes.cjs`)。它捕获**字段映射**,但不含**编排 + 写安全参数**,且"配一套"要手动连接三处。
+- **三个 latent 模版 helper(schema-only,非 first-class)**:`connector-template-derive.cjs`(DF-T2a payload 模版派生,纯计算)、`reference-mapping-templates.cjs`(DF-T3a 参考映射 schema 规范化 + 空 sheet 结构)、`stock-preparation-templates.cjs`(DF-C1 stock-prep 表模版)。三者都是 normalize + 结构派生工具,**无存储、无 CRUD、无实例化**。
+- **无 first-class 存储的"集成模版"对象**。
+
+## 2. 目标:一个 declarative 的 first-class 模版对象 + 实例化
+
+`integration-template` = 一条 declarative 记录,组合 **source + target + mapping + orchestration + write-safety 参数**;**"实例化" = 从模版原子生成 pipeline + field-mappings + system.config**(三件拼装自动化)。K3 WISE / PLM BOM 各出一个**参考模版实例**。
+
+## 3. 开放裁决项(owner 必须先签)
+
+S3 触及一个**新存储对象 + migration**,以下语义必须 owner 先裁,impl 才能机械执行:
+
+1. **实例化原子性**:template→(pipeline + mappings + system.config)必须 all-or-nothing。是用单事务跨三表写,还是 saga + 补偿?**推荐:单 DB 事务**(三表同库,057 同迁移);失败整体回滚,不留半实例化。
+2. **模版版本 vs 已实例化 live pipeline**:模版改了,已从它实例化的 live pipeline 怎么办?**推荐:实例化 = snapshot(拷贝语义),live pipeline 与模版解耦**(模版后续变更不回溯改 live pipeline);模版记 version,实例记 `instantiatedFromTemplateId + templateVersion` 供追溯,但**不自动 re-sync**。(否则改模版会静默改生产 pipeline = 危险。)
+3. **参考模版注册**:K3 WISE / PLM BOM 参考模版是**baked-in 示例**(opt-in 注册,不默认推给所有租户),还是随插件装?**推荐:opt-in 注册的示例**,不默认实例化。
+4. **写安全参数承载**:模版的 write-safety 参数 = 引用 S1b 的 **target write profile**(per-kind),不在模版里重定义安全策略。模版只选 target kind + object + keyFields/mappings;安全写仍走 C6 + profile。
+5. **S3 ↔ S2 依赖**:K3 参考模版的 target = K3 kind。K3 安全写(S2)仍 gated(实体机 + 红线)。**S3 可先落 multitable 参考模版**(已 sandbox-ready),K3 模版的 runtime 写等 S2。即 S3 存储/实例化与 S2 解耦:模版可引用任意 kind,实际写仍受该 kind 的 gate。
+
+## 4. 触点(盘点 §3-§4)+ 与 S4 无冲突
+
+- **新增**:`lib/integration-templates.cjs`(normalizer + CRUD + 实例化)、`migrations/058_create_integration_templates.sql`(`integration_templates` 表)。
+- **改**:`http-routes.cjs`(+5 routes:list/get/upsert/instantiate/delete + handlers;ROUTES 数组尾 + 新 handler 区,与 S4 的 `ADAPTER_METADATA`/`adaptersList`/`describeAdapterKind` 区**不相交**)、`index.cjs`(registry 装配 + communication API)、`pipelines.cjs`(暴露内部 `createPipelineFromTemplate` 组合 helper,**无签名变更**)。
+- **不碰** `contracts.cjs` 的 adapter registry(S3 只 `listAdapterKinds()` 读校验 target kind 存在);故 **S3 与 S4(改 registry + ADAPTER_METADATA)在 `contracts.cjs` 零冲突,在 `http-routes.cjs` 区段不相交**。
+
+## 5. 分刀计划(每刀 opt-in + 独立 PR + 审阅;contracts/storage-first)
+
+> 前置:本设计锁经 owner 签字(§3 开放裁决项)。
+
+- **S3-1(contract + storage)**:`integration_templates` 表(migration 058)+ normalizer + CRUD(upsert/get/list/delete),**不含 instantiate**;routes 只挂 CRUD。验收:迁移可前/后向、normalizer enum-strict、CRUD round-trip、values-free。
+- **S3-2(实例化)**:`instantiateTemplate` = 单事务生成 pipeline + mappings + system.config(§3-1 原子性);snapshot 语义(§3-2);route `POST …/instantiate`。验收:原子(失败整体回滚)、snapshot 不回溯 live pipeline、wire-vs-fixture 集成测试断真实 route。
+- **S3-3(参考模版)**:multitable 参考模版示例(sandbox-ready);K3/PLM 模版**记录但 runtime 写 gated**(K3 等 S2,PLM 见 S5)。opt-in 注册。
+
+## 6. 红线 / 不变式
+
+- 实例化**只写我们自己的 config 表**(pipelines / mappings / external_systems.config),**不写任何外部系统**;实际外部/sandbox 写仍走 C6 + profile(本刀不碰)。
+- 凭据只经 credential store;模版**不存凭据**(只引用 system / dataSourceId)。
+- **首笔真实外部写仍 = 独立 owner 授权**;S3 不解锁它。
+- K3 Submit/Audit/BOM 红线不开;K3 模版 runtime 写 = S2 gate。
+- values-free;**改模版不静默改已实例化的 live pipeline**(snapshot)。
+
+## 7. 不做什么(防 scope 漂移)
+
+- 不改 `REQUIRED_ADAPTER_METHODS`;不动 S4 的 adapter registry/metadata;不重写 PLM stock-prep(S5,短期不重写);不开 K3 runtime 写(S2);不开首笔生产外部写(owner)。


### PR DESCRIPTION
## What

**Refresh the verification MD** (it was stale/wrong — still called S1a's capability `targetWriteLifecycle`, retired in #2894, and listed S1b as "design-locked / impl gated", but S1b-1/2/3 are built+merged). Now reflects the **completed S1b sandbox arc**:
- DONE: S1a hardening (#2882) + S1a-retire (#2894) + S1b-1 (#2887) + S1b-2 (#2892) + S1b-3 (#2898). C6 safe-write lifecycle generalized off `sql-write-gated` via **target write profile + raw write-source**; own `metasheet:multitable` rides it in **sandbox (zero external write)**. Per-slice evidence (reviews APPROVE, SQL zero-drift, empirical non-vacuousness).
- GATED (each its own opt-in): S2 (K3 — entity-machine + red lines), S3 (design-locked here), S4 (scoped ~13 files), S5 (短期不重写), first production write (owner).

**Adds the S3 design-lock** — first-class `integration_templates` object + migration 058 + instantiation, with open owner decisions (instantiation atomicity; template-version vs live pipelines = snapshot; reference-template registration; write-safety via S1b profiles; S3/S2 decoupling) + S3-1/2/3 plan. Disjoint from S4.

## Boundary
Docs-only. No runtime/migration. First production external write remains a separate owner gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)