### PR TITLE
test(multitable): history field-audit D6 — formula-taint reveal golden

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -206,6 +206,7 @@ jobs:
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \
             tests/integration/multitable-history-audit-log-realdb.test.ts \
+            tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-history-field-audit-arc-dev-verification-20260621.md
+++ b/docs/development/multitable-history-field-audit-arc-dev-verification-20260621.md
@@ -23,17 +23,18 @@
 - **L6 双面同一 resolver**：全局历史（events/detail via `buildHistoryAllowedFieldsBySheet`）与按记录历史（per-record route）走同一 reveal 链；两面 parity（golden）。
 - **L7 reveal 不进任何写/恢复路径（by construction）**：`loadRevealedFieldIds`（掀遮罩的函数）仅被 3 条读路由可达，grep 证实无 write/restore/preview/PIT 调用方。
 - **L8 reveal 必带 reason 并写审计**：`?reveal=1` 无 `reason` → 400（三面 golden）；`ticket` 可选。
-- **D6 公式 taint 不被 reveal 掀**（结构性，已 TRACE）：reveal 只掀本表 `field_permissions` scope，`maskStoredRecordFieldIds` 仍无条件执行；`resolveTaintedFormulaFieldIds` 的「外表字段是否被拒」经 `resolveForeignFieldReadability` **独立**解析（不取自被 reveal 拓宽的候选集），故跨表物化公式值在 reveal 下仍被 taint 丢弃。
+- **D6 公式 taint 不被 reveal 掀**（已 TRACE + **真库 golden**）：reveal 只掀本表 `field_permissions` scope，`maskStoredRecordFieldIds` 仍无条件执行；`resolveTaintedFormulaFieldIds` 的「外表字段是否被拒」经 `resolveForeignFieldReadability` **独立**解析（不取自被 reveal 拓宽的候选集），故跨表物化公式值在 reveal 下仍被 taint 丢弃。专项 golden `...reveal-taint-realdb`（跨表 lookup→formula→taint）：control 证非空过（不被拒者见公式值）+ baseline 证 taint 正常遮 + **reveal 下仍遮**。
 - **D5 默认有限期**：无 expiry 且非 standing → 90 天有限窗；standing 必须显式 + 标记（goldens）。
 
 ## 2. 验证
 
 - backend `tsc --noEmit`：**0 error**。
-- **真库历史 goldens：42/42 pass**（`metasheet_test`）：
+- **真库历史 goldens：46/46 pass**（`metasheet_test`；含后补的 D6 taint golden ×4）：
   - `multitable-history-events-realdb`（#2968 边界）**8/8 byte-identical**（reveal 默认关 → 行为不变，A1/A2 接缝与 boundary 证明）；
   - `multitable-history-audit-grant-realdb`（A1+硬化）**15**：能力门 / 无 admin 旁路 / user+role+group 自授拒 / 默认有限期 / standing / 发证撤证审计 / **原子回滚（issue+revoke）** / 重复→409；
   - `multitable-history-audit-reveal-realdb`（A2）**13**：默认遮 / 持证无 flag 遮 / reveal 成功（id+值+计数）/ reason→400 / **自授拒** / 过期拒 / **行级 deny 仍生效** / hidden 不掀 / reveal 审计（无值）/ **审计失败→降级遮** / per-record parity / 无 admin 旁路；
-  - `multitable-history-audit-log-realdb`（A3）**6**：能力门（非能力 + admin role 均拒）/ base 作用域 / **无值** / kind 过滤。
+  - `multitable-history-audit-log-realdb`（A3）**6**：能力门（非能力 + admin role 均拒）/ base 作用域 / **无值** / kind 过滤；
+  - `multitable-history-audit-reveal-taint-realdb`（D6 后补）**4**：control（不被拒者见公式值，非空过）/ taint baseline（被拒者正常遮）/ **D6 reveal 下仍遮**。
 - **Mutation checks（4，全部 load-bearing）**：① 授权门加 isAdminRole 旁路 → admin-role golden 失败；② 发证改回非事务 → 原子回滚 golden 失败；③ 去掉 `granted_by <> $2` → 自授 golden 失败；④ 去掉 audit-degrade → 未审计 reveal golden 失败。
 - backend unit：**3756/3756 pass**（本地重跑，无回归；arc 只增集成 goldens，不增 unit）。
 - 无 FE 改动；迁移仅 A1 一张表。
@@ -42,7 +43,7 @@
 
 - **审计失败降级为遮罩 200**：安全（无未审计泄露），但审计者不被告知 reveal 被抑制——刻意取舍（可改 503，留作 owner 决定）。
 - **reason 走 query string**：是 actor 自己的理由、非敏感；合规面用 header 更干净——记为可选 follow-up。
-- **专门的 formula-taint reveal golden**：D6 已 TRACE 结构性成立，但 fixture 无公式字段；专项 golden 留作 follow-up。
+- ~~专门的 formula-taint reveal golden~~：**已补**（`...reveal-taint-realdb`，4 条，含 control 防空过）——D6 现有真库 golden，非仅结构性。
 - **role/group 间接自授的 issue-time guardrail 是 fast-fail**（成员关系可变）；**不可变闭合是 reveal-time `granted_by`**——两者并存，文档不再称 issue-time「完整」。
 
 ## 4. 后续（gated，未建）

--- a/packages/core-backend/tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A2 D6 — History field-audit reveal does NOT lift formula-taint (real DB).
+ *
+ * Design-lock: docs/development/multitable-history-field-audit-permission-design-lock-20260620.md (#2973).
+ * The reveal lifts the per-subject `field_permissions` scope ONLY. A formula column whose cross-base lookup
+ * input is denied to the actor is "tainted" — masked by `maskStoredRecordFieldIds`, NOT by a local
+ * field_permission. D6 requires that masking to SURVIVE a reveal (else a reveal-holder could read a
+ * materialized foreign-derived value they are denied). This was previously asserted structurally (the taint
+ * resolver derives foreign-denial independently via resolveForeignFieldReadability); this golden pins it on
+ * the wire. Fixture models multitable-lookup-foreign-field-mask-sibling-reads.test.ts.
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_A = `base_rvt_a_${TS}` // history base
+const BASE_B = `base_rvt_b_${TS}` // cross-base foreign
+const FS_X = `sheet_rvt_fx_${TS}` // foreign sheet (BASE_B)
+const MS = `sheet_rvt_main_${TS}` // history sheet (BASE_A)
+const FLD_XTARGET = `fld_rvt_xt_${TS}` // foreign target, denied to DENY_VIEWER
+const FLD_LINK = `fld_rvt_lk_${TS}`
+const FLD_LU = `fld_rvt_lu_${TS}` // lookup over the foreign target
+const FLD_F = `fld_rvt_f_${TS}` // formula = {lookup}+1, materialized = 8 (TAINTED for DENY_VIEWER)
+const FLD_STATUS = `fld_rvt_st_${TS}` // plain visible column (control)
+const REC_FX = `rec_rvt_fx_${TS}`
+const REC_M1 = `rec_rvt_m1_${TS}`
+const TAINT_BATCH = `batch_rvt_${TS}` // a revision touching FLD_F + FLD_STATUS
+const DENY_VIEWER = `user_rvt_deny_${TS}` // denied the foreign target → FLD_F tainted
+const ALLOW_VIEWER = `user_rvt_allow_${TS}` // no denial → sees FLD_F (non-vacuous control)
+const ISSUER = `user_rvt_issuer_${TS}`
+const FORMULA_VALUE = 8
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+
+function appAs(userId: string): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => {
+    ;(req as any).user = { id: userId, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:base:read'] }
+    next()
+  })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const detail = (app: Express, batchId: string, query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/bases/${BASE_A}/history/events/${batchId}`).query(query)
+type Change = { recordId: string; changedFieldIds: string[]; after: Record<string, unknown> | null }
+const changeFor = (res: { body?: { data?: { changes?: Change[] } } }) =>
+  (res.body?.data?.changes ?? []).find((c) => c.recordId === REC_M1)
+
+describeIfDatabase('history field-audit reveal — D6: taint is NOT lifted by reveal (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_A, 'RVT A'])
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_B, 'RVT B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS_X, BASE_B, 'RVT Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_A, 'RVT Main'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_XTARGET, FS_X, 'XTarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FX, FS_X, JSON.stringify({ [FLD_XTARGET]: 7 })])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS_X }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_XTARGET, foreignSheetId: FS_X }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_F, MS, 'FormulaCol', 'formula', JSON.stringify({ expression: `={${FLD_LU}}+1` }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATUS, MS, 'Status', 'string', '{}', 4])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_M1, MS, JSON.stringify({ [FLD_LINK]: [REC_FX], [FLD_F]: FORMULA_VALUE, [FLD_STATUS]: 'public' })])
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_rvt_${TS}`, FLD_LINK, REC_M1, REC_FX])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)', [MS, FLD_F, FLD_LU, MS])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [FS_X, FLD_XTARGET, 'user', DENY_VIEWER, false, false])
+    for (const uid of [DENY_VIEWER, ALLOW_VIEWER, ISSUER]) {
+      await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [uid])
+    }
+    // A revision on REC_M1 touching the formula column + the plain column.
+    await q(
+      `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id)
+       VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', $3, ARRAY[$4,$5]::text[], '{}'::jsonb, $6::jsonb, $7)`,
+      [MS, REC_M1, ISSUER, FLD_F, FLD_STATUS, JSON.stringify({ [FLD_F]: FORMULA_VALUE, [FLD_STATUS]: 'public' }), TAINT_BATCH],
+    )
+    // A valid field-audit grant for DENY_VIEWER on BASE_A, issued by ISSUER (granted_by != viewer).
+    await q(
+      `INSERT INTO meta_history_audit_grants (base_id, subject_type, subject_id, granted_by, reason, expires_at, is_standing)
+       VALUES ($1,'user',$2,$3,'seed', $4, false)`,
+      [BASE_A, DENY_VIEWER, ISSUER, new Date(TS + 30 * 86400000).toISOString()],
+    )
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_history_audit_grants WHERE base_id = $1', [BASE_A]).catch(() => {})
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS_X, MS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS_X]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS_X]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS_X]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_A, BASE_B]]).catch(() => {})
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[DENY_VIEWER, ALLOW_VIEWER, ISSUER]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('control (non-vacuous): a viewer NOT denied the foreign field sees the formula column in history', async () => {
+    const d = await detail(appAs(ALLOW_VIEWER), TAINT_BATCH)
+    expect(d.status).toBe(200)
+    const c = changeFor(d)
+    expect(c?.changedFieldIds).toContain(FLD_F) // formula genuinely changed + visible when not tainted
+    expect(c?.after?.[FLD_F]).toBe(FORMULA_VALUE)
+  })
+
+  test('taint baseline (no reveal): the denied viewer sees the formula column MASKED (taint)', async () => {
+    const d = await detail(appAs(DENY_VIEWER), TAINT_BATCH)
+    expect(d.status).toBe(200)
+    const c = changeFor(d)
+    expect(c?.changedFieldIds).not.toContain(FLD_F) // tainted (its lookup reads a denied foreign field)
+    expect(c?.after?.[FLD_F]).toBeUndefined()
+    expect(c?.changedFieldIds).toContain(FLD_STATUS) // plain column still visible
+  })
+
+  test('D6: reveal does NOT lift the formula-taint — the tainted column stays masked even under ?reveal=1', async () => {
+    const d = await detail(appAs(DENY_VIEWER), TAINT_BATCH, { reveal: '1', reason: 'taint-audit' })
+    expect(d.status).toBe(200)
+    const c = changeFor(d)
+    // reveal lifts the per-subject field_permissions scope, NOT the cross-sheet formula-taint:
+    expect(c?.changedFieldIds).not.toContain(FLD_F) // STILL masked under reveal
+    expect(c?.after?.[FLD_F]).toBeUndefined() // the foreign-derived value never leaks
+    expect(c?.changedFieldIds).toContain(FLD_STATUS) // and the plain column is still there (reveal didn't break the read)
+  })
+})


### PR DESCRIPTION
## What

Closes the one named field-audit follow-up that was pure development (no decision, no gate): the **formula-taint reveal golden** for **D6** (reveal lifts the per-subject `field_permissions` scope, **never** the cross-sheet formula-taint).

The arc shipped D6 as a **structural** claim verified by tracing `resolveTaintedFormulaFieldIds` (it derives foreign-denial independently via `resolveForeignFieldReadability`, not from the reveal-widened candidate set). This adds the **on-the-wire golden**.

## Fixture (models `multitable-lookup-foreign-field-mask-sibling-reads`)

A cross-base lookup→formula chain where the foreign target is **denied** to the viewer, so the materialized formula column is **tainted** (masked by `maskStoredRecordFieldIds`, not a local `field_permission`). 4 goldens on the history detail surface:

- **control (non-vacuous)**: a viewer NOT denied the foreign field **sees** the formula column → proves it genuinely materialized + the test can't pass by masking everything;
- **taint baseline (no reveal)**: the denied viewer sees it **masked** → proves taint actually triggers;
- **D6**: the denied viewer **with `?reveal=1` + reason** STILL sees it masked → reveal never lifts the cross-sheet taint.

## Verification

4/4 new goldens; full history suite **46/46** (was 42); arc MD D6 line updated. Pure test + doc — **no src / FE / migration** change.

This was the only remaining field-audit item that's development rather than an owner decision or a gated write-path. Everything else genuinely remaining needs your specific opt-in (design decisions; or the global-history restore tails, which need their own design-locks first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)