### PR TITLE
fix(multitable): correct API-token create UI scopes to the backend enum (contract drift)

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -485,7 +485,9 @@ const showTokenForm = ref(false)
 const newTokenPlaintext = ref<string | null>(null)
 const copiedNewToken = ref(false)
 const tokenDraft = ref({ name: '', scopes: [] as string[], expiresAt: '' })
-const availableScopes = ['read', 'write', 'admin']
+// Must match the backend enum ALL_API_TOKEN_SCOPES (packages/core-backend/src/multitable/api-tokens.ts).
+// The old ['read','write','admin'] were rejected by the server (400) — a contract/UI drift.
+const availableScopes = ['records:read', 'records:write', 'fields:read', 'comments:read', 'comments:write', 'webhooks:manage']
 
 // ---- Webhooks ----
 const webhooks = ref<Webhook[]>([])

--- a/apps/web/src/multitable/utils/meta-api-token-labels.ts
+++ b/apps/web/src/multitable/utils/meta-api-token-labels.ts
@@ -14,6 +14,8 @@ export type MetaApiTokenLabelKey =
   | 'token.loading' | 'token.empty' | 'token.meta.scopes'
   | 'token.meta.created' | 'token.meta.lastUsed' | 'token.meta.expires'
   | 'token.scope.none' | 'token.scope.read' | 'token.scope.write' | 'token.scope.admin'
+  | 'token.scope.records-read' | 'token.scope.records-write' | 'token.scope.fields-read'
+  | 'token.scope.comments-read' | 'token.scope.comments-write' | 'token.scope.webhooks-manage'
   | 'token.action.copy' | 'token.action.copied' | 'token.action.create'
   | 'token.action.rotate' | 'token.action.revoke'
   | 'webhook.newTitle' | 'webhook.editTitle' | 'webhook.name'
@@ -95,6 +97,12 @@ const LABELS: Record<MetaApiTokenLabelKey, { en: string; zh: string }> = {
   'token.scope.read': { en: 'read', zh: '读取' },
   'token.scope.write': { en: 'write', zh: '写入' },
   'token.scope.admin': { en: 'admin', zh: '管理' },
+  'token.scope.records-read': { en: 'Records: read', zh: '记录：读取' },
+  'token.scope.records-write': { en: 'Records: write', zh: '记录：写入' },
+  'token.scope.fields-read': { en: 'Fields: read', zh: '字段：读取' },
+  'token.scope.comments-read': { en: 'Comments: read', zh: '评论：读取' },
+  'token.scope.comments-write': { en: 'Comments: write', zh: '评论：写入' },
+  'token.scope.webhooks-manage': { en: 'Webhooks: manage', zh: 'Webhook：管理' },
   'token.action.copy': { en: 'Copy', zh: '复制' },
   'token.action.copied': { en: 'Copied!', zh: '已复制！' },
   'token.action.create': { en: 'Create', zh: '创建' },
@@ -239,7 +247,19 @@ export function apiManagerTitle(canManageDingTalkGroups: boolean, isZh: boolean)
   return apiTokenLabel(canManageDingTalkGroups ? 'title.full' : 'title.basic', isZh)
 }
 
+const API_SCOPE_LABEL_KEY: Record<string, MetaApiTokenLabelKey> = {
+  'records:read': 'token.scope.records-read',
+  'records:write': 'token.scope.records-write',
+  'fields:read': 'token.scope.fields-read',
+  'comments:read': 'token.scope.comments-read',
+  'comments:write': 'token.scope.comments-write',
+  'webhooks:manage': 'token.scope.webhooks-manage',
+}
+
 export function apiScopeLabel(scope: string, isZh: boolean): string {
+  const key = API_SCOPE_LABEL_KEY[scope]
+  if (key) return apiTokenLabel(key, isZh)
+  // Legacy/unknown values render raw (covers any pre-existing read/write/admin display).
   if (scope === 'read') return apiTokenLabel('token.scope.read', isZh)
   if (scope === 'write') return apiTokenLabel('token.scope.write', isZh)
   if (scope === 'admin') return apiTokenLabel('token.scope.admin', isZh)

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -592,7 +592,7 @@ describe('MetaApiTokenManager', () => {
     const newTokenBtn = document.querySelector('[data-token-new]') as HTMLButtonElement
     newTokenBtn.click()
     await flushPromises()
-    expect(document.querySelector('[data-token-scope="read"]')).toBeTruthy()
+    expect(document.querySelector('[data-token-scope="records:read"]')).toBeTruthy()
     expect(document.querySelector('[data-token-form]')?.textContent).toContain('权限范围')
 
     const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement


### PR DESCRIPTION
## What

Small contract/UI-drift fix (separate from #1/#2 per your guidance). The token-create form offered `['read','write','admin']` — none of which are in the backend `ALL_API_TOKEN_SCOPES`, so submitting them returned **400**. Replaced with the real **6** (`records:read`, `records:write`, `fields:read`, `comments:read`, `comments:write`, `webhooks:manage`), each with a typed bilingual label via the `meta-api-token-labels` module (`apiScopeLabel` now maps the 6 + keeps legacy `read/write/admin` as a display fallback).

FE-only; low risk. Specs pass locally: `meta-api-token-labels` (8) + `multitable-api-token-manager` (31).

## Scope note (honest)
This **only repairs the broken create form**. API tokens still authenticate **no data route** (no `apiTokenAuth` mounted) — actually enabling the open API is the separate **#2 design-lock** (route matrix / scope→operation / base-sheet scoping), not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)