### PR TITLE
feat(plm-collab): V1.1 modern-surface pact (manifest + BOM context) + pilot-hide stubbed approval CTA

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1934,6 +1934,12 @@ const selectedPlmApprovalCapabilityEntry = computed<PlmApprovalCapabilityEntry |
       actionStatus,
     }
   }
+  // V1.1 pilot: approval_automation has no execution engine yet (action_status "stubbed").
+  // Do NOT show an UPGRADE CTA that would over-promise an automation product to an unentitled
+  // external pilot. The entitled/'enabled' entry above stays (it honestly tells a buyer that
+  // notify is still a placeholder). Self-correcting: once the engine ships, action_status changes
+  // away from "stubbed" and this upgrade entry returns.
+  if (actionStatus === 'stubbed') return null
   return {
     state: 'upgrade',
     badge: '可升级',

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -3281,7 +3281,7 @@ describe('IntegrationWorkbenchView', () => {
     expect(calls.some((u) => u.includes('/bom-multitable/'))).toBe(false)
   })
 
-  it('C3: shows only the upgrade affordance for supported but not entitled approval automation', async () => {
+  it('V1.1: hides the upgrade CTA for a supported-but-unentitled STUBBED approval automation (no over-promise)', async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') {
         return jsonResponse([
@@ -3338,12 +3338,11 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(8)
 
+    // V1.1 pilot: approval_automation is still a stub (no execution engine), so its upgrade CTA is
+    // suppressed — an unentitled external pilot must not be shown an automation product promise.
+    // (The entitled/'enabled' entry is unaffected — see the "marks stubbed actions" test above.)
     const entry = container.querySelector('[data-testid="plm-approval-capability-entry"]') as HTMLElement | null
-    expect(entry).not.toBeNull()
-    expect(entry!.dataset.state).toBe('upgrade')
-    expect(entry!.textContent).toContain('升级审批自动化')
-    expect(entry!.textContent).toContain('尚未开通 approval_automation')
-    expect(entry!.textContent).not.toContain('ECO 审批自动化')
+    expect(entry).toBeNull()
   })
 
   it('C3: hides approval automation entry for unsupported or unavailable PLM capability manifests', async () => {

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3395,6 +3395,237 @@
           }
         }
       }
+    },
+    {
+      "description": "fetch the advisory PLM integration capability manifest for an entitled tenant",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable license"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/integrations/capabilities",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "schema_version": "v1",
+          "provider": "yuantus-plm",
+          "advisory": true,
+          "features": {
+            "bom_multitable": {
+              "supported": true,
+              "api_version": "v1",
+              "entitled": true,
+              "scenarios": [
+                "bom_review"
+              ],
+              "cache_scope": {
+                "supported": "global",
+                "entitled": "tenant"
+              }
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.schema_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.provider": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.advisory": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.features.bom_multitable.supported": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.features.bom_multitable.entitled": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.features.bom_multitable.api_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "fetch the governed read-only BOM multitable context for an entitled part",
+      "providerStates": [
+        {
+          "name": "tenant-1 holds an active plm.bom_multitable license and part 01H000000000000000000000P1 has a Part-BOM line"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/bom/multitable/01H000000000000000000000P1/context",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.example",
+          "x-tenant-id": "tenant-1"
+        },
+        "matchingRules": {
+          "header": {
+            "$.Authorization": {
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "feature_key": "bom_multitable",
+          "entitled": true,
+          "upgrade": {
+            "available": false
+          },
+          "context": {
+            "part": {
+              "part_id": "01H000000000000000000000P1",
+              "item_number": "P-0001",
+              "name": "Mounting Bracket",
+              "state": "Released",
+              "generation": 1
+            },
+            "lines": [
+              {
+                "bom_line_id": "01H000000000000000000000R1",
+                "part_id": "01H000000000000000000000P2",
+                "item_number": "P-0002",
+                "name": "Bolt M6",
+                "state": "Released",
+                "generation": 1,
+                "quantity": 4,
+                "uom": "ea",
+                "find_num": "10",
+                "refdes": "B1",
+                "level": 1,
+                "path": [
+                  "01H000000000000000000000P1"
+                ],
+                "path_labels": [
+                  "P-0001"
+                ],
+                "source_version": 1,
+                "source_updated_at": "2026-04-11T00:00:00.000Z",
+                "sync_status": "snapshot"
+              }
+            ],
+            "source_version": 1,
+            "source_updated_at": "2026-04-11T00:00:00.000Z",
+            "sync_status": "snapshot",
+            "template_key": "bom_review"
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.feature_key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.entitled": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.part.part_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines": {
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.context.lines[*].bom_line_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].quantity": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.template_key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
+++ b/packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json
@@ -3490,6 +3490,27 @@
                   "match": "type"
                 }
               ]
+            },
+            "$.features.bom_multitable.scenarios": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.features.bom_multitable.cache_scope.supported": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.features.bom_multitable.cache_scope.entitled": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
             }
           }
         }
@@ -3617,6 +3638,160 @@
               ]
             },
             "$.context.template_key": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.upgrade.available": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.part.item_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.part.name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.part.state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.part.generation": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].part_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].item_number": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].state": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].generation": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].uom": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].find_num": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].refdes": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].level": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].path": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].path_labels": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].source_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].source_updated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.lines[*].sync_status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.source_version": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.source_updated_at": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.context.sync_status": {
               "matchers": [
                 {
                   "match": "type"

--- a/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
+++ b/packages/core-backend/tests/contract/plm-adapter-yuantus.pact.test.ts
@@ -110,6 +110,9 @@ const PACT_PATHS = [
   { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F8/history' },
   { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F9/diff' },
   { method: 'GET', path: '/api/v1/cad/files/01H000000000000000000000F11/mesh-stats' },
+  // PLM-COLLAB V1.1: the two modern Path-A surfaces (advisory manifest + governed BOM context).
+  { method: 'GET', path: '/api/v1/integrations/capabilities' },
+  { method: 'GET', path: '/api/v1/bom/multitable/01H000000000000000000000P1/context' },
 ] as const
 
 function loadPact(): PactDocument {
@@ -180,6 +183,8 @@ describe('Pact: Metasheet2 consumer -> YuantusPLM provider (Wave 1 + Wave 2 docu
       '/api/v1/cad/files/${fileId}/diff',
       '/api/v1/cad/files/${fileId}/mesh-stats',
       'fetchYuantusFileMetadata',
+      '/api/v1/integrations/capabilities',
+      '/api/v1/bom/multitable/${partId}/context',
     ]
     for (const ep of endpointsToFind) {
       expect(


### PR DESCRIPTION
## Summary (PLM-COLLAB V1.1 — owner-gated)
Two Path-A hardening changes for the first external pilot:
- **Pact:** add the 2 interactions Path A actually uses — `GET /api/v1/integrations/capabilities` + `GET /api/v1/bom/multitable/{partId}/context` — to the consumer contract, plus their entries in `PACT_PATHS` and `endpointsToFind` (the anti-drift check that every pacted endpoint is called by `PLMAdapter`).
- **Workbench pilot-hide:** suppress the `approval_automation` **upgrade** CTA when `action_status === 'stubbed'`, so an unentitled external pilot is not shown an automation product promise (no execution engine yet). The entitled `'enabled'` entry is unaffected; self-correcting once the engine ships.

## Verification (local)
- `plm-adapter-yuantus.pact.test.ts` — **14 passed** (count/order + every endpoint called by PLMAdapter).
- `IntegrationWorkbenchView.spec.ts` — **40 passed** (entitled+stubbed → enabled shown; unentitled+stubbed → hidden; unsupported → null).
- `vue-tsc` clean; eslint 0 errors on changed files.

## Scope
V1.1 = manifest + BOM context only. embed-token pact → V1.2; multi-`kid` → V2. Pairs with the Yuantus provider-seed PR for CI pact verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
