### PR TITLE
feat(multitable): 2a view filter — isAnyOf/isNoneOf set-membership operators (backend)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3140,6 +3140,16 @@ export function evaluateMetaFilterCondition(
   if (opNorm === 'isnot' || opNorm === 'notequal') return leftNorm !== rightNorm
   if (opNorm === 'contains') return rightNorm === '' ? true : leftNorm.includes(rightNorm)
   if (opNorm === 'doesnotcontain') return rightNorm === '' ? true : !leftNorm.includes(rightNorm)
+  // 2a (view filter operators): set-membership over a multi-value selection — `value` is an array of
+  // option values (so it reads condition.value directly, not the scalar-normalized `value`). Empty
+  // array = inactive filter (match all), mirroring the empty-`contains` convention above. Each element
+  // is case/whitespace-normalized like `is`/`contains` so a select-option match stays consistent.
+  if (opNorm === 'isanyof' || opNorm === 'isnoneof') {
+    const arr = Array.isArray(condition.value) ? condition.value : []
+    if (arr.length === 0) return true
+    const member = arr.some((v) => toComparableString(v).trim().toLowerCase() === leftNorm)
+    return opNorm === 'isanyof' ? member : !member
+  }
   return true
 }
 

--- a/packages/core-backend/tests/unit/multitable-view-filter-operators.test.ts
+++ b/packages/core-backend/tests/unit/multitable-view-filter-operators.test.ts
@@ -1,0 +1,38 @@
+/**
+ * 2a (view filter operators) — is_any_of / is_none_of set membership on select/text fields.
+ * First 2a slice: backend evaluator engine (the FE picker follows). Pure function, no DB.
+ */
+import { describe, test, expect } from 'vitest'
+
+import { evaluateMetaFilterCondition } from '../../src/routes/univer-meta'
+
+// FE sends camelCase operators ('isNot', 'doesNotContain', …); the evaluator lowercases. Use the same.
+const sel = (cell: unknown, operator: string, value: unknown) =>
+  evaluateMetaFilterCondition('select', cell, { fieldId: 'f', operator, value })
+
+describe('view filter — isAnyOf / isNoneOf (2a)', () => {
+  test('isAnyOf matches when the cell value is in the array', () => {
+    expect(sel('open', 'isAnyOf', ['open', 'closed'])).toBe(true)
+    expect(sel('archived', 'isAnyOf', ['open', 'closed'])).toBe(false)
+  })
+
+  test('isAnyOf is case/whitespace-insensitive (mirrors is/contains normalization)', () => {
+    expect(sel('  Open ', 'isAnyOf', ['open'])).toBe(true)
+    expect(sel('open', 'isAnyOf', ['OPEN', 'CLOSED'])).toBe(true)
+  })
+
+  test('isNoneOf is the negation', () => {
+    expect(sel('open', 'isNoneOf', ['open', 'closed'])).toBe(false)
+    expect(sel('archived', 'isNoneOf', ['open', 'closed'])).toBe(true)
+  })
+
+  test('empty array = inactive filter (match all) — mirrors empty contains', () => {
+    expect(sel('anything', 'isAnyOf', [])).toBe(true)
+    expect(sel('anything', 'isNoneOf', [])).toBe(true)
+  })
+
+  test('non-array value never throws (treated as inactive)', () => {
+    expect(sel('open', 'isAnyOf', 'open')).toBe(true)
+    expect(sel('open', 'isNoneOf', undefined)).toBe(true)
+  })
+})


### PR DESCRIPTION
Opens the **2a** track (view filter operator depth) from the capability-depth hardening plan (#2924), in parallel with 1a.

First slice = the evaluator engine for **set membership** on select/text fields:
- **isAnyOf**: cell ∈ selected option array; **isNoneOf**: negation.
- `value` is an array (read from `condition.value`, not the scalar-normalized value).
- empty array = inactive filter (match all), mirroring the empty-`contains` convention.
- each element case/whitespace-normalized like `is`/`contains` → consistent select-option matching.

Backend-only (pure `evaluateMetaFilterCondition` addition); the rollup-filter compat path is untouched (its test stays green). Pure unit golden: membership / negation / case-insensitivity / empty=inactive / non-array safety. `tsc` clean.

**Continuation (2a):** FE filter-builder picker (multi-select value input) + remaining operators — `between`, relative-date (reusing conditional-formatting's relative-date semantics), nested condition groups, filter-by-link/lookup value — each its own slice (those carry the value-shape/TZ edge cases, handled carefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)