### PR TITLE
fix(multitable): 2b-S2 trash rule-deny — close LOCK-4 (deny-aware total) + LOCK-6 (restore 404, no oracle)

### DIFF
--- a/docs/development/multitable-2b-trash-restore-rule-deny-design-lock-20260618.md
+++ b/docs/development/multitable-2b-trash-restore-rule-deny-design-lock-20260618.md
@@ -1,6 +1,9 @@
 # 2b 条件读权限 → 回收站(trash)/恢复(restore)继承 — 设计锁(design-lock)
 
-> **状态**:design-lock(**owner 决策 2026-06-18 = Build**:"被条件规则拒读的记录,即使进了回收站也不可见/不可恢复" 作为安全一致性要求)。**实现 GATED —— 本文先锁语义,owner ratify 后再写 runtime**(与 S1b 同一门:design-lock → 签字 → impl)。
+> **状态**:**IMPLEMENTED**(owner 决策 2026-06-18 = Build:"被条件规则拒读的记录,即使进了回收站也不可见/不可恢复" 作为安全一致性要求)。
+> - **首版 runtime by #2900**(`b86751f77`,并行 effort,与本设计锁并发开发):LOCK-1/2(shared evaluator + `loadRuleDeniedTrashRecordIds` 对 `meta_records_trash.data` 求值)、LOCK-3(trash list hide)、LOCK-5(restore refuse)、LOCK-7(admin bypass)、LOCK-8(flag-off inert)均已落地。
+> - **LOCK-4 + LOCK-6 fix by 本 PR**(owner review 指出 #2900 未按这两条实现):**LOCK-4** —— `total` 改为 deny-aware(`listDeletedRecords` 新增 `excludeRecordIds`,COUNT+page 同口径排除,不再泄露隐藏记录基数);**LOCK-6** —— rule-denied restore 改返回与"记录不存在"完全同形态的 **404 NOT_FOUND**(非 403),消除存在性 oracle。real-DB golden 同步改 `total === 1` + restore 404 + 不存在 id 同形态断言。
+> - 历史:本设计锁原写"实现 GATED, ratify 后再写 runtime";但 runtime 已由 #2900 先行合入 `origin/main`,故状态据实改为 IMPLEMENTED(+ LOCK-4/6 fix)。LOCK-1..8 仍是本特性的安全合同。
 > **口径**:本文写 MetaSheet 自有安全设计口径,不引用任何竞品。
 > **基线**:代码实测 @ `origin/main`(`permission-service.ts`、`permission-rule-evaluator.ts`、`record-service.ts`、`routes/univer-meta.ts`)。
 

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -861,6 +861,10 @@ export class RecordService {
     resolveSheetAccess: RecordDeleteInput['resolveSheetAccess']
     limit?: number
     offset?: number
+    // 2b-S2 LOCK-4: record ids the caller has determined are read-denied for this actor (grant-deny ∪
+    // trash rule-deny). Excluded in SQL from BOTH the COUNT and the page, so `total` can't reveal the
+    // cardinality of hidden trashed records (deny-aware count, not just deny-filtered rows).
+    excludeRecordIds?: string[]
   }): Promise<{
     records: Array<{ recordId: string; sheetId: string; data: Record<string, unknown>; originalVersion: number; createdBy: string | null; deletedBy: string | null; deletedAt: string }>
     total: number
@@ -877,18 +881,23 @@ export class RecordService {
     // allow restore of) rows created by other users. Apply the own-only filter in SQL so total+pagination
     // stay exact. Full-write / admin scopes see all trash for the sheet (no extra filter).
     const ownOnly = requiresOwnWriteRowPolicy(sheetScope, access.isAdminRole)
-    const ownSql = ownOnly ? ' AND created_by = $OWN' : ''
+    const excludeIds = input.excludeRecordIds && input.excludeRecordIds.length > 0 ? input.excludeRecordIds : null
     try {
-      const totalRes = await this.pool.query(
-        `SELECT COUNT(*)::int AS n FROM meta_records_trash WHERE sheet_id = $1${ownSql.replace('$OWN', '$2')}`,
-        ownOnly ? [sheetId, access.userId] : [sheetId],
-      )
+      // Build COUNT + page with the same own-only and (LOCK-4) deny-exclude predicates so total and
+      // pagination stay exact. Placeholders are appended in order to avoid index drift.
+      const countParams: unknown[] = [sheetId]
+      let countSql = 'SELECT COUNT(*)::int AS n FROM meta_records_trash WHERE sheet_id = $1'
+      if (ownOnly) { countParams.push(access.userId); countSql += ` AND created_by = $${countParams.length}` }
+      if (excludeIds) { countParams.push(excludeIds); countSql += ` AND record_id <> ALL($${countParams.length}::text[])` }
+      const totalRes = await this.pool.query(countSql, countParams)
       const total = Number((totalRes.rows[0] as { n?: number } | undefined)?.n ?? 0)
-      const rowsRes = await this.pool.query(
-        `SELECT record_id, sheet_id, data, original_version, created_by, deleted_by, deleted_at
-         FROM meta_records_trash WHERE sheet_id = $1${ownSql.replace('$OWN', '$4')} ORDER BY deleted_at DESC LIMIT $2 OFFSET $3`,
-        ownOnly ? [sheetId, limit, offset, access.userId] : [sheetId, limit, offset],
-      )
+      const pageParams: unknown[] = [sheetId, limit, offset]
+      let pageSql = `SELECT record_id, sheet_id, data, original_version, created_by, deleted_by, deleted_at
+         FROM meta_records_trash WHERE sheet_id = $1`
+      if (ownOnly) { pageParams.push(access.userId); pageSql += ` AND created_by = $${pageParams.length}` }
+      if (excludeIds) { pageParams.push(excludeIds); pageSql += ` AND record_id <> ALL($${pageParams.length}::text[])` }
+      pageSql += ' ORDER BY deleted_at DESC LIMIT $2 OFFSET $3'
+      const rowsRes = await this.pool.query(pageSql, pageParams)
       const records = (rowsRes.rows as Array<Record<string, unknown>>).map((r) => ({
         recordId: String(r.record_id),
         sheetId: String(r.sheet_id),

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -11374,9 +11374,26 @@ export function univerMetaRouter(): Router {
         return res.status(401).json({ error: 'Authentication required' })
       }
       const recordService = new RecordService(pool, eventBus)
+      // 2b-S2 LOCK-4: compute the SHEET-WIDE trash deny set BEFORE listing, so listDeletedRecords excludes
+      // denied rows from BOTH the COUNT and the page — an aggregate `total` that still counted hidden rows
+      // would leak their cardinality. grant-deny (record_permissions, persists across delete) ∪ rule-deny
+      // over ALL trashed rows' data (page-independent; loadRuleDeniedRecordIds reads live meta_records only,
+      // so a rule-denied record would otherwise resurface here once deleted). Admin-bypass + flag-off inert
+      // mirror the read surfaces (default-OFF → byte-identical to pre-2b).
+      let excludeRecordIds: string[] = []
+      if (!access.isAdminRole && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
+        const [grantDenied, ruleDeniedTrash] = await Promise.all([
+          loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId),
+          loadRuleDeniedTrashRecordIds(pool.query.bind(pool), sheetId),
+        ])
+        const merged = new Set<string>(grantDenied)
+        for (const id of ruleDeniedTrash) merged.add(id)
+        excludeRecordIds = [...merged]
+      }
       const result = await recordService.listDeletedRecords({
         sheetId,
         access,
+        ...(excludeRecordIds.length > 0 ? { excludeRecordIds } : {}),
         ...(Number.isFinite(limitRaw) ? { limit: limitRaw } : {}),
         ...(Number.isFinite(offsetRaw) ? { offset: offsetRaw } : {}),
         resolveSheetAccess: async (sid) => {
@@ -11392,23 +11409,10 @@ export function univerMetaRouter(): Router {
       const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
       const allowedFieldIds = computeAllowedFieldIds(visibleFields, capabilities, fieldScopeMap)
       const visibleFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, visibleFields, allowedFieldIds)
-      // #18 row-level read-deny (flag-gated, default-OFF → byte-identical): drop trashed records the actor
-      // is denied so a denied record's data never surfaces via trash. (total left as-is — the
-      // canDeleteRecord-gated trash count may include a denied row; exact-count exclusion is a minor follow-up.)
-      let trashRecords = result.records
-      if (!access.isAdminRole && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)) {
-        // grant-deny (record_permissions, persists across delete) ∪ rule-deny evaluated against the
-        // TRASHED records' data (loadRuleDeniedRecordIds reads live meta_records only, so a rule-denied
-        // record would otherwise resurface here once deleted — 2b-S2 trash-surface close-out).
-        const trashedIds = result.records.map((rec) => rec.recordId)
-        const [deniedIds, ruleDeniedTrash] = await Promise.all([
-          loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId),
-          loadRuleDeniedTrashRecordIds(pool.query.bind(pool), sheetId, trashedIds),
-        ])
-        for (const id of ruleDeniedTrash) deniedIds.add(id)
-        if (deniedIds.size > 0) trashRecords = result.records.filter((rec) => !deniedIds.has(rec.recordId))
-      }
-      const maskedRecords = trashRecords.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
+      // 2b-S2: records AND total are already deny-aware (excluded in SQL via excludeRecordIds above), so no
+      // post-filter is needed here — both the row set and the count hide rule-denied / grant-denied trashed
+      // records (LOCK-3 list-hide + LOCK-4 count-exclude). Field-read mask still applies to the survivors.
+      const maskedRecords = result.records.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
       return res.json({ ok: true, data: { records: maskedRecords, total: result.total } })
     } catch (err) {
       if (err instanceof RecordServicePermissionError) {
@@ -11439,9 +11443,13 @@ export function univerMetaRouter(): Router {
       // 2b-S2 trash-surface close-out: a record currently denied by a CONDITIONAL READ-DENY RULE for
       // this actor must not be restorable — otherwise restore would reintroduce a rule-denied record onto
       // the live/operable path. Resolve the trashed record's sheet; if the flag is on, the actor is
-      // non-admin, and a conditional rule denies the trashed record's data, refuse (403). Admin-bypass +
+      // non-admin, and a conditional rule denies the trashed record's data, refuse. Admin-bypass +
       // flag-off inert mirror the read surfaces. (Scope: conditional-rule deny only — grant-deny
       // (record_permissions) on restore is pre-existing and out of this change's scope.)
+      // LOCK-6: the refusal must be INDISTINGUISHABLE from "no such deleted record" — return the EXACT same
+      // 404 NOT_FOUND body the restore path produces for a missing id (RecordNotFoundError → 404 with
+      // `No deleted record to restore: <id>`), NOT a 403. A 403-vs-404 difference would be an existence
+      // oracle letting a canDeleteRecord actor enumerate which rule-hidden records sit in the trash.
       if (!access.isAdminRole) {
         const trashRow = await pool.query('SELECT sheet_id FROM meta_records_trash WHERE record_id = $1 LIMIT 1', [recordId])
         const trashSheetId = (trashRow.rows[0] as { sheet_id?: unknown } | undefined)?.sheet_id
@@ -11449,7 +11457,7 @@ export function univerMetaRouter(): Router {
           && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), trashSheetId)) {
           const ruleDenied = await loadRuleDeniedTrashRecordIds(pool.query.bind(pool), trashSheetId, [recordId])
           if (ruleDenied.has(recordId)) {
-            return sendForbidden(res, 'Cannot restore a record you are not permitted to read')
+            return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `No deleted record to restore: ${recordId}` } })
           }
         }
       }

--- a/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-conditional-rule-trash-realdb.test.ts
@@ -118,18 +118,28 @@ describeIfDatabase('#18 phase-2 conditional read-deny — trash list + restore (
     const ids = (res.body?.data?.records ?? []).map((r: { recordId: string }) => r.recordId)
     expect(ids).not.toContain(REC_SECRET) // the denied record's row + data are excluded
     expect(ids).toContain(REC_PUBLIC)
-    // KNOWN CAVEAT (pinned, out of this scope): `total` is a sheet-wide COUNT(*) in listDeletedRecords,
-    // NOT adjusted for the deny filter — it still counts the hidden row. Pre-existing count behavior also
-    // shared with grant-deny (route comments it a minor follow-up); the data is protected, only the count
-    // is unadjusted. Pinned so a future deny-aware counter is an intentional change, not a silent one.
-    expect(res.body?.data?.total).toBe(2)
+    // LOCK-4 (deny-aware count): `total` now EXCLUDES denied trashed records in SQL (listDeletedRecords
+    // excludeRecordIds), so the aggregate can't reveal the cardinality of hidden rows — 2 trashed, 1 denied → 1.
+    expect(res.body?.data?.total).toBe(1)
   })
 
-  test('enforce — flag ON + deny rule: restoring the rule-denied record is REFUSED (403); a non-denied record restores (200)', async () => {
+  test('enforce — flag ON + deny rule: restoring the rule-denied record is REFUSED as 404 not-found (no existence oracle); a non-denied record restores (200)', async () => {
     await setFlag(true)
     await setRules(denySecretRule)
     const denied = await restore(REC_SECRET)
-    expect(denied.status).toBe(403)
+    // LOCK-6: the refusal is INDISTINGUISHABLE from "no such deleted record" — the SAME 404 NOT_FOUND body a
+    // genuinely-nonexistent id returns (`No deleted record to restore: <probed id>`). A 403 would be an
+    // existence oracle letting a canDeleteRecord actor enumerate which rule-hidden records sit in the trash.
+    expect(denied.status).toBe(404)
+    expect(denied.body?.error?.code).toBe('NOT_FOUND')
+    expect(denied.body?.error?.message).toBe(`No deleted record to restore: ${REC_SECRET}`)
+    // a genuinely-nonexistent id returns the SAME shape (status + code + id-echoing message format), so the
+    // two cases are indistinguishable for any given probe id (the echoed id is attacker-supplied, not a leak).
+    const GHOST_ID = 'rec_nonexistent_oracle_probe'
+    const ghost = await restore(GHOST_ID)
+    expect(ghost.status).toBe(404)
+    expect(ghost.body?.error?.code).toBe('NOT_FOUND')
+    expect(ghost.body?.error?.message).toBe(`No deleted record to restore: ${GHOST_ID}`)
     // the refused record stays in trash (not resurrected onto the live path)
     const trashRow = await q('SELECT 1 FROM meta_records_trash WHERE sheet_id = $1 AND record_id = $2', [SHEET_ID, REC_SECRET])
     expect(trashRow.rows.length).toBe(1)


### PR DESCRIPTION
Owner review found **#2900** shipped the trash rule-deny but missed the two security locks the design-lock (#2905) named. Fix-forward:

- **[P1] LOCK-4** — trash `total` was a sheet-wide COUNT(*) that still counted hidden rows (cardinality leak). Now `listDeletedRecords` takes `excludeRecordIds`; the route computes the **sheet-wide** deny set (grant-deny ∪ trash rule-deny, page-independent) → COUNT + pagination + rows all deny-aware in SQL. Test: `total === 1`.
- **[P1] LOCK-6** — rule-denied restore returned **403** (existence oracle). Now returns the **identical 404 NOT_FOUND body** a missing id produces (`No deleted record to restore: <id>`). Test: restore-denied → 404 + a genuinely-nonexistent-id same-shape assertion (no oracle).
- **[P2]** design-lock #2905 status → IMPLEMENTED by #2900 + LOCK-4/6 fixed here.

Backend tsc clean; real-DB golden updated (runs in `test (20.x)`). LOCK-1/2/3/5/7/8 from #2900 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)