### PR TITLE
fix(multitable): finite-guard the history search row cap (no LIMIT NaN from the test seam)

### DIFF
--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -205,7 +205,11 @@ export async function loadHistoryBatchSummaries(
   // over a huge history is bounded. Capping a READ-ONLY search yields incomplete results, NOT a failure — do
   // NOT fail-closed here (unlike T5/PV-7, search has no execution-matches-preview invariant to protect).
   const searchQuery = params.search && params.search.trim() ? params.search.trim().toLowerCase() : null
-  const searchRowCap = Math.max(Number(params.searchRowCap ?? SEARCH_CANDIDATE_ROW_CAP), 1)
+  // Finite positive integer only. Resolve the default FIRST (`??` catches null + undefined — `Number(null)` is
+  // 0, which would otherwise clamp to LIMIT 1 instead of the default), then guard: a non-finite value falls
+  // back to the default (never `LIMIT NaN`), a fractional value is floored (never `LIMIT 2.5`). SQL-interpolated.
+  const numericRowCap = Number(params.searchRowCap ?? SEARCH_CANDIDATE_ROW_CAP)
+  const searchRowCap = Number.isFinite(numericRowCap) ? Math.max(Math.floor(numericRowCap), 1) : SEARCH_CANDIDATE_ROW_CAP
   const res = await query(
     `SELECT id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, batch_id, created_at${searchQuery ? ', snapshot' : ''}
      FROM meta_record_revisions

--- a/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-realdb.test.ts
@@ -354,4 +354,19 @@ describeIfDatabase('global-history events — LOCK-3 security goldens (real DB)'
     const full = await loadHistoryBatchSummaries(q, { ...params, searchRowCap: 10000 }, access)
     expect(full.searchTruncated).toBe(false) // generous cap → complete
   })
+
+  test('T2b search cap is finite-guarded: a NaN / non-integer searchRowCap never produces invalid SQL', async () => {
+    await mixedFieldRev()
+    const params = { sheetIds: [SHEET_ID], allowedFieldsBySheet: new Map([[SHEET_ID, new Set([STATUS, SALARY])]]), search: '99999' }
+    const access = { userId: USER_ID, isAdminRole: false }
+    // NaN → falls back to the default cap (no `LIMIT NaN` — the await would reject on invalid SQL); not truncated.
+    const nanCap = await loadHistoryBatchSummaries(q, { ...params, searchRowCap: NaN }, access)
+    expect(nanCap.searchTruncated).toBe(false)
+    // null → the DEFAULT cap, NOT 1 (Number(null)===0 would clamp to LIMIT 1 → spuriously "truncated").
+    const nullCap = await loadHistoryBatchSummaries(q, { ...params, searchRowCap: null as unknown as number }, access)
+    expect(nullCap.searchTruncated).toBe(false)
+    // A fractional cap is floored to a valid integer LIMIT (no `LIMIT 1.9`); floor(1.9)=1 with ≥2 rows → truncated.
+    const fracCap = await loadHistoryBatchSummaries(q, { ...params, searchRowCap: 1.9 }, access)
+    expect(fracCap.searchTruncated).toBe(true)
+  })
 })


### PR DESCRIPTION
Fix-forward for two reviewer findings on merged #2991 (`18ada24d`).

## Bug

`history-projection.ts` computed the search candidate cap as:
```
const searchRowCap = Math.max(Number(params.searchRowCap ?? SEARCH_CANDIDATE_ROW_CAP), 1)
```
- `searchRowCap: NaN` → `Math.max(NaN, 1) === NaN` → `LIMIT NaN` (invalid SQL → query rejects);
- a fractional value passes straight through → `LIMIT 2.5`;
- (follow-up review) `Number(null) === 0` → `null` clamps to `LIMIT 1` instead of the default 20000.

**Not externally reachable** (the route never sets `searchRowCap`), but the projection is exported and the seam is a real internal contract, so it's worth hardening.

## Fix

Resolve the default **first** (`??` catches null + undefined), then guard finite / floor / positive:
```
const numericRowCap = Number(params.searchRowCap ?? SEARCH_CANDIDATE_ROW_CAP)
const searchRowCap = Number.isFinite(numericRowCap) ? Math.max(Math.floor(numericRowCap), 1) : SEARCH_CANDIDATE_ROW_CAP
```
- `null` / `undefined` → default 20000;
- `NaN` / `Infinity` / non-numeric → default 20000 (never `LIMIT NaN`);
- fractional → floored (never `LIMIT 2.5`); `<=0` → 1.

## Verification

Golden: `NaN` → no reject + default (`searchTruncated` false); **`null` → default, not 1** (false); `1.9` → floor 1 → truncated. **Mutation-checked twice**: re-wrap as `Number(... ?? default)` → the NaN golden fails (`LIMIT NaN`); drop the `??`-first → the null golden fails (`LIMIT 1` → spuriously truncated). tsc 0; events goldens **20 → 21**. Backend-only, no FE, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)