### PR TITLE
feat(multitable): 2a FE filter picker — isAnyOf/isNoneOf user-usable (multi-select)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -130,4 +130,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run multitable web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder --reporter=dot

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -62,6 +62,21 @@
             </select>
             <span v-if="isUnaryOp(rule.operator)" class="meta-toolbar__filter-empty-hint">{{ l('toolbar.noValueNeeded') }}</span>
             <select
+              v-else-if="isArrayOp(rule.operator) && isSelectLikeField(rule.fieldId)"
+              class="meta-toolbar__filter-value"
+              multiple
+              :aria-label="l('toolbar.filterValue')"
+              data-filter-multi-value="true"
+              @change="onFilterMultiValueChange(idx, $event)"
+            >
+              <option
+                v-for="option in getSelectOptions(rule.fieldId)"
+                :key="option.value"
+                :value="option.value"
+                :selected="Array.isArray(rule.value) && rule.value.includes(option.value)"
+              >{{ option.label }}</option>
+            </select>
+            <select
               v-else-if="isSelectLikeField(rule.fieldId)"
               class="meta-toolbar__filter-value"
               :value="String(rule.value ?? '')"
@@ -300,6 +315,10 @@ function dedupeGroupIds(ids: string[]): string[] {
 const hiddenCount = computed(() => props.hiddenFieldIds.length)
 const UNARY = new Set(['isEmpty', 'isNotEmpty'])
 const isUnaryOp = (op: string) => UNARY.has(op)
+// 2a: array-valued operators (set membership) — value is an array of option values, rendered as a
+// multi-select. Mirrors the backend evaluateMetaFilterCondition isAnyOf/isNoneOf branch.
+const ARRAY_OPS = new Set(['isAnyOf', 'isNoneOf'])
+const isArrayOp = (op: string) => ARRAY_OPS.has(op)
 const getField = (id: string) => props.fields.find((f) => f.id === id)
 const getFieldType = (id: string) => getField(id)?.type ?? 'string'
 const isSelectLikeField = (id: string) => {
@@ -360,8 +379,14 @@ function onFilterFieldChange(idx: number, fieldId: string) {
 function onFilterOperatorChange(idx: number, operator: string) {
   const r = { ...props.filterRules[idx], operator }
   if (isUnaryOp(operator)) r.value = undefined
-  else if (r.value === undefined) r.value = getDefaultFilterValue(r.fieldId)
+  else if (isArrayOp(operator)) r.value = Array.isArray(r.value) ? r.value : [] // start empty array (= inactive)
+  else if (r.value === undefined || Array.isArray(r.value)) r.value = getDefaultFilterValue(r.fieldId) // scalar op: drop stale array
   emit('update-filter', idx, r)
+}
+function onFilterMultiValueChange(idx: number, event: Event) {
+  const sel = event.target as HTMLSelectElement
+  const values = Array.from(sel.selectedOptions).map((o) => o.value)
+  emit('update-filter', idx, { ...props.filterRules[idx], value: values })
 }
 function onFilterValueChange(idx: number, value: string) {
   const ft = getFieldType(props.filterRules[idx].fieldId)

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -156,6 +156,8 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
   select: [
     { value: 'is', label: 'is' },
     { value: 'isNot', label: 'is not' },
+    { value: 'isAnyOf', label: 'is any of' },
+    { value: 'isNoneOf', label: 'is none of' },
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -263,4 +263,42 @@ describe('MetaToolbar i18n', () => {
     expect(panel.textContent).toContain('筛选更改将在应用后生效。')
     expect(panel.textContent).not.toContain('Apply filter changes')
   })
+
+  // 2a: isAnyOf/isNoneOf user-usable via a multi-select value control
+  it('offers isAnyOf/isNoneOf for select fields', async () => {
+    const { container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+    })
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement
+    const ops = Array.from(operatorSelect.options).map((o) => o.value)
+    expect(ops).toContain('isAnyOf')
+    expect(ops).toContain('isNoneOf')
+  })
+
+  it('renders a multi-select for isAnyOf and emits an ARRAY value', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'isAnyOf', value: [] }],
+    })
+    const panel = await openFilterPanel(root)
+    const multi = panel.querySelector('select[data-filter-multi-value="true"]') as HTMLSelectElement | null
+    expect(multi).toBeTruthy()
+    expect(multi!.multiple).toBe(true)
+    expect(Array.from(multi!.options).map((o) => o.value)).toEqual(['todo', 'done'])
+    multi!.options[0].selected = true
+    multi!.options[1].selected = true
+    multi!.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(state.filterRules[0]).toEqual({ fieldId: 'status', operator: 'isAnyOf', value: ['todo', 'done'] })
+  })
+
+  it('switching to isAnyOf seeds an empty ARRAY value (not a scalar)', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+    })
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement
+    await setSelectValue(operatorSelect, 'isAnyOf')
+    expect(state.filterRules[0]).toEqual({ fieldId: 'status', operator: 'isAnyOf', value: [] })
+  })
 })


### PR DESCRIPTION
Makes the backend **isAnyOf/isNoneOf** (#2932) **user-usable** via the filter-builder — the goal's 2a next cut.

- Operators added to the select field's filter menu.
- `MetaToolbar` renders a `<select multiple>` of the field's options for array operators, binding the condition value to a `string[]` (`isArrayOp` + `onFilterMultiValueChange`). Switching **to** an array op seeds an empty array (= inactive filter); switching **away** drops a stale array.
- Array value shape matches the backend evaluator exactly (`Array.isArray(condition.value)`).

**Tests** (`meta-toolbar-filter-builder.spec`, **now added to the web-guard CI gate** — it wasn't gated before, so this also closes a coverage gap): operators offered; multi-select renders options + emits an **array**; switching to isAnyOf seeds `[]`. 11 pass locally.

2a continuation: between / relative-date (reuse conditional-formatting semantics) / nested groups / filter-by-link-value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)