### PR TITLE
feat(multitable): history field-audit A3 — audit-trail read surface + arc verification MD

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -205,6 +205,7 @@ jobs:
             tests/integration/multitable-history-events-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \
+            tests/integration/multitable-history-audit-log-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-history-field-audit-arc-dev-verification-20260621.md
+++ b/docs/development/multitable-history-field-audit-arc-dev-verification-20260621.md
@@ -1,0 +1,51 @@
+# History Field-Audit Permission — A1→A3 arc 开发与验证 MD
+
+> 对应 /goal「请根据计划完成余下所有的开发。可并行开发，完成后给出开发及验证 MD」。
+> **计划 = design-lock #2973（`2b6a4fd48`）的分阶段 TODO（A0✅→A1→A2→A3）。本 MD 覆盖整条 arc 余下全部开发并已全部落 `main`。**
+> 这是一个**独立的、受治理的 break-glass**：admin 单凭身份永不解锁字段历史；解锁靠独立授予，且**授予与每次使用都被审计**。
+
+## 0. 分阶段交付（全部 MERGED / landing）
+
+| 阶段 | 内容 | PR / SHA |
+|---|---|---|
+| **A1** | grant 模型 + 平台能力 + 发证/撤证路由 + resolver 接缝（不接遮罩） | #2976 `09564b78c` |
+| **A1 硬化** | 复审修两 P1：发证/撤证+审计**事务原子化**；issue-time role/group 自授 guardrail + 更正「完整 LOCK-2」过度声称 | #2979 `7e75ec7c3` |
+| **A2** | **reveal 运行时**（真正掀字段遮罩的一刀）+ audit-before-disclosure | #2981 `472a1c745` |
+| **A3** | 审计流水只读面（who-granted / who-revealed，gated on 同一能力） | 本 PR |
+
+## 1. 落地的 LOCK（L1–L8，逐条有真库 golden 或结构性保证）
+
+- **L1 独立授予**：唯一能掀历史字段遮罩的是 `meta_history_audit_grants` 中的有效 grant；`admin`/`multitable:admin`/行级 admin-bypass 都不附带。无 grant → 完全等于 #2968 遮罩（边界 8/8 byte-identical）。
+- **L2 授权 + 职责分离 + 发证审计 + 不可自扩**：发证唯一钥匙 = 平台能力 `multitable:history-field-audit:grant`（**只**在发证/撤证/审计面检查，**绝不**并入任何 `SHEET_*` 集；**无 isAdminRole 旁路**，mutation-checked）。issuer≠grantee：user 直接自授（issue-time 拒）+ role/group 间接自授（issue-time guardrail）+ **reveal-time `granted_by <> revealer`（不可变闭合，subsumes 全部自授路径，mutation-checked）**。grantee 不持能力→不能再发证自扩。发证/撤证与 grant mutation **同一事务**（审计失败→回滚，mutation-checked）。
+- **L3 fail-closed / inert**：无 grant / 能力关 / 任何解析边缘 → 遮罩，绝不泄。过期 grant → 不解（golden）。
+- **L4 只掀字段轴，不掀行轴，只读**：reveal 只在 actor 本就能行读的记录上掀字段；**行级 deny 在 reveal 下仍生效**（golden）；不授任何写。
+- **L5 reveal 自审计 + 审计不存值 + audit-before-disclosure**：每次 reveal 先写一条 `operation_audit_logs`（actor/base/scope/reason，**无值**）**再**披露；**审计失败→降级为遮罩响应**（never unaudited reveal，mutation-checked）。发证审计同样只存 scope。
+- **L6 双面同一 resolver**：全局历史（events/detail via `buildHistoryAllowedFieldsBySheet`）与按记录历史（per-record route）走同一 reveal 链；两面 parity（golden）。
+- **L7 reveal 不进任何写/恢复路径（by construction）**：`loadRevealedFieldIds`（掀遮罩的函数）仅被 3 条读路由可达，grep 证实无 write/restore/preview/PIT 调用方。
+- **L8 reveal 必带 reason 并写审计**：`?reveal=1` 无 `reason` → 400（三面 golden）；`ticket` 可选。
+- **D6 公式 taint 不被 reveal 掀**（结构性，已 TRACE）：reveal 只掀本表 `field_permissions` scope，`maskStoredRecordFieldIds` 仍无条件执行；`resolveTaintedFormulaFieldIds` 的「外表字段是否被拒」经 `resolveForeignFieldReadability` **独立**解析（不取自被 reveal 拓宽的候选集），故跨表物化公式值在 reveal 下仍被 taint 丢弃。
+- **D5 默认有限期**：无 expiry 且非 standing → 90 天有限窗；standing 必须显式 + 标记（goldens）。
+
+## 2. 验证
+
+- backend `tsc --noEmit`：**0 error**。
+- **真库历史 goldens：42/42 pass**（`metasheet_test`）：
+  - `multitable-history-events-realdb`（#2968 边界）**8/8 byte-identical**（reveal 默认关 → 行为不变，A1/A2 接缝与 boundary 证明）；
+  - `multitable-history-audit-grant-realdb`（A1+硬化）**15**：能力门 / 无 admin 旁路 / user+role+group 自授拒 / 默认有限期 / standing / 发证撤证审计 / **原子回滚（issue+revoke）** / 重复→409；
+  - `multitable-history-audit-reveal-realdb`（A2）**13**：默认遮 / 持证无 flag 遮 / reveal 成功（id+值+计数）/ reason→400 / **自授拒** / 过期拒 / **行级 deny 仍生效** / hidden 不掀 / reveal 审计（无值）/ **审计失败→降级遮** / per-record parity / 无 admin 旁路；
+  - `multitable-history-audit-log-realdb`（A3）**6**：能力门（非能力 + admin role 均拒）/ base 作用域 / **无值** / kind 过滤。
+- **Mutation checks（4，全部 load-bearing）**：① 授权门加 isAdminRole 旁路 → admin-role golden 失败；② 发证改回非事务 → 原子回滚 golden 失败；③ 去掉 `granted_by <> $2` → 自授 golden 失败；④ 去掉 audit-degrade → 未审计 reveal golden 失败。
+- backend unit：**3756/3756 pass**（本地重跑，无回归；arc 只增集成 goldens，不增 unit）。
+- 无 FE 改动；迁移仅 A1 一张表。
+
+## 3. 显式设计选择（命名，非隐藏）
+
+- **审计失败降级为遮罩 200**：安全（无未审计泄露），但审计者不被告知 reveal 被抑制——刻意取舍（可改 503，留作 owner 决定）。
+- **reason 走 query string**：是 actor 自己的理由、非敏感；合规面用 header 更干净——记为可选 follow-up。
+- **专门的 formula-taint reveal golden**：D6 已 TRACE 结构性成立，但 fixture 无公式字段；专项 golden 留作 follow-up。
+- **role/group 间接自授的 issue-time guardrail 是 fast-fail**（成员关系可变）；**不可变闭合是 reveal-time `granted_by`**——两者并存，文档不再称 issue-time「完整」。
+
+## 4. 后续（gated，未建）
+
+- 强制 `ticket`；sheet/字段集级 grant 作用域；graduated metadata-only tier（D7 defer）；reveal 也掀 taint（D6，需独立决定）；上述 §3 三个 follow-up。
+- L2(d) 是否允许平级转授：现状锁为「grantee 不能再发证/转授」，owner 可放宽。

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6788,6 +6788,61 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  // A3 — History Field-Audit audit-trail read surface. Read-only "who granted / revoked / revealed what" over
+  // operation_audit_logs, gated on the SAME platform capability that manages grants (LOCK-5: the auditor is
+  // itself auditable). The serializer picks ONLY scope fields from metadata — never echoes a record field value.
+  router.get('/bases/:baseId/history-audit-log', async (req: Request, res: Response) => {
+    try {
+      const access = await requireHistoryAuditGrantAuthority(req, res)
+      if (!access) return
+      const pool = poolManager.get()
+      const baseId = typeof req.params.baseId === 'string' ? req.params.baseId.trim() : ''
+      if (!baseId) return res.status(400).json({ ok: false, error: { code: 'BAD_REQUEST', message: 'baseId required' } })
+      const limitRaw = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 100
+      const offsetRaw = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+      const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 200) : 100
+      const offset = Number.isFinite(offsetRaw) ? Math.max(offsetRaw, 0) : 0
+      const kindFilter = req.query.kind === 'grant' || req.query.kind === 'reveal' ? String(req.query.kind) : null
+      const resourceTypes = kindFilter === 'reveal'
+        ? ['meta_history_audit_reveal']
+        : kindFilter === 'grant'
+          ? ['meta_history_audit_grant']
+          : ['meta_history_audit_grant', 'meta_history_audit_reveal']
+      const rows = (await pool.query(
+        `SELECT id, actor_id, action, resource_type, metadata, created_at
+         FROM operation_audit_logs
+         WHERE resource_type = ANY($1::text[]) AND metadata->>'baseId' = $2
+         ORDER BY created_at DESC
+         LIMIT $3 OFFSET $4`,
+        [resourceTypes, baseId, limit, offset],
+      )).rows as Array<Record<string, unknown>>
+      const entries = rows.map((r) => {
+        const md = (r.metadata && typeof r.metadata === 'object' ? r.metadata : {}) as Record<string, unknown>
+        return {
+          id: String(r.id),
+          actorId: typeof r.actor_id === 'string' ? r.actor_id : null,
+          action: String(r.action),
+          kind: r.resource_type === 'meta_history_audit_reveal' ? 'reveal' : 'grant',
+          subjectType: typeof md.subjectType === 'string' ? md.subjectType : null,
+          subjectId: typeof md.subjectId === 'string' ? md.subjectId : null,
+          reason: typeof md.reason === 'string' ? md.reason : null,
+          ticket: typeof md.ticket === 'string' ? md.ticket : null,
+          scope: typeof md.scope === 'string' ? md.scope : null,
+          grantId: typeof md.grantId === 'string' ? md.grantId : null,
+          at: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at ?? ''),
+        }
+      })
+      const names = await resolveUserDisplayNames(pool.query.bind(pool), entries.map((e) => e.actorId).filter((x): x is string => !!x))
+      const enriched = entries.map((e) => ({ ...e, actorName: e.actorId ? names.get(e.actorId) ?? null : null }))
+      return res.json({ ok: true, data: { entries: enriched, limit, offset } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] history audit-log failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to load audit log' } })
+    }
+  })
+
   // ---------------------------------------------------------------------------
   // Layer 1 — record-level version restore.
   // Design-lock: docs/development/multitable-record-restore-layer1-design-20260615.md

--- a/packages/core-backend/tests/integration/multitable-history-audit-log-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-audit-log-realdb.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A3 — History Field-Audit audit-trail read surface: goldens (real DB).
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * GET /bases/:baseId/history-audit-log lists the grant + reveal audit rows for a base. Pins:
+ *   - it is gated on the SAME platform capability that issues grants (the auditor is itself auditable);
+ *   - it is scoped to the base; and
+ *   - it returns scope metadata only — never any record field value.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_log_${TS}`
+const OTHER_BASE = `base_log_other_${TS}`
+const CAP = 'multitable:history-field-audit:grant'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser: string | undefined = `user_log_${TS}`
+let curPerms: string[] = [CAP]
+let curRoles: string[] = ['member']
+
+const auditLog = (query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/bases/${BASE_ID}/history-audit-log`).query(query)
+
+// Seed an operation_audit_logs row of the given kind for a base.
+const seedAudit = (kind: 'grant' | 'reveal', baseId: string, action: string, md: Record<string, unknown>) =>
+  q(
+    `INSERT INTO operation_audit_logs (actor_id, actor_type, action, resource_type, resource_id, metadata, meta)
+     VALUES ($1,'user',$2,$3,$4,$5::jsonb,$5::jsonb)`,
+    [
+      `actor_${TS}`,
+      action,
+      kind === 'reveal' ? 'meta_history_audit_reveal' : 'meta_history_audit_grant',
+      baseId,
+      JSON.stringify({ baseId, ...md }),
+    ],
+  )
+
+const clearAudit = () =>
+  q("DELETE FROM operation_audit_logs WHERE resource_type IN ('meta_history_audit_grant','meta_history_audit_reveal') AND metadata->>'baseId' = ANY($1::text[])", [[BASE_ID, OTHER_BASE]])
+
+describeIfDatabase('history field-audit audit-log — A3 read surface (real DB)', () => {
+  beforeAll(() => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = curUser ? { id: curUser, roles: curRoles, perms: curPerms } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+  })
+
+  afterAll(async () => { await clearAudit().catch(() => {}) })
+
+  beforeEach(async () => {
+    curUser = `user_log_${TS}`; curPerms = [CAP]; curRoles = ['member']
+    await clearAudit()
+    await seedAudit('grant', BASE_ID, 'history_field_audit_grant.issue', { subjectType: 'user', subjectId: 'grantee1', reason: 'issue-reason' })
+    await seedAudit('reveal', BASE_ID, 'history_field_audit.reveal', { scope: 'history.events', reason: 'reveal-reason', grantId: 'g1' })
+    await seedAudit('grant', OTHER_BASE, 'history_field_audit_grant.issue', { subjectType: 'user', subjectId: 'x', reason: 'other' })
+  })
+  afterEach(async () => { await clearAudit() })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('gate: a caller WITHOUT the grant capability is rejected (the auditor is auditable, by the same key)', async () => {
+    curPerms = ['multitable:admin', 'multitable:read'] // base-admin, no field-audit cap
+    expect((await auditLog()).status).toBe(403)
+    curRoles = ['admin']; curPerms = ['multitable:read'] // coarse admin role, no cap
+    expect((await auditLog()).status).toBe(403)
+  })
+
+  test('cap holder: sees the grant + reveal entries for the base, newest first', async () => {
+    const res = await auditLog()
+    expect(res.status).toBe(200)
+    const entries = res.body?.data?.entries as Array<{ kind: string; action: string; reason: string | null }>
+    expect(entries.length).toBe(2)
+    expect(entries.map((e) => e.kind).sort()).toEqual(['grant', 'reveal'])
+    expect(entries.find((e) => e.kind === 'reveal')?.reason).toBe('reveal-reason')
+  })
+
+  test('base-scoped: another base\'s audit rows are not shown', async () => {
+    const entries = (await auditLog()).body?.data?.entries as Array<{ subjectId: string | null }>
+    expect(entries.every((e) => e.subjectId !== 'x')).toBe(true) // the OTHER_BASE grant is excluded
+  })
+
+  test('no values: entries carry scope metadata only, never a record field value', async () => {
+    const entries = (await auditLog()).body?.data?.entries as Array<Record<string, unknown>>
+    for (const e of entries) {
+      const keys = Object.keys(e)
+      expect(keys).not.toContain('value'); expect(keys).not.toContain('values')
+      expect(keys).not.toContain('after'); expect(keys).not.toContain('snapshot'); expect(keys).not.toContain('data')
+    }
+  })
+
+  test('kind filter: ?kind=reveal returns only reveal entries', async () => {
+    const entries = (await auditLog({ kind: 'reveal' })).body?.data?.entries as Array<{ kind: string }>
+    expect(entries.length).toBe(1)
+    expect(entries[0].kind).toBe('reveal')
+  })
+})


### PR DESCRIPTION
## What

A3 — the **audit-trail read surface**, completing the History Field-Audit Permission arc (#2973). Read-only "who granted / revoked / revealed what" over `operation_audit_logs`, **gated on the same `multitable:history-field-audit:grant` capability** that issues grants (LOCK-5: the auditor is itself auditable). **Scope-only**: the serializer picks `subject/reason/scope/grantId`, never echoes a record field value.

`GET /bases/:baseId/history-audit-log` — cap-gated, base-scoped, `?kind=grant|reveal` filter, `limit`/`offset`.

This PR also lands the **single arc verification MD** (`multitable-history-field-audit-arc-dev-verification-20260621.md`) covering A1 (#2976) + A1 hardening (#2979) + A2 (#2981) + A3 — with the L1–L8 + D5/D6 lock→golden map and the 4 mutation checks.

## Verification

- **6 A3 goldens**: cap gate rejects a non-cap holder AND a coarse `admin` role; base-scoped (other base excluded); **no values** in entries; `?kind` filter.
- **Full history suite 42/42**: events/#2968 boundary **8 byte-identical** + grant 15 + reveal 13 + log 6.
- tsc 0; unit **3756/3756**. No FE, no migration.

## Arc complete

A1 grant layer → A1 hardening (atomicity + self-grant) → A2 reveal (the mask-lift, audit-before-disclosure) → A3 trail. Per the design-lock, runtime is fully gated: nothing reveals without an explicit `?reveal=1` + reason + a valid non-self-issued grant, and every reveal + every grant is audited.

Named follow-ups (in the MD §3): dedicated formula-taint reveal golden (D6 verified structurally); reason-in-header vs query; audit-failure degrades to masked-200 (deliberate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)