### PR TITLE
feat(multitable): 2a view filter — relative-date operators (isToday/thisWeek/thisMonth/lastNDays/overdue, backend)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3088,10 +3088,50 @@ async function computeDependentLookupRollupRecords(
   return results
 }
 
+const RELATIVE_DATE_OPERATORS = new Set([
+  'istoday', 'isyesterday', 'istomorrow', 'isthisweek', 'isthismonth',
+  'islastndays', 'isnextndays', 'isoverdue',
+])
+
+/**
+ * 2a relative-date view-filter operators. Compares the cell's calendar day to `nowMs` (injectable for
+ * deterministic tests). Returns `null` when `opNorm` is not a relative-date operator (caller falls
+ * through to its catch-all), and `false` when the cell has no parseable date. `islastndays`/`isnextndays`
+ * read the window size N from `rawValue` and never match on an invalid N (< 1 / non-finite).
+ * Day math is in **UTC** — consistent with how date-only cell strings are parsed (`Date.parse` → UTC
+ * midnight), so a host's local TZ offset can never shift the day boundary. Week starts Monday (ISO);
+ * day windows are inclusive on the boundary.
+ */
+function evaluateRelativeDateOp(opNorm: string, cellEpoch: number | null, rawValue: unknown, nowMs: number): boolean | null {
+  if (!RELATIVE_DATE_OPERATORS.has(opNorm)) return null
+  if (cellEpoch === null) return false
+  const dayStart = (ms: number): number => { const d = new Date(ms); d.setUTCHours(0, 0, 0, 0); return d.getTime() }
+  const shiftDays = (ms: number, n: number): number => { const d = new Date(ms); d.setUTCHours(0, 0, 0, 0); d.setUTCDate(d.getUTCDate() + n); return d.getTime() }
+  const cellDay = dayStart(cellEpoch)
+  const today = dayStart(nowMs)
+  const n = Math.trunc(Number(rawValue))
+  switch (opNorm) {
+    case 'istoday': return cellDay === today
+    case 'isyesterday': return cellDay === shiftDays(nowMs, -1)
+    case 'istomorrow': return cellDay === shiftDays(nowMs, 1)
+    case 'isthismonth': { const c = new Date(cellDay), t = new Date(today); return c.getUTCFullYear() === t.getUTCFullYear() && c.getUTCMonth() === t.getUTCMonth() }
+    case 'isthisweek': {
+      const ws = new Date(nowMs); ws.setUTCHours(0, 0, 0, 0); ws.setUTCDate(ws.getUTCDate() - ((ws.getUTCDay() + 6) % 7)) // back to Monday
+      const weekStart = ws.getTime(); const weekEnd = shiftDays(weekStart, 7)
+      return cellDay >= weekStart && cellDay < weekEnd
+    }
+    case 'islastndays': return Number.isFinite(n) && n >= 1 && cellDay >= shiftDays(nowMs, -(n - 1)) && cellDay <= today
+    case 'isnextndays': return Number.isFinite(n) && n >= 1 && cellDay >= today && cellDay <= shiftDays(nowMs, n)
+    case 'isoverdue': return cellDay < today
+    default: return null
+  }
+}
+
 export function evaluateMetaFilterCondition(
   type: UniverMetaField['type'],
   cellValue: unknown,
   condition: MetaFilterCondition,
+  nowMs: number = Date.now(), // injectable clock so relative-date operators are deterministically testable
 ): boolean {
   // `rollup → number` here is a LEGACY FALLBACK only: every caller resolves the field through
   // resolveEffectiveFieldType first (rollup → its result kind string/boolean/number), so a raw 'rollup'
@@ -3115,6 +3155,13 @@ export function evaluateMetaFilterCondition(
     if (opNorm === 'greaterequal' || opNorm === 'isgreaterequal') return left !== null && right !== null && left >= right
     if (opNorm === 'less' || opNorm === 'isless') return left !== null && right !== null && left < right
     if (opNorm === 'lessequal' || opNorm === 'islessequal') return left !== null && right !== null && left <= right
+    // 2a (view filter operators): relative-date operators (date fields only). Compares the cell's LOCAL
+    // calendar day against `nowMs`. The helper returns null when `opNorm` is not a relative-date op, so a
+    // numeric field (or an unknown op) falls through to the catch-all below unchanged.
+    if (effectiveType === 'date') {
+      const rel = evaluateRelativeDateOp(opNorm, left, condition.value, nowMs)
+      if (rel !== null) return rel
+    }
     // Unrecognized operator on a numeric field → no-op (pre-existing catch-all). Accepted
     // reclassification effect: a `contains`/`doesNotContain` filter persisted on currency/
     // percent/rating BEFORE Slice 1 (when they fell back to the string operator set) now lands

--- a/packages/core-backend/tests/unit/multitable-view-filter-relative-date.test.ts
+++ b/packages/core-backend/tests/unit/multitable-view-filter-relative-date.test.ts
@@ -1,0 +1,79 @@
+/**
+ * 2a (view filter operators) — relative-date operators on date fields.
+ * isToday / isYesterday / isTomorrow / isThisWeek / isThisMonth / isLastNDays / isNextNDays / isOverdue.
+ * Pure evaluator, deterministic via the injected clock (4th arg). Day math is UTC, matching how
+ * date-only cell strings are parsed, so results are host-timezone-stable.
+ */
+import { describe, test, expect } from 'vitest'
+import { evaluateMetaFilterCondition } from '../../src/routes/univer-meta'
+
+// Fixed "now" = 2026-06-17 (a Wednesday) noon UTC. This week (Mon-start) = Jun 15..21; month = June.
+const NOW = Date.UTC(2026, 5, 17, 12, 0, 0)
+const d = (cell: unknown, operator: string, value?: unknown) =>
+  evaluateMetaFilterCondition('date', cell, { fieldId: 'd', operator, value }, NOW)
+
+describe('view filter — relative-date operators (2a)', () => {
+  test('isToday / isYesterday / isTomorrow', () => {
+    expect(d('2026-06-17', 'isToday')).toBe(true)
+    expect(d('2026-06-16', 'isToday')).toBe(false)
+    expect(d('2026-06-16', 'isYesterday')).toBe(true)
+    expect(d('2026-06-18', 'isTomorrow')).toBe(true)
+    expect(d('2026-06-17', 'isTomorrow')).toBe(false)
+  })
+
+  test('isToday is UTC-day stable for a datetime within the same UTC day', () => {
+    expect(d('2026-06-17T23:30:00Z', 'isToday')).toBe(true)
+    expect(d('2026-06-18T00:30:00Z', 'isToday')).toBe(false)
+  })
+
+  test('isThisWeek (Monday-start) covers Mon..Sun of the current week only', () => {
+    expect(d('2026-06-15', 'isThisWeek')).toBe(true)  // Monday
+    expect(d('2026-06-21', 'isThisWeek')).toBe(true)  // Sunday
+    expect(d('2026-06-22', 'isThisWeek')).toBe(false) // next Monday
+    expect(d('2026-06-14', 'isThisWeek')).toBe(false) // last Sunday
+  })
+
+  test('isThisMonth', () => {
+    expect(d('2026-06-01', 'isThisMonth')).toBe(true)
+    expect(d('2026-06-30', 'isThisMonth')).toBe(true)
+    expect(d('2026-05-31', 'isThisMonth')).toBe(false)
+    expect(d('2026-07-01', 'isThisMonth')).toBe(false)
+  })
+
+  test('isLastNDays is the inclusive window [now-(N-1) .. now]', () => {
+    expect(d('2026-06-11', 'isLastNDays', 7)).toBe(true)  // 7-day window = Jun 11..17
+    expect(d('2026-06-17', 'isLastNDays', 7)).toBe(true)  // today is in-window
+    expect(d('2026-06-10', 'isLastNDays', 7)).toBe(false) // one day too early
+    expect(d('2026-06-18', 'isLastNDays', 7)).toBe(false) // future not in "last"
+  })
+
+  test('isNextNDays is the inclusive window [now .. now+N]', () => {
+    expect(d('2026-06-17', 'isNextNDays', 7)).toBe(true)
+    expect(d('2026-06-24', 'isNextNDays', 7)).toBe(true)
+    expect(d('2026-06-25', 'isNextNDays', 7)).toBe(false)
+    expect(d('2026-06-16', 'isNextNDays', 7)).toBe(false) // past not in "next"
+  })
+
+  test('isLastNDays / isNextNDays never match on an invalid N', () => {
+    expect(d('2026-06-17', 'isLastNDays', 0)).toBe(false)
+    expect(d('2026-06-17', 'isLastNDays', 'x')).toBe(false)
+    expect(d('2026-06-17', 'isNextNDays', -3)).toBe(false)
+  })
+
+  test('isOverdue = strictly before today', () => {
+    expect(d('2026-06-16', 'isOverdue')).toBe(true)
+    expect(d('2026-06-17', 'isOverdue')).toBe(false) // today is not overdue
+    expect(d('2026-06-18', 'isOverdue')).toBe(false)
+  })
+
+  test('a cell with no date never matches a relative-date operator', () => {
+    expect(d(null, 'isToday')).toBe(false)
+    expect(d('', 'isThisMonth')).toBe(false)
+    expect(d('not-a-date', 'isOverdue')).toBe(false)
+  })
+
+  test('non-relative operators still work (helper returns null → falls through)', () => {
+    expect(d('2026-06-17', 'is', '2026-06-17')).toBe(true)
+    expect(d('2026-06-18', 'greater', '2026-06-17')).toBe(true)
+  })
+})


### PR DESCRIPTION
Owner-directed capability-depth **2a** (view filter operator depth). Adds the **relative-date** operator family to `evaluateMetaFilterCondition`, complementing the parallel **isAnyOf/isNoneOf** slice (#2932). **Backend evaluator only** — the FE picker is the follow-up, mirroring the #2932 → #2935 split.

## Operators (date fields)
`isToday`, `isYesterday`, `isTomorrow`, `isThisWeek` (Monday-start ISO), `isThisMonth`, `isLastNDays` / `isNextNDays` (window size N from `value`; never match on invalid N), `isOverdue` (strictly before today).

## Correctness notes
- **Injectable clock** (optional 4th param `nowMs = Date.now()`) → deterministic tests; all existing 3-arg callers are unaffected (default param).
- **UTC day math** — consistent with how date-only cell strings parse (`Date.parse` → UTC midnight), so a host's local TZ offset can't shift the day boundary (the off-by-one trap).
- A cell with no parseable date never matches; a non-relative operator returns `null` from the helper and falls through to the existing comparison handling unchanged.

## Verification
Per-operator goldens (`multitable-view-filter-relative-date.test.ts`) incl. window edges, invalid-N, UTC-day stability for a datetime, null-cell, and fall-through for non-relative ops.

No runtime/security gate touched. Remaining 2a items (link/lookup filter-by-value, nested AND/OR groups) and the FE picker are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)