### PR TITLE
feat(multitable): send_webhook B1-S2 — SSRF guard core (the #1 egress control)

### DIFF
--- a/packages/core-backend/src/multitable/webhook-ssrf-guard.ts
+++ b/packages/core-backend/src/multitable/webhook-ssrf-guard.ts
@@ -1,0 +1,114 @@
+/**
+ * SSRF guard for the `send_webhook` button action (B1-S2, design-lock #2897 §3.1) — THE #1 egress
+ * control. A field author supplies the target URL, so the server must refuse to be turned into a
+ * request-forgery proxy into the internal network.
+ *
+ * Policy (all required):
+ *  - https-only (no http/file/other schemes).
+ *  - Block private / loopback / link-local / metadata / "this-host" targets, IPv4 AND IPv6
+ *    (incl. IPv4-mapped IPv6, so a private v4 can't be smuggled in mapped form).
+ *  - Resolve the name and reject if ANY resolved address is internal (multi-record names included).
+ *  - Resolve-then-pin: callers connect to the returned pinned addresses, not the name, to defeat
+ *    DNS-rebinding between check and use.
+ *
+ * Pure + injectable resolver so it is deterministically testable without real DNS.
+ */
+import { lookup as dnsLookup } from 'node:dns/promises'
+
+export type SsrfLookupFn = (hostname: string) => Promise<Array<{ address: string; family: number }>>
+
+export type SsrfCheckResult =
+  | { ok: true; protocol: 'https:'; hostname: string; addresses: string[] }
+  | { ok: false; reason: string }
+
+/** Internal/unsafe IPv4? Malformed input is treated as unsafe (fail-closed). */
+export function isInternalIpv4(ip: string): boolean {
+  const parts = ip.trim().split('.')
+  if (parts.length !== 4) return true
+  const nums = parts.map((p) => (/^\d{1,3}$/.test(p) ? Number(p) : NaN))
+  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true
+  const [a, b] = nums
+  if (a === 0) return true // 0.0.0.0/8 "this host"
+  if (a === 127) return true // loopback 127/8
+  if (a === 10) return true // RFC1918 10/8
+  if (a === 172 && b >= 16 && b <= 31) return true // RFC1918 172.16/12
+  if (a === 192 && b === 168) return true // RFC1918 192.168/16
+  if (a === 169 && b === 254) return true // link-local 169.254/16 (incl. cloud metadata 169.254.169.254)
+  return false
+}
+
+/** Internal/unsafe IPv6? Handles loopback, unspecified, ULA (fc00::/7), link-local (fe80::/10),
+ *  and IPv4-mapped (::ffff:a.b.c.d / ::ffff:HHHH:HHHH) by unwrapping to the embedded IPv4. */
+export function isInternalIpv6(ip: string): boolean {
+  let a = ip.trim().toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  const zone = a.indexOf('%') // strip a scope id (fe80::1%eth0)
+  if (zone !== -1) a = a.slice(0, zone)
+  if (a === '::1' || a === '0:0:0:0:0:0:0:1') return true // loopback
+  if (a === '::' || a === '0:0:0:0:0:0:0:0') return true // unspecified
+  // IPv4-mapped: ::ffff:a.b.c.d  (dotted) or ::ffff:HHHH:HHHH (hex) → check the embedded IPv4.
+  const mappedDotted = a.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+  if (mappedDotted) return isInternalIpv4(mappedDotted[1])
+  const mappedHex = a.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16)
+    const lo = parseInt(mappedHex[2], 16)
+    return isInternalIpv4(`${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`)
+  }
+  const firstHextet = (a.split(':')[0] || '').padStart(4, '0') // leading "::" → "0000" (not fc/fe)
+  const firstByte = parseInt(firstHextet.slice(0, 2), 16)
+  const secondByte = parseInt(firstHextet.slice(2, 4), 16)
+  if (Number.isNaN(firstByte)) return true // unparseable → fail-closed
+  if ((firstByte & 0xfe) === 0xfc) return true // ULA fc00::/7 (fc / fd)
+  if (firstByte === 0xfe && (secondByte & 0xc0) === 0x80) return true // link-local fe80::/10
+  return false
+}
+
+/** Is a resolved IP literal internal/unsafe (either family)? */
+export function isInternalAddress(ip: string): boolean {
+  return ip.includes(':') ? isInternalIpv6(ip) : isInternalIpv4(ip)
+}
+
+/** Name-based block: never resolve obviously-internal names (defence-in-depth alongside the IP check). */
+function isInternalHostname(host: string): boolean {
+  const h = host.trim().toLowerCase().replace(/\.$/, '')
+  if (h === 'localhost') return true
+  if (h.endsWith('.localhost') || h.endsWith('.internal') || h.endsWith('.local')) return true
+  return false
+}
+
+/**
+ * Validate a target URL for an egress webhook. Returns the pinned addresses on success (caller connects
+ * to those, not the name). Rejects (never throws) with a stable reason on any unsafe target.
+ */
+export async function checkWebhookTargetUrl(rawUrl: unknown, lookupFn: SsrfLookupFn = ((h) => dnsLookup(h, { all: true }))): Promise<SsrfCheckResult> {
+  if (typeof rawUrl !== 'string' || rawUrl.trim().length === 0) return { ok: false, reason: 'URL is required' }
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return { ok: false, reason: 'URL is malformed' }
+  }
+  if (parsed.protocol !== 'https:') return { ok: false, reason: `scheme not allowed: ${parsed.protocol} (https only)` }
+  const hostname = parsed.hostname.replace(/^\[/, '').replace(/\]$/, '')
+  if (isInternalHostname(hostname)) return { ok: false, reason: 'target host is internal' }
+
+  // A bare IP literal is checked directly (no DNS). A name is resolved and EVERY address checked.
+  if (isInternalAddress(hostname) && (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(':'))) {
+    return { ok: false, reason: 'target IP is internal' }
+  }
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname) || hostname.includes(':')) {
+    return { ok: true, protocol: 'https:', hostname, addresses: [hostname] } // public IP literal
+  }
+
+  let resolved: Array<{ address: string; family: number }>
+  try {
+    resolved = await lookupFn(hostname)
+  } catch {
+    return { ok: false, reason: 'target host did not resolve' }
+  }
+  if (!resolved || resolved.length === 0) return { ok: false, reason: 'target host did not resolve' }
+  for (const { address } of resolved) {
+    if (isInternalAddress(address)) return { ok: false, reason: 'target resolves to an internal address' }
+  }
+  return { ok: true, protocol: 'https:', hostname, addresses: resolved.map((r) => r.address) }
+}

--- a/packages/core-backend/tests/unit/webhook-ssrf-guard.test.ts
+++ b/packages/core-backend/tests/unit/webhook-ssrf-guard.test.ts
@@ -1,0 +1,97 @@
+/**
+ * SSRF guard goldens for send_webhook (B1-S2, #2897 §3.1) — the #1 egress control. Adversarial: every
+ * private/loopback/link-local/metadata range (IPv4 + IPv6 + IPv4-mapped) must be rejected; a name that
+ * resolves to ANY internal address must be rejected (incl. multi-record / rebinding-shaped); only a
+ * public https target with all-public resolved addresses is allowed (and pinned).
+ */
+import { describe, test, expect } from 'vitest'
+import {
+  isInternalIpv4,
+  isInternalIpv6,
+  isInternalAddress,
+  checkWebhookTargetUrl,
+  type SsrfLookupFn,
+} from '../../src/multitable/webhook-ssrf-guard'
+
+describe('SSRF guard — IPv4 ranges', () => {
+  test('private / loopback / link-local / metadata / this-host are internal', () => {
+    for (const ip of ['127.0.0.1', '127.1.2.3', '10.0.0.1', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '0.0.0.0']) {
+      expect(isInternalIpv4(ip), ip).toBe(true)
+    }
+  })
+  test('public IPv4 is allowed', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34', '172.32.0.1', '172.15.0.1']) {
+      expect(isInternalIpv4(ip), ip).toBe(false)
+    }
+  })
+  test('malformed IPv4 fails closed (treated as internal)', () => {
+    for (const ip of ['bad', '1.2.3', '999.1.1.1', '1.2.3.4.5', '']) expect(isInternalIpv4(ip), ip).toBe(true)
+  })
+})
+
+describe('SSRF guard — IPv6 ranges', () => {
+  test('loopback / unspecified / ULA / link-local are internal', () => {
+    for (const ip of ['::1', '::', 'fc00::1', 'fd12:3456::1', 'fe80::1', 'febf::1']) {
+      expect(isInternalIpv6(ip), ip).toBe(true)
+    }
+  })
+  test('IPv4-mapped private is internal (dotted AND hex forms — no smuggling)', () => {
+    expect(isInternalIpv6('::ffff:127.0.0.1')).toBe(true)
+    expect(isInternalIpv6('::ffff:10.0.0.1')).toBe(true)
+    expect(isInternalIpv6('::ffff:7f00:1')).toBe(true) // hex form of 127.0.0.1
+    expect(isInternalIpv6('::ffff:0a00:1')).toBe(true) // hex form of 10.0.0.1
+  })
+  test('public IPv6 (and public IPv4-mapped) is allowed', () => {
+    expect(isInternalIpv6('2606:4700:4700::1111')).toBe(false) // public
+    expect(isInternalIpv6('::ffff:8.8.8.8')).toBe(false)
+    expect(isInternalIpv6('fe80::1%eth0')).toBe(true) // scope id stripped, still link-local
+  })
+  test('isInternalAddress dispatches by family', () => {
+    expect(isInternalAddress('10.0.0.1')).toBe(true)
+    expect(isInternalAddress('fc00::1')).toBe(true)
+    expect(isInternalAddress('8.8.8.8')).toBe(false)
+  })
+})
+
+describe('SSRF guard — checkWebhookTargetUrl', () => {
+  const noLookup: SsrfLookupFn = async () => { throw new Error('should not resolve') }
+  const resolveTo = (addrs: string[]): SsrfLookupFn => async () => addrs.map((address) => ({ address, family: address.includes(':') ? 6 : 4 }))
+
+  test('non-https schemes are rejected', async () => {
+    expect((await checkWebhookTargetUrl('http://example.com', noLookup)).ok).toBe(false)
+    expect((await checkWebhookTargetUrl('file:///etc/passwd', noLookup)).ok).toBe(false)
+  })
+  test('missing / malformed URL is rejected', async () => {
+    expect((await checkWebhookTargetUrl('', noLookup)).ok).toBe(false)
+    expect((await checkWebhookTargetUrl('not a url', noLookup)).ok).toBe(false)
+    expect((await checkWebhookTargetUrl(undefined, noLookup)).ok).toBe(false)
+  })
+  test('internal hostnames are rejected without resolving', async () => {
+    for (const u of ['https://localhost/x', 'https://api.internal/x', 'https://db.local/x']) {
+      expect((await checkWebhookTargetUrl(u, noLookup)).ok, u).toBe(false)
+    }
+  })
+  test('internal IP literals are rejected (no DNS)', async () => {
+    for (const u of ['https://127.0.0.1/x', 'https://169.254.169.254/latest/meta-data', 'https://[::1]/x', 'https://[fc00::1]/x']) {
+      expect((await checkWebhookTargetUrl(u, noLookup)).ok, u).toBe(false)
+    }
+  })
+  test('a public IP literal is allowed (pinned to itself)', async () => {
+    const r = await checkWebhookTargetUrl('https://8.8.8.8/hook', noLookup)
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.addresses).toEqual(['8.8.8.8'])
+  })
+  test('a name resolving to an internal address is rejected (incl. one internal among many)', async () => {
+    expect((await checkWebhookTargetUrl('https://evil.example.com/x', resolveTo(['10.0.0.5']))).ok).toBe(false)
+    expect((await checkWebhookTargetUrl('https://evil.example.com/x', resolveTo(['93.184.216.34', '169.254.169.254']))).ok).toBe(false)
+    expect((await checkWebhookTargetUrl('https://evil.example.com/x', resolveTo(['::ffff:127.0.0.1']))).ok).toBe(false)
+  })
+  test('a public name resolving to all-public addresses is allowed and pinned', async () => {
+    const r = await checkWebhookTargetUrl('https://hooks.example.com/x', resolveTo(['93.184.216.34', '2606:4700::1111']))
+    expect(r.ok).toBe(true)
+    if (r.ok) { expect(r.hostname).toBe('hooks.example.com'); expect(r.addresses).toContain('93.184.216.34') }
+  })
+  test('a name that does not resolve is rejected', async () => {
+    expect((await checkWebhookTargetUrl('https://nope.example.com/x', resolveTo([]))).ok).toBe(false)
+  })
+})


### PR DESCRIPTION
First, self-contained piece of the owner-directed **`send_webhook`** button action (per the owner-reviewed design-lock **#2897 §3.1**, the #1 egress control). **Standalone new module — inert (nothing wires it yet)**, so it has zero collision surface with the parallel 2a/webhook work. The dispatch wiring (capability gate + dedup + audit + value-scrub redaction) follows and is where the live security review applies.

## `webhook-ssrf-guard.ts` — `checkWebhookTargetUrl(url, lookupFn?)`
- **https-only** (no http/file/other schemes)
- **blocks private/loopback/link-local/metadata/this-host, IPv4 + IPv6:** v4 `127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (incl. metadata `169.254.169.254`), `0/8`; v6 `::1`, `::`, **`fc00::/7`** (ULA), **`fe80::/10`** (link-local), and **IPv4-mapped `::ffff:*`** in *both* dotted and hex forms (no smuggling a private v4 in mapped form)
- **name-based block** (`.internal`/`.local`/`localhost`)
- **resolve-then-pin:** resolves the name, rejects if **any** resolved address is internal (multi-record names included), and returns the **pinned** addresses so the caller connects to those, not the name → defeats DNS-rebinding between check and use
- **fail-closed:** malformed IP/address input is treated as internal
- pure + injectable resolver → deterministically testable without real DNS

## Verification
Adversarial goldens (`webhook-ssrf-guard.test.ts`): every private range rejected (v4 / v6 / IPv4-mapped dotted+hex), public allowed, name→internal rejected (incl. one-internal-among-many and rebinding shape), non-https/malformed rejected, public name pinned.

Inert + comprehensively tested → safe to land; the live `send_webhook` dispatch that *uses* this guard is the follow-up where your full security review applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)