### PR TITLE
feat(multitable): recycle bin — human-readable record title + deletedBy + restore confirm

### DIFF
--- a/apps/web/src/multitable/components/TrashModal.vue
+++ b/apps/web/src/multitable/components/TrashModal.vue
@@ -15,16 +15,30 @@
       <p v-if="error" class="meta-trash__error" role="alert">{{ error }}</p>
 
       <div v-if="loading" class="meta-trash__hint">{{ t('加载中…', 'Loading…') }}</div>
-      <ul v-else-if="records.length" class="meta-trash__list">
-        <li v-for="rec in records" :key="rec.recordId" class="meta-trash__row">
-          <span class="meta-trash__id" :title="rec.recordId">{{ rec.recordId }}</span>
-          <span class="meta-trash__meta">{{ formatDeleted(rec.deletedAt) }}</span>
+      <ul v-else-if="rows.length" class="meta-trash__list">
+        <li v-for="row in rows" :key="row.rec.recordId" class="meta-trash__row">
+          <div class="meta-trash__identity">
+            <span class="meta-trash__title-text" :title="row.rec.recordId" data-test="trash-record-title">{{ row.title }}</span>
+            <span class="meta-trash__meta">{{ formatDeleted(row.rec.deletedAt) }}<template v-if="row.rec.deletedBy"> · {{ deletedByLabel(row.rec.deletedBy) }}</template></span>
+          </div>
+          <template v-if="confirmingId === row.rec.recordId">
+            <span class="meta-trash__confirm-text">{{ t(`恢复「${row.title}」？`, `Restore “${row.title}”?`) }}</span>
+            <button
+              class="meta-trash__restore"
+              type="button"
+              data-test="trash-restore-confirm"
+              :disabled="restoringIds.includes(row.rec.recordId)"
+              @click="confirmRestore(row.rec.recordId)"
+            >{{ restoringIds.includes(row.rec.recordId) ? t('恢复中…', 'Restoring…') : t('确定恢复', 'Confirm') }}</button>
+            <button class="meta-trash__cancel" type="button" @click="confirmingId = null">{{ t('取消', 'Cancel') }}</button>
+          </template>
           <button
+            v-else
             class="meta-trash__restore"
             type="button"
-            :disabled="restoringIds.includes(rec.recordId)"
-            @click="onRestore(rec.recordId)"
-          >{{ restoringIds.includes(rec.recordId) ? t('恢复中…', 'Restoring…') : t('恢复', 'Restore') }}</button>
+            data-test="trash-restore"
+            @click="confirmingId = row.rec.recordId"
+          >{{ t('恢复', 'Restore') }}</button>
         </li>
       </ul>
       <p v-else class="meta-trash__hint">{{ t('回收站为空', 'The recycle bin is empty') }}</p>
@@ -33,24 +47,54 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import { useTrash } from '../composables/useTrash'
+import { pickRecordTitle } from '../utils/field-display'
+import { historyActor } from '../utils/meta-record-labels'
+import type { MetaDeletedRecord, MetaField } from '../types'
 
-const props = defineProps<{ open: boolean; sheetId: string }>()
+// `fields` is the current sheet's field list (passed by the workbench). It lets a trashed row show a
+// human-readable title from its backend-masked data instead of the raw record id.
+const props = defineProps<{ open: boolean; sheetId: string; fields?: MetaField[] }>()
 const emit = defineEmits<{ (e: 'close'): void; (e: 'restored', recordId: string): void }>()
 
 const { isZh } = useLocale()
 const t = (zh: string, en: string) => (isZh.value ? zh : en)
 const { records, loading, error, restoringIds, load, restore } = useTrash()
 
+// Which row (if any) is awaiting an in-DOM restore confirmation. Cleared on (re)open.
+const confirmingId = ref<string | null>(null)
+
 watch(
   () => [props.open, props.sheetId] as const,
   ([open, sheetId]) => {
     if (open && sheetId) void load(sheetId)
+    confirmingId.value = null
   },
   { immediate: true },
 )
+
+// A trashed record's human-readable title: the first field (by column order) whose backend-masked
+// value renders to a non-empty display string. Masked / unreadable fields render '—' and are skipped,
+// so a field the actor can't read transparently falls through to the next readable field. When nothing
+// is readable, fall back to a short form of the raw record id so the row is still identifiable.
+function recordTitle(rec: MetaDeletedRecord): string {
+  return pickRecordTitle({ fields: props.fields ?? [], data: rec.data, isZh: isZh.value }) ?? shortRecordId(rec.recordId)
+}
+
+function shortRecordId(id: string): string {
+  const trimmed = id.startsWith('rec_') ? id.slice(4) : id
+  return `#${trimmed.slice(0, 8)}`
+}
+
+// deletedBy is a user id; the FE has no name directory for actors, so reuse the same "由/by <id>"
+// affordance the record-history timeline uses (consistent, and better than hiding who deleted it).
+function deletedByLabel(actorId: string): string {
+  return historyActor(actorId, isZh.value)
+}
+
+const rows = computed(() => records.value.map((rec) => ({ rec, title: recordTitle(rec) })))
 
 function formatDeleted(iso: string): string {
   if (!iso) return ''
@@ -58,8 +102,9 @@ function formatDeleted(iso: string): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
-async function onRestore(recordId: string): Promise<void> {
+async function confirmRestore(recordId: string): Promise<void> {
   const ok = await restore(recordId)
+  confirmingId.value = null
   if (ok) emit('restored', recordId)
 }
 </script>
@@ -72,9 +117,12 @@ async function onRestore(recordId: string): Promise<void> {
 .meta-trash__close { background: none; border: none; font-size: 20px; line-height: 1; cursor: pointer; color: inherit; }
 .meta-trash__list { list-style: none; margin: 0; padding: 0; }
 .meta-trash__row { display: flex; align-items: center; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--meta-border, #eee); }
-.meta-trash__id { font-family: monospace; font-size: 12px; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.meta-trash__meta { color: var(--meta-text-secondary, #888); font-size: 12px; white-space: nowrap; }
+.meta-trash__identity { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.meta-trash__title-text { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-trash__meta { color: var(--meta-text-secondary, #888); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-trash__confirm-text { font-size: 12px; color: var(--meta-text-secondary, #888); white-space: nowrap; }
 .meta-trash__restore { cursor: pointer; }
+.meta-trash__cancel { cursor: pointer; background: none; border: none; color: var(--meta-text-secondary, #888); }
 .meta-trash__restore:disabled { cursor: default; opacity: 0.6; }
 .meta-trash__error { color: var(--meta-danger, #c0392b); margin: 0 0 8px; }
 .meta-trash__hint { color: var(--meta-text-secondary, #888); padding: 12px 0; }

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -209,3 +209,23 @@ export function formatFieldDisplay(params: {
 
   return String(value)
 }
+
+/**
+ * Pick a human-readable title for a record from its (possibly backend-masked) `data`: the first field
+ * in column order whose value renders to a non-empty display string via `formatFieldDisplay`. Masked /
+ * unreadable / empty fields render `'—'` and are skipped, so a field the actor can't read transparently
+ * falls through to the next readable one. Returns `null` when nothing is readable — the caller decides
+ * the fallback (e.g. a short record id). Used by the recycle bin so a trashed row is identifiable.
+ */
+export function pickRecordTitle(params: {
+  fields: MetaField[]
+  data: Record<string, unknown>
+  isZh?: boolean
+}): string | null {
+  const ordered = [...params.fields].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  for (const field of ordered) {
+    const text = formatFieldDisplay({ field, value: params.data[field.id], isZh: params.isZh })
+    if (text && text !== '—') return text
+  }
+  return null
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -464,6 +464,7 @@
     <TrashModal
       :open="showTrash"
       :sheet-id="workbench.activeSheetId.value"
+      :fields="scopedAllFields"
       @close="showTrash = false"
       @restored="onTrashRestored"
     />

--- a/apps/web/tests/multitable-trash-fe.spec.ts
+++ b/apps/web/tests/multitable-trash-fe.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useTrash } from '../src/multitable/composables/useTrash'
-import type { MetaDeletedRecord } from '../src/multitable/types'
+import { pickRecordTitle } from '../src/multitable/utils/field-display'
+import type { MetaDeletedRecord, MetaField } from '../src/multitable/types'
 
 // #15 recycle bin — useTrash composable contract. Locks: load populates list+total; restore is
 // optimistic-on-success (removes row, decrements total) and NEVER throws — a 409 (id occupied) / 403
@@ -55,5 +56,31 @@ describe('useTrash — recycle bin composable', () => {
     const { load } = useTrash(c)
     await load('')
     expect((c as { listDeletedRecords: { mock: { calls: unknown[] } } }).listDeletedRecords.mock.calls.length).toBe(0)
+  })
+})
+
+// The recycle bin shows a human-readable title for each trashed row instead of the raw record id, so a
+// record is identifiable before restore. Title = first field (by column ORDER) whose backend-masked
+// value renders non-empty; masked/empty fields fall through; null when nothing is readable.
+describe('pickRecordTitle — recycle bin record identity', () => {
+  const f = (id: string, order: number, type = 'text'): MetaField => ({ id, name: id, type: type as MetaField['type'], order })
+
+  it('picks the first field by ORDER with a non-empty value (not array position)', () => {
+    const fields = [f('b', 2), f('a', 1)]
+    expect(pickRecordTitle({ fields, data: { a: 'Acme Corp', b: 'x' } })).toBe('Acme Corp')
+  })
+
+  it('skips masked / empty fields (—) and falls through to the next readable field', () => {
+    // a denied/masked primary field is simply absent from the backend-masked data → renders '—' → skipped
+    const fields = [f('secret', 1), f('name', 2)]
+    expect(pickRecordTitle({ fields, data: { name: 'Visible Name' } })).toBe('Visible Name')
+  })
+
+  it('returns null when no field is readable (caller falls back to a short record id)', () => {
+    expect(pickRecordTitle({ fields: [f('a', 1), f('b', 2)], data: {} })).toBeNull()
+  })
+
+  it('returns null with no fields', () => {
+    expect(pickRecordTitle({ fields: [], data: { a: 'x' } })).toBeNull()
   })
 })


### PR DESCRIPTION
Owner UX review: the recycle bin listed trashed records by raw `rec_<uuid>`. Small FE slice to make a trashed row **identifiable** (purge deliberately OUT — separate product decision).

- **Title** per row: first field (by column order) whose backend-masked value renders non-empty (`pickRecordTitle`, extracted to `field-display.ts` + unit-tested). Masked/denied field → '—' → falls through; nothing readable → short `#<id8>` fallback.
- **deletedBy** shown next to the delete time (reuses the history '由/by <id>' affordance).
- **In-DOM restore confirm** using the readable title (`恢复「<title>」？`) instead of blind one-click-by-UUID.

Tests: `pickRecordTitle` cases (order / masked-skip / null-fallback) added to the web-guard-gated `multitable-trash-fe.spec.ts` (9/9). `vue-tsc -b` clean. FE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)