### PR TITLE
feat(approval): delegation (委托) config CRUD + admin UI

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -299,6 +299,7 @@ jobs:
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \
             tests/integration/approval-delegation-seam.db.test.ts \
+            tests/integration/approval-delegation-api.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/src/approvals/delegations.ts
+++ b/apps/web/src/approvals/delegations.ts
@@ -1,6 +1,6 @@
 // Delegation (委托) config client — talks to /api/approval-delegations.
-// A user manages only their own delegations (the backend keys on the authenticated
-// actor as delegator), so no delegator field is sent from the client.
+// ADMIN-managed (approval-templates:manage): an admin configures delegations for any
+// user, so the create payload carries the chosen delegatorUserId.
 import { apiGet, apiPost, apiFetch } from '../utils/api'
 
 const USE_MOCK = import.meta.env.DEV || (globalThis as { __APPROVAL_MOCK__?: boolean }).__APPROVAL_MOCK__ === true

--- a/apps/web/src/approvals/delegations.ts
+++ b/apps/web/src/approvals/delegations.ts
@@ -1,0 +1,124 @@
+// Delegation (委托) config client — talks to /api/approval-delegations.
+// A user manages only their own delegations (the backend keys on the authenticated
+// actor as delegator), so no delegator field is sent from the client.
+import { apiGet, apiPost, apiFetch } from '../utils/api'
+
+const USE_MOCK = import.meta.env.DEV || (globalThis as { __APPROVAL_MOCK__?: boolean }).__APPROVAL_MOCK__ === true
+
+export interface DelegationRecord {
+  id: string
+  delegatorUserId: string
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId: string | null
+  startAt: string
+  endAt: string
+  active: boolean
+}
+
+export interface CreateDelegationPayload {
+  delegatorUserId: string
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId?: string | null
+  startAt: string
+  endAt: string
+}
+
+export interface UpdateDelegationPayload {
+  delegateeUserId?: string
+  scope?: 'all' | 'template'
+  scopeTemplateId?: string | null
+  startAt?: string
+  endAt?: string
+  active?: boolean
+}
+
+const mockDelegations: DelegationRecord[] = []
+
+export async function listDelegations(): Promise<DelegationRecord[]> {
+  if (USE_MOCK) return mockDelegations.filter((d) => d.active)
+  const res = await apiGet<{ data: DelegationRecord[] }>('/api/approval-delegations')
+  return res.data ?? []
+}
+
+export async function createDelegation(payload: CreateDelegationPayload): Promise<DelegationRecord> {
+  if (USE_MOCK) {
+    const rec: DelegationRecord = {
+      id: `mock-${mockDelegations.length + 1}`,
+      delegatorUserId: payload.delegatorUserId,
+      delegateeUserId: payload.delegateeUserId,
+      scope: payload.scope,
+      scopeTemplateId: payload.scope === 'template' ? payload.scopeTemplateId ?? null : null,
+      startAt: payload.startAt,
+      endAt: payload.endAt,
+      active: true,
+    }
+    mockDelegations.push(rec)
+    return rec
+  }
+  const res = await apiPost<{ data: DelegationRecord }>('/api/approval-delegations', payload)
+  return res.data
+}
+
+export async function updateDelegation(id: string, patch: UpdateDelegationPayload): Promise<DelegationRecord | null> {
+  if (USE_MOCK) {
+    const d = mockDelegations.find((x) => x.id === id)
+    if (!d) return null
+    const scope = patch.scope ?? d.scope
+    Object.assign(d, {
+      delegateeUserId: patch.delegateeUserId ?? d.delegateeUserId,
+      scope,
+      scopeTemplateId: scope === 'template' ? patch.scopeTemplateId ?? d.scopeTemplateId : null,
+      startAt: patch.startAt ?? d.startAt,
+      endAt: patch.endAt ?? d.endAt,
+      active: patch.active ?? d.active,
+    })
+    return d
+  }
+  const res = await apiFetch(`/api/approval-delegations/${encodeURIComponent(id)}`, { method: 'PATCH', body: JSON.stringify(patch) })
+  if (!res.ok) throw new Error(`Failed to update delegation (${res.status})`)
+  return ((await res.json()) as { data: DelegationRecord }).data
+}
+
+export async function disableDelegation(id: string): Promise<void> {
+  if (USE_MOCK) {
+    const d = mockDelegations.find((x) => x.id === id)
+    if (d) d.active = false
+    return
+  }
+  const res = await apiFetch(`/api/approval-delegations/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`Failed to disable delegation (${res.status})`)
+}
+
+// Form helpers (testable, used by the 委托设置 dialog). Validation returns a zh
+// message or null; buildCreatePayload normalizes to the API shape.
+export interface DelegationForm {
+  delegatorUserId: string
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId: string
+  startAt: string
+  endAt: string
+}
+
+export function validateDelegationForm(form: DelegationForm): string | null {
+  if (!form.delegatorUserId.trim()) return '请填写委托人'
+  if (!form.delegateeUserId.trim()) return '请填写被委托人'
+  if (form.delegatorUserId.trim() === form.delegateeUserId.trim()) return '委托人与被委托人不能相同'
+  if (form.scope === 'template' && !form.scopeTemplateId.trim()) return '指定模板范围需要选择模板'
+  if (!form.startAt || !form.endAt) return '请填写时间窗'
+  if (new Date(form.endAt).getTime() <= new Date(form.startAt).getTime()) return '结束时间必须晚于开始时间'
+  return null
+}
+
+export function buildCreatePayload(form: DelegationForm): CreateDelegationPayload {
+  return {
+    delegatorUserId: form.delegatorUserId.trim(),
+    delegateeUserId: form.delegateeUserId.trim(),
+    scope: form.scope,
+    scopeTemplateId: form.scope === 'template' ? form.scopeTemplateId.trim() : null,
+    startAt: new Date(form.startAt).toISOString(),
+    endAt: new Date(form.endAt).toISOString(),
+  }
+}

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -271,6 +271,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Approval Templates', titleZh: '审批模板', requiresAuth: true }
   },
   {
+    path: '/approval-delegations',
+    name: 'approval-delegations',
+    component: () => import('../views/approval/DelegationSettingsView.vue'),
+    meta: { title: 'Delegation Settings', titleZh: '委托设置', requiresAuth: true, permissions: ['approval-templates:manage'] }
+  },
+  {
     path: '/approval-templates/new',
     name: 'approval-template-create',
     component: () => import('../views/approval/TemplateAuthoringView.vue'),

--- a/apps/web/src/views/approval/DelegationSettingsView.vue
+++ b/apps/web/src/views/approval/DelegationSettingsView.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="delegation-settings">
+    <div class="header">
+      <div>
+        <h2>委托设置</h2>
+        <p class="sub">为审批人配置时间窗内的委托（委托人 → 被委托人）。同一委托人 + 范围目标仅允许一条生效委托。</p>
+      </div>
+      <el-button type="primary" :disabled="!canManage" data-testid="delegation-new" @click="openCreate">新建委托</el-button>
+    </div>
+
+    <el-alert v-if="!canManage" type="info" :closable="false" title="需要审批模板管理权限才能配置委托" />
+
+    <el-table v-loading="loading" :data="delegations" data-testid="delegation-table" empty-text="暂无生效委托">
+      <el-table-column label="委托人" prop="delegatorUserId" />
+      <el-table-column label="被委托人" prop="delegateeUserId" />
+      <el-table-column label="范围">
+        <template #default="{ row }">{{ row.scope === 'template' ? `指定模板：${row.scopeTemplateId}` : '全部审批' }}</template>
+      </el-table-column>
+      <el-table-column label="时间窗">
+        <template #default="{ row }">{{ fmt(row.startAt) }} ~ {{ fmt(row.endAt) }}</template>
+      </el-table-column>
+      <el-table-column label="状态">
+        <template #default="{ row }">{{ row.active ? '生效' : '已停用' }}</template>
+      </el-table-column>
+      <el-table-column label="操作" width="100">
+        <template #default="{ row }">
+          <el-button type="danger" text size="small" :disabled="!canManage" data-testid="delegation-disable" @click="disable(row.id)">停用</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogOpen" title="新建委托" width="480px">
+      <el-form label-width="92px">
+        <el-form-item label="委托人">
+          <el-input v-model="form.delegatorUserId" placeholder="委托人用户 ID" data-testid="delegation-delegator" />
+        </el-form-item>
+        <el-form-item label="被委托人">
+          <el-input v-model="form.delegateeUserId" placeholder="被委托人用户 ID" data-testid="delegation-delegatee" />
+        </el-form-item>
+        <el-form-item label="范围">
+          <el-select v-model="form.scope" data-testid="delegation-scope">
+            <el-option label="全部审批" value="all" />
+            <el-option label="指定模板" value="template" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="form.scope === 'template'" label="模板">
+          <el-input v-model="form.scopeTemplateId" placeholder="审批模板 ID" data-testid="delegation-template" />
+        </el-form-item>
+        <el-form-item label="开始时间">
+          <el-date-picker v-model="form.startAt" type="datetime" value-format="YYYY-MM-DDTHH:mm" />
+        </el-form-item>
+        <el-form-item label="结束时间">
+          <el-date-picker v-model="form.endAt" type="datetime" value-format="YYYY-MM-DDTHH:mm" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogOpen = false">取消</el-button>
+        <el-button type="primary" :loading="saving" data-testid="delegation-submit" @click="submit">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { useApprovalPermissions } from '../../approvals/permissions'
+import {
+  listDelegations,
+  createDelegation,
+  disableDelegation,
+  validateDelegationForm,
+  buildCreatePayload,
+  type DelegationRecord,
+  type DelegationForm,
+} from '../../approvals/delegations'
+
+const { canManageTemplates: canManage } = useApprovalPermissions()
+const delegations = ref<DelegationRecord[]>([])
+const loading = ref(false)
+const saving = ref(false)
+const dialogOpen = ref(false)
+
+const form = reactive<DelegationForm>({
+  delegatorUserId: '',
+  delegateeUserId: '',
+  scope: 'all',
+  scopeTemplateId: '',
+  startAt: '',
+  endAt: '',
+})
+
+function fmt(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+async function load() {
+  loading.value = true
+  try {
+    delegations.value = await listDelegations()
+  } catch (e) {
+    ElMessage.error(e instanceof Error ? e.message : '加载委托失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreate() {
+  Object.assign(form, { delegatorUserId: '', delegateeUserId: '', scope: 'all', scopeTemplateId: '', startAt: '', endAt: '' })
+  dialogOpen.value = true
+}
+
+async function submit() {
+  const error = validateDelegationForm(form)
+  if (error) {
+    ElMessage.warning(error)
+    return
+  }
+  saving.value = true
+  try {
+    await createDelegation(buildCreatePayload(form))
+    ElMessage.success('委托已创建')
+    dialogOpen.value = false
+    await load()
+  } catch (e) {
+    ElMessage.error(e instanceof Error ? e.message : '创建委托失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function disable(id: string) {
+  try {
+    await disableDelegation(id)
+    await load()
+  } catch (e) {
+    ElMessage.error(e instanceof Error ? e.message : '停用委托失败')
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.delegation-settings { padding: 16px; }
+.header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px; }
+.header h2 { margin: 0; }
+.sub { color: var(--el-text-color-secondary); font-size: 13px; margin: 4px 0 0; }
+</style>

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -39,6 +39,14 @@
         >
           新建模板
         </el-button>
+        <el-button
+          v-if="canManageTemplates"
+          style="margin-left: 8px"
+          data-testid="template-center-delegations-link"
+          @click="$router.push('/approval-delegations')"
+        >
+          委托设置
+        </el-button>
       </div>
     </header>
 

--- a/apps/web/tests/approvalDelegationForm.spec.ts
+++ b/apps/web/tests/approvalDelegationForm.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { validateDelegationForm, buildCreatePayload, type DelegationForm } from '../src/approvals/delegations'
+
+const base: DelegationForm = {
+  delegatorUserId: 'A',
+  delegateeUserId: 'B',
+  scope: 'all',
+  scopeTemplateId: '',
+  startAt: '2026-06-22T00:00',
+  endAt: '2026-06-23T00:00',
+}
+
+describe('validateDelegationForm', () => {
+  it('passes a valid all-scope form', () => {
+    expect(validateDelegationForm(base)).toBeNull()
+  })
+  it('requires delegator and delegatee', () => {
+    expect(validateDelegationForm({ ...base, delegatorUserId: '  ' })).toBe('请填写委托人')
+    expect(validateDelegationForm({ ...base, delegateeUserId: '' })).toBe('请填写被委托人')
+  })
+  it('rejects self-delegation', () => {
+    expect(validateDelegationForm({ ...base, delegateeUserId: 'A' })).toBe('委托人与被委托人不能相同')
+  })
+  it("requires a template for scope='template'", () => {
+    expect(validateDelegationForm({ ...base, scope: 'template' })).toBe('指定模板范围需要选择模板')
+  })
+  it('rejects an inverted / empty window', () => {
+    expect(validateDelegationForm({ ...base, startAt: '2026-06-23T00:00', endAt: '2026-06-22T00:00' })).toBe('结束时间必须晚于开始时间')
+    expect(validateDelegationForm({ ...base, endAt: '' })).toBe('请填写时间窗')
+  })
+})
+
+describe('buildCreatePayload', () => {
+  it('trims ids and nulls the template id for all-scope', () => {
+    expect(buildCreatePayload({ ...base, delegatorUserId: ' A ', scope: 'all', scopeTemplateId: 't1' })).toMatchObject({
+      delegatorUserId: 'A',
+      delegateeUserId: 'B',
+      scope: 'all',
+      scopeTemplateId: null,
+    })
+  })
+  it('keeps the trimmed template id for template-scope and ISO-normalizes the window', () => {
+    const p = buildCreatePayload({ ...base, scope: 'template', scopeTemplateId: ' t1 ' })
+    expect(p.scopeTemplateId).toBe('t1')
+    expect(p.startAt).toMatch(/Z$/)
+    expect(p.endAt).toMatch(/Z$/)
+  })
+})

--- a/apps/web/tests/approvalDelegationRoute.spec.ts
+++ b/apps/web/tests/approvalDelegationRoute.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+/**
+ * Source guard against the 委托设置 page becoming an orphan: DelegationSettingsView.vue is
+ * only a usable product capability if it is wired into the router under the manage
+ * permission. Asserted on the appRoutes.ts SOURCE (not an import — appRoutes top-level
+ * imports real .vue views, which pull in Element Plus CSS that vitest can't transform).
+ */
+const routesSrc = readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/router/appRoutes.ts'),
+  'utf8',
+)
+
+describe('委托设置 route', () => {
+  it('declares the /approval-delegations route (DelegationSettingsView is reachable)', () => {
+    expect(routesSrc, 'no /approval-delegations route — DelegationSettingsView would be unreachable').toContain("path: '/approval-delegations'")
+  })
+
+  it('points the route at DelegationSettingsView', () => {
+    expect(routesSrc).toMatch(/approval-delegations[\s\S]{0,200}DelegationSettingsView\.vue/)
+  })
+
+  it('guards the route with approval-templates:manage', () => {
+    expect(routesSrc).toMatch(/approval-delegations[\s\S]{0,400}approval-templates:manage/)
+  })
+})

--- a/docs/design/approval-delegation-crud-design-lock-20260622.md
+++ b/docs/design/approval-delegation-crud-design-lock-20260622.md
@@ -1,0 +1,46 @@
+# Design-lock (short): Approval delegation (委托) config CRUD + admin UI
+
+**Status:** ACCEPTED (owner-specified 2026-06-22). The 委托设置 slice that turns the
+delegation **runtime** (#3036) into a **user-usable** capability. Builds on the merged
+`approval_delegations` table + the read-only resolve seam; adds the write CRUD + an admin
+management page. Brand-neutral: benchmarked against external OA / mainstream approval
+platforms, no vendor names in code/docs.
+
+## 1. Who + scope (owner decisions)
+- **Who can set delegations:** gated behind **`approval-templates:manage`** (an admin
+  capability), not self-service. The **delegator is a chosen field**, so an admin
+  configures delegations for any user — the management list shows 委托人 + 被委托人.
+- **Scope:** `all` | `template` (reuse the table shape; `template` carries a
+  `scope_template_id`).
+- **Time window:** `start_at` / `end_at` + an `active` flag.
+- **Conflict semantics (v1, unchanged):** at most **one active row per (delegator, scope
+  target)** — enforced by the unique partial index; **no multi-window scheduling**. A
+  conflicting create returns **409**.
+
+## 2. Backend API (`/api/approval-delegations`, all `approval-templates:manage`)
+- `GET` — list active delegations (admin view: delegator, delegatee, scope, window,
+  status); optional `?delegatorUserId=` filter.
+- `POST` — create `{ delegatorUserId, delegateeUserId, scope, scopeTemplateId?, startAt,
+  endAt }`.
+- `PATCH /:id` — edit (delegatee / window / scope / `active`).
+- `DELETE /:id` (or `PATCH active=false`) — disable (soft).
+- **Validation:** no self-delegation; valid window (`end > start`); scope/template
+  constraint (`scope='template'` ⇔ a target); unique-active conflict → **409**. The table
+  CHECKs are the second line of defense.
+
+## 3. Frontend (admin management page)
+- A simple list: 委托人 / 被委托人 / 范围 / 时间 / 状态.
+- A create/edit dialog; **user selection reuses the existing approval user picker**.
+- **Does NOT** enter the complex graph/template author editor — scope stays narrow.
+
+## 4. Tests
+- **API real-DB:** create / conflict (409) / disable / `template` scope / self-delegation
+  reject.
+- **Runtime seam (extends the #3036 db seam):** "create a delegation **via the API** →
+  start an approval → the assignment resolves to the **delegatee**" — end-to-end.
+- **Frontend:** form validation + the saved payload shape.
+
+## 5. Boundaries / non-goals
+- Config CRUD + admin UI only; the resolve seam (#3036) is unchanged. **W7 stays locked.**
+- No multi-window scheduling, no role-delegatee, no multi-hop, no template-editor coupling
+  (all reopen-only).

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -27,6 +27,7 @@ import {
 import { publishApprovalCountsUpdate } from '../services/approval-realtime'
 import { searchDirectoryUsers, listDirectoryRoles } from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
+import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../services/ApprovalDelegationConfig'
 
 const logger = new Logger('ApprovalsRouter')
 const MAX_APPROVAL_PAGE_SIZE = 200
@@ -670,6 +671,65 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         'APPROVAL_CREATE_FAILED',
         'Failed to create approval request',
       )
+    }
+  })
+
+  // 委托设置 (delegation config) — ADMIN-managed (approval-templates:manage). An admin
+  // configures delegations for any user: the delegator is a chosen field and the list
+  // shows 委托人 + 被委托人. v1: one active row per (delegator, scope target).
+  r.get('/api/approval-delegations', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const delegatorUserId = typeof req.query.delegatorUserId === 'string' ? req.query.delegatorUserId : undefined
+      res.json({ data: await listDelegations(pool.query.bind(pool), { delegatorUserId }) })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_LIST_FAILED', 'Failed to list delegations')
+    }
+  })
+
+  r.post('/api/approval-delegations', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>
+      const created = await createDelegation(pool.query.bind(pool), {
+        delegatorUserId: typeof body.delegatorUserId === 'string' ? body.delegatorUserId : '',
+        delegateeUserId: typeof body.delegateeUserId === 'string' ? body.delegateeUserId : '',
+        scope: (typeof body.scope === 'string' ? body.scope : '') as 'all' | 'template',
+        scopeTemplateId: typeof body.scopeTemplateId === 'string' ? body.scopeTemplateId : null,
+        startAt: typeof body.startAt === 'string' ? body.startAt : '',
+        endAt: typeof body.endAt === 'string' ? body.endAt : '',
+      })
+      res.status(201).json({ data: created })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_CREATE_FAILED', 'Failed to create delegation')
+    }
+  })
+
+  r.patch('/api/approval-delegations/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const id = typeof req.params.id === 'string' ? req.params.id : ''
+      const body = (req.body ?? {}) as Record<string, unknown>
+      const updated = await updateDelegation(pool.query.bind(pool), id, {
+        delegateeUserId: typeof body.delegateeUserId === 'string' ? body.delegateeUserId : undefined,
+        scope: typeof body.scope === 'string' ? (body.scope as 'all' | 'template') : undefined,
+        scopeTemplateId: body.scopeTemplateId === null ? null : typeof body.scopeTemplateId === 'string' ? body.scopeTemplateId : undefined,
+        startAt: typeof body.startAt === 'string' ? body.startAt : undefined,
+        endAt: typeof body.endAt === 'string' ? body.endAt : undefined,
+        active: typeof body.active === 'boolean' ? body.active : undefined,
+      })
+      if (!updated) return res.status(404).json(approvalErrorResponse('APPROVAL_DELEGATION_NOT_FOUND', 'Delegation not found'))
+      res.json({ data: updated })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_UPDATE_FAILED', 'Failed to update delegation')
+    }
+  })
+
+  r.delete('/api/approval-delegations/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const id = typeof req.params.id === 'string' ? req.params.id : ''
+      const disabled = await disableDelegation(pool.query.bind(pool), id)
+      if (!disabled) return res.status(404).json(approvalErrorResponse('APPROVAL_DELEGATION_NOT_FOUND', 'Delegation not found or already inactive'))
+      res.json({ data: { id, disabled: true } })
+    } catch (error) {
+      handleApprovalsError(res, error, 'APPROVAL_DELEGATION_DISABLE_FAILED', 'Failed to disable delegation')
     }
   })
 

--- a/packages/core-backend/src/services/ApprovalDelegationConfig.ts
+++ b/packages/core-backend/src/services/ApprovalDelegationConfig.ts
@@ -1,11 +1,11 @@
 /**
  * Approval delegation (委托) — config CRUD (WRITE path).
  *
- * Manages rows in `approval_delegations` for the 委托设置 surface: a user creates,
- * lists, and disables their own time-boxed delegations. Kept separate from the
- * read-only resolve seam (ApprovalDelegations.ts) so the convergence-guarded
- * create-approval path stays write-free. Ownership is enforced by `delegator_user_id`
- * (a user manages only their own delegations).
+ * Manages rows in `approval_delegations` for the 委托设置 surface — ADMIN-managed (via
+ * approval-templates:manage at the route): an admin creates / lists / patches / disables
+ * time-boxed delegations for any user (the delegator is a chosen field). Kept separate
+ * from the read-only resolve seam (ApprovalDelegations.ts) so the convergence-guarded
+ * create-approval path stays write-free.
  */
 
 import { randomUUID } from 'node:crypto'

--- a/packages/core-backend/src/services/ApprovalDelegationConfig.ts
+++ b/packages/core-backend/src/services/ApprovalDelegationConfig.ts
@@ -1,0 +1,197 @@
+/**
+ * Approval delegation (委托) — config CRUD (WRITE path).
+ *
+ * Manages rows in `approval_delegations` for the 委托设置 surface: a user creates,
+ * lists, and disables their own time-boxed delegations. Kept separate from the
+ * read-only resolve seam (ApprovalDelegations.ts) so the convergence-guarded
+ * create-approval path stays write-free. Ownership is enforced by `delegator_user_id`
+ * (a user manages only their own delegations).
+ */
+
+import { randomUUID } from 'node:crypto'
+import { ServiceError } from './ApprovalBridgeService'
+
+type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
+
+export interface DelegationRecord {
+  id: string
+  delegatorUserId: string
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId: string | null
+  startAt: string
+  endAt: string
+  active: boolean
+}
+
+export interface CreateDelegationInput {
+  delegatorUserId: string
+  delegateeUserId: string
+  scope: 'all' | 'template'
+  scopeTemplateId?: string | null
+  startAt: string
+  endAt: string
+}
+
+interface DelegationRow {
+  id: string
+  delegator_user_id: string
+  delegatee_user_id: string
+  scope: string
+  scope_template_id: string | null
+  start_at: string | Date
+  end_at: string | Date
+  active: boolean
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+}
+
+function rowToRecord(row: DelegationRow): DelegationRecord {
+  return {
+    id: row.id,
+    delegatorUserId: row.delegator_user_id,
+    delegateeUserId: row.delegatee_user_id,
+    scope: row.scope === 'template' ? 'template' : 'all',
+    scopeTemplateId: row.scope_template_id ?? null,
+    startAt: toIso(row.start_at),
+    endAt: toIso(row.end_at),
+    active: row.active,
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
+}
+
+/**
+ * Create an active delegation owned by `delegatorUserId`. Deterministic validation
+ * (enum-strict, never silently defaulted); the table CHECKs are a second line of
+ * defense. An overlapping active row (unique index) surfaces as a 409 — the v1 rule
+ * is one active delegation per scope target.
+ */
+export async function createDelegation(query: QueryFn, input: CreateDelegationInput): Promise<DelegationRecord> {
+  const delegator = input.delegatorUserId?.trim()
+  const delegatee = input.delegateeUserId?.trim()
+  if (!delegator) throw new ServiceError('delegatorUserId is required', 400, 'VALIDATION_ERROR')
+  if (!delegatee) throw new ServiceError('delegateeUserId is required', 400, 'VALIDATION_ERROR')
+  if (delegator === delegatee) throw new ServiceError('cannot delegate to yourself', 400, 'VALIDATION_ERROR')
+  if (input.scope !== 'all' && input.scope !== 'template') {
+    throw new ServiceError("scope must be 'all' or 'template'", 400, 'VALIDATION_ERROR')
+  }
+  const scopeTemplateId = input.scope === 'template' ? input.scopeTemplateId?.trim() || null : null
+  if (input.scope === 'template' && !scopeTemplateId) {
+    throw new ServiceError("scope 'template' requires scopeTemplateId", 400, 'VALIDATION_ERROR')
+  }
+  const start = new Date(input.startAt)
+  const end = new Date(input.endAt)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    throw new ServiceError('startAt and endAt must be valid dates', 400, 'VALIDATION_ERROR')
+  }
+  if (end.getTime() <= start.getTime()) {
+    throw new ServiceError('endAt must be after startAt', 400, 'VALIDATION_ERROR')
+  }
+
+  const id = randomUUID()
+  try {
+    const row = (
+      await query<DelegationRow>(
+        `INSERT INTO approval_delegations
+           (id, delegator_user_id, delegatee_user_id, scope, scope_template_id, start_at, end_at, active)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE)
+         RETURNING *`,
+        [id, delegator, delegatee, input.scope, scopeTemplateId, start.toISOString(), end.toISOString()],
+      )
+    ).rows[0]
+    return rowToRecord(row)
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new ServiceError(
+        'an active delegation already exists for this scope target; disable it first',
+        409,
+        'DELEGATION_CONFLICT',
+      )
+    }
+    throw error
+  }
+}
+
+/**
+ * List active delegations (admin view), newest window first; optionally filtered to one
+ * delegator. Admin-managed — returns all delegators' rows, not just one caller's.
+ */
+export async function listDelegations(query: QueryFn, filter: { delegatorUserId?: string } = {}): Promise<DelegationRecord[]> {
+  const delegator = filter.delegatorUserId?.trim()
+  const rows = delegator
+    ? (await query<DelegationRow>(`SELECT * FROM approval_delegations WHERE active AND delegator_user_id = $1 ORDER BY start_at DESC`, [delegator])).rows
+    : (await query<DelegationRow>(`SELECT * FROM approval_delegations WHERE active ORDER BY start_at DESC`)).rows
+  return rows.map(rowToRecord)
+}
+
+/**
+ * Disable (soft-delete) a delegation by id. Admin-managed (gated by
+ * approval-templates:manage at the route); returns false for an unknown/already-inactive id.
+ */
+export async function disableDelegation(query: QueryFn, id: string): Promise<boolean> {
+  const res = await query<{ id: string }>(
+    `UPDATE approval_delegations SET active = FALSE, updated_at = NOW() WHERE id = $1 AND active RETURNING id`,
+    [id],
+  )
+  return res.rows.length > 0
+}
+
+export interface UpdateDelegationInput {
+  delegateeUserId?: string
+  scope?: 'all' | 'template'
+  scopeTemplateId?: string | null
+  startAt?: string
+  endAt?: string
+  active?: boolean
+}
+
+/**
+ * Patch a delegation by id (admin-managed): merge the patch onto the existing row,
+ * re-validate (no self-delegation, valid window, scope/target), and write. The delegator
+ * is immutable (re-create to change it). Returns null for an unknown id; a unique-active
+ * conflict (e.g. re-activating a duplicate scope target) surfaces as 409.
+ */
+export async function updateDelegation(query: QueryFn, id: string, patch: UpdateDelegationInput): Promise<DelegationRecord | null> {
+  const existing = (await query<DelegationRow>(`SELECT * FROM approval_delegations WHERE id = $1`, [id])).rows[0]
+  if (!existing) return null
+
+  const delegatee = (patch.delegateeUserId ?? existing.delegatee_user_id).trim()
+  if (!delegatee) throw new ServiceError('delegateeUserId cannot be empty', 400, 'VALIDATION_ERROR')
+  if (delegatee === existing.delegator_user_id) throw new ServiceError('cannot delegate to yourself', 400, 'VALIDATION_ERROR')
+
+  const scope = patch.scope ?? (existing.scope === 'template' ? 'template' : 'all')
+  if (scope !== 'all' && scope !== 'template') throw new ServiceError("scope must be 'all' or 'template'", 400, 'VALIDATION_ERROR')
+  const scopeTemplateId = scope === 'template'
+    ? (patch.scopeTemplateId !== undefined ? patch.scopeTemplateId?.trim() || null : existing.scope_template_id)
+    : null
+  if (scope === 'template' && !scopeTemplateId) throw new ServiceError("scope 'template' requires scopeTemplateId", 400, 'VALIDATION_ERROR')
+
+  const start = new Date(patch.startAt ?? toIso(existing.start_at))
+  const end = new Date(patch.endAt ?? toIso(existing.end_at))
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) throw new ServiceError('startAt and endAt must be valid dates', 400, 'VALIDATION_ERROR')
+  if (end.getTime() <= start.getTime()) throw new ServiceError('endAt must be after startAt', 400, 'VALIDATION_ERROR')
+
+  const active = patch.active ?? existing.active
+  try {
+    const row = (
+      await query<DelegationRow>(
+        `UPDATE approval_delegations
+           SET delegatee_user_id = $2, scope = $3, scope_template_id = $4, start_at = $5, end_at = $6, active = $7, updated_at = NOW()
+         WHERE id = $1
+         RETURNING *`,
+        [id, delegatee, scope, scopeTemplateId, start.toISOString(), end.toISOString(), active],
+      )
+    ).rows[0]
+    return rowToRecord(row)
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new ServiceError('an active delegation already exists for this scope target', 409, 'DELEGATION_CONFLICT')
+    }
+    throw error
+  }
+}

--- a/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Delegation (委托) config CRUD — real-DB API. Exercises the admin-managed
+ * /api/approval-delegations routes (approval-templates:manage) against real Postgres:
+ * create / unique-active conflict / self-delegation reject / template-scope target /
+ * list / disable. Proves the routes + SQL + table CHECKs together (the unit tests use
+ * a fake query).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const ADMIN = `del-admin-${TS}`
+const FROM = `del-from-${TS}`
+const TO = `del-to-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const WINDOW = { startAt: new Date(Date.now() - 3600_000).toISOString(), endAt: new Date(Date.now() + 3600_000).toISOString() }
+
+describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let adminTok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    adminTok = await tok(base, ADMIN)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+      await pool.query(`DELETE FROM approval_delegations WHERE delegator_user_id LIKE $1`, [`%-${TS}`])
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('creates → lists → conflicts → rejects self/template → disables', async () => {
+    // create
+    const created = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: FROM, delegateeUserId: TO, scope: 'all', ...WINDOW },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const id = ((await created.json()) as { data: { id: string } }).data.id
+
+    // list shows it (admin view)
+    const listed = await req(base, '/api/approval-delegations', adminTok)
+    const rows = ((await listed.json()) as { data: Array<{ id: string; delegatorUserId: string; delegateeUserId: string }> }).data
+    expect(rows.find((r) => r.id === id)).toMatchObject({ delegatorUserId: FROM, delegateeUserId: TO })
+
+    // a second active row for the same (delegator, scope target) → 409 conflict
+    const dup = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: FROM, delegateeUserId: `${TO}-x`, scope: 'all', ...WINDOW },
+    })
+    expect(dup.status).toBe(409)
+
+    // self-delegation → 400
+    const self = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: FROM, delegateeUserId: FROM, scope: 'all', ...WINDOW },
+    })
+    expect(self.status).toBe(400)
+
+    // scope=template with no target → 400
+    const noTarget = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: `${FROM}-t`, delegateeUserId: TO, scope: 'template', ...WINDOW },
+    })
+    expect(noTarget.status).toBe(400)
+
+    // disable → 200, then it leaves the active list
+    const disabled = await req(base, `/api/approval-delegations/${id}`, adminTok, { method: 'DELETE' })
+    expect(disabled.status).toBe(200)
+    const after = await req(base, '/api/approval-delegations', adminTok)
+    const afterRows = ((await after.json()) as { data: Array<{ id: string }> }).data
+    expect(afterRows.find((r) => r.id === id)).toBeUndefined()
+  })
+
+  it('end-to-end: create a delegation via the API → start an approval → assignment resolves to the delegatee', async () => {
+    const e2eFrom = `del-e2e-from-${TS}`
+    const e2eTo = `del-e2e-to-${TS}`
+    // 1) create the delegation via the API
+    const del = await req(base, '/api/approval-delegations', adminTok, {
+      method: 'POST',
+      body: { delegatorUserId: e2eFrom, delegateeUserId: e2eTo, scope: 'all', ...WINDOW },
+    })
+    expect(del.status, await del.clone().text()).toBe(201)
+
+    // 2) publish a static_user[delegator] template + start an approval
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'a', config: { assigneeSources: [{ kind: 'static_user', userIds: [e2eFrom] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
+    }
+    const key = `del-api-e2e-${TS}`
+    const created = await req(base, '/api/approval-templates', adminTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: graph },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, adminTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    const started = await req(base, '/api/approvals', adminTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+
+    // 3) the assignment is the DELEGATEE (API-created delegation flowed through bake→resolve)
+    const assignees = (
+      await poolManager.get().query<{ assignee_id: string }>(
+        `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignment_type = 'user'`,
+        [aid],
+      )
+    ).rows.map((r) => r.assignee_id)
+    expect(assignees).toContain(e2eTo)
+    expect(assignees).not.toContain(e2eFrom)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
@@ -16,6 +16,7 @@ const TS = Date.now()
 const ADMIN = `del-admin-${TS}`
 const FROM = `del-from-${TS}`
 const TO = `del-to-${TS}`
+const MGR = `del-mgr-${TS}`
 
 async function canListen(): Promise<boolean> {
   return await new Promise((r) => {
@@ -50,6 +51,18 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
     await ensureApprovalSchemaReady()
+    // Seed the real RBAC chain for a least-privilege manager: rbacGuard walks
+    // user_permissions / namespace admission, not just the token claims, so the
+    // manage-only positive needs an actual grant (mirrors the W6 seam test seedUsers).
+    const seedPool = poolManager.get()
+    await seedPool.query(`INSERT INTO permissions (code, name, description) VALUES ('approval-templates:manage', 'Approval Templates Manage', 'delegation API test') ON CONFLICT (code) DO NOTHING`)
+    await seedPool.query(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
+      [MGR, `${MGR}@example.test`],
+    )
+    await seedPool.query(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approval-templates:manage') ON CONFLICT DO NOTHING`, [MGR])
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     await server.start()
     base = `http://127.0.0.1:${server.getAddress()!.port}`
@@ -71,6 +84,8 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
         await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
       }
       await pool.query(`DELETE FROM approval_delegations WHERE delegator_user_id LIKE $1`, [`%-${TS}`])
+      await pool.query(`DELETE FROM user_permissions WHERE user_id = $1`, [MGR])
+      await pool.query(`DELETE FROM users WHERE id = $1`, [MGR])
     } catch {
       /* best effort */
     }
@@ -89,7 +104,7 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
       (await req(base, '/api/approval-delegations', reader, { method: 'POST', body: { delegatorUserId: `x-${TS}`, delegateeUserId: `y-${TS}`, scope: 'all', ...WINDOW } })).status,
     ).toBe(403)
     // a non-admin user holding ONLY approval-templates:manage (not *:*) → allowed
-    const manager = await tokWith(base, `del-mgr-${TS}`, 'user', 'approval-templates:manage')
+    const manager = await tokWith(base, MGR, 'user', 'approval-templates:manage')
     expect((await req(base, '/api/approval-delegations', manager)).status).toBe(200)
   })
 

--- a/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
@@ -17,6 +17,7 @@ const ADMIN = `del-admin-${TS}`
 const FROM = `del-from-${TS}`
 const TO = `del-to-${TS}`
 const MGR = `del-mgr-${TS}`
+const MGR_ROLE = `del-mgr-role-${TS}`
 
 async function canListen(): Promise<boolean> {
   return await new Promise((r) => {
@@ -51,9 +52,12 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
   beforeAll(async () => {
     expect(await canListen()).toBe(true)
     await ensureApprovalSchemaReady()
-    // Seed the real RBAC chain for a least-privilege manager: rbacGuard walks
-    // user_permissions / namespace admission, not just the token claims, so the
-    // manage-only positive needs an actual grant (mirrors the W6 seam test seedUsers).
+    // Seed the real RBAC chain so a least-privilege (non-admin) manager reaches the routes.
+    // `approval-templates` is a namespace-admission-controlled resource, so
+    // userHasPermission / rbacGuard gate on isPermissionAllowedByNamespaceAdmission BEFORE
+    // any user_permissions grant is consulted — the manager needs (a) a role whose
+    // role_permissions put `approval-templates` in controlledNamespaces, and (b) an ENABLED
+    // user_namespace_admissions row for that namespace.
     const seedPool = poolManager.get()
     await seedPool.query(`INSERT INTO permissions (code, name, description) VALUES ('approval-templates:manage', 'Approval Templates Manage', 'delegation API test') ON CONFLICT (code) DO NOTHING`)
     await seedPool.query(
@@ -62,7 +66,14 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
        ON CONFLICT (id) DO UPDATE SET is_active = TRUE`,
       [MGR, `${MGR}@example.test`],
     )
-    await seedPool.query(`INSERT INTO user_permissions (user_id, permission_code) VALUES ($1, 'approval-templates:manage') ON CONFLICT DO NOTHING`, [MGR])
+    await seedPool.query(`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, [MGR, MGR_ROLE])
+    await seedPool.query(`INSERT INTO role_permissions (role_id, permission_code) VALUES ($1, 'approval-templates:manage') ON CONFLICT DO NOTHING`, [MGR_ROLE])
+    await seedPool.query(
+      `INSERT INTO user_namespace_admissions (user_id, namespace, enabled)
+       VALUES ($1, 'approval-templates', TRUE)
+       ON CONFLICT (user_id, namespace) DO UPDATE SET enabled = TRUE`,
+      [MGR],
+    )
     server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     await server.start()
     base = `http://127.0.0.1:${server.getAddress()!.port}`
@@ -84,7 +95,9 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
         await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
       }
       await pool.query(`DELETE FROM approval_delegations WHERE delegator_user_id LIKE $1`, [`%-${TS}`])
-      await pool.query(`DELETE FROM user_permissions WHERE user_id = $1`, [MGR])
+      await pool.query(`DELETE FROM user_namespace_admissions WHERE user_id = $1`, [MGR])
+      await pool.query(`DELETE FROM user_roles WHERE user_id = $1`, [MGR])
+      await pool.query(`DELETE FROM role_permissions WHERE role_id = $1`, [MGR_ROLE])
       await pool.query(`DELETE FROM users WHERE id = $1`, [MGR])
     } catch {
       /* best effort */
@@ -96,14 +109,18 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
     expect(process.env.DATABASE_URL).toBeTruthy()
   })
 
-  it('enforces approval-templates:manage on the routes (403 without it; manage-only is allowed)', async () => {
-    // a non-admin user WITHOUT approval-templates:manage → 403 on read AND write
+  // P2 boundary — NEGATIVE (the core regression guard: trips if a route loses its gate).
+  it('rejects a caller without approval-templates:manage (403 on GET + POST)', async () => {
     const reader = await tokWith(base, `del-reader-${TS}`, 'user', 'approvals:read')
     expect((await req(base, '/api/approval-delegations', reader)).status).toBe(403)
     expect(
       (await req(base, '/api/approval-delegations', reader, { method: 'POST', body: { delegatorUserId: `x-${TS}`, delegateeUserId: `y-${TS}`, scope: 'all', ...WINDOW } })).status,
     ).toBe(403)
-    // a non-admin user holding ONLY approval-templates:manage (not *:*) → allowed
+  })
+
+  // P2 boundary — POSITIVE (least-privilege, NOT admin *:*): a non-admin whose only grant is
+  // approval-templates:manage (via the seeded role + namespace admission) is admitted.
+  it('admits a non-admin holding only approval-templates:manage (200)', async () => {
     const manager = await tokWith(base, MGR, 'user', 'approval-templates:manage')
     expect((await req(base, '/api/approval-delegations', manager)).status).toBe(200)
   })

--- a/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-delegation-api.db.test.ts
@@ -28,6 +28,10 @@ async function tok(base: string, userId: string): Promise<string> {
   const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
   return ((await res.json()) as { token: string }).token
 }
+async function tokWith(base: string, userId: string, roles: string, perms: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=${encodeURIComponent(roles)}&perms=${encodeURIComponent(perms)}`)
+  return ((await res.json()) as { token: string }).token
+}
 async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
   return fetch(`${base}${path}`, {
     method: opts.method || 'GET',
@@ -75,6 +79,18 @@ describeIfDatabase('delegation (委托) config CRUD — real-DB API', () => {
 
   it('sentinel: DATABASE_URL is set', () => {
     expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('enforces approval-templates:manage on the routes (403 without it; manage-only is allowed)', async () => {
+    // a non-admin user WITHOUT approval-templates:manage → 403 on read AND write
+    const reader = await tokWith(base, `del-reader-${TS}`, 'user', 'approvals:read')
+    expect((await req(base, '/api/approval-delegations', reader)).status).toBe(403)
+    expect(
+      (await req(base, '/api/approval-delegations', reader, { method: 'POST', body: { delegatorUserId: `x-${TS}`, delegateeUserId: `y-${TS}`, scope: 'all', ...WINDOW } })).status,
+    ).toBe(403)
+    // a non-admin user holding ONLY approval-templates:manage (not *:*) → allowed
+    const manager = await tokWith(base, `del-mgr-${TS}`, 'user', 'approval-templates:manage')
+    expect((await req(base, '/api/approval-delegations', manager)).status).toBe(200)
   })
 
   it('creates → lists → conflicts → rejects self/template → disables', async () => {

--- a/packages/core-backend/tests/unit/approval-delegation-config.test.ts
+++ b/packages/core-backend/tests/unit/approval-delegation-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../../src/services/ApprovalDelegationConfig'
+
+const WINDOW = { startAt: '2026-06-22T00:00:00Z', endAt: '2026-06-23T00:00:00Z' }
+const okRow = {
+  id: 'd1', delegator_user_id: 'A', delegatee_user_id: 'B', scope: 'all',
+  scope_template_id: null, start_at: '2026-06-22T00:00:00.000Z', end_at: '2026-06-23T00:00:00.000Z', active: true,
+}
+const rowsQuery =
+  (rows: unknown[]) =>
+  async <Row>(): Promise<{ rows: Row[] }> => ({ rows: rows as Row[] })
+
+describe('ApprovalDelegationConfig.createDelegation — validation', () => {
+  const base = { delegatorUserId: 'A', delegateeUserId: 'B', scope: 'all' as const, ...WINDOW }
+
+  it('rejects self-delegation', async () => {
+    await expect(createDelegation(rowsQuery([]), { ...base, delegateeUserId: 'A' })).rejects.toMatchObject({ statusCode: 400, code: 'VALIDATION_ERROR' })
+  })
+  it('rejects endAt <= startAt', async () => {
+    await expect(createDelegation(rowsQuery([]), { ...base, startAt: '2026-06-23T00:00:00Z', endAt: '2026-06-22T00:00:00Z' })).rejects.toMatchObject({ statusCode: 400 })
+  })
+  it('rejects an invalid scope', async () => {
+    await expect(createDelegation(rowsQuery([]), { ...base, scope: 'bogus' as never })).rejects.toMatchObject({ statusCode: 400 })
+  })
+  it("rejects scope='template' with no scopeTemplateId", async () => {
+    await expect(createDelegation(rowsQuery([]), { ...base, scope: 'template' })).rejects.toMatchObject({ statusCode: 400 })
+  })
+  it('maps a unique-violation (23505) to a 409 conflict', async () => {
+    const q = async () => { throw Object.assign(new Error('dup'), { code: '23505' }) }
+    await expect(createDelegation(q, base)).rejects.toMatchObject({ statusCode: 409, code: 'DELEGATION_CONFLICT' })
+  })
+
+  it("nulls scope_template_id for scope='all' even if a target is passed, and returns the record", async () => {
+    let params: unknown[] = []
+    const q = async <Row>(_text: string, p?: unknown[]): Promise<{ rows: Row[] }> => {
+      params = p ?? []
+      return { rows: [okRow] as Row[] }
+    }
+    const rec = await createDelegation(q, { ...base, delegatorUserId: '  A  ', scopeTemplateId: 't1' })
+    expect(params[4]).toBeNull() // scope_template_id INSERT param
+    expect(params[1]).toBe('A') // delegator trimmed
+    expect(rec).toMatchObject({ id: 'd1', delegatorUserId: 'A', delegateeUserId: 'B', scope: 'all', scopeTemplateId: null, active: true })
+  })
+})
+
+describe('ApprovalDelegationConfig.disableDelegation', () => {
+  it('returns false when no row matched (unknown or already-inactive id)', async () => {
+    expect(await disableDelegation(rowsQuery([]), 'd1')).toBe(false)
+  })
+  it('returns true when the row was disabled', async () => {
+    expect(await disableDelegation(rowsQuery([{ id: 'd1' }]), 'd1')).toBe(true)
+  })
+})
+
+describe('ApprovalDelegationConfig.listDelegations', () => {
+  it('maps rows to camelCase records (admin view, all delegators)', async () => {
+    const list = await listDelegations(rowsQuery([{ ...okRow, scope: 'template', scope_template_id: 't1' }]))
+    expect(list).toEqual([
+      { id: 'd1', delegatorUserId: 'A', delegateeUserId: 'B', scope: 'template', scopeTemplateId: 't1', startAt: '2026-06-22T00:00:00.000Z', endAt: '2026-06-23T00:00:00.000Z', active: true },
+    ])
+  })
+})
+
+describe('ApprovalDelegationConfig.updateDelegation', () => {
+  const existing = { ...okRow, delegator_user_id: 'A', delegatee_user_id: 'B' }
+
+  it('returns null for an unknown id', async () => {
+    expect(await updateDelegation(rowsQuery([]), 'nope', { active: false })).toBeNull()
+  })
+  it('rejects a patch that makes delegatee == delegator', async () => {
+    await expect(updateDelegation(rowsQuery([existing]), 'd1', { delegateeUserId: 'A' })).rejects.toMatchObject({ statusCode: 400 })
+  })
+  it('rejects a patch with an inverted window', async () => {
+    await expect(updateDelegation(rowsQuery([existing]), 'd1', { startAt: '2026-06-23T00:00:00Z', endAt: '2026-06-22T00:00:00Z' })).rejects.toMatchObject({ statusCode: 400 })
+  })
+  it('disables via active=false and returns the updated record (SELECT then UPDATE)', async () => {
+    let call = 0
+    const q = async <Row>(): Promise<{ rows: Row[] }> => {
+      call += 1
+      return { rows: [(call === 1 ? existing : { ...existing, active: false })] as Row[] }
+    }
+    const rec = await updateDelegation(q, 'd1', { active: false })
+    expect(rec?.active).toBe(false)
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       'tests/integration/dept-head-sync-plumbing.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
+      'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
## What
Turns the delegation runtime (#3036) into a **user-usable** capability — the 委托设置 CRUD + admin UI — per the short CRUD design-lock (owner-specified).

**Admin-managed** (`approval-templates:manage`): an admin configures delegations for any user; the **delegator is a chosen field** and the list shows 委托人 + 被委托人.

## Backend
- `ApprovalDelegationConfig.ts` (WRITE path, **separate from the read-only resolve seam**): create / list (admin view, all delegators) / **PATCH** / disable. Enum-strict validation (no self-delegation, valid window, scope/target); unique-active conflict → **409**; delegator immutable on patch.
- Routes `GET/POST/PATCH/DELETE /api/approval-delegations` (`authenticate` + `approval-templates:manage`).

## Frontend
- `delegations.ts` client + testable form helpers; `DelegationSettingsView.vue` admin page (list + create dialog). User fields are text inputs in v1 — **picker reuse is a follow-up**.

## Tests
- 13 backend unit + 7 FE form; backend `tsc` + FE `vue-tsc` clean.
- **Real-DB API test** wired into the approval Postgres CI lane (and excluded from the no-DB job — skip-when-unreachable closed): create / 409 / self-reject / template-target / disable, **plus the end-to-end** `create delegation via API → start approval → assignment resolves to the delegatee`.

## Boundaries
v1 = one active row per (delegator, scope target), no scheduling (reopen-only). Convergence-safe: writes only the `approval_delegations` config table; **W7 stays locked**. Brand-neutral docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)