### PR TITLE
feat(web): FOS-3 — generic field-option-sync UI (rename + preset picker, dual-route preserves stock-prep+actions)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1261,6 +1261,32 @@ export async function syncIntegrationStockPreparationOptions(
   return parseIntegrationResponse<IntegrationStockPreparationOptionSyncResult>(response)
 }
 
+// FOS-2/FOS-3: generic, preset-driven field-option-sync. Resolves a FOS-1 preset by presetId and
+// patches the mapped fields' option metadata only (no business-row write, no external system,
+// no action bindings — actions remain the stock-prep-specific route). The server is admin-gated and
+// returns values-free evidence. Mirrors the stock-prep payload shape sans action bindings.
+export interface IntegrationFieldOptionSyncPayload extends IntegrationScope {
+  projectId?: string | null
+  optionSets?: Record<string, unknown>
+}
+
+export interface IntegrationFieldOptionSyncResult {
+  ok?: boolean
+  target?: Record<string, unknown>
+  evidence?: Record<string, unknown>
+}
+
+export async function syncIntegrationFieldOptions(
+  presetId: string,
+  payload: IntegrationFieldOptionSyncPayload,
+): Promise<IntegrationFieldOptionSyncResult> {
+  const response = await apiFetch('/api/integration/field-options/sync', {
+    method: 'POST',
+    body: JSON.stringify({ ...payload, presetId }),
+  })
+  return parseIntegrationResponse<IntegrationFieldOptionSyncResult>(response)
+}
+
 // Only 'open' letters are replayable — the server enforces the same, but the UI
 // must not even offer replay for replayed/discarded letters (a second live ERP
 // write). Keep this in lock-step with the backend guard in pipeline-runner.cjs.

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1005,11 +1005,19 @@
       <div v-if="auth.hasPermission('integration:admin')" class="integration-workbench__table-action" data-testid="stock-option-sync-panel">
         <div class="integration-workbench__panel-head">
           <div>
-            <h3>备料选项同步</h3>
-            <p>管理员同步 select/dropdown 选项，并可把选项绑定到后端白名单里的预定义动作。</p>
+            <h3>字段选项同步</h3>
+            <p>管理员按预设把 select/dropdown 字段选项元数据写入对应字段；只改字段定义，不写业务行。</p>
           </div>
           <span class="integration-workbench__badge">admin · metadata-only</span>
         </div>
+        <label class="integration-workbench__inline-field">
+          <span>同步预设</span>
+          <select v-model="fieldOptionSyncPresetId" data-testid="field-options-preset">
+            <option v-for="preset in fieldOptionSyncPresets" :key="preset.presetId" :value="preset.presetId">
+              {{ preset.label }}
+            </option>
+          </select>
+        </label>
         <label>
           <span>optionSets JSON</span>
           <textarea
@@ -1020,19 +1028,26 @@
           />
         </label>
         <p class="integration-workbench__hint" data-testid="stock-option-sync-boundary">
-          这里只写字段选项和 optionActionBindings 元数据；不执行动作，不接受 SQL/JS/URL/function body，不写 PLM/K3/业务行。
+          这里只写字段选项元数据；不执行动作，不接受 SQL/JS/URL/function body，不写 PLM/K3/业务行。带 actionBindings 的选项走备料兼容路径（动作绑定泛化待 FOS-4）。
         </p>
         <div class="integration-workbench__actions">
           <button
             type="button"
             class="integration-workbench__button"
-            data-testid="stock-option-sync-run"
+            data-testid="field-options-sync-run"
             :disabled="!stockPreparationOptionSyncCanRun"
-            @click="syncStockPreparationOptions"
+            @click="syncFieldOptions"
           >
-            {{ syncingStockPreparationOptions ? '同步中' : '同步备料选项' }}
+            {{ syncingStockPreparationOptions ? '同步中' : '同步字段选项' }}
           </button>
         </div>
+        <p
+          v-if="fieldOptionSyncPathNote"
+          class="integration-workbench__hint"
+          data-testid="field-options-sync-path"
+        >
+          {{ fieldOptionSyncPathNote }}
+        </p>
         <pre v-if="stockPreparationOptionSyncEvidenceText" data-testid="stock-option-sync-evidence">{{ stockPreparationOptionSyncEvidenceText }}</pre>
       </div>
 
@@ -1352,6 +1367,7 @@ import {
   summarizeFieldProvenance,
   saveIntegrationTableActionConflictPolicies,
   syncIntegrationStockPreparationOptions,
+  syncIntegrationFieldOptions,
   testExternalSystemConnection,
   upsertWorkbenchExternalSystem,
   upsertIntegrationPipeline,
@@ -2551,6 +2567,17 @@ const tableActionEvidenceText = computed(() => {
   const evidence = tableActionApplyResult.value?.evidence || tableActionDryRunResult.value?.evidence
   return evidence ? JSON.stringify(evidence, null, 2) : ''
 })
+// FOS-3: the field-option-sync presets resolve a FOS-1 preset on the generic
+// /api/integration/field-options/sync route. Only the stock-preparation preset is
+// wired today (additional presets are gated to FOS-4); hardcoding the single option
+// keeps FOS-3 minimal while the picker UI is the generalization seam.
+const fieldOptionSyncPresets = [
+  { presetId: 'preset.stock-preparation.v1', label: '备料选项同步 / Stock Preparation' },
+] as const
+const fieldOptionSyncPresetId = ref<string>(fieldOptionSyncPresets[0].presetId)
+// FOS-3: which route the last submit took. Surfaced as a DOM note so the dual-route
+// dispatch is never silent — actionBindings keep the stock-prep compatibility path.
+const fieldOptionSyncPathNote = ref('')
 const stockPreparationOptionSyncPlaceholder = JSON.stringify({
   optionSets: {
     material_type: [
@@ -4332,21 +4359,64 @@ function buildStockPreparationOptionSyncPayload(): Record<string, unknown> {
   return { optionSets: record }
 }
 
-async function syncStockPreparationOptions(): Promise<void> {
+// FOS-3: detect option entries that carry action bindings. This is a SUPERSET of the
+// generic route's reject condition (http-routes.cjs: per-option `actionBindings`/`actions`
+// arrays), using key-presence so nothing the generic route would 422 ever reaches it —
+// such payloads are routed to the stock-prep compatibility path instead. Scans the
+// NORMALIZED optionSets map's option arrays (top-level keys are field/source ids).
+function payloadCarriesActionBindings(payload: Record<string, unknown>): boolean {
+  const optionSets = payload.optionSets
+  if (!optionSets || typeof optionSets !== 'object' || Array.isArray(optionSets)) return false
+  for (const rawOptions of Object.values(optionSets as Record<string, unknown>)) {
+    if (!Array.isArray(rawOptions)) continue
+    if (rawOptions.some((option) =>
+      Boolean(option) && typeof option === 'object' && !Array.isArray(option)
+      && ('actionBindings' in (option as Record<string, unknown>) || 'actions' in (option as Record<string, unknown>)))) {
+      return true
+    }
+  }
+  return false
+}
+
+async function syncFieldOptions(): Promise<void> {
   if (!auth.hasPermission('integration:admin')) {
-    setStatus('只有管理员可以同步备料选项。', 'error')
+    setStatus('只有管理员可以同步字段选项。', 'error')
     return
   }
   syncingStockPreparationOptions.value = true
   stockPreparationOptionSyncResult.value = null
+  fieldOptionSyncPathNote.value = ''
   try {
-    const result = await syncIntegrationStockPreparationOptions({
+    const payload = buildStockPreparationOptionSyncPayload()
+    // Route to the legacy stock-preparation route when the payload carries action bindings OR
+    // uses the legacy alias keys (optionSources/configInfo). The generic route's request allowlist
+    // accepts only a pure { optionSets } shape, so those alias payloads — which the stock-prep route
+    // still supports — must not reach the generic route (it would 400 and break existing usage).
+    const usesLegacyAliases = 'optionSources' in payload || 'configInfo' in payload
+    if (payloadCarriesActionBindings(payload) || usesLegacyAliases) {
+      // action bindings / legacy aliases → existing stock-preparation route (options + predefined
+      // actions preserved unchanged). Body kept byte-identical to the legacy capability.
+      const result = await syncIntegrationStockPreparationOptions({
+        ...currentScope(),
+        ...payload,
+      })
+      stockPreparationOptionSyncResult.value = result
+      fieldOptionSyncPathNote.value = 'action bindings → stock-preparation compatibility path（动作绑定/兼容字段走备料兼容路径）'
+      const fieldCount = Number(result.target?.fieldCount || 0)
+      setStatus(`字段选项同步完成（备料兼容路径）：${fieldCount} 个字段已更新。`, 'success')
+      return
+    }
+    // pure options → generic preset-driven field-option-sync route.
+    const projectId = typeof payload.projectId === 'string' ? payload.projectId : undefined
+    const result = await syncIntegrationFieldOptions(fieldOptionSyncPresetId.value, {
       ...currentScope(),
-      ...buildStockPreparationOptionSyncPayload(),
+      optionSets: payload.optionSets as Record<string, unknown> | undefined,
+      ...(projectId ? { projectId } : {}),
     })
     stockPreparationOptionSyncResult.value = result
+    fieldOptionSyncPathNote.value = `generic field-option-sync → ${fieldOptionSyncPresetId.value}（通用字段选项路径）`
     const fieldCount = Number(result.target?.fieldCount || 0)
-    setStatus(`备料选项同步完成：${fieldCount} 个字段已更新。`, 'success')
+    setStatus(`字段选项同步完成：${fieldCount} 个字段已更新。`, 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   } finally {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -4265,14 +4265,19 @@ describe('IntegrationWorkbenchView', () => {
     expect(evidence).not.toContain('dry-token')
   })
 
-  it('C6: lets admins sync stock-preparation options and predefined action bindings without client scope or payload fields', async () => {
+  it('C6/FOS-3: routes optionSets carrying action bindings to the legacy stock-preparation route without client scope or payload fields', async () => {
     localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
     const syncBodies: Array<Record<string, unknown>> = []
+    const genericBodies: Array<Record<string, unknown>> = []
     apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/integration/adapters') return jsonResponse([])
       if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
       if (url === '/api/integration/staging/descriptors') return jsonResponse([])
       if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/field-options/sync') {
+        genericBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ ok: true, target: { fieldCount: 0 }, evidence: {} })
+      }
       if (url === '/api/integration/stock-preparation/options/sync') {
         const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
         syncBodies.push(body)
@@ -4304,8 +4309,11 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi(12)
 
-    expect(container.querySelector('[data-testid="stock-option-sync-panel"]')?.textContent).toContain('备料选项同步')
+    // FOS-3: panel is generalized to 字段选项同步 with the stock-preparation preset selected by default.
+    expect(container.querySelector('[data-testid="stock-option-sync-panel"] h3')?.textContent).toContain('字段选项同步')
     expect(container.querySelector('[data-testid="stock-option-sync-boundary"]')?.textContent).toContain('不接受 SQL/JS/URL/function body')
+    const presetSelect = container.querySelector('[data-testid="field-options-preset"]') as HTMLSelectElement
+    expect(presetSelect.value).toBe('preset.stock-preparation.v1')
     const textarea = container.querySelector('[data-testid="stock-option-sync-json"]') as HTMLTextAreaElement
     textarea.value = JSON.stringify({
       optionSets: {
@@ -4319,11 +4327,13 @@ describe('IntegrationWorkbenchView', () => {
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi()
 
-    const syncButton = container.querySelector('[data-testid="stock-option-sync-run"]') as HTMLButtonElement
+    const syncButton = container.querySelector('[data-testid="field-options-sync-run"]') as HTMLButtonElement
     expect(syncButton.disabled).toBe(false)
     syncButton.click()
     await flushUi(10)
 
+    // action bindings → legacy route only; the generic route must NOT be hit.
+    expect(genericBodies).toHaveLength(0)
     expect(syncBodies).toHaveLength(1)
     expect(syncBodies[0]).toEqual({
       tenantId: 'default',
@@ -4341,9 +4351,155 @@ describe('IntegrationWorkbenchView', () => {
     expect(syncBodies[0]).not.toHaveProperty('target')
     expect(syncBodies[0]).not.toHaveProperty('plan')
     expect(syncBodies[0]).not.toHaveProperty('payload')
+    expect(syncBodies[0]).not.toHaveProperty('presetId')
+    // dual-route is not silent: the compat path is indicated in the DOM.
+    expect(container.querySelector('[data-testid="field-options-sync-path"]')?.textContent).toContain('stock-preparation compatibility path')
     const evidence = container.querySelector('[data-testid="stock-option-sync-evidence"]')?.textContent || ''
     expect(evidence).toContain('material_type')
     expect(evidence).not.toContain('plate')
     expect(evidence).not.toContain('Plate')
+  })
+
+  it('FOS-3: routes pure option sets to the generic /field-options/sync route with the resolved presetId', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const syncBodies: Array<Record<string, unknown>> = []
+    const genericBodies: Array<Record<string, unknown>> = []
+    const genericUrls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/stock-preparation/options/sync') {
+        syncBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ ok: true, target: { fieldCount: 1 }, evidence: {} })
+      }
+      if (url === '/api/integration/field-options/sync') {
+        genericUrls.push(url)
+        genericBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({
+          ok: true,
+          target: { presetId: 'preset.stock-preparation.v1', targetTable: 'plm_stock_preparation_main', fieldCount: 1 },
+          evidence: {
+            presetId: 'preset.stock-preparation.v1',
+            targetTable: 'plm_stock_preparation_main',
+            fields: [
+              { field: 'materialType', sourceKey: 'material_type', optionCount: 1 },
+            ],
+            skipped: [],
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const textarea = container.querySelector('[data-testid="stock-option-sync-json"]') as HTMLTextAreaElement
+    textarea.value = JSON.stringify({
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+      },
+    })
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const syncButton = container.querySelector('[data-testid="field-options-sync-run"]') as HTMLButtonElement
+    expect(syncButton.disabled).toBe(false)
+    syncButton.click()
+    await flushUi(10)
+
+    // pure options → generic route only; legacy stock-preparation route must NOT be hit.
+    expect(syncBodies).toHaveLength(0)
+    expect(genericUrls).toEqual(['/api/integration/field-options/sync'])
+    expect(genericBodies).toHaveLength(1)
+    expect(genericBodies[0]).toMatchObject({
+      tenantId: 'default',
+      workspaceId: null,
+      presetId: 'preset.stock-preparation.v1',
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+      },
+    })
+    // dual-route is not silent: the generic path is indicated in the DOM.
+    expect(container.querySelector('[data-testid="field-options-sync-path"]')?.textContent).toContain('generic field-option-sync')
+    expect(container.querySelector('[data-testid="field-options-sync-path"]')?.textContent).toContain('preset.stock-preparation.v1')
+    // evidence is values-free: only field/source ids + counts, never option values.
+    const evidence = container.querySelector('[data-testid="stock-option-sync-evidence"]')?.textContent || ''
+    expect(evidence).toContain('material_type')
+    expect(evidence).toContain('materialType')
+    expect(evidence).not.toContain('plate')
+    expect(evidence).not.toContain('Plate')
+  })
+
+  it('FOS-3: routes legacy alias payloads (optionSources/configInfo) to the stock-preparation route, not the generic route', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
+    const syncBodies: Array<Record<string, unknown>> = []
+    const genericBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/field-options/sync') {
+        genericBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ ok: true, target: { fieldCount: 0 }, evidence: {} })
+      }
+      if (url === '/api/integration/stock-preparation/options/sync') {
+        syncBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ ok: true, target: { fieldCount: 1 }, evidence: { fields: [{ field: 'materialType' }], skipped: [] } })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const textarea = container.querySelector('[data-testid="stock-option-sync-json"]') as HTMLTextAreaElement
+    // legacy alias key, pure options (no action bindings): the generic route's allowlist would
+    // reject optionSources, so this must take the stock-preparation compatibility path.
+    textarea.value = JSON.stringify({
+      optionSources: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+      },
+    })
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const syncButton = container.querySelector('[data-testid="field-options-sync-run"]') as HTMLButtonElement
+    syncButton.click()
+    await flushUi(10)
+
+    expect(genericBodies).toHaveLength(0)
+    expect(syncBodies).toHaveLength(1)
+    expect(syncBodies[0]).toEqual({
+      tenantId: 'default',
+      workspaceId: null,
+      optionSources: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+      },
+    })
+    expect(container.querySelector('[data-testid="field-options-sync-path"]')?.textContent).toContain('stock-preparation compatibility path')
   })
 })


### PR DESCRIPTION
## What (FOS-3, per the FOS-0 design-lock + owner-locked spec)

Generalize the Data Factory option-sync UI: rename the stock-prep panel to generic **字段选项同步** / button **同步字段选项**, add a **preset picker** (default `备料选项同步 / Stock Preparation`), and route to the FOS-2 generic route — **without breaking existing action-binding usage**.

- **Dual-route (no silent break):** on submit, inspect the JSON — **pure `{optionSets}` → generic** `/api/integration/field-options/sync` with `presetId`; **carries `actionBindings`/`actions` OR legacy alias keys `optionSources`/`configInfo` → existing** `/stock-preparation/options/sync` (byte-identical body; options+actions capability preserved). The chosen path is shown in the DOM (`data-testid="field-options-sync-path"`) — never silent. The actionBindings detector is a **superset** of the backend's reject condition (so nothing the generic route would 422 reaches it); alias keys are caught because the generic allowlist is `optionSets`-only.
- **Copy:** drops the generic action-binding promise (action bindings = stock-prep compat path; generalization deferred to **FOS-4**); keeps the values-free boundary note.
- **Service:** new `syncIntegrationFieldOptions(presetId, payload)` → the generic route.

## Verification
Real FE gate **`vue-tsc -b` PASS**; `IntegrationWorkbenchView.spec.ts` **42/42** (new: pure→generic+presetId asserted, actionBindings→legacy [generic not hit], alias→legacy, values-free evidence). Adversarial review **APPROVE**. (Full FE suite's other failures are verified pre-existing baseline noise, unrelated.)

## Boundary
Frontend-only (Vue + a TS service fn; no backend change — FOS-2 added the route); metadata-only; values-free DOM; admin-gated (FE + backend). FOS-4 (additional presets + action-binding generalization) stays gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)