### PR TITLE
fix(multitable): global-history LOCK-3 field layer — mask hidden field id/value/count

### DIFF
--- a/docs/development/multitable-global-history-mvp-dev-verification-20260619.md
+++ b/docs/development/multitable-global-history-mvp-dev-verification-20260619.md
@@ -1,8 +1,16 @@
 # 全局历史与时点恢复 — read-only MVP 开发与验证 MD
 
 > 对应 /goal「根据开发计划及 todo MD 完成开发，完成后给出开发及验证 MD」。
-> **范围 = canonical 计划授权的只读 MVP（T0 ratify + T1 + T1b + T4 + T2/T3），已全部落 `main`。** restore/PIT/config（T5/T6/T8/T9）按计划保持 gated，未建（各自独立 owner opt-in）。
+> **范围 = canonical 计划授权的只读 MVP（T0 ratify + T1 + T1b + T4 + T2a/T3），已落 `main`。** T2a = 最小时间线（actor/source/action 筛选 + 可展开明细 + 入口/空/加载/错误态）；T2b（时间区间/sheet/字段筛选、可见数据搜索、cursor 分页）= 只读 follow-up（在 MVP 范围内、未 gated、尚未建）。restore/PIT/config（T5/T6/T8/T9）按计划保持 gated，未建（各自独立 owner opt-in）。
 > 设计基准：`multitable-global-history-pit-restore-design-lock-20260619.md` + `...-todo-20260619.md` + T0 已决项 `multitable-global-history-t0-resolved-decisions-20260619.md`。
+
+## 0. 复审修正（2026-06-20）
+
+owner 复审在已合并的只读 MVP 上发现两点，本次同一 PR 一并修正：
+
+- **[P1/安全] LOCK-3 字段层漏洞（已修）**：投影只做了行级 deny，未做字段级 `field_permissions` 掩码。可读某 record、但被禁读其中某字段的用户，仍能从 `changedFieldIds` 看到隐藏字段 id、从 `visibleAffectedFieldCount` 看到其计数、从明细 `after` 读到其值——违反 LOCK-3「隐藏字段不出现在 filter/detail/preview/count」。修法与按记录历史路由完全对齐：路由按 sheet 解析可读字段集（`loadAllowedFieldIds` → `maskStoredRecordFieldIds`，即可见字段 ∧ 字段权限 ∧ 公式 taint），传入投影；投影掩码 `changedFieldIds` / `after` 快照 / 字段计数（fail-closed：map 缺该 sheet → 全掩）。**说明**：字段权限**不**对 admin 放行（与按记录历史路由一致；仅行级 deny 对 admin 放行）——如需 admin 看全字段是另一项 owner 决定。
+- **[P2/范围] T2 过度声称（已修文档）**：原文「T2/T3 全部完成」名不副实——实际只发了 T2a 最小时间线（actor/source/action）。本次将 T2 切分为 T2a（已发）/ T2b（只读 follow-up），见 TODO 与上方 front-matter；不在本 PR 扩 FE（搜索/cursor 需新增后端，属独立切片）。
+- **[P3/测试] goldens 补字段层向量（已补）**：原 6 条 goldens 只覆盖行级 deny，漏了字段掩码，正是 P1 漏过的原因。新增 2 条同 actor、仅切换 `field_permissions` 拒绝行的 goldens（A=无拒绝对照=防空过守卫；B=拒绝→字段 id/值/计数均不漏、同变更的可见字段仍在）。**mutation check**：临时关闭掩码 → B 失败（`expected 2 to be 1`，字段计数泄漏）、A 仍过 → 证明 golden load-bearing。
 
 ## 1. 交付范围（authorized 只读 MVP — 已 MERGED）
 
@@ -12,28 +20,31 @@
 | **T1** | `meta_record_revisions.batch_id` 分组键（单动作=自身 id；bulk 共享一个 = LOCK-12 确定性边界，非并行写库 LOCK-1） | ✅ #2961 (`5cf527ac5`) |
 | **T1b** | `history-projection.ts` project-on-read 投影（按 `COALESCE(batch_id, id::text)` 分组，LOCK-11 排序）+ `GET /bases/:baseId/history/events[/:batchId]` | ✅ #2961 |
 | **T4** | sheet 级读门（`filterReadableSheetRowsForAccess`）+ record 级 deny（投影内）+ LOCK-3 real-DB security goldens | ✅ #2961 |
-| **T2/T3** | 只读 FE 历史中心（时间线 + actor/source/action 筛选 + 可展开批次明细）+ `useHistoryCenter` composable + 🕰 工具栏入口 | ✅ #2961 |
+| **T2a/T3** | 只读 FE 历史中心（时间线 + actor/source/action 筛选 + 可展开批次明细）+ `useHistoryCenter` composable + 🕰 工具栏入口 | ✅ #2961 |
+| **T2b** | 时间区间/sheet/字段筛选、可见数据搜索、cursor 分页（只读 follow-up，搜索/cursor 需新增后端） | ⬜ 未建（MVP 范围内、未 gated） |
 
 ## 2. 关键设计锁落地
 
 - **LOCK-1**（read model 非并行写库）：投影只读现有 `meta_record_revisions`；唯一写侧改动 = 在现有日志上加 `batch_id` 分组列（nullable、inert），不复制行、不另立事实源。
 - **LOCK-12**（一次用户动作 = 一个 batch）：单动作默认 `batch_id = 修订自身 id`；bulk `patchRecords` 全行共享一个 `batch_id`（→「bulk = 一个 batch」）。legacy 行（NULL）回退自身 id（各自一 batch，不误并），标 `provenanceQuality='legacy'`。
 - **LOCK-11**（排序确定性）：`created_at DESC, version DESC, id DESC`（现表 uuid PK 无 sequence，不假设）。
-- **LOCK-3**（权限先于 list/count/detail）：行级 rule/grant-deny 整条 record 从投影剔除；整批被拒 → 批次不可见且不计入 total；混合批次仅报 `visibleAffected*`（post-filter）；明细对「被拒」与「不存在」返回**同一 404**（无存在性 oracle）；admin bypass + flag-off inert，复用现有 `loadDeniedRecordIds` 机制。
+- **LOCK-3**（权限先于 list/count/detail）：**行层** = 行级 rule/grant-deny 整条 record 从投影剔除；整批被拒 → 批次不可见且不计入 total；混合批次仅报 `visibleAffected*`（post-filter）；明细对「被拒」与「不存在」返回**同一 404**（无存在性 oracle）；admin bypass + flag-off inert，复用现有 `loadDeniedRecordIds` 机制。**字段层（§0 P1 复审补全）** = 路由按 sheet 解析 `loadAllowedFieldIds` → `maskStoredRecordFieldIds`（可见 ∧ 字段权限 ∧ 公式 taint）传入投影，掩码 `changedFieldIds` / `after` / 字段计数（fail-closed）；与按记录历史路由同链，字段权限不对 admin 放行。
 
 ## 3. LOCK-3 real-DB security goldens（load-bearing — CI `test (20.x)` PASS）
 
-`multitable-history-events-realdb.test.ts`（plugin-tests 白名单，6/6 绿）：
+`multitable-history-events-realdb.test.ts`（plugin-tests 白名单，**8/8 绿**）：
 - bulk 动作 = 一个 batch，报 2 条可见记录；
 - flag-ON + deny：整批被拒的 batch 不出现且 total 不计；混合批次的被拒 record 被剔除（total + `visibleAffectedRecordCount` 均 post-filter）；
 - 明细：被拒 batch 与不存在 batch 同为 404（同 shape，无 oracle）；可见混合批次仍可打开，仅含未被拒 record；
 - admin bypass：管理员看到被拒 batch + 完整计数；
-- flag-off：即使已写 deny 规则，全部可见（byte-inert）。
+- flag-off：即使已写 deny 规则，全部可见（byte-inert）；
+- **字段层对照（§0 P1）= 无 `field_permissions` 拒绝时，混合字段变更报 2 个字段且 `after` 含其值（防空过守卫）；**
+- **字段层拒绝（§0 P1）= 同 actor 加 `field_permissions` 拒绝行后，`changedFieldIds`/`after`/`visibleAffectedFieldCount` 均不含被拒字段，同变更的可见字段仍在（surgical）。**
 
 ## 4. 验证汇总
 
 - backend `tsc --noEmit`：0 error；
-- backend unit：**3726/3726 pass**（无回归，含 record-history / record-write 改动）；
+- backend unit：**3735/3735 pass**（本次复审分支重跑，无回归；MVP 当时为 3726，差额来自其间其他 PR）；
 - web `vue-tsc -b`：0 error；
 - web FE：`multitable-history-fe.spec.ts` **5/5 pass**（composable load/toggle 永不抛、denied→null 无 oracle）；入 `multitable-web-guard` vitest 列表；
 - **real-DB goldens：CI PASS**（#2961 合并即 `test (20.x)` 绿）。
@@ -52,4 +63,5 @@
 
 ## 6. PR / SHA 账本
 
-- 设计锁 canonical（前序）：#2952（`108ed1bd9`）；T0 ratify 对象：**#2958（`db520a26f`）**；只读 MVP：**#2961（`5cf527ac5`）**。
+- 设计锁 canonical（前序）：#2952（`108ed1bd9`）；T0 ratify 对象：**#2958（`db520a26f`）**；只读 MVP：**#2961（`5cf527ac5`）**；本 MVP MD：#2965（`82e663347`）。
+- **复审修正（§0 P1 字段层 + P3 goldens + P2 T2 re-scope）：#2968（合并后回填 SHA）。**

--- a/docs/development/multitable-global-history-pit-restore-todo-20260619.md
+++ b/docs/development/multitable-global-history-pit-restore-todo-20260619.md
@@ -71,18 +71,24 @@ Tests:
 
 ### T2 - Global History Center Read-Only UI
 
-Status: TODO, blocked on T1 + T4 route contract.
+Status: split. **T2a SHIPPED (#2961); T2b FOLLOW-UP (read-only, in MVP envelope, not gated, not yet built).**
+The original single T2 scope over-stated what shipped; this split records the actual line.
 
 Goal: add a global history center entry and timeline UI.
 
-Scope:
+Scope — T2a (SHIPPED, #2961):
 
-- toolbar / more-menu entry;
+- toolbar / more-menu entry (🕰);
 - timeline list of batches;
-- filters for time, actor, action, source, sheet, field;
-- search by visible record title / data;
-- cursor pagination;
+- filters for actor, action, source;
+- expandable per-batch detail (the T3 drilldown);
 - empty, loading, error states.
+
+Scope — T2b (FOLLOW-UP, read-only, NOT yet built — each a small slice, not gated):
+
+- time-range (from/to) + sheet + field filters in the FE — backend already accepts `from`/`to`/`sheetId` (the FE just doesn't wire them); a **field** filter needs a new backend param;
+- search by visible record title / data — needs a new backend data-search param (a separate slice);
+- cursor pagination — the current backend is `offset`/`limit`; a cursor needs a new backend param.
 
 Out of scope:
 
@@ -126,7 +132,10 @@ Tests:
 
 ### T4 - Permission-Safe Query Hardening
 
-Status: TODO, should land before or together with T2/T3.
+Status: row layer SHIPPED in #2961; **field layer was MISSING there (the "hidden fields absent" locks + their
+goldens below were specified but not implemented — #2961 shipped only the row-level goldens yet claimed LOCK-3
+done). Field layer + the two field-mask goldens landed in the 2026-06-20 review-fix PR (see the MVP verification
+MD §0).** Both layers now done; mutation-checked.
 
 Goal: history queries cannot become a side channel.
 

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -30,6 +30,16 @@ export interface HistoryEventsParams {
    * boundary and applies record-level LOCK-3 deny on top of it.
    */
   sheetIds: string[]
+  /**
+   * LOCK-3 FIELD layer. Per-sheet readable field-id sets = (visible property fields ∧ field_permissions
+   * scope ∧ formula-taint drop), resolved by the caller (route) via the SAME chain the per-record history
+   * route uses (`loadAllowedFieldIds` → `maskStoredRecordFieldIds`). A changed field id / snapshot value /
+   * field count for a field NOT in this set is dropped, so a row-readable-but-field-denied actor never sees
+   * the hidden field's id, value, or count. A sheet missing from the map → empty set → every field masked
+   * (FAIL CLOSED). Field-permissions are NOT admin-bypassed (parity with the per-record route); only
+   * row-level deny is (see `loadDeniedBySheet`).
+   */
+  allowedFieldsBySheet: Map<string, Set<string>>
   actorId?: string
   source?: string
   action?: string
@@ -95,6 +105,24 @@ function isDenied(deniedBySheet: Map<string, Set<string>>, sheetId: string, reco
   return deniedBySheet.get(sheetId)?.has(recordId) === true
 }
 
+const EMPTY_FIELD_SET: ReadonlySet<string> = new Set()
+
+/** LOCK-3 field layer: per-sheet allowed field-id set; a sheet missing from the map masks every field (fail-closed). */
+function allowedFieldsFor(map: Map<string, Set<string>>, sheetId: string): ReadonlySet<string> {
+  return map.get(sheetId) ?? EMPTY_FIELD_SET
+}
+
+/**
+ * Keep only the allowed field-id keys of a stored snapshot/patch object (mirrors univer-meta's
+ * `filterRecordDataByFieldIds`; kept local to avoid a routes→projection import cycle). A null/non-object
+ * snapshot stays null (matching the prior `after` semantics); an all-masked object becomes `{}` so no
+ * denied value leaks.
+ */
+function filterDataByAllowedFields(data: unknown, allowed: ReadonlySet<string>): Record<string, unknown> | null {
+  if (data === null || data === undefined || typeof data !== 'object' || Array.isArray(data)) return null
+  return Object.fromEntries(Object.entries(data as Record<string, unknown>).filter(([fieldId]) => allowed.has(fieldId)))
+}
+
 /**
  * List permission-filtered batch summaries for a base, newest first. Totals + pagination are computed
  * AFTER permission filtering (LOCK-3): a fully-denied batch never appears and never counts.
@@ -144,7 +172,8 @@ export async function loadHistoryBatchSummaries(
     for (const row of g) {
       if (isDenied(deniedBySheet, row.sheet_id, row.record_id)) continue // LOCK-3: drop denied record's rows
       visibleRecords.add(row.record_id)
-      for (const f of row.changed_field_ids) visibleFields.add(f)
+      const allowed = allowedFieldsFor(params.allowedFieldsBySheet, row.sheet_id) // LOCK-3 field layer
+      for (const f of row.changed_field_ids) if (allowed.has(f)) visibleFields.add(f) // count only readable fields
     }
     if (visibleRecords.size === 0) continue // LOCK-3: fully-denied batch is invisible AND not counted
     const head = g[0]
@@ -197,6 +226,7 @@ export async function loadHistoryBatchDetail(
   sheetIds: string[],
   batchId: string,
   access: HistoryAccess,
+  allowedFieldsBySheet: Map<string, Set<string>>,
 ): Promise<HistoryBatchDetail | null> {
   if (sheetIds.length === 0) return null
   const res = await query(
@@ -217,10 +247,13 @@ export async function loadHistoryBatchDetail(
   for (const r of rows) {
     const sheetId = String(r.sheet_id)
     const recordId = String(r.record_id)
-    if (isDenied(deniedBySheet, sheetId, recordId)) continue // LOCK-3
+    if (isDenied(deniedBySheet, sheetId, recordId)) continue // LOCK-3: row layer
     if (!head) head = r
     visibleRecords.add(recordId)
-    const fields = Array.isArray(r.changed_field_ids) ? r.changed_field_ids.map(String) : []
+    // LOCK-3 field layer: drop field ids / snapshot values / counts for fields this actor cannot read, so a
+    // row-readable-but-field-denied actor never learns the hidden field's id, value, or that it changed.
+    const allowed = allowedFieldsFor(allowedFieldsBySheet, sheetId)
+    const fields = (Array.isArray(r.changed_field_ids) ? r.changed_field_ids.map(String) : []).filter((f) => allowed.has(f))
     for (const f of fields) visibleFields.add(f)
     changes.push({
       sheetId,
@@ -229,7 +262,7 @@ export async function loadHistoryBatchDetail(
       version: Number(r.version ?? 0),
       changedFieldIds: fields,
       before: null, // T1b: before/after diff hydration is a detail refinement; after = snapshot
-      after: r.snapshot && typeof r.snapshot === 'object' ? (r.snapshot as Record<string, unknown>) : null,
+      after: filterDataByAllowedFields(r.snapshot, allowed),
     })
   }
   if (!head || visibleRecords.size === 0) return null // fully denied → same as missing (LOCK-3, no oracle)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3744,6 +3744,30 @@ async function loadAllowedFieldIds(query: QueryFn, sheetId: string | null | unde
   return computeAllowedFieldIds(fields, capabilities, fieldScopeMap)
 }
 
+/**
+ * Global History LOCK-3 FIELD layer: build the per-sheet readable field-id sets the project-on-read
+ * history projection masks with. Uses the EXACT chain the per-record history route uses —
+ * `loadAllowedFieldIds` (visible property fields ∧ field_permissions scope) then `maskStoredRecordFieldIds`
+ * (formula-taint drop, so a materialized formula value over a denied foreign lookup can't echo through a
+ * snapshot). One resolver pass per sheet; field-permissions are NOT admin-bypassed here, matching the
+ * per-record route (only row-level deny is admin-bypassed). Callers pass the minimal sheet set actually in
+ * scope (the detail route passes just the batch's sheet(s), not the whole base) to bound the cost.
+ */
+async function buildHistoryAllowedFieldsBySheet(
+  req: Request,
+  query: QueryFn,
+  sheetIds: string[],
+  userId: string,
+): Promise<Map<string, Set<string>>> {
+  const map = new Map<string, Set<string>>()
+  for (const sheetId of sheetIds) {
+    const { capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+    const baseAllowed = await loadAllowedFieldIds(query, sheetId, userId, capabilities)
+    map.set(sheetId, await maskStoredRecordFieldIds(req, query, sheetId, undefined, baseAllowed))
+  }
+  return map
+}
+
 // #2052 (b): PURE — returns a redacted COPY (view configs are cached/shared; never mutate in place, or a
 // per-user redaction corrupts a later cross-user read). For each filterInfo condition on a field NOT in
 // allowedFieldIds, OMIT the `value` key (keep fieldId+operator so the client can still render the chip);
@@ -6385,10 +6409,13 @@ export function univerMetaRouter(): Router {
       const limit = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
       const offset = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
       const str = (v: unknown): string | undefined => (typeof v === 'string' && v.trim() ? v.trim() : undefined)
+      // LOCK-3 field layer: a base-level list can show any readable sheet, so resolve allowed fields for all.
+      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), readableSheetIds, access.userId)
       const { batches, total } = await loadHistoryBatchSummaries(
         pool.query.bind(pool),
         {
           sheetIds: readableSheetIds,
+          allowedFieldsBySheet,
           actorId: str(req.query.actorId),
           source: str(req.query.source),
           action: str(req.query.action),
@@ -6420,7 +6447,17 @@ export function univerMetaRouter(): Router {
       if (!baseId || !batchId) return res.status(400).json({ ok: false, error: { code: 'BAD_REQUEST', message: 'baseId and batchId required' } })
       const sheetRows = (await pool.query('SELECT id FROM meta_sheets WHERE base_id = $1 AND deleted_at IS NULL', [baseId])).rows as Array<{ id: unknown }>
       const readable = await filterReadableSheetRowsForAccess(pool.query.bind(pool), sheetRows.map((r) => ({ id: String(r.id) })), access)
-      const detail = await loadHistoryBatchDetail(pool.query.bind(pool), readable.map((r) => r.id), batchId, { userId: access.userId, isAdminRole: access.isAdminRole })
+      const readableSheetIds = readable.map((r) => r.id)
+      // LOCK-3 field layer: resolve allowed fields ONLY for the sheet(s) this batch actually touches (a batch
+      // is normally one sheet) — same grouping key as the projection (LOCK-12 COALESCE(batch_id, id)).
+      const batchSheetIds = readableSheetIds.length === 0
+        ? []
+        : ((await pool.query(
+            `SELECT DISTINCT sheet_id FROM meta_record_revisions WHERE sheet_id = ANY($1::text[]) AND COALESCE(batch_id, id::text) = $2`,
+            [readableSheetIds, batchId],
+          )).rows as Array<{ sheet_id: unknown }>).map((r) => String(r.sheet_id))
+      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), batchSheetIds, access.userId)
+      const detail = await loadHistoryBatchDetail(pool.query.bind(pool), readableSheetIds, batchId, { userId: access.userId, isAdminRole: access.isAdminRole }, allowedFieldsBySheet)
       // Denied and missing share the SAME 404 shape (LOCK-3: no existence oracle).
       if (!detail) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'History batch not found' } })
       const names = await resolveUserDisplayNames(pool.query.bind(pool), detail.actorId ? [detail.actorId] : [])

--- a/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
@@ -6,15 +6,18 @@
  *   - a row-level rule-denied record never leaks through the batch list, the total, or the visible
  *     affected counts (a batch whose every record is denied is invisible AND uncounted; a mixed batch
  *     reports only the visible record/field counts);
+ *   - a field_permissions-denied FIELD on a row-readable record never leaks its id (changedFieldIds),
+ *     value (detail.after), or count (visibleAffectedFieldCount) — masked surgically, the visible field
+ *     of the same change still passes (the LOCK-3 field layer, parity with the per-record history route);
  *   - batch detail for a denied batch shares the SAME 404 shape as a missing batch (no existence oracle);
- *   - admin bypasses; flag-off is byte-inert;
+ *   - admin bypasses (row layer); flag-off is byte-inert;
  *   - a bulk action (shared batch_id) is ONE batch (the T1 acceptance), end-to-end through the projection.
  *
  * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
@@ -24,10 +27,12 @@ const TS = Date.now()
 const BASE_ID = `base_gh_${TS}`
 const SHEET_ID = `sheet_gh_${TS}`
 const STATUS = `fld_gh_status_${TS}`
+const SALARY = `fld_gh_salary_${TS}` // a second field, field_permission-deniable (LOCK-3 field layer)
 const REC_SECRET = `rec_gh_secret_${TS}`
 const REC_PUBLIC = `rec_gh_public_${TS}`
 const BULK_BATCH = `batch_gh_bulk_${TS}` // one bulk action touching BOTH records (shared id)
 const SECRET_BATCH = `batch_gh_secret_${TS}` // a single-record action on the secret record only
+const FIELD_BATCH = `batch_gh_field_${TS}` // a single-record action on REC_PUBLIC touching STATUS + SALARY
 const USER_ID = `user_gh_${TS}`
 
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
@@ -49,6 +54,26 @@ const batchOf = (res: { body?: { data?: { batches?: Array<{ batchId: string }> }
   (res.body?.data?.batches ?? []).find((b) => b.batchId === id) as
     | { batchId: string; visibleAffectedRecordCount: number; visibleAffectedFieldCount: number }
     | undefined
+
+type ChangeShape = { recordId: string; changedFieldIds: string[]; after: Record<string, unknown> | null }
+const changeOf = (res: { body?: { data?: { changes?: ChangeShape[] } } }, recordId: string) =>
+  (res.body?.data?.changes ?? []).find((c) => c.recordId === recordId)
+
+// A single-record action on the VISIBLE record touching BOTH fields (STATUS + SALARY). Added INSIDE the
+// field-layer tests (after the beforeEach seed) so the existing total===2 assertions are not perturbed.
+const mixedFieldRev = () =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+     VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', $3, ARRAY[$4,$5]::text[], '{}'::jsonb, $6::jsonb, $7)`,
+    [SHEET_ID, REC_PUBLIC, USER_ID, STATUS, SALARY, JSON.stringify({ [STATUS]: 'public', [SALARY]: 99999 }), FIELD_BATCH],
+  )
+// field_permissions row hiding a field from the test user (subject_type='user'); afterEach clears it.
+const denyFieldForUser = (fieldId: string) =>
+  q(
+    `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+     VALUES ($1,$2,'user',$3,false,false)`,
+    [SHEET_ID, fieldId, USER_ID],
+  )
 
 const seed = async () => {
   await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID])
@@ -81,14 +106,22 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'GH Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'GH Sheet'])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET_ID, 'Salary', 'number', '{}', 2])
   })
 
   afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  // The field layer toggles a field_permissions row; clear it after every test so the row-layer goldens
+  // (which assume no field denial) stay isolated regardless of order.
+  afterEach(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
   })
 
   beforeEach(async () => {
@@ -160,5 +193,36 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     expect(batchIds(res)).toContain(SECRET_BATCH)
     expect(res.body?.data?.total).toBe(2)
     expect(batchOf(res, BULK_BATCH)?.visibleAffectedRecordCount).toBe(2)
+  })
+
+  // LOCK-3 FIELD layer. These two tests differ ONLY by the field_permissions denial row, on the SAME actor.
+  // Test A is the false-green guard: it proves SALARY genuinely changed and is visible without a denial, so
+  // Test B's absence assertions cannot pass vacuously.
+  test('field layer (no denial = control): a mixed-field change reports BOTH fields and the value', async () => {
+    await mixedFieldRev()
+    const res = await events()
+    expect(res.status).toBe(200)
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(2) // STATUS + SALARY both visible
+    const d = await detail(FIELD_BATCH)
+    expect(d.status).toBe(200)
+    const change = changeOf(d, REC_PUBLIC)
+    expect(change?.changedFieldIds).toContain(SALARY) // field genuinely changed (guards against a vacuous pass)
+    expect(change?.after?.[SALARY]).toBe(99999) // value present when the field is allowed
+    expect(d.body?.data?.visibleAffectedFieldCount).toBe(2)
+  })
+
+  test('field layer (denial): a field_permissions-denied field is absent from changedFieldIds, after, and the field count', async () => {
+    await mixedFieldRev()
+    await denyFieldForUser(SALARY)
+    const res = await events()
+    expect(res.status).toBe(200)
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1) // only STATUS counted — SALARY masked
+    const d = await detail(FIELD_BATCH)
+    expect(d.status).toBe(200)
+    const change = changeOf(d, REC_PUBLIC)
+    expect(change?.changedFieldIds).toEqual([STATUS]) // hidden field id absent
+    expect(change?.after?.[SALARY]).toBeUndefined() // hidden value absent from the snapshot
+    expect(change?.after?.[STATUS]).toBe('public') // visible field of the SAME change still passes (surgical)
+    expect(d.body?.data?.visibleAffectedFieldCount).toBe(1) // detail count masked too
   })
 })


### PR DESCRIPTION
## Why

Owner review of the merged global-history read-only MVP (#2961/#2965) found a **LOCK-3 field-layer leak** plus a scoping overclaim. This PR fixes both in one focused change.

### P1 (security) — hidden-field leak in the history projection
`GET /bases/:baseId/history/events[/:batchId]` applied only the **row-level** deny; it never applied `field_permissions` / field-mask. A user who can read a record but **not** one of its fields could still:
- infer the hidden field id from `changedFieldIds`,
- read its value from the detail `after` snapshot,
- see it counted in `visibleAffectedFieldCount`.

That violates LOCK-3 ("hidden fields absent from filters/detail/preview/counts") and diverges from the per-record history route, which already redacts via `redactRecordRevisionEntry` / `maskStoredRecordFieldIds`.

### Fix — parity with the per-record history route
- The route builds a per-sheet allowed-field map via `loadAllowedFieldIds` → `maskStoredRecordFieldIds` (visible property fields ∧ `field_permissions` scope ∧ formula-taint drop). The **detail** route scopes the map to just the batch's sheet(s) using the same LOCK-12 grouping key (`COALESCE(batch_id, id::text)`), so it doesn't resolve field-perms for the whole base on a single open.
- The projection masks `changedFieldIds`, the `after` snapshot, and the field count by that set. **Fail-closed**: a sheet missing from the map masks every field.
- ⚠️ **Decision to confirm:** field-permissions are **NOT admin-bypassed** here, matching the per-record history route (only the *row-level* deny is admin-bypassed). So an admin auditing history won't see field-denied columns. If you want admin field-bypass for history, that's a separate change — flag it and I'll do it.

### P3 (tests) — field-mask goldens
The original 6 real-DB goldens covered only row-level deny — exactly why P1 slipped through. Added **2 goldens** (same actor, differing only by the `field_permissions` denial row):
- **control (no denial):** mixed-field change reports both fields and the value — proves the field genuinely changed, so the denial test can't pass vacuously;
- **denial:** `changedFieldIds` / `after` / `visibleAffectedFieldCount` all exclude the denied field, while the visible field of the *same* change still passes (surgical).

**Mutation-checked:** temporarily disabling the mask fails the denial golden (`expected 2 to be 1`) while the control still passes → the golden is load-bearing. 6/6 → **8/8**.

### P2 (docs) — correct the T2 overclaim
The MVP verification MD claimed "all authorized development complete," but shipped T2 = actor/source/action only. Re-scoped docs-only (no FE drift): shipped UI = **T2a minimal timeline**; **T2b** (time-range/sheet/field filters, visible-data search, cursor pagination) = read-only follow-up, **not gated**, not yet built (search + cursor need new backend). TODO **T4** now records the field layer was specified-but-missing in #2961.

## Verification
- backend `tsc --noEmit`: 0 errors
- backend unit: **3735/3735**
- real-DB LOCK-3 goldens: **8/8** (mutation-checked)
- `git diff --check` clean; no hidden/bidirectional Unicode; **no FE change**

## Scope
Backend projection + route + 1 integration test + 2 docs. Gated tails (T5/T6 restore, T8 PIT, T9 config) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)