### PR TITLE
feat(approval): delegation (委托) runtime — backend (resolver substitution + bake + storage)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -297,6 +297,7 @@ jobs:
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \
+            tests/integration/approval-delegation-seam.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/packages/core-backend/src/db/migrations/zzzz20260622060000_create_approval_delegations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260622060000_create_approval_delegations.ts
@@ -31,13 +31,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       CONSTRAINT chk_approval_delegations_window CHECK (end_at > start_at),
       CONSTRAINT chk_approval_delegations_not_self CHECK (delegator_user_id <> delegatee_user_id),
       CONSTRAINT chk_approval_delegations_scope CHECK (scope IN ('all', 'template')),
+      -- Bidirectional: scope='template' REQUIRES a target, and scope='all' REQUIRES
+      -- scope_template_id IS NULL (an 'all' row with a stray target would be ambiguous,
+      -- since resolveActiveDelegationMap ignores scope_template_id for 'all' rows).
       CONSTRAINT chk_approval_delegations_scope_target
-        CHECK (scope <> 'template' OR scope_template_id IS NOT NULL)
+        CHECK ((scope = 'template') = (scope_template_id IS NOT NULL))
     )
   `.execute(db)
 
-  // One ACTIVE delegation per (delegator, scope target) — rejects overlapping active
-  // windows (v1: a delegator has at most one active delegation per scope target).
+  // v1 semantics: at most ONE active delegation per (delegator, scope target) — i.e.
+  // "one enabled row per scope target", NOT time-range-overlap scheduling. Two active
+  // rows are rejected even with non-overlapping future windows; multi-window scheduling
+  // (range-overlap exclusion / CRUD overlap validation) is a reopen-only enhancement.
   // COALESCE keeps 'all'-scope rows unique without a partial-null collision.
   await sql`
     CREATE UNIQUE INDEX IF NOT EXISTS uq_approval_delegations_active

--- a/packages/core-backend/src/db/migrations/zzzz20260622060000_create_approval_delegations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260622060000_create_approval_delegations.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration: approval delegation (委托) config store
+ *
+ * Purpose: persist time-boxed delegations so a delegator's resolved approval
+ * assignments route to a delegatee. The runtime is read-only at resolve time —
+ * active delegations are frozen into the instance snapshot at create and applied
+ * inside ApprovalAssigneeResolver.pushResolved; this table is the config source.
+ * Tables: approval_delegations (new).
+ * Breaking: No — new table, additive.
+ */
+
+import { sql, type Kysely } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'approval_delegations')
+  if (exists) return
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS approval_delegations (
+      id TEXT PRIMARY KEY,
+      delegator_user_id TEXT NOT NULL,
+      delegatee_user_id TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'all',
+      scope_template_id TEXT,
+      start_at TIMESTAMPTZ NOT NULL,
+      end_at TIMESTAMPTZ NOT NULL,
+      active BOOLEAN NOT NULL DEFAULT TRUE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT chk_approval_delegations_window CHECK (end_at > start_at),
+      CONSTRAINT chk_approval_delegations_not_self CHECK (delegator_user_id <> delegatee_user_id),
+      CONSTRAINT chk_approval_delegations_scope CHECK (scope IN ('all', 'template')),
+      CONSTRAINT chk_approval_delegations_scope_target
+        CHECK (scope <> 'template' OR scope_template_id IS NOT NULL)
+    )
+  `.execute(db)
+
+  // One ACTIVE delegation per (delegator, scope target) — rejects overlapping active
+  // windows (v1: a delegator has at most one active delegation per scope target).
+  // COALESCE keeps 'all'-scope rows unique without a partial-null collision.
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_approval_delegations_active
+      ON approval_delegations (delegator_user_id, scope, COALESCE(scope_template_id, ''))
+      WHERE active
+  `.execute(db)
+
+  // Resolve-time lookup: active delegations matching a template + the create instant.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_delegations_lookup
+      ON approval_delegations (active, scope, scope_template_id, start_at, end_at)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS approval_delegations`.execute(db)
+}

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -92,32 +92,23 @@ function extractDelegationMap(snapshot: Record<string, unknown> | null): Record<
 export function resolveApprovalAssignees(
   options: ResolveApprovalAssigneesOptions,
 ): ResolvedApprovalAssignment[] {
-  const sources = options.config.assigneeSources
-  if (!sources) {
-    return (options.config.assigneeIds ?? []).map((assigneeId) => ({
-      assignmentType: options.config.assigneeType === 'role' ? 'role' : 'user',
-      assigneeId,
-      nodeKey: options.nodeKey,
-      sourceStep: options.sourceStep,
-    }))
-  }
-
   const resolved: ResolvedApprovalAssignment[] = []
   const seen = new Set<string>()
   // Delegation substitution map (delegator -> delegatee), frozen in the instance
-  // snapshot at create. Applied inside pushResolved BEFORE the dedup key.
+  // snapshot at create. Applied inside pushResolved BEFORE the dedup key — so it
+  // covers BOTH the legacy assigneeIds path and the assigneeSources path.
   const delegations = extractDelegationMap(options.requesterSnapshot)
 
   const pushResolved = (
     assignmentType: 'user' | 'role',
     assigneeId: string,
-    source: ApprovalAssigneeSource,
+    source: ApprovalAssigneeSource | null,
     sourceIndex: number,
   ): void => {
     // Delegation (委托): a resolved USER assignee who is an active delegator routes to
     // the delegatee. Substituted HERE — before the dedup key — so `seen` dedups on the
-    // delegatee: a delegatee already resolved by another source collapses to one. One
-    // hop only (the delegatee's own delegation is not re-resolved); user-only.
+    // delegatee: a delegatee already resolved collapses to one. One hop only (the
+    // delegatee's own delegation is not re-resolved); user-only.
     let finalId = assigneeId
     let delegatedFrom: string | undefined
     if (assignmentType === 'user') {
@@ -130,14 +121,30 @@ export function resolveApprovalAssignees(
     const key = `${assignmentType}:${finalId}`
     if (seen.has(key)) return
     seen.add(key)
-    const metadata = metadataFor(source, sourceIndex)
+    // Legacy (no source) stays metadata-free UNLESS a delegation applied — then it
+    // carries `delegatedFrom` only (no `resolvedFrom`, so downstream dynamic-source
+    // discriminators still treat it as a legacy/non-dynamic assignment).
+    const base = source ? metadataFor(source, sourceIndex) : undefined
+    const metadata = delegatedFrom ? { ...(base ?? {}), delegatedFrom } : base
     resolved.push({
       assignmentType,
       assigneeId: finalId,
       nodeKey: options.nodeKey,
       sourceStep: options.sourceStep,
-      metadata: delegatedFrom ? { ...metadata, delegatedFrom } : metadata,
+      ...(metadata ? { metadata } : {}),
     })
+  }
+
+  const sources = options.config.assigneeSources
+  if (!sources) {
+    // Legacy assigneeType/assigneeIds — routed through pushResolved so delegation
+    // applies to existing templates too (delegation is a property of the approval task,
+    // not only newly-authored assigneeSources). Metadata-free unless a delegation hits.
+    const legacyType: 'user' | 'role' = options.config.assigneeType === 'role' ? 'role' : 'user'
+    for (const assigneeId of options.config.assigneeIds ?? []) {
+      pushResolved(legacyType, assigneeId, null, 0)
+    }
+    return resolved
   }
 
   sources.forEach((source, sourceIndex) => {

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -75,6 +75,20 @@ function assertFormUserSource(
   }
 }
 
+// Delegation map (delegator localUserId -> delegatee localUserId), read from the
+// frozen instance snapshot. Both ids normalized; malformed entries dropped.
+function extractDelegationMap(snapshot: Record<string, unknown> | null): Record<string, string> {
+  const raw = snapshot?.delegations
+  if (!isRecord(raw)) return {}
+  const map: Record<string, string> = {}
+  for (const [delegator, delegatee] of Object.entries(raw)) {
+    const d = normalizeId(delegator)
+    const t = normalizeId(delegatee)
+    if (d && t) map[d] = t
+  }
+  return map
+}
+
 export function resolveApprovalAssignees(
   options: ResolveApprovalAssigneesOptions,
 ): ResolvedApprovalAssignment[] {
@@ -90,6 +104,9 @@ export function resolveApprovalAssignees(
 
   const resolved: ResolvedApprovalAssignment[] = []
   const seen = new Set<string>()
+  // Delegation substitution map (delegator -> delegatee), frozen in the instance
+  // snapshot at create. Applied inside pushResolved BEFORE the dedup key.
+  const delegations = extractDelegationMap(options.requesterSnapshot)
 
   const pushResolved = (
     assignmentType: 'user' | 'role',
@@ -97,15 +114,29 @@ export function resolveApprovalAssignees(
     source: ApprovalAssigneeSource,
     sourceIndex: number,
   ): void => {
-    const key = `${assignmentType}:${assigneeId}`
+    // Delegation (委托): a resolved USER assignee who is an active delegator routes to
+    // the delegatee. Substituted HERE — before the dedup key — so `seen` dedups on the
+    // delegatee: a delegatee already resolved by another source collapses to one. One
+    // hop only (the delegatee's own delegation is not re-resolved); user-only.
+    let finalId = assigneeId
+    let delegatedFrom: string | undefined
+    if (assignmentType === 'user') {
+      const delegatee = delegations[assigneeId]
+      if (delegatee && delegatee !== assigneeId) {
+        delegatedFrom = assigneeId
+        finalId = delegatee
+      }
+    }
+    const key = `${assignmentType}:${finalId}`
     if (seen.has(key)) return
     seen.add(key)
+    const metadata = metadataFor(source, sourceIndex)
     resolved.push({
       assignmentType,
-      assigneeId,
+      assigneeId: finalId,
       nodeKey: options.nodeKey,
       sourceStep: options.sourceStep,
-      metadata: metadataFor(source, sourceIndex),
+      metadata: delegatedFrom ? { ...metadata, delegatedFrom } : metadata,
     })
   }
 

--- a/packages/core-backend/src/services/ApprovalDelegations.ts
+++ b/packages/core-backend/src/services/ApprovalDelegations.ts
@@ -1,0 +1,58 @@
+/**
+ * Approval delegation (委托) — resolve-time read seam (READ-ONLY).
+ *
+ * Reads the `approval_delegations` config table and produces the frozen
+ * delegator -> delegatee substitution map for one approval at create time. The
+ * map is baked into the instance snapshot (before the executor resolves the
+ * initial state) and applied inside `ApprovalAssigneeResolver.pushResolved` — so
+ * an in-flight approval never re-routes under a later config edit.
+ *
+ * Boundary: SELECTs `approval_delegations` only; writes nothing; touches no
+ * `approval_*` instance / `automation_*` table. Best-effort — callers swallow
+ * failures so a delegation read never blocks approval creation.
+ */
+
+type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
+
+interface ActiveDelegationRow {
+  delegator_user_id: string
+  delegatee_user_id: string
+}
+
+/**
+ * The active delegation map for `templateId` at instant `now`: delegations that are
+ * `active`, whose `[start_at, end_at)` window contains `now`, scoped either to all
+ * templates or to this template. Returns `delegator -> delegatee`.
+ *
+ * A delegator may hold at most one active row per scope target (unique index), but
+ * can hold one `all` row and one `template` row at once; the **template** scope wins
+ * (more specific) via `ORDER BY scope` (`'all'` < `'template'`, so the template row
+ * is applied last). Self-delegations cannot exist (table CHECK), so the map has no
+ * self-edge.
+ */
+export async function resolveActiveDelegationMap(
+  query: QueryFn,
+  options: { templateId: string; now: Date },
+): Promise<Record<string, string>> {
+  const rows = (
+    await query<ActiveDelegationRow>(
+      `SELECT delegator_user_id, delegatee_user_id
+         FROM approval_delegations
+        WHERE active
+          AND start_at <= $1 AND end_at > $1
+          AND (scope = 'all' OR (scope = 'template' AND scope_template_id = $2))
+        ORDER BY scope`,
+      [options.now.toISOString(), options.templateId],
+    )
+  ).rows
+
+  const map: Record<string, string> = {}
+  for (const row of rows) {
+    const delegator = typeof row.delegator_user_id === 'string' ? row.delegator_user_id.trim() : ''
+    const delegatee = typeof row.delegatee_user_id === 'string' ? row.delegatee_user_id.trim() : ''
+    if (delegator && delegatee && delegator !== delegatee) {
+      map[delegator] = delegatee
+    }
+  }
+  return map
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -41,6 +41,7 @@ import {
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
+import { resolveActiveDelegationMap } from './ApprovalDelegations'
 import type {
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
@@ -2650,6 +2651,25 @@ export class ApprovalProductService {
       )
     }
 
+    // Delegation (委托) — freeze the active delegator->delegatee map (scoped to this
+    // template + the create instant) into the snapshot BEFORE the executor resolves the
+    // initial state, so the resolver's pushResolved substitution reads a frozen set and an
+    // in-flight approval never re-routes under a later config edit. Best-effort: a read
+    // failure must not block create.
+    let delegationMap: Record<string, string> = {}
+    try {
+      delegationMap = await resolveActiveDelegationMap(pool.query.bind(pool), {
+        templateId: request.templateId,
+        now: new Date(),
+      })
+    } catch (error) {
+      metricsLogger.warn(
+        `Failed to resolve active delegations for template ${request.templateId}: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`,
+      )
+    }
+
     const requesterSnapshot: ApprovalRequesterSnapshot = {
       id: actor.userId,
       name: actor.userName || actor.userId,
@@ -2660,6 +2680,7 @@ export class ApprovalProductService {
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
       ...(orgRelations.deptHeadId ? { deptHeadId: orgRelations.deptHeadId } : {}),
       ...(orgRelations.managerChainIds ? { managerChainIds: orgRelations.managerChainIds } : {}),
+      ...(Object.keys(delegationMap).length > 0 ? { delegations: delegationMap } : {}),
     }
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {
       assignmentResolver: buildApprovalAssignmentResolver({

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -117,6 +117,11 @@ export interface ApprovalAssigneeResolutionMetadata {
     sourceIndex: number
     fieldId?: string
   }
+  /**
+   * Set when a delegation (委托) substituted this assignee: the original delegator's
+   * id. The resolved `assigneeId` is already the delegatee; this is audit-trail only.
+   */
+  delegatedFrom?: string
 }
 
 export interface ConditionNodeConfig {
@@ -246,6 +251,14 @@ export interface ApprovalRequesterSnapshot {
    * to its own `levels`. Purely additive; existing snapshots omit it.
    */
   managerChainIds?: string[]
+  /**
+   * Delegation (委托) substitution map (delegator localUserId -> delegatee localUserId),
+   * frozen at create time from the active `approval_delegations` scoped to this template
+   * + the create-time instant. Read by `ApprovalAssigneeResolver` inside `pushResolved`
+   * to route a delegator's resolved assignment to the delegatee. Absent when no active
+   * delegation applies; purely additive.
+   */
+  delegations?: Record<string, string>
   [key: string]: unknown
 }
 

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -112,7 +112,13 @@ export type ApprovalAssigneeSource =
   | { kind: 'manager_at_level'; level: number }
 
 export interface ApprovalAssigneeResolutionMetadata {
-  resolvedFrom: {
+  /**
+   * Present for assignees resolved from an `assigneeSources` entry (the dynamic-source
+   * discriminator downstream keys on its presence). Absent for legacy `assigneeIds`
+   * assignments — including a legacy assignment that a delegation substituted, which
+   * then carries only `delegatedFrom`.
+   */
+  resolvedFrom?: {
     kind: ApprovalAssigneeSourceKind
     sourceIndex: number
     fieldId?: string

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -5,7 +5,7 @@ const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
 // 'add_sign' / 'reduce_sign' (mirrors migration
 // zzzz20260616130000_add_add_reduce_sign_actions_to_approval_records.ts). The
 // version marker re-runs the DDL on an already-bootstrapped test DB.
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260616-p1b-add-reduce-sign-action'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260622-delegations'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -360,6 +360,28 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_tenant_terminal ON approval_metrics(tenant_id, terminal_at DESC)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_template ON approval_metrics(template_id) WHERE template_id IS NOT NULL`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_breached_active ON approval_metrics(tenant_id, sla_breached) WHERE sla_breached = TRUE`)
+
+    // approval_delegations (委托) — mirrors migration zzzz20260622060000_create_approval_delegations.
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS approval_delegations (
+        id TEXT PRIMARY KEY,
+        delegator_user_id TEXT NOT NULL,
+        delegatee_user_id TEXT NOT NULL,
+        scope TEXT NOT NULL DEFAULT 'all',
+        scope_template_id TEXT,
+        start_at TIMESTAMPTZ NOT NULL,
+        end_at TIMESTAMPTZ NOT NULL,
+        active BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT chk_approval_delegations_window CHECK (end_at > start_at),
+        CONSTRAINT chk_approval_delegations_not_self CHECK (delegator_user_id <> delegatee_user_id),
+        CONSTRAINT chk_approval_delegations_scope CHECK (scope IN ('all', 'template')),
+        CONSTRAINT chk_approval_delegations_scope_target CHECK ((scope = 'template') = (scope_template_id IS NOT NULL))
+      )
+    `)
+    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS uq_approval_delegations_active ON approval_delegations (delegator_user_id, scope, COALESCE(scope_template_id, '')) WHERE active`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_delegations_lookup ON approval_delegations (active, scope, scope_template_id, start_at, end_at)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_scan ON approval_metrics(started_at) WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND sla_breached = FALSE`)
     await client.query(`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS breach_notified_at TIMESTAMPTZ`)
     await client.query(`CREATE INDEX IF NOT EXISTS approval_metrics_breach_pending_idx ON approval_metrics (sla_breached_at NULLS FIRST, started_at) WHERE sla_breached = TRUE AND breach_notified_at IS NULL`)

--- a/packages/core-backend/tests/integration/approval-delegation-seam.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-seam.db.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Delegation (委托) bake→resolve seam — real-DB create/start.
+ *
+ * Proves the seam THIS feature introduces (P2c): createApproval() READS
+ * approval_delegations, FREEZES the active delegator->delegatee map into
+ * requester_snapshot, and INSERTS the SUBSTITUTED assignment. A static_user node points
+ * at the delegator; an active 'all'-scope delegation routes it to the delegatee. The
+ * substitution/dedup LOGIC itself is covered by the resolver unit tests — this proves
+ * the real DB wire (read → freeze → insert) that the unit tests hand-feed.
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `del-req-${TS}`
+const DELEGATOR = `del-from-${TS}`
+const DELEGATEE = `del-to-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+describeIfDatabase('delegation (委托) bake→resolve seam — real-DB create/start', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    // Active 'all'-scope delegation DELEGATOR -> DELEGATEE covering the create instant.
+    await pool.query(
+      `INSERT INTO approval_delegations (id, delegator_user_id, delegatee_user_id, scope, start_at, end_at, active)
+       VALUES ($1, $2, $3, 'all', NOW() - INTERVAL '1 day', NOW() + INTERVAL '1 day', TRUE)`,
+      [`deld-${TS}`, DELEGATOR, DELEGATEE],
+    )
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+      await pool.query(`DELETE FROM approval_delegations WHERE id = $1`, [`deld-${TS}`])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('reads approval_delegations → freezes into requester_snapshot → inserts the delegatee assignment', async () => {
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'a',
+          config: { assigneeSources: [{ kind: 'static_user', userIds: [DELEGATOR] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+        },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
+    }
+    const key = `del-seam-${TS}`
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300) // node resolves to the DELEGATEE (a valid assignee), not empty
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+
+    const pool = poolManager.get()
+    // (1) read → freeze: the active delegation is baked into the instance snapshot.
+    const snap = (
+      await pool.query<{ requester_snapshot: { delegations?: Record<string, string> } | null }>(
+        `SELECT requester_snapshot FROM approval_instances WHERE id = $1`,
+        [aid],
+      )
+    ).rows[0]?.requester_snapshot
+    expect(snap?.delegations).toEqual({ [DELEGATOR]: DELEGATEE })
+
+    // (2) freeze → insert substituted: the pending assignee is the DELEGATEE, and the
+    // DELEGATOR was never inserted as an assignment.
+    const assignees = (
+      await pool.query<{ assignee_id: string }>(
+        `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignment_type = 'user'`,
+        [aid],
+      )
+    ).rows.map((r) => r.assignee_id)
+    expect(assignees).toContain(DELEGATEE)
+    expect(assignees).not.toContain(DELEGATOR)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -47,9 +47,10 @@ describe('approval admin jump migration and bootstrap sync', () => {
   it('T-bootstrap keeps approval_schema_bootstrap action check aligned with add_sign/reduce_sign (P1-B)', async () => {
     const source = await fs.readFile(BOOTSTRAP_PATH, 'utf8')
 
-    // Lane D (P1-B 加签/减签) bumped the bootstrap: the action CHECK now also
-    // permits add_sign/reduce_sign, mirroring migration zzzz20260616130000.
-    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260616-p1b-add-reduce-sign-action'")
+    // The delegation runtime added approval_delegations to the bootstrap and bumped the
+    // version; the action CHECK still permits add_sign/reduce_sign (Lane D / migration
+    // zzzz20260616130000).
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260622-delegations'")
     expect(source).toContain("'remind', 'jump', 'add_sign', 'reduce_sign'")
   })
 

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -280,4 +280,51 @@ describe('ApprovalAssigneeResolver', () => {
       },
     ])
   })
+
+  // delegation (委托) — substitution INSIDE pushResolved, before the dedup key,
+  // user-only, with delegatedFrom metadata; dedup runs on the substituted id.
+  function resolveWithDelegations(
+    assigneeSources: ApprovalNodeConfig['assigneeSources'],
+    delegations: Record<string, string>,
+  ) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources },
+      formSnapshot: {},
+      requesterSnapshot: { id: 'requester-1', delegations },
+    })
+  }
+
+  it('substitutes a delegated user assignee and records delegatedFrom', () => {
+    expect(resolveWithDelegations([{ kind: 'static_user', userIds: ['A'] }], { A: 'B' })).toEqual([
+      { assignmentType: 'user', assigneeId: 'B', nodeKey: 'review', sourceStep: 2, metadata: { resolvedFrom: { kind: 'static_user', sourceIndex: 0 }, delegatedFrom: 'A' } },
+    ])
+  })
+
+  it('KEYSTONE: delegator A→B where B is already another source assignee resolves to exactly one B', () => {
+    // Substitution before the dedup key collapses A→B and the existing B to one B. A
+    // post-loop replace would build the seen key on A, then replace → two B entries.
+    const result = resolveWithDelegations([{ kind: 'static_user', userIds: ['A', 'B'] }], { A: 'B' })
+    expect(result.map((r) => r.assigneeId)).toEqual(['B'])
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not substitute role assignees (user-only)', () => {
+    expect(resolveWithDelegations([{ kind: 'static_role', roleIds: ['A'] }], { A: 'B' })).toEqual([
+      { assignmentType: 'role', assigneeId: 'A', nodeKey: 'review', sourceStep: 2, metadata: { resolvedFrom: { kind: 'static_role', sourceIndex: 0 } } },
+    ])
+  })
+
+  it('is one hop only: A→B→C resolves A to B, not C', () => {
+    expect(resolveWithDelegations([{ kind: 'static_user', userIds: ['A'] }], { A: 'B', B: 'C' }).map((r) => r.assigneeId))
+      .toEqual(['B'])
+  })
+
+  it('ignores a self-delegation entry and a missing map (no substitution, no delegatedFrom)', () => {
+    const selfLoop = resolveWithDelegations([{ kind: 'static_user', userIds: ['A'] }], { A: 'A' })
+    expect(selfLoop.map((r) => r.assigneeId)).toEqual(['A'])
+    expect(selfLoop[0].metadata).toEqual({ resolvedFrom: { kind: 'static_user', sourceIndex: 0 } })
+    expect(resolveWithDelegations([{ kind: 'static_user', userIds: ['A'] }], {}).map((r) => r.assigneeId)).toEqual(['A'])
+  })
 })

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -327,4 +327,31 @@ describe('ApprovalAssigneeResolver', () => {
     expect(selfLoop[0].metadata).toEqual({ resolvedFrom: { kind: 'static_user', sourceIndex: 0 } })
     expect(resolveWithDelegations([{ kind: 'static_user', userIds: ['A'] }], {}).map((r) => r.assigneeId)).toEqual(['A'])
   })
+
+  // P1 regression: delegation applies to LEGACY assigneeIds templates too (not only
+  // authored assigneeSources). The legacy path now routes through pushResolved.
+  function resolveLegacy(assigneeIds: string[], delegations: Record<string, string>) {
+    return resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeType: 'user', assigneeIds },
+      formSnapshot: {},
+      requesterSnapshot: { id: 'requester-1', delegations },
+    })
+  }
+
+  it('applies delegation to a legacy assigneeIds template (A→B, B already listed → one B)', () => {
+    const result = resolveLegacy(['A', 'B'], { A: 'B' })
+    expect(result.map((r) => r.assigneeId)).toEqual(['B'])
+    expect(result).toHaveLength(1)
+    // legacy-delegated metadata carries delegatedFrom but NO resolvedFrom (stays non-dynamic)
+    expect(result[0].metadata).toEqual({ delegatedFrom: 'A' })
+  })
+
+  it('keeps a legacy assigneeIds template metadata-free when no delegation applies', () => {
+    expect(resolveLegacy(['A', 'B'], {})).toEqual([
+      { assignmentType: 'user', assigneeId: 'A', nodeKey: 'review', sourceStep: 2 },
+      { assignmentType: 'user', assigneeId: 'B', nodeKey: 'review', sourceStep: 2 },
+    ])
+  })
 })

--- a/packages/core-backend/tests/unit/approval-delegations.test.ts
+++ b/packages/core-backend/tests/unit/approval-delegations.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { resolveActiveDelegationMap } from '../../src/services/ApprovalDelegations'
+
+describe('resolveActiveDelegationMap', () => {
+  const fakeQuery =
+    (rows: Array<{ delegator_user_id: string; delegatee_user_id: string }>) =>
+    async <Row>(): Promise<{ rows: Row[] }> => ({ rows: rows as unknown as Row[] })
+
+  const now = new Date('2026-06-22T00:00:00Z')
+
+  it('builds a delegator->delegatee map from active rows', async () => {
+    const map = await resolveActiveDelegationMap(
+      fakeQuery([
+        { delegator_user_id: 'A', delegatee_user_id: 'B' },
+        { delegator_user_id: 'C', delegatee_user_id: 'D' },
+      ]),
+      { templateId: 't1', now },
+    )
+    expect(map).toEqual({ A: 'B', C: 'D' })
+  })
+
+  it('template scope wins over all scope (SQL ORDER BY applies the template row last)', async () => {
+    // The query orders 'all' before 'template'; the map builder's last-write-wins then
+    // lets the template row override the all row for the same delegator.
+    const map = await resolveActiveDelegationMap(
+      fakeQuery([
+        { delegator_user_id: 'A', delegatee_user_id: 'B' }, // all (ordered first)
+        { delegator_user_id: 'A', delegatee_user_id: 'C' }, // template (ordered last)
+      ]),
+      { templateId: 't1', now },
+    )
+    expect(map).toEqual({ A: 'C' })
+  })
+
+  it('drops malformed and self rows', async () => {
+    const map = await resolveActiveDelegationMap(
+      fakeQuery([
+        { delegator_user_id: 'A', delegatee_user_id: 'A' }, // self (defensive; table CHECK blocks it)
+        { delegator_user_id: '  ', delegatee_user_id: 'B' }, // empty delegator
+        { delegator_user_id: 'C', delegatee_user_id: 'D' },
+      ]),
+      { templateId: 't1', now },
+    )
+    expect(map).toEqual({ C: 'D' })
+  })
+
+  it('passes the create instant + templateId as the window + scope params', async () => {
+    let captured: unknown[] = []
+    const spyQuery = async <Row>(_text: string, params?: unknown[]): Promise<{ rows: Row[] }> => {
+      captured = params ?? []
+      return { rows: [] as Row[] }
+    }
+    await resolveActiveDelegationMap(spyQuery, { templateId: 't1', now: new Date('2026-06-22T03:00:00Z') })
+    expect(captured).toEqual(['2026-06-22T03:00:00.000Z', 't1'])
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'tests/integration/approval-postgate-acceptance.api.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
+      'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
## What
Backend runtime for the ratified delegation design-lock (**#3025**): a time-boxed `delegator → delegatee` substitution.

## The locked review gates (all implemented)
- **Substitution INSIDE `pushResolved`, before the dedup key** — user-only, `delegatedFrom` metadata, `seen` dedup on the **substituted** id. The **KEYSTONE test** proves it: `A→B` where B is already another source's assignee resolves to **exactly one B** (a post-loop replace would produce two). One hop; self-delegation ignored.
- **Bake frozen-at-create** — active delegations scoped to template + the create instant captured into the requester snapshot **before `resolveInitialState()`** (best-effort; never blocks create).
- **`approval_delegations` table** — unique active per (delegator, scope-target); window + non-self CHECKs.

## Tests (29 backend unit, tsc clean)
Resolver: substitution / KEYSTONE dedup / one-hop / self-skip / role-not-substituted / `delegatedFrom`. Read-query: map-builder / template-scope-wins / param-shape.

## Scope + follow-up
**Backend runtime only.** Follow-up = **委托设置 CRUD + write API** and a **real-DB service-level bake→substitute test**. Convergence-safe: writes only `approval_delegations` config — no `approval_*`/`automation_*` instance write, W7 stays locked, no graph change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)