### PR TITLE
docs(multitable): flip last stale §2 trash sub-item to BUILT (#2900) — 9/9 closeout consistent

### DIFF
--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -64,9 +64,10 @@
   - [x] Real-DB summary subset tests (#2841).
   - [x] Real-DB export and aggregate/dashboard tests (#2890 — export-xlsx parse + view-aggregate total).
   - [x] Real-DB link-picker test (#2890 link-options) + search/filter deny-before-filter (#2890).
-  - [!] Real-DB **trash list/restore** — DEFERRED, owner-gated. `loadRuleDeniedRecordIds` evaluates live
-    `meta_records` only (code-acknowledged docstring); extending rule-deny to trashed records + gating
-    restore is new access-control on a flag-off feature → explicit owner decision (build vs record-as-deferral). See §5.
+  - [x] Real-DB **trash list/restore** — BUILT (选 Build, #2900). `loadRuleDeniedTrashRecordIds` evaluates
+    rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list and restore
+    is refused (403) for a currently-rule-denied record. Real-DB golden green in `test (20.x)`. (Trash `total`
+    COUNT not deny-adjusted — pre-existing, shared with grant-deny; records excluded, count is a minor follow-up.)
   - [x] CI allowlist confirmation — `plugin-tests.yml:194` registers enforce-realdb (verified by reading the workflow, not inferred from green jobs); the goldens ran green in `test (20.x)` on #2890.
 
 - [x] 2b-S3 Authoring UI (#2847, + text-type operator allowlist fix).


### PR DESCRIPTION
Final consistency fix for the 2b-S2 9/9 closeout. The §2 nested trash acceptance sub-item in the TODO still read "DEFERRED, owner-gated … explicit owner decision (build vs record-as-deferral)", which contradicts the BUILT state already recorded everywhere else (§2 header, §5, plan §2 STATUS + S2 row, verification MD) after #2900 merged on 选 Build.

Flips that one line to `[x] BUILT (#2900)` with the same pre-existing count caveat. Docs-only; depends on merged #2900/#2906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)