### PR TITLE
fix(onprem): retry deploy healthcheck after PM2 restart

### DIFF
--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -14,7 +14,9 @@ param(
   [string]$RestartService = '1',
   [string]$StagingRoot = '',
   [string]$DependencyRefreshTimeoutSec = '1800',
-  [string]$DependencyRefreshHeartbeatSec = '60'
+  [string]$DependencyRefreshHeartbeatSec = '60',
+  [string]$HealthcheckAttempts = '12',
+  [string]$HealthcheckDelaySec = '5'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -511,7 +513,7 @@ function Expand-PackageArchive {
   throw "Unsupported package extension (expected .zip, .tgz, or .tar.gz): $ArchivePath"
 }
 
-function Invoke-Healthcheck {
+function Invoke-HealthcheckOnce {
   param([string]$Url)
 
   try {
@@ -521,6 +523,41 @@ function Invoke-Healthcheck {
   catch {
     return $false
   }
+}
+
+function Invoke-Healthcheck {
+  param(
+    [string[]]$Urls,
+    [int]$Attempts,
+    [int]$DelaySec
+  )
+
+  if ($null -eq $Urls -or $Urls.Count -eq 0) {
+    throw 'Healthcheck URLs must not be empty'
+  }
+  if ($Attempts -lt 1) {
+    throw 'HealthcheckAttempts must be a positive integer'
+  }
+  if ($DelaySec -lt 1) {
+    throw 'HealthcheckDelaySec must be a positive integer'
+  }
+
+  for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+    foreach ($url in $Urls) {
+      Write-Info "Healthcheck attempt ${attempt}/${Attempts}: $url"
+      if (Invoke-HealthcheckOnce -Url $url) {
+        Write-Info "Healthcheck OK ($url)"
+        return $true
+      }
+    }
+
+    if ($attempt -lt $Attempts -and $DelaySec -gt 0) {
+      Write-Info "Healthcheck not ready; retrying in ${DelaySec}s"
+      Start-Sleep -Seconds $DelaySec
+    }
+  }
+
+  return $false
 }
 
 $resolvedRoot = Resolve-NormalizedPath -Candidate $RootDir -Label 'RootDir'
@@ -654,10 +691,11 @@ try {
   if ($RunHealthcheck -ne '0') {
     $healthUrl = ($BaseUrl.TrimEnd('/')) + '/health'
     $pluginsUrl = ($ApiBase.TrimEnd('/')) + '/plugins'
-    if (-not (Invoke-Healthcheck -Url $healthUrl) -and -not (Invoke-Healthcheck -Url $pluginsUrl)) {
+    $healthcheckAttemptsValue = Convert-PositiveInt -Value $HealthcheckAttempts -Label 'HealthcheckAttempts'
+    $healthcheckDelayValue = Convert-PositiveInt -Value $HealthcheckDelaySec -Label 'HealthcheckDelaySec'
+    if (-not (Invoke-Healthcheck -Urls @($healthUrl, $pluginsUrl) -Attempts $healthcheckAttemptsValue -DelaySec $healthcheckDelayValue)) {
       throw "Healthcheck failed for $healthUrl and $pluginsUrl"
     }
-    Write-Info "Healthcheck OK ($healthUrl or $pluginsUrl)"
   }
 
   Write-Info "Package deploy complete"

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -22,6 +22,27 @@ test('Windows apply helper bootstraps SYSTEM-safe tool PATH and resolves pnpm fr
   assert.match(script, /\$pnpmPath = \$pnpmInstallPath/)
 })
 
+test('Windows apply helper retries post-PM2 healthcheck during warmup and remains fail-closed', () => {
+  const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
+
+  assert.match(script, /\[string\]\$HealthcheckAttempts = '12'/)
+  assert.match(script, /\[string\]\$HealthcheckDelaySec = '5'/)
+  assert.match(script, /function Invoke-HealthcheckOnce/)
+  assert.match(script, /function Invoke-Healthcheck/)
+  assert.match(script, /for \(\$attempt = 1; \$attempt -le \$Attempts; \$attempt\+\+\)/)
+  assert.match(script, /foreach \(\$url in \$Urls\)/)
+  assert.match(script, /Invoke-HealthcheckOnce -Url \$url/)
+  assert.match(script, /Start-Sleep -Seconds \$DelaySec/)
+  assert.match(script, /return \$false/)
+  assert.match(script, /Convert-PositiveInt -Value \$HealthcheckAttempts -Label 'HealthcheckAttempts'/)
+  assert.match(script, /Convert-PositiveInt -Value \$HealthcheckDelaySec -Label 'HealthcheckDelaySec'/)
+  assert.match(script, /Invoke-Healthcheck -Urls @\(\$healthUrl, \$pluginsUrl\) -Attempts \$healthcheckAttemptsValue -DelaySec \$healthcheckDelayValue/)
+  assert.match(script, /throw "Healthcheck failed for \$healthUrl and \$pluginsUrl"/)
+
+  const oldSingleProbe = /if \(-not \(Invoke-Healthcheck -Url \$healthUrl\) -and -not \(Invoke-Healthcheck -Url \$pluginsUrl\)\)/
+  assert.doesNotMatch(script, oldSingleProbe)
+})
+
 test('PM2 startup helper initializes SYSTEM profile env before invoking PM2', () => {
   const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
 


### PR DESCRIPTION
## Summary

Fixes the #2769 S1/S3/S4 package deploy HOLD shape where the Windows apply helper returned `deployApplyExit=1` because the immediate post-PM2 healthcheck raced app warmup, while the same root/API/plugins endpoints were 200 shortly afterward.

Changes:

- Adds bounded retry/backoff to `scripts/ops/multitable-onprem-apply-package.ps1` healthcheck.
- Defaults: `HealthcheckAttempts=12`, `HealthcheckDelaySec=5`.
- The helper checks both `/health` and `/api/plugins` each attempt; either 2xx endpoint passes the deploy healthcheck.
- Still fail-closed: if neither endpoint becomes healthy within the bounded window, deploy exits non-zero as before.
- Adds a static hardening test so the helper cannot regress to the old single-probe shape.

## Boundary

- Release hygiene only.
- No runtime app behavior change.
- No S2/K3 change; no K3 Save / Submit / Audit / BOM.
- No S5 change.
- No production/batch/first external write authorization.

## Verification

```text
node --test scripts/ops/onprem-windows-system-hardening.test.mjs
# pass: 6/6

pwsh -NoProfile -Command '$tokens=$null; $errors=$null; $null=[System.Management.Automation.Language.Parser]::ParseFile("scripts/ops/multitable-onprem-apply-package.ps1", [ref]$tokens, [ref]$errors); if ($errors.Count) { $errors | Format-List; exit 1 }'
# pass

git diff --check
# pass
```
