### PR TITLE
feat(multitable): dashboard cross-filtering — click a chart segment to filter the other panels

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -23,7 +23,20 @@
           class="meta-chart__legend"
           data-legend="true"
         >
-          <div v-for="(pt, idx) in chartData.dataPoints" :key="idx" class="meta-chart__legend-item">
+          <!-- Cross-filtering: the pie/funnel point legend is HTML, so clicking a legend row is the
+               accessible twin of clicking a canvas slice — both emit the row's label. Empty labels
+               (uncategorized) carry no filterable value, so their row is not interactive. -->
+          <div
+            v-for="(pt, idx) in chartData.dataPoints"
+            :key="idx"
+            class="meta-chart__legend-item"
+            :class="{ 'meta-chart__legend-item--clickable': pt.label !== '' }"
+            :role="pt.label !== '' ? 'button' : undefined"
+            :tabindex="pt.label !== '' ? 0 : undefined"
+            :data-legend-segment="pt.label !== '' ? pt.label : undefined"
+            @click="pt.label !== '' && emit('segment-click', pt.label)"
+            @keydown.enter="pt.label !== '' && emit('segment-click', pt.label)"
+          >
             <span class="meta-chart__legend-swatch" :style="{ background: pt.color || defaultColor(idx) }"></span>
             <span class="meta-chart__legend-label">{{ pt.label }}</span>
             <span class="meta-chart__legend-value">{{ pt.value }}</span>
@@ -97,6 +110,12 @@ const props = defineProps<{
   // whose share-of-total dial is misleading for a non-additive aggregation (avg/min/max).
   aggregation?: AggregationFunction
 }>()
+// Cross-filtering (dashboard): a click on a chart SEGMENT emits the clicked category's LABEL. The
+// renderer has no `dataSource`, so it cannot know which FIELD the label belongs to — the parent
+// (MetaDashboardView) maps `label → { fieldId: dataSource.groupByFieldId, value: label }` and folds
+// it into the SAME dashboard-filter state #3007 added (no parallel filter path). The renderer only
+// surfaces the user's intent; turning it into a (permission-gated) filter is the parent's job.
+const emit = defineEmits<{ (e: 'segment-click', label: string): void }>()
 const { isZh } = useLocale()
 
 // Additive aggregations are the only ones whose Σ values is a meaningful whole, so the gauge's
@@ -154,7 +173,18 @@ function renderChart(): void {
     return
   }
   if (!chartEl.value) return
-  if (!chart) chart = echarts.init(chartEl.value)
+  if (!chart) {
+    chart = echarts.init(chartEl.value)
+    // Cross-filtering: a click on a series item (bar/pie/funnel/line/area marks) emits the clicked
+    // category's label. `params.name` is the dataPoint label (= the group-by category value). Bound
+    // once on init (not per setOption) — ECharts keeps the handler across re-renders. The parent
+    // decides whether the source chart can become a cross-filter (scatter/date-grouped/gauge have no
+    // group-by category, so the parent no-ops those; see onSegmentClick in MetaDashboardView).
+    chart.on('click', (params: unknown) => {
+      const name = (params as { name?: unknown } | undefined)?.name
+      if (typeof name === 'string' && name !== '') emit('segment-click', name)
+    })
+  }
   ensureResizeObserver()
   const option = buildChartOption(props.chartData, props.displayConfig)
   if (option) chart.setOption(option, true)
@@ -214,6 +244,9 @@ onBeforeUnmount(teardownChart)
 .meta-chart__legend { display: flex; flex-direction: column; gap: 4px; }
 .meta-chart__legend--inline { flex-direction: row; flex-wrap: wrap; gap: 12px; margin-top: 8px; }
 .meta-chart__legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; }
+.meta-chart__legend-item--clickable { cursor: pointer; border-radius: 4px; padding: 1px 3px; margin: -1px -3px; }
+.meta-chart__legend-item--clickable:hover { background: #f1f5f9; }
+.meta-chart__legend-item--clickable:focus-visible { outline: 2px solid #2563eb; outline-offset: 1px; }
 .meta-chart__legend-swatch { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
 .meta-chart__legend-label { color: #475569; }
 .meta-chart__legend-value { color: #0f172a; font-weight: 600; margin-left: auto; }

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -68,6 +68,26 @@
       >
         <div class="meta-dashboard__panel-header">
           <span class="meta-dashboard__panel-chart-name">{{ panelTitle(panel) }}</span>
+          <!-- Cross-filtering: the source panel (the chart whose segment is driving the dashboard
+               filter) shows an active chip "field = value ×". Clicking × clears the cross-filter; the
+               chip is the visible cue for which segment is filtering the rest. -->
+          <span
+            v-if="crossFilter && crossFilter.panelId === panel.id"
+            class="meta-dashboard__crossfilter-chip"
+            data-crossfilter-active="true"
+            :data-crossfilter-field="crossFilter.fieldId"
+            :data-crossfilter-value="crossFilter.value"
+          >
+            <span class="meta-dashboard__crossfilter-text">{{ crossFilterFieldName }} = {{ crossFilter.value }}</span>
+            <button
+              class="meta-dashboard__crossfilter-clear"
+              type="button"
+              data-action="clear-crossfilter"
+              :aria-label="viewRenderLabel('dashboard.crossFilterClear', isZh)"
+              :title="viewRenderLabel('dashboard.crossFilterClear', isZh)"
+              @click="clearCrossFilter"
+            >&times;</button>
+          </span>
           <div class="meta-dashboard__panel-controls">
             <select
               :value="panel.size"
@@ -98,6 +118,7 @@
               :chart-data="panelChartData(panel)!"
               :display-config="panelChartConfig(panel)?.displayConfig"
               :aggregation="panelChartConfig(panel)?.dataSource?.aggregation?.function"
+              @segment-click="(label: string) => onSegmentClick(panel, label)"
             />
             <div v-else class="meta-dashboard__panel-loading">{{ viewRenderLabel('dashboard.loadingChart', isZh) }}</div>
           </template>
@@ -540,6 +561,14 @@ const metricDataMap = ref<Record<string, ChartData>>({})
 // applied to EVERY data panel's aggregation (see activeDashboardFilters). '' / absent = "All" = no
 // constraint. The widget's configured field lives in panel.filterConfig.fieldId.
 const filterSelections = ref<Record<string, string>>({})
+// Cross-filtering: clicking a chart segment sets ONE active cross-filter on that chart's group-by
+// field = the clicked segment's value. It reuses the SAME dashboard-filter mechanism filterSelections
+// feeds (activeDashboardFilters → getChartData/previewChartData → applyDashboardFilter) — NOT a
+// parallel path: it just contributes one more entry to activeDashboardFilters, AND-combined with the
+// widget selections, and rides the identical permission-safe aggregation route. `panelId` records the
+// source panel (so clicking the same segment again toggles it off, and the UI marks the source).
+// Equals-only (mirrors the widget). At most one cross-filter at a time (Feishu drill-down behavior).
+const crossFilter = ref<{ panelId: string; fieldId: string; value: string } | null>(null)
 const activeDashboardId = ref<string>(props.dashboardId ?? '')
 const showAddPanel = ref(false)
 const showAddWidget = ref(false)
@@ -654,6 +683,14 @@ const activeDashboardFilters = computed<DashboardFilter[]>(() => {
     if (value === undefined || value === '') continue
     out.push({ fieldId, value })
   }
+  // Cross-filter rides the SAME list (AND-combined with the widget selections). It passes through the
+  // identical dashboardFilterableField property-visibility gate, so a cross-filter on a field the actor
+  // can't read is dropped here AND the backend's isChartDataRestricted refuses the chart wholesale — no
+  // new leak path. This is the single point where a cross-filter becomes a server-bound constraint.
+  const cf = crossFilter.value
+  if (cf && dashboardFilterableField(cf.fieldId)) {
+    out.push({ fieldId: cf.fieldId, value: cf.value })
+  }
   return out
 })
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
@@ -745,17 +782,54 @@ function metricDisplayConfig(panel: DashboardPanel): ChartDisplayConfig {
   }
 }
 
-// B4: a dashboard-level filter change re-aggregates EVERY data panel. The chartId-keyed chartDataMap
-// (and panel.id-keyed metricDataMap) are filter-unaware caches, and loadPanelData skips already-loaded
-// charts — so the same chart would never refetch under a new filter. Clear both caches, then reload
-// with the new active filter applied. (Cross-filtering — a chart segment driving others — is a separate
-// follow-up; this is one filter widget → all panels.)
-function onFilterControlChange(panelId: string, value: string) {
-  filterSelections.value = { ...filterSelections.value, [panelId]: value }
+// A dashboard-level filter change (widget selection OR cross-filter) re-aggregates EVERY data panel.
+// The chartId-keyed chartDataMap (and panel.id-keyed metricDataMap) are filter-unaware caches, and
+// loadPanelData skips already-loaded charts — so the same chart would never refetch under a new
+// filter. Clear both caches, then reload with the new activeDashboardFilters applied.
+function refetchAllPanelsWithActiveFilters() {
   chartDataMap.value = {}
   metricDataMap.value = {}
   void loadPanelData()
 }
+
+// B4: one filter widget → all panels. The chosen value enters activeDashboardFilters keyed by panel.id.
+function onFilterControlChange(panelId: string, value: string) {
+  filterSelections.value = { ...filterSelections.value, [panelId]: value }
+  refetchAllPanelsWithActiveFilters()
+}
+
+// Cross-filtering: a chart segment was clicked. Resolve the source chart's group-by field; the clicked
+// segment's `label` is that field's value → set a cross-filter on (groupByFieldId = label). A chart
+// with NO group-by field (scatter's x/y projection, a date-grouped chart whose buckets are not field
+// values, a single-value gauge) yields no field here → the click is a no-op (never a broken filter).
+// Clicking the SAME segment again toggles it off. The cross-filter then flows through the shared
+// activeDashboardFilters path, so the source chart re-aggregates too ("filtering itself is fine") and
+// every other panel narrows by it — reusing #3007's permission-safe aggregation route end to end.
+function onSegmentClick(panel: DashboardPanel, label: string) {
+  const fieldId = panelChartConfig(panel)?.dataSource?.groupByFieldId
+  if (!fieldId) return
+  const current = crossFilter.value
+  if (current && current.panelId === panel.id && current.fieldId === fieldId && current.value === label) {
+    crossFilter.value = null
+  } else {
+    crossFilter.value = { panelId: panel.id, fieldId, value: label }
+  }
+  refetchAllPanelsWithActiveFilters()
+}
+
+// Cross-filtering: clear the active cross-filter (the visible "× clear" control). No-op if none active.
+function clearCrossFilter() {
+  if (!crossFilter.value) return
+  crossFilter.value = null
+  refetchAllPanelsWithActiveFilters()
+}
+
+// The display name of the cross-filter's field (for the active-filter chip). Falls back to the raw id
+// if the field is no longer property-visible (defensive — such a cross-filter is dropped from the
+// server-bound list anyway by the dashboardFilterableField gate in activeDashboardFilters).
+const crossFilterFieldName = computed(() =>
+  crossFilter.value ? (dashboardFilterableField(crossFilter.value.fieldId)?.name ?? crossFilter.value.fieldId) : '',
+)
 
 // B4: metric needs a value field only for sum/avg/min/max (count aggregates row presence).
 const widgetRequiresValueField = computed(() =>
@@ -1278,7 +1352,12 @@ async function finishRename() {
 
 watch(
   () => activeDashboard.value?.id,
-  () => { void loadPanelData() },
+  () => {
+    // Switching dashboards drops any cross-filter (its source panel belongs to the previous
+    // dashboard); the widget selections are panel.id-keyed so they harmlessly find no match.
+    crossFilter.value = null
+    void loadPanelData()
+  },
 )
 
 watch(
@@ -1398,6 +1477,34 @@ onBeforeUnmount(resetChartPreview)
 
 .meta-dashboard__panel-chart-name { font-size: 13px; font-weight: 600; color: #0f172a; }
 .meta-dashboard__panel-controls { display: flex; align-items: center; gap: 6px; }
+
+/* Cross-filter active chip on the source panel header. */
+.meta-dashboard__crossfilter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 8px;
+  padding: 2px 4px 2px 8px;
+  border: 1px solid #2563eb;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 600;
+  max-width: 60%;
+}
+.meta-dashboard__crossfilter-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-dashboard__crossfilter-clear {
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  border-radius: 999px;
+}
+.meta-dashboard__crossfilter-clear:hover { background: #dbeafe; }
 
 .meta-dashboard__panel-body { padding: 12px 14px; flex: 1; display: flex; align-items: center; justify-content: center; }
 .meta-dashboard__panel-loading { font-size: 12px; color: #94a3b8; }

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -147,6 +147,7 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.filterValueLabel'
   | 'dashboard.filterValuePlaceholder'
   | 'dashboard.filterConfigNote'
+  | 'dashboard.crossFilterClear'
   | 'dashboard.addWidgetAction'
   | 'dashboard.loadingMetric'
   | 'chart.label'
@@ -294,6 +295,7 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.filterValueLabel',
   'dashboard.filterValuePlaceholder',
   'dashboard.filterConfigNote',
+  'dashboard.crossFilterClear',
   'dashboard.addWidgetAction',
   'dashboard.loadingMetric',
   'chart.label',
@@ -451,6 +453,7 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
     en: 'This filter applies to every data panel in the dashboard.',
     zh: '此筛选器将作用于仪表盘中的每个数据面板。',
   },
+  'dashboard.crossFilterClear': { en: 'Clear cross-filter', zh: '清除联动筛选' },
   'dashboard.addWidgetAction': { en: 'Add', zh: '添加' },
   'dashboard.loadingMetric': { en: 'Loading metric...', zh: '正在加载指标...' },
   'chart.label': { en: 'Label', zh: '标签' },

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -12,9 +12,15 @@ const mocks = vi.hoisted(() => {
   const setOption = vi.fn()
   const resize = vi.fn()
   const dispose = vi.fn()
-  const instance = { setOption, resize, dispose }
+  // `on` captures the renderer's 'click' handler (cross-filtering): jsdom can't synthesize a real
+  // canvas click, so a test invokes the captured handler to simulate a segment click.
+  let clickHandler: ((params: unknown) => void) | null = null
+  const on = vi.fn((event: string, cb: (params: unknown) => void) => {
+    if (event === 'click') clickHandler = cb
+  })
+  const instance = { setOption, resize, dispose, on }
   const init = vi.fn(() => instance)
-  return { setOption, resize, dispose, init, instance }
+  return { setOption, resize, dispose, on, init, instance, fireClick: (params: unknown) => clickHandler?.(params) }
 })
 vi.mock('echarts/core', () => ({ init: mocks.init, use: vi.fn() }))
 vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {}, ScatterChart: {} }))
@@ -489,5 +495,38 @@ describe('MetaChartRenderer', () => {
     expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(0)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+  })
+
+  // ---- Cross-filtering: a clicked segment emits its label (parent maps it to a dashboard filter) ----
+
+  it('emits segment-click with the clicked canvas segment label (ECharts click → params.name)', async () => {
+    const clicks: string[] = []
+    mount({ chartData: barData, onSegmentClick: (label: string) => clicks.push(label) })
+    await flushPromises()
+    // jsdom can't synthesize a canvas click; the renderer bound its handler via chart.on('click', …),
+    // captured by the mock. Fire it like ECharts would (params carries the dataPoint `name`).
+    mocks.fireClick({ name: 'B', value: 20 })
+    expect(clicks).toEqual(['B'])
+  })
+
+  it('does NOT emit segment-click for an empty / malformed canvas click payload', async () => {
+    const clicks: string[] = []
+    mount({ chartData: barData, onSegmentClick: (label: string) => clicks.push(label) })
+    await flushPromises()
+    mocks.fireClick({ name: '' })       // empty category → not filterable
+    mocks.fireClick({})                  // no name (e.g. axis/blank area)
+    mocks.fireClick({ name: 123 })       // non-string
+    expect(clicks).toEqual([])
+  })
+
+  it('emits segment-click from the HTML pie/funnel legend row (the accessible twin of a slice click)', async () => {
+    const clicks: string[] = []
+    const { container } = mount({ chartData: pieData, onSegmentClick: (label: string) => clicks.push(label) })
+    await flushPromises()
+    const blueRow = container.querySelector('[data-legend-segment="Blue"]') as HTMLElement
+    expect(blueRow).toBeTruthy()
+    expect(blueRow.getAttribute('role')).toBe('button')
+    blueRow.click()
+    expect(clicks).toEqual(['Blue'])
   })
 })

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -12,9 +12,20 @@ async function settleMicrotasksAndRender() {
 }
 
 // MetaDashboardView renders MetaChartRenderer, which now uses ECharts (needs a canvas absent in
-// jsdom) → mock the runtime entry points so the dashboard mounts cleanly.
+// jsdom) → mock the runtime entry points so the dashboard mounts cleanly. The init stub now also
+// exposes `on` (the renderer binds a 'click' handler for cross-filtering); jsdom can't synthesize a
+// real canvas click, so the stub CAPTURES the handler so a test can invoke it to simulate a segment
+// click. `echartsClickHandlers` collects one entry per chart instance (in mount order).
+const echartsClickHandlers = vi.hoisted(() => [] as Array<(params: unknown) => void>)
 vi.mock('echarts/core', () => ({
-  init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() })),
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    on: vi.fn((event: string, cb: (params: unknown) => void) => {
+      if (event === 'click') echartsClickHandlers.push(cb)
+    }),
+  })),
   use: vi.fn(),
 }))
 vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, FunnelChart: {}, GaugeChart: {}, ScatterChart: {} }))
@@ -125,6 +136,17 @@ function mount(props: Record<string, unknown>) {
   return { container, app }
 }
 
+// Cross-filtering: a dashboard-filter change clears chartDataMap, which unmounts→remounts each chart
+// (loading→rendered), so echarts.init runs again and the renderer re-binds its 'click' handler. Each
+// remount pushes a fresh entry into echartsClickHandlers, so the CURRENT live handler (bound to the
+// mounted instance whose emit reaches the live @segment-click listener) is always the LAST one — fire
+// that, never a stale index. `nth` (1-based from the end among the live charts) targets which chart
+// when several are mounted: 1 = the last-mounted chart, 2 = the one before, etc.
+function fireSegmentClick(name: string, nth = 1) {
+  const handler = echartsClickHandlers[echartsClickHandlers.length - nth]
+  handler?.({ name })
+}
+
 describe('MetaDashboardView', () => {
   // S1-9: MetaChartRenderer is an async chunk (defineAsyncComponent). Resolve its loader ONCE up
   // front (real timers) so every test — including the fake-timer preview tests — renders the
@@ -152,6 +174,7 @@ describe('MetaDashboardView', () => {
     vi.useRealTimers()
     useLocale().setLocale('en')
     document.body.innerHTML = ''
+    echartsClickHandlers.length = 0
     vi.restoreAllMocks()
   })
 
@@ -1493,5 +1516,154 @@ describe('MetaDashboardView', () => {
     expect(container.textContent).toContain('指标卡')
     expect(container.textContent).toContain('文本说明')
     expect(container.textContent).toContain('筛选器')
+  })
+
+  // ---- Cross-filtering: clicking a chart segment drives the SAME dashboard-filter state as the widget ----
+
+  it('cross-filter: clicking a chart segment sets a dashboard filter on the chart group-by field = the clicked value, and refetches panels with it applied', async () => {
+    // Two charts so we can see the OTHER panel narrow; chart_1 is the click source (groupBy fld_status).
+    const chart1 = fakeChart()
+    const chart2 = fakeChart({ id: 'chart_2', name: 'Second', dataSource: { sheetId: 'sheet_1', groupByFieldId: 'fld_status', aggregation: { function: 'count' } } })
+    const dashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_1', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
+        { id: 'panel_2', type: 'chart', chartId: 'chart_2', size: 'medium', order: 1 },
+      ],
+    })
+    const { client } = mockClient([dashboard], [chart1, chart2])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    // Two chart instances mounted → two captured click handlers (mount order = panel order).
+    expect(echartsClickHandlers.length).toBeGreaterThanOrEqual(2)
+    getDataSpy.mockClear()
+
+    // Click a segment on the FIRST chart (simulated via the captured ECharts click handler).
+    echartsClickHandlers[0]({ name: 'open', value: 5 })
+    await flushPromises()
+
+    // BOTH panels refetched with the cross-filter applied (same shape #3007's widget filter uses).
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [{ fieldId: 'fld_status', value: 'open' }])
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_2', [{ fieldId: 'fld_status', value: 'open' }])
+
+    // The source panel shows the active cross-filter chip (field = value) + a clear control.
+    const chip = container.querySelector('[data-panel-id="panel_1"] [data-crossfilter-active]')
+    expect(chip).toBeTruthy()
+    expect(chip?.getAttribute('data-crossfilter-field')).toBe('fld_status')
+    expect(chip?.getAttribute('data-crossfilter-value')).toBe('open')
+    expect(chip?.textContent).toContain('Status = open')
+    // Only the source panel is marked, not the other.
+    expect(container.querySelector('[data-panel-id="panel_2"] [data-crossfilter-active]')).toBeNull()
+  })
+
+  it('cross-filter: clicking the SAME segment again toggles it off (refetch with no filter)', async () => {
+    const { client } = mockClient([fakeDashboard()], [fakeChart()])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    expect(echartsClickHandlers.length).toBeGreaterThanOrEqual(1)
+
+    fireSegmentClick('open')
+    await flushPromises()
+    expect(container.querySelector('[data-crossfilter-active]')).toBeTruthy()
+
+    getDataSpy.mockClear()
+    fireSegmentClick('open') // same segment → toggle OFF (use the live, post-remount handler)
+    await flushPromises()
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [])
+    expect(container.querySelector('[data-crossfilter-active]')).toBeNull()
+  })
+
+  it('cross-filter: the explicit clear control removes the cross-filter (refetch with no filter)', async () => {
+    const { client } = mockClient([fakeDashboard()], [fakeChart()])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    fireSegmentClick('closed')
+    await flushPromises()
+    expect(container.querySelector('[data-crossfilter-active]')).toBeTruthy()
+
+    getDataSpy.mockClear()
+    ;(container.querySelector('[data-action="clear-crossfilter"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', [])
+    expect(container.querySelector('[data-crossfilter-active]')).toBeNull()
+  })
+
+  it('cross-filter: AND-combines with an explicit widget selection (both on the chart refetch AND a metric preview-data)', async () => {
+    const dashboard = fakeDashboard({
+      panels: [
+        { id: 'panel_chart', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 },
+        { id: 'panel_metric', type: 'metric', title: 'KPI', size: 'small', order: 1, metricConfig: { aggregation: 'count' } },
+        { id: 'panel_filter', type: 'filter', title: 'Amount', size: 'small', order: 2, filterConfig: { fieldId: 'fld_amount' } },
+      ],
+    })
+    const { client } = mockClient([dashboard], [fakeChart()])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'number', dataPoints: [{ label: 'KPI', value: 1 }], total: 1 })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    // Set the widget filter first (fld_amount = 50).
+    const amountText = container.querySelector('[data-panel-id="panel_filter"] [data-field="filter-control-text"]') as HTMLInputElement
+    amountText.value = '50'
+    amountText.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // Now cross-filter via a chart segment click (fld_status = open). The widget change above remounted
+    // the chart, so fire the LIVE (latest) handler, not the stale initial one.
+    getDataSpy.mockClear()
+    previewSpy.mockClear()
+    expect(echartsClickHandlers.length).toBeGreaterThanOrEqual(1)
+    fireSegmentClick('open')
+    await flushPromises()
+
+    // Both constraints ride the SAME filter list (widget first, then cross-filter), AND-combined.
+    const expectedFilters = [
+      { fieldId: 'fld_amount', value: '50' },
+      { fieldId: 'fld_status', value: 'open' },
+    ]
+    expect(getDataSpy).toHaveBeenCalledWith('sheet_1', 'chart_1', expectedFilters)
+    expect(previewSpy).toHaveBeenCalledWith('sheet_1', expect.objectContaining({ chartType: 'number' }), expectedFilters)
+  })
+
+  it('cross-filter: clicking a segment on a chart with NO group-by field (date-grouped) is a no-op', async () => {
+    const dateChart = fakeChart({
+      dataSource: { sheetId: 'sheet_1', dateFieldId: 'fld_date', dateGrouping: 'month', aggregation: { function: 'count' } },
+    })
+    const { client } = mockClient([fakeDashboard()], [dateChart])
+    const getDataSpy = vi.spyOn(client, 'getChartData')
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    expect(echartsClickHandlers.length).toBeGreaterThanOrEqual(1)
+
+    getDataSpy.mockClear()
+    fireSegmentClick('2026-01') // a date bucket label, NOT a field value
+    await flushPromises()
+
+    // No group-by field → no cross-filter set, no refetch, no chip.
+    expect(getDataSpy).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-crossfilter-active]')).toBeNull()
+  })
+
+  it('cross-filter: switching dashboards clears the active cross-filter', async () => {
+    const dashA = fakeDashboard({ id: 'dash_A', name: 'A', panels: [{ id: 'panel_a', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 }] })
+    const dashB = fakeDashboard({ id: 'dash_B', name: 'B', panels: [{ id: 'panel_b', type: 'chart', chartId: 'chart_1', size: 'medium', order: 0 }] })
+    const { client } = mockClient([dashA, dashB], [fakeChart()])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    fireSegmentClick('open')
+    await flushPromises()
+    expect(container.querySelector('[data-crossfilter-active]')).toBeTruthy()
+
+    // Switch dashboards via the selector → cross-filter resets.
+    const select = container.querySelector('[data-field="dashboard-select"]') as HTMLSelectElement
+    select.value = 'dash_B'
+    select.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(container.querySelector('[data-crossfilter-active]')).toBeNull()
   })
 })


### PR DESCRIPTION
## What

Feishu-parity follow-up to **#3007** (functional dashboard-level filtering). Clicking a chart segment now sets a dashboard filter on that chart's group-by field = the clicked segment's value, narrowing every other data panel. Clicking the same segment again — or the active chip's clear control — removes it.

This was the explicit follow-up #3007 deferred ("Cross-filtering — a chart segment driving others — is a separate follow-up").

## How clicks map to #3007's filter state (no parallel path)

It is **pure FE wiring of clicks into the dashboard-filter state #3007 already added** — no new backend filter semantics:

1. **`MetaChartRenderer` emits `segment-click`** with the clicked category's **label**.
   - ECharts canvas marks (bar/pie/funnel/line/area) emit via `chart.on('click', params.name)`.
   - The HTML pie/funnel point-legend rows are the accessible twin (`role="button"` + Enter), emitting the same label.
   - The renderer has no `dataSource`, so it only surfaces the label — it never decides the field.
2. **`MetaDashboardView` maps `(panel, label)` → `{ fieldId: dataSource.groupByFieldId, value: label }`** into a single `crossFilter` ref, and folds it into the **same `activeDashboardFilters` computed** the filter widgets feed. From there it flows unchanged through `getChartData` / `previewChartData` → `applyDashboardFilter`, **AND-combined** with any widget selection — exactly the mechanism #3007 established.
3. A chart with **no group-by field** (scatter x/y projection, date-grouped buckets, single-value gauge) yields no `fieldId` → the click is a **no-op** (never a broken `{fieldId: undefined}` filter).
4. The **source panel shows an active `field = value ×` chip** (visible cross-filter cue + clear control).
5. Switching dashboards resets the cross-filter (its source panel belongs to the previous board).

**Scope (MVP, matches the task):** one active cross-filter at a time — clicking a segment on another chart replaces it; clicking the same segment again clears it. This is the plain reading of "clicking again removes it" and composes correctly with an explicit widget selection. Self-filtering the source chart is intentional ("and itself is fine"). Multi-source simultaneous cross-filtering is out of scope.

## Security — no new leak (reuses #3007's permission-safe path)

The cross-filter passes through the **identical `dashboardFilterableField` property-visibility gate** inside `activeDashboardFilters`, so a cross-filter on a field the actor cannot read is dropped client-side **and** the backend's `isChartDataRestricted` (#3007) refuses the chart wholesale *before* records load. It rides the same aggregation route and can only narrow the already field-masked + row-denied set, never widen it. No backend changes.

## Tests (FE-only; the backend path is #3007's, already real-DB tested)

- **`MetaChartRenderer`**: a captured canvas click → emits the segment label; empty / malformed payloads don't emit; the HTML legend row emits its label.
- **`MetaDashboardView`**: clicking a segment sets the dashboard filter (field+value) and refetches every panel with it applied; clicking again toggles off (`[]`); the clear control removes it; cross-filter AND-combines with a widget selection on **both** `getChartData` and a metric's `previewChartData`; a no-group-by (date-grouped) source click is a no-op; switching dashboards clears it.
- Extended the echarts `init` mock in both dashboard + chart-renderer specs with `on` (captures the click handler) so the new behavior is exercisable in jsdom (canvas clicks can't be synthesized there).

## Validation

- `pnpm install --frozen-lockfile` — clean (no dependency changes).
- web `vue-tsc -b` — **0 errors**.
- backend `tsc --noEmit` — **0 errors** (no backend code touched).
- `CI=true pnpm --filter @metasheet/core-backend test` — **4693 passed, 0 failed** (incl. #3007's dashboard-level-filter real-DB test).
- Dashboard + chart-renderer FE specs — **90/90 pass** (incl. the 9 new cross-filter tests).
- Label-parity i18n specs — **20/20 pass**.
- The repo's broad web suite has 17 pre-existing failing files (socket/auth/presence env flakiness); verified **identical (17 files / 111 tests) on a clean `origin/main` worktree** — not introduced here.

## How to verify

1. Open a dashboard with ≥2 chart panels grouped by a `select` field (e.g. status), plus a metric or a second chart.
2. Click a bar / pie slice (or its legend row). Every other panel re-aggregates to that category; the source panel shows the active chip.
3. Click the same segment again, or the chip's `×` — the filter clears and panels reset.
4. Add a filter widget, pick a value, then cross-filter — both constraints AND-combine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)