### PR TITLE
docs(multitable): Time Machine — T6/T8/T9 write-slice design-locks + program roadmap

### DIFF
--- a/docs/development/multitable-global-history-t6-scoped-restore-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t6-scoped-restore-design-lock-20260621.md
@@ -1,0 +1,98 @@
+# Multitable Global History — T6 Scoped Restore (DESIGN-LOCK)
+
+> Status: **DESIGN-LOCK, docs-only. Runtime GATED behind ratification of §6 (D1–D4) + an explicit owner opt-in.**
+> T6 is the first WRITE slice of the restore program — it executes a previewed restore by writing forward
+> revisions. This doc is the 设计 deliverable; **no T6 runtime is built until ratified**.
+> Basis: the canonical global-history design-lock (`...-pit-restore-design-lock-20260619.md`, LOCK-9/10/11/12)
+> and the T5 restore-preview design-lock (`...-t5-restore-preview-design-lock-20260621.md`, PV-1..PV-7). T6
+> CONSUMES T5's preview; it references those locks, does not re-derive them.
+
+## 1. Problem + why T6 is NOT "just Layer-1, batch-scoped"
+
+A scoped restore re-applies a previously-recorded value to a selected set of records/fields, by writing a NEW
+forward revision (history is append-only — restore never rewrites the past). The per-record restore (Layer 1,
+`POST /sheets/:sheetId/records/:recordId/restore`) already does exactly this for ONE record the actor named.
+
+**The trap (load-bearing):** Layer-1's write path does NOT check row-level rule-deny — it never needed to,
+because the actor named one record they could already edit. T6 fans across MANY records at once, which is
+exactly where a record the actor cannot read/write gets silently restored if the gate is not re-applied
+**per record across the fan-out**. So T6 is Layer-1's mechanism PLUS a new permission surface. That surface
+is the reason T6 is design-locked, not a mechanical extension.
+
+## 2. Locks (T6; SR-* are scoped-restore-specific)
+
+- **SR-1 — Forward-only, append-only (non-destructive write).** A restore writes new revisions (`action='update'`
+  / `action='create'` for undelete) that bring records to the restored values; it NEVER deletes or rewrites
+  prior revisions. The restore is itself a `source='restore'` batch (LOCK-12), inspectable in history, and can
+  be restored again (re-restore must not corrupt history).
+- **SR-2 — Per-record permission re-application across the fan-out (THE new lock).** For EVERY record in the
+  scope, T6 re-applies, at write time: (a) row-level rule-deny (`loadDeniedRecordIds` — NOT in the Layer-1 write
+  path today; T6 adds it), (b) the per-field write gate (`FieldMutationGuard`: not hidden/read-only + the
+  field_permissions `visible/readOnly` mask), (c) optimistic `expected_version`. A denied record or a denied
+  field is dropped from the applied set in `revert`/scoped mode; in any all-or-nothing mode it BLOCKS the whole
+  execution (SR-5). The preview already computed the visible/permitted set (T5 PV-2); T6 RE-VERIFIES at write
+  time — never trusts the preview's permission verdict (the world may have changed since preview).
+- **SR-3 — Execution matches the preview (preview-identity required).** T6 requires a server-verifiable preview
+  identity (the T5-deferred token) that BINDS the strategy + scope + the computed diff. The executed change set
+  is the previewed one; a record/field not in the preview cannot be restored, and a `revert` token cannot drive
+  a `reset` (and vice versa). A stale preview (data changed since) is rejected or re-previewed, never silently
+  applied. (The token mechanism itself is D1.)
+- **SR-4 — Reveal never composes with restore (field-audit LOCK-7, cross-arc).** A history field-audit reveal
+  widens only what history SHOWS; it can never widen what a restore WRITES. The T6 write path never consults
+  `resolveActiveRevealGrant`/`loadRevealedFieldIds`; the restorable field set is the actor's NORMAL (masked)
+  write-permitted set. Verifiable by construction (grep).
+- **SR-5 — All-or-nothing for the destructive sub-modes (LOCK-10).** `revert`-scoped may partial-skip denied
+  targets (and reports them). A `reset`-style scope (delete post-T-created) is all-or-nothing: any single
+  delete/update/undelete permission failure blocks the ENTIRE execution — no partial skip, no fail-halfway.
+- **SR-6 — Atomic, idempotent execution.** The whole scoped restore commits in ONE transaction (forward
+  revisions + the `source=restore` batch row). Re-submitting the same preview identity must not double-apply
+  (idempotency key = the preview identity); a retry after a partial failure leaves the table unchanged.
+
+## 3. What T6 reuses (no re-derivation)
+
+`RecordWriteService.patchRecords` (the forward-revision write + `recordRecordRevision` chokepoint, already used
+by Layer-1 restore with `source:'restore'`); `FieldMutationGuard` (per-field write gate); `loadDeniedRecordIds`
+(row-deny — newly wired into the write path per SR-2); the optimistic `expected_version` check; T5's computed
+diff + preview identity.
+
+## 4. Forward-constraints (NOT T6)
+
+The destructive POINT-IN-TIME rollback (delete post-T-created records across a whole sheet) is **T8**, not T6 —
+T6 restores a SELECTED scope (records/fields/changes/a batch subset), never a sheet-wide reset. Config/schema
+restore is T9.
+
+## 5. Test plan (when built)
+
+Real-DB: selected-field restore writes a forward revision; partial-batch restore; **a row-denied record in the
+scope is NOT restored (SR-2)**; **a denied/hidden field is NOT restored (SR-2)**; **a reveal grant does not let
+a denied field be restored (SR-4, mutation/grep)**; the restore appears as a `source=restore` batch in history
+and is itself inspectable; re-restore doesn't corrupt history; a forged/mismatched/stale preview identity is
+rejected (SR-3); `reset`-scope all-or-nothing blocks on any single failure (SR-5); idempotent retry (SR-6).
+Mutation-checks: drop the per-record row-deny re-application → the denied-record golden leaks a write.
+
+## 6. Decisions to ratify (before any T6 build)
+
+- **D1 — Preview identity mechanism.** Signed short-lived payload (binds strategy+scope+diff-hash+actor) vs a
+  persisted preview row vs a cache entry. Recommend: **signed payload + a freshness check** (cheap, stateless,
+  binds execution to the exact previewed diff).
+- **D2 — Conflict policy when live data changed since preview.** Reject-and-re-preview (safest) vs apply-anyway
+  for non-conflicting fields. Recommend: **reject-and-re-preview** for v1.
+- **D3 — Who may execute a scoped restore.** The sheet write/`canEditRecord` capability (same as Layer-1), plus
+  the restore is audited. Recommend: yes, gate on `canEditRecord` + audit.
+- **D4 — Undelete in scope.** Does T6 support restoring a deleted record (write an `action='create'` undelete)
+  in a scoped restore, or is undelete deferred? Recommend: **support undelete** (it is the high-value case), with
+  the same per-record gate.
+
+## 7. Gated TODO
+
+- ⬜ **T6-0 — ratify** this doc (D1–D4) + explicit owner opt-in to open the first write slice.
+- 🔒 **T6-1 — preview-identity contract** (D1): mint at preview (T5-2), verify at execute. Contract + goldens.
+- 🔒 **T6-2 — scoped-restore execute** (read the identity → re-verify per-record gates SR-2 → atomic forward
+  revisions SR-6 → `source=restore` batch). Real-DB goldens (§5) + mutation checks. **The dangerous slice —
+  reviewed alone.**
+- 🔒 **T6-3 — FE restore panel** (select scope → preview → confirm → execute), separate gated slice.
+
+## 8. Out of scope / anti-goals
+
+Sheet-wide point-in-time reset (T8); config/schema restore (T9); composing a field-audit reveal into a restore
+(SR-4 forbids it); any write before T5 preview + a preview identity exist.

--- a/docs/development/multitable-global-history-t8-pit-restore-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t8-pit-restore-design-lock-20260621.md
@@ -1,0 +1,82 @@
+# Multitable Global History — T8 Point-In-Time Restore (DESIGN-LOCK)
+
+> Status: **DESIGN-LOCK, docs-only. OWNER-GATED — the single most dangerous slice in the program.** Runtime
+> requires a SEPARATE explicit owner ratification of the rollback semantics (§6), beyond ratifying this doc.
+> Prerequisites (per the canonical plan T8): T7 point-in-time read-only view PROVEN, T5 restore-preview PROVEN,
+> async/max-size decided. **No T8 runtime is built until all of those + owner ratification.**
+> Basis: canonical design-lock LOCK-9/10/11/12; the T5 preview lock; the T6 scoped-restore lock (T8 is the
+> sheet-wide generalization of T6's write, over the T7/T5-1 as-of-T reconstruction).
+
+## 1. Problem + the two strategies (LOCK-10)
+
+T8 restores a whole sheet (or a permission-filtered subset) to its state as of time T. Two named modes — the
+distinction is the whole safety story:
+
+- **Revert-to-T (default, NON-destructive):** undo post-T changes, undelete post-T deletions; **records created
+  after T are KEPT** (flagged in preview). Result = "data as of T, plus anything new since." Zero data loss —
+  fully expressible as a large T6 scoped restore (forward revisions only).
+- **Reset-to-T (explicit, DESTRUCTIVE, hard-gated):** the above PLUS **delete records created after T** → the
+  table exactly as of T. This is the only mode that destroys data, and it is the reason T8 is owner-gated.
+
+## 2. Locks (T8; PIT-* are point-in-time-restore-specific)
+
+- **PIT-1 — Preview-first, always (no blind rollback).** T8 execution requires a T5 preview + preview identity
+  (SR-3) for the FULL computed change set. There is no "reset to T" endpoint that skips the dry-run.
+- **PIT-2 — Reset is all-or-nothing with a full permission preflight (LOCK-10).** Before any destructive write,
+  EVERY record/field to be deleted/updated/undeleted is permission-checked in the dry-run; ANY failure blocks
+  the entire Reset (no partial skip, no fail-halfway). Revert may partial-skip; Reset may not.
+- **PIT-3 — Counts never leak (LOCK-3), reset is the leak-prone mode (PV-4).** The post-T-created delete-candidate
+  set ranges over records the actor may not see; its count is `visibleAffected*` (post-filter), and a record the
+  actor cannot read must not be inferable from any count delta.
+- **PIT-4 — As-of-T reconstruction is the T5-1 primitive (LOCK-9/11).** T8 reconstructs over the SAME delete-aware,
+  deterministic `reconstructRecordsAtT`; it does not re-derive "state at T" (the failure mode is three slices
+  encoding three subtly-different semantics).
+- **PIT-5 — The rollback is itself recorded + inspectable.** T8 writes forward revisions + a `source=restore`
+  batch (LOCK-12) describing the rollback; the rollback can be understood in history (and, for Revert, itself
+  reverted).
+- **PIT-6 — Bounded + async above a threshold.** A rollback over more than the ratified max-size runs async
+  (job) with progress; it never holds a giant synchronous transaction open. Above the hard ceiling it is
+  refused (fail-closed), not truncated (a truncated rollback breaks atomicity).
+- **PIT-7 — Reveal never composes (SR-4 / field-audit LOCK-7).** A reveal grant never widens what a rollback
+  writes or deletes.
+
+## 3. Forward-constraints / reuse
+
+Reuses T5-1 (reconstructor), T5-2 (preview), T6 (the per-record forward-revision write + per-record gate
+re-application SR-2, generalized sheet-wide). Adds only: the post-T-created enumeration (Reset), the async job
+runner + size ceiling, and the destructive delete path (the one genuinely new, hard-gated capability).
+
+## 4. Test plan (when built)
+
+Real-DB: full-sheet Revert dry-run keeps post-T-created; full-sheet Reset dry-run lists post-T-created as delete
+candidates; Reset all-or-nothing blocks on any single permission failure (PIT-2); no count/existence leak under
+Reset (PIT-3); forward revisions + restore batch created (PIT-5); the rollback is inspectable; conflict handling;
+above-ceiling refusal (PIT-6, fail-closed); reveal-doesn't-compose (PIT-7). Browser evidence for the rollback
+confirmation UX. Mutation-checks on PIT-2 (drop a preflight check → a denied target slips into the destructive set).
+
+## 5. Decisions to ratify (the heavy ones — SEPARATE owner sign-off, not just doc approval)
+
+- **D1 — Reset (destructive) at all, in v1?** Recommend: ship **Revert-only first** (zero data loss); Reset as a
+  later, separately-ratified slice. This de-risks the whole program — Revert covers most "go back to T" needs.
+- **D2 — Who may execute a sheet rollback.** A capability strictly ABOVE normal record-write (e.g. a base-admin
+  or a dedicated `multitable:history-restore` capability), since one call rewrites a whole table. Recommend: a
+  dedicated capability, never plain `canEditRecord`.
+- **D3 — Async threshold + hard max size.** The record/field-count above which the rollback runs async, and the
+  ceiling above which it is refused. Recommend: sync under a few hundred records, async above, hard-refuse above
+  a configured ceiling.
+- **D4 — Confirmation / two-step + audit.** A destructive Reset requires an explicit typed confirmation + is
+  audited with actor/T/scope (never values). Recommend: yes.
+- **D5 — Scope granularity.** Whole sheet only, or a permission-filtered subset (a view/filter)? Recommend:
+  whole sheet first; subset is a follow-up.
+
+## 6. Gated TODO
+
+- ⬜ **T8-0 — ratify** this doc AND the rollback semantics (D1–D5) as a SEPARATE explicit owner sign-off.
+- 🔒 **T8-1 — Revert-to-T** (non-destructive, owner-opt-in) over T7 + T6's write. Real-DB goldens + browser UX.
+- 🔒 **T8-2 — Reset-to-T** (destructive, SEPARATE owner ratification, only after Revert proven). The hard-gated
+  delete path + async runner + ceiling. Reviewed alone, most adversarial test pass in the program.
+
+## 7. Out of scope / anti-goals
+
+Config/schema rollback (T9); any rollback without a preview + preview identity; a synchronous unbounded rollback;
+Reset before Revert is proven; composing a reveal into a rollback.

--- a/docs/development/multitable-global-history-t9-config-history-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t9-config-history-design-lock-20260621.md
@@ -1,0 +1,70 @@
+# Multitable Global History — T9 Config History (DESIGN-LOCK)
+
+> Status: **DESIGN-LOCK, docs-only. OWNER-GATED — a SEPARATE program after data history, not part of the
+> data-restore line (T5–T8).** Runtime requires its own ratification + opt-in.
+> Basis: the canonical global-history design-lock (which scopes T9 as "track and display schema/view/config
+> changes", explicitly separate from data history, no mixed config+data restore until separately designed).
+
+## 1. Problem + the hard boundary
+
+Data history (T1–T8) tracks RECORD changes (`meta_record_revisions`). T9 tracks CONFIG changes — the schema and
+settings around the data: field create/delete/rename/type-change, view filter/sort/group changes, permission
+rule changes, (later) automation config. These are a DIFFERENT change stream with different semantics, blast
+radius, and restore model.
+
+**The hard boundary (load-bearing):** config history is SEPARATE from data history, and **config restore is
+separate from data restore — there is NO mixed config+data restore until it is explicitly, separately designed.**
+Restoring a field's old type while the data has moved on, or restoring a permission rule mid-flight, is a
+different and more dangerous operation than restoring a record value; conflating them is the failure mode this
+lock forbids.
+
+## 2. Locks (T9; CH-* are config-history-specific)
+
+- **CH-1 — Separate stream, separate store.** Config changes are recorded in their own append-only log (e.g.
+  `meta_config_revisions` — entity_type ∈ {field, view, permission, …}, entity_id, action, before/after config
+  snapshot, actor, source, created_at), NOT in `meta_record_revisions`. Data-history projections never read it
+  and vice versa.
+- **CH-2 — Read-only first.** The first T9 release is a config-history VIEW (who changed which field/view/rule,
+  when, before→after) — no config restore. Restore is a later, separately-designed slice (CH boundary).
+- **CH-3 — Permission-gated display.** Config detail is visible only to authorized users (the people who can
+  manage schema/permissions for that base/sheet) — a config-change log is itself sensitive (it reveals the
+  permission structure). Denied users see nothing; same LOCK-3 no-existence-oracle discipline.
+- **CH-4 — No config value leak via the log.** A permission-rule change log must not become a side channel that
+  reveals field values or restricted scopes; it records the CONFIG delta (rule shape), redacted of any embedded
+  secrets/values, same redaction discipline as the audit logs.
+- **CH-5 — Config restore (if ever) is its own design-lock.** No mixed config+data restore; a field-type revert
+  with live data of the new type is a conflict that needs explicit semantics (block / coerce / refuse). Deferred.
+
+## 3. Why this is gated + separate
+
+T9 has no dependency on the T5–T8 data-restore line and a much larger design surface (every config-bearing
+entity has its own change semantics). Building it as part of the data-history /goal would conflate two programs.
+It is captured here so the program is fully PLANNED, and held for its own opt-in.
+
+## 4. Test plan (when built, read-only first)
+
+Real-DB: a field create/rename/type-change is captured as a config revision; a view filter/sort/group change is
+captured; a permission-rule change is captured; config detail is visible only to authorized users (denied → not
+found shape, CH-3); the log carries no field values / secrets (CH-4). No restore tests until a separate config-
+restore design exists (CH-5).
+
+## 5. Decisions to ratify (before any T9 build)
+
+- **D1 — Which config entities in v1?** Recommend: **fields + views** first (highest-value, clearest semantics);
+  permission rules + automation config as later slices.
+- **D2 — Capture mechanism.** A chokepoint at the config-write paths (field/view CRUD) writing `meta_config_
+  revisions`, mirroring the `recordRecordRevision` chokepoint. Recommend: yes, one chokepoint per entity family.
+- **D3 — Who may view config history.** The base/sheet schema-admin (`canManageFields` / the structure
+  managers). Recommend: gate on the manage capability for that entity.
+
+## 6. Gated TODO
+
+- ⬜ **T9-0 — ratify** this doc (D1–D3) + a SEPARATE opt-in (this is a new program, not a continuation of T5–T8).
+- 🔒 **T9-1 — `meta_config_revisions` + capture chokepoint** for the v1 entities (D1). Real-DB goldens.
+- 🔒 **T9-2 — config-history read-only view** (permission-gated, CH-3/CH-4). Goldens + browser evidence.
+- 🔒 **T9-3+ — config restore** — its OWN design-lock first (CH-5); not part of T9 v1.
+
+## 7. Out of scope / anti-goals
+
+Any config RESTORE in v1 (CH-2/CH-5); mixed config+data restore (CH-5); recording config in
+`meta_record_revisions` (CH-1); an ungated config-history surface (CH-3).

--- a/docs/development/multitable-global-history-timemachine-program-roadmap-20260621.md
+++ b/docs/development/multitable-global-history-timemachine-program-roadmap-20260621.md
@@ -1,0 +1,61 @@
+# Multitable Global History / Time Machine — Program Roadmap (T5–T9)
+
+> The 规划 for "complete the remaining history-records + Time Machine development plan." It records the staged
+> execution, the build-vs-design-lock split, and the ratification gates. The read-only foundation is built; the
+> write/destructive slices are design-locked (the 设计 deliverable) and held for explicit owner ratification.
+
+## 0. Where the line already is (shipped)
+
+T0–T4 + T2a/T2b are COMPLETE on `main`: the read-only history center (timeline, batch detail, filters, search,
+cursor) with the LOCK-3 field+row permission layer, the field-audit break-glass arc (A1–A3), and the search
+hardening. See `…-mvp-dev-verification…`, `…-t2b-filters-dev-verification…`, and the field-audit arc MD.
+
+## 1. The principle that splits this program
+
+Restore has a **safe half** (everything a restore needs to SHOW / reconstruct — read-only) and a **dangerous
+half** (everything it needs to WRITE / delete). The /goal asked for 规划 + 完成 + **设计及验证MD**: so the
+read-only half is BUILT (with verification MD), and the write half is delivered as **design-locks** (the 设计
+MD that the goal explicitly asked for) + held for ratification. Design-locking the writes is delivering the
+requested artifact, not gating.
+
+## 2. Built now (read-only, verification MD)
+
+- **T5-1 — as-of-time-T reconstructor** (`record-reconstructor.ts`): `reconstructRecordsAtT` — the pure-read
+  primitive (LOCK-9 delete-aware + LOCK-11 deterministic). The shared root; pinned FIRST with 7 real-DB goldens
+  incl. the delete-at-T pin. **BUILT.**
+- **T5-2 — restore-preview endpoint** (read-only diff over T5-1): the T5 design-lock #2985 (PV-1..PV-7). Computes
+  what a restore WOULD change, writes nothing. Builds on the pinned T5-1.
+- **T7 — point-in-time read-only view**: the reconstructor projected over a sheet with LOCK-3 masking + pagination
+  ("open the table as of T, read-only"). Builds on the pinned T5-1; de-risks T8.
+
+All three share T5-1's exact contract — **parallelize the leaves (T5-2, T7), never the shared root.**
+
+## 3. Design-locked now (write / destructive — the 设计 deliverable, NOT built)
+
+- **T6 — scoped restore** (`…-t6-scoped-restore-design-lock…`): the first WRITE — forward revisions over a
+  selected scope. Key lock SR-2: batch fan-out is a NEW permission surface (Layer-1's write path never checked
+  row-deny; T6 must re-apply every gate per-record). Gated on D1–D4 + opt-in.
+- **T8 — point-in-time restore** (`…-t8-pit-restore-design-lock…`): the destructive sheet rollback. Revert-to-T
+  (non-destructive, recommend ship first) vs Reset-to-T (destructive, SEPARATE owner ratification). The single
+  most dangerous slice; hard-gated.
+- **T9 — config history** (`…-t9-config-history-design-lock…`): a SEPARATE program (schema/view/permission change
+  history), read-only first, config restore deferred to its own design. No mixed config+data restore.
+
+## 4. Ratification gates (yours)
+
+- **T5 D1/D2/D5** — for the read-only preview (T5-2). Proceeding on the recommended defaults (D1 token→defer T6,
+  D2 record-version+batch first, D5 gate on restore-capability) under the planning authority of 请规划; **veto
+  any one and I adjust.**
+- **T6-0 / T8-0 / T9-0** — each write/config slice needs its own explicit opt-in before runtime; **T8 (destructive
+  Reset) needs a separate rollback-semantics sign-off** beyond doc approval.
+
+## 5. Execution order (dependency-correct)
+
+1. ✅ T5-1 reconstructor (root, pinned).
+2. ▶ T5-2 preview + T7 PIT-view (parallel leaves off the pinned T5-1).
+3. ✅ T6 / T8 / T9 design-locks (this docs set — the 设计 deliverable).
+4. ⏸ T6/T8/T9 runtime — each gated on its ratification; **not started**.
+
+The first release surface stays read-only (reconstruct + preview + as-of-T view); no write/rollback opens until
+ratified. This honors "全部完成" — everything is either built (read-only) or designed (writes) — without
+self-authorizing a destructive restore.


### PR DESCRIPTION
The **设计 deliverable** for the restore program's write/destructive slices — the half that is *design-locked, not built* (per the read-only-vs-write split the goal's "设计及验证MD" asks for). **docs-only; all runtime gated** behind each slice's ratification.

- **T6 scoped restore** — the first WRITE (forward revisions over a selected scope). Key lock **SR-2**: batch fan-out is a **new permission surface** the per-record Layer-1 restore never exercised (its write path doesn't check row-deny), so every gate is re-applied per-record across the fan-out. + preview-identity (SR-3), reveal-never-composes (SR-4), all-or-nothing destructive sub-modes (SR-5), atomic+idempotent (SR-6).
- **T8 PIT restore** — the destructive sheet rollback. **Revert-to-T** (non-destructive, recommend ship first) vs **Reset-to-T** (destructive, **separate owner rollback-semantics sign-off**). Preview-first, all-or-nothing preflight, count-leak-safe, bounded+async, reveal-never-composes. The most dangerous slice.
- **T9 config history** — a **separate program** (schema/view/permission change history), read-only first; config restore deferred to its own design; no mixed config+data restore.
- **Program roadmap** — the staged execution + build-vs-design-lock split + ratification gates (T5 D1/D2/D5 proceeding-on-recommendations, **veto any**; T6-0/T8-0/T9-0 each a separate opt-in).

Companion to the runtime that's building (T5-1 reconstructor #2993; T5-2 preview + T7 PIT-view next). No competitor brand names; MetaSheet's own principles throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)