### PR TITLE
docs(multitable): correct per-field MD empty-handling to post-#3045 behavior

### DIFF
--- a/docs/development/multitable-restore-per-field-through-preview-dev-verification-20260622.md
+++ b/docs/development/multitable-restore-per-field-through-preview-dev-verification-20260622.md
@@ -17,8 +17,10 @@
 - **Probe-safe ordering:** mask *then* `fieldIds`-filter — a requested-but-hidden field is already gone before the
   selection, so no 403-vs-no-op oracle.
 - **Empty handling:** an empty `fieldIds` array → **400** (schema `.min(1)`); a selection that nets zero changes
-  (unchanged/hidden) → **no executable identity** (preview returns `previewIdentity: null`, execute no-ops
-  *before* consulting the identity) — never a `hash([])` executable token.
+  (unchanged/hidden) → **no executable identity** — preview returns `previewIdentity: null`, and execute
+  **verifies the identity FIRST**, so an arbitrary / foreign / forged token → **409 `PREVIEW_IDENTITY_INVALID`**;
+  the empty-diff noop is reachable only AFTER a valid identity is consumed — never a `hash([])` executable token.
+  (Corrected post-#3045 `d0c27aed`: the earlier "noop before consulting the identity" was the bug that PR fixed.)
 - **FE:** the drawer already emits `fieldIds`; the client + workbench now carry it through preview→execute, and
   the legacy `restoreFieldsDirect` direct-`/restore` fallback is removed. Full-record and per-field share one path.
 


### PR DESCRIPTION
Owner review **[P3]**: the slice-2 verification MD still described the empty-filtered-diff path as "no-ops **before** consulting the identity" — the *pre-#3045* behavior, which #3045 (`d0c27aed`) reversed.

Corrected to match the code (`restore-execute` verifies first, noops second): *preview returns `previewIdentity: null`, and execute **verifies the identity first** (arbitrary/foreign/forged token → 409 `PREVIEW_IDENTITY_INVALID`); the empty-diff noop is reachable only after a valid identity is consumed.* docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)