### PR TITLE
feat(multitable): global-history T2b cursor pagination — stable key-cursor (completes T2b)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1457,13 +1457,14 @@ export class MultitableApiClient {
   // --- Global History & Point-in-Time Restore (read-only) ---
   async listHistoryEvents(
     baseId: string,
-    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; q?: string; limit?: number; offset?: number },
-  ): Promise<{ batches: HistoryBatchSummary[]; total: number }> {
+    params?: { sheetId?: string; actorId?: string; source?: string; action?: string; from?: string; to?: string; fieldId?: string; q?: string; cursor?: string; limit?: number; offset?: number },
+  ): Promise<{ batches: HistoryBatchSummary[]; total: number; nextCursor: string | null }> {
     const res = await this.fetch(`/api/multitable/bases/${encodeURIComponent(baseId)}/history/events${qs(params ?? {})}`)
-    const data = await this.parseJson<{ batches?: unknown[]; total?: number }>(res)
+    const data = await this.parseJson<{ batches?: unknown[]; total?: number; nextCursor?: unknown }>(res)
     return {
       batches: Array.isArray(data?.batches) ? data.batches.map(normalizeHistoryBatchSummary) : [],
       total: Number(data?.total ?? 0),
+      nextCursor: typeof data?.nextCursor === 'string' ? data.nextCursor : null,
     }
   }
 

--- a/apps/web/src/multitable/components/HistoryCenterModal.vue
+++ b/apps/web/src/multitable/components/HistoryCenterModal.vue
@@ -59,6 +59,14 @@
         </li>
       </ul>
       <p v-else class="meta-hist__hint">{{ t('暂无历史记录', 'No history yet') }}</p>
+      <button
+        v-if="nextCursor && !loading"
+        class="meta-hist__more"
+        type="button"
+        data-test="hist-load-more"
+        :disabled="loadingMore"
+        @click="loadMore"
+      >{{ loadingMore ? t('加载中…', 'Loading…') : t('加载更多', 'Load more') }}</button>
     </div>
   </div>
 </template>
@@ -85,7 +93,7 @@ const filterTo = ref('')
 const filterField = ref('')
 const scopeAllSheets = ref(false) // T2b: default to the active sheet; opt in to all readable tables
 
-const { batches, loading, error, expandedId, detail, detailLoading, load, toggle: toggleBatch } = useHistoryCenter()
+const { batches, loading, loadingMore, error, nextCursor, expandedId, detail, detailLoading, load, loadMore, toggle: toggleBatch } = useHistoryCenter()
 
 function reload(): Promise<void> {
   return load(props.baseId, {

--- a/apps/web/src/multitable/composables/useHistoryCenter.ts
+++ b/apps/web/src/multitable/composables/useHistoryCenter.ts
@@ -16,35 +16,64 @@ type HistoryClient = Pick<typeof multitableClient, 'listHistoryEvents' | 'getHis
 export function useHistoryCenter(client: HistoryClient = multitableClient) {
   const batches = ref<HistoryBatchSummary[]>([])
   const loading = ref(false)
+  const loadingMore = ref(false)
   const error = ref<string | null>(null)
+  const nextCursor = ref<string | null>(null) // T2b cursor: present → another page is reachable
   const expandedId = ref<string | null>(null)
   const detail = ref<HistoryBatchDetail | null>(null)
   const detailLoading = ref(false)
+  // Remembered for loadMore so the next page reuses the SAME filter set (a cursor is only valid for its filters).
+  let lastBaseId = ''
+  let lastFilters: HistoryFilters = {}
+
+  const clientParams = (filters: HistoryFilters, cursor?: string) => ({
+    sheetId: filters.sheetId || undefined,
+    actorId: filters.actorId || undefined,
+    source: filters.source || undefined,
+    action: filters.action || undefined,
+    from: filters.from || undefined,
+    to: filters.to || undefined,
+    fieldId: filters.fieldId || undefined,
+    q: filters.search || undefined,
+    cursor,
+    limit: 100,
+  })
 
   async function load(baseId: string, filters: HistoryFilters = {}): Promise<void> {
     if (!baseId) return
+    lastBaseId = baseId
+    lastFilters = filters
     loading.value = true
     error.value = null
     expandedId.value = null
     detail.value = null
+    nextCursor.value = null
     try {
-      const res = await client.listHistoryEvents(baseId, {
-        sheetId: filters.sheetId || undefined,
-        actorId: filters.actorId || undefined,
-        source: filters.source || undefined,
-        action: filters.action || undefined,
-        from: filters.from || undefined,
-        to: filters.to || undefined,
-        fieldId: filters.fieldId || undefined,
-        q: filters.search || undefined,
-        limit: 100,
-      })
+      const res = await client.listHistoryEvents(baseId, clientParams(filters))
       batches.value = res.batches
+      nextCursor.value = res.nextCursor
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load history'
       batches.value = []
+      nextCursor.value = null
     } finally {
       loading.value = false
+    }
+  }
+
+  // T2b "load more": fetch the next cursor page and APPEND. Never throws — on failure it stops paging
+  // (clears the cursor) and keeps the batches already shown, so a click can't leak an unhandled rejection.
+  async function loadMore(): Promise<void> {
+    if (!nextCursor.value || !lastBaseId || loadingMore.value) return
+    loadingMore.value = true
+    try {
+      const res = await client.listHistoryEvents(lastBaseId, clientParams(lastFilters, nextCursor.value))
+      batches.value = [...batches.value, ...res.batches]
+      nextCursor.value = res.nextCursor
+    } catch {
+      nextCursor.value = null
+    } finally {
+      loadingMore.value = false
     }
   }
 
@@ -65,5 +94,5 @@ export function useHistoryCenter(client: HistoryClient = multitableClient) {
     }
   }
 
-  return { batches, loading, error, expandedId, detail, detailLoading, load, toggle }
+  return { batches, loading, loadingMore, error, nextCursor, expandedId, detail, detailLoading, load, loadMore, toggle }
 }

--- a/apps/web/tests/multitable-history-fe.spec.ts
+++ b/apps/web/tests/multitable-history-fe.spec.ts
@@ -25,7 +25,7 @@ type FakeClient = Parameters<typeof useHistoryCenter>[0]
 type Spied = { listHistoryEvents: ReturnType<typeof vi.fn>; getHistoryBatch: ReturnType<typeof vi.fn> }
 function fakeClient(over: Partial<Spied> = {}): FakeClient {
   return {
-    listHistoryEvents: over.listHistoryEvents ?? vi.fn().mockResolvedValue({ batches: [batch('b1', 2), batch('b2')], total: 2 }),
+    listHistoryEvents: over.listHistoryEvents ?? vi.fn().mockResolvedValue({ batches: [batch('b1', 2), batch('b2')], total: 2, nextCursor: null }),
     getHistoryBatch: over.getHistoryBatch ?? vi.fn().mockResolvedValue(detailOf('b1')),
   } as FakeClient
 }
@@ -48,6 +48,29 @@ describe('useHistoryCenter — read-only history center', () => {
     const params = spied(c).listHistoryEvents.mock.calls[0][1]
     // T2b: time-range + field filter + search forwarded alongside actor/source/action (search → client `q`)
     expect(params).toMatchObject({ actorId: 'u9', source: 'automation', action: 'create', from: '2026-06-01T00:00:00Z', to: '2026-06-30T23:59:59Z', fieldId: 'fld_x', q: 'invoice-42' })
+  })
+
+  it('T2b loadMore APPENDS the next cursor page, forwards the cursor, and stops when exhausted', async () => {
+    const calls = vi.fn()
+      .mockResolvedValueOnce({ batches: [batch('b1')], total: 3, nextCursor: 'cur1' })
+      .mockResolvedValueOnce({ batches: [batch('b2')], total: 3, nextCursor: null })
+    const c = fakeClient({ listHistoryEvents: calls })
+    const { batches, nextCursor, load, loadMore } = useHistoryCenter(c)
+    await load('base1', { search: 'x' })
+    expect(batches.value.map((b) => b.batchId)).toEqual(['b1'])
+    expect(nextCursor.value).toBe('cur1')
+    await loadMore()
+    expect(batches.value.map((b) => b.batchId)).toEqual(['b1', 'b2']) // appended, not replaced
+    expect(nextCursor.value).toBeNull() // exhausted
+    expect(calls.mock.calls[1][1]).toMatchObject({ cursor: 'cur1', q: 'x' }) // forwards cursor + reuses filters
+  })
+
+  it('T2b loadMore is a no-op when there is no nextCursor', async () => {
+    const c = fakeClient() // default mock → nextCursor null
+    const { load, loadMore } = useHistoryCenter(c)
+    await load('base1')
+    await loadMore()
+    expect(spied(c).listHistoryEvents.mock.calls.length).toBe(1) // no extra fetch
   })
 
   it('load NEVER throws — surfaces the error and clears batches', async () => {

--- a/docs/development/multitable-global-history-pit-restore-todo-20260619.md
+++ b/docs/development/multitable-global-history-pit-restore-todo-20260619.md
@@ -71,7 +71,7 @@ Tests:
 
 ### T2 - Global History Center Read-Only UI
 
-Status: split. **T2a SHIPPED (#2961); T2b filters slice SHIPPED (2026-06-21: time-range + sheet-scope + field filter); T2b search SHIPPED (2026-06-21: post-mask snapshot value-search, leak-free); T2b cursor pagination still FOLLOW-UP (read-only, in MVP envelope, not gated, needs new backend cursor preserving the post-filter `total` semantics).**
+Status: **T2a + T2b COMPLETE (2026-06-21).** T2a #2961; T2b filters (time-range + sheet-scope + field filter), T2b search (post-mask snapshot value-search, leak-free), and T2b cursor pagination (stable key-cursor over the post-filter set, `total` preserved) all SHIPPED. Only the cross-table field-dropdown UX in "all tables" mode remains a non-blocking nicety (owner-deferred). The T2 read-only history center is now feature-complete.
 The original single T2 scope over-stated what shipped; this split records the actual line.
 
 Goal: add a global history center entry and timeline UI.

--- a/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t2b-filters-dev-verification-20260621.md
@@ -40,3 +40,12 @@
 - **成本**：搜索时才 SELECT snapshot；候选行 cap 20000 + 命中即 `console.warn` 截断——**不 fail-closed**（只读搜索截断只是结果不全，无 execution-matches-preview 不变式，不照搬 T5/PV-7）。
 - 后端 `?q=`；FE 搜索框 → `useHistoryCenter` → client `q`。
 - **验证**：events goldens 10→14（**positive control 非空过** + **field-mask leak-free** + **row-deny leak-free** + **total post-search**）；完整历史套件 **52/52**；**mutation**：把 search 改成匹配 raw snapshot → field-mask leak-free golden 失败（被拒值泄漏），row-deny leak-free 仍过（依赖 row-skip 而非字段掩码）——精确隔离两轴守卫。tsc/vue-tsc 0；FE spec 5/5。
+
+## 6. T2b cursor 分页子刀（SHIPPED 2026-06-21 —— T2b 完整）
+
+稳定 key-cursor（Option A，over 已过滤的批次集；`total` 保持精确 post-filter）。
+
+- **设计抉择**：精确 post-filter `total` 需 load-all + filter——这正是高效 cursor 要避免的。owner 要「保持 post-filter total 语义」→ 选 Option A（cursor over post-filter `all`，total 不变）。买到的是**页可达**（此前 FE 写死 limit:100，第 101 条不可达）+ **并发头插下稳定**（offset 会重显边界行；key-cursor 不会）；**不**降 DB 负载（每页仍 load-all——这是 total 精确的代价；SQL 级高效需换成 `hasMore` 估算，单列为 deferred）。
+- **关键正确性**：cursor 比较键必须与 `all` 的排序**字节一致**。`all` 显式 `sort(compareBatchKeyDesc)` = (createdAt DESC, **batchId DESC**)，cursor 也比这个元组；batchId 全局唯一，破 createdAt 平局——否则边界落在时间戳平局上会 skip/duplicate。cursor = opaque base64(`createdAt|batchId`)；malformed → 当首页（不崩）。offset 保留（无消费者，但移除是无谓 churn）。
+- **leak**：cursor 编码的是 actor 已见批次的键，且 over 已 post-filter 的 `all` → 永不能寻址被拒批次。
+- **验证**：events goldens 14→18（**limit=1 全量分页 exactly-once 无 skip/dup** + **同 createdAt 两批跨页边界仍 exactly-once = 平局 golden** + **分页中 total 恒为 post-filter** + **malformed cursor→首页不崩**）；完整历史套件 **56/56**；**mutation**：去掉 compareBatchKeyDesc 的 batchId 平局位 → 平局 golden 失败（一条 tie 批次被 skip，`expected 0 to be 1`）——证明平局位 load-bearing。FE：`loadMore` 追加（不替换）+ 透传 cursor + 复用 filters，永不抛；「加载更多」按钮（nextCursor 时显示）。FE spec 5→7；vue-tsc 0；unit 3756/3756；无迁移。

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -59,6 +59,9 @@ export interface HistoryEventsParams {
    * language; numbers/dates are matched by their stringified form. `total` is post-search.
    */
   search?: string
+  /** T2b cursor pagination: opaque (createdAt, batchId) of the last batch of the previous page. When present,
+   *  it takes precedence over `offset` (which is left working for any legacy caller). */
+  cursor?: string
   limit?: number
   offset?: number
 }
@@ -127,6 +130,35 @@ const EMPTY_FIELD_SET: ReadonlySet<string> = new Set()
 /** T2b search candidate-row cap (bound the snapshot load over a huge history; hitting it logs + truncates, never fails). */
 const SEARCH_CANDIDATE_ROW_CAP = 20000
 
+/**
+ * T2b cursor pagination (Option A — a stable key-cursor over the post-filter batch list; `total` stays exact).
+ * The cursor is the opaque (createdAt, batchId) of the last batch on a page. Pagination is over `all` AFTER it
+ * is sorted by the SAME total order the cursor compares on — (createdAt DESC, batchId DESC) — so a page
+ * boundary that lands on a createdAt tie cannot skip or duplicate (batchId is globally unique, the tiebreak).
+ * This buys page-reachability + stability under concurrent top-inserts; it does NOT reduce DB load (every page
+ * still loads + filters all rows — an exact post-filter `total` requires that). True SQL-level efficiency would
+ * trade the exact total for a `hasMore` estimate; that is a deferred follow-up, not this slice.
+ */
+function encodeHistoryCursor(b: { createdAt: string; batchId: string }): string {
+  return Buffer.from(`${b.createdAt}|${b.batchId}`, 'utf8').toString('base64')
+}
+function decodeHistoryCursor(cursor: string): { createdAt: string; batchId: string } | null {
+  try {
+    const raw = Buffer.from(cursor, 'base64').toString('utf8')
+    const sep = raw.lastIndexOf('|') // batchId is opaque but never contains '|' in our id space; split on the last
+    if (sep <= 0) return null
+    return { createdAt: raw.slice(0, sep), batchId: raw.slice(sep + 1) }
+  } catch {
+    return null // malformed cursor → treated as no cursor (first page); never throws
+  }
+}
+/** Total DESC order over (createdAt, batchId); batchId breaks createdAt ties. <0 → a sorts before b. */
+function compareBatchKeyDesc(a: { createdAt: string; batchId: string }, b: { createdAt: string; batchId: string }): number {
+  if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? 1 : -1
+  if (a.batchId !== b.batchId) return a.batchId < b.batchId ? 1 : -1
+  return 0
+}
+
 /** LOCK-3 field layer: per-sheet allowed field-id set; a sheet missing from the map masks every field (fail-closed). */
 function allowedFieldsFor(map: Map<string, Set<string>>, sheetId: string): ReadonlySet<string> {
   return map.get(sheetId) ?? EMPTY_FIELD_SET
@@ -151,9 +183,9 @@ export async function loadHistoryBatchSummaries(
   query: QueryFn,
   params: HistoryEventsParams,
   access: HistoryAccess,
-): Promise<{ batches: HistoryBatchSummary[]; total: number }> {
+): Promise<{ batches: HistoryBatchSummary[]; total: number; nextCursor: string | null }> {
   const sheetIds = params.sheetIds
-  if (sheetIds.length === 0) return { batches: [], total: 0 }
+  if (sheetIds.length === 0) return { batches: [], total: 0, nextCursor: null }
   const deniedBySheet = await loadDeniedBySheet(query, sheetIds, access)
 
   // Filters are pushed to SQL; ordering is LOCK-11. Grouping by COALESCE(batch_id, id) is done in JS so
@@ -230,9 +262,24 @@ export async function loadHistoryBatchSummaries(
   }
 
   const total = all.length // post-permission-filter total (LOCK-3) — never the raw revision/batch count
-  const offset = Math.max(Number(params.offset ?? 0), 0)
   const limit = Math.min(Math.max(Number(params.limit ?? 50), 1), 100)
-  return { batches: all.slice(offset, offset + limit), total }
+  // Sort by the SAME total order the cursor compares on (createdAt DESC, batchId DESC) so a tie-straddling page
+  // boundary can't skip/duplicate. (Encounter order already ~matches but disagrees at createdAt ties.)
+  all.sort(compareBatchKeyDesc)
+  // Pagination start: a cursor (if valid) wins over offset and points just past the previous page's last batch.
+  let start = 0
+  const cur = params.cursor ? decodeHistoryCursor(params.cursor) : null
+  if (cur) {
+    const idx = all.findIndex((b) => compareBatchKeyDesc(b, cur) > 0) // first batch strictly AFTER the cursor
+    start = idx === -1 ? all.length : idx
+  } else if (params.offset) {
+    start = Math.max(Number(params.offset), 0)
+  }
+  const batches = all.slice(start, start + limit)
+  const nextCursor = start + limit < all.length && batches.length > 0
+    ? encodeHistoryCursor(batches[batches.length - 1])
+    : null
+  return { batches, total, nextCursor }
 }
 
 export interface HistoryChange {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6524,7 +6524,7 @@ export function univerMetaRouter(): Router {
       const revealActive = await resolveHistoryRevealActive(pool.query.bind(pool), baseId, access.userId, revealRequested, reason, ticket, 'history.events')
       // LOCK-3 field layer: a base-level list can show any readable sheet, so resolve allowed fields for all.
       const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), readableSheetIds, access.userId, revealActive)
-      const { batches, total } = await loadHistoryBatchSummaries(
+      const { batches, total, nextCursor } = await loadHistoryBatchSummaries(
         pool.query.bind(pool),
         {
           sheetIds: readableSheetIds,
@@ -6536,6 +6536,7 @@ export function univerMetaRouter(): Router {
           to: str(req.query.to),
           fieldId: str(req.query.fieldId),
           search: str(req.query.q),
+          cursor: str(req.query.cursor),
           limit: Number.isFinite(limit) ? limit : 50,
           offset: Number.isFinite(offset) ? offset : 0,
         },
@@ -6543,7 +6544,7 @@ export function univerMetaRouter(): Router {
       )
       const names = await resolveUserDisplayNames(pool.query.bind(pool), batches.map((b) => b.actorId).filter((x): x is string => !!x))
       const enriched = batches.map((b) => ({ ...b, actorName: b.actorId ? names.get(b.actorId) ?? null : null }))
-      return res.json({ ok: true, data: { batches: enriched, total } })
+      return res.json({ ok: true, data: { batches: enriched, total, nextCursor } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
@@ -33,6 +33,8 @@ const REC_PUBLIC = `rec_gh_public_${TS}`
 const BULK_BATCH = `batch_gh_bulk_${TS}` // one bulk action touching BOTH records (shared id)
 const SECRET_BATCH = `batch_gh_secret_${TS}` // a single-record action on the secret record only
 const FIELD_BATCH = `batch_gh_field_${TS}` // a single-record action on REC_PUBLIC touching STATUS + SALARY
+const TIE_A = `batch_gh_tie_a_${TS}` // two batches sharing ONE created_at (cursor tie-break test)
+const TIE_B = `batch_gh_tie_b_${TS}`
 const USER_ID = `user_gh_${TS}`
 
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
@@ -67,6 +69,29 @@ const mixedFieldRev = () =>
      VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', $3, ARRAY[$4,$5]::text[], '{}'::jsonb, $6::jsonb, $7)`,
     [SHEET_ID, REC_PUBLIC, USER_ID, STATUS, SALARY, JSON.stringify({ [STATUS]: 'public', [SALARY]: 99999 }), FIELD_BATCH],
   )
+// A single-record visible-record revision (REC_PUBLIC) at an EXPLICIT created_at + batch_id (cursor tests).
+const revAt = (batchId: string, createdAt: string) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id, created_at)
+     VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, ARRAY[$4]::text[], '{}'::jsonb, $5::jsonb, $6, $7)`,
+    [SHEET_ID, REC_PUBLIC, USER_ID, STATUS, JSON.stringify({ [STATUS]: 'public' }), batchId, createdAt],
+  )
+// Page through (limit=1) collecting batchIds; asserts `total` is constant across pages. Returns {seen, total}.
+const pageAll = async (extra: Record<string, unknown> = {}): Promise<{ seen: string[]; total: number }> => {
+  const seen: string[] = []
+  let cursor: string | undefined
+  let total = -1
+  for (let i = 0; i < 50; i++) {
+    const res = await events({ ...extra, limit: 1, ...(cursor ? { cursor } : {}) })
+    expect(res.status).toBe(200)
+    if (total === -1) total = res.body?.data?.total
+    else expect(res.body?.data?.total).toBe(total) // total is constant across pages
+    seen.push(...batchIds(res))
+    cursor = res.body?.data?.nextCursor ?? undefined
+    if (!cursor) break
+  }
+  return { seen, total }
+}
 // field_permissions row hiding a field from the test user (subject_type='user'); afterEach clears it.
 const denyFieldForUser = (fieldId: string) =>
   q(
@@ -274,5 +299,39 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     const res = await events({ q: '99999' }) // only FIELD_BATCH carries 99999
     expect(batchIds(res)).toEqual([FIELD_BATCH])
     expect(res.body?.data?.total).toBe(1) // post-search total
+  })
+
+  // ----- T2b cursor pagination (stable key-cursor over the post-filter set) -----
+
+  test('T2b cursor: paging with limit=1 returns every batch EXACTLY once (no skip / no duplicate)', async () => {
+    await mixedFieldRev() // 3 batches: BULK, SECRET, FIELD
+    const { seen, total } = await pageAll()
+    expect(total).toBe(3)
+    expect(seen.length).toBe(3)
+    expect(new Set(seen).size).toBe(3) // no duplicates
+    expect(new Set(seen)).toEqual(new Set([BULK_BATCH, SECRET_BATCH, FIELD_BATCH])) // no skips
+  })
+
+  test('T2b cursor: two batches sharing ONE created_at straddling a page boundary — still exactly once', async () => {
+    const sameTime = new Date(TS - 60000).toISOString()
+    await revAt(TIE_A, sameTime)
+    await revAt(TIE_B, sameTime) // identical created_at, different batchId → the tie the cursor must break
+    const { seen } = await pageAll()
+    expect(seen.filter((id) => id === TIE_A).length).toBe(1) // the tie-break golden: no skip/duplicate
+    expect(seen.filter((id) => id === TIE_B).length).toBe(1)
+  })
+
+  test('T2b cursor: total stays POST-filter while paging (a row-denied batch is neither paged nor counted)', async () => {
+    await setRules(denySecretRule)
+    await setFlag(true) // SECRET_BATCH fully denied → invisible
+    const { seen, total } = await pageAll()
+    expect(seen).not.toContain(SECRET_BATCH) // a cursor from a visible page can never reach the denied batch
+    expect(total).toBe(seen.length) // total == the matches the actor can see
+  })
+
+  test('T2b cursor: a malformed cursor is treated as the first page (defined behavior, no crash)', async () => {
+    const res = await events({ cursor: 'not-a-valid-cursor!!!' })
+    expect(res.status).toBe(200)
+    expect(batchIds(res).length).toBeGreaterThan(0) // first page, not a 500
   })
 })


### PR DESCRIPTION
## What

The final **T2b** piece (read-only): a **stable key-cursor** over the post-filter batch list, with the exact post-filter `total` preserved (your "保持 post-filter total 语义").

- **backend**: `loadHistoryBatchSummaries` returns `nextCursor`. `all` is sorted by the **same total order the cursor compares on** — `(createdAt DESC, batchId DESC)` — so a page boundary on a `createdAt` **tie** can't skip/duplicate (`batchId` is the globally-unique tiebreak). Cursor = opaque `base64(createdAt|batchId)`; malformed → first page (never crashes). Cursor wins over `offset`; `offset` left working. Route accepts `?cursor=`, returns `nextCursor`.
- **FE**: `useHistoryCenter` gains `nextCursor` + `loadMore` (APPENDS the next page, forwards the cursor, reuses filters, never throws); a "load more" button shows while `nextCursor` is non-null.

## Honest framing

This buys **page reachability** (the FE was capped at limit:100, so batch 101 was unreachable) + **stability under concurrent top-inserts** (offset re-shows the boundary; a key-cursor doesn't). It does **not** reduce DB load — an exact post-filter `total` requires loading + filtering all rows. True SQL-level efficiency would trade the exact total for a `hasMore` estimate; that's a deferred follow-up, not this slice.

## Verification

- backend `tsc` 0, web `vue-tsc -b` 0.
- events goldens **14 → 18**: paging with limit=1 returns every batch **exactly once**; **two batches sharing one `created_at` straddling a page boundary** still exactly once (the tie golden); `total` stays post-filter while paging; a malformed cursor → first page (no crash).
- full history suite **56/56**; FE spec **5 → 7** (loadMore appends + forwards cursor + no-op without cursor); unit **3756/3756**; no migration.
- **Mutation-checked**: drop the `batchId` tiebreak from the comparator → the tie golden fails (a tie batch is **skipped**, `expected 0 to be 1`) — proving the tiebreak is load-bearing.

## T2b complete

filters + search + cursor all shipped. The cross-table field-dropdown UX in "all tables" mode is the only remaining non-blocking nicety (your deferral). The T2 read-only history center is feature-complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)