### PR TITLE
feat(multitable): global-history T6-2 — scoped restore execute (first write; identity-gated, row-deny, idempotent)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -211,6 +211,7 @@ jobs:
             tests/integration/multitable-record-reconstructor-realdb.test.ts \
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
+            tests/integration/multitable-restore-execute-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-global-history-t6-2-scoped-execute-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t6-2-scoped-execute-dev-verification-20260621.md
@@ -1,0 +1,68 @@
+# Global History — T6-2 Scoped Restore Execute 开发与验证 MD
+
+> The FIRST write slice of the restore program (owner-ratified). `POST /sheets/:sheetId/records/:recordId/
+> restore-execute` consumes a T6-1 preview identity and performs a single-record record-version restore by
+> writing a forward revision. Built as a NEW route (not a change to `/restore`) so the identity is REQUIRED by
+> construction and the shipped restore path + its 34 goldens are untouched.
+
+## 1. Flow
+
+1. Mint (now wired into T5-2): the `restore-preview` response returns a `previewIdentity` binding the MASKED diff
+   the actor saw (T6-1).
+2. Execute: `restore-execute { targetVersion, expectedVersion, previewIdentity }`:
+   - `canEditRecord` + record exists;
+   - **SR-2 row-deny** (NEW): `loadDeniedRecordIds` — a row-read-denied record → 404 (no-oracle), before any work;
+   - `expectedVersion` pre-check (409);
+   - recompute the MASKED diff (the same set T5-2 hashed) → `hashPreviewChanges` → **verify the identity** against
+     claims computed FRESH at execute (`verifyRestorePreviewIdentity`); reject → 409 (410 if expired);
+   - apply via the canonical `patchRecords` spine, `source='restore'` — which enforces the field write gate +
+     `expectedVersion` (CAS in a `SELECT FOR UPDATE` txn) + writes the forward revision + Yjs/ formula recompute.
+
+## 2. The locks (SR-* from the T6 design-lock)
+
+- **SR-3 execution-matches-preview**: the identity binds the diff hash; the execute re-derives the diff fresh and
+  rejects any mismatch. A stale diff (data / field-permissions moved since preview) re-hashes differently → reject.
+- **SR-2 per-record permission re-application** (the NEW surface Layer-1 never had): sheet-level `canEditRecord`
+  and per-record row-read-deny are orthogonal, so a sheet editor CAN be read-denied on a record — restoring it
+  would write data they cannot read. The row-deny check closes that. **Mutation-checked**: drop it → the denied
+  record restores (200 instead of 404).
+- **idempotency (SR-6)**: at-most-once via the `expectedVersion` CAS — execute moves N→N+1, a replay carries
+  `expectedVersion=N`, current is N+1 → 409. No dedupe table. (And the changesHash would also reject the replay:
+  the post-restore diff is empty → hash mismatch.)
+- **reveal-free by construction**: the verified/applied diff is the MASKED set the actor saw; T5-2 has no reveal
+  path, so a reveal grant can never enter the writable set. Inherited from T6-1, not re-enforced here.
+- **no silent partial restore under schema drift**: a snapshot field deleted from the current schema can't be
+  faithfully reproduced. The preview WITHHOLDS an executable identity when `schemaDrift` (returns
+  `previewIdentity: null`); `restore-execute` ALSO re-checks and rejects with `SCHEMA_DRIFT` (422) before any
+  write — defense in depth, matching `/restore`'s behavior. Otherwise execute would silently restore only the
+  surviving fields.
+- **v1 scope-lock**: the identity binds ONE record-version; `restore-execute` is single-record only. Batch /
+  field-subset scope is a later slice (a `scope` claim + scope hash).
+
+## 3. Verification
+
+- backend `tsc` 0; no migration; FE deferred to T6-3.
+- **7 real-DB goldens**: **END-TO-END** (a real preview identity → execute → record restored — the drift guard
+  across the three diff copies); identity required (missing → 400, tampered → 409, not written); **SR-2 row-deny**
+  (denied → 404); replay → 409 (CAS); cross-record (an identity for one record can't execute another → 409);
+  **schema-drift** (preview withholds the identity + execute → 422, record unchanged).
+- **Mutation check (manual, local — NOT a CI gate)**: to confirm the SR-2 row-deny is load-bearing, the check
+  `if (denied.has(recordId)) return 404` was temporarily changed to `… && false`; the *SR-2 row-deny* golden then
+  failed (`execute` returned **200 instead of 404**, restoring the denied record); the change was reverted (no
+  `MUTATION-PROBE` residue remains — verified by grep). This is a one-off manual verification, not an automated
+  mutation gate.
+- **Boundary / no-regression**: the existing `/restore` goldens **34/34 unchanged** (the route was not touched);
+  T5-2 preview **6/6** (the `previewIdentity` addition is additive); unit suite green (1 pre-existing
+  order-dependent flake, `data-source-scope`, passes 20/20 in isolation and is untouched by this diff).
+
+## 4. Out of scope / separate findings
+
+- **T6-3 FE restore panel** (preview → confirm → execute, showing changed / skipped / conflict reasons) — next.
+- batch / multi-record / field-subset restore — a later slice (needs a `scope` claim, per the T6-1 [P2] lock).
+- **`/restore` row-deny bypass — fixed in a follow-up BEFORE T6-3 (per owner review):** the direct `/restore`
+  route predates SR-2 and lacks the row-level read-deny gate, so it bypasses the new chain. This slice keeps it
+  out (the advisor's "don't touch the shipped write path in the same slice"), but it is NOT left open — the next
+  PR adds the same row-deny gate to `/restore` (additive; the 34 goldens stay green + a new row-deny golden)
+  before the FE (T6-3) ships, so the FE's new preview→execute chain isn't undercut by an open legacy route.
+- the diff is computed in three places (`/restore`, T5-2 preview, T6-2 execute); the END-TO-END golden guards
+  against drift. Unifying them behind one helper is a follow-up P3 (deferred — not a write-path refactor now).

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,6 +73,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
+import { hashPreviewChanges, mintRestorePreviewIdentity, verifyRestorePreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
   HistoryAuditGrantError,
@@ -7453,7 +7454,22 @@ export function univerMetaRouter(): Router {
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
       const visibleChanges = changes.filter((c) => allowed.has(c.fieldId))
-      return res.json({ ok: true, data: { changes: visibleChanges, visibleAffectedFieldCount: visibleChanges.length, schemaDrift, targetVersion: previewTargetVersion } })
+      // T6-2: mint a preview identity binding this MASKED diff (what the actor saw) so a later restore-execute can
+      // confirm execution matches this preview (SR-3). Reveal-free by construction (this route has no reveal path).
+      // NOT executable under schema drift: a snapshot field deleted from the current schema can't be faithfully
+      // reproduced, so an executable identity would let execute SILENTLY partial-restore the surviving fields.
+      // Withhold the identity (FE must surface the drift); execute also re-checks and rejects (defense in depth).
+      const previewIdentity = schemaDrift
+        ? null
+        : mintRestorePreviewIdentity({
+            sheetId,
+            recordId,
+            targetVersion: previewTargetVersion,
+            strategy: 'revert',
+            changesHash: hashPreviewChanges(visibleChanges),
+            actorId: access.userId,
+          })
+      return res.json({ ok: true, data: { changes: visibleChanges, visibleAffectedFieldCount: visibleChanges.length, schemaDrift, targetVersion: previewTargetVersion, previewIdentity } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7718,6 +7734,140 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] record restore failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to restore record' } })
+    }
+  })
+
+  // Global History — T6-2: scoped restore EXECUTE (the first write). Consumes a T6-1 preview identity and
+  // performs a single-record record-version restore (v1 scope-lock: the identity binds one record). Distinct
+  // from the direct `/restore` route so the identity is REQUIRED by construction (SR-3) and the shipped restore
+  // path is untouched. Re-runs the CURRENT permissions at execute (never trusts the preview's verdict): row-deny
+  // (the NEW SR-2 surface) + field write gate + expectedVersion (the latter two via the canonical patchRecords
+  // spine). The forward revision (source='restore') is transactional + idempotent (a replay recomputes an empty
+  // diff → changesHash mismatch → reject; and expectedVersion moved → 409). Reveal-free by construction: the
+  // verified diff is the MASKED set the actor saw at preview, so a reveal grant can never enter the writable set.
+  router.post('/sheets/:sheetId/records/:recordId/restore-execute', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    const exParsed = z.object({
+      targetVersion: z.number().int().positive(),
+      expectedVersion: z.number().int().nonnegative(),
+      previewIdentity: z.string().min(1),
+    }).safeParse(req.body)
+    if (!exParsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: exParsed.error.message } })
+    const { targetVersion, expectedVersion, previewIdentity } = exParsed.data
+    const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
+    const NON_RESTORABLE = new Set(['formula', 'lookup', 'rollup', 'link', 'attachment', 'button', 'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy'])
+    const sameVal = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+    const sameLinks = (a: string[], b: string[]): boolean => a.length === b.length && [...a].sort().join(' ') === [...b].sort().join(' ')
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canEditRecord) return sendForbidden(res)
+
+      const currentRes = await pool.query('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+      if (currentRes.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      const currentRow = currentRes.rows[0] as { version?: unknown; data?: unknown }
+      const currentVersion = Number(currentRow.version ?? 0)
+      // SR-2 row-deny (NEW vs /restore): sheet-edit capability and per-record row-read-deny are orthogonal, so a
+      // sheet editor can be read-denied on this record — restoring it would write data they cannot read. Denied
+      // → 404 (the same no-oracle shape as a missing record). Admin bypasses, parity with the read surfaces.
+      if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))) {
+        const denied = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (denied.has(recordId)) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+      if (expectedVersion !== currentVersion) {
+        return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: `Record is at version ${currentVersion}, expected ${expectedVersion}` } })
+      }
+      const currentData = asRec(currentRow.data)
+
+      const revRes = await pool.query(`SELECT action, snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2 AND version = $3 ORDER BY created_at DESC`, [sheetId, recordId, targetVersion])
+      const revRows = revRes.rows as Array<{ action?: unknown; snapshot?: unknown }>
+      if (revRows.length === 0) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: `No revision at version ${targetVersion}` } })
+      const targetRev = revRows.find((r) => r.action !== 'delete')
+      if (!targetRev) return res.status(422).json({ ok: false, error: { code: 'RESTORE_UNSUPPORTED', message: `Version ${targetVersion} is a delete revision; undelete is not supported in this slice` } })
+      if (targetRev.snapshot === null || targetRev.snapshot === undefined) return res.status(422).json({ ok: false, error: { code: 'SNAPSHOT_UNAVAILABLE', message: `Revision ${targetVersion} has no stored snapshot` } })
+      const targetSnapshot = asRec(targetRev.snapshot)
+
+      const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+      if (!patchContext) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById } = patchContext
+      const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
+
+      // Schema drift: a snapshot field absent from the current schema can't be faithfully reproduced. The preview
+      // withholds an executable identity on drift, but execute MUST re-check (a drifted execute would silently
+      // partial-restore only the surviving fields) — reject before any write, matching /restore's SCHEMA_DRIFT.
+      for (const fid of Object.keys(targetSnapshot)) {
+        if (!fieldById.has(fid)) return res.status(422).json({ ok: false, error: { code: 'SCHEMA_DRIFT', message: `Field ${fid} in revision ${targetVersion} no longer exists in the current schema` } })
+      }
+
+      // The faithful set ∪ unset diff (same shape as /restore + T5-2's preview), then MASK to the actor's allowed
+      // fields — this masked set is exactly what T5-2's preview hashed into the identity (3rd copy of the diff;
+      // the end-to-end preview→execute golden is the drift guard, unifying the copies is a follow-up P3).
+      const diff: RecordChange[] = []
+      for (const [fid, guard] of fieldById.entries()) {
+        if (rawTypeById.get(fid) === 'button') continue
+        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
+        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
+        if (guard.type === 'link') {
+          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
+          if (!sameLinks(normalizeLinkIds(currentData[fid]), target)) diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
+          continue
+        }
+        if (NON_RESTORABLE.has(guard.type)) continue
+        if (inSnap) {
+          if (!sameVal(currentData[fid], targetSnapshot[fid])) diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })
+        } else if (inCur) {
+          diff.push({ recordId, fieldId: fid, value: null, expectedVersion: currentVersion, op: 'unset' })
+        }
+      }
+      const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
+      const maskedDiff = diff.filter((c) => allowed.has(c.fieldId))
+
+      // Verify the identity against claims recomputed FRESH from the current masked diff (execution matches the
+      // preview). A stale diff (data / permissions moved) re-hashes differently → mismatch → reject → re-preview.
+      const recomputedHash = hashPreviewChanges(maskedDiff.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value })))
+      const verdict = verifyRestorePreviewIdentity(previewIdentity, { sheetId, recordId, targetVersion, strategy: 'revert', changesHash: recomputedHash, actorId: access.userId })
+      if (!verdict.valid) {
+        const status = verdict.reason === 'expired' ? 410 : 409
+        return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Preview identity rejected (${verdict.reason})` } })
+      }
+
+      if (maskedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      try {
+        const result = await recordWriteService.patchRecords({
+          sheetId,
+          changesByRecord: new Map([[recordId, maskedDiff]]),
+          actorId: getRequestActorId(req),
+          fields,
+          visiblePropertyFields: readableEchoFields,
+          visiblePropertyFieldIds: readableEchoFieldIds,
+          attachmentFields,
+          fieldById,
+          capabilities,
+          sheetScope,
+          access,
+          source: 'restore',
+        })
+        const newVersion = result.updated.find((u) => u.recordId === recordId)?.version ?? currentVersion + 1
+        return res.json({ ok: true, data: { recordId, newVersion, noop: false, restoredFieldIds: maskedDiff.map((c) => c.fieldId) } })
+      } catch (err) {
+        if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: (err as Error).message } })
+        if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: (err as Error).message } })
+        if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: (err as Error).message } })
+        throw err
+      }
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] restore-execute failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute restore' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-restore-execute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-execute-realdb.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Global History — T6-2: scoped restore EXECUTE (real DB; the first write slice).
+ *
+ * Load-bearing golden = END-TO-END: a real T5-2 preview mints an identity, a real T6-2 execute consumes it and
+ * writes the forward revision. This is the drift guard for the three copies of the diff (/restore, T5-2 preview,
+ * T6-2 execute) — if any diverges, the changesHash won't match and execute 4xx's. Plus the NEW surfaces: row-deny
+ * (SR-2, mutation-checked), identity-required, and replay idempotency.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rx_${TS}`
+const SHEET = `sheet_rx_${TS}`
+const NAME = `fld_rx_name_${TS}`
+const SALARY = `fld_rx_salary_${TS}`
+const REC = `rec_rx_${TS}`
+const REC_DENIED = `rec_rx_denied_${TS}`
+const VIEWER = `user_rx_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser = VIEWER
+let curRoles = ['member']
+const preview = (recordId: string, body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${recordId}/restore-preview`).send(body)
+const execute = (recordId: string, body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${recordId}/restore-execute`).send(body)
+const recordData = async (recordId: string) => ((await q('SELECT data FROM meta_records WHERE id = $1', [recordId])).rows[0] as { data: Record<string, unknown> } | undefined)?.data
+
+describeIfDatabase('multitable scoped restore execute — T6-2 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: curUser, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RX Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RX Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+
+  // Fresh: REC at v2 {NAME:'b', SALARY:200}; v1 snapshot {NAME:'a', SALARY:100}. No field/row deny by default.
+  beforeEach(async () => {
+    curUser = VIEWER; curRoles = ['member']
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = '[]'::jsonb WHERE id = $1", [SHEET])
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC, SHEET, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, REC, NAME, SALARY, JSON.stringify({ [NAME]: 'a', [SALARY]: 100 })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, REC, NAME, SALARY, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('END-TO-END: a real preview identity is accepted and the record is restored to the target version', async () => {
+    const pv = await preview(REC, { targetVersion: 1 })
+    expect(pv.status).toBe(200)
+    const identity = pv.body?.data?.previewIdentity as string
+    expect(typeof identity).toBe('string')
+    const ex = await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: identity })
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.noop).toBe(false)
+    expect(await recordData(REC)).toMatchObject({ [NAME]: 'a', [SALARY]: 100 }) // restored to v1
+  })
+
+  test('identity required: a missing identity is 400; a tampered identity is rejected (the route enforces verify)', async () => {
+    expect((await execute(REC, { targetVersion: 1, expectedVersion: 2 })).status).toBe(400) // missing
+    const identity = (await preview(REC, { targetVersion: 1 })).body?.data?.previewIdentity as string
+    const tampered = identity.slice(0, -4) + (identity.slice(-4) === 'AAAA' ? 'BBBB' : 'AAAA')
+    const ex = await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: tampered })
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    expect(await recordData(REC)).toMatchObject({ [NAME]: 'b' }) // NOT restored — write-gated on a valid identity
+  })
+
+  test('SR-2 row-deny: a row-read-denied record cannot be executed (404 no-oracle)', async () => {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC_DENIED, SHEET, JSON.stringify({ [NAME]: 'secret' })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3]::text[], '{}'::jsonb, $4::jsonb, now())`, [SHEET, REC_DENIED, NAME, JSON.stringify({ [NAME]: 'old' })])
+    // Mint a well-formed identity for the denied record BEFORE turning on the deny (so the only thing stopping
+    // execute is the row-deny gate, not a bad identity).
+    const identity = (await preview(REC_DENIED, { targetVersion: 1 })).body?.data?.previewIdentity as string
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET, JSON.stringify([{ id: 'r1', fieldId: NAME, operator: 'eq', value: 'secret', effect: 'deny_read' }])])
+    const ex = await execute(REC_DENIED, { targetVersion: 1, expectedVersion: 2, previewIdentity: identity })
+    expect(ex.status).toBe(404) // denied → not-found shape, no oracle, before any write
+    await q('DELETE FROM meta_records WHERE id = $1', [REC_DENIED])
+  })
+
+  test('replay idempotency: re-executing the same identity is rejected (the version moved → 409)', async () => {
+    const identity = (await preview(REC, { targetVersion: 1 })).body?.data?.previewIdentity as string
+    expect((await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: identity })).status).toBe(200) // first wins
+    const replay = await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: identity })
+    expect(replay.status).toBe(409) // second: expectedVersion 2 != current 3 (CAS) — at-most-once
+  })
+
+  test('cross-record: an identity minted for one record cannot execute another', async () => {
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC_DENIED, SHEET, JSON.stringify({ [NAME]: 'x' })])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3]::text[], '{}'::jsonb, $4::jsonb, now())`, [SHEET, REC_DENIED, NAME, JSON.stringify({ [NAME]: 'y' })])
+    const identityForRec = (await preview(REC, { targetVersion: 1 })).body?.data?.previewIdentity as string
+    const ex = await execute(REC_DENIED, { targetVersion: 1, expectedVersion: 2, previewIdentity: identityForRec }) // wrong record
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    await q('DELETE FROM meta_records WHERE id = $1', [REC_DENIED])
+  })
+
+  test('schema-drift: preview withholds the identity and execute rejects (no silent partial restore)', async () => {
+    const GHOST = `fld_rx_ghost_${TS}` // present in the v1 snapshot but NOT in the current schema
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = $2', [SHEET, REC])
+    await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3]::text[], '{}'::jsonb, $4::jsonb, now())`, [SHEET, REC, NAME, JSON.stringify({ [NAME]: 'a', [GHOST]: 'x' })])
+    const pv = await preview(REC, { targetVersion: 1 })
+    expect(pv.body?.data?.schemaDrift).toBe(true)
+    expect(pv.body?.data?.previewIdentity).toBeNull() // no executable identity under drift
+    // a forced execute (any identity) must reject on drift, BEFORE any write — never a silent partial restore.
+    const ex = await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: 'forged.token.value' })
+    expect(ex.status).toBe(422)
+    expect(ex.body?.error?.code).toBe('SCHEMA_DRIFT')
+    expect(await recordData(REC)).toMatchObject({ [NAME]: 'b' }) // unchanged — nothing written
+  })
+})


### PR DESCRIPTION
The **first write slice** of the restore program (owner-ratified). New route `POST /sheets/:sheetId/records/:recordId/restore-execute` consumes a **T6-1 preview identity** and performs a single-record record-version restore via a forward revision. Built as a **new route** (option A) so the identity is **required by construction** (SR-3) and the shipped `/restore` path + its 34 goldens are **untouched**.

## Flow
T5-2 preview now mints a `previewIdentity` (binding the **masked** diff the actor saw). `restore-execute { targetVersion, expectedVersion, previewIdentity }` → `canEditRecord` → **SR-2 row-deny** → `expectedVersion` 409 → recompute masked diff → `hashPreviewChanges` → `verifyRestorePreviewIdentity` (execution matches preview) → apply via the canonical **`patchRecords`** spine (`source='restore'`), which enforces the field write gate + `expectedVersion` CAS + the forward revision.

## New surfaces
- **SR-2 row-deny** (new vs `/restore`): sheet `canEditRecord` and per-record row-read-deny are orthogonal → a sheet editor can be read-denied on a record; restoring it would write data they can't read. `loadDeniedRecordIds` closes it (denied → 404 no-oracle). **Mutation-checked**: drop it → the denied record restores.
- **idempotency**: at-most-once via the `expectedVersion` CAS (replay → 409); the post-restore empty diff would also mismatch the `changesHash`. No dedupe table.
- **reveal-free by construction** (applied diff is the masked set); **v1 = single record-version**.

## Verification
tsc 0; **6 real-DB goldens** (END-TO-END preview→execute drift guard · identity required · **SR-2 row-deny + mutation** · replay→409 · cross-record→409); **`/restore` 34/34 unchanged** (no regression); T5-2 6/6. unit 3794/3795 — the 1 failure (`data-source-scope`) is a pre-existing order-dependent flake (20/20 isolated, untouched). No migration.

## Separate finding (not fixed here)
The direct `/restore` route lacks row-level read-deny (predates SR-2); fixing it touches the shipped write path, so it's logged for its own slice.

## Next
T6-3 FE restore panel (preview → confirm → execute, showing changed / skipped / conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)