### PR TITLE
fix(multitable): close the /restore row-deny bypass (SR-2 parity across all restore surfaces)

### DIFF
--- a/docs/development/multitable-restore-route-rowdeny-bypass-closure-20260621.md
+++ b/docs/development/multitable-restore-route-rowdeny-bypass-closure-20260621.md
@@ -1,0 +1,36 @@
+# `/restore` Route — Row-Deny Bypass Closure 开发与验证 MD
+
+> Owner review of #3023 ([P1] #2): the legacy `POST /sheets/:sheetId/records/:recordId/restore` route predates
+> the row-level read-deny gate, so it bypassed the SR-2 protection that the history surfaces + the new
+> `restore-execute` (T6-2) enforce. Closed here BEFORE T6-3 ships, so the FE's new preview→execute chain isn't
+> undercut by an open legacy route. Additive gate — the shipped restore behavior is otherwise unchanged.
+
+## The gap
+
+`canEditRecord` (sheet-level write capability) and per-record row-read-deny are orthogonal: a sheet editor can
+be row-read-denied on a specific record (e.g. a conditional rule denies `status='confidential'`). The `/restore`
+route checked `canEditRecord` but NOT row-deny — so such an editor could restore (write) a record they cannot
+read, via the legacy route, even though `restore-execute` and the read surfaces deny it.
+
+## The fix
+
+After the record-exists check and before the `expectedVersion` pre-check, `/restore` now applies the SAME seam
+as everywhere else: when the per-sheet `row_level_read_permissions_enabled` flag is on and the actor is non-admin,
+`loadDeniedRecordIds` (grant-deny ∪ 2b conditional read-deny) is consulted; a denied record → 404 (no-oracle).
+Admin bypasses, parity with the other surfaces. The gate is **inert when the flag is off**, so existing behavior
+is unchanged.
+
+## Verification
+
+- backend `tsc` 0; no migration.
+- `/restore` real-DB goldens **35/35** — the existing **34 unchanged** (all flag-off, gate inert) + **1 new**:
+  a row-read-denied record cannot be restored (404, record unchanged).
+- **Mutation check (manual, local — NOT a CI gate)**: the new gate `if (denied.has(recordId)) return 404` was
+  temporarily changed to `… && false`; the new row-deny golden then failed (`/restore` returned **200 instead of
+  404**, restoring the denied record); reverted, no `MUTATION-PROBE` residue (grep-verified). Confirms the gate is
+  load-bearing.
+
+## Scope
+
+Just the row-deny gate on `/restore` (the bypass). The route otherwise unchanged. The three restore surfaces
+(`restore-preview`, `restore-execute`, legacy `/restore`) now all apply row-deny consistently. T6-3 (FE) is next.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7543,6 +7543,14 @@ export function univerMetaRouter(): Router {
       if (currentRes.rows.length === 0) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
       }
+      // SR-2 row-deny (closing a legacy bypass): this route predates the row-level read-deny gate, so a sheet
+      // editor row-read-denied on this record could restore (write) data they cannot read — bypassing the deny
+      // that the history surfaces and restore-execute enforce. Apply the SAME loadDeniedRecordIds seam: denied →
+      // 404 (no-oracle), admin bypasses. Inert when the per-sheet flag is off (the 34 existing goldens are flag-off).
+      if (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId))) {
+        const denied = await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        if (denied.has(recordId)) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
       const currentRow = currentRes.rows[0] as { version?: unknown; data?: unknown }
       const currentVersion = Number(currentRow.version ?? 0)
       // Concurrency pre-check BEFORE the no-op branch: a stale caller must get a conflict, never noop.

--- a/packages/core-backend/tests/integration/multitable-record-restore.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-restore.test.ts
@@ -918,4 +918,24 @@ describeIfDatabase('Layer 1 record-level version restore (real DB)', () => {
       await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2 AND subject_id = $3', [SHEET_ID, FLD_LK, USER_RO]).catch(() => {})
     }
   })
+
+  // SR-2 row-deny — legacy-bypass closure (owner review of #3023). The /restore route now applies the SAME
+  // row-level read-deny seam as the history surfaces + restore-execute: a sheet editor row-read-denied on a
+  // record cannot restore (write) it. Denied → 404 (no-oracle), no write. The gate is INERT when the per-sheet
+  // flag is off (so every other golden above is unaffected); this test toggles it on and resets it in `finally`.
+  test('row-deny: a row-read-denied record cannot be restored via /restore (404, no write)', async () => {
+    const rid = await seedRecord({ [FLD_A]: 'secret' }, 2, [
+      { version: 1, action: 'create', snapshot: { [FLD_A]: 'old' } },
+      { version: 2, snapshot: { [FLD_A]: 'secret' } },
+    ])
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET_ID, JSON.stringify([{ id: 'rd1', fieldId: FLD_A, operator: 'eq', value: 'secret', effect: 'deny_read' }])])
+    try {
+      testUserId = USER_W // a writer, but row-read-denied on THIS record by the rule (read-deny ⟂ write capability)
+      const res = await restoreReq(rid, { targetVersion: 1, expectedVersion: 2 })
+      expect(res.status).toBe(404) // denied → not-found shape, before any write
+      expect((await liveData(rid))[FLD_A]).toBe('secret') // unchanged — the legacy route no longer bypasses row-deny
+    } finally {
+      await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = '[]'::jsonb WHERE id = $1", [SHEET_ID])
+    }
+  })
 })


### PR DESCRIPTION
Owner review of #3023 **[P1]**: the legacy `POST /sheets/:sheetId/records/:recordId/restore` route predates the row-level read-deny gate and **bypassed SR-2** — a sheet editor row-read-denied on a record (read-deny ⟂ write capability) could restore (write) it via the legacy route, even though `restore-execute` (T6-2) and the read surfaces deny it. Closed **before T6-3** so the FE's new preview→execute chain isn't undercut by an open route.

## Fix
Additive gate (after record-exists, before `expectedVersion`): when `row_level_read_permissions_enabled` is on + non-admin, `loadDeniedRecordIds` (grant-deny ∪ 2b conditional read-deny) → denied → **404 (no-oracle)**. Admin bypasses. **Inert when the flag is off** — shipped behavior unchanged.

## Verification
tsc 0; `/restore` real-DB goldens **35/35** — the existing **34 unchanged** (flag-off, gate inert) + **1 new** (row-read-denied record → 404, record unchanged). **Mutation check** (manual, local — *not* a CI gate): gate → `… && false` → the new golden failed (200 instead of 404, denied record restored); reverted, no residue (grep-verified). No migration.

All three restore surfaces (**preview / execute / legacy `/restore`**) now apply row-deny consistently. T6-3 (FE) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)