### PR TITLE
docs(multitable): restore diff-unify design-lock (pure-extract reconciliation record)

### DIFF
--- a/docs/development/multitable-restore-diff-unify-designlock-20260621.md
+++ b/docs/development/multitable-restore-diff-unify-designlock-20260621.md
@@ -1,0 +1,75 @@
+# Restore Diff Unification — DESIGN-LOCK / IMPL NOTE (pure extract, reconciliation record)
+
+> Owner-ratified follow-up (T6 P3). Collapse the diff logic in the THREE restore routes (`/restore`,
+> `restore-preview` T5-2, `restore-execute` T6-2) onto ONE shared helper. **This is a RECONCILIATION record, not
+> a dedup record:** `/restore` predates the other two, which were independently *mirrored* — so the three are not
+> copies, they are three implementations that mostly agree. "Zero behavior change" is therefore not literally
+> achievable; the one place they disagree is named below and resolved to a declared canonical, proven by the
+> existing goldens staying green on reachable inputs.
+
+## 1. The three locked constraints (owner)
+
+1. **The helper is a DIFF PRODUCER, never a permission authority.** It computes the canonical raw diff from
+   already-resolved inputs; it makes no permission decision and reads no permission state.
+2. **schema-drift, row-deny, and the write/field gate stay at each route's existing layer** — the helper does NOT
+   absorb them. (Refinement, per review: the helper produces ONLY the raw diff — there is NO "masked diff"
+   variant in the helper, because masking is exactly where permission lives. Each route computes its own allowed
+   set and filters the raw diff itself: `restore-preview`/`restore-execute` via `loadAllowedFieldIds` +
+   `maskStoredRecordFieldIds`; `/restore` via `fieldIds`-selection + `canSeeField` + the `hasForbidden` gate.
+   With no mask in the helper, constraints #1 and #2 hold by construction, and the `changesHash` stays computed
+   over the route's own masked set.)
+3. **Behavioral equivalence is PROVEN, not asserted** — by the existing goldens (unchanged assertions) + an
+   end-to-end golden. No "while I'm in here" fixes beyond the one declared canonicalization in §3.
+
+## 2. Reconciliation diff (all shared pieces compared, char-for-char)
+
+| piece | `/restore` | `restore-preview` (T5-2) | `restore-execute` (T6-2) | verdict |
+|---|---|---|---|---|
+| non-restorable set | `NON_RESTORABLE_TYPES` (11) | `NON_RESTORABLE` (11) | `NON_RESTORABLE` (11) | **identical** (same 11 members, same spelling) |
+| scalar equality | `sameValue` | `sameVal` | `sameVal` | **identical** (`JSON.stringify(a ?? null) === …`) |
+| loop body | button-skip → link-branch → non-restorable-skip → inSnap set / inCur unset | same | same | **identical** logic/ordering |
+| link equality | `sameLinkSet` — `.every()` set-compare | `sameLinks` — `.sort().join(' ')` | `sameLinks` — `.sort().join(' ')` | **DIVERGES → §3** |
+| change shape | full `RecordChange` `{recordId,fieldId,value,expectedVersion,op}` | `{fieldId,op,value}` | full `RecordChange` | projection only (not behavior) |
+
+## 3. The ONE canonicalization — link equality
+
+`sameLinks` (`[...a].sort().join(' ') === [...b].sort().join(' ')`) has a **delimiter collision**: `['a b']` and
+`['a','b']` both serialize to `'a b'`. This is reachable — `normalizeLinkIds` parses a legacy `'a b,c'` value into
+`['a b','c']`, so a space-bearing token can occur. `/restore`'s `sameLinkSet` (length check + sorted `.every()`)
+has no collision.
+
+- **Canonical = `/restore`'s `sameLinkSet` (robust set-equality).** Rationale: (a) it leaves the SHIPPED
+  destructive write path byte-identical — only the two newer paths converge, minimizing blast radius where it is
+  worst; (b) it is the correct one; (c) on every input the common path produces, `.every()` and `.join(' ')` are
+  identical, so it is behavior-preserving on the reachable, golden-covered space.
+- **Declared delta:** `restore-preview` + `restore-execute` change behavior ONLY for a link value containing a
+  space-bearing id, where they previously could mis-report two ids as equal. Bounded: a wrong preview "would
+  change"; a real `restore-execute` write hits the spine's link-target validation and fails closed. This is the
+  single declared behavior change of this slice — surfaced, not silently applied.
+
+## 4. The helper (raw-diff producer)
+
+`packages/core-backend/src/multitable/record-restore-diff.ts`:
+```
+computeRecordRestoreDiff(args: {
+  fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion
+}): RecordChange[]
+```
+Produces the canonical raw diff (`RecordChange[]`, the full shape). Pure (no I/O, no permission). The shared
+`NON_RESTORABLE_TYPES`, `isRestorableType`, `sameValue`, and the canonical `sameLinkSet` move into this module.
+Call sites: `/restore` uses the result directly; `restore-execute` uses it directly; `restore-preview` maps each
+`RecordChange` to its `{fieldId, op, value}` projection (drop `recordId`/`expectedVersion`) before hashing/masking.
+
+## 5. Acceptance (the gate — equivalence is proven, not asserted)
+
+- The existing goldens stay green with **UNCHANGED assertions**: `/restore` **35/35**, `restore-preview` **6/6**,
+  `restore-execute` **7/7**. (A required assertion edit = a behavior change = STOP.)
+- The **end-to-end** preview→execute golden (T6-2) stays green (the cross-path consistency the helper must preserve).
+- **One new golden** on the helper: the canonical `sameLinkSet` distinguishes `['a b']` from `['a','b']` — pins
+  the §3 choice + blocks a future "simplification" back to `.join(' ')`.
+- `tsc` 0; no migration; no route behavior change beyond the §3 declared delta.
+
+## 6. Out of scope (NOT this slice)
+
+Per-field-through-preview; batch/scope identity; any change to schema-drift / row-deny / write-gate / field-mask /
+expectedVersion / return codes. The helper is extraction-only; everything permission-bearing stays in the routes.


### PR DESCRIPTION
Owner-ratified T6 follow-up **(1)**: the design-lock/impl note (note-first, before any code) for collapsing the diff logic in `/restore` + `restore-preview` (T5-2) + `restore-execute` (T6-2) onto one shared helper.

Written as a **reconciliation record, not a dedup record** — `/restore` predates the other two (independently *mirrored*), so they're three implementations that mostly agree, and "zero behavior change" isn't literally achievable. The one divergence is named and resolved.

## Locks your three constraints
1. helper = **diff producer, never a permission authority**;
2. schema-drift / row-deny / write-gate **stay in each route** — refined to **raw-diff-only** (no masked variant in the helper; masking is where permission lives, so routes filter the raw diff themselves — your constraint #2 holds by construction);
3. equivalence **proven by unchanged goldens + e2e**, no convenient fixes.

## Reconciliation result
`NON_RESTORABLE` (11), `sameValue`, loop body — **byte-identical** across all three. **One** divergence: link equality (`/restore`'s robust `.every()` vs T5-2/T6-2's `.join(' ')`, which collides `['a b']` vs `['a','b']` — reachable via `normalizeLinkIds` legacy parse). **Canonical = `/restore`'s robust impl** (shipped write path stays byte-identical; the two newer paths converge = the single **declared** behavior delta, bounded).

## Gate
`/restore` 35 + preview 6 + execute 7 goldens green with **unchanged assertions** + e2e + one new golden pinning the canonical. Impl (`record-restore-diff.ts`) is the next slice, **gated on your ratification of this note** + the two decisions in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)