### PR TITLE
refactor(multitable): unify the restore diff onto one canonical helper (pure extract, T6 P3)

### DIFF
--- a/docs/development/multitable-restore-diff-unify-designlock-20260621.md
+++ b/docs/development/multitable-restore-diff-unify-designlock-20260621.md
@@ -33,10 +33,13 @@
 
 ## 3. The ONE canonicalization — link equality
 
-`sameLinks` (`[...a].sort().join(' ') === [...b].sort().join(' ')`) has a **delimiter collision**: `['a b']` and
-`['a','b']` both serialize to `'a b'`. This is reachable — `normalizeLinkIds` parses a legacy `'a b,c'` value into
-`['a b','c']`, so a space-bearing token can occur. `/restore`'s `sameLinkSet` (length check + sorted `.every()`)
-has no collision.
+`sameLinks` (`[...a].sort().join(' ') === [...b].sort().join(' ')`) has a **delimiter collision**, but ONLY for
+EQUAL-LENGTH sets (the leading `a.length === b.length` short-circuits unequal ones — so the first-cut example
+`['a b']` vs `['a','b']` is *not* actually a collision, it's caught by the length check). The real case is two
+distinct same-size sets whose space-joins coincide: `['a','b c']` and `['a b','c']` (both length 2) both serialize
+to `'a b c'`. This requires a link id that itself contains a space — latent/defensive rather than common, since
+generated record ids have none, but reachable via a legacy `normalizeLinkIds` parse of `'a,b c'` → `['a','b c']`
+vs `'a b,c'` → `['a b','c']`. `/restore`'s `sameLinkSet` (length check + sorted `.every()`) has no collision.
 
 - **Canonical = `/restore`'s `sameLinkSet` (robust set-equality).** Rationale: (a) it leaves the SHIPPED
   destructive write path byte-identical — only the two newer paths converge, minimizing blast radius where it is

--- a/packages/core-backend/src/multitable/record-restore-diff.ts
+++ b/packages/core-backend/src/multitable/record-restore-diff.ts
@@ -1,0 +1,79 @@
+import type { RecordChange } from './record-write-service'
+
+/**
+ * The CANONICAL record-version restore diff — the single source the three restore routes share (`/restore`,
+ * `restore-preview` T5-2, `restore-execute` T6-2). Pure: a DIFF PRODUCER, never a permission authority. It makes
+ * no permission decision and reads no permission state; masking / schema-drift / row-deny / write-gate /
+ * expectedVersion all stay in the routes (each route filters this raw diff with its own allowed set).
+ *
+ * Design-lock: docs/development/multitable-restore-diff-unify-designlock-20260621.md. This is a RECONCILIATION of
+ * three independently-written implementations that mostly agreed; the one divergence (link equality) is resolved
+ * to the robust `/restore` set-compare below (the two newer paths previously used a `.join(' ')` form that
+ * collides on space-bearing ids; canonical = robust, so the shipped write path stays byte-identical).
+ */
+
+// Non-restorable field types: computed / system-auto / link / attachment / button are not scalar-restorable.
+const NON_RESTORABLE_TYPES = new Set([
+  'formula', 'lookup', 'rollup', 'link', 'attachment', 'button',
+  'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy',
+])
+const isRestorableType = (t: string): boolean => !NON_RESTORABLE_TYPES.has(t)
+const sameValue = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+
+/**
+ * CANONICAL link-set equality: order-insensitive, with NO delimiter collision. (`['a','b c']` and `['a b','c']` are
+ * DISTINCT but a `.sort().join(' ')` form collides both to `'a b c'`; reachable only if a link id itself contains
+ * a space — e.g. the legacy `normalizeLinkIds` parse of `'a,b c'` → `['a','b c']` vs `'a b,c'` → `['a b','c']`.) Exported only so a golden can pin it through the public
+ * helper; routes use `computeRecordRestoreDiff`, not this directly.
+ */
+export function canonicalSameLinkSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sa = [...a].sort()
+  const sb = [...b].sort()
+  return sa.every((v, i) => v === sb[i])
+}
+
+export interface RestoreDiffInput {
+  /** field id → guard; only `guard.type` is read (ReadonlyMap so a `Map<string, FieldMutationGuard>` is assignable). */
+  fieldById: ReadonlyMap<string, { type: string }>
+  /** field id → raw DB type; used to exclude the no-value `button` trigger (which `mapFieldType` folds to string). */
+  rawTypeById: ReadonlyMap<string, string>
+  targetSnapshot: Record<string, unknown>
+  currentData: Record<string, unknown>
+  recordId: string
+  currentVersion: number
+  /** the route's canonical link-id parser (injected to avoid a route↔helper import cycle; all three pass the same one). */
+  normalizeLinkIds: (value: unknown) => string[]
+}
+
+/**
+ * The faithful set ∪ unset diff over restorable fields. Link fields emit a SET of the normalized id array (routed
+ * through patchRecords, which re-syncs meta_links) — never a data-`unset` — and only when the id set actually
+ * differs (canonical set-equality). Scalar fields: SET when present-and-different, UNSET when absent-from-snapshot
+ * but present-in-current. The `button` no-value trigger and all non-restorable types are skipped.
+ */
+export function computeRecordRestoreDiff(input: RestoreDiffInput): RecordChange[] {
+  const { fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion, normalizeLinkIds } = input
+  const diff: RecordChange[] = []
+  for (const [fid, guard] of fieldById.entries()) {
+    if (rawTypeById.get(fid) === 'button') continue
+    const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
+    const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
+    if (guard.type === 'link') {
+      const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
+      if (!canonicalSameLinkSet(normalizeLinkIds(currentData[fid]), target)) {
+        diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
+      }
+      continue
+    }
+    if (!isRestorableType(guard.type)) continue
+    if (inSnap) {
+      if (!sameValue(currentData[fid], targetSnapshot[fid])) {
+        diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })
+      }
+    } else if (inCur) {
+      diff.push({ recordId, fieldId: fid, value: null, expectedVersion: currentVersion, op: 'unset' })
+    }
+  }
+  return diff
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,6 +74,7 @@ import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import { hashPreviewChanges, mintRestorePreviewIdentity, verifyRestorePreviewIdentity } from '../multitable/restore-preview-identity'
+import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
   HistoryAuditGrantError,
@@ -7429,26 +7430,10 @@ export function univerMetaRouter(): Router {
       for (const fid of Object.keys(targetSnapshot)) if (!previewCtx.fieldById.has(fid)) { schemaDrift = true; break }
 
       // Mirror of the restore route's set ∪ unset diff (scalar) + link-as-report. Helpers mirror restore (P3 dup).
-      const NON_RESTORABLE = new Set(['formula', 'lookup', 'rollup', 'link', 'attachment', 'button', 'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy'])
-      const sameVal = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
-      const sameLinks = (a: string[], b: string[]): boolean => a.length === b.length && [...a].sort().join(' ') === [...b].sort().join(' ')
-      const changes: Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }> = []
-      for (const [fid, guard] of previewCtx.fieldById.entries()) {
-        if (rawTypeById.get(fid) === 'button') continue
-        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
-        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
-        if (guard.type === 'link') {
-          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
-          if (!sameLinks(normalizeLinkIds(currentData[fid]), target)) changes.push({ fieldId: fid, op: 'set', value: target })
-          continue
-        }
-        if (NON_RESTORABLE.has(guard.type)) continue
-        if (inSnap) {
-          if (!sameVal(currentData[fid], targetSnapshot[fid])) changes.push({ fieldId: fid, op: 'set', value: targetSnapshot[fid] })
-        } else if (inCur) {
-          changes.push({ fieldId: fid, op: 'unset', value: null })
-        }
-      }
+      // T6 P3 unify: the canonical raw diff (shared computeRecordRestoreDiff). The preview projects it to
+      // {fieldId,op,value} for the changesHash + masking; recordId/expectedVersion are dropped (preview writes nothing).
+      const changes = computeRecordRestoreDiff({ fieldById: previewCtx.fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion: 0, normalizeLinkIds })
+        .map((c) => ({ fieldId: c.fieldId, op: (c.op ?? 'set') as 'set' | 'unset', value: c.value }))
       // PV-2 mask: filter the diff to the actor's allowed fields (visible ∧ field_permissions, taint-dropped),
       // so a hidden field that WOULD change never appears in the preview — the SAME chain as history detail.
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
@@ -7511,21 +7496,6 @@ export function univerMetaRouter(): Router {
     // excluded; `button` is the no-value trigger (also caught by raw type below). `link` is listed as a
     // defensive backstop, but link fields never reach this check — they are handled by a dedicated SET
     // path (Slice 2a) above the scalar branch, which re-syncs meta_links + the mirror through the spine.
-    const NON_RESTORABLE_TYPES = new Set([
-      'formula', 'lookup', 'rollup', 'link', 'attachment', 'button',
-      'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy',
-    ])
-    const isRestorableType = (t: string): boolean => !NON_RESTORABLE_TYPES.has(t)
-    const sameValue = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
-    // Link state is authoritative in meta_links, which is an unordered SET — so a pure reorder of the
-    // data-mirror id array is NOT a meaningful change and must not emit a spurious SET (version bump +
-    // data reorder while meta_links is unchanged). Compare link ids order-insensitively.
-    const sameLinkSet = (a: string[], b: string[]): boolean => {
-      if (a.length !== b.length) return false
-      const sa = [...a].sort()
-      const sb = [...b].sort()
-      return sa.every((v, i) => v === sb[i])
-    }
 
     try {
       const pool = poolManager.get()
@@ -7625,35 +7595,9 @@ export function univerMetaRouter(): Router {
       }
 
       // Faithful set ∪ unset diff over restorable fields.
-      const diff: RecordChange[] = []
-      for (const [fid, guard] of fieldById.entries()) {
-        if (rawTypeById.get(fid) === 'button') continue // no-value trigger (mapFieldType folds it to 'string')
-        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
-        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
-        // Slice 2a — link fields: restore the snapshot's link id array (or [] when absent at version N)
-        // as a SET routed through patchRecords, which re-syncs meta_links + the twoWay mirror fan-out.
-        // NEVER a data-`unset` (that touches only the data mirror and would desync the join table).
-        // Only emit when the id set actually differs (preserves no-op). The link config (guard.link)
-        // drives the spine's meta_links sync; a snapshot referencing a now-deleted foreign record is
-        // rejected fail-closed by the spine's link-target validation (VALIDATION_ERROR). Use the CANONICAL
-        // normalizeLinkIds (handles legacy `'["a","b"]'` / `'a,b'` / trim / dedup) so a legacy-shaped
-        // snapshot or current value is parsed identically to the write path, not mis-read as one id.
-        if (guard.type === 'link') {
-          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
-          if (!sameLinkSet(normalizeLinkIds(currentData[fid]), target)) {
-            diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
-          }
-          continue
-        }
-        if (!isRestorableType(guard.type)) continue
-        if (inSnap) {
-          if (!sameValue(currentData[fid], targetSnapshot[fid])) {
-            diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })
-          }
-        } else if (inCur) {
-          diff.push({ recordId, fieldId: fid, value: null, expectedVersion: currentVersion, op: 'unset' })
-        }
-      }
+      // T6 P3 unify: the canonical raw diff (shared computeRecordRestoreDiff). Masking / gate / schema-drift /
+      // expectedVersion stay below in this route — the helper only produces the raw diff.
+      const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion, normalizeLinkIds })
 
       // Per-field (column-level) restore: when the caller passes `fieldIds`, restrict the diff to that
       // selection. The atomic gate below then runs over only the selected subset — so a user can restore
@@ -7765,9 +7709,6 @@ export function univerMetaRouter(): Router {
     if (!exParsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: exParsed.error.message } })
     const { targetVersion, expectedVersion, previewIdentity } = exParsed.data
     const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
-    const NON_RESTORABLE = new Set(['formula', 'lookup', 'rollup', 'link', 'attachment', 'button', 'autoNumber', 'createdTime', 'modifiedTime', 'createdBy', 'modifiedBy'])
-    const sameVal = (a: unknown, b: unknown): boolean => JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
-    const sameLinks = (a: string[], b: string[]): boolean => a.length === b.length && [...a].sort().join(' ') === [...b].sort().join(' ')
     try {
       const pool = poolManager.get()
       const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
@@ -7813,23 +7754,9 @@ export function univerMetaRouter(): Router {
       // The faithful set ∪ unset diff (same shape as /restore + T5-2's preview), then MASK to the actor's allowed
       // fields — this masked set is exactly what T5-2's preview hashed into the identity (3rd copy of the diff;
       // the end-to-end preview→execute golden is the drift guard, unifying the copies is a follow-up P3).
-      const diff: RecordChange[] = []
-      for (const [fid, guard] of fieldById.entries()) {
-        if (rawTypeById.get(fid) === 'button') continue
-        const inSnap = Object.prototype.hasOwnProperty.call(targetSnapshot, fid)
-        const inCur = Object.prototype.hasOwnProperty.call(currentData, fid)
-        if (guard.type === 'link') {
-          const target = inSnap ? normalizeLinkIds(targetSnapshot[fid]) : []
-          if (!sameLinks(normalizeLinkIds(currentData[fid]), target)) diff.push({ recordId, fieldId: fid, value: target, expectedVersion: currentVersion, op: 'set' })
-          continue
-        }
-        if (NON_RESTORABLE.has(guard.type)) continue
-        if (inSnap) {
-          if (!sameVal(currentData[fid], targetSnapshot[fid])) diff.push({ recordId, fieldId: fid, value: targetSnapshot[fid], expectedVersion: currentVersion, op: 'set' })
-        } else if (inCur) {
-          diff.push({ recordId, fieldId: fid, value: null, expectedVersion: currentVersion, op: 'unset' })
-        }
-      }
+      // T6 P3 unify: the canonical raw diff (shared computeRecordRestoreDiff). Masking / gate / schema-drift /
+      // expectedVersion stay below in this route — the helper only produces the raw diff.
+      const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion, normalizeLinkIds })
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
       const maskedDiff = diff.filter((c) => allowed.has(c.fieldId))

--- a/packages/core-backend/tests/unit/record-restore-diff.test.ts
+++ b/packages/core-backend/tests/unit/record-restore-diff.test.ts
@@ -1,0 +1,58 @@
+/**
+ * T6 P3 — the unified canonical restore diff (`computeRecordRestoreDiff`). Pure unit; pins the PUBLIC helper
+ * behavior (not the private `sameLinkSet`), per the design-lock acceptance: the collision case must be exercised
+ * THROUGH the helper's link branch, so a future "simplification" back to `.join(' ')` fails here.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { computeRecordRestoreDiff } from '../../src/multitable/record-restore-diff'
+
+// Minimal stand-in for the route's normalizeLinkIds (array → string[]; the helper only needs the parse contract).
+const nlz = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : typeof v === 'string' && v ? [v] : [])
+
+describe('computeRecordRestoreDiff — canonical shared restore diff', () => {
+  it('link collision (the canonicalization): equal-length sets whose .join would collide is a CHANGE, not a no-op', () => {
+    // `.sort().join(' ')` would equate these (both → "a b") and emit nothing; the robust canonical must not.
+    const diff = computeRecordRestoreDiff({
+      fieldById: new Map([['lk', { type: 'link' }]]),
+      rawTypeById: new Map([['lk', 'link']]),
+      targetSnapshot: { lk: ['a b', 'c'] },
+      currentData: { lk: ['a', 'b c'] },
+      recordId: 'r1', currentVersion: 2, normalizeLinkIds: nlz,
+    })
+    expect(diff).toHaveLength(1) // robust set-compare sees ['a','b c'] != ['a b','c']; a .join(' ') form would miss it (both 'a b c')
+    expect(diff[0]).toMatchObject({ recordId: 'r1', fieldId: 'lk', op: 'set', value: ['a b', 'c'], expectedVersion: 2 })
+  })
+
+  it('link no-op: the same id set in a different order emits nothing (order-insensitive)', () => {
+    const diff = computeRecordRestoreDiff({
+      fieldById: new Map([['lk', { type: 'link' }]]),
+      rawTypeById: new Map([['lk', 'link']]),
+      targetSnapshot: { lk: ['a', 'b'] }, currentData: { lk: ['b', 'a'] },
+      recordId: 'r1', currentVersion: 2, normalizeLinkIds: nlz,
+    })
+    expect(diff).toHaveLength(0)
+  })
+
+  it('scalar set / unset, with non-restorable + button + no-op all skipped', () => {
+    const diff = computeRecordRestoreDiff({
+      fieldById: new Map<string, { type: string }>([
+        ['s', { type: 'string' }],    // changed → set
+        ['u', { type: 'number' }],    // present now, absent in snapshot → unset
+        ['f', { type: 'formula' }],   // non-restorable → skip
+        ['b', { type: 'string' }],    // raw type 'button' → skip
+        ['same', { type: 'string' }], // unchanged → no-op
+      ]),
+      rawTypeById: new Map([['b', 'button']]),
+      targetSnapshot: { s: 'new', same: 'x' },
+      currentData: { s: 'old', u: 5, same: 'x' },
+      recordId: 'r1', currentVersion: 3, normalizeLinkIds: nlz,
+    })
+    const byField = Object.fromEntries(diff.map((c) => [c.fieldId, c]))
+    expect(byField.s).toMatchObject({ op: 'set', value: 'new', expectedVersion: 3 })
+    expect(byField.u).toMatchObject({ op: 'unset' })
+    expect(byField.f).toBeUndefined()
+    expect(byField.b).toBeUndefined()
+    expect(byField.same).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Owner-ratified follow-up **(1)**, implementing the design-lock (`f04c0621`). Collapse the diff logic in `/restore` + `restore-preview` (T5-2) + `restore-execute` (T6-2) onto one shared **`computeRecordRestoreDiff`** (`record-restore-diff.ts`).

## Boundary (your two confirmed forks)
- **raw-diff producer only** — no permission decision, no masked variant. Masking / schema-drift / row-deny / write-gate / `expectedVersion` all **stay in each route** (routes filter the raw diff with their own allowed set). `normalizeLinkIds` is injected as a param (no route↔helper import cycle).
- **canonical link equality = `/restore`'s robust `.every()`** — the shipped write path stays **byte-identical**; T5-2/T6-2 converge off the `.join(' ')` form.

## Reconciliation, honestly
Three *independently-written* impls: `NON_RESTORABLE` (11), `sameValue`, loop body were byte-identical; the one divergence was link equality. The `.join` collision turned out **narrower** than first stated — it only mis-equates **equal-length** sets (the length check short-circuits unequal ones), so the real case is `['a','b c']` vs `['a b','c']` (both → `'a b c'`), **latent/defensive** (generated record ids have no spaces). The mutation-check caught that my *first* collision example (`['a b']` vs `['a','b']`) didn't actually trigger the bug; the golden + the note §3 example are corrected to the equal-length case.

## Acceptance (proven, not asserted)
`/restore` 35 + `restore-preview` 6 + `restore-execute` 7 = **48/48 with UNCHANGED assertions** (incl. e2e preview→execute); tsc 0; unit **3819/3819**. New unit golden exercises the collision **through** `computeRecordRestoreDiff` (public helper) — **mutation-proven**: reverting the canonical to `.join(' ')` fails it. No route behavior change beyond the one declared canonicalization; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)