### PR TITLE
feat(approval): continuous_managers resolver + authoring (PR-2, reading A)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -60,6 +60,10 @@ export interface ApprovalStepDraft {
   sourceKind: ApprovalStepSourceKind
   idsText: string
   fieldId: string
+  // How many management levels the `continuous_managers` source resolves (level 1 =
+  // direct manager). Carried for every step but only meaningful when
+  // `sourceKind === 'continuous_managers'`; the backend re-validates `[1, 10]`.
+  levels: number
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy
   // Self-approver authoring: the editable toggle (merge the requester in as an
@@ -142,6 +146,7 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     sourceKind: 'requester',
     idsText: '',
     fieldId: '',
+    levels: 2,
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
     mergeWithRequester: false,
@@ -237,6 +242,7 @@ function stepDraftFromApprovalNode(
   let sourceKind: ApprovalStepSourceKind = 'requester'
   let idsText = ''
   let fieldId = ''
+  let levels = 2
   if (source?.kind === 'static_user') {
     sourceKind = 'static_user'
     idsText = formatIds(source.userIds)
@@ -252,6 +258,9 @@ function stepDraftFromApprovalNode(
     sourceKind = 'direct_manager'
   } else if (source?.kind === 'dept_head') {
     sourceKind = 'dept_head'
+  } else if (source?.kind === 'continuous_managers') {
+    sourceKind = 'continuous_managers'
+    levels = source.levels
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -271,6 +280,7 @@ function stepDraftFromApprovalNode(
     sourceKind,
     idsText,
     fieldId,
+    levels,
     approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
     mergeWithRequester,
@@ -366,7 +376,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers'].includes(source?.kind)) return true
     }
     return false
   })
@@ -449,6 +459,9 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   }
   if (step.sourceKind === 'dept_head') {
     return { kind: 'dept_head' }
+  }
+  if (step.sourceKind === 'continuous_managers') {
+    return { kind: 'continuous_managers', levels: step.levels }
   }
   return { kind: 'requester' }
 }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -77,6 +77,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'form_field_user'; fieldId: string }
   | { kind: 'direct_manager' }
   | { kind: 'dept_head' }
+  | { kind: 'continuous_managers'; levels: number }
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -283,8 +283,19 @@
                 <el-option label="发起人" value="requester" />
                 <el-option label="直属上级" value="direct_manager" />
                 <el-option label="部门主管" value="dept_head" />
+                <el-option label="连续多级上级" value="continuous_managers" />
                 <el-option label="表单用户字段" value="form_field_user" />
               </el-select>
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
+              <el-input-number
+                v-model="step.levels"
+                :min="1"
+                :max="10"
+                :step="1"
+                :disabled="readOnly"
+                data-testid="approval-step-levels"
+              />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'static_user'" label="选择用户">
               <el-select

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -95,6 +95,21 @@ const ElInput = defineComponent({
   },
 })
 
+const ElInputNumber = defineComponent({
+  name: 'ElInputNumber',
+  props: { modelValue: Number, disabled: Boolean, min: Number, max: Number, step: Number },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      type: 'number',
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', Number((event.target as HTMLInputElement).value)),
+    })
+  },
+})
+
 const ElSelect = defineComponent({
   name: 'ElSelect',
   props: { modelValue: [String, Array], disabled: Boolean },
@@ -167,6 +182,7 @@ function installStubs(app: VueApp<Element>) {
   app.directive('loading', {})
   app.component('ElButton', ElButton)
   app.component('ElInput', ElInput)
+  app.component('ElInputNumber', ElInputNumber)
   app.component('ElSelect', ElSelect)
   app.component('ElOption', ElOption)
   app.component('ElCheckbox', ElCheckbox)
@@ -449,6 +465,22 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].sourceKind).toBe('dept_head')
   })
 
+  it('round-trips a continuous_managers source incl. levels (save emits {kind, levels}; levels survives the real wire)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'cm'
+    draft.name = '多级上级审批'
+    draft.steps[0].sourceKind = 'continuous_managers'
+    draft.steps[0].levels = 3
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'continuous_managers', levels: 3 }])
+
+    // wire-vs-fixture trap: assert `levels` survives the real serialize→parse, not a hand-built chip.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('continuous_managers')
+    expect(rehydrated.steps[0].levels).toBe(3)
+  })
+
   // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
   function buildAutoApprovalTemplate(
     policy: AutoApprovalPolicy,
@@ -647,6 +679,20 @@ describe('TemplateAuthoringView', () => {
     expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
     expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('dept_head') // hydrated back
+  })
+
+  it('continuous_managers reads back editable: a saved continuous_managers template is NOT fail-closed (sourceKind + levels input hydrated)', async () => {
+    routeParams = { id: 'tpl_cm' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildComboGraph({ assigneeSources: [{ kind: 'continuous_managers', levels: 3 }], approvalMode: 'all', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // in the allowlist → not fail-closed
+    expect((container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).disabled).toBe(false) // editable
+    expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('continuous_managers') // hydrated back
+    expect(container!.querySelector('[data-testid="approval-step-levels"]')).not.toBeNull() // the levels input renders for this kind
   })
 
   it('updates an existing supported template without replacing it through create', async () => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -146,6 +146,24 @@ export function resolveApprovalAssignees(
         }
         break
       }
+      case 'continuous_managers': {
+        // Resolve to the requester's management chain (levels 1..source.levels),
+        // frozen in the snapshot at start (no live directory re-query). pushResolved's
+        // seen-set dedups a person appearing at two levels; self-exclusion drops a hop
+        // that resolves to the requester. An empty result falls through to the node's
+        // emptyAssigneePolicy; the node's approvalMode (会签 all / 或签 any) then governs
+        // how the resolved chain must act.
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        const rawChain = options.requesterSnapshot?.managerChainIds
+        const chain = Array.isArray(rawChain) ? rawChain : []
+        chain.slice(0, source.levels).forEach((entry) => {
+          const managerId = normalizeId(entry)
+          if (managerId && managerId !== requesterId) {
+            pushResolved('user', managerId, source, sourceIndex)
+          }
+        })
+        break
+      }
       case 'form_field_user': {
         assertFormUserSource(source, options.formSchema, options.nodeKey)
         const assigneeId = resolveFormUserValue(options.formSnapshot[source.fieldId])

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -40,7 +40,7 @@ import {
   validateApprovalFormData,
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
-import { resolveApprovalRequesterOrgRelations, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
+import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import type {
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
@@ -413,6 +413,15 @@ function normalizeApprovalAssigneeSources(
         return { kind: 'direct_manager' }
       case 'dept_head':
         return { kind: 'dept_head' }
+      case 'continuous_managers': {
+        // Deterministic validation — an out-of-range / non-integer / missing
+        // `levels` is rejected, never silently defaulted (enum-strictness).
+        const levels = source.levels
+        if (typeof levels !== 'number' || !Number.isInteger(levels) || levels < 1 || levels > MAX_MANAGER_CHAIN_LEVELS) {
+          failValidation(context, `${sourcePath}.levels must be an integer between 1 and ${MAX_MANAGER_CHAIN_LEVELS}`)
+        }
+        return { kind: 'continuous_managers', levels }
+      }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -95,6 +95,13 @@ export type ApprovalAssigneeSource =
   | { kind: 'form_field_user'; fieldId: string }
   | { kind: 'direct_manager' }
   | { kind: 'dept_head' }
+  /**
+   * Requester's management chain, levels 1..`levels` (level 1 = direct manager),
+   * resolved into this node's approver set from the baked `managerChainIds`
+   * snapshot. The node's `approvalMode` (会签 all / 或签 any) governs aggregation.
+   * `levels` is validated `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time.
+   */
+  | { kind: 'continuous_managers'; levels: number }
 
 export interface ApprovalAssigneeResolutionMetadata {
   resolvedFrom: {

--- a/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-direct-manager.api.test.ts
@@ -30,18 +30,20 @@ async function tok(base: string, userId: string): Promise<string> {
 async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
   return fetch(`${base}${path}`, { method: opts.method || 'GET', headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) }, ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}) })
 }
-function graph(emptyAssigneePolicy: 'auto-approve' | 'error', kind: 'direct_manager' | 'dept_head' = 'direct_manager') {
+type OrgSourceKind = 'direct_manager' | 'dept_head' | 'continuous_managers'
+function graph(emptyAssigneePolicy: 'auto-approve' | 'error', kind: OrgSourceKind = 'direct_manager') {
+  const source = kind === 'continuous_managers' ? { kind, levels: 2 } : { kind }
   return {
     nodes: [
       { key: 'start', type: 'start', name: 's', config: {} },
-      { key: 'approval_1', type: 'approval', name: '上级', config: { assigneeSources: [{ kind }], approvalMode: 'single', emptyAssigneePolicy } },
+      { key: 'approval_1', type: 'approval', name: '上级', config: { assigneeSources: [source], approvalMode: 'single', emptyAssigneePolicy } },
       { key: 'end', type: 'end', name: 'e', config: {} },
     ],
     edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
   }
 }
 
-describeIfDatabase('direct_manager + dept_head assignee sources — real-DB create/start', () => {
+describeIfDatabase('direct_manager + dept_head + continuous_managers assignee sources — real-DB create/start', () => {
   let server: MetaSheetServer | undefined, base = '', reqTok = ''
 
   beforeAll(async () => {
@@ -55,7 +57,7 @@ describeIfDatabase('direct_manager + dept_head assignee sources — real-DB crea
   afterAll(async () => {
     try {
       const pool = poolManager.get()
-      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`dm-%-${TS}%`])).rows.map((r) => r.id as string)
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
       if (tids.length > 0) {
         const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
         if (iids.length > 0) {
@@ -74,7 +76,7 @@ describeIfDatabase('direct_manager + dept_head assignee sources — real-DB crea
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  async function publish(key: string, emptyAssigneePolicy: 'auto-approve' | 'error', kind: 'direct_manager' | 'dept_head' = 'direct_manager'): Promise<string> {
+  async function publish(key: string, emptyAssigneePolicy: 'auto-approve' | 'error', kind: OrgSourceKind = 'direct_manager'): Promise<string> {
     const created = await req(base, '/api/approval-templates', reqTok, { method: 'POST', body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph(emptyAssigneePolicy, kind) } })
     expect(created.status, await created.clone().text()).toBe(201) // normalizer accepts the org-derived source kind
     const tid = ((await created.json()) as { id: string }).id
@@ -112,6 +114,28 @@ describeIfDatabase('direct_manager + dept_head assignee sources — real-DB crea
 
   it('dept_head error branch: a requester with no department head makes the dept_head node fail-create', async () => {
     const tid = await publish(`dh-err-${TS}`, 'error', 'dept_head')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status).toBeGreaterThanOrEqual(400)
+  })
+
+  // continuous_managers — same scope as above: the normalizer must accept the
+  // levels'd source on publish, and the real create/start path runs the resolver
+  // → an unresolvable chain (this requester has no directory chain) → empty →
+  // emptyAssigneePolicy on both branches. The RESOLVED non-empty chain is unit-
+  // covered (the chain walk through the real seam in approval-manager-chain.test.ts,
+  // the scanner, and the resolver case), not re-seeded as a directory fixture here.
+  it('continuous_managers auto-approve branch: publish accepts {kind, levels}; an unresolvable chain auto-resolves the node', async () => {
+    const tid = await publish(`cm-auto-${TS}`, 'auto-approve', 'continuous_managers')
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+    const status = (await (await req(base, `/api/approvals/${aid}`, reqTok)).json()) as any
+    expect(['approved', 'completed', 'auto_approved']).toContain(String(status.status ?? status.data?.status))
+  })
+
+  it('continuous_managers error branch: an unresolvable chain makes the node fail-create (empty assignee)', async () => {
+    const tid = await publish(`cm-err-${TS}`, 'error', 'continuous_managers')
     const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
     expect(started.status).toBeGreaterThanOrEqual(400)
   })

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -84,6 +84,42 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveDeptHead({ id: 'requester-1', deptHeadId: 'requester-1' })).toEqual([])
   })
 
+  // continuous_managers — resolves the snapshot managerChainIds, sliced to `levels`.
+  function resolveContinuousManagers(levels: number, requesterSnapshot: Record<string, unknown> | null) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'continuous_managers', levels }] },
+      formSnapshot: {},
+      requesterSnapshot,
+    })
+  }
+
+  const cmEntry = (assigneeId: string) => ({
+    assignmentType: 'user', assigneeId, nodeKey: 'review', sourceStep: 2,
+    metadata: { resolvedFrom: { kind: 'continuous_managers', sourceIndex: 0 } },
+  })
+
+  it('resolves continuous_managers to the chain sliced to levels, with metadata', () => {
+    expect(resolveContinuousManagers(2, { id: 'requester-1', managerChainIds: ['m1', 'm2', 'm3'] }))
+      .toEqual([cmEntry('m1'), cmEntry('m2')])
+  })
+
+  it('resolves the whole chain when it is shorter than levels', () => {
+    expect(resolveContinuousManagers(5, { id: 'requester-1', managerChainIds: ['m1', 'm2'] }))
+      .toEqual([cmEntry('m1'), cmEntry('m2')])
+  })
+
+  it('resolves continuous_managers to empty with no chain (falls to emptyAssigneePolicy)', () => {
+    expect(resolveContinuousManagers(3, { id: 'requester-1' })).toEqual([])
+    expect(resolveContinuousManagers(3, null)).toEqual([])
+  })
+
+  it('excludes self and dedups within the sliced chain', () => {
+    expect(resolveContinuousManagers(4, { id: 'requester-1', managerChainIds: ['requester-1', 'm2', 'm2', 'm3'] }))
+      .toEqual([cmEntry('m2'), cmEntry('m3')])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1270,6 +1270,47 @@ describe('ApprovalProductService', () => {
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects continuous_managers with invalid levels before hitting the database (no silent default)', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    const requestWithLevels = (levels: unknown) => ({
+      key: 'cm-bad',
+      name: 'CM Bad',
+      visibilityScope: { type: 'all', ids: [] },
+      formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: 'Chain',
+            config: {
+              assigneeSources: [{ kind: 'continuous_managers', levels }],
+              approvalMode: 'all',
+              emptyAssigneePolicy: 'error',
+            },
+          },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    })
+
+    for (const badLevels of [0, 11, 1.5, undefined, 'two']) {
+      await expect(service.createTemplate(requestWithLevels(badLevels) as never)).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.assigneeSources[0].levels must be an integer between 1 and 10',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+    }
+    expect(pgState.pool.connect).not.toHaveBeenCalled()
+  })
+
   it('rejects invalid visibility rules before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()


### PR DESCRIPTION
## What

**PR-2 of the `continuous_managers` arc** (design-lock #2886, reading **A**), stacked on the now-merged PR-1 plumbing (#2893, `550d57adb`). Consumes PR-1's baked `managerChainIds` to make the source **authorable + resolvable end-to-end**. Reading A: the chain (levels 1..K) fills **one node's** approver set; the node's existing `approvalMode` (会签 all / 或签 any) aggregates it. Reading B (sequential escalation) stays carved out; **W7 stays locked**.

## Changes

**Backend**
- `types`: `ApprovalAssigneeSourceKind += 'continuous_managers'`; union member `{ kind, levels }`.
- `normalizer`: deterministic `levels` validation — integer in `[1, MAX_MANAGER_CHAIN_LEVELS]`, else **explicit reject** (no silent default, per the #1776 enum-strictness rule).
- `resolver`: case reads `requesterSnapshot.managerChainIds`, slices to `levels`, **self-excludes the requester** (`!== requesterId`), and relies on `pushResolved`'s seen-set for dedup; empty → `emptyAssigneePolicy`.

**Frontend**
- type mirror + step model gains `levels` (default 2); `draftFromTemplate` hydrates it, `sourceFromStep` emits `{ kind, levels }`; `unsupportedTemplateAuthoringReason` allowlist += `'continuous_managers'` (else saved templates read back fail-closed — the #2852 trap); authoring option **连续多级上级** + an `el-input-number` levels field.

## Tests

- resolver unit **+4** (slice-to-levels / short-chain / empty→policy / self-exclude+dedup).
- normalizer **+1**: invalid `levels` (0 / 11 / 1.5 / missing / non-number) **all rejected before the DB**.
- FE spec **+2**: `levels` survives the **real wire** (serialize→parse, not a fixture) + mounted read-back not fail-closed (sourceKind + levels input hydrated); adds an `ElInputNumber` stub.
- integration **+2**: publish accepts `{ kind, levels }`; unresolvable chain → `emptyAssigneePolicy` both branches.

Re-verified on the merged-PR-1 base: backend tsc clean, backend 69/69, FE 31/31; no `.js` emitted.

## Scope / gating

Reading **B** carved out (future graph-expansion feature). **W7 locked.** `MAX_MANAGER_CHAIN_LEVELS` fixed at 10 (configurability a future opt-in). Completes the org-derived-assignee family: `direct_manager` (#2852) · `dept_head` (#2863/#2871/#2873) · `continuous_managers` (#2893 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
