### PR TITLE
feat(attendance): self-calculate severe-late / absence-late report tiers (#5 RT-1)

### DIFF
--- a/docs/development/attendance-report-tiering-rt1-dev-verification-20260622.md
+++ b/docs/development/attendance-report-tiering-rt1-dev-verification-20260622.md
@@ -1,0 +1,58 @@
+# Dev + Verification — Attendance report tiering (#5 RT-1)
+
+> **Arc**: #5 (report tiering) · **Slice**: RT-1 (settings + compute) · **PR**: #3069 (branch `feat/attendance-report-tiering-rt1-20260622`, **not merged** — owner-gated hot-core review) · **Design-lock**: `attendance-report-tiering-designlock-20260622.md` (#3055, §3 = recommended column) · **Date**: 2026-06-22 · MetaSheet 口径.
+
+This is one arc of the remaining-line plan (#3048). The plan sequences the remainder as Wave 1 (#4 ∥ #2, Codex) · **Wave 2 (#5 → #6, serial, this lane)** · Wave 3 (#8). Per the agreed pace, this session built **#5 RT-1 only**, then reassesses; #6/#8 follow serially (they share the record-compute path and must not land concurrently).
+
+---
+
+## 1. What shipped
+
+`lateMinutes` is already computed truthfully (from `lateGraceMinutes` + the shift). Severe-late / absence-late are just **tiers of the same lateness**, so RT-1 derives them the same way instead of trusting record meta.
+
+| Piece | Where | Note |
+|---|---|---|
+| Threshold defaults | `DEFAULT_RULE` (`severeLateThresholdMinutes` 30 / `absenceLateThresholdMinutes` 60) | §3a recommended defaults, over the grace window |
+| Tier derivation | `computeLateTierCounts(lateMinutes, rule)` (pure) | falls back to `DEFAULT_RULE`; **enforces** nesting `late ⊇ severe ⊇ absence` via `effectiveAbsence = max(absence, severe)`; `0` disables a tier |
+| Persist (one site) | `computeAttendanceRecordUpsertValues` writes `severe_late_count` / `severe_late_minutes` / `absence_late_count` into the record `meta` | derived from the **effective** (post-override) `lateMinutes` → a manual override re-tiers |
+| Report read | unchanged — `getAttendanceRecordReportFieldValue` already reads those meta keys | the populated meta makes the existing read return the computed value |
+
+**Why this seam.** The report-field read (`getAttendanceRecordReportFieldValue(row, code)`) has only the record `row`, not the rule — threading the rule through `buildAttendanceRecordReportExportItem(Async)` + the formula value-map + every caller would sprawl. The rule **is** in scope at `computeAttendanceRecordUpsertValues` (where `lateMinutes` is finalized), so the tier is computed once and written into the meta the report already reads. Net production change: **+1 helper, +1 write, +2 rule defaults** — no change to the report-field read or the 7 `computeMetrics` callers.
+
+**Legacy compat (§3c).** Records that predate this carry no tier keys → the report's existing meta-fallback reads `0`, unchanged. No closed period is restated.
+
+## 2. Verification
+
+### 2.1 Unit (no DB) — `packages/core-backend/tests/unit/attendance-report-tiering.test.ts` — **9/9 local pass**
+- **Tier math**: defaults (35→severe, 20→none, 0→none); nesting (70→both; 60 at 30/60→both); per-group override (20 at sev15→severe); disabled (`0`→never; severe-on/absence-off); fractional/non-numeric coercion.
+- **Nesting enforcement** vs incoherent `absence < severe` (absence 20 / severe 50): a 30-min record yields `{severe:0, absence:0}` (never absence-without-severe); a 60-min record yields both. This closes the correctness gap the review flagged.
+- **Wiring** through the **real** `computeAttendanceRecordUpsertValues` (not a fixture): a `09:45` punch with the default rule → `lateMinutes=35` → the returned `metaJson` carries `severe_late_count=1, severe_late_minutes=35, absence_late_count=0`; a `10:30` punch → `80` → both tiers; a `09:05` punch → `0` → zeros.
+
+### 2.2 Real-DB integration — `packages/core-backend/tests/integration/attendance-plugin.test.ts` — runs in `plugin-tests.yml` (real Postgres)
+Imports a severe-late (`09:45` → 35 min) + an absence-level (`10:30` → 80 min) record, reads `GET /api/attendance/records`, and asserts the per-record `report_values` carry the self-calculated tiers — `late_count=1` (plumbing) → `severe_late_count=1`, `severe_late_duration=35`, `absence_late_count=0` for the 35-min day; `severe=1 / absence=1` for the 80-min day. This exercises the **actual report/export projection** (field-by-field), catching the recurring "render passes, real wire drops the field" trap.
+
+### 2.3 Gates
+`node -c` clean · `tsc --noEmit` **0 errors** · broad attendance unit sweep **199 pass / 0 fail** (no meta-exact-match regression from always-writing the 3 keys) · CI on #3069 (the `test (18.x/20.x)` + `plugin-tests` real-DB step) — see the PR.
+
+## 3. Split — RT-1a (deferred, named so it can't drop)
+
+Per-group **configurable** thresholds need three things that travel together:
+1. **Persistence** — `attendance_rules` is **typed columns** (not a JSON blob), so storing `severe_late_threshold_minutes` / `absence_late_threshold_minutes` needs a **migration** + threading through the rule INSERT / `mapRuleRow` / the override resolver.
+2. **Write-side enum-strict normalizer** — `z.int().min(0)` on the rule/shift routes + an `absence ≥ severe ≥ lateGraceMinutes` **reject** (the #1776 rule: missing/non-integer/out-of-range → explicit reject, never a silent default). A normalizer that validates a field it can't yet store would be incoherent, so it lands with (1).
+3. **Admin UI + 口径 tooltip** (the design-lock RT-3 humanization slice).
+
+v1 thresholds are the ordered 30/60 defaults, so the nesting invariant already holds; the helper enforces it regardless of config, so RT-1a can add per-group values safely.
+
+Also still deferred (design-lock §3d / §4): 出勤口径 (free-hours/unscheduled-not-counted day-count) and 公式函数 (TEXT/FILTER/REGEX) — distinct surfaces from late-tiering.
+
+## 4. Remaining line (after this arc)
+
+| Arc | Lane | Status |
+|---|---|---|
+| #5 report tiering | this lane | **RT-1 in PR #3069**; RT-1a (above) next; RT-2 export/sync wiring + RT-3 UI + RT-4 staging |
+| #6 pending-leave / team availability | this lane | design-lock #3056 (TA-0) **拍板-pending**; serial **after #5** |
+| #8 cross-midnight | this lane | design-lock first (NS-0); serial; heaviest |
+| #4 / #2 | Codex lane | Wave 1, file-disjoint, parallel — owner to confirm session ownership (plan #3048 flag #1) |
+
+## 5. Governance
+design-lock (#3055, recommended §3) → build (this PR, recommended §3) → **owner review of the hot-core change** → CI + real-DB → (merge) → RT-1a … RT-4 → staging smoke → tracker backfill. Serial vs #6/#8. Not merged pending owner review. MetaSheet 口径; no competitor names in code/tests.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -10609,6 +10609,79 @@ attendanceIntegrationDescribe(
     expect(lastOutAtIso.startsWith(`${workDate}T18:00:00`)).toBe(true)
   })
 
+  it('#5 report tiering — severe-late / absence-late tiers are self-calculated and round-trip through the records report (real DB)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    // collision-free future year; a Monday (workday) + the next day (Tuesday, workday).
+    const year = 3600 + (Number.parseInt(runSuffix.slice(-4), 36) % 1000)
+    const firstOfOctober = new Date(Date.UTC(year, 9, 1))
+    const monday = new Date(firstOfOctober)
+    while (monday.getUTCDay() !== 1) monday.setUTCDate(monday.getUTCDate() + 1)
+    const severeDate = monday.toISOString().slice(0, 10)
+    const absenceObj = new Date(monday)
+    absenceObj.setUTCDate(monday.getUTCDate() + 1)
+    const absenceDate = absenceObj.toISOString().slice(0, 10)
+    const userId = `attendance-rt1-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+      // Default rule: 09:00 start, 10-min grace, severe 30 / absence 60 (over the grace window).
+      //   09:45 → 35 min late  (≥ severe 30, < absence 60) → severe-late only.
+      //   10:30 → 80 min late  (≥ absence 60)              → severe + absence (tiers nest).
+      const importPayload = {
+        userId,
+        rows: [
+          { workDate: severeDate, fields: { firstInAt: `${severeDate}T09:45:00Z`, lastOutAt: `${severeDate}T18:00:00Z` } },
+          { workDate: absenceDate, fields: { firstInAt: `${absenceDate}T10:30:00Z`, lastOutAt: `${absenceDate}T18:00:00Z` } },
+        ],
+        mode: 'override',
+      }
+      const importRes = await requestJson(`${baseUrl}/api/attendance/import`, { method: 'POST', headers, body: JSON.stringify(importPayload) })
+      expect(importRes.status, importRes.raw).toBe(200)
+      expect(Number((importRes.body as { data?: { imported?: number } } | undefined)?.data?.imported ?? 0)).toBeGreaterThanOrEqual(2)
+
+      const recordsRes = await requestJson(
+        `${baseUrl}/api/attendance/records?userId=${encodeURIComponent(userId)}&from=${severeDate}&to=${absenceDate}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(recordsRes.status).toBe(200)
+      const items = (recordsRes.body as { data?: { items?: any[] } } | undefined)?.data?.items ?? []
+      const byDate = (d: string) => items.find((r) => String(r?.work_date || '').slice(0, 10) === d)
+
+      // severe-only record: late_count proves the report plumbing; severe=1 proves self-calc; absence=0 proves the boundary.
+      const severe = byDate(severeDate)
+      expect(severe, 'severe-late record present').toBeTruthy()
+      expect(Number(severe?.late_minutes)).toBe(35)
+      const severeRv = (severe?.report_values ?? {}) as Record<string, unknown>
+      expect(Number(severeRv.late_count ?? -1)).toBe(1)
+      expect(Number(severeRv.severe_late_count ?? -1)).toBe(1)
+      expect(Number(severeRv.severe_late_duration ?? -1)).toBe(35)
+      expect(Number(severeRv.absence_late_count ?? -1)).toBe(0)
+
+      // absence-level record: both tiers fire (nested).
+      const absence = byDate(absenceDate)
+      expect(absence, 'absence-late record present').toBeTruthy()
+      expect(Number(absence?.late_minutes)).toBe(80)
+      const absenceRv = (absence?.report_values ?? {}) as Record<string, unknown>
+      expect(Number(absenceRv.severe_late_count ?? -1)).toBe(1)
+      expect(Number(absenceRv.absence_late_count ?? -1)).toBe(1)
+    } finally {
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1', [userId]).catch(() => {})
+      await pool.end().catch(() => {})
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
   it('exposes workday context for holiday overrides and shift schedules on attendance records', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-report-tiering.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-tiering.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #5 report tiering (design-lock #3055) — severe-late / absence-late as first-class self-calc.
+ * Unit-level (no DB): (1) the pure tier math `computeLateTierCounts`, and (2) the WIRING — the pure
+ * `computeAttendanceRecordUpsertValues` writes the tiers into the record `meta` the report fields read,
+ * derived from the (post-override) lateMinutes + the per-group rule thresholds. The report-field read of
+ * that meta is unchanged existing behavior; the real-DB end-to-end (upsert→export) is the integration test.
+ */
+import { describe, it, expect } from 'vitest'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const { computeLateTierCounts, computeAttendanceRecordUpsertValues } =
+  attendancePlugin.__attendanceReportFieldCatalogForTests as {
+    computeLateTierCounts: (lateMinutes: number, rule: Record<string, unknown>) => { severeLateCount: number; severeLateMinutes: number; absenceLateCount: number }
+    computeAttendanceRecordUpsertValues: (options: Record<string, unknown>) => { lateMinutes: number; metaJson: string }
+  }
+
+describe('computeLateTierCounts (#5 tier math)', () => {
+  it('defaults to severe 30 / absence 60 when the rule omits thresholds', () => {
+    expect(computeLateTierCounts(35, {})).toEqual({ severeLateCount: 1, severeLateMinutes: 35, absenceLateCount: 0 })
+    expect(computeLateTierCounts(20, {})).toEqual({ severeLateCount: 0, severeLateMinutes: 0, absenceLateCount: 0 })
+    expect(computeLateTierCounts(0, {})).toEqual({ severeLateCount: 0, severeLateMinutes: 0, absenceLateCount: 0 })
+  })
+
+  it('tiers are NESTED — past the absence threshold a record is also severe-late', () => {
+    expect(computeLateTierCounts(70, {})).toEqual({ severeLateCount: 1, severeLateMinutes: 70, absenceLateCount: 1 })
+    expect(computeLateTierCounts(60, { severeLateThresholdMinutes: 30, absenceLateThresholdMinutes: 60 }))
+      .toEqual({ severeLateCount: 1, severeLateMinutes: 60, absenceLateCount: 1 })
+  })
+
+  it('honours per-group rule overrides', () => {
+    expect(computeLateTierCounts(20, { severeLateThresholdMinutes: 15, absenceLateThresholdMinutes: 40 }))
+      .toEqual({ severeLateCount: 1, severeLateMinutes: 20, absenceLateCount: 0 })
+  })
+
+  it('a threshold of 0 DISABLES that tier (never counts)', () => {
+    expect(computeLateTierCounts(120, { severeLateThresholdMinutes: 0, absenceLateThresholdMinutes: 0 }))
+      .toEqual({ severeLateCount: 0, severeLateMinutes: 0, absenceLateCount: 0 })
+    // severe enabled, absence disabled (0): severe still fires, absence never does.
+    expect(computeLateTierCounts(120, { severeLateThresholdMinutes: 30, absenceLateThresholdMinutes: 0 }))
+      .toEqual({ severeLateCount: 1, severeLateMinutes: 120, absenceLateCount: 0 })
+  })
+
+  it('ENFORCES nesting against incoherent config (absence < severe) — never absence-without-severe', () => {
+    // absence(20) < severe(50): a 30-min record must NOT count as absence while not severe.
+    expect(computeLateTierCounts(30, { severeLateThresholdMinutes: 50, absenceLateThresholdMinutes: 20 }))
+      .toEqual({ severeLateCount: 0, severeLateMinutes: 0, absenceLateCount: 0 })
+    // past the (higher) severe threshold, both fire — effectiveAbsence is lifted to severe.
+    expect(computeLateTierCounts(60, { severeLateThresholdMinutes: 50, absenceLateThresholdMinutes: 20 }))
+      .toEqual({ severeLateCount: 1, severeLateMinutes: 60, absenceLateCount: 1 })
+  })
+
+  it('floors fractional / coerces non-numeric lateMinutes', () => {
+    expect(computeLateTierCounts(30.9, {}).severeLateCount).toBe(1)
+    expect(computeLateTierCounts('not a number' as unknown as number, {}).severeLateCount).toBe(0)
+  })
+})
+
+describe('computeAttendanceRecordUpsertValues — tier WIRING into record meta (no DB)', () => {
+  const rule = {
+    orgId: 'default',
+    timezone: 'UTC',
+    workStartTime: '09:00',
+    workEndTime: '18:00',
+    lateGraceMinutes: 10,
+    earlyGraceMinutes: 10,
+    severeLateThresholdMinutes: 30,
+    absenceLateThresholdMinutes: 60,
+    roundingMinutes: 5,
+    isOvernight: false,
+  }
+  const baseOptions = (firstIn: string) => ({
+    existingRow: null,
+    updateFirstInAt: new Date(firstIn),
+    updateLastOutAt: new Date('2026-09-21T18:00:00Z'),
+    workDate: '2026-09-21',
+    mode: 'override',
+    isWorkday: true,
+    meta: {},
+    rule,
+    leaveMinutes: 0,
+    overtimeMinutes: 0,
+  })
+  const metaOf = (firstIn: string) => {
+    const values = computeAttendanceRecordUpsertValues(baseOptions(firstIn))
+    return { lateMinutes: values.lateMinutes, meta: JSON.parse(values.metaJson) as Record<string, number> }
+  }
+
+  it('a severe-late punch (09:45 → 35 min late, ≥ severe 30) writes severe_late_count=1, absence=0', () => {
+    const { lateMinutes, meta } = metaOf('2026-09-21T09:45:00Z')
+    expect(lateMinutes).toBe(35)
+    expect(meta.severe_late_count).toBe(1)
+    expect(meta.severe_late_minutes).toBe(35)
+    expect(meta.absence_late_count).toBe(0)
+  })
+
+  it('an absence-level punch (10:30 → 80 min late, ≥ absence 60) writes BOTH tiers', () => {
+    const { lateMinutes, meta } = metaOf('2026-09-21T10:30:00Z')
+    expect(lateMinutes).toBe(80)
+    expect(meta.severe_late_count).toBe(1)
+    expect(meta.absence_late_count).toBe(1)
+  })
+
+  it('an on-time / within-grace punch (09:05) writes zeros — the report reflects no tier', () => {
+    const { lateMinutes, meta } = metaOf('2026-09-21T09:05:00Z')
+    expect(lateMinutes).toBe(0)
+    expect(meta.severe_late_count).toBe(0)
+    expect(meta.severe_late_minutes).toBe(0)
+    expect(meta.absence_late_count).toBe(0)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -20,9 +20,41 @@ const DEFAULT_RULE = {
   workEndTime: '18:00',
   lateGraceMinutes: 10,
   earlyGraceMinutes: 10,
+  // #5 report tiering (design-lock #3055): lateness tiers above the grace window. severe ≤ absence.
+  severeLateThresholdMinutes: 30,
+  absenceLateThresholdMinutes: 60,
   roundingMinutes: 5,
   workingDays: [1, 2, 3, 4, 5],
   isDefault: true,
+}
+
+// #5 report tiering (design-lock #3055): derive severe-late / absence-late tier counts from the
+// (post-override) lateMinutes and the rule thresholds, so the report metrics are SELF-CALCULATED instead
+// of trusted from record meta (the prior summary.* passthrough). v1 thresholds come from DEFAULT_RULE
+// (severe 30 / absence 60); per-group persistence + a write-side enum-strict normalizer (absence ≥ severe ≥
+// grace reject) land in RT-1a (needs a rule-table migration — attendance_rules is typed columns).
+// Tiers are NESTED — an absence-level record is always also severe-late, mirroring late_count counting
+// every late day: late ⊇ severe ⊇ absence. We ENFORCE the nesting here (effectiveAbsence = max(absence,
+// severe)) so incoherent config can never yield absence-without-severe; a threshold of 0 DISABLES that
+// tier (preserved through the max). Pure function — unit-tested; the single write is in
+// computeAttendanceRecordUpsertValues, into the record meta the report fields already read.
+function computeLateTierCounts(lateMinutes, rule) {
+  const lm = Math.max(0, Math.floor(Number(lateMinutes) || 0))
+  const severe = Number.isFinite(Number(rule?.severeLateThresholdMinutes))
+    ? Math.max(0, Number(rule.severeLateThresholdMinutes))
+    : DEFAULT_RULE.severeLateThresholdMinutes
+  const absenceConfigured = Number.isFinite(Number(rule?.absenceLateThresholdMinutes))
+    ? Math.max(0, Number(rule.absenceLateThresholdMinutes))
+    : DEFAULT_RULE.absenceLateThresholdMinutes
+  // Enforce nesting without resurrecting a disabled (0) absence tier.
+  const effectiveAbsence = absenceConfigured > 0 ? Math.max(absenceConfigured, severe) : 0
+  const severeLateCount = severe > 0 && lm >= severe ? 1 : 0
+  const absenceLateCount = effectiveAbsence > 0 && lm >= effectiveAbsence ? 1 : 0
+  return {
+    severeLateCount,
+    severeLateMinutes: severeLateCount ? lm : 0,
+    absenceLateCount,
+  }
 }
 const DEFAULT_SHIFT = {
   orgId: DEFAULT_ORG_ID,
@@ -16361,6 +16393,16 @@ function computeAttendanceRecordUpsertValues(options) {
       finalMetrics.status = overrideMetrics.status.trim()
     }
   }
+  // #5 report tiering (design-lock #3055): write the (post-override) lateness tiers into the record meta
+  // the report fields already read (severe_late_count / severe_late_minutes / absence_late_count). Computed
+  // from the EFFECTIVE lateMinutes (so a manual lateMinutes override re-tiers) + the per-group rule
+  // thresholds. Legacy records that predate this never carry these keys → the report fallback reads 0,
+  // unchanged (no history restatement).
+  const lateTiers = computeLateTierCounts(finalMetrics.lateMinutes, rule)
+  finalMeta.severe_late_count = lateTiers.severeLateCount
+  finalMeta.severe_late_minutes = lateTiers.severeLateMinutes
+  finalMeta.absence_late_count = lateTiers.absenceLateCount
+
   const status = statusOverride ?? finalMetrics.status
 
   return {
@@ -18033,6 +18075,7 @@ module.exports = {
     attendanceReportRecordRowKey,
     buildAttendanceImportMultiPunchMeta,
     computeAttendanceRecordUpsertValues,
+    computeLateTierCounts,
     resolveAttendanceImportRawClient,
     buildAttendanceImportCopyQuery,
     attachAttendanceImportCopyStreamErrorSink,


### PR DESCRIPTION
## #5 RT-1 — self-calculate severe-late / absence-late report tiers

Promotes **严重迟到 / 旷工级迟到** from record-meta **passthrough** to first-class, **self-calculated** report metrics (design-lock `docs/development/attendance-report-tiering-designlock-20260622.md`, #3055). Today `late_count` self-calcs from `lateMinutes` but `severe_late_count` / `severe_late_duration` / `absence_late_count` read whatever a record's meta happens to carry; this computes them from the rule.

### What RT-1 ships
- **`DEFAULT_RULE`** gains `severeLateThresholdMinutes` / `absenceLateThresholdMinutes` (§3-recommended defaults **30 / 60** over the grace window).
- **`computeLateTierCounts(lateMinutes, rule)`** — pure tier derivation, falls back to `DEFAULT_RULE` when a rule omits them. Tiers **nest** (`late ⊇ severe ⊇ absence`) and the nesting is **enforced** (`effectiveAbsence = max(absence, severe)`) so incoherent config can never produce absence-without-severe; a `0` threshold disables that tier.
- **One write site**: `computeAttendanceRecordUpsertValues` writes the (post-override) tiers into the record `meta` the report fields **already read** (`severe_late_count` / `severe_late_minutes` / `absence_late_count`). **No change** to the report-field read path or the 7 `computeMetrics` callers. Derived from the **effective** `lateMinutes`, so a manual override re-tiers.
- **Legacy compat**: records that predate this carry no keys → the report fallback reads `0`, unchanged (no history restatement).

### Tests
- **unit (no DB)** — `attendance-report-tiering.test.ts`: tier math (defaults / nesting / **nesting-enforcement vs incoherent `absence < severe`** / disabled / coercion) + the **wiring** through the real `computeAttendanceRecordUpsertValues` (a 09:45 punch → 35 min late → `severe_late_count=1` in the record meta — no fixture).
- **real-DB integration** — `attendance-plugin.test.ts`: import a severe-late (35 min) + absence-level (80 min) record → the records-report `report_values` carry the self-calculated tiers (boundary at 60: `severe=1/absence=0` vs `severe=1/absence=1`), round-tripping through the **actual** report/export projection (the wire-vs-fixture landmine the design-lock flagged). Runs in `plugin-tests.yml` against real Postgres.

### Split as RT-1a (deferred, named so it can't drop)
Per-group threshold **persistence** (`attendance_rules` is typed columns → needs a migration) + the **write-side enum-strict normalizer** (`z.int().min(0)` + `absence ≥ severe ≥ grace` reject, per the #1776 rule) + admin UI. A normalizer that validates a field it can't yet store would be incoherent, so it travels with the persistence it guards. v1 thresholds are the ordered 30/60 defaults, so the nesting invariant already holds; the helper enforces it regardless.

### Scope / process
- **Serial with #6/#8** (all touch the record-compute / summary path) — do not land concurrently (plan #3048 §2/§7).
- Not for merge yet — owner-gated review of the hot-core change. MetaSheet 口径; no competitor names in code/tests.
- Design-lock §3 used the **recommended** column (defaults / persist-via-meta / legacy-fallback / 3d deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
