### PR TITLE
feat(multitable): global-history T6-1 — restore preview-identity contract (mint/verify, no write)

### DIFF
--- a/docs/development/multitable-global-history-t6-1-preview-identity-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t6-1-preview-identity-dev-verification-20260621.md
@@ -1,0 +1,56 @@
+# Global History — T6-1 Restore Preview-Identity Contract 开发与验证 MD
+
+> First step of the T6 scoped-restore slice (owner-ratified). **Contract ONLY** — the mint/verify module +
+> goldens, per the T6 design-lock SR-3. **Touches no route and writes nothing**; the mint→preview and
+> verify→execute wiring + the forward-revision write are T6-2 (the owner's "不直接碰 destructive restore").
+
+## 1. What it is
+
+`restore-preview-identity.ts`: a stateless, signed identity a preview (T5-2) will mint and the restore execute
+(T6-2) will verify, so **execution matches the preview** (SR-3).
+
+- `mintRestorePreviewIdentity(claims, expiresIn='10m')` → a JWT/HS256 token (same primitive as invite-tokens,
+  via `secretManager` `RESTORE_PREVIEW_SECRET` → `JWT_SECRET` fallback).
+- `verifyRestorePreviewIdentity(token, expected)` → `{ valid, reason }`. JWT covers signature + expiry; the
+  per-claim checks bind every axis.
+- `hashPreviewChanges(changes)` → the canonical diff hash bound into the identity.
+
+**Bound claims:** `{ sheetId, recordId, targetVersion, strategy:'revert', changesHash, actorId }`.
+
+**SCOPE LOCK (v1 = record-version only).** This identity binds a SINGLE record-version restore — it does NOT
+express a batch / multi-record / field-subset scope. So **T6-2 v1 must execute a single-record record-version
+restore ONLY**; the design-lock's batch / fan-out restore is a LATER slice that adds a `scope` claim (kind +
+recordIds/fieldIds/batchId) and binds a scope canonical hash. A matching `changesHash` must not be read as
+authorizing a wider scope. (Per the owner review: don't let the docs imply a batch/fan-out identity is done.)
+
+## 2. The locks it establishes (for T6-2 to inherit)
+
+- **Execution-matches-preview** = the `changesHash` (sha256 of the MASKED preview changes) + scope + strategy.
+  A stale diff (data — or the actor's field permissions — moved since preview) makes the execute's re-hash
+  diverge → reject → re-preview.
+- **changesHash is ORDER-INVARIANT** (the correctness pin): sort by `fieldId`, include `op`, stable value
+  serialization (`JSON.stringify(v ?? null)`, the same form the diff uses). A non-deterministic hash would make
+  every restore re-hash diverge → a silent denial-of-restore. Golden asserts two array orders → equal hash.
+- **Reveal-safe BY CONSTRUCTION**: the hash is over the MASKED changes (what the actor saw); T5-2's preview has
+  no reveal path, so the identity can only ever bind reveal-free fields. The design-lock's "a reveal grant never
+  enters the writable set" is therefore INHERITED at T6-2, not re-solved.
+- **Actor-bound**: an identity minted for A is unusable by B — else B could replay A's identity to skip B's own
+  permission computation at execute. (golden: actor mismatch → reject.)
+- **Strategy = `revert` only**: the destructive `reset` is T8, never T6.
+
+## 3. Verification
+
+- backend `tsc` 0.
+- **6 unit goldens** (pure; no DB, no route): mint→verify roundtrip valid; tampered token rejected (signature);
+  expired → `reason:'expired'`; every bound axis mismatched (sheet/record/version/strategy/changesHash/actor) →
+  rejected; changesHash order-invariant; changesHash distinguishes a changed value.
+- `jsonwebtoken` is already a direct dep — no lockfile change. No migration, no FE, no route touched.
+
+## 4. Out of scope (explicitly T6-2 / later — so they don't creep in)
+
+- mint→preview wiring (T5-2 response returns the identity) and verify→execute wiring — **T6-2**.
+- the forward-revision write (`source='restore'`), the per-record permission re-application across the fan-out
+  (SR-2: row-deny + field write gate + expectedVersion), the atomic + idempotent execution — **T6-2**.
+- single-use / anti-replay: needs server state; the `changesHash` already defeats stale replay, so this is a
+  **T6-2 idempotency** concern, not the identity contract.
+- the destructive sheet-wide reset — **T8**.

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -1,0 +1,90 @@
+import jwt, { type SignOptions } from 'jsonwebtoken'
+import { createHash } from 'node:crypto'
+import { secretManager } from '../security/SecretManager'
+import { resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
+
+/**
+ * Global History — T6-1: the RECORD-VERSION restore preview-identity contract (mint + verify), per the T6
+ * scoped-restore design-lock (SR-3). A record-version preview (T5-2) mints an identity that BINDS its
+ * (record + targetVersion + strategy + the MASKED diff the actor saw + actor); the eventual restore execute
+ * (T6-2) verifies it so "execution matches the preview". This module is the CONTRACT ONLY — it is NOT wired
+ * into any route and writes nothing (the mint->preview and verify->execute wiring + the forward-revision write
+ * are T6-2).
+ *
+ * SCOPE LOCK (v1): this identity binds a SINGLE record-version restore — `{ sheetId, recordId, targetVersion }`.
+ * It deliberately does NOT express a batch / multi-record / field-subset scope. T6-2 v1 must therefore execute
+ * a single-record record-version restore ONLY; a batch / fan-out restore identity is a later slice that adds a
+ * `scope` claim (kind + recordIds/fieldIds/batchId) and binds a scope canonical hash. Do not read this v1
+ * identity as authorizing a wider scope just because `changesHash` matches.
+ *
+ * Stateless (JWT/HS256, same primitive as invite-tokens): signature defeats tampering, `exp` bounds the window,
+ * and `changesHash` defeats stale replay (if the data — or the actor's field permissions — moved since preview,
+ * the execute's re-hash diverges -> reject -> re-preview). Single-use / anti-replay needs server state and is a
+ * T6-2 idempotency concern, NOT this slice.
+ */
+
+export interface RestorePreviewIdentityClaims {
+  sheetId: string
+  recordId: string
+  targetVersion: number
+  /** v1 = `revert` only (the destructive `reset` is T8, never T6). */
+  strategy: 'revert'
+  /** sha256 of the MASKED preview changes (what the actor saw) — see hashPreviewChanges. */
+  changesHash: string
+  /** the actor the preview was minted for — a preview minted for A is unusable by B (no permission-skip replay). */
+  actorId: string
+}
+
+const DEFAULT_TTL: SignOptions['expiresIn'] = '10m'
+
+function getSecret(): string {
+  const dedicated = secretManager.get('RESTORE_PREVIEW_SECRET', { required: false })
+  return dedicated ? resolveRuntimeJwtSecret(dedicated) : resolveRuntimeJwtSecret(process.env.JWT_SECRET)
+}
+
+/**
+ * Canonical, ORDER-INVARIANT hash of the MASKED preview changes — what the actor saw (reveal-free by
+ * construction: T5-2's preview has no reveal path, so the identity can only ever bind reveal-free fields, and
+ * "a reveal grant never enters the writable set" is inherited at T6-2, not re-solved). Determinism is critical:
+ * a non-deterministic hash would make every restore re-hash "diverge" -> a silent denial-of-restore. Each change
+ * is serialized as a JSON array `[fieldId, op, value ?? null]` (no delimiter bytes), and the set is sorted by
+ * fieldId before hashing.
+ */
+export function hashPreviewChanges(changes: Array<{ fieldId: string; op: string; value: unknown }>): string {
+  const canon = [...changes]
+    .sort((a, b) => (a.fieldId < b.fieldId ? -1 : a.fieldId > b.fieldId ? 1 : 0))
+    .map((c) => JSON.stringify([c.fieldId, c.op, c.value ?? null]))
+  return createHash('sha256').update(JSON.stringify(canon)).digest('hex')
+}
+
+export function mintRestorePreviewIdentity(claims: RestorePreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'restore-preview', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface VerifyResult {
+  valid: boolean
+  /** why it failed (telemetry / 4xx mapping); absent when valid. */
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_recordId' | 'mismatch_targetVersion' | 'mismatch_strategy' | 'mismatch_changesHash' | 'mismatch_actorId'
+}
+
+/**
+ * Verify a preview identity against the EXPECTED claims the caller (T6-2) computes fresh at execute time. JWT
+ * verification covers signature + expiry; the per-claim checks bind scope/strategy/diff/actor so a token cannot
+ * be replayed for a different record, a stale diff, or by a different actor.
+ */
+export function verifyRestorePreviewIdentity(token: string, expected: RestorePreviewIdentityClaims): VerifyResult {
+  let payload: Partial<RestorePreviewIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<RestorePreviewIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'restore-preview') return { valid: false, reason: 'wrong_type' }
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.recordId !== expected.recordId) return { valid: false, reason: 'mismatch_recordId' }
+  if (payload.targetVersion !== expected.targetVersion) return { valid: false, reason: 'mismatch_targetVersion' }
+  if (payload.strategy !== expected.strategy) return { valid: false, reason: 'mismatch_strategy' }
+  if (payload.changesHash !== expected.changesHash) return { valid: false, reason: 'mismatch_changesHash' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  return { valid: true }
+}

--- a/packages/core-backend/tests/unit/restore-preview-identity.test.ts
+++ b/packages/core-backend/tests/unit/restore-preview-identity.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Global History — T6-1: restore preview-identity contract goldens (pure unit; no DB, no route).
+ *
+ * The contract that lets the eventual restore execute (T6-2) confirm "execution matches the preview" (SR-3).
+ * T6-1 is the mint/verify module ONLY — verified here against SYNTHETIC expected claims; the execute computing
+ * the real diff → expected → verify → write is T6-2.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  hashPreviewChanges,
+  mintRestorePreviewIdentity,
+  verifyRestorePreviewIdentity,
+  type RestorePreviewIdentityClaims,
+} from '../../src/multitable/restore-preview-identity'
+
+const baseClaims = (): RestorePreviewIdentityClaims => ({
+  sheetId: 'sheet_1',
+  recordId: 'rec_1',
+  targetVersion: 3,
+  strategy: 'revert',
+  changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 'a' }, { fieldId: 'f2', op: 'unset', value: null }]),
+  actorId: 'user_1',
+})
+
+describe('restore preview identity — T6-1 contract', () => {
+  it('mint → verify roundtrip is valid against the matching expected claims', () => {
+    const claims = baseClaims()
+    const token = mintRestorePreviewIdentity(claims)
+    expect(verifyRestorePreviewIdentity(token, claims)).toEqual({ valid: true })
+  })
+
+  it('a tampered token is rejected (signature)', () => {
+    const token = mintRestorePreviewIdentity(baseClaims())
+    const tampered = token.slice(0, -3) + (token.slice(-3) === 'AAA' ? 'BBB' : 'AAA')
+    expect(verifyRestorePreviewIdentity(tampered, baseClaims()).valid).toBe(false)
+  })
+
+  it('an expired identity is rejected with reason "expired"', () => {
+    const token = mintRestorePreviewIdentity(baseClaims(), '-1s') // already past
+    expect(verifyRestorePreviewIdentity(token, baseClaims())).toEqual({ valid: false, reason: 'expired' })
+  })
+
+  it('every bound claim must match — a mismatch on any axis is rejected', () => {
+    const claims = baseClaims()
+    const token = mintRestorePreviewIdentity(claims)
+    expect(verifyRestorePreviewIdentity(token, { ...claims, sheetId: 'other' }).reason).toBe('mismatch_sheetId')
+    expect(verifyRestorePreviewIdentity(token, { ...claims, recordId: 'other' }).reason).toBe('mismatch_recordId')
+    expect(verifyRestorePreviewIdentity(token, { ...claims, targetVersion: 99 }).reason).toBe('mismatch_targetVersion')
+    // strategy is a load-bearing SR-3 bind; cast past the v1 `'revert'`-only type so the guard is pinned for
+    // when `'reset'` is ever added — a revert identity must never satisfy a reset execution.
+    expect(verifyRestorePreviewIdentity(token, { ...claims, strategy: 'reset' as unknown as 'revert' }).reason).toBe('mismatch_strategy')
+    expect(verifyRestorePreviewIdentity(token, { ...claims, changesHash: 'deadbeef' }).reason).toBe('mismatch_changesHash') // stale diff → reject
+    expect(verifyRestorePreviewIdentity(token, { ...claims, actorId: 'user_2' }).reason).toBe('mismatch_actorId') // B cannot replay A's identity
+  })
+
+  it('changesHash is ORDER-INVARIANT (else a restore could never execute — re-hash would always diverge)', () => {
+    const a = hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 1 }, { fieldId: 'f2', op: 'set', value: 2 }])
+    const b = hashPreviewChanges([{ fieldId: 'f2', op: 'set', value: 2 }, { fieldId: 'f1', op: 'set', value: 1 }])
+    expect(a).toBe(b)
+  })
+
+  it('changesHash DISTINGUISHES a different change set (a changed value → different hash)', () => {
+    const a = hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 1 }])
+    const b = hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 2 }])
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
First step of the owner-ratified **T6 scoped-restore** slice. **Contract only** (per the T6 design-lock SR-3): the mint/verify module + goldens. **Touches no route and writes nothing** — the mint→preview + verify→execute wiring and the forward-revision write are T6-2 (your "不直接碰 destructive restore").

## What

`restore-preview-identity.ts`: a stateless **JWT/HS256** identity (same primitive as invite-tokens, via `secretManager` `RESTORE_PREVIEW_SECRET` → `JWT_SECRET` fallback) binding `{ sheetId, recordId, targetVersion, strategy:'revert', changesHash, actorId }`. `verifyRestorePreviewIdentity(token, expected)` checks signature + expiry + every bound claim, so T6-2's execute can confirm **execution matches the preview** (SR-3).

## Properties T6-2 inherits (not re-solved)

- **`changesHash`** = sha256 of the **masked** preview changes, **order-invariant** (sort by `fieldId`, include `op`, stable value serialization) — a non-deterministic hash would silently deny every restore. Golden pins order-invariance + distinction.
- **reveal-safe by construction**: the hash is over the masked changes; T5-2 has no reveal path → the identity can only bind reveal-free fields → "a reveal grant never enters the writable set" is inherited at T6-2.
- **actor-bound**: a preview minted for A is unusable by B (no permission-skip replay).
- **strategy = `revert` only** (reset = T8).

## Verification

tsc 0; **6 unit goldens** (roundtrip · tamper · expired · every-axis mismatch · order-invariance · distinguishes). `jsonwebtoken` already a direct dep (no lockfile change). **No migration, no FE, no route, no write.**

## Next (T6-2, separate slice)

Wire mint→T5-2 preview response + verify→execute; re-apply per-record gates (row-deny + field write gate + expectedVersion) across the fan-out; forward-revision write (`source='restore'`), transactional + idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)