### PR TITLE
feat(multitable): send_webhook B1-S2 — resolve-then-pin egress helper (connect-to-pinned proof)

### DIFF
--- a/packages/core-backend/src/multitable/webhook-pinned-fetch.ts
+++ b/packages/core-backend/src/multitable/webhook-pinned-fetch.ts
@@ -1,0 +1,81 @@
+/**
+ * SSRF-safe egress for the send_webhook button action (B1-S2, #2897 §3.1). The SSRF guard
+ * (`checkWebhookTargetUrl`) validates the URL and returns the resolved addresses; this helper then
+ * connects to ONE of those PINNED addresses instead of re-resolving the hostname — closing the
+ * DNS-rebinding window between the check and the request. A plain `fetch(url)` would re-resolve and
+ * defeat the guard ("resolve-then-pin only works if you connect to the pin").
+ *
+ * The original hostname is preserved: TLS SNI keeps the URL's hostname and the `Host` header is forced
+ * to the URL host (a caller-supplied Host is stripped — no virtual-host confusion); only DNS resolution
+ * is overridden via the `lookup` option. No retry (at-most-once). Returns the status only — resolved on
+ * the response HEADERS, then the socket is destroyed, so a slow/endless body can never stall the action
+ * and the body is never read/persisted/logged.
+ */
+import https from 'node:https'
+import type { IncomingMessage } from 'node:http'
+
+export type PinnedFetchResult = { status: number; ok: boolean }
+
+export type HttpsRequestFn = typeof https.request
+
+export interface PinnedFetchOptions {
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+  timeoutMs: number
+}
+
+export async function pinnedHttpsFetch(
+  url: string,
+  pinnedAddress: string,
+  family: 4 | 6,
+  opts: PinnedFetchOptions,
+  requestImpl: HttpsRequestFn = https.request,
+): Promise<PinnedFetchResult> {
+  return await new Promise<PinnedFetchResult>((resolve, reject) => {
+    let settled = false
+    const finish = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      fn()
+    }
+    // Force the Host header to the URL's host. A caller-supplied Host would split the HTTP identity from
+    // the pinned connection + TLS SNI (virtual-host confusion), so strip any caller host/Host and set it
+    // from the URL — Host stays aligned with what was validated and connected to.
+    const safeHeaders: Record<string, string> = {}
+    for (const [k, v] of Object.entries(opts.headers ?? {})) {
+      if (k.toLowerCase() === 'host') continue
+      safeHeaders[k] = v
+    }
+    safeHeaders.host = new URL(url).host
+    const req = requestImpl(
+      url,
+      {
+        method: opts.method ?? 'POST',
+        headers: safeHeaders,
+        timeout: opts.timeoutMs,
+        // THE pin: bypass DNS and connect to the pre-validated address. SNI keeps the URL's hostname
+        // (https.request default) and the Host header is forced to it above, so the connection targets
+        // the checked IP while the TLS/HTTP identity stays the original host — the rebinding window is closed.
+        lookup: (_hostname: string, _options: unknown, cb: (err: Error | null, address: string, family: number) => void) => {
+          cb(null, pinnedAddress, family)
+        },
+      } as https.RequestOptions,
+      (res: IncomingMessage) => {
+        // Resolve on HEADERS — the status is known here. Do NOT await the body: a malicious target could
+        // stream an endless/slow body to keep the action open and dodge an inactivity timeout. Destroy the
+        // socket to discard the (never-read) body immediately.
+        const status = res.statusCode ?? 0
+        finish(() => resolve({ status, ok: status >= 200 && status < 300 }))
+        res.destroy()
+      },
+    )
+    req.on('error', (e: Error) => finish(() => reject(e)))
+    req.on('timeout', () => {
+      req.destroy(new Error('webhook request timed out'))
+      finish(() => reject(new Error('webhook request timed out')))
+    })
+    if (typeof opts.body === 'string' && opts.body.length > 0) req.write(opts.body)
+    req.end()
+  })
+}

--- a/packages/core-backend/tests/unit/webhook-pinned-fetch.test.ts
+++ b/packages/core-backend/tests/unit/webhook-pinned-fetch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * pinnedHttpsFetch goldens — the resolve-then-pin egress for send_webhook (#2897 §3.1, owner review #1).
+ * THE load-bearing test: the connection target must be the PINNED address from the SSRF check, not a
+ * re-resolution of the hostname — otherwise resolve-then-pin is paper security (DNS rebinding wins).
+ */
+import { describe, test, expect } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { pinnedHttpsFetch, type HttpsRequestFn } from '../../src/multitable/webhook-pinned-fetch'
+
+// A controllable fake https.request. On `req.end()` it drives the helper-supplied `lookup` with an
+// ATTACKER-CONTROLLED hostname and records the address `lookup` returns — i.e. the actual connect
+// target. A correct pin returns the validated IP and ignores the hostname.
+function makeFakeRequest(status: number, mode: { error?: Error; timeout?: boolean; neverEnd?: boolean } = {}) {
+  let captured: { address: string; family: number } | null = null
+  let capturedHeaders: Record<string, string> = {}
+  let resDestroyed = false
+  const writes: string[] = []
+  const request = ((_url: unknown, options: any, cb: any) => {
+    capturedHeaders = options.headers ?? {}
+    const req: any = new EventEmitter()
+    req.write = (chunk: string) => { writes.push(String(chunk)) }
+    req.destroy = () => {}
+    req.end = () => {
+      options.lookup('rebind.attacker.example', {}, (_e: unknown, address: string, family: number) => {
+        captured = { address, family }
+      })
+      if (mode.error) { setImmediate(() => req.emit('error', mode.error)); return }
+      if (mode.timeout) { setImmediate(() => req.emit('timeout')); return }
+      const res: any = new EventEmitter()
+      res.statusCode = status
+      res.resume = () => {}
+      res.destroy = () => { resDestroyed = true }
+      // neverEnd: deliver headers (cb) but NEVER emit 'end' — proves the helper resolves on headers.
+      setImmediate(() => { cb(res); if (!mode.neverEnd) res.emit('end') })
+    }
+    return req
+  }) as unknown as HttpsRequestFn
+  return { request, captured: () => captured, headers: () => capturedHeaders, resDestroyed: () => resDestroyed, writes: () => writes }
+}
+
+describe('pinnedHttpsFetch — resolve-then-pin egress', () => {
+  test('connects to the PINNED address, not the (re-resolvable) hostname — resolve-then-pin proof', async () => {
+    const fake = makeFakeRequest(200)
+    const r = await pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1000, body: '{"a":1}' }, fake.request)
+    expect(r).toEqual({ status: 200, ok: true })
+    // The connect target (= what `lookup` returned) is the validated PINNED ip, NOT a re-resolution of
+    // 'rebind.attacker.example'. This is the property that makes resolve-then-pin real.
+    expect(fake.captured()).toEqual({ address: '93.184.216.34', family: 4 })
+    expect(fake.writes()).toEqual(['{"a":1}'])
+  })
+
+  test('pins an IPv6 address too', async () => {
+    const fake = makeFakeRequest(204)
+    const r = await pinnedHttpsFetch('https://hooks.example.com/x', '2606:4700::1111', 6, { timeoutMs: 1000 }, fake.request)
+    expect(r.ok).toBe(true)
+    expect(fake.captured()).toEqual({ address: '2606:4700::1111', family: 6 })
+  })
+
+  test('forces Host to the URL host (strips a caller-supplied Host) — no virtual-host confusion [P2]', async () => {
+    const fake = makeFakeRequest(200)
+    await pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1000, headers: { Host: 'attacker.evil', 'X-Custom': 'keep' } }, fake.request)
+    const h = fake.headers()
+    expect(h.host).toBe('hooks.example.com') // Host forced to the URL host
+    expect('Host' in h).toBe(false) // the caller's capital-Host was stripped
+    expect(h['X-Custom']).toBe('keep') // unrelated headers preserved
+  })
+
+  test('resolves on headers even if the body never ends; destroys the socket (slow-body DoS closed) [P2]', async () => {
+    const fake = makeFakeRequest(200, { neverEnd: true })
+    const r = await pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1000 }, fake.request)
+    expect(r).toEqual({ status: 200, ok: true }) // resolved without awaiting 'end'
+    expect(fake.resDestroyed()).toBe(true) // body discarded immediately
+  })
+
+  test('a non-2xx response is { ok: false } (surfaced, not thrown; body never read)', async () => {
+    const fake = makeFakeRequest(503)
+    const r = await pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1000 }, fake.request)
+    expect(r).toEqual({ status: 503, ok: false })
+  })
+
+  test('a transport error rejects', async () => {
+    const fake = makeFakeRequest(0, { error: new Error('ECONNREFUSED') })
+    await expect(pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1000 }, fake.request)).rejects.toThrow('ECONNREFUSED')
+  })
+
+  test('a timeout rejects', async () => {
+    const fake = makeFakeRequest(0, { timeout: true })
+    await expect(pinnedHttpsFetch('https://hooks.example.com/x', '93.184.216.34', 4, { timeoutMs: 1 }, fake.request)).rejects.toThrow('timed out')
+  })
+})


### PR DESCRIPTION
The second `send_webhook` security piece (#2897 §3.1, **your review priority #1**). #2950's SSRF guard validates the URL and returns the resolved addresses; this helper **connects to one of those pinned addresses** instead of re-resolving the hostname — closing the DNS-rebinding window. A plain `fetch(url)` re-resolves and defeats the guard.

## `pinnedHttpsFetch(url, pinnedAddress, family, opts, requestImpl?)`
- `https.request` with a `lookup` that returns the **pre-validated IP** (bypasses DNS); the URL hostname still drives **TLS SNI + `Host` header**, so identity stays the host while the socket targets the checked IP.
- **at-most-once: NO retry.**
- returns **status only** — the response body is drained and never read/persisted/logged (no response-body leak).
- injectable request impl → deterministically testable.

## The load-bearing test (your #1 requirement)
A fake `https.request` drives the helper's `lookup` with an **attacker-controlled rebinding hostname** (`rebind.attacker.example`) and asserts the connect target is the **pinned IP** regardless — proving resolve-then-pin is real, not paper. Plus: non-2xx → `ok:false`, transport error / timeout reject, IPv6 pin.

Standalone new module (**inert until the dispatch wires it**) → zero collision surface. **Next** is the dispatch — capability gate + SSRF check pre-txn + `dedup → egress(this helper, retry off) → audit + delivery`, value-scrubbed — where your full security review (all 4 priorities) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)