### PR TITLE
feat(multitable): global-history T7 — point-in-time read-only view (oracle-safe)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -209,6 +209,7 @@ jobs:
             tests/integration/multitable-history-audit-log-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
+            tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-global-history-t7-pit-view-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t7-pit-view-dev-verification-20260621.md
@@ -1,0 +1,51 @@
+# Global History — T7 Point-In-Time Read-Only View 开发与验证 MD
+
+> The second read-only leaf of the Time Machine program (after T5-1 the reconstructor), built ON the pinned
+> `reconstructRecordsAtT`. `GET /sheets/:sheetId/point-in-time?asOf=<ISO>&limit&offset` — "open the table as of
+> T, read-only." Reconstructs over `meta_record_revisions`; **writes nothing**.
+
+## 1. The permission resolution (stated up front, so it isn't the next thing caught)
+
+- **Row-deny = CURRENT-deny, via the SAME seam as every other history surface** (`loadDeniedRecordIds` =
+  grant-deny ∪ 2b conditional read-deny, gated on non-admin + `loadRowLevelReadDenyEnabled`). **NOT as-of-T deny.**
+  Reason: as-of-T deny would let a record that was `public` at T but is **denied now** show its historical
+  contents → the PIT view becomes an **oracle** to read a currently-forbidden record. Current-deny never shows a
+  currently-denied record, and matches events / batch-detail / #2968 (cross-surface consistency is the
+  leak-preventing kind). Uses `loadDeniedRecordIds`, **not** `deriveRecordPermissions` (which would miss 2b
+  conditional read-deny).
+- **Field-mask** reuses the history allowed-field chain (`loadAllowedFieldIds` → `maskStoredRecordFieldIds`):
+  visible ∧ field_permissions, formula-taint dropped. A field hidden NOW is masked from the T-data.
+- **Reveal never composes** (field-audit LOCK-7 / PV-3): the T7 path has no reveal branch.
+
+## 2. The v1 scope boundary (three points — a PRODUCT choice, not a safety deny)
+
+1. **T7 v1 shows only records that CURRENTLY EXIST**, reconstructed to their T-state. Records **deleted since T**
+   do **not** appear in the as-of-T view.
+2. This is a **product-scope** decision (de-risk: ship the live-record as-of-T view first), **not a security
+   deny** — a deleted-since-T record isn't "denied", it's simply out of v1.
+3. Consumers must NOT infer from T7 v1's filtered result: a future undelete (T6/T8) must reconstruct the
+   deleted set from revisions directly, **not** from "what T7 omitted." The deleted-record-at-T case gets its
+   own slice with its own deny decision.
+
+## 3. Verification
+
+- backend `tsc --noEmit` **0**.
+- **7 real-DB goldens** (`metasheet_test`), oracle-first:
+  - **ORACLE-NEGATIVE (load-bearing)**: a record `public` at T but DENIED now is **absent** from the records AND
+    excluded from `total`; a genuinely-readable record IS present (non-vacuous);
+  - positive (a currently-readable record shows its **as-of-T** state, not current);
+  - field-mask (a `field_permissions`-denied field is absent from the as-of-T record, visible field still there);
+  - deleted-since-T **out of v1** (existed at T, deleted now → absent);
+  - admin bypass (an admin sees the now-denied record — parity with the other surfaces);
+  - validation (missing / invalid `asOf` → 400).
+- **Mutation check**: disable the current row-deny skip → the oracle-negative golden **fails** (the now-denied
+  record leaks its T-state into the view) → proves the current-deny is the load-bearing oracle closure.
+- Boundary: history events goldens **22/22** + reconstructor **7/7** unchanged (T7 only adds a route). unit
+  **3756/3756**. No migration.
+
+## 4. What is NOT covered (next slices)
+
+T5-2 restore-preview (the diff over T5-1 + revision snapshots) is the next read-only leaf (built after T7 so the
+two leaves don't touch the permission root at once). The write/destructive slices (T6 scoped restore, T8 PIT
+restore) + T9 config history are **design-locked, not built** (see their design-locks + the program roadmap),
+each gated on its own ratification.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -72,6 +72,7 @@ import {
 import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssignableDirectory } from '../multitable/person-field-restriction'
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
+import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
   HistoryAuditGrantError,
@@ -6972,6 +6973,65 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] history batch detail failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to load history batch' } })
+    }
+  })
+
+  // Global History — T7: point-in-time read-only view. The table "as of T", restricted to records that
+  // CURRENTLY EXIST (deleted-since-T records are OUT of v1 — a product-scope choice, NOT a safety deny). Row-deny
+  // uses the SAME loadDeniedRecordIds seam as the history surfaces (grant-deny ∪ 2b conditional read-deny),
+  // evaluated against CURRENT data (current-deny, never as-of-T: a record public-at-T but denied-now must NOT
+  // become an oracle to read it). Field-mask reuses loadAllowedFieldIds + maskStoredRecordFieldIds. Reveal never
+  // composes here (no reveal path). Read-only: reconstructs over meta_record_revisions, writes nothing.
+  router.get('/sheets/:sheetId/point-in-time', async (req: Request, res: Response) => {
+    try {
+      const pool = poolManager.get()
+      const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+      const asOf = typeof req.query.asOf === 'string' ? req.query.asOf.trim() : ''
+      if (!sheetId || !asOf) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and asOf are required' } })
+      const asMs = Date.parse(asOf)
+      if (!Number.isFinite(asMs)) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must be a valid timestamp' } })
+      const asOfIso = new Date(asMs).toISOString()
+      const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
+      const offsetParam = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+      const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 200) : 50
+      const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0
+
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canRead) return sendForbidden(res)
+
+      // Scope to CURRENTLY-LIVE records (deleted-since-T are out of v1).
+      const liveIds = ((await pool.query('SELECT id FROM meta_records WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: unknown }>).map((r) => String(r.id))
+      if (liveIds.length === 0) return res.json({ ok: true, data: { records: [], total: 0, asOf: asOfIso } })
+
+      // T-state of those live records (LOCK-9/11); keep the ones that existed at T.
+      const stateMap = await reconstructRecordsAtT(pool.query.bind(pool), sheetId, asOfIso, liveIds)
+      // Current row-deny (same seam as history): grant-deny ∪ conditional-rule-deny, non-admin + flag-on.
+      let denied = new Set<string>()
+      if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))) {
+        denied = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+      }
+      // Field-mask: the SAME allowed-field chain as history detail (visible ∧ field_permissions, taint-dropped).
+      const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
+
+      const visible: Array<{ recordId: string; version: number | null; data: Record<string, unknown> }> = []
+      for (const id of liveIds) {
+        const st = stateMap.get(id)
+        if (!st || !st.exists) continue // did not exist at T
+        if (denied.has(id)) continue // current row-deny — never shows a currently-denied record
+        const maskedData: Record<string, unknown> = {}
+        for (const [fid, val] of Object.entries(st.data ?? {})) if (allowed.has(fid)) maskedData[fid] = val
+        visible.push({ recordId: id, version: st.version, data: maskedData })
+      }
+      visible.sort((a, b) => (a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0)) // stable pagination
+      const total = visible.length // post-permission-filter total (LOCK-3)
+      return res.json({ ok: true, data: { records: visible.slice(offset, offset + limit), total, asOf: asOfIso } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] point-in-time view failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to load point-in-time view' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-pit-view-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-pit-view-realdb.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Global History — T7: point-in-time read-only view (real DB).
+ *
+ * The view is "the table as of T", restricted to records that CURRENTLY EXIST. The load-bearing security claim
+ * is the ORACLE-NEGATIVE: a record that was readable at T but is DENIED now (current row-deny) must NOT appear —
+ * otherwise the PIT view is an oracle to read a currently-forbidden record's historical contents. Row-deny is
+ * the SAME loadDeniedRecordIds seam as the history surfaces (grant-deny ∪ 2b conditional read-deny), evaluated
+ * against CURRENT data (current-deny, never as-of-T). field-mask reuses the history allowed-field chain.
+ * deleted-since-T records are OUT of v1 (product scope, not a safety deny).
+ *
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_pit_${TS}`
+const SHEET = `sheet_pit_${TS}`
+const STATUS = `fld_pit_status_${TS}`
+const SALARY = `fld_pit_salary_${TS}` // field_permissions-denied to VIEWER
+const REC_PUBLIC = `rec_pit_public_${TS}` // readable now + at T
+const REC_ORACLE = `rec_pit_oracle_${TS}` // PUBLIC at T, but DENIED now (the oracle test)
+const REC_DELETED = `rec_pit_deleted_${TS}` // existed at T, deleted since (out of v1)
+const VIEWER = `user_pit_viewer_${TS}`
+const T1 = '2026-06-01T00:00:00Z' // the as-of point (records public here)
+const T2 = '2026-06-02T00:00:00Z' // later: oracle goes secret, deleted record is deleted
+const AS_OF = '2026-06-01T12:00:00Z' // between T1 and T2
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser = VIEWER
+let curRoles = ['member']
+const asUser = (id: string, roles: string[]) => { curUser = id; curRoles = roles }
+
+const rev = (recordId: string, version: number, action: 'create' | 'update' | 'delete', data: Record<string, unknown>, createdAt: string) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, 'rest', ARRAY[$5]::text[], '{}'::jsonb, $6::jsonb, $7)`,
+    [SHEET, recordId, version, action, STATUS, JSON.stringify(data), createdAt],
+  )
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET, JSON.stringify(rules)])
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET, on])
+const pit = (query: Record<string, unknown> = {}) => request(app).get(`/api/multitable/sheets/${SHEET}/point-in-time`).query({ asOf: AS_OF, ...query })
+const recordIds = (res: { body?: { data?: { records?: Array<{ recordId: string }> } } }) => (res.body?.data?.records ?? []).map((r) => r.recordId)
+
+describeIfDatabase('multitable point-in-time read-only view — T7 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: curUser, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'PIT Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'PIT Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET, 'Status', 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+    // CURRENT live records (meta_records): REC_PUBLIC + REC_ORACLE exist now; REC_DELETED does NOT.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC_PUBLIC, SHEET, JSON.stringify({ [STATUS]: 'public', [SALARY]: 100 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC_ORACLE, SHEET, JSON.stringify({ [STATUS]: 'secret', [SALARY]: 200 })]) // DENIED now
+    // Revisions: each record was PUBLIC at T1; the oracle went secret at T2; the deleted record was deleted at T2.
+    await rev(REC_PUBLIC, 1, 'create', { [STATUS]: 'public', [SALARY]: 100 }, T1)
+    await rev(REC_ORACLE, 1, 'create', { [STATUS]: 'public', [SALARY]: 200 }, T1) // PUBLIC at T1
+    await rev(REC_ORACLE, 2, 'update', { [STATUS]: 'secret', [SALARY]: 200 }, T2) // secret since T2
+    await rev(REC_DELETED, 1, 'create', { [STATUS]: 'public' }, T1) // existed at T1
+    await rev(REC_DELETED, 2, 'delete', { [STATUS]: 'public' }, T2) // deleted since T2
+    // field_permissions: deny SALARY to VIEWER. conditional_read_rules: deny status='secret'.
+    await q(`INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`, [SHEET, SALARY, VIEWER])
+    await setRules([{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }])
+    await setFlag(true)
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+
+  beforeEach(() => { asUser(VIEWER, ['member']) })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('ORACLE-NEGATIVE: a record public-at-T but DENIED-now is ABSENT (not in records, not in total)', async () => {
+    const res = await pit()
+    expect(res.status).toBe(200)
+    expect(recordIds(res)).not.toContain(REC_ORACLE) // current-deny: never shows a currently-denied record's T-state
+    expect(recordIds(res)).toContain(REC_PUBLIC) // non-vacuous: the genuinely-readable record IS present
+    expect(res.body?.data?.total).toBe(1) // total counts only the visible record (oracle + deleted excluded)
+  })
+
+  test('positive: a currently-readable record shows its AS-OF-T state', async () => {
+    const c = (await pit()).body?.data?.records?.find((r: { recordId: string }) => r.recordId === REC_PUBLIC) as { data: Record<string, unknown> } | undefined
+    expect(c?.data?.[STATUS]).toBe('public') // T-state
+  })
+
+  test('field-mask: a field_permissions-denied field is absent from the as-of-T record', async () => {
+    const c = (await pit()).body?.data?.records?.find((r: { recordId: string }) => r.recordId === REC_PUBLIC) as { data: Record<string, unknown> } | undefined
+    expect(c?.data?.[SALARY]).toBeUndefined() // SALARY denied to VIEWER → masked even in the PIT view
+    expect(c?.data?.[STATUS]).toBe('public') // visible field still present (surgical mask)
+  })
+
+  test('deleted-since-T is OUT of v1 (product scope): a record that existed at T but is deleted now is absent', async () => {
+    expect(recordIds(await pit())).not.toContain(REC_DELETED)
+  })
+
+  test('admin bypass: an admin sees the now-denied record (parity with the other history surfaces)', async () => {
+    asUser('admin_pit', ['admin'])
+    expect(recordIds(await pit())).toContain(REC_ORACLE) // admin bypasses row-deny
+  })
+
+  test('validation: a missing / invalid asOf is a 400', async () => {
+    expect((await request(app).get(`/api/multitable/sheets/${SHEET}/point-in-time`)).status).toBe(400)
+    expect((await pit({ asOf: 'not-a-date' })).status).toBe(400)
+  })
+})


### PR DESCRIPTION
The second read-only leaf of the Time Machine program, built on the pinned **T5-1 reconstructor**. `GET /sheets/:sheetId/point-in-time?asOf=<ISO>` — "open the table as of T, read-only." Reconstructs over `meta_record_revisions`; **writes nothing**.

## Permission resolution — current-deny by reuse (NOT as-of-T)

- **row-deny = the same `loadDeniedRecordIds` seam** as every history surface (grant-deny ∪ 2b conditional read-deny), evaluated against **current** data. As-of-T deny would let a record `public`-at-T but **denied-now** show its historical contents → an **oracle**; current-deny never shows a currently-denied record and matches events/detail/#2968. (`loadDeniedRecordIds`, **not** `deriveRecordPermissions` — so 2b read-deny isn't missed.)
- **field-mask** reuses `loadAllowedFieldIds` + `maskStoredRecordFieldIds`.
- **reveal never composes** (no reveal path; PV-3 / LOCK-7).
- **scope = currently-live records**; deleted-since-T is **out of v1** — a product-scope choice, *not* a safety deny (documented, with the note that T6/T8 undelete must not infer from T7's filtered set).

## Verification

**7 real-DB goldens, oracle-first**: **ORACLE-NEGATIVE** (public-at-T-but-denied-now → absent **and** excluded from `total`; a readable record IS present), positive (shows the **as-of-T** state), field-mask, deleted-since-T out of v1, admin bypass, `asOf`→400. **Mutation-checked**: disable the current-deny skip → the oracle leaks → proves it's load-bearing. tsc 0; history events **22/22** + reconstructor **7/7** unchanged; no migration. Verification MD included.

Unit **3768/3770** — the 2 failures (`data-source-readonly`, `hierarchy-parent-link-guard`) are pre-existing order-dependent flakes (pass **34/34 in isolation**, untouched by this diff).

**Next:** T5-2 restore-preview (the last read-only leaf, after this so the two don't touch the permission root at once). The write slices (T6/T8) + T9 stay design-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)