### PR TITLE
feat(multitable): functional dashboard-level filtering (B4 — one filter widget → all panels)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + record recycle-bin delete/restore)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -227,6 +227,7 @@ jobs:
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-dashboard-preview-data.test.ts \
             tests/integration/multitable-dashboard-chart-rowdeny-realdb.test.ts \
+            tests/integration/multitable-dashboard-level-filter-realdb.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \
             tests/integration/multitable-record-lock.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -57,6 +57,7 @@ import type {
   ChartCreateInput,
   ChartData,
   Dashboard,
+  DashboardFilter,
   DashboardUpdateInput,
   FormShareConfig,
   FormShareConfigUpdate,
@@ -2196,18 +2197,28 @@ export class MultitableApiClient {
     await this.parseJson(res)
   }
 
-  async getChartData(sheetId: string, chartId: string): Promise<ChartData> {
+  async getChartData(sheetId: string, chartId: string, dashboardFilters?: DashboardFilter[]): Promise<ChartData> {
+    // B4: an active dashboard-level filter rides on the query as URL-encoded JSON; omitted when empty
+    // (= no constraint). The server AND-combines it with the chart's own filter and rejects a denied
+    // filter field wholesale (it never reaches an unmasked scan).
+    const qs = dashboardFilters && dashboardFilters.length > 0
+      ? `?dashboardFilter=${encodeURIComponent(JSON.stringify(dashboardFilters))}`
+      : ''
     const res = await this.fetch(
-      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/${encodeURIComponent(chartId)}/data`,
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/${encodeURIComponent(chartId)}/data${qs}`,
     )
     return this.parseJson<ChartData>(res)
   }
 
-  async previewChartData(sheetId: string, input: ChartCreateInput): Promise<ChartData> {
+  async previewChartData(sheetId: string, input: ChartCreateInput, dashboardFilters?: DashboardFilter[]): Promise<ChartData> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/preview-data`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(toChartCreateWire(input)),
+      // B4: a metric card refetches through preview-data, so the dashboard filter rides on the body.
+      body: JSON.stringify({
+        ...toChartCreateWire(input),
+        ...(dashboardFilters && dashboardFilters.length > 0 ? { dashboardFilter: dashboardFilters } : {}),
+      }),
     })
     return this.parseJson<ChartData>(res)
   }

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -121,23 +121,38 @@
             />
             <div v-else class="meta-dashboard__panel-loading" data-widget="text-empty">{{ viewRenderLabel('dashboard.textEmpty', isZh) }}</div>
           </template>
-          <!-- Filter / control: PRESENTATIONAL ONLY — local UI state, drives no other panel. -->
+          <!-- Filter / control: FUNCTIONAL — the chosen value filters EVERY data panel (AND-combined
+               with each chart's own filter). Configured field = panel.filterConfig.fieldId; the value
+               dropdown is populated from that field's SCHEMA options (no record scan → no row-deny
+               leak), falling back to a free text input when the field has no options. -->
           <template v-else-if="panelType(panel) === 'filter'">
             <div class="meta-dashboard__filter-widget" data-widget="filter">
+              <span class="meta-dashboard__filter-field-label" data-field="filter-field-name">{{ dashboardFilterableField(panel.filterConfig?.fieldId)?.name ?? viewRenderLabel('dashboard.filterField', isZh) }}</span>
               <select
+                v-if="dashboardFilterOptions(panel).length > 0"
                 :value="filterSelections[panel.id] ?? ''"
                 class="meta-dashboard__select meta-dashboard__select--sm"
                 data-field="filter-control"
+                :aria-label="viewRenderLabel('dashboard.filterValueLabel', isZh)"
                 @change="onFilterControlChange(panel.id, ($event.target as HTMLSelectElement).value)"
               >
                 <option value="">{{ viewRenderLabel('dashboard.filterAllOption', isZh) }}</option>
                 <option
-                  v-for="field in chartFields"
-                  :key="field.id"
-                  :value="field.id"
-                >{{ field.name }}</option>
+                  v-for="value in dashboardFilterOptions(panel)"
+                  :key="value"
+                  :value="value"
+                >{{ value }}</option>
               </select>
-              <small class="meta-dashboard__hint" data-hint="filter-presentational">{{ viewRenderLabel('dashboard.filterPresentationalNote', isZh) }}</small>
+              <input
+                v-else
+                :value="filterSelections[panel.id] ?? ''"
+                class="meta-dashboard__input meta-dashboard__input--sm"
+                type="text"
+                data-field="filter-control-text"
+                :aria-label="viewRenderLabel('dashboard.filterValueLabel', isZh)"
+                :placeholder="viewRenderLabel('dashboard.filterValuePlaceholder', isZh)"
+                @change="onFilterControlChange(panel.id, ($event.target as HTMLInputElement).value)"
+              />
             </div>
           </template>
         </div>
@@ -265,7 +280,7 @@
             </label>
           </template>
 
-          <!-- Filter config (presentational only) -->
+          <!-- Filter config: pick the field this dashboard-level filter constrains on. -->
           <template v-else-if="widgetDraft.kind === 'filter'">
             <label class="meta-dashboard__field">
               <span>{{ viewRenderLabel('dashboard.filterField', isZh) }}</span>
@@ -275,7 +290,7 @@
                   {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
                 </option>
               </select>
-              <small class="meta-dashboard__hint" data-hint="filter-presentational-config">{{ viewRenderLabel('dashboard.filterPresentationalNote', isZh) }}</small>
+              <small class="meta-dashboard__hint" data-hint="filter-config-note">{{ viewRenderLabel('dashboard.filterConfigNote', isZh) }}</small>
             </label>
           </template>
         </div>
@@ -496,7 +511,7 @@ const MetaChartRenderer = defineAsyncComponent({
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
-import type { AggregationFunction, ChartDisplayConfig, ChartType, Dashboard, DashboardPanel, DashboardPanelType, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
+import type { AggregationFunction, ChartDisplayConfig, ChartType, Dashboard, DashboardFilter, DashboardPanel, DashboardPanelType, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import { useLocale } from '../../composables/useLocale'
 import { dashboardDefaultName, viewRenderLabel, viewSizeLabel } from '../utils/meta-view-render-labels'
@@ -520,8 +535,10 @@ const chartConfigMap = ref<Record<string, ChartConfig>>({})
 // B4: metric-card data is keyed by panel.id (a metric has no chartId) so it never
 // collides with the chartId-keyed chartDataMap.
 const metricDataMap = ref<Record<string, ChartData>>({})
-// B4: presentational filter selections — LOCAL UI state only, keyed by panel.id.
-// Deliberately not persisted and drives nothing else (scoped-out functional filter).
+// B4: dashboard-level filter selections — the chosen VALUE per filter widget, keyed by panel.id.
+// Not persisted (a transient view state); each non-empty selection becomes an equals-constraint
+// applied to EVERY data panel's aggregation (see activeDashboardFilters). '' / absent = "All" = no
+// constraint. The widget's configured field lives in panel.filterConfig.fieldId.
 const filterSelections = ref<Record<string, string>>({})
 const activeDashboardId = ref<string>(props.dashboardId ?? '')
 const showAddPanel = ref(false)
@@ -609,6 +626,36 @@ const editingChart = computed(() => editingChartId.value ? chartConfigMap.value[
 const editingDateGrouped = computed(() => Boolean(editingChart.value?.dataSource.dateFieldId))
 
 const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? []))
+// B4: only PROPERTY-VISIBLE fields are filterable (mirrors chartFields) — the runtime filter widget
+// never offers a hidden field, and the server independently rejects a denied filter field, so a hidden
+// field can't become a probe side-channel even via a hand-crafted request.
+function dashboardFilterableField(fieldId: string | undefined): MetaField | undefined {
+  if (!fieldId) return undefined
+  return chartFields.value.find((f) => f.id === fieldId)
+}
+// B4: a configured filter field's selectable VALUES come from its SCHEMA options (select/multiSelect
+// `options`), not from a record scan — so the value dropdown sidesteps row-level read-deny entirely
+// (options are field config, not data). A field without schema options renders a free text input.
+function dashboardFilterOptions(panel: DashboardPanel): string[] {
+  const field = dashboardFilterableField(panel.filterConfig?.fieldId)
+  return (field?.options ?? []).map((o) => o.value)
+}
+// B4: resolve every filter widget's chosen value into the equals-constraint list sent to the
+// aggregation routes. AND-combined server-side; an empty/"All" selection contributes nothing. A
+// selection whose configured field is no longer property-visible is dropped (never sent).
+const activeDashboardFilters = computed<DashboardFilter[]>(() => {
+  const panels = activeDashboard.value?.panels ?? []
+  const out: DashboardFilter[] = []
+  for (const panel of panels) {
+    if ((panel.type ?? 'chart') !== 'filter') continue
+    const fieldId = panel.filterConfig?.fieldId
+    if (!fieldId || !dashboardFilterableField(fieldId)) continue
+    const value = filterSelections.value[panel.id]
+    if (value === undefined || value === '') continue
+    out.push({ fieldId, value })
+  }
+  return out
+})
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
 const numericFields = computed(() => chartFields.value.filter((field) => isNumericMetricField(field)))
 // r12: scatter is the one non-grouped chart type — it hides groupBy/aggregation/value/series/bar-mode
@@ -698,9 +745,16 @@ function metricDisplayConfig(panel: DashboardPanel): ChartDisplayConfig {
   }
 }
 
-// B4: presentational filter — update LOCAL state only. No data refetch, no cross-panel effect.
+// B4: a dashboard-level filter change re-aggregates EVERY data panel. The chartId-keyed chartDataMap
+// (and panel.id-keyed metricDataMap) are filter-unaware caches, and loadPanelData skips already-loaded
+// charts — so the same chart would never refetch under a new filter. Clear both caches, then reload
+// with the new active filter applied. (Cross-filtering — a chart segment driving others — is a separate
+// follow-up; this is one filter widget → all panels.)
 function onFilterControlChange(panelId: string, value: string) {
   filterSelections.value = { ...filterSelections.value, [panelId]: value }
+  chartDataMap.value = {}
+  metricDataMap.value = {}
+  void loadPanelData()
 }
 
 // B4: metric needs a value field only for sum/avg/min/max (count aggregates row presence).
@@ -821,7 +875,9 @@ async function loadPanelData() {
     if (kind === 'chart') {
       if (!panel.chartId || chartDataMap.value[panel.chartId]) return
       try {
-        const data = await props.client!.getChartData(props.sheetId, panel.chartId)
+        // B4: thread the active dashboard filter so the aggregation is narrowed (AND-combined with
+        // the chart's own filter). Empty = no constraint (the client omits the query param).
+        const data = await props.client!.getChartData(props.sheetId, panel.chartId, activeDashboardFilters.value)
         chartDataMap.value[panel.chartId] = data
       } catch {
         // skip
@@ -847,7 +903,8 @@ async function loadMetricData(panel: DashboardPanel) {
   if (!props.client || metricDataMap.value[panel.id] || metricInFlight.has(panel.id)) return
   metricInFlight.add(panel.id)
   try {
-    const data = await props.client.previewChartData(props.sheetId, buildMetricChartInput(panel))
+    // B4: a metric card narrows by the active dashboard filter too (preview-data carries it on the body).
+    const data = await props.client.previewChartData(props.sheetId, buildMetricChartInput(panel), activeDashboardFilters.value)
     metricDataMap.value[panel.id] = data
   } catch {
     // skip — panel keeps its loading state
@@ -1354,6 +1411,8 @@ onBeforeUnmount(resetChartPreview)
   flex-direction: column;
   gap: 6px;
 }
+.meta-dashboard__filter-field-label { font-size: 11px; font-weight: 600; color: #64748b; }
+.meta-dashboard__input--sm { padding: 3px 6px; font-size: 11px; }
 .meta-dashboard__textarea {
   resize: vertical;
   min-height: 80px;

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -1267,12 +1267,22 @@ export interface DashboardTextConfig {
   content: string
 }
 
-// B4 filter/control: PRESENTATIONAL-ONLY in this arc — it renders a control whose
-// value lives in local UI state and drives NOTHING else. A functional cross-panel
-// filter is a separate, design-locked slice (see designDecisions in the arc map).
+// B4 filter/control: a FUNCTIONAL dashboard-level filter. The widget is configured with a `fieldId`
+// (which field to filter on); at runtime the user picks a VALUE for that field and it becomes an
+// additional equals-constraint applied to EVERY data panel's aggregation (AND-combined with each
+// chart's own filter). The "All" selection clears it. Cross-filtering (click a chart segment → filter
+// the rest) is a separate follow-up, not this slice.
 export interface DashboardFilterConfig {
-  /** Field the (presentational) control is labeled against. */
+  /** Field this control filters on. The runtime value dropdown is populated from this field. */
   fieldId?: string
+}
+
+// B4: one resolved dashboard-level filter (field + chosen value) sent to the aggregation routes. The
+// server AND-combines all active filters and rejects one whose field the actor cannot read (it never
+// becomes a side-channel onto a hidden column). Equals-only by design — the widget surfaces one value.
+export interface DashboardFilter {
+  fieldId: string
+  value: unknown
 }
 
 export interface DashboardPanel {

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -143,8 +143,10 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.textContentPlaceholder'
   | 'dashboard.textEmpty'
   | 'dashboard.filterField'
-  | 'dashboard.filterPresentationalNote'
   | 'dashboard.filterAllOption'
+  | 'dashboard.filterValueLabel'
+  | 'dashboard.filterValuePlaceholder'
+  | 'dashboard.filterConfigNote'
   | 'dashboard.addWidgetAction'
   | 'dashboard.loadingMetric'
   | 'chart.label'
@@ -288,8 +290,10 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.textContentPlaceholder',
   'dashboard.textEmpty',
   'dashboard.filterField',
-  'dashboard.filterPresentationalNote',
   'dashboard.filterAllOption',
+  'dashboard.filterValueLabel',
+  'dashboard.filterValuePlaceholder',
+  'dashboard.filterConfigNote',
   'dashboard.addWidgetAction',
   'dashboard.loadingMetric',
   'chart.label',
@@ -431,7 +435,7 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.widgetKind': { en: 'Widget type', zh: '组件类型' },
   'dashboard.widgetKindMetric': { en: 'Metric card', zh: '指标卡' },
   'dashboard.widgetKindText': { en: 'Text note', zh: '文本说明' },
-  'dashboard.widgetKindFilter': { en: 'Filter (preview)', zh: '筛选器（预览）' },
+  'dashboard.widgetKindFilter': { en: 'Filter', zh: '筛选器' },
   'dashboard.widgetTitle': { en: 'Title', zh: '标题' },
   'dashboard.untitledWidget': { en: 'Untitled', zh: '未命名' },
   'dashboard.metricPrefix': { en: 'Prefix (optional)', zh: '前缀（可选）' },
@@ -440,11 +444,13 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.textContentPlaceholder': { en: 'Write a note (basic formatting allowed)…', zh: '撰写说明（支持基础格式）…' },
   'dashboard.textEmpty': { en: 'Empty text widget. Edit it to add content.', zh: '空文本组件。编辑以添加内容。' },
   'dashboard.filterField': { en: 'Field', zh: '字段' },
-  'dashboard.filterPresentationalNote': {
-    en: 'Preview only — this control does not filter other panels yet.',
-    zh: '仅供预览——此控件暂不会筛选其他面板。',
-  },
   'dashboard.filterAllOption': { en: 'All', zh: '全部' },
+  'dashboard.filterValueLabel': { en: 'Value', zh: '值' },
+  'dashboard.filterValuePlaceholder': { en: 'Type a value to filter by…', zh: '输入筛选值…' },
+  'dashboard.filterConfigNote': {
+    en: 'This filter applies to every data panel in the dashboard.',
+    zh: '此筛选器将作用于仪表盘中的每个数据面板。',
+  },
   'dashboard.addWidgetAction': { en: 'Add', zh: '添加' },
   'dashboard.loadingMetric': { en: 'Loading metric...', zh: '正在加载指标...' },
   'chart.label': { en: 'Label', zh: '标签' },

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -50,7 +50,8 @@ function fakeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
 }
 
 const chartFields: MetaField[] = [
-  { id: 'fld_status', name: 'Status', type: 'select' },
+  // fld_status carries schema options → the B4 filter widget populates its value dropdown from them.
+  { id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'open' }, { value: 'closed' }] },
   { id: 'fld_amount', name: 'Amount', type: 'number' },
   { id: 'fld_date', name: 'Created', type: 'date' },
   { id: 'fld_hidden', name: 'Hidden', type: 'string', property: { hidden: true } },
@@ -1216,11 +1217,12 @@ describe('MetaDashboardView', () => {
     const panel = container.querySelector('[data-panel-id="panel_metric"]')
     expect(panel?.getAttribute('data-panel-type')).toBe('metric')
     // Computes through previewChartData (NOT getChartData) with a synthesized number config.
+    // B4: the 3rd arg is the active dashboard filter list — empty here (no filter widget on this dashboard).
     expect(previewSpy).toHaveBeenCalledTimes(1)
     expect(previewSpy).toHaveBeenCalledWith('sheet_1', expect.objectContaining({
       chartType: 'number',
       dataSource: expect.objectContaining({ aggregation: { function: 'sum', fieldId: 'fld_amount' } }),
-    }))
+    }), [])
     // No persisted chart fetch (no chartId on a metric panel).
     const dataLoads = fetchFn.mock.calls.filter(([url]: [string]) => /\/charts\/[^/]+\/data/.test(url))
     expect(dataLoads.length).toBe(0)
@@ -1287,38 +1289,102 @@ describe('MetaDashboardView', () => {
     expect(link?.getAttribute('target')).toBe('_blank')
   })
 
-  it('B4 filter: renders a PRESENTATIONAL control and updates local state only (no refetch / no cross-panel effect)', async () => {
+  it('B4 filter: a FUNCTIONAL value dropdown (from the configured field schema options) refetches every data panel with the filter; "All" clears it', async () => {
     const filterDashboard = fakeDashboard({
       panels: [
         { id: 'panel_chart', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
         { id: 'panel_filter', type: 'filter', title: 'Status filter', size: 'small', order: 1, filterConfig: { fieldId: 'fld_status' } },
       ],
     })
-    const { client, fetchFn } = mockClient([filterDashboard], [fakeChart()])
+    const { client } = mockClient([filterDashboard], [fakeChart()])
     const getDataSpy = vi.spyOn(client, 'getChartData')
     const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
     await flushPromises()
 
     const filterPanel = container.querySelector('[data-panel-id="panel_filter"]')
     expect(filterPanel?.getAttribute('data-panel-type')).toBe('filter')
+    // The OLD presentational note is gone — the widget is real now.
+    expect(filterPanel?.querySelector('[data-hint="filter-presentational"]')).toBeNull()
+    // The value dropdown lists the configured field's SCHEMA options (open/closed) + the "All" option,
+    // NOT a list of fields. (Schema options → no record scan → no row-deny leak.)
     const control = filterPanel?.querySelector('[data-field="filter-control"]') as HTMLSelectElement
     expect(control).toBeTruthy()
-    // Clearly labeled as presentational.
-    expect(filterPanel?.querySelector('[data-hint="filter-presentational"]')).toBeTruthy()
+    const optionValues = Array.from(control.options).map((o) => o.value)
+    expect(optionValues).toEqual(['', 'open', 'closed'])
 
-    const dataCallsBefore = getDataSpy.mock.calls.length
-    const patchBefore = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH').length
+    getDataSpy.mockClear()
 
-    control.value = 'fld_status'
+    // Pick a value → every data panel (the one chart) refetches WITH the dashboard filter applied.
+    control.value = 'open'
     control.dispatchEvent(new Event('change'))
     await flushPromises()
 
-    // Changing the control triggers NO data refetch and NO dashboard PATCH (local UI state only).
-    expect(getDataSpy.mock.calls.length).toBe(dataCallsBefore)
-    const patchAfter = fetchFn.mock.calls.filter(([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH').length
-    expect(patchAfter).toBe(patchBefore)
-    // The chart panel still renders unchanged (filter does not drive it).
-    expect(container.querySelector('[data-panel-id="panel_chart"] [data-chart-canvas]')).toBeTruthy()
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [{ fieldId: 'fld_status', value: 'open' }])
+
+    // Select "All" → refetch with NO filter (empty list).
+    getDataSpy.mockClear()
+    control.value = ''
+    control.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [])
+  })
+
+  it('B4 filter: a configured field WITHOUT schema options renders a free text input that applies on change', async () => {
+    // fld_amount has no `options` → the runtime widget falls back to a text input for the value.
+    const filterDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_chart', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
+        { id: 'panel_filter', type: 'filter', title: 'Amount filter', size: 'small', order: 1, filterConfig: { fieldId: 'fld_amount' } },
+      ],
+    })
+    const { client } = mockClient([filterDashboard], [fakeChart()])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    const filterPanel = container.querySelector('[data-panel-id="panel_filter"]')
+    expect(filterPanel?.querySelector('[data-field="filter-control"]')).toBeNull() // no select
+    const text = filterPanel?.querySelector('[data-field="filter-control-text"]') as HTMLInputElement
+    expect(text).toBeTruthy()
+
+    getDataSpy.mockClear()
+    text.value = '100'
+    text.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [{ fieldId: 'fld_amount', value: '100' }])
+  })
+
+  it('B4 filter: the active filter also rides on a metric card refetch (preview-data) and AND-combines multiple widgets', async () => {
+    const filterDashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_metric', type: 'metric', title: 'KPI', size: 'small', order: 0, metricConfig: { aggregation: 'count' } },
+        { id: 'panel_f1', type: 'filter', title: 'Status', size: 'small', order: 1, filterConfig: { fieldId: 'fld_status' } },
+        { id: 'panel_f2', type: 'filter', title: 'Amount', size: 'small', order: 2, filterConfig: { fieldId: 'fld_amount' } },
+      ],
+    })
+    const { client } = mockClient([filterDashboard], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'number', dataPoints: [{ label: 'KPI', value: 1 }], total: 1 })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    // Set the first filter (a select value).
+    const statusControl = container.querySelector('[data-panel-id="panel_f1"] [data-field="filter-control"]') as HTMLSelectElement
+    statusControl.value = 'open'
+    statusControl.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // Set the second filter (a text value) — both should now AND-combine on the next refetch.
+    previewSpy.mockClear()
+    const amountText = container.querySelector('[data-panel-id="panel_f2"] [data-field="filter-control-text"]') as HTMLInputElement
+    amountText.value = '50'
+    amountText.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // The metric card refetched via preview-data carrying BOTH filters.
+    expect(previewSpy).toHaveBeenCalledWith('sheet_1', expect.objectContaining({ chartType: 'number' }), [
+      { fieldId: 'fld_status', value: 'open' },
+      { fieldId: 'fld_amount', value: '50' },
+    ])
   })
 
   it('B4 mixed: a dashboard with [chart, metric, text] renders all three widget kinds in one grid', async () => {
@@ -1426,6 +1492,6 @@ describe('MetaDashboardView', () => {
     expect(container.textContent).toContain('组件类型')
     expect(container.textContent).toContain('指标卡')
     expect(container.textContent).toContain('文本说明')
-    expect(container.textContent).toContain('筛选器（预览）')
+    expect(container.textContent).toContain('筛选器')
   })
 })

--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -50,6 +50,38 @@ export interface ChartData {
 
 type RecordRow = { data: Record<string, unknown> }
 
+/**
+ * B4 dashboard-level filter: one (field, value) equals-constraint chosen in a dashboard filter widget.
+ * Applied to EVERY data panel's record set BEFORE aggregation (AND-combined with each chart's own
+ * `filterRecords`). Equals-only by design — the widget surfaces a single chosen value, mirroring the
+ * chart's own `equals` operator coercion exactly (`String(val) === String(value)`).
+ */
+export interface DashboardFilter {
+  fieldId: string
+  value: unknown
+}
+
+/** Shared equals matcher — the exact coercion `filterRecords`' `equals` branch uses, factored so the
+ *  dashboard pre-filter and the chart's own filter agree byte-for-byte (a null/absent field never matches). */
+function recordMatchesEquals(data: Record<string, unknown>, fieldId: string, value: unknown): boolean {
+  const val = data[fieldId]
+  return val != null && String(val) === String(value)
+}
+
+/**
+ * B4: narrow an ALREADY-masked / row-denied record set by the active dashboard filter(s) BEFORE it
+ * reaches the aggregation engine. AND-combines all filters; an empty list is a pass-through (no
+ * constraint, the "All" selection). Operates ONLY on the caller's pre-loaded `loadChartRecords`
+ * output — it never queries — so it inherits the field-mask + row-level read-deny already applied and
+ * cannot widen the visible set or leak a denied field's value. A filter on a field absent from the
+ * masked `data` (e.g. a denied field that was projected out) matches nothing → the route's restricted
+ * gate must reject such a filter UP FRONT so this never silently empties a chart instead.
+ */
+export function applyDashboardFilter(records: RecordRow[], filters: DashboardFilter[]): RecordRow[] {
+  if (filters.length === 0) return records
+  return records.filter((r) => filters.every((f) => recordMatchesEquals(r.data, f.fieldId, f.value)))
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -372,7 +404,7 @@ export class ChartAggregationService {
       const val = r.data[filterFieldId]
       switch (filterOperator) {
         case 'equals':
-          return val != null && String(val) === String(filterValue)
+          return recordMatchesEquals(r.data, filterFieldId, filterValue)
         case 'not_equals':
           return val == null || String(val) !== String(filterValue)
         case 'contains':

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -32,7 +32,8 @@ import { poolManager } from '../integration/db/connection-pool'
 import type { MultitableCapabilities } from '../multitable/access'
 import type { AggregationFunction, ChartConfig, ChartCreateInput, ChartType } from '../multitable/charts'
 import { assertScatterFields, assertSeriesConstraints } from '../multitable/charts'
-import type { ChartData } from '../multitable/chart-aggregation-service'
+import type { ChartData, DashboardFilter } from '../multitable/chart-aggregation-service'
+import { applyDashboardFilter } from '../multitable/chart-aggregation-service'
 import { DashboardService } from '../multitable/dashboard-service'
 import type { MultitableField } from '../multitable/field-codecs'
 import { loadFieldsForSheet } from '../multitable/loaders'
@@ -199,8 +200,19 @@ function chartReferencedFieldIds(chart: ChartConfig): string[] {
   return ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
 
-function isChartDataRestricted(chart: ChartConfig, allowedFieldIds: Set<string>): boolean {
-  return chartReferencedFieldIds(chart).some((fieldId) => !allowedFieldIds.has(fieldId))
+/**
+ * B4: a dashboard-level filter on a field the actor cannot read is a side-channel — answering "how
+ * many records have hidden-field = X" leaks the hidden column by probing. So a dashboard filter
+ * referencing a non-allowed field RESTRICTS the whole chart (same wholesale-refuse discipline as a
+ * chart that references a denied field), and this is checked BEFORE any record is loaded or filtered.
+ */
+function isChartDataRestricted(
+  chart: ChartConfig,
+  allowedFieldIds: Set<string>,
+  dashboardFilters: DashboardFilter[] = [],
+): boolean {
+  if (chartReferencedFieldIds(chart).some((fieldId) => !allowedFieldIds.has(fieldId))) return true
+  return dashboardFilters.some((f) => !allowedFieldIds.has(f.fieldId))
 }
 
 function restrictedChartData(chart: ChartConfig): ChartData {
@@ -224,6 +236,39 @@ function readBarMode(display: unknown): 'stacked' | 'grouped' | undefined {
 
 function readString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+/**
+ * B4: parse the dashboard-level filter(s) off a request. Accepts:
+ *   - GET  /charts/:id/data        → a `dashboardFilter` query param holding URL-encoded JSON
+ *   - POST /charts/:id/preview-data → a `dashboardFilter` body value (already JSON-parsed by express)
+ * Either form normalizes to a list of `{ fieldId, value }`. An entry is kept ONLY when `fieldId` is a
+ * non-empty string and `value` is present and non-empty (an empty/"All" selection contributes no
+ * constraint and is dropped here, so the aggregation is unconstrained). Malformed input → [] (treated
+ * as "no filter", never an error — a filter is an optional narrowing, not a contract field). The field
+ * is NOT permission-checked here; the route's restricted gate does that against allowedFieldIds.
+ */
+function parseDashboardFilters(raw: unknown): DashboardFilter[] {
+  let value = raw
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return []
+    }
+  }
+  if (!Array.isArray(value)) return []
+  const out: DashboardFilter[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const fieldId = readString((entry as { fieldId?: unknown }).fieldId)
+    if (!fieldId) continue
+    const v = (entry as { value?: unknown }).value
+    // Drop empty selections: undefined/null/'' = the "All" option = no constraint.
+    if (v === undefined || v === null || v === '') continue
+    out.push({ fieldId, value: v })
+  }
+  return out
 }
 
 function buildPreviewChart(sheetId: string, userId: string, body: unknown): ChartConfig {
@@ -348,18 +393,20 @@ export function dashboardRouter() {
       const auth = await requireSheetRead(req, res, req.params.sheetId)
       if (!auth) return
       const chart = buildPreviewChart(req.params.sheetId, auth.userId, req.body)
+      // B4: a metric card refetches through preview-data, so the dashboard filter rides on the body.
+      const dashboardFilters = parseDashboardFilters((req.body as { dashboardFilter?: unknown } | undefined)?.dashboardFilter)
       const allowedFieldIds = await loadAllowedFieldIds(
         auth.query,
         req.params.sheetId,
         auth.userId,
         auth.capabilities,
       )
-      if (isChartDataRestricted(chart, allowedFieldIds)) {
+      if (isChartDataRestricted(chart, allowedFieldIds, dashboardFilters)) {
         res.json(restrictedChartData(chart))
         return
       }
       const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access, allowedFieldIds)
-      const data = await dashboardService.computeChartDataForConfig(chart, records)
+      const data = await dashboardService.computeChartDataForConfig(chart, applyDashboardFilter(records, dashboardFilters))
       res.json(data)
     } catch (err: unknown) {
       res.status(400).json({ error: (err as Error).message })
@@ -442,18 +489,24 @@ export function dashboardRouter() {
         res.status(404).json({ error: 'Chart not found' })
         return
       }
+      // B4: an optional dashboard-level filter (one filter widget → every data panel). Parsed off the
+      // query; AND-combined with the chart's own filter. A denied filter field restricts wholesale.
+      const dashboardFilters = parseDashboardFilters(req.query.dashboardFilter)
       const allowedFieldIds = await loadAllowedFieldIds(
         auth.query,
         req.params.sheetId,
         auth.userId,
         auth.capabilities,
       )
-      if (isChartDataRestricted(chart, allowedFieldIds)) {
+      if (isChartDataRestricted(chart, allowedFieldIds, dashboardFilters)) {
         res.json(restrictedChartData(chart))
         return
       }
       const records = await loadChartRecords(auth.query, req.params.sheetId, auth.access, allowedFieldIds)
-      const data = await dashboardService.getChartData(req.params.id, records)
+      // B4: narrow the ALREADY-masked + row-denied record set by the dashboard filter BEFORE aggregation.
+      // computeChartData then runs the chart's own filterRecords on the narrowed set → AND for free, and
+      // every chart type (number/scatter/grouped) is covered uniformly (it's a record-level pre-filter).
+      const data = await dashboardService.getChartData(req.params.id, applyDashboardFilter(records, dashboardFilters))
       res.json(data)
     } catch (err: unknown) {
       res.status(500).json({ error: (err as Error).message })

--- a/packages/core-backend/tests/integration/multitable-dashboard-level-filter-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-level-filter-realdb.test.ts
@@ -1,0 +1,222 @@
+/**
+ * B4 dashboard-LEVEL filtering — real-DB integration (chart-data + preview-data aggregation paths).
+ *
+ * A dashboard filter widget's (field, value) selection becomes an additional equals-constraint applied
+ * to EVERY data panel's aggregation, AND-combined with the chart's own filter. This golden locks:
+ *   1. NARROW: a dashboard filter narrows the aggregate to the matching records (per chart-data + preview).
+ *   2. AND: it combines with a chart's OWN filter (intersection, not replacement).
+ *   3. ALL: an empty/absent filter is a pass-through (the unfiltered aggregate).
+ *   4. MULTI: two filter widgets AND-combine.
+ *   5. ROW-DENY HOLDS: a row excluded by a read-deny rule stays excluded even when the dashboard filter
+ *      would otherwise select it (the filter narrows the ALREADY-row-denied set; it cannot widen it).
+ *   6. FIELD-MASK HOLDS / NO SIDE-CHANNEL: a dashboard filter on a field the actor CANNOT read restricts
+ *      the chart wholesale (empty + metadata.restricted) and never leaks the hidden field's value — so it
+ *      can't be used to probe a hidden column ("how many rows have secret = X").
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { dashboardRouter, getDashboardService } from '../../src/routes/dashboard'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_dlf_${TS}`
+const SHEET_ID = `sheet_dlf_${TS}`
+const REGION = `fld_dlf_region_${TS}`
+const STATUS = `fld_dlf_status_${TS}`
+const SECRET = `fld_dlf_secret_${TS}` // denied to the reader → must not be filterable as a side-channel
+// Charts: one plain group-by-region count; one group-by-region count with its OWN filter status=open.
+const CHART_REGION = `chart_dlf_region_${TS}`
+const CHART_REGION_OPEN = `chart_dlf_region_open_${TS}`
+const USER_ID = `u_dlf_reader_${TS}`
+const USER_DENIED = `u_dlf_denied_${TS}`
+const SECRET_CANARY = 'do-not-leak-dlf-canary'
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const asJson = (v: unknown) => JSON.stringify(v)
+let app: Express
+let testUserId = USER_ID
+let testRoles: string[] = []
+let testPerms: string[] = ['multitable:read']
+
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, asJson(rules)])
+
+type Body = { dataPoints?: Array<{ label: string; value: number }>; total?: number; metadata?: { restricted?: boolean; recordCount?: number } }
+const bucket = (body: Body, label: string) => (body.dataPoints ?? []).find((p) => p.label === label)?.value
+
+// GET /charts/:id/data with an optional dashboard filter list (URL-encoded JSON).
+const chartData = async (chartId: string, filters?: Array<{ fieldId: string; value: unknown }>) => {
+  let url = `/api/multitable/sheets/${SHEET_ID}/charts/${chartId}/data`
+  if (filters && filters.length) url += `?dashboardFilter=${encodeURIComponent(JSON.stringify(filters))}`
+  const res = await request(app).get(url)
+  expect(res.status).toBe(200)
+  return res.body as Body
+}
+
+// POST /charts/preview-data (group-by-region count — a VALID preview shape) with an optional dashboard
+// filter on the body. (A groupBy is required by the preview-data validator for every non-scatter type.)
+const previewByRegion = async (filters?: Array<{ fieldId: string; value: unknown }>) => {
+  const res = await request(app)
+    .post(`/api/multitable/sheets/${SHEET_ID}/charts/preview-data`)
+    .send({
+      name: 'by region',
+      type: 'bar',
+      dataSource: { groupByFieldId: REGION, aggregation: { function: 'count' } },
+      ...(filters && filters.length ? { dashboardFilter: filters } : {}),
+    })
+  expect(res.status).toBe(200)
+  return res.body as Body
+}
+
+describeIfDatabase('B4 dashboard-level filtering (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined; next() })
+    app.use('/api/multitable', dashboardRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'DLF Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'DLF Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [REGION, SHEET_ID, 'Region', 'select', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SECRET, SHEET_ID, 'Secret', 'string', '{}', 3])
+    // SECRET denied to USER_DENIED at field-permission layer-3 (property.hidden UNSET) so the deny is solely RBAC.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, SECRET, 'user', USER_DENIED, false, false])
+
+    // 5 records:
+    //   east/open, east/open, east/closed, west/open, west/closed
+    // → region count: east=3, west=2 ; status=open count: east=2, west=1 ; (east AND open)=2.
+    const rec = (id: string, region: string, status: string) =>
+      q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [id, SHEET_ID, asJson({ [REGION]: region, [STATUS]: status, [SECRET]: SECRET_CANARY })])
+    await rec(`rec_dlf_1_${TS}`, 'east', 'open')
+    await rec(`rec_dlf_2_${TS}`, 'east', 'open')
+    await rec(`rec_dlf_3_${TS}`, 'east', 'closed')
+    await rec(`rec_dlf_4_${TS}`, 'west', 'open')
+    await rec(`rec_dlf_5_${TS}`, 'west', 'closed')
+
+    await q(
+      `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [CHART_REGION, 'Count by region', 'bar', SHEET_ID, asJson({ groupByFieldId: REGION, aggregation: { function: 'count' } }), '{}', USER_ID],
+    )
+    // Chart with its OWN filter status=open — used to prove AND-combination with a dashboard filter.
+    await q(
+      `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [CHART_REGION_OPEN, 'Open by region', 'bar', SHEET_ID, asJson({ groupByFieldId: REGION, aggregation: { function: 'count' }, filterFieldId: STATUS, filterOperator: 'equals', filterValue: 'open' }), '{}', USER_ID],
+    )
+  })
+
+  afterAll(async () => {
+    getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    testRoles = []
+    testPerms = ['multitable:read']
+    await setFlag(false)
+    await setRules([])
+    getDashboardService().setRecordProvider(async () => [])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('ALL — no dashboard filter: the full aggregate (east=3, west=2)', async () => {
+    const body = await chartData(CHART_REGION)
+    expect(bucket(body, 'east')).toBe(3)
+    expect(bucket(body, 'west')).toBe(2)
+  })
+
+  test('NARROW — dashboard filter status=open narrows EVERY bucket (east=2, west=1)', async () => {
+    const body = await chartData(CHART_REGION, [{ fieldId: STATUS, value: 'open' }])
+    expect(bucket(body, 'east')).toBe(2)
+    expect(bucket(body, 'west')).toBe(1)
+    expect(body.metadata?.recordCount).toBe(3) // 3 open records total
+  })
+
+  test('NARROW — dashboard filter region=east narrows to one bucket (east=3, west gone)', async () => {
+    const body = await chartData(CHART_REGION, [{ fieldId: REGION, value: 'east' }])
+    expect(bucket(body, 'east')).toBe(3)
+    expect(bucket(body, 'west')).toBeUndefined()
+  })
+
+  test('AND — dashboard filter region=east + the chart\'s OWN filter status=open → intersection (east=2 only)', async () => {
+    // CHART_REGION_OPEN already filters status=open; add a dashboard filter region=east.
+    const body = await chartData(CHART_REGION_OPEN, [{ fieldId: REGION, value: 'east' }])
+    expect(bucket(body, 'east')).toBe(2) // east AND open
+    expect(bucket(body, 'west')).toBeUndefined() // west excluded by the dashboard filter
+  })
+
+  test('MULTI — two dashboard filters (region=east AND status=open) AND-combine (east=2 only)', async () => {
+    const body = await chartData(CHART_REGION, [
+      { fieldId: REGION, value: 'east' },
+      { fieldId: STATUS, value: 'open' },
+    ])
+    expect(bucket(body, 'east')).toBe(2)
+    expect(bucket(body, 'west')).toBeUndefined()
+    expect(body.metadata?.recordCount).toBe(2)
+  })
+
+  test('ALL — an empty selection in the list is dropped (behaves like no filter)', async () => {
+    const body = await chartData(CHART_REGION, [{ fieldId: STATUS, value: '' }])
+    expect(bucket(body, 'east')).toBe(3)
+    expect(bucket(body, 'west')).toBe(2)
+  })
+
+  test('preview-data — a chart narrows by the dashboard filter (open: east=2, west=1)', async () => {
+    const all = await previewByRegion()
+    expect(bucket(all, 'east')).toBe(3)
+    expect(bucket(all, 'west')).toBe(2)
+    const open = await previewByRegion([{ fieldId: STATUS, value: 'open' }])
+    expect(bucket(open, 'east')).toBe(2)
+    expect(bucket(open, 'west')).toBe(1)
+    expect(open.metadata?.recordCount).toBe(3)
+  })
+
+  test('ROW-DENY HOLDS — a read-denied row stays excluded even when the dashboard filter would select it', async () => {
+    // Deny status=closed rows; then filter region=east. east has 2 open + 1 closed; the closed one is
+    // denied, so the filtered east count is 2 (not 3) — the filter narrows the already-row-denied set.
+    await setFlag(true)
+    await setRules([{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'closed', effect: 'deny_read' }])
+    const body = await chartData(CHART_REGION, [{ fieldId: REGION, value: 'east' }])
+    expect(bucket(body, 'east')).toBe(2) // 3 east rows − 1 denied closed = 2
+  })
+
+  test('NO SIDE-CHANNEL — a dashboard filter on a DENIED field restricts the chart (no value leak)', async () => {
+    // The reader who CANNOT read SECRET tries to filter on it → restricted, not a probe of the hidden column.
+    testUserId = USER_DENIED
+    testPerms = ['multitable:read']
+    const body = await chartData(CHART_REGION, [{ fieldId: SECRET, value: SECRET_CANARY }])
+    expect(body).toMatchObject({ chartId: CHART_REGION, dataPoints: [], total: 0, metadata: { restricted: true, recordCount: 0 } })
+    expect(JSON.stringify(body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('NO SIDE-CHANNEL — same denied-field filter via preview-data is also restricted', async () => {
+    testUserId = USER_DENIED
+    testPerms = ['multitable:read']
+    const body = await previewByRegion([{ fieldId: SECRET, value: SECRET_CANARY }])
+    expect(body.metadata?.restricted).toBe(true)
+    expect((body.dataPoints ?? []).length).toBe(0)
+    expect(JSON.stringify(body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('an allowed reader CAN filter on a readable field unaffected (control for the deny test)', async () => {
+    // The non-denied USER_ID filtering on a readable field works normally — proves the restriction is
+    // field-permission-scoped, not a blanket reject of all dashboard filters.
+    const body = await chartData(CHART_REGION, [{ fieldId: STATUS, value: 'open' }])
+    expect(body.metadata?.restricted).toBeUndefined()
+    expect(bucket(body, 'east')).toBe(2)
+  })
+})


### PR DESCRIPTION
## What

Makes the multitable dashboard **filter widget functional** (Feishu-parity lane "B4 dashboard-level filtering"). It was previously presentational (`data-hint="filter-presentational"`, `filterSelections` drove nothing). Now a filter widget's chosen value becomes an additional equals-constraint applied to **every** data panel's aggregation, AND-combined with each chart's own filter. Empty / "All" = no constraint.

**Verified the gap first:** the widget only updated local state (`onFilterControlChange`), never refetched panels — confirmed presentational, so the STOP condition did not apply.

## Backend (`chart-aggregation-service.ts` + `routes/dashboard.ts`)

- New `applyDashboardFilter(records, filters)` narrows the **already field-masked + row-denied** record set (the `loadChartRecords` output) **before** aggregation — a record-level pre-filter, so `number` / `scatter` / grouped charts are all covered uniformly. Reuses the existing equals coercion (`recordMatchesEquals`, which also now backs `filterRecords`' own `equals` branch).
- `GET /charts/:id/data` reads the filter from the query (URL-encoded JSON); `POST /charts/preview-data` reads it from the body. Both AND-combine all active filters with each chart's own filter.
- **Security:** `isChartDataRestricted` now also restricts the chart wholesale when a dashboard filter references a field the actor cannot read — **checked before any record loads** — so a hidden field can't be probed as a side-channel ("how many rows have secret = X"). The filter only ever narrows the already-masked + row-denied set; it cannot widen it or reintroduce a masked-out field.

## Frontend (`MetaDashboardView.vue` + `client.ts` + `types.ts`)

- The runtime filter widget now picks a **value** for its configured field: a dropdown populated from the field's **schema options** (select/multiSelect — no record scan, so no row-deny leak), or a free text input when the field has no options. "All" clears it.
- On a filter change, the `chartId`/panel-keyed data caches are cleared and every panel refetches with the active filter threaded through `getChartData` (GET) and `previewChartData` (POST — metric cards).
- Dropped the "presentational" note; relabeled the widget kind from "Filter (preview)" → "Filter". All new/changed strings go through the existing `meta-view-render-labels` typed module (i18n strict-zero).

## Scope

Dashboard-level filtering only (**one filter widget → all panels**). **Cross-filtering** (click a chart segment → filter others) is a deliberate **follow-up**, not built here. Other noted follow-ups: a distinct-values value dropdown for non-option fields would need its own `loadChartRecords`-style masked endpoint; sequence-guarding rapid filter toggles (current behavior meets "single change → refetch with filter; All clears").

## Tests

- **Real-DB integration** — `tests/integration/multitable-dashboard-level-filter-realdb.test.ts` (registered in `.github/workflows/plugin-tests.yml`): narrow / AND-with-chart's-own-filter / multi-widget-AND / "All" clears / preview-data narrows / **ROW-DENY holds under filter** / **denied-field filter → restricted (no canary leak)** on both the chart-data and preview-data paths. **12/12 pass against a real Postgres.**
- **FE** — value selection refetches panels with the filter; "All" clears; value dropdown from schema options; text-input fallback; metric-card refetch carries the filter; multi-widget AND.

## Validation (all green)

- `pnpm install --frozen-lockfile` (no lockfile change)
- Backend `tsc --noEmit` → 0 errors; Web `vue-tsc -b` → 0 errors
- Full backend unit suite (`CI=true … test`, non-watch): **4676 passed, 0 failed**
- Structural guards (egress-coverage / taint-chokepoint / record-lock): **8 passed**
- New integration test 12/12 + existing dashboard integration tests (authz / rowdeny / preview-data) 26/26 — no regression
- FE dashboard + label specs: **57 passed**

## Aggregation permissions still hold

With the dashboard filter applied, field-mask + row-deny are preserved: the filter narrows the **already-masked + row-denied** record set (never a fresh unfiltered/unmasked scan), and a filter referencing a **denied field** restricts the chart wholesale **before records load** — so a denied field can't be used as a leaking filter. This is asserted directly by the ROW-DENY and NO-SIDE-CHANNEL integration tests (canary absent; restricted output) on both the chart-data and preview-data routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)