### PR TITLE
feat(multitable): export RESPECTS THE VIEW FILTER (full filtered set + sort, masked, csv+xlsx) — supersedes #3003

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -236,6 +236,7 @@ jobs:
             tests/integration/multitable-lookup-foreign-field-mask-view.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-export.test.ts \
             tests/integration/multitable-export-permission-canary.test.ts \
+            tests/integration/multitable-export-allrows-maskroute-realdb.test.ts \
             tests/integration/multitable-person-directory-route.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-write.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-create.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -323,6 +323,20 @@ function firstFieldError(fieldErrors?: Record<string, string>): string | null {
   return first ?? null
 }
 
+// Extract the download filename from a Content-Disposition header (handles both `filename="x.csv"` and
+// RFC-5987 `filename*=UTF-8''x.csv`). Falls back to a generic name so the download always has one.
+function parseContentDispositionFilename(header: string | null): string {
+  if (header) {
+    const star = header.match(/filename\*=(?:UTF-8'')?([^;]+)/i)
+    if (star?.[1]) {
+      try { return decodeURIComponent(star[1].trim().replace(/^["']|["']$/g, '')) } catch { /* fall through */ }
+    }
+    const plain = header.match(/filename="?([^";]+)"?/i)
+    if (plain?.[1]) return plain[1].trim()
+  }
+  return 'export'
+}
+
 type RawComment = Partial<MultitableComment> & {
   spreadsheetId?: string
   rowId?: string
@@ -1344,6 +1358,47 @@ export class MultitableApiClient {
     const query = qs({ ...(rest as Record<string, string | undefined>), statsFields: statsFields && statsFields.length ? statsFields.join(',') : undefined })
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/view-aggregate${query}`)
     return this.parseJson(res)
+  }
+
+  // Full-sheet export (the mask-preserving backend route). The server applies the SAME field_permissions +
+  // view-hidden + §2a.3 formula-taint masking as the grid read, AFTER the `fieldIds` selection (which can
+  // only NARROW within the permitted set, never widen), then cursor-paginates the WHOLE sheet up to the
+  // server's row cap. This is why "all rows" goes here instead of serializing the 50-row client page:
+  // the client only holds one masked page; the server holds the full masked sheet. Returns the binary blob
+  // + the server's suggested filename (Content-Disposition). On a non-2xx (e.g. 400 when the column
+  // selection resolves to zero exportable columns) it throws a MultitableApiError so the caller can toast
+  // the server message rather than downloading an error body.
+  async exportSheet(params: {
+    sheetId: string
+    viewId?: string
+    fieldIds?: string[]
+    format: 'csv' | 'xlsx'
+  }): Promise<{ blob: Blob; filename: string }> {
+    const query = qs({
+      viewId: params.viewId,
+      // The route accepts the comma-joined form (?fieldIds=a,b); join here. An empty/absent selection
+      // means "all permitted columns" server-side — never send an empty fieldIds (that would be a 400).
+      fieldIds: params.fieldIds && params.fieldIds.length ? params.fieldIds.join(',') : undefined,
+      format: params.format,
+    })
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(params.sheetId)}/export-xlsx${query}`)
+    if (!res.ok) {
+      // Reuse the shared error normalization (same shape parseJson throws) so the caller sees the
+      // server's VALIDATION_ERROR / FORBIDDEN message + code, not a generic "failed to fetch".
+      const isZh = this.resolveIsZh()
+      const raw = await res.text()
+      const payload = normalizeApiErrorPayload(raw ? safeParseJson(raw) : null, isZh)
+      const error = new Error(firstFieldError(payload.fieldErrors) ?? payload.message ?? apiDefaultErrorMessage(payload.code, res.status, isZh)) as Error & {
+        status?: number
+        code?: string
+      }
+      error.name = 'MultitableApiError'
+      error.status = res.status
+      error.code = payload.code
+      throw error
+    }
+    const blob = await res.blob()
+    return { blob, filename: parseContentDispositionFilename(res.headers.get('Content-Disposition')) }
   }
 
   // Formula dry-run (#5b): evaluate an UNSAVED expression against caller-supplied sample values.

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -53,7 +53,7 @@ export type WorkbenchLabelKey =
   | 'toast.externalContextBusy' | 'toast.externalContextUnsaved'
   | 'toast.baseCreateBlocked' | 'toast.baseCreateFailed'
   | 'toast.importCancelled' | 'toast.importFailed'
-  | 'toast.excelExportFailed' | 'toast.bulkDeleteFailed'
+  | 'toast.excelExportFailed' | 'toast.csvExportFailed' | 'toast.bulkDeleteFailed'
   | 'toast.workbenchInitFailed'
   | 'confirm.discardContextChanges' | 'confirm.discardRecordChanges'
   | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
@@ -199,6 +199,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.importCancelled': { en: 'Import cancelled', zh: '导入已取消' },
   'toast.importFailed': { en: 'Import failed', zh: '导入失败' },
   'toast.excelExportFailed': { en: 'Excel export failed', zh: 'Excel 导出失败' },
+  'toast.csvExportFailed': { en: 'CSV export failed', zh: 'CSV 导出失败' },
   'toast.bulkDeleteFailed': { en: 'Bulk delete failed', zh: '批量删除失败' },
   'toast.workbenchInitFailed': { en: 'Failed to initialize workbench', zh: '初始化工作台失败' },
 

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3093,10 +3093,23 @@ function onGridSelectionChange(recordIds: string[]) {
 }
 
 // --- Export (A2: column/row selection via MetaExportDialog) ---
-// The toolbar's CSV/XLSX buttons now open the export-options dialog (column
-// checklist + row scope + format) instead of exporting immediately. Export
-// stays fully client-side over grid.rows — already permission-masked at read
-// time — so filtering already-authorized columns/rows adds no auth surface.
+// The toolbar's CSV/XLSX buttons open the export-options dialog (column checklist
+// + row scope + format). Two scopes, two paths:
+//   - "all rows"  → the MASK-PRESERVING BACKEND ROUTE (client.exportSheet). The
+//     client grid is page-replaced at DEFAULT_PAGE_SIZE (50), so a client-side
+//     "all rows" could only ever serialize the loaded page — a data-loss bug.
+//     The route cursor-paginates the FULL sheet and re-applies the SAME
+//     field_permissions + view-hidden + §2a.3 formula-taint mask AFTER the
+//     fieldIds selection (selection narrows within the permitted set, never
+//     widens). NOTE: "all rows" = the full sheet, NOT the view-filtered subset
+//     (the route applies view HIDDEN-FIELDS but not the view's row filter/sort);
+//     view-filtered export is a follow-up.
+//   - "selected rows" → stays CLIENT-SIDE over grid.rows. Those rows are the
+//     /view response, already field-permission AND §2a.3-taint masked at read
+//     time (univer-meta.ts GET /view: filterRecordDataByFieldIds over the
+//     taint-masked allowedFieldIds), so serializing the chosen subset adds no
+//     egress surface. The selected ids are necessarily within the loaded page,
+//     so completeness is not at stake here.
 type GridExportField = (typeof scopedGridFields)['value'][number]
 type GridExportRow = (typeof grid.rows)['value'][number]
 
@@ -3115,18 +3128,43 @@ function onExportDialogConfirm(payload: ExportConfirmPayload) {
   // Preserve the on-screen column order; ignore unknown ids defensively.
   const fields = scopedGridFields.value.filter((f) => selectedFieldIds.has(f.id))
   if (!fields.length) return
-  const rows = payload.rowScope === 'selected'
-    ? grid.rows.value.filter((r) => exportSelectedRecordIds.value.has(r.id))
-    : grid.rows.value
-  if (payload.format === 'csv') doExportCsv(fields, rows)
-  else void doExportXlsx(fields, rows)
+  if (payload.rowScope === 'selected') {
+    // Client-side: the loaded+masked rows, narrowed to the selection.
+    const rows = grid.rows.value.filter((r) => exportSelectedRecordIds.value.has(r.id))
+    if (payload.format === 'csv') doExportCsv(fields, rows)
+    else void doExportXlsx(fields, rows)
+    return
+  }
+  // All rows → full-sheet masked backend route.
+  void exportAllRowsViaRoute(fields.map((f) => f.id), payload.format)
+}
+
+async function exportAllRowsViaRoute(fieldIds: string[], format: 'csv' | 'xlsx') {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  try {
+    const { blob, filename } = await workbench.client.exportSheet({
+      sheetId,
+      viewId: workbench.activeViewId.value || undefined,
+      fieldIds,
+      format,
+    })
+    triggerDownloadNamed(blob, filename || `${sheetId}.${format}`)
+  } catch (err: any) {
+    showError(err?.message ?? wb(format === 'csv' ? 'toast.csvExportFailed' : 'toast.excelExportFailed', isZh.value))
+  }
 }
 
 function triggerDownload(blob: Blob, extension: string) {
+  triggerDownloadNamed(blob, `${workbench.activeSheetId.value || 'export'}.${extension}`)
+}
+
+// Download a blob under an exact filename (the server's Content-Disposition for the route path).
+function triggerDownloadNamed(blob: Blob, filename: string) {
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `${workbench.activeSheetId.value || 'export'}.${extension}`
+  a.download = filename
   a.click()
   URL.revokeObjectURL(url)
 }

--- a/apps/web/tests/multitable/export-sheet-client.test.ts
+++ b/apps/web/tests/multitable/export-sheet-client.test.ts
@@ -1,0 +1,95 @@
+/**
+ * MultitableApiClient.exportSheet — the rewired "all rows" export path.
+ *
+ * The export picker's "all rows" scope no longer serializes the client-loaded grid page (the verified
+ * 50-row data-loss bug); it calls this method, which hits the mask-preserving backend route with the
+ * picker's chosen fieldIds + the active viewId. The server applies field_permissions + view-hidden +
+ * §2a.3 taint masking AFTER the selection (selection narrows, never widens) — these tests assert the
+ * REQUEST is shaped correctly (the mask itself is enforced + tested server-side, in the real-DB suite).
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { MultitableApiClient } from '../../src/multitable/api/client'
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  })
+}
+
+describe('MultitableApiClient.exportSheet — all-rows mask-route request shaping', () => {
+  it('requests the export route with viewId + comma-joined fieldIds + format, and returns blob + filename', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('col\r\nval', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="My_Sheet.csv"',
+        },
+      }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    const { blob, filename } = await client.exportSheet({
+      sheetId: 'sheet_1',
+      viewId: 'view_1',
+      fieldIds: ['fld_a', 'fld_b'],
+      format: 'csv',
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const url = fetchFn.mock.calls[0][0] as string
+    expect(url).toContain('/api/multitable/sheets/sheet_1/export-xlsx')
+    // fieldIds are sent as the comma-joined form the route parses; viewId + format passthrough.
+    expect(url).toContain('viewId=view_1')
+    expect(url).toContain(`fieldIds=${encodeURIComponent('fld_a,fld_b')}`)
+    expect(url).toContain('format=csv')
+    expect(filename).toBe('My_Sheet.csv')
+    // The response body is returned as a Blob (the caller hands it to the download helper). Assert it is a
+    // non-empty Blob rather than reading .text() (jsdom's Blob has no usable .text()); end-to-end content is
+    // covered by the real-DB suite.
+    expect(blob).toBeInstanceOf(Blob)
+    expect(blob.size).toBeGreaterThan(0)
+  })
+
+  it('omits fieldIds entirely when the selection is empty (route then exports all permitted columns)', async () => {
+    const fetchFn = vi.fn(async () => new Response('x', { status: 200, headers: { 'Content-Type': 'text/csv' } }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.exportSheet({ sheetId: 'sheet_1', fieldIds: [], format: 'xlsx' })
+
+    const url = fetchFn.mock.calls[0][0] as string
+    // No empty fieldIds= (an empty selection server-side is a 400; "all columns" is the absence of the param).
+    expect(url).not.toContain('fieldIds=')
+    expect(url).toContain('format=xlsx')
+    // No viewId when not provided.
+    expect(url).not.toContain('viewId=')
+  })
+
+  it('throws a MultitableApiError carrying the server message + code on a non-2xx (so the caller can toast it)', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(400, { ok: false, error: { code: 'VALIDATION_ERROR', message: 'fieldIds selection resolved to no exportable columns (unknown or not permitted)' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(
+      client.exportSheet({ sheetId: 'sheet_1', fieldIds: ['nope'], format: 'xlsx' }),
+    ).rejects.toMatchObject({
+      name: 'MultitableApiError',
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'fieldIds selection resolved to no exportable columns (unknown or not permitted)',
+    })
+  })
+
+  it('falls back to a generic filename when Content-Disposition is absent', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('bin', { status: 200, headers: { 'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' } }),
+    )
+    const client = new MultitableApiClient({ fetchFn })
+
+    const { filename } = await client.exportSheet({ sheetId: 'sheet_1', format: 'xlsx' })
+    expect(filename).toBe('export')
+  })
+})

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4388,8 +4388,43 @@ function parseJsonFormField(value: unknown, fieldName: string): unknown {
 }
 
 function buildXlsxAttachmentFilename(sheetName: string): string {
+  return buildExportAttachmentFilename(sheetName, 'xlsx')
+}
+
+// Shared attachment-filename builder for the export route (xlsx + csv share the same sanitization).
+function buildExportAttachmentFilename(sheetName: string, extension: 'xlsx' | 'csv'): string {
   const base = sheetName.replace(/[^\w.-]+/g, '_').replace(/^_+|_+$/g, '') || 'multitable'
-  return `${base}.xlsx`
+  return `${base}.${extension}`
+}
+
+// Parse the optional ?format= query param for the export route. Default 'xlsx' (back-compat). 'csv' is the
+// only other accepted value; anything else is an explicit 400 (no silent fallback — a typo'd format must
+// not silently downgrade to xlsx). Returned as a discriminated result so the caller emits a VALIDATION_ERROR.
+function parseExportFormat(value: unknown):
+  | { ok: true; format: 'xlsx' | 'csv' }
+  | { ok: false; message: string } {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (raw === '' || raw === 'xlsx') return { ok: true, format: 'xlsx' }
+  if (raw === 'csv') return { ok: true, format: 'csv' }
+  return { ok: false, message: `Unsupported export format: ${raw} (expected 'xlsx' or 'csv')` }
+}
+
+// Serialize the already-MASKED header + cell matrix as CSV (RFC-4180-ish). The `rows` cells are the
+// serializeXlsxCell projection (string | number | boolean | null | undefined), so this only stringifies +
+// quotes — it adds NO data access and inherits the same field/view/§2a.3-taint mask applied upstream.
+function buildExportCsv(
+  headers: string[],
+  rows: Array<Array<string | number | boolean | null | undefined>>,
+): string {
+  const escape = (value: string | number | boolean | null | undefined): string => {
+    if (value === null || value === undefined) return ''
+    const s = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value)
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  }
+  const lines = [headers.map(escape).join(',')]
+  for (const row of rows) lines.push(row.map(escape).join(','))
+  // CRLF line endings = the CSV de-facto standard (Excel-friendly).
+  return lines.join('\r\n')
 }
 
 async function loadDashboardSourceRows(args: {
@@ -9577,6 +9612,17 @@ export function univerMetaRouter(): Router {
     // hint only; it is intersected with the permitted/masked field set below and can ONLY narrow,
     // never widen — a denied/masked/tainted id requested here stays excluded.
     const requestedFieldIds = parseFieldIdSelection(req.query.fieldIds)
+    // Output format. Default 'xlsx' (unchanged behavior). 'csv' emits the SAME masked + cursor-paginated
+    // FULL-SHEET record set, only re-serialized as CSV — every field/view/§2a.3-taint mask below runs
+    // BEFORE the format branch (the `fields`/`fieldIds`/`rows` pipeline is format-agnostic), so CSV
+    // inherits the identical enforcement with no separate masking path. Unknown values 400 (no silent
+    // fallback — the enum-strictness convention; a typo'd format must not silently downgrade to xlsx).
+    const formatResult = parseExportFormat(req.query.format)
+    if (formatResult.ok === false) {
+      const message = formatResult.message
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message } })
+    }
+    const format = formatResult.format
     if (!sheetId) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
     }
@@ -9680,15 +9726,25 @@ export function univerMetaRouter(): Router {
         cursor = result.hasMore && rows.length < XLSX_MAX_ROWS ? result.nextCursor ?? undefined : undefined
       } while (cursor)
 
+      const headers = fields.map((field) => field.name)
+      // Format branch (mask already applied above — headers/rows are the masked projection). The
+      // truncation header is emitted for BOTH formats so a client can detect a >XLSX_MAX_ROWS cap.
+      res.setHeader('X-MetaSheet-XLSX-Truncated', truncated ? 'true' : 'false')
+      if (format === 'csv') {
+        const csv = buildExportCsv(headers, rows)
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+        res.setHeader('Content-Disposition', `attachment; filename="${buildExportAttachmentFilename(sheet.name, 'csv')}"`)
+        // UTF-8 BOM so Excel opens non-ASCII (e.g. CJK) CSV without mojibake — matches common export tooling.
+        return res.send(Buffer.concat([Buffer.from('﻿', 'utf8'), Buffer.from(csv, 'utf8')]))
+      }
       const xlsx = await loadXlsxModule()
       const buffer = buildXlsxBuffer(xlsx, {
         sheetName: sheet.name,
-        headers: fields.map((field) => field.name),
+        headers,
         rows,
       })
       res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
       res.setHeader('Content-Disposition', `attachment; filename="${buildXlsxAttachmentFilename(sheet.name)}"`)
-      res.setHeader('X-MetaSheet-XLSX-Truncated', truncated ? 'true' : 'false')
       return res.send(buffer)
     } catch (err) {
       if (err instanceof ValidationError) {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -9634,8 +9634,14 @@ export function univerMetaRouter(): Router {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       }
       let viewHiddenFieldIds: string[] = []
+      // Capture the resolved view so the export can apply its ROW filter + sort (not only the
+      // hidden-field mask). #3003 wired "all rows" to this route but exported the WHOLE sheet — it read
+      // view.hiddenFieldIds and ignored view.filterInfo / view.sortInfo, so a filtered view still
+      // exported every row. parity fix: export ALL rows OF THE VIEW'S FILTER (the full filtered set,
+      // not a page, not the unfiltered sheet), in the view's sort order.
+      let view: SharedMultitableViewConfig | null = null
       if (viewId) {
-        const view = await tryResolveViewShared(pool.query.bind(pool), viewId)
+        view = await tryResolveViewShared(pool.query.bind(pool), viewId)
         if (!view || view.sheetId !== sheetId) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
         }
@@ -9697,34 +9703,180 @@ export function univerMetaRouter(): Router {
       const exportDeniedIds = (!access.isAdminRole && access.userId && await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))
         ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
         : null
-      let cursor: string | undefined
       let truncated = false
-      do {
-        const result = await queryRecordsWithCursor({
-          query: pool.query.bind(pool),
-          sheetId,
-          cursor,
-          limit: Math.min(5000, XLSX_MAX_ROWS - rows.length),
-        })
-        for (const record of result.items) {
-          if (exportDeniedIds && exportDeniedIds.has(record.id)) continue
-          const data = filterRecordDataByFieldIds(record.data, fieldIds)
-          rows.push(fields.map((field) => {
-            const cell = data[field.id]
-            // Rich-longText export = the §7 plain-text projection, NOT the raw HTML
-            // (a cell must read as text, never `<p>…</p>`).
-            if (field.type === 'longText' && isRichLongTextProperty(field.property) && typeof cell === 'string') {
-              return serializeXlsxCell(richLongTextToPlainText(cell))
-            }
-            return serializeXlsxCell(cell)
-          }))
-          if (rows.length >= XLSX_MAX_ROWS) {
-            truncated = result.hasMore
-            break
+
+      // SHARED projection (single egress chokepoint): both the streaming and the filtered-load branch
+      // funnel each surviving record through THIS one `filterRecordDataByFieldIds(record.data, fieldIds)`
+      // call — `fieldIds` is the fully-masked set (field_permissions ∧ view-hidden ∧ §2a.3-taint ∧
+      // selection). Keeping it a single call-site preserves the egress-coverage + taint-chokepoint
+      // guard counts (a denied/tainted column never reaches a cell regardless of which branch ran).
+      const projectRecord = (record: { data: Record<string, unknown> }): Array<string | number | boolean | null | undefined> => {
+        const data = filterRecordDataByFieldIds(record.data, fieldIds)
+        return fields.map((field) => {
+          const cell = data[field.id]
+          // Rich-longText export = the §7 plain-text projection, NOT the raw HTML
+          // (a cell must read as text, never `<p>…</p>`).
+          if (field.type === 'longText' && isRichLongTextProperty(field.property) && typeof cell === 'string') {
+            return serializeXlsxCell(richLongTextToPlainText(cell))
           }
+          return serializeXlsxCell(cell)
+        })
+      }
+
+      // Resolve the view's ROW filter + sort. CRITICAL: the filter/sort prune set is NOT the output
+      // `fieldIds` — it is `/view`'s SELECTION set: layer-2 ∧ layer-3 (field_permissions) ∧ §2a.3-taint,
+      // with view-hidden DELIBERATELY EXCLUDED (hiddenFieldIds: []). Two distinct concerns, exactly as
+      // GET /view separates them (:10114 / comment :10127-10131):
+      //   • OUTPUT columns (`fields`/`fieldIds`): view-hidden + per-request selection apply — those
+      //     columns aren't EMITTED.
+      //   • FILTER/SORT eligibility (`filterSortFieldIds`): a field the actor can READ stays
+      //     filterable/sortable even if it's view-HIDDEN or the user didn't SELECT it for export. The
+      //     canonical saved-filter idiom hides the filtered column (hide `status`, filter status=active);
+      //     pruning the filter by the output set would silently export the WHOLE sheet (#3003's bug).
+      // The prune STILL drops permission-denied + §2a.3-tainted fields (silently, like a non-existent
+      // field — no existence/value oracle, no leak via the filter); it only stops dropping
+      // readable-but-hidden / readable-but-unselected fields. Reuses fieldScopeMap from the output derive.
+      const filterSortPerms = deriveFieldPermissions(visibleFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+      let filterSortFieldIds = new Set(
+        visibleFields.filter((field) => filterSortPerms[field.id]?.visible !== false).map((field) => field.id),
+      )
+      filterSortFieldIds = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, visibleFields, filterSortFieldIds)
+      const exportFieldTypeById = new Map(visibleFields.map((field) => [field.id, resolveEffectiveFieldType(field)] as const))
+      const rawExportFilterInfo = view ? parseMetaFilterInfo(view.filterInfo) : null
+      const exportFilterInfo = rawExportFilterInfo
+        ? pruneFilterNode(rawExportFilterInfo, (c) => exportFieldTypeById.has(c.fieldId) && filterSortFieldIds.has(c.fieldId))
+        : null
+      const exportSortRules = (view ? parseMetaSortRules(view.sortInfo) : []).filter(
+        (rule) => exportFieldTypeById.has(rule.fieldId) && filterSortFieldIds.has(rule.fieldId),
+      )
+      const hasFilterOrSort = !!exportFilterInfo || exportSortRules.length > 0
+
+      if (!hasFilterOrSort) {
+        // No view filter/sort (or the only conditions were on masked fields) → keep #3003's full-sheet
+        // cursor stream byte-identical: keyset-paginate the whole sheet up to XLSX_MAX_ROWS.
+        let cursor: string | undefined
+        do {
+          const result = await queryRecordsWithCursor({
+            query: pool.query.bind(pool),
+            sheetId,
+            cursor,
+            limit: Math.min(5000, XLSX_MAX_ROWS - rows.length),
+          })
+          for (const record of result.items) {
+            if (exportDeniedIds && exportDeniedIds.has(record.id)) continue
+            rows.push(projectRecord(record))
+            if (rows.length >= XLSX_MAX_ROWS) {
+              truncated = result.hasMore
+              break
+            }
+          }
+          cursor = result.hasMore && rows.length < XLSX_MAX_ROWS ? result.nextCursor ?? undefined : undefined
+        } while (cursor)
+      } else {
+        // View has a row filter and/or sort. Computed-field (lookup/rollup/formula) and link conditions
+        // need in-memory evaluation (no SQL form), and a globally-correct sort can't be done per-page —
+        // so this branch loads-all then filters/sorts/caps, mirroring GET /view's in-memory branch. The
+        // memory profile equals a filtered /view of the same sheet; the output stays bounded by
+        // XLSX_MAX_ROWS. The masked projection (`projectRecord`) is reused unchanged afterward.
+        const recordRes = await pool.query(
+          'SELECT id, version, data, created_at FROM meta_records WHERE sheet_id = $1 ORDER BY created_at ASC, id ASC',
+          [sheetId],
+        )
+        let all = (recordRes.rows as Array<{ id: unknown; version: unknown; data: unknown; created_at: unknown }>).map((r) => ({
+          id: String(r.id),
+          version: Number(r.version ?? 1),
+          data: normalizeJson(r.data),
+          createdAt: r.created_at as unknown,
+        }))
+
+        // #18 row-level read-deny: drop denied records BEFORE filter/sort/cap so the filtered set, the
+        // truncation flag, and the exported rows all exclude them (parity with the cursor branch).
+        if (exportDeniedIds) all = all.filter((rec) => !exportDeniedIds.has(rec.id))
+
+        const relationalLinkFields = fields
+          .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: parseLinkFieldConfig(field.property) } : null))
+          .filter((value): value is { fieldId: string; cfg: LinkFieldConfig } => !!value && !!value.cfg)
+        const computedFieldIdSet = new Set(
+          visibleFields.filter((field) => field.type === 'lookup' || field.type === 'rollup').map((field) => field.id),
+        )
+        // Only materialize lookup/rollup when the filter OR sort actually references a computed field
+        // (same gate as /view's needsComputedFilterSort) — a scalar-only filtered export skips it.
+        const needsComputedFilterSort =
+          computedFieldIdSet.size > 0 &&
+          (exportSortRules.some((rule) => computedFieldIdSet.has(rule.fieldId)) ||
+            collectLeafConditions(exportFilterInfo).some((c) => computedFieldIdSet.has(c.fieldId)))
+        let linkValuesByRecord: Map<string, Map<string, string[]>> | null = null
+        if (needsComputedFilterSort && all.length > 0) {
+          linkValuesByRecord = await loadLinkValuesByRecord(pool.query.bind(pool), all.map((r) => r.id), relationalLinkFields)
+          await applyLookupRollup(req, pool.query.bind(pool), sheetId, fields, all, relationalLinkFields, linkValuesByRecord)
         }
-        cursor = result.hasMore && rows.length < XLSX_MAX_ROWS ? result.nextCursor ?? undefined : undefined
-      } while (cursor)
+
+        // Link-FILTER materialization (parity with /view): a link condition matches on the linked
+        // records' PERMISSION-FILTERED display strings + ids from meta_links — never record.data — so a
+        // denied foreign link can neither match a value op nor leak its display. The summary map is used
+        // ONLY by the predicate below and then discarded (no new wire-egress channel).
+        const linkFilterFieldIds = new Set(
+          collectLeafConditions(exportFilterInfo).filter((c) => exportFieldTypeById.get(c.fieldId) === 'link').map((c) => c.fieldId),
+        )
+        const linkFilterFields = relationalLinkFields.filter((rl) => linkFilterFieldIds.has(rl.fieldId))
+        let filterLinkValues: Map<string, Map<string, string[]>> | null = null
+        let filterLinkSummaries: Map<string, Map<string, LinkedRecordSummary[]>> | null = null
+        if (linkFilterFields.length > 0 && all.length > 0) {
+          filterLinkValues = await loadLinkValuesByRecord(pool.query.bind(pool), all.map((r) => r.id), linkFilterFields)
+          filterLinkSummaries = await buildLinkSummaries(req, pool.query.bind(pool), sheetId, all, linkFilterFields, filterLinkValues)
+        }
+
+        if (exportFilterInfo) {
+          all = all.filter((record) => evaluateFilterNode(exportFilterInfo, (condition) => {
+            const fieldType = exportFieldTypeById.get(condition.fieldId)
+            if (!fieldType) return true
+            if (fieldType === 'link') {
+              const ids = filterLinkValues?.get(record.id)?.get(condition.fieldId) ?? []
+              const displays = (filterLinkSummaries?.get(record.id)?.get(condition.fieldId) ?? []).map((s) => s.display)
+              return evaluateLinkFilterCondition(ids, displays, condition)
+            }
+            return evaluateMetaFilterCondition(fieldType, record.data[condition.fieldId], condition)
+          }))
+        }
+
+        // Native person sort-by-DISPLAY (parity with /view): order person cells by the visible name,
+        // not the raw userId array. Resolve the display map only for person fields in the sort rules.
+        const personSortFieldIds = new Set(
+          exportSortRules.filter((rule) => exportFieldTypeById.get(rule.fieldId) === 'person').map((rule) => rule.fieldId),
+        )
+        const personSortDisplayByUserId = personSortFieldIds.size > 0
+          ? await resolvePersonSortDisplayMap(pool.query.bind(pool), all, personSortFieldIds)
+          : new Map<string, string>()
+        const personSortKey = (value: unknown): string => {
+          if (!Array.isArray(value) || value.length === 0) return ''
+          return value
+            .map((item) => (typeof item === 'string' && item.trim() ? (personSortDisplayByUserId.get(item.trim()) ?? item.trim()) : ''))
+            .filter(Boolean)
+            .join(', ')
+        }
+
+        if (exportSortRules.length > 0) {
+          all = [...all].sort((a, b) => {
+            for (const rule of exportSortRules) {
+              const fieldType = exportFieldTypeById.get(rule.fieldId) ?? 'string'
+              const aValue = personSortFieldIds.has(rule.fieldId) ? personSortKey(a.data[rule.fieldId]) : a.data[rule.fieldId]
+              const bValue = personSortFieldIds.has(rule.fieldId) ? personSortKey(b.data[rule.fieldId]) : b.data[rule.fieldId]
+              const cmp = compareMetaSortValue(fieldType, aValue, bValue, rule.desc)
+              if (cmp !== 0) return cmp
+            }
+            // Stable tiebreak identical to /view: created_at then id.
+            const aEpoch = toEpoch(a.createdAt)
+            const bEpoch = toEpoch(b.createdAt)
+            if (aEpoch !== null && bEpoch !== null && aEpoch !== bEpoch) return aEpoch > bEpoch ? 1 : -1
+            return a.id.localeCompare(b.id)
+          })
+        }
+
+        // Cap the FILTERED set at XLSX_MAX_ROWS — truncation reflects the filtered count, not raw rows.
+        truncated = all.length > XLSX_MAX_ROWS
+        const capped = truncated ? all.slice(0, XLSX_MAX_ROWS) : all
+        for (const record of capped) rows.push(projectRecord(record))
+      }
 
       const headers = fields.map((field) => field.name)
       // Format branch (mask already applied above — headers/rows are the masked projection). The

--- a/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
@@ -37,6 +37,16 @@ const F_SECRET = `fld_exp_secret_${TS}` // field_permissions-denied to VIEWER
 const VIEWER = `user_exp_viewer_${TS}`
 // > the FE DEFAULT_PAGE_SIZE (50). 120 also exceeds it by >2 pages, so a page-bound export would be obvious.
 const SEED_ROWS = 120
+// Views exercising the row filter + sort (the parity fix this file extends). Distinct ids per view so the
+// loaders' module-level view cache never returns a stale config (we never mutate a view after creating it).
+const VIEW_FILTER = `view_exp_filter_${TS}` // Amount >= 30 → rows 30..119 (90 rows: > the 50-page AND < the 120-sheet)
+const VIEW_FILTER_THRESHOLD = 30
+const VIEW_NO_FILTER = `view_exp_nofilter_${TS}` // empty filter/sort → must export the FULL sheet
+const VIEW_SORT_DESC = `view_exp_sortdesc_${TS}` // sort Amount desc → rows must come back 119..0
+const VIEW_FILTER_DENIED = `view_exp_filterdenied_${TS}` // filter on the DENIED Secret field → silently dropped
+// Hide the filtered column (the canonical saved-filter idiom): hide Amount, still filter Amount >= 30.
+// The filter MUST still apply (read-permitted field, just not emitted) → 90 rows, Amount column absent.
+const VIEW_FILTER_HIDDEN = `view_exp_filterhidden_${TS}`
 
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
@@ -119,10 +129,26 @@ describeIfDatabase('multitable export "all rows" via mask route (real DB)', () =
       `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
       [SHEET, F_SECRET, VIEWER],
     )
+
+    // Views for the row-filter + sort parity cases. filter_info / sort_info carry the same shapes GET /view
+    // reads (parseMetaFilterInfo / parseMetaSortRules), so the export reuses the IDENTICAL evaluation.
+    const view = (id: string, filterInfo: unknown, sortInfo: unknown, hiddenFieldIds: string[] = []) =>
+      q('INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, hidden_field_ids) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb)',
+        [id, SHEET, id, 'grid', JSON.stringify(filterInfo), JSON.stringify(sortInfo), JSON.stringify(hiddenFieldIds)])
+    const FILTER_AMOUNT = { conjunction: 'and', conditions: [{ fieldId: F_AMOUNT, operator: 'greaterequal', value: VIEW_FILTER_THRESHOLD }] }
+    await view(VIEW_FILTER, FILTER_AMOUNT, null)
+    await view(VIEW_NO_FILTER, null, null)
+    await view(VIEW_SORT_DESC, null, { rules: [{ fieldId: F_AMOUNT, desc: true }] })
+    // Filter on the DENIED Secret field — must be pruned (silently dropped, no oracle), so the export
+    // returns the FULL sheet (the denied condition behaves exactly like a non-existent field).
+    await view(VIEW_FILTER_DENIED, { conjunction: 'and', conditions: [{ fieldId: F_SECRET, operator: 'is', value: 'secret_5' }] }, null)
+    // Hide the filtered column: Amount is view-hidden BUT still the filter target. A read-permitted field
+    // stays filterable even when hidden from output (parity with GET /view) → filter applies, Amount absent.
+    await view(VIEW_FILTER_HIDDEN, FILTER_AMOUNT, null, [F_AMOUNT])
   })
 
   afterAll(async () => {
-    for (const t of ['field_permissions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    for (const t of ['field_permissions', 'meta_views', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
     await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
@@ -198,5 +224,105 @@ describeIfDatabase('multitable export "all rows" via mask route (real DB)', () =
     const res = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ format: 'pdf' })
     expect(res.status).toBe(400)
     expect(res.body?.error?.code).toBe('VALIDATION_ERROR')
+  })
+
+  // ── View row-filter + sort parity (the held-PR #3003 semantic this change resolves) ───────────────────
+  // The export of a FILTERED view must return ALL rows OF THE FILTER (the full filtered set) — not the
+  // 50-row client page, and not the unfiltered sheet. Amount >= 30 selects rows 30..119 = 90 rows, which is
+  // BOTH > the FE page size (so it can't be a page) AND < the full sheet (so it can't be unfiltered).
+  const EXPECTED_FILTERED = SEED_ROWS - VIEW_FILTER_THRESHOLD // 90
+
+  test('(g) a FILTERED view exports exactly the filtered subset — all of it, not 50, not the whole sheet (xlsx)', async () => {
+    const rows = await exportXlsxRows({ viewId: VIEW_FILTER })
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    expect(header).toEqual(['Name', 'Amount']) // mask still holds (Secret denied)
+    expect(body.length).toBe(EXPECTED_FILTERED) // EXACTLY the filtered set
+    expect(body.length).toBeGreaterThan(50) // not a page
+    expect(body.length).toBeLessThan(SEED_ROWS) // not the unfiltered sheet
+    // The exported Names are EXACTLY rows 30..119 — the right subset, not just the right count.
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.size).toBe(EXPECTED_FILTERED)
+    expect(names.has(`row_${String(VIEW_FILTER_THRESHOLD).padStart(4, '0')}`)).toBe(true) // row_0030 included (boundary, >= )
+    expect(names.has('row_0029')).toBe(false) // row_0029 excluded (just below threshold)
+    expect(names.has(`row_${String(SEED_ROWS - 1).padStart(4, '0')}`)).toBe(true) // row_0119 included
+    // No Amount below the threshold leaked through.
+    const minAmount = Math.min(...body.map((r) => Number(r[1])))
+    expect(minAmount).toBe(VIEW_FILTER_THRESHOLD)
+  })
+
+  test('(g-csv) the SAME filtered subset for CSV (filter + mask both hold)', async () => {
+    const { status, rows } = await exportCsvRows({ viewId: VIEW_FILTER })
+    expect(status).toBe(200)
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    expect(header).toEqual(['Name', 'Amount'])
+    expect(body.length).toBe(EXPECTED_FILTERED)
+    expect(body.length).toBeGreaterThan(50)
+    expect(Math.min(...body.map((r) => Number(r[1])))).toBe(VIEW_FILTER_THRESHOLD)
+    expect(rows.flat().some((c) => c.startsWith('secret_'))).toBe(false) // denied value never leaks
+  })
+
+  test('(g-mask) the field+taint mask still holds on a filtered view even when the denied id is requested (xlsx+csv)', async () => {
+    // Request the denied Secret column AND filter the view: selection can only narrow, filter narrows rows.
+    const x = await exportXlsxRows({ viewId: VIEW_FILTER, fieldIds: `${F_NAME},${F_SECRET}` })
+    expect(x[0]).toEqual(['Name']) // Secret dropped by the mask despite being requested
+    expect(x.slice(1).length).toBe(EXPECTED_FILTERED) // filter still applied
+    expect(x.flat().some((c) => c.startsWith('secret_'))).toBe(false)
+    const c = await exportCsvRows({ viewId: VIEW_FILTER, fieldIds: `${F_NAME},${F_SECRET}` })
+    expect(c.status).toBe(200)
+    expect(c.rows[0]).toEqual(['Name'])
+    expect(c.rows.slice(1).length).toBe(EXPECTED_FILTERED)
+    expect(c.rows.flat().some((cell) => cell.startsWith('secret_'))).toBe(false)
+  })
+
+  test('(h) a no-filter view exports the FULL sheet (parity with the no-view all-rows path)', async () => {
+    const rows = await exportXlsxRows({ viewId: VIEW_NO_FILTER })
+    const body = rows.slice(1)
+    expect(rows[0]).toEqual(['Name', 'Amount'])
+    expect(body.length).toBe(SEED_ROWS) // the WHOLE sheet, not a page
+    expect(new Set(body.map((r) => r[0])).size).toBe(SEED_ROWS)
+  })
+
+  test('(i) the view SORT is applied (Amount desc → 119..0, full sheet, masked)', async () => {
+    const rows = await exportXlsxRows({ viewId: VIEW_SORT_DESC })
+    const body = rows.slice(1)
+    expect(rows[0]).toEqual(['Name', 'Amount'])
+    expect(body.length).toBe(SEED_ROWS) // sort-only view still exports the full sheet
+    const amounts = body.map((r) => Number(r[1]))
+    expect(amounts[0]).toBe(SEED_ROWS - 1) // first row = highest Amount (119)
+    expect(amounts[amounts.length - 1]).toBe(0) // last row = lowest Amount (0)
+    // Strictly descending end-to-end (proves a real global sort, not a per-page one).
+    const isDescending = amounts.every((v, idx) => idx === 0 || amounts[idx - 1] >= v)
+    expect(isDescending).toBe(true)
+  })
+
+  test('(j) SECURITY: a filter on a DENIED field is silently dropped (no oracle) → exports the full sheet, no leak', async () => {
+    // The view filters Secret == 'secret_5'. Secret is field_permissions-denied to VIEWER, so the condition
+    // is pruned exactly like a non-existent field — NOT applied. Result: the full sheet (filter inert), and
+    // crucially no denied value reaches any cell (header masked, no secret_* anywhere).
+    const rows = await exportXlsxRows({ viewId: VIEW_FILTER_DENIED })
+    expect(rows[0]).toEqual(['Name', 'Amount']) // Secret column masked
+    expect(rows.slice(1).length).toBe(SEED_ROWS) // denied filter dropped → full sheet (not narrowed to 1 row)
+    expect(rows.flat().some((c) => c.startsWith('secret_'))).toBe(false) // no denied value leaked via the filter
+  })
+
+  test('(k) the filtered column may be VIEW-HIDDEN and still filter (hide Amount, filter Amount>=30 → 90 rows, no Amount column)', async () => {
+    // The canonical saved-filter idiom: hide the column you filter on. A read-permitted but view-hidden
+    // field must still narrow the rows (parity with GET /view) — the column is just absent from output.
+    // This is the case the OTHER seeded views (hidden_field_ids: []) structurally cannot reach.
+    const rows = await exportXlsxRows({ viewId: VIEW_FILTER_HIDDEN })
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    expect(header).toEqual(['Name']) // Amount hidden from OUTPUT (view-hidden) — but still filtered ON
+    expect(header).not.toContain('Amount')
+    expect(body.length).toBe(EXPECTED_FILTERED) // filter STILL applied despite the column being hidden (not 120)
+    expect(body.length).toBeGreaterThan(50)
+    expect(body.length).toBeLessThan(SEED_ROWS)
+    // The surviving rows are exactly 30..119 (proves it filtered on Amount, not something else).
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.has(`row_${String(VIEW_FILTER_THRESHOLD).padStart(4, '0')}`)).toBe(true)
+    expect(names.has('row_0029')).toBe(false)
+    expect(names.has(`row_${String(SEED_ROWS - 1).padStart(4, '0')}`)).toBe(true)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-export-allrows-maskroute-realdb.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Export "all rows" via the mask-preserving backend route — full-sheet completeness + mask (real DB).
+ *
+ * The verified bug: the multitable export picker serialized the CLIENT-LOADED grid page (page size 50),
+ * so "all rows" exported at most 50 rows. The fix rewires "all rows" to the backend route
+ * (univer-meta.ts GET /sheets/:sheetId/export-xlsx), which cursor-paginates the WHOLE sheet and applies
+ * the SAME field_permissions + view-hidden + §2a.3 formula-taint masking AFTER the `fieldIds` selection.
+ *
+ * THE keystone here (vs the existing mock-pool canary multitable-export-permission-canary.test.ts): a
+ * REAL DB seeded with > the FE page size (120 rows) — asserting ALL of them are exported proves the route
+ * returns the full sheet, not a 50-row page. Plus, against real seeded `field_permissions`: a denied
+ * column is excluded even when its id is passed in `fieldIds` (the mask is the enforcement boundary;
+ * selection can only narrow), a permitted subset narrows correctly, and the SAME masking holds for the
+ * new `format=csv` path (the format branch re-serializes the already-masked rows; it adds no data access).
+ *
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const xlsx = await import('xlsx') as unknown as {
+  read: (data: unknown, opts: { type: string }) => { SheetNames: string[]; Sheets: Record<string, unknown> }
+  utils: { sheet_to_json: (ws: unknown, opts: { header: 1; raw: false; defval: string }) => string[][] }
+}
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_exp_${TS}`
+const SHEET = `sheet_exp_${TS}`
+const F_NAME = `fld_exp_name_${TS}`
+const F_AMOUNT = `fld_exp_amount_${TS}`
+const F_SECRET = `fld_exp_secret_${TS}` // field_permissions-denied to VIEWER
+const VIEWER = `user_exp_viewer_${TS}`
+// > the FE DEFAULT_PAGE_SIZE (50). 120 also exceeds it by >2 pages, so a page-bound export would be obvious.
+const SEED_ROWS = 120
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+
+// Parse a binary xlsx export response into a header+cells matrix.
+async function exportXlsxRows(query: Record<string, string> = {}): Promise<string[][]> {
+  const res = await request(app)
+    .get(`/api/multitable/sheets/${SHEET}/export-xlsx`)
+    .query(query)
+    .buffer(true)
+    .parse((r, cb) => {
+      const chunks: Buffer[] = []
+      r.on('data', (c) => chunks.push(Buffer.from(c)))
+      r.on('end', () => cb(null, Buffer.concat(chunks)))
+    })
+  expect(res.status).toBe(200)
+  const parsed = xlsx.read(res.body, { type: 'buffer' })
+  return xlsx.utils.sheet_to_json(parsed.Sheets[parsed.SheetNames[0]], { header: 1, raw: false, defval: '' })
+}
+
+// Parse a CSV export response into a header+cells matrix (BOM-stripped, CRLF-split, RFC-4180 unquoting).
+async function exportCsvRows(query: Record<string, string> = {}): Promise<{ status: number; rows: string[][]; contentType: string }> {
+  const res = await request(app)
+    .get(`/api/multitable/sheets/${SHEET}/export-xlsx`)
+    .query({ format: 'csv', ...query })
+    .buffer(true)
+    .parse((r, cb) => {
+      const chunks: Buffer[] = []
+      r.on('data', (c) => chunks.push(Buffer.from(c)))
+      r.on('end', () => cb(null, Buffer.concat(chunks)))
+    })
+  const text = Buffer.isBuffer(res.body) ? res.body.toString('utf8').replace(/^﻿/, '') : ''
+  const rows = text.length === 0 ? [] : text.split('\r\n').map(parseCsvLine)
+  return { status: res.status, rows, contentType: String(res.header['content-type'] ?? '') }
+}
+
+// Minimal RFC-4180 single-line parser (no embedded newlines in this test's data) → string cells.
+function parseCsvLine(line: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++ } else { inQuotes = false }
+      } else { cur += ch }
+    } else if (ch === '"') { inQuotes = true }
+    else if (ch === ',') { out.push(cur); cur = '' }
+    else { cur += ch }
+  }
+  out.push(cur)
+  return out
+}
+
+describeIfDatabase('multitable export "all rows" via mask route (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: VIEWER, roles: ['member'], perms: ['multitable:read'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'Export Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'Export Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_AMOUNT, SHEET, 'Amount', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [F_SECRET, SHEET, 'Secret', 'string', '{}', 3])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+
+    // Seed SEED_ROWS records. Name is the row's zero-padded index so we can assert the full set is present.
+    for (let i = 0; i < SEED_ROWS; i++) {
+      const name = `row_${String(i).padStart(4, '0')}`
+      await q(
+        'INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [`rec_exp_${TS}_${i}`, SHEET, JSON.stringify({ [F_NAME]: name, [F_AMOUNT]: i, [F_SECRET]: `secret_${i}` })],
+      )
+    }
+    // field_permissions: deny F_SECRET to VIEWER (subject-scoped read mask).
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET, F_SECRET, VIEWER],
+    )
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) "all rows" exports the FULL sheet (every seeded row, > the 50-row client page)', async () => {
+    const rows = await exportXlsxRows()
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    // Name + Amount only (Secret denied) — header proves the mask, body proves completeness.
+    expect(header).toEqual(['Name', 'Amount'])
+    expect(body.length).toBe(SEED_ROWS) // THE regression: not capped at the FE page size (50)
+    expect(body.length).toBeGreaterThan(50)
+    // Every distinct seeded Name is present exactly once (no page truncation, no dupes).
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.size).toBe(SEED_ROWS)
+    expect(names.has('row_0000')).toBe(true)
+    expect(names.has(`row_${String(SEED_ROWS - 1).padStart(4, '0')}`)).toBe(true)
+  })
+
+  test('(b) a field_permissions-denied column is EXCLUDED even when its id is passed in fieldIds (mask holds)', async () => {
+    // Request the denied column explicitly alongside a permitted one — selection must not widen past the mask.
+    const rows = await exportXlsxRows({ fieldIds: `${F_NAME},${F_SECRET}` })
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    expect(header).toEqual(['Name']) // Secret dropped by the mask despite being requested
+    expect(flat).not.toContain('Secret')
+    expect(flat.some((c) => c.startsWith('secret_'))).toBe(false) // no denied value leaked in any cell
+    expect(rows.slice(1).length).toBe(SEED_ROWS) // still the full sheet
+  })
+
+  test('(c) selecting a subset of ALLOWED columns narrows correctly (and stays full-sheet)', async () => {
+    const rows = await exportXlsxRows({ fieldIds: F_AMOUNT })
+    const header = rows[0] ?? []
+    expect(header).toEqual(['Amount']) // narrowed to the one requested permitted column
+    expect(rows.slice(1).length).toBe(SEED_ROWS)
+  })
+
+  test('(d-1) CSV "all rows" exports the FULL sheet with the SAME field mask', async () => {
+    const { status, rows, contentType } = await exportCsvRows()
+    expect(status).toBe(200)
+    expect(contentType).toContain('text/csv')
+    const header = rows[0] ?? []
+    const body = rows.slice(1)
+    expect(header).toEqual(['Name', 'Amount']) // Secret masked in CSV too
+    expect(body.length).toBe(SEED_ROWS)
+    expect(body.length).toBeGreaterThan(50)
+    const names = new Set(body.map((r) => r[0]))
+    expect(names.size).toBe(SEED_ROWS)
+  })
+
+  test('(d-2) CSV SECURITY: a denied column requested via fieldIds is excluded (mask holds for CSV)', async () => {
+    const { status, rows } = await exportCsvRows({ fieldIds: `${F_NAME},${F_SECRET}` })
+    expect(status).toBe(200)
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    expect(header).toEqual(['Name'])
+    expect(flat.some((c) => c.startsWith('secret_'))).toBe(false)
+  })
+
+  test('(e) all-foreign fieldIds → 400 (no empty/200 file) for both formats', async () => {
+    const xlsxRes = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ fieldIds: 'nope1,nope2' })
+    expect(xlsxRes.status).toBe(400)
+    expect(xlsxRes.body?.error?.code).toBe('VALIDATION_ERROR')
+    const csvRes = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ format: 'csv', fieldIds: 'nope1,nope2' })
+    expect(csvRes.status).toBe(400)
+    expect(csvRes.body?.error?.code).toBe('VALIDATION_ERROR')
+  })
+
+  test('(f) an unsupported format value is a 400 (no silent fallback to xlsx)', async () => {
+    const res = await request(app).get(`/api/multitable/sheets/${SHEET}/export-xlsx`).query({ format: 'pdf' })
+    expect(res.status).toBe(400)
+    expect(res.body?.error?.code).toBe('VALIDATION_ERROR')
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-egress-coverage-guard.test.ts
@@ -71,7 +71,15 @@ const GOLDEN: Record<string, Partial<Record<(typeof EGRESS_HELPERS)[number], num
     // so a hidden link can neither match a value op nor leak its display. Locking test:
     // tests/integration/multitable-filter-by-link-view.test.ts (denied-link non-leak + isEmpty
     // permission-invariant + admin-bypass/flag-OFF canaries).
-    buildLinkSummaries: 6,
+    // 7 = +1 for the view-filtered EXPORT (export-xlsx, view row-filter parity): when a filtered view's
+    // filter references a LINK field, export-xlsx materializes the same permission-filtered display set to
+    // evaluate evaluateLinkFilterCondition over the loaded rows, then DISCARDS it (it is never serialized —
+    // the export cells come from the single filterRecordDataByFieldIds(record.data, fieldIds) projection,
+    // which never includes a link cell's display). Identical filter-internal/discarded pattern as GET /view,
+    // so it adds no NEW wire-egress channel; the denied-link non-leak is already locked by
+    // multitable-filter-by-link-view.test.ts, and the export parity case is in
+    // tests/integration/multitable-export-allrows-maskroute-realdb.test.ts.
+    buildLinkSummaries: 7,
     serializeLinkSummaryMap: 1,
     // 3 = linkSummaries + attachmentSummaries + native person (人员) personSummaries (design
     // 2026-06-16). The personSummaries egress is routed through the SAME layer-2 ∧ layer-3


### PR DESCRIPTION
## Resolves the held PR #3003's open semantic

**Supersedes #3003** (please close it in favor of this PR). This branch *contains* #3003's commit unchanged (rewiring "export all rows" to the mask-preserving full-sheet route `GET /sheets/:sheetId/export-xlsx` + `?format=csv`) and adds the one thing #3003 was HELD on: **the export now respects the view's ROW filter + sort**, not only its hidden-fields.

### The held semantic (now fixed = option A)

#3003 applied the view's `hidden_field_ids` but ignored its `filter_info` / `sort_info`, so exporting a **filtered** view emitted the **entire sheet**. This makes "export all rows" of a view export **ALL rows OF THE VIEW'S FILTER** — the full filtered set, not the 50-row page, not the unfiltered sheet — in the view's sort order. No FE change needed: the client already sends the active `viewId`; the route now honors its filter.

## Filter-application approach (mirrors `GET /view`, not `view-aggregate`)

Branch on the view's **pruned** filter/sort:

- **No filter AND no sort** → keep #3003's full-sheet **cursor stream byte-identical** (preserves the proven mask + truncation + #3003's tests a–f, which use no `viewId`).
- **Filter or sort present** → **load-all → filter → sort → cap**, reusing the *identical* evaluation `GET /view` uses:
  - `parseMetaFilterInfo` + `pruneFilterNode` + `evaluateFilterNode` / `evaluateMetaFilterCondition`
  - **link** filters via `loadLinkValuesByRecord` + `buildLinkSummaries` + `evaluateLinkFilterCondition`
  - **computed** (lookup/rollup/formula) via `applyLookupRollup`, gated on `needsComputedFilterSort` (only when the filter/sort references a computed field)
  - sort via `compareMetaSortValue` + person sort-by-display, with the `created_at`→`id` tiebreak

**Deliberate divergence from the issue's "per-page cursor loop" suggestion** (called out for review): a per-page sort can't be globally correct, and SQL `->>` ordering can't match `/view`'s type-aware compare (numeric/date/bool/person), so the filter+sort path **loads-all like `/view` itself does** for this case — the harder requirement ("reuse the SAME filter evaluation `/view` uses") wins. The issue anticipated this ("slower for filtered exports, but correct + still bounded by `XLSX_MAX_ROWS`"). `view-aggregate` was the wrong template — it **422s** on computed/link filters; the issue requires *evaluating* them. Memory profile = a filtered `/view` of the same sheet; output stays bounded by `XLSX_MAX_ROWS` (truncation reflects the **filtered** count).

## Security — the field + §2a.3-taint mask still holds for BOTH formats

- **One masking chokepoint, both branches.** Every surviving record funnels through a single `filterRecordDataByFieldIds(record.data, fieldIds)` — the `field_permissions` ∧ view-hidden ∧ §2a.3-taint ∧ selection masked set. A denied / hidden / tainted column **never reaches a cell** in xlsx OR csv, even when its id is passed in `fieldIds`. The single call-site preserves the egress-coverage + taint-chokepoint guard counts (no regression to #3003's proven mask). Verified by the §2a.3 export-taint suite (`multitable-lookup-foreign-field-mask-export.test.ts`, green) and new cases (g-mask).
- **Filter-permission discipline (no leak via the filter).** The filter/sort **prune set** is `/view`'s SELECTION set — layer-2 ∧ layer-3 (`field_permissions`) ∧ §2a.3-taint, **`hiddenFieldIds: []`** — deliberately NOT the output `fieldIds`. So a *read-permitted* field stays filterable even when view-**hidden** or **unselected** (the canonical "hide the column you filter on" idiom keeps working — case **k**), while a permission-**denied** / **tainted** filter field is **silently dropped** (behaves exactly like a non-existent field — no existence/value oracle, case **j**).
- **Link-filter materialization is filter-internal / discarded** (never serialized) — the same pattern already documented for `/view` + the dashboard; egress-coverage GOLDEN `buildLinkSummaries` 6→7 updated with a mirroring comment, and the denied-link non-leak is already locked by `multitable-filter-by-link-view.test.ts`.

## Tests (extend #3003's real-DB suite; already registered in `plugin-tests.yml`)

Seeds **120 rows** (> the 50-row FE page) and adds filtered / sort / view-hidden views:

- **(g)** a FILTERED view (`Amount >= 30`) exports **exactly the 90-row subset** — `> 50` (not a page) AND `< 120` (not the sheet), and the *exact* Names 30..119
- **(g-csv)** the SAME filtered subset for CSV (filter + mask both hold)
- **(g-mask)** filter STILL applies when the output selection omits the filter field; denied id requested → still masked (xlsx + csv)
- **(h)** a no-filter view = the **full sheet**
- **(i)** sort `Amount desc` applied **globally** end-to-end (119..0)
- **(j)** SECURITY: a filter on a **denied** field is silently dropped → full sheet, no leak
- **(k)** a **view-hidden** filter column still filters (90 rows, column absent from output)

**15/15 pass** on a fresh migrated real DB. Neighboring filter real-DB suites (`/view` search/filter/sort mask, `view-aggregate`, filter-by-link, dashboard-filter-oracle, export-permission-canary, lookup-foreign-field-mask-export) all stay green — no regression.

## Validation

- `pnpm install --frozen-lockfile` — clean (no lockfile drift)
- `cd packages/core-backend && npx tsc --noEmit -p tsconfig.json` — **0 errors**
- `pnpm --filter @metasheet/web exec vue-tsc -b` — **0 errors** (#3003's web changes still compile on current main)
- `CI=true pnpm --filter @metasheet/core-backend test` — **358 files / 4693 tests passed, 0 failed** (104 files / 840 real-DB tests skipped without `DATABASE_URL`)
- Structural guards (egress-coverage / §2a.3 taint-chokepoint / raw-record-data-projection / record-lock) — **11/11 green**
- Rebased onto latest `origin/main` (8485e80c0); clean, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)