### PR TITLE
fix(ops): preserve workflow contract artifacts

### DIFF
--- a/.github/workflows/attendance-import-perf-highscale.yml
+++ b/.github/workflows/attendance-import-perf-highscale.yml
@@ -295,7 +295,9 @@ jobs:
             return "$rc"
           }
 
-          if run_once "$attempt1_log" node ./scripts/ops/attendance-import-perf.mjs; then
+          if run_once "$attempt1_log" env \
+            OUTPUT_DIR="${log_dir}" \
+            node ./scripts/ops/attendance-import-perf.mjs; then
             rc_first=0
           else
             rc_first="$?"
@@ -317,6 +319,7 @@ jobs:
           echo "Transient high-scale perf failure detected; retrying once with expanded commit retries."
           sleep 20
           if run_once "$attempt2_log" env \
+            OUTPUT_DIR="${log_dir}" \
             COMMIT_RETRIES="${COMMIT_RETRIES_RETRY}" \
             COMMIT_RETRIES_LARGE="${COMMIT_RETRIES_LARGE_RETRY}" \
             node ./scripts/ops/attendance-import-perf.mjs; then

--- a/.github/workflows/phase5-baseline-rotation.yml
+++ b/.github/workflows/phase5-baseline-rotation.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install deps
         run: |
           corepack enable
+          corepack prepare pnpm@10.16.1 --activate
           pnpm install --frozen-lockfile
 
       - name: Count consecutive PASS days
@@ -59,4 +60,3 @@ jobs:
           title: "Phase5: Baseline rotation (14-day PASS streak)"
           body: "Automated baseline rotation based on 14 consecutive PASS nightly validations."
           branch: chore/phase5-baseline-rotation
-

--- a/scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs
+++ b/scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs
@@ -29,3 +29,11 @@ test('highscale workflow writes runtime classification into issue output and art
   assert.match(raw, /High-scale perf benchmark classified as runtime failure\./)
   assert.match(raw, /PERF_CLASSIFICATION: \$\{\{ needs\.perf\.outputs\.classification \|\| '' \}\}/)
 })
+
+test('highscale workflow writes perf-summary.json under the uploaded artifact tree', () => {
+  const raw = workflowRaw()
+
+  assert.match(raw, /OUTPUT_DIR="\$\{log_dir\}"/)
+  assert.match(raw, /output\/playwright\/attendance-import-perf-highscale\/\*\*/)
+  assert.doesNotMatch(raw, /run_once "\$attempt[12]_log" node \.\/scripts\/ops\/attendance-import-perf\.mjs/)
+})

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -63,6 +63,15 @@ test('regression workflow limits nightly artifact PR contents', () => {
   assert.doesNotMatch(raw, /add-paths:[\s\S]*package\.json/)
 })
 
+test('baseline rotation workflow pins pnpm before installing dependencies', () => {
+  const raw = readWorkflow('.github/workflows/phase5-baseline-rotation.yml')
+
+  assert.match(raw, /node-version:\s+'18'/)
+  assert.match(raw, /corepack enable/)
+  assert.match(raw, /corepack prepare pnpm@10\.16\.1 --activate/)
+  assert.match(raw, /pnpm install --frozen-lockfile/)
+})
+
 test('attendance remote metrics reuses metrics scrape auth fallback', () => {
   const raw = readWorkflow('.github/workflows/attendance-remote-metrics-prod.yml')
 


### PR DESCRIPTION
## Summary
- pin Phase 5 baseline rotation to pnpm@10.16.1 before install so Node 18 jobs do not pick up pnpm 11
- set OUTPUT_DIR for attendance highscale perf runs so perf-summary.json lands inside the uploaded highscale artifact tree
- add contract coverage for both workflow contracts

## Verification
- node --test scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
- git diff --check HEAD~1 HEAD

Related: #1