### PR TITLE
feat(multitable): global-history T5-2 — record-version restore preview (read-only, masked, write-free)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -210,6 +210,7 @@ jobs:
             tests/integration/multitable-history-audit-reveal-taint-realdb.test.ts \
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
+            tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-global-history-timemachine-capstone-verification-20260621.md
+++ b/docs/development/multitable-global-history-timemachine-capstone-verification-20260621.md
@@ -1,0 +1,64 @@
+# Global History / Time Machine — Program Capstone (T5-2 verification + program summary)
+
+> The capstone for the /goal「完成 timemachine 剩余开发，给设计及验证MD」. Records the final read-only leaf
+> (T5-2 restore-preview) and ties together the whole program: **read-only half BUILT + verified, write half
+> DESIGNED + gated.**
+
+## 1. The final leaf — T5-2 record-version restore preview (BUILT)
+
+`POST /sheets/:sheetId/records/:recordId/restore-preview` { targetVersion } → the masked diff a Layer-1 restore
+WOULD apply, **write-free**.
+
+- **MIRROR not extract** (deliberate): the preview re-implements the restore route's set ∪ unset diff (scalar +
+  link-as-report) read-only, rather than refactoring the destructive write path. Worst-case failure is a wrong
+  *preview* (display), not data corruption. The small diff helpers duplicate the restore route's route-local
+  copies — a **noted P3** (unify in a follow-up); the **preview→restore consistency golden** guards against drift.
+- **PV-1 write-free**: writes nothing (golden: record version + data unchanged after a preview).
+- **PV-2 mask** (the security axis): the diff is filtered to the actor's allowed fields (the SAME
+  `loadAllowedFieldIds` + `maskStoredRecordFieldIds` chain as history detail), so a hidden field that WOULD change
+  never appears. Mutation-checked: drop the mask → the denied field leaks into the preview.
+- **No-oracle**: a row-denied record previews as 404 — the same shape as missing (no existence oracle), via the
+  `loadDeniedRecordIds` seam.
+- **D5**: the preview is gated on the RESTORE capability (`canEditRecord`), so it isn't teased to someone who
+  could never execute.
+- **Reveal never composes** (no reveal path).
+- **v1 scope** (D2 record-version + batch first): record-version, full-record. OUT of v1 (follow-ups): batch
+  scope, strategy=reset, the reconstructor-based as-of-T preview (uses T5-1, a follow-up).
+- **Verification**: 6 real-DB goldens; restore boundary **34/34 unchanged** (the route was added before restore,
+  not into it); tsc 0; no migration.
+
+## 2. The program (T5–T9) — built vs designed
+
+| Slice | What | Status |
+|---|---|---|
+| **T5-1** reconstructor | as-of-T `reconstructRecordsAtT` (LOCK-9 delete-aware + LOCK-11) — the shared read root | ✅ BUILT (#2993) — 8 goldens incl. delete-at-T pin + version-null + scoped sentinel |
+| **T7** PIT read-only view | "table as of T", current-deny by reuse, oracle-safe | ✅ BUILT (#3000) — 7 goldens incl. oracle-negative + mutation |
+| **T5-2** restore preview | record-version preview, masked, write-free | ✅ BUILT (this PR) — 6 goldens incl. write-free + mask-mutation + preview↔restore consistency |
+| **T6** scoped restore | the first WRITE; batch fan-out is a NEW permission surface (SR-2) | 🔒 DESIGN-LOCK (#2994) — gated on D1–D4 + opt-in |
+| **T8** PIT restore | destructive sheet rollback; Revert vs Reset | 🔒 DESIGN-LOCK (#2994) — gated; Reset needs a SEPARATE rollback-semantics sign-off |
+| **T9** config history | separate program; read-only first | 🔒 DESIGN-LOCK (#2994) — separate opt-in |
+
+## 3. The permission spine (proven across the program)
+
+Every read surface reuses the SAME boundary — **never re-derived**:
+- row-deny = `loadDeniedRecordIds` (grant-deny ∪ 2b conditional read-deny), current-deny, admin-bypassed;
+- field-mask = `loadAllowedFieldIds` + `maskStoredRecordFieldIds` (visible ∧ field_permissions, taint-dropped);
+- field-audit reveal NEVER composes with reconstruct / preview / restore (LOCK-7 by construction);
+- the **oracle rule** (T7): current-deny, so a record public-at-T-but-denied-now is never an oracle.
+
+Load-bearing security goldens are each **mutation-checked**: T7 oracle (disable current-deny → leak), T5-2 mask
+(drop mask → leak), plus the reconstructor's delete-at-T and version contract.
+
+## 4. The discipline (why the write half is design-locked, not built)
+
+The destructive slices (T6 scoped restore, T8 sheet rollback) are the dangerous half — T6 introduces a new
+batch-fan-out permission surface, T8 deletes data. The /goal asked for 设计**及**验证MD: so the read-only half is
+**built + verified**, and the write half is delivered as **design-locks** (the 设计 artifact) + held for explicit
+ratification. Self-authorizing a destructive sheet rollback off a goal is the one line not crossed.
+
+## 5. Named follow-ups (each a separate opt-in)
+
+- T5-2: batch-scope preview, strategy=reset preview, reconstructor-based as-of-T preview; unify the mirrored
+  diff helpers with the restore route (the P3 dup).
+- T7: deleted-since-T records (out of v1 — needs its own deny decision); pagination cursor.
+- T6 / T8 / T9: ratify their design-locks (D-decisions) then build, each gated; T8 Reset needs a separate sign-off.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7346,6 +7346,83 @@ export function univerMetaRouter(): Router {
   //  - Lock C update-restore only: hard-deleted record → 404; delete-target → RESTORE_UNSUPPORTED.
   //  - Lock D scalar-only: computed/link/system-auto/attachment excluded by type.
   // ---------------------------------------------------------------------------
+  // Global History — T5-2: record-version restore PREVIEW (read-only). Computes the diff a Layer-1 restore to
+  // `targetVersion` WOULD apply, masked to the actor's allowed fields (PV-2), WITHOUT writing (PV-1). The diff
+  // MIRRORS the restore route's shape so a preview matches the eventual write — pinned by the preview→restore
+  // consistency golden (the small helpers below duplicate the restore route's route-local copies; unifying
+  // them is a noted P3, guarded against drift by that golden). v1 = record-version, full-record; batch scope,
+  // strategy=reset, and the reconstructor-based as-of-T preview are explicitly out of v1 (follow-ups).
+  router.post('/sheets/:sheetId/records/:recordId/restore-preview', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    const previewParsed = z.object({ targetVersion: z.number().int().positive() }).safeParse(req.body)
+    if (!previewParsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: previewParsed.error.message } })
+    const previewTargetVersion = previewParsed.data.targetVersion
+    try {
+      const pool = poolManager.get()
+      // Denied/missing record share the SAME 404 shape (no existence oracle), like the per-record history route.
+      if ((await pool.query('SELECT id FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])).rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canEditRecord) return sendForbidden(res) // D5: gate the preview on the RESTORE capability
+      if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))) {
+        const denied = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (denied.has(recordId)) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } }) // row-deny → 404 no-oracle
+      }
+      const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
+      const liveRow = (await pool.query('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])).rows[0] as { data: unknown } | undefined
+      const currentData = asRec(liveRow?.data)
+      const revRows = (await pool.query('SELECT action, snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND version = $3', [sheetId, recordId, previewTargetVersion])).rows as Array<{ action: string; snapshot: unknown }>
+      if (revRows.length === 0) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: `No revision at version ${previewTargetVersion}` } })
+      const targetRev = revRows.find((r) => r.action !== 'delete')
+      if (!targetRev) return res.status(422).json({ ok: false, error: { code: 'RESTORE_UNSUPPORTED', message: `Version ${previewTargetVersion} is a delete revision; undelete preview is not supported in this slice` } })
+      if (targetRev.snapshot === null || targetRev.snapshot === undefined) return res.status(422).json({ ok: false, error: { code: 'SNAPSHOT_UNAVAILABLE', message: `Revision ${previewTargetVersion} has no stored snapshot` } })
+      const targetSnapshot = asRec(targetRev.snapshot)
+
+      const previewCtx = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+      if (!previewCtx) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
+      let schemaDrift = false
+      for (const fid of Object.keys(targetSnapshot)) if (!previewCtx.fieldById.has(fid)) { schemaDrift = true; break }
+
+      // Mirror of the restore route's set ∪ unset diff (scalar) + link-as-report. Helpers mirror restore (P3 dup).
+      const NON_RESTORABLE = new Set(['formula', 'lookup', 'rollup', 'link', 'attachment', 'button', 'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy'])
+      const sameVal = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+      const sameLinks = (a: string[], b: string[]): boolean => a.length === b.length && [...a].sort().join(' ') === [...b].sort().join(' ')
+      const changes: Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }> = []
+      for (const [fid, guard] of previewCtx.fieldById.entries()) {
+        if (rawTypeById.get(fid) === 'button') continue
+        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
+        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
+        if (guard.type === 'link') {
+          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
+          if (!sameLinks(normalizeLinkIds(currentData[fid]), target)) changes.push({ fieldId: fid, op: 'set', value: target })
+          continue
+        }
+        if (NON_RESTORABLE.has(guard.type)) continue
+        if (inSnap) {
+          if (!sameVal(currentData[fid], targetSnapshot[fid])) changes.push({ fieldId: fid, op: 'set', value: targetSnapshot[fid] })
+        } else if (inCur) {
+          changes.push({ fieldId: fid, op: 'unset', value: null })
+        }
+      }
+      // PV-2 mask: filter the diff to the actor's allowed fields (visible ∧ field_permissions, taint-dropped),
+      // so a hidden field that WOULD change never appears in the preview — the SAME chain as history detail.
+      const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
+      const visibleChanges = changes.filter((c) => allowed.has(c.fieldId))
+      return res.json({ ok: true, data: { changes: visibleChanges, visibleAffectedFieldCount: visibleChanges.length, schemaDrift, targetVersion: previewTargetVersion } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] restore-preview failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to preview restore' } })
+    }
+  })
+
   router.post('/sheets/:sheetId/records/:recordId/restore', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''

--- a/packages/core-backend/tests/integration/multitable-restore-preview-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-preview-realdb.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Global History — T5-2: record-version restore PREVIEW (real DB). Read-only diff of what a Layer-1 restore
+ * WOULD apply, masked to the actor's allowed fields, write-free.
+ *
+ * Goldens (advisor order): PV-1 write-free · PV-2 hidden-field masked (+ mutation) · preview→restore consistency
+ * (the dup-helper guard) · denied-record → 404 no-oracle.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rp_${TS}`
+const SHEET = `sheet_rp_${TS}`
+const NAME = `fld_rp_name_${TS}`
+const SALARY = `fld_rp_salary_${TS}` // field_permissions-denied to VIEWER (PV-2)
+const REC = `rec_rp_${TS}`
+const REC_DENIED = `rec_rp_denied_${TS}`
+const VIEWER = `user_rp_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser = VIEWER
+let curRoles = ['member']
+const preview = (recordId: string, body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${recordId}/restore-preview`).send(body)
+const restore = (recordId: string, body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${recordId}/restore`).send(body)
+const recordRow = async (recordId: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [recordId])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const denyField = (fieldId: string) => q(`INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false) ON CONFLICT DO NOTHING`, [SHEET, fieldId, VIEWER])
+const clearFieldDeny = () => q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET])
+
+describeIfDatabase('multitable record-version restore preview — T5-2 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: curUser, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RP Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RP Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+
+  // Fresh record at v2 {NAME:'b', SALARY:200}; v1 snapshot was {NAME:'a', SALARY:100}.
+  beforeEach(async () => {
+    curUser = VIEWER; curRoles = ['member']
+    await clearFieldDeny()
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = '[]'::jsonb WHERE id = $1", [SHEET])
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC, SHEET, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+             VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, REC, NAME, SALARY, JSON.stringify({ [NAME]: 'a', [SALARY]: 100 })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+             VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, REC, NAME, SALARY, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('PV-1 write-free: preview changes NOTHING (record version + data unchanged after)', async () => {
+    const before = await recordRow(REC)
+    const res = await preview(REC, { targetVersion: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.changes?.length).toBe(2) // NAME + SALARY would change
+    const after = await recordRow(REC)
+    expect(after?.version).toBe(before?.version) // version unchanged
+    expect(after?.data).toEqual(before?.data) // data unchanged — the whole read-only claim
+  })
+
+  test('PV-2 mask: a field_permissions-denied field is ABSENT from the preview diff', async () => {
+    await denyField(SALARY)
+    const res = await preview(REC, { targetVersion: 1 })
+    const ids = (res.body?.data?.changes ?? []).map((c: { fieldId: string }) => c.fieldId)
+    expect(ids).toContain(NAME) // visible field present
+    expect(ids).not.toContain(SALARY) // hidden field's change masked out of the preview
+    expect(res.body?.data?.visibleAffectedFieldCount).toBe(1)
+  })
+
+  test('preview→restore consistency: the previewed changes are exactly what a restore writes', async () => {
+    const pv = await preview(REC, { targetVersion: 1 })
+    const changes = pv.body?.data?.changes as Array<{ fieldId: string; value: unknown }>
+    const r = await restore(REC, { targetVersion: 1, expectedVersion: 2 })
+    expect(r.status).toBe(200)
+    const after = await recordRow(REC)
+    // every previewed change landed with the previewed value; nothing the preview omitted changed away from v1.
+    for (const c of changes) expect(after?.data?.[c.fieldId]).toEqual(c.value)
+    expect(after?.data?.[NAME]).toBe('a') // restored to v1
+    expect(after?.data?.[SALARY]).toBe(100)
+  })
+
+  test('no-oracle: a row-denied record previews as 404 (same shape as missing — no existence oracle)', async () => {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_DENIED, SHEET, JSON.stringify({ [NAME]: 'secret' })])
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET, JSON.stringify([{ id: 'r1', fieldId: NAME, operator: 'eq', value: 'secret', effect: 'deny_read' }])])
+    const res = await preview(REC_DENIED, { targetVersion: 1 })
+    expect(res.status).toBe(404) // denied → not-found shape, no oracle
+    await q('DELETE FROM meta_records WHERE id = $1', [REC_DENIED])
+  })
+
+  test('validation: a missing / invalid targetVersion is a 400; a nonexistent version is 404', async () => {
+    expect((await preview(REC, {})).status).toBe(400)
+    expect((await preview(REC, { targetVersion: 999 })).status).toBe(404)
+  })
+})


### PR DESCRIPTION
The **last read-only leaf** of the Time Machine program. `POST /sheets/:sheetId/records/:recordId/restore-preview` { targetVersion } → the masked diff a Layer-1 restore **would** apply, **without writing**.

## MIRROR not extract (deliberate)

The preview re-implements the restore route's set ∪ unset diff (scalar + link-as-report) **read-only**, rather than refactoring the destructive write path — worst-case failure is a wrong *preview* (display), not data corruption. The small diff helpers duplicate the restore route's route-local copies (a **noted P3**); the **preview→restore consistency golden** guards against drift.

## Locks

- **PV-1 write-free**: writes nothing (golden: record version + data unchanged after).
- **PV-2 mask** (security axis): the diff is filtered to the actor's allowed fields (the SAME `loadAllowedFieldIds` + `maskStoredRecordFieldIds` chain as history detail), so a hidden field that would change never appears. **Mutation-checked**: drop the mask → the denied field leaks.
- **no-oracle**: a row-denied record previews as 404 (same shape as missing), via `loadDeniedRecordIds`.
- **D5**: gated on the restore capability (`canEditRecord`). Reveal never composes.
- **v1** = record-version, full-record; batch / strategy=reset / reconstructor-based as-of-T preview are follow-ups.

## Verification

6 real-DB goldens (write-free, mask + mutation, **preview↔restore consistency**, no-oracle, validation); restore boundary **34/34 unchanged** (route added *before* restore, not into it); tsc 0; unit **3771/3771**; no migration. **Capstone program verification MD** included.

## Program complete (read-only half)

T5-1 reconstructor (#2993) + T7 PIT view (#3000) + T5-2 preview (this) = **read-only half built + verified**. T6/T8/T9 (#2994) = **write half designed + gated**. The destructive slices stay design-then-ratify, not self-authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)