### PR TITLE
feat(multitable): filter-by-link first cut — link conditions over permission-filtered display (2a)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -233,6 +233,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-aggregate.test.ts \
             tests/integration/multitable-rollup-countall-nongating.test.ts \
             tests/integration/multitable-rollup-filter-condition.test.ts \
+            tests/integration/multitable-filter-by-link-view.test.ts \
             tests/integration/multitable-rollup-string-bool-reducers.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts \
             tests/integration/multitable-dashboard-filterinfo-oracle.test.ts \

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -258,7 +258,13 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+  // 2a filter-by-link (first cut): `is`/`contains` compare against the linked records' permission-filtered
+  // DISPLAY strings (backend evaluateLinkFilterCondition); `isEmpty`/`isNotEmpty` test raw link presence.
+  // Free-text value (no linked-record picker yet — deferred per design-lock D4). The row renders the
+  // default free-text input for is/contains since link is not select-like (MetaFilterConditionRow).
   link: [
+    { value: 'is', label: 'is' },
+    { value: 'contains', label: 'contains' },
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -158,6 +158,35 @@ describe('MetaToolbar filter builder', () => {
     expect(panel.textContent).toContain('checkbox')
   })
 
+  it('exposes is/contains for link fields (filter-by-link first cut) with a free-text value control', async () => {
+    const { state, container: root } = mountToolbar({
+      fields: [{ id: 'project', name: 'Project', type: 'link', property: { foreignSheetId: 'fs1' } } as MetaField],
+      filterRules: [{ fieldId: 'project', operator: 'isEmpty', value: undefined }],
+    })
+
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement | null
+    expect(operatorSelect).toBeTruthy()
+    // first cut (design-lock D4): is / contains / isEmpty / isNotEmpty offered for a link field
+    expect(Array.from(operatorSelect!.options).map((o) => o.value)).toEqual(['is', 'contains', 'isEmpty', 'isNotEmpty'])
+    // isEmpty is a presence op → no value control rendered (raw presence)
+    expect(panel.querySelector('[aria-label="Filter value"]')).toBeNull()
+
+    // switch to contains → free-text input appears (no linked-record picker yet — D4 free-text first)
+    await setSelectValue(operatorSelect!, 'contains')
+    const valueInput = panel.querySelector('input[aria-label="Filter value"]') as HTMLInputElement | null
+    expect(valueInput).toBeTruthy()
+    expect(valueInput!.getAttribute('type')).toBe('text')
+    expect(state.filterRules[0]).toEqual({ fieldId: 'project', operator: 'contains', value: '' })
+
+    // typing the linked record's display flows through unchanged (compared backend-side against the
+    // permission-filtered display set)
+    valueInput!.value = 'Acme'
+    valueInput!.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(state.filterRules[0]).toEqual({ fieldId: 'project', operator: 'contains', value: 'Acme' })
+  })
+
   it('treats future multiSelect fields as option-backed filters', async () => {
     const { state, container: root } = mountToolbar({
       fields: [

--- a/docs/development/multitable-field-read-gate-tracker-20260602.md
+++ b/docs/development/multitable-field-read-gate-tracker-20260602.md
@@ -48,6 +48,7 @@ The **locking test** is the real-DB integration test wired into `.github/workflo
 | ✅🔒 | **linkSummaries** (`buildLinkSummaries`) foreign default-display value across `GET /view` · single-record read · link-options `data.selected` · write-echo (review follow-up to F5) | Med | #2198 | `multitable-link-summary-display-field-mask` |
 | ✅🔒 | **D1** `form-context` (recordId load) + `POST /views/:id/submit` echo layer-3 mask — **identified-path leak (NOT no-op)**; anonymous moot (no subject) | Med | #2210 | `multitable-form-context-submit-field-mask` |
 | ✅ | **kanban / gallery / calendar** view-data egress scan — **scan-clean, no live egress** (standalone view plugins are dead-sample/unreachable; product reuses the gated `/view`) | Diligence | #2206 | *scan-clean — no test (no live egress); see scan doc + §3 latent-risk note* |
+| ✅🔒 | **filter-by-link** reuses `buildLinkSummaries` to materialize the permission-filtered display set for a `link` filter condition (`GET /view` + `loadDashboardSourceRows`) — **filter-internal, NO new wire-egress** (the displays gate the predicate via `evaluateLinkFilterCondition`, then are discarded; never serialized). Egress GOLDEN `buildLinkSummaries` 4→6. | Med | #2970 | `multitable-filter-by-link-view` (denied-link non-leak · `isEmpty` perm-invariant · admin/flag-OFF canaries) |
 
 ### 2c. §2a.3 — foreign-field-level over-read (materialized formula taint)
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3307,6 +3307,31 @@ export function evaluateMetaFilterCondition(
   return true
 }
 
+// 2a filter-by-link (first cut) — evaluate a link-field leaf condition. Kept PURE (no DB/IO) so it is
+// parity-testable: the route materializes the inputs, this decides the match. Two evaluation bases, BY
+// DESIGN (multitable-2a-filter-by-link-lookup-designlock §2):
+//   • PRESENCE (isEmpty / isNotEmpty) → the RAW link id count (from meta_links). Permission-INVARIANT and
+//     touches no display string, so a row whose links are ALL hidden from the requester still reads as
+//     non-empty (it has links). This is the D5 leak avoided: never empty-for-restricted / non-empty-for-full.
+//   • VALUE (contains / is) → the PERMISSION-FILTERED visible display set (denied foreign records already
+//     excluded upstream by buildLinkSummaries). A hidden link can neither produce a value match nor leak its
+//     display string. Multi-valued (D6): contains = any visible display contains the substring; is =
+//     MEMBERSHIP (any visible display equals the value exactly), not whole-set equality.
+// Any other operator is inert (match-all), mirroring evaluateMetaFilterCondition's catch-all.
+export function evaluateLinkFilterCondition(
+  rawLinkIds: string[],
+  visibleDisplays: string[],
+  condition: MetaFilterCondition,
+): boolean {
+  const opNorm = condition.operator.trim().toLowerCase()
+  if (opNorm === 'isempty') return rawLinkIds.length === 0
+  if (opNorm === 'isnotempty') return rawLinkIds.length > 0
+  const right = toComparableString(normalizeFilterScalar(condition.value)).trim().toLowerCase()
+  if (opNorm === 'contains') return right === '' ? true : visibleDisplays.some((d) => d.trim().toLowerCase().includes(right))
+  if (opNorm === 'is' || opNorm === 'equal') return visibleDisplays.some((d) => d.trim().toLowerCase() === right)
+  return true
+}
+
 function toEpoch(value: unknown): number | null {
   if (value instanceof Date) return value.getTime()
   if (typeof value === 'number' && Number.isFinite(value)) return value
@@ -3951,10 +3976,30 @@ async function loadDashboardSourceRows(args: {
     await applyLookupRollup(req, query, sheetId, fields, rows, relationalLinkFields, linkValuesByRecord)
   }
 
+  // 2a filter-by-link: materialize permission-filtered display strings for the link fields the filter
+  // references (the linkValuesByRecord load above is gated on needsComputedFields, which a link-only
+  // filter does not trip). Same discipline as /view — presence + display come from meta_links via the
+  // relational load, never record.data.
+  const linkFilterFieldIds = new Set(
+    collectLeafConditions(filterInfo).filter((c) => fieldTypeById.get(c.fieldId) === 'link').map((c) => c.fieldId),
+  )
+  const linkFilterFields = relationalLinkFields.filter((rl) => linkFilterFieldIds.has(rl.fieldId))
+  let filterLinkValues: Map<string, Map<string, string[]>> | null = null
+  let filterLinkSummaries: Map<string, Map<string, LinkedRecordSummary[]>> | null = null
+  if (linkFilterFields.length > 0 && rows.length > 0) {
+    filterLinkValues = await loadLinkValuesByRecord(query, rows.map((r) => r.id), linkFilterFields)
+    filterLinkSummaries = await buildLinkSummaries(req, query, sheetId, rows, linkFilterFields, filterLinkValues)
+  }
+
   if (filterInfo) {
     rows = rows.filter((record) => evaluateFilterNode(filterInfo, (condition) => {
       const fieldType = fieldTypeById.get(condition.fieldId)
       if (!fieldType) return true
+      if (fieldType === 'link') {
+        const ids = filterLinkValues?.get(record.id)?.get(condition.fieldId) ?? []
+        const displays = (filterLinkSummaries?.get(record.id)?.get(condition.fieldId) ?? []).map((s) => s.display)
+        return evaluateLinkFilterCondition(ids, displays, condition)
+      }
       return evaluateMetaFilterCondition(fieldType, record.data[condition.fieldId], condition)
     }))
   }
@@ -8879,12 +8924,17 @@ export function univerMetaRouter(): Router {
       const selectableFields = visibleFields.filter((field) => selectableFieldIds.has(field.id))
 
       // Computed (lookup/rollup/formula) filter conditions can't be evaluated here (no applyLookupRollup),
-      // so the filtered set would silently disagree with /view. HARD-FAIL instead (deferred to #4-3b-2).
-      // Only SELECTABLE (non-denied) conditions trip this — a denied condition is dropped (= non-existent),
-      // matching /view, so it never forces a 422 (which would break the parity invariant).
+      // and a `link` condition can't either (no buildLinkSummaries on this path) — either would make the
+      // filtered set silently DISAGREE with /view (which DOES support both). HARD-FAIL instead so the
+      // aggregate never diverges (computed deferred to #4-3b-2; link-aggregate is a filter-by-link
+      // follow-up). Only SELECTABLE (non-denied) conditions trip this — a denied condition is dropped
+      // (= non-existent), matching /view, so it never forces a 422 (which would break the parity invariant).
+      // NB: COMPUTED_FILTER_TYPES is reused by the group-by-axis 422 below (grouping by a computed field);
+      // link is added to the FILTER guard only, not to group-by.
       const COMPUTED_FILTER_TYPES = new Set(['lookup', 'rollup', 'formula'])
-      if (collectLeafConditions(filterInfo).some((c) => selectableFieldIds.has(c.fieldId) && COMPUTED_FILTER_TYPES.has(filterFieldTypeById.get(c.fieldId) ?? ''))) {
-        return res.status(422).json({ ok: false, error: { code: 'AGGREGATE_COMPUTED_FILTER_UNSUPPORTED', message: 'Aggregation over a view filtering on a computed (lookup/rollup/formula) field is not yet supported' } })
+      const isAggregateUnsupportedFilterType = (t: string) => COMPUTED_FILTER_TYPES.has(t) || t === 'link'
+      if (collectLeafConditions(filterInfo).some((c) => selectableFieldIds.has(c.fieldId) && isAggregateUnsupportedFilterType(filterFieldTypeById.get(c.fieldId) ?? ''))) {
+        return res.status(422).json({ ok: false, error: { code: 'AGGREGATE_COMPUTED_FILTER_UNSUPPORTED', message: 'Aggregation over a view filtering on a computed (lookup/rollup/formula) or link field is not yet supported' } })
       }
 
       // D3c permission composite → which fields' aggregates may be OUTPUT (layer-1∧layer-3; reuses fieldScopeMap above)
@@ -9338,6 +9388,23 @@ export function univerMetaRouter(): Router {
           )
         }
 
+        // 2a filter-by-link (first cut): materialize the linked records' permission-filtered DISPLAY strings
+        // for the link fields the filter references, BEFORE the predicate runs. Link ids live in meta_links
+        // (record.data[linkField] is discarded + rebuilt by the read path at :9406-9416), so presence AND
+        // display come from the relational load — never record.data. Scoped to the referenced link fields;
+        // permission discipline (denied foreign ids, field-mask display, cross-base gate) is reused verbatim
+        // from buildLinkSummaries (materialize-then-filter, never read-raw-then-mask).
+        const linkFilterFieldIds = new Set(
+          collectLeafConditions(filterInfo).filter((c) => fieldTypeById.get(c.fieldId) === 'link').map((c) => c.fieldId),
+        )
+        const linkFilterFields = relationalLinkFields.filter((rl) => linkFilterFieldIds.has(rl.fieldId))
+        let filterLinkValues: Map<string, Map<string, string[]>> | null = null
+        let filterLinkSummaries: Map<string, Map<string, LinkedRecordSummary[]>> | null = null
+        if (linkFilterFields.length > 0) {
+          filterLinkValues = await loadLinkValuesByRecord(pool.query.bind(pool), all.map((r) => r.id), linkFilterFields)
+          filterLinkSummaries = await buildLinkSummaries(req, pool.query.bind(pool), sheetId, all, linkFilterFields, filterLinkValues)
+        }
+
         if (hasSearch) {
           all = all.filter((record) => recordMatchesSearch(record, searchableFields, search))
         }
@@ -9348,6 +9415,11 @@ export function univerMetaRouter(): Router {
             all = all.filter((record) => evaluateFilterNode(pruned, (condition) => {
               const fieldType = fieldTypeById.get(condition.fieldId)
               if (!fieldType) return true
+              if (fieldType === 'link') {
+                const ids = filterLinkValues?.get(record.id)?.get(condition.fieldId) ?? []
+                const displays = (filterLinkSummaries?.get(record.id)?.get(condition.fieldId) ?? []).map((s) => s.display)
+                return evaluateLinkFilterCondition(ids, displays, condition)
+              }
               return evaluateMetaFilterCondition(fieldType, record.data[condition.fieldId], condition)
             }))
           }

--- a/packages/core-backend/tests/integration/multitable-filter-by-link-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-filter-by-link-view.test.ts
@@ -1,0 +1,213 @@
+/**
+ * 2a filter-by-link (first cut) — real-DB /view wire + permission goldens.
+ *
+ * Proves a `link`-field filter condition compares against the linked records' PERMISSION-FILTERED display
+ * strings through the real GET /view handler (wire-vs-fixture-drift guard), and that the design-lock's
+ * permission invariants hold end-to-end (multitable-2a-filter-by-link-lookup-designlock §2 / D1·D2·D5·D6):
+ *
+ *   D1/D6 value ops: `is` = membership over visible displays (exact, not substring); `contains` = substring.
+ *   D2 denied-link: a link to a foreign record the actor can't read is EXCLUDED from the comparison set —
+ *     `is "Secret"` / `contains "secret"` match NOTHING for the denied actor (no match, no display leak),
+ *     while an admin (and the same actor with the foreign flag OFF) DO match → proves the deny is the cause.
+ *   D5 presence ops: `isEmpty`/`isNotEmpty` test RAW link presence (meta_links), permission-INVARIANT —
+ *     a row whose links are ALL hidden is NOT empty (it has links); identical result for restricted vs admin.
+ *   Composition: a link leaf works inside a nested OR/AND group.
+ *
+ * Link ids live in meta_links (NOT record.data), so this also locks that the filter sources presence +
+ * display from the relational load. Runs only with DATABASE_URL via the plugin-tests.yml step.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER = `u_fbl_${TS}`
+const BASE_ID = `base_fbl_${TS}`
+const FS = `sheet_fbl_for_${TS}` // foreign sheet (linked)
+const MS = `sheet_fbl_main_${TS}` // main sheet (filtered)
+
+const FLD_FNAME = `fld_fbl_fname_${TS}` // foreign display field (string → buildLinkSummaries auto-picks it)
+const FLD_LINK = `fld_fbl_link_${TS}`
+const FLD_GROUP = `fld_fbl_group_${TS}` // groupable column on MS (dashboard group-by axis)
+
+const FR_ACME = `rec_fbl_acme_${TS}` // Name: Acme   (visible)
+const FR_GLOBEX = `rec_fbl_globex_${TS}` // Name: Globex (visible)
+const FR_SECRET = `rec_fbl_secret_${TS}` // Name: Secret (row-denied to USER on FS)
+
+const M_A = `rec_fbl_m_a_${TS}` // links [Acme]
+const M_AG = `rec_fbl_m_ag_${TS}` // links [Acme, Globex]
+const M_S = `rec_fbl_m_s_${TS}` // links [Secret]        → all-hidden for USER
+const M_AS = `rec_fbl_m_as_${TS}` // links [Acme, Secret] → mixed
+const M_NONE = `rec_fbl_m_none_${TS}` // links []
+
+// views (one per filter under test)
+const V_IS_ACME = `v_fbl_is_acme_${TS}`
+const V_IS_GLOB = `v_fbl_is_glob_${TS}` // `is "Glob"` (partial) — exact membership ⇒ no match
+const V_CONTAINS_GLOB = `v_fbl_contains_glob_${TS}`
+const V_IS_SECRET = `v_fbl_is_secret_${TS}`
+const V_CONTAINS_SECRET = `v_fbl_contains_secret_${TS}`
+const V_ISEMPTY = `v_fbl_isempty_${TS}`
+const V_ISNOTEMPTY = `v_fbl_isnotempty_${TS}`
+const V_NESTED = `v_fbl_nested_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+let testRoles: string[] = ['member']
+function buildApp(): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: USER, roles: testRoles, perms: ['multitable:read', 'multitable:base:read'], permissions: ['multitable:read', 'multitable:base:read'] }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const setForeignFlag = (on: boolean) =>
+  q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [FS, on])
+async function viewRowIds(viewId: string): Promise<string[]> {
+  const res = await request(buildApp()).get(`/api/multitable/view?sheetId=${MS}&viewId=${viewId}&limit=50&offset=0`)
+  expect(res.status).toBe(200)
+  return (res.body.data.rows as Array<{ id: string }>).map((r) => r.id).sort()
+}
+const sortIds = (...ids: string[]) => ids.slice().sort()
+const grid = (conditions: unknown[], conjunction: 'and' | 'or' = 'and') => JSON.stringify({ conjunction, conditions })
+async function seedView(id: string, filterInfo: string): Promise<void> {
+  await q(
+    'INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, sort_info, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)',
+    [id, MS, id, 'grid', '[]', filterInfo, JSON.stringify({ rules: [] }), JSON.stringify({})],
+  )
+}
+async function dashboardTotal(viewId: string): Promise<number> {
+  const res = await request(buildApp()).post('/api/multitable/dashboard/query').send({
+    sheetId: MS, viewId, widgets: [{ title: 'g', chartType: 'bar', groupByFieldId: FLD_GROUP, metric: 'count' }],
+  })
+  expect(res.status).toBe(200)
+  return (res.body?.data?.widgets?.[0]?.totalRecords as number) ?? -1
+}
+async function aggregateStatus(viewId: string): Promise<number> {
+  return (await request(buildApp()).get(`/api/multitable/sheets/${MS}/view-aggregate?viewId=${viewId}`)).status
+}
+
+describeIfDatabase('multitable filter-by-link over real /view (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'FBL Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS, BASE_ID, 'FBL Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_ID, 'FBL Main'])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FNAME, FS, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR_ACME, FS, JSON.stringify({ [FLD_FNAME]: 'Acme' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR_GLOBEX, FS, JSON.stringify({ [FLD_FNAME]: 'Globex' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR_SECRET, FS, JSON.stringify({ [FLD_FNAME]: 'Secret' })])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_GROUP, MS, 'Group', 'string', '{}', 2])
+    // main records — record.data[FLD_LINK] is intentionally NOT the source of truth (the read path
+    // discards it); links live in meta_links below. We store an empty array to prove the filter never
+    // reads record.data for link presence/display. FLD_GROUP is a plain group-by axis for the dashboard.
+    const mainGroup: Record<string, string> = { [M_A]: 'g1', [M_AG]: 'g1', [M_S]: 'g2', [M_AS]: 'g1', [M_NONE]: 'g2' }
+    for (const id of [M_A, M_AG, M_S, M_AS, M_NONE]) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [id, MS, JSON.stringify({ [FLD_LINK]: [], [FLD_GROUP]: mainGroup[id] })])
+    }
+    const links: Array<[string, string]> = [
+      [M_A, FR_ACME],
+      [M_AG, FR_ACME], [M_AG, FR_GLOBEX],
+      [M_S, FR_SECRET],
+      [M_AS, FR_ACME], [M_AS, FR_SECRET],
+    ]
+    let i = 0
+    for (const [rec, fr] of links) {
+      await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_fbl_${i++}_${TS}`, FLD_LINK, rec, fr])
+    }
+
+    // FR_SECRET is row-denied ('none') to USER on the FOREIGN sheet; flag turned ON in beforeAll.
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [FS, FR_SECRET, 'user', USER, 'none'])
+    await setForeignFlag(true)
+
+    await seedView(V_IS_ACME, grid([{ fieldId: FLD_LINK, operator: 'is', value: 'Acme' }]))
+    await seedView(V_IS_GLOB, grid([{ fieldId: FLD_LINK, operator: 'is', value: 'Glob' }]))
+    await seedView(V_CONTAINS_GLOB, grid([{ fieldId: FLD_LINK, operator: 'contains', value: 'glob' }]))
+    await seedView(V_IS_SECRET, grid([{ fieldId: FLD_LINK, operator: 'is', value: 'Secret' }]))
+    await seedView(V_CONTAINS_SECRET, grid([{ fieldId: FLD_LINK, operator: 'contains', value: 'secret' }]))
+    await seedView(V_ISEMPTY, grid([{ fieldId: FLD_LINK, operator: 'isEmpty' }]))
+    await seedView(V_ISNOTEMPTY, grid([{ fieldId: FLD_LINK, operator: 'isNotEmpty' }]))
+    // nested: (link is "Acme" OR link contains "glob") wrapped in the root AND group
+    await seedView(V_NESTED, grid([{ conjunction: 'or', conditions: [
+      { fieldId: FLD_LINK, operator: 'is', value: 'Acme' },
+      { fieldId: FLD_LINK, operator: 'contains', value: 'glob' },
+    ] }]))
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [FS]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('D1/D6 — `is` is membership over visible displays (exact), `contains` is substring', async () => {
+    testRoles = ['member']; await setForeignFlag(true)
+    expect(await viewRowIds(V_IS_ACME)).toEqual(sortIds(M_A, M_AG, M_AS)) // any visible display === "Acme"
+    expect(await viewRowIds(V_IS_GLOB)).toEqual([]) // "Glob" ≠ "Globex" exactly → no match (is is not substring)
+    expect(await viewRowIds(V_CONTAINS_GLOB)).toEqual(sortIds(M_AG)) // "Globex" contains "glob"
+  })
+
+  test('D2 — a denied linked record is EXCLUDED from the comparison set (no match, no display leak)', async () => {
+    testRoles = ['member']; await setForeignFlag(true)
+    expect(await viewRowIds(V_IS_SECRET)).toEqual([]) // "Secret" is hidden → never matched
+    expect(await viewRowIds(V_CONTAINS_SECRET)).toEqual([]) // hidden display not in the comparison set
+  })
+
+  test('D2 — admin bypass + flag-OFF canary prove the deny (not a blanket hide) is what excludes Secret', async () => {
+    // admin sees Secret → the rows DO exist and the filter logic matches them
+    testRoles = ['admin']; await setForeignFlag(true)
+    expect(await viewRowIds(V_IS_SECRET)).toEqual(sortIds(M_S, M_AS))
+    // same actor, foreign flag OFF → no deny → Secret visible → matches (proves exclusion was the deny)
+    testRoles = ['member']; await setForeignFlag(false)
+    expect(await viewRowIds(V_IS_SECRET)).toEqual(sortIds(M_S, M_AS))
+    await setForeignFlag(true)
+  })
+
+  test('D5 — isEmpty/isNotEmpty are raw-presence + permission-INVARIANT (all-hidden row is NOT empty)', async () => {
+    testRoles = ['member']; await setForeignFlag(true)
+    // M_S links only the hidden Secret, but it HAS a raw link → not empty for the restricted user.
+    expect(await viewRowIds(V_ISEMPTY)).toEqual(sortIds(M_NONE))
+    expect(await viewRowIds(V_ISNOTEMPTY)).toEqual(sortIds(M_A, M_AG, M_S, M_AS))
+    // admin gets the identical presence result → permission-invariant (the D5 leak avoided).
+    testRoles = ['admin']
+    expect(await viewRowIds(V_ISEMPTY)).toEqual(sortIds(M_NONE))
+    expect(await viewRowIds(V_ISNOTEMPTY)).toEqual(sortIds(M_A, M_AG, M_S, M_AS))
+    testRoles = ['member']
+  })
+
+  test('composition — a link leaf works inside a nested OR group', async () => {
+    testRoles = ['member']; await setForeignFlag(true)
+    // (is "Acme" OR contains "glob") → Acme rows ∪ Globex rows
+    expect(await viewRowIds(V_NESTED)).toEqual(sortIds(M_A, M_AG, M_AS))
+  })
+
+  test('dashboard /dashboard/query applies the same link filter + permission discipline', async () => {
+    testRoles = ['member']; await setForeignFlag(true)
+    expect(await dashboardTotal(V_IS_ACME)).toBe(3) // M_A, M_AG, M_AS
+    expect(await dashboardTotal(V_IS_SECRET)).toBe(0) // hidden Secret excluded from the comparison set
+  })
+
+  test('view-aggregate HARD-FAILS (422) on a link filter — preserves the /view parity invariant', async () => {
+    // /view supports link filters; view-aggregate can't evaluate them on its path, so it 422s rather than
+    // silently disagree (link-aggregate is a deferred follow-up, same stance as computed-field filters).
+    testRoles = ['member']; await setForeignFlag(true)
+    expect(await aggregateStatus(V_IS_ACME)).toBe(422)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -63,7 +63,15 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     // tests/integration/multitable-record-recycle-bin.test.ts (field_permissions.visible=false absent from trash data).
     filterRecordDataByFieldIds: 15,
     loadRecordSummaries: 3,
-    buildLinkSummaries: 4,
+    // 6 = +2 for the 2a filter-by-link materialization in GET /view and loadDashboardSourceRows. These two
+    // call-sites are FILTER-INTERNAL: buildLinkSummaries computes the permission-filtered display set used
+    // ONLY by the link filter predicate (evaluateLinkFilterCondition) and is then DISCARDED — it is never
+    // serialized to the response, so it adds no NEW wire-egress channel. The permission discipline is
+    // buildLinkSummaries' own (denied foreign ids excluded, field-mask display auto-pick, cross-base gate),
+    // so a hidden link can neither match a value op nor leak its display. Locking test:
+    // tests/integration/multitable-filter-by-link-view.test.ts (denied-link non-leak + isEmpty
+    // permission-invariant + admin-bypass/flag-OFF canaries).
+    buildLinkSummaries: 6,
     serializeLinkSummaryMap: 1,
     // 3 = linkSummaries + attachmentSummaries + native person (人员) personSummaries (design
     // 2026-06-16). The personSummaries egress is routed through the SAME layer-2 ∧ layer-3

--- a/packages/core-backend/tests/unit/multitable-link-filter-condition.test.ts
+++ b/packages/core-backend/tests/unit/multitable-link-filter-condition.test.ts
@@ -1,0 +1,85 @@
+/**
+ * 2a filter-by-link (first cut) — pure leaf evaluator `evaluateLinkFilterCondition`.
+ *
+ * Two evaluation bases, by design (multitable-2a-filter-by-link-lookup-designlock §2 / D5·D6):
+ *   • PRESENCE (isEmpty / isNotEmpty) → RAW link id count. Permission-INVARIANT; touches no display.
+ *   • VALUE (contains / is) → the PERMISSION-FILTERED visible display set (denied links already excluded
+ *     upstream). contains = any visible display contains substring; is = membership (exact equals one).
+ *
+ * The keystone security case (the D5 leak this split avoids): a row whose links are ALL hidden from the
+ * requester has rawLinkIds.length > 0 but visibleDisplays = []. isEmpty MUST stay false (it HAS links) so
+ * the restricted user never sees an "empty" match a full-permission user wouldn't; contains/is MUST NOT
+ * match (nothing visible to match, no display string leaks).
+ */
+import { describe, expect, it } from 'vitest'
+import { evaluateLinkFilterCondition } from '../../src/routes/univer-meta'
+
+const cond = (operator: string, value?: unknown) => ({ fieldId: 'link1', operator, value })
+
+describe('evaluateLinkFilterCondition — presence (raw, permission-invariant)', () => {
+  it('isEmpty: true only when there are no raw link ids', () => {
+    expect(evaluateLinkFilterCondition([], [], cond('isEmpty'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isEmpty'))).toBe(false)
+  })
+
+  it('isNotEmpty: true when there is at least one raw link id', () => {
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isNotEmpty'))).toBe(true)
+    expect(evaluateLinkFilterCondition([], [], cond('isNotEmpty'))).toBe(false)
+  })
+
+  it('presence ignores visibleDisplays entirely (permission-invariant)', () => {
+    // same raw ids, different visible sets (full vs all-denied) → identical presence result
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isEmpty'))).toBe(false)
+    expect(evaluateLinkFilterCondition(['r1'], [], cond('isEmpty'))).toBe(false)
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isNotEmpty'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1'], [], cond('isNotEmpty'))).toBe(true)
+  })
+})
+
+describe('evaluateLinkFilterCondition — value (permission-filtered display set)', () => {
+  it('contains: case/space-insensitive substring over any visible display (D6 any)', () => {
+    expect(evaluateLinkFilterCondition(['r1', 'r2'], ['Acme Corp', 'Globex'], cond('contains', 'acme'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1', 'r2'], ['Acme Corp', 'Globex'], cond('contains', 'GLOB'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1', 'r2'], ['Acme Corp', 'Globex'], cond('contains', 'initech'))).toBe(false)
+  })
+
+  it('contains with empty value = match-all (mirrors string-branch convention)', () => {
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('contains', ''))).toBe(true)
+    expect(evaluateLinkFilterCondition([], [], cond('contains', ''))).toBe(true)
+  })
+
+  it('is: membership — any visible display equals the value exactly, not whole-set equality (D6)', () => {
+    expect(evaluateLinkFilterCondition(['r1', 'r2'], ['Acme', 'Globex'], cond('is', 'Acme'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1', 'r2'], ['Acme', 'Globex'], cond('is', 'globex'))).toBe(true)
+    // substring is NOT a match for `is`
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme Corp'], cond('is', 'Acme'))).toBe(false)
+  })
+})
+
+describe('evaluateLinkFilterCondition — D5 keystone: all-links-hidden row', () => {
+  const allHidden = ['hiddenRecA', 'hiddenRecB'] // raw ids exist…
+  const noVisible: string[] = [] // …but none are visible to the requester
+
+  it('isEmpty stays FALSE for an all-hidden-links row (no empty-for-restricted / non-empty-for-full leak)', () => {
+    expect(evaluateLinkFilterCondition(allHidden, noVisible, cond('isEmpty'))).toBe(false)
+    expect(evaluateLinkFilterCondition(allHidden, noVisible, cond('isNotEmpty'))).toBe(true)
+  })
+
+  it('value operators never match via a hidden link (no display-string leak)', () => {
+    expect(evaluateLinkFilterCondition(allHidden, noVisible, cond('contains', 'hidden'))).toBe(false)
+    expect(evaluateLinkFilterCondition(allHidden, noVisible, cond('is', 'hiddenRecA'))).toBe(false)
+  })
+})
+
+describe('evaluateLinkFilterCondition — first-cut scope', () => {
+  it('operators outside contains/is/isEmpty/isNotEmpty are inert (match-all), mirroring the catch-all', () => {
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isNot', 'Acme'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('doesNotContain', 'Acme'))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('isAnyOf', ['Acme']))).toBe(true)
+  })
+
+  it('operator matching is case/space-tolerant on the operator token', () => {
+    expect(evaluateLinkFilterCondition([], [], cond(' IsEmpty '))).toBe(true)
+    expect(evaluateLinkFilterCondition(['r1'], ['Acme'], cond('CONTAINS', 'acme'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Implements the **first slice of the ratified 2a filter-by-link design-lock** (#2964 → `multitable-2a-filter-by-link-lookup-designlock`, decisions D1–D6). A `link`-field filter condition now compares against the linked records' **permission-filtered display strings** instead of the opaque foreign-id array (which fell through to the string branch and never matched what the user typed).

## The crux it solves

At filter time the read path holds **raw foreign ids**, not displays — and those ids live in `meta_links`, **not** `record.data[linkField]` (the read path discards + rebuilds that column at `:9406-9416`). So the filter materializes presence + display from the relational load (`loadLinkValuesByRecord` + `buildLinkSummaries`) **before** the predicate runs, scoped to the link fields the filter references, reusing `buildLinkSummaries`' permission discipline verbatim (denied foreign ids excluded, field-mask display, cross-base gate) — **materialize-then-filter, never read-raw-then-mask**.

## Locked semantics (D1–D6)

- **D1/D6 value ops** — `contains` = any visible display contains the substring; `is` = **membership** (any visible display equals the value exactly), not whole-set equality. Over the **permission-filtered** display set (D2: a denied linked record is excluded → no match, no display-string leak).
- **D5 presence ops** — `isEmpty`/`isNotEmpty` test **raw `meta_links` presence**, permission-**invariant**. The keystone leak this avoids: a row whose links are *all* hidden from the requester is **not** empty (it has links) — never `empty-for-restricted` / `non-empty-for-full`. (`isEmpty` never touches a display string.)

## Scope across surfaces (no silent divergence)

- **`/view`** (records list) — full support.
- **dashboard** (`loadDashboardSourceRows`) — full support (it already loaded `linkValuesByRecord`; link was the one filter type it didn't materialize).
- **view-aggregate** — **HARD-FAILS (422)** on a link filter, the same stance it already takes for computed (lookup/rollup/formula) filters, so its total can never silently disagree with `/view`. (`COMPUTED_FILTER_TYPES` is preserved for the group-by-axis 422; link is added to the *filter* guard only.)

## FE

The link operator menu gains `is` / `contains` (free-text value — link is not select-like, so the existing free-text input renders). The **linked-record picker is deferred per D4**.

## Tests

- **10 pure unit cases** (`evaluateLinkFilterCondition`) incl. the D5 all-hidden-links keystone, D6 membership-vs-substring, and inert-op behavior.
- **Real-DB `/view` goldens** (`multitable-filter-by-link-view.test.ts`, registered in `plugin-tests.yml`): membership/substring · denied-link excluded + non-leak + **admin-bypass & flag-OFF canaries** (proving the *deny* is what excludes, not a blanket hide) · `isEmpty` permission-invariant (incl. all-hidden row) · nested-group composition · **dashboard parity** · **view-aggregate 422**.

Backend `tsc --noEmit` clean; unit + FE specs green locally (real-DB goldens run in CI via the plugin-tests step).

## Deferred (gated follow-ups, per the design-lock)

- Lookup-field filtering (next slice, over the materialized lookup value).
- Linked-record **picker** value control (D4 free-text first).
- Link-**aggregate** support (so view-aggregate computes rather than 422s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)