### PR TITLE
docs(multitable): reconcile parity ladder + T5-2 roadmap wording + export comment (review follow-ups)

### DIFF
--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3111,9 +3111,9 @@ function onGridSelectionChange(recordIds: string[]) {
 //     The route cursor-paginates the FULL sheet and re-applies the SAME
 //     field_permissions + view-hidden + §2a.3 formula-taint mask AFTER the
 //     fieldIds selection (selection narrows within the permitted set, never
-//     widens). NOTE: "all rows" = the full sheet, NOT the view-filtered subset
-//     (the route applies view HIDDEN-FIELDS but not the view's row filter/sort);
-//     view-filtered export is a follow-up.
+//     widens). NOTE: "all rows" exports the view's FULL set respecting the view's
+//     row filter + sort + hidden-fields (#3010) — the entire (filtered) view, not
+//     just the loaded page; a view with no filter exports the full sheet.
 //   - "selected rows" → stays CLIENT-SIDE over grid.rows. Those rows are the
 //     /view response, already field-permission AND §2a.3-taint masked at read
 //     time (univer-meta.ts GET /view: filterRecordDataByFieldIds over the

--- a/docs/development/multitable-benchmark-refresh-ladder-20260621.md
+++ b/docs/development/multitable-benchmark-refresh-ladder-20260621.md
@@ -5,6 +5,36 @@
 > ladder materially **over-counted the remaining gaps** — three of its "gaps" are already shipped. Verify
 > each lane against main before building.
 
+---
+
+## ⚠ RECONCILIATION — 2026-06-21 (post-#3005, AUTHORITATIVE — read this, not §1–§3)
+
+The §1–§3 body below is the **as-of-#3005 snapshot** and is now superseded by this banner. Since #3005, the
+following all shipped to `origin/main`; treat THIS as the current parity ledger:
+
+- **#3006** A4 required-IF → SHIPPED (was the §3 "A4-rIF" gap).
+- **#3007** B4 dashboard-level filtering → SHIPPED (was the §3 "B4" gap).
+- **#3009** dashboard cross-filtering → SHIPPED (was the §3 "B4 cross-filtering" gap).
+- **#3010** filter-respecting export → SHIPPED, **supersedes #3003 (now CLOSED)** — export respects the view's
+  row filter + sort; the §1 "Open held #3003" item and the §3 "Export filtered-view" gap are RESOLVED.
+- **#3011** formula-editor exposure of the relation functions (RELSUMIF/…/RELVALUES) → SHIPPED.
+- **#3008** A1 grid virtualization (windowing + infinite-scroll activation, FUNCTIONAL) → SHIPPED (was the §3
+  "decision-gated A1"; built — the windowing fix needed no perf-baseline prereq).
+- Also verified already-shipped (NOT gaps): the button side-effect arc (update_record / send_notification /
+  send_webhook), the cross-base link UI (#2611), and the row-level read-deny foundation. **Five staleness
+  traps total** — the §1/§3 "remaining gaps" list is stale; do NOT build from it.
+
+**Genuine remaining frontier (all decision-gated or parallel-owned — verified against origin/main):**
+- **#6 AI field** — needs a provider / model / cost decision.
+- **#7 external-source sync UI** — needs connector + auth decisions (which systems, how they authenticate).
+- **#5 row-level rule engine** — read-deny foundation shipped; evolving in parallel; security-sensitive.
+- **#9 Time Machine write-slice** — XL; owned by the parallel global-history session.
+
+**Net:** the multitable is at/near Feishu parity for everything buildable without a product decision. The
+B1-S1 `send_notification` line in §3 is also stale (it shipped). Next round: start from this banner.
+
+---
+
 ## 1. Shipped since the 20260615 ladder
 
 - **Filter-by-link** — filter records by a linked-record's display value, permission-safe (denied link →
@@ -18,7 +48,7 @@
   filtered column (server min/max via `/view-aggregate?statsFields`), stats gated on the masked aggregate
   field set (a denied numeric column returns no min/max — leak-gate proven).
 
-**Open, held on a decision:** **#3003** export "all rows" — fixes the 50-row client-page data-loss (routes
+**[RESOLVED via #3010 — see the top RECONCILIATION banner.]** ~~Open, held on a decision:~~ **#3003** export "all rows" — fixes the 50-row client-page data-loss (routes
 through the mask-preserving full-sheet route; field+taint mask proven for xlsx+csv). Held on a product call:
 "all rows" currently = the **entire sheet**, not the **view-filtered** subset (route applies view
 hidden-fields but not the row filter). Options on the PR: (A) respect the view filter, (B) relabel "entire
@@ -34,7 +64,7 @@ The 20260615 ladder listed these as gaps; they are **already shipped** — do no
 
 Lesson (now 3×): the audit drifts faster than the code; **verify each candidate lane against main before building** — blind ladder-building has wasted-build risk.
 
-## 3. Genuine remaining gaps
+## 3. Genuine remaining gaps  *(SUPERSEDED — see the top RECONCILIATION banner; #3006–#3011 shipped these)*
 
 **Ungated / buildable now (small):**
 - **A4-rIF** conditional-required (`required-IF`) — a field required only when a condition holds; reuse the existing field-visibility-rule condition vocabulary + the form's submit validation. Small, FE-led.

--- a/docs/development/multitable-global-history-timemachine-program-roadmap-20260621.md
+++ b/docs/development/multitable-global-history-timemachine-program-roadmap-20260621.md
@@ -23,12 +23,13 @@ requested artifact, not gating.
 - **T5-1 — as-of-time-T reconstructor** (`record-reconstructor.ts`): `reconstructRecordsAtT` — the pure-read
   primitive (LOCK-9 delete-aware + LOCK-11 deterministic). The shared root; pinned FIRST with 7 real-DB goldens
   incl. the delete-at-T pin. **BUILT.**
-- **T5-2 — restore-preview endpoint** (read-only diff over T5-1): the T5 design-lock #2985 (PV-1..PV-7). Computes
-  what a restore WOULD change, writes nothing. Builds on the pinned T5-1.
+- **T5-2 — restore-preview endpoint** (record-version restore-preview): the T5 design-lock #2985 (PV-1..PV-7).
+  Computes what restoring a record to `targetVersion` WOULD change, masked to the actor's fields, writes nothing.
+  Reconstructor-based as-of-T preview (over T5-1) deferred as a follow-up — matches §4 D2 (record-version first).
 - **T7 — point-in-time read-only view**: the reconstructor projected over a sheet with LOCK-3 masking + pagination
   ("open the table as of T, read-only"). Builds on the pinned T5-1; de-risks T8.
 
-All three share T5-1's exact contract — **parallelize the leaves (T5-2, T7), never the shared root.**
+T7 builds on T5-1's exact as-of-T contract; T5-2 v1 is record-version-based (the as-of-T reconstructor preview is the deferred follow-up). **Parallelize the leaves (T5-2, T7), never the shared root.**
 
 ## 3. Design-locked now (write / destructive — the 设计 deliverable, NOT built)
 
@@ -52,7 +53,7 @@ All three share T5-1's exact contract — **parallelize the leaves (T5-2, T7), n
 ## 5. Execution order (dependency-correct)
 
 1. ✅ T5-1 reconstructor (root, pinned).
-2. ▶ T5-2 preview + T7 PIT-view (parallel leaves off the pinned T5-1).
+2. ▶ T5-2 preview (record-version) + T7 PIT-view (off the pinned T5-1) — parallel leaves.
 3. ✅ T6 / T8 / T9 design-locks (this docs set — the 设计 deliverable).
 4. ⏸ T6/T8/T9 runtime — each gated on its ratification; **not started**.
 


### PR DESCRIPTION
Three review-driven cleanups (no runtime change), addressing the reviewer findings:

**Medium — parity ladder stale.** `multitable-benchmark-refresh-ladder-20260621.md` still listed #3003 open + A4-rIF/B4/export-filtered-view as gaps + A1 gated, but #3006/#3007/#3008/#3009/#3010/#3011 all shipped since #3005. Added an **AUTHORITATIVE reconciliation banner** at the top (the 6 shipped PRs + the genuine remaining frontier = #5/#6/#7/#9, decision-gated/parallel), and marked #3003 RESOLVED-via-#3010 + §3 SUPERSEDED inline — so the next round starts from the current map, not the old one.

**Low — T5-2 roadmap wording.** `…timemachine-program-roadmap-20260621.md` §2/§5 said T5-2 is "read-only diff over T5-1" / "Builds on the pinned T5-1". Shipped T5-2 is **record-version** restore-preview (`POST …/restore-preview` takes `z.object({ targetVersion })`; the real-DB test posts `{ targetVersion: 1 }`; §4 D2 already says "record-version first"). Reworded to record-version preview with the reconstructor-based as-of-T preview noted as deferred.

**Low — export comment.** `MultitableWorkbench.vue` export comment said "all rows" = full sheet, NOT view-filtered, + "view-filtered export is a follow-up" — stale after #3010. Now: "all rows" respects the view's row filter + sort + hidden-fields (#3010).

web `vue-tsc -b` 0. Docs + one comment line; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)