### PR TITLE
fix(multitable): export "all rows" via mask-preserving full-sheet route (+csv), not the 50-row client page

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -235,6 +235,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-view.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-export.test.ts \
             tests/integration/multitable-export-permission-canary.test.ts \
+            tests/integration/multitable-export-allrows-maskroute-realdb.test.ts \
             tests/integration/multitable-person-directory-route.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-write.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-create.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -322,6 +322,20 @@ function firstFieldError(fieldErrors?: Record<string, string>): string | null {
   return first ?? null
 }
 
+// Extract the download filename from a Content-Disposition header (handles both `filename="x.csv"` and
+// RFC-5987 `filename*=UTF-8''x.csv`). Falls back to a generic name so the download always has one.
+function parseContentDispositionFilename(header: string | null): string {
+  if (header) {
+    const star = header.match(/filename\*=(?:UTF-8'')?([^;]+)/i)
+    if (star?.[1]) {
+      try { return decodeURIComponent(star[1].trim().replace(/^["']|["']$/g, '')) } catch { /* fall through */ }
+    }
+    const plain = header.match(/filename="?([^";]+)"?/i)
+    if (plain?.[1]) return plain[1].trim()
+  }
+  return 'export'
+}
+
 type RawComment = Partial<MultitableComment> & {
   spreadsheetId?: string
   rowId?: string
@@ -1334,6 +1348,47 @@ export class MultitableApiClient {
     const { sheetId, ...rest } = params
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/view-aggregate${qs(rest as Record<string, string | undefined>)}`)
     return this.parseJson(res)
+  }
+
+  // Full-sheet export (the mask-preserving backend route). The server applies the SAME field_permissions +
+  // view-hidden + §2a.3 formula-taint masking as the grid read, AFTER the `fieldIds` selection (which can
+  // only NARROW within the permitted set, never widen), then cursor-paginates the WHOLE sheet up to the
+  // server's row cap. This is why "all rows" goes here instead of serializing the 50-row client page:
+  // the client only holds one masked page; the server holds the full masked sheet. Returns the binary blob
+  // + the server's suggested filename (Content-Disposition). On a non-2xx (e.g. 400 when the column
+  // selection resolves to zero exportable columns) it throws a MultitableApiError so the caller can toast
+  // the server message rather than downloading an error body.
+  async exportSheet(params: {
+    sheetId: string
+    viewId?: string
+    fieldIds?: string[]
+    format: 'csv' | 'xlsx'
+  }): Promise<{ blob: Blob; filename: string }> {
+    const query = qs({
+      viewId: params.viewId,
+      // The route accepts the comma-joined form (?fieldIds=a,b); join here. An empty/absent selection
+      // means "all permitted columns" server-side — never send an empty fieldIds (that would be a 400).
+      fieldIds: params.fieldIds && params.fieldIds.length ? params.fieldIds.join(',') : undefined,
+      format: params.format,
+    })
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(params.sheetId)}/export-xlsx${query}`)
+    if (!res.ok) {
+      // Reuse the shared error normalization (same shape parseJson throws) so the caller sees the
+      // server's VALIDATION_ERROR / FORBIDDEN message + code, not a generic "failed to fetch".
+      const isZh = this.resolveIsZh()
+      const raw = await res.text()
+      const payload = normalizeApiErrorPayload(raw ? safeParseJson(raw) : null, isZh)
+      const error = new Error(firstFieldError(payload.fieldErrors) ?? payload.message ?? apiDefaultErrorMessage(payload.code, res.status, isZh)) as Error & {
+        status?: number
+        code?: string
+      }
+      error.name = 'MultitableApiError'
+      error.status = res.status
+      error.code = payload.code
+      throw error
+    }
+    const blob = await res.blob()
+    return { blob, filename: parseContentDispositionFilename(res.headers.get('Content-Disposition')) }
   }
 
   // Formula dry-run (#5b): evaluate an UNSAVED expression against caller-supplied sample values.

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -53,7 +53,7 @@ export type WorkbenchLabelKey =
   | 'toast.externalContextBusy' | 'toast.externalContextUnsaved'
   | 'toast.baseCreateBlocked' | 'toast.baseCreateFailed'
   | 'toast.importCancelled' | 'toast.importFailed'
-  | 'toast.excelExportFailed' | 'toast.bulkDeleteFailed'
+  | 'toast.excelExportFailed' | 'toast.csvExportFailed' | 'toast.bulkDeleteFailed'
   | 'toast.workbenchInitFailed'
   | 'confirm.discardContextChanges' | 'confirm.discardRecordChanges'
   | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
@@ -199,6 +199,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.importCancelled': { en: 'Import cancelled', zh: '导入已取消' },
   'toast.importFailed': { en: 'Import failed', zh: '导入失败' },
   'toast.excelExportFailed': { en: 'Excel export failed', zh: 'Excel 导出失败' },
+  'toast.csvExportFailed': { en: 'CSV export failed', zh: 'CSV 导出失败' },
   'toast.bulkDeleteFailed': { en: 'Bulk delete failed', zh: '批量删除失败' },
   'toast.workbenchInitFailed': { en: 'Failed to initialize workbench', zh: '初始化工作台失败' },
 

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3010,10 +3010,23 @@ function onGridSelectionChange(recordIds: string[]) {
 }
 
 // --- Export (A2: column/row selection via MetaExportDialog) ---
-// The toolbar's CSV/XLSX buttons now open the export-options dialog (column
-// checklist + row scope + format) instead of exporting immediately. Export
-// stays fully client-side over grid.rows — already permission-masked at read
-// time — so filtering already-authorized columns/rows adds no auth surface.
+// The toolbar's CSV/XLSX buttons open the export-options dialog (column checklist
+// + row scope + format). Two scopes, two paths:
+//   - "all rows"  → the MASK-PRESERVING BACKEND ROUTE (client.exportSheet). The
+//     client grid is page-replaced at DEFAULT_PAGE_SIZE (50), so a client-side
+//     "all rows" could only ever serialize the loaded page — a data-loss bug.
+//     The route cursor-paginates the FULL sheet and re-applies the SAME
+//     field_permissions + view-hidden + §2a.3 formula-taint mask AFTER the
+//     fieldIds selection (selection narrows within the permitted set, never
+//     widens). NOTE: "all rows" = the full sheet, NOT the view-filtered subset
+//     (the route applies view HIDDEN-FIELDS but not the view's row filter/sort);
+//     view-filtered export is a follow-up.
+//   - "selected rows" → stays CLIENT-SIDE over grid.rows. Those rows are the
+//     /view response, already field-permission AND §2a.3-taint masked at read
+//     time (univer-meta.ts GET /view: filterRecordDataByFieldIds over the
+//     taint-masked allowedFieldIds), so serializing the chosen subset adds no
+//     egress surface. The selected ids are necessarily within the loaded page,
+//     so completeness is not at stake here.
 type GridExportField = (typeof scopedGridFields)['value'][number]
 type GridExportRow = (typeof grid.rows)['value'][number]
 
@@ -3032,18 +3045,43 @@ function onExportDialogConfirm(payload: ExportConfirmPayload) {
   // Preserve the on-screen column order; ignore unknown ids defensively.
   const fields = scopedGridFields.value.filter((f) => selectedFieldIds.has(f.id))
   if (!fields.length) return
-  const rows = payload.rowScope === 'selected'
-    ? grid.rows.value.filter((r) => exportSelectedRecordIds.value.has(r.id))
-    : grid.rows.value
-  if (payload.format === 'csv') doExportCsv(fields, rows)
-  else void doExportXlsx(fields, rows)
+  if (payload.rowScope === 'selected') {
+    // Client-side: the loaded+masked rows, narrowed to the selection.
+    const rows = grid.rows.value.filter((r) => exportSelectedRecordIds.value.has(r.id))
+    if (payload.format === 'csv') doExportCsv(fields, rows)
+    else void doExportXlsx(fields, rows)
+    return
+  }
+  // All rows → full-sheet masked backend route.
+  void exportAllRowsViaRoute(fields.map((f) => f.id), payload.format)
+}
+
+async function exportAllRowsViaRoute(fieldIds: string[], format: 'csv' | 'xlsx') {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  try {
+    const { blob, filename } = await workbench.client.exportSheet({
+      sheetId,
+      viewId: workbench.activeViewId.value || undefined,
+      fieldIds,
+      format,
+    })
+    triggerDownloadNamed(blob, filename || `${sheetId}.${format}`)
+  } catch (err: any) {
+    showError(err?.message ?? wb(format === 'csv' ? 'toast.csvExportFailed' : 'toast.excelExportFailed', isZh.value))
+  }
 }
 
 function triggerDownload(blob: Blob, extension: string) {
+  triggerDownloadNamed(blob, `${workbench.activeSheetId.value || 'export'}.${extension}`)
+}
+
+// Download a blob under an exact filename (the server's Content-Disposition for the route path).
+function triggerDownloadNamed(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `${workbench.activeSheetId.value || 'export'}.${extension}`
+  a.download = filename
   a.click()
   URL.revokeObjectURL(url)
 }

--- a/apps/web/tests/multitable/export-sheet-client.test.ts
+++ b/apps/web/tests/multitable/export-sheet-client.test.ts
@@ -1,0 +1,95 @@
+/**
+ * MultitableApiClient.exportSheet — the rewired "all rows" export path.
+ *
+ * The export picker's "all rows" scope no longer serializes the client-loaded grid page (the verified
+ * 50-row data-loss bug); it calls this method, which hits the mask-preserving backend route with the
+ * picker's chosen fieldIds + the active viewId. The server applies field_permissions + view-hidden +
+ * §2a.3 taint masking AFTER the selection (selection narrows, never widens) — these tests assert the
+ * REQUEST is shaped correctly (the mask itself is enforced + tested server-side, in the real-DB suite).
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { MultitableApiClient } from '../../src/multitable/api/client'
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+describe('MultitableApiClient.exportSheet — all-rows mask-route request shaping', () => {
+  it('requests the export route with viewId + comma-joined fieldIds + format, and returns blob + filename', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('col\r\nval', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="My_Sheet.csv"',
+        },
+      }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    const { blob, filename } = await client.exportSheet({
+      sheetId: 'sheet_1',
+      viewId: 'view_1',
+      fieldIds: ['fld_a', 'fld_b'],
+      format: 'csv',
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const url = fetchFn.mock.calls[0][0] as string
+    expect(url).toContain('/api/multitable/sheets/sheet_1/export-xlsx')
+    // fieldIds are sent as the comma-joined form the route parses; viewId + format passthrough.
+    expect(url).toContain('viewId=view_1')
+    expect(url).toContain(`fieldIds=${encodeURIComponent('fld_a,fld_b')}`)
+    expect(url).toContain('format=csv')
+    expect(filename).toBe('My_Sheet.csv')
+    // The response body is returned as a Blob (the caller hands it to the download helper). Assert it is a
+    // non-empty Blob rather than reading .text() (jsdom's Blob has no usable .text()); end-to-end content is
+    // covered by the real-DB suite.
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.size).toBeGreaterThan(0)
+  })
+
+  it('omits fieldIds entirely when the selection is empty (route then exports all permitted columns)', async () => {
+    const fetchFn = vi.fn(async () => new Response('x', { status: 200, headers: { 'Content-Type': 'text/csv' } }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.exportSheet({ sheetId: 'sheet_1', fieldIds: [], format: 'xlsx' })
+
+    const url = fetchFn.mock.calls[0][0] as string
+    // No empty fieldIds= (an empty selection server-side is a 400; "all columns" is the absence of the param).
+    expect(url).not.toContain('fieldIds=')
+    expect(url).toContain('format=xlsx')
+    // No viewId when not provided.
+    expect(url).not.toContain('viewId=')
+  })
+
+  it('throws a MultitableApiError carrying the server message + code on a non-2xx (so the caller can toast it)', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(400, { ok: false, error: { code: 'VALIDATION_ERROR', message: 'fieldIds selection resolved to no exportable columns (unknown or not permitted)' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(
+      client.exportSheet({ sheetId: 'sheet_1', fieldIds: ['nope'], format: 'xlsx' }),
+    ).rejects.toMatchObject({
+      name: 'MultitableApiError',
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'fieldIds selection resolved to no exportable columns (unknown or not permitted)',
+    })
+  })
+
+  it('falls back to a generic filename when Content-Disposition is absent', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('bin', { status: 200, headers: { 'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    const { filename } = await client.exportSheet({ sheetId: 'sheet_1', format: 'xlsx' })
+    expect(filename).toBe('export')
+  })
+})

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4384,8 +4384,43 @@ function parseJsonFormField(value: unknown, fieldName: string): unknown {
 }
 
 function buildXlsxAttachmentFilename(sheetName: string): string {
+  return buildExportAttachmentFilename(sheetName, 'xlsx')
+}
+
+// Shared attachment-filename builder for the export route (xlsx + csv share the same sanitization).
+function buildExportAttachmentFilename(sheetName: string, extension: 'xlsx' | 'csv'): string {
   const base = sheetName.replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'multitable'
-  return `${base}.xlsx`
+  return `${base}.${extension}`
+}
+
+// Parse the optional ?format= query param for the export route. Default 'xlsx' (back-compat). 'csv' is the
+// only other accepted value; anything else is an explicit 400 (no silent fallback — a typo'd format must
+// not silently downgrade to xlsx). Returned as a discriminated result so the caller emits a VALIDATION_ERROR.
+function parseExportFormat(value: unknown):
+  | { ok: true; format: 'xlsx' | 'csv' }
+  | { ok: false; message: string } {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (raw === '' || raw === 'xlsx') return { ok: true, format: 'xlsx' }
+  if (raw === 'csv') return { ok: true, format: 'csv' }
+  return { ok: false, message: `Unsupported export format: ${raw} (expected 'xlsx' or 'csv')` }
+}
+
+// Serialize the already-MASKED header + cell matrix as CSV (RFC-4180-ish). The `rows` cells are the
+// serializeXlsxCell projection (string | number | boolean | null | undefined), so this only stringifies +
+// quotes — it adds NO data access and inherits the same field/view/§2a.3-taint mask applied upstream.
+function buildExportCsv(
+  headers: string[],
+  rows: Array<Array<string | number | boolean | null | undefined>>,
+): string {
+  const escape = (value: string | number | boolean | null | undefined): string => {
+    if (value === null || value === undefined) return ''
+    const s = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value)
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  }
+  const lines = [headers.map(escape).join(',')]
+  for (const row of rows) lines.push(row.map(escape).join(','))
+  // CRLF line endings = the CSV de-facto standard (Excel-friendly).
+  return lines.join('\r\n')
 }
 
 async function loadDashboardSourceRows(args: {
@@ -9573,6 +9608,17 @@ export function univerMetaRouter(): Router {
     // hint only; it is intersected with the permitted/masked field set below and can ONLY narrow,
     // never widen — a denied/masked/tainted id requested here stays excluded.
     const requestedFieldIds = parseFieldIdSelection(req.query.fieldIds)
+    // Output format. Default 'xlsx' (unchanged behavior). 'csv' emits the SAME masked + cursor-paginated
+    // FULL-SHEET record set, only re-serialized as CSV — every field/view/§2a.3-taint mask below runs
+    // BEFORE the format branch (the `fields`/`fieldIds`/`rows` pipeline is format-agnostic), so CSV
+    // inherits the identical enforcement with no separate masking path. Unknown values 400 (no silent
+    // fallback — the enum-strictness convention; a typo'd format must not silently downgrade to xlsx).
+    const formatResult = parseExportFormat(req.query.format)
+    if (formatResult.ok === false) {
+      const message = formatResult.message
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message } })
+    }
+    const format = formatResult.format
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
     }
@@ -9676,15 +9722,25 @@ export function univerMetaRouter(): Router {
         cursor = result.hasMore && rows.length < XLSX_MAX_ROWS ? result.nextCursor ?? undefined : undefined
       } while (cursor)
 
+      const headers = fields.map((field) => field.name)
+      // Format branch (mask already applied above — headers/rows are the masked projection). The
+      // truncation header is emitted for BOTH formats so a client can detect a >XLSX_MAX_ROWS cap.
+      res.setHeader('X-MetaSheet-XLSX-Truncated', truncated ? 'true' : 'false')
+      if (format === 'csv') {
+        const csv = buildExportCsv(headers, rows)
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+        res.setHeader('Content-Disposition', `attachment; filename="${buildExportAttachmentFilename(sheet.name, 'csv')}"`)
+        // UTF-8 BOM so Excel opens non-ASCII (e.g. CJK) CSV without mojibake — matches common export tooling.
+        return res.send(Buffer.concat([Buffer.from('﻿', 'utf8'), Buffer.from(csv, 'utf8')]))
+      }
       const xlsx = await loadXlsxModule()
       const buffer = buildXlsxBuffer(xlsx, {
         sheetName: sheet.name,
-        headers: fields.map((field) => field.name),
+        headers,
         rows,
       })
       res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
       res.setHeader('Content-Disposition', `attachment; filename="${buildXlsxAttachmentFilename(sheet.name)}"`)
-      res.setHeader('X-MetaSheet-XLSX-Truncated', truncated ? 'true' : 'false')
       return res.send(buffer)
     } catch (err) {
       if (err instanceof ValidationError) {

--- a/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Export "all rows" via the mask-preserving backend route — full-sheet completeness + mask (real DB).
+ *
+ * The verified bug: the multitable export picker serialized the CLIENT-LOADED grid page (page size 50),
+ * so "all rows" exported at most 50 rows. The fix rewires "all rows" to the backend route
+ * (univer-meta.ts GET /sheets/:sheetId/export-xlsx), which cursor-paginates the WHOLE sheet and applies
+ * the SAME field_permissions + view-hidden + §2a.3 formula-taint masking AFTER the `fieldIds` selection.
+ *
+ * THE keystone here (vs the existing mock-pool canary multitable-export-permission-canary.test.ts): a
+ * REAL DB seeded with > the FE page size (120 rows) — asserting ALL of them are exported proves the route
+ * returns the full sheet, not a 50-row page. Plus, against real seeded `field_permissions`: a denied
+ * column is excluded even when its id is passed in `fieldIds` (the mask is the enforcement boundary;
+ * selection can only narrow), a permitted subset narrows correctly, and the SAME masking holds for the
+ * new `format=csv` path (the format branch re-serializes the already-masked rows; it adds no data access).
+ *
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const xlsx = await import('xlsx') as unknown as {
+  read: (data: unknown, opts: { type: string }) => { SheetNames: string[]; Sheets: Record<string, unknown> }
+  utils: { sheet_to_json: (ws: unknown, opts: { header: 1; raw: false; defval: string }) => string[][] }
+}
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_exp_${TS}`
+const SHEET = `sheet_exp_${TS}`
+const F_NAME = `fld_exp_name_${TS}`
+const F_AMOUNT = `fld_exp_amount_${TS}`
+const F_SECRET = `fld_exp_secret_${TS}` // field_permissions-denied to VIEWER
+const VIEWER = `user_exp_viewer_${TS}`
+// > the FE DEFAULT_PAGE_SIZE (50). 120 also exceeds it by >2 pages, so a page-bound export would be obvious.
+const SEED_ROWS = 120
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+// Parse a binary xlsx export response into a header+cells matrix.
+async function exportXlsxRows(query: Record<string, string> = {}): Promise<string[][]> {
+  const res = await request(app)
+    .get(`/api/multitable/sheets/${SHEET}/export-xlsx`)
+    .query(query)
+    .buffer(true)
+    .parse((r, cb) => {
+      const chunks: Buffer[] = []
+      r.on('data', (c) => chunks.push(Buffer.from(c)))
+      r.on('end', () => cb(null, Buffer.concat(chunks)))
+    })
+  expect(res.status).toBe(200)
+  const parsed = xlsx.read(res.body, { type: 'buffer' })
+  return xlsx.utils.sheet_to_json(parsed.Sheets[parsed.SheetNames[0]], { header: 1, raw: false, defval: '' })
+}
+
+// Parse a CSV export response into a header+cells matrix (BOM-stripped, CRLF-split, RFC-4180 unquoting).
+async function exportCsvRows(query: Record<string, string> = {}): Promise<{ status: number; rows: string[][]; contentType: string }> {
+  const res = await request(app)
+    .get(`/api/multitable/sheets/${SHEET}/export-xlsx`)
+    .query({ format: 'csv', ...query })
+    .buffer(true)
+    .parse((r, cb) => {
+      const chunks: Buffer[] = []
+      r.on('data', (c) => chunks.push(Buffer.from(c)))
+      r.on('end', () => cb(null, Buffer.concat(chunks)))
+    })
+  const text = Buffer.isBuffer(res.body) ? res.body.toString('utf8').replace(/^﻿/, '') : ''
+  const rows = text.length === 0 ? [] : text.split('\r\n').map(parseCsvLine)
+  return { status: res.status, rows, contentType: String(res.header['content-type'] ?? '') }
+}
+
+// Minimal RFC-4180 single-line parser (no embedded newlines in this test's data) → string cells.
+function parseCsvLine(line: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++ } else { inQuotes = false }
+      } else { cur += ch }
+    } else if (ch === '"') { inQuotes = true }
+    else if (ch === ',') { out.push(cur); cur = '' }
+    else { cur += ch }
+  }
+  out.push(cur)
+  return out
+}
+
+describeIfDatabase('multitable export "all rows" via mask route (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: VIEWER, roles: ['member'], perms: ['multitable:read'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'Export Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'Export Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_AMOUNT, SHEET, 'Amount', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_SECRET, SHEET, 'Secret', 'string', '{}', 3])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+
+    // Seed SEED_ROWS records. Name is the row's zero-padded index so we can assert the full set is present.
+    for (let i = 0; i < SEED_ROWS; i++) {
+      const name = `row_${String(i).padStart(4, '0')}`
+      await q(
+        'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [`rec_exp_${TS}_${i}`, SHEET, JSON.stringify({ [F_NAME]: name, [F_AMOUNT]: i, [F_SECRET]: `secret_${i}` })],
+      )
+    }
+    // field_permissions: deny F_SECRET to VIEWER (subject-scoped read mask).
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET, F_SECRET, VIEWER],
+    )
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) "all rows" exports the FULL sheet (every seeded row, > the 50-row client page)', async () => {
+    const rows = await exportXlsxRows()
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    // Name + Amount only (Secret denied) — header proves the mask, body proves completeness.
+    expect(header).toEqual(['Name', 'Amount'])
+    expect(body.length).toBe(SEED_ROWS) // THE regression: not capped at the FE page size (50)
+    expect(body.length).toBeGreaterThan(50)
+    // Every distinct seeded Name is present exactly once (no page truncation, no dupes).
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.size).toBe(SEED_ROWS)
+    expect(names.has('row_0000')).toBe(true)
+    expect(names.has(`row_${String(SEED_ROWS - 1).padStart(4, '0')}`)).toBe(true)
+  })
+
+  test('(b) a field_permissions-denied column is EXCLUDED even when its id is passed in fieldIds (mask holds)', async () => {
+    // Request the denied column explicitly alongside a permitted one — selection must not widen past the mask.
+    const rows = await exportXlsxRows({ fieldIds: `${F_NAME},${F_SECRET}` })
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    expect(header).toEqual(['Name']) // Secret dropped by the mask despite being requested
+    expect(flat).not.toContain('Secret')
+    expect(flat.some((c) => c.startsWith('secret_'))).toBe(false) // no denied value leaked in any cell
+    expect(rows.slice(1).length).toBe(SEED_ROWS) // still the full sheet
+  })
+
+  test('(c) selecting a subset of ALLOWED columns narrows correctly (and stays full-sheet)', async () => {
+    const rows = await exportXlsxRows({ fieldIds: F_AMOUNT })
+    const header = rows[0] ?? []
+    expect(header).toEqual(['Amount']) // narrowed to the one requested permitted column
+    expect(rows.slice(1).length).toBe(SEED_ROWS)
+  })
+
+  test('(d-1) CSV "all rows" exports the FULL sheet with the SAME field mask', async () => {
+    const { status, rows, contentType } = await exportCsvRows()
+    expect(status).toBe(200)
+    expect(contentType).toContain('text/csv')
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    expect(header).toEqual(['Name', 'Amount']) // Secret masked in CSV too
+    expect(body.length).toBe(SEED_ROWS)
+    expect(body.length).toBeGreaterThan(50)
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.size).toBe(SEED_ROWS)
+  })
+
+  test('(d-2) CSV SECURITY: a denied column requested via fieldIds is excluded (mask holds for CSV)', async () => {
+    const { status, rows } = await exportCsvRows({ fieldIds: `${F_NAME},${F_SECRET}` })
+    expect(status).toBe(200)
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    expect(header).toEqual(['Name'])
+    expect(flat.some((c) => c.startsWith('secret_'))).toBe(false)
+  })
+
+  test('(e) all-foreign fieldIds → 400 (no empty/200 file) for both formats', async () => {
+    const xlsxRes = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ fieldIds: 'nope1,nope2' })
+    expect(xlsxRes.status).toBe(400)
+    expect(xlsxRes.body?.error?.code).toBe('VALIDATION_ERROR')
+    const csvRes = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ format: 'csv', fieldIds: 'nope1,nope2' })
+    expect(csvRes.status).toBe(400)
+    expect(csvRes.body?.error?.code).toBe('VALIDATION_ERROR')
+  })
+
+  test('(f) an unsupported format value is a 400 (no silent fallback to xlsx)', async () => {
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ format: 'pdf' })
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('VALIDATION_ERROR')
+  })
+})


### PR DESCRIPTION
## The bug (verified, re-confirmed)

The multitable export picker (`MetaExportDialog.vue`) is shipped and wired, but the handler serialized the **client-loaded grid page** instead of the full sheet:

- `MultitableWorkbench.vue` → `onExportDialogConfirm` exported over `grid.rows` (client-side `doExportCsv` / `doExportXlsx`).
- The grid is page-replaced at `DEFAULT_PAGE_SIZE = 50` (`useMultitableGrid.ts`).
- So choosing **"all rows"** exported at most 50 rows (the loaded page) — a data-loss correctness bug (Feishu exports the whole sheet).
- Meanwhile a mask-preserving backend route existed but was unused by the FE: `GET /sheets/:sheetId/export-xlsx` (`univer-meta.ts`, PR #2591) — it applies `field_permissions` + view-hidden + §2a.3 formula-taint masking **after** the `fieldIds` selection, cursor-paginates the full sheet up to `XLSX_MAX_ROWS`, and 400s on an empty selection.

## The fix (rewiring)

**"All rows" → the mask-preserving backend route.** A new `MultitableApiClient.exportSheet({ sheetId, viewId, fieldIds, format })` hits `GET /sheets/:sheetId/export-xlsx` (auth attached via `apiFetch`, so the request carries the bearer token — a bare `<a href>` download could not), returns the binary blob + the server's `Content-Disposition` filename, and throws a `MultitableApiError` on non-2xx so the caller toasts the server message instead of downloading an error body. The picker's chosen visible columns are sent as `fieldIds` (selection may only **narrow** within the allowed set), plus the active `viewId` (drives the view hidden-field mask + scope validation).

**CSV: `?format=csv` on the SAME route** (chosen over a sibling route or FE-side streaming). The field/view/§2a.3-taint mask runs **before** the format branch — the `headers`/`rows` pipeline is format-agnostic — so CSV inherits the **identical** enforcement with no separate masking path (the cleanest option: it reuses the same masked cell projection, incl. the rich-longText→plain-text step). The route emits CSV with a UTF-8 BOM (Excel-friendly for CJK) + CRLF. An unsupported `format` value is a **400** (no silent fallback to xlsx — the repo's enum-strictness convention). Both formats emit `X-MetaSheet-XLSX-Truncated`.

**"Selected rows" stays client-side** over `grid.rows` (documented in code). Those rows come from `GET /view`, which masks via `filterRecordDataByFieldIds(row.data, allowedFieldIds)` where `allowedFieldIds` is the **taint-masked** set (`maskStoredRecordFieldIds`) — i.e. `grid.rows` are already field-permission AND §2a.3-taint masked, so serializing the chosen subset adds no egress surface. The selected ids are necessarily within the loaded page, so completeness is not at stake. This keeps the change minimal (no new `recordIds` route param).

## Security property (preserved)

A field-permission-hidden or formula-tainted column does **not** appear in the export even if its id is passed in `fieldIds`. The mask is computed **before** the format branch, so it holds for **both** xlsx and csv on the full-sheet path. Selection narrows, never widens — a denied/tainted id requested in `fieldIds` simply falls out of the intersection. Verified by tests (b) and (d-2). The three structural guards (raw-record-data-projection / egress, §2a.3 taint-chokepoint, record-lock) stay green — no new `filterRecordDataByFieldIds` / raw-projection / taint-resolver call site was added.

## Scope notes (named for review)

- **"All rows" = the full sheet, NOT the view-filtered subset.** The route applies the view's hidden-fields but not its row filter/sort (retrofitting in-memory filter/eval would abandon cursor streaming, add a row cap, and a 422-on-computed-filter failure mode — out of scope for this surgical fix). View-filtered export is a follow-up.
- **Column order**: the route emits sheet field order; the old client path used on-screen column order. If a user reordered view columns, the all-rows export column order now follows the sheet, not the view. Cosmetic.

## Tests

- **Real-DB integration** (`multitable-export-allrows-maskroute-realdb.test.ts`, registered in `plugin-tests.yml` inside the `DATABASE_URL`-gated real-DB step): seeds **120 rows** (> the 50-row page) and asserts **ALL** are exported (xlsx + csv); a `field_permissions`-denied column is **excluded even when its id is in `fieldIds`** (xlsx + csv); an allowed subset **narrows**; all-foreign selection and unsupported format both **400**. 8/8 pass via the exact CI command (`vitest --config vitest.integration.config.ts run`).
- **FE unit** (`export-sheet-client.test.ts`): `exportSheet` requests the route with `viewId` + comma-joined `fieldIds` + `format`, omits empty `fieldIds`, returns blob + `Content-Disposition` filename, and throws the server error (message + code) on non-2xx. 4/4 pass.

## Validation

- `pnpm install --frozen-lockfile` — clean (no lockfile drift).
- `cd packages/core-backend && npx tsc --noEmit -p tsconfig.json` — **0 errors**.
- `pnpm --filter @metasheet/web exec vue-tsc -b` — **0 errors**.
- `CI=true pnpm --filter @metasheet/core-backend test` — **357 files / 4676 tests passed, 0 failed** (103 files / 815 real-DB tests skipped without `DATABASE_URL`, as expected).
- Structural guards (egress / taint-chokepoint / record-lock) — green.
- Web suite: the 17 failing files / 111 failing tests are **pre-existing on clean origin/main** (verified by stash → identical baseline); this PR adds **+1 passing file / +4 passing tests** and **zero** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)