### PR TITLE
docs(multitable): reconcile 2b read-deny to 9/9 BUILT (#2900+#2910) — drop stale 8/9 / Build-vs-Defer tails

### DIFF
--- a/docs/development/development-completion-plan-and-verification-20260618.md
+++ b/docs/development/development-completion-plan-and-verification-20260618.md
@@ -16,7 +16,7 @@
 
 | Track | 已完成 (on main) | gated 剩余 | 权威 ledger |
 |---|---|---|---|
-| **多维表 (multitable)** | 2a 全标量 CRDT · 2b 条件读权限 S1–S4(读-deny 8/9 surface)· 2c 人员目录 S2–S4 · #18 行级读拒 | **2b trash/restore rule-deny 继承(owner-gated Build/Defer)** · roadmap pool(导出/required-if/仪表盘联动/网格虚拟化 reopen-only/AI rings/原生同步表/FOL 深链/A6 余项) | `multitable-gated-remainder-development-plan/todo-20260618.md` |
+| **多维表 (multitable)** | 2a 全标量 CRDT · 2b 条件读权限 S1–S4(读-deny 9/9 surface,含 trash #2900/#2910)· 2c 人员目录 S2–S4 · #18 行级读拒 | roadmap pool(导出/required-if/仪表盘联动/网格虚拟化 reopen-only/AI rings/原生同步表/FOL 深链/A6 余项) | `multitable-gated-remainder-development-plan/todo-20260618.md` |
 | **数据库/系统对接 (data-source)** | C2–C6 · Release · S1a(合同层;orphaned 面已由 #2894 retire) | **S1b(impl 进行中 #2887/#2892,S1b-3 续接)** · S2 · S3 · S4 · S5 · 首笔生产外部写 | `data-source-system-integration-plan-and-verification-20260618.md` |
 | **考勤 H2 (attendance core)** | 一天多班次 · 排班发布/草稿 · 临时班次 · 加班三段 · 自动对班 A2 · C5 通知 · **排班合规引擎(block-on-save runtime)** · **打卡策略组** | §1 OUT 红线(算薪/防作弊/AI/人脸/原生 app/插件市场,🚫) · H3 高级(调度/换班/多门店,gated;3a 可建) | `attendance-dingtalk-benchmark-target-and-tracker-20260601.md` |
 | **考勤年假引擎 (annual-leave)** | 引擎 L0–L5c(含 L5a/b/c admin)+ 员工自助 surfaces | **L6 staging smoke(owner-run gate,非自主构建)** | `attendance-annual-leave-admin-operations-dev-plan-20260617.md` |
@@ -25,7 +25,7 @@
 
 ### 2.1 多维表 (multitable) — 全部完成
 - **2a 实时标量 CRDT(全标量集)**:select/date **#2832**、duration **#2838**、dateTime **#2849**(canonical-UTC-ISO 不变量);number/currency/percent/boolean/rating/multiSelect 此前已落。无标量类型仍是 REST-only。
-- **2b #18 条件读权限规则 S1–S4**:evaluator **#2836** · enforcement(接入 #18 seam,flag-off inert)**#2841** · authoring UI/API **#2847** · content-keyed parse cache(staleness-free)**#2861**。**读-deny 覆盖 8/9 read surfaces**(list/view/search-filter · single-record · summary · aggregate/dashboard · export · link-picker;real-DB goldens 由 **#2890** 补齐,green in `test (20.x)`)。**第 9 个 surface —— trash list/restore —— 是 deliberate deferral,不是缺陷**:`loadRuleDeniedRecordIds` 只评估 live `meta_records`,trashed 记录不在该 live 路径里(code-acknowledged),故"把条件 rule-deny 完全继承到 trash/restore"是**新的 access-control 行为 = 显式 owner-gated Build-vs-Defer 决策**(见 §3.3,及权威 `multitable-development-completion-verification-20260618.md` L14–16/26 + TODO §5)。**恢复(restore)功能本身已可用、已完成**;待决的只是这条安全增强。(注:`plugins/plugin-intelligent-restore` 是旧的/示例式 plugin 壳,**不是**已交付的主线恢复功能,不能据它判断完成度。)
+- **2b #18 条件读权限规则 S1–S4**:evaluator **#2836** · enforcement(接入 #18 seam,flag-off inert)**#2841** · authoring UI/API **#2847** · content-keyed parse cache(staleness-free)**#2861**。**读-deny 覆盖 9/9 read surfaces**:8 个 live surface(list/view/search-filter · single-record · summary · aggregate/dashboard · export · link-picker,real-DB goldens **#2890**)+ 第 9 个 **trash list/restore**(owner 选 Build:**#2900** 实现 hide + refuse-restore,**#2910** 补 LOCK-4 deny-aware total + LOCK-6 restore 404 not-found-shape)。trashed 记录经 `loadRuleDeniedTrashRecordIds` 对 `meta_records_trash.data` 求值 → 隐藏 + 拒绝 restore,total 不泄露基数,restore 与 not-found 同形态。(注:`plugins/plugin-intelligent-restore` 是旧的/示例式 plugin 壳,**不是**已交付的主线恢复功能,不能据它判断完成度。)
 - **2c 人员字段 → 组织成员目录 S2–S4**:source = B 设计锁 **#2860** · resolver **#2866** · `canEditRecord`-gated directory endpoint **#2867** · `MetaPersonPicker` 接线 **#2869** · S4 inactive/historical 显示线索(read-only cell/summary cue)**#2874**;fail-closed 写校验 **#2833 + #2854**。
 - **closeout/ledger 一致性**:**#2878**(2c COMPLETE closeout)· **#2881**(P1/P2/P3 reconciliation + #2877 carve-out)· **#2883**(grounding-line 2c)· **#2885**(`MetaPersonPicker` 注释对齐)。**#2877**(2c-S4 picker-chip)= **CLOSED not-landed**(S4 口径由 #2874 cell/summary cue 满足;picker chip 为不同 surface 的补充打磨,非正确性缺口)。
 
@@ -67,11 +67,11 @@
 - **H3 钉钉级高级**(调度/换班/多门店/设备围栏/人脸/算薪)— gated,不一口吞;**3a 可建**(多门店挂部门,约 1–2 周)单点 opt-in;3b 不自研。
 - **§1 OUT 红线**(算薪 SaaS/防作弊/AI/人脸/原生 app/插件市场)— 🚫 明确不做。
 
-### 3.3 多维表 — 待决 owner 决策 + roadmap pool
+### 3.3 多维表 roadmap pool(reopen-only / 未来候选)
 
-- **【安全决策 · 非 reopen-only】2b 条件读权限 → trash list/restore 继承(owner-gated Build vs Defer)**:条件 rule-deny 现覆盖 8/9 read surfaces;**trash list/restore 未继承**(`loadRuleDeniedRecordIds` 只评估 live `meta_records`,trashed 记录不在该路径)。**Build** = 关闭「被 rule 隐藏的记录仍可能经 trash 可见/可恢复」这条 read-deny 旁路 —— 需先出 design-lock(rule 如何对 trashed 记录求值:它们有 stored 字段值但无 live `meta_records` 行);**Defer** = 记录为已知、bounded、被接受的 gap(仅当 #18 phase-2 规则开启 ∧ 记录已 trash ∧ 用户有 trash 访问 三者同时成立才暴露)。**本会话不自建,等 owner 明确选 Build 或 Defer。**
+> 注:2b 条件读权限 → trash list/restore 继承已 **BUILT**(owner 选 Build;#2900 LOCK-1/2/3/5/7/8 + #2910 LOCK-4/6 —— 全部满足),不再是待决 owner 决策。
 
-**roadmap pool(reopen-only / 未来候选):** 服务端全量导出 · 表单 `required-if` · 仪表盘联动筛选/下钻 · 仪表盘缺失日期桶/系列数上限 · **网格虚拟化(D2 verdict 判定不需要,reopen-only)** · AI rings 进阶 · 原生同步/外源表 · FOL 深链(多跳/公式套公式/物化/Yjs 重算/automation 触发)· automation A6 余项。各为独立 gated opt-in。
+服务端全量导出 · 表单 `required-if` · 仪表盘联动筛选/下钻 · 仪表盘缺失日期桶/系列数上限 · **网格虚拟化(D2 verdict 判定不需要,reopen-only)** · AI rings 进阶 · 原生同步/外源表 · FOL 深链(多跳/公式套公式/物化/Yjs 重算/automation 触发)· automation A6 余项。各为独立 gated opt-in。
 
 ## 4. 本轮 ledger hygiene(已做,非 gated)
 

--- a/docs/development/multitable-2b-trash-restore-rule-deny-design-lock-20260618.md
+++ b/docs/development/multitable-2b-trash-restore-rule-deny-design-lock-20260618.md
@@ -9,7 +9,7 @@
 
 ## 0. 一句话
 
-条件读权限规则(2b)的 read-deny 目前覆盖 **8/9** read surfaces;第 9 个 —— **回收站 list + 恢复(undelete)** —— 未继承,因为 `loadRuleDeniedRecordIds` 只对 **live `meta_records`** 求值,而 trashed 记录在独立的 `meta_records_trash` 表里。本设计把同一套规则求值扩到 trash snapshot,使「被规则拒读的记录」在回收站里**既不可见、也不可恢复**,且严格保持 #18 既有不变量(admin-bypass / flag-off inert / 不泄露基数)。
+条件读权限规则(2b)的 read-deny 现覆盖 **9/9** read surfaces:8 个 live surface + 第 9 个 **回收站 list + 恢复(undelete)**。trash 此前未继承(`loadRuleDeniedRecordIds` 只对 live `meta_records` 求值,trashed 记录在独立的 `meta_records_trash` 表),**现已由 #2900(LOCK-1/2/3/5/7/8)+ #2910(LOCK-4 deny-aware total / LOCK-6 restore 404 not-found-shape)实现**:同一套规则对 trash snapshot 求值,使「被规则拒读的记录」在回收站里**既不可见、也不可恢复**(数据 + 基数都不泄露,restore 与 not-found 同形态),严格保持 #18 既有不变量(admin-bypass / flag-off inert)。
 
 ## 1. 现状对账(代码实测,verified)
 
@@ -52,7 +52,7 @@
 `loadRowLevelReadDenyEnabled(sheetId)` 为 false(默认)时,trash list + undelete **与 pre-2b 逐字节一致**:不发 `conditional_read_rules` 查询、不对 trash 求值。列缺失 / 规则空 / 表缺失(pre-migration)→ inert,**绝不** 500、绝不静默放行成 deny 之外的行为(沿用 `loadRuleDeniedRecordIds` 既有 fail-closed-on-error)。
 
 ## 4. 不变量(继承 #18,必须保持)
-deny-wins(并集)· admin-bypass(LOCK-7)· flag-off byte-identical(LOCK-8)· 无基数泄露(LOCK-4 + LOCK-6)· fail-closed(LOCK-2)· 不改 grant-deny 范围(§1)· 不碰 live 8/9 surfaces · 不碰版本恢复(6259)。
+deny-wins(并集)· admin-bypass(LOCK-7)· flag-off byte-identical(LOCK-8)· 无基数泄露(LOCK-4 + LOCK-6)· fail-closed(LOCK-2)· 不改 grant-deny 范围(§1)· 不碰 live(非-trash)read surfaces · 不碰版本恢复(6259)。
 
 ## 5. 验收 / 测试计划(real-DB,impl 阶段交付)
 1. **trash list 排除**:flag-on、非 admin、一条 trashed 记录其 data 命中规则 → 不在 list;`total` 也 -1(LOCK-3/4)。
@@ -62,7 +62,7 @@ deny-wins(并集)· admin-bypass(LOCK-7)· flag-off byte-identical(LOCK-8)· 无
 5. **undelete 正常**:非 denied trashed 记录 → 正常复活。
 6. **deleted-field fail-closed**:规则引用的字段在 trash 后被删 → 该 trashed 行 deny(list 排除 + undelete 拒)(LOCK-2 预期副作用)。
 7. **grant-deny 回归**:grant-denied trashed 记录仍被排除(§1 未回归)。
-8. CI allowlist 确认(不靠 green job 推断);live 8/9 surfaces 回归不变。
+8. CI allowlist 确认(不靠 green job 推断);live(非-trash)read surfaces 回归不变。
 
 ## 6. 实现切片(ratify 后,各自 gated;**现在不写**)
 - **S1**:共享求值核 + `loadRuleDeniedTrashRecordIds`(纯逻辑 + 单测:fail-closed / 字段缺失 / 空规则 / flag-off-inert 等价)。
@@ -71,4 +71,4 @@ deny-wins(并集)· admin-bypass(LOCK-7)· flag-off byte-identical(LOCK-8)· 无
 - 每片独立 PR + real-DB 反向测试;先 S1(逻辑)再 S2/S3(路由)。
 
 ## 7. STOP
-**本文是 design-lock,不含 runtime。** 上述 LOCK-1..8 是 ratify 对象;owner 签字后才进 §6 实现。未签字前不写 runtime(同 S1b design-lock #2884 → 签字 → impl 的门)。
+**本文原为 design-lock(ratify-then-impl);runtime 已实现并落 `origin/main`** —— #2900(并行 effort,LOCK-1/2/3/5/7/8)+ #2910(LOCK-4/6 fix)。LOCK-1..8 现为本特性的安全合同(已全部满足),非待 ratify 项。


### PR DESCRIPTION
Tiny docs-only reconciliation. Now that #2900 + #2910 landed (2b read-deny 9/9, both security locks honored), two docs still read the old framing:

- **[P2]** `development-completion-plan-and-verification-20260618.md` (the 'is development done?' entry doc): §1 table line, §2.1 bullet, §3.3 → 8/9 + owner-gated Build/Defer → **9/9 BUILT** (#2900 + #2910).
- **[P3]** design-lock §0 + §7 STOP pre-runtime tails → IMPLEMENTED; also dropped two 'live 8/9 surfaces' invariants → 'live (non-trash)' to cut grep noise.

Grep-verified: zero `8/9` / `deliberate deferral` / `Build vs Defer` / pre-runtime-STOP left in either file. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)