### PR TITLE
feat(multitable): 1b Slice B — RELLOOKUP (relation-scoped single-row lookup)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1213,12 +1213,19 @@ const RELATION_AGG_FUNCTIONS: Record<string, RollupAggregation> = {
   RELCOUNTIF: 'countall', // counts MATCHED linked records (no sum target — 4-arg form, see the parser)
 }
 
+// Slice B — lookup family: single-row first-match resolution (NOT aggregation). Same grammar + the same
+// permission/taint/fan-out pipeline as the aggregations; the resolver returns the FIRST matched linked
+// record's returnField (in link order) instead of reducing the set.
+const RELATION_LOOKUP_FUNCTIONS = new Set<string>(['RELLOOKUP'])
+const REL_NA_SENTINEL = '#N/A' // lookup not-found (no matched row) — distinct from #PERM! (a denied FIELD)
+
 type RelationAggregationCall = {
   fnName: string
-  aggregation: RollupAggregation
+  kind: 'aggregation' | 'lookup'
+  aggregation: RollupAggregation | null // null when kind === 'lookup'
   linkFieldId: string
-  targetFieldId: string
-  criteria: { fieldId: string; operator: string; valueExpr: string }
+  targetFieldId: string // the returnField when kind === 'lookup'
+  criteria: { fieldId: string; operator: string; valueExpr: string } // the matchField when kind === 'lookup'
 }
 
 // Split a call's arg list on top-level commas, respecting double-quoted strings.
@@ -1255,8 +1262,10 @@ export function parseRelationAggregationCall(expression: string): RelationAggreg
   const m = /^([A-Za-z_]+)\s*\(([\s\S]*)\)$/.exec(expression.trim())
   if (!m) return null
   const fnName = m[1].toUpperCase()
-  const aggregation = RELATION_AGG_FUNCTIONS[fnName]
-  if (!aggregation) return null
+  const aggregation = RELATION_AGG_FUNCTIONS[fnName] ?? null
+  const isLookup = RELATION_LOOKUP_FUNCTIONS.has(fnName)
+  if (!aggregation && !isLookup) return null
+  const kind: 'aggregation' | 'lookup' = isLookup ? 'lookup' : 'aggregation'
   const args = splitTopLevelArgs(m[2])
   if (!args) return null
   // RELCOUNTIF counts MATCHED linked records — no sum target (4 args: link, criteria, op, value). The
@@ -1284,14 +1293,15 @@ export function parseRelationAggregationCall(expression: string): RelationAggreg
     valueExpr = args[4]
   }
   if (!linkFieldId || !targetFieldId || !criteriaFieldId || !operator || valueExpr.length === 0) return null
-  return { fnName, aggregation, linkFieldId, targetFieldId, criteria: { fieldId: criteriaFieldId, operator, valueExpr } }
+  // RELLOOKUP uses the 5-arg branch: link, returnField (→ targetFieldId), matchField (→ criteria.fieldId), op, value.
+  return { fnName, kind, aggregation, linkFieldId, targetFieldId, criteria: { fieldId: criteriaFieldId, operator, valueExpr } }
 }
 
 // True iff the expression MENTIONS a relation-aggregation function but is NOT a sole
 // call (e.g. `RELSUMIF(...)+1`). Slice A is sole-call only; the recompute path turns
 // this into a fail-loud diagnostic rather than a silent wrong value or a raw #NAME?.
 export function expressionHasRelationAggregationButNotSole(expression: string): boolean {
-  const mentions = Object.keys(RELATION_AGG_FUNCTIONS).some((fn) => new RegExp(`\\b${fn}\\s*\\(`, 'i').test(expression))
+  const mentions = [...Object.keys(RELATION_AGG_FUNCTIONS), ...RELATION_LOOKUP_FUNCTIONS].some((fn) => new RegExp(`\\b${fn}\\s*\\(`, 'i').test(expression))
   if (!mentions) return false
   return parseRelationAggregationCall(expression) === null
 }
@@ -1344,7 +1354,7 @@ async function resolveRelationAggregation(
   // Authoritative linked ids come from meta_links (record.data[linkField] is not the source of truth).
   const linkValues = await loadLinkValuesByRecord(query, [recordId], [{ fieldId: call.linkFieldId, cfg: linkCfg }])
   const linkIds = linkValues.get(recordId)?.get(call.linkFieldId) ?? []
-  if (linkIds.length === 0) return aggregateRollup([], 0, call.aggregation)
+  if (linkIds.length === 0) return call.kind === 'lookup' ? REL_NA_SENTINEL : aggregateRollup([], 0, call.aggregation as RollupAggregation)
   // §5 cap — fail loud before any scan/materialization (count-first), never run unbounded.
   if (linkIds.length > MAX_RELATION_SCAN_RECORDS) return REL_AGG_LIMIT_SENTINEL
 
@@ -1372,10 +1382,10 @@ async function resolveRelationAggregation(
   if (!access.isAdminRole && access.userId && (await loadRowLevelReadDenyEnabled(query, foreignSheetId))) {
     deniedForeign = await loadDeniedRecordIds(query, foreignSheetId, access.userId)
   }
-  const foreignRecords: Array<Record<string, unknown>> = []
+  const byId = new Map<string, Record<string, unknown>>()
   for (const raw of foreignRes.rows as Array<{ id: unknown; data: unknown }>) {
-    if (deniedForeign?.has(String(raw.id))) continue
-    foreignRecords.push(normalizeJson(raw.data))
+    if (deniedForeign?.has(String(raw.id))) continue // denied ROW → absent (skipped); never #PERM! (that is field-level)
+    byId.set(String(raw.id), normalizeJson(raw.data))
   }
 
   // Criteria field type (effective) for type-correct comparison + the operator-compat runtime guard:
@@ -1387,21 +1397,35 @@ async function resolveRelationAggregation(
   if (!isRollupFilterOperatorCompatible(criteriaType, call.criteria.operator)) return '#ERROR!'
   const criteriaValue = resolveRelationCriteriaValue(call.criteria.valueExpr, recordData)
 
+  const matchesCriteria = (data: Record<string, unknown>): boolean => evaluateMetaFilterCondition(
+    criteriaType as UniverMetaField['type'],
+    data[call.criteria.fieldId],
+    { fieldId: call.criteria.fieldId, operator: call.criteria.operator, value: criteriaValue },
+  )
+
+  // Slice B — lookup: return the FIRST matched linked record's returnField (= targetFieldId), in LINK order;
+  // no match → #N/A. A denied ROW was skipped above (absent → can't be the match), so this never yields
+  // #PERM! — only a denied FIELD is #PERM! (gated earlier). Same materialization/permission path as aggregation.
+  if (call.kind === 'lookup') {
+    for (const id of linkIds) {
+      const data = byId.get(id)
+      if (!data || !matchesCriteria(data)) continue
+      const v = data[call.targetFieldId]
+      return v === null || v === undefined ? REL_NA_SENTINEL : (v as number | string | boolean)
+    }
+    return REL_NA_SENTINEL
+  }
+
   const values: unknown[] = []
   let count = 0
-  for (const data of foreignRecords) {
-    const matches = evaluateMetaFilterCondition(
-      criteriaType as UniverMetaField['type'],
-      data[call.criteria.fieldId],
-      { fieldId: call.criteria.fieldId, operator: call.criteria.operator, value: criteriaValue },
-    )
-    if (!matches) continue
+  for (const data of byId.values()) {
+    if (!matchesCriteria(data)) continue
     count += 1
     const v = data[call.targetFieldId]
     if (v === null || v === undefined) continue
     values.push(v)
   }
-  return aggregateRollup(values, count, call.aggregation)
+  return aggregateRollup(values, count, call.aggregation as RollupAggregation)
 }
 
 // The trimmed, '='-stripped expression of a formula field (from property.expression), or null.

--- a/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
+++ b/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
@@ -40,6 +40,9 @@ const FLD_CURVAL = `fld_rel_curval_${TS}` // current-record string used as a {fl
 const FLD_AVGIF = `fld_rel_avgif_${TS}` // = RELAVGIF(link, amt, status, is, {curval}) -> avg(10,20) = 15
 const FLD_COUNTIF = `fld_rel_countif_${TS}` // = RELCOUNTIF(link, status, is, {curval}) -> count(paid) = 2 (4-arg)
 const FLD_SECRETCOUNT = `fld_rel_seccount_${TS}` // = RELCOUNTIF(link, SECRET, greater, 0) -> 3; DENIED-criteria leak gate
+const FLD_LOOKUP = `fld_rel_lookup_${TS}` // = RELLOOKUP(link, status, amt, is, 10) -> 'paid' (FR1, only amt=10; order-independent)
+const FLD_LOOKUP_NA = `fld_rel_lookupna_${TS}` // = RELLOOKUP(link, status, amt, is, 999) -> #N/A (no match)
+const FLD_LOOKUP_SECRET = `fld_rel_lookupsec_${TS}` // = RELLOOKUP(link, SECRET, amt, is, 10) -> 100; DENIED returnField leak gate
 
 const FR1 = `rec_rel_f1_${TS}` // amt 10, status paid,   secret 100
 const FR2 = `rec_rel_f2_${TS}` // amt 20, status paid,   secret 200
@@ -112,6 +115,11 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     // RELCOUNTIF over the DENIED foreign SECRET field as criteria — the target=criteria bridge must route it
     // through the same taint gate (a count over a denied criteria would otherwise leak its distribution).
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRETCOUNT, MS, 'SecretCount', 'formula', JSON.stringify({ expression: `RELCOUNTIF("${FLD_LINK}","${FLD_SECRET}","greater","0")` }), 8])
+    // Slice B — RELLOOKUP(link, returnField, matchField, op, value): single-row first-match. Single-match
+    // criteria (amt=10 → only FR1) keeps the assertion order-independent.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP, MS, 'Lookup', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_STATUS}","${FLD_AMT}","is","10")` }), 9])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP_NA, MS, 'LookupNA', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_STATUS}","${FLD_AMT}","is","999")` }), 10])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP_SECRET, MS, 'LookupSecret', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_SECRET}","${FLD_AMT}","is","10")` }), 11])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3], [FLD_CURVAL]: 'unpaid' })])
     for (const fr of [FR1, FR2, FR3]) {
@@ -119,7 +127,7 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     }
     // Formula deps on the current-record criteria field {CURVAL} (the recompute trigger; the create handler
     // would register it via extractFieldReferences, but these fields are seeded via SQL → insert directly).
-    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF, FLD_AVGIF, FLD_COUNTIF, FLD_SECRETCOUNT]) {
+    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF, FLD_AVGIF, FLD_COUNTIF, FLD_SECRETCOUNT, FLD_LOOKUP, FLD_LOOKUP_NA, FLD_LOOKUP_SECRET]) {
       await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [MS, ff, FLD_CURVAL])
     }
     // DENY cannot read the foreign SECRET field → any RELSUMIF over it must be masked for DENY on read.
@@ -165,6 +173,14 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
   test('A.3 — RELAVGIF averages the matched target (15) and RELCOUNTIF counts matched records (2, 4-arg)', async () => {
     expect(await readField(ALLOW, FLD_AVGIF)).toBe(15) // avg amt where paid: (10+20)/2
     expect(await readField(ALLOW, FLD_COUNTIF)).toBe(2) // count where status=paid: FR1, FR2
+  })
+
+  test('B — RELLOOKUP: first matched record (happy), not-found #N/A, and denied-returnField leak gate', async () => {
+    expect(await readField(ALLOW, FLD_LOOKUP)).toBe('paid') // returnField=status of the (only) amt=10 record (FR1)
+    expect(await readField(ALLOW, FLD_LOOKUP_NA)).toBe('#N/A') // no linked record has amt=999
+    // leak gate: returnField is the DENIED SECRET field → allowed reader gets the value, denied reader's field is dropped
+    expect(await readField(ALLOW, FLD_LOOKUP_SECRET)).toBe(100) // FR1.secret (the amt=10 match)
+    expect(await hasField(DENY, FLD_LOOKUP_SECRET)).toBe(false)
   })
 
   // A.2 — foreign-write fan-out (reverse-edge). Runs LAST: it mutates FR1's amount, which the earlier

--- a/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
+++ b/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
@@ -19,6 +19,7 @@ describe('parseRelationAggregationCall — sole-call grammar', () => {
     const c = parseRelationAggregationCall('RELSUMIF("fld_link", "fld_amt", "fld_status", "is", "paid")')
     expect(c).toEqual({
       fnName: 'RELSUMIF',
+      kind: 'aggregation',
       aggregation: 'sum',
       linkFieldId: 'fld_link',
       targetFieldId: 'fld_amt',
@@ -55,16 +56,24 @@ describe('parseRelationAggregationCall — sole-call grammar', () => {
 
   it('A.3 — parses RELAVGIF (avg) with the same 5-arg signature as RELSUMIF', () => {
     expect(parseRelationAggregationCall('RELAVGIF("fld_link","fld_amt","fld_status","is","paid")')).toEqual({
-      fnName: 'RELAVGIF', aggregation: 'avg', linkFieldId: 'fld_link', targetFieldId: 'fld_amt',
+      fnName: 'RELAVGIF', kind: 'aggregation', aggregation: 'avg', linkFieldId: 'fld_link', targetFieldId: 'fld_amt',
       criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
     })
   })
 
   it('A.3 — parses RELCOUNTIF (countall, 4-arg, no sum target → targetFieldId = criteria for the readability gate)', () => {
     expect(parseRelationAggregationCall('RELCOUNTIF("fld_link","fld_status","is","paid")')).toEqual({
-      fnName: 'RELCOUNTIF', aggregation: 'countall', linkFieldId: 'fld_link', targetFieldId: 'fld_status',
+      fnName: 'RELCOUNTIF', kind: 'aggregation', aggregation: 'countall', linkFieldId: 'fld_link', targetFieldId: 'fld_status',
       criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
     })
+  })
+
+  it('B — parses RELLOOKUP (kind=lookup, 5-arg: link, returnField→target, matchField→criteria, op, value)', () => {
+    expect(parseRelationAggregationCall('RELLOOKUP("fld_link","fld_name","fld_status","is","paid")')).toEqual({
+      fnName: 'RELLOOKUP', kind: 'lookup', aggregation: null, linkFieldId: 'fld_link', targetFieldId: 'fld_name',
+      criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
+    })
+    expect(parseRelationAggregationCall('RELLOOKUP("a","b","c","is")')).toBeNull() // 4 args → null (lookup is 5-arg)
   })
 
   it('A.3 — per-function arity: RELCOUNTIF needs 4 (5→null); RELAVGIF/RELSUMIF need 5 (4→null)', () => {


### PR DESCRIPTION
Fourth slice of the 1b record-set implementation (off merged main, separate slice). Adds the **lookup family** — single-row first-match resolution — on top of the merged aggregation slices (#2978, #2995).

**`RELLOOKUP("link", "returnField", "matchField", "op", "value")`** returns the **first matched linked record's returnField** (in link order); `#N/A` when none match.

A unified `kind: 'aggregation' | 'lookup'` discriminant means the **parser, recompute hook, read-leak taint edge, fan-out, dep-registration, and validator all reuse the Slice A pipeline verbatim** — the only new code is a first-match branch in `resolveRelationAggregation` (same materialize-then-filter permission path: readable-sheet gate, foreign-FIELD `#PERM!`, row-deny exclusion, `#LIMIT!` caps).

**Semantics (per design-lock):**
- denied **field** (returnField or matchField) → `#PERM!` at write / **read-taint drop** at read;
- denied **row** → skipped (absent → can't be the match) → never `#PERM!`;
- no match → `#N/A`.

## Tests
- Parser unit: RELLOOKUP 5-arg, `kind=lookup`, arity (4→null).
- Real-DB goldens (registered): happy (first match → `'paid'`), not-found (`#N/A`), and the **denied-returnField leak gate** (allowed→100, denied→field absent).
- Unit suite green non-watch (`CI=true`, 356 files / 0 fail); tsc 0; taint-chokepoint count unchanged at 6 (reuses the existing taint loop — no new resolver call site).

`VLOOKUP`/`INDEX`/`MATCH` aliases + composition stay deferred (sole-call cliff still fails loud). Slice C (array) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)