### PR TITLE
fix(multitable): wire dashboard chart aggregation to real records with row-level read-deny (P0 audit defect)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -215,6 +215,7 @@ jobs:
             tests/integration/multitable-form-context-submit-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-dashboard-preview-data.test.ts \
+            tests/integration/multitable-dashboard-chart-rowdeny-realdb.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \
             tests/integration/multitable-record-lock.test.ts \

--- a/packages/core-backend/src/multitable/dashboard-service.ts
+++ b/packages/core-backend/src/multitable/dashboard-service.ts
@@ -231,20 +231,26 @@ export class DashboardService {
   // Chart data computation
   // -----------------------------------------------------------------------
 
-  async getChartData(chartId: string): Promise<ChartData> {
+  async getChartData(chartId: string, records?: Array<{ data: Record<string, unknown> }>): Promise<ChartData> {
     const chart = await this.getChart(chartId)
     if (!chart) throw new Error(`Chart not found: ${chartId}`)
 
-    return this.computeChartDataForConfig(chart)
+    return this.computeChartDataForConfig(chart, records)
   }
 
-  async computeChartDataForConfig(chart: ChartConfig): Promise<ChartData> {
-    let records: Array<{ data: Record<string, unknown> }> = []
-    if (this.recordProvider) {
-      records = await this.recordProvider(chart.sheetId)
+  /**
+   * Compute chart data. Callers SHOULD pass `records` already loaded with the actor's row-level
+   * read-deny applied (the production route does this via loadChartRecords) so aggregation never leaks
+   * over records the actor cannot read. When `records` is omitted, fall back to the injected
+   * recordProvider (test wiring) or an empty set.
+   */
+  async computeChartDataForConfig(chart: ChartConfig, records?: Array<{ data: Record<string, unknown> }>): Promise<ChartData> {
+    let recs = records
+    if (!recs) {
+      recs = this.recordProvider ? await this.recordProvider(chart.sheetId) : []
     }
 
-    return this.aggregationService.computeChartData(chart, records)
+    return this.aggregationService.computeChartData(chart, recs)
   }
 }
 

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -99,6 +99,7 @@ async function loadChartRecords(
   query: QueryFn,
   sheetId: string,
   access: ResolvedRequestAccess,
+  allowedFieldIds: Set<string>,
 ): Promise<Array<{ data: Record<string, unknown> }>> {
   const rowsRes = await query('SELECT id, data FROM meta_records WHERE sheet_id = $1', [sheetId])
   let rows = rowsRes.rows as Array<{ id?: unknown; data?: unknown }>
@@ -106,7 +107,17 @@ async function loadChartRecords(
     const denied = await loadDeniedRecordIds(query, sheetId, access.userId)
     if (denied.size > 0) rows = rows.filter((r) => typeof r.id === 'string' && !denied.has(r.id))
   }
-  return rows.map((r) => ({ data: r.data && typeof r.data === 'object' ? (r.data as Record<string, unknown>) : {} }))
+  // Field mask: project each row to ONLY the actor's allowed fields BEFORE it reaches the aggregation
+  // engine — defense-in-depth so a denied field's value can never be aggregated/leaked, independent of
+  // the route's isChartDataRestricted gate. (Also keeps this off the raw-record-data egress surface.)
+  return rows.map((row) => {
+    const src = row.data && typeof row.data === 'object' ? (row.data as Record<string, unknown>) : {}
+    const masked: Record<string, unknown> = {}
+    for (const fid of allowedFieldIds) {
+      if (Object.prototype.hasOwnProperty.call(src, fid)) masked[fid] = src[fid]
+    }
+    return { data: masked }
+  })
 }
 
 async function requireSheetRead(
@@ -347,7 +358,7 @@ export function dashboardRouter() {
         res.json(restrictedChartData(chart))
         return
       }
-      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access)
+      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access, allowedFieldIds)
       const data = await dashboardService.computeChartDataForConfig(chart, records)
       res.json(data)
     } catch (err: unknown) {
@@ -441,7 +452,7 @@ export function dashboardRouter() {
         res.json(restrictedChartData(chart))
         return
       }
-      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access)
+      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access, allowedFieldIds)
       const data = await dashboardService.getChartData(req.params.id, records)
       res.json(data)
     } catch (err: unknown) {

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -38,11 +38,14 @@ import type { MultitableField } from '../multitable/field-codecs'
 import { loadFieldsForSheet } from '../multitable/loaders'
 import { deriveFieldPermissions, isFieldPermissionHidden } from '../multitable/permission-derivation'
 import {
+  loadDeniedRecordIds,
   loadFieldPermissionScopeMap,
+  loadRowLevelReadDenyEnabled,
   resolveSheetCapabilities,
   resolveSheetReadableCapabilities,
   type QueryFn,
 } from '../multitable/permission-service'
+import type { ResolvedRequestAccess } from '../multitable/access'
 
 const dashboardService = new DashboardService()
 const CHART_TYPES = new Set<ChartType>(['bar', 'line', 'pie', 'number', 'table', 'area', 'funnel', 'gauge', 'scatter'])
@@ -82,6 +85,28 @@ type SheetAuthContext = {
   query: QueryFn
   userId: string
   capabilities: MultitableCapabilities
+  access: ResolvedRequestAccess
+}
+
+/**
+ * Load the records that feed chart aggregation, with the SAME row-level read-deny the live read
+ * surfaces apply (grant-deny ∪ conditional-rule-deny via loadDeniedRecordIds), so chart totals/series
+ * never aggregate over records the actor cannot read. Admin-bypass + flag-off inert mirror /view +
+ * /view-aggregate exactly. (Field-level masking is handled separately at the route via
+ * loadAllowedFieldIds + isChartDataRestricted — a chart over a non-visible field is refused wholesale.)
+ */
+async function loadChartRecords(
+  query: QueryFn,
+  sheetId: string,
+  access: ResolvedRequestAccess,
+): Promise<Array<{ data: Record<string, unknown> }>> {
+  const rowsRes = await query('SELECT id, data FROM meta_records WHERE sheet_id = $1', [sheetId])
+  let rows = rowsRes.rows as Array<{ id?: unknown; data?: unknown }>
+  if (!access.isAdminRole && access.userId && await loadRowLevelReadDenyEnabled(query, sheetId)) {
+    const denied = await loadDeniedRecordIds(query, sheetId, access.userId)
+    if (denied.size > 0) rows = rows.filter((r) => typeof r.id === 'string' && !denied.has(r.id))
+  }
+  return rows.map((r) => ({ data: r.data && typeof r.data === 'object' ? (r.data as Record<string, unknown>) : {} }))
 }
 
 async function requireSheetRead(
@@ -99,7 +124,7 @@ async function requireSheetRead(
     sendForbidden(res)
     return null
   }
-  return { query, userId: access.userId, capabilities }
+  return { query, userId: access.userId, capabilities, access }
 }
 
 async function requireSheetManageViews(
@@ -117,7 +142,7 @@ async function requireSheetManageViews(
     sendForbidden(res)
     return null
   }
-  return { query, userId: access.userId, capabilities }
+  return { query, userId: access.userId, capabilities, access }
 }
 
 function filterVisiblePropertyFields(fields: MultitableField[]): MultitableField[] {
@@ -322,7 +347,8 @@ export function dashboardRouter() {
         res.json(restrictedChartData(chart))
         return
       }
-      const data = await dashboardService.computeChartDataForConfig(chart)
+      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access)
+      const data = await dashboardService.computeChartDataForConfig(chart, records)
       res.json(data)
     } catch (err: unknown) {
       res.status(400).json({ error: (err as Error).message })
@@ -415,7 +441,8 @@ export function dashboardRouter() {
         res.json(restrictedChartData(chart))
         return
       }
-      const data = await dashboardService.getChartData(req.params.id)
+      const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access)
+      const data = await dashboardService.getChartData(req.params.id, records)
       res.json(data)
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message })

--- a/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
@@ -100,6 +100,9 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID_DENIED, false, false])
+    // Seed a REAL record carrying the canary: the route now loads meta_records via the wired path, so an
+    // allowed user sees the value and a denied user is masked — exercising production, not a provider fixture.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_f0b_${TS}`, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: 'visible bucket', [FLD_SECRET]: SECRET_CANARY })])
 
     await insertChart(CHART_ID)
     await insertChart(CHART_SECRET_ID, {
@@ -123,6 +126,7 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
 
   afterAll(async () => {
     getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM multitable_dashboards WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
@@ -237,14 +241,9 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
     expect((await request(app).delete(`/api/multitable/sheets/${SHEET_ID}/dashboards/${createdDashboardId}`)).status).toBe(204)
   })
 
-  test('R8: chart data withholds a denied referenced field while proving the injected provider can leak it for an allowed user', async () => {
-    getDashboardService().setRecordProvider(async (sheetId: string) => {
-      if (sheetId !== SHEET_ID) return []
-      return [
-        { data: { [FLD_VISIBLE]: 'visible bucket', [FLD_SECRET]: SECRET_CANARY } },
-      ]
-    })
-
+  test('R8: chart data withholds a denied referenced field while a real record value surfaces for an allowed user', async () => {
+    // Canary record seeded in the DB (beforeAll); the route loads it via the wired path. Allowed user
+    // sees the value; denied user gets restricted output (field mask short-circuits before record load).
     testUserId = USER_ID
     testPerms = ['multitable:read']
     const allowed = await chartData(CHART_SECRET_ID)
@@ -270,11 +269,7 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
 
   test('R9 (v2-d): a denied seriesByFieldId restricts chart data — the field values do not leak as series names', async () => {
     // groupBy = visible bucket, seriesBy = the SECRET field → series names would be the secret values.
-    getDashboardService().setRecordProvider(async (sheetId: string) => {
-      if (sheetId !== SHEET_ID) return []
-      return [{ data: { [FLD_VISIBLE]: 'visible bucket', [FLD_SECRET]: SECRET_CANARY } }]
-    })
-
+    // The canary record is seeded in the DB (beforeAll) and loaded via the wired route path.
     // Allowed reader: series IS computed → the secret value surfaces as a series name (proves the leak vector).
     testUserId = USER_ID
     testPerms = ['multitable:read']

--- a/packages/core-backend/tests/integration/multitable-dashboard-chart-rowdeny-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-chart-rowdeny-realdb.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Dashboard chart aggregation — production wiring + row-level read-deny (real DB).
+ *
+ * Two things this golden locks, both previously unverified (charts were only tested via an injected
+ * setRecordProvider, so prod computed on [] and row-deny over chart records was never exercised):
+ *   1. WIRING: with NO record provider injected, the chart-data route loads real meta_records itself and
+ *      aggregates them → non-empty data (the empty-charts-in-prod defect would make this fail).
+ *   2. ROW-DENY: a conditional read-deny rule excludes the denied record from the aggregate (no
+ *      count/label leak), with the SAME admin-bypass + flag-off-inert semantics as /view + /view-aggregate.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { dashboardRouter, getDashboardService } from '../../src/routes/dashboard'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_crd_chart_${TS}`
+const SHEET_ID = `sheet_crd_chart_${TS}`
+const STATUS = `fld_crd_chart_status_${TS}`
+const CHART_ID = `chart_crd_${TS}`
+const USER_ID = `u_crd_chart_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const asJson = (v: unknown) => JSON.stringify(v)
+let app: Express
+let testUserId = USER_ID
+let testRoles: string[] = []
+let testPerms: string[] = ['multitable:read']
+
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, asJson(rules)])
+const denySecretRule = [{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }]
+
+const chartData = async () => {
+  const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts/${CHART_ID}/data`)
+  expect(res.status).toBe(200)
+  return res.body as { dataPoints?: Array<{ label: string; value: number }>; total?: number; metadata?: { restricted?: boolean } }
+}
+const bucket = (body: { dataPoints?: Array<{ label: string; value: number }> }, label: string) =>
+  (body.dataPoints ?? []).find((p) => p.label === label)?.value
+
+describeIfDatabase('dashboard chart aggregation — wiring + row-level read-deny (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined; next() })
+    app.use('/api/multitable', dashboardRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'CRD Chart Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'CRD Chart Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    // 2 open + 1 secret
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_crd_o1_${TS}`, SHEET_ID, asJson({ [STATUS]: 'open' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_crd_o2_${TS}`, SHEET_ID, asJson({ [STATUS]: 'open' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_crd_s1_${TS}`, SHEET_ID, asJson({ [STATUS]: 'secret' })])
+    await q(
+      `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by)
+       VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [CHART_ID, 'Count by status', 'bar', SHEET_ID, asJson({ groupByFieldId: STATUS, aggregation: { function: 'count' } }), '{}', USER_ID],
+    )
+  })
+
+  afterAll(async () => {
+    getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    testRoles = []
+    testPerms = ['multitable:read']
+    await setFlag(false)
+    await setRules([])
+    // Empty provider on purpose: the route must NOT depend on it — it loads real meta_records.
+    getDashboardService().setRecordProvider(async () => [])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('wiring — with NO provider, the chart aggregates real records (non-empty)', async () => {
+    const body = await chartData()
+    expect((body.dataPoints ?? []).length).toBeGreaterThan(0) // would be 0 if prod still computed on []
+    expect(bucket(body, 'open')).toBe(2)
+    expect(bucket(body, 'secret')).toBe(1)
+  })
+
+  test('row-deny — flag ON + deny rule: the denied record is excluded from the aggregate (no leak)', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    const body = await chartData()
+    expect(bucket(body, 'open')).toBe(2) // visible records still aggregated
+    expect(bucket(body, 'secret')).toBeUndefined() // denied record contributes nothing
+    expect(JSON.stringify(body)).not.toContain('"secret"')
+  })
+
+  test('inert — flag OFF even with a deny rule: all records aggregate (default-off changes nothing)', async () => {
+    await setRules(denySecretRule)
+    await setFlag(false)
+    const body = await chartData()
+    expect(bucket(body, 'secret')).toBe(1)
+  })
+
+  test('admin bypass — flag ON + deny rule: an admin still sees the denied record in the aggregate', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    testRoles = ['admin']
+    const body = await chartData()
+    expect(bucket(body, 'secret')).toBe(1)
+    testRoles = []
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -73,6 +73,13 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
       'INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
       [SHEET_ID, FLD_SECRET, 'user', USER_DENIED, false, false],
     )
+    // Seed REAL meta_records: the route now loads records itself (with row-level read-deny) and passes
+    // them into chart aggregation, so these tests exercise the wired PRODUCTION path — not a
+    // setRecordProvider fixture (the bypass that previously let the empty-prod-charts defect hide).
+    let recSeq = 0
+    for (const r of rows) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_biv2b2_${TS}_${recSeq++}`, SHEET_ID, JSON.stringify(r.data)])
+    }
     await q(
       `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by)
        VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
@@ -104,11 +111,14 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
   beforeEach(() => {
     testUserId = USER_ID
     testPerms = ['multitable:read']
-    getDashboardService().setRecordProvider(async (sheetId: string) => (sheetId === SHEET_ID ? rows : []))
+    // Empty provider on purpose: the route must NOT depend on it (it loads real meta_records). P1/P2
+    // computing non-empty data with this empty provider is the proof the wired DB path is in use.
+    getDashboardService().setRecordProvider(async () => [])
   })
 
   afterAll(async () => {
     getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})

--- a/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
@@ -18,7 +18,9 @@ vi.mock('../../src/integration/db/connection-pool', () => ({
   poolManager: {
     get: () => ({
       getInternalPool: () => ({}),
-      query: vi.fn(),
+      // loadChartRecords issues a SELECT over meta_records; return an empty rowset so the wired
+      // chart-data path runs without a DB (the route no longer depends on setRecordProvider).
+      query: vi.fn(async () => ({ rows: [] })),
     }),
   },
 }))
@@ -59,6 +61,10 @@ vi.mock('../../src/multitable/permission-service', () => ({
     },
   })),
   loadFieldPermissionScopeMap: vi.fn(async () => new Map()),
+  // Used by loadChartRecords (the wired chart-data path) — default to inert so the unit wiring test
+  // exercises the route without a real DB.
+  loadRowLevelReadDenyEnabled: vi.fn(async () => false),
+  loadDeniedRecordIds: vi.fn(async () => new Set()),
 }))
 
 // Mount on a fresh app in the same way index.ts does.


### PR DESCRIPTION
## What

Closes **P0 audit defect #1** (verified): `DashboardService.setRecordProvider` was only ever called in tests; production had no provider, so chart endpoints computed every chart against `records = []` → **charts rendered empty in prod** while tests stayed green via an injected fixture (wire-vs-fixture drift).

## Fix (route loads records via the wired path; provider is now only a service/unit fallback)
- **`routes/dashboard.ts`** — new `loadChartRecords(query, sheetId, access)` loads real `meta_records` and applies the **same row-level read-deny as `/view` + `/view-aggregate`** (`loadDeniedRecordIds` = grant-deny ∪ conditional-rule-deny; admin-bypass; flag-off inert), so chart totals/series never aggregate over records the actor can't read. Both chart-data endpoints (saved + preview) pass these records into aggregation. Field-level masking is unchanged (`loadAllowedFieldIds` + `isChartDataRestricted`, which short-circuits **before** record load). `SheetAuthContext` now carries `access`.
- **`dashboard-service.ts`** — `getChartData` / `computeChartDataForConfig` accept an optional pre-loaded `records`; the route always passes them. `setRecordProvider` remains a fallback for the service/unit layer only — **the route no longer depends on it** (your boundary).

## Test migration (the defect existed *because* these only tested the provider bypass)
- **`multitable-dashboard-preview-data`** + **`multitable-dashboard-chart-authz`** — migrated from `setRecordProvider` fixtures to seeding real `meta_records`, so they exercise the wired production path (chart-authz's R8/R9 canary now comes from a seeded record; the field-mask restricted-path assertions are unchanged; `beforeEach` sets an *empty* provider so P1/P2 computing non-empty data is itself the proof the DB path is used).
- **NEW `multitable-dashboard-chart-rowdeny-realdb`** — with **no provider**, the chart aggregates real records (non-empty — would fail if prod still computed on `[]`); a conditional-rule-denied record is **excluded from the aggregate** (no count/label leak), flag-off inert + admin-bypass. Registered in `plugin-tests.yml`.

`tsc --noEmit` clean; all three tests compile (DB-gated skip locally; real-DB run in `test (20.x)`).

P0 batch: #3 field-write merged (#2914); this is #1. #2 (open-API) → design-lock, not auto-built. FE token-scope drift → separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)