### PR TITLE
feat(integration): FOS-2b — field-option-sync sync-mode merge runtime (no-delete / no-silent-write / replace zero-drift)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/field-option-sync-runtime.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/field-option-sync-runtime.test.cjs
@@ -7,7 +7,7 @@ const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const path = require('node:path')
 
-const { syncFieldOptions } = require(path.join(__dirname, '..', 'lib', 'field-option-sync-runtime.cjs'))
+const { syncFieldOptions, mergeFieldOptions } = require(path.join(__dirname, '..', 'lib', 'field-option-sync-runtime.cjs'))
 
 // ZERO-DRIFT STRUCTURAL LOCK: the stock-prep option-sync module MUST route through this kernel and
 // MUST NOT carry its own patch loop / patch call (else it would be a parallel copy that could drift
@@ -253,7 +253,119 @@ async function main() {
     'incomplete errorFactory throws',
   )
 
-  console.log('field-option-sync-runtime: kernel loop/skip/patch/error-if-none + guards tests passed')
+  // ==== FOS-2b sync-mode runtime — owner-gated LOCKS ====
+
+  // LOCK 1 — NO DELETE: disable_missing marks current-not-in-source as disabled, NEVER drops it.
+  {
+    const merged = mergeFieldOptions(
+      [{ value: 'a' }, { value: 'b' }],
+      [{ value: 'a' }],
+      'disable_missing',
+      'update_from_source',
+    )
+    const b = merged.find((o) => o.value === 'b')
+    assert.ok(b, 'disable_missing KEEPS the missing option (no delete)')
+    assert.equal(b.disabled, true, 'missing option is DISABLED, not removed')
+    assert.equal(merged.length, 2, 'no option dropped')
+    // append also never removes
+    const app = mergeFieldOptions([{ value: 'a' }], [{ value: 'b' }], 'append', 'update_from_source')
+    assert.deepEqual(app.map((o) => o.value).sort(), ['a', 'b'], 'append unions current + source (nothing removed)')
+  }
+
+  // conflictPolicy on overlap: keep_existing preserves CURRENT (human) fields; update_from_source takes source.
+  {
+    const keep = mergeFieldOptions([{ value: 'a', label: 'Human' }], [{ value: 'a', label: 'Source' }], 'append', 'keep_existing')
+    assert.equal(keep.find((o) => o.value === 'a').label, 'Human', 'keep_existing preserves the human label')
+    const upd = mergeFieldOptions([{ value: 'a', label: 'Human' }], [{ value: 'a', label: 'Source' }], 'append', 'update_from_source')
+    assert.equal(upd.find((o) => o.value === 'a').label, 'Source', 'update_from_source overwrites from source')
+  }
+
+  // LOCK 2 — NO SILENT WRITE: manual_confirm patches NOTHING; returns values-free held evidence.
+  {
+    const provisioning = createProvisioning()
+    const { synced, held } = await syncFieldOptions({
+      provisioning,
+      projectId: 'tenant_1:integration-core',
+      targetObjectId: 'obj_demo',
+      optionFields: [OPTION_FIELDS[0]],
+      optionSets: { material_type: { options: [{ value: 'x' }, { value: 'y' }] } },
+      buildPropertyPatch,
+      resolveSkipReason,
+      errorFactory: makeErrorFactory(),
+      syncMode: 'replace',
+      conflictPolicy: 'manual_confirm',
+      readCurrentOptions: async () => [{ value: 'x' }],
+    })
+    assert.equal(provisioning.calls.length, 0, 'manual_confirm makes ZERO patch calls (no silent write)')
+    assert.equal(synced.length, 0, 'manual_confirm syncs nothing')
+    assert.equal(held.length, 1, 'manual_confirm returns a held preview')
+    assert.equal(held[0].wouldAdd, 1, 'held: y would be added')
+    assert.equal(held[0].wouldUpdate, 1, 'held: x would be updated')
+    assert.equal(/"x"|"y"/.test(JSON.stringify(held[0])), false, 'held evidence is values-free (no option values)')
+  }
+
+  // LOCK 3 — REPLACE ZERO-DRIFT: default mode does NOT read current and patches the RAW set byte-identically.
+  {
+    const provisioning = createProvisioning()
+    let reads = 0
+    await syncFieldOptions({
+      provisioning,
+      projectId: 'tenant_1:integration-core',
+      targetObjectId: 'obj_demo',
+      optionFields: [OPTION_FIELDS[0]],
+      optionSets: { material_type: { options: [{ value: 'a' }, { value: 'b' }] } },
+      buildPropertyPatch,
+      resolveSkipReason,
+      errorFactory: makeErrorFactory(),
+      // defaults: replace + update_from_source
+      readCurrentOptions: async () => { reads += 1; return [{ value: 'zzz' }] },
+    })
+    assert.equal(reads, 0, 'replace+update_from_source does NOT read current options (fast path)')
+    assert.deepEqual(
+      provisioning.calls[0].propertyPatch.options,
+      [{ value: 'a' }, { value: 'b' }],
+      'patches the RAW source set (byte-identical — zero-drift)',
+    )
+  }
+
+  // disable_missing through the kernel: the merged effective set (incl. the kept-disabled option) is patched.
+  {
+    const provisioning = createProvisioning()
+    await syncFieldOptions({
+      provisioning,
+      projectId: 'tenant_1:integration-core',
+      targetObjectId: 'obj_demo',
+      optionFields: [OPTION_FIELDS[0]],
+      optionSets: { material_type: { options: [{ value: 'a' }] } },
+      buildPropertyPatch,
+      resolveSkipReason,
+      errorFactory: makeErrorFactory(),
+      syncMode: 'disable_missing',
+      conflictPolicy: 'update_from_source',
+      readCurrentOptions: async () => [{ value: 'a' }, { value: 'b' }],
+    })
+    const patched = provisioning.calls[0].propertyPatch.options.map((o) => o.value)
+    assert.deepEqual(patched, ['a', 'b'], 'disable_missing patches a + b (b KEPT, not deleted)')
+  }
+
+  // fail-closed: a non-default mode without readCurrentOptions throws (cannot merge blind).
+  await assert.rejects(
+    () => syncFieldOptions({
+      provisioning: createProvisioning(),
+      projectId: 'p',
+      targetObjectId: 'o',
+      optionFields: [OPTION_FIELDS[0]],
+      optionSets: { material_type: { options: [] } },
+      buildPropertyPatch,
+      resolveSkipReason,
+      errorFactory: makeErrorFactory(),
+      syncMode: 'append',
+    }),
+    /requires readCurrentOptions/,
+    'non-default mode without readCurrentOptions fails closed',
+  )
+
+  console.log('field-option-sync-runtime: kernel loop/skip/patch/error-if-none + guards + FOS-2b sync-mode locks tests passed')
 }
 
 main().catch((error) => {

--- a/plugins/plugin-integration-core/lib/field-option-sync-runtime.cjs
+++ b/plugins/plugin-integration-core/lib/field-option-sync-runtime.cjs
@@ -39,6 +39,13 @@ async function syncFieldOptions({
   buildPropertyPatch,
   resolveSkipReason,
   errorFactory,
+  // FOS-2b: sync-mode runtime. Defaults reproduce the pre-FOS-2b behavior EXACTLY (replace +
+  // update_from_source = full overwrite, no read, no merge) so stock-prep stays byte-identical.
+  syncMode = 'replace',
+  conflictPolicy = 'update_from_source',
+  // readCurrentOptions(field) => Promise<optionObject[]|null> — required ONLY for non-default modes
+  // (append / disable_missing / keep_existing / manual_confirm), wired by the caller to getObjectField.
+  readCurrentOptions,
 } = {}) {
   if (!provisioning || typeof provisioning.patchObjectFieldProperty !== 'function') {
     throw new TypeError('syncFieldOptions requires provisioning.patchObjectFieldProperty')
@@ -59,8 +66,15 @@ async function syncFieldOptions({
 
   const fields = Array.isArray(optionFields) ? optionFields : []
   const sets = optionSets && typeof optionSets === 'object' ? optionSets : {}
+  // ZERO-DRIFT fast path: replace + update_from_source = the exact pre-FOS-2b behavior (no read, no
+  // merge). stock-prep stays here. Any other mode reads current options + merges.
+  const isDefaultMode = syncMode === 'replace' && conflictPolicy === 'update_from_source'
+  if (!isDefaultMode && typeof readCurrentOptions !== 'function') {
+    throw new TypeError('syncFieldOptions: non-default syncMode/conflictPolicy requires readCurrentOptions(field)')
+  }
   const synced = []
   const skipped = []
+  const held = []
 
   for (const field of fields) {
     const sourceKey = field.optionSource.key
@@ -73,9 +87,26 @@ async function syncFieldOptions({
       })
       continue
     }
+
+    let effectiveSet = set
+    if (!isDefaultMode) {
+      const current = (await readCurrentOptions(field)) || []
+      const sourceOptions = Array.isArray(set.options) ? set.options : []
+      // manual_confirm NEVER writes: collect values-free held evidence (counts only) of what would change.
+      if (conflictPolicy === 'manual_confirm') {
+        held.push({
+          field: field.id,
+          optionSource: { ...field.optionSource },
+          ...diffOptionCounts(current, sourceOptions, syncMode),
+        })
+        continue
+      }
+      effectiveSet = { ...set, options: mergeFieldOptions(current, sourceOptions, syncMode, conflictPolicy) }
+    }
+
     let propertyPatch
     try {
-      propertyPatch = buildPropertyPatch(field, set)
+      propertyPatch = buildPropertyPatch(field, effectiveSet)
       await provisioning.patchObjectFieldProperty({
         projectId,
         objectId: targetObjectId,
@@ -88,17 +119,86 @@ async function syncFieldOptions({
     synced.push({
       field: field.id,
       optionSource: { ...field.optionSource },
-      set,
+      set: effectiveSet,
     })
   }
 
-  if (synced.length === 0) {
+  // A manual_confirm preview (held > 0) is a valid no-write outcome, not "nothing synced".
+  if (synced.length === 0 && held.length === 0) {
     throw errorFactory.noFieldsSynced({ targetObjectId, skipped })
   }
 
-  return { synced, skipped }
+  return { synced, skipped, held }
+}
+
+// FOS-2b: merge current + source options per syncMode × conflictPolicy. Pure function (no I/O).
+// - append: keep all current, add new-from-source (NOTHING removed).
+// - disable_missing: source set + current-not-in-source marked disabled (NEVER removed/deleted).
+// - replace (only reached with a non-default conflictPolicy): source set; current-not-in-source
+//   dropped (replace semantics). (replace + update_from_source never reaches here — fast path.)
+// conflictPolicy for overlapping values: keep_existing preserves the CURRENT option's fields
+// (human label/color/etc.); update_from_source takes the source option.
+function mergeFieldOptions(current, source, syncMode, conflictPolicy) {
+  const cur = Array.isArray(current) ? current : []
+  const src = Array.isArray(source) ? source : []
+  const curByValue = new Map(cur.map((o) => [o.value, o]))
+  const srcByValue = new Map(src.map((o) => [o.value, o]))
+  const resolveOverlap = (c, s) => (conflictPolicy === 'keep_existing' ? { ...c } : { ...s })
+
+  if (syncMode === 'append') {
+    const out = []
+    const seen = new Set()
+    for (const c of cur) {
+      const s = srcByValue.get(c.value)
+      out.push(s ? resolveOverlap(c, s) : { ...c })
+      seen.add(c.value)
+    }
+    for (const s of src) {
+      if (!seen.has(s.value)) out.push({ ...s })
+    }
+    return out
+  }
+
+  if (syncMode === 'disable_missing') {
+    const out = []
+    const seen = new Set()
+    for (const s of src) {
+      const c = curByValue.get(s.value)
+      out.push(c ? resolveOverlap(c, s) : { ...s })
+      seen.add(s.value)
+    }
+    for (const c of cur) {
+      if (!seen.has(c.value)) out.push({ ...c, disabled: true }) // disable, NEVER delete
+    }
+    return out
+  }
+
+  // replace with a non-default conflictPolicy (e.g. replace + keep_existing).
+  return src.map((s) => {
+    const c = curByValue.get(s.value)
+    return c ? resolveOverlap(c, s) : { ...s }
+  })
+}
+
+// FOS-2b: values-free diff counts for manual_confirm held evidence (counts only — no values/labels).
+function diffOptionCounts(current, source, syncMode) {
+  const curValues = new Set((Array.isArray(current) ? current : []).map((o) => o.value))
+  const srcValues = new Set((Array.isArray(source) ? source : []).map((o) => o.value))
+  let wouldAdd = 0
+  let wouldUpdate = 0
+  let wouldDisable = 0
+  for (const v of srcValues) {
+    if (curValues.has(v)) wouldUpdate += 1
+    else wouldAdd += 1
+  }
+  if (syncMode === 'disable_missing') {
+    for (const v of curValues) if (!srcValues.has(v)) wouldDisable += 1
+  }
+  return { wouldAdd, wouldUpdate, wouldDisable }
 }
 
 module.exports = {
   syncFieldOptions,
+  mergeFieldOptions,
+  diffOptionCounts,
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -2146,12 +2146,26 @@ function createHandlers(services, options = {}) {
       // color/order/label/disabled, dedup, max-options). Throws OPTION_SYNC_* (422, values-free).
       const optionSets = optionSetsFromInput(input.optionSets)
 
-      const { synced, skipped } = await syncFieldOptions({
+      const { synced, skipped, held } = await syncFieldOptions({
         provisioning,
         projectId: input.projectId,
         targetObjectId: preset.targetTable,
         optionFields,
         optionSets,
+        // FOS-2b: drive the preset's sync semantics. replace + update_from_source = the FOS-2 fast path
+        // (no read, no merge). Other modes read current options via the (read-only) getObjectField.
+        syncMode: preset.syncMode,
+        conflictPolicy: preset.conflictPolicy,
+        readCurrentOptions: async (field) => {
+          const current = await provisioning.getObjectField({
+            projectId: input.projectId,
+            objectId: preset.targetTable,
+            fieldId: field.id,
+          })
+          return current && current.property && Array.isArray(current.property.options)
+            ? current.property.options
+            : []
+        },
         buildPropertyPatch: (field, set) => ({
           options: set.options.map((option) => {
             const out = { value: option.value }
@@ -2185,12 +2199,17 @@ function createHandlers(services, options = {}) {
 
       return sendOk(res, {
         ok: true,
+        // FOS-2b: manual_confirm produces a values-free preview (held) and writes NOTHING.
+        held: held.length > 0,
         target: {
           presetId: preset.presetId,
           targetTable: preset.targetTable,
           fieldCount: synced.length,
+          heldFieldCount: held.length,
         },
         evidence: summarizeFieldOptionSyncEvidence({ preset, synced, skipped }),
+        // held entries are values-free: { field, optionSource:{key,type}, wouldAdd, wouldUpdate, wouldDisable }
+        heldEvidence: held,
       })
     },
 


### PR DESCRIPTION
## What (FOS-2b, owner-gated)

Makes the FOS-1 enums real runtime (on FOS-2b-pre's read-only `getObjectField`). **Owner locks, all tested: no-delete, no-silent-write, replace zero-drift.**

- Kernel `syncFieldOptions` + `mergeFieldOptions`: `append` (union, nothing removed), `disable_missing` (source + current-not-in-source **disabled, never deleted**), conflictPolicy `keep_existing` (preserve current human fields) / `update_from_source` (take source) / `manual_confirm` (**patches nothing**, returns values-free `held` counts). **replace + update_from_source = FOS-2 fast path (no read/merge) → stock-prep byte-identical.** Non-default mode without `readCurrentOptions` → fail-closed.
- Generic route: passes preset syncMode/conflictPolicy + a `getObjectField`-backed reader; returns held evidence for manual_confirm.
- Stock-prep wrapper: unchanged (defaults → fast path).

## Verification (the locks)
LOCK1 no-delete, LOCK2 no-silent-write (0 patch calls + values-free held), LOCK3 replace zero-drift (default does NOT read; raw set patched byte-identical) + keep_existing/update_from_source + disable_missing integration + fail-closed guard. **Zero-drift proven non-vacuous** (break kernel patch → stock-prep test fails). All affected plugin suites green.

## Boundary
Metadata-only; getObjectField read-only; no business-row/external/K3/production write; no migration; admin-gated; values-free. New modes become end-to-end reachable when a non-default preset is added (**FOS-4**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)