### PR TITLE
docs(multitable): pin denied-link does-not-match + SUMIF naming-gate semantics (reviewer follow-up)

### DIFF
--- a/docs/development/multitable-1b-recordset-range-formula-designlock-20260619.md
+++ b/docs/development/multitable-1b-recordset-range-formula-designlock-20260619.md
@@ -40,6 +40,14 @@ skeleton is a separate gated extension** (its own opt-in + §5 caps), tracked in
 state this scope difference in its own surface (function help / release note) so users are not surprised the
 first cut aggregates linked records, not an arbitrary sheet column.
 
+**🔒 Naming gate (binding on the Slice A impl PR):** relation-scoped Slice A does **not** promise classic
+`SUMIF` parity. If the implementation exposes the names `SUMIF` / `COUNTIFS` / `AVERAGEIF` to users, the
+Slice A PR MUST re-confirm semantics/naming at that point and make the relation-scoped (NOT whole-sheet)
+reach explicit in the user-facing surface (function help / error text / release note). Reusing the
+well-known spreadsheet names **without** that disclaimer is not permitted — a user must never be led to
+believe whole-sheet range scan is already supported. (If a clean relation-scoped name is preferable to an
+`*IF` name carrying whole-sheet baggage, that naming decision is made in the Slice A PR, not assumed here.)
+
 ## 2. The eight locked blocks
 
 ### Block 1 — Reference model

--- a/docs/development/multitable-2a-filter-by-link-lookup-designlock-20260619.md
+++ b/docs/development/multitable-2a-filter-by-link-lookup-designlock-20260619.md
@@ -38,6 +38,15 @@ The owner ratified the leaning options. They are now **locked** and define the f
 - **D2 — a denied linked record is excluded from the comparison set** for **value operators** (`contains`/
   `is`): a hidden link is simply "not a match", consistent with row-deny precedent, and its display string
   is never compared or surfaced. (Presence operators are the explicit exception — see D5.)
+  - **Semantics pin: this is a "does not match", NOT an error.** A hidden link among a row's links silently
+    fails to contribute a match; it never raises `#PERM!` or errors the condition (one denied link must not
+    blank a whole filter result). This differs from 1b record-set *aggregation*, where a partial-permission
+    aggregate returns a sentinel because the number would encode the hidden rows — a filter non-match leaks
+    nothing, so it stays a plain non-match.
+  - **Materialization-order pin: the exclusion happens DURING display materialization, before eval.**
+    `buildLinkSummaries` drops denied foreign ids while assembling the display set, so the pure evaluator is
+    structurally **never handed a denied display string** to compare — leak-proof by construction, not by a
+    post-eval check. (Implemented exactly so in #2970.)
 - **D3 — reuse the nested-groups per-leaf evaluator threading.** Extend the existing per-leaf evaluator to
   receive the record's permission-filtered link summaries; link conditions are normal leaves inside the
   nested AND/OR tree — no separate link-only pass.


### PR DESCRIPTION
Two semantics clarifications requested at review of the already-merged 2a/1b design-locks (#2964, #2963). Docs-only.

**2a filter-by-link (`multitable-2a-filter-by-link-lookup-designlock`, D2):**
- Pins that a denied linked record's exclusion is a **"does not match", NOT an error/`#PERM!`** — one hidden link must not blank a whole filter result (contrast with 1b *aggregation*, where a partial-permission aggregate returns a sentinel because the number would encode hidden rows; a filter non-match leaks nothing).
- Pins that the exclusion happens **during display materialization** (`buildLinkSummaries` drops denied foreign ids), so the pure evaluator is **never handed a denied display** — leak-proof by construction, exactly as implemented + real-DB-locked in #2970.

**1b record-set (`multitable-1b-recordset-range-formula-designlock`, §1):**
- Adds a **binding naming gate** on the Slice A impl PR: relation-scoped Slice A does **not** promise classic whole-sheet `SUMIF` parity; if it exposes the `SUMIF`/`COUNTIFS`/`AVERAGEIF` names it must re-confirm semantics/naming and make the relation-scoped reach explicit in the user-facing surface, so no user assumes whole-sheet range scan is supported.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)