### PR TITLE
feat(multitable): 2a view filter — between operator (numeric + date, backend)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3155,6 +3155,18 @@ export function evaluateMetaFilterCondition(
     if (opNorm === 'greaterequal' || opNorm === 'isgreaterequal') return left !== null && right !== null && left >= right
     if (opNorm === 'less' || opNorm === 'isless') return left !== null && right !== null && left < right
     if (opNorm === 'lessequal' || opNorm === 'islessequal') return left !== null && right !== null && left <= right
+    // 2a: between — inclusive range. `value` is a [min, max] array (read condition.value directly, not
+    // the scalar-normalized value). Reversed bounds tolerated (min/max swap); a missing/incomplete or
+    // unparseable bound = inactive filter (match all), mirroring the empty-filter convention. Works for
+    // numeric AND date (toComparable already maps date cells → epoch in this branch).
+    if (opNorm === 'between') {
+      const arr = Array.isArray(condition.value) ? condition.value : []
+      if (arr.length < 2) return true
+      const a = toComparable(arr[0]); const b = toComparable(arr[1])
+      if (a === null || b === null) return true
+      if (left === null) return false
+      return left >= Math.min(a, b) && left <= Math.max(a, b)
+    }
     // 2a (view filter operators): relative-date operators (date fields only). Compares the cell's LOCAL
     // calendar day against `nowMs`. The helper returns null when `opNorm` is not a relative-date op, so a
     // numeric field (or an unknown op) falls through to the catch-all below unchanged.

--- a/packages/core-backend/tests/unit/multitable-view-filter-operators.test.ts
+++ b/packages/core-backend/tests/unit/multitable-view-filter-operators.test.ts
@@ -36,3 +36,38 @@ describe('view filter — isAnyOf / isNoneOf (2a)', () => {
     expect(sel('open', 'isNoneOf', undefined)).toBe(true)
   })
 })
+
+describe('view filter — between (2a)', () => {
+  const num = (cell: unknown, value: unknown) =>
+    evaluateMetaFilterCondition('number', cell, { fieldId: 'n', operator: 'between', value })
+  const date = (cell: unknown, value: unknown) =>
+    evaluateMetaFilterCondition('date', cell, { fieldId: 'd', operator: 'between', value })
+
+  test('numeric between is inclusive', () => {
+    expect(num(15, [10, 20])).toBe(true)
+    expect(num(10, [10, 20])).toBe(true) // lower bound inclusive
+    expect(num(20, [10, 20])).toBe(true) // upper bound inclusive
+    expect(num(5, [10, 20])).toBe(false)
+    expect(num(25, [10, 20])).toBe(false)
+  })
+
+  test('reversed bounds tolerated', () => {
+    expect(num(15, [20, 10])).toBe(true)
+  })
+
+  test('incomplete / unparseable / non-array bounds = inactive (match all)', () => {
+    expect(num(999, [10])).toBe(true) // one bound → inactive
+    expect(num(999, [])).toBe(true)
+    expect(num(999, 'x')).toBe(true) // non-array → inactive
+    expect(num(999, ['x', 'y'])).toBe(true) // unparseable bounds → inactive
+  })
+
+  test('null cell never matches a real range', () => {
+    expect(num(null, [10, 20])).toBe(false)
+  })
+
+  test('date between (epoch comparison)', () => {
+    expect(date('2026-02-15', ['2026-02-01', '2026-02-28'])).toBe(true)
+    expect(date('2026-03-15', ['2026-02-01', '2026-02-28'])).toBe(false)
+  })
+})


### PR DESCRIPTION
2a continuation (after isAnyOf/isNoneOf #2932 + relative-date #2936). Adds the inclusive **`between`** operator to `evaluateMetaFilterCondition` for **numeric and date** fields.

- `value` is a `[min, max]` array (read `condition.value` directly).
- inclusive bounds; reversed bounds tolerated (min/max swap).
- missing / incomplete / unparseable bound = inactive (match all) — same convention as contains/isAnyOf.
- null cell never matches a real range; date uses the branch's epoch comparison.

Backend-only pure evaluator addition. Unit golden: inclusivity / reversed / inactive-on-incomplete / null-cell / date-range (10 tests). `tsc` clean. FE two-bound value control is the companion slice. SUMIF/COUNTIFS/AVERAGEIF stay in 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)