### PR TITLE
feat(multitable): B-1 AI bulk-preview backend (charge-on-generation, masked diff, per-row gates)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -271,6 +271,7 @@ jobs:
             tests/integration/multitable-webhook-event-bridge.test.ts \
             tests/integration/multitable-webhook-retry-tick.test.ts \
             tests/integration/multitable-ai-shortcut-run.test.ts \
+            tests/integration/multitable-ai-bulk-preview.test.ts \
             tests/integration/multitable-ai-ledger-retention.test.ts \
             tests/integration/multitable-ai-suggest-formula.test.ts \
             tests/integration/data-source-c3-keyset-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260621140000_create_multitable_ai_bulk_preview_cache.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260621140000_create_multitable_ai_bulk_preview_cache.ts
@@ -1,0 +1,68 @@
+/**
+ * Migration: Create the multitable AI bulk-preview run cache (B-1, §3 of
+ * docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md).
+ *
+ * Purpose: persist ONE row per generated bulk-preview output, keyed by
+ * (run_id, record_id), so a later confirm-write (B-2) reads the cached value —
+ * NOT in-memory (a confirm survives a restart and is always explainable). The
+ * `proposed_value` is the AI-generated text for that row's target field; the
+ * row also carries the `preview_version` it was generated against (anti-TOCTOU:
+ * B-2 rides this into patchRecords as expectedVersion) and the per-row usage /
+ * cost actually settled into the usage ledger.
+ *
+ * The CHARGE for a generated row is booked in multitable_ai_usage_ledger at
+ * preview time, INDEPENDENT of this cache. GC'ing an abandoned run via
+ * expires_at NEVER un-charges it (design §4: charge-on-generation, never
+ * released). This table is the cached-OUTPUT store, not the charge ledger.
+ *
+ * Structural template: multitable_ai_usage_ledger
+ * (zzzz20260611090000_create_multitable_ai_usage_ledger.ts) — TEXT ids, a
+ * NUMERIC(12,6) cost column, and an index supporting the cheap aging sweep.
+ *
+ * Never stores prompt or source text; only the single proposed target value.
+ *
+ * Tables: multitable_ai_bulk_preview_cache
+ * Breaking: No
+ */
+
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+const TABLE = 'multitable_ai_bulk_preview_cache'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE)
+  if (!exists) {
+    console.log(`[Migration] Creating table: ${TABLE}`)
+
+    await sql`
+      CREATE TABLE IF NOT EXISTS multitable_ai_bulk_preview_cache (
+        run_id TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        sheet_id TEXT NOT NULL,
+        field_id TEXT NOT NULL,
+        preview_version INTEGER NOT NULL,
+        proposed_value TEXT NOT NULL,
+        usage_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd NUMERIC(12, 6) NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        expires_at TIMESTAMPTZ NOT NULL,
+        PRIMARY KEY (run_id, record_id)
+      )
+    `.execute(db)
+  } else {
+    console.log(`[Migration] Table ${TABLE} already exists, skipping`)
+  }
+
+  // B-2 commit reads by run_id; the aging sweep scans by expires_at.
+  await sql`CREATE INDEX IF NOT EXISTS idx_mt_ai_bulk_cache_run ON multitable_ai_bulk_preview_cache (run_id)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_mt_ai_bulk_cache_expires ON multitable_ai_bulk_preview_cache (expires_at)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_mt_ai_bulk_cache_run`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_mt_ai_bulk_cache_expires`.execute(db)
+  await sql`DROP TABLE IF EXISTS multitable_ai_bulk_preview_cache`.execute(db)
+}

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from 'express'
+import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import { requireAdminRole } from '../guards/audit-integration'
 import { redactString, redactValue } from '../multitable/automation-log-redact'
@@ -34,7 +35,12 @@ import {
   createRecordWriteHelpers,
   getYjsInvalidatorForRoutes,
   requireRecordReadable,
+  parseMetaFilterInfo,
+  evaluateFilterNode,
+  evaluateMetaFilterCondition,
+  collectLeafConditions,
   type RecordPatchRouteContext,
+  type MetaFilterCondition,
 } from './univer-meta'
 import {
   RecordWriteService,
@@ -50,8 +56,9 @@ import { normalizeJson } from '../multitable/field-codecs'
 import { poolManager } from '../integration/db/connection-pool'
 import { eventBus } from '../integration/events/event-bus'
 import { createRateLimiter } from '../middleware/rate-limiter'
-import { ensureRecordWriteAllowed, resolveSheetCapabilities } from '../multitable/permission-service'
-import { loadFieldsForSheet } from '../multitable/loaders'
+import { ensureRecordWriteAllowed, resolveSheetCapabilities, resolveSheetReadableCapabilities } from '../multitable/permission-service'
+import { loadFieldsForSheet, tryResolveView } from '../multitable/loaders'
+import { insertBulkPreviewCacheRow, type BulkPreviewCacheRow } from '../services/ai-bulk-preview-cache'
 
 /**
  * Multitable AI routes — A1 readiness (M1b) + A2 shortcut preview/run (M2).
@@ -110,6 +117,26 @@ interface ShortcutRequestContext {
   action: AiUsageAction
   userId: string
 }
+
+/**
+ * Res-free per-attempt outcome of `runShortcutCore` (B-1). The discriminant is
+ * the charge boundary: only `charged` consumed the provider (and the quota);
+ * every other variant is provider-never-reached → UNCHARGED. `settle` is
+ * present only on `charged` so a caller can re-settle the STATUS keeping usage
+ * (e.g. a downstream write conflict) without re-charging.
+ */
+type ShortcutCoreOutcome =
+  | { kind: 'unsafe_input'; message: string }
+  | { kind: 'blocked'; message: string }
+  | { kind: 'reserve_failed'; message: string }
+  | { kind: 'quota_exhausted'; reason: string }
+  | { kind: 'generation_failed_before_usage'; httpStatus: number; code: string; message: string }
+  | {
+      kind: 'charged'
+      result: AiCompletionResult
+      usage: AiUsage
+      settle: (status: AiUsageLedgerStatus, error?: string | null) => Promise<void>
+    }
 
 function sendStatus(
   res: Response,
@@ -218,26 +245,37 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
   })
 
   /**
-   * Shared gate pipeline from "prompt assembled" onward (review-fix F1,
-   * RESERVE-THEN-SETTLE): unsafe scan → double-confirm/readiness preflight
-   * (blocked: zero-token row, NO lock) → burst limit (429: NO lock, NO ledger
-   * row) → quota RESERVE (one SHORT advisory-locked tx: stale sweep → SUM
-   * incl. in_flight → insert the in_flight reservation) → provider call (NO
-   * lock / NO pooled connection held) → SETTLE the reservation to actual
-   * usage → onSuccess (run: patch + Yjs; write failures re-settle the status
-   * KEEPING usage via `finalize`). Settles are best-effort (§2.5); a failing
-   * reserve fails closed as `blocked`.
+   * RES-FREE reserve-then-settle CORE (review-fix F1) — the unit the bulk path
+   * reuses per row WITHOUT touching `res` (so a 200-row loop cannot double-send;
+   * the single-record `executeShortcut` below is now a thin wrapper over this).
+   *
+   * Gate order from "prompt assembled" onward: unsafe scan → double-confirm/
+   * readiness preflight (blocked: zero-token row, NO lock) → quota RESERVE (one
+   * SHORT advisory-locked tx: stale sweep → SUM incl. in_flight → insert the
+   * in_flight reservation) → provider call (NO lock / NO pooled connection
+   * held) → SETTLE the reservation to actual usage. Settles are best-effort
+   * (§2.5); a failing reserve fails closed.
+   *
+   * The BURST LIMITER is deliberately NOT here — it is a per-HTTP-request guard
+   * the caller applies ONCE (per-row bounding is the D3 row-cap + the D4 quota
+   * pre-check, never tenantBurstRpm self-tripping mid-batch).
+   *
+   * Returns a discriminated per-row outcome:
+   *  - `unsafe_input`                    — not sent, NO ledger row, UNCHARGED.
+   *  - `blocked`                         — preflight blocked: zero-token ledger row, UNCHARGED.
+   *  - `reserve_failed`                  — ledger unavailable, fail-closed, UNCHARGED (no row).
+   *  - `quota_exhausted`                 — reserve rejected, UNCHARGED (no row).
+   *  - `generation_failed_before_usage`  — provider blocked/errored with NO usage → settled to
+   *                                        zero usage, UNCHARGED (provider never produced output).
+   *  - `charged`                         — the provider returned (succeeded OR errored WITH usage);
+   *                                        settled to ACTUAL usage = CHARGED. `result` carries the
+   *                                        completion (text present only when `result.ok`); `settle`
+   *                                        re-settles the STATUS keeping usage (write failures etc.).
    */
-  async function executeShortcut(
-    req: Request,
-    res: Response,
+  async function runShortcutCore(
     ctx: ShortcutRequestContext,
     prompt: string,
-    onSuccess: (
-      result: AiCompletionResult & { ok: true },
-      finalize: (status: AiUsageLedgerStatus, error?: string) => Promise<void>,
-    ) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<ShortcutCoreOutcome> {
     const baseEntry = {
       subjectKey: ctx.userId,
       userId: ctx.userId,
@@ -259,17 +297,14 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         estimatedCostUsd: 0,
         status: 'unsafe_input',
       })
-      return sendStatus(
-        res,
-        422,
-        'unsafe_input',
-        'AI_UNSAFE_INPUT',
-        'The assembled prompt contains secret-shaped content; the request was not sent.',
-      )
+      return {
+        kind: 'unsafe_input',
+        message: 'The assembled prompt contains secret-shaped content; the request was not sent.',
+      }
     }
 
     // Double-confirm / readiness / price preflight — `blocked` resolves BEFORE
-    // the limiter and the reserve (zero-token row, no lock, zero outbound).
+    // the reserve (zero-token row, no lock, zero outbound).
     // complete() re-runs the same gates internally (defense in depth).
     const pre = aiClient.preflight()
     // `in`-guard (not `!pre.ok`): non-strict tsconfig, no boolean-discriminant narrowing.
@@ -283,13 +318,7 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         status: 'blocked',
         error: pre.message,
       })
-      return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', pre.message)
-    }
-
-    // Burst rate limit (Q-3) — 429 EARLY: no lock, no pooled connection held,
-    // and NEVER a ledger row (the limiter responds itself).
-    if ((await applyBurstLimiter(burstLimiter, req, res)) === 'limited') {
-      return
+      return { kind: 'blocked', message: pre.message }
     }
 
     // Quota RESERVE — the advisory locks wrap ONLY this short check+insert
@@ -321,10 +350,10 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
     } catch (err) {
       // Quota-reserve-time ledger unavailability → fail closed (§2.5).
       console.error('[multitable-ai] quota reserve failed; failing closed:', err)
-      return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', 'AI usage ledger is unavailable; request blocked (fail-closed).')
+      return { kind: 'reserve_failed', message: 'AI usage ledger is unavailable; request blocked (fail-closed).' }
     }
     if ('reason' in reservation) {
-      return sendStatus(res, 429, 'quota_exhausted', 'AI_QUOTA_EXHAUSTED', `AI usage quota exhausted (${reservation.reason}).`)
+      return { kind: 'quota_exhausted', reason: reservation.reason }
     }
     const reservationId = reservation.reservationId
 
@@ -355,21 +384,90 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
 
     if (result.status === 'blocked') {
       // Post-reserve blocked = the env raced between preflight and the call —
-      // settle to zero usage (result.usage is null on blocked) with the blocking status.
+      // settle to zero usage (result.usage is null on blocked). The provider
+      // never produced output → UNCHARGED (generation_failed_before_usage).
       await settle('blocked', result.message ?? null)
-      return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', result.message ?? 'AI requests are not enabled for this deployment.')
+      return { kind: 'generation_failed_before_usage', httpStatus: 503, code: 'AI_BLOCKED', message: result.message ?? 'AI requests are not enabled for this deployment.' }
     }
 
     if (result.status === 'provider_error') {
-      // Tokens are recorded whenever the provider returned usage — the money is spent.
+      // Charge invariant (§2.5): tokens are recorded WHENEVER the provider
+      // returned usage — the money is spent. A provider error with NO usage =
+      // generation_failed_before_usage (UNCHARGED, zero-token settle); a
+      // provider error WITH usage settles the ACTUAL tokens (CHARGED) — the
+      // output was produced even though the call surfaced an error.
       await settle('provider_error', result.message ?? null)
-      return sendStatus(res, 502, 'provider_error', 'AI_PROVIDER_ERROR', result.message ?? 'AI provider request failed.')
+      if (result.usage) {
+        return { kind: 'charged', result: result as AiCompletionResult, usage, settle }
+      }
+      return { kind: 'generation_failed_before_usage', httpStatus: 502, code: 'AI_PROVIDER_ERROR', message: result.message ?? 'AI provider request failed.' }
     }
 
-    // Settle to actual usage BEFORE the downstream write so the quota account
-    // reflects the real spend even if the write path crashes mid-flight.
+    // Settle to actual usage BEFORE any downstream write so the quota account
+    // reflects the real spend even if the write path crashes mid-flight. The
+    // provider was called and produced OUTPUT → CHARGED. NB: a 200 that omits a
+    // usage object is still a successful generation → CHARGED at zero tokens
+    // (token-sum invariant holds: 0 == 0). That is distinct from an
+    // error/blocked result with null usage above, which produced NO output and
+    // is generation_failed_before_usage (UNCHARGED). The discriminator is
+    // "output produced?", not "usage object present?".
     await settle('succeeded')
-    await onSuccess(result as AiCompletionResult & { ok: true }, (status, error) => settle(status, error ?? null))
+    return { kind: 'charged', result: result as AiCompletionResult & { ok: true }, usage, settle }
+  }
+
+  /**
+   * Single-record thin wrapper over `runShortcutCore` (review-fix F1 gate
+   * order preserved): burst limit (429 EARLY: NO lock, NO ledger row, the
+   * limiter responds itself) → core → map the per-row outcome to `res` →
+   * onSuccess on the charged-success path (run: patch + Yjs; write failures
+   * re-settle the status KEEPING usage via `finalize`).
+   */
+  async function executeShortcut(
+    req: Request,
+    res: Response,
+    ctx: ShortcutRequestContext,
+    prompt: string,
+    onSuccess: (
+      result: AiCompletionResult & { ok: true },
+      finalize: (status: AiUsageLedgerStatus, error?: string) => Promise<void>,
+    ) => Promise<void>,
+  ): Promise<void> {
+    // Burst rate limit (Q-3) — runs BEFORE the core's reserve (gate order
+    // unchanged): 429 EARLY, no lock, no pooled connection held, NEVER a
+    // ledger row (the limiter responds itself).
+    if ((await applyBurstLimiter(burstLimiter, req, res)) === 'limited') {
+      return
+    }
+
+    const outcome = await runShortcutCore(ctx, prompt)
+    switch (outcome.kind) {
+      case 'unsafe_input':
+        return sendStatus(res, 422, 'unsafe_input', 'AI_UNSAFE_INPUT', outcome.message)
+      case 'blocked':
+        return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', outcome.message)
+      case 'reserve_failed':
+        return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', outcome.message)
+      case 'quota_exhausted':
+        return sendStatus(res, 429, 'quota_exhausted', 'AI_QUOTA_EXHAUSTED', `AI usage quota exhausted (${outcome.reason}).`)
+      case 'generation_failed_before_usage':
+        return sendStatus(
+          res,
+          outcome.httpStatus,
+          outcome.httpStatus === 502 ? 'provider_error' : 'blocked',
+          outcome.code,
+          outcome.message,
+        )
+      case 'charged': {
+        if (!outcome.result.ok) {
+          // A charged-but-errored row (provider error WITH usage) has no usable
+          // text on the single-record path — surface the provider error (the
+          // spend is already settled).
+          return sendStatus(res, 502, 'provider_error', 'AI_PROVIDER_ERROR', outcome.result.message ?? 'AI provider request failed.')
+        }
+        await onSuccess(outcome.result as AiCompletionResult & { ok: true }, (status, error) => outcome.settle(status, error ?? null))
+        return
+      }
+    }
   }
 
   router.post('/sheets/:sheetId/ai/shortcut/preview', async (req: Request, res: Response) => {
@@ -638,6 +736,317 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
     } catch (err) {
       console.error('[multitable-ai] shortcut run failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to run AI shortcut' } })
+    }
+  })
+
+  /**
+   * B-1 — AI bulk-PREVIEW (INTERNAL, not in OpenAPI). Apply an ALREADY-PERSISTED
+   * field.property.aiShortcut across MANY records at once, generating + charging
+   * per provider-called row, returning the proposed values for a review-before-
+   * write (the WRITE itself is B-2 — this route never writes a record).
+   *
+   * Design lock:
+   * docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md
+   *
+   * Posture (extend, don't fork): the SAME per-record gate sequence + the SAME
+   * res-free reserve-then-settle core (runShortcutCore), looped per row. The
+   * BURST limiter runs ONCE at route entry (per-HTTP-request guard); per-row
+   * bounding is the D3 row-cap + the D4 quota pre-check.
+   *
+   * Gate map:
+   *  - inline config REJECTED (run parity).
+   *  - SHEET-LEVEL gates ONCE (hoisted out of the loop): record-read capability
+   *    → canEditRecord → buildRecordPatchContext → target type ∈ {string,longText}
+   *    + layer-3 fieldPermissions[fieldId] (visible/readOnly) → persisted config.
+   *  - D2-A scope: the FULL server-resolved filtered set (scope:'view' applies
+   *    the view's persisted filterInfo over ALL records, NOT the loaded page);
+   *    scope:'sheet' = whole sheet. Optional recordIds intersect the set.
+   *  - D3-A cap: |resolved set| > MULTITABLE_AI_BULK_MAX_ROWS → 400
+   *    BULK_SCOPE_TOO_LARGE (no silent truncation).
+   *  - D4: pre-check rows × per-row est-tokens vs the per-tenant cap; whole run
+   *    won't fit → AI_BULK_QUOTA_INSUFFICIENT (generate NOTHING).
+   *  - PER ROW (D5 + D1-A): requireRecordReadable (read-deny → OMITTED from the
+   *    response entirely) → ensureRecordWriteAllowed (not writable →
+   *    skipped_no_perm, NO generation) → readRecordOnce (capture version) →
+   *    assembleMaskedPrompt (unreadable sources NEVER enter the prompt) →
+   *    runShortcutCore. A provider-called row is CHARGED + cached + returned;
+   *    its diff is MASKED (masked:true when any source field was dropped). A
+   *    provider-never-reached row (skipped/over-cap/quota/no-usage) is UNCHARGED.
+   *  - 429/blocked mid-batch PAUSES the run: stop and return PARTIAL; un-reached
+   *    rows are uncharged. (AiCompletionResult collapses provider 429 into
+   *    provider_error, so a provider failure stops the batch — un-reached rows
+   *    are never charged.)
+   */
+  router.post('/sheets/:sheetId/ai/shortcut/bulk-preview', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    // Persisted config only (run parity) — reject inline config BEFORE shape parse.
+    if (req.body && typeof req.body === 'object' && 'config' in (req.body as Record<string, unknown>)) {
+      return res.status(400).json({
+        ok: false,
+        error: { code: 'AI_INLINE_CONFIG_REJECTED', message: 'bulk-preview executes only the persisted field.property.aiShortcut config; inline config is not accepted' },
+      })
+    }
+    const schema = z.object({
+      fieldId: z.string().min(1).max(50),
+      scope: z.enum(['view', 'sheet']),
+      viewId: z.string().min(1).max(50).optional(),
+      recordIds: z.array(z.string().min(1).max(50)).max(5000).optional(),
+    })
+    const parsed = schema.safeParse(req.body)
+    if (!sheetId || !parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: !sheetId ? 'sheetId is required' : parsed.error?.message } })
+    }
+    const { fieldId, scope, viewId, recordIds } = parsed.data
+    if (scope === 'view' && !viewId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'viewId is required when scope is "view"' } })
+    }
+
+    // Burst rate limit ONCE at entry (per-HTTP-request guard) — never per row.
+    if ((await applyBurstLimiter(burstLimiter, req, res)) === 'limited') {
+      return
+    }
+
+    try {
+      const pool = poolManager.get() as unknown as PoolLike
+      const query = pool.query.bind(pool) as QueryFn
+      const ledgerQuery = pool.query.bind(pool) as AiUsageQueryFn
+
+      // ── SHEET-LEVEL gates (ONCE, hoisted) ──────────────────────────────────
+      const { access, capabilities, sheetScope } = await resolveSheetReadableCapabilities(req, query, sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } })
+      }
+      if (!capabilities.canRead) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+      }
+      if (!capabilities.canEditRecord) {
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } })
+      }
+
+      const patchContext = await buildRecordPatchContext(req, query, sheetId, access, capabilities)
+      if (!patchContext) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      }
+
+      const targetField = patchContext.fields.find((field) => field.id === fieldId)
+      if (!targetField) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Field not found: ${fieldId}` } })
+      }
+      if (!AI_SHORTCUT_TARGET_FIELD_TYPES.has(targetField.type)) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'VALIDATION_ERROR', message: `AI shortcut target field must be string or longText, got: ${targetField.type}` },
+        })
+      }
+      // Layer-3 write gate (#2106 F3) — the per-record run's enforcement point, hoisted.
+      const targetPermission = patchContext.fieldPermissions[fieldId]
+      if (!targetPermission || targetPermission.visible === false || targetPermission.readOnly === true) {
+        return res.status(403).json({ ok: false, error: { code: 'FIELD_FORBIDDEN', message: `AI shortcut target field is not editable: ${fieldId}` } })
+      }
+
+      const resolved = resolvePersistedShortcutConfig(patchContext, fieldId)
+      if ('error' in resolved) {
+        return res.status(resolved.httpStatus).json({ ok: false, error: { code: resolved.code, message: resolved.error } })
+      }
+      const config = resolved.config
+
+      // ── D2-A scope: server-resolved FULL filtered set (NOT the loaded page) ──
+      // Resolve the view filter over the SAME visible field set the read path
+      // uses (patchContext.fields), reusing parseMetaFilterInfo + evaluateFilterNode
+      // (the #3010 export semantic). scope:'sheet' = every record on the sheet.
+      const fieldTypeById = new Map(patchContext.fields.map((field) => [field.id, field.type]))
+      // A condition on a field the actor cannot SELECT (layer-2 ∧ layer-3 denied)
+      // is dropped = treated as non-existent (parity with /view); a computed
+      // (lookup/rollup/formula) filter can't be evaluated here without
+      // applyLookupRollup, so it's dropped too (the row simply isn't excluded by
+      // it — conservative: a bulk preview must not silently disagree with the
+      // grid by SILENTLY DROPPING rows it can't evaluate).
+      const selectableFieldIds = patchContext.readableEchoFieldIds
+      const COMPUTED_FILTER_TYPES = new Set(['lookup', 'rollup', 'formula'])
+
+      let filterNode: ReturnType<typeof parseMetaFilterInfo> = null
+      if (scope === 'view') {
+        const view = await tryResolveView(query, viewId!, new Map())
+        if (!view || view.sheetId !== sheetId) {
+          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
+        }
+        filterNode = parseMetaFilterInfo(view.filterInfo)
+      }
+
+      const recordIdFilter = recordIds && recordIds.length > 0 ? new Set(recordIds) : null
+      const recordRes = await query('SELECT id, version, data FROM meta_records WHERE sheet_id = $1', [sheetId])
+      let candidateIds = (recordRes.rows as Array<{ id: unknown; data: unknown }>)
+        .map((row) => ({ id: String(row.id), data: normalizeJson(row.data) }))
+        .filter((row) => (recordIdFilter ? recordIdFilter.has(row.id) : true))
+      if (filterNode) {
+        // A leaf on a denied (non-selectable) OR computed (lookup/rollup/formula)
+        // field is treated as non-existent — it matches everything (does not
+        // exclude the row), matching /view's "denied field == non-existent" rule
+        // and refusing to SILENTLY DROP rows a materialized read can't evaluate.
+        const leafMatches = (leaf: MetaFilterCondition, cellValue: unknown): boolean => {
+          if (!selectableFieldIds.has(leaf.fieldId)) return true
+          if (COMPUTED_FILTER_TYPES.has(fieldTypeById.get(leaf.fieldId) ?? '')) return true
+          return evaluateMetaFilterCondition(fieldTypeById.get(leaf.fieldId)!, cellValue, leaf)
+        }
+        // Short-circuit when EVERY leaf is dropped (no real filtering left).
+        const hasEvaluableLeaf = collectLeafConditions(filterNode).some(
+          (leaf) => selectableFieldIds.has(leaf.fieldId) && !COMPUTED_FILTER_TYPES.has(fieldTypeById.get(leaf.fieldId) ?? ''),
+        )
+        if (hasEvaluableLeaf) {
+          candidateIds = candidateIds.filter((row) =>
+            evaluateFilterNode(filterNode!, (leaf) => leafMatches(leaf, row.data[leaf.fieldId])),
+          )
+        }
+      }
+      const candidates = candidateIds.map((row) => row.id)
+
+      // ── D3-A hard row cap (no silent truncation) ───────────────────────────
+      const maxRows = (() => {
+        const raw = Number(process.env.MULTITABLE_AI_BULK_MAX_ROWS)
+        return Number.isInteger(raw) && raw > 0 ? raw : 200
+      })()
+      if (candidates.length > maxRows) {
+        return res.status(400).json({
+          ok: false,
+          error: { code: 'BULK_SCOPE_TOO_LARGE', message: `Bulk scope resolves to ${candidates.length} rows, over the cap of ${maxRows}. Narrow the view/selection.`, total: candidates.length, cap: maxRows },
+        })
+      }
+
+      // ── D4 pre-check: whole run must fit the per-tenant token cap ───────────
+      // Estimate rows × per-row tokens (the same conservative bound a single run
+      // reserves) against the CALLER's daily/weekly token windows. If it can't
+      // fit, refuse the WHOLE run before generating anything (no partial spend).
+      const pre = aiClient.preflight()
+      if ('message' in pre) {
+        // Provider not ready — refuse the whole run up front (no per-row blocked rows).
+        return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', pre.message)
+      }
+      if (candidates.length > 0) {
+        const perRowEstTokens = conservativePromptTokenEstimate('') + pre.caps.maxOutputTokens
+        const estTotalTokens = candidates.length * perRowEstTokens
+        const sums = await sumAiUsageWindows(ledgerQuery, access.userId)
+        const dailyFits = sums.userDailyTokens + estTotalTokens <= pre.caps.tenantDailyTokenCap
+        const weeklyFits = sums.userWeeklyTokens + estTotalTokens <= pre.caps.tenantWeeklyTokenCap
+        if (!dailyFits || !weeklyFits) {
+          return res.status(429).json({
+            ok: false,
+            status: 'quota_exhausted',
+            error: {
+              code: 'AI_BULK_QUOTA_INSUFFICIENT',
+              message: `This bulk run needs ~${estTotalTokens} tokens which exceeds the remaining per-tenant ${!dailyFits ? 'daily' : 'weekly'} token quota; nothing was generated.`,
+            },
+          })
+        }
+      }
+
+      // ── PER-ROW generation (D5 gates + D1-A charge-on-generation) ───────────
+      const runId = `aibulk_${randomUUID()}`
+      const rows: Array<{ recordId: string; version: number; proposed: string; masked: boolean; writable: boolean }> = []
+      const skipped: Array<{ recordId: string; reason: string }> = []
+      let settledCost = 0
+      let paused = false
+
+      // The full source-field set the config wants — used to flag a masked diff
+      // (a row whose readable source set is smaller generated against a reduced
+      // context, so the viewer is told the proposal may be incomplete).
+      const configSourceCount = config.sourceFieldIds.length
+
+      for (const recordId of candidates) {
+        // Row-level READ gate (reuses requireRecordReadable → row-level read-deny
+        // / conditional-read rules). A read-denied row is OMITTED from the
+        // response ENTIRELY (never a skipped entry that would confirm existence).
+        const readable = await requireRecordReadable(req, query, sheetId, recordId)
+        if ('status' in readable) {
+          // 404 (record vanished mid-run) / 403 (row-level read-deny) → omit silently.
+          continue
+        }
+
+        const captured = await readRecordOnce(query, sheetId, recordId)
+        if (!captured) {
+          continue // vanished between the SELECT and the per-row read — omit.
+        }
+
+        // Row-policy WRITE gate (own-write scope etc.) — not writable → skipped, NO generation.
+        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, captured.createdBy, 'edit')) {
+          skipped.push({ recordId, reason: 'skipped_no_perm' })
+          continue
+        }
+
+        // Mask + assemble: unreadable source fields NEVER enter the prompt.
+        const prompt = assembleMaskedPrompt(config, patchContext, captured.data)
+        // masked diff: how many of the config's sources actually survived the read mask.
+        const readableSourceCount = config.sourceFieldIds.filter((id) => patchContext.readableEchoFieldIds.has(id)).length
+        const masked = readableSourceCount < configSourceCount
+
+        const outcome = await runShortcutCore(
+          { pool, sheetId, recordId, fieldId, action: 'preview', userId: access.userId },
+          prompt,
+        )
+
+        if (outcome.kind === 'charged') {
+          const usageTokens = outcome.usage.promptTokens + outcome.usage.completionTokens
+          const costUsd = outcome.result.estimatedCostUsd
+          settledCost += costUsd
+          const proposed = outcome.result.ok ? (outcome.result.text ?? '') : ''
+          // Persist the cached output (B-2 reads this). The CHARGE is already in
+          // the usage ledger via runShortcutCore's settle — the cache is the
+          // output store, never the charge ledger.
+          const cacheRow: BulkPreviewCacheRow = {
+            runId,
+            actorId: access.userId,
+            sheetId,
+            fieldId,
+            recordId,
+            previewVersion: captured.version,
+            proposedValue: proposed,
+            usageTokens,
+            costUsd,
+          }
+          try {
+            await insertBulkPreviewCacheRow(ledgerQuery, cacheRow)
+          } catch (err) {
+            // Cache insert is best-effort vs the already-booked charge — never
+            // un-charge / never 500 a run whose provider spend already settled.
+            console.error('[multitable-ai] bulk-preview cache insert failed (best effort):', err)
+          }
+          rows.push({ recordId, version: captured.version, proposed, masked, writable: true })
+          continue
+        }
+
+        if (outcome.kind === 'quota_exhausted' || outcome.kind === 'blocked' || outcome.kind === 'reserve_failed') {
+          // Quota/availability hit mid-batch → PAUSE: stop here, return partial.
+          // This row + every un-reached row is UNCHARGED.
+          skipped.push({ recordId, reason: outcome.kind === 'quota_exhausted' ? 'rate_limited_before_call' : 'blocked_before_call' })
+          paused = true
+          break
+        }
+
+        if (outcome.kind === 'generation_failed_before_usage') {
+          // Provider failed with NO usage (incl. a collapsed 429) → UNCHARGED.
+          // A provider failure pauses the batch (un-reached rows uncharged).
+          skipped.push({ recordId, reason: 'generation_failed_before_usage' })
+          paused = true
+          break
+        }
+
+        if (outcome.kind === 'unsafe_input') {
+          // Secret-shaped prompt for this row — not sent, UNCHARGED; skip the row
+          // but DO NOT pause (other rows may be clean).
+          skipped.push({ recordId, reason: 'unsafe_input' })
+          continue
+        }
+      }
+
+      return res.json({
+        runId,
+        rows,
+        skipped,
+        settledCost,
+        capped: paused,
+      })
+    } catch (err) {
+      console.error('[multitable-ai] bulk-preview failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to run AI bulk preview' } })
     }
   })
 

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -879,19 +879,31 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         .map((row) => ({ id: String(row.id), data: normalizeJson(row.data) }))
         .filter((row) => (recordIdFilter ? recordIdFilter.has(row.id) : true))
       if (filterNode) {
-        // A leaf on a denied (non-selectable) OR computed (lookup/rollup/formula)
-        // field is treated as non-existent — it matches everything (does not
-        // exclude the row), matching /view's "denied field == non-existent" rule
-        // and refusing to SILENTLY DROP rows a materialized read can't evaluate.
+        // A COMPUTED (lookup/rollup/formula) filter leaf the actor CAN select cannot be
+        // evaluated here without hydration. Treating it as match-all would generate AI
+        // for rows OUTSIDE the user's view (over-scope + over-charge for a write-preview),
+        // so v1 REFUSES rather than silently over-generate. (A computed leaf on a DENIED
+        // field is dropped = non-existent, parity with the actor's own /view which also
+        // can't apply it.) Reusing the #3010 computed-filter hydration is the later option.
+        const computedLeaf = collectLeafConditions(filterNode).find(
+          (leaf) => selectableFieldIds.has(leaf.fieldId) && COMPUTED_FILTER_TYPES.has(fieldTypeById.get(leaf.fieldId) ?? ''),
+        )
+        if (computedLeaf) {
+          return res.status(422).json({
+            ok: false,
+            error: {
+              code: 'AI_BULK_VIEW_FILTER_UNSUPPORTED',
+              message: 'This view filters on a computed (lookup/rollup/formula) field, which bulk preview cannot resolve yet — narrow the view to non-computed filters, or pass an explicit record selection.',
+            },
+          })
+        }
+        // A leaf on a denied (non-selectable) field is treated as non-existent (matches
+        // everything), matching the actor's own /view "denied field == non-existent" rule.
         const leafMatches = (leaf: MetaFilterCondition, cellValue: unknown): boolean => {
           if (!selectableFieldIds.has(leaf.fieldId)) return true
-          if (COMPUTED_FILTER_TYPES.has(fieldTypeById.get(leaf.fieldId) ?? '')) return true
           return evaluateMetaFilterCondition(fieldTypeById.get(leaf.fieldId)!, cellValue, leaf)
         }
-        // Short-circuit when EVERY leaf is dropped (no real filtering left).
-        const hasEvaluableLeaf = collectLeafConditions(filterNode).some(
-          (leaf) => selectableFieldIds.has(leaf.fieldId) && !COMPUTED_FILTER_TYPES.has(fieldTypeById.get(leaf.fieldId) ?? ''),
-        )
+        const hasEvaluableLeaf = collectLeafConditions(filterNode).some((leaf) => selectableFieldIds.has(leaf.fieldId))
         if (hasEvaluableLeaf) {
           candidateIds = candidateIds.filter((row) =>
             evaluateFilterNode(filterNode!, (leaf) => leafMatches(leaf, row.data[leaf.fieldId])),
@@ -900,30 +912,61 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
       }
       const candidates = candidateIds.map((row) => row.id)
 
-      // ── D3-A hard row cap (no silent truncation) ───────────────────────────
+      // ── D5 gates BEFORE D3/D4: only PROVIDER-BOUND rows count toward cap/quota ──
+      // Build the generation set FIRST so a read-denied row is OMITTED (never counted →
+      // no hidden-row oracle via total/400/429) and a not-writable row is skipped_no_perm
+      // (never counted toward the provider-call cap/quota → a small real batch is never
+      // false-blocked by many unreadable/unwritable rows). The version captured here
+      // rides into the run cache as previewVersion (anti-TOCTOU for B-2).
+      const runId = `aibulk_${randomUUID()}`
+      const skipped: Array<{ recordId: string; reason: string }> = []
+      // CHARGED but NOT confirmable (provider responded WITH usage but errored, or the
+      // run-cache write failed). Distinct from `skipped` (UNCHARGED). B-2 must never
+      // treat a `failures` row as committable — there is no usable cached output.
+      const failures: Array<{ recordId: string; reason: string }> = []
+      // The full source-field set the config wants — used to flag a masked diff (a row
+      // whose readable source set is smaller generated against a reduced context).
+      const configSourceCount = config.sourceFieldIds.length
+
+      const generationCandidates: Array<{ recordId: string; version: number; data: Record<string, unknown> }> = []
+      for (const recordId of candidates) {
+        // Row-level READ gate — a read-denied / vanished row is OMITTED entirely (never
+        // counted, never a skipped entry that would confirm existence = no oracle).
+        const readable = await requireRecordReadable(req, query, sheetId, recordId)
+        if ('status' in readable) continue
+        const captured = await readRecordOnce(query, sheetId, recordId)
+        if (!captured) continue
+        // Row-policy WRITE gate — not writable → skipped_no_perm, NOT counted toward cap/quota.
+        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, captured.createdBy, 'edit')) {
+          skipped.push({ recordId, reason: 'skipped_no_perm' })
+          continue
+        }
+        generationCandidates.push({ recordId, version: captured.version, data: captured.data })
+      }
+
+      // ── D3-A hard row cap on the PROVIDER-BOUND set (total = generatable rows, no leak) ──
       const maxRows = (() => {
         const raw = Number(process.env.MULTITABLE_AI_BULK_MAX_ROWS)
         return Number.isInteger(raw) && raw > 0 ? raw : 200
       })()
-      if (candidates.length > maxRows) {
+      if (generationCandidates.length > maxRows) {
         return res.status(400).json({
           ok: false,
-          error: { code: 'BULK_SCOPE_TOO_LARGE', message: `Bulk scope resolves to ${candidates.length} rows, over the cap of ${maxRows}. Narrow the view/selection.`, total: candidates.length, cap: maxRows },
+          error: { code: 'BULK_SCOPE_TOO_LARGE', message: `Bulk scope resolves to ${generationCandidates.length} generatable rows, over the cap of ${maxRows}. Narrow the view/selection.`, total: generationCandidates.length, cap: maxRows },
         })
       }
 
-      // ── D4 pre-check: whole run must fit the per-tenant token cap ───────────
-      // Estimate rows × per-row tokens (the same conservative bound a single run
-      // reserves) against the CALLER's daily/weekly token windows. If it can't
-      // fit, refuse the WHOLE run before generating anything (no partial spend).
+      // ── D4 pre-check on the PROVIDER-BOUND set: whole run must fit the per-tenant cap ──
+      // Estimate generatable-rows × per-row tokens against the CALLER's daily/weekly
+      // windows; if it can't fit, refuse the WHOLE run before generating (no partial spend).
       const pre = aiClient.preflight()
       if ('message' in pre) {
         // Provider not ready — refuse the whole run up front (no per-row blocked rows).
         return sendStatus(res, 503, 'blocked', 'AI_BLOCKED', pre.message)
       }
-      if (candidates.length > 0) {
+      if (generationCandidates.length > 0) {
         const perRowEstTokens = conservativePromptTokenEstimate('') + pre.caps.maxOutputTokens
-        const estTotalTokens = candidates.length * perRowEstTokens
+        const estTotalTokens = generationCandidates.length * perRowEstTokens
         const sums = await sumAiUsageWindows(ledgerQuery, access.userId)
         const dailyFits = sums.userDailyTokens + estTotalTokens <= pre.caps.tenantDailyTokenCap
         const weeklyFits = sums.userWeeklyTokens + estTotalTokens <= pre.caps.tenantWeeklyTokenCap
@@ -939,43 +982,14 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         }
       }
 
-      // ── PER-ROW generation (D5 gates + D1-A charge-on-generation) ───────────
-      const runId = `aibulk_${randomUUID()}`
+      // ── PER-ROW generation (D1-A charge-on-generation) over the gated set ───────────
       const rows: Array<{ recordId: string; version: number; proposed: string; masked: boolean; writable: boolean }> = []
-      const skipped: Array<{ recordId: string; reason: string }> = []
-      // CHARGED but NOT confirmable (provider responded WITH usage but errored, or the
-      // run-cache write failed). Distinct from `skipped` (UNCHARGED). B-2 must never
-      // treat a `failures` row as committable — there is no usable cached output.
-      const failures: Array<{ recordId: string; reason: string }> = []
       let settledCost = 0
       let paused = false
 
-      // The full source-field set the config wants — used to flag a masked diff
-      // (a row whose readable source set is smaller generated against a reduced
-      // context, so the viewer is told the proposal may be incomplete).
-      const configSourceCount = config.sourceFieldIds.length
-
-      for (const recordId of candidates) {
-        // Row-level READ gate (reuses requireRecordReadable → row-level read-deny
-        // / conditional-read rules). A read-denied row is OMITTED from the
-        // response ENTIRELY (never a skipped entry that would confirm existence).
-        const readable = await requireRecordReadable(req, query, sheetId, recordId)
-        if ('status' in readable) {
-          // 404 (record vanished mid-run) / 403 (row-level read-deny) → omit silently.
-          continue
-        }
-
-        const captured = await readRecordOnce(query, sheetId, recordId)
-        if (!captured) {
-          continue // vanished between the SELECT and the per-row read — omit.
-        }
-
-        // Row-policy WRITE gate (own-write scope etc.) — not writable → skipped, NO generation.
-        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, captured.createdBy, 'edit')) {
-          skipped.push({ recordId, reason: 'skipped_no_perm' })
-          continue
-        }
-
+      for (const cand of generationCandidates) {
+        const recordId = cand.recordId
+        const captured = { version: cand.version, data: cand.data }
         // Mask + assemble: unreadable source fields NEVER enter the prompt.
         const prompt = assembleMaskedPrompt(config, patchContext, captured.data)
         // masked diff: how many of the config's sources actually survived the read mask.

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -943,6 +943,10 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
       const runId = `aibulk_${randomUUID()}`
       const rows: Array<{ recordId: string; version: number; proposed: string; masked: boolean; writable: boolean }> = []
       const skipped: Array<{ recordId: string; reason: string }> = []
+      // CHARGED but NOT confirmable (provider responded WITH usage but errored, or the
+      // run-cache write failed). Distinct from `skipped` (UNCHARGED). B-2 must never
+      // treat a `failures` row as committable — there is no usable cached output.
+      const failures: Array<{ recordId: string; reason: string }> = []
       let settledCost = 0
       let paused = false
 
@@ -984,13 +988,26 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         )
 
         if (outcome.kind === 'charged') {
+          // The CHARGE stands regardless of what follows — runShortcutCore already
+          // settled provider usage into the ledger (provider spend is real).
           const usageTokens = outcome.usage.promptTokens + outcome.usage.completionTokens
           const costUsd = outcome.result.estimatedCostUsd
           settledCost += costUsd
-          const proposed = outcome.result.ok ? (outcome.result.text ?? '') : ''
-          // Persist the cached output (B-2 reads this). The CHARGE is already in
-          // the usage ledger via runShortcutCore's settle — the cache is the
-          // output store, never the charge ledger.
+
+          // `charged` ALSO covers provider_error-WITH-usage (runShortcutCore: the
+          // provider billed but produced no usable output). That row is CHARGED but
+          // NOT confirmable — never cache an empty/failed output, never return it as
+          // writable (B-2 commits ONLY real cached outputs). Pause: a provider
+          // erroring mid-batch must not keep spending on subsequent rows.
+          if (!outcome.result.ok) {
+            failures.push({ recordId, reason: 'provider_error_charged' })
+            paused = true
+            break
+          }
+
+          const proposed = outcome.result.text ?? ''
+          // Persist the cached output — B-2 commits ONLY from this. The cache is the
+          // OUTPUT store, never the charge ledger (the charge already settled above).
           const cacheRow: BulkPreviewCacheRow = {
             runId,
             actorId: access.userId,
@@ -1002,12 +1019,21 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
             usageTokens,
             costUsd,
           }
+          let cached = false
           try {
             await insertBulkPreviewCacheRow(ledgerQuery, cacheRow)
+            cached = true
           } catch (err) {
-            // Cache insert is best-effort vs the already-booked charge — never
-            // un-charge / never 500 a run whose provider spend already settled.
-            console.error('[multitable-ai] bulk-preview cache insert failed (best effort):', err)
+            console.error('[multitable-ai] bulk-preview cache insert failed (fail-closed for this row):', err)
+          }
+          if (!cached) {
+            // FAIL-CLOSED (#3019 persistent-run-cache lock): the row is CHARGED
+            // (provider spend is real) but has NO cached output for B-2 to commit,
+            // so it must NOT be a confirmable row. Pause — a cache outage would
+            // otherwise charge every subsequent row un-confirmably.
+            failures.push({ recordId, reason: 'cache_failed_after_generation' })
+            paused = true
+            break
           }
           rows.push({ recordId, version: captured.version, proposed, masked, writable: true })
           continue
@@ -1041,6 +1067,7 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
         runId,
         rows,
         skipped,
+        failures,
         settledCost,
         capped: paused,
       })

--- a/packages/core-backend/src/services/ai-bulk-preview-cache.ts
+++ b/packages/core-backend/src/services/ai-bulk-preview-cache.ts
@@ -17,7 +17,6 @@
  *    settled. NEVER stores prompt or source text.
  */
 
-import { redactString } from '../multitable/automation-log-redact'
 
 export const AI_BULK_PREVIEW_CACHE_TABLE = 'multitable_ai_bulk_preview_cache'
 
@@ -49,9 +48,13 @@ export interface BulkPreviewCacheRow {
 
 /**
  * Insert one cached output row (PK = (run_id, record_id)). `proposed_value` is
- * defensively run through the shared redactor before insert (the provider text
- * is model output, but the redactor is cheap defense in depth — same posture as
- * the usage-ledger `error` column).
+ * stored EXACTLY as previewed — NO redaction. The cache is the value B-2 commits,
+ * and it MUST equal what the user reviewed ("confirm what you see = what's written");
+ * it also matches the per-record run, which writes the raw model text to the field
+ * (multitable-ai.ts shortcut/run, `value: result.text`). Redacting here would commit
+ * a different value than the user confirmed. (The cache is short-lived + TTL'd, and
+ * the same raw text reaches the field on commit regardless, so there is nothing to
+ * "defend" by diverging the stored value from the previewed one.)
  */
 export async function insertBulkPreviewCacheRow(
   query: AiBulkPreviewCacheQueryFn,
@@ -71,7 +74,7 @@ export async function insertBulkPreviewCacheRow(
       row.sheetId,
       row.fieldId,
       Math.max(0, Math.round(row.previewVersion)),
-      redactString(row.proposedValue),
+      row.proposedValue,
       Math.max(0, Math.round(row.usageTokens)),
       row.costUsd,
       expiresAt.toISOString(),

--- a/packages/core-backend/src/services/ai-bulk-preview-cache.ts
+++ b/packages/core-backend/src/services/ai-bulk-preview-cache.ts
@@ -1,0 +1,118 @@
+/**
+ * Multitable AI bulk-preview run cache (B-1) — the PERSISTENT store of one
+ * generated proposed value per (runId, recordId).
+ *
+ * Design lock §3/§4:
+ * docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md
+ *
+ *  - NOT in-memory: a later confirm-write (B-2) reads the cached value, so a
+ *    confirm survives a process restart and is always explainable.
+ *  - One row per GENERATED output (provider-called row). The CHARGE itself is
+ *    booked in multitable_ai_usage_ledger at preview time, INDEPENDENT of this
+ *    cache — a TTL sweep over expires_at GC's abandoned runs but NEVER
+ *    un-charges them (charge-on-generation, never released).
+ *  - Stores only the single proposed TARGET value (`proposed_value`), the
+ *    `preview_version` it was generated against (anti-TOCTOU: B-2 rides this
+ *    into patchRecords as expectedVersion), and the per-row usage/cost actually
+ *    settled. NEVER stores prompt or source text.
+ */
+
+import { redactString } from '../multitable/automation-log-redact'
+
+export const AI_BULK_PREVIEW_CACHE_TABLE = 'multitable_ai_bulk_preview_cache'
+
+/** Default cache TTL (ms) — a short window GC's abandoned runs cheaply (§3). */
+export const AI_BULK_PREVIEW_CACHE_TTL_MS = 30 * 60_000
+
+export type AiBulkPreviewCacheQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export interface BulkPreviewCacheRow {
+  runId: string
+  actorId: string
+  sheetId: string
+  fieldId: string
+  recordId: string
+  /** The record `version` the proposal was generated against (B-2 expectedVersion). */
+  previewVersion: number
+  /** The AI-generated proposed value for the target field. */
+  proposedValue: string
+  /** prompt + completion tokens actually settled for this row. */
+  usageTokens: number
+  /** 估算 cost actually settled for this row. */
+  costUsd: number
+  /** Absolute expiry; defaults to now + AI_BULK_PREVIEW_CACHE_TTL_MS. */
+  expiresAt?: Date
+}
+
+/**
+ * Insert one cached output row (PK = (run_id, record_id)). `proposed_value` is
+ * defensively run through the shared redactor before insert (the provider text
+ * is model output, but the redactor is cheap defense in depth — same posture as
+ * the usage-ledger `error` column).
+ */
+export async function insertBulkPreviewCacheRow(
+  query: AiBulkPreviewCacheQueryFn,
+  row: BulkPreviewCacheRow,
+): Promise<void> {
+  const expiresAt = row.expiresAt ?? new Date(Date.now() + AI_BULK_PREVIEW_CACHE_TTL_MS)
+  await query(
+    `INSERT INTO ${AI_BULK_PREVIEW_CACHE_TABLE}
+       (run_id, record_id, actor_id, sheet_id, field_id, preview_version,
+        proposed_value, usage_tokens, cost_usd, expires_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+     ON CONFLICT (run_id, record_id) DO NOTHING`,
+    [
+      row.runId,
+      row.recordId,
+      row.actorId,
+      row.sheetId,
+      row.fieldId,
+      Math.max(0, Math.round(row.previewVersion)),
+      redactString(row.proposedValue),
+      Math.max(0, Math.round(row.usageTokens)),
+      row.costUsd,
+      expiresAt.toISOString(),
+    ],
+  )
+}
+
+/** Read all cached rows for a run (B-2 commit reads this). Exported for tests + the future commit ring. */
+export async function readBulkPreviewCacheRows(
+  query: AiBulkPreviewCacheQueryFn,
+  runId: string,
+): Promise<Array<{
+  runId: string
+  recordId: string
+  actorId: string
+  sheetId: string
+  fieldId: string
+  previewVersion: number
+  proposedValue: string
+  usageTokens: number
+  costUsd: number
+  expiresAt: string
+}>> {
+  const result = await query(
+    `SELECT run_id, record_id, actor_id, sheet_id, field_id, preview_version,
+            proposed_value, usage_tokens, cost_usd, expires_at
+       FROM ${AI_BULK_PREVIEW_CACHE_TABLE}
+      WHERE run_id = $1
+      ORDER BY created_at ASC`,
+    [runId],
+  )
+  return (result.rows as Array<Record<string, unknown>>).map((r) => ({
+    runId: String(r.run_id),
+    recordId: String(r.record_id),
+    actorId: String(r.actor_id),
+    sheetId: String(r.sheet_id),
+    fieldId: String(r.field_id),
+    previewVersion: Number(r.preview_version ?? 0),
+    proposedValue: String(r.proposed_value ?? ''),
+    usageTokens: Number(r.usage_tokens ?? 0),
+    costUsd: Number(r.cost_usd ?? 0),
+    expiresAt: String(r.expires_at),
+  }))
+}

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
@@ -1,0 +1,443 @@
+/**
+ * B-1 AI bulk-PREVIEW — REAL-DB suite.
+ *
+ * Design lock:
+ * docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md
+ *
+ * Locks the five B-1 acceptance subjects:
+ *  1. Mixed-permission LEAK gate (D5, fail-first): a row-level READ-denied row
+ *     is OMITTED entirely; a readable-but-not-writable row is `skipped_no_perm`
+ *     with NO generation; a readable row whose SOURCE field is denied generates
+ *     with the masked source NEVER in the prompt (captured fetch body) NOR the
+ *     diff, flagged `masked`.
+ *  2. Charge-on-generation GOLDEN (D1-A): provider-called rows are booked into
+ *     the existing usage ledger; skipped / no-usage rows book nothing; the
+ *     ledger token-sum delta == the provider usage-sum (== fetch calls).
+ *  3. D3-A cap → 400 BULK_SCOPE_TOO_LARGE + D4 quota-insufficient → refuse-zero.
+ *  4. Run-cache rows persisted with the full shape (one per generated output).
+ *  5. ZERO real provider calls (fetch is the injected construction seam).
+ *
+ * Provider HTTP is NEVER real — fetchFn is injected at router construction (the
+ * production seam) and returns a canned anthropic-shaped response. The outbound
+ * request BODY is captured so the mask assertion is over the REAL prompt, not a
+ * fixture (wire-vs-fixture-drift discipline).
+ *
+ * Wired into .github/workflows/plugin-tests.yml multitable real-DB explicit list.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { createMultitableAiRoutes } from '../../src/routes/multitable-ai'
+import { AI_USAGE_LEDGER_TABLE } from '../../src/services/ai-usage-ledger'
+import { AI_BULK_PREVIEW_CACHE_TABLE } from '../../src/services/ai-bulk-preview-cache'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_b1_${TS}`
+const SHEET_ID = `sheet_b1_${TS}`
+const VIEW_ID = `view_b1_${TS}`
+const FLD_SRC = `fld_b1_src_${TS}`
+const FLD_SECRET = `fld_b1_secret_${TS}` // a SOURCE field denied to the actor (layer-3)
+const FLD_TARGET = `fld_b1_target_${TS}`
+const FLD_FLAG = `fld_b1_flag_${TS}` // a filterable string field for the view-scope test
+
+// The actor under test (member with write — own-write scope added per test).
+const ACTOR = `u_b1_actor_${TS}`
+const OTHER = `u_b1_other_${TS}` // creator of the not-writable row
+
+// A distinctive sentinel placed in the DENIED source field — must never appear
+// in any outbound prompt body nor any response (the real leak assertion).
+const SECRET_SENTINEL = `SECRET-${'leakcanary'.repeat(2)}-${TS}`
+const API_KEY_SENTINEL = `sk-${'bulkleak000'.repeat(3)}`
+
+const AI_ENV_KEYS = [
+  'MULTITABLE_AI_ENABLED',
+  'MULTITABLE_AI_PROVIDER',
+  'MULTITABLE_AI_API_KEY',
+  'MULTITABLE_AI_BASE_URL',
+  'MULTITABLE_AI_MODEL',
+  'MULTITABLE_AI_REQUEST_TIMEOUT_MS',
+  'MULTITABLE_AI_MAX_OUTPUT_TOKENS',
+  'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_BURST_RPM',
+  'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP',
+  'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS',
+  'MULTITABLE_AI_BULK_MAX_ROWS',
+] as const
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+let stubUsage = { input_tokens: 20, output_tokens: 10 }
+let fetchCallCount = 0
+/** When true the provider stub returns a NON-200 with no usage = the genuine generation_failed_before_usage path. */
+let providerErrorMode = false
+const capturedBodies: string[] = []
+const savedEnv = new Map<string, string | undefined>()
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const fetchStub = (async (_url: unknown, init?: unknown) => {
+  fetchCallCount += 1
+  const body = (init as { body?: unknown } | undefined)?.body
+  if (typeof body === 'string') capturedBodies.push(body)
+  if (providerErrorMode) {
+    // Provider FAILURE with NO usage → AiCompletionResult.status='provider_error',
+    // usage=null → the core's generation_failed_before_usage (UNCHARGED) path.
+    return new Response(JSON.stringify({ error: 'upstream boom' }), { status: 500, headers: { 'content-type': 'application/json' } })
+  }
+  return new Response(
+    JSON.stringify({ content: [{ type: 'text', text: 'AI OUT' }], usage: { ...stubUsage } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  )
+}) as typeof fetch
+
+const bulkReq = (body: Record<string, unknown>) =>
+  request(app).post(`/api/multitable/sheets/${SHEET_ID}/ai/shortcut/bulk-preview`).send(body)
+
+const ledgerRows = async () => {
+  const res = await q(
+    `SELECT action, status, prompt_tokens, completion_tokens FROM ${AI_USAGE_LEDGER_TABLE} WHERE sheet_id = $1 ORDER BY occurred_at ASC`,
+    [SHEET_ID],
+  )
+  return res.rows as Array<{ action: string; status: string; prompt_tokens: number; completion_tokens: number }>
+}
+const ledgerTokenSum = async () => {
+  const res = await q(
+    `SELECT COALESCE(SUM(prompt_tokens + completion_tokens), 0) AS total FROM ${AI_USAGE_LEDGER_TABLE} WHERE sheet_id = $1`,
+    [SHEET_ID],
+  )
+  return Number((res.rows[0] as { total: string }).total)
+}
+const cacheRows = async (runId: string) => {
+  const res = await q(
+    `SELECT run_id, record_id, actor_id, sheet_id, field_id, preview_version, proposed_value, usage_tokens, cost_usd, expires_at
+       FROM ${AI_BULK_PREVIEW_CACHE_TABLE} WHERE run_id = $1 ORDER BY record_id ASC`,
+    [runId],
+  )
+  return res.rows as Array<Record<string, unknown>>
+}
+
+async function seedRecord(recordId: string, data: Record<string, unknown>, createdBy: string) {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [
+    recordId,
+    SHEET_ID,
+    JSON.stringify(data),
+    createdBy,
+  ])
+}
+
+/** Wipe the per-run side effects so each test starts from a clean ledger/cache. */
+async function resetLedgerAndCache() {
+  await q(`DELETE FROM ${AI_USAGE_LEDGER_TABLE} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+  await q(`DELETE FROM ${AI_BULK_PREVIEW_CACHE_TABLE} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+  fetchCallCount = 0
+  capturedBodies.length = 0
+}
+
+describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
+  beforeAll(async () => {
+    for (const key of AI_ENV_KEYS) {
+      savedEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    process.env.MULTITABLE_AI_ENABLED = '1'
+    process.env.MULTITABLE_AI_PROVIDER = 'anthropic'
+    process.env.MULTITABLE_AI_API_KEY = API_KEY_SENTINEL
+    process.env.MULTITABLE_AI_MODEL = 'claude-sonnet-4-6'
+    process.env.MULTITABLE_AI_CONFIRM_LIVE_REQUESTS = '1'
+
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = currentUser
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+    app.use('/api/multitable', createMultitableAiRoutes({ fetchFn: fetchStub }))
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'B1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'B1 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SRC, SHEET_ID, 'Notes', 'string', '{}', 1])
+    // FLD_SECRET is a SOURCE field of the shortcut, but layer-3 denied to the actor.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    // Target: persisted aiShortcut summarizing BOTH sources (so a denied source is detectable as masked).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [
+      FLD_TARGET,
+      SHEET_ID,
+      'Summary',
+      'string',
+      JSON.stringify({ aiShortcut: { kind: 'summarize', sourceFieldIds: [FLD_SRC, FLD_SECRET] } }),
+      3,
+    ])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FLAG, SHEET_ID, 'Flag', 'string', '{}', 4])
+
+    // Layer-3 deny FLD_SECRET to the actor (field_permissions: visible=false → denied read).
+    await q(
+      `INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only)
+       VALUES ($1,$2,'user',$3,false,false)`,
+      [SHEET_ID, FLD_SECRET, ACTOR],
+    )
+    // Enable row-level read-deny enforcement so an access_level='none' grant
+    // actually denies read on the per-record path (#18 is flag-gated).
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = true WHERE id = $1', [SHEET_ID])
+  })
+
+  afterAll(async () => {
+    await q(`DELETE FROM ${AI_USAGE_LEDGER_TABLE} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+    await q(`DELETE FROM ${AI_BULK_PREVIEW_CACHE_TABLE} WHERE sheet_id = $1`, [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+    for (const key of AI_ENV_KEYS) {
+      const value = savedEnv.get(key)
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
+  beforeEach(async () => {
+    currentUser = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    stubUsage = { input_tokens: 20, output_tokens: 10 }
+    providerErrorMode = false
+    // Reset per-test caps (a low cap leaking forward would turn later tests red).
+    process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = savedEnv.get('MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP') ?? ''
+    process.env.MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP = savedEnv.get('MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP') ?? ''
+    if (!process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP) delete process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP
+    if (!process.env.MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP) delete process.env.MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP
+    delete process.env.MULTITABLE_AI_BULK_MAX_ROWS
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await resetLedgerAndCache()
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ── Test 1: mixed-permission LEAK gate (fail-first) ───────────────────────
+  test('LEAK gate: read-deny omitted, unwritable skipped, masked-source never in prompt/diff', async () => {
+    // Own-write scope: actor may write only records they CREATED.
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+
+    // R_OK: actor-created, fully readable → GENERATED (masked because FLD_SECRET denied).
+    const R_OK = `rec_b1_ok_${TS}`
+    await seedRecord(R_OK, { [FLD_SRC]: 'public notes', [FLD_SECRET]: SECRET_SENTINEL }, ACTOR)
+    // R_READDENY: actor-created (so removing the read gate would GENERATE it — fail-first) but
+    // record-level read-DENIED → must be OMITTED from the response entirely.
+    const R_READDENY = `rec_b1_readdeny_${TS}`
+    await seedRecord(R_READDENY, { [FLD_SRC]: 'hidden row', [FLD_SECRET]: SECRET_SENTINEL }, ACTOR)
+    await q(
+      `INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,'user',$3,'none')`,
+      [SHEET_ID, R_READDENY, ACTOR],
+    )
+    // R_NOWRITE: created by SOMEONE ELSE → readable but own-write policy denies → skipped_no_perm.
+    const R_NOWRITE = `rec_b1_nowrite_${TS}`
+    await seedRecord(R_NOWRITE, { [FLD_SRC]: 'others row', [FLD_SECRET]: SECRET_SENTINEL }, OTHER)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+
+    const rowIds = (res.body.rows as Array<{ recordId: string }>).map((r) => r.recordId)
+    const skippedIds = (res.body.skipped as Array<{ recordId: string; reason: string }>)
+
+    // R_OK generated + flagged masked (FLD_SECRET dropped from its prompt).
+    expect(rowIds).toContain(R_OK)
+    const okRow = (res.body.rows as Array<{ recordId: string; masked: boolean; writable: boolean; proposed: string }>).find((r) => r.recordId === R_OK)!
+    expect(okRow.masked).toBe(true)
+    expect(okRow.writable).toBe(true)
+    expect(okRow.proposed).toBe('AI OUT')
+
+    // R_READDENY omitted from BOTH rows and skipped (never confirms existence).
+    expect(rowIds).not.toContain(R_READDENY)
+    expect(skippedIds.map((s) => s.recordId)).not.toContain(R_READDENY)
+
+    // R_NOWRITE skipped_no_perm, NOT generated.
+    expect(rowIds).not.toContain(R_NOWRITE)
+    expect(skippedIds).toContainEqual({ recordId: R_NOWRITE, reason: 'skipped_no_perm' })
+
+    // THE REAL LEAK ASSERTION (over the captured outbound prompt, not a fixture):
+    // the denied source sentinel appears in NO prompt body and NO response.
+    expect(capturedBodies.length).toBe(1) // only R_OK reached the provider
+    for (const body of capturedBodies) expect(body).not.toContain(SECRET_SENTINEL)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_SENTINEL)
+    // But the READABLE source DID enter the prompt (proves we didn't just drop everything).
+    expect(capturedBodies[0]).toContain('public notes')
+
+    expect(JSON.stringify(res.body)).not.toContain(API_KEY_SENTINEL)
+  })
+
+  // ── Test 2: charge-on-generation golden ───────────────────────────────────
+  test('charge-on-generation: provider-called rows booked; skipped books nothing; token-sum delta == provider usage', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    stubUsage = { input_tokens: 30, output_tokens: 12 } // 42 tokens/charged row
+
+    // 2 writable (actor) → charged; 1 not-writable (other) → skipped, no charge.
+    const C1 = `rec_b1_c1_${TS}`
+    const C2 = `rec_b1_c2_${TS}`
+    const C_SKIP = `rec_b1_cskip_${TS}`
+    await seedRecord(C1, { [FLD_SRC]: 'one' }, ACTOR)
+    await seedRecord(C2, { [FLD_SRC]: 'two' }, ACTOR)
+    await seedRecord(C_SKIP, { [FLD_SRC]: 'three' }, OTHER)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    expect((res.body.rows as unknown[]).length).toBe(2)
+    expect(res.body.skipped).toContainEqual({ recordId: C_SKIP, reason: 'skipped_no_perm' })
+
+    // Provider was called exactly once per charged row.
+    expect(fetchCallCount).toBe(2)
+
+    // Ledger: exactly the 2 charged preview rows, each at the ACTUAL usage; skipped books NOTHING.
+    const rows = await ledgerRows()
+    expect(rows.length).toBe(2)
+    expect(rows.every((r) => r.action === 'preview' && r.status === 'succeeded')).toBe(true)
+
+    // THE CHARGE INVARIANT: ledger token-sum == provider usage-sum (== calls × 42).
+    expect(await ledgerTokenSum()).toBe(2 * (30 + 12))
+    // settledCost is positive and only over charged rows.
+    expect(res.body.settledCost).toBeGreaterThan(0)
+  })
+
+  test('charge-on-generation: a provider failure with NO output books NOTHING (generation_failed_before_usage)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    // Provider FAILS (non-200, no usage) → generation_failed_before_usage → UNCHARGED + pauses batch.
+    providerErrorMode = true
+
+    const N1 = `rec_b1_n1_${TS}`
+    await seedRecord(N1, { [FLD_SRC]: 'will fail' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    expect((res.body.rows as unknown[]).length).toBe(0)
+    expect(res.body.skipped).toContainEqual({ recordId: N1, reason: 'generation_failed_before_usage' })
+
+    // Provider WAS reached, but produced no output / no usage → ledger token-sum stays 0 (booked nothing).
+    expect(fetchCallCount).toBe(1)
+    expect(await ledgerTokenSum()).toBe(0)
+  })
+
+  // ── Test 3: cap → 400 + quota-insufficient → refuse-zero ──────────────────
+  test('D3-A over-cap → 400 BULK_SCOPE_TOO_LARGE, nothing generated', async () => {
+    process.env.MULTITABLE_AI_BULK_MAX_ROWS = '2'
+    for (let i = 0; i < 3; i += 1) await seedRecord(`rec_b1_cap${i}_${TS}`, { [FLD_SRC]: `r${i}` }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('BULK_SCOPE_TOO_LARGE')
+    expect(res.body.error.total).toBe(3)
+    expect(res.body.error.cap).toBe(2)
+    expect(fetchCallCount).toBe(0) // generated nothing
+    expect(await ledgerTokenSum()).toBe(0)
+  })
+
+  test('D4 quota-insufficient → AI_BULK_QUOTA_INSUFFICIENT, generates nothing', async () => {
+    // Per-row estimate ≈ conservativePromptTokenEstimate('') + maxOutputTokens(1024) ≈ 1024.
+    // Cap 1500 fits ONE row but not TWO → the whole 2-row run is refused up front.
+    process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = '1500'
+    await seedRecord(`rec_b1_q1_${TS}`, { [FLD_SRC]: 'a' }, ACTOR)
+    await seedRecord(`rec_b1_q2_${TS}`, { [FLD_SRC]: 'b' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(429)
+    expect(res.body.error.code).toBe('AI_BULK_QUOTA_INSUFFICIENT')
+    expect(fetchCallCount).toBe(0) // generate NOTHING
+    expect(await ledgerTokenSum()).toBe(0)
+  })
+
+  // ── Test 4: run-cache rows persisted with the full shape ──────────────────
+  test('run-cache: one persisted row per generated output with the full shape', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    stubUsage = { input_tokens: 7, output_tokens: 3 }
+    const K1 = `rec_b1_k1_${TS}`
+    const K2 = `rec_b1_k2_${TS}`
+    await seedRecord(K1, { [FLD_SRC]: 'kache one' }, ACTOR)
+    await seedRecord(K2, { [FLD_SRC]: 'kache two' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    const runId = res.body.runId as string
+    expect(runId).toMatch(/^aibulk_/)
+
+    const cached = await cacheRows(runId)
+    expect(cached.length).toBe(2)
+    for (const row of cached) {
+      expect(row.run_id).toBe(runId)
+      expect(row.actor_id).toBe(ACTOR)
+      expect(row.sheet_id).toBe(SHEET_ID)
+      expect(row.field_id).toBe(FLD_TARGET)
+      expect([K1, K2]).toContain(row.record_id)
+      expect(Number(row.preview_version)).toBe(1)
+      expect(row.proposed_value).toBe('AI OUT')
+      expect(Number(row.usage_tokens)).toBe(7 + 3)
+      expect(Number(row.cost_usd)).toBeGreaterThan(0)
+      expect(row.expires_at).toBeTruthy()
+    }
+    // The response rows carry the version that rides into B-2 as expectedVersion.
+    for (const r of res.body.rows as Array<{ version: number }>) expect(r.version).toBe(1)
+  })
+
+  // ── D2-A: server-resolved FULL filtered set (view scope) ──────────────────
+  test('D2-A view scope: only filter-matching rows generate (full filtered set, not a page)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    // View filters FLD_FLAG == 'keep'.
+    await q(
+      `INSERT INTO meta_views (id, sheet_id, name, type, filter_info) VALUES ($1,$2,$3,'grid',$4::jsonb)`,
+      [VIEW_ID, SHEET_ID, 'Keep view', JSON.stringify({ conjunction: 'and', conditions: [{ fieldId: FLD_FLAG, operator: 'is', value: 'keep' }] })],
+    )
+    const M1 = `rec_b1_m1_${TS}`
+    const M2 = `rec_b1_m2_${TS}`
+    const DROP = `rec_b1_drop_${TS}`
+    await seedRecord(M1, { [FLD_SRC]: 'm1', [FLD_FLAG]: 'keep' }, ACTOR)
+    await seedRecord(M2, { [FLD_SRC]: 'm2', [FLD_FLAG]: 'keep' }, ACTOR)
+    await seedRecord(DROP, { [FLD_SRC]: 'drop', [FLD_FLAG]: 'skip' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'view', viewId: VIEW_ID })
+    expect(res.status).toBe(200)
+    const rowIds = (res.body.rows as Array<{ recordId: string }>).map((r) => r.recordId).sort()
+    expect(rowIds).toEqual([M1, M2].sort())
+    expect(rowIds).not.toContain(DROP)
+    expect(fetchCallCount).toBe(2) // only the filtered set generated
+  })
+
+  // ── Contract guards: inline config rejected; response shape pinned ────────
+  test('inline config is rejected (run parity)', async () => {
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet', config: { kind: 'summarize', sourceFieldIds: [FLD_SRC] } })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('AI_INLINE_CONFIG_REJECTED')
+    expect(fetchCallCount).toBe(0)
+  })
+
+  test('response top-level shape is pinned (fixture-drift discipline)', async () => {
+    await seedRecord(`rec_b1_shape_${TS}`, { [FLD_SRC]: 'x' }, ACTOR)
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    expect(Object.keys(res.body).sort()).toEqual(['capped', 'rows', 'runId', 'settledCost', 'skipped'])
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
@@ -76,6 +76,8 @@ let stubUsage = { input_tokens: 20, output_tokens: 10 }
 let fetchCallCount = 0
 /** When true the provider stub returns a NON-200 with no usage = the genuine generation_failed_before_usage path. */
 let providerErrorMode = false
+/** When true the stub returns NON-200 but WITH usage = provider_error-WITH-usage → core 'charged' + !ok (charged-failure). */
+let providerErrorWithUsageMode = false
 const capturedBodies: string[] = []
 const savedEnv = new Map<string, string | undefined>()
 
@@ -89,6 +91,11 @@ const fetchStub = (async (_url: unknown, init?: unknown) => {
     // Provider FAILURE with NO usage → AiCompletionResult.status='provider_error',
     // usage=null → the core's generation_failed_before_usage (UNCHARGED) path.
     return new Response(JSON.stringify({ error: 'upstream boom' }), { status: 500, headers: { 'content-type': 'application/json' } })
+  }
+  if (providerErrorWithUsageMode) {
+    // NON-200 but the body carries usage → extractUsageFromBody finds it + !response.ok
+    // → providerError(usage) → core 'charged' + !result.ok (a CHARGED failure, not a success).
+    return new Response(JSON.stringify({ error: 'billed but failed', usage: { ...stubUsage } }), { status: 500, headers: { 'content-type': 'application/json' } })
   }
   return new Response(
     JSON.stringify({ content: [{ type: 'text', text: 'AI OUT' }], usage: { ...stubUsage } }),
@@ -209,6 +216,7 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
     currentUser = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
     stubUsage = { input_tokens: 20, output_tokens: 10 }
     providerErrorMode = false
+    providerErrorWithUsageMode = false
     // Reset per-test caps (a low cap leaking forward would turn later tests red).
     process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = savedEnv.get('MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP') ?? ''
     process.env.MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP = savedEnv.get('MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP') ?? ''
@@ -337,6 +345,58 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
     expect(await ledgerTokenSum()).toBe(0)
   })
 
+  test('charge: provider_error WITH usage → CHARGED, NO cache row, NO writable row (charged-failure)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    stubUsage = { input_tokens: 30, output_tokens: 12 }
+    providerErrorWithUsageMode = true // provider billed usage but returned an error → charged + !ok
+
+    const E1 = `rec_b1_e1_${TS}`
+    await seedRecord(E1, { [FLD_SRC]: 'billed but failed' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    // NOT a confirmable/writable row, and NOT in `skipped` (it WAS charged).
+    expect((res.body.rows as unknown[]).length).toBe(0)
+    expect(res.body.failures).toContainEqual({ recordId: E1, reason: 'provider_error_charged' })
+
+    // CHARGED: provider spend is real — the ledger booked the usage even with no output.
+    expect(fetchCallCount).toBe(1)
+    expect(await ledgerTokenSum()).toBe(30 + 12)
+    // NO cached output → B-2 can never confirm it.
+    expect((await cacheRows(res.body.runId as string)).length).toBe(0)
+  })
+
+  test('cache insert failure → CHARGED but fail-closed (cache_failed_after_generation), NO confirmable row', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    stubUsage = { input_tokens: 25, output_tokens: 11 }
+
+    const F1 = `rec_b1_cachefail_${TS}`
+    await seedRecord(F1, { [FLD_SRC]: 'generates ok but the cache write breaks' }, ACTOR)
+
+    // Force a GENUINE cache INSERT failure: rename the cache table away for the run.
+    await q(`ALTER TABLE ${AI_BULK_PREVIEW_CACHE_TABLE} RENAME TO ${AI_BULK_PREVIEW_CACHE_TABLE}_bak`)
+    try {
+      const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+      expect(res.status).toBe(200)
+      // Provider succeeded + billed, but the cache write failed → FAIL-CLOSED:
+      // NOT a writable/confirmable row; recorded as a CHARGED failure.
+      expect((res.body.rows as unknown[]).length).toBe(0)
+      expect(res.body.failures).toContainEqual({ recordId: F1, reason: 'cache_failed_after_generation' })
+      // CHARGED: the provider was called + billed despite the cache failure (ledger table is NOT renamed).
+      expect(fetchCallCount).toBe(1)
+      expect(await ledgerTokenSum()).toBe(25 + 11)
+    } finally {
+      // ALWAYS restore the table so subsequent tests + reset hooks work.
+      await q(`ALTER TABLE ${AI_BULK_PREVIEW_CACHE_TABLE}_bak RENAME TO ${AI_BULK_PREVIEW_CACHE_TABLE}`)
+    }
+  })
+
   // ── Test 3: cap → 400 + quota-insufficient → refuse-zero ──────────────────
   test('D3-A over-cap → 400 BULK_SCOPE_TOO_LARGE, nothing generated', async () => {
     process.env.MULTITABLE_AI_BULK_MAX_ROWS = '2'
@@ -438,6 +498,6 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
     await seedRecord(`rec_b1_shape_${TS}`, { [FLD_SRC]: 'x' }, ACTOR)
     const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
     expect(res.status).toBe(200)
-    expect(Object.keys(res.body).sort()).toEqual(['capped', 'rows', 'runId', 'settledCost', 'skipped'])
+    expect(Object.keys(res.body).sort()).toEqual(['capped', 'failures', 'rows', 'runId', 'settledCost', 'skipped'])
   })
 })

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
@@ -425,6 +425,78 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
     expect(await ledgerTokenSum()).toBe(0)
   })
 
+  test('cap counts ONLY provider-bound rows: read-denied rows over the cap do NOT 400 (no hidden-row oracle)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    process.env.MULTITABLE_AI_BULK_MAX_ROWS = '1' // cap = 1 GENERATABLE row
+
+    const G1 = `rec_b1_capok_${TS}`
+    await seedRecord(G1, { [FLD_SRC]: 'generate me' }, ACTOR)
+    // 3 read-denied rows (actor-created so WRITE would pass; the READ gate omits them) →
+    // raw candidates = 4 > cap, but generatable = 1. Pre-fix this 400'd AND leaked total=4.
+    for (let i = 0; i < 3; i += 1) {
+      const H = `rec_b1_caphidden${i}_${TS}`
+      await seedRecord(H, { [FLD_SRC]: 'hidden' }, ACTOR)
+      await q(
+        `INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,'user',$3,'none')`,
+        [SHEET_ID, H, ACTOR],
+      )
+    }
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200) // NOT 400 — hidden rows are never counted toward the cap
+    expect((res.body.rows as unknown[]).length).toBe(1)
+    expect(fetchCallCount).toBe(1)
+  })
+
+  test('quota counts ONLY provider-bound rows: many unwritable rows do NOT trip AI_BULK_QUOTA_INSUFFICIENT', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    // Cap 1500 fits ONE generatable row (~1024) but not two (same math as the Test 3 quota case).
+    process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = '1500'
+
+    await seedRecord(`rec_b1_qok_${TS}`, { [FLD_SRC]: 'mine' }, ACTOR) // 1 writable
+    // 5 NOT-writable rows (created by OTHER) → skipped_no_perm, NOT counted toward quota.
+    // Pre-fix, the estimate over 6 rows (~6144) would have 429'd the whole run.
+    for (let i = 0; i < 5; i += 1) await seedRecord(`rec_b1_qother${i}_${TS}`, { [FLD_SRC]: 'theirs' }, OTHER)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200) // NOT 429 — unwritable rows are never counted toward the quota
+    expect((res.body.rows as unknown[]).length).toBe(1)
+    expect((res.body.skipped as Array<{ reason: string }>).filter((s) => s.reason === 'skipped_no_perm').length).toBe(5)
+  })
+
+  test('view filter on a COMPUTED (formula) field → 422 AI_BULK_VIEW_FILTER_UNSUPPORTED, generates NOTHING (no out-of-view rows)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    const FLD_FORMULA = `fld_b1_formula_${TS}`
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FORMULA, SHEET_ID, 'Calc', 'formula', '{}', 9])
+    const CVIEW = `view_b1_computed_${TS}`
+    await q(
+      `INSERT INTO meta_views (id, sheet_id, name, type, filter_info) VALUES ($1,$2,$3,'grid',$4::jsonb)`,
+      [CVIEW, SHEET_ID, 'Computed view', JSON.stringify({ conjunction: 'and', conditions: [{ fieldId: FLD_FORMULA, operator: 'is', value: 'x' }] })],
+    )
+    // Rows the formula filter would exclude in the grid — they must NOT be generated.
+    await seedRecord(`rec_b1_cf1_${TS}`, { [FLD_SRC]: 'a' }, ACTOR)
+    await seedRecord(`rec_b1_cf2_${TS}`, { [FLD_SRC]: 'b' }, ACTOR)
+
+    try {
+      const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'view', viewId: CVIEW })
+      expect(res.status).toBe(422) // refused — never match-all, never out-of-view generation
+      expect(res.body.error.code).toBe('AI_BULK_VIEW_FILTER_UNSUPPORTED')
+      expect(fetchCallCount).toBe(0)
+    } finally {
+      // meta_fields isn't reset between tests — drop the formula field so it can't perturb others.
+      await q('DELETE FROM meta_fields WHERE id = $1', [FLD_FORMULA]).catch(() => {})
+    }
+  })
+
   // ── Test 4: run-cache rows persisted with the full shape ──────────────────
   test('run-cache: one persisted row per generated output with the full shape', async () => {
     await q(

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-preview.test.ts
@@ -73,6 +73,7 @@ const AI_ENV_KEYS = [
 let app: Express
 let currentUser: { id: string; roles: string[]; perms: string[] } = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
 let stubUsage = { input_tokens: 20, output_tokens: 10 }
+let stubText = 'AI OUT'
 let fetchCallCount = 0
 /** When true the provider stub returns a NON-200 with no usage = the genuine generation_failed_before_usage path. */
 let providerErrorMode = false
@@ -98,7 +99,7 @@ const fetchStub = (async (_url: unknown, init?: unknown) => {
     return new Response(JSON.stringify({ error: 'billed but failed', usage: { ...stubUsage } }), { status: 500, headers: { 'content-type': 'application/json' } })
   }
   return new Response(
-    JSON.stringify({ content: [{ type: 'text', text: 'AI OUT' }], usage: { ...stubUsage } }),
+    JSON.stringify({ content: [{ type: 'text', text: stubText }], usage: { ...stubUsage } }),
     { status: 200, headers: { 'content-type': 'application/json' } },
   )
 }) as typeof fetch
@@ -215,6 +216,7 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
   beforeEach(async () => {
     currentUser = { id: ACTOR, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
     stubUsage = { input_tokens: 20, output_tokens: 10 }
+    stubText = 'AI OUT'
     providerErrorMode = false
     providerErrorWithUsageMode = false
     // Reset per-test caps (a low cap leaking forward would turn later tests red).
@@ -564,6 +566,28 @@ describeIfDatabase('B-1 AI bulk-preview (real DB)', () => {
     expect(res.status).toBe(400)
     expect(res.body.error.code).toBe('AI_INLINE_CONFIG_REJECTED')
     expect(fetchCallCount).toBe(0)
+  })
+
+  test('cache stores the EXACT previewed value — no redaction (confirm-what-you-see == what B-2 writes)', async () => {
+    await q(
+      `INSERT INTO spreadsheet_permissions (sheet_id, subject_type, subject_id, perm_code) VALUES ($1,'user',$2,$3)`,
+      [SHEET_ID, ACTOR, 'multitable:write-own'],
+    )
+    // An output that WOULD trip the shared redactor (contains a sk- token). The cache
+    // must store it VERBATIM so B-2 commits exactly what the preview showed — and so it
+    // matches the per-record run, which writes the raw model text. Pre-fix, the cache
+    // held the redacted form → B-2 would write a value the user never confirmed.
+    stubText = `summary ${API_KEY_SENTINEL} end`
+    const X1 = `rec_b1_exact_${TS}`
+    await seedRecord(X1, { [FLD_SRC]: 'redactor-triggering output' }, ACTOR)
+
+    const res = await bulkReq({ fieldId: FLD_TARGET, scope: 'sheet' })
+    expect(res.status).toBe(200)
+    const previewRow = (res.body.rows as Array<{ recordId: string; proposed: string }>).find((r) => r.recordId === X1)!
+    expect(previewRow.proposed).toBe(stubText) // preview returns the raw value
+    const cached = await cacheRows(res.body.runId as string)
+    // cache == preview, NOT redacted (the sk- token survives verbatim).
+    expect(cached.find((c) => c.record_id === X1)!.proposed_value).toBe(stubText)
   })
 
   test('response top-level shape is pinned (fixture-drift discipline)', async () => {


### PR DESCRIPTION
First impl ring of the ratified design-lock #3019 (D1–D6). **Preview only** — generates proposed values across the view's filtered set, charges at generation, caches; no writing (that's B-2). Extends the per-record `shortcut/run` pipeline (same gates, ledger, reserve-then-settle), not a fork.

**Faithful to the ratified D1–D6:**
- **D1-A charge-on-generation / never-release:** tagged-union `charged | quota_exhausted | reserve_failed | generation_failed_before_usage`; only `charged` consumed the provider+quota; `settle` re-settles STATUS keeping usage. No release path.
- **D2** server-resolved filtered set (`parseMetaFilterInfo`+`evaluateFilterNode`, not a page). **D3-A** hard cap → `400 BULK_SCOPE_TOO_LARGE`. **D4** whole-run pre-check → `AI_BULK_QUOTA_INSUFFICIENT` (generate nothing).
- **D5** per-row gates: read-denied → omitted (no existence oracle); not-writable → `skipped_no_perm` (no generation); diff `masked` flag when a source field is dropped by the viewer's read mask.
- New persistent run-cache (`ai_bulk_preview_cache` migration + `ai-bulk-preview-cache.ts`); new `POST …/ai/shortcut/bulk-preview`.

**Verification:** backend tsc 0; structural guards 70/70 (egress/taint/record-lock/raw-projection); the 10 real-DB goldens (leak gate, charge-on-generation, no-usage-uncharged, over-cap, quota, run-cache shape, view-scope, inline-reject, shape-pinned, DB sentinel) **skip locally without Postgres → must verify in CI test 20.x.**

Note: built via an agent that hit a stream-idle stall after committing but before its own final review/push — recovered from the clean commit; I reviewed the route + test list before pushing. Please review the leak gate + charge boundary; I'll hold merge until CI (real-DB) is green + your APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)