### PR TITLE
feat(multitable): actor display names — history “by <name>” + recycle-bin deletedBy by name

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -715,6 +715,7 @@ function normalizeRecordHistoryEntry(payload: Partial<MetaRecordRevision> | null
     action,
     source: typeof payload?.source === 'string' ? payload.source : 'rest',
     actorId: typeof payload?.actorId === 'string' ? payload.actorId : null,
+    actorName: typeof payload?.actorName === 'string' ? payload.actorName : null,
     changedFieldIds: Array.isArray(payload?.changedFieldIds) ? payload.changedFieldIds.map(String) : [],
     patch: isPlainObject(payload?.patch) ? payload.patch : {},
     snapshot: payload?.snapshot === null || payload?.snapshot === undefined

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -320,7 +320,7 @@
             </div>
             <div class="meta-record-drawer__history-meta">
               <span>{{ formatHistoryTime(item.createdAt) }}</span>
-              <span v-if="item.actorId">{{ historyActor(item.actorId, isZh) }}</span>
+              <span v-if="item.actorId">{{ historyActor(item.actorName || item.actorId, isZh) }}</span>
               <span>{{ item.source }}</span>
             </div>
             <div v-if="item.changedFieldIds.length" class="meta-record-drawer__history-fields">

--- a/apps/web/src/multitable/components/TrashModal.vue
+++ b/apps/web/src/multitable/components/TrashModal.vue
@@ -19,7 +19,7 @@
         <li v-for="row in rows" :key="row.rec.recordId" class="meta-trash__row">
           <div class="meta-trash__identity">
             <span class="meta-trash__title-text" :title="row.rec.recordId" data-test="trash-record-title">{{ row.title }}</span>
-            <span class="meta-trash__meta">{{ formatDeleted(row.rec.deletedAt) }}<template v-if="row.rec.deletedBy"> · {{ deletedByLabel(row.rec.deletedBy) }}</template></span>
+            <span class="meta-trash__meta">{{ formatDeleted(row.rec.deletedAt) }}<template v-if="row.rec.deletedBy"> · {{ deletedByLabel(row.rec.deletedByName || row.rec.deletedBy) }}</template></span>
           </div>
           <template v-if="confirmingId === row.rec.recordId">
             <span class="meta-trash__confirm-text">{{ t(`恢复「${row.title}」？`, `Restore “${row.title}”?`) }}</span>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -307,6 +307,8 @@ export interface MetaDeletedRecord {
   originalVersion: number
   createdBy: string | null
   deletedBy: string | null
+  /** Backend-resolved display name (name → email) for `deletedBy`; null when unresolved → fall back to the id. */
+  deletedByName?: string | null
   deletedAt: string
 }
 
@@ -318,6 +320,8 @@ export interface MetaRecordRevision {
   action: MetaRecordRevisionAction
   source: string
   actorId: string | null
+  /** Backend-resolved display name (name → email) for `actorId`; null when unresolved → fall back to the id. */
+  actorName?: string | null
   changedFieldIds: string[]
   patch: Record<string, unknown>
   snapshot: Record<string, unknown> | null

--- a/packages/core-backend/src/multitable/user-display.ts
+++ b/packages/core-backend/src/multitable/user-display.ts
@@ -1,0 +1,34 @@
+export type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+
+/**
+ * Resolve a `userId → display name` map for a set of user ids, using the canonical preference
+ * `name → email` (the same order `buildPersonSummaries` uses for person fields). Only ids with a real
+ * name/email are returned; an id with neither is omitted so the caller falls back to the raw id.
+ * Returns an empty map (graceful) if the `users` table is absent — e.g. a minimal test harness.
+ *
+ * Read-only and NOT permission-gated: a user's display name is not sensitive on its own (it already
+ * shows wherever that user appears — person fields, assignees, comments). This resolves the actor of an
+ * action (who deleted / who changed), not record content.
+ */
+export async function resolveUserDisplayNames(
+  query: QueryFn,
+  userIds: Array<string | null | undefined>,
+): Promise<Map<string, string>> {
+  const ids = [...new Set(userIds.filter((id): id is string => typeof id === 'string' && id.length > 0))]
+  const out = new Map<string, string>()
+  if (ids.length === 0) return out
+  try {
+    const res = await query('SELECT id, email, name FROM users WHERE id = ANY($1::text[])', [ids])
+    for (const u of res.rows as Array<{ id?: unknown; email?: unknown; name?: unknown }>) {
+      const id = typeof u.id === 'string' ? u.id : String(u.id ?? '')
+      if (!id) continue
+      const name = typeof u.name === 'string' ? u.name.trim() : ''
+      const email = typeof u.email === 'string' ? u.email.trim() : ''
+      const display = name || email
+      if (display) out.set(id, display)
+    }
+  } catch {
+    // users table absent (minimal harness) — return empty; callers fall back to the raw id.
+  }
+  return out
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -70,6 +70,7 @@ import {
   type SheetPermissionScope,
 } from '../multitable/permission-service'
 import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssignableDirectory } from '../multitable/person-field-restriction'
+import { resolveUserDisplayNames } from '../multitable/user-display'
 import {
   loadFieldsForSheet as loadFieldsForSheetShared,
   loadSheetRow as loadSheetRowShared,
@@ -6231,7 +6232,11 @@ export function univerMetaRouter(): Router {
       const allowedFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowedFieldIds)
       const items = (await listRecordRevisions(pool.query.bind(pool), { sheetId, recordId, limit, offset }))
         .map((item) => redactRecordRevisionEntry(item, allowedFieldIds))
-      return res.json({ ok: true, data: { items, limit, offset } })
+      // Enrich each revision's actor with a display name (name → email) so the history timeline can show
+      // "by <name>" instead of a raw user id; falls back to the id on the client when unresolved.
+      const actorNames = await resolveUserDisplayNames(pool.query.bind(pool), items.map((it) => it.actorId))
+      const enrichedItems = items.map((it) => ({ ...it, actorName: it.actorId ? (actorNames.get(it.actorId) ?? null) : null }))
+      return res.json({ ok: true, data: { items: enrichedItems, limit, offset } })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_revisions')) {
         return res.json({ ok: true, data: { items: [], limit, offset } })
@@ -11412,7 +11417,14 @@ export function univerMetaRouter(): Router {
       // 2b-S2: records AND total are already deny-aware (excluded in SQL via excludeRecordIds above), so no
       // post-filter is needed here — both the row set and the count hide rule-denied / grant-denied trashed
       // records (LOCK-3 list-hide + LOCK-4 count-exclude). Field-read mask still applies to the survivors.
-      const maskedRecords = result.records.map((rec) => ({ ...rec, data: filterRecordDataByFieldIds(rec.data, visibleFieldIds) }))
+      // Enrich each trashed row's deletedBy with a display name (name → email) so the recycle bin can show
+      // who deleted it by name instead of a raw user id; falls back to the id on the client when unresolved.
+      const deletedByNames = await resolveUserDisplayNames(pool.query.bind(pool), result.records.map((rec) => rec.deletedBy))
+      const maskedRecords = result.records.map((rec) => ({
+        ...rec,
+        data: filterRecordDataByFieldIds(rec.data, visibleFieldIds),
+        deletedByName: rec.deletedBy ? (deletedByNames.get(rec.deletedBy) ?? null) : null,
+      }))
       return res.json({ ok: true, data: { records: maskedRecords, total: result.total } })
     } catch (err) {
       if (err instanceof RecordServicePermissionError) {

--- a/packages/core-backend/tests/unit/multitable-user-display.test.ts
+++ b/packages/core-backend/tests/unit/multitable-user-display.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { resolveUserDisplayNames } from '../../src/multitable/user-display'
+
+function fakeQuery(rows: Array<{ id: string; email?: string | null; name?: string | null }>) {
+  return async (_sql: string, params?: unknown[]) => {
+    const ids = (params?.[0] as string[]) ?? []
+    return { rows: rows.filter((r) => ids.includes(r.id)) }
+  }
+}
+
+describe('resolveUserDisplayNames', () => {
+  it('prefers name → email; omits ids with neither (caller falls back to the raw id)', async () => {
+    const q = fakeQuery([
+      { id: 'u1', name: 'Alice', email: 'a@x.com' },
+      { id: 'u2', name: '', email: 'b@x.com' },
+      { id: 'u3', name: null, email: null },
+    ])
+    const m = await resolveUserDisplayNames(q, ['u1', 'u2', 'u3', 'u4'])
+    expect(m.get('u1')).toBe('Alice')
+    expect(m.get('u2')).toBe('b@x.com')
+    expect(m.has('u3')).toBe(false) // no name/email → omitted → caller shows the id
+    expect(m.has('u4')).toBe(false) // not a known user
+  })
+
+  it('dedups + ignores null/empty ids; empty input issues no query', async () => {
+    let calls = 0
+    const q = async () => { calls++; return { rows: [] as unknown[] } }
+    expect((await resolveUserDisplayNames(q, [])).size).toBe(0)
+    expect((await resolveUserDisplayNames(q, [null, undefined, ''])).size).toBe(0)
+    expect(calls).toBe(0)
+  })
+
+  it('is graceful when the users table is absent (throws) → empty map', async () => {
+    const q = async () => { throw new Error('relation "users" does not exist') }
+    expect((await resolveUserDisplayNames(q, ['u1'])).size).toBe(0)
+  })
+
+  it('trims whitespace in name/email', async () => {
+    const q = fakeQuery([{ id: 'u1', name: '  Bob  ', email: '' }])
+    expect((await resolveUserDisplayNames(q, ['u1'])).get('u1')).toBe('Bob')
+  })
+})


### PR DESCRIPTION
The future enhancement we discussed: resolve actor user ids → display names so both surfaces show a **person, not a raw id**.

- **Backend enrichment** (one batched query/request, no FE N+1): new `resolveUserDisplayNames` (userId → `name → email`, omit-when-neither, graceful on absent `users` table). History endpoint adds `actorName`; trash list adds `deletedByName`. Both additive; read-only, not permission-gated (a display name isn't sensitive — it's the action's actor).
- **FE**: types + client parse + drawer (`by <name>`) + TrashModal (deletedBy by name), **id fallback preserved**.
- Same gap fixed on **both** the recycle bin and the record-history timeline in one slice.

Tests: `resolveUserDisplayNames` unit (name→email / omit / dedup / absent-table / trim) 4/4; backend tsc + `vue-tsc -b` clean; trash FE spec 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)