### PR TITLE
feat(multitable): per-field restore through preview→execute (slice 2; filter-then-hash, no new scope)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -212,6 +212,7 @@ jobs:
             tests/integration/multitable-pit-view-realdb.test.ts \
             tests/integration/multitable-restore-preview-realdb.test.ts \
             tests/integration/multitable-restore-execute-realdb.test.ts \
+            tests/integration/multitable-restore-per-field-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1697,10 +1697,14 @@ export class MultitableApiClient {
 
   // T6-2 chain: preview what a record-version restore WOULD change (read-only, masked), returning the identity
   // the execute consumes. Pair with restoreExecuteRecord — never restore from the FE without showing the preview.
-  async restorePreviewRecord(sheetId: string, recordId: string, targetVersion: number): Promise<RestorePreviewResult> {
+  async restorePreviewRecord(sheetId: string, recordId: string, targetVersion: number, fieldIds?: string[]): Promise<RestorePreviewResult> {
+    // fieldIds (optional) = a per-field (column-subset) preview; omitted = full-record. The server filters the
+    // masked diff to the selection before hashing, so the identity binds exactly this subset.
+    const body: { targetVersion: number; fieldIds?: string[] } = { targetVersion }
+    if (fieldIds && fieldIds.length > 0) body.fieldIds = fieldIds
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/restore-preview`,
-      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetVersion }) },
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
     )
     return this.parseJson<RestorePreviewResult>(res)
   }
@@ -1708,10 +1712,13 @@ export class MultitableApiClient {
   // Execute a previewed restore, carrying the previewIdentity from restorePreviewRecord (SR-3: the server
   // confirms execution matches the preview). Writes a forward revision; row-deny / field-gate / version are
   // re-checked server-side.
-  async restoreExecuteRecord(sheetId: string, recordId: string, targetVersion: number, expectedVersion: number, previewIdentity: string): Promise<RestoreRecordResult> {
+  async restoreExecuteRecord(sheetId: string, recordId: string, targetVersion: number, expectedVersion: number, previewIdentity: string, fieldIds?: string[]): Promise<RestoreRecordResult> {
+    // fieldIds must match the selection the identity was minted for (the server re-filters + re-hashes).
+    const body: { targetVersion: number; expectedVersion: number; previewIdentity: string; fieldIds?: string[] } = { targetVersion, expectedVersion, previewIdentity }
+    if (fieldIds && fieldIds.length > 0) body.fieldIds = fieldIds
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/restore-execute`,
-      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ targetVersion, expectedVersion, previewIdentity }) },
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
     )
     return this.parseJson<RestoreRecordResult>(res)
   }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1858,30 +1858,19 @@ const restorePreview = ref<{
   schemaDrift: boolean
   executable: boolean
   identity: string | null
-  payload: { recordId: string; targetVersion: number; expectedVersion: number } | null
+  payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] } | null
 }>({ visible: false, loading: false, changes: [], schemaDrift: false, executable: false, identity: null, payload: null })
 
 const restorePreviewFieldName = (fieldId: string): string => scopedAllFields.value.find((f) => f.id === fieldId)?.name ?? fieldId
 
-async function restoreFieldsDirect(sheetId: string, payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
-  if (!window.confirm(recordLabel('record.restoreConfirm', isZh.value))) return
-  try {
-    const result = await workbench.client.restoreRecordVersion(sheetId, payload.recordId, payload.targetVersion, payload.expectedVersion, payload.fieldIds)
-    showSuccess(recordLabel(result.noop ? 'record.restoreNoop' : 'record.restoreSuccess', isZh.value))
-    await grid.loadViewData(grid.page.value.offset)
-    if (selectedRecordId.value) await refreshSelectedRecordContext(selectedRecordId.value)
-  } catch (error) {
-    showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
-  }
-}
-
 async function onRestoreRecordVersion(payload: { recordId: string; targetVersion: number; expectedVersion: number; fieldIds?: string[] }) {
   const sheetId = workbench.activeSheetId.value
   if (!sheetId) return
-  if (payload.fieldIds && payload.fieldIds.length > 0) { await restoreFieldsDirect(sheetId, payload); return }
-  restorePreview.value = { visible: true, loading: true, changes: [], schemaDrift: false, executable: false, identity: null, payload: { recordId: payload.recordId, targetVersion: payload.targetVersion, expectedVersion: payload.expectedVersion } }
+  // Full-record AND per-field (column-subset) both go through preview→confirm→execute now — fieldIds is carried
+  // through so the preview shows exactly the selected changes and the identity binds that filtered set.
+  restorePreview.value = { visible: true, loading: true, changes: [], schemaDrift: false, executable: false, identity: null, payload: { recordId: payload.recordId, targetVersion: payload.targetVersion, expectedVersion: payload.expectedVersion, fieldIds: payload.fieldIds } }
   try {
-    const pv = await workbench.client.restorePreviewRecord(sheetId, payload.recordId, payload.targetVersion)
+    const pv = await workbench.client.restorePreviewRecord(sheetId, payload.recordId, payload.targetVersion, payload.fieldIds)
     restorePreview.value = { ...restorePreview.value, loading: false, changes: pv.changes, schemaDrift: pv.schemaDrift, executable: pv.previewIdentity != null, identity: pv.previewIdentity }
   } catch (error) {
     restorePreview.value = { ...restorePreview.value, visible: false }
@@ -1893,10 +1882,10 @@ async function onConfirmRestore() {
   const sheetId = workbench.activeSheetId.value
   const state = restorePreview.value
   if (!sheetId || !state.payload || !state.identity) { restorePreview.value = { ...state, visible: false }; return }
-  const { recordId, targetVersion, expectedVersion } = state.payload
+  const { recordId, targetVersion, expectedVersion, fieldIds } = state.payload
   restorePreview.value = { ...state, visible: false }
   try {
-    const result = await workbench.client.restoreExecuteRecord(sheetId, recordId, targetVersion, expectedVersion, state.identity)
+    const result = await workbench.client.restoreExecuteRecord(sheetId, recordId, targetVersion, expectedVersion, state.identity, fieldIds)
     showSuccess(recordLabel(result.noop ? 'record.restoreNoop' : 'record.restoreSuccess', isZh.value))
     await grid.loadViewData(grid.page.value.offset)
     if (selectedRecordId.value) await refreshSelectedRecordContext(selectedRecordId.value)

--- a/docs/development/multitable-restore-per-field-through-preview-dev-verification-20260622.md
+++ b/docs/development/multitable-restore-per-field-through-preview-dev-verification-20260622.md
@@ -1,0 +1,45 @@
+# Restore Per-Field-Through-Preview 开发与验证 MD (slice 2)
+
+> Owner-ratified T6 follow-up (2). Route a per-field (column-subset) restore through the same
+> preview→confirm→execute chain as full-record, instead of the legacy direct `/restore`. A field subset is a
+> FILTER of the single-record-version diff — folded into the `changesHash` — **not** a new identity scope.
+
+## 1. The design (advisor pre-checked, owner-ratified)
+
+- **No new scope claim.** The canonical `changesHash` is over `[fieldId, op, value]` per entry, so it already
+  binds *which* fields change and *to what*. A different selection → a different filtered diff → a different hash
+  → reject. Per-field stays inside record-version-v1; the T6-1 identity claims are untouched (the [P2] scope-lock
+  is about MULTIPLE records — that's slice 3). The identity comment was updated to say exactly this (so it isn't
+  the next stale line).
+- **Filter-then-hash, symmetric at both routes (the load-bearing constraint).** `restore-preview` and
+  `restore-execute` each: recompute the full diff → mask → **filter to `fieldIds` → hash the FILTERED result →
+  (execute) verify**. The selection is folded into the hashed value at both ends, never trusted as a side input.
+- **Probe-safe ordering:** mask *then* `fieldIds`-filter — a requested-but-hidden field is already gone before the
+  selection, so no 403-vs-no-op oracle.
+- **Empty handling:** an empty `fieldIds` array → **400** (schema `.min(1)`); a selection that nets zero changes
+  (unchanged/hidden) → **no executable identity** (preview returns `previewIdentity: null`, execute no-ops
+  *before* consulting the identity) — never a `hash([])` executable token.
+- **FE:** the drawer already emits `fieldIds`; the client + workbench now carry it through preview→execute, and
+  the legacy `restoreFieldsDirect` direct-`/restore` fallback is removed. Full-record and per-field share one path.
+
+## 2. Verification
+
+- backend `tsc` 0; `vue-tsc -b` 0; no migration.
+- **9 per-field real-DB goldens**: happy path (preview [A] → execute [A] restores only A); **KEYSTONE** [A,B]→[A,C]
+  reject; **full-identity → subset-execute reject** (the case that distinguishes filter-then-hash from verify-full
+  — **mutation-proven**: hashing the full diff at execute makes it fail); subset → full-execute reject;
+  order/dup-insensitive ([B,A,A] ≡ [A,B]); unchanged → no identity; hidden → no identity (masked before filter);
+  empty array → 400 at both routes.
+- **Existing suites unchanged-green:** `restore-preview` 6 + `restore-execute` 7 + `/restore` 35 = **48/48**, no
+  assertion edits (the per-field path is additive; the full-record path is byte-identical).
+- **FE web-guard (official filter): 321/321 across 32 files** (incl. the dialog spec, grid, history).
+- **Slice-1 cleanup folded in:** the two stale "diff unify is a P3 follow-up" comments are removed.
+
+## 3. Known pre-existing (NOT this slice)
+
+The `multitable-workbench-*` specs (incl. `restore-wiring`) fail on a **shared scaffold error** (`Cannot read
+'value'`) that is **pre-existing on `main`** — verified by stashing this slice's FE changes and re-running (still
+17/17 fail). They are the "historical/flaky" specs the web-guard deliberately excludes, so they do not run in CI.
+One consequence: `restore-wiring.spec.ts` is a wire-drift lock whose assertion (the *old* per-field-direct
+`restoreRecordVersion` call) is now stale; it should be updated when that scaffold is fixed (a separate
+pre-existing issue, out of this slice's scope).

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -12,10 +12,12 @@ import { resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
  * are T6-2).
  *
  * SCOPE LOCK (v1): this identity binds a SINGLE record-version restore — `{ sheetId, recordId, targetVersion }`.
- * It deliberately does NOT express a batch / multi-record / field-subset scope. T6-2 v1 must therefore execute
- * a single-record record-version restore ONLY; a batch / fan-out restore identity is a later slice that adds a
- * `scope` claim (kind + recordIds/fieldIds/batchId) and binds a scope canonical hash. Do not read this v1
- * identity as authorizing a wider scope just because `changesHash` matches.
+ * A FIELD SUBSET of that record-version is NOT a separate scope — it is represented by the filtered `changesHash`:
+ * preview + execute both filter the masked diff to the selected `fieldIds` and hash the FILTERED result, so a
+ * different selection yields a different hash and cannot be replayed (the selection is folded into the hash, never
+ * trusted as a side input). What this identity deliberately does NOT express is a MULTI-RECORD / batch / PIT
+ * scope; that is a later slice that adds a `scope` claim (kind + recordIds/batchId) and binds a scope canonical
+ * hash. Do not read this v1 identity as authorizing a MULTI-RECORD scope just because `changesHash` matches.
  *
  * Stateless (JWT/HS256, same primitive as invite-tokens): signature defeats tampering, `exp` bounds the window,
  * and `changesHash` defeats stale replay (if the data — or the actor's field permissions — moved since preview,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7397,9 +7397,13 @@ export function univerMetaRouter(): Router {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
     if (!sheetId || !recordId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
-    const previewParsed = z.object({ targetVersion: z.number().int().positive() }).safeParse(req.body)
+    const previewParsed = z.object({ targetVersion: z.number().int().positive(), fieldIds: z.array(z.string().min(1)).min(1).optional() }).safeParse(req.body)
     if (!previewParsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: previewParsed.error.message } })
     const previewTargetVersion = previewParsed.data.targetVersion
+    // T6 per-field: an optional fieldIds subset. Omitted = full-record. Provided = the masked diff is FILTERED to
+    // this selection BEFORE hashing (filter-then-hash; fieldIds is folded into the changesHash, never a trusted
+    // side input). The empty array is rejected by the schema (.min(1)) — never a hash([]) executable token.
+    const previewFieldIds = previewParsed.data.fieldIds
     try {
       const pool = poolManager.get()
       // Denied/missing record share the SAME 404 shape (no existence oracle), like the per-record history route.
@@ -7429,8 +7433,7 @@ export function univerMetaRouter(): Router {
       let schemaDrift = false
       for (const fid of Object.keys(targetSnapshot)) if (!previewCtx.fieldById.has(fid)) { schemaDrift = true; break }
 
-      // Mirror of the restore route's set ∪ unset diff (scalar) + link-as-report. Helpers mirror restore (P3 dup).
-      // T6 P3 unify: the canonical raw diff (shared computeRecordRestoreDiff). The preview projects it to
+      // T6 P3: the shared computeRecordRestoreDiff is the source; the preview projects it to
       // {fieldId,op,value} for the changesHash + masking; recordId/expectedVersion are dropped (preview writes nothing).
       const changes = computeRecordRestoreDiff({ fieldById: previewCtx.fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion: 0, normalizeLinkIds })
         .map((c) => ({ fieldId: c.fieldId, op: (c.op ?? 'set') as 'set' | 'unset', value: c.value }))
@@ -7439,22 +7442,27 @@ export function univerMetaRouter(): Router {
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
       const visibleChanges = changes.filter((c) => allowed.has(c.fieldId))
+      // Per-field: filter the ALREADY-MASKED diff to the selection (mask-then-filter, so a hidden requested field is
+      // already gone — no 403-vs-no-op probe). Order/dups are irrelevant — a Set membership over the masked diff.
+      const selectedChanges = previewFieldIds ? visibleChanges.filter((c) => new Set(previewFieldIds).has(c.fieldId)) : visibleChanges
       // T6-2: mint a preview identity binding this MASKED diff (what the actor saw) so a later restore-execute can
       // confirm execution matches this preview (SR-3). Reveal-free by construction (this route has no reveal path).
       // NOT executable under schema drift: a snapshot field deleted from the current schema can't be faithfully
       // reproduced, so an executable identity would let execute SILENTLY partial-restore the surviving fields.
       // Withhold the identity (FE must surface the drift); execute also re-checks and rejects (defense in depth).
-      const previewIdentity = schemaDrift
+      // No executable identity when the (filtered) diff is empty — a selection that nets zero changes behaves like
+      // the no-op/drift path, never a hash([]) executable token.
+      const previewIdentity = (schemaDrift || selectedChanges.length === 0)
         ? null
         : mintRestorePreviewIdentity({
             sheetId,
             recordId,
             targetVersion: previewTargetVersion,
             strategy: 'revert',
-            changesHash: hashPreviewChanges(visibleChanges),
+            changesHash: hashPreviewChanges(selectedChanges),
             actorId: access.userId,
           })
-      return res.json({ ok: true, data: { changes: visibleChanges, visibleAffectedFieldCount: visibleChanges.length, schemaDrift, targetVersion: previewTargetVersion, previewIdentity } })
+      return res.json({ ok: true, data: { changes: selectedChanges, visibleAffectedFieldCount: selectedChanges.length, schemaDrift, targetVersion: previewTargetVersion, previewIdentity } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7705,9 +7713,11 @@ export function univerMetaRouter(): Router {
       targetVersion: z.number().int().positive(),
       expectedVersion: z.number().int().nonnegative(),
       previewIdentity: z.string().min(1),
+      // T6 per-field: optional subset, symmetric with restore-preview. Empty array rejected by .min(1).
+      fieldIds: z.array(z.string().min(1)).min(1).optional(),
     }).safeParse(req.body)
     if (!exParsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: exParsed.error.message } })
-    const { targetVersion, expectedVersion, previewIdentity } = exParsed.data
+    const { targetVersion, expectedVersion, previewIdentity, fieldIds: executeFieldIds } = exParsed.data
     const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
     try {
       const pool = poolManager.get()
@@ -7751,33 +7761,33 @@ export function univerMetaRouter(): Router {
         if (!fieldById.has(fid)) return res.status(422).json({ ok: false, error: { code: 'SCHEMA_DRIFT', message: `Field ${fid} in revision ${targetVersion} no longer exists in the current schema` } })
       }
 
-      // The faithful set ∪ unset diff (same shape as /restore + T5-2's preview), then MASK to the actor's allowed
-      // fields — this masked set is exactly what T5-2's preview hashed into the identity (3rd copy of the diff;
-      // the end-to-end preview→execute golden is the drift guard, unifying the copies is a follow-up P3).
-      // T6 P3 unify: the canonical raw diff (shared computeRecordRestoreDiff). Masking / gate / schema-drift /
-      // expectedVersion stay below in this route — the helper only produces the raw diff.
+      // T6 P3: the shared computeRecordRestoreDiff is the source; masking / gate / schema-drift / expectedVersion
+      // stay in this route — the helper only produces the raw diff.
       const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData, recordId, currentVersion, normalizeLinkIds })
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
       const maskedDiff = diff.filter((c) => allowed.has(c.fieldId))
+      // Per-field: filter the ALREADY-MASKED diff to the selection (mask-then-filter, symmetric with the preview),
+      // so the hash is over the SAME filtered set the preview minted. Order/dups irrelevant (Set membership).
+      const selectedDiff = executeFieldIds ? maskedDiff.filter((c) => new Set(executeFieldIds).has(c.fieldId)) : maskedDiff
+      // An empty (filtered) diff is a no-op BEFORE the identity is even consulted — no hash([]) token can "succeed".
+      if (selectedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
 
-      // Verify the identity against claims recomputed FRESH from the current masked diff (execution matches the
+      // Verify the identity against claims recomputed FRESH from the current FILTERED diff (execution matches the
       // preview). A stale diff (data / permissions moved) re-hashes differently → mismatch → reject → re-preview.
-      const recomputedHash = hashPreviewChanges(maskedDiff.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value })))
+      const recomputedHash = hashPreviewChanges(selectedDiff.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value })))
       const verdict = verifyRestorePreviewIdentity(previewIdentity, { sheetId, recordId, targetVersion, strategy: 'revert', changesHash: recomputedHash, actorId: access.userId })
       if (!verdict.valid) {
         const status = verdict.reason === 'expired' ? 410 : 409
         return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Preview identity rejected (${verdict.reason})` } })
       }
-
-      if (maskedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
       if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
       try {
         const result = await recordWriteService.patchRecords({
           sheetId,
-          changesByRecord: new Map([[recordId, maskedDiff]]),
+          changesByRecord: new Map([[recordId, selectedDiff]]),
           actorId: getRequestActorId(req),
           fields,
           visiblePropertyFields: readableEchoFields,
@@ -7790,7 +7800,7 @@ export function univerMetaRouter(): Router {
           source: 'restore',
         })
         const newVersion = result.updated.find((u) => u.recordId === recordId)?.version ?? currentVersion + 1
-        return res.json({ ok: true, data: { recordId, newVersion, noop: false, restoredFieldIds: maskedDiff.map((c) => c.fieldId) } })
+        return res.json({ ok: true, data: { recordId, newVersion, noop: false, restoredFieldIds: selectedDiff.map((c) => c.fieldId) } })
       } catch (err) {
         if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) return res.status(409).json({ ok: false, error: { code: 'VERSION_CONFLICT', message: (err as Error).message } })
         if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: (err as Error).message } })

--- a/packages/core-backend/tests/integration/multitable-restore-per-field-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-per-field-realdb.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Global History — slice (2): per-field-through-preview (real DB). A fieldIds subset is a FILTER of the same
+ * single-record-version diff, folded into the changesHash (filter-then-hash, symmetric at preview + execute) —
+ * NOT a new identity scope. Locks: the [A,B]→[A,C] keystone (selection bound), preview-subset→execute-full
+ * reject, empty/unchanged/hidden → no executable identity, empty array → 400, and order/dup-insensitivity.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_pf_${TS}`
+const SHEET = `sheet_pf_${TS}`
+const NAME = `f_name_${TS}`
+const SALARY = `f_salary_${TS}`
+const NOTE = `f_note_${TS}`
+const UNCH = `f_unch_${TS}` // unchanged v1→current → never in the diff
+const SECRET = `f_secret_${TS}` // hidden from VIEWER via field_permissions
+const REC = `rec_pf_${TS}`
+const VIEWER = `user_pf_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const preview = (body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${REC}/restore-preview`).send(body)
+const execute = (body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${REC}/restore-execute`).send(body)
+const dataOf = async () => ((await q('SELECT data FROM meta_records WHERE id = $1', [REC])).rows[0] as { data: Record<string, unknown> } | undefined)?.data
+const field = (id: string, name: string, type: string, order: number) => q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [id, SHEET, name, type, '{}', order])
+
+describeIfDatabase('multitable per-field restore through preview — slice (2) (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: VIEWER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'PF'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'PF'])
+    await field(NAME, 'Name', 'string', 1); await field(SALARY, 'Salary', 'number', 2); await field(NOTE, 'Note', 'string', 3)
+    await field(UNCH, 'Unch', 'string', 4); await field(SECRET, 'Secret', 'string', 5)
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [VIEWER])
+    // SECRET hidden from VIEWER (so a [SECRET] selection masks to empty).
+    await q(`INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,false,false)`, [SHEET, SECRET, VIEWER])
+  })
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {}); await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {}); await q('DELETE FROM users WHERE id = $1', [VIEWER]).catch(() => {})
+  })
+  // v2 current {b,200,z,same,s2}; v1 snapshot {a,100,y,same,s1}. Restore→v1 changes NAME,SALARY,NOTE,SECRET (UNCH stays).
+  beforeEach(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET]); await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [REC, SHEET, JSON.stringify({ [NAME]: 'b', [SALARY]: 200, [NOTE]: 'z', [UNCH]: 'same', [SECRET]: 's2' })])
+    const rev = (v: number, action: string, data: Record<string, unknown>) => q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5]::text[],'{}'::jsonb,$6::jsonb,now())`, [SHEET, REC, v, action, NAME, JSON.stringify(data)])
+    await rev(1, 'create', { [NAME]: 'a', [SALARY]: 100, [NOTE]: 'y', [UNCH]: 'same', [SECRET]: 's1' })
+    await rev(2, 'update', { [NAME]: 'b', [SALARY]: 200, [NOTE]: 'z', [UNCH]: 'same', [SECRET]: 's2' })
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('happy path: preview [NAME] → execute [NAME] restores ONLY NAME', async () => {
+    const id = (await preview({ targetVersion: 1, fieldIds: [NAME] })).body?.data?.previewIdentity as string
+    expect(typeof id).toBe('string')
+    const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: id, fieldIds: [NAME] })
+    expect(ex.status).toBe(200)
+    const d = await dataOf()
+    expect(d?.[NAME]).toBe('a') // restored
+    expect(d?.[SALARY]).toBe(200); expect(d?.[NOTE]).toBe('z') // untouched
+  })
+
+  test('KEYSTONE: an identity minted for [NAME,SALARY] cannot execute [NAME,NOTE]', async () => {
+    const id = (await preview({ targetVersion: 1, fieldIds: [NAME, SALARY] })).body?.data?.previewIdentity as string
+    const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: id, fieldIds: [NAME, NOTE] })
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID') // different filtered set → different hash
+    expect((await dataOf())?.[NAME]).toBe('b') // nothing written
+  })
+
+  test('a FULL-record identity cannot execute a per-field SUBSET (filter-then-hash, not verify-full)', async () => {
+    // mint over the full diff (no fieldIds → hash(full)); a [NAME] execute hashes only {NAME} → diverges → reject.
+    // This is the case that distinguishes filter-then-hash from a buggy verify-full-then-filter-the-write.
+    const id = (await preview({ targetVersion: 1 })).body?.data?.previewIdentity as string
+    const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: id, fieldIds: [NAME] })
+    expect(ex.status).toBe(409)
+    expect((await dataOf())?.[NAME]).toBe('b') // nothing written
+  })
+
+  test('a subset identity cannot execute the FULL record (omitted fieldIds)', async () => {
+    const id = (await preview({ targetVersion: 1, fieldIds: [NAME] })).body?.data?.previewIdentity as string
+    const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: id }) // no fieldIds = full diff
+    expect(ex.status).toBe(409)
+    expect((await dataOf())?.[NAME]).toBe('b')
+  })
+
+  test('order / duplicates are irrelevant: [NAME,SALARY] preview, [SALARY,NAME,NAME] execute succeeds', async () => {
+    const id = (await preview({ targetVersion: 1, fieldIds: [NAME, SALARY] })).body?.data?.previewIdentity as string
+    const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: id, fieldIds: [SALARY, NAME, NAME] })
+    expect(ex.status).toBe(200) // same Set → same filtered diff → same hash
+    const d = await dataOf(); expect(d?.[NAME]).toBe('a'); expect(d?.[SALARY]).toBe(100)
+  })
+
+  test('an UNCHANGED-field selection yields no executable identity (empty filtered diff)', async () => {
+    const pv = await preview({ targetVersion: 1, fieldIds: [UNCH] })
+    expect(pv.body?.data?.changes).toHaveLength(0)
+    expect(pv.body?.data?.previewIdentity).toBeNull()
+  })
+
+  test('a HIDDEN-field selection yields no executable identity (masked out before the filter)', async () => {
+    const pv = await preview({ targetVersion: 1, fieldIds: [SECRET] }) // SECRET hidden from VIEWER
+    expect(pv.body?.data?.changes).toHaveLength(0)
+    expect(pv.body?.data?.previewIdentity).toBeNull()
+  })
+
+  test('an empty fieldIds array is a 400 at both preview and execute (never a hash([]) token)', async () => {
+    expect((await preview({ targetVersion: 1, fieldIds: [] })).status).toBe(400)
+    expect((await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: 'x.y.z', fieldIds: [] })).status).toBe(400)
+  })
+})


### PR DESCRIPTION
Owner-ratified T6 follow-up **(2)**. A per-field (column-subset) restore now goes through the same **preview→confirm→execute** chain as full-record (filtered), instead of the legacy direct `/restore`. A field subset is a **filter** of the single-record-version diff folded into the `changesHash` — **not** a new identity scope (the T6-1 [P2] scope-lock is about *multiple records*; that's slice 3, untouched).

## Design (advisor pre-checked)
- **No new scope claim** — the `changesHash` (over `[fieldId, op, value]`) already binds the selection.
- **Filter-then-hash, symmetric** — both routes filter the masked diff to `fieldIds` and hash the **filtered** result; the selection is never a trusted side input.
- **Probe-safe** mask-then-filter; **empty array → 400**; empty filtered diff → **no executable identity** (never a `hash([])` token).
- Identity scope comment updated (field-subset = filtered hash, not a scope claim). **Slice-1 cleanup folded in**: the two stale "diff unify is a P3 follow-up" comments removed.
- **FE**: client + workbench carry `fieldIds` through preview→execute; legacy `restoreFieldsDirect` removed.

## Verification
backend tsc 0; `vue-tsc -b` 0; **9 per-field real-DB goldens** (happy · **KEYSTONE [A,B]→[A,C] reject** · full-identity→subset reject **mutation-proven** · subset→full reject · order/dup-insensitive · unchanged/hidden→no-identity · empty-array→400); existing **48/48 unchanged assertions**; FE web-guard **321/321**. No migration.

## Pre-existing (not this slice)
The `multitable-workbench-*` specs (incl. `restore-wiring`) fail on a **shared scaffold error on `main`** — verified by stashing this slice's FE changes (still 17/17 fail); they're excluded from the web-guard. `restore-wiring`'s assertion is now stale (old per-field-direct path); update it when that scaffold is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)