### PR TITLE
fix(multitable): SSRF guard — fail-closed on malformed IPv6 (net.isIP) [#2950 P3]

### DIFF
--- a/packages/core-backend/src/multitable/webhook-ssrf-guard.ts
+++ b/packages/core-backend/src/multitable/webhook-ssrf-guard.ts
@@ -14,6 +14,7 @@
  * Pure + injectable resolver so it is deterministically testable without real DNS.
  */
 import { lookup as dnsLookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 
 export type SsrfLookupFn = (hostname: string) => Promise<Array<{ address: string; family: number }>>
 
@@ -45,7 +46,8 @@ export function isInternalIpv6(ip: string): boolean {
   if (zone !== -1) a = a.slice(0, zone)
   if (a === '::1' || a === '0:0:0:0:0:0:0:1') return true // loopback
   if (a === '::' || a === '0:0:0:0:0:0:0:0') return true // unspecified
-  // IPv4-mapped: ::ffff:a.b.c.d  (dotted) or ::ffff:HHHH:HHHH (hex) → check the embedded IPv4.
+  // IPv4-mapped: ::ffff:a.b.c.d  (dotted) or ::ffff:HHHH:HHHH (hex) → check the embedded IPv4. Handled
+  // BEFORE the net.isIP guard so the dotted-quad form (whose net.isIP support varies) is unambiguous.
   const mappedDotted = a.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
   if (mappedDotted) return isInternalIpv4(mappedDotted[1])
   const mappedHex = a.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
@@ -54,6 +56,10 @@ export function isInternalIpv6(ip: string): boolean {
     const lo = parseInt(mappedHex[2], 16)
     return isInternalIpv4(`${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`)
   }
+  // Fail-closed: a malformed-but-first-hextet-parseable string (e.g. "2606:nonsense") would otherwise read
+  // as public via the prefix check below. By here `a` is a plain (non-mapped) IPv6, so net.isIP is
+  // unambiguous — reject anything that is not a syntactically valid IPv6. (#2950 P3.)
+  if (isIP(a) !== 6) return true
   const firstHextet = (a.split(':')[0] || '').padStart(4, '0') // leading "::" → "0000" (not fc/fe)
   const firstByte = parseInt(firstHextet.slice(0, 2), 16)
   const secondByte = parseInt(firstHextet.slice(2, 4), 16)

--- a/packages/core-backend/tests/unit/webhook-ssrf-guard.test.ts
+++ b/packages/core-backend/tests/unit/webhook-ssrf-guard.test.ts
@@ -46,6 +46,11 @@ describe('SSRF guard — IPv6 ranges', () => {
     expect(isInternalIpv6('::ffff:8.8.8.8')).toBe(false)
     expect(isInternalIpv6('fe80::1%eth0')).toBe(true) // scope id stripped, still link-local
   })
+  test('malformed IPv6 fails closed (treated as internal), not read as public via first hextet (#2950 P3)', () => {
+    for (const ip of ['2606:nonsense', 'fc00:garbage', '12345::1', 'fc00:::1', 'not-an-ip', '2606:4700:zzzz::1']) {
+      expect(isInternalIpv6(ip), ip).toBe(true)
+    }
+  })
   test('isInternalAddress dispatches by family', () => {
     expect(isInternalAddress('10.0.0.1')).toBe(true)
     expect(isInternalAddress('fc00::1')).toBe(true)


### PR DESCRIPTION
Review follow-up to #2950 ([P3]). `isInternalIpv6()` judged solely by the first hextet, so a **malformed-but-first-segment-parseable** string (e.g. `2606:nonsense`) fell through to the prefix check and read as **public** — violating the fail-closed contract. A real URL parser / DNS won't feed such values, but the guard must not depend on that.

**Fix:** a `net.isIP(a) === 6` gate, placed **after** the IPv4-mapped handling so the dotted `::ffff:a.b.c.d` form (whose `net.isIP` support varies across runtimes) stays unambiguous — only a plain non-mapped IPv6 reaches the gate, where genuine garbage now fails closed (→ treated as internal). All valid forms (`::1`, `::`, IPv4-mapped, ULA, link-local, public) are unchanged.

**Test:** malformed-IPv6 cases (`2606:nonsense` / `fc00:garbage` / `12345::1` / `fc00:::1` / `not-an-ip` / bad-hextet) all return `true` (internal); public + mapped cases unchanged.

Closes the [P3] finding before the `send_webhook` wiring uses the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)