### PR TITLE
fix(approval): align FE manager-chain cap comment + add module-level env smoke (P2/P3 polish)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -62,7 +62,11 @@ export interface ApprovalStepDraft {
   fieldId: string
   // How many management levels the `continuous_managers` source resolves (level 1 =
   // direct manager). Carried for every step but only meaningful when
-  // `sourceKind === 'continuous_managers'`; the backend re-validates `[1, 10]`.
+  // `sourceKind === 'continuous_managers'`. The backend re-validates against its
+  // configurable cap `[1, MAX_MANAGER_CHAIN_LEVELS]` (default 10, env
+  // `APPROVAL_MANAGER_CHAIN_MAX_LEVELS`, hard ceiling 50). The authoring UI (v1)
+  // intentionally fixes the input max at 10; reading the server cap into the UI so
+  // ops can configure more than 10 is a follow-up (not wired in v1).
   levels: number
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -288,6 +288,9 @@
               </el-select>
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'continuous_managers'" label="上级层级数">
+              <!-- v1: UI input cap fixed at 10. The backend cap is configurable
+                   (APPROVAL_MANAGER_CHAIN_MAX_LEVELS, default 10, hard ceiling 50);
+                   reading the server cap into :max so ops can author >10 is a follow-up. -->
               <el-input-number
                 v-model="step.levels"
                 :min="1"

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   resolveApprovalRequesterOrgRelations,
   resolveMaxManagerChainLevels,
@@ -224,6 +224,30 @@ describe('resolveMaxManagerChainLevels (configurable cap, env APPROVAL_MANAGER_C
   it('fails SAFE to the default on any invalid value (never throws, never 0/negative/fractional)', () => {
     for (const bad of ['0', '-3', '3.5', 'abc', 'NaN', '1e3', '0x10']) {
       expect(resolveMaxManagerChainLevels(bad)).toBe(DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+    }
+  })
+
+  // Module-level smoke: the EXPORTED `MAX_MANAGER_CHAIN_LEVELS` is resolved from the env at module
+  // LOAD (a deploy-time read), so the pure-resolver tests above don't by themselves prove the exported
+  // const honors the env. A fresh import under env=3 must actually yield 3 — `resetModules` + re-import
+  // is required because the const is captured once at load. (Restores env + resets in `finally` so the
+  // env-loaded instance never leaks into another test.)
+  it('module-level MAX_MANAGER_CHAIN_LEVELS reflects the env at load (env=3 → 3, env=invalid → default)', async () => {
+    const prev = process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS
+    try {
+      process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS = '3'
+      vi.resetModules()
+      const underEnv3 = await import('../../src/services/ApprovalDirectoryOrg')
+      expect(underEnv3.MAX_MANAGER_CHAIN_LEVELS).toBe(3)
+
+      process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS = 'not-a-number'
+      vi.resetModules()
+      const underBadEnv = await import('../../src/services/ApprovalDirectoryOrg')
+      expect(underBadEnv.MAX_MANAGER_CHAIN_LEVELS).toBe(underBadEnv.DEFAULT_MAX_MANAGER_CHAIN_LEVELS)
+    } finally {
+      if (prev === undefined) delete process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS
+      else process.env.APPROVAL_MANAGER_CHAIN_MAX_LEVELS = prev
+      vi.resetModules()
     }
   })
 })


### PR DESCRIPTION
Two non-blocking polish follow-ups on the configurable manager-chain cap (#2915), per review.

## P2 — FE cap honesty (no behavior change)
The backend cap is now configurable (`APPROVAL_MANAGER_CHAIN_MAX_LEVELS`, default 10, hard ceiling 50), but the FE authoring still implied a fixed `[1, 10]`:
- `templateAuthoring.ts` comment corrected: backend re-validates `[1, MAX_MANAGER_CHAIN_LEVELS]` (default 10, env-configurable, ceiling 50).
- `TemplateAuthoringView.vue` `:max="10"` now carries a note that the UI input cap is **intentionally fixed at 10 in v1**; reading the server cap into the UI so ops can author >10 is a follow-up (a product decision, not wired here).

This resolves the misleading-comment / silent UI≠backend mismatch without making the >10 product call.

## P3 — make the env-confirmation real (not softened)
The cap had only **pure-resolver** tests (`resolveMaxManagerChainLevels(raw)`), but the exported `MAX_MANAGER_CHAIN_LEVELS` is resolved from env at **module load** — which those tests don't prove. Adds a module-level smoke (`vi.resetModules()` + fresh `import`) asserting **env=3 → 3** and **env=invalid → default**, restoring env in `finally`. So the "env-confirmed MAX" claim is now actually covered, rather than weakening the wording.

Scope: 3 files, no runtime behavior change (UI stays at 10; backend unchanged). Verification of the new test is via the core-backend unit suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)