### PR TITLE
feat(multitable): 2a FE — between filter picker (two-bound), user-usable

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -76,6 +76,25 @@
                 :selected="Array.isArray(rule.value) && rule.value.includes(option.value)"
               >{{ option.label }}</option>
             </select>
+            <template v-else-if="isBetweenOp(rule.operator)">
+              <input
+                class="meta-toolbar__filter-value"
+                :type="getInputType(rule.fieldId)"
+                :value="Array.isArray(rule.value) ? (rule.value[0] ?? '') : ''"
+                :aria-label="l('toolbar.filterValue')"
+                data-filter-between-min="true"
+                @change="onFilterBetweenChange(idx, 0, ($event.target as HTMLInputElement).value)"
+              />
+              <span class="meta-toolbar__filter-between-sep">–</span>
+              <input
+                class="meta-toolbar__filter-value"
+                :type="getInputType(rule.fieldId)"
+                :value="Array.isArray(rule.value) ? (rule.value[1] ?? '') : ''"
+                :aria-label="l('toolbar.filterValue')"
+                data-filter-between-max="true"
+                @change="onFilterBetweenChange(idx, 1, ($event.target as HTMLInputElement).value)"
+              />
+            </template>
             <select
               v-else-if="isSelectLikeField(rule.fieldId)"
               class="meta-toolbar__filter-value"
@@ -319,6 +338,9 @@ const isUnaryOp = (op: string) => UNARY.has(op)
 // multi-select. Mirrors the backend evaluateMetaFilterCondition isAnyOf/isNoneOf branch.
 const ARRAY_OPS = new Set(['isAnyOf', 'isNoneOf'])
 const isArrayOp = (op: string) => ARRAY_OPS.has(op)
+// 2a: between — value is a [min, max] array, rendered as two bound inputs. Mirrors the backend
+// evaluateMetaFilterCondition between branch (inclusive, reversed-tolerant).
+const isBetweenOp = (op: string) => op === 'between'
 const getField = (id: string) => props.fields.find((f) => f.id === id)
 const getFieldType = (id: string) => getField(id)?.type ?? 'string'
 const isSelectLikeField = (id: string) => {
@@ -379,7 +401,7 @@ function onFilterFieldChange(idx: number, fieldId: string) {
 function onFilterOperatorChange(idx: number, operator: string) {
   const r = { ...props.filterRules[idx], operator }
   if (isUnaryOp(operator)) r.value = undefined
-  else if (isArrayOp(operator)) r.value = Array.isArray(r.value) ? r.value : [] // start empty array (= inactive)
+  else if (isArrayOp(operator) || isBetweenOp(operator)) r.value = Array.isArray(r.value) ? r.value : [] // start empty array (= inactive)
   else if (r.value === undefined || Array.isArray(r.value)) r.value = getDefaultFilterValue(r.fieldId) // scalar op: drop stale array
   emit('update-filter', idx, r)
 }
@@ -387,6 +409,12 @@ function onFilterMultiValueChange(idx: number, event: Event) {
   const sel = event.target as HTMLSelectElement
   const values = Array.from(sel.selectedOptions).map((o) => o.value)
   emit('update-filter', idx, { ...props.filterRules[idx], value: values })
+}
+function onFilterBetweenChange(idx: number, slot: 0 | 1, value: string) {
+  const r = props.filterRules[idx]
+  const cur = Array.isArray(r.value) ? [...r.value] : []
+  cur[slot] = value
+  emit('update-filter', idx, { ...r, value: [cur[0], cur[1]] }) // always a [min, max] pair (backend coerces strings + tolerates incomplete)
 }
 function onFilterValueChange(idx: number, value: string) {
   const ft = getFieldType(props.filterRules[idx].fieldId)

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -100,6 +100,7 @@ const NUMERIC_FILTER_OPERATORS: Array<{ value: string; label: string }> = [
   { value: 'greaterEqual', label: '≥' },
   { value: 'less', label: '<' },
   { value: 'lessEqual', label: '≤' },
+  { value: 'between', label: 'between' },
   { value: 'isEmpty', label: 'is empty' },
   { value: 'isNotEmpty', label: 'is not empty' },
 ]
@@ -172,6 +173,7 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isNot', label: 'is not' },
     { value: 'greater', label: 'after' },
     { value: 'less', label: 'before' },
+    { value: 'between', label: 'between' },
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -301,4 +301,35 @@ describe('MetaToolbar i18n', () => {
     await setSelectValue(operatorSelect, 'isAnyOf')
     expect(state.filterRules[0]).toEqual({ fieldId: 'status', operator: 'isAnyOf', value: [] })
   })
+
+  // 2a: between — two-bound value control on numeric fields
+  it('offers between for numeric fields and renders two-bound inputs emitting a [min,max] array', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'amount', operator: 'between', value: [] }],
+    })
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement
+    expect(Array.from(operatorSelect.options).map((o) => o.value)).toContain('between')
+    const minInput = panel.querySelector('input[data-filter-between-min="true"]') as HTMLInputElement | null
+    const maxInput = panel.querySelector('input[data-filter-between-max="true"]') as HTMLInputElement | null
+    expect(minInput).toBeTruthy()
+    expect(maxInput).toBeTruthy()
+    minInput!.value = '10'
+    minInput!.dispatchEvent(new Event('change'))
+    await nextTick()
+    maxInput!.value = '20'
+    maxInput!.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(state.filterRules[0]).toEqual({ fieldId: 'amount', operator: 'between', value: ['10', '20'] })
+  })
+
+  it('switching to between seeds an empty array (two-bound, not scalar)', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'amount', operator: 'greater', value: 5 }],
+    })
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement
+    await setSelectValue(operatorSelect, 'between')
+    expect(state.filterRules[0]).toEqual({ fieldId: 'amount', operator: 'between', value: [] })
+  })
 })


### PR DESCRIPTION
Makes the `between` backend (#2940) **user-usable** — 2a continuation.

- Adds `between` to the numeric + date filter operator menus.
- `MetaToolbar` renders a **two-bound** value control (min + max, field's input type) binding the condition value to a `[min, max]` pair; switching to between seeds an empty array (= inactive / backend match-all). Value shape matches the backend evaluator.

Tests (`meta-toolbar-filter-builder`, already gated in web-guard): between offered for numeric; two-bound inputs emit `[min,max]`; switching seeds `[]`. 13 pass.

2a continuation remaining: relative-date FE (valueless + N-input), nested groups, filter-by-link/lookup value. SUMIF/COUNTIFS/AVERAGEIF stay in 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)