### PR TITLE
feat(multitable): OAPI-1 read continuation — records:read on view/aggregate/summary + fields:read; ratify design-lock

### DIFF
--- a/docs/development/multitable-openapi-token-auth-designlock-20260619.md
+++ b/docs/development/multitable-openapi-token-auth-designlock-20260619.md
@@ -1,9 +1,19 @@
-# Multitable Open-API Token Auth — Design-Lock (REVIEW BEFORE IMPLEMENTATION)
+# Multitable Open-API Token Auth — Design-Lock (RATIFIED)
 
-> Status: **PROPOSED design-lock — do NOT mount auth until ratified.**
+> Status: **RATIFIED 2026-06-19.** The §2 decisions are owner-signed (see "Ratification" below). Read-only
+> routes are being mounted slice by slice: `records:read` (#2929) + the read continuation (`records:read`
+> on `/view`/`/view-aggregate`/`/records-summary`; `fields:read` on `/fields`) this slice. `comments:read`
+> and all write routes remain unmounted pending their own slices.
 > Grounding: `origin/main` (2026-06-19). Owner-gated: this enables a public data API surface; it is
 > NOT a wiring bug-fix. Mounting token auth without the decisions below would create a **half-authorized
 > entry point** (worse than today's "tokens authenticate nothing").
+
+## Ratification (owner-signed 2026-06-19)
+1. **Route matrix (§2.1) ratified as proposed** — export/import/automation/dashboard/permission/token-mgmt/attachments stay **session-only** (no `records:export` scope this lock).
+2. **Scoping (§2.3): Option A (creator-wide, capability-scoped) for v1; Option B (per-base/sheet) as the fast-follow (OAPI-4).** A token never exceeds its creator's *live* permissions (resolved per-request from the DB, not from a cached/req object).
+3. **Auth precedence + limits (§2.4): token-wins on token-accepting routes; 600 req/min/token default.**
+4. **Read-only-first phasing (§4) confirmed** — no write route is token-exposed before OAPI-2/3.
+> **Drift note:** #2929 mounted `records:read` (correctly, per this ratification) while this doc still read "PROPOSED"; this status flip closes that drift so the doc matches `main`.
 
 ## 0. Problem
 
@@ -84,6 +94,9 @@ permission management, api-token management, attachments upload. (Rationale: bul
 
 ## 4. Phased implementation (each a gated, separately-opted-in slice)
 1. **OAPI-1** `requireScope` guard + mount `apiTokenAuth` on the **read** routes only (`records:read`, `fields:read`, `comments:read`) — read-only blast radius first. Real-DB golden: valid-scope 200, missing-scope 403, revoked 401, creator-permission-still-applies (denied row/field stays denied via token).
+   - **#2929**: `records:read` on `GET /records`, `/records/:id`. **DONE.**
+   - **Continuation (this slice)**: `records:read` on `GET /view`, `/sheets/:sheetId/view-aggregate`, `/records-summary`; `fields:read` on `GET /fields`. **DONE** — each verified to apply the creator's row-deny *before aggregating* (the `/view-aggregate` total + `/records-summary` slice exclude a row-denied record), guards proven via wrong-scope→403 + revoked→401 per route, and the gate allowlist anchored `^…$` with adjacent-route over-match denied (no JWT-skip bypass).
+   - **Remaining**: `comments:read` — lives in `comments.ts` behind `rbacGuard`, with ~8 GET sub-routes; the in-scope set + how token-scope composes with `rbacGuard` is its own (small) decision. **Deferred to the next slice.**
 2. **OAPI-2** write routes (`records:write`, `comments:write`) + audit events + rate limit.
 3. **OAPI-3** webhooks:manage.
 4. **OAPI-4 (v2 scoping)** per-base/sheet `ApiToken` columns + UI + enforcement (Option B).

--- a/packages/core-backend/src/multitable/oapi-read-allowlist.ts
+++ b/packages/core-backend/src/multitable/oapi-read-allowlist.ts
@@ -10,16 +10,34 @@
  * `apiTokenAuth` (univer-meta.ts). Read-only by construction: no write/side-effecting path is listed,
  * so a token can never reach one (it 401s there).
  *
- * OAPI-1 scope: `records:read` only — GET /records (list) and GET /records/:id (single). The remaining
- * read surfaces (view / view-aggregate / records-summary → records:read; fields → fields:read;
- * comments → comments:read) are the same pattern and land as the OAPI-1 continuation.
+ * OAPI-1 scope (univer-meta read surface): `records:read` — GET /records (list), /records/:id (single),
+ * /view, /sheets/:sheetId/view-aggregate, /records-summary; and `fields:read` — GET /fields. All apply the
+ * creator's row-deny + field-permission stack per-request (Option A). `comments:read` lives in a different
+ * router (`comments.ts`, `rbacGuard`-based) and is the remaining OAPI-1 slice — NOT yet allowlisted here.
  */
 const TOKEN_BEARER_PREFIX = 'Bearer mst_'
 
-// GET /api/multitable/records (list) and GET /api/multitable/records/<id> (single). Exactly 0 or 1 path
-// segment after `records` — so `/records-summary`, `/records/:id/history`, `/records/:id/restore`, etc.
-// are NOT matched (they are not part of OAPI-1).
-const RECORDS_READ_PATH = /^\/api\/multitable\/records(?:\/[^/]+)?$/
+/**
+ * THE auth boundary. Each pattern must be in **exact lockstep** with a route that mounts BOTH
+ * `apiTokenAuth` + `requireScope` (univer-meta.ts), and every pattern is **anchored `^…$`**. Rationale:
+ * a match lets an `mst_` bearer SKIP the global JWT gate to reach those per-route guards. An OVER-match
+ * (a path with no guards) would be a silent no-auth bypass — `requireScope` fail-opens when no token
+ * scopes are attached. Under-match merely 401s a token (harmless). So: anchor everything; never add a
+ * pattern without the matching mounted guards; keep the adjacent-route exclusions below intentional.
+ */
+const OAPI_READ_PATHS: readonly RegExp[] = [
+  // records:read — GET /records (list), /records/:id (single). Exactly 0/1 segment after `records`, so
+  // `/records-summary` (own pattern below), `/records/:id/history`, `/records/:id/restore` do NOT match.
+  /^\/api\/multitable\/records(?:\/[^/]+)?$/,
+  // records:read — GET /records-summary (a SIBLING of /records, not under it).
+  /^\/api\/multitable\/records-summary$/,
+  // records:read — GET /view. NOT `/views` (list-views), `/views/:id/permissions`, `/sheets/:id/view`.
+  /^\/api\/multitable\/view$/,
+  // records:read — GET /sheets/:sheetId/view-aggregate (exactly one sheetId segment).
+  /^\/api\/multitable\/sheets\/[^/]+\/view-aggregate$/,
+  // fields:read — GET /fields ONLY. NOT `/fields/:id/link-options`, NOT `/sheets/:id/person-fields/:id/directory`.
+  /^\/api\/multitable\/fields$/,
+]
 
 export function isApiTokenBearer(authHeader: string | undefined): boolean {
   return typeof authHeader === 'string' && authHeader.startsWith(TOKEN_BEARER_PREFIX)
@@ -33,5 +51,5 @@ export function isApiTokenBearer(authHeader: string | undefined): boolean {
 export function isOapiReadAllowlistRequest(method: string, path: string, authHeader: string | undefined): boolean {
   if (!isApiTokenBearer(authHeader)) return false
   if (method !== 'GET') return false
-  return RECORDS_READ_PATH.test(path)
+  return OAPI_READ_PATHS.some((pattern) => pattern.test(path))
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6870,7 +6870,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/fields', async (req: Request, res: Response) => {
+  router.get('/fields', apiTokenAuth, requireScope('fields:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
@@ -8602,7 +8602,7 @@ export function univerMetaRouter(): Router {
   // Aggregation footer (benchmark v2 #4-3b-1): aggregate the full (unpaginated) PERSISTED-view-filtered
   // record set. view-config-driven (view.config.aggregations), no ad-hoc params. Field visibility uses
   // the D3c export composite (hidden fields' aggregates OMITTED — leak guard). Max-rows hard-fails (413).
-  router.get('/sheets/:sheetId/view-aggregate', async (req: Request, res: Response) => {
+  router.get('/sheets/:sheetId/view-aggregate', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const viewId = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : ''
     const search = normalizeSearchTerm(req.query.search) // same normalization as /view (trim+lowercase) → search parity
@@ -8905,7 +8905,7 @@ export function univerMetaRouter(): Router {
     }
   })
 
-  router.get('/view', async (req: Request, res: Response) => {
+  router.get('/view', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetIdParam = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : undefined
     const viewIdParam = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : undefined
     const seed = req.query.seed === 'true'
@@ -10620,7 +10620,7 @@ export function univerMetaRouter(): Router {
    *
    * Returns: { ok: true, data: { records: [{id, display}], page: {offset, limit, total, hasMore} } }
    */
-  router.get('/records-summary', async (req: Request, res: Response) => {
+  router.get('/records-summary', apiTokenAuth, requireScope('records:read'), async (req: Request, res: Response) => {
     const sheetId = typeof req.query.sheetId === 'string' ? req.query.sheetId.trim() : ''
     const displayFieldId = typeof req.query.displayFieldId === 'string' ? req.query.displayFieldId.trim() : null
     const search = typeof req.query.search === 'string' ? req.query.search.trim().toLowerCase() : ''

--- a/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-oapi1-token-read-realdb.test.ts
@@ -38,6 +38,7 @@ let app: Express
 let tokReadOk = '' // records:read
 let tokNoScope = '' // comments:read only
 let tokRevoked = '' // records:read, then revoked
+let tokFields = '' // fields:read (no records:read)
 const auth = (path: string, token: string) => request(app).get(path).set('Authorization', `Bearer ${token}`)
 const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
 const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
@@ -63,6 +64,7 @@ describeIfDatabase('OAPI-1 read-only API-token routes (real DB)', () => {
     const svc = new ApiTokenService(db)
     tokReadOk = (await svc.createToken(CREATOR, { name: 'read-ok', scopes: ['records:read'] })).plainTextToken
     tokNoScope = (await svc.createToken(CREATOR, { name: 'no-scope', scopes: ['comments:read'] })).plainTextToken
+    tokFields = (await svc.createToken(CREATOR, { name: 'fields', scopes: ['fields:read'] })).plainTextToken
     const revoked = await svc.createToken(CREATOR, { name: 'revoked', scopes: ['records:read'] })
     tokRevoked = revoked.plainTextToken
     await svc.revokeToken(revoked.token.id, CREATOR)
@@ -127,5 +129,44 @@ describeIfDatabase('OAPI-1 read-only API-token routes (real DB)', () => {
     expect(res.status).toBe(401) // no apiTokenAuth on write → actor unset → rejected
     const check = await q('SELECT data FROM meta_records WHERE id = $1', [REC_OPEN])
     expect((check.rows[0] as { data?: Record<string, unknown> })?.data?.[STATUS]).toBe('open') // unchanged
+  })
+
+  // ---- OAPI-1 continuation: records:read on /view, /view-aggregate, /records-summary; fields:read on /fields ----
+
+  // Guard-proof per route: wrong-scope → 403 and revoked → 401 prove BOTH apiTokenAuth + requireScope are
+  // mounted (a happy-200 alone passes even if apiTokenAuth were missing). A valid token must NOT 401/403.
+  test('records:read guards mounted on /view + /view-aggregate + /records-summary (403 wrong-scope, 401 revoked)', async () => {
+    for (const p of [
+      '/api/multitable/view',
+      `/api/multitable/sheets/${SHEET_ID}/view-aggregate`,
+      '/api/multitable/records-summary',
+    ]) {
+      expect((await auth(p, tokNoScope).query({ sheetId: SHEET_ID })).status).toBe(403) // requireScope mounted
+      expect((await auth(p, tokRevoked).query({ sheetId: SHEET_ID })).status).toBe(401) // apiTokenAuth mounted
+      expect([401, 403]).not.toContain((await auth(p, tokReadOk).query({ sheetId: SHEET_ID })).status) // valid passes guards
+    }
+  })
+
+  test('fields:read guard mounted on /fields (200 with fields:read; 403 with records:read-only; 401 revoked)', async () => {
+    expect((await auth('/api/multitable/fields', tokFields).query({ sheetId: SHEET_ID })).status).toBe(200)
+    expect((await auth('/api/multitable/fields', tokReadOk).query({ sheetId: SHEET_ID })).status).toBe(403) // records:read ≠ fields:read
+    expect((await auth('/api/multitable/fields', tokRevoked).query({ sheetId: SHEET_ID })).status).toBe(401)
+  })
+
+  // The spine on the AGGREGATE surfaces: a row the creator is read-denied must not be counted/summarized
+  // (aggregation is the classic place row-deny gets dropped — count-before-filter).
+  test('NEVER EXCEEDS CREATOR (aggregates) — denied row excluded from /records-summary records + /view-aggregate total', async () => {
+    await setFlag(true)
+    await setRules([{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }])
+
+    const summary = await auth('/api/multitable/records-summary', tokReadOk).query({ sheetId: SHEET_ID, limit: 100 })
+    expect(summary.status).toBe(200)
+    const sIds = (summary.body?.data?.records ?? []).map((r: { id: string }) => r.id)
+    expect(sIds).toContain(REC_OPEN)
+    expect(sIds).not.toContain(REC_SECRET) // denied → not in the summary slice
+
+    const agg = await auth(`/api/multitable/sheets/${SHEET_ID}/view-aggregate`, tokReadOk).query({ sheetId: SHEET_ID })
+    expect(agg.status).toBe(200)
+    expect(agg.body?.data?.total).toBe(1) // denied REC_SECRET excluded from the aggregate row set (no count leak)
   })
 })

--- a/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
+++ b/packages/core-backend/tests/unit/multitable-oapi-read-allowlist.test.ts
@@ -18,9 +18,15 @@ describe('OAPI-1 read-allowlist gate matcher', () => {
     expect(isApiTokenBearer(undefined)).toBe(false)
   })
 
-  test('ALLOWS: mst_ + GET on the records read routes', () => {
+  test('ALLOWS: mst_ + GET on the OAPI-1 read routes (records:read + fields:read surface)', () => {
+    // records:read
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records', MST)).toBe(true)
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_123', MST)).toBe(true)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records-summary', MST)).toBe(true)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/view', MST)).toBe(true)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/sheets/s1/view-aggregate', MST)).toBe(true)
+    // fields:read
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/fields', MST)).toBe(true)
   })
 
   test('DENIES: non-mst_ bearer (session/JWT) → false (normal JWT gate runs)', () => {
@@ -34,12 +40,20 @@ describe('OAPI-1 read-allowlist gate matcher', () => {
     expect(isOapiReadAllowlistRequest('DELETE', '/api/multitable/records/rec_1', MST)).toBe(false)
   })
 
-  test('DENIES: paths outside the OAPI-1 records read routes (fail-closed)', () => {
-    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records-summary', MST)).toBe(false)
+  test('DENIES: adjacent/unguarded paths (fail-closed — no over-match = no JWT-skip bypass)', () => {
+    // records family
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_1/history', MST)).toBe(false)
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/records/rec_1/restore', MST)).toBe(false)
+    // /view vs /views (list) and /views/:id/permissions — NOT in scope
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/views', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/views/v1/permissions', MST)).toBe(false)
+    // /sheets/:id/view is NOT the guarded /view route; bare /view-aggregate (no /sheets/:id) is not a route
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/sheets/s1/view', MST)).toBe(false)
-    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/fields', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/view-aggregate', MST)).toBe(false)
+    // /fields ALLOWED, but its PII/expansion siblings are NOT
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/fields/f1/link-options', MST)).toBe(false)
+    expect(isOapiReadAllowlistRequest('GET', '/api/multitable/sheets/s1/person-fields/f1/directory', MST)).toBe(false)
+    // misc
     expect(isOapiReadAllowlistRequest('GET', '/api/multitable/form-context', MST)).toBe(false)
     expect(isOapiReadAllowlistRequest('GET', '/api/other/records', MST)).toBe(false)
   })


### PR DESCRIPTION
## What

Completes the **univer-meta read surface** of the ratified **OAPI-1** token-auth slice (after #2929 did `records:read` on `/records` + `/records/:id`), and flips the design-lock **PROPOSED → RATIFIED**.

**Owner-ratified §2 decisions** (per your goal): route matrix as proposed (export/import/automation/etc. stay session-only) · **Option A** (creator-wide, capability-scoped) v1, Option B fast-follow · token-wins + 600/min · read-only-first. Closes the drift where #2929 mounted `records:read` while the doc still said "PROPOSED".

## Routes mounted (`apiTokenAuth` + `requireScope`, Option A = authorize AS creator)

- `records:read`: `GET /view`, `/sheets/:sheetId/view-aggregate`, `/records-summary`
- `fields:read`: `GET /fields`

## Security (advisor-guided, design-lock §3/§4)

- **The allowlist regex IS the auth boundary.** A match lets an `mst_` bearer **skip JWT** to reach the per-route guards, and `requireScope` **fail-opens** when no scopes are attached — so an over-match would be a *silent no-auth bypass*, not a feature miss. Refactored to an **anchored `^…$` set** in exact lockstep with the mounted routes, excluding the adjacent traps: `/view` ≠ `/views` ≠ `/views/:id/permissions` ≠ `/sheets/:id/view`; `/records-summary` is a **sibling** of `/records`; `/fields` ≠ `/fields/:id/link-options` ≠ `person-fields/:id/directory` (PII).
- **Aggregate row-deny verified** (count-before-filter is the classic hole): each handler drops `loadDeniedRecordIds(creator)` **before** aggregating, so `/view-aggregate` `total` + `/records-summary` slice exclude a row-denied record.
- **Live perms**: `apiTokenAuth` sets a perms-less `req.user`; handlers resolve the creator's *live* permissions per-request — a token can't carry stale/elevated perms.

## Tests (15 green; tsc clean; no `.js`)

- **allowlist unit** — `ALLOWS` view/aggregate/summary/fields; `DENIES` the over-match traps (`/views`, `/views/:id/permissions`, `/sheets/:id/view`, `/fields/:id/link-options`, `person-fields/:id/directory`) → proves **no JWT-skip bypass**.
- **real-DB golden** (extends #2929): per-route **wrong-scope→403 + revoked→401** (proves BOTH guards mounted), `fields:read` 200/403/401, and the aggregate/summary **never-exceeds-creator** spine (denied row excluded from `total` + summary).

## Deferred / out of scope

`comments:read` (in `comments.ts` behind `rbacGuard`, ~8 GET sub-routes — its own slice + scope decision; **see the question in the PR thread**). Write routes stay session-only (OAPI-2+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
