### PR TITLE
feat(multitable): 1a formula — date-function edge hardening (EDATE month-clamp + SECOND/DAYS)

### DIFF
--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -364,6 +364,21 @@ export class FormulaEngine {
       firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayNr + 3)
       return 1 + Math.round((target.getTime() - firstThursday.getTime()) / (7 * 24 * 3600 * 1000))
     })
+
+    // ── 1a date-function edge hardening: month-end CLAMP + HOUR/MINUTE/SECOND triplet + day-diff ──
+    this.functions.set('EDATE', (date: unknown, months: unknown = 0) => {
+      // Shift by whole months and CLAMP day to the target month's last day (Excel EDATE), so
+      // EDATE('2026-01-31', 1) → 2026-02-28 (vs DATEADD ...,'months' which overflows to early March).
+      const d = this.coerceDateValue(date); if (!d) return '#VALUE!'
+      const m = Math.trunc(Number(months) || 0)
+      // Reuse EOMONTH's "day 0 of next month = last day of target month" to get the clamp bound.
+      const lastDay = new Date(d.getFullYear(), d.getMonth() + m + 1, 0).getDate()
+      return new Date(d.getFullYear(), d.getMonth() + m, Math.min(d.getDate(), lastDay))
+    })
+    // SECOND completes the HOUR/MINUTE/SECOND triplet (mirrors HOUR/MINUTE exactly).
+    this.functions.set('SECOND', (date: unknown) => { const d = this.coerceDateValue(date); return d ? d.getSeconds() : '#VALUE!' })
+    // DAYS(end_date, start_date): integer calendar-day diff in Excel arg order (note: datedif is start,end).
+    this.functions.set('DAYS', (endDate: unknown, startDate: unknown) => this.datedif(startDate, endDate, 'D'))
   }
 
   /** Timezone-stable date coercion: a bare 'YYYY-MM-DD' is parsed as LOCAL midnight (matching DATE()),
@@ -385,6 +400,8 @@ export class FormulaEngine {
     const out = new Date(d.getTime())
     if (u === 'days' || u === 'day' || u === 'd') out.setDate(out.getDate() + n)
     else if (u === 'weeks' || u === 'week' || u === 'w') out.setDate(out.getDate() + n * 7)
+    // Month-end rollover follows JS setMonth: Jan 31 + 1mo → Mar 2/3 (the short month overflows forward),
+    // NOT clamped to Feb 28. This is intentional/legacy here; EDATE is the month-end-CLAMPED alternative.
     else if (u === 'months' || u === 'month' || u === 'm') out.setMonth(out.getMonth() + n)
     else if (u === 'years' || u === 'year' || u === 'y') out.setFullYear(out.getFullYear() + n)
     else if (u === 'hours' || u === 'hour' || u === 'h') out.setHours(out.getHours() + n)

--- a/packages/core-backend/tests/unit/formula-1a-text-date-expansion.test.ts
+++ b/packages/core-backend/tests/unit/formula-1a-text-date-expansion.test.ts
@@ -92,12 +92,46 @@ describe('1a scalar text + date expansion', () => {
     })
   })
 
+  describe('1a date-function edge hardening', () => {
+    test('EDATE shifts whole months and CLAMPS to the target month-end', async () => {
+      // The central edge: a long-month day-of-month that the target short month cannot hold.
+      expect(await calc('=YEAR(EDATE(DATE(2026, 1, 31), 1))')).toBe(2026)
+      expect(await calc('=MONTH(EDATE(DATE(2026, 1, 31), 1))')).toBe(2)
+      expect(await calc('=DAY(EDATE(DATE(2026, 1, 31), 1))')).toBe(28) // Jan 31 + 1mo → Feb 28 (2026 not leap)
+      expect(await calc('=DAY(EDATE(DATE(2024, 1, 31), 1))')).toBe(29) // leap year → Feb 29
+      expect(await calc('=DAY(EDATE(DATE(2026, 3, 31), -1))')).toBe(28) // Mar 31 − 1mo → Feb 28
+      expect(await calc('=MONTH(EDATE(DATE(2026, 3, 31), -1))')).toBe(2)
+      // A day the target month CAN hold is preserved unchanged (no spurious clamping).
+      expect(await calc('=DAY(EDATE(DATE(2026, 1, 15), 2))')).toBe(15)
+      expect(await calc('=MONTH(EDATE(DATE(2026, 1, 15), 2))')).toBe(3)
+    })
+    test('DATEADD ...,"months" does NOT clamp — it overflows forward (documented contrast to EDATE)', async () => {
+      // Same Jan-31 + 1 month input as the EDATE clamp test above: setMonth rolls the extra days into
+      // the next month, so the result lands in MARCH, not February. This contrast is intentional/locked.
+      expect(await calc('=MONTH(DATEADD(DATE(2026, 1, 31), 1, "months"))')).toBe(3)
+    })
+    test('EDATE returns #VALUE! on an invalid date', async () => {
+      expect(await calc('=EDATE("not-a-date", 1)')).toBe('#VALUE!')
+    })
+    test('SECOND extracts seconds; #VALUE! on garbage (completes HOUR/MINUTE/SECOND)', async () => {
+      expect(await calc('=SECOND("2026-01-01T13:30:45")')).toBe(45)
+      expect(await calc('=SECOND("not-a-date")')).toBe('#VALUE!')
+    })
+    test('DAYS is the integer day-diff in (end, start) order; signed; #VALUE! on garbage', async () => {
+      expect(await calc('=DAYS(DATE(2026, 1, 10), DATE(2026, 1, 1))')).toBe(9)
+      expect(await calc('=DAYS(DATE(2026, 1, 1), DATE(2026, 1, 10))')).toBe(-9) // reversed args → negative
+      expect(await calc('=DAYS("bad", DATE(2026, 1, 1))')).toBe('#VALUE!')
+      expect(await calc('=DAYS(DATE(2026, 1, 1), "bad")')).toBe('#VALUE!')
+    })
+  })
+
   test('the full 1a set is registered (math via #2930 + text/date here); range/criteria are NOT', () => {
     const names = new Set(engine.getRegisteredFunctionNames())
     const scalar1a = [
       'INT', 'TRUNC', 'EXP', 'LN', 'LOG', // math (#2930)
       'FIND', 'SEARCH', 'REPLACE', 'REPT', 'TEXT', 'REGEXMATCH', 'REGEXEXTRACT', 'REGEXREPLACE', // text
       'HOUR', 'MINUTE', 'DATEADD', 'EOMONTH', 'WORKDAY', 'WEEKNUM', // date
+      'EDATE', 'SECOND', 'DAYS', // date-edge hardening (month-clamp + HOUR/MINUTE/SECOND triplet + day-diff)
     ]
     for (const fn of scalar1a) expect(names.has(fn), `missing ${fn}`).toBe(true)
     // SUMIF/COUNTIFS/AVERAGEIF need range/criteria semantics (1b) — must not be smuggled in as scalar.


### PR DESCRIPTION
## Summary

Bounded, backend-only **1a** slice for the formula engine. **Edge-led**: it first fixes the month-end **boundary (边界)**, then completes two scalar date-function gaps. All three additions are pure **scalar** date functions — no range / criteria / array semantics.

### The edge (lead)
`DATEADD(date, n, 'months')` delegates to JS `Date.setMonth`, which **overflows** a long-month day-of-month that the target short month cannot hold: `Jan 31 + 1 month` rolls forward into **early March** (Mar 2/3), not Feb 28.

**Conscious decision:** that existing `DATEADD` rollover is **left UNCHANGED** — altering it would silently change live formulas. It's now annotated at the `dateAdd` `'months'` branch and **locked by a contrast test** placed right next to the EDATE clamp test, so the difference is explicit.

### Functions added
| Function | Behavior |
|---|---|
| `EDATE(date, months)` | Shift by whole months, then **CLAMP** the day to the target month-end (correct Excel EDATE). `Jan 31 +1 → Feb 28`; leap `Jan 31 +1 → Feb 29`; `Mar 31 −1 → Feb 28`. `months` via `Math.trunc(Number(months) || 0)` (EOMONTH idiom); clamp bound reuses EOMONTH's "day 0 of next month = last day". `#VALUE!` on invalid date. |
| `SECOND(date)` | Completes the `HOUR`/`MINUTE`/`SECOND` triplet — mirrors `HOUR`/`MINUTE` exactly. `#VALUE!` on garbage. |
| `DAYS(end_date, start_date)` | Integer calendar-day diff in Excel **(end, start)** arg order; reuses private `datedif(start, end, 'D')` for coercion + `#VALUE!`; signed (reversed args → negative). |

### Tests
New nested `describe('1a date-function edge hardening')` in `formula-1a-text-date-expansion.test.ts`: EDATE month-end clamp (Jan 31 → Feb 28, leap → Feb 29, negative months, no-spurious-clamp), EDATE invalid → `#VALUE!`; the **DATEADD-overflow contrast** (`MONTH(DATEADD(Jan 31, 1, 'months')) === 3`); SECOND extract + invalid; DAYS signed diff + invalid. The in-test registered-function parity list gains `EDATE`/`SECOND`/`DAYS` and **keeps** the `SUMIF`/`COUNTIFS`/`AVERAGEIF → absent` assertions.

### Out of scope (explicit)
`SUMIF`, `COUNTIFS`, `AVERAGEIF` and any range/criteria/aggregation/array function remain reserved for the separate **1b** design-lock. `NETWORKDAYS`/`YEARFRAC` not included. No FE / view-filter / `univer-meta.ts` changes.

### Verification (local)
- Backend `tsc --noEmit` — clean (exit 0).
- `vitest run formula-1a-text-date-expansion formula-functions-expansion formula-engine multitable-formula-engine` — **185/185 passed** (the 1a date/text suite: 17 tests).

`git diff --stat`: 2 files, +51 (engine.ts +17, test +34). No catalog file exists — the function catalog is dynamic via `getRegisteredFunctionNames()`; the only parity surface is the in-test list, which is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)