### PR TITLE
feat(ci): publish consumer pact to pact-broker (advisory, draft — activate post-provisioning)

### DIFF
--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -79,3 +79,21 @@ jobs:
         run: |
           pnpm --filter @metasheet/core-backend test:contract
           pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot
+
+      - name: Publish consumer pact to broker (advisory, Phase A)
+        # Auto-gate Phase A: runs ONLY when ops has provisioned the broker secret; non-blocking.
+        # Strictly additive (test:contract above is unchanged). UNVERIFIED until a live PactFlow
+        # instance + secrets exist — see the Yuantus dev & verification MD runbook.
+        if: ${{ secrets.PACT_BROKER_BASE_URL != '' }}
+        continue-on-error: true
+        env:
+          PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+          PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+          export PATH="$PWD/pact/bin:$PATH"
+          pact-broker publish packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json \
+            --consumer-app-version "${GITHUB_SHA}" \
+            --branch "${GITHUB_REF_NAME}" \
+            --broker-base-url "$PACT_BROKER_BASE_URL" \
+            --broker-token "$PACT_BROKER_TOKEN"

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -98,6 +98,7 @@ jobs:
         env:
           PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
           PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+          PACT_BROKER_ERROR_ON_UNKNOWN_OPTION: "true"
         run: |
           if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
             echo "[pact-broker] PACT_BROKER_BASE_URL not set — skipping advisory publish."

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts'
       - 'packages/core-backend/package.json'
       - 'pnpm-lock.yaml'
+      - 'scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs'
       - '.github/workflows/yuantus-pact-consumer.yml'
   push:
     branches: [main]
@@ -18,6 +19,7 @@ on:
       - 'packages/core-backend/tests/unit/plm-adapter-yuantus.test.ts'
       - 'packages/core-backend/package.json'
       - 'pnpm-lock.yaml'
+      - 'scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs'
       - '.github/workflows/yuantus-pact-consumer.yml'
 
 permissions:
@@ -41,6 +43,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+
+      - name: Run pact broker workflow contract test
+        run: node --test scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -1,6 +1,7 @@
 name: Yuantus Pact Consumer
 
 on:
+  workflow_dispatch: {}
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -94,6 +94,10 @@ jobs:
             echo "[pact-broker] PACT_BROKER_BASE_URL not set — skipping advisory publish."
             exit 0
           fi
+          if [ -z "${PACT_BROKER_TOKEN:-}" ]; then
+            echo "::error title=Pact broker token missing::PACT_BROKER_BASE_URL is set but PACT_BROKER_TOKEN is empty; broker publish is configured but invalid."
+            exit 1
+          fi
           curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
           export PATH="$PWD/pact/bin:$PATH"
           pact-broker publish packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json \

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -1,6 +1,9 @@
 name: Yuantus Pact Consumer
 
 on:
+  # Manual activation is available after this workflow_dispatch-enabled workflow exists on
+  # the default branch. Before merge, use the pull_request rerun/push path after secrets
+  # are provisioned; the post-merge push:main run is what publishes the mainBranch pact.
   workflow_dispatch: {}
   pull_request:
     branches: [main]

--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -81,15 +81,19 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot
 
       - name: Publish consumer pact to broker (advisory, Phase A)
-        # Auto-gate Phase A: runs ONLY when ops has provisioned the broker secret; non-blocking.
-        # Strictly additive (test:contract above is unchanged). UNVERIFIED until a live PactFlow
-        # instance + secrets exist — see the Yuantus dev & verification MD runbook.
-        if: ${{ secrets.PACT_BROKER_BASE_URL != '' }}
+        # Auto-gate Phase A: a SHELL guard (below) skips this until ops provisions the broker secret —
+        # NOT a step `if:` (the `secrets` context is unavailable to `steps.if`, so it would skip even
+        # after the secret is set). Non-blocking; strictly additive (test:contract above is unchanged).
+        # UNVERIFIED until a live PactFlow instance + secrets exist — see the Yuantus dev & verification MD.
         continue-on-error: true
         env:
           PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
           PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
         run: |
+          if [ -z "${PACT_BROKER_BASE_URL:-}" ]; then
+            echo "[pact-broker] PACT_BROKER_BASE_URL not set — skipping advisory publish."
+            exit 0
+          fi
           curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
           export PATH="$PWD/pact/bin:$PATH"
           pact-broker publish packages/core-backend/tests/contract/pacts/metasheet2-yuantus-plm.json \

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const workflowPath = '.github/workflows/yuantus-pact-consumer.yml'
+
+function readWorkflow() {
+  return readFileSync(path.join(repoRoot, workflowPath), 'utf8')
+}
+
+test('yuantus pact consumer broker publish stays advisory and secret-guarded', () => {
+  const raw = readWorkflow()
+  const checkStep = raw.indexOf('Run Yuantus pact consumer checks')
+  const publishStep = raw.indexOf('Publish consumer pact to broker (advisory, Phase A)')
+
+  assert.ok(checkStep >= 0, 'local consumer checks step must exist')
+  assert.ok(publishStep > checkStep, 'broker publish must run only after local consumer checks')
+  assert.match(raw, /pnpm --filter @metasheet\/core-backend test:contract/)
+  assert.match(raw, /Publish consumer pact to broker \(advisory, Phase A\)[\s\S]*continue-on-error: true/)
+  assert.match(
+    raw,
+    /env:\s*\n\s*PACT_BROKER_BASE_URL: \$\{\{ secrets\.PACT_BROKER_BASE_URL \}\}\s*\n\s*PACT_BROKER_TOKEN: \$\{\{ secrets\.PACT_BROKER_TOKEN \}\}/,
+  )
+  assert.doesNotMatch(raw, /if:\s*\$\{\{\s*secrets\.PACT_BROKER_/)
+  assert.match(
+    raw,
+    /if \[ -z "\$\{PACT_BROKER_BASE_URL:-\}" \]; then[\s\S]*PACT_BROKER_BASE_URL not set[\s\S]*exit 0/,
+  )
+  assert.match(
+    raw,
+    /if \[ -z "\$\{PACT_BROKER_TOKEN:-\}" \]; then[\s\S]*Pact broker token missing[\s\S]*exit 1/,
+  )
+})
+
+test('yuantus pact consumer broker publish uses git SHA and broker branch semantics', () => {
+  const raw = readWorkflow()
+
+  assert.match(
+    raw,
+    /pact-broker publish packages\/core-backend\/tests\/contract\/pacts\/metasheet2-yuantus-plm\.json/,
+  )
+  assert.match(raw, /--consumer-app-version "\$\{GITHUB_SHA\}"/)
+  assert.match(raw, /--branch "\$\{GITHUB_REF_NAME\}"/)
+  assert.match(raw, /--broker-base-url "\$PACT_BROKER_BASE_URL"/)
+  assert.match(raw, /--broker-token "\$PACT_BROKER_TOKEN"/)
+  assert.doesNotMatch(raw, /--tag\b/)
+})

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -31,7 +31,7 @@ test('yuantus pact consumer broker publish stays advisory and secret-guarded', (
   assert.match(raw, /Publish consumer pact to broker \(advisory, Phase A\)[\s\S]*continue-on-error: true/)
   assert.match(
     raw,
-    /env:\s*\n\s*PACT_BROKER_BASE_URL: \$\{\{ secrets\.PACT_BROKER_BASE_URL \}\}\s*\n\s*PACT_BROKER_TOKEN: \$\{\{ secrets\.PACT_BROKER_TOKEN \}\}/,
+    /env:\s*\n\s*PACT_BROKER_BASE_URL: \$\{\{ secrets\.PACT_BROKER_BASE_URL \}\}\s*\n\s*PACT_BROKER_TOKEN: \$\{\{ secrets\.PACT_BROKER_TOKEN \}\}\s*\n\s*PACT_BROKER_ERROR_ON_UNKNOWN_OPTION: "true"/,
   )
   assert.doesNotMatch(raw, /if:\s*\$\{\{\s*secrets\.PACT_BROKER_/)
   assert.match(

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -17,7 +17,9 @@ test('yuantus pact consumer broker publish stays advisory and secret-guarded', (
   const checkStep = raw.indexOf('Run Yuantus pact consumer checks')
   const publishStep = raw.indexOf('Publish consumer pact to broker (advisory, Phase A)')
 
-  assert.match(raw, /on:\s*\n\s*workflow_dispatch: \{\}/)
+  assert.match(raw, /workflow_dispatch: \{\}/)
+  assert.match(raw, /workflow_dispatch-enabled workflow exists on/)
+  assert.match(raw, /post-merge push:main run is what publishes the mainBranch pact/)
   assert.ok(checkStep >= 0, 'local consumer checks step must exist')
   assert.ok(publishStep > checkStep, 'broker publish must run only after local consumer checks')
   assert.match(raw, new RegExp(contractTestPath.replaceAll('/', '\\/'), 'g'))

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -17,6 +17,7 @@ test('yuantus pact consumer broker publish stays advisory and secret-guarded', (
   const checkStep = raw.indexOf('Run Yuantus pact consumer checks')
   const publishStep = raw.indexOf('Publish consumer pact to broker (advisory, Phase A)')
 
+  assert.match(raw, /on:\s*\n\s*workflow_dispatch: \{\}/)
   assert.ok(checkStep >= 0, 'local consumer checks step must exist')
   assert.ok(publishStep > checkStep, 'broker publish must run only after local consumer checks')
   assert.match(raw, new RegExp(contractTestPath.replaceAll('/', '\\/'), 'g'))

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const workflowPath = '.github/workflows/yuantus-pact-consumer.yml'
+const contractTestPath = 'scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs'
 
 function readWorkflow() {
   return readFileSync(path.join(repoRoot, workflowPath), 'utf8')
@@ -18,6 +19,11 @@ test('yuantus pact consumer broker publish stays advisory and secret-guarded', (
 
   assert.ok(checkStep >= 0, 'local consumer checks step must exist')
   assert.ok(publishStep > checkStep, 'broker publish must run only after local consumer checks')
+  assert.match(raw, new RegExp(contractTestPath.replaceAll('/', '\\/'), 'g'))
+  assert.match(
+    raw,
+    /Run pact broker workflow contract test[\s\S]*node --test scripts\/ops\/yuantus-pact-consumer-broker-workflow-contract\.test\.mjs/,
+  )
   assert.match(raw, /pnpm --filter @metasheet\/core-backend test:contract/)
   assert.match(raw, /Publish consumer pact to broker \(advisory, Phase A\)[\s\S]*continue-on-error: true/)
   assert.match(


### PR DESCRIPTION
**Phase A** of the pact-broker auto-gate (MetaSheet2 *consumer* side). **Draft + owner-gated — do not merge until ops provisions the PactFlow account + the two secrets and one real publish run is green.**

Adds one **advisory, secret-guarded** step to `yuantus-pact-consumer.yml` after `test:contract`: empty `PACT_BROKER_BASE_URL` skips cleanly; URL set with empty `PACT_BROKER_TOKEN` emits `configured but invalid` and exits non-zero inside the advisory step; otherwise it publishes the hand-authored pact (`--consumer-app-version` = SHA, `--branch` = ref). `PACT_BROKER_ERROR_ON_UNKNOWN_OPTION=true` is set so misspelled broker CLI flags fail at activation instead of becoming vacuous advisory green. **Strictly additive** — `test:contract` is unchanged.

Adds and wires `scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs` into the `yuantus-pact-consumer` workflow itself. The guard test pins the workflow shape: local consumer checks run before publish, no `steps.if` secrets guard is used, the URL/token shell guards stay load-bearing, SHA + broker `--branch` semantics are used, legacy `--tag` does not come back, unknown-option fail-fast stays enabled, and future edits to the guard test path retrigger this workflow.

Activation nuance: `workflow_dispatch` is present and tested, but GitHub exposes manual dispatch only once the workflow-dispatch-enabled workflow exists on the default branch. Before this PR merges, the real publish smoke after secrets are provisioned should use the `pull_request` rerun/push path. The post-merge `push: main` run is what publishes the real `mainBranch` consumer pact for Yuantus to verify; manual dispatch is then useful for reruns.

CI green on current head `6d5de54`.

**Honest status:** with no broker/secrets yet, a green run means the broker step **skipped**, not that publishing works. Exact CLI flags + auth must be confirmed against a live broker at activation. Pairs with the Yuantus provider verify+publish+can-i-deploy PR; sequencing is consumer-publish → provider-pull per the corrected runbook.
