### PR TITLE
feat(multitable): global-history T6-3 — FE restore panel (preview → confirm → execute)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -36,6 +36,9 @@ on:
       - 'apps/web/src/multitable/utils/sheet-cursor-state.ts'
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
+      - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
+      - 'apps/web/src/multitable/utils/meta-record-labels.ts'
+      - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
@@ -77,6 +80,9 @@ on:
       - 'apps/web/src/multitable/utils/sheet-cursor-state.ts'
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
+      - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
+      - 'apps/web/src/multitable/utils/meta-record-labels.ts'
+      - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
@@ -140,4 +146,4 @@ jobs:
         # accumulation/loadMore) added so the grid virtualization ACTIVATION has real CI enforcement —
         # the guard already triggers on MetaGridTable.vue / useMultitableGrid.ts / MultitableWorkbench.vue
         # edits but, before this, ran none of those specs (and plugin-tests.yml only build-checks web).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog --reporter=dot

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -959,6 +959,21 @@ export interface RestoreRecordResult {
   skippedFieldIds: string[]
 }
 
+// T6: a record-version restore PREVIEW (read-only) — the masked diff a restore would apply, plus the
+// preview identity the execute consumes. `previewIdentity` is null when not executable (schema drift).
+export interface RestorePreviewChange {
+  fieldId: string
+  op: 'set' | 'unset'
+  value: unknown
+}
+export interface RestorePreviewResult {
+  changes: RestorePreviewChange[]
+  visibleAffectedFieldCount: number
+  schemaDrift: boolean
+  targetVersion: number
+  previewIdentity: string | null
+}
+
 export interface AiShortcutPreviewData {
   status: 'succeeded'
   action: 'preview'
@@ -1676,6 +1691,27 @@ export class MultitableApiClient {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       },
+    )
+    return this.parseJson<RestoreRecordResult>(res)
+  }
+
+  // T6-2 chain: preview what a record-version restore WOULD change (read-only, masked), returning the identity
+  // the execute consumes. Pair with restoreExecuteRecord — never restore from the FE without showing the preview.
+  async restorePreviewRecord(sheetId: string, recordId: string, targetVersion: number): Promise<RestorePreviewResult> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/restore-preview`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetVersion }) },
+    )
+    return this.parseJson<RestorePreviewResult>(res)
+  }
+
+  // Execute a previewed restore, carrying the previewIdentity from restorePreviewRecord (SR-3: the server
+  // confirms execution matches the preview). Writes a forward revision; row-deny / field-gate / version are
+  // re-checked server-side.
+  async restoreExecuteRecord(sheetId: string, recordId: string, targetVersion: number, expectedVersion: number, previewIdentity: string): Promise<RestoreRecordResult> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/restore-execute`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetVersion, expectedVersion, previewIdentity }) },
     )
     return this.parseJson<RestoreRecordResult>(res)
   }

--- a/apps/web/src/multitable/components/RestorePreviewDialog.vue
+++ b/apps/web/src/multitable/components/RestorePreviewDialog.vue
@@ -1,0 +1,180 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="restore-preview-overlay" data-test="restore-preview" @click.self="onCancel">
+      <div class="restore-preview-modal" role="dialog" :aria-label="l('record.restorePreviewTitle')">
+        <div class="restore-preview__header">
+          <strong>{{ l('record.restorePreviewTitle') }}</strong>
+          <button class="restore-preview__close" :aria-label="l('record.restorePreviewCancel')" @click="onCancel">&times;</button>
+        </div>
+
+        <div class="restore-preview__body">
+          <p v-if="loading" class="restore-preview__hint" data-test="restore-preview-loading">{{ l('record.restorePreviewLoading') }}</p>
+
+          <!-- Conflict: schema drift → not executable (the server withheld an identity). No confirm. -->
+          <p v-else-if="schemaDrift || !executable" class="restore-preview__hint restore-preview__hint--warn" role="alert" data-test="restore-preview-conflict">
+            {{ l('record.restorePreviewConflict') }}
+          </p>
+
+          <!-- No-op: nothing would change. -->
+          <p v-else-if="changes.length === 0" class="restore-preview__hint" data-test="restore-preview-empty">{{ l('record.restorePreviewNoChanges') }}</p>
+
+          <!-- The masked diff: which fields would change, and to what. -->
+          <template v-else>
+            <p class="restore-preview__label">{{ l('record.restorePreviewWillChange') }}</p>
+            <ul class="restore-preview__changes" data-test="restore-preview-changes">
+              <li v-for="change in changes" :key="change.fieldId" class="restore-preview__change">
+                <span class="restore-preview__field">{{ fieldName(change.fieldId) }}</span>
+                <span class="restore-preview__op">{{ change.op === 'unset' ? l('record.restorePreviewUnset') : l('record.restorePreviewSet') }}</span>
+                <span v-if="change.op === 'set'" class="restore-preview__value">{{ displayValue(change.value) }}</span>
+              </li>
+            </ul>
+          </template>
+        </div>
+
+        <div class="restore-preview__footer">
+          <button type="button" class="restore-preview__btn" @click="onCancel">{{ l('record.restorePreviewCancel') }}</button>
+          <button
+            type="button"
+            class="restore-preview__btn restore-preview__btn--primary"
+            :disabled="!canConfirm"
+            data-test="restore-preview-confirm"
+            @click="onConfirm"
+          >
+            {{ l('record.restorePreviewExecute') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { RestorePreviewChange } from '../api/client'
+import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
+
+const props = defineProps<{
+  visible: boolean
+  loading: boolean
+  changes: RestorePreviewChange[]
+  schemaDrift: boolean
+  /** false when the server withheld a preview identity (e.g. schema drift) — restore is blocked. */
+  executable: boolean
+  /** resolve a field id to its display name (the workbench owns the field map). */
+  fieldName: (fieldId: string) => string
+  isZh: boolean
+}>()
+
+const emit = defineEmits<{ (e: 'confirm'): void; (e: 'cancel'): void }>()
+
+const l = (key: MetaRecordLabelKey): string => recordLabel(key, props.isZh)
+// Confirm only when there is a real, executable, non-empty change set — never offers to "restore" a conflict or a no-op.
+const canConfirm = computed(() => !props.loading && props.executable && !props.schemaDrift && props.changes.length > 0)
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+function onConfirm(): void {
+  if (canConfirm.value) emit('confirm')
+}
+function onCancel(): void {
+  emit('cancel')
+}
+</script>
+
+<style scoped>
+.restore-preview-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.restore-preview-modal {
+  background: var(--surface, #fff);
+  border-radius: 10px;
+  width: min(440px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2);
+}
+.restore-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, #e2e8f0);
+}
+.restore-preview__close {
+  border: none;
+  background: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-secondary, #64748b);
+}
+.restore-preview__body {
+  padding: 16px;
+  overflow-y: auto;
+}
+.restore-preview__label {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+.restore-preview__hint {
+  margin: 0;
+  color: var(--text-secondary, #64748b);
+}
+.restore-preview__hint--warn {
+  color: var(--danger, #b91c1c);
+}
+.restore-preview__changes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.restore-preview__change {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 6px 8px;
+  background: var(--surface-muted, #f1f5f9);
+  border-radius: 6px;
+}
+.restore-preview__field { font-weight: 600; }
+.restore-preview__op { color: var(--text-secondary, #64748b); font-size: 12px; }
+.restore-preview__value { word-break: break-word; }
+.restore-preview__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border, #e2e8f0);
+}
+.restore-preview__btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #cbd5e1);
+  background: var(--surface, #fff);
+  cursor: pointer;
+}
+.restore-preview__btn--primary {
+  background: var(--primary, #2563eb);
+  color: #fff;
+  border-color: var(--primary, #2563eb);
+}
+.restore-preview__btn--primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -43,6 +43,9 @@ export type MetaRecordLabelKey =
   // --- Layer 1 record-level restore (Slice 3) ---
   | 'record.restore' | 'record.restoreTitle' | 'record.restoreConfirm'
   | 'record.restoreSuccess' | 'record.restoreNoop' | 'record.errorRestore'
+  | 'record.restorePreviewTitle' | 'record.restorePreviewWillChange' | 'record.restorePreviewNoChanges'
+  | 'record.restorePreviewConflict' | 'record.restorePreviewExecute' | 'record.restorePreviewCancel'
+  | 'record.restorePreviewLoading' | 'record.restorePreviewSet' | 'record.restorePreviewUnset'
   // FE-owned static fallback strings (the `error?.message ?? l(...)`
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
@@ -108,6 +111,15 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.restoreConfirm': { en: 'Restore this record to the selected version? This creates a new version; it does not erase history.', zh: '将记录恢复到所选版本？这会生成一条新版本，不会抹除历史。' },
   'record.restoreSuccess': { en: 'Restored', zh: '已恢复' },
   'record.restoreNoop': { en: 'Already at this version', zh: '已是该版本' },
+  'record.restorePreviewTitle': { en: 'Review restore', zh: '确认恢复' },
+  'record.restorePreviewWillChange': { en: 'These fields will change:', zh: '以下字段将被修改：' },
+  'record.restorePreviewNoChanges': { en: 'Nothing would change — the record already matches this version.', zh: '没有变化 — 记录已与该版本一致。' },
+  'record.restorePreviewConflict': { en: 'Cannot restore: the schema changed since this version (a field no longer exists). Restore is blocked to avoid a partial result.', zh: '无法恢复：该版本之后表结构已变化（某字段已不存在）。为避免部分恢复，已阻止。' },
+  'record.restorePreviewExecute': { en: 'Restore', zh: '恢复' },
+  'record.restorePreviewCancel': { en: 'Cancel', zh: '取消' },
+  'record.restorePreviewLoading': { en: 'Loading preview…', zh: '正在加载预览…' },
+  'record.restorePreviewSet': { en: 'set', zh: '设为' },
+  'record.restorePreviewUnset': { en: 'clear', zh: '清空' },
   'record.errorRestore': { en: 'Restore failed', zh: '恢复失败' },
   'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -388,6 +388,17 @@
       @confirm="onExportDialogConfirm"
       @cancel="exportDialogVisible = false"
     />
+    <RestorePreviewDialog
+      :visible="restorePreview.visible"
+      :loading="restorePreview.loading"
+      :changes="restorePreview.changes"
+      :schema-drift="restorePreview.schemaDrift"
+      :executable="restorePreview.executable"
+      :field-name="restorePreviewFieldName"
+      :is-zh="isZh"
+      @confirm="onConfirmRestore"
+      @cancel="onCancelRestore"
+    />
     <MetaLinkPicker
       :visible="linkPickerVisible"
       :field="linkPickerField"
@@ -562,6 +573,8 @@ import MetaViewTabBar from '../components/MetaViewTabBar.vue'
 import MetaToolbar from '../components/MetaToolbar.vue'
 import MetaGridTable from '../components/MetaGridTable.vue'
 import MetaExportDialog, { type ExportConfirmPayload } from '../components/MetaExportDialog.vue'
+import RestorePreviewDialog from '../components/RestorePreviewDialog.vue'
+import type { RestorePreviewChange } from '../api/client'
 import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaNotificationBell from '../components/MetaNotificationBell.vue'
@@ -1835,24 +1848,65 @@ async function onToggleRecordLock(payload: { recordId: string; locked: boolean }
 // confirm + API call + refresh (mirrors onToggleRecordLock). The backend error carries `.code`
 // (VERSION_CONFLICT / VERSION_EXPIRED / RESTORE_UNSUPPORTED / SNAPSHOT_UNAVAILABLE / SCHEMA_DRIFT /
 // RESTORE_FORBIDDEN); we surface error.message (already localized server-side) with a static fallback.
-async function onRestoreRecordVersion(payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
-  const sheetId = workbench.activeSheetId.value
-  if (!sheetId) return
+// T6-3: full-record restore goes through preview→confirm→execute (the T6-2 chain); the panel shows what would
+// change before the actor commits, and a schema-drift conflict blocks it. Per-field (column-level) restore keeps
+// the existing direct path (the T6 identity binds the full-record diff; per-field-through-preview is a follow-up).
+const restorePreview = ref<{
+  visible: boolean
+  loading: boolean
+  changes: RestorePreviewChange[]
+  schemaDrift: boolean
+  executable: boolean
+  identity: string | null
+  payload: { recordId: string; targetVersion: number; expectedVersion: number } | null
+}>({ visible: false, loading: false, changes: [], schemaDrift: false, executable: false, identity: null, payload: null })
+
+const restorePreviewFieldName = (fieldId: string): string => scopedAllFields.value.find((f) => f.id === fieldId)?.name ?? fieldId
+
+async function restoreFieldsDirect(sheetId: string, payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
   if (!window.confirm(recordLabel('record.restoreConfirm', isZh.value))) return
   try {
-    const result = await workbench.client.restoreRecordVersion(
-      sheetId,
-      payload.recordId,
-      payload.targetVersion,
-      payload.expectedVersion,
-      payload.fieldIds,
-    )
+    const result = await workbench.client.restoreRecordVersion(sheetId, payload.recordId, payload.targetVersion, payload.expectedVersion, payload.fieldIds)
     showSuccess(recordLabel(result.noop ? 'record.restoreNoop' : 'record.restoreSuccess', isZh.value))
     await grid.loadViewData(grid.page.value.offset)
     if (selectedRecordId.value) await refreshSelectedRecordContext(selectedRecordId.value)
   } catch (error) {
     showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
   }
+}
+
+async function onRestoreRecordVersion(payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  if (payload.fieldIds && payload.fieldIds.length > 0) { await restoreFieldsDirect(sheetId, payload); return }
+  restorePreview.value = { visible: true, loading: true, changes: [], schemaDrift: false, executable: false, identity: null, payload: { recordId: payload.recordId, targetVersion: payload.targetVersion, expectedVersion: payload.expectedVersion } }
+  try {
+    const pv = await workbench.client.restorePreviewRecord(sheetId, payload.recordId, payload.targetVersion)
+    restorePreview.value = { ...restorePreview.value, loading: false, changes: pv.changes, schemaDrift: pv.schemaDrift, executable: pv.previewIdentity != null, identity: pv.previewIdentity }
+  } catch (error) {
+    restorePreview.value = { ...restorePreview.value, visible: false }
+    showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
+  }
+}
+
+async function onConfirmRestore() {
+  const sheetId = workbench.activeSheetId.value
+  const state = restorePreview.value
+  if (!sheetId || !state.payload || !state.identity) { restorePreview.value = { ...state, visible: false }; return }
+  const { recordId, targetVersion, expectedVersion } = state.payload
+  restorePreview.value = { ...state, visible: false }
+  try {
+    const result = await workbench.client.restoreExecuteRecord(sheetId, recordId, targetVersion, expectedVersion, state.identity)
+    showSuccess(recordLabel(result.noop ? 'record.restoreNoop' : 'record.restoreSuccess', isZh.value))
+    await grid.loadViewData(grid.page.value.offset)
+    if (selectedRecordId.value) await refreshSelectedRecordContext(selectedRecordId.value)
+  } catch (error) {
+    showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
+  }
+}
+
+function onCancelRestore() {
+  restorePreview.value = { ...restorePreview.value, visible: false }
 }
 
 async function onReloadConflict() {

--- a/apps/web/tests/multitable-restore-preview-dialog.spec.ts
+++ b/apps/web/tests/multitable-restore-preview-dialog.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+/**
+ * T6-3 — RestorePreviewDialog: the confirm panel for the preview→confirm→execute restore chain. The load-bearing
+ * UI safety is `canConfirm`: the actor can only commit a real, executable, non-empty change set — never a
+ * schema-drift conflict or a no-op. Mounted via createApp + a jsdom container; the dialog Teleports to body, so
+ * we query document.body. `onConfirm`/`onCancel` props capture the component's emits.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import RestorePreviewDialog from '../src/multitable/components/RestorePreviewDialog.vue'
+import type { RestorePreviewChange } from '../src/multitable/api/client'
+
+type Props = {
+  visible: boolean
+  loading: boolean
+  changes: RestorePreviewChange[]
+  schemaDrift: boolean
+  executable: boolean
+  fieldName: (id: string) => string
+  isZh: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const mounted: Array<{ unmount: () => void }> = []
+function mountDialog(overrides: Partial<Props>) {
+  const props: Props = {
+    visible: true, loading: false, changes: [], schemaDrift: false, executable: false,
+    fieldName: (id) => `name:${id}`, isZh: false, onConfirm: vi.fn(), onCancel: vi.fn(), ...overrides,
+  }
+  const app = createApp(RestorePreviewDialog, props as unknown as Record<string, unknown>)
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  app.mount(container)
+  mounted.push(app)
+  return props
+}
+const q = (sel: string) => document.body.querySelector(sel) as HTMLElement | null
+
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+
+describe('RestorePreviewDialog — T6-3 confirm panel', () => {
+  it('renders the masked changes and ENABLES confirm when executable + non-empty', async () => {
+    const props = mountDialog({ executable: true, changes: [{ fieldId: 'f1', op: 'set', value: 'hello' }, { fieldId: 'f2', op: 'unset', value: null }] })
+    await nextTick()
+    expect(q('[data-test="restore-preview-changes"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('name:f1') // field name resolved
+    expect(document.body.textContent).toContain('hello') // set value shown
+    const confirm = q('[data-test="restore-preview-confirm"]') as HTMLButtonElement
+    expect(confirm.disabled).toBe(false)
+    confirm.click()
+    expect(props.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the conflict and BLOCKS confirm under schema drift (not executable)', async () => {
+    const props = mountDialog({ executable: false, schemaDrift: true, changes: [{ fieldId: 'f1', op: 'set', value: 'x' }] })
+    await nextTick()
+    expect(q('[data-test="restore-preview-conflict"]')).toBeTruthy()
+    const confirm = q('[data-test="restore-preview-confirm"]') as HTMLButtonElement
+    expect(confirm.disabled).toBe(true)
+    confirm.click()
+    expect(props.onConfirm).not.toHaveBeenCalled() // a conflict can never be "confirmed"
+  })
+
+  it('shows no-changes and BLOCKS confirm on an empty (no-op) diff', async () => {
+    mountDialog({ executable: true, changes: [] })
+    await nextTick()
+    expect(q('[data-test="restore-preview-empty"]')).toBeTruthy()
+    expect((q('[data-test="restore-preview-confirm"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('shows the loading state and blocks confirm while the preview loads', async () => {
+    mountDialog({ loading: true, executable: true, changes: [{ fieldId: 'f1', op: 'set', value: 'x' }] })
+    await nextTick()
+    expect(q('[data-test="restore-preview-loading"]')).toBeTruthy()
+    expect((q('[data-test="restore-preview-confirm"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('emits cancel from the cancel button', async () => {
+    const props = mountDialog({ executable: true, changes: [{ fieldId: 'f1', op: 'set', value: 'x' }] })
+    await nextTick()
+    const cancel = document.body.querySelectorAll('.restore-preview__btn')[0] as HTMLButtonElement
+    cancel.click()
+    expect(props.onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/docs/development/multitable-global-history-t6-3-fe-restore-panel-dev-verification-20260621.md
+++ b/docs/development/multitable-global-history-t6-3-fe-restore-panel-dev-verification-20260621.md
@@ -1,0 +1,45 @@
+# Global History — T6-3 FE Restore Panel 开发与验证 MD
+
+> The final slice of the owner-ratified T6 staging. Wires the preview→confirm→execute restore chain into the
+> multitable FE: the record drawer EMITS a restore intent, the workbench OWNS the flow, and a confirm panel
+> shows what would change (and any conflict) before the actor commits — with the T6-1 identity carried through.
+
+## 1. Shape (per the owner's review)
+
+- **`api/client.ts`**: `restorePreviewRecord(sheetId, recordId, targetVersion)` → `{ changes, schemaDrift,
+  previewIdentity, … }`; `restoreExecuteRecord(sheetId, recordId, targetVersion, expectedVersion,
+  previewIdentity)` → the restore result.
+- **`MetaRecordDrawer`**: unchanged — it still only EMITS the restore intent `{ recordId, targetVersion,
+  expectedVersion }` (the drawer does not own confirm/execute).
+- **`MultitableWorkbench`** (the upper-level handler): `onRestoreRecordVersion` now, for a FULL-record restore,
+  calls `restorePreviewRecord` → opens the panel → on confirm calls `restoreExecuteRecord` with the identity →
+  refreshes. Per-field (column-level) restore keeps the existing direct `/restore` path (the T6 identity binds
+  the full-record diff; per-field-through-preview is a follow-up).
+- **`RestorePreviewDialog.vue`** (new): shows the masked changes (field name + set/clear + value), a no-op
+  message, or a **schema-drift conflict**; confirm is enabled ONLY for a real, executable, non-empty change set.
+
+## 2. The UI safety (`canConfirm`)
+
+The actor can commit ONLY when `!loading && executable && !schemaDrift && changes.length > 0`. So a schema-drift
+conflict (the server withheld the identity → `previewIdentity: null` → `executable=false`) shows the conflict and
+the confirm button is **disabled** — the FE cannot drive a blocked restore. A no-op (empty diff) and the loading
+state also disable confirm. This mirrors the backend (T6-2 rejects drift / empty-diff replays); the FE never
+offers an action the server would refuse.
+
+## 3. Verification
+
+- **`vue-tsc -b` 0** (full web typecheck).
+- **5 dialog specs** (jsdom mount): changes render + confirm enabled (executable, non-empty); schema-drift →
+  conflict shown + confirm **disabled** + no `confirm` emit; empty diff → no-op + disabled; loading → disabled;
+  cancel emits. Added to the `multitable-web-guard` filter + path triggers.
+- Web-guard slice green locally (representative: dialog + history + trash + grid specs, 157/157).
+
+## 4. T6 complete + follow-ups
+
+T6-1 (identity contract #3016) + T6-2 (scoped execute + schema-drift #3023/`4203c165`) + `/restore` row-deny
+closure (#3026) + T6-3 (this FE panel) = the ratified T6 staging is done; all three restore surfaces (preview /
+execute / legacy `/restore`) enforce row-deny; the FE only restores through preview→execute.
+
+Named follow-ups (each a separate opt-in): per-field restore through the preview chain; batch / multi-record /
+field-subset restore (a `scope` claim on the identity); unify the three diff copies behind one helper (the P3).
+T8 (destructive PIT restore) + T9 (config history) remain design-locked + gated.


### PR DESCRIPTION
The **final slice** of the owner-ratified T6 staging. Wires the preview→confirm→execute restore chain into the multitable FE: the record drawer **emits** the restore intent (unchanged), the workbench **owns** the flow, and a confirm panel shows what would change (and any conflict) before the actor commits — carrying the T6-1 identity through.

## What
- **`api/client.ts`**: `restorePreviewRecord` + `restoreExecuteRecord`.
- **`MultitableWorkbench.onRestoreRecordVersion`**: full-record restore → `restorePreviewRecord` → `RestorePreviewDialog` → on confirm → `restoreExecuteRecord(identity)` → refresh. Per-field (column) restore keeps the existing direct `/restore` path (the T6 identity binds the full-record diff; per-field-through-preview is a follow-up).
- **`RestorePreviewDialog.vue`** (new): shows the masked changes / no-op / **schema-drift conflict**. `canConfirm` safety — confirm enabled ONLY for a real, executable, non-empty change set; a conflict (server withheld the identity → `executable=false`), a no-op, or loading all disable it. Mirrors the backend — the FE never offers an action the server would refuse.
- **`meta-record-labels.ts`**: typed restore-preview labels (zh/en).

## Verification
**`vue-tsc -b` 0**; **5 jsdom dialog specs** (changes+enabled / drift→conflict+disabled+no-emit / no-op→disabled / loading→disabled / cancel emits) added to the `multitable-web-guard` filter + path triggers; web-guard slice green locally (157/157 across representative specs). **No backend change, no migration.**

## T6 complete
T6-1 (#3016) + T6-2 (#3023 `4203c165`) + `/restore` row-deny (#3026) + T6-3 (this) = the ratified staging is done; all three restore surfaces enforce row-deny; the FE only restores through preview→execute. Follow-ups (per-field-through-preview, batch scope, unify the diff copies) + T8/T9 remain gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)