### PR TITLE
feat(multitable): 1b Slice C — RELVALUES (relation-scoped array return) — closes the record-set arc

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1218,12 +1218,16 @@ const RELATION_AGG_FUNCTIONS: Record<string, RollupAggregation> = {
 // permission/taint/fan-out pipeline as the aggregations; the resolver returns the FIRST matched linked
 // record's returnField (in link order) instead of reducing the set.
 const RELATION_LOOKUP_FUNCTIONS = new Set<string>(['RELLOOKUP'])
+// Slice C — array family: return the permission-filtered matched target values as an ARRAY (no reduction).
+// Same grammar + the same materialize/permission/taint/fan-out pipeline; the resolver returns the values[]
+// in link order instead of aggregating (Slice A) or first-matching (Slice B).
+const RELATION_ARRAY_FUNCTIONS = new Set<string>(['RELVALUES'])
 const REL_NA_SENTINEL = '#N/A' // lookup not-found (no matched row) — distinct from #PERM! (a denied FIELD)
 
 type RelationAggregationCall = {
   fnName: string
-  kind: 'aggregation' | 'lookup'
-  aggregation: RollupAggregation | null // null when kind === 'lookup'
+  kind: 'aggregation' | 'lookup' | 'array'
+  aggregation: RollupAggregation | null // null when kind === 'lookup' | 'array'
   linkFieldId: string
   targetFieldId: string // the returnField when kind === 'lookup'
   criteria: { fieldId: string; operator: string; valueExpr: string } // the matchField when kind === 'lookup'
@@ -1265,8 +1269,9 @@ export function parseRelationAggregationCall(expression: string): RelationAggreg
   const fnName = m[1].toUpperCase()
   const aggregation = RELATION_AGG_FUNCTIONS[fnName] ?? null
   const isLookup = RELATION_LOOKUP_FUNCTIONS.has(fnName)
-  if (!aggregation && !isLookup) return null
-  const kind: 'aggregation' | 'lookup' = isLookup ? 'lookup' : 'aggregation'
+  const isArray = RELATION_ARRAY_FUNCTIONS.has(fnName)
+  if (!aggregation && !isLookup && !isArray) return null
+  const kind: 'aggregation' | 'lookup' | 'array' = isLookup ? 'lookup' : isArray ? 'array' : 'aggregation'
   const args = splitTopLevelArgs(m[2])
   if (!args) return null
   // RELCOUNTIF counts MATCHED linked records — no sum target (4 args: link, criteria, op, value). The
@@ -1302,7 +1307,7 @@ export function parseRelationAggregationCall(expression: string): RelationAggreg
 // call (e.g. `RELSUMIF(...)+1`). Slice A is sole-call only; the recompute path turns
 // this into a fail-loud diagnostic rather than a silent wrong value or a raw #NAME?.
 export function expressionHasRelationAggregationButNotSole(expression: string): boolean {
-  const mentions = [...Object.keys(RELATION_AGG_FUNCTIONS), ...RELATION_LOOKUP_FUNCTIONS].some((fn) => new RegExp(`\\b${fn}\\s*\\(`, 'i').test(expression))
+  const mentions = [...Object.keys(RELATION_AGG_FUNCTIONS), ...RELATION_LOOKUP_FUNCTIONS, ...RELATION_ARRAY_FUNCTIONS].some((fn) => new RegExp(`\\b${fn}\\s*\\(`, 'i').test(expression))
   if (!mentions) return false
   return parseRelationAggregationCall(expression) === null
 }
@@ -1346,7 +1351,7 @@ async function resolveRelationAggregation(
   recordData: Record<string, unknown>,
   call: RelationAggregationCall,
   fields: UniverMetaField[],
-): Promise<number | string | boolean | null> {
+): Promise<number | string | boolean | null | unknown[]> {
   const linkField = fields.find((f) => f.id === call.linkFieldId && f.type === 'link')
   const linkCfg = linkField ? parseLinkFieldConfig(linkField.property) : null
   const foreignSheetId = linkCfg?.foreignSheetId
@@ -1355,7 +1360,7 @@ async function resolveRelationAggregation(
   // Authoritative linked ids come from meta_links (record.data[linkField] is not the source of truth).
   const linkValues = await loadLinkValuesByRecord(query, [recordId], [{ fieldId: call.linkFieldId, cfg: linkCfg }])
   const linkIds = linkValues.get(recordId)?.get(call.linkFieldId) ?? []
-  if (linkIds.length === 0) return call.kind === 'lookup' ? REL_NA_SENTINEL : aggregateRollup([], 0, call.aggregation as RollupAggregation)
+  if (linkIds.length === 0) return call.kind === 'lookup' ? REL_NA_SENTINEL : call.kind === 'array' ? [] : aggregateRollup([], 0, call.aggregation as RollupAggregation)
   // §5 cap — fail loud before any scan/materialization (count-first), never run unbounded.
   if (linkIds.length > MAX_RELATION_SCAN_RECORDS) return REL_AGG_LIMIT_SENTINEL
 
@@ -1415,6 +1420,20 @@ async function resolveRelationAggregation(
       return v === null || v === undefined ? REL_NA_SENTINEL : (v as number | string | boolean)
     }
     return REL_NA_SENTINEL
+  }
+
+  // Slice C — array: return ALL matched target values in LINK order, permission-filtered (denied rows were
+  // excluded above; a denied FIELD is gated to #PERM! earlier), null/undefined skipped. No reduction — the
+  // caller gets the raw array; the read-taint mask drops the whole field for a reader who can't see it.
+  if (call.kind === 'array') {
+    const out: unknown[] = []
+    for (const id of linkIds) {
+      const data = byId.get(id)
+      if (!data || !matchesCriteria(data)) continue
+      const v = data[call.targetFieldId]
+      if (v !== null && v !== undefined) out.push(v)
+    }
+    return out
   }
 
   const values: unknown[] = []

--- a/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
+++ b/packages/core-backend/tests/integration/multitable-relation-aggregation.test.ts
@@ -43,6 +43,8 @@ const FLD_SECRETCOUNT = `fld_rel_seccount_${TS}` // = RELCOUNTIF(link, SECRET, g
 const FLD_LOOKUP = `fld_rel_lookup_${TS}` // = RELLOOKUP(link, status, amt, is, 10) -> 'paid' (FR1, only amt=10; order-independent)
 const FLD_LOOKUP_NA = `fld_rel_lookupna_${TS}` // = RELLOOKUP(link, status, amt, is, 999) -> #N/A (no match)
 const FLD_LOOKUP_SECRET = `fld_rel_lookupsec_${TS}` // = RELLOOKUP(link, SECRET, amt, is, 10) -> 100; DENIED returnField leak gate
+const FLD_VALUES = `fld_rel_values_${TS}` // = RELVALUES(link, amt, status, is, {curval}) -> [10, 20] (paid, link order)
+const FLD_VALUES_SECRET = `fld_rel_valuessec_${TS}` // = RELVALUES(link, SECRET, status, is, {curval}) -> [100,200]; DENIED leak gate
 
 const FR1 = `rec_rel_f1_${TS}` // amt 10, status paid,   secret 100
 const FR2 = `rec_rel_f2_${TS}` // amt 20, status paid,   secret 200
@@ -120,6 +122,9 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP, MS, 'Lookup', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_STATUS}","${FLD_AMT}","is","10")` }), 9])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP_NA, MS, 'LookupNA', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_STATUS}","${FLD_AMT}","is","999")` }), 10])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP_SECRET, MS, 'LookupSecret', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_SECRET}","${FLD_AMT}","is","10")` }), 11])
+    // Slice C — RELVALUES(link, target, criteria, op, value): array of ALL matched target values (link order).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUES, MS, 'Values', 'formula', JSON.stringify({ expression: `RELVALUES("${FLD_LINK}","${FLD_AMT}","${FLD_STATUS}","is",{${FLD_CURVAL}})` }), 12])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VALUES_SECRET, MS, 'ValuesSecret', 'formula', JSON.stringify({ expression: `RELVALUES("${FLD_LINK}","${FLD_SECRET}","${FLD_STATUS}","is",{${FLD_CURVAL}})` }), 13])
 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3], [FLD_CURVAL]: 'unpaid' })])
     for (const fr of [FR1, FR2, FR3]) {
@@ -127,7 +132,7 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     }
     // Formula deps on the current-record criteria field {CURVAL} (the recompute trigger; the create handler
     // would register it via extractFieldReferences, but these fields are seeded via SQL → insert directly).
-    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF, FLD_AVGIF, FLD_COUNTIF, FLD_SECRETCOUNT, FLD_LOOKUP, FLD_LOOKUP_NA, FLD_LOOKUP_SECRET]) {
+    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_CLIFF, FLD_AVGIF, FLD_COUNTIF, FLD_SECRETCOUNT, FLD_LOOKUP, FLD_LOOKUP_NA, FLD_LOOKUP_SECRET, FLD_VALUES, FLD_VALUES_SECRET]) {
       await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [MS, ff, FLD_CURVAL])
     }
     // DENY cannot read the foreign SECRET field → any RELSUMIF over it must be masked for DENY on read.
@@ -181,6 +186,13 @@ describeIfDatabase('multitable 1b Slice A — relation-scoped RELSUMIF (real DB)
     // leak gate: returnField is the DENIED SECRET field → allowed reader gets the value, denied reader's field is dropped
     expect(await readField(ALLOW, FLD_LOOKUP_SECRET)).toBe(100) // FR1.secret (the amt=10 match)
     expect(await hasField(DENY, FLD_LOOKUP_SECRET)).toBe(false)
+  })
+
+  test('C — RELVALUES returns the matched values as an ARRAY (link order) + denied-field leak gate', async () => {
+    expect(await readField(ALLOW, FLD_VALUES)).toEqual([10, 20]) // amts where status=paid: FR1, FR2 (link order)
+    // leak gate: array over the DENIED SECRET field → allowed reader gets the array, denied reader's field is dropped
+    expect(await readField(ALLOW, FLD_VALUES_SECRET)).toEqual([100, 200])
+    expect(await hasField(DENY, FLD_VALUES_SECRET)).toBe(false)
   })
 
   // A.2 — foreign-write fan-out (reverse-edge). Runs LAST: it mutates FR1's amount, which the earlier

--- a/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
+++ b/packages/core-backend/tests/unit/multitable-relation-aggregation-parse.test.ts
@@ -76,6 +76,14 @@ describe('parseRelationAggregationCall — sole-call grammar', () => {
     expect(parseRelationAggregationCall('RELLOOKUP("a","b","c","is")')).toBeNull() // 4 args → null (lookup is 5-arg)
   })
 
+  it('C — parses RELVALUES (kind=array, 5-arg) — same shape, array-return (aggregation null)', () => {
+    expect(parseRelationAggregationCall('RELVALUES("fld_link","fld_amt","fld_status","is","paid")')).toEqual({
+      fnName: 'RELVALUES', kind: 'array', aggregation: null, linkFieldId: 'fld_link', targetFieldId: 'fld_amt',
+      criteria: { fieldId: 'fld_status', operator: 'is', valueExpr: '"paid"' },
+    })
+    expect(parseRelationAggregationCall('RELVALUES("a","b","c","is")')).toBeNull() // 4 args → null (array is 5-arg)
+  })
+
   it('A.3 — per-function arity: RELCOUNTIF needs 4 (5→null); RELAVGIF/RELSUMIF need 5 (4→null)', () => {
     expect(parseRelationAggregationCall('RELCOUNTIF("a","b","c","is","x")')).toBeNull() // 5 args → not COUNTIF
     expect(parseRelationAggregationCall('RELAVGIF("a","b","c","is")')).toBeNull() // 4 args → not AVGIF


### PR DESCRIPTION
Final slice of the 1b record-set arc (off merged main). Adds the **array family** — return the matched values as an array (no reduction) — completing relation-scoped record-set formulas.

**`RELVALUES("link", "target", "criteria", "op", "value")`** returns ALL matched target values as an **array** in link order.

A third `kind: 'array'` on the unified discriminant means **parser, recompute hook, read-leak taint edge, fan-out, dep-registration, and validator all reuse the pipeline verbatim** — only an array-return branch in `resolveRelationAggregation` is new (same materialize-then-filter permission path; denied rows excluded, denied **field** → `#PERM!`/read-taint drop, empty links → `[]`). The resolver's return type is widened to include `unknown[]`; the value persists as JSON and is masked per-reader on read.

## Tests
- Parser unit: RELVALUES `kind=array`, arity.
- Real-DB goldens: array value `[10, 20]` (link order) + the **denied-field leak gate** (allowed→`[100,200]`, denied→field absent).
- Unit suite green non-watch (`CI=true`, 357 files / 0 fail); tsc 0; taint count unchanged at 6.

## Arc complete
`RELSUMIF` (#2978) · `RELAVGIF`/`RELCOUNTIF` (#2995) · `RELLOOKUP` (#2998) · `RELVALUES` (this) — the 1b relation-scoped record-set formula arc is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)