### PR TITLE
ci(core-backend): add type-check script so the recursive gate covers core-backend

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "type-check": "tsc --noEmit",
     "build:cache": "tsc -p tsconfig.cache.tests.json",
     "dev": "tsx watch src/index.ts",
     "dev:core": "tsx src/index.ts",


### PR DESCRIPTION
## Gap
Root `type-check` = `pnpm -r type-check` (recursive), which only runs in packages that **have** a `type-check` script. `@metasheet/core-backend` had **none**, so the CI type-check job (`plugin-tests.yml` → `pnpm type-check`) **silently skipped it entirely**. That's how 2 latent `src/` TS errors reached the #2966 branch unnoticed — a discriminated-union narrowing error under `strict:false`, and a `logger.error` Error-arg mismatch. (Thanks to the owner for the precise diagnosis: root has the gate, but core-backend lacks the script + its tsconfig excludes tests.)

## Fix (one line)
Add `"type-check": "tsc --noEmit"` to core-backend. This **auto-wires** core-backend into the existing `pnpm -r type-check` CI gate — **no workflow YAML change**. Verified `pnpm --filter @metasheet/core-backend type-check` = **0 errors** on current main, so the gate is green from day one and catches future `src/` regressions like the two above.

## Scope (deliberately bounded)
Covers `src`/`core`/`types` (the package tsconfig **excludes test files**). Type-checking the **test suite** too would surface **~474 pre-existing errors** across many test files (comments.api 82, snapshot-protection 55, …) — a separate, much larger cleanup. **Not bundled here.** If you want test coverage, it's best done incrementally (e.g. a `tsconfig.typecheck.json` adopted file-by-file) — happy to scope that as its own track.

**Not self-merging** — CI infra change, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)