### PR TITLE
feat(core-backend): FOS-2b-pre — read-only getObjectField provisioning API (field-option-sync prerequisite)

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -46,6 +46,7 @@ import {
   ensureObject as ensureMultitableObject,
   ensureView as ensureMultitableView,
   patchObjectFieldProperty as patchProvisionedObjectFieldProperty,
+  getObjectField as getProvisionedObjectField,
   type MultitableProvisioningQueryFn,
 } from './multitable/provisioning'
 import {
@@ -499,6 +500,21 @@ export class MetaSheetServer {
                 propertyPatch,
               })
             })
+          },
+          getObjectField: async ({ projectId, objectId, fieldId }) => {
+            // Read-only — a plain pooled query (no transaction needed for a SELECT).
+            const readQuery: MultitableProvisioningQueryFn = async (sql, params) => {
+              const result = await poolManager.get().query(sql, params)
+              return {
+                rows: Array.isArray((result as { rows?: unknown[] }).rows)
+                  ? (result as { rows: unknown[] }).rows
+                  : [],
+                rowCount: typeof (result as { rowCount?: number }).rowCount === 'number'
+                  ? (result as { rowCount: number }).rowCount
+                  : undefined,
+              }
+            }
+            return getProvisionedObjectField({ query: readQuery, projectId, objectId, fieldId })
           },
         },
         records: {

--- a/packages/core-backend/src/multitable/plugin-scope.ts
+++ b/packages/core-backend/src/multitable/plugin-scope.ts
@@ -225,6 +225,16 @@ export function createPluginScopedMultitableApi(
         })
         return multitable.provisioning.patchObjectFieldProperty(input)
       },
+      getObjectField: async (input) => {
+        // Read-only, but same project/object scope enforcement as the patch path.
+        assertProjectIdAllowedForPlugin(pluginName, input.projectId)
+        await hooks.assertObjectScope?.({
+          pluginName,
+          projectId: input.projectId,
+          objectId: input.objectId,
+        })
+        return multitable.provisioning.getObjectField(input)
+      },
     },
     records: {
       listRecords: async (input) => {

--- a/packages/core-backend/src/multitable/provisioning.ts
+++ b/packages/core-backend/src/multitable/provisioning.ts
@@ -405,6 +405,40 @@ export async function patchObjectFieldProperty(
   }
 }
 
+export type GetObjectFieldInput = {
+  query: MultitableProvisioningQueryFn
+  projectId: string
+  objectId: string
+  fieldId: string
+}
+
+// FOS-2b-pre: read-only getter for a provisioned field's CURRENT property (including a select field's
+// `options`). SELECT only — no write, no sanitize/merge. Returns null when the field does not exist
+// (caller decides). Mirrors the read half of patchObjectFieldProperty; field-option-sync merge modes
+// (append / disable_missing / keep_existing) read current options through this before patching.
+export async function getObjectField(
+  input: GetObjectFieldInput,
+): Promise<MultitableProvisioningField | null> {
+  const sheetId = getObjectSheetId(input.projectId, input.objectId)
+  const physicalFieldId = getObjectFieldId(input.projectId, input.objectId, input.fieldId)
+  const existing = await input.query(
+    `SELECT id, sheet_id, name, type, property, "order"
+     FROM meta_fields
+     WHERE sheet_id = $1 AND id = $2`,
+    [sheetId, physicalFieldId],
+  )
+  const row = (existing.rows as any[])[0]
+  if (!row) return null
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    name: String(row.name),
+    type: String(row.type) as MultitableProvisioningFieldType,
+    property: normalizeJson(row.property),
+    order: Number(row.order ?? 0),
+  }
+}
+
 export async function ensureView(
   input: EnsureViewInput,
 ): Promise<MultitableProvisioningView> {

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -418,6 +418,19 @@ export interface MultitableProvisioningAPI {
     property: Record<string, unknown>
     order: number
   }>
+  // FOS-2b-pre: read-only — returns a field's current property (incl. select options), or null if absent.
+  getObjectField(input: {
+    projectId: string
+    objectId: string
+    fieldId: string
+  }): Promise<{
+    id: string
+    sheetId: string
+    name: string
+    type: MultitableProvisioningFieldType
+    property: Record<string, unknown>
+    order: number
+  } | null>
 }
 
 export interface MultitableRecordsAPI {

--- a/packages/core-backend/tests/unit/multitable-provisioning.test.ts
+++ b/packages/core-backend/tests/unit/multitable-provisioning.test.ts
@@ -8,6 +8,7 @@ import {
   ensureView,
   findObjectSheet,
   patchObjectFieldProperty,
+  getObjectField,
   resolveObjectFieldIds,
   type MultitableProvisioningQueryFn,
 } from '../../src/multitable/provisioning'
@@ -387,6 +388,55 @@ describe('multitable provisioning helper', () => {
       }),
     ).rejects.toThrow('Unsafe field property patch key')
     expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  it('FOS-2b-pre: getObjectField reads current field property (incl. options) read-only; null when absent', async () => {
+    const { query, fields } = createQuery()
+
+    await ensureObject({
+      query,
+      projectId: 'tenant_7:fos',
+      descriptor: {
+        id: 'catalog',
+        name: 'Catalog',
+        fields: [
+          {
+            id: 'kind',
+            name: 'Kind',
+            type: 'select',
+            options: ['a', 'b'],
+            property: { stockPreparation: { ownership: 'human_preserved' } },
+          },
+        ],
+      },
+    })
+
+    const stored = fields.find((field) => field.name === 'Kind')
+    expect(stored).toBeTruthy()
+    const before = JSON.parse(JSON.stringify(fields))
+
+    const got = await getObjectField({
+      query,
+      projectId: 'tenant_7:fos',
+      objectId: 'catalog',
+      fieldId: 'kind',
+    })
+    // reads the CURRENT stored property, including the select options
+    expect(got).not.toBeNull()
+    expect(got?.property).toEqual(stored?.property)
+    expect((got?.property as { options?: unknown[] }).options?.length).toBe(2)
+
+    // read-only: the stored fields are byte-identical after the read (no UPDATE)
+    expect(fields).toEqual(before)
+
+    // missing field → null (read-only: caller decides; does NOT throw, unlike patch)
+    const missing = await getObjectField({
+      query,
+      projectId: 'tenant_7:fos',
+      objectId: 'catalog',
+      fieldId: 'doesNotExist',
+    })
+    expect(missing).toBeNull()
   })
 
   it('ensures one view with deterministic id and normalized config', async () => {


### PR DESCRIPTION
## What (FOS-2b-pre, split from FOS-2b per owner)

A **read-only** host getter `getObjectField` so a plugin can read a field's **current** `property` (incl. select `options`) before patching — the prerequisite for FOS-2b's sync-mode merge runtime (append / disable_missing / keep_existing).

**Why it's needed:** the only existing "read" path (`ensureObject`) is an UPSERT (`ON CONFLICT DO UPDATE SET property = EXCLUDED.property`) that would **wipe** the options when the descriptor omits them; `patchObjectFieldProperty` only returns *after* patching. So there's no safe plugin-side read today.

- `provisioning.ts`: `getObjectField` — SELECT-only (same `meta_fields` read the patch path uses); returns the field or **null** if absent (no throw). No write/sanitize/merge.
- `types/plugin.ts`: interface method. `index.ts`: wired read-only (plain pooled query, no tx). `plugin-scope.ts`: wrapper with the same project/object scope enforcement as patch.
- Test: returns current property incl. options; read-only (store byte-identical after); null on miss.

## Verification
Host **`tsc` build PASS**; `multitable-provisioning` (16) + `multitable-plugin-scope` (2) tests PASS.

## Boundary
Read-only (SELECT only); no migration; **no sync-mode runtime** (that's FOS-2b, deferred); no plugin runtime change; no write/external/K3. `REQUIRED_ADAPTER_METHODS` not involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)