### PR TITLE
feat(approval): Reading B / B1 — manager_at_level assignee source (sequential 逐级 approval)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -68,6 +68,9 @@ export interface ApprovalStepDraft {
   // intentionally fixes the input max at 10; reading the server cap into the UI so
   // ops can configure more than 10 is a follow-up (not wired in v1).
   levels: number
+  // Single 1-based management level the `manager_at_level` source resolves;
+  // meaningful only when `sourceKind === 'manager_at_level'`. Same backend cap as `levels`.
+  level: number
   approvalMode: ApprovalMode
   emptyAssigneePolicy: EmptyAssigneePolicy
   // Self-approver authoring: the editable toggle (merge the requester in as an
@@ -151,6 +154,7 @@ export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
     idsText: '',
     fieldId: '',
     levels: 2,
+    level: 1,
     approvalMode: 'single',
     emptyAssigneePolicy: 'error',
     mergeWithRequester: false,
@@ -247,6 +251,7 @@ function stepDraftFromApprovalNode(
   let idsText = ''
   let fieldId = ''
   let levels = 2
+  let level = 1
   if (source?.kind === 'static_user') {
     sourceKind = 'static_user'
     idsText = formatIds(source.userIds)
@@ -265,6 +270,9 @@ function stepDraftFromApprovalNode(
   } else if (source?.kind === 'continuous_managers') {
     sourceKind = 'continuous_managers'
     levels = source.levels
+  } else if (source?.kind === 'manager_at_level') {
+    sourceKind = 'manager_at_level'
+    level = source.level
   } else if (legacyType === 'user') {
     sourceKind = 'static_user'
     idsText = formatIds(legacyIds)
@@ -285,6 +293,7 @@ function stepDraftFromApprovalNode(
     idsText,
     fieldId,
     levels,
+    level,
     approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
     emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
     mergeWithRequester,
@@ -380,7 +389,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     if (sources !== undefined) {
       if (!Array.isArray(sources) || sources.length !== 1) return true
       const source = sources[0] as ApprovalAssigneeSource
-      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers'].includes(source?.kind)) return true
+      if (!['static_user', 'static_role', 'requester', 'form_field_user', 'direct_manager', 'dept_head', 'continuous_managers', 'manager_at_level'].includes(source?.kind)) return true
     }
     return false
   })
@@ -466,6 +475,9 @@ function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
   }
   if (step.sourceKind === 'continuous_managers') {
     return { kind: 'continuous_managers', levels: step.levels }
+  }
+  if (step.sourceKind === 'manager_at_level') {
+    return { kind: 'manager_at_level', level: step.level }
   }
   return { kind: 'requester' }
 }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -78,6 +78,7 @@ export type ApprovalAssigneeSource =
   | { kind: 'direct_manager' }
   | { kind: 'dept_head' }
   | { kind: 'continuous_managers'; levels: number }
+  | { kind: 'manager_at_level'; level: number }
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -284,6 +284,7 @@
                 <el-option label="直属上级" value="direct_manager" />
                 <el-option label="部门主管" value="dept_head" />
                 <el-option label="连续多级上级" value="continuous_managers" />
+                <el-option label="指定层级上级" value="manager_at_level" />
                 <el-option label="表单用户字段" value="form_field_user" />
               </el-select>
             </el-form-item>
@@ -298,6 +299,16 @@
                 :step="1"
                 :disabled="readOnly"
                 data-testid="approval-step-levels"
+              />
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'manager_at_level'" label="指定上级层级">
+              <el-input-number
+                v-model="step.level"
+                :min="1"
+                :max="10"
+                :step="1"
+                :disabled="readOnly"
+                data-testid="approval-step-level"
               />
             </el-form-item>
             <el-form-item v-if="step.sourceKind === 'static_user'" label="选择用户">

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -481,6 +481,22 @@ describe('approval template authoring helpers', () => {
     expect(rehydrated.steps[0].levels).toBe(3)
   })
 
+  it('round-trips a manager_at_level source incl. level (save emits {kind, level}; level survives the real wire)', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'mal'
+    draft.name = '逐级上级审批'
+    draft.steps[0].sourceKind = 'manager_at_level'
+    draft.steps[0].level = 2
+
+    const payload = buildCreateTemplatePayload(draft)
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([{ kind: 'manager_at_level', level: 2 }])
+
+    // wire-vs-fixture trap: assert `level` survives the real serialize→parse, not a hand-built chip.
+    const rehydrated = draftFromTemplate(buildTemplate({ approvalGraph: payload.approvalGraph }))
+    expect(rehydrated.steps[0].sourceKind).toBe('manager_at_level')
+    expect(rehydrated.steps[0].level).toBe(2)
+  })
+
   // Lane E — self-approver authoring (autoApprovalPolicy.mergeWithRequester).
   function buildAutoApprovalTemplate(
     policy: AutoApprovalPolicy,

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -164,6 +164,21 @@ export function resolveApprovalAssignees(
         })
         break
       }
+      case 'manager_at_level': {
+        // Resolve to a SINGLE level of the requester's management chain (the
+        // `source.level`-th manager, level 1 = direct manager), frozen in the
+        // snapshot. Self-exclusion drops a hop resolving to the requester; an empty
+        // result (chain shorter than `level`) falls through to emptyAssigneePolicy.
+        // Authoring N nodes at levels 1..N composes sequential 逐级 approval (B1).
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        const rawChain = options.requesterSnapshot?.managerChainIds
+        const chain = Array.isArray(rawChain) ? rawChain : []
+        const managerId = normalizeId(chain[source.level - 1])
+        if (managerId && managerId !== requesterId) {
+          pushResolved('user', managerId, source, sourceIndex)
+        }
+        break
+      }
       case 'form_field_user': {
         assertFormUserSource(source, options.formSchema, options.nodeKey)
         const assigneeId = resolveFormUserValue(options.formSnapshot[source.fieldId])

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -170,6 +170,12 @@ export function resolveApprovalAssignees(
         // snapshot. Self-exclusion drops a hop resolving to the requester; an empty
         // result (chain shorter than `level`) falls through to emptyAssigneePolicy.
         // Authoring N nodes at levels 1..N composes sequential 逐级 approval (B1).
+        // managerChainIds is DENSE — resolveManagerChain (ApprovalDirectoryOrg) walks
+        // THROUGH unlinked/self rungs at snapshot-build (pushes only linked, non-self
+        // ids), so chain[level-1] is the level-th *linked* manager. The design's
+        // "positional pick" and "skip-unlinked walk" reconcile here: the walk already
+        // happened at build. A null rung (defensive, never produced by the builder)
+        // resolves that level to empty via normalizeId — positional, no compaction.
         const requesterId = normalizeId(options.requesterSnapshot?.id)
         const rawChain = options.requesterSnapshot?.managerChainIds
         const chain = Array.isArray(rawChain) ? rawChain : []

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -18,8 +18,9 @@
  *     crosses an automation boundary.
  *   - It is NOT a resolver kind. The `direct_manager` / `dept_head` assignee-source
  *     kinds are now LIVE in `ApprovalAssigneeResolver` and consume the snapshot
- *     fields this module bakes (`managerId` / `deptHeadId`); `continuous_managers`
- *     remains future/DESIGN-ONLY. Either way this module's sole job is unchanged:
+ *     fields this module bakes (`managerId` / `deptHeadId`); the `managerChainIds`
+ *     chain is consumed by the LIVE `continuous_managers` and `manager_at_level`
+ *     kinds. Either way this module's sole job is unchanged:
  *     snapshot plumbing — it populates those fields and does not resolve assignees
  *     itself.
  *
@@ -56,10 +57,11 @@ export interface ApprovalRequesterOrgRelations {
    * the requester is flagged leader of their own dept, `managerId` may be the
    * requester (harmless; the resolver drops it) while this chain skips past it.
    * Only populated when the caller opts in via `includeManagerChain` (i.e. a
-   * published graph actually uses the `continuous_managers` source). Cycle-guarded
-   * and capped at `MAX_MANAGER_CHAIN_LEVELS`; unlinked hops are walked through but
-   * not included. Read by the `continuous_managers` assignee-source kind (which
-   * slices it to its own `levels`). Omitted when the chain resolves empty.
+   * published graph uses a management-chain source — `continuous_managers` or
+   * `manager_at_level`). Cycle-guarded and capped at `MAX_MANAGER_CHAIN_LEVELS`;
+   * unlinked hops are walked through but not included (so the array is DENSE).
+   * Read by `continuous_managers` (slices it to its own `levels`) and
+   * `manager_at_level` (picks the single id at `level - 1`). Omitted when empty.
    */
   managerChainIds?: string[]
 }
@@ -235,9 +237,9 @@ export async function resolveApprovalRequesterOrgRelations(
 
   // 4) Manager chain (opt-in): walk leader_in_dept hop-by-hop up the org tree,
   //    starting from the requester. Only runs when the caller opts in — i.e. a
-  //    published graph actually uses `continuous_managers` — so the per-hop
-  //    queries are NOT added to every approval. Same point-in-time + self-exclusion
-  //    posture as the direct manager above.
+  //    published graph uses a management-chain source (`continuous_managers` or
+  //    `manager_at_level`) — so the per-hop queries are NOT added to every approval.
+  //    Same point-in-time + self-exclusion posture as the direct manager above.
   if (options.includeManagerChain) {
     const chain = await resolveManagerChain(
       integrationId,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -422,6 +422,15 @@ function normalizeApprovalAssigneeSources(
         }
         return { kind: 'continuous_managers', levels }
       }
+      case 'manager_at_level': {
+        // Deterministic validation — an out-of-range / non-integer / missing
+        // `level` is rejected, never silently defaulted (enum-strictness).
+        const level = source.level
+        if (typeof level !== 'number' || !Number.isInteger(level) || level < 1 || level > MAX_MANAGER_CHAIN_LEVELS) {
+          failValidation(context, `${sourcePath}.level must be an integer between 1 and ${MAX_MANAGER_CHAIN_LEVELS}`)
+        }
+        return { kind: 'manager_at_level', level }
+      }
       case 'form_field_user':
         if (!isNonEmptyString(source.fieldId)) {
           failValidation(context, `${sourcePath}.fieldId is required`)

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1532,19 +1532,22 @@ function getApprovalNodeConfig(runtimeGraph: RuntimeGraph, nodeKey: string): App
 }
 
 /**
- * True when any approval node's assignee sources include a `continuous_managers`
- * source. Used at create time to decide whether to walk the (more expensive)
- * management chain into the requester snapshot — keeping the extra per-hop
- * directory queries off every approval that does not use the source. `kind` is
- * read structurally so this works before the kind is added to the typed union.
+ * True when any approval node's assignee sources include a management-chain source
+ * (`continuous_managers` or `manager_at_level`). Used at create time to decide
+ * whether to walk the (more expensive) management chain into the requester snapshot
+ * — keeping the extra per-hop directory queries off every approval that does not use
+ * such a source. `kind` is read structurally so this works before the kind is added
+ * to the typed union.
  */
-export function runtimeGraphUsesContinuousManagers(runtimeGraph: RuntimeGraph): boolean {
+export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolean {
   return runtimeGraph.nodes.some((node) => {
     if (node.type !== 'approval') return false
     const config: unknown = node.config
     const sources = isRecord(config) ? config.assigneeSources : undefined
     if (!Array.isArray(sources)) return false
-    return sources.some((source) => isRecord(source) && source.kind === 'continuous_managers')
+    return sources.some(
+      (source) => isRecord(source) && (source.kind === 'continuous_managers' || source.kind === 'manager_at_level'),
+    )
   })
 }
 
@@ -2629,11 +2632,11 @@ export class ApprovalProductService {
     // payload. READ-ONLY (directory_* SELECTs only) and best-effort: a directory
     // read failure must never block create, so an unresolved lookup just omits the
     // fields. direct_manager / dept_head read managerId / deptHeadId; the chain is
-    // walked only when the published graph uses continuous_managers (so the extra
-    // per-hop queries stay off every approval). Absence falls through to the node's
-    // emptyAssigneePolicy.
+    // walked only when the published graph uses a management-chain source
+    // (continuous_managers or manager_at_level) — so the extra per-hop queries stay
+    // off every approval. Absence falls through to the node's emptyAssigneePolicy.
     const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
-    const needsManagerChain = runtimeGraphUsesContinuousManagers(runtimeGraph)
+    const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
     try {
       orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool), {

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,7 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
-export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -102,6 +102,14 @@ export type ApprovalAssigneeSource =
    * `levels` is validated `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time.
    */
   | { kind: 'continuous_managers'; levels: number }
+  /**
+   * The requester's manager at a SINGLE chain level (`level` = 1 → direct manager,
+   * 2 → manager's manager, …), resolved from the baked `managerChainIds` snapshot.
+   * Authoring N approval nodes at levels 1..N composes sequential 逐级 approval
+   * (Reading B / B1) — no publish-time auto-expansion. `level` is validated
+   * `[1, MAX_MANAGER_CHAIN_LEVELS]` at normalize time.
+   */
+  | { kind: 'manager_at_level'; level: number }
 
 export interface ApprovalAssigneeResolutionMetadata {
   resolvedFrom: {

--- a/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { query } from '../../src/db/pg'
 import { resolveApprovalRequesterOrgRelations } from '../../src/services/ApprovalDirectoryOrg'
+import { runtimeGraphUsesManagerChain } from '../../src/services/ApprovalProductService'
+import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
+import type { RuntimeGraph } from '../../src/types/approval-product'
 
 /**
  * continuous_managers chain walk — REAL DB. The unit test
@@ -84,6 +87,30 @@ describeIfDatabase('continuous_managers chain walk (real DB)', () => {
     const rel = await resolveApprovalRequesterOrgRelations(U_R, queryFn, { includeManagerChain: true })
     expect(rel.managerChainIds).toEqual([U_M]) // exactly one level; level-2 finds no leader → stops
     expect(rel.managerId).toBe(U_M) // chain[0] agrees with the shipped direct-manager resolution
+  })
+
+  it('B1 end-to-end: a manager_at_level template bakes the chain (scanner gate) and resolves the level-1 manager', async () => {
+    // Regression for the bake-gate bug: prove the FULL B1 path on the real org —
+    // (1) the scanner sees manager_at_level so createApproval sets includeManagerChain,
+    // (2) the chain bakes into the snapshot, (3) the resolver picks the level's manager.
+    const runtimeGraph = {
+      nodes: [{ key: 'approval_1', type: 'approval', config: { assigneeSources: [{ kind: 'manager_at_level', level: 1 }] } }],
+    } as unknown as RuntimeGraph
+    expect(runtimeGraphUsesManagerChain(runtimeGraph)).toBe(true)
+
+    const rel = await resolveApprovalRequesterOrgRelations(U_R, queryFn, { includeManagerChain: true })
+    expect(rel.managerChainIds).toEqual([U_M])
+
+    const resolved = resolveApprovalAssignees({
+      nodeKey: 'approval_1',
+      sourceStep: 1,
+      config: { assigneeSources: [{ kind: 'manager_at_level', level: 1 }] },
+      formSnapshot: {},
+      requesterSnapshot: { id: U_R, managerChainIds: rel.managerChainIds },
+    })
+    expect(resolved).toEqual([
+      { assignmentType: 'user', assigneeId: U_M, nodeKey: 'approval_1', sourceStep: 1, metadata: { resolvedFrom: { kind: 'manager_at_level', sourceIndex: 0 } } },
+    ])
   })
 
   it('does not bake the chain when includeManagerChain is off (only the direct manager)', async () => {

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -155,6 +155,17 @@ describe('ApprovalAssigneeResolver', () => {
     expect(resolveManagerAtLevel(2, { id: 'requester-1', managerChainIds: ['requester-1', 'm2'] })).toEqual([malEntry('m2')])
   })
 
+  // Density-contract pin: the production snapshot is DENSE (resolveManagerChain in
+  // ApprovalDirectoryOrg pushes only linked, non-self ids — it walks THROUGH unlinked
+  // rungs), so positional chain[level-1] = the level-th linked manager. This pins the
+  // defensive behavior if a null/'' rung ever reached the resolver: that level resolves
+  // empty (positional, no compaction), and a later dense level is unaffected.
+  it('manager_at_level treats a null/empty rung positionally (dense-snapshot contract)', () => {
+    expect(resolveManagerAtLevel(2, { id: 'requester-1', managerChainIds: ['m1', null as never, 'm3'] })).toEqual([])
+    expect(resolveManagerAtLevel(1, { id: 'requester-1', managerChainIds: ['m1', null as never, 'm3'] })).toEqual([malEntry('m1')])
+    expect(resolveManagerAtLevel(3, { id: 'requester-1', managerChainIds: ['m1', null as never, 'm3'] })).toEqual([malEntry('m3')])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -120,6 +120,41 @@ describe('ApprovalAssigneeResolver', () => {
       .toEqual([cmEntry('m2'), cmEntry('m3')])
   })
 
+  // manager_at_level (Reading B / B1) — resolves a SINGLE level of the snapshot
+  // managerChainIds (chain[level-1]); N authored nodes at levels 1..N = 顺序逐级.
+  function resolveManagerAtLevel(level: number, requesterSnapshot: Record<string, unknown> | null) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'manager_at_level', level }] },
+      formSnapshot: {},
+      requesterSnapshot,
+    })
+  }
+
+  const malEntry = (assigneeId: string) => ({
+    assignmentType: 'user', assigneeId, nodeKey: 'review', sourceStep: 2,
+    metadata: { resolvedFrom: { kind: 'manager_at_level', sourceIndex: 0 } },
+  })
+
+  it('resolves manager_at_level to the single chain manager at that 1-based level', () => {
+    expect(resolveManagerAtLevel(1, { id: 'requester-1', managerChainIds: ['m1', 'm2', 'm3'] }))
+      .toEqual([malEntry('m1')])
+    expect(resolveManagerAtLevel(3, { id: 'requester-1', managerChainIds: ['m1', 'm2', 'm3'] }))
+      .toEqual([malEntry('m3')])
+  })
+
+  it('resolves manager_at_level to empty when the chain is shorter than the level (→ emptyAssigneePolicy)', () => {
+    expect(resolveManagerAtLevel(4, { id: 'requester-1', managerChainIds: ['m1', 'm2'] })).toEqual([])
+    expect(resolveManagerAtLevel(2, { id: 'requester-1' })).toEqual([])
+    expect(resolveManagerAtLevel(2, null)).toEqual([])
+  })
+
+  it('self-excludes manager_at_level when the picked level resolves to the requester', () => {
+    expect(resolveManagerAtLevel(1, { id: 'requester-1', managerChainIds: ['requester-1', 'm2'] })).toEqual([])
+    expect(resolveManagerAtLevel(2, { id: 'requester-1', managerChainIds: ['requester-1', 'm2'] })).toEqual([malEntry('m2')])
+  })
+
   it('resolves requester and static sources with source metadata', () => {
     expect(resolve({
       assigneeSources: [

--- a/packages/core-backend/tests/unit/approval-manager-chain.test.ts
+++ b/packages/core-backend/tests/unit/approval-manager-chain.test.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_MAX_MANAGER_CHAIN_LEVELS,
   MANAGER_CHAIN_LEVELS_HARD_CEILING,
 } from '../../src/services/ApprovalDirectoryOrg'
-import { runtimeGraphUsesContinuousManagers } from '../../src/services/ApprovalProductService'
+import { runtimeGraphUsesManagerChain } from '../../src/services/ApprovalProductService'
 import type { RuntimeGraph } from '../../src/types/approval-product'
 
 /**
@@ -185,21 +185,34 @@ describe('manager-chain walk (resolveApprovalRequesterOrgRelations + includeMana
   })
 })
 
-describe('runtimeGraphUsesContinuousManagers (conditional-bake scanner)', () => {
+describe('runtimeGraphUsesManagerChain (conditional-bake scanner)', () => {
   const graph = (sources: unknown): RuntimeGraph =>
     ({ nodes: [{ key: 'n1', type: 'approval', config: { assigneeSources: sources } }] }) as unknown as RuntimeGraph
 
   it('detects a continuous_managers source on an approval node', () => {
-    expect(runtimeGraphUsesContinuousManagers(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(true)
+    expect(runtimeGraphUsesManagerChain(graph([{ kind: 'continuous_managers', levels: 2 }]))).toBe(true)
+  })
+
+  // Regression (the bug this rename fixes): a manager_at_level-only template MUST
+  // trigger the chain bake. Before the fix the scanner only saw continuous_managers,
+  // so createApproval skipped includeManagerChain, the resolver saw an empty chain,
+  // and every B1 node fell to emptyAssigneePolicy — breaking B1's happy path.
+  it('detects a manager_at_level source on an approval node (B1 bake gate)', () => {
+    expect(runtimeGraphUsesManagerChain(graph([{ kind: 'manager_at_level', level: 1 }]))).toBe(true)
+    expect(runtimeGraphUsesManagerChain(graph([{ kind: 'manager_at_level', level: 3 }]))).toBe(true)
+  })
+
+  it('detects manager_at_level mixed with non-chain sources', () => {
+    expect(runtimeGraphUsesManagerChain(graph([{ kind: 'requester' }, { kind: 'manager_at_level', level: 2 }]))).toBe(true)
   })
 
   it('returns false when only other source kinds are present', () => {
-    expect(runtimeGraphUsesContinuousManagers(graph([{ kind: 'direct_manager' }, { kind: 'static_user', userIds: ['x'] }]))).toBe(false)
+    expect(runtimeGraphUsesManagerChain(graph([{ kind: 'direct_manager' }, { kind: 'static_user', userIds: ['x'] }]))).toBe(false)
   })
 
   it('returns false for nodes without assignee sources or non-approval nodes', () => {
-    expect(runtimeGraphUsesContinuousManagers({ nodes: [{ key: 'c', type: 'condition', config: {} }] } as unknown as RuntimeGraph)).toBe(false)
-    expect(runtimeGraphUsesContinuousManagers({ nodes: [] } as unknown as RuntimeGraph)).toBe(false)
+    expect(runtimeGraphUsesManagerChain({ nodes: [{ key: 'c', type: 'condition', config: {} }] } as unknown as RuntimeGraph)).toBe(false)
+    expect(runtimeGraphUsesManagerChain({ nodes: [] } as unknown as RuntimeGraph)).toBe(false)
   })
 })
 

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1311,6 +1311,47 @@ describe('ApprovalProductService', () => {
     expect(pgState.pool.connect).not.toHaveBeenCalled()
   })
 
+  it('rejects manager_at_level with invalid level before hitting the database (no silent default)', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    const requestWithLevel = (level: unknown) => ({
+      key: 'mal-bad',
+      name: 'MAL Bad',
+      visibilityScope: { type: 'all', ids: [] },
+      formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: 'Start', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            name: 'Level',
+            config: {
+              assigneeSources: [{ kind: 'manager_at_level', level }],
+              approvalMode: 'all',
+              emptyAssigneePolicy: 'error',
+            },
+          },
+          { key: 'end', type: 'end', name: 'End', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    })
+
+    for (const badLevel of [0, 11, 1.5, undefined, 'two']) {
+      await expect(service.createTemplate(requestWithLevel(badLevel) as never)).rejects.toMatchObject({
+        message: 'approvalGraph.nodes[1].config.assigneeSources[0].level must be an integer between 1 and 10',
+        statusCode: 400,
+        code: 'VALIDATION_ERROR',
+      })
+    }
+    expect(pgState.pool.connect).not.toHaveBeenCalled()
+  })
+
   it('rejects invalid visibility rules before hitting the database', async () => {
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService()


### PR DESCRIPTION
## What
Implements the **owner-ratified B1 design-lock (#2980)** — a per-level `manager_at_level` assignee source. An author places **N sequential approval nodes** (levels 1..N) to get 顺序逐级 approval; **no publish-time auto-expansion** (that is B2, reopen-only). Reuses the already-baked `managerChainIds` snapshot (continuous_managers PR-1 #2893) — no new plumbing.

This closes the DingTalk **逐级审批** parity gap. `continuous_managers` (会签/或签 over the whole chain in one node) stays for the aggregate reading; `manager_at_level` is the per-level/sequential reading.

## Backend
- `ApprovalAssigneeSourceKind += 'manager_at_level'`; union arm `{ level: number }`.
- Resolver `case 'manager_at_level'`: returns `managerChainIds[level-1]` + self-exclusion; a chain shorter than `level` → **empty** → node's existing `emptyAssigneePolicy` (no new failure mode, identical to continuous_managers short-chain).
- Normalizer: deterministic `level` validation `[1, MAX_MANAGER_CHAIN_LEVELS]`, **enum-strict** — missing / non-integer / out-of-range is an explicit rejection, never a silent default (#1776 rule).

## Frontend
- FE type union + arm; draft hydrate; `sourceFromStep`; the **`unsupportedTemplateAuthoringReason` allowlist** (else a saved `manager_at_level` template reads back fail-closed — the `direct_manager` #2852 trap); authoring option + a `level` number input.

## Tests (all green)
- **Resolver:** right level / short-chain→empty / self-exclusion.
- **Normalizer:** invalid `level` rejected before the DB (no silent default).
- **FE:** save→read-back **wire round-trip for `level`** (wire-vs-fixture drift rule — asserts the field survives the real serialize→parse).
- 66 backend unit + 32 FE pass; **backend `tsc` + FE `vue-tsc -b` clean**.

## Boundaries (convergence-safe, mirrors continuous_managers)
Resolver-only — **no writes**, no `approval_*`/`automation_*` write, **W7 result write-back stays locked**, no graph-runtime / auto-expand / parallel-condition change. Out of scope: B2 auto-expand-at-publish (reopen-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)