### PR TITLE
feat(multitable): 1b Slice A.3 — RELAVGIF + RELCOUNTIF (complete the relation-scoped IF-family)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1209,6 +1209,8 @@ const MAX_RELATION_SCAN_RECORDS = 1000
 // extension point for RELCOUNTIF/RELAVGIF (own goldens each).
 const RELATION_AGG_FUNCTIONS: Record<string, RollupAggregation> = {
   RELSUMIF: 'sum',
+  RELAVGIF: 'avg',
+  RELCOUNTIF: 'countall', // counts MATCHED linked records (no sum target — 4-arg form, see the parser)
 }
 
 type RelationAggregationCall = {
@@ -1256,12 +1258,31 @@ export function parseRelationAggregationCall(expression: string): RelationAggreg
   const aggregation = RELATION_AGG_FUNCTIONS[fnName]
   if (!aggregation) return null
   const args = splitTopLevelArgs(m[2])
-  if (!args || args.length !== 5) return null
-  const linkFieldId = unquoteStringArg(args[0])
-  const targetFieldId = unquoteStringArg(args[1])
-  const criteriaFieldId = unquoteStringArg(args[2])
-  const operator = unquoteStringArg(args[3])
-  const valueExpr = args[4]
+  if (!args) return null
+  // RELCOUNTIF counts MATCHED linked records — no sum target (4 args: link, criteria, op, value). The
+  // others sum/avg a foreign target (5 args: link, target, criteria, op, value). For COUNTIF, targetFieldId
+  // is set to the criteria field so the foreign-FIELD readability + taint gates (which key on targetFieldId)
+  // still cover the only foreign field it reads (and `countall` ignores the per-record value).
+  let linkFieldId: string | null
+  let targetFieldId: string | null
+  let criteriaFieldId: string | null
+  let operator: string | null
+  let valueExpr: string
+  if (fnName === 'RELCOUNTIF') {
+    if (args.length !== 4) return null
+    linkFieldId = unquoteStringArg(args[0])
+    criteriaFieldId = unquoteStringArg(args[1])
+    operator = unquoteStringArg(args[2])
+    valueExpr = args[3]
+    targetFieldId = criteriaFieldId
+  } else {
+    if (args.length !== 5) return null
+    linkFieldId = unquoteStringArg(args[0])
+    targetFieldId = unquoteStringArg(args[1])
+    criteriaFieldId = unquoteStringArg(args[2])
+    operator = unquoteStringArg(args[3])
+    valueExpr = args[4]
+  }
   if (!linkFieldId || !targetFieldId || !criteriaFieldId || !operator || valueExpr.length === 0) return null
   return { fnName, aggregation, linkFieldId, targetFieldId, criteria: { fieldId: criteriaFieldId, operator, valueExpr } }
 }

--- a/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
+++ b/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
@@ -37,6 +37,9 @@ const FLD_SUMIF = `fld_rel_sumif_${TS}` // = RELSUMIF(link, amt, status, is, pai
 const FLD_SECRETSUM = `fld_rel_secsum_${TS}` // = RELSUMIF(link, SECRET, status, is, paid) -> 300 (leak gate)
 const FLD_CLIFF = `fld_rel_cliff_${TS}` // = RELSUMIF(...)+1  -> composition cliff -> #ERROR!
 const FLD_CURVAL = `fld_rel_curval_${TS}` // current-record string used as a {fld} criteria value
+const FLD_AVGIF = `fld_rel_avgif_${TS}` // = RELAVGIF(link, amt, status, is, {curval}) -> avg(10,20) = 15
+const FLD_COUNTIF = `fld_rel_countif_${TS}` // = RELCOUNTIF(link, status, is, {curval}) -> count(paid) = 2 (4-arg)
+const FLD_SECRETCOUNT = `fld_rel_seccount_${TS}` // = RELCOUNTIF(link, SECRET, greater, 0) -> 3; DENIED-criteria leak gate
 
 const FR1 = `rec_rel_f1_${TS}` // amt 10, status paid,   secret 100
 const FR2 = `rec_rel_f2_${TS}` // amt 20, status paid,   secret 200
@@ -104,6 +107,11 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SUMIF, MS, 'SumIf', 'formula', relExpr(FLD_AMT), 3])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRETSUM, MS, 'SecretSum', 'formula', relExpr(FLD_SECRET), 4])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_CLIFF, MS, 'Cliff', 'formula', JSON.stringify({ expression: `RELSUMIF("${FLD_LINK}","${FLD_AMT}","${FLD_STATUS}","is",{${FLD_CURVAL}})+1` }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_AVGIF, MS, 'AvgIf', 'formula', JSON.stringify({ expression: `RELAVGIF("${FLD_LINK}","${FLD_AMT}","${FLD_STATUS}","is",{${FLD_CURVAL}})` }), 6])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_COUNTIF, MS, 'CountIf', 'formula', JSON.stringify({ expression: `RELCOUNTIF("${FLD_LINK}","${FLD_STATUS}","is",{${FLD_CURVAL}})` }), 7])
+    // RELCOUNTIF over the DENIED foreign SECRET field as criteria — the target=criteria bridge must route it
+    // through the same taint gate (a count over a denied criteria would otherwise leak its distribution).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRETCOUNT, MS, 'SecretCount', 'formula', JSON.stringify({ expression: `RELCOUNTIF("${FLD_LINK}","${FLD_SECRET}","greater","0")` }), 8])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3], [FLD_CURVAL]: 'unpaid' })])
     for (const fr of [FR1, FR2, FR3]) {
@@ -111,7 +119,7 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     }
     // Formula deps on the current-record criteria field {CURVAL} (the recompute trigger; the create handler
     // would register it via extractFieldReferences, but these fields are seeded via SQL → insert directly).
-    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF]) {
+    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF, FLD_AVGIF, FLD_COUNTIF, FLD_SECRETCOUNT]) {
       await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [MS, ff, FLD_CURVAL])
     }
     // DENY cannot read the foreign SECRET field → any RELSUMIF over it must be masked for DENY on read.
@@ -144,10 +152,19 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     expect(await hasField(DENY, FLD_SECRETSUM)).toBe(false)
     // and the readable aggregate is unaffected for DENY (amount + status are readable).
     expect(await readField(DENY, FLD_SUMIF)).toBe(30)
+    // A.3 RELCOUNTIF leak gate: a COUNT whose CRITERIA is the denied SECRET field (no separate target —
+    // target=criteria bridge) must also be dropped for DENY, else the match count leaks SECRET's distribution.
+    expect(await readField(ALLOW, FLD_SECRETCOUNT)).toBe(3) // SECRET > 0 for all 3 linked records
+    expect(await hasField(DENY, FLD_SECRETCOUNT)).toBe(false)
   })
 
   test('composition cliff: RELSUMIF composed with arithmetic is rejected fail-loud as #ERROR! (not silent-wrong)', async () => {
     expect(await readField(ALLOW, FLD_CLIFF)).toBe('#ERROR!')
+  })
+
+  test('A.3 — RELAVGIF averages the matched target (15) and RELCOUNTIF counts matched records (2, 4-arg)', async () => {
+    expect(await readField(ALLOW, FLD_AVGIF)).toBe(15) // avg amt where paid: (10+20)/2
+    expect(await readField(ALLOW, FLD_COUNTIF)).toBe(2) // count where status=paid: FR1, FR2
   })
 
   // A.2 — foreign-write fan-out (reverse-edge). Runs LAST: it mutates FR1's amount, which the earlier

--- a/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
+++ b/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
@@ -53,6 +53,25 @@ describe('parseRelationAggregationCall — sole-call grammar', () => {
     expect(parseRelationAggregationCall('RELSUMIF(a,b,c,is,x)')).toBeNull() // unquoted ids
   })
 
+  it('A.3 — parses RELAVGIF (avg) with the same 5-arg signature as RELSUMIF', () => {
+    expect(parseRelationAggregationCall('RELAVGIF("fld_link","fld_amt","fld_status","is","paid")')).toEqual({
+      fnName: 'RELAVGIF', aggregation: 'avg', linkFieldId: 'fld_link', targetFieldId: 'fld_amt',
+      criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
+    })
+  })
+
+  it('A.3 — parses RELCOUNTIF (countall, 4-arg, no sum target → targetFieldId = criteria for the readability gate)', () => {
+    expect(parseRelationAggregationCall('RELCOUNTIF("fld_link","fld_status","is","paid")')).toEqual({
+      fnName: 'RELCOUNTIF', aggregation: 'countall', linkFieldId: 'fld_link', targetFieldId: 'fld_status',
+      criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
+    })
+  })
+
+  it('A.3 — per-function arity: RELCOUNTIF needs 4 (5→null); RELAVGIF/RELSUMIF need 5 (4→null)', () => {
+    expect(parseRelationAggregationCall('RELCOUNTIF("a","b","c","is","x")')).toBeNull() // 5 args → not COUNTIF
+    expect(parseRelationAggregationCall('RELAVGIF("a","b","c","is")')).toBeNull() // 4 args → not AVGIF
+  })
+
   it('returns null when a nested paren appears (outside the Slice A grammar)', () => {
     expect(parseRelationAggregationCall('RELSUMIF("a","b","c","is",SUM(1,2))')).toBeNull()
   })


### PR DESCRIPTION
Third sub-slice of the 1b record-set implementation, on top of the merged Slice A (#2978). Adds the two remaining named criteria-aggregation functions, reusing Slice A's parser / resolver / recompute hook / **read-leak taint edge** / **fan-out** verbatim — leak-safe by construction.

- **`RELAVGIF`** — 5-arg (`link, target, criteria, op, value`), aggregation `avg`. One map entry; inherits the entire wired pipeline.
- **`RELCOUNTIF`** — 4-arg (`link, criteria, op, value`), aggregation `countall` (counts MATCHED linked records; no sum target). `targetFieldId` is set to the criteria field so the foreign-FIELD readability + taint gates (which key on `targetFieldId`) cover the only foreign field it reads, and `countall` ignores the per-record value.

**Security — the RELCOUNTIF target=criteria bridge is leak-gated.** Because RELCOUNTIF has no separate target, a denied *criteria* field would leak its distribution via the match count. The new real-DB golden proves it: `RELCOUNTIF` over the denied `SECRET` field → allowed reader gets `3`, **denied reader gets the field absent** (taint drop). This is the COUNTIF analogue of Slice A's read-leak gate.

## Tests
- Parser unit (14): RELAVGIF 5-arg, RELCOUNTIF 4-arg, per-function arity (RELCOUNTIF 5→null, RELAVGIF 4→null).
- Real-DB goldens (in the registered `multitable-relation-aggregation.test.ts`): `RELAVGIF=15`, `RELCOUNTIF=2`, and the **RELCOUNTIF-over-denied-criteria leak gate**.
- Unit suite green non-watch (`CI=true`, 356 files, 0 fail); tsc 0; structural guards unaffected (no new taint/UPDATE/egress site — just 2 map entries + per-function parser arity).

Composition (`RELSUMIF(...)+1`) stays deferred (the sole-call cliff still fails loud). Slice B (lookup) and Slice C (array) follow as their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)