### PR TITLE
feat(multitable): history field-audit A2 — reveal runtime (explicit break-glass, audit-before-disclosure)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -204,6 +204,7 @@ jobs:
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/multitable-history-events-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
+            tests/integration/multitable-history-audit-reveal-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/packages/core-backend/src/multitable/history-audit-grant-service.ts
+++ b/packages/core-backend/src/multitable/history-audit-grant-service.ts
@@ -235,42 +235,46 @@ export async function listHistoryAuditGrants(query: QueryFn, baseId: string): Pr
 }
 
 /**
- * The active, non-expired grant for any of the actor's subject keys on a base (or null). A2 reads this to
- * decide whether a reveal is permitted; A1 exposes it for grant administration + tests. `subjectKeys` is the
- * actor's identity set: their user id + role ids + member-group ids, each as `{type, id}`.
+ * A2 reveal-authority resolver. Returns the active, non-expired grant that authorises `userId` to reveal
+ * field-permission-masked history on `baseId` — matching the actor by user id, role membership, OR
+ * member-group membership (the same subject model as `field_permissions`) — and EXCLUDING any grant the
+ * actor issued to themselves.
+ *
+ * `granted_by <> userId` is the IMMUTABLE, subject-type-agnostic LOCK-2a closure: because `granted_by` never
+ * changes, it defeats every self-grant path — direct (user→own id) AND indirect (a role/group the issuer
+ * later joined) — that an issue-time membership check structurally cannot. Returns null when no qualifying
+ * grant exists. Fail-closed: any resolver error (e.g. a missing membership table) → null → no reveal → the
+ * masked response, never a leak.
  */
-export async function loadActiveHistoryAuditGrant(
+export async function resolveActiveRevealGrant(
   query: QueryFn,
   baseId: string,
-  subjectKeys: Array<{ type: HistoryAuditGrantSubjectType; id: string }>,
+  userId: string,
   nowMs: number,
 ): Promise<HistoryAuditGrantRow | null> {
-  if (subjectKeys.length === 0) return null
-  const types = subjectKeys.map((k) => k.type)
-  const ids = subjectKeys.map((k) => k.id)
-  const res = await query(
-    `SELECT id, base_id, subject_type, subject_id, granted_by, reason, ticket, expires_at, is_standing, created_at
-     FROM meta_history_audit_grants
-     WHERE base_id = $1
-       AND revoked_at IS NULL
-       AND (expires_at IS NULL OR expires_at > $4)
-       AND (subject_type, subject_id) IN (
-         SELECT * FROM unnest($2::text[], $3::text[])
-       )
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    [baseId, types, ids, new Date(nowMs).toISOString()],
-  )
-  const rows = res.rows as Array<Record<string, unknown>>
-  return rows.length > 0 ? serializeGrantRow(rows[0]) : null
-}
-
-/**
- * A1/A2 SEAM. A2 will compute the field ids a valid grant + explicit reveal request lifts and UNION them into
- * the #2968 allowed-field set. For A1 this ALWAYS returns an empty set (no reveal) and is NOT called from the
- * history mask path — so the history field mask is byte-for-byte the #2968 behaviour. Do not wire this into
- * `buildHistoryAllowedFieldsBySheet` or the per-record allowed-set until the A2 opt-in.
- */
-export async function resolveHistoryFieldAuditReveal(): Promise<Set<string>> {
-  return new Set<string>()
+  if (!baseId || !userId) return null
+  try {
+    const res = await query(
+      `SELECT g.id, g.base_id, g.subject_type, g.subject_id, g.granted_by, g.reason, g.ticket, g.expires_at, g.is_standing, g.created_at
+       FROM meta_history_audit_grants g
+       WHERE g.base_id = $1
+         AND g.revoked_at IS NULL
+         AND (g.expires_at IS NULL OR g.expires_at > $3)
+         AND g.granted_by <> $2
+         AND (
+           (g.subject_type = 'user' AND g.subject_id = $2)
+           OR (g.subject_type = 'role' AND EXISTS (
+                 SELECT 1 FROM user_roles ur WHERE ur.user_id = $2 AND ur.role_id = g.subject_id))
+           OR (g.subject_type = 'member-group' AND EXISTS (
+                 SELECT 1 FROM platform_member_group_members m WHERE m.user_id = $2 AND m.group_id::text = g.subject_id))
+         )
+       ORDER BY g.created_at DESC
+       LIMIT 1`,
+      [baseId, userId, new Date(nowMs).toISOString()],
+    )
+    const rows = res.rows as Array<Record<string, unknown>>
+    return rows.length > 0 ? serializeGrantRow(rows[0]) : null
+  } catch {
+    return null // fail-closed: a resolver error never enables a reveal
+  }
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -78,6 +78,7 @@ import {
   issueHistoryAuditGrant,
   revokeHistoryAuditGrant,
   listHistoryAuditGrants,
+  resolveActiveRevealGrant,
 } from '../multitable/history-audit-grant-service'
 import {
   loadFieldsForSheet as loadFieldsForSheetShared,
@@ -3777,6 +3778,18 @@ async function loadAllowedFieldIds(query: QueryFn, sheetId: string | null | unde
 }
 
 /**
+ * A2 reveal allowed-field set: visible property fields with the per-subject `field_permissions` scope LIFTED
+ * (empty scope map). This lifts ONLY the field_permissions axis — `filterVisiblePropertyFields` inside
+ * `computeAllowedFieldIds` still drops field-definition `hidden`/system fields, the caller still applies the
+ * formula-taint mask afterwards (D6), and row-level deny is unaffected. Used only after a valid reveal grant
+ * is confirmed.
+ */
+async function loadRevealedFieldIds(query: QueryFn, sheetId: string, capabilities: MultitableCapabilities): Promise<Set<string>> {
+  const fields = await loadFieldsForSheet(query, sheetId)
+  return computeAllowedFieldIds(fields, capabilities, new Map<string, FieldPermissionScope>())
+}
+
+/**
  * Global History LOCK-3 FIELD layer: build the per-sheet readable field-id sets the project-on-read
  * history projection masks with. Uses the EXACT chain the per-record history route uses —
  * `loadAllowedFieldIds` (visible property fields ∧ field_permissions scope) then `maskStoredRecordFieldIds`
@@ -3790,14 +3803,55 @@ async function buildHistoryAllowedFieldsBySheet(
   query: QueryFn,
   sheetIds: string[],
   userId: string,
+  reveal = false,
 ): Promise<Map<string, Set<string>>> {
   const map = new Map<string, Set<string>>()
   for (const sheetId of sheetIds) {
     const { capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
-    const baseAllowed = await loadAllowedFieldIds(query, sheetId, userId, capabilities)
+    // A2 reveal lifts ONLY the per-subject field_permissions scope; taint is still masked below (D6), hidden/
+    // system fields stay excluded, and row-level deny (projection row layer) is untouched.
+    const baseAllowed = reveal
+      ? await loadRevealedFieldIds(query, sheetId, capabilities)
+      : await loadAllowedFieldIds(query, sheetId, userId, capabilities)
     map.set(sheetId, await maskStoredRecordFieldIds(req, query, sheetId, undefined, baseAllowed))
   }
   return map
+}
+
+/**
+ * A2 reveal gate (audit-before-disclosure). Returns true ONLY when (a) an explicit reveal was requested,
+ * (b) the actor holds a valid non-expired grant they did NOT self-issue (`resolveActiveRevealGrant` enforces
+ * `granted_by <> actor` — the immutable LOCK-2a closure), AND (c) the reveal-intent audit row was written
+ * FIRST. If the audit write fails we degrade to false (the masked response): there is never an unaudited
+ * reveal — the read-side of LOCK-2c / LOCK-5. The caller enforces reason-required (L8). We log INTENT
+ * (who / base / scope / reason / grantId), never a field-value diff.
+ */
+async function resolveHistoryRevealActive(
+  query: QueryFn,
+  baseId: string,
+  userId: string,
+  revealRequested: boolean,
+  reason: string | undefined,
+  ticket: string | undefined,
+  scope: string,
+): Promise<boolean> {
+  if (!revealRequested) return false
+  const grant = await resolveActiveRevealGrant(query, baseId, userId, Date.now())
+  if (!grant) return false
+  try {
+    const meta = JSON.stringify({
+      baseId, scope, reason: reason ?? null, ticket: ticket ?? null,
+      grantId: grant.id, subjectType: grant.subjectType, subjectId: grant.subjectId,
+    })
+    await query(
+      `INSERT INTO operation_audit_logs (actor_id, actor_type, action, resource_type, resource_id, metadata, meta)
+       VALUES ($1, 'user', 'history_field_audit.reveal', 'meta_history_audit_reveal', $2, $3::jsonb, $3::jsonb)`,
+      [userId, baseId, meta],
+    )
+  } catch {
+    return false // audit write failed → never disclose unaudited revealed data
+  }
+  return true
 }
 
 // #2052 (b): PURE — returns a redacted COPY (view configs are cached/shared; never mutate in place, or a
@@ -6461,8 +6515,15 @@ export function univerMetaRouter(): Router {
       const limit = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
       const offset = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
       const str = (v: unknown): string | undefined => (typeof v === 'string' && v.trim() ? v.trim() : undefined)
+      // A2 field-audit reveal: explicit opt-in (?reveal=1) + a reason (L8); the audit-before-disclosure gate
+      // resolves a valid non-self-issued grant and logs the reveal BEFORE any unmasked field is built.
+      const revealRequested = req.query.reveal === '1' || req.query.reveal === 'true'
+      const reason = str(req.query.reason)
+      const ticket = str(req.query.ticket)
+      if (revealRequested && !reason) return res.status(400).json({ ok: false, error: { code: 'REASON_REQUIRED', message: 'A field-audit reveal requires a reason' } })
+      const revealActive = await resolveHistoryRevealActive(pool.query.bind(pool), baseId, access.userId, revealRequested, reason, ticket, 'history.events')
       // LOCK-3 field layer: a base-level list can show any readable sheet, so resolve allowed fields for all.
-      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), readableSheetIds, access.userId)
+      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), readableSheetIds, access.userId, revealActive)
       const { batches, total } = await loadHistoryBatchSummaries(
         pool.query.bind(pool),
         {
@@ -6508,7 +6569,13 @@ export function univerMetaRouter(): Router {
             `SELECT DISTINCT sheet_id FROM meta_record_revisions WHERE sheet_id = ANY($1::text[]) AND COALESCE(batch_id, id::text) = $2`,
             [readableSheetIds, batchId],
           )).rows as Array<{ sheet_id: unknown }>).map((r) => String(r.sheet_id))
-      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), batchSheetIds, access.userId)
+      // A2 field-audit reveal (audit-before-disclosure); reason required (L8), ticket optional.
+      const revealRequested = req.query.reveal === '1' || req.query.reveal === 'true'
+      const dReason = typeof req.query.reason === 'string' && req.query.reason.trim() ? req.query.reason.trim() : undefined
+      const dTicket = typeof req.query.ticket === 'string' && req.query.ticket.trim() ? req.query.ticket.trim() : undefined
+      if (revealRequested && !dReason) return res.status(400).json({ ok: false, error: { code: 'REASON_REQUIRED', message: 'A field-audit reveal requires a reason' } })
+      const revealActive = await resolveHistoryRevealActive(pool.query.bind(pool), baseId, access.userId, revealRequested, dReason, dTicket, `history.batch:${batchId}`)
+      const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), batchSheetIds, access.userId, revealActive)
       const detail = await loadHistoryBatchDetail(pool.query.bind(pool), readableSheetIds, batchId, { userId: access.userId, isAdminRole: access.isAdminRole }, allowedFieldsBySheet)
       // Denied and missing share the SAME 404 shape (LOCK-3: no existence oracle).
       if (!detail) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'History batch not found' } })
@@ -6566,7 +6633,18 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      const baseAllowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      // A2 field-audit reveal (audit-before-disclosure); reason required (L8). Reveal lifts ONLY the field
+      // mask — the row-deny check above already ran and is unaffected (LOCK-4).
+      const revealRequested = req.query.reveal === '1' || req.query.reveal === 'true'
+      const pReason = typeof req.query.reason === 'string' && req.query.reason.trim() ? req.query.reason.trim() : undefined
+      const pTicket = typeof req.query.ticket === 'string' && req.query.ticket.trim() ? req.query.ticket.trim() : undefined
+      if (revealRequested && !pReason) return res.status(400).json({ ok: false, error: { code: 'REASON_REQUIRED', message: 'A field-audit reveal requires a reason' } })
+      const recBaseRow = await pool.query('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])
+      const recBaseId = recBaseRow.rows.length > 0 ? String((recBaseRow.rows[0] as { base_id: unknown }).base_id) : ''
+      const revealActive = await resolveHistoryRevealActive(pool.query.bind(pool), recBaseId, access.userId, revealRequested, pReason, pTicket, `history.record:${recordId}`)
+      const baseAllowedFieldIds = revealActive
+        ? await loadRevealedFieldIds(pool.query.bind(pool), sheetId, capabilities)
+        : await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       // §2a.3 (m1) via the single CHOKEPOINT (maskStoredRecordFieldIds): a record-revision
       // snapshot/patch can carry a MATERIALIZED formula value whose foreign lookup input is masked for
       // this actor; the source-sheet allowed-field set above does not catch it (the formula field

--- a/packages/core-backend/tests/integration/multitable-history-audit-grant-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-audit-grant-realdb.test.ts
@@ -19,7 +19,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { univerMetaRouter } from '../../src/routes/univer-meta'
-import { resolveHistoryFieldAuditReveal } from '../../src/multitable/history-audit-grant-service'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -174,11 +173,6 @@ describeIfDatabase('history field-audit grant — A1 LOCK-2 governance goldens (
     expect((await auditRows('history_field_audit_grant.revoke')).length).toBe(1)
     // revoking an already-revoked / unknown grant → 404 (same shape)
     expect((await revoke(grantId)).status).toBe(404)
-  })
-
-  test('A1/A2 seam: resolveHistoryFieldAuditReveal returns no reveal (history mask untouched in A1)', async () => {
-    const revealed = await resolveHistoryFieldAuditReveal()
-    expect(revealed.size).toBe(0)
   })
 
   // ----- A1 hardening (owner review): atomicity + indirect self-grant guardrail -----

--- a/packages/core-backend/tests/integration/multitable-history-audit-reveal-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-audit-reveal-realdb.test.ts
@@ -1,0 +1,236 @@
+/**
+ * A2 — History Field-Audit reveal runtime: security goldens (real DB).
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * The reveal lifts the per-subject `field_permissions` scope on the history surfaces — and ONLY that. These
+ * goldens pin every load-bearing property:
+ *   - default masked (#2968) with NO grant, even with ?reveal=1 (D1/LOCK-1);
+ *   - a valid grant but NO reveal flag → still masked (D1: closed by default even for holders);
+ *   - a valid grant + ?reveal=1 + reason → the field_permissions-denied field is revealed (id+value+count);
+ *   - reason is REQUIRED on reveal → 400 (L8);
+ *   - a SELF-issued grant (granted_by === revealer) does NOT enable reveal — the immutable LOCK-2a closure;
+ *   - an expired grant does NOT enable reveal (LOCK-3);
+ *   - row-level deny STILL applies under reveal — a row-denied record stays invisible (LOCK-4: field axis only);
+ *   - field-definition hidden fields are NOT lifted by reveal (reveal lifts ONLY the field_permissions axis);
+ *   - every reveal writes an `operation_audit_logs` record (actor/base/scope/reason, NO values) BEFORE
+ *     disclosure, and an audit-write failure DEGRADES to the masked response (LOCK-5 read-side).
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_rev_${TS}`
+const SHEET_ID = `sheet_rev_${TS}`
+const STATUS = `fld_rev_status_${TS}`
+const SALARY = `fld_rev_salary_${TS}` // field_permission-denied to the VIEWER
+const HIDDEN = `fld_rev_hidden_${TS}` // field-definition hidden (property.hidden) — never lifted by reveal
+const REC_PUBLIC = `rec_rev_public_${TS}`
+const REC_SECRET = `rec_rev_secret_${TS}`
+const FIELD_BATCH = `batch_rev_field_${TS}` // REC_PUBLIC touching STATUS+SALARY+HIDDEN
+const SECRET_BATCH = `batch_rev_secret_${TS}` // REC_SECRET (row-deny target)
+const VIEWER = `user_rev_viewer_${TS}` // the auditor/reader; field_permissions denies SALARY
+const ISSUER = `user_rev_issuer_${TS}` // grants to VIEWER (granted_by != VIEWER)
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser: string | undefined = VIEWER
+let curPerms: string[] = ['multitable:read', 'multitable:write']
+let curRoles: string[] = ['member']
+
+const events = (query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/bases/${BASE_ID}/history/events`).query({ limit: 100, ...query })
+const detail = (batchId: string, query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/bases/${BASE_ID}/history/events/${batchId}`).query(query)
+const recordHistory = (query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/sheets/${SHEET_ID}/records/${REC_PUBLIC}/history`).query(query)
+
+type Batch = { batchId: string; visibleAffectedFieldCount: number }
+const batchOf = (res: { body?: { data?: { batches?: Batch[] } } }, id: string) =>
+  (res.body?.data?.batches ?? []).find((b) => b.batchId === id)
+const batchIds = (res: { body?: { data?: { batches?: Batch[] } } }) => (res.body?.data?.batches ?? []).map((b) => b.batchId)
+
+const denySalaryRule = [{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }]
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
+
+// Insert a grant TO the VIEWER, issued by `grantedBy`, expiring `daysFromNow` out (null = standing).
+const grantToViewer = (grantedBy: string, daysFromNow: number | null = 30) =>
+  q(
+    `INSERT INTO meta_history_audit_grants (base_id, subject_type, subject_id, granted_by, reason, expires_at, is_standing)
+     VALUES ($1,'user',$2,$3,'seed', $4, $5)`,
+    [BASE_ID, VIEWER, grantedBy, daysFromNow === null ? null : new Date(TS + daysFromNow * 86400000).toISOString(), daysFromNow === null],
+  )
+const clearGrants = () => q('DELETE FROM meta_history_audit_grants WHERE base_id = $1', [BASE_ID])
+const revealAudits = async () =>
+  (await q(`SELECT actor_id, metadata FROM operation_audit_logs WHERE action = 'history_field_audit.reveal' AND metadata->>'baseId' = $1`, [BASE_ID]))
+    .rows as Array<{ actor_id: string; metadata: Record<string, unknown> }>
+
+describeIfDatabase('history field-audit reveal — A2 security goldens (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = curUser ? { id: curUser, roles: curRoles, perms: curPerms } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Rev Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'Rev Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET_ID, 'Salary', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [HIDDEN, SHEET_ID, 'HiddenF', 'number', '{"hidden":true}', 3])
+    for (const [rid, status] of [[REC_PUBLIC, 'public'], [REC_SECRET, 'secret']] as const) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid, SHEET_ID, JSON.stringify({ [STATUS]: status })])
+    }
+    for (const uid of [VIEWER, ISSUER]) {
+      await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [uid])
+    }
+    // REC_PUBLIC revision touching STATUS + SALARY + HIDDEN.
+    await q(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+       VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', $3, ARRAY[$4,$5,$6]::text[], '{}'::jsonb, $7::jsonb, $8)`,
+      [SHEET_ID, REC_PUBLIC, ISSUER, STATUS, SALARY, HIDDEN, JSON.stringify({ [STATUS]: 'public', [SALARY]: 99999, [HIDDEN]: 7 }), FIELD_BATCH],
+    )
+    // REC_SECRET revision (row-deny target).
+    await q(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+       VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, ARRAY[$4]::text[], '{}'::jsonb, $5::jsonb, $6)`,
+      [SHEET_ID, REC_SECRET, ISSUER, STATUS, JSON.stringify({ [STATUS]: 'secret' }), SECRET_BATCH],
+    )
+    // Baseline: field_permissions denies SALARY to the VIEWER (this is what reveal lifts).
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET_ID, SALARY, VIEWER],
+    )
+  })
+
+  afterAll(async () => {
+    for (const t of ['meta_history_audit_grants', 'field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) {
+      await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+    }
+    await q("DELETE FROM operation_audit_logs WHERE action = 'history_field_audit.reveal' AND metadata->>'baseId' = $1", [BASE_ID]).catch(() => {})
+    await q('DELETE FROM meta_history_audit_grants WHERE base_id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[VIEWER, ISSUER]]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    curUser = VIEWER; curPerms = ['multitable:read', 'multitable:write']; curRoles = ['member']
+    await clearGrants(); await setFlag(false); await setRules([])
+    await q("DELETE FROM operation_audit_logs WHERE action = 'history_field_audit.reveal' AND metadata->>'baseId' = $1", [BASE_ID])
+  })
+  afterEach(async () => { await clearGrants() })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('LOCK-1 default: NO grant + ?reveal=1 → SALARY stays masked (= #2968)', async () => {
+    const res = await events({ reveal: '1', reason: 'x' })
+    expect(res.status).toBe(200)
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1) // STATUS only — SALARY masked
+  })
+
+  test('D1: a valid grant WITHOUT the reveal flag → still masked (closed by default even for holders)', async () => {
+    await grantToViewer(ISSUER)
+    const res = await events()
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1)
+  })
+
+  test('reveal: a valid grant + ?reveal=1 + reason → SALARY revealed (id + value + count)', async () => {
+    await grantToViewer(ISSUER)
+    const res = await events({ reveal: '1', reason: 'SOC2 audit' })
+    expect(res.status).toBe(200)
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(2) // STATUS + SALARY
+    const d = await detail(FIELD_BATCH, { reveal: '1', reason: 'SOC2 audit' })
+    const change = (d.body?.data?.changes ?? []).find((c: { recordId: string }) => c.recordId === REC_PUBLIC) as
+      | { changedFieldIds: string[]; after: Record<string, unknown> } | undefined
+    expect(change?.changedFieldIds).toContain(SALARY)
+    expect(change?.after?.[SALARY]).toBe(99999)
+  })
+
+  test('L8: ?reveal=1 without a reason → 400', async () => {
+    await grantToViewer(ISSUER)
+    expect((await events({ reveal: '1' })).status).toBe(400)
+    expect((await detail(FIELD_BATCH, { reveal: '1' })).status).toBe(400)
+    expect((await recordHistory({ reveal: '1' })).status).toBe(400)
+  })
+
+  test('LOCK-2a closure: a SELF-issued grant (granted_by === revealer) does NOT enable reveal', async () => {
+    await grantToViewer(VIEWER) // self-issued
+    const res = await events({ reveal: '1', reason: 'x' })
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1) // masked — self-grant ignored
+  })
+
+  test('LOCK-3: an expired grant does NOT enable reveal', async () => {
+    await grantToViewer(ISSUER, -1) // expired yesterday
+    const res = await events({ reveal: '1', reason: 'x' })
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1)
+  })
+
+  test('no admin bypass: an admin role WITHOUT a grant + ?reveal=1 → still masked', async () => {
+    curRoles = ['admin'] // isAdminRole, but holds NO field-audit grant
+    const res = await events({ reveal: '1', reason: 'x' })
+    expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1) // reveal needs a grant, not a role
+  })
+
+  test('LOCK-4: row-level deny STILL applies under reveal — a row-denied record stays invisible', async () => {
+    await grantToViewer(ISSUER)
+    await setRules(denySalaryRule); await setFlag(true) // deny status='secret' records
+    const res = await events({ reveal: '1', reason: 'x' })
+    expect(res.status).toBe(200)
+    expect(batchIds(res)).toContain(FIELD_BATCH)
+    expect(batchIds(res)).not.toContain(SECRET_BATCH) // reveal lifts the FIELD axis, never the ROW axis
+  })
+
+  test('reveal lifts ONLY field_permissions: a field-definition hidden field is NOT revealed', async () => {
+    await grantToViewer(ISSUER)
+    const d = await detail(FIELD_BATCH, { reveal: '1', reason: 'x' })
+    const change = (d.body?.data?.changes ?? []).find((c: { recordId: string }) => c.recordId === REC_PUBLIC) as
+      | { changedFieldIds: string[]; after: Record<string, unknown> } | undefined
+    expect(change?.changedFieldIds).toContain(SALARY) // field_permissions lifted
+    expect(change?.changedFieldIds).not.toContain(HIDDEN) // field-definition hidden NOT lifted
+    expect(change?.after?.[HIDDEN]).toBeUndefined()
+  })
+
+  test('LOCK-5: a reveal writes ONE audit record (actor/base/reason, no values)', async () => {
+    await grantToViewer(ISSUER)
+    await events({ reveal: '1', reason: 'incident-42' })
+    const rows = await revealAudits()
+    expect(rows.length).toBe(1)
+    expect(rows[0].actor_id).toBe(VIEWER)
+    expect(rows[0].metadata.reason).toBe('incident-42')
+    const keys = Object.keys(rows[0].metadata)
+    expect(keys).not.toContain('value'); expect(keys).not.toContain('after'); expect(keys).not.toContain('snapshot')
+  })
+
+  test('LOCK-5 read-side: if the reveal-audit write fails, the response DEGRADES to masked (never unaudited reveal)', async () => {
+    await grantToViewer(ISSUER)
+    await q('DROP TRIGGER IF EXISTS _rev_fail_audit_trg ON operation_audit_logs', [])
+    await q(`CREATE OR REPLACE FUNCTION _rev_fail_audit() RETURNS trigger AS $f$ BEGIN RAISE EXCEPTION 'forced'; END; $f$ LANGUAGE plpgsql`, [])
+    await q('CREATE TRIGGER _rev_fail_audit_trg BEFORE INSERT ON operation_audit_logs FOR EACH ROW EXECUTE FUNCTION _rev_fail_audit()', [])
+    try {
+      const res = await events({ reveal: '1', reason: 'x' })
+      expect(res.status).toBe(200)
+      expect(batchOf(res, FIELD_BATCH)?.visibleAffectedFieldCount).toBe(1) // audit failed → masked, not revealed
+    } finally {
+      await q('DROP TRIGGER IF EXISTS _rev_fail_audit_trg ON operation_audit_logs', []).catch(() => {})
+      await q('DROP FUNCTION IF EXISTS _rev_fail_audit()', []).catch(() => {})
+    }
+  })
+
+  test('per-record surface: reveal lifts the field mask there too (parity)', async () => {
+    const masked = await recordHistory()
+    const mItem = (masked.body?.data?.items ?? []).find((it: { changedFieldIds: string[] }) => it.changedFieldIds.includes(STATUS)) as
+      | { changedFieldIds: string[] } | undefined
+    expect(mItem?.changedFieldIds).not.toContain(SALARY) // masked by default
+    await grantToViewer(ISSUER)
+    const revealed = await recordHistory({ reveal: '1', reason: 'x' })
+    const rItem = (revealed.body?.data?.items ?? []).find((it: { changedFieldIds: string[] }) => it.changedFieldIds.includes(STATUS)) as
+      | { changedFieldIds: string[] } | undefined
+    expect(rItem?.changedFieldIds).toContain(SALARY) // revealed
+  })
+})


### PR DESCRIPTION
## What

A2 — the **reveal runtime**, the slice that actually lifts the history field mask. Wired into both surfaces (global events/detail + per-record history), end-to-end gated. This is the dangerous slice; it is landed alone for focused review (per the design-lock staging).

## How it's gated

- **Explicit opt-in**: `?reveal=1` + a **required `reason`** (L8). Default (no flag) is **byte-identical to #2968**.
- **Valid grant required** (`resolveActiveRevealGrant`): matches the actor by user / role / member-group **AND** excludes `granted_by === actor` — the **immutable LOCK-2a self-grant closure**. This subsumes the A1 issue-time guardrail and defeats the indirect (role/group) self-grant that a mutable issue-time check structurally cannot.
- **Audit-before-disclosure (LOCK-5 read-side)**: the reveal-intent audit row (actor / base / scope / reason, **no values**) is written **first**; if it fails, the response **degrades to masked** — never an unaudited reveal.
- **Reveal lifts ONLY the per-subject `field_permissions` scope**:
  - row-level deny still applies (**LOCK-4** — golden);
  - formula-taint still drops (**D6** — `resolveTaintedFormulaFieldIds` derives foreign-denial independently via `resolveForeignFieldReadability`, not from the widened set — traced, see below);
  - field-definition `hidden`/system fields stay hidden (golden).
- **LOCK-7 by construction**: `loadRevealedFieldIds` is reachable only from the 3 read routes — never a write/restore/preview/PIT path (grep-confirmed).

## Verification

**13 real-DB reveal goldens**: default-masked (no grant) · grant-without-flag masked (D1) · reveal works (id+value+count) · `reason`→400 (all 3 surfaces) · **self-grant denied** · expired denied · **row-deny still applies under reveal** · hidden-field not lifted · reveal writes audit (no values) · **audit-fail → degrade to masked** · per-record parity · **no admin bypass**.

**Mutation-checked** (both load-bearing): remove the `granted_by` closure → the self-grant golden fails (`2`≠`1`); remove the audit-degrade → the unaudited-reveal golden fails.

#2968 boundary **8/8 byte-identical**; A1 grant goldens **15/15**; tsc 0; unit **3756/3756**.

## Deliberate choices (named, not hidden)

- Audit-failure degrades to a **masked 200** (safe — no unaudited leak; the auditor isn't told the reveal was suppressed).
- `reason` rides in the **query string** (it's the actor's own justification, not sensitive; a header is cleaner — noted as a possible follow-up).
- A dedicated **formula-taint reveal golden** is a follow-up (D6 is verified structurally by tracing the resolver, but the fixture has no formula field).

Retires the A1 resolver seam (`resolveHistoryFieldAuditReveal`) now that reveal is wired for real.

**Next: A3** (audit-trail read surface) + the one arc verification MD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)