### PR TITLE
docs(multitable): sync 2b-S2 closeout after #2910

### DIFF
--- a/docs/development/multitable-development-completion-verification-20260618.md
+++ b/docs/development/multitable-development-completion-verification-20260618.md
@@ -14,10 +14,10 @@
 >   **#2890** added goldens for view/search-filter, aggregate/dashboard, export, and link-picker → 8/9. The 9th
 >   — **trash list/restore** — was the one access-control surface left; surfaced as an owner decision and the
 >   owner picked **选 Build**, shipped in **#2900**: `loadRuleDeniedTrashRecordIds` hides rule-denied deleted
->   records from the trash list and **refuses restore (403)** for a currently-rule-denied record, so it can't
->   be reintroduced onto the live path. Real-DB golden green in `test (20.x)` → **9/9**. Known caveat (pre-existing,
->   out of scope): trash `total` COUNT is not deny-adjusted (records excluded; aggregate count shared with
->   grant-deny — a minor cross-cutting follow-up, pinned by a test). Grant-deny on restore is likewise pre-existing.
+>   records from the trash list and gates restore so a currently-rule-denied record cannot be reintroduced
+>   onto the live path. **#2910** then closed the follow-up locks: trash `total` is deny-aware and restore-denied
+>   returns the same 404 shape as a missing deleted record (no existence oracle). Real-DB golden green in
+>   `test (20.x)` → **9/9**. Grant-deny on restore is pre-existing/out of this scope.
 > - **2c · #16 person org-directory — ALL COVERED.** Native `userId[]`; fail-closed validator across all write
 >   paths (incl. import via shared `createRecord`); active-only directory resolver; `canEditRecord`-gated
 >   endpoint; picker display-parity + no-silent-drop; inactive cue. **CI gap closed:** the two FE specs
@@ -26,8 +26,8 @@
 >
 > **Net for the `/goal`:** every planned arc (2a / 2b / 2c) is built + tested on main; verification surfaced and
 > closed three real gaps — two test/CI (#2890, #2891) and, on the owner's 选 Build, the last access-control
-> surface (#2900, trash rule-deny → **2b-S2 9/9**). No owner decision is pending. The only future candidates are
-> reopen-only / roadmap-pool items (#2877 picker-chip; #17 grid-virtualization; the trash-`total` count caveat),
+> surface (#2900 + #2910, trash rule-deny → **2b-S2 9/9**, deny-aware total, no restore oracle). No owner decision is pending. The only future candidates are
+> reopen-only / roadmap-pool items (#2877 picker-chip; #17 grid-virtualization),
 > none of which is autonomous planned remainder.
 >
 > Status: **VERIFICATION** of the `/goal` "complete all development per the plan/TODO MD".

--- a/docs/development/multitable-gated-remainder-development-plan-20260618.md
+++ b/docs/development/multitable-gated-remainder-development-plan-20260618.md
@@ -113,7 +113,7 @@ Non-goals:
 
 ## 2. 2b · #18 Phase-2 Permission Rule Engine
 
-> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841), with real-DB read-surface goldens over **9/9** surfaces (#2890 added view/search-filter, aggregate/dashboard, export, link-picker to the prior list/single/summary; **#2900 closed the last surface — trash list/restore**, owner picked 选 Build); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history. **Known caveat (pre-existing, out of scope): the trash `total` COUNT is not deny-adjusted — records are excluded, only the aggregate count is not (shared with grant-deny; a minor cross-cutting follow-up).**
+> **STATUS (2026-06-18): COMPLETE (S1–S4).** S1 parser/evaluator, fail-closed (#2836); S2 conditional read-deny enforcement wired into the static-#18 seam, flag-off inert (#2841), with real-DB read-surface goldens over **9/9** surfaces (#2890 added view/search-filter, aggregate/dashboard, export, link-picker to the prior list/single/summary; **#2900 closed the last surface — trash list/restore**, owner picked 选 Build; **#2910 closed the follow-up cardinality/oracle locks** by making trash `total` deny-aware and returning restore-denied as the same 404 shape as missing); S3 authoring UI + API (#2847); **S4 content-keyed parse cache (#2861) — staleness-free (DB reads are NOT cached; the per-read rules load is the freshness guarantee).** §2.1–§2.4 retained as history.
 
 ### 2.1 Current Contract
 
@@ -158,7 +158,7 @@ Recommended implementation slices after the gate opens:
 |---|---|---|
 | ✅ 2b-S0 | Security design-lock and adversarial threat model. (Settled — S1–S3 built on the locked rule model.) | Owner sign-off; no runtime. |
 | ✅ 2b-S1 | Pure evaluator + parser, no route wiring. **(#2836)** | Unit matrix per field type/operator; malformed rule fail-closed. |
-| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record (#2841), summaries (#2841), view, search/filter, aggregate/dashboard, export, link picker (**#2890**) + trash list/restore (**#2900** — hide + restore-refuse) = **9/9**. Count caveat: trash `total` not deny-adjusted (records excluded; aggregate count pre-existing, shared with grant-deny). |
+| ✅ 2b-S2 | Backend enforcement for the same read surfaces covered by static #18. **(#2841 — wired into the #18 seam, flag-off inert)** | Real-DB golden over list, single record (#2841), summaries (#2841), view, search/filter, aggregate/dashboard, export, link picker (**#2890**) + trash list/restore (**#2900** — hide + restore gating; **#2910** — deny-aware `total` + restore 404/no-oracle) = **9/9**. |
 | ✅ 2b-S3 | Authoring UI for conditional rules. **(#2847, + text-type operator allowlist fix)** | Frontend tests + browser evidence; no silent rule loss on edit. |
 | ✅ 2b-S4 | Performance and caching pass. **(#2861 — content-keyed parse cache; staleness-free, DB reads not cached.)** | Unit cache cases (hit / equals-direct / content-change re-parse / 200-rule set parsed once across 50 reads / cyclic bypass). |
 

--- a/docs/development/multitable-gated-remainder-todo-20260618.md
+++ b/docs/development/multitable-gated-remainder-todo-20260618.md
@@ -59,15 +59,16 @@
   - [ ] Deleted/hidden predicate field tests.
 
 - [x] 2b-S2 Backend enforcement (#2841 — wired into the #18 seam, flag-off inert). Real-DB read-surface
-  goldens cover **9/9 surfaces** — 8 via #2890 + trash list/restore via #2900 (owner picked 选 Build).
+  goldens cover **9/9 surfaces** — 8 via #2890 + trash list/restore via #2900 (owner picked 选 Build),
+  with the follow-up cardinality/oracle locks closed by #2910.
   - [x] Real-DB list / single-record / view tests (#2841 list+single; #2890 view-aggregate).
   - [x] Real-DB summary subset tests (#2841).
   - [x] Real-DB export and aggregate/dashboard tests (#2890 — export-xlsx parse + view-aggregate total).
   - [x] Real-DB link-picker test (#2890 link-options) + search/filter deny-before-filter (#2890).
-  - [x] Real-DB **trash list/restore** — BUILT (选 Build, #2900). `loadRuleDeniedTrashRecordIds` evaluates
-    rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list and restore
-    is refused (403) for a currently-rule-denied record. Real-DB golden green in `test (20.x)`. (Trash `total`
-    COUNT not deny-adjusted — pre-existing, shared with grant-deny; records excluded, count is a minor follow-up.)
+  - [x] Real-DB **trash list/restore** — BUILT (选 Build, #2900 + #2910). `loadRuleDeniedTrashRecordIds`
+    evaluates rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list;
+    `total` is deny-aware; restore returns the same 404 shape as a missing deleted record for a
+    currently-rule-denied record (no existence oracle). Real-DB golden green in `test (20.x)`.
   - [x] CI allowlist confirmation — `plugin-tests.yml:194` registers enforce-realdb (verified by reading the workflow, not inferred from green jobs); the goldens ran green in `test (20.x)` on #2890.
 
 - [x] 2b-S3 Authoring UI (#2847, + text-type operator allowlist fix).
@@ -114,6 +115,6 @@ These are future candidates or reopen-only lines. They are not open work in the 
 
 No active multitable development *arc* remains — **2a, 2b (through S4 `#2861`, now 9/9 read surfaces), and 2c (through S4 `#2874`) are all complete and closed; none is a "next option".** Both prior owner decisions are resolved (#2877 closed not-landed; 2b-S2 trash = 选 Build, shipped). No owner decision is pending:
 
-- **[x] 2b-S2 trash list/restore rule-deny — BUILT (选 Build, #2900):** conditional read-deny now covers **9/9** read surfaces. `loadRuleDeniedTrashRecordIds` evaluates rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list, and restore is refused (403) for a currently-rule-denied record (can't reintroduce it onto the live path). Admin-bypass + flag-off inert mirror the read surfaces; real-DB golden green in `test (20.x)`. **Known caveat (pre-existing, out of scope):** the trash `total` COUNT is sheet-wide and not deny-adjusted (records are excluded, only the aggregate count is not) — shared with grant-deny, a minor cross-cutting follow-up; pinned by a test, not a leak of record data. Grant-deny on restore is likewise pre-existing/out of this scope.
+- **[x] 2b-S2 trash list/restore rule-deny — BUILT (选 Build, #2900 + #2910):** conditional read-deny now covers **9/9** read surfaces. `loadRuleDeniedTrashRecordIds` evaluates rules against `meta_records_trash` → rule-denied deleted records are hidden from the trash list, trash `total` is deny-aware, and restore returns the same 404 shape as a missing deleted record for a currently-rule-denied record (can't reintroduce it onto the live path, no existence oracle). Admin-bypass + flag-off inert mirror the read surfaces; real-DB golden green in `test (20.x)`. Grant-deny on restore remains pre-existing/out of this scope.
 - **[x] `#2877` (2c-S4 picker-chip affordance) — CLOSED not-landed (2026-06-18):** the green, display-only PR marking no-longer-assignable chips inside `MetaPersonPicker` (the one S4 surface `#2874` left out) was **closed rather than landed**. S4's display-affordance bar is met by `#2874` (cell/summary cue) and ratified by the merged closeout `#2878`; the picker chip is supplementary polish on a different surface, **not** a correctness gap (re-assignment is already fail-closed by `#2854`, and the picker already excludes inactive members per `#2869`). Branch preserved — reopen as an explicitly-scoped picker-polish item if wanted, not as "the last 2c slice".
 - **[~] Revisit grid performance:** opt into D2 high-scale harness/re-baseline work first; row virtualization stays closed unless the verdict flips.


### PR DESCRIPTION
## Summary

- update the multitable gated-remainder plan/TODO/verification docs after #2910
- remove the stale trash total-count caveat now that #2910 makes trash totals deny-aware
- replace the stale restore 403 wording with the shipped restore-denied 404/no-oracle behavior

## Verification

- 
- targeted text scan for stale trash total / restore 403 caveat phrases

Docs-only.