### PR TITLE
fix(integration): S3-1b — template version system-managed (auto-bump + optimistic lock)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/integration-templates.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/integration-templates.test.cjs
@@ -5,6 +5,7 @@ const path = require('node:path')
 const {
   createIntegrationTemplateRegistry,
   TemplateNotFoundError,
+  TemplateVersionConflictError,
   __internals,
 } = require(path.join(__dirname, '..', 'lib', 'integration-templates.cjs'))
 
@@ -57,7 +58,7 @@ async function main() {
   assert.throws(() => __internals.normalizeTemplateInput({ tenantId: 't', name: 'x', targetKind: 'k', orchestrationConfig: [] }), /must be an object/, 'orchestrationConfig object')
 
   const norm = __internals.normalizeTemplateInput({ tenantId: 't1', name: 'tmpl', targetKind: 'metasheet:multitable' })
-  assert.equal(norm.version, 1, 'version defaults to 1')
+  assert.equal(norm.version, undefined, 'normalizer does NOT default version (system-managed; resolved in upsert)')
   assert.equal(norm.status, 'active', 'status defaults active')
   assert.equal(norm.workspaceId, null, 'workspaceId nullable')
   assert.deepEqual(norm.keyFields, [])
@@ -91,8 +92,35 @@ async function main() {
   })
   assert.equal(updated.id, 'tmpl_1', 'upsert matched existing by scope+name (no duplicate)')
   assert.equal(updated.targetObject, 'approved_materials_v2')
-  assert.equal(updated.updatedAt, 'updated-ts', 'update bumps updated_at (no DB trigger on 061)')
+  assert.equal(updated.version, 2, 'S3-1b: edit without a supplied version auto-bumps v1 -> v2')
+  assert.equal(updated.updatedAt, 'updated-ts', 'update bumps updated_at (061 trigger in PG; in-memory test db bumps in app)')
   assert.equal(db.rows.filter((r) => r._table === 'integration_templates').length, 1, 'no duplicate row')
+
+  // --- S3-1b: version-bump + optimistic-concurrency semantics ---
+  // another plain edit (no version supplied) -> v3
+  const v3 = await reg.upsertTemplate({
+    tenantId: 't1', workspaceId: 'w1', name: 'k3-material',
+    targetKind: 'metasheet:multitable', targetObject: 'approved_materials_v3',
+  })
+  assert.equal(v3.version, 3, 'consecutive edit auto-bumps v2 -> v3')
+  // stale supplied version (current is 3) -> 409 conflict, NOT a silent overwrite
+  await assert.rejects(
+    () => reg.upsertTemplate({
+      tenantId: 't1', workspaceId: 'w1', name: 'k3-material',
+      targetKind: 'metasheet:multitable', targetObject: 'x', version: 1,
+    }),
+    (e) => e instanceof TemplateVersionConflictError && e.status === 409 && e.details.expected === 3 && e.details.actual === 1,
+    'stale supplied version is an optimistic conflict (409), not a silent overwrite',
+  )
+  // the conflict did not mutate the row
+  assert.equal((await reg.getTemplate({ tenantId: 't1', workspaceId: 'w1', id: 'tmpl_1' })).version, 3, 'conflicted update left version at 3')
+  assert.equal((await reg.getTemplate({ tenantId: 't1', workspaceId: 'w1', id: 'tmpl_1' })).targetObject, 'approved_materials_v3', 'conflicted update did not overwrite fields')
+  // correct supplied version (3) -> passes optimistic check and bumps to 4
+  const v4 = await reg.upsertTemplate({
+    tenantId: 't1', workspaceId: 'w1', name: 'k3-material',
+    targetKind: 'metasheet:multitable', targetObject: 'approved_materials_v4', version: 3,
+  })
+  assert.equal(v4.version, 4, 'matching supplied version passes the optimistic check and bumps v3 -> v4')
 
   const list = await reg.listTemplates({ tenantId: 't1', workspaceId: 'w1' })
   assert.equal(list.length, 1)

--- a/plugins/plugin-integration-core/lib/integration-templates.cjs
+++ b/plugins/plugin-integration-core/lib/integration-templates.cjs
@@ -38,6 +38,18 @@ class TemplateNotFoundError extends Error {
   }
 }
 
+// S3-1b: optimistic-concurrency conflict on update — a caller-supplied `version` that no longer
+// matches the stored version (a concurrent edit happened). 409 so the route surfaces it as such.
+class TemplateVersionConflictError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'TemplateVersionConflictError'
+    this.status = 409
+    this.code = 'INTEGRATION_TEMPLATE_VERSION_CONFLICT'
+    this.details = details
+  }
+}
+
 function requiredString(value, field) {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new TemplateValidationError(`${field} is required`, { field })
@@ -75,13 +87,40 @@ function jsonObject(value, field) {
   return value
 }
 
+// S3-1b: version is SYSTEM-MANAGED, not a plain settable field. The normalizer no longer
+// defaults to 1 — it returns undefined when absent (meaning "no caller-supplied version"), and
+// validates a supplied value. upsertTemplate/resolveTemplateVersion decides the stored version:
+// create -> 1; edit without version -> existing+1 (auto-bump); edit WITH version -> optimistic
+// lock (must match current, else 409), then bump.
 function normalizeVersion(value) {
-  if (value === undefined || value === null || value === '') return 1
+  if (value === undefined || value === null || value === '') return undefined
   const numeric = Number(value)
   if (!Number.isInteger(numeric) || numeric < 1) {
     throw new TemplateValidationError('version must be a positive integer', { field: 'version' })
   }
   return numeric
+}
+
+function resolveTemplateVersion(existing, requestedVersion) {
+  if (!existing) {
+    // create: version is system-managed and starts at 1 (a caller-supplied version is ignored
+    // on create — there is nothing to optimistic-lock against).
+    return 1
+  }
+  const currentVersion = Number(existing.version)
+  if (requestedVersion === undefined) {
+    // normal edit: auto-bump so every change advances the version (snapshot provenance).
+    return currentVersion + 1
+  }
+  // caller supplied a version => optimistic-concurrency lock: it must equal the current version;
+  // never a silent overwrite. On match, still bump.
+  if (requestedVersion !== currentVersion) {
+    throw new TemplateVersionConflictError(
+      `template version conflict: expected current version ${currentVersion}, caller sent ${requestedVersion} — reload and retry`,
+      { field: 'version', expected: currentVersion, actual: requestedVersion },
+    )
+  }
+  return currentVersion + 1
 }
 
 function normalizeStatus(value) {
@@ -203,12 +242,13 @@ function createIntegrationTemplateRegistry({ db, idGenerator = crypto.randomUUID
   async function upsertTemplate(input) {
     const normalized = normalizeTemplateInput(input)
     const existing = await selectExisting(normalized)
+    const version = resolveTemplateVersion(existing, normalized.version)
     const baseRow = {
       tenant_id: normalized.tenantId,
       workspace_id: normalized.workspaceId,
       project_id: normalized.projectId,
       name: normalized.name,
-      version: normalized.version,
+      version,
       description: normalized.description,
       source_kind: normalized.sourceKind,
       source_object: normalized.sourceObject,
@@ -289,10 +329,12 @@ module.exports = {
   createIntegrationTemplateRegistry,
   TemplateValidationError,
   TemplateNotFoundError,
+  TemplateVersionConflictError,
   __internals: {
     TEMPLATES_TABLE,
     VALID_STATUSES,
     normalizeTemplateInput,
     rowToTemplate,
+    resolveTemplateVersion,
   },
 }


### PR DESCRIPTION
## What (S3-1b — review P1, before S3-2)

S3-1's `version` was a plain settable field (normalizeVersion → 1; upsertTemplate wrote it directly), so a normal edit kept version=1 and **silently overwrote** — which would falsify S3-2's `instantiatedFromTemplateId + templateVersion` snapshot provenance. Make version **system-managed** (owner-ratified):
- `normalizeVersion` → `undefined` when absent (no default-to-1); validates if present.
- `resolveTemplateVersion(existing, requested)`: create → 1; edit without version → existing+1 (**auto-bump**); edit **with** version → **optimistic-concurrency lock** (must equal current, else `TemplateVersionConflictError` 409 — never silent overwrite — then bump).
- New `TemplateVersionConflictError` (status 409); the route's error handler already maps `.status`, so no route change.

## Tests
create v1 → edit(no version) **v2** → edit(no version) **v3** → stale-version edit ⇒ **409** (row unchanged at v3, fields not overwritten) → matching-version edit ⇒ **v4**. **Empirically non-vacuous**: reverting to the old silent-set behavior fails the v1→v2 bump assertion. integration-templates / http-routes / migration-sql / adapter-contracts green.

## Boundary (unchanged)
Still **no instantiation**, no external write, writes **only** `integration_templates`; no migration change (version column already in 061); REQUIRED_ADAPTER_METHODS untouched. This is the load-bearing version semantics S3-2 depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)