### PR TITLE
feat(multitable): history field-audit A1 — governed grant model + LOCK-2 (no reveal wired)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -203,6 +203,7 @@ jobs:
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/multitable-history-events-realdb.test.ts \
+            tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-history-audit-A1-dev-verification-20260621.md
+++ b/docs/development/multitable-history-audit-A1-dev-verification-20260621.md
@@ -1,0 +1,51 @@
+# History Field-Audit Permission — A1 开发与验证 MD
+
+> 对应 /goal「根据计划并行开发，完成后给出开发及验证 MD」。
+> **计划 = design-lock #2973（`2b6a4fd48`）的分阶段 TODO（A0✅→A1→A2→A3）。本次只做 A1**——这是设计锁明确的「first allowed runtime slice」，A2/A3 各为独立 opt-in。
+> **A1 = grant 模型 + contract + 完整 LOCK-2 治理层 + 发证/撤证自审计 + resolver 接缝（返回 no-reveal，不接遮罩）。** A1 刻意**不**接任何 reveal 进历史遮罩——边界证明见 §4。
+
+## 0. 为什么只做 A1（而非 A1+A2）
+
+design-lock 把 A1（grant 合约，不接遮罩）与 A2（真正掀遮罩的 reveal 运行时）**显式分闸**：A2 是唯一危险的一刀（它让受限字段值可被读出），owner 两条消息前刚把它单列为独立 opt-in 以便单独审查。本 /goal 说「根据计划」——执行计划的分阶段，而非把闸合并。A1 已是完整可验证的交付（迁移 + 平台能力 + 发证/撤证路由 + 全 LOCK-2 层 + 自审计 + resolver 接缝），其验证 MD 正是围绕 LOCK-2 治理 goldens 写成。A2（reveal 运行时）是下一道闸，**未建**。
+
+## 1. 交付物（A1，全部本 PR）
+
+| 件 | 内容 |
+|---|---|
+| 迁移 | `meta_history_audit_grants`（mirror `field_permissions` 形态：subject_type user/role/member-group + base 作用域 + `expires_at` + `is_standing` + `reason`/`ticket` + soft-delete `revoked_at`）；**部分唯一索引**（每 base+subject 至多一条 active）；CHECK `is_standing OR expires_at IS NOT NULL`（D5：非 standing 必有限期） |
+| 平台能力 | `multitable:history-field-audit:grant` —— **独立**能力码，**只**在发证/撤证路由检查，**绝不**并入任何 `SHEET_*` 能力集 |
+| 服务 | `history-audit-grant-service.ts`：`issueHistoryAuditGrant`（LOCK-2a 自授拒绝 + D5 默认有限期 + 自审计）、`revokeHistoryAuditGrant`（soft-delete + 自审计）、`listHistoryAuditGrants`（仅 active）、`loadActiveHistoryAuditGrant`（A2 将读的 active+未过期查询）、`resolveHistoryFieldAuditReveal`（**接缝：A1 恒返回空集**） |
+| 路由 | `POST/GET/DELETE /bases/:baseId/history-audit-grants[/:grantId]`，授权门=`requireHistoryAuditGrantAuthority`（**只认能力码，无 isAdminRole 旁路**）+ base/subject 存在校验（mirror field_permissions） |
+| 自审计 | 发证/撤证直插 `operation_audit_logs`（`metadata`+`meta`，action `history_field_audit_grant.issue|.revoke`，存 actor/base/subject/reason/expiry/standing——**无任何记录字段值**） |
+| goldens | `multitable-history-audit-grant-realdb.test.ts`（11 条，入 plugin-tests `test (20.x)` 白名单） |
+
+## 2. 落地的 LOCK（L2 治理层）
+
+- **L2 授权**：发证唯一钥匙 = 平台能力 `multitable:history-field-audit:grant`。base-admin（`multitable:admin`）、粗粒度 `admin` role **都不能**发证（**无 isAdminRole 旁路**——见 §4 mutation）。
+- **L2a 禁自授**：user 给自己 user-id 发证 → 403 `SELF_GRANT`。
+- **L2(d) 不可自扩**：grantee 不持有 `:grant` 能力 → 无法再发证/转授扩大自己范围（我落成「既不能自扩、也不能再转授」；owner 可收窄为允许平级转授）。
+- **L2c 发证/撤证均写审计**：各写一条 `operation_audit_logs`。
+- **D5 默认有限期**：无 `expires_at` 且非 standing → 套 90 天有限窗；standing 必须显式 `standing:true`，并在行 + 审计中标记。
+- **L5（A1 范围）**：审计只存 grant scope，绝无字段值。
+
+## 3. A1/A2 接缝（边界）
+
+`resolveHistoryFieldAuditReveal()` 在 A1 **恒返回空集**，且**未**被 `buildHistoryAllowedFieldsBySheet` 或按记录历史的 allowed-set 调用。A2 才把它（按显式 reveal flag + 有效 grant）UNION 进遮罩。`history-projection.ts` 与 #2968 goldens 文件**零改动**。
+
+## 4. 验证
+
+- backend `tsc --noEmit`：**0 error**。
+- **A1 LOCK-2 goldens：11/11 pass**（真库 `metasheet_test`）：base-admin 拒 / admin-role 拒（无旁路）/ 能力持有者可发 / 自授 403 / grantee 不可再发 / 默认有限期 / standing 显式+标记 / 发证审计（含 reason、无值）/ 撤证 soft-delete+审计+active 列表剔除+重复撤证 404 / resolver 返回 no-reveal。
+- **边界证明：#2968 历史 goldens 仍 8/8 pass 且文件 byte-identical**——A1 对遮罩零改动（A1 停、A2 始的干净分界）。
+- **Mutation check（最关键）**：在授权门临时加 `|| !access.isAdminRole`（admin 旁路）→「admin-role 拒」golden **失败**（`expected 201 to be 403`，admin 越过能力码发证成功）；还原后 11/11 绿 → 证明该 golden load-bearing，正是 L2 地雷的守卫。
+- backend unit：**3745/3745 pass**（本地重跑，无回归；A1 只增集成 goldens，不增 unit）。
+
+## 5. A1 已知边界 / 留给后续
+
+- **role/group 自授**：A1 只硬拦 user 自授（issuer===subjectId）。issuer 给「自己所属的 role/group」发证（间接自授）未拦——需成员关系查询，属策略判断，连同 L2(d) 转授口径一并留给 owner 定。
+- **能力分配 UI / 注册表**：`multitable:history-field-audit:grant` 作为自由能力码在路由侧 enforce；纳入权限目录/分配面板是 admin 面（A3 邻域）的事。
+- **未建（独立 opt-in）**：**A2** reveal 运行时（接遮罩 + reveal-flag 门 + 每次 reveal 自审计 + 真库 goldens：holder-无-flag-仍遮、行级 deny 仍生效、L7 不进 restore/preview/PIT、过期/越权遮、mutation）；**A3** 审计流水只读面。
+
+## 6. 下一道闸
+
+**A2 = reveal 运行时（真正掀字段遮罩的一刀）。** 需 owner 显式开闸；开时一并定：(a) L2(d) 是否允许平级转授；(b) role/group 自授是否硬拦。A2 前不动遮罩。

--- a/packages/core-backend/src/db/migrations/zzzz20260621100000_create_meta_history_audit_grants.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260621100000_create_meta_history_audit_grants.ts
@@ -1,0 +1,53 @@
+/**
+ * A1 — History Field-Audit Permission: the governed grant store.
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * A grant is the ONLY thing that can later (A2) lift the history field mask for a subject on a base. It is
+ * issued ONLY by a holder of the `multitable:history-field-audit:grant` platform capability (never base-admin;
+ * issuer != grantee), is default-finite (D5), and carries the issue `reason` (L8). This migration adds the
+ * store only; A1 does NOT wire any reveal into the history mask (the resolver returns no-reveal).
+ */
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_history_audit_grants (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      base_id text NOT NULL,
+      subject_type text NOT NULL CHECK (subject_type IN ('user', 'role', 'member-group')),
+      subject_id text NOT NULL,
+      granted_by text NOT NULL,
+      reason text,
+      ticket text,
+      -- D5: default-finite. expires_at NULL is allowed ONLY when is_standing = true (an explicit choice,
+      -- marked here and in the audit trail); the issue route applies a finite default otherwise.
+      expires_at timestamptz,
+      is_standing boolean NOT NULL DEFAULT false,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      revoked_at timestamptz,
+      revoked_by text,
+      CONSTRAINT meta_history_audit_grants_standing_or_finite
+        CHECK (is_standing = true OR expires_at IS NOT NULL)
+    )
+  `.execute(db)
+
+  // One ACTIVE grant per (base, subject); revoked rows are retained for in-table lineage but do not block a
+  // fresh grant. A2's resolver reads only active, non-expired rows.
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_meta_history_audit_grants_active
+      ON meta_history_audit_grants (base_id, subject_type, subject_id)
+      WHERE revoked_at IS NULL
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_history_audit_grants_lookup
+      ON meta_history_audit_grants (base_id, subject_type, subject_id, revoked_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS meta_history_audit_grants CASCADE`.execute(db)
+}

--- a/packages/core-backend/src/multitable/history-audit-grant-service.ts
+++ b/packages/core-backend/src/multitable/history-audit-grant-service.ts
@@ -1,0 +1,241 @@
+/**
+ * A1 — History Field-Audit Permission: governed grant service (business rules + persistence + self-audit).
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * A grant is the ONLY thing that can later (A2) lift the history field mask. This module owns the data-layer
+ * LOCK-2 rules — issuer != grantee, default-finite expiry (D5), and the issue/revoke self-audit (LOCK-2c) —
+ * plus the active-grant lookup A2 will read. The route owns the authority gate (the platform capability) and
+ * subject-existence validation.
+ *
+ * A1 does NOT wire any reveal into the history mask: `resolveHistoryFieldAuditReveal` returns an empty set
+ * (no reveal), so the #2968 history mask is byte-for-byte unchanged. That byte-identity is the A1/A2 seam.
+ */
+import type { QueryFn } from './permission-service'
+
+/** The standalone platform capability that authorizes issuing/revoking grants. LOCK-2: it is NEVER folded
+ *  into any SHEET_* capability set — base-admin (`multitable:admin`) must not gain it implicitly. */
+export const HISTORY_FIELD_AUDIT_GRANT_PERMISSION = 'multitable:history-field-audit:grant'
+
+/** D5: when an issue request gives neither an explicit expiry nor explicit standing, this finite window is
+ *  applied. Standing (no expiry) must be an explicit choice and is marked on the row + in the audit trail. */
+export const DEFAULT_HISTORY_AUDIT_GRANT_WINDOW_DAYS = 90
+
+export type HistoryAuditGrantSubjectType = 'user' | 'role' | 'member-group'
+
+export interface HistoryAuditGrantRow {
+  id: string
+  baseId: string
+  subjectType: HistoryAuditGrantSubjectType
+  subjectId: string
+  grantedBy: string
+  reason: string | null
+  ticket: string | null
+  expiresAt: string | null
+  isStanding: boolean
+  createdAt: string
+}
+
+export interface IssueHistoryAuditGrantInput {
+  baseId: string
+  subjectType: HistoryAuditGrantSubjectType
+  subjectId: string
+  reason?: string | null
+  ticket?: string | null
+  /** ISO timestamp. Ignored when `standing` is true; defaulted to now()+window when absent and not standing. */
+  expiresAt?: string | null
+  /** D5: explicit standing (no expiry). Must be set deliberately; never the implicit default. */
+  standing?: boolean
+}
+
+export type HistoryAuditGrantErrorCode = 'SELF_GRANT' | 'INVALID_EXPIRY'
+
+export class HistoryAuditGrantError extends Error {
+  code: HistoryAuditGrantErrorCode
+  constructor(code: HistoryAuditGrantErrorCode, message: string) {
+    super(message)
+    this.code = code
+    this.name = 'HistoryAuditGrantError'
+  }
+}
+
+function asIso(value: unknown): string | null {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string' && value) return value
+  return null
+}
+
+function serializeGrantRow(row: Record<string, unknown>): HistoryAuditGrantRow {
+  return {
+    id: String(row.id),
+    baseId: String(row.base_id),
+    subjectType: String(row.subject_type) as HistoryAuditGrantSubjectType,
+    subjectId: String(row.subject_id),
+    grantedBy: String(row.granted_by),
+    reason: typeof row.reason === 'string' ? row.reason : null,
+    ticket: typeof row.ticket === 'string' ? row.ticket : null,
+    expiresAt: asIso(row.expires_at),
+    isStanding: row.is_standing === true,
+    createdAt: asIso(row.created_at) ?? '',
+  }
+}
+
+/**
+ * LOCK-2c / LOCK-5: write the grant issue/revoke to `operation_audit_logs`. The metadata carries the grant
+ * SCOPE (base, subject, reason, ticket, expiry, standing) — never any record field VALUES (A1 reveals
+ * nothing). Best-effort wrapper semantics are NOT used: an audit-write failure must surface (the caller is
+ * inside the same request and the audit record is part of the contract), so this awaits the insert directly.
+ */
+async function writeGrantAudit(
+  query: QueryFn,
+  action: 'history_field_audit_grant.issue' | 'history_field_audit_grant.revoke',
+  actorId: string,
+  grant: HistoryAuditGrantRow,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  const meta = JSON.stringify({
+    baseId: grant.baseId,
+    subjectType: grant.subjectType,
+    subjectId: grant.subjectId,
+    reason: grant.reason,
+    ticket: grant.ticket,
+    expiresAt: grant.expiresAt,
+    isStanding: grant.isStanding,
+    ...extra,
+  })
+  await query(
+    `INSERT INTO operation_audit_logs (actor_id, actor_type, action, resource_type, resource_id, metadata, meta)
+     VALUES ($1, 'user', $2, 'meta_history_audit_grant', $3, $4::jsonb, $4::jsonb)`,
+    [actorId, action, grant.id, meta],
+  )
+}
+
+/**
+ * Issue a grant. LOCK-2: issuer != grantee (a user cannot grant to themselves); D5: default-finite expiry
+ * unless `standing` is explicitly set. The route MUST have already verified the issuer holds
+ * `HISTORY_FIELD_AUDIT_GRANT_PERMISSION` (authority gate) and that the subject/base exist. Writes the
+ * issue audit record (LOCK-2c) in the same call.
+ */
+export async function issueHistoryAuditGrant(
+  query: QueryFn,
+  input: IssueHistoryAuditGrantInput,
+  issuerUserId: string,
+  nowMs: number,
+): Promise<HistoryAuditGrantRow> {
+  // LOCK-2a: issuer != grantee. The unambiguous case is a user granting to their own user id.
+  if (input.subjectType === 'user' && input.subjectId === issuerUserId) {
+    throw new HistoryAuditGrantError('SELF_GRANT', 'An issuer cannot grant history field-audit to themselves')
+  }
+
+  // D5: standing must be explicit; otherwise apply the finite default (or honour an explicit future expiry).
+  let expiresAt: string | null
+  let isStanding: boolean
+  if (input.standing === true) {
+    expiresAt = null
+    isStanding = true
+  } else if (input.expiresAt) {
+    const ms = Date.parse(input.expiresAt)
+    if (!Number.isFinite(ms)) throw new HistoryAuditGrantError('INVALID_EXPIRY', 'expiresAt is not a valid timestamp')
+    if (ms <= nowMs) throw new HistoryAuditGrantError('INVALID_EXPIRY', 'expiresAt must be in the future')
+    expiresAt = new Date(ms).toISOString()
+    isStanding = false
+  } else {
+    expiresAt = new Date(nowMs + DEFAULT_HISTORY_AUDIT_GRANT_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString()
+    isStanding = false
+  }
+
+  const res = await query(
+    `INSERT INTO meta_history_audit_grants
+       (base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id, base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing, created_at`,
+    [
+      input.baseId,
+      input.subjectType,
+      input.subjectId,
+      issuerUserId,
+      input.reason ?? null,
+      input.ticket ?? null,
+      expiresAt,
+      isStanding,
+    ],
+  )
+  const grant = serializeGrantRow((res.rows as Array<Record<string, unknown>>)[0])
+  await writeGrantAudit(query, 'history_field_audit_grant.issue', issuerUserId, grant)
+  return grant
+}
+
+/**
+ * Revoke (soft-delete) an active grant by id within a base. Returns false if no active grant matched.
+ * Writes the revoke audit record (LOCK-2c).
+ */
+export async function revokeHistoryAuditGrant(
+  query: QueryFn,
+  baseId: string,
+  grantId: string,
+  revokerUserId: string,
+): Promise<boolean> {
+  const res = await query(
+    `UPDATE meta_history_audit_grants
+       SET revoked_at = now(), revoked_by = $3
+     WHERE id = $1 AND base_id = $2 AND revoked_at IS NULL
+     RETURNING id, base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing, created_at`,
+    [grantId, baseId, revokerUserId],
+  )
+  const rows = res.rows as Array<Record<string, unknown>>
+  if (rows.length === 0) return false
+  await writeGrantAudit(query, 'history_field_audit_grant.revoke', revokerUserId, serializeGrantRow(rows[0]))
+  return true
+}
+
+/** List the ACTIVE grants on a base (revoked rows excluded). Read surface for administering grants. */
+export async function listHistoryAuditGrants(query: QueryFn, baseId: string): Promise<HistoryAuditGrantRow[]> {
+  const res = await query(
+    `SELECT id, base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing, created_at
+     FROM meta_history_audit_grants
+     WHERE base_id = $1 AND revoked_at IS NULL
+     ORDER BY created_at DESC`,
+    [baseId],
+  )
+  return (res.rows as Array<Record<string, unknown>>).map(serializeGrantRow)
+}
+
+/**
+ * The active, non-expired grant for any of the actor's subject keys on a base (or null). A2 reads this to
+ * decide whether a reveal is permitted; A1 exposes it for grant administration + tests. `subjectKeys` is the
+ * actor's identity set: their user id + role ids + member-group ids, each as `{type, id}`.
+ */
+export async function loadActiveHistoryAuditGrant(
+  query: QueryFn,
+  baseId: string,
+  subjectKeys: Array<{ type: HistoryAuditGrantSubjectType; id: string }>,
+  nowMs: number,
+): Promise<HistoryAuditGrantRow | null> {
+  if (subjectKeys.length === 0) return null
+  const types = subjectKeys.map((k) => k.type)
+  const ids = subjectKeys.map((k) => k.id)
+  const res = await query(
+    `SELECT id, base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing, created_at
+     FROM meta_history_audit_grants
+     WHERE base_id = $1
+       AND revoked_at IS NULL
+       AND (expires_at IS NULL OR expires_at > $4)
+       AND (subject_type, subject_id) IN (
+         SELECT * FROM unnest($2::text[], $3::text[])
+       )
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [baseId, types, ids, new Date(nowMs).toISOString()],
+  )
+  const rows = res.rows as Array<Record<string, unknown>>
+  return rows.length > 0 ? serializeGrantRow(rows[0]) : null
+}
+
+/**
+ * A1/A2 SEAM. A2 will compute the field ids a valid grant + explicit reveal request lifts and UNION them into
+ * the #2968 allowed-field set. For A1 this ALWAYS returns an empty set (no reveal) and is NOT called from the
+ * history mask path — so the history field mask is byte-for-byte the #2968 behaviour. Do not wire this into
+ * `buildHistoryAllowedFieldsBySheet` or the per-record allowed-set until the A2 opt-in.
+ */
+export async function resolveHistoryFieldAuditReveal(): Promise<Set<string>> {
+  return new Set<string>()
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,6 +73,13 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import {
+  HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
+  HistoryAuditGrantError,
+  issueHistoryAuditGrant,
+  revokeHistoryAuditGrant,
+  listHistoryAuditGrants,
+} from '../multitable/history-audit-grant-service'
+import {
   loadFieldsForSheet as loadFieldsForSheetShared,
   loadSheetRow as loadSheetRowShared,
   tryResolveView as tryResolveViewShared,
@@ -6583,6 +6590,118 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list record history failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record history' } })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // History Field-Audit Permission — A1 grant management (issue / list / revoke).
+  // Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+  // LOCK-2: the SOLE authority is the standalone platform capability; base-admin / multitable:admin / a coarse
+  // 'admin' role can NOT issue (NO isAdminRole bypass). A1 does NOT wire any reveal into the history mask.
+  // ---------------------------------------------------------------------------
+  async function requireHistoryAuditGrantAuthority(
+    req: Request,
+    res: Response,
+  ): Promise<Awaited<ReturnType<typeof resolveRequestAccess>> | null> {
+    const access = await resolveRequestAccess(req)
+    if (!access.userId) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      return null
+    }
+    // LOCK-2: the capability is the only key. NO isAdminRole / multitable:admin bypass — else every base/space
+    // admin could self-serve restricted-field history, which is exactly the anti-goal of a separate permission.
+    if (!access.permissions.includes(HISTORY_FIELD_AUDIT_GRANT_PERMISSION)) {
+      sendForbidden(res)
+      return null
+    }
+    return access
+  }
+
+  router.post('/bases/:baseId/history-audit-grants', async (req: Request, res: Response) => {
+    try {
+      const access = await requireHistoryAuditGrantAuthority(req, res)
+      if (!access) return
+      const pool = poolManager.get()
+      const baseId = typeof req.params.baseId === 'string' ? req.params.baseId.trim() : ''
+      if (!baseId) return res.status(400).json({ ok: false, error: { code: 'BAD_REQUEST', message: 'baseId required' } })
+      const schema = z.object({
+        subjectType: z.enum(['user', 'role', 'member-group']),
+        subjectId: z.string().min(1),
+        reason: z.string().max(2000).optional(),
+        ticket: z.string().max(200).optional(),
+        expiresAt: z.string().optional(),
+        standing: z.boolean().optional(),
+      })
+      const parsed = schema.safeParse(req.body)
+      if (!parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid grant body' } })
+      const { subjectType, subjectId } = parsed.data
+      const baseCheck = await pool.query('SELECT id FROM meta_bases WHERE id = $1', [baseId])
+      if (baseCheck.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Base not found: ${baseId}` } })
+      // Subject must exist — mirror the field_permissions route's subject validation.
+      if (subjectType === 'user') {
+        const u = await pool.query('SELECT id FROM users WHERE id = $1', [subjectId])
+        if (u.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `User not found: ${subjectId}` } })
+      } else if (subjectType === 'role') {
+        const r = await pool.query('SELECT id FROM roles WHERE id = $1', [subjectId])
+        if (r.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Role not found: ${subjectId}` } })
+      } else {
+        const g = await pool.query('SELECT id FROM platform_member_groups WHERE id::text = $1', [subjectId])
+        if (g.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Member group not found: ${subjectId}` } })
+      }
+      const grant = await issueHistoryAuditGrant(
+        pool.query.bind(pool),
+        { baseId, subjectType, subjectId, reason: parsed.data.reason, ticket: parsed.data.ticket, expiresAt: parsed.data.expiresAt, standing: parsed.data.standing },
+        access.userId,
+        Date.now(),
+      )
+      return res.status(201).json({ ok: true, data: grant })
+    } catch (err) {
+      if (err instanceof HistoryAuditGrantError) {
+        return res.status(err.code === 'SELF_GRANT' ? 403 : 400).json({ ok: false, error: { code: err.code, message: err.message } })
+      }
+      if (err && typeof err === 'object' && 'code' in err && (err as { code?: string }).code === '23505') {
+        return res.status(409).json({ ok: false, error: { code: 'GRANT_EXISTS', message: 'An active grant already exists for this subject on this base' } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] issue history-audit grant failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to issue grant' } })
+    }
+  })
+
+  router.get('/bases/:baseId/history-audit-grants', async (req: Request, res: Response) => {
+    try {
+      const access = await requireHistoryAuditGrantAuthority(req, res)
+      if (!access) return
+      const pool = poolManager.get()
+      const baseId = typeof req.params.baseId === 'string' ? req.params.baseId.trim() : ''
+      if (!baseId) return res.status(400).json({ ok: false, error: { code: 'BAD_REQUEST', message: 'baseId required' } })
+      const grants = await listHistoryAuditGrants(pool.query.bind(pool), baseId)
+      return res.json({ ok: true, data: { grants } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list history-audit grants failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to list grants' } })
+    }
+  })
+
+  router.delete('/bases/:baseId/history-audit-grants/:grantId', async (req: Request, res: Response) => {
+    try {
+      const access = await requireHistoryAuditGrantAuthority(req, res)
+      if (!access) return
+      const pool = poolManager.get()
+      const baseId = typeof req.params.baseId === 'string' ? req.params.baseId.trim() : ''
+      const grantId = typeof req.params.grantId === 'string' ? req.params.grantId.trim() : ''
+      if (!baseId || !grantId) return res.status(400).json({ ok: false, error: { code: 'BAD_REQUEST', message: 'baseId and grantId required' } })
+      const revoked = await revokeHistoryAuditGrant(pool.query.bind(pool), baseId, grantId, access.userId)
+      if (!revoked) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Active grant not found' } })
+      return res.json({ ok: true, data: { revoked: true } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] revoke history-audit grant failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to revoke grant' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-history-audit-grant-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-audit-grant-realdb.test.ts
@@ -1,0 +1,169 @@
+/**
+ * A1 — History Field-Audit Permission: LOCK-2 grant-governance goldens (real DB).
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * These pin the load-bearing LOCK-2 separation-of-duties contract for issuing/revoking the grant that A2 will
+ * use to lift the history field mask:
+ *   - the SOLE authority is the standalone platform capability `multitable:history-field-audit:grant`;
+ *     base-admin (`multitable:admin`) and a coarse `admin` role are REJECTED (no isAdminRole bypass);
+ *   - issuer != grantee (no self-grant); a grantee holds no capability so cannot re-issue / self-widen;
+ *   - default-finite expiry (D5): issue without expiry → a finite window; standing must be explicit + marked;
+ *   - issue AND revoke each write an `operation_audit_logs` record (LOCK-2c) carrying grant SCOPE, no values;
+ *   - the A1/A2 seam: `resolveHistoryFieldAuditReveal()` returns no reveal (A1 does not touch the mask).
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { resolveHistoryFieldAuditReveal } from '../../src/multitable/history-audit-grant-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_hag_${TS}`
+const ISSUER = `user_hag_issuer_${TS}` // holds the grant capability
+const GRANTEE = `user_hag_grantee_${TS}` // receives a grant; holds NO capability
+const CAP = 'multitable:history-field-audit:grant'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+// Per-request identity, swapped per test via asUser().
+let curUser: string | undefined = ISSUER
+let curRoles: string[] = ['member']
+let curPerms: string[] = [CAP]
+const asUser = (id: string | undefined, perms: string[], roles: string[] = ['member']) => { curUser = id; curPerms = perms; curRoles = roles }
+
+const issue = (body: Record<string, unknown>) =>
+  request(app).post(`/api/multitable/bases/${BASE_ID}/history-audit-grants`).send(body)
+const listGrants = () => request(app).get(`/api/multitable/bases/${BASE_ID}/history-audit-grants`)
+const revoke = (grantId: string) => request(app).delete(`/api/multitable/bases/${BASE_ID}/history-audit-grants/${grantId}`)
+
+type AuditRow = { actor_id: string; action: string; metadata: Record<string, unknown> }
+const auditRows = async (action: string): Promise<AuditRow[]> =>
+  (await q(
+    `SELECT actor_id, action, metadata FROM operation_audit_logs
+     WHERE resource_type = 'meta_history_audit_grant' AND action = $1 AND metadata->>'baseId' = $2
+     ORDER BY created_at ASC`,
+    [action, BASE_ID],
+  )).rows as AuditRow[]
+
+describeIfDatabase('history field-audit grant — A1 LOCK-2 governance goldens (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = curUser ? { id: curUser, roles: curRoles, perms: curPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2) ON CONFLICT (id) DO NOTHING', [BASE_ID, 'HAG Base'])
+    for (const uid of [ISSUER, GRANTEE]) {
+      await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [uid])
+    }
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_history_audit_grants WHERE base_id = $1', [BASE_ID]).catch(() => {})
+    await q("DELETE FROM operation_audit_logs WHERE resource_type = 'meta_history_audit_grant' AND metadata->>'baseId' = $1", [BASE_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[ISSUER, GRANTEE]]).catch(() => {})
+  })
+
+  beforeEach(() => { asUser(ISSUER, [CAP], ['member']) })
+  afterEach(async () => {
+    await q('DELETE FROM meta_history_audit_grants WHERE base_id = $1', [BASE_ID]).catch(() => {})
+    await q("DELETE FROM operation_audit_logs WHERE resource_type = 'meta_history_audit_grant' AND metadata->>'baseId' = $1", [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('LOCK-2 authority: base-admin (multitable:admin, no grant cap) is REJECTED from issuing', async () => {
+    asUser('user_baseadmin', ['multitable:admin', 'multitable:read', 'multitable:write'], ['member'])
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE })
+    expect(res.status).toBe(403)
+  })
+
+  test('LOCK-2 authority: a coarse admin ROLE (no grant cap) is REJECTED (no isAdminRole bypass)', async () => {
+    asUser('user_admin_role', ['multitable:read'], ['admin'])
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE })
+    expect(res.status).toBe(403)
+  })
+
+  test('LOCK-2 authority: a holder of the grant capability CAN issue', async () => {
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE, reason: 'SOC2 review' })
+    expect(res.status).toBe(201)
+    expect(res.body?.data?.subjectId).toBe(GRANTEE)
+    expect(res.body?.data?.grantedBy).toBe(ISSUER)
+  })
+
+  test('LOCK-2a: issuer cannot grant to themselves (SELF_GRANT 403)', async () => {
+    const res = await issue({ subjectType: 'user', subjectId: ISSUER })
+    expect(res.status).toBe(403)
+    expect(res.body?.error?.code).toBe('SELF_GRANT')
+  })
+
+  test('LOCK-2 (no self-widen): a grantee holds no capability, so cannot re-issue', async () => {
+    // issue a grant to GRANTEE first (as the authorised issuer)
+    expect((await issue({ subjectType: 'user', subjectId: GRANTEE })).status).toBe(201)
+    // now act AS the grantee (their token has no grant cap) → cannot widen by re-issuing
+    asUser(GRANTEE, ['multitable:read', 'multitable:write'], ['member'])
+    const res = await issue({ subjectType: 'user', subjectId: 'someone_else' })
+    expect(res.status).toBe(403)
+  })
+
+  test('D5 default-finite: issuing without expiry applies a finite window (not standing)', async () => {
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE })
+    expect(res.status).toBe(201)
+    expect(res.body?.data?.isStanding).toBe(false)
+    const exp = Date.parse(res.body?.data?.expiresAt)
+    expect(Number.isFinite(exp)).toBe(true)
+    expect(exp).toBeGreaterThan(Date.now() + 80 * 24 * 3600 * 1000) // ~90d window, generously bounded
+    expect(exp).toBeLessThan(Date.now() + 100 * 24 * 3600 * 1000)
+  })
+
+  test('D5 standing must be explicit + is marked (no implicit unbounded grant)', async () => {
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE, standing: true })
+    expect(res.status).toBe(201)
+    expect(res.body?.data?.isStanding).toBe(true)
+    expect(res.body?.data?.expiresAt).toBeNull()
+  })
+
+  test('LOCK-2c: issuing writes an audit record with actor + scope, and NO field values', async () => {
+    const res = await issue({ subjectType: 'user', subjectId: GRANTEE, reason: 'incident-123' })
+    expect(res.status).toBe(201)
+    const rows = await auditRows('history_field_audit_grant.issue')
+    expect(rows.length).toBe(1)
+    expect(rows[0].actor_id).toBe(ISSUER)
+    expect(rows[0].metadata.subjectId).toBe(GRANTEE)
+    expect(rows[0].metadata.reason).toBe('incident-123')
+    // LOCK-5 shape: grant audit carries scope only — never any record field value snapshot.
+    const keys = Object.keys(rows[0].metadata)
+    expect(keys).not.toContain('value')
+    expect(keys).not.toContain('values')
+    expect(keys).not.toContain('snapshot')
+    expect(keys).not.toContain('after')
+  })
+
+  test('LOCK-2c: revoke soft-deletes, writes an audit record, and drops the grant from the active list', async () => {
+    const created = await issue({ subjectType: 'user', subjectId: GRANTEE })
+    const grantId = created.body?.data?.id as string
+    expect((await listGrants()).body?.data?.grants?.length).toBe(1)
+    const rev = await revoke(grantId)
+    expect(rev.status).toBe(200)
+    expect((await listGrants()).body?.data?.grants?.length).toBe(0) // active list excludes revoked
+    expect((await auditRows('history_field_audit_grant.revoke')).length).toBe(1)
+    // revoking an already-revoked / unknown grant → 404 (same shape)
+    expect((await revoke(grantId)).status).toBe(404)
+  })
+
+  test('A1/A2 seam: resolveHistoryFieldAuditReveal returns no reveal (history mask untouched in A1)', async () => {
+    const revealed = await resolveHistoryFieldAuditReveal()
+    expect(revealed.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## What

First runtime slice (**A1**) of the History Field-Audit Permission design-lock (#2973). Per `/goal` "根据计划" and the design-lock's explicit staging (A1→A2→A3, gates between), this builds **only the governed grant layer** and deliberately does **NOT** wire any reveal into the history field mask.

**A2 (the reveal runtime — the one piece that actually lifts the mask) is the next gate and is NOT in this PR.**

## Delivered

- **Migration** `meta_history_audit_grants` — mirrors `field_permissions` (subject user/role/member-group, base scope, `expires_at`, `is_standing`, `reason`/`ticket`, soft-delete `revoked_at`); partial-unique (one active grant per base+subject); `CHECK (is_standing OR expires_at IS NOT NULL)`.
- **Standalone platform capability** `multitable:history-field-audit:grant` — checked **only** at issue/revoke; never folded into any `SHEET_*` capability set (so base-admin / `multitable:admin` can't gain it implicitly).
- **Service** `history-audit-grant-service.ts` (issue/revoke/list/loadActive) + the **resolver seam** `resolveHistoryFieldAuditReveal` returning empty (no reveal in A1). Issue/revoke each write an `operation_audit_logs` record (grant scope only, no values).
- **Routes** `POST/GET/DELETE /bases/:baseId/history-audit-grants` with the capability-only authority gate (**no `isAdminRole` bypass**) + base/subject existence validation.

## LOCK-2 (the crux — separation of duties)

authority = the cap (base-admin AND a coarse `admin` role both **rejected**) · issuer ≠ grantee (`SELF_GRANT`) · grantee holds no cap → can't re-issue/self-widen · issue+revoke both audited · D5 default-finite expiry (standing must be explicit + marked).

## Verification

- backend `tsc` 0 errors.
- **11/11 real-DB LOCK-2 goldens** (`multitable-history-audit-grant-realdb.test.ts`, in the `test (20.x)` allowlist).
- **Boundary proof**: the #2968 history goldens stay **8/8 byte-identical** — A1 changed zero masking behavior (the clean A1/A2 seam).
- **Mutation-checked**: add an `isAdminRole` bypass to the gate → the admin-role golden fails (`expected 201 to be 403`); revert → 11/11. The "no admin bypass" golden is load-bearing.
- backend unit **3745/3745**.

## Known A1 edges (named, for owner)

- Only **user** self-grant is hard-blocked; issuer→own-role/group (indirect self-grant) is not (needs membership lookup — a policy call). Flagged with the L2(d) re-grant question.
- A2 (reveal runtime) + A3 (audit-trail read surface) remain separate opt-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)