### PR TITLE
feat(multitable): OAPI-1 — read-only API-token routes (records:read)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -193,6 +193,7 @@ jobs:
             tests/integration/multitable-rowlevel-readdeny-enforce.test.ts \
             tests/integration/multitable-conditional-rule-enforce-realdb.test.ts \
             tests/integration/multitable-conditional-rule-trash-realdb.test.ts \
+            tests/integration/multitable-oapi1-token-read-realdb.test.ts \
             tests/integration/multitable-fieldperm-write-gate-patch-realdb.test.ts \
             tests/integration/multitable-conditional-rules-api.test.ts \
             tests/integration/multitable-rowlevel-readdeny-xrec.test.ts \

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -151,6 +151,7 @@ import plmEmbedRouter from './routes/plm-embed'
 import { createHostPluginStorage } from './plugins/plugin-durable-storage'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
+import { isOapiReadAllowlistRequest } from './multitable/oapi-read-allowlist'
 import { dashboardRouter } from './routes/dashboard'
 import { createAutomationRoutes } from './routes/automation'
 import { createMultitableAiRoutes } from './routes/multitable-ai'
@@ -975,6 +976,10 @@ export class MetaSheetServer {
     this.app.use((req: Request, res: Response, next: NextFunction) => {
       if (isWhitelisted(req.path)) return next()
       if (isPublicFormAuthBypass(req)) return optionalJwtAuthMiddleware(req, res, next)
+      // OAPI-1: let an `mst_` API token reach the per-route apiTokenAuth + requireScope guards on the
+      // read allowlist ONLY (fail-closed). An `mst_` bearer on any non-allowlisted path falls through to
+      // jwtAuthMiddleware → 401, so tokens can never reach write/side-effecting or non-gating routes.
+      if (isOapiReadAllowlistRequest(req.method, req.path, req.headers.authorization)) return next()
       if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
       return next()
     })

--- a/packages/core-backend/src/multitable/oapi-read-allowlist.ts
+++ b/packages/core-backend/src/multitable/oapi-read-allowlist.ts
@@ -1,0 +1,37 @@
+/**
+ * OAPI-1 read-route allowlist (open-API token auth — design-lock
+ * docs/development/multitable-openapi-token-auth-designlock-20260619.md).
+ *
+ * The global JWT gate (index.ts) 401s any non-JWT bearer. An `mst_` API token must reach the per-route
+ * `apiTokenAuth` + `requireScope` guards to authenticate — but ONLY on the exact read routes below.
+ * This matcher is the single fail-closed switch the gate consults: an `mst_` bearer on a listed read
+ * route passes through (the route then validates the token + enforces scope); an `mst_` bearer ANYWHERE
+ * else falls through to `jwtAuthMiddleware` → 401. Keep this in lockstep with the routes that mount
+ * `apiTokenAuth` (univer-meta.ts). Read-only by construction: no write/side-effecting path is listed,
+ * so a token can never reach one (it 401s there).
+ *
+ * OAPI-1 scope: `records:read` only — GET /records (list) and GET /records/:id (single). The remaining
+ * read surfaces (view / view-aggregate / records-summary → records:read; fields → fields:read;
+ * comments → comments:read) are the same pattern and land as the OAPI-1 continuation.
+ */
+const TOKEN_BEARER_PREFIX = 'Bearer mst_'
+
+// GET /api/multitable/records (list) and GET /api/multitable/records/<id> (single). Exactly 0 or 1 path
+// segment after `records` — so `/records-summary`, `/records/:id/history`, `/records/:id/restore`, etc.
+// are NOT matched (they are not part of OAPI-1).
+const RECORDS_READ_PATH = /^\/api\/multitable\/records(?:\/[^/]+)?$/
+
+export function isApiTokenBearer(authHeader: string | undefined): boolean {
+  return typeof authHeader === 'string' && authHeader.startsWith(TOKEN_BEARER_PREFIX)
+}
+
+/**
+ * True only for an `mst_`-token GET request to an OAPI-1 read route. Used by the global gate to let such
+ * a request through to the per-route `apiTokenAuth`/`requireScope`. Fail-closed: anything not matched
+ * here (wrong method, write path, non-token bearer, any other path) returns false → normal JWT gate.
+ */
+export function isOapiReadAllowlistRequest(method: string, path: string, authHeader: string | undefined): boolean {
+  if (!isApiTokenBearer(authHeader)) return false
+  if (method !== 'GET') return false
+  return RECORDS_READ_PATH.test(path)
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -117,6 +117,7 @@ import { validateRecord, getDefaultValidationRules } from '../multitable/field-v
 import type { FieldValidationConfig } from '../multitable/field-validation'
 import { assertRichLongTextToggleAllowed, BATCH1_FIELD_TYPES, coerceBatch1Value, isPersonSingleRecord, isRichLongTextProperty, normalizeMultiSelectValue, richLongTextToPlainText, validateLongTextValue, validatePersonValue } from '../multitable/field-codecs'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
+import { apiTokenAuth, requireScope } from '../middleware/api-token-auth'
 import {
   AutomationRuleValidationError,
   getAutomationServiceInstance,
@@ -10233,7 +10234,7 @@ export function univerMetaRouter(): Router {
    * When `cursor` is absent the first page is returned.
    * When `cursor` is present, offset-based params are ignored.
    */
-  router.get('/records', async (req: Request, res: Response) => {
+  router.get('/records', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
@@ -10362,7 +10363,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/records/:recordId', async (req: Request, res: Response) => {
+  router.get('/records/:recordId', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     const sheetIdParam = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : undefined
     const viewIdParam = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : undefined

--- a/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
@@ -1,0 +1,131 @@
+/**
+ * OAPI-1 — read-only API-token routes (real DB).
+ * Design-lock: docs/development/multitable-openapi-token-auth-designlock-20260619.md.
+ *
+ * Proves an `mst_` token authenticates GET /records (records:read) AS ITS CREATOR (Option A) through the
+ * full permission stack, with deny-by-default scope + revoke:
+ *   - valid records:read token → 200, returns records;
+ *   - token missing records:read → 403 INSUFFICIENT_SCOPE;
+ *   - revoked token → 401;
+ *   - no token → 401 (auth required);
+ *   - NEVER EXCEEDS CREATOR (the spine): a record the creator is row-level-denied is NOT returned through
+ *     the token — the token reads exactly what the creator can, no more;
+ *   - READ-ONLY: the same token on a write route (POST /patch) is rejected (no apiTokenAuth mounted there).
+ *
+ * Token validation runs against the kysely `db`; records/flags via poolManager — both on DATABASE_URL.
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ApiTokenService } from '../../src/multitable/api-token-service'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_oapi1_${TS}`
+const SHEET_ID = `sheet_oapi1_${TS}`
+const STATUS = `fld_oapi1_status_${TS}`
+const REC_OPEN = `rec_oapi1_open_${TS}`
+const REC_SECRET = `rec_oapi1_secret_${TS}`
+const CREATOR = `user_oapi1_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let tokReadOk = '' // records:read
+let tokNoScope = '' // comments:read only
+let tokRevoked = '' // records:read, then revoked
+const auth = (path: string, token: string) => request(app).get(path).set('Authorization', `Bearer ${token}`)
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
+
+describeIfDatabase('OAPI-1 read-only API-token routes (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    // No fake-user middleware: the route's apiTokenAuth must set the actor from the token itself.
+    app.use('/api/multitable', univerMetaRouter())
+
+    // Creator with REAL perms (token requests load via listUserPermissions, not req.user.perms); non-admin.
+    await q(`INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+             VALUES ($1,$2,$3,'x','member',$4::jsonb, TRUE, FALSE)
+             ON CONFLICT (id) DO UPDATE SET permissions = EXCLUDED.permissions`,
+      [CREATOR, `${CREATOR}@t.local`, 'OAPI1 Creator', JSON.stringify(['multitable:read'])])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'OAPI1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'OAPI1 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_OPEN, SHEET_ID, JSON.stringify({ [STATUS]: 'open' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_SECRET, SHEET_ID, JSON.stringify({ [STATUS]: 'secret' })])
+
+    const svc = new ApiTokenService(db)
+    tokReadOk = (await svc.createToken(CREATOR, { name: 'read-ok', scopes: ['records:read'] })).plainTextToken
+    tokNoScope = (await svc.createToken(CREATOR, { name: 'no-scope', scopes: ['comments:read'] })).plainTextToken
+    const revoked = await svc.createToken(CREATOR, { name: 'revoked', scopes: ['records:read'] })
+    tokRevoked = revoked.plainTextToken
+    await svc.revokeToken(revoked.token.id, CREATOR)
+  })
+
+  afterAll(async () => {
+    await db.deleteFrom('multitable_api_tokens').where('created_by', '=', CREATOR).execute().catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [CREATOR]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    await setFlag(false)
+    await setRules([])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('valid records:read token → 200, returns records (authenticates as creator)', async () => {
+    const res = await auth('/api/multitable/records', tokReadOk).query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(200)
+    const ids = (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+    expect(ids).toContain(REC_OPEN)
+    expect(ids).toContain(REC_SECRET)
+  })
+
+  test('token missing records:read → 403 INSUFFICIENT_SCOPE', async () => {
+    const res = await auth('/api/multitable/records', tokNoScope).query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).toContain('INSUFFICIENT_SCOPE')
+  })
+
+  test('revoked token → 401', async () => {
+    const res = await auth('/api/multitable/records', tokRevoked).query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(401)
+  })
+
+  test('no token → 401 (auth required)', async () => {
+    const res = await request(app).get('/api/multitable/records').query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(401)
+  })
+
+  test('NEVER EXCEEDS CREATOR — a row the creator is rule-denied is not returned through the token', async () => {
+    await setFlag(true)
+    await setRules([{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }])
+    const res = await auth('/api/multitable/records', tokReadOk).query({ sheetId: SHEET_ID, limit: 100 })
+    expect(res.status).toBe(200)
+    const ids = (res.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+    expect(ids).toContain(REC_OPEN)
+    expect(ids).not.toContain(REC_SECRET) // creator (non-admin) is denied this row → token is too
+  })
+
+  test('READ-ONLY — the same token on a write route (POST /patch) is rejected', async () => {
+    const res = await request(app).post('/api/multitable/patch')
+      .set('Authorization', `Bearer ${tokReadOk}`)
+      .send({ sheetId: SHEET_ID, changes: [{ recordId: REC_OPEN, fieldId: STATUS, value: 'hacked' }] })
+    expect(res.status).toBe(401) // no apiTokenAuth on write → actor unset → rejected
+    const check = await q('SELECT data FROM meta_records WHERE id = $1', [REC_OPEN])
+    expect((check.rows[0] as { data?: Record<string, unknown> })?.data?.[STATUS]).toBe('open') // unchanged
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
@@ -1,0 +1,46 @@
+/**
+ * OAPI-1 gate matcher — the fail-closed switch the global JWT gate consults to let an mst_ token through
+ * to the per-route apiTokenAuth on the read allowlist ONLY. Everything else must return false (→ JWT gate
+ * → 401). This locks the read-only blast radius at the gate.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { isApiTokenBearer, isOapiReadAllowlistRequest } from '../../src/multitable/oapi-read-allowlist'
+
+const MST = 'Bearer mst_abc123'
+const JWT = 'Bearer eyJhbGciOi.x.y'
+
+describe('OAPI-1 read-allowlist gate matcher', () => {
+  test('isApiTokenBearer: only mst_ bearers', () => {
+    expect(isApiTokenBearer(MST)).toBe(true)
+    expect(isApiTokenBearer(JWT)).toBe(false)
+    expect(isApiTokenBearer('mst_abc')).toBe(false) // missing "Bearer "
+    expect(isApiTokenBearer(undefined)).toBe(false)
+  })
+
+  test('ALLOWS: mst_ + GET on the records read routes', () => {
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records', MST)).toBe(true)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_123', MST)).toBe(true)
+  })
+
+  test('DENIES: non-mst_ bearer (session/JWT) → false (normal JWT gate runs)', () => {
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records', JWT)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records', undefined)).toBe(false)
+  })
+
+  test('DENIES: non-GET methods (read-only)', () => {
+    expect(isOapiReadAllowlistRequest('POST', '/api/multitable/records', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('PATCH', '/api/multitable/records/rec_1', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
+  })
+
+  test('DENIES: paths outside the OAPI-1 records read routes (fail-closed)', () => {
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records-summary', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_1/history', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_1/restore', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/sheets/s1/view', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/fields', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/form-context', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/other/records', MST)).toBe(false)
+  })
+})


### PR DESCRIPTION
Implements the **ratified OAPI-1** (open-API token auth design-lock #2923): `mst_` API tokens become consumable on the **read-only** records routes — the last "built but not powered" capability. Read-only blast radius; a token can never reach a write/side-effecting route.

## Wiring (security-critical, advisor-reviewed)
- **`oapi-read-allowlist.ts`** — one **fail-closed** matcher = the only paths where an `mst_` token may authenticate (`GET /records`, `GET /records/:id` → `records:read`). Everything else → false → normal JWT gate → 401.
- **Global gate (`index.ts`)** — after the public-form branch, an `mst_` bearer on an allowlist read route passes through to the per-route `apiTokenAuth`; an `mst_` bearer **anywhere else** falls through to `jwtAuthMiddleware` → **401** (verified it 401s non-JWT bearers). Placed *after* the public-form branch so those auth-bypass routes are never reachable by a token (the hole the advisor flagged).
- **Routes (`univer-meta.ts`)** — `GET /records` + `GET /records/:recordId` now run `apiTokenAuth` + `requireScope('records:read')`. Write routes are **not** mounted → tokens 401 there.

## Option A (creator-scoped) — never exceeds creator
`apiTokenAuth` sets `req.user = { id: createdBy }`, so the request authorizes **as the creator** through the full stack (`resolveRequestAccess` → `listUserPermissions(creator)` + the same field-mask / row-deny). Verified: the final `resolveRequestAccess` branch loads the creator's real perms. A token reads **exactly what its creator can — no more**.

## Tests
- **Unit (matcher)**: allows `mst_`+GET on the 2 read paths; denies non-`mst_`, non-GET, and every other path (records-summary, `/:id/history`, `/view`, `/fields`, `form-context`…) — fail-closed.
- **Real-DB golden** (in `plugin-tests.yml`): valid token 200; missing scope 403; revoked 401; no token 401; **NEVER-EXCEEDS-CREATOR** (a row-deny-hidden record is absent through the token — the spine); **READ-ONLY** (same token on `POST /patch` → 401, record unchanged).

`tsc` clean. Continuation (same pattern): view/aggregate/summary → `records:read`; `fields:read`; `comments:read`. Write/export/automation/dashboard stay session-only (later locks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)