### PR TITLE
feat(approval): configurable manager-chain max-levels (APPROVAL_MANAGER_CHAIN_MAX_LEVELS)

### DIFF
--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -64,9 +64,33 @@ export interface ApprovalRequesterOrgRelations {
   managerChainIds?: string[]
 }
 
-/** Hard ceiling on how far up the org tree the bake-time walk climbs. The per-source
- * `levels` slices this; the cap only bounds the walk cost + a pathological deep tree. */
-export const MAX_MANAGER_CHAIN_LEVELS = 10
+/** Default cap on how far up the org tree the bake-time walk climbs when unconfigured. */
+export const DEFAULT_MAX_MANAGER_CHAIN_LEVELS = 10
+/** Hard upper bound on the *configurable* cap — even a misconfigured env can't make the
+ * walk unbounded (each level is a sequential pair of directory queries). */
+export const MANAGER_CHAIN_LEVELS_HARD_CEILING = 50
+
+/**
+ * Resolve the configurable chain cap from a raw env value (pure, so it is unit-testable).
+ * `undefined`/missing or any invalid value (non-integer, < 1) → the safe default; a valid
+ * value is clamped to `[1, MANAGER_CHAIN_LEVELS_HARD_CEILING]`. Fail-safe, never throws —
+ * a bad env must not break approval creation.
+ */
+export function resolveMaxManagerChainLevels(raw: string | undefined): number {
+  const trimmed = raw?.trim()
+  // Accept ONLY a plain positive decimal integer — reject scientific (`1e3`), hex
+  // (`0x10`), signed, and fractional forms rather than silently coercing them.
+  if (!trimmed || !/^[0-9]+$/.test(trimmed)) return DEFAULT_MAX_MANAGER_CHAIN_LEVELS
+  const parsed = Number(trimmed)
+  if (parsed < 1) return DEFAULT_MAX_MANAGER_CHAIN_LEVELS
+  return Math.min(parsed, MANAGER_CHAIN_LEVELS_HARD_CEILING)
+}
+
+/** Cap on how far up the org tree the bake-time walk climbs — env-configurable via
+ * `APPROVAL_MANAGER_CHAIN_MAX_LEVELS` (default 10, hard-ceiling 50). The per-source
+ * `levels` slices this; the cap only bounds the walk cost + a pathological deep tree.
+ * Resolved at module load (a deploy-time setting, like the other `APPROVAL_*` tunables). */
+export const MAX_MANAGER_CHAIN_LEVELS = resolveMaxManagerChainLevels(process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS)
 
 interface LeaderInDeptEntry {
   dept_id?: unknown

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+import {
+  resolveApprovalRequesterOrgRelations,
+  resolveMaxManagerChainLevels,
+  DEFAULT_MAX_MANAGER_CHAIN_LEVELS,
+  MANAGER_CHAIN_LEVELS_HARD_CEILING,
+} from '../../src/services/ApprovalDirectoryOrg'
 import { runtimeGraphUsesContinuousManagers } from '../../src/services/ApprovalProductService'
 import type { RuntimeGraph } from '../../src/types/approval-product'
 
@@ -195,5 +200,30 @@ describe('runtimeGraphUsesContinuousManagers (conditional-bake scanner)', () => 
   it('returns false for nodes without assignee sources or non-approval nodes', () => {
     expect(runtimeGraphUsesContinuousManagers({ nodes: [{ key: 'c', type: 'condition', config: {} }] } as unknown as RuntimeGraph)).toBe(false)
     expect(runtimeGraphUsesContinuousManagers({ nodes: [] } as unknown as RuntimeGraph)).toBe(false)
+  })
+})
+
+describe('resolveMaxManagerChainLevels (configurable cap, env APPROVAL_MANAGER_CHAIN_MAX_LEVELS)', () => {
+  it('defaults to 10 when unconfigured / blank', () => {
+    expect(resolveMaxManagerChainLevels(undefined)).toBe(DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+    expect(resolveMaxManagerChainLevels('')).toBe(DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+    expect(resolveMaxManagerChainLevels('   ')).toBe(DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+  })
+
+  it('honors a valid positive integer', () => {
+    expect(resolveMaxManagerChainLevels('1')).toBe(1)
+    expect(resolveMaxManagerChainLevels('5')).toBe(5)
+    expect(resolveMaxManagerChainLevels(String(MANAGER_CHAIN_LEVELS_HARD_CEILING))).toBe(MANAGER_CHAIN_LEVELS_HARD_CEILING)
+  })
+
+  it('clamps above the hard ceiling (a misconfig can never make the walk unbounded)', () => {
+    expect(resolveMaxManagerChainLevels('100')).toBe(MANAGER_CHAIN_LEVELS_HARD_CEILING)
+    expect(resolveMaxManagerChainLevels('99999')).toBe(MANAGER_CHAIN_LEVELS_HARD_CEILING)
+  })
+
+  it('fails SAFE to the default on any invalid value (never throws, never 0/negative/fractional)', () => {
+    for (const bad of ['0', '-3', '3.5', 'abc', 'NaN', '1e3', '0x10']) {
+      expect(resolveMaxManagerChainLevels(bad)).toBe(DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+    }
   })
 })


### PR DESCRIPTION
## What

Remaining org-derived-assignee item: makes the `continuous_managers` chain-walk depth cap **configurable** (was a hardcoded 10), via env `APPROVAL_MANAGER_CHAIN_MAX_LEVELS` — consistent with the other `APPROVAL_*` deploy-time tunables.

- Pure, exported `resolveMaxManagerChainLevels(raw)`: default **10** when unset/blank; accepts **only a plain positive decimal integer** (rejects scientific/hex/signed/fractional rather than coercing); clamps to `[1, MANAGER_CHAIN_LEVELS_HARD_CEILING=50]` so a misconfig can't make the walk unbounded; fail-safe to default, never throws.
- `MAX_MANAGER_CHAIN_LEVELS` is resolved at module load; all consumers (the `clampChainLevels` walk cap + the normalizer's `levels` ceiling) pick it up unchanged, and the normalizer's reject message tracks the configured N.

## Tests

+4 unit: default/blank · valid integer · hard-ceiling clamp · fail-safe on invalid (`0`/`-3`/`3.5`/`abc`/`NaN`/`1e3`/`0x10`). Env smoke confirms `MAX=3` under `env=3`. tsc clean; no `.js`.

## Scope

Pure addition; default behavior unchanged (still 10 when unset). Hard-ceiling 50 keeps the walk bounded. Part of completing the remaining org-derived-assignee items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)