### PR TITLE
fix(multitable): restore-execute verifies the identity before the empty-diff noop (slice 2 [P2])

### DIFF
--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1848,9 +1848,9 @@ async function onToggleRecordLock(payload: { recordId: string; locked: boolean }
 // confirm + API call + refresh (mirrors onToggleRecordLock). The backend error carries `.code`
 // (VERSION_CONFLICT / VERSION_EXPIRED / RESTORE_UNSUPPORTED / SNAPSHOT_UNAVAILABLE / SCHEMA_DRIFT /
 // RESTORE_FORBIDDEN); we surface error.message (already localized server-side) with a static fallback.
-// T6-3: full-record restore goes through preview→confirm→execute (the T6-2 chain); the panel shows what would
-// change before the actor commits, and a schema-drift conflict blocks it. Per-field (column-level) restore keeps
-// the existing direct path (the T6 identity binds the full-record diff; per-field-through-preview is a follow-up).
+// T6: BOTH full-record and per-field (column-subset) restore go through preview→confirm→execute; the panel shows
+// what would change before the actor commits, and a schema-drift conflict blocks it. fieldIds is carried through
+// so the preview + identity bind exactly the selected subset (the legacy direct /restore fallback was removed).
 const restorePreview = ref<{
   visible: boolean
   loading: boolean

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7770,9 +7770,6 @@ export function univerMetaRouter(): Router {
       // Per-field: filter the ALREADY-MASKED diff to the selection (mask-then-filter, symmetric with the preview),
       // so the hash is over the SAME filtered set the preview minted. Order/dups irrelevant (Set membership).
       const selectedDiff = executeFieldIds ? maskedDiff.filter((c) => new Set(executeFieldIds).has(c.fieldId)) : maskedDiff
-      // An empty (filtered) diff is a no-op BEFORE the identity is even consulted — no hash([]) token can "succeed".
-      if (selectedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
-
       // Verify the identity against claims recomputed FRESH from the current FILTERED diff (execution matches the
       // preview). A stale diff (data / permissions moved) re-hashes differently → mismatch → reject → re-preview.
       const recomputedHash = hashPreviewChanges(selectedDiff.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value })))
@@ -7781,6 +7778,10 @@ export function univerMetaRouter(): Router {
         const status = verdict.reason === 'expired' ? 410 : 409
         return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Preview identity rejected (${verdict.reason})` } })
       }
+      // Empty filtered diff is a no-op — but ONLY AFTER a valid identity is consumed. Preview never mints an
+      // identity for an empty diff, so a forged/arbitrary token 409s at the verify above; a success ALWAYS
+      // consumes a valid preview identity, never an empty-selection bypass.
+      if (selectedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
       if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])

--- a/packages/core-backend/tests/integration/multitable-restore-per-field-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-per-field-realdb.test.ts
@@ -113,6 +113,21 @@ describeIfDatabase('multitable per-field restore through preview — slice (2) (
     expect(pv.body?.data?.previewIdentity).toBeNull()
   })
 
+  test('empty filtered diff + ANY token → 409 (no 200-noop bypass of the identity verify)', async () => {
+    // A valid signed token, minted for [NAME] (a different, non-empty selection).
+    const realToken = (await preview({ targetVersion: 1, fieldIds: [NAME] })).body?.data?.previewIdentity as string
+    // Each of these filters to an EMPTY diff (unchanged / hidden / unknown). The execute must 409 — the success
+    // contract consumes a valid identity, and the [NAME] token's hash != hash([]). NOT a 200 noop.
+    for (const fids of [[UNCH], [SECRET], ['ghost_field_x']]) {
+      const ex = await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: realToken, fieldIds: fids })
+      expect(ex.status).toBe(409)
+      expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    }
+    // a forged/garbage token likewise 409s (signature), never a noop.
+    expect((await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: 'forged.token.value', fieldIds: [UNCH] })).status).toBe(409)
+    expect((await dataOf())?.[NAME]).toBe('b') // nothing written
+  })
+
   test('an empty fieldIds array is a 400 at both preview and execute (never a hash([]) token)', async () => {
     expect((await preview({ targetVersion: 1, fieldIds: [] })).status).toBe(400)
     expect((await execute({ targetVersion: 1, expectedVersion: 2, previewIdentity: 'x.y.z', fieldIds: [] })).status).toBe(400)


### PR DESCRIPTION
Owner review of #3042 **[P2]** (a real semantic bug I introduced in slice 2). `restore-execute` returned a **200 noop for an empty filtered diff BEFORE verifying the preview identity** — so a caller could present any non-empty (even forged) `previewIdentity` and, as long as `fieldIds` filtered to empty (unchanged / hidden / unknown), get a successful noop, **bypassing the identity verification**. No write, no leak, but it breaks T6's contract: a successful `restore-execute` must consume a **valid** identity.

## Fix (as you suggested)
**Verify `hashPreviewChanges(selectedDiff)` first, then the `selectedDiff.length === 0` noop.** Preview never mints an identity for an empty diff, so an empty filtered selection re-hashes to `hash([])`, which no minted token matches (and a forged token fails the signature) → **409 `PREVIEW_IDENTITY_INVALID`**, never a 200 bypass.

## Golden (mutation-proven)
Empty filtered diff (`[UNCH]` / `[SECRET]` / unknown) + **any** token (a real `[NAME]` token or a forged string) → **409, nothing written**. Re-introducing the noop-before-verify fails it.

## [P3]
The FE comment in `MultitableWorkbench.vue` still said per-field "keeps the existing direct path / per-field-through-preview is a follow-up" — updated (both paths go through preview→execute).

## Verification
backend tsc 0; `vue-tsc -b` 0; per-field **10/10** + restore-execute 7 + restore-preview 6 unchanged. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)