### PR TITLE
feat(attendance): per-group configurable late-tier thresholds + enum-strict normalizer (#5 RT-1a)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260622000000_add_attendance_late_tier_thresholds.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260622000000_add_attendance_late_tier_thresholds.ts
@@ -1,0 +1,25 @@
+import type { Kysely } from 'kysely'
+import { addColumnIfNotExists, checkTableExists, dropColumnIfExists } from './_patterns'
+
+// #5 RT-1a (design-lock #3055): per-group lateness tier thresholds on attendance_rules so
+// severe-late / absence-late are configurable, not just the RT-1 code defaults. Additive + defaulted to
+// the §3 recommended 30 / 60 (over the grace window), so existing rows keep tiering identically to RT-1.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const rulesExists = await checkTableExists(db, 'attendance_rules')
+  if (!rulesExists) return
+  await addColumnIfNotExists(db, 'attendance_rules', 'severe_late_threshold_minutes', 'integer', {
+    notNull: true,
+    defaultTo: 30,
+  })
+  await addColumnIfNotExists(db, 'attendance_rules', 'absence_late_threshold_minutes', 'integer', {
+    notNull: true,
+    defaultTo: 60,
+  })
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const rulesExists = await checkTableExists(db, 'attendance_rules')
+  if (!rulesExists) return
+  await dropColumnIfExists(db, 'attendance_rules', 'severe_late_threshold_minutes')
+  await dropColumnIfExists(db, 'attendance_rules', 'absence_late_threshold_minutes')
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -10682,6 +10682,74 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('#5 RT-1a — per-group thresholds are configurable end-to-end + the normalizer rejects incoherent input (real DB)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const orgId = `rt1a-org-${runSuffix}` // isolated org — never pollutes the shared default rule
+    const year = 3600 + (Number.parseInt(runSuffix.slice(-4), 36) % 1000)
+    const firstOfOctober = new Date(Date.UTC(year, 9, 1))
+    const monday = new Date(firstOfOctober)
+    while (monday.getUTCDay() !== 1) monday.setUTCDate(monday.getUTCDate() + 1)
+    const workDate = monday.toISOString().slice(0, 10)
+    const userId = `attendance-rt1a-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+      const orgHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'x-org-id': orgId }
+      const putRule = (body: Record<string, unknown>) => requestJson(`${baseUrl}/api/attendance/rules/default`, {
+        method: 'PUT', headers: orgHeaders, body: JSON.stringify({ orgId, ...body }),
+      })
+
+      // Normalizer (design-lock §2 / the #1776 enum-strict rule) — reject BEFORE any persistence:
+      const ordered = { workStartTime: '09:00', workEndTime: '18:00', lateGraceMinutes: 10 }
+      expect((await putRule({ ...ordered, severeLateThresholdMinutes: 50, absenceLateThresholdMinutes: 20 })).status).toBe(400) // absence < severe
+      expect((await putRule({ lateGraceMinutes: 30, severeLateThresholdMinutes: 20, absenceLateThresholdMinutes: 60 })).status).toBe(400) // severe < grace
+      expect((await putRule({ ...ordered, severeLateThresholdMinutes: 15.5 })).status).toBe(400) // non-integer (Zod)
+      expect((await putRule({ ...ordered, severeLateThresholdMinutes: -5 })).status).toBe(400) // negative (Zod)
+
+      // Valid custom rule: severe 15 / absence 40 (ordered, ≥ grace 10).
+      const okRes = await putRule({ ...ordered, severeLateThresholdMinutes: 15, absenceLateThresholdMinutes: 40 })
+      expect(okRes.status, okRes.raw).toBe(200)
+      const ruleData = (okRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+      expect(Number(ruleData.severeLateThresholdMinutes)).toBe(15) // RETURNING * → mapRuleRow surfaces it
+      expect(Number(ruleData.absenceLateThresholdMinutes)).toBe(40)
+
+      // Import a 20-min-late record (09:30): 20 ≥ custom 15 → severe; would be 0 at the RT-1 default 30.
+      const importRes = await requestJson(`${baseUrl}/api/attendance/import`, {
+        method: 'POST', headers: orgHeaders,
+        body: JSON.stringify({ userId, mode: 'override', rows: [{ workDate, fields: { firstInAt: `${workDate}T09:30:00Z`, lastOutAt: `${workDate}T18:00:00Z` } }] }),
+      })
+      expect(importRes.status, importRes.raw).toBe(200)
+
+      const recordsRes = await requestJson(
+        `${baseUrl}/api/attendance/records?userId=${encodeURIComponent(userId)}&from=${workDate}&to=${workDate}`,
+        { headers: { Authorization: `Bearer ${token}`, 'x-org-id': orgId } },
+      )
+      expect(recordsRes.status).toBe(200)
+      const items = (recordsRes.body as { data?: { items?: any[] } } | undefined)?.data?.items ?? []
+      const record = items.find((r) => String(r?.work_date || '').slice(0, 10) === workDate)
+      expect(record, 'record present').toBeTruthy()
+      expect(Number(record?.late_minutes)).toBe(20)
+      const rv = (record?.report_values ?? {}) as Record<string, unknown>
+      // the per-group threshold flowed through loadDefaultRule → mapRuleRow → computeLateTierCounts:
+      expect(Number(rv.severe_late_count ?? -1)).toBe(1) // 20 ≥ custom 15 (would be 0 at the default 30)
+      expect(Number(rv.absence_late_count ?? -1)).toBe(0) // 20 < custom 40
+    } finally {
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1', [userId]).catch(() => {})
+      await pool.query('DELETE FROM attendance_rules WHERE org_id = $1', [orgId]).catch(() => {})
+      await pool.end().catch(() => {})
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
   it('exposes workday context for holiday overrides and shift schedules on attendance records', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-report-tiering.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-tiering.test.ts
@@ -9,10 +9,11 @@ import { describe, it, expect } from 'vitest'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
-const { computeLateTierCounts, computeAttendanceRecordUpsertValues } =
+const { computeLateTierCounts, computeAttendanceRecordUpsertValues, mapRuleRow } =
   attendancePlugin.__attendanceReportFieldCatalogForTests as {
     computeLateTierCounts: (lateMinutes: number, rule: Record<string, unknown>) => { severeLateCount: number; severeLateMinutes: number; absenceLateCount: number }
     computeAttendanceRecordUpsertValues: (options: Record<string, unknown>) => { lateMinutes: number; metaJson: string }
+    mapRuleRow: (row: Record<string, unknown>) => { severeLateThresholdMinutes: number; absenceLateThresholdMinutes: number; lateGraceMinutes: number }
   }
 
 describe('computeLateTierCounts (#5 tier math)', () => {
@@ -107,5 +108,22 @@ describe('computeAttendanceRecordUpsertValues — tier WIRING into record meta (
     expect(meta.severe_late_count).toBe(0)
     expect(meta.severe_late_minutes).toBe(0)
     expect(meta.absence_late_count).toBe(0)
+  })
+})
+
+describe('RT-1a — mapRuleRow reads the persisted per-group thresholds, feeding the tier compute (no DB)', () => {
+  it('reads severe_late_threshold_minutes / absence_late_threshold_minutes off the row', () => {
+    const rule = mapRuleRow({ id: 'r1', late_grace_minutes: 10, severe_late_threshold_minutes: 15, absence_late_threshold_minutes: 40 })
+    expect(rule.severeLateThresholdMinutes).toBe(15)
+    expect(rule.absenceLateThresholdMinutes).toBe(40)
+    // the persisted custom threshold then drives the tier: 20 min late ≥ custom 15 → severe (would be 0 at the default 30).
+    expect(computeLateTierCounts(20, rule)).toEqual({ severeLateCount: 1, severeLateMinutes: 20, absenceLateCount: 0 })
+  })
+
+  it('falls back to the RT-1 defaults (30 / 60) for a legacy row missing the columns', () => {
+    const rule = mapRuleRow({ id: 'r2', late_grace_minutes: 10 })
+    expect(rule.severeLateThresholdMinutes).toBe(30)
+    expect(rule.absenceLateThresholdMinutes).toBe(60)
+    expect(computeLateTierCounts(20, rule).severeLateCount).toBe(0) // 20 < default 30
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7515,6 +7515,13 @@ function normalizeRuleOverride(value) {
     earlyGraceMinutes: Number.isFinite(Number(override.earlyGraceMinutes))
       ? Math.max(0, Number(override.earlyGraceMinutes))
       : undefined,
+    // #5 RT-1a: per-group lateness tier thresholds carry through the override merge (now persisted).
+    severeLateThresholdMinutes: Number.isFinite(Number(override.severeLateThresholdMinutes))
+      ? Math.max(0, Number(override.severeLateThresholdMinutes))
+      : undefined,
+    absenceLateThresholdMinutes: Number.isFinite(Number(override.absenceLateThresholdMinutes))
+      ? Math.max(0, Number(override.absenceLateThresholdMinutes))
+      : undefined,
     roundingMinutes: Number.isFinite(Number(override.roundingMinutes))
       ? Math.max(0, Number(override.roundingMinutes))
       : undefined,
@@ -7547,6 +7554,9 @@ function mapRuleRow(row) {
     workEndTime: row.work_end_time ?? DEFAULT_RULE.workEndTime,
     lateGraceMinutes: Number(row.late_grace_minutes ?? DEFAULT_RULE.lateGraceMinutes),
     earlyGraceMinutes: Number(row.early_grace_minutes ?? DEFAULT_RULE.earlyGraceMinutes),
+    // #5 RT-1a: per-group lateness tier thresholds (read the persisted column, fall back to the RT-1 default).
+    severeLateThresholdMinutes: Number(row.severe_late_threshold_minutes ?? DEFAULT_RULE.severeLateThresholdMinutes),
+    absenceLateThresholdMinutes: Number(row.absence_late_threshold_minutes ?? DEFAULT_RULE.absenceLateThresholdMinutes),
     roundingMinutes: Number(row.rounding_minutes ?? DEFAULT_RULE.roundingMinutes),
     workingDays: normalizeWorkingDays(row.working_days),
     isDefault: row.is_default ?? true,
@@ -12280,7 +12290,7 @@ async function loadDefaultRule(db, orgId) {
   try {
     const rows = await db.query(
       `SELECT id, name, timezone, work_start_time, work_end_time, late_grace_minutes,
-              early_grace_minutes, rounding_minutes, working_days, is_default, org_id
+              early_grace_minutes, severe_late_threshold_minutes, absence_late_threshold_minutes, rounding_minutes, working_days, is_default, org_id
        FROM attendance_rules
        WHERE is_default = true AND org_id = $1
        ORDER BY created_at DESC
@@ -12290,7 +12300,7 @@ async function loadDefaultRule(db, orgId) {
     if (!rows.length && targetOrg !== DEFAULT_ORG_ID) {
       const fallbackRows = await db.query(
         `SELECT id, name, timezone, work_start_time, work_end_time, late_grace_minutes,
-                early_grace_minutes, rounding_minutes, working_days, is_default, org_id
+                early_grace_minutes, severe_late_threshold_minutes, absence_late_threshold_minutes, rounding_minutes, working_days, is_default, org_id
          FROM attendance_rules
          WHERE is_default = true AND org_id = $1
          ORDER BY created_at DESC
@@ -18076,6 +18086,7 @@ module.exports = {
     buildAttendanceImportMultiPunchMeta,
     computeAttendanceRecordUpsertValues,
     computeLateTierCounts,
+    mapRuleRow,
     resolveAttendanceImportRawClient,
     buildAttendanceImportCopyQuery,
     attachAttendanceImportCopyStreamErrorSink,
@@ -27625,6 +27636,8 @@ module.exports = {
           workEndTime: z.string().optional(),
           lateGraceMinutes: z.number().int().min(0).optional(),
           earlyGraceMinutes: z.number().int().min(0).optional(),
+          severeLateThresholdMinutes: z.number().int().min(0).optional(),
+          absenceLateThresholdMinutes: z.number().int().min(0).optional(),
           roundingMinutes: z.number().int().min(0).optional(),
           workingDays: z.array(z.number().int().min(0).max(6)).optional(),
           orgId: z.string().optional(),
@@ -27643,8 +27656,25 @@ module.exports = {
           workEndTime: parsed.data.workEndTime ?? DEFAULT_RULE.workEndTime,
           lateGraceMinutes: parsed.data.lateGraceMinutes ?? DEFAULT_RULE.lateGraceMinutes,
           earlyGraceMinutes: parsed.data.earlyGraceMinutes ?? DEFAULT_RULE.earlyGraceMinutes,
+          severeLateThresholdMinutes: parsed.data.severeLateThresholdMinutes ?? DEFAULT_RULE.severeLateThresholdMinutes,
+          absenceLateThresholdMinutes: parsed.data.absenceLateThresholdMinutes ?? DEFAULT_RULE.absenceLateThresholdMinutes,
           roundingMinutes: parsed.data.roundingMinutes ?? DEFAULT_RULE.roundingMinutes,
           workingDays: parsed.data.workingDays ?? DEFAULT_RULE.workingDays,
+        }
+
+        // #5 RT-1a normalizer (design-lock §2, the #1776 enum-strict rule): Zod already rejected
+        // non-integers / negatives; now reject incoherent tiers on the RESOLVED payload so a partial
+        // update can't persist an out-of-order rule. absence-late ≥ severe-late ≥ grace.
+        if (!(payload.absenceLateThresholdMinutes >= payload.severeLateThresholdMinutes
+              && payload.severeLateThresholdMinutes >= payload.lateGraceMinutes)) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'absenceLateThresholdMinutes ≥ severeLateThresholdMinutes ≥ lateGraceMinutes is required.',
+            },
+          })
+          return
         }
 
         const orgId = getOrgId(req)
@@ -27654,8 +27684,8 @@ module.exports = {
 
             const rows = await trx.query(
               `INSERT INTO attendance_rules
-               (id, org_id, name, timezone, work_start_time, work_end_time, late_grace_minutes, early_grace_minutes, rounding_minutes, working_days, is_default)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, true)
+               (id, org_id, name, timezone, work_start_time, work_end_time, late_grace_minutes, early_grace_minutes, severe_late_threshold_minutes, absence_late_threshold_minutes, rounding_minutes, working_days, is_default)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, true)
                RETURNING *`,
               [
                 randomUUID(),
@@ -27666,6 +27696,8 @@ module.exports = {
                 payload.workEndTime,
                 payload.lateGraceMinutes,
                 payload.earlyGraceMinutes,
+                payload.severeLateThresholdMinutes,
+                payload.absenceLateThresholdMinutes,
                 payload.roundingMinutes,
                 JSON.stringify(payload.workingDays),
               ]


### PR DESCRIPTION
## #5 RT-1a — per-group configurable late-tier thresholds + enum-strict normalizer

**Stacked on #3069 (RT-1).** Base is the RT-1 branch; the diff shows only RT-1a. Completes #5's configurability (design-lock #3055 §3b/§5): severe-late / absence-late thresholds become per-org-rule configurable, not just the RT-1 code defaults — the actual DingTalk-parity feature.

### Changes
- **Migration** — additive `severe_late_threshold_minutes` / `absence_late_threshold_minutes` on `attendance_rules` (`NOT NULL DEFAULT 30 / 60`, idempotent guarded), so existing rows tier identically to RT-1.
- **Read** — `mapRuleRow` reads the columns (fallback to `DEFAULT_RULE`), and **both** `loadDefaultRule` SELECTs carry them. These are *explicit-column* projections (the field-by-field wire landmine in our memory), so without this the per-group value would silently never reach the compute. `loadDefaultRule` feeds 10+ consumers including the import/upsert compute path.
- **Write + normalizer** — `PUT /api/attendance/rules/default` gains `z.int().min(0)` on both fields **and** a resolved-payload check rejecting incoherent tiers (`absence ≥ severe ≥ grace`). This is the #1776 enum-strict discipline: non-integer / negative / out-of-order → `400`, never a silent default.
- **Override merge** — `normalizeRuleOverride` carries the thresholds through (now persisted).

### Tests
- **unit (no DB)** — `mapRuleRow` reads the persisted columns and feeds `computeLateTierCounts`: a custom severe `15` flips a 20-min-late record to severe where the default `30` would not; a legacy row missing the columns falls back to `30 / 60`.
- **real-DB integration** — PUT a custom-org rule (`severe 15 / absence 40`, isolated via `x-org-id` so the shared `default` rule is untouched), import a 20-min-late record → `report_values.severe_late_count = 1` (would be `0` at the default `30`), proving the per-group threshold round-trips `loadDefaultRule → mapRuleRow → computeLateTierCounts`. Plus the normalizer rejects `absence<severe` / `severe<grace` / non-integer / negative with `400` **before any persistence**.

### Scope
- Per-org rule only; **shift-level** thresholds (`attendance_shifts`) remain a possible follow-up.
- Serial with #6/#8; not for merge until RT-1 (#3069) lands — then this rebases onto main.
- MetaSheet 口径; no competitor names in code/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
