### PR TITLE
feat(multitable): A5 full-column scale stats (conditional-formatting scale over the whole filtered column)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -887,6 +887,12 @@ export interface ViewAggregateResult {
   groupFieldId?: string
   groupFieldIds?: string[]
   groups?: ViewAggregateGroup[]
+  // A5 full-column scale stats: present ONLY when `statsFields` was requested. Per-field { min, max,
+  // count } over the WHOLE filtered (+ permission-masked) column — the conditional-formatting scale
+  // (data-bar denominator + color-scale endpoints) uses this instead of the client page's local min/max.
+  // A requested field that the actor cannot read (hidden / denied / tainted / non-numeric) is OMITTED
+  // here (its distribution must not leak), so a missing field → caller keeps its page-local fallback.
+  stats?: Record<string, { min: number; max: number; count: number }>
 }
 
 // Formula dry-run (#5b, design #1869). Diagnostics carry structured context; the client localizes by
@@ -1330,9 +1336,12 @@ export class MultitableApiClient {
   // Footer aggregation (#4-3b-1): server aggregates over the full filtered set. On 413 (too large)
   // parseJson throws a MultitableApiError with code 'AGGREGATE_TOO_LARGE' — caller handles, never
   // falls back to local aggregation.
-  async aggregateView(params: { sheetId: string; viewId?: string; search?: string }): Promise<ViewAggregateResult> {
-    const { sheetId, ...rest } = params
-    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/view-aggregate${qs(rest as Record<string, string | undefined>)}`)
+  async aggregateView(params: { sheetId: string; viewId?: string; search?: string; statsFields?: string[] }): Promise<ViewAggregateResult> {
+    const { sheetId, statsFields, ...rest } = params
+    // A5: request full-column numeric min/max/count for the given fields (conditional-formatting scale).
+    // Joined CSV → the server omits `stats` entirely when this is absent (byte-identical footer shape).
+    const query = qs({ ...(rest as Record<string, string | undefined>), statsFields: statsFields && statsFields.length ? statsFields.join(',') : undefined })
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/view-aggregate${query}`)
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -540,18 +540,76 @@ const EMPTY_SCALE_MAP: FieldScaleMap = Object.freeze({
   byField: Object.freeze({}) as Record<string, FieldScaleResult>,
 }) as FieldScaleMap
 
+/** Server-computed full-column numeric stats per fieldId (A5). Mirrors the
+ *  `view-aggregate?statsFields=…` response's `stats` map — min/max over the WHOLE
+ *  filtered+permission-masked column. A field absent here → no server stats (the
+ *  builder falls back to the page-local min/max for that field). */
+export type FieldScaleServerStats = Record<string, { min: number; max: number; count?: number }>
+
+// Numeric field types that accept a value→endpoint scale (data-bar / color-scale auto range). Mirror of
+// the backend `isNumericFieldType` (aggregation-helpers.ts) — keep in sync. Only these can request
+// full-column server stats (the server also re-checks the type before returning any min/max).
+const NUMERIC_SCALE_FIELD_TYPES: ReadonlySet<string> = new Set(['number', 'currency', 'percent', 'rating', 'duration', 'autoNumber'])
+
+/**
+ * A5 lazy gate: which fieldIds need a FULL-COLUMN server min/max. A field qualifies iff its (first,
+ * enabled) scale rule is `dataBar` or `colorScale` AND its range is `auto` (a `fixed` range uses its own
+ * bounds; `iconSet` uses absolute thresholds — neither needs min/max) AND the field is a numeric type.
+ * Returns a sorted, de-duplicated list (stable cache key). Empty → the caller skips the network entirely.
+ */
+export function scaleStatsFieldIds(
+  rules: ConditionalFormattingScaleRule[],
+  fieldTypeById: Record<string, string | undefined>,
+): string[] {
+  const out = new Set<string>()
+  for (const rule of rules) {
+    if (!rule.enabled) continue
+    if (rule.kind !== 'dataBar' && rule.kind !== 'colorScale') continue
+    if (rule.range.mode !== 'auto') continue
+    if (out.has(rule.fieldId)) continue
+    const type = fieldTypeById[rule.fieldId]
+    if (!type || !NUMERIC_SCALE_FIELD_TYPES.has(type)) continue
+    out.add(rule.fieldId)
+  }
+  return [...out].sort()
+}
+
+/**
+ * A5 idle-gated refetch decision (pure — extracted so it is unit-tested without mounting the workbench).
+ * The full-column stats are over the PERSISTED view filter, so the caller must NOT refetch while the grid is
+ * loading (the persist may be in flight) and must NOT refetch on an unchanged key (pagination / no-op).
+ *
+ * The KEY encodes the post-apply (persisted) filter + search + view + requested fields. Returning
+ * `{ fetch: true }` ALSO yields the key the caller must store as the new `lastKey`. The contract that makes
+ * draft-filter edits safe: the caller passes the live key (which reflects a draft edit) but only INVOKES
+ * this on idle-safe triggers — a draft edit alone never calls in, so it can neither fetch nor advance
+ * `lastKey`; the post-apply call then sees `key !== lastKey` and fetches. See MultitableWorkbench wiring.
+ */
+export function decideScaleStatsRefetch(
+  input: { loading: boolean; key: string; lastKey: string },
+): { fetch: false } | { fetch: true; key: string } {
+  if (input.loading) return { fetch: false } // mid-load → wait for the idle edge
+  if (input.key === input.lastKey) return { fetch: false } // unchanged (pagination / no-op re-fire)
+  return { fetch: true, key: input.key }
+}
+
 /**
  * Pre-compute scale presentation (data-bar / color-scale / icon-set) per
- * (fieldId, recordId). Mirrors the backend `buildFieldScaleMap`: min/max over
- * the passed records (auto) or the rule's fixed range; dataBar → 0..100 fill
+ * (fieldId, recordId). Mirrors the backend `buildFieldScaleMap`: for an `auto`
+ * range, the min/max come from `serverStats` (full filtered column) when that
+ * field has an entry, else from the passed records (page-local fallback); a
+ * `fixed` range always uses the rule's own bounds. dataBar → 0..100 fill
  * (degenerate range → full bar, negatives take negativeColor); colorScale →
- * interpolated scaleColor; iconSet → iconKey bucket; non-numeric skipped; first
- * rule per field wins. The grid renders all three (MetaGridTable, #2640/#2680).
- * Caller passes the already-loaded/masked rows (client-side discipline).
+ * interpolated scaleColor; iconSet → iconKey bucket (absolute thresholds — never
+ * uses min/max); non-numeric skipped; first rule per field wins. The grid renders
+ * all three (MetaGridTable, #2640/#2680). Caller passes the already-loaded/masked
+ * rows for per-record presentation; `serverStats` only relocates the AUTO
+ * endpoints to the full column (A5) — the per-record cell values are still local.
  */
 export function buildFieldScaleMap(
   rules: ConditionalFormattingScaleRule[],
   records: ReadonlyArray<MetaRecord | { id?: string; data?: Record<string, unknown> }>,
+  serverStats?: FieldScaleServerStats,
 ): FieldScaleMap {
   if (!rules.length || !records.length) return EMPTY_SCALE_MAP
   const byField: Record<string, FieldScaleResult> = {}
@@ -565,9 +623,14 @@ export function buildFieldScaleMap(
 
     let min: number
     let max: number
+    const serverEntry = serverStats?.[rule.fieldId]
     if (rule.range.mode === 'fixed' && typeof rule.range.min === 'number' && typeof rule.range.max === 'number') {
       min = rule.range.min
       max = rule.range.max
+    } else if (serverEntry && Number.isFinite(serverEntry.min) && Number.isFinite(serverEntry.max)) {
+      // A5: auto range over the FULL filtered column (server stats) — not just the loaded page.
+      min = serverEntry.min
+      max = serverEntry.max
     } else {
       let lo = Infinity
       let hi = -Infinity

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -610,7 +610,7 @@ import {
 } from '../utils/view-display-prefs'
 import { useAiShortcut } from '../composables/useAiShortcut'
 import type { AiShortcutConfigInput } from '../api/client'
-import { buildFieldScaleMap, buildRecordFormattingMap, extractRulesFromConfig, extractScaleRulesFromConfig } from '../utils/conditional-formatting'
+import { buildFieldScaleMap, buildRecordFormattingMap, decideScaleStatsRefetch, extractRulesFromConfig, extractScaleRulesFromConfig, scaleStatsFieldIds, type FieldScaleServerStats } from '../utils/conditional-formatting'
 import {
   decorateAndSortBases,
   readFavoriteBaseIds,
@@ -1040,11 +1040,25 @@ const conditionalFormattingByRecord = computed(() => buildRecordFormattingMap(
   grid.rows.value,
   scopedAllFields.value,
 ))
-// A5-1: data-bar scale formatting. min/max over the already-loaded/masked rows
-// (client-side discipline; full-column server aggregate is a separate follow-up).
-const conditionalFormattingScaleByField = computed(() => buildFieldScaleMap(
+const conditionalFormattingScaleRules = computed(() =>
   extractScaleRulesFromConfig(workbench.activeView.value?.config),
+)
+// A5: full-column scale stats fetched lazily from the server (view-aggregate?statsFields) and keyed per
+// (view+filter+search). When present for a field, buildFieldScaleMap uses the FULL-column min/max for that
+// field's AUTO-range data-bar/color-scale endpoints; absent (no rule, non-numeric, denied, or fetch
+// failed) → it falls back to the page-local min/max. The per-record cell presentation is always local.
+const scaleServerStats = ref<FieldScaleServerStats>({})
+// A5-1/2/3: data-bar / color-scale / icon-set scale formatting. Per-record presentation over the loaded
+// rows; AUTO endpoints relocated to the full filtered column via scaleServerStats (A5) when available.
+const conditionalFormattingScaleByField = computed(() => buildFieldScaleMap(
+  conditionalFormattingScaleRules.value,
   grid.rows.value,
+  scaleServerStats.value,
+))
+// Numeric fields whose (auto-range) data-bar/color-scale rule needs a full-column min/max. Empty → no fetch.
+const autoScaleStatsFieldIds = computed(() => scaleStatsFieldIds(
+  conditionalFormattingScaleRules.value,
+  Object.fromEntries(scopedAllFields.value.map((f) => [f.id, f.type])),
 ))
 const readOnlyFieldIds = computed(() =>
   Object.entries(effectiveFieldPermissions.value)
@@ -2326,6 +2340,75 @@ watch(
   () => { void loadAggregates() },
   { immediate: true },
 )
+
+// A5: full-column scale stats. Fetch min/max/count over the WHOLE filtered + permission-masked column for
+// every auto-range numeric data-bar/color-scale field, so the gradient/bar denominator is correct across
+// pages. Lazy (only fields with such a rule), cached per view+filter+search, server enforces the leak gate
+// (a denied/tainted/non-numeric column returns no stats → we keep the page-local fallback for it).
+let scaleStatsReqSeq = 0
+async function loadScaleStats() {
+  const sheetId = workbench.activeSheetId.value
+  const viewId = workbench.activeViewId.value
+  const statsFields = autoScaleStatsFieldIds.value
+  const seq = ++scaleStatsReqSeq // monotonic: a slow stale response must not overwrite a newer one
+  if (!sheetId || statsFields.length === 0) {
+    scaleServerStats.value = {} // no scale rules need a full-column min/max → drop to page-local
+    return
+  }
+  try {
+    const r = await workbench.client.aggregateView({ sheetId, viewId: viewId || undefined, search: searchText.value || undefined, statsFields })
+    if (seq !== scaleStatsReqSeq) return // a newer request superseded this one
+    scaleServerStats.value = r.stats ?? {}
+  } catch {
+    if (seq !== scaleStatsReqSeq) return
+    // 413 (too large) / 422 (computed-filter view) / network → clear so buildFieldScaleMap falls back to
+    // the page-local min/max for these fields (the existing, correct degradation — never an error surface).
+    scaleServerStats.value = {}
+  }
+}
+// Idle-gated trigger (race-free): the server reads the PERSISTED view filterInfo. A filter APPLY routes
+// through grid.applySortFilter → loadViewData, which sets grid.loading=true BEFORE it awaits
+// persistSortFilter, so the loading true→false edge fires AFTER the filter is persisted and the grid
+// filter refs agree with it. View-switch / search / pagination / scale-rule edits all flow through here.
+//
+// CRUCIAL: the draft filter refs are part of the dedup KEY (so the post-apply fetch isn't deduped against a
+// pre-apply one) but are NOT watch SOURCES. A draft edit (e.g. onSetConjunction mutates filterConjunction
+// with no apply) must NOT trigger a fetch — the server still has the OLD persisted filter, and worse, firing
+// would advance lastScaleStatsKey to the draft key and then SUPPRESS the real post-apply fetch (stale stats).
+// So the handler runs only on idle-safe triggers, and computes/compares the full key (reading the filter
+// refs) INSIDE the handler — draft edits can neither trigger nor advance lastScaleStatsKey.
+const scaleStatsKey = () => JSON.stringify([
+  workbench.activeSheetId.value,
+  workbench.activeViewId.value,
+  grid.filterConjunction.value,
+  grid.filterRules.value,
+  grid.filterGroups.value,
+  searchText.value,
+  autoScaleStatsFieldIds.value,
+])
+let lastScaleStatsKey = ''
+watch(
+  // Triggers = idle-safe signals only. Filter APPLY is captured by the grid.loading edge (every apply goes
+  // through loadViewData); draft filter mutations are deliberately absent so they cannot trigger/dedup-advance.
+  [
+    () => grid.loading.value,
+    () => workbench.activeSheetId.value,
+    () => workbench.activeViewId.value,
+    () => searchText.value,
+    () => autoScaleStatsFieldIds.value.join(','),
+  ],
+  () => {
+    // Pure decision (unit-tested in multitable-cf-scale): skip while loading, skip on unchanged key,
+    // otherwise fetch + adopt the new key. The key reads the live (possibly-draft) filter refs, but this
+    // handler only runs on idle-safe triggers, so a draft edit can neither fetch nor advance lastScaleStatsKey.
+    const decision = decideScaleStatsRefetch({ loading: grid.loading.value, key: scaleStatsKey(), lastKey: lastScaleStatsKey })
+    if (!decision.fetch) return
+    lastScaleStatsKey = decision.key
+    void loadScaleStats()
+  },
+  { immediate: true },
+)
+
 // Nested grouping: setGroupFields PERSISTS groupInfo (server reads it to compute per-level subtotals),
 // so re-aggregate only AFTER the persist resolves — otherwise the request would read the stale
 // groupInfo and the new level's subtotals would never appear. Local display-grouping updates instantly

--- a/apps/web/tests/multitable-cf-scale.spec.ts
+++ b/apps/web/tests/multitable-cf-scale.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildFieldScaleMap,
+  decideScaleStatsRefetch,
   extractScaleRulesFromConfig,
   sanitizeScaleRule,
   sanitizeScaleRules,
+  scaleStatsFieldIds,
   lerpHexColor,
 } from '../src/multitable/utils/conditional-formatting'
 import { CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT } from '../src/multitable/types'
@@ -182,5 +184,145 @@ describe('FE lerpHexColor parity', () => {
     expect(lerpHexColor('#000000ff', '#ffffff00', 0.5)).toBe('#808080')
     expect(lerpHexColor('#000000', '#ffffff', -1)).toBe('#000000')
     expect(lerpHexColor('#000000', '#ffffff', 2)).toBe('#ffffff')
+  })
+})
+
+// ===========================================================================
+// A5 full-column scale stats: when the caller passes server min/max (the whole
+// filtered column), the AUTO-range builder uses THOSE endpoints instead of the
+// page-local min/max — so the gradient/bar is correct across pages.
+// ===========================================================================
+
+describe('A5 buildFieldScaleMap uses server stats for the auto-range endpoints', () => {
+  // The loaded PAGE only has values 10..20, but the full column (server) is 0..100.
+  const page = [
+    { id: 'r1', data: { fld_n: 10 } },
+    { id: 'r2', data: { fld_n: 20 } },
+  ]
+
+  it('data-bar: page-local would be 10/20; server 0..100 → r1=10%, r2=20% (full column)', () => {
+    const rule = sanitizeScaleRule(validBar())! // auto range
+    // Sanity: WITHOUT server stats the page-local endpoints make r1=0%, r2=100%.
+    const local = buildFieldScaleMap([rule], page).byField.fld_n
+    expect([local.min, local.max]).toEqual([10, 20])
+    expect([local.byRecordId.r1.barPct, local.byRecordId.r2.barPct]).toEqual([0, 100])
+    // WITH server stats the endpoints become the full column 0..100.
+    const f = buildFieldScaleMap([rule], page, { fld_n: { min: 0, max: 100, count: 50 } }).byField.fld_n
+    expect([f.min, f.max]).toEqual([0, 100])
+    expect(f.byRecordId.r1.barPct).toBe(10) // 10 / 100
+    expect(f.byRecordId.r2.barPct).toBe(20) // 20 / 100
+  })
+
+  it('color-scale: interpolates against the server min/max, not the page min/max', () => {
+    const rule = sanitizeScaleRule({
+      id: 'cs', fieldId: 'fld_n', kind: 'colorScale', order: 0, range: { mode: 'auto' },
+      colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+    })!
+    // Full column 0..100 → value 10 sits at t=0.1 → #1a1a1a (not #000000 it would be at page-local min).
+    const f = buildFieldScaleMap([rule], page, { fld_n: { min: 0, max: 100 } }).byField.fld_n
+    expect(f.byRecordId.r1.scaleColor).toBe(lerpHexColor('#000000', '#ffffff', 0.1))
+    expect(f.byRecordId.r1.scaleColor).not.toBe('#000000') // would be #000000 with page-local min=10
+  })
+
+  it('a FIXED range ignores server stats (uses its own bounds)', () => {
+    const fixed = sanitizeScaleRule(validBar({ range: { mode: 'fixed', min: 0, max: 50 } }))!
+    const f = buildFieldScaleMap([fixed], page, { fld_n: { min: 0, max: 100 } }).byField.fld_n
+    expect([f.min, f.max]).toEqual([0, 50]) // fixed bounds win over server stats
+    expect(f.byRecordId.r2.barPct).toBe(40) // 20 / 50, NOT 20 / 100
+  })
+
+  it('falls back to page-local min/max when the field has no server entry', () => {
+    const rule = sanitizeScaleRule(validBar())!
+    const f = buildFieldScaleMap([rule], page, { other_field: { min: 0, max: 100 } }).byField.fld_n
+    expect([f.min, f.max]).toEqual([10, 20]) // no fld_n entry → page-local
+  })
+
+  it('ignores a server entry with non-finite bounds (defensive) → page-local', () => {
+    const rule = sanitizeScaleRule(validBar())!
+    const f = buildFieldScaleMap([rule], page, { fld_n: { min: NaN, max: 100 } as { min: number; max: number } }).byField.fld_n
+    expect([f.min, f.max]).toEqual([10, 20])
+  })
+})
+
+describe('A5 scaleStatsFieldIds — the lazy fetch gate', () => {
+  const numericTypes = { fld_n: 'number', fld_cur: 'currency', fld_str: 'text' }
+
+  it('includes only auto-range data-bar / color-scale on a numeric field', () => {
+    const bar = sanitizeScaleRule(validBar({ id: 'b', fieldId: 'fld_n' }))!
+    const cs = sanitizeScaleRule({
+      id: 'c', fieldId: 'fld_cur', kind: 'colorScale', order: 1, range: { mode: 'auto' },
+      colorScale: { stops: [{ at: 'min', color: '#000000' }, { at: 'max', color: '#ffffff' }] },
+    })!
+    expect(scaleStatsFieldIds([bar, cs], numericTypes)).toEqual(['fld_cur', 'fld_n']) // sorted, de-duped
+  })
+
+  it('excludes iconSet (absolute thresholds), fixed range, and non-numeric / unknown fields', () => {
+    const icon = sanitizeScaleRule({
+      id: 'i', fieldId: 'fld_n', kind: 'iconSet', order: 0, range: { mode: 'auto' },
+      iconSet: { set: 'arrows3', thresholds: [10, 20] },
+    })!
+    const fixedBar = sanitizeScaleRule(validBar({ id: 'fx', fieldId: 'fld_cur', range: { mode: 'fixed', min: 0, max: 9 } }))!
+    const strBar = sanitizeScaleRule(validBar({ id: 's', fieldId: 'fld_str' }))! // string field
+    const unknownBar = sanitizeScaleRule(validBar({ id: 'u', fieldId: 'fld_missing' }))!
+    expect(scaleStatsFieldIds([icon, fixedBar, strBar, unknownBar], numericTypes)).toEqual([])
+  })
+
+  it('excludes disabled rules', () => {
+    const disabled = sanitizeScaleRule(validBar({ id: 'd', fieldId: 'fld_n', enabled: false }))!
+    expect(scaleStatsFieldIds([disabled], numericTypes)).toEqual([])
+  })
+})
+
+describe('A5 decideScaleStatsRefetch — idle-gated refetch decision', () => {
+  it('does not fetch while loading (persist may be in flight)', () => {
+    expect(decideScaleStatsRefetch({ loading: true, key: 'B', lastKey: 'A' })).toEqual({ fetch: false })
+  })
+
+  it('does not fetch when the key is unchanged (pagination / no-op re-fire)', () => {
+    expect(decideScaleStatsRefetch({ loading: false, key: 'A', lastKey: 'A' })).toEqual({ fetch: false })
+  })
+
+  it('fetches + adopts the new key when idle and the key changed', () => {
+    expect(decideScaleStatsRefetch({ loading: false, key: 'B', lastKey: 'A' })).toEqual({ fetch: true, key: 'B' })
+  })
+
+  // The regression this guards: a DRAFT filter edit (no apply) must NOT advance lastKey, otherwise the
+  // real post-apply fetch is suppressed and the scale renders B's rows with A's (stale) min/max. The
+  // workbench only INVOKES this on idle-safe triggers (the grid.loading edge + view/search/fields), never
+  // on a draft filter ref change — so a draft edit never reaches this decision. We simulate the full flow:
+  // the only calls that happen are at the loading edges; the draft mutation in between is a no-call.
+  it('draft-edit-then-apply still fetches with the POST-APPLY key (no stale suppression)', () => {
+    let lastKey = ''
+    const apply = (loading: boolean, key: string) => {
+      const d = decideScaleStatsRefetch({ loading, key, lastKey })
+      if (d.fetch) lastKey = d.key
+      return d.fetch
+    }
+    // 1) Filter A applied: loading goes true (no fetch) then false (fetch A).
+    expect(apply(true, 'K_A')).toBe(false)
+    expect(apply(false, 'K_A')).toBe(true)
+    expect(lastKey).toBe('K_A')
+    // 2) User edits a DRAFT filter to B with NO apply → the workbench does NOT call decide at all (the
+    //    filter refs are not watch triggers). lastKey stays K_A. (No invocation = nothing to assert here.)
+    // 3) User clicks apply: loading true (no fetch), persist B, loading false → the key is now K_B (the
+    //    handler reads the just-persisted refs) → fetch fires for B. This is the bug fix.
+    expect(apply(true, 'K_B')).toBe(false)
+    expect(apply(false, 'K_B')).toBe(true)
+    expect(lastKey).toBe('K_B')
+  })
+
+  // Counter-proof: if a draft edit WERE allowed to call decide (the buggy wiring), it would advance lastKey
+  // to K_B before apply, and the post-apply call would be suppressed → stale. This documents WHY the
+  // workbench must not put the draft filter refs in the watch source list.
+  it('counter-proof: a draft edit reaching decide would suppress the post-apply fetch (the bug)', () => {
+    let lastKey = ''
+    const apply = (loading: boolean, key: string) => {
+      const d = decideScaleStatsRefetch({ loading, key, lastKey })
+      if (d.fetch) lastKey = d.key
+      return d.fetch
+    }
+    expect(apply(false, 'K_A')).toBe(true) // A applied + fetched
+    expect(apply(false, 'K_B')).toBe(true) // BUGGY: draft edit reaches decide while idle → advances to K_B
+    expect(apply(false, 'K_B')).toBe(false) // post-apply: key already K_B → SUPPRESSED (stale stats)
   })
 })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -87,7 +87,7 @@ import {
   tryResolveView as tryResolveViewShared,
   type MultitableViewConfig as SharedMultitableViewConfig,
 } from '../multitable/loaders'
-import { parseAggregations, aggregateField, groupRowsByFields, type AggregateGroupBucket, type AggregationFn } from '../multitable/aggregation-helpers'
+import { parseAggregations, aggregateField, groupRowsByFields, isNumericFieldType, type AggregateGroupBucket, type AggregationFn } from '../multitable/aggregation-helpers'
 import { ensureLegacyBase as ensureLegacyBaseShared } from '../multitable/provisioning'
 import {
   MultitableTemplateConflictError,
@@ -9704,6 +9704,25 @@ export function univerMetaRouter(): Router {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const viewId = typeof req.query.viewId === 'string' ? req.query.viewId.trim() : ''
     const search = normalizeSearchTerm(req.query.search) // same normalization as /view (trim+lowercase) → search parity
+    // A5 full-column scale stats: optional CSV of field ids the caller wants numeric min/max/count for
+    // (conditional-formatting scale endpoints — data-bar denominator + color-scale gradient bounds, computed
+    // over the WHOLE filtered column, not the client page). ABSENT (or empty) → `stats` is OMITTED from the
+    // response (byte-identical to the footer-only shape — the existing aggregate tests assert exact bodies).
+    // Each requested field is gated through the SAME layer-1∧layer-3∧taint-survived OUTPUT set as the footer
+    // aggregates (aggregateFieldTypeById below), so a hidden/denied/tainted field yields NO stats (its
+    // min/max would leak the column's distribution) — see the leak gate at the stats build.
+    const statsFieldIds = (() => {
+      const raw = req.query.statsFields
+      const csv = typeof raw === 'string' ? raw : Array.isArray(raw) && typeof raw[0] === 'string' ? (raw[0] as string) : ''
+      if (!csv) return null
+      const seen = new Set<string>()
+      for (const part of csv.split(',')) {
+        const id = part.trim()
+        if (id) seen.add(id)
+        if (seen.size >= 200) break // bound the request fan-out (a sheet can't realistically scale > this many columns)
+      }
+      return seen.size > 0 ? seen : null
+    })()
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
     }
@@ -9823,6 +9842,33 @@ export function univerMetaRouter(): Router {
         }
         return out
       }
+
+      // A5 full-column SCALE STATS (only when statsFields was requested). Per-field { min, max, count }
+      // over the SAME filtered + row-deny-masked `rows` the footer aggregates use, so the conditional-
+      // formatting scale (data-bar denominator + color-scale endpoints) spans the WHOLE filtered column,
+      // not the client page. LEAK GATE: a requested field is included ONLY if it survived
+      // aggregateFieldTypeById (layer-1∧layer-3∧§2a.3-taint, identical to computeAggregates) AND is a
+      // numeric type — a hidden/denied/tainted/non-numeric field gets NO entry, so its distribution
+      // (min/max) is never disclosed. `count` is the numeric-value count (omits non-numeric/empty cells),
+      // matching what the FE scale uses; min===max is valid (a constant column → FE renders a full bar).
+      const computeScaleStats = (): Record<string, { min: number; max: number; count: number }> => {
+        const out: Record<string, { min: number; max: number; count: number }> = {}
+        if (!statsFieldIds) return out
+        for (const fieldId of statsFieldIds) {
+          const fieldType = aggregateFieldTypeById.get(fieldId)
+          if (!fieldType || !isNumericFieldType(fieldType)) continue // hidden / denied / tainted / non-numeric → omit (no leak)
+          // countNonEmpty over a numeric field = the count of numeric values that fed min/max (numeric
+          // fields never hold non-numeric non-empty cells in practice; empty cells are excluded by both).
+          const values = rows.map((rec) => rec.data[fieldId])
+          const min = aggregateField(values, 'min', fieldType)
+          const max = aggregateField(values, 'max', fieldType)
+          if (min === null || max === null) continue // no numeric values in the filtered column → omit
+          const count = aggregateField(values, 'countNonEmpty', fieldType) ?? 0
+          out[fieldId] = { min, max, count }
+        }
+        return out
+      }
+
       // group subtotals (#4-3b-2a / nested grouping): grid group fields are view.groupInfo.fieldIds
       // (ordered list, NEW multi-level shape) with dual-read of the legacy single view.groupInfo.fieldId
       // for back-compat (NOT view.config.groupFieldId). Resolve + run the 422 gates BEFORE the grand
@@ -9856,9 +9902,12 @@ export function univerMetaRouter(): Router {
       }
 
       const aggregates = computeAggregates(rows.map((rec) => rec.data))
+      // `stats` is added ONLY when statsFields was requested → when absent the response stays
+      // byte-identical to the footer-only shape (the existing aggregate tests assert exact bodies).
+      const statsField = statsFieldIds ? { stats: computeScaleStats() } : {}
       if (groupFieldIds.length === 0) {
-        // not grouped → response byte-identical to #4-3b-1
-        return res.json({ ok: true, data: { total: rows.length, aggregates } })
+        // not grouped → response byte-identical to #4-3b-1 (plus `stats` iff requested)
+        return res.json({ ok: true, data: { total: rows.length, aggregates, ...statsField } })
       }
       // Recurse the bucket tree → response tree. Each node aggregates over its OWN full membership
       // (node.rows); children are NEVER summed for avg/countDistinct (groupRowsByFields keeps node.rows
@@ -9872,8 +9921,8 @@ export function univerMetaRouter(): Router {
         }))
       const groups = serializeBuckets(groupRowsByFields(rows.map((rec) => rec.data), groupFieldIds))
       // Emit the ordered fieldIds[] (NEW) plus the legacy single groupFieldId = level-1 (back-compat for
-      // any reader still on the single-field shape).
-      return res.json({ ok: true, data: { total: rows.length, aggregates, groupFieldId: groupFieldIds[0], groupFieldIds, groups } })
+      // any reader still on the single-field shape). `stats` (grand-total scale stats) appended iff requested.
+      return res.json({ ok: true, data: { total: rows.length, aggregates, groupFieldId: groupFieldIds[0], groupFieldIds, groups, ...statsField } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/integration/multitable-view-aggregate.test.ts
+++ b/packages/core-backend/tests/integration/multitable-view-aggregate.test.ts
@@ -295,4 +295,54 @@ describeIfDatabase('multitable view-aggregate (real DB)', () => {
     const groups = res.body.data.groups as Array<{ children?: unknown }>
     expect(groups.every((g) => g.children === undefined)).toBe(true) // single level → no nesting
   })
+
+  // ---- A5 full-column scale stats (statsFields) ----
+
+  test('STATS ABSENT: no statsFields → response has NO `stats` key (byte-identical footer shape)', async () => {
+    const res = await aggregate(V_MAIN) // no statsFields param
+    expect(res.status).toBe(200)
+    expect(res.body.data.stats).toBeUndefined()
+  })
+
+  test('STATS full-column: min/max/count over the FULL set (60 rows), NOT a page', async () => {
+    // FLD_QTY = 1..60. A page-scoped scan (50 rows) would yield max 50; the full column must be 60.
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_MAIN}&statsFields=${FLD_QTY}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.total).toBe(N)
+    expect(res.body.data.stats[FLD_QTY]).toEqual({ min: 1, max: 60, count: 60 })
+  })
+
+  test('STATS LEAK GATE: a field-permission-denied numeric column returns NO stats', async () => {
+    // FLD_SECRET is numeric (1..60) but field_permissions.visible=false for USER. Its min/max would leak
+    // the column's distribution → it MUST be omitted from `stats` (the SAME gate as the footer aggregate).
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_MAIN}&statsFields=${FLD_QTY},${FLD_SECRET}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.stats[FLD_QTY]).toEqual({ min: 1, max: 60, count: 60 }) // readable → present
+    expect(res.body.data.stats[FLD_SECRET]).toBeUndefined() // denied → omitted, NOT null/0 (no distribution leak)
+  })
+
+  test('STATS respects the PERSISTED view filter (cat=A → odd i, qty 1..59)', async () => {
+    // V_FILTER persists cat=A → odd i → FLD_QTY ∈ {1,3,…,59}: min 1, max 59, count 30. Proves the stats
+    // are scoped to the FILTERED set (not the whole sheet).
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_FILTER}&statsFields=${FLD_QTY}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.total).toBe(30)
+    expect(res.body.data.stats[FLD_QTY]).toEqual({ min: 1, max: 59, count: 30 })
+  })
+
+  test('STATS non-numeric / unknown requested fields are omitted (no leak, no error)', async () => {
+    // FLD_CAT is a string → not a numeric scale field; a bogus id has no field. Both omitted; FLD_QTY present.
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_MAIN}&statsFields=${FLD_CAT},nope_${TS},${FLD_QTY}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.stats[FLD_CAT]).toBeUndefined() // string → omitted
+    expect(res.body.data.stats[`nope_${TS}`]).toBeUndefined() // unknown → omitted
+    expect(res.body.data.stats[FLD_QTY]).toBeDefined()
+  })
+
+  test('STATS coexist with grouping: a grouped view still returns grand-total `stats`', async () => {
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_GROUP}&statsFields=${FLD_QTY}`)
+    expect(res.status).toBe(200)
+    expect(res.body.data.groups).toBeDefined() // grouping intact
+    expect(res.body.data.stats[FLD_QTY]).toEqual({ min: 1, max: 60, count: 60 }) // grand-total full-column stats
+  })
 })


### PR DESCRIPTION
## What & why

Feishu-parity lane **A5 — full-column scale aggregation**.

Conditional-formatting **color-scale gradient** + **data-bar denominator** were computed over the **client-loaded page (~50 rows)**, so the gradient/bar was wrong once data spanned more than one page. Feishu computes the scale over the whole **(filtered)** column. The render (`MetaGridTable.vue` scale fill) is already shipped; this swaps only the **min/max source** to a permission-correct full-column one.

**STEP 1 (verified, not assumed):** the page-scoped min/max is the `auto`-range branch of `buildFieldScaleMap` in `apps/web/src/multitable/utils/conditional-formatting.ts` — it iterated the passed `records` (the loaded page; the old docstring literally said "Caller passes the already-loaded/masked rows"). Confirmed page-scoped, not server-fed → A5 was **not** done.

## What I built

**Backend** — extended `GET /api/multitable/sheets/:sheetId/view-aggregate` (the existing view-aggregate path, which already applies the view filter, row-level deny, and field-permission/taint masking) with an optional **`statsFields`** (CSV) param. Returns `stats: { [fieldId]: { min, max, count } }` over the **same filtered + row-deny-masked record set** the footer aggregates use.

- **Leak gate (security):** stats are emitted **only** for fields that survived the existing `aggregateFieldTypeById` set — **layer-1 ∧ layer-3 ∧ §2a.3-taint** (identical to `computeAggregates`) **and** are a numeric type. A field-permission-hidden / denied / taint-dropped / non-numeric field gets **no `stats` entry** (a min/max would leak the column's distribution). Row-level-denied rows are already excluded from `rows` before the stats run.
- **No new leak surface:** reuses the already-masked field set + the pure `aggregateField` reducer — **no** new `filterRecordDataByFieldIds` / raw-`.data` projection / taint-resolver call. The egress-coverage, taint-chokepoint, raw-projection, and record-lock structural guards stay green.
- **Byte-identical when absent:** `stats` is added only when `statsFields` is present, so the footer-only response shape is unchanged (the existing exact-body aggregate tests still pass).

**Frontend**
- `buildFieldScaleMap(rules, records, serverStats?)` — an `auto` range now prefers the full-column server min/max when present, else falls back to the page-local scan. `fixed` range and `iconSet` (absolute thresholds) are untouched.
- `MultitableWorkbench.vue` — fetches stats **lazily** (only numeric columns with an `auto` data-bar/color-scale rule, via `scaleStatsFieldIds`), **cached** per `view+filter+search`, **refetched on filter change** via an **idle-gated** watcher (fires on the `grid.loading` true→false edge, i.e. **after** the filter persists — race-free) with a monotonic seq guard. On 413/422/network it clears the stats → page-local fallback (never an error surface). The refetch decision is a pure, unit-tested function (`decideScaleStatsRefetch`); draft filter edits are kept **out** of the watch triggers so they can't advance the dedup key and suppress the real post-apply fetch.

## Tests

- **Real-DB integration** (extends `multitable-view-aggregate.test.ts`, already registered in `plugin-tests.yml`): full-column min/max/count over **60 rows** (proves full-column, not the 50-row page); **denied numeric column returns NO stats** (leak gate); **view filter narrows** the stats (cat=A → 30 rows, min 1/max 59); byte-identical when absent; non-numeric/unknown omitted; grouping coexistence. **25/25 pass** against local Postgres.
- **FE unit** (`multitable-cf-scale.spec.ts`): scale uses server min/max when present (data-bar + color-scale); `fixed`/no-entry/non-finite fallbacks; `scaleStatsFieldIds` gate; the idle-gated refetch decision incl. the **draft-then-apply regression + its counter-proof**. **28/28 pass.**

## Validation (all green)

- `pnpm install --frozen-lockfile` (no lockfile change)
- `core-backend` `tsc --noEmit` → 0 errors; `@metasheet/web` `vue-tsc -b` → 0 errors
- `CI=true pnpm --filter @metasheet/core-backend test` → **4676 passed, 0 failed**
- Structural guards (egress-coverage / taint-chokepoint / raw-projection / record-lock) → green

## Security statement

Field-permission and §2a.3 taint masking **is enforced** on the stats: a numeric column the actor cannot read (field-permission-hidden, denied, or taint-dropped) returns **no min/max** — verified by the `STATS LEAK GATE` real-DB test. Row-level-denied rows are excluded from the stats. Non-numeric/unknown fields are omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)