### PR TITLE
fix(multitable): Time Machine review fixes — reconstructor version contract + sentinel + T6/T9 doc boundaries

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -171,6 +171,7 @@ jobs:
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+          METASHEET_REAL_DB_TEST_STEP: '1' # marks the real-DB allowlist step so a fail-not-skip sentinel can scope its throw here only
         run: |
           : "${DATABASE_URL:?DATABASE_URL is required for multitable real-DB integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \

--- a/docs/development/multitable-global-history-t6-scoped-restore-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t6-scoped-restore-design-lock-20260621.md
@@ -41,9 +41,12 @@ is the reason T6 is design-locked, not a mechanical extension.
   widens only what history SHOWS; it can never widen what a restore WRITES. The T6 write path never consults
   `resolveActiveRevealGrant`/`loadRevealedFieldIds`; the restorable field set is the actor's NORMAL (masked)
   write-permitted set. Verifiable by construction (grep).
-- **SR-5 — All-or-nothing for the destructive sub-modes (LOCK-10).** `revert`-scoped may partial-skip denied
-  targets (and reports them). A `reset`-style scope (delete post-T-created) is all-or-nothing: any single
-  delete/update/undelete permission failure blocks the ENTIRE execution — no partial skip, no fail-halfway.
+- **SR-5 — Optional all-or-nothing scoped mode; T6 NEVER deletes (the T6/T8 boundary, LOCK-10).** T6 writes
+  ONLY forward revisions over the selected scope — it has **no destructive mode and never deletes post-T-created
+  records** (sheet-wide reset / delete-post-T-created is **T8's Reset, not T6**). The default scoped restore may
+  partial-skip denied targets (and reports them); an OPTIONAL all-or-nothing scoped mode instead blocks the
+  ENTIRE restore if any selected target is denied (no partial skip, no fail-halfway) — but still writes only
+  forward revisions (set/unset/undelete), never a delete.
 - **SR-6 — Atomic, idempotent execution.** The whole scoped restore commits in ONE transaction (forward
   revisions + the `source=restore` batch row). Re-submitting the same preview identity must not double-apply
   (idempotency key = the preview identity); a retry after a partial failure leaves the table unchanged.

--- a/docs/development/multitable-global-history-t9-config-history-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t9-config-history-design-lock-20260621.md
@@ -20,10 +20,17 @@ lock forbids.
 
 ## 2. Locks (T9; CH-* are config-history-specific)
 
-- **CH-1 — Separate stream, separate store.** Config changes are recorded in their own append-only log (e.g.
-  `meta_config_revisions` — entity_type ∈ {field, view, permission, …}, entity_id, action, before/after config
-  snapshot, actor, source, created_at), NOT in `meta_record_revisions`. Data-history projections never read it
-  and vice versa.
+- **CH-1 — Separate stream, separate store, SCOPE-KEYED.** Config changes are recorded in their own append-only
+  log `meta_config_revisions`, NOT in `meta_record_revisions` (data-history projections never read it, and vice
+  versa). The schema MUST lock the scope keys the CH-3 permission gate filters on, not just the entity:
+  - **`base_id text NOT NULL`** — every config change belongs to a base (the gate's primary scope);
+  - **`sheet_id text NULL`** — the sheet for field/view changes; **null for base-level config** (e.g. base
+    permission rules) — so the gate can distinguish base-scope from sheet-scope authority;
+  - `entity_type` ∈ {field, view, permission, …}, `entity_id`, `action`, before/after config snapshot
+    (redacted per CH-4), `actor_id`, `source`, `created_at`;
+  - **indexed on `(base_id, sheet_id, created_at DESC)`** so the gated read is scoped cleanly by base/sheet and
+    paginates in LOCK-11 order. Without these scope keys the CH-3 permission gate cannot land stably (it would
+    have to infer scope from `entity_id`, which is not authority-bearing).
 - **CH-2 — Read-only first.** The first T9 release is a config-history VIEW (who changed which field/view/rule,
   when, before→after) — no config restore. Restore is a later, separately-designed slice (CH boundary).
 - **CH-3 — Permission-gated display.** Config detail is visible only to authorized users (the people who can

--- a/packages/core-backend/src/multitable/record-reconstructor.ts
+++ b/packages/core-backend/src/multitable/record-reconstructor.ts
@@ -57,11 +57,15 @@ export async function reconstructRecordsAtT(
   for (const raw of res.rows as Array<Record<string, unknown>>) {
     const recordId = String(raw.record_id)
     const deleted = raw.action === 'delete'
+    // version is `number | null` per the contract: a finite numeric value stays a number; anything else (null /
+    // undefined / non-numeric) becomes null — NEVER coerced to 0, so "unknown version" cannot masquerade as a
+    // real version 0 for the T5-2 / T7 / T8 consumers. Check `typeof` BEFORE Number() — `Number(null) === 0`
+    // would otherwise resurrect the very bug this guards against.
     out.set(recordId, {
       recordId,
       exists: !deleted,
       data: deleted ? null : asRecord(raw.snapshot),
-      version: typeof raw.version === 'number' ? raw.version : Number(raw.version ?? 0),
+      version: typeof raw.version === 'number' && Number.isFinite(raw.version) ? raw.version : null,
     })
   }
   return out

--- a/packages/core-backend/tests/integration/multitable-record-reconstructor-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-reconstructor-realdb.test.ts
@@ -26,12 +26,29 @@ const rev = (recordId: string, version: number, action: 'create' | 'update' | 'd
     [SHEET, recordId, version, action, data === null ? null : JSON.stringify(data), createdAtIso],
   )
 
+// Top-level (NOT inside describeIfDatabase) so it runs even without a DB and FAILS — not silently skips — when
+// the REAL-DB ALLOWLIST STEP runs this file without the harness. Scoped to that step via the workflow-injected
+// METASHEET_REAL_DB_TEST_STEP env: the NORMAL core-backend test job also collects this file (CI=true, no
+// DATABASE_URL) and there the sentinel MUST pass — the describeIfDatabase goldens skip; we don't red that job.
+test('sentinel: the real-DB allowlist step must have DATABASE_URL (fail-not-skip, scoped to that step)', () => {
+  if (process.env.METASHEET_REAL_DB_TEST_STEP === '1' && !process.env.DATABASE_URL) {
+    throw new Error('real-DB allowlist step is missing DATABASE_URL — the harness is broken, not legitimately skippable')
+  }
+  expect(true).toBe(true)
+})
+
+// Pins the `number | null` version contract via a mock query: `version` column is NOT NULL in the DB, so a
+// null can only arrive through a degraded/mocked row — and it must become null, never 0.
+test('version contract: a non-numeric version normalizes to null, NOT 0 (unknown ≠ real version 0)', async () => {
+  const mockQuery = (async () => ({ rows: [{ record_id: 'r', action: 'update', snapshot: { f: 'x' }, version: null }] })) as unknown as Parameters<typeof reconstructRecordsAtT>[0]
+  const map = await reconstructRecordsAtT(mockQuery, 'sheet', '2026-06-01T00:00:00Z')
+  expect(map.get('r')).toMatchObject({ exists: true, data: { f: 'x' }, version: null })
+})
+
 describeIfDatabase('record reconstruction as of T — T5-1 (real DB)', () => {
   beforeAll(() => { /* the reconstructor reads only meta_record_revisions; no sheet/record seed needed */ })
   afterEach(async () => { await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {}) })
   afterAll(async () => { await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {}) })
-
-  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
 
   test('state at T = the latest revision <= T (create → update → update)', async () => {
     await rev(REC, 1, 'create', { f: 'a' }, '2026-06-01T00:00:00Z')


### PR DESCRIPTION
Owner review of the merged #2993 (T5-1 reconstructor) + #2994 (design-locks) — 4 P2s, fixed forward.

- **[P2] T5-1 version contract** — `Number(raw.version ?? 0)` coerced `null` → `0` (`Number(null) === 0`), conflating "unknown version" with a real version 0 on the shared root. Fixed with a `typeof`-before-`Number` guard → `number | null`. Pinned with a **mock-query boundary test** (the column is NOT NULL, so null only arrives via a degraded row) — which caught my *first* wrong fix (`Number(raw.version)`, same gotcha). 
- **[P2] T5-1 sentinel "fails-not-skips" actually skipped** — it was inside `describeIfDatabase`, so a missing `DATABASE_URL` skipped the whole suite. Moved to a **top-level** test that throws when CI runs this allowlisted file without `DATABASE_URL`.
- **[P2] T6 design-lock SR-5 ↔ §4 conflict** — SR-5 mentioned a "reset-style scope (delete post-T-created)" while §4 says T6 never does sheet-wide reset. Rewrote SR-5: **T6 has no destructive mode and never deletes post-T-created** (that's T8's Reset); the optional all-or-nothing is a *scoped* block-all over forward revisions only.
- **[P2] T9 design-lock CH-1 schema too loose** — added the scope keys the CH-3 gate needs: `base_id` (NOT NULL) + `sheet_id` (nullable for base-level config) + index `(base_id, sheet_id, created_at)`.

tsc 0; reconstructor goldens **8/8** (incl. version-null + the fail-not-skip sentinel). Code + 2 design-lock docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)