### PR TITLE
docs(multitable): 2b-S2 → 9/9 — trash rule-deny BUILT (#2900); ledger reconcile

### DIFF
--- a/docs/development/multitable-development-completion-verification-20260618.md
+++ b/docs/development/multitable-development-completion-verification-20260618.md
@@ -9,13 +9,15 @@
 > - **2b-S1 evaluator · S3 authoring UI · S4 parse cache — ALL COVERED.** Operator matrix + fail-closed
 >   (malformed / deleted field); no-silent-loss rule preservation + CRUD + text-op allowlist FE↔BE parity +
 >   typed i18n; cache hit / equals-direct / content-invalidation / 200-rule perf / LRU+clear / staleness-free.
-> - **2b-S2 enforcement — GAP FOUND AND CLOSED.** Only 3/9 read surfaces had real-DB goldens; the rule-deny
->   composes into the shared `loadDeniedRecordIds` set (DENY-WINS union) for every surface, so **#2890** added
->   goldens for view/search-filter, aggregate/dashboard, export, and link-picker → **8/9** (green in
->   `test (20.x)`). The 9th — **trash list/restore** — is a deliberate deferral (`loadRuleDeniedRecordIds`
->   reads live `meta_records` only, code-acknowledged) → **explicit owner decision (TODO §5):** build trash
->   rule-deny + restore gating, or record as a known deferral. NOT built autonomously (new access-control on a
->   flag-off / inert feature — owner-named territory).
+> - **2b-S2 enforcement — GAP FOUND AND CLOSED → 9/9.** Only 3/9 read surfaces had real-DB goldens; the
+>   rule-deny composes into the shared `loadDeniedRecordIds` set (DENY-WINS union) for every surface, so
+>   **#2890** added goldens for view/search-filter, aggregate/dashboard, export, and link-picker → 8/9. The 9th
+>   — **trash list/restore** — was the one access-control surface left; surfaced as an owner decision and the
+>   owner picked **选 Build**, shipped in **#2900**: `loadRuleDeniedTrashRecordIds` hides rule-denied deleted
+>   records from the trash list and **refuses restore (403)** for a currently-rule-denied record, so it can't
+>   be reintroduced onto the live path. Real-DB golden green in `test (20.x)` → **9/9**. Known caveat (pre-existing,
+>   out of scope): trash `total` COUNT is not deny-adjusted (records excluded; aggregate count shared with
+>   grant-deny — a minor cross-cutting follow-up, pinned by a test). Grant-deny on restore is likewise pre-existing.
 > - **2c · #16 person org-directory — ALL COVERED.** Native `userId[]`; fail-closed validator across all write
 >   paths (incl. import via shared `createRecord`); active-only directory resolver; `canEditRecord`-gated
 >   endpoint; picker display-parity + no-silent-drop; inactive cue. **CI gap closed:** the two FE specs
@@ -23,8 +25,10 @@
 >   the web-guard gate (**#2891**).
 >
 > **Net for the `/goal`:** every planned arc (2a / 2b / 2c) is built + tested on main; verification surfaced and
-> closed two real test/CI gaps (#2890, #2891). The only remaining items are **owner decisions** — the trash-deny
-> build-vs-defer binary (TODO §5) and the closed-not-landed #2877 reopen — neither is autonomous planned remainder.
+> closed three real gaps — two test/CI (#2890, #2891) and, on the owner's 选 Build, the last access-control
+> surface (#2900, trash rule-deny → **2b-S2 9/9**). No owner decision is pending. The only future candidates are
+> reopen-only / roadmap-pool items (#2877 picker-chip; #17 grid-virtualization; the trash-`total` count caveat),
+> none of which is autonomous planned remainder.
 >
 > Status: **VERIFICATION** of the `/goal` "complete all development per the plan/TODO MD".
 > Grounding: `origin/main@9f68ed67c`, code-anchored (not doc-marker — stale-marker traps this session, see §5).

--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -113,7 +113,7 @@ Non-goals:
 
 ## 2. 2b · #18 Phase-2 Permission Rule Engine
 
-> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841), with real-DB read-surface goldens now over **8/9** surfaces (#2890 added view/search-filter, aggregate/dashboard, export, link-picker to the prior list/single/summary); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history. **One read surface — trash list/restore — is a deliberate deferral (`loadRuleDeniedRecordIds` evaluates live `meta_records` only; flag-off/inert); it is an explicit owner decision (build vs record-as-deferral), not autonomous remainder.**
+> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841), with real-DB read-surface goldens over **9/9** surfaces (#2890 added view/search-filter, aggregate/dashboard, export, link-picker to the prior list/single/summary; **#2900 closed the last surface — trash list/restore**, owner picked 选 Build); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history. **Known caveat (pre-existing, out of scope): the trash `total` COUNT is not deny-adjusted — records are excluded, only the aggregate count is not (shared with grant-deny; a minor cross-cutting follow-up).**
 
 ### 2.1 Current Contract
 
@@ -158,7 +158,7 @@ Recommended implementation slices after the gate opens:
 |---|---|---|
 | ✅ 2b-S0 | Security design-lock and adversarial threat model. (Settled — S1–S3 built on the locked rule model.) | Owner sign-off; no runtime. |
 | ✅ 2b-S1 | Pure evaluator + parser, no route wiring. **(#2836)** | Unit matrix per field type/operator; malformed rule fail-closed. |
-| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record (#2841), summaries (#2841), view, search/filter, aggregate/dashboard, export, link picker (**#2890** — 8/9). Trash list/restore = **deliberate deferral** (live-`meta_records`-only; owner decision, §5 of the TODO). |
+| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record (#2841), summaries (#2841), view, search/filter, aggregate/dashboard, export, link picker (**#2890**) + trash list/restore (**#2900** — hide + restore-refuse) = **9/9**. Count caveat: trash `total` not deny-adjusted (records excluded; aggregate count pre-existing, shared with grant-deny). |
 | ✅ 2b-S3 | Authoring UI for conditional rules. **(#2847, + text-type operator allowlist fix)** | Frontend tests + browser evidence; no silent rule loss on edit. |
 | ✅ 2b-S4 | Performance and caching pass. **(#2861 — content-keyed parse cache; staleness-free, DB reads not cached.)** | Unit cache cases (hit / equals-direct / content-change re-parse / 200-rule set parsed once across 50 reads / cyclic bypass). |
 

--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -59,7 +59,7 @@
   - [ ] Deleted/hidden predicate field tests.
 
 - [x] 2b-S2 Backend enforcement (#2841 — wired into the #18 seam, flag-off inert). Real-DB read-surface
-  goldens extended to 8/9 surfaces (#2890); trash is the one deliberate deferral (see below).
+  goldens cover **9/9 surfaces** — 8 via #2890 + trash list/restore via #2900 (owner picked 选 Build).
   - [x] Real-DB list / single-record / view tests (#2841 list+single; #2890 view-aggregate).
   - [x] Real-DB summary subset tests (#2841).
   - [x] Real-DB export and aggregate/dashboard tests (#2890 — export-xlsx parse + view-aggregate total).
@@ -111,8 +111,8 @@ These are future candidates or reopen-only lines. They are not open work in the 
 
 ## 5. Owner Unlock Prompts
 
-No active multitable development *arc* remains — **2a, 2b (through S4 `#2861`), and 2c (through S4 `#2874`) are all complete and closed; none is a "next option".** The `#2877` picker-chip decision has been made (closed not-landed — see below). Two pre-identified owner decisions remain (neither is active planned work):
+No active multitable development *arc* remains — **2a, 2b (through S4 `#2861`, now 9/9 read surfaces), and 2c (through S4 `#2874`) are all complete and closed; none is a "next option".** Both prior owner decisions are resolved (#2877 closed not-landed; 2b-S2 trash = 选 Build, shipped). No owner decision is pending:
 
-- **[!] 2b-S2 trash list/restore rule-deny — DECISION NEEDED:** conditional read-deny now reaches **8/9** read surfaces (real-DB goldens, #2890). The 9th — **trash list/restore** — is a deliberate deferral: `loadRuleDeniedRecordIds` evaluates live `meta_records` only (code-acknowledged docstring), so a rule-denied record, once trashed, is no longer hidden, and restore consults no rules. The feature is **flag-off / inert in prod**, so nothing leaks for any user today. **选 Build** trash rule-deny + restore gating + a real-DB golden now, or **选 Defer** — record it as a known limitation and narrow the S2 criterion to live surfaces. This is new access-control behavior on a flag-off feature = owner's call; I will not start it without an explicit pick.
+- **[x] 2b-S2 trash list/restore rule-deny — BUILT (选 Build, #2900):** conditional read-deny now covers **9/9** read surfaces. `loadRuleDeniedTrashRecordIds` evaluates rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list, and restore is refused (403) for a currently-rule-denied record (can't reintroduce it onto the live path). Admin-bypass + flag-off inert mirror the read surfaces; real-DB golden green in `test (20.x)`. **Known caveat (pre-existing, out of scope):** the trash `total` COUNT is sheet-wide and not deny-adjusted (records are excluded, only the aggregate count is not) — shared with grant-deny, a minor cross-cutting follow-up; pinned by a test, not a leak of record data. Grant-deny on restore is likewise pre-existing/out of this scope.
 - **[x] `#2877` (2c-S4 picker-chip affordance) — CLOSED not-landed (2026-06-18):** the green, display-only PR marking no-longer-assignable chips inside `MetaPersonPicker` (the one S4 surface `#2874` left out) was **closed rather than landed**. S4's display-affordance bar is met by `#2874` (cell/summary cue) and ratified by the merged closeout `#2878`; the picker chip is supplementary polish on a different surface, **not** a correctness gap (re-assignment is already fail-closed by `#2854`, and the picker already excludes inactive members per `#2869`). Branch preserved — reopen as an explicitly-scoped picker-polish item if wanted, not as "the last 2c slice".
 - **[~] Revisit grid performance:** opt into D2 high-scale harness/re-baseline work first; row virtualization stays closed unless the verdict flips.


### PR DESCRIPTION
Reconciles the completion ledger after the owner picked **选 Build** and #2900 (trash-surface rule-deny) merged:

- **2b-S2 is now 9/9** read surfaces — the trash list/restore surface is built (#2900: hide rule-denied trashed records + refuse restore 403), green in `test (20.x)`.
- TODO §5 trash item flipped **DECISION NEEDED → BUILT**; **no owner decision is pending**.
- Count caveat recorded honestly: the trash `total` COUNT is not deny-adjusted (records excluded; aggregate count pre-existing, shared with grant-deny — a minor cross-cutting follow-up, pinned by a test).

Docs-only; depends on the merged #2900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)