### PR TITLE
fix(multitable): hoist deepLinkedRecord to fix a latent TDZ in MultitableWorkbench

### DIFF
--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -875,6 +875,8 @@ const deepLinkedRecordCommentsScope = ref<MetaCommentsScope | null>(null)
 const deepLinkedRecordFieldPermissions = ref<Record<string, MetaFieldPermission>>({})
 const deepLinkedRecordViewPermissions = ref<Record<string, MetaViewPermission>>({})
 const deepLinkedRecordRowActions = ref<MetaRowActions | null>(null)
+// declared up-front (before effectiveFieldPermissions/scopedAllFields that read it) to avoid a TDZ on eager eval.
+const deepLinkedRecord = ref<MetaRecord | null>(null)
 const standaloneFormFieldPermissions = ref<Record<string, MetaFieldPermission>>({})
 const standaloneFormViewPermissions = ref<Record<string, MetaViewPermission>>({})
 const standaloneFormRowActions = ref<MetaRowActions | null>(null)
@@ -3447,7 +3449,6 @@ async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string
 }
 
 // --- Deep-link record fetch (when record not in current page) ---
-const deepLinkedRecord = ref<MetaRecord | null>(null)
 
 async function resolveDeepLink(recordId: string, options?: { openComments?: boolean; highlightCommentId?: string | null; markReadCommentId?: string | null; targetFieldId?: string | null }) {
   // First check if it's in the current rows


### PR DESCRIPTION
The root scaffold bug behind the `multitable-workbench-*` spec failures, and a **latent production TDZ**.

`deepLinkedRecord` was declared at ~line 3450, but `effectiveFieldPermissions` / `scopedAllFields` (computeds at ~1014/1043) read it ~2400 lines earlier. In production the computeds stay lazy until render (after setup, after 3450), so it works by ordering luck — but any **eager evaluation during setup** throws `ReferenceError: Cannot access 'deepLinkedRecord' before initialization` (which the workbench specs hit on mount). Hoisted the `ref(null)` declaration up next to the other `deepLinkedRecord*` refs — pure declaration-order change, no behavior change.

## Verification
`vue-tsc -b` 0; **official multitable web-guard 321/321** (no guarded-spec regression).

## Scope (honest)
This fixes the TDZ (the shared root). The remaining `multitable-workbench-*` failures are **separate, deeper mock-drift** — the excluded/flaky specs mock a 3600-line component and have fallen behind (`auth.getToken`, `grid.filterGroups`, and more revealed per layer), plus the `restore-wiring` spec's assertion is now stale (asserts the pre-slice-2 `restoreRecordVersion` path). Getting all 8 green + into the guard is a dedicated test-infra effort (85 tests, multi-layer), not bundled here. These specs are excluded from CI, so there's no urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)