### PR TITLE
feat(integration): FOS-4 (prove-the-path) — 2nd preset (disable_missing) + target-keyed readiness + HTTP wire-test (closes P2)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -3623,6 +3623,7 @@ function createTableActionRecordsApi() {
 function createStockPreparationTargetProvisioningApi({
   sheetExists = false,
   missingFields = [],
+  currentOptionsByField = {}, // FOS-4: { [targetFieldId]: [{value,...}] } served by the read-only getObjectField
 } = {}) {
   const calls = []
   let sheet = sheetExists
@@ -3657,6 +3658,20 @@ function createStockPreparationTargetProvisioningApi({
           property: field.property || {},
           order: index,
         })),
+      }
+    },
+    // FOS-2b-pre: read-only current-field-options reader (used by non-default sync modes).
+    async getObjectField(input) {
+      calls.push(['getObjectField', clone(input)])
+      const options = currentOptionsByField[input.fieldId]
+      if (!options) return null
+      return {
+        id: `fld_${input.fieldId}`,
+        sheetId: sheet ? sheet.id : 'sheet_stock_canonical_private',
+        name: input.fieldId,
+        type: 'select',
+        property: { options: clone(options) },
+        order: 0,
       }
     },
     async patchObjectFieldProperty(input) {
@@ -3844,6 +3859,59 @@ async function testStockPreparationOptionSyncRoute() {
   })
   assert.equal(res.statusCode, 422)
   assert.equal(res.body.error.code, 'OPTION_SYNC_EXECUTABLE_REJECTED')
+}
+
+async function testFieldOptionsSyncDisableMissing() {
+  // FOS-4 (prove-the-path / P2 wire-test): the 2nd catalog preset (disable_missing) drives the generic
+  // route through the REAL getObjectField-backed closure (closing the wire-vs-fixture gap), and proves
+  // disable_missing only DISABLES the missing option in the real route — never deletes it.
+  const DISABLE_PRESET_ID = 'preset.stock-preparation.disable-missing.v1'
+  const provisioning = createStockPreparationTargetProvisioningApi({
+    sheetExists: true,
+    currentOptionsByField: {
+      materialType: [{ value: 'plate', label: 'Plate' }, { value: 'bar', label: 'Bar' }],
+      blankType: [{ value: 'casting' }],
+    },
+  })
+  const records = createTableActionRecordsApi()
+  const { routes } = mountRoutes(createMockServices().services, {
+    provisioningApi: provisioning.api,
+    recordsApi: records.recordsApi,
+  })
+
+  // source DROPS 'bar' from materialType (present in current); disable_missing must keep+disable it.
+  const res = await invoke(routes, 'POST', '/api/integration/field-options/sync', {
+    user: ADMIN_USER,
+    body: {
+      presetId: DISABLE_PRESET_ID,
+      optionSets: {
+        material_type: [{ value: 'plate' }],
+        blank_type: [{ value: 'casting' }],
+      },
+    },
+  })
+  assertOkResponse(res, 200)
+
+  // (1) the route REACHED the real getObjectField closure — the FOS-2b non-default path is now live (P2 closed)
+  assert.ok(findCalls(provisioning.calls, 'getObjectField').length >= 1, 'route reached the real getObjectField closure')
+
+  // (2) per-preset readiness binding (target-keyed) covered the 2nd preset — it got past readiness to patch
+  const patches = findCalls(provisioning.calls, 'patchObjectFieldProperty')
+  const materialPatch = patches.find((call) => call[1].fieldId === 'materialType')
+  assert.ok(materialPatch, 'materialType patched via the disable-missing preset (readiness bound by target)')
+  assert.equal(materialPatch[1].objectId, 'plm_stock_preparation_main', 'targets the canonical stock-prep objectId')
+
+  // (3) disable_missing ONLY DISABLES the missing option (bar) — NEVER deletes it
+  const opts = materialPatch[1].propertyPatch.options
+  assert.deepEqual(opts.map((o) => o.value).sort(), ['bar', 'plate'], 'bar is KEPT (not deleted) under disable_missing')
+  assert.equal(opts.find((o) => o.value === 'bar').disabled, true, 'bar is DISABLED (disable_missing only disables in the real route)')
+
+  // (4) values-free evidence — no option values/labels leak
+  assert.equal(
+    /"plate"|"bar"|"Plate"|"Bar"/.test(JSON.stringify(res.body.data.evidence || {})),
+    false,
+    'evidence is values-free (no option values/labels)',
+  )
 }
 
 async function testFieldOptionsSyncRoute() {
@@ -5085,6 +5153,7 @@ async function main() {
   await testStockPreparationTargetProvisioningRoutes()
   await testStockPreparationOptionSyncRoute()
   await testFieldOptionsSyncRoute()
+  await testFieldOptionsSyncDisableMissing()
   await testTableActionRoutes()
   await testLargeBomBackgroundExpansionJobRoutes()
   await testLargeBomBackgroundExpansionJobsSurviveDurableRouteRemount()

--- a/plugins/plugin-integration-core/lib/field-option-sync-contract.cjs
+++ b/plugins/plugin-integration-core/lib/field-option-sync-contract.cjs
@@ -162,6 +162,26 @@ const FIELD_OPTION_SYNC_PRESETS = Object.freeze([
     conflictPolicy: 'update_from_source', // §7
     triggerMode: 'manual', // §7
   }),
+  // FOS-4 (prove-the-path): a 2nd reference preset on the SAME stock-prep canonical table, differing
+  // ONLY by a non-default syncMode (disable_missing). Purpose is not product-surface expansion — it
+  // proves: the catalog carries a 2nd preset, the per-preset readiness binding works, the generic
+  // route truly reaches getObjectField, and disable_missing only DISABLES (never deletes) in the real
+  // route (HTTP wire-test, closing the P2 caveat). Real domain presets / authoring remain FOS-4+.
+  Object.freeze({
+    presetId: 'preset.stock-preparation.disable-missing.v1',
+    label: 'Stock-preparation option sync (disable-missing)',
+    sourceKind: 'static-preset',
+    sourceObjectOrTable: 'operator-config',
+    targetKind: TARGET_KIND,
+    targetTable: 'plm_stock_preparation_main', // same canonical own-sheet target as the v1 preset
+    optionFields: Object.freeze([
+      Object.freeze({ valueField: 'material_type', targetField: 'materialType', targetFieldType: 'single_select' }),
+      Object.freeze({ valueField: 'blank_type', targetField: 'blankType', targetFieldType: 'single_select' }),
+    ]),
+    syncMode: 'disable_missing', // the non-default mode being proven end-to-end
+    conflictPolicy: 'update_from_source',
+    triggerMode: 'manual',
+  }),
 ])
 
 // Returns deep, validated copies of the catalog (asserts values-free first; never mutates the frozen consts).

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -135,6 +135,9 @@ const {
   syncStockPreparationOptions,
   optionSetsFromInput,
 } = require('./stock-preparation-option-sync.cjs')
+// FOS-4: canonical stock-prep objectId — readiness is bound per TARGET, so any preset targeting this
+// table (v1 replace + the disable-missing prove-the-path preset) reuses the canonical readiness check.
+const { STOCK_PREPARATION_MAIN_TABLE_TEMPLATE } = require('./stock-preparation-templates.cjs')
 // FOS-2: generic field-option-sync route — resolve a FOS preset (FOS-1 catalog), validate operator
 // option sets against the preset's source keys, and patch each mapped field's options + generic
 // `fieldOptionSync` metadata through the SAME kernel stock-prep uses (no parallel write path).
@@ -2099,11 +2102,13 @@ function createHandlers(services, options = {}) {
       const provisioning = getFieldOptionSyncProvisioning()
       const optionFields = fieldOptionSyncKernelFields(preset)
 
-      // FOS-2: readiness gate, bound per preset. The stock-preparation preset targets the canonical
-      // stock-prep table, so it reuses that table's readiness inspection — parity with the stock-prep
-      // route: never patch an unprovisioned target (avoids a partial patch / opaque FIELD_PATCH_FAILED).
-      // Fail closed for any preset without a readiness binding (additional presets are gated to FOS-4).
-      if (preset.presetId === 'preset.stock-preparation.v1') {
+      // FOS-4: readiness gate bound per TARGET (not per preset id). Any preset targeting the canonical
+      // stock-prep table reuses that table's readiness inspection — so BOTH the v1 (replace) preset and
+      // the disable-missing prove-the-path preset are covered without enumerating preset ids. Parity with
+      // the stock-prep route: never patch an unprovisioned target (avoids a partial patch / opaque
+      // FIELD_PATCH_FAILED). Presets targeting a DIFFERENT table still fail closed until they declare
+      // their own readiness binding (a later slice).
+      if (preset.targetTable === STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId) {
         const readiness = await inspectStockPreparationCanonicalTarget({ context, projectId: input.projectId, permission: 'admin' })
         if (readiness.ready !== true) {
           throw new HttpRouteError(422, 'FIELD_OPTION_SYNC_TARGET_NOT_READY', 'field-option-sync target is not ready', {
@@ -2112,8 +2117,9 @@ function createHandlers(services, options = {}) {
           })
         }
       } else {
-        throw new HttpRouteError(422, 'FIELD_OPTION_SYNC_PRESET_NO_READINESS', 'preset has no readiness binding (additional presets are gated to FOS-4)', {
+        throw new HttpRouteError(422, 'FIELD_OPTION_SYNC_PRESET_NO_READINESS', 'preset target has no readiness binding (presets for other tables are gated to a later slice)', {
           presetId: preset.presetId,
+          targetObjectId: preset.targetTable,
         })
       }
 


### PR DESCRIPTION
## What (FOS-4 = prove-the-path, owner-chosen)

A minimal 2nd reference preset on the **same** stock-prep canonical table, differing **only** by `syncMode=disable_missing` — to prove the FOS-2b runtime end-to-end and close the FOS-2b P2 wire-vs-fixture caveat. **Not** product-surface expansion.

- **contract**: `preset.stock-preparation.disable-missing.v1` added to the FOS-1 catalog (same target; disable_missing). Values-free; v1 stays preset[0].
- **route**: readiness gate re-bound **per TARGET** (was per preset id) → any preset targeting the canonical stock-prep objectId reuses its readiness inspection (covers both presets); other tables still fail closed (later slice).
- **HTTP wire-test (closes P2)**: the disable_missing preset drives the generic route through the **real `getObjectField`-backed closure** — asserts getObjectField is reached, target-keyed readiness covers the 2nd preset, **disable_missing keeps+disables `bar` (never deletes)**, values-free evidence. (Adds getObjectField to the test mock.)

## Proves (your 5 goals)
catalog carries a 2nd preset · per-preset(target) readiness works · generic route truly reaches `getObjectField` · disable_missing only-disables-not-deletes in the real route · the P2 wire-test is covered.

## Boundary / deferral
action-binding generalization explicitly **deferred to FOS-4b**. Metadata-only; getObjectField read-only; no business-row/external/K3/production write; no migration; admin-gated; values-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)