### PR TITLE
feat(multitable): global-history T2b filters — time-range + sheet-scope + leak-free field filter

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1457,7 +1457,7 @@ export class MultitableApiClient {
   // --- Global History & Point-in-Time Restore (read-only) ---
   async listHistoryEvents(
     baseId: string,
-    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; limit?: number; offset?: number },
+    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; limit?: number; offset?: number },
   ): Promise<{ batches: HistoryBatchSummary[]; total: number }> {
     const res = await this.fetch(`/api/multitable/bases/${encodeURIComponent(baseId)}/history/events${qs(params ?? {})}`)
     const data = await this.parseJson<{ batches?: unknown[]; total?: number }>(res)

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -22,6 +22,15 @@
           <option value="update">{{ t('更新', 'Update') }}</option>
           <option value="delete">{{ t('删除', 'Delete') }}</option>
         </select>
+        <input v-model="filterFrom" type="date" class="meta-hist__filter" :aria-label="t('起始日期', 'From date')" data-test="hist-filter-from" @change="reload" />
+        <input v-model="filterTo" type="date" class="meta-hist__filter" :aria-label="t('结束日期', 'To date')" data-test="hist-filter-to" @change="reload" />
+        <select v-if="fields && fields.length" v-model="filterField" class="meta-hist__filter" :aria-label="t('字段', 'Field')" data-test="hist-filter-field" @change="reload">
+          <option value="">{{ t('全部字段', 'All fields') }}</option>
+          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+        </select>
+        <label v-if="sheetId" class="meta-hist__scope" data-test="hist-filter-scope">
+          <input v-model="scopeAllSheets" type="checkbox" @change="reload" />{{ t('全部表', 'All tables') }}
+        </label>
         <button class="meta-hist__apply" type="button" data-test="hist-apply" @click="reload">{{ t('筛选', 'Filter') }}</button>
       </div>
 
@@ -60,7 +69,7 @@ import { useHistoryCenter } from '../composables/useHistoryCenter'
 import { historyActor } from '../utils/meta-record-labels'
 import type { HistoryBatchSummary } from '../types'
 
-const props = defineProps<{ open: boolean; baseId: string; sheetId?: string }>()
+const props = defineProps<{ open: boolean; baseId: string; sheetId?: string; fields?: Array<{ id: string; name: string }> }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const { isZh } = useLocale()
@@ -69,15 +78,25 @@ const t = (zh: string, en: string) => (isZh.value ? zh : en)
 const filterActor = ref('')
 const filterSource = ref('')
 const filterAction = ref('')
+const filterFrom = ref('')
+const filterTo = ref('')
+const filterField = ref('')
+const scopeAllSheets = ref(false) // T2b: default to the active sheet; opt in to all readable tables
 
 const { batches, loading, error, expandedId, detail, detailLoading, load, toggle: toggleBatch } = useHistoryCenter()
 
 function reload(): Promise<void> {
   return load(props.baseId, {
-    sheetId: props.sheetId,
+    // sheet scope: the active sheet by default; "all tables" clears it (the backend then spans every
+    // readable sheet in the base). The field filter is leak-free server-side (post-mask), so the dropdown
+    // is a convenience, not a security boundary.
+    sheetId: scopeAllSheets.value ? undefined : props.sheetId,
     actorId: filterActor.value,
     source: filterSource.value,
     action: filterAction.value,
+    from: filterFrom.value ? new Date(`${filterFrom.value}T00:00:00`).toISOString() : undefined,
+    to: filterTo.value ? new Date(`${filterTo.value}T23:59:59.999`).toISOString() : undefined,
+    fieldId: filterField.value,
   })
 }
 

--- a/apps/web/src/multitable/composables/useHistoryCenter.ts
+++ b/apps/web/src/multitable/composables/useHistoryCenter.ts
@@ -10,7 +10,7 @@ import type { HistoryBatchSummary, HistoryBatchDetail } from '../types'
  * NEVER throw — a failure surfaces via `error` / a null detail, so a click can't leak an unhandled
  * rejection. The client is injectable for testing.
  */
-type HistoryFilters = { sheetId?: string; actorId?: string; source?: string; action?: string }
+type HistoryFilters = { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string }
 type HistoryClient = Pick<typeof multitableClient, 'listHistoryEvents' | 'getHistoryBatch'>
 
 export function useHistoryCenter(client: HistoryClient = multitableClient) {
@@ -33,6 +33,9 @@ export function useHistoryCenter(client: HistoryClient = multitableClient) {
         actorId: filters.actorId || undefined,
         source: filters.source || undefined,
         action: filters.action || undefined,
+        from: filters.from || undefined,
+        to: filters.to || undefined,
+        fieldId: filters.fieldId || undefined,
         limit: 100,
       })
       batches.value = res.batches

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -476,6 +476,7 @@
       :open="showHistory"
       :base-id="activeBaseId || ''"
       :sheet-id="workbench.activeSheetId.value"
+      :fields="propertyVisibleGridFields"
       @close="showHistory = false"
     />
   </div>

--- a/apps/web/tests/multitable-history-fe.spec.ts
+++ b/apps/web/tests/multitable-history-fe.spec.ts
@@ -44,9 +44,10 @@ describe('useHistoryCenter — read-only history center', () => {
     const { load } = useHistoryCenter(c)
     await load('')
     expect(spied(c).listHistoryEvents.mock.calls.length).toBe(0)
-    await load('base1', { actorId: 'u9', source: 'automation', action: 'create' })
+    await load('base1', { actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x' })
     const params = spied(c).listHistoryEvents.mock.calls[0][1]
-    expect(params).toMatchObject({ actorId: 'u9', source: 'automation', action: 'create' })
+    // T2b: time-range + field filter forwarded alongside actor/source/action
+    expect(params).toMatchObject({ actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x' })
   })
 
   it('load NEVER throws — surfaces the error and clears batches', async () => {

--- a/docs/development/multitable-global-history-pit-restore-todo-20260619.md
+++ b/docs/development/multitable-global-history-pit-restore-todo-20260619.md
@@ -71,7 +71,7 @@ Tests:
 
 ### T2 - Global History Center Read-Only UI
 
-Status: split. **T2a SHIPPED (#2961); T2b FOLLOW-UP (read-only, in MVP envelope, not gated, not yet built).**
+Status: split. **T2a SHIPPED (#2961); T2b filters slice SHIPPED (2026-06-21: time-range + sheet-scope + field filter, field filter leak-free post-mask); T2b search + cursor pagination still FOLLOW-UP (read-only, in MVP envelope, not gated, need new backend).**
 The original single T2 scope over-stated what shipped; this split records the actual line.
 
 Goal: add a global history center entry and timeline UI.
@@ -86,9 +86,9 @@ Scope — T2a (SHIPPED, #2961):
 
 Scope — T2b (FOLLOW-UP, read-only, NOT yet built — each a small slice, not gated):
 
-- time-range (from/to) + sheet + field filters in the FE — backend already accepts `from`/`to`/`sheetId` (the FE just doesn't wire them); a **field** filter needs a new backend param;
-- search by visible record title / data — needs a new backend data-search param (a separate slice);
-- cursor pagination — the current backend is `offset`/`limit`; a cursor needs a new backend param.
+- ~~time-range (from/to) + sheet + field filters in the FE~~ — **SHIPPED 2026-06-21**: from/to date inputs + sheet-scope toggle (FE-wired the backend's existing params) + a `fieldId` filter (new backend param, applied POST-mask so it's leak-free: a field the actor can't read is never in `visibleFields`, so filtering by it returns no batch);
+- search by visible record title / data — FOLLOW-UP (needs a new backend data-search param; search must only hit records/fields the actor can read — LOCK-3 boundary);
+- cursor pagination — FOLLOW-UP (the current backend is `offset`/`limit`; a cursor needs a new backend param + must keep the LOCK-3 "total is post-filter" semantics).
 
 Out of scope:
 

--- a/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
@@ -1,0 +1,30 @@
+# Global History — T2b filters slice 开发与验证 MD
+
+> 对应 /goal「完成余下所有的开发…给验证MD」中 owner 指定「**T2b 只读历史中心增强，可直接开发**」的一项。
+> **范围 = T2b 的 filters 子刀（read-only，在已 ratify 的 MVP 范围内，不 gated）**：时间区间 + sheet 范围 +
+> 字段筛选。T2b 余下两子刀（可见数据搜索、cursor 分页）需新增后端，作为后续命名子刀（见 §4）。
+
+## 1. 交付
+
+| 件 | 内容 |
+|---|---|
+| 后端 | 历史投影 `loadHistoryBatchSummaries` 新增 `fieldId` 筛选——**post-mask**（在 `visibleFields` 上判定）：仅返回该字段对当前 actor **可见**地变更过的批次。`from`/`to`/`sheetId` 后端早已支持（FE 此前未接）。events 路由透传 `fieldId`。 |
+| 前端 | `HistoryCenterModal` 新增：时间区间（from/to 日期输入）、字段下拉（`:fields` 由 workbench 传当前表可读字段）、「全部表」范围开关（默认当前表）。`useHistoryCenter` + client 透传 `from`/`to`/`fieldId`。 |
+
+## 2. 关键安全属性：字段筛选 LEAK-FREE（post-mask）
+
+字段筛选在 **post-mask 可见字段集**上判定（`if (fieldId && !visibleFields.has(fieldId)) continue`），不是 raw `changed_field_ids`。后果:被 `field_permissions` 拒读的字段**永不在** `visibleFields` 里 → 按它筛选 → **0 批次**。actor 因此**无法**用「按字段 X 筛选」反推「哪些批次动过隐藏字段 X」。这与 #2968 的 LOCK-3 边界一致(字段不出现在 filter/detail/count)。
+
+## 3. 验证
+
+- backend `tsc --noEmit` **0**；web `vue-tsc -b` **0**。
+- **真库 events goldens 8→10**：新增「字段筛选返回触及可读字段的批次」+「**字段筛选 leak-free**：按被拒字段筛选返回 0 批次」。完整历史套件 **48/48**（events 10 + grant 15 + reveal 13 + log 6 + taint 4）。
+- **Mutation check**：把字段筛选改成 raw/pre-mask（`g.some(r => r.changed_field_ids.includes(fieldId))`）→ leak-free golden **失败**（被拒字段命中、批次泄漏）→ 证明 post-mask 放置 load-bearing。
+- FE `multitable-history-fe.spec.ts` **5/5**：`load` 透传 `from`/`to`/`fieldId`（连同 actor/source/action）。
+- 无迁移；FE 改动经 multitable-web-guard 覆盖（触发路径含 HistoryCenterModal/useHistoryCenter/spec；vue-tsc 覆盖 client + workbench）。
+
+## 4. T2b 余下子刀（read-only，未建；各需新增后端，命名 follow-up）
+
+- **可见数据搜索**（按可见记录标题/数据搜历史）——需新增后端 data-search 参数，且搜索面必须只命中 actor 可读的记录/字段（同 LOCK-3 边界,设计时单列)。
+- **cursor 分页**——当前后端是 offset/limit；cursor 需新增后端游标，且要保持 LOCK-3「total 为 post-filter」语义。
+- 字段下拉目前取**当前表**可读字段；「全部表」范围下的跨表字段筛选 UX 可后续细化。

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -45,6 +45,12 @@ export interface HistoryEventsParams {
   action?: string
   from?: string
   to?: string
+  /**
+   * T2b field filter — keep only batches that touched this field, applied POST-mask: a batch matches iff the
+   * field is in its VISIBLE field set. A field the actor cannot read is never visible, so filtering by it
+   * yields no batches (no "which batches touched the hidden field" probe) — the LOCK-3 boundary holds.
+   */
+  fieldId?: string
   limit?: number
   offset?: number
 }
@@ -176,6 +182,7 @@ export async function loadHistoryBatchSummaries(
       for (const f of row.changed_field_ids) if (allowed.has(f)) visibleFields.add(f) // count only readable fields
     }
     if (visibleRecords.size === 0) continue // LOCK-3: fully-denied batch is invisible AND not counted
+    if (params.fieldId && !visibleFields.has(params.fieldId)) continue // T2b field filter (post-mask, leak-free)
     const head = g[0]
     const actions = new Set(g.map((r) => r.action))
     all.push({

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6534,6 +6534,7 @@ export function univerMetaRouter(): Router {
           action: str(req.query.action),
           from: str(req.query.from),
           to: str(req.query.to),
+          fieldId: str(req.query.fieldId),
           limit: Number.isFinite(limit) ? limit : 50,
           offset: Number.isFinite(offset) ? offset : 0,
         },

--- a/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
@@ -225,4 +225,21 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     expect(change?.after?.[STATUS]).toBe('public') // visible field of the SAME change still passes (surgical)
     expect(d.body?.data?.visibleAffectedFieldCount).toBe(1) // detail count masked too
   })
+
+  // ----- T2b field filter (post-mask, leak-free) -----
+
+  test('T2b field filter: ?fieldId returns batches that touched a READABLE field', async () => {
+    await mixedFieldRev()
+    expect(batchIds(await events({ fieldId: STATUS }))).toContain(FIELD_BATCH)
+    expect(batchIds(await events({ fieldId: SALARY }))).toContain(FIELD_BATCH) // SALARY readable here → matches
+  })
+
+  test('T2b field filter is LEAK-FREE: filtering by a field_permissions-denied field returns NO batch (post-mask)', async () => {
+    await mixedFieldRev()
+    await denyFieldForUser(SALARY)
+    // The denied field is never in the batch's VISIBLE field set, so filtering by it yields nothing — the
+    // actor cannot probe "which batches touched the hidden field". A readable field still filters normally.
+    expect(batchIds(await events({ fieldId: SALARY }))).not.toContain(FIELD_BATCH)
+    expect(batchIds(await events({ fieldId: STATUS }))).toContain(FIELD_BATCH)
+  })
 })


### PR DESCRIPTION
## What

Owner-directed **T2b read-only history-center enhancement** (you flagged it 「可直接开发」; in the ratified MVP envelope, not gated): wire the history center's **time-range** + **sheet scope**, and add a **field filter**.

- **backend**: `loadHistoryBatchSummaries` gains a `fieldId` filter applied **POST-mask** (on the batch's *visible* field set, not raw `changed_field_ids`) — so it is **leak-free**: a `field_permissions`-denied field is never in `visibleFields`, so filtering by it returns no batch (the actor can't probe "which batches touched the hidden field"). `from`/`to`/`sheetId` were already backend-supported. The events route passes `fieldId`.
- **FE**: `HistoryCenterModal` gains from/to date inputs, a field dropdown (the workbench passes the active sheet's readable fields), and a "this sheet / all tables" scope toggle; `useHistoryCenter` + client forward `from`/`to`/`fieldId`.

## Verification

- backend `tsc` 0, web `vue-tsc -b` 0.
- events goldens **8 → 10**: field filter returns readable-field batches; **field filter LEAK-FREE** (a denied field → no batch). **Mutation-checked**: switch to raw/pre-mask filtering → the leak-free golden fails (denied field leaks).
- full history suite **48/48**; FE history spec **5/5** (`load` forwards from/to/fieldId).
- **no migration.**
- ⚠️ unit suite: **3755/3756** — the 1 failure is `plm-workbench-routes.test.ts`, a **pre-existing order-dependent flake** (passes **36/36 in isolation**; my diff touches **zero** PLM files). Not a T2b regression.

## Scope

T2b **filters** slice only. T2b **search** + **cursor pagination** remain read-only follow-ups (each needs a new backend param; search must stay within the LOCK-3 boundary, cursor must keep the post-filter `total` semantics) — named in the TODO + dev MD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)