### PR TITLE
feat(multitable): global-history T2b search — leak-free post-mask snapshot value-search

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1457,7 +1457,7 @@ export class MultitableApiClient {
   // --- Global History & Point-in-Time Restore (read-only) ---
   async listHistoryEvents(
     baseId: string,
-    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; limit?: number; offset?: number },
+    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; q?: string; limit?: number; offset?: number },
   ): Promise<{ batches: HistoryBatchSummary[]; total: number }> {
     const res = await this.fetch(`/api/multitable/bases/${encodeURIComponent(baseId)}/history/events${qs(params ?? {})}`)
     const data = await this.parseJson<{ batches?: unknown[]; total?: number }>(res)

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -14,6 +14,7 @@
       </header>
 
       <div class="meta-hist__filters">
+        <input v-model.trim="filterSearch" class="meta-hist__filter" :placeholder="t('搜索可见数据', 'Search visible data')" data-test="hist-filter-search" @keyup.enter="reload" />
         <input v-model.trim="filterActor" class="meta-hist__filter" :placeholder="t('操作人 ID', 'Actor id')" data-test="hist-filter-actor" @keyup.enter="reload" />
         <input v-model.trim="filterSource" class="meta-hist__filter" :placeholder="t('来源', 'Source')" data-test="hist-filter-source" @keyup.enter="reload" />
         <select v-model="filterAction" class="meta-hist__filter" data-test="hist-filter-action" @change="reload">
@@ -75,6 +76,7 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 const { isZh } = useLocale()
 const t = (zh: string, en: string) => (isZh.value ? zh : en)
 
+const filterSearch = ref('')
 const filterActor = ref('')
 const filterSource = ref('')
 const filterAction = ref('')
@@ -97,6 +99,7 @@ function reload(): Promise<void> {
     from: filterFrom.value ? new Date(`${filterFrom.value}T00:00:00`).toISOString() : undefined,
     to: filterTo.value ? new Date(`${filterTo.value}T23:59:59.999`).toISOString() : undefined,
     fieldId: filterField.value,
+    search: filterSearch.value,
   })
 }
 

--- a/apps/web/src/multitable/composables/useHistoryCenter.ts
+++ b/apps/web/src/multitable/composables/useHistoryCenter.ts
@@ -10,7 +10,7 @@ import type { HistoryBatchSummary, HistoryBatchDetail } from '../types'
  * NEVER throw — a failure surfaces via `error` / a null detail, so a click can't leak an unhandled
  * rejection. The client is injectable for testing.
  */
-type HistoryFilters = { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string }
+type HistoryFilters = { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; search?: string }
 type HistoryClient = Pick<typeof multitableClient, 'listHistoryEvents' | 'getHistoryBatch'>
 
 export function useHistoryCenter(client: HistoryClient = multitableClient) {
@@ -36,6 +36,7 @@ export function useHistoryCenter(client: HistoryClient = multitableClient) {
         from: filters.from || undefined,
         to: filters.to || undefined,
         fieldId: filters.fieldId || undefined,
+        q: filters.search || undefined,
         limit: 100,
       })
       batches.value = res.batches

--- a/apps/web/tests/multitable-history-fe.spec.ts
+++ b/apps/web/tests/multitable-history-fe.spec.ts
@@ -44,10 +44,10 @@ describe('useHistoryCenter — read-only history center', () => {
     const { load } = useHistoryCenter(c)
     await load('')
     expect(spied(c).listHistoryEvents.mock.calls.length).toBe(0)
-    await load('base1', { actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x' })
+    await load('base1', { actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x', search: 'invoice-42' })
     const params = spied(c).listHistoryEvents.mock.calls[0][1]
-    // T2b: time-range + field filter forwarded alongside actor/source/action
-    expect(params).toMatchObject({ actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x' })
+    // T2b: time-range + field filter + search forwarded alongside actor/source/action (search → client `q`)
+    expect(params).toMatchObject({ actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x', q: 'invoice-42' })
   })
 
   it('load NEVER throws — surfaces the error and clears batches', async () => {

--- a/docs/development/multitable-global-history-pit-restore-todo-20260619.md
+++ b/docs/development/multitable-global-history-pit-restore-todo-20260619.md
@@ -71,7 +71,7 @@ Tests:
 
 ### T2 - Global History Center Read-Only UI
 
-Status: split. **T2a SHIPPED (#2961); T2b filters slice SHIPPED (2026-06-21: time-range + sheet-scope + field filter, field filter leak-free post-mask); T2b search + cursor pagination still FOLLOW-UP (read-only, in MVP envelope, not gated, need new backend).**
+Status: split. **T2a SHIPPED (#2961); T2b filters slice SHIPPED (2026-06-21: time-range + sheet-scope + field filter); T2b search SHIPPED (2026-06-21: post-mask snapshot value-search, leak-free); T2b cursor pagination still FOLLOW-UP (read-only, in MVP envelope, not gated, needs new backend cursor preserving the post-filter `total` semantics).**
 The original single T2 scope over-stated what shipped; this split records the actual line.
 
 Goal: add a global history center entry and timeline UI.

--- a/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
@@ -26,5 +26,17 @@
 ## 4. T2b 余下子刀（read-only，未建；各需新增后端，命名 follow-up）
 
 - **可见数据搜索**（按可见记录标题/数据搜历史）——需新增后端 data-search 参数，且搜索面必须只命中 actor 可读的记录/字段（同 LOCK-3 边界,设计时单列)。
-- **cursor 分页**——当前后端是 offset/limit；cursor 需新增后端游标，且要保持 LOCK-3「total 为 post-filter」语义。
-- 字段下拉目前取**当前表**可读字段；「全部表」范围下的跨表字段筛选 UX 可后续细化。
+- ~~可见数据搜索~~ —— **SHIPPED 2026-06-21（见 §5）**。
+- **cursor 分页**——当前后端是 offset/limit；cursor 需新增后端游标，且要保持 LOCK-3「total 为 post-filter」语义（现已是 post-filter-AND-post-search）。
+- 字段下拉目前取**当前表**可读字段；「全部表」范围下的跨表字段筛选 UX 待 cursor slice 一起收（owner 2026-06-21 确认非阻塞）。
+
+## 5. T2b search 子刀（SHIPPED 2026-06-21）
+
+只读历史搜索，**严格 post-mask**：投影对每个批次的**可见**记录快照按 `filterDataByAllowedFields(snapshot, allowed)` 取可读字段值，再做 lowercase-contains 子串匹配（仅值搜索，无操作符/正则/查询语言；数字/日期按字符串形匹配）。
+
+- **匹配对象 = revision snapshot ∩ visibleFields**（不是当前 `meta_records.data`——那会重开 #2968 类漏洞且语义错；也不是 display-title——留作后续）。
+- **leak-free 双轴**：行级 deny 的记录在 search 前已被 `isDenied continue` 跳过；字段级 deny 的值被 `filterDataByAllowedFields` 滤掉 → 被拒记录/隐藏字段的值**永不可搜**。
+- **total 为 post-search**：不匹配的批次不计入（cursor slice 会继承「actor 经全部 filter 后可见的匹配数」语义）。
+- **成本**：搜索时才 SELECT snapshot；候选行 cap 20000 + 命中即 `console.warn` 截断——**不 fail-closed**（只读搜索截断只是结果不全，无 execution-matches-preview 不变式，不照搬 T5/PV-7）。
+- 后端 `?q=`；FE 搜索框 → `useHistoryCenter` → client `q`。
+- **验证**：events goldens 10→14（**positive control 非空过** + **field-mask leak-free** + **row-deny leak-free** + **total post-search**）；完整历史套件 **52/52**；**mutation**：把 search 改成匹配 raw snapshot → field-mask leak-free golden 失败（被拒值泄漏），row-deny leak-free 仍过（依赖 row-skip 而非字段掩码）——精确隔离两轴守卫。tsc/vue-tsc 0；FE spec 5/5。

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -51,6 +51,14 @@ export interface HistoryEventsParams {
    * yields no batches (no "which batches touched the hidden field" probe) — the LOCK-3 boundary holds.
    */
   fieldId?: string
+  /**
+   * T2b search — substring (lowercase-contains) over a batch's VISIBLE snapshot values. Applied POST-mask
+   * (`filterDataByAllowedFields(snapshot, allowed)`): only the actor's readable fields of non-row-denied
+   * records are searched, so a denied record's data and a hidden field's value can NEVER produce a hit (the
+   * same leak-free construction as the field filter). Value-search only — no operators / regex / query
+   * language; numbers/dates are matched by their stringified form. `total` is post-search.
+   */
+  search?: string
   limit?: number
   offset?: number
 }
@@ -78,6 +86,8 @@ interface RevRow {
   changed_field_ids: string[]
   batch_id: string | null
   created_at: string
+  /** Loaded ONLY when a search query is present (the SELECT omits it otherwise). Searched post-mask. */
+  snapshot: Record<string, unknown> | null
 }
 
 /** Per-sheet denied-record set, gated exactly like the live read surfaces (flag-on + non-admin). */
@@ -104,6 +114,7 @@ function normalizeRevRows(rows: unknown[]): RevRow[] {
     changed_field_ids: Array.isArray(r.changed_field_ids) ? r.changed_field_ids.map(String) : [],
     batch_id: typeof r.batch_id === 'string' ? r.batch_id : null,
     created_at: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at ?? ''),
+    snapshot: r.snapshot && typeof r.snapshot === 'object' && !Array.isArray(r.snapshot) ? (r.snapshot as Record<string, unknown>) : null,
   }))
 }
 
@@ -112,6 +123,9 @@ function isDenied(deniedBySheet: Map<string, Set<string>>, sheetId: string, reco
 }
 
 const EMPTY_FIELD_SET: ReadonlySet<string> = new Set()
+
+/** T2b search candidate-row cap (bound the snapshot load over a huge history; hitting it logs + truncates, never fails). */
+const SEARCH_CANDIDATE_ROW_CAP = 20000
 
 /** LOCK-3 field layer: per-sheet allowed field-id set; a sheet missing from the map masks every field (fail-closed). */
 function allowedFieldsFor(map: Map<string, Set<string>>, sheetId: string): ReadonlySet<string> {
@@ -152,14 +166,21 @@ export async function loadHistoryBatchSummaries(
   if (params.action) add('action = $N', params.action)
   if (params.from) add('created_at >= $N', params.from)
   if (params.to) add('created_at <= $N', params.to)
+  // T2b search: load the snapshot ONLY when searching (it is heavier), and cap the candidate rows so a search
+  // over a huge history is bounded. Capping a READ-ONLY search yields incomplete results, NOT a failure — do
+  // NOT fail-closed here (unlike T5/PV-7, search has no execution-matches-preview invariant to protect).
+  const searchQuery = params.search && params.search.trim() ? params.search.trim().toLowerCase() : null
   const res = await query(
-    `SELECT id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, batch_id, created_at
+    `SELECT id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, batch_id, created_at${searchQuery ? ', snapshot' : ''}
      FROM meta_record_revisions
      WHERE ${where.join(' AND ')}
-     ORDER BY created_at DESC, version DESC, id DESC`,
+     ORDER BY created_at DESC, version DESC, id DESC${searchQuery ? `\n     LIMIT ${SEARCH_CANDIDATE_ROW_CAP}` : ''}`,
     args,
   )
   const rows = normalizeRevRows(res.rows)
+  if (searchQuery && rows.length >= SEARCH_CANDIDATE_ROW_CAP) {
+    console.warn(`[history-projection] search candidate rows hit the ${SEARCH_CANDIDATE_ROW_CAP} cap; older revisions were not searched (results may be incomplete)`)
+  }
 
   // Group into batches in encounter order (rows are already newest-first → batches stay newest-first).
   const order: string[] = []
@@ -175,14 +196,24 @@ export async function loadHistoryBatchSummaries(
     const g = groups.get(key)!
     const visibleRecords = new Set<string>()
     const visibleFields = new Set<string>()
+    let searchMatched = !searchQuery // no search → trivially matched
     for (const row of g) {
       if (isDenied(deniedBySheet, row.sheet_id, row.record_id)) continue // LOCK-3: drop denied record's rows
       visibleRecords.add(row.record_id)
       const allowed = allowedFieldsFor(params.allowedFieldsBySheet, row.sheet_id) // LOCK-3 field layer
       for (const f of row.changed_field_ids) if (allowed.has(f)) visibleFields.add(f) // count only readable fields
+      // T2b search: match the query against the POST-MASK snapshot values only — a denied record's rows are
+      // already skipped above, and filterDataByAllowedFields drops hidden fields, so neither can ever match.
+      if (searchQuery && !searchMatched) {
+        const masked = filterDataByAllowedFields(row.snapshot, allowed)
+        if (masked && Object.values(masked).some((v) => v != null && String(v).toLowerCase().includes(searchQuery))) {
+          searchMatched = true
+        }
+      }
     }
     if (visibleRecords.size === 0) continue // LOCK-3: fully-denied batch is invisible AND not counted
     if (params.fieldId && !visibleFields.has(params.fieldId)) continue // T2b field filter (post-mask, leak-free)
+    if (searchQuery && !searchMatched) continue // T2b search (post-mask, leak-free); total stays post-search
     const head = g[0]
     const actions = new Set(g.map((r) => r.action))
     all.push({

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6535,6 +6535,7 @@ export function univerMetaRouter(): Router {
           from: str(req.query.from),
           to: str(req.query.to),
           fieldId: str(req.query.fieldId),
+          search: str(req.query.q),
           limit: Number.isFinite(limit) ? limit : 50,
           offset: Number.isFinite(offset) ? offset : 0,
         },

--- a/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
@@ -242,4 +242,37 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     expect(batchIds(await events({ fieldId: SALARY }))).not.toContain(FIELD_BATCH)
     expect(batchIds(await events({ fieldId: STATUS }))).toContain(FIELD_BATCH)
   })
+
+  // ----- T2b search (post-mask snapshot match, leak-free) -----
+
+  test('T2b search positive control: a VISIBLE field value IS searchable (non-vacuous)', async () => {
+    await mixedFieldRev() // FIELD_BATCH snapshot = { STATUS: 'public', SALARY: 99999 }
+    expect(batchIds(await events({ q: '99999' }))).toContain(FIELD_BATCH) // SALARY value (visible) searchable
+    expect(batchIds(await events({ q: 'public' }))).toContain(FIELD_BATCH) // STATUS value searchable
+  })
+
+  test('T2b search is LEAK-FREE (field-mask): a field_permissions-denied value is NOT searchable (post-mask)', async () => {
+    await mixedFieldRev()
+    await denyFieldForUser(SALARY)
+    // 99999 lives ONLY in the now-denied SALARY → searching it must return no batch (can't probe hidden values).
+    expect(batchIds(await events({ q: '99999' }))).not.toContain(FIELD_BATCH)
+    // non-vacuous: the still-visible STATUS value is still searchable.
+    expect(batchIds(await events({ q: 'public' }))).toContain(FIELD_BATCH)
+  })
+
+  test('T2b search is LEAK-FREE (row-deny): a row-denied record value is NOT searchable', async () => {
+    await setRules(denySecretRule)
+    await setFlag(true) // deny status='secret' records (REC_SECRET)
+    // 'secret' lives only in the row-denied REC_SECRET → searching it returns nothing.
+    expect(batchIds(await events({ q: 'secret' }))).toHaveLength(0)
+    // non-vacuous: 'public' (REC_PUBLIC, visible) still matches the bulk batch.
+    expect(batchIds(await events({ q: 'public' }))).toContain(BULK_BATCH)
+  })
+
+  test('T2b search: total is POST-search (a non-matching batch is not counted)', async () => {
+    await mixedFieldRev()
+    const res = await events({ q: '99999' }) // only FIELD_BATCH carries 99999
+    expect(batchIds(res)).toEqual([FIELD_BATCH])
+    expect(res.body?.data?.total).toBe(1) // post-search total
+  })
 })


### PR DESCRIPTION
## What

Owner-ordered **T2b search** (read-only, in the ratified MVP envelope): history search that is **strictly post-mask** — it cannot search hidden fields or denied records.

- **backend**: `loadHistoryBatchSummaries` gains a `q` substring search. Match = **revision snapshot ∩ `visibleFields`**: per batch, each *visible* record's snapshot is filtered to the actor's readable fields (`filterDataByAllowedFields`) then lowercase-contains-matched. **Leak-free on both axes** — a row-denied record's rows are skipped *before* the match; a hidden field's value is dropped by the mask — so neither can produce a hit. (Deliberately **not** current `meta_records.data`, which would re-open #2968; **not** display-title, deferred.) Value-search only (no operators/regex). `total` stays **post-search**. Snapshot is SELECTed only when searching; candidate rows capped at 20000 with a `console.warn` on truncation — **not fail-closed** (a read-only search has no execution-matches-preview invariant; T5/PV-7's fail-closed is for a *write* preview, not this).
- **FE**: a search box in `HistoryCenterModal` → `useHistoryCenter` → client `q`.

## Verification

- backend `tsc` 0, web `vue-tsc -b` 0.
- events goldens **10 → 14**: **positive control** (a visible value IS searchable — non-vacuous); **field-mask leak-free** (a denied value is NOT searchable); **row-deny leak-free** (a denied record's value is NOT searchable); **total is post-search**.
- full history suite **52/52**; FE spec **5/5**; unit **3756/3756**; no migration.
- **Mutation-checked** (the security claim): match the *raw* snapshot → the field-mask leak-free golden fails (denied value `99999` leaks) while the row-deny golden still passes (it depends on the row-skip, not the mask) — precisely isolating each axis's guard.

## Scope

T2b **cursor pagination** is the last remaining follow-up (a backend cursor preserving the post-filter `total` — now post-filter-AND-post-search). The cross-table field-dropdown UX folds in with it (your non-blocking call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)