### PR TITLE
feat(formula): 1a scalar math expansion — INT/TRUNC/LN/LOG/EXP

### DIFF
--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -271,6 +271,30 @@ export class FormulaEngine {
       const scaled = Number((n * f).toPrecision(15))
       return (n >= 0 ? Math.floor(scaled) : Math.ceil(scaled)) / f
     })
+
+    // 1a (capability-depth hardening) — scalar math expansion. All single-value-in/out, no range/array
+    // semantics (range/criteria funcs like SUMIF are 1b). Excel-compatible sentinels on bad input.
+    this.functions.set('INT', (x: unknown) => {
+      const n = Number(x); return Number.isNaN(n) ? '#VALUE!' : Math.floor(n) // Excel INT rounds toward -∞
+    })
+    this.functions.set('TRUNC', (x: unknown, digits: unknown = 0) => {
+      const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
+      const f = Math.pow(10, Math.trunc(Number(digits) || 0))
+      return Math.trunc(n * f) / f // truncate toward zero (distinct from INT/floor for negatives)
+    })
+    this.functions.set('LN', (x: unknown) => {
+      const n = Number(x); if (Number.isNaN(n)) return '#VALUE!'
+      return n <= 0 ? '#NUM!' : Math.log(n)
+    })
+    this.functions.set('LOG', (x: unknown, base: unknown = 10) => {
+      const n = Number(x); const b = Number(base)
+      if (Number.isNaN(n) || Number.isNaN(b)) return '#VALUE!'
+      if (n <= 0 || b <= 0 || b === 1) return '#NUM!'
+      return Math.log(n) / Math.log(b)
+    })
+    this.functions.set('EXP', (x: unknown) => {
+      const n = Number(x); return Number.isNaN(n) ? '#VALUE!' : Math.exp(n)
+    })
   }
 
   /**

--- a/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
+++ b/packages/core-backend/tests/unit/formula-functions-expansion.test.ts
@@ -94,4 +94,33 @@ describe('Formula library expansion', () => {
     expect(await calc('=ISERROR(SQRT(-1))')).toBe(true)
     expect(await calc('=IFERROR(SQRT(-1), "x")')).toBe('x')
   })
+
+  // 1a scalar math expansion (capability-depth hardening)
+  test('INT rounds toward -∞ (distinct from TRUNC for negatives)', async () => {
+    expect(await calc('=INT(4.7)')).toBe(4)
+    expect(await calc('=INT(-4.2)')).toBe(-5)
+    expect(await calc('=INT("x")')).toBe('#VALUE!')
+  })
+
+  test('TRUNC truncates toward zero, with optional digits', async () => {
+    expect(await calc('=TRUNC(4.78)')).toBe(4)
+    expect(await calc('=TRUNC(-4.78)')).toBe(-4) // toward zero, NOT -5
+    expect(await calc('=TRUNC(4.789, 2)')).toBe(4.78)
+    expect(await calc('=TRUNC("x")')).toBe('#VALUE!')
+  })
+
+  test('LN / LOG with domain sentinels', async () => {
+    expect(await calc('=LN(1)')).toBe(0)
+    expect(await calc('=LN(0)')).toBe('#NUM!')
+    expect(await calc('=LN(-2)')).toBe('#NUM!')
+    expect(await calc('=LOG(100)')).toBe(2) // base 10 default
+    expect(await calc('=LOG(8, 2)')).toBe(3)
+    expect(await calc('=LOG(0)')).toBe('#NUM!')
+    expect(await calc('=LOG(10, 1)')).toBe('#NUM!') // base 1 undefined
+  })
+
+  test('EXP', async () => {
+    expect(await calc('=EXP(0)')).toBe(1)
+    expect(await calc('=EXP("x")')).toBe('#VALUE!')
+  })
 })


### PR DESCRIPTION
First **1a** batch from the capability-depth hardening plan (#2924) — scalar formula depth, the recommended do-first track.

Adds 5 genuinely-scalar math functions (single-value in/out, **no** range/array semantics — range/criteria funcs like SUMIF correctly stay in 1b):
- **INT** (rounds toward −∞) and **TRUNC** (toward zero, optional digits) — unit golden locks the negative-number distinction.
- **LN** / **LOG** (default base 10) with `#NUM!` domain sentinels (≤0, base 1).
- **EXP**; `#VALUE!` on non-numeric input.

Backend-only (fast CI), 15 unit tests pass, `tsc` clean. Continuation: catalog (`formula-docs.ts`) reconcile so the picker advertises them, then the text/date/regex batches (those carry TZ/format/flag edge cases, handled as careful slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)