### PR TITLE
feat(multitable): A4 required-IF — conditional-required form fields (requiredWhen)

### DIFF
--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -42,7 +42,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="text"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="textControlValue(formData[field.id])"
@@ -68,7 +68,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             rows="5"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="textControlValue(formData[field.id])"
@@ -83,7 +83,7 @@
             inputmode="text"
             :placeholder="lc('cell.barcodePlaceholder')"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="textControlValue(formData[field.id])"
@@ -98,7 +98,7 @@
             inputmode="text"
             :placeholder="lc('cell.qrcodePlaceholder')"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="textControlValue(formData[field.id])"
@@ -112,7 +112,7 @@
             type="text"
             :placeholder="lc('cell.locationPlaceholder')"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="locationAddressValue(formData[field.id])"
@@ -125,7 +125,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="number"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="formData[field.id] ?? ''"
@@ -142,7 +142,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="date"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="formData[field.id] ?? ''"
@@ -155,7 +155,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="datetime-local"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="dateTimeInputValue(formData[field.id])"
@@ -167,7 +167,7 @@
             class="meta-form-view__input"
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="formData[field.id] ?? ''"
@@ -183,7 +183,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             multiple
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
             :value="multiSelectValue(field.id)"
@@ -244,7 +244,7 @@
             type="number"
             step="any"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :value="formData[field.id] ?? ''"
             @input="formData[field.id] = ($event.target as HTMLInputElement).value === '' ? null : Number(($event.target as HTMLInputElement).value)"
@@ -272,7 +272,7 @@
             inputmode="numeric"
             :placeholder="durationPlaceholderFor(field)"
             :disabled="isFieldReadOnly(field.id)"
-            :aria-required="field.required ? 'true' : undefined"
+            :aria-required="fieldIsRequired(field) ? 'true' : undefined"
             :value="durationDisplayFor(field)"
             @change="onDurationChange(field, ($event.target as HTMLInputElement).value)"
           />
@@ -405,7 +405,7 @@ import {
   locationValueFromAddress,
 } from '../utils/field-display'
 import { isSystemField } from '../utils/system-fields'
-import { isFieldVisible } from '../utils/field-visibility'
+import { isFieldConditionallyRequired, isFieldVisible } from '../utils/field-visibility'
 import { resolveFormPages } from '../utils/form-layout'
 
 const props = defineProps<{
@@ -476,6 +476,21 @@ const editableFields = computed(() => {
       isFieldVisible(field, formData, byId),
   )
 })
+
+// A4 (required-IF): is `field` required RIGHT NOW? Static `field.required` OR a
+// satisfied `property.requiredWhen` condition (conditional-required, evaluated
+// through the same path as visibility). Drives BOTH the submit gate (`validate`)
+// and the `aria-required` indicator so the two never disagree. `formData` is
+// read inside `isFieldConditionallyRequired`, so anything bound to this
+// re-computes live as the user edits the dependency. The hidden-field guarantee
+// is structural: both call sites operate on VISIBLE fields only (the template
+// renders `currentPageFields` ⊆ `editableFields`; `validate` iterates
+// `editableFields`), so a field hidden by a visibility rule is never treated as
+// conditionally required.
+function fieldIsRequired(field: MetaField): boolean {
+  if (field.required) return true
+  return isFieldConditionallyRequired(field, formData, fieldsById.value)
+}
 
 // A4: render pages, derived from the layout + the FULL visible field list.
 // `editableFields` (above) stays the authoritative visible list that
@@ -597,10 +612,14 @@ onBeforeUnmount(() => {
 function validate(): boolean {
   const errs: Record<string, string> = {}
   // Iterate the FULL visible field list (NOT the current page) so a required
-  // field on another page can never slip through unvalidated.
+  // field on another page can never slip through unvalidated. A field counts as
+  // required if it is statically `required` OR its `requiredWhen` condition holds
+  // (`fieldIsRequired`). Because this list is the VISIBLE set, a field hidden by
+  // a visibility rule is excluded here and so can never block submit when its
+  // requiredWhen condition is (vacuously) satisfied.
   for (const f of editableFields.value) {
     const v = formData[f.id]
-    if (f.required && isEmptyFormValue(v)) {
+    if (fieldIsRequired(f) && isEmptyFormValue(v)) {
       errs[f.id] = requiredField(f.name, isZh.value)
     }
   }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -160,6 +160,12 @@ export const CONDITIONAL_FORMATTING_SCALE_RULE_LIMIT = 20
 // Reuses the conditional-formatting operator vocabulary. PRESENTATION ONLY — not
 // a security boundary (see utils/field-visibility.ts). Mirrors backend
 // `field-visibility-rule.ts`.
+//
+// The SAME shape is reused for `property.requiredWhen` (conditional-required /
+// "required-IF"): a field required in the form only when the condition holds.
+// One condition grammar serves show-IF and required-IF — see
+// `getFieldRequiredWhenRule` / `isFieldConditionallyRequired` in
+// utils/field-visibility.ts.
 export interface FieldVisibilityRule {
   fieldId: string
   operator: ConditionalFormattingOperator

--- a/apps/web/src/multitable/utils/field-visibility.ts
+++ b/apps/web/src/multitable/utils/field-visibility.ts
@@ -64,14 +64,73 @@ export function isFieldVisible(
 ): boolean {
   const rule = getFieldVisibilityRule(field)
   if (!rule) return true
+  return evaluateConditionRule(rule, recordData, fieldsById, options)
+}
+
+/**
+ * Evaluate a single `{ fieldId, operator, value }` condition against the current
+ * record data by reusing the conditional-formatting evaluator. Shared by the
+ * show-IF (`isFieldVisible`) and required-IF (`isFieldConditionallyRequired`)
+ * gates so they can never diverge on how a condition is judged. A dangling
+ * dependency (named field absent from `fieldsById`) resolves to FALSE — a
+ * missing reference must not silently flip the gate on.
+ */
+function evaluateConditionRule(
+  rule: FieldVisibilityRule,
+  recordData: Record<string, unknown>,
+  fieldsById: Record<string, MetaField | undefined>,
+  options: VisibilityEvaluateOptions = {},
+): boolean {
   const dependency = fieldsById[rule.fieldId]
   if (!dependency) return false
   // Reuse the conditional-formatting evaluator by synthesizing the full rule
   // envelope it expects (id/order/style/enabled are irrelevant to the boolean).
   return evaluateRule(
-    { id: '__visibility__', order: 0, fieldId: rule.fieldId, operator: rule.operator, value: rule.value, style: {}, enabled: true },
+    { id: '__condition__', order: 0, fieldId: rule.fieldId, operator: rule.operator, value: rule.value, style: {}, enabled: true },
     recordData,
     dependency,
     options,
   )
+}
+
+/**
+ * Read + lightly validate a field's `property.requiredWhen` (conditional-required
+ * rule). Returns `null` when absent or malformed (⇒ the field has no
+ * required-IF; only its static `field.required` applies). REUSES the
+ * `FieldVisibilityRule` shape + the same operator-validity check as
+ * `getFieldVisibilityRule` — there is one condition grammar for show-IF and
+ * required-IF. The backend is canonical; this guards a hand-built / stale rule.
+ */
+export function getFieldRequiredWhenRule(field: MetaField): FieldVisibilityRule | null {
+  const raw = isPlainObject(field.property) ? field.property.requiredWhen : undefined
+  if (!isPlainObject(raw)) return null
+  const fieldId = typeof raw.fieldId === 'string' ? raw.fieldId.trim() : ''
+  if (!fieldId) return null
+  if (!isOperator(raw.operator)) return null
+  const rule: FieldVisibilityRule = { fieldId, operator: raw.operator }
+  if ('value' in raw) rule.value = raw.value
+  return rule
+}
+
+/**
+ * Is `field` conditionally required given the current record data? FALSE when the
+ * field has no `requiredWhen` rule (its static `field.required` is then the only
+ * requiredness — handled by the caller). When a rule is present, the field is
+ * required iff its condition holds, evaluated through the SAME path as visibility.
+ *
+ * This is ONLY the conditional half: the form's submit validation treats a field
+ * as required when `field.required` (static) OR this returns true. The caller is
+ * responsible for restricting the check to currently-VISIBLE fields, so a field
+ * hidden by a visibility rule is never conditionally required (you cannot fill an
+ * invisible field; it must not block submit).
+ */
+export function isFieldConditionallyRequired(
+  field: MetaField,
+  recordData: Record<string, unknown>,
+  fieldsById: Record<string, MetaField | undefined>,
+  options: VisibilityEvaluateOptions = {},
+): boolean {
+  const rule = getFieldRequiredWhenRule(field)
+  if (!rule) return false
+  return evaluateConditionRule(rule, recordData, fieldsById, options)
 }

--- a/apps/web/tests/multitable-required-if.spec.ts
+++ b/apps/web/tests/multitable-required-if.spec.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+
+import MetaFormView from '../src/multitable/components/MetaFormView.vue'
+import {
+  getFieldRequiredWhenRule,
+  isFieldConditionallyRequired,
+} from '../src/multitable/utils/field-visibility'
+import type { MetaField } from '../src/multitable/types'
+
+// Conditional-REQUIRED ("required-IF", A4): a field with
+// `property.requiredWhen { fieldId: Y, operator: 'eq', value: 'Z' }` is required
+// in the public form ONLY when Y === Z; otherwise optional. A field hidden by a
+// visibility rule is NEVER conditionally required (you can't fill an invisible
+// field, so it must not block submit). The rule REUSES the visibility-rule shape
+// + operator vocabulary (the "equals" token is `eq`).
+
+// Status drives both Reason's required-IF and Detail's visibility.
+const STATUS_FIELD: MetaField = {
+  id: 'fld_status',
+  name: 'Status',
+  type: 'select',
+  options: [{ value: 'open' }, { value: 'rejected' }],
+}
+// `Reason` is required only when Status === 'rejected'. Always visible.
+const REASON_FIELD: MetaField = {
+  id: 'fld_reason',
+  name: 'Reason',
+  type: 'string',
+  property: { requiredWhen: { fieldId: 'fld_status', operator: 'eq', value: 'rejected' } },
+}
+// `Detail` is HIDDEN unless Status === 'open', AND required-when Status ===
+// 'rejected'. The two conditions are mutually exclusive on purpose: whenever the
+// requiredWhen condition holds (Status === 'rejected'), the field is hidden — so
+// it must never block submit.
+const HIDDEN_BUT_REQUIRED_FIELD: MetaField = {
+  id: 'fld_detail',
+  name: 'Detail',
+  type: 'string',
+  property: {
+    visibilityRule: { fieldId: 'fld_status', operator: 'eq', value: 'open' },
+    requiredWhen: { fieldId: 'fld_status', operator: 'eq', value: 'rejected' },
+  },
+}
+const PLAIN_FIELD: MetaField = { id: 'fld_plain', name: 'Plain', type: 'string' }
+
+const FIELDS_BY_ID: Record<string, MetaField | undefined> = {
+  [STATUS_FIELD.id]: STATUS_FIELD,
+  [REASON_FIELD.id]: REASON_FIELD,
+  [HIDDEN_BUT_REQUIRED_FIELD.id]: HIDDEN_BUT_REQUIRED_FIELD,
+  [PLAIN_FIELD.id]: PLAIN_FIELD,
+}
+
+describe('getFieldRequiredWhenRule', () => {
+  it('reads a well-formed requiredWhen rule off the property (round-trip shape)', () => {
+    expect(getFieldRequiredWhenRule(REASON_FIELD)).toEqual({
+      fieldId: 'fld_status',
+      operator: 'eq',
+      value: 'rejected',
+    })
+  })
+
+  it('returns null for a field without a requiredWhen rule', () => {
+    expect(getFieldRequiredWhenRule(PLAIN_FIELD)).toBeNull()
+  })
+
+  it('returns null for a malformed rule (missing fieldId / bad operator)', () => {
+    expect(getFieldRequiredWhenRule({ id: 'x', name: 'X', type: 'string', property: { requiredWhen: { operator: 'eq' } } })).toBeNull()
+    expect(getFieldRequiredWhenRule({ id: 'x', name: 'X', type: 'string', property: { requiredWhen: { fieldId: 'y', operator: 'frob' } } })).toBeNull()
+  })
+
+  it('does not confuse visibilityRule for requiredWhen', () => {
+    const visOnly: MetaField = {
+      id: 'fld_v',
+      name: 'V',
+      type: 'string',
+      property: { visibilityRule: { fieldId: 'fld_status', operator: 'eq', value: 'open' } },
+    }
+    expect(getFieldRequiredWhenRule(visOnly)).toBeNull()
+  })
+})
+
+describe('isFieldConditionallyRequired — evaluator', () => {
+  it('no requiredWhen rule ⇒ not conditionally required', () => {
+    expect(isFieldConditionallyRequired(PLAIN_FIELD, { fld_status: 'rejected' }, FIELDS_BY_ID)).toBe(false)
+  })
+
+  it('condition TRUE ⇒ conditionally required', () => {
+    expect(isFieldConditionallyRequired(REASON_FIELD, { fld_status: 'rejected' }, FIELDS_BY_ID)).toBe(true)
+  })
+
+  it('condition FALSE ⇒ not conditionally required', () => {
+    expect(isFieldConditionallyRequired(REASON_FIELD, { fld_status: 'open' }, FIELDS_BY_ID)).toBe(false)
+    expect(isFieldConditionallyRequired(REASON_FIELD, {}, FIELDS_BY_ID)).toBe(false)
+  })
+
+  it('dangling dependency reference ⇒ not required (does not silently force required)', () => {
+    const orphan: MetaField = {
+      id: 'fld_o',
+      name: 'O',
+      type: 'string',
+      property: { requiredWhen: { fieldId: 'fld_missing', operator: 'eq', value: 'x' } },
+    }
+    expect(isFieldConditionallyRequired(orphan, { fld_missing: 'x' }, {})).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Component-level: the form's submit gate actually honours required-IF and the
+// hidden-field exemption. This is the feature proof (not just the evaluator).
+// ---------------------------------------------------------------------------
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function mountForm(onSubmit: (data: Record<string, unknown>) => void): { app: VueApp; container: HTMLElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(MetaFormView, {
+    fields: [STATUS_FIELD, REASON_FIELD, HIDDEN_BUT_REQUIRED_FIELD, PLAIN_FIELD],
+    record: null,
+    loading: false,
+    onSubmit,
+  })
+  app.mount(container)
+  return { app, container }
+}
+
+function clickSubmit(container: HTMLElement) {
+  const form = container.querySelector('form') as HTMLFormElement
+  form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }))
+}
+
+function setStatus(container: HTMLElement, value: string) {
+  const select = container.querySelector('#field_fld_status') as HTMLSelectElement
+  select.value = value
+  select.dispatchEvent(new Event('change'))
+}
+
+describe('MetaFormView — conditional-required (required-IF) submit gate', () => {
+  it('condition TRUE → empty conditionally-required field BLOCKS submit', async () => {
+    const onSubmit = vi.fn()
+    const { app, container } = mountForm(onSubmit)
+    try {
+      await flushUi()
+      // Status = rejected ⇒ Reason is now required; it is empty.
+      setStatus(container, 'rejected')
+      await flushUi()
+
+      // aria-required reflects the active conditional requirement.
+      expect(container.querySelector('#field_fld_reason')?.getAttribute('aria-required')).toBe('true')
+
+      clickSubmit(container)
+      await flushUi()
+
+      // Submit is blocked: no emit, and an inline required error appears on Reason.
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(container.querySelector('#error_fld_reason')).not.toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('condition TRUE but field FILLED → submit allowed', async () => {
+    const onSubmit = vi.fn()
+    const { app, container } = mountForm(onSubmit)
+    try {
+      await flushUi()
+      setStatus(container, 'rejected')
+      await flushUi()
+      const reason = container.querySelector('#field_fld_reason') as HTMLInputElement
+      reason.value = 'Not a fit'
+      reason.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      clickSubmit(container)
+      await flushUi()
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(onSubmit.mock.calls[0][0]).toMatchObject({ fld_status: 'rejected', fld_reason: 'Not a fit' })
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('condition FALSE → conditionally-required field is OPTIONAL (empty submit allowed)', async () => {
+    const onSubmit = vi.fn()
+    const { app, container } = mountForm(onSubmit)
+    try {
+      await flushUi()
+      // Status = open ⇒ Reason's requiredWhen condition is FALSE; leave it empty.
+      setStatus(container, 'open')
+      await flushUi()
+
+      // aria-required is absent while the condition does not hold.
+      expect(container.querySelector('#field_fld_reason')?.getAttribute('aria-required')).toBeNull()
+
+      clickSubmit(container)
+      await flushUi()
+
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      // Reason was empty and NOT included as a blocking error.
+      expect(container.querySelector('#error_fld_reason')).toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('HIDDEN field with requiredWhen → NOT required (does not block submit)', async () => {
+    const onSubmit = vi.fn()
+    const { app, container } = mountForm(onSubmit)
+    try {
+      await flushUi()
+      // Status = rejected ⇒ Detail's requiredWhen holds BUT Detail's visibility
+      // rule (visible only when Status === 'open') hides it. A hidden field must
+      // never be conditionally required.
+      setStatus(container, 'rejected')
+      await flushUi()
+
+      // Detail is hidden from the DOM entirely.
+      expect(container.querySelector('#field_fld_detail')).toBeNull()
+      // Fill the visible required-IF field so ONLY the hidden one could block.
+      const reason = container.querySelector('#field_fld_reason') as HTMLInputElement
+      reason.value = 'Reason given'
+      reason.dispatchEvent(new Event('input'))
+      await flushUi()
+
+      clickSubmit(container)
+      await flushUi()
+
+      // Submit succeeds: the hidden requiredWhen field did not block it.
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+      expect(container.querySelector('#error_fld_detail')).toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+
+  it('static required still blocks regardless of any requiredWhen', async () => {
+    // Sanity: backward-compat — a statically required field with no requiredWhen
+    // behaves exactly as today.
+    const onSubmit = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const STATIC_REQ: MetaField = { id: 'fld_req', name: 'Req', type: 'string', required: true }
+    const app = createApp(MetaFormView, {
+      fields: [STATIC_REQ],
+      record: null,
+      loading: false,
+      onSubmit,
+    })
+    app.mount(container)
+    try {
+      await flushUi()
+      expect(container.querySelector('#field_fld_req')?.getAttribute('aria-required')).toBe('true')
+      clickSubmit(container)
+      await flushUi()
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(container.querySelector('#error_fld_req')).not.toBeNull()
+    } finally {
+      app.unmount()
+      container.remove()
+    }
+  })
+})

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -1,7 +1,7 @@
 import sanitizeHtml from 'sanitize-html'
 import { normalizeAutoNumberProperty } from './auto-number-property'
 import { fieldTypeRegistry } from './field-type-registry'
-import { withFieldVisibilityRule } from './field-visibility-rule'
+import { withFieldRequiredWhenRule, withFieldVisibilityRule } from './field-visibility-rule'
 
 export type MultitableFieldType =
   | 'string'
@@ -228,11 +228,15 @@ export function sanitizeFieldProperty(
   type: MultitableFieldType | string,
   property: unknown,
 ): Record<string, unknown> {
-  // `visibilityRule` is a CROSS-CUTTING property (any field type may carry it),
-  // so it is sanitized + merged uniformly after the per-type normalization
-  // rather than relying on each branch's incidental `...obj` passthrough (which
-  // would also let a *malformed* rule leak through). See field-visibility-rule.ts.
-  return withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property)
+  // `visibilityRule` + `requiredWhen` are CROSS-CUTTING properties (any field
+  // type may carry them), so they are sanitized + merged uniformly after the
+  // per-type normalization rather than relying on each branch's incidental
+  // `...obj` passthrough (which would also let a *malformed* rule leak through).
+  // See field-visibility-rule.ts.
+  return withFieldRequiredWhenRule(
+    withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+    property,
+  )
 }
 
 function sanitizeFieldPropertyByType(

--- a/packages/core-backend/src/multitable/field-visibility-rule.ts
+++ b/packages/core-backend/src/multitable/field-visibility-rule.ts
@@ -89,3 +89,40 @@ export function withFieldVisibilityRule(
   }
   return { ...sanitizedByType, visibilityRule: rule }
 }
+
+/**
+ * Conditional-REQUIRED rule (`property.requiredWhen`). A field carrying this rule
+ * is required in the public form ONLY when the condition holds against the
+ * record being filled — the "required-IF" counterpart to `visibilityRule`'s
+ * "show-IF". It REUSES the exact `FieldVisibilityRule` shape (same single
+ * `{ fieldId, operator, value }` condition + the same conditional-formatting
+ * operator vocabulary), so `sanitizeFieldVisibilityRule` is the shared
+ * normalizer — there is deliberately no second condition grammar.
+ *
+ * Absent/invalid rule ⇒ the key is omitted, so a field without a rule behaves
+ * exactly as today (static `required` only; backward-compatible). Like
+ * `withFieldVisibilityRule`, this is the single cross-cutting merge applied at
+ * BOTH `sanitizeFieldProperty` chokepoints (read-serialize + write) so a
+ * malformed rule can never leak through a type branch's `...obj` passthrough.
+ *
+ * NOTE: persistence only. Like static `field.required`, `requiredWhen` is
+ * ENFORCED client-side (in the form view's submit validation, visibility-aware);
+ * `validateRecord` keys off `property.validation[]`, not these top-level gates.
+ * Sanitizing here keeps the authored rule durable on the field property without
+ * adding a new server gate that would reject submits existing forms accept.
+ */
+export function withFieldRequiredWhenRule(
+  sanitizedByType: Record<string, unknown>,
+  rawProperty: unknown,
+): Record<string, unknown> {
+  const candidate = isPlainObject(rawProperty) ? rawProperty.requiredWhen : undefined
+  const rule = sanitizeFieldVisibilityRule(candidate)
+  if (!rule) {
+    if ('requiredWhen' in sanitizedByType) {
+      const { requiredWhen: _omit, ...rest } = sanitizedByType
+      return rest
+    }
+    return sanitizedByType
+  }
+  return { ...sanitizedByType, requiredWhen: rule }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -16,7 +16,7 @@ import {
   isFieldPermissionHidden,
 } from '../multitable/permission-derivation'
 import { validateAiShortcutFieldProperty } from '../multitable/ai-shortcut-config'
-import { withFieldVisibilityRule } from '../multitable/field-visibility-rule'
+import { withFieldRequiredWhenRule, withFieldVisibilityRule } from '../multitable/field-visibility-rule'
 import { parseConditionalRules } from '../multitable/permission-rule-evaluator'
 import { withFormLayout, projectPublicFormLayout, sanitizeFormRedirectUrl } from '../multitable/form-layout'
 import { projectFormContextView } from '../multitable/form-context-view-projection'
@@ -2117,10 +2117,14 @@ function applyFieldValidationNormalisation(obj: Record<string, unknown>): Record
 }
 
 function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown): Record<string, unknown> {
-  // `visibilityRule` is cross-cutting (any field type) — sanitize + merge it
-  // uniformly so the write path can never leak a malformed rule via `...obj`
-  // passthrough. Mirrors field-codecs.ts's sanitizeFieldProperty (shared helper).
-  return withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property)
+  // `visibilityRule` + `requiredWhen` are cross-cutting (any field type) —
+  // sanitize + merge them uniformly so the write path can never leak a malformed
+  // rule via `...obj` passthrough. Mirrors field-codecs.ts's sanitizeFieldProperty
+  // (shared helpers).
+  return withFieldRequiredWhenRule(
+    withFieldVisibilityRule(sanitizeFieldPropertyByType(type, property), property),
+    property,
+  )
 }
 
 function sanitizeFieldPropertyByType(type: UniverMetaField['type'], property: unknown): Record<string, unknown> {

--- a/packages/core-backend/tests/unit/multitable-field-required-when-rule.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-required-when-rule.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  sanitizeFieldProperty,
+  serializeFieldRow,
+} from '../../src/multitable/field-codecs'
+import {
+  withFieldRequiredWhenRule,
+} from '../../src/multitable/field-visibility-rule'
+
+// Conditional-REQUIRED ("required-IF", A4): a field's `property.requiredWhen`
+// rides the field property JSON, REUSING the conditional-formatting / visibility
+// operator vocabulary + shape. These assert the rule is sanitized cross-cuttingly
+// (every field type) and round-trips through the read-serialize path — NOT via
+// incidental `...obj` passthrough. Enforcement is client-side (form view); this
+// covers only durable PERSISTENCE of the authored rule.
+
+describe('withFieldRequiredWhenRule', () => {
+  it('merges a sanitized rule onto a property object under the requiredWhen key', () => {
+    expect(
+      withFieldRequiredWhenRule({ foo: 1 }, { requiredWhen: { fieldId: 'fld_y', operator: 'eq', value: 'Z' } }),
+    ).toEqual({ foo: 1, requiredWhen: { fieldId: 'fld_y', operator: 'eq', value: 'Z' } })
+  })
+
+  it('keeps value-less operators (is_empty) without a value key', () => {
+    expect(
+      withFieldRequiredWhenRule({}, { requiredWhen: { fieldId: 'fld_y', operator: 'is_empty' } }),
+    ).toEqual({ requiredWhen: { fieldId: 'fld_y', operator: 'is_empty' } })
+  })
+
+  it('trims fieldId', () => {
+    expect(
+      withFieldRequiredWhenRule({}, { requiredWhen: { fieldId: '  fld_y  ', operator: 'eq', value: 1 } }),
+    ).toEqual({ requiredWhen: { fieldId: 'fld_y', operator: 'eq', value: 1 } })
+  })
+
+  it('omits the key when the rule is absent or invalid', () => {
+    expect(withFieldRequiredWhenRule({ foo: 1 }, {})).toEqual({ foo: 1 })
+    expect(withFieldRequiredWhenRule({ foo: 1 }, { requiredWhen: { operator: 'eq' } })).toEqual({ foo: 1 })
+    // `eq` requires a value (operator vocab inherited from conditional-formatting)
+    expect(withFieldRequiredWhenRule({ foo: 1 }, { requiredWhen: { fieldId: 'fld_y', operator: 'eq' } })).toEqual({ foo: 1 })
+    // a passed-through invalid rule on the by-type result is dropped
+    expect(withFieldRequiredWhenRule({ foo: 1, requiredWhen: { bad: true } }, {})).toEqual({ foo: 1 })
+  })
+
+  it('is independent of visibilityRule (each key merged on its own)', () => {
+    // A property carrying BOTH rules keeps both after their respective merges.
+    const out = withFieldRequiredWhenRule(
+      { visibilityRule: { fieldId: 'fld_v', operator: 'eq', value: 'open' } },
+      { requiredWhen: { fieldId: 'fld_y', operator: 'eq', value: 'Z' } },
+    )
+    expect(out).toEqual({
+      visibilityRule: { fieldId: 'fld_v', operator: 'eq', value: 'open' },
+      requiredWhen: { fieldId: 'fld_y', operator: 'eq', value: 'Z' },
+    })
+  })
+})
+
+describe('sanitizeFieldProperty preserves requiredWhen cross-cuttingly', () => {
+  const RULE = { fieldId: 'fld_y', operator: 'eq', value: 'Z' }
+
+  // Cover types whose sanitizer does NOT end in a bare `...obj` (string/select/
+  // number/link/autoNumber) plus a few plain ones — the rule must survive ALL.
+  for (const type of ['string', 'number', 'select', 'link', 'autoNumber', 'longText', 'rating']) {
+    it(`survives type=${type}`, () => {
+      const out = sanitizeFieldProperty(type, { requiredWhen: { ...RULE } })
+      expect(out.requiredWhen).toEqual(RULE)
+    })
+  }
+
+  it('drops a malformed rule rather than passing it through', () => {
+    const out = sanitizeFieldProperty('string', { requiredWhen: { operator: 'eq' } })
+    expect('requiredWhen' in out).toBe(false)
+  })
+
+  it('no rule ⇒ no requiredWhen key', () => {
+    const out = sanitizeFieldProperty('string', {})
+    expect('requiredWhen' in out).toBe(false)
+  })
+
+  it('keeps visibilityRule and requiredWhen side-by-side on one field', () => {
+    const out = sanitizeFieldProperty('string', {
+      visibilityRule: { fieldId: 'fld_v', operator: 'eq', value: 'open' },
+      requiredWhen: { ...RULE },
+    })
+    expect(out.visibilityRule).toEqual({ fieldId: 'fld_v', operator: 'eq', value: 'open' })
+    expect(out.requiredWhen).toEqual(RULE)
+  })
+})
+
+describe('serializeFieldRow round-trips requiredWhen through the read path', () => {
+  it('a stored field with a requiredWhen reads back with the rule', () => {
+    const field = serializeFieldRow({
+      id: 'fld_x',
+      name: 'Reason',
+      type: 'string',
+      order: 3,
+      property: { requiredWhen: { fieldId: 'fld_status', operator: 'eq', value: 'rejected' } },
+    })
+    expect(field.property?.requiredWhen).toEqual({ fieldId: 'fld_status', operator: 'eq', value: 'rejected' })
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-loaders.test.ts
+++ b/packages/core-backend/tests/unit/multitable-loaders.test.ts
@@ -106,6 +106,34 @@ describe('multitable loaders helper', () => {
     expect(result[0]).toMatchObject({ id: 'fld_name', type: 'string' })
   })
 
+  it('carries conditional rules (visibilityRule + requiredWhen) through to the field property', async () => {
+    // The public form (`GET /form-context`) gets its fields via loadFieldsForSheet,
+    // which serializes each row through serializeFieldRow → sanitizeFieldProperty.
+    // Both the visibility (show-IF) and required-IF rules must survive that path or
+    // the conditional form logic silently no-ops on the wire. (Wire-vs-fixture
+    // drift guard: the feature evaluates these rules client-side, so they MUST
+    // reach the client.)
+    const pool = createPool((_sql, params) => {
+      expect(params).toEqual(['sheet_cond'])
+      return [
+        {
+          id: 'fld_reason',
+          name: 'Reason',
+          type: 'string',
+          property: {
+            visibilityRule: { fieldId: 'fld_status', operator: 'eq', value: 'rejected' },
+            requiredWhen: { fieldId: 'fld_status', operator: 'eq', value: 'rejected' },
+          },
+          order: 1,
+        },
+      ]
+    })
+
+    const result = await loadFieldsForSheet(pool.query, 'sheet_cond')
+    expect(result[0].property?.visibilityRule).toEqual({ fieldId: 'fld_status', operator: 'eq', value: 'rejected' })
+    expect(result[0].property?.requiredWhen).toEqual({ fieldId: 'fld_status', operator: 'eq', value: 'rejected' })
+  })
+
   it('loads one view config and caches it', async () => {
     let calls = 0
     const cache = new Map<string, any>()


### PR DESCRIPTION
## What

Closes the last A4 public-form-logic gap: **required-IF** — a field that is required only when a condition on another field holds (e.g. *"Reason is required when Status = Rejected"*). The multitable public form already had multi-page layout, prefill, post-submit redirect, static `required`, and field-**visibility** rules (show/hide a field by a condition). This adds the conditional-required counterpart, reusing the visibility-rule vocabulary end-to-end.

## How — reuse, no new condition system

One condition grammar serves both show-IF and required-IF: the same single `{ fieldId, operator, value }` shape, the same conditional-formatting operator set, the same evaluator.

**Model (persistence).** A field's `property.requiredWhen` carries the rule. New `withFieldRequiredWhenRule` mirrors `withFieldVisibilityRule` and is merged at **both** `sanitizeFieldProperty` chokepoints (`field-codecs.ts` read-serialize + `univer-meta.ts` write), reusing `sanitizeFieldVisibilityRule` for value validation — so a malformed rule can never leak through a type branch's `...obj` passthrough. Absent rule ⇒ behaves exactly as today (static `required` only) — **backward-compatible**.

**Validation (the core).** In `MetaFormView` submit validation a field is required if `field.required` (static) **OR** its `requiredWhen` condition evaluates true against the current form data (`fieldIsRequired` / `isFieldConditionallyRequired`, sharing the visibility evaluator). The check and the `aria-required` indicator both run over the **visible** field set only (template renders `currentPageFields` ⊆ `editableFields`; `validate()` iterates `editableFields`), so:

> **A field hidden by a visibility rule is NEVER conditionally-required** and can never block submit.

A dangling dependency resolves to false (not required), matching visibility's dangling→false.

**Authoring.** Like visibility rules today, the rule is authored on the field `property` — there is no dedicated multitable dialog for *either* rule. This is consistent with the existing pattern; a follow-up could add authoring dialogs for visibility + required-IF together.

## Server-side: persistence yes, enforcement at client-parity

`validateRecord` (the server form-submit / record-create validator) keys off `property.validation[]` engine rules, **never** the top-level `field.required` gate — so static `required` is already client-only on the server today. To preserve parity (and the task constraint *not to add a server gate that rejects submits existing forms accept*), `requiredWhen` enforcement stays client-side, exactly like static `required`. Persistence **is** server-side and durable, and the rule survives the public-form wire (`/form-context` → `loadFieldsForSheet` → `serializeFieldRow`), the same path visibility uses.

## Tests

- **FE** (`multitable-required-if.spec.ts`, 13): condition true → submit blocked when empty; condition false → optional (empty submit allowed); **hidden field with requiredWhen → not required (does not block)**; static required still blocks; `aria-required` tracks the live condition; `getFieldRequiredWhenRule` round-trip; dangling-dependency → not required.
- **BE** (`multitable-field-required-when-rule.test.ts`, 16): sanitize + cross-type survival (string/number/select/link/autoNumber/longText/rating) + visibility/requiredWhen coexistence + `serializeFieldRow` read-path round-trip.
- **BE wire** (`multitable-loaders.test.ts`, +1): `loadFieldsForSheet` carries `visibilityRule` + `requiredWhen` through to the field property — locks the public-form field path against wire-vs-fixture drift.

## Validation (all green)

- `pnpm install --frozen-lockfile` — clean (no new deps)
- `packages/core-backend` `tsc --noEmit` — 0 errors
- `pnpm --filter @metasheet/web exec vue-tsc -b` — 0 errors
- `CI=true pnpm --filter @metasheet/core-backend test` — **4693 passed, 0 failed** (813 skipped, pre-existing real-DB-gated)
- FE specs — 21 passed (13 new + 8 visibility regression)
- Structural guards (egress-coverage / taint-chokepoint / record-lock) — 8/8 green (record-data egress surface unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)