### PR TITLE
feat(integration): FOS-4b-2 — generic action-binding DRY-RUN path (dry-run-only; no write; apply gated)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/field-option-sync-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/field-option-sync-contract.test.cjs
@@ -112,8 +112,13 @@ async function main() {
     'unregistered permittedActionId rejected (enum-strict ∈ registry)',
   )
   assert.throws(() => normalizeFieldOptionSyncPreset(validPreset({ permittedActionIds: 'x' })), /must be an array/, 'permittedActionIds must be an array')
-  // catalog presets bind no actions
-  assert.ok(listFieldOptionSyncPresets().every((p) => Array.isArray(p.permittedActionIds) && p.permittedActionIds.length === 0), 'catalog presets carry no action bindings')
+  // catalog: every preset's permittedActionIds is a valid array of registered actions; only the
+  // FOS-4b-2 with-actions preset permits one (the rest are []).
+  const cat = listFieldOptionSyncPresets()
+  assert.ok(cat.every((p) => Array.isArray(p.permittedActionIds)), 'every preset has a permittedActionIds array')
+  const withActions = cat.find((p) => p.presetId === 'preset.stock-preparation.with-actions.v1')
+  assert.deepEqual(withActions.permittedActionIds, ['plm.stock-preparation.pull-bom.v1'], 'with-actions preset permits the registered stock-prep action')
+  assert.ok(cat.filter((p) => p.presetId !== 'preset.stock-preparation.with-actions.v1').every((p) => p.permittedActionIds.length === 0), 'all other catalog presets bind no actions')
 
   console.log('✓ field-option-sync-contract: normalizer + enum-strict + required + values-free(non-vacuous) + catalog + deep-copy + permittedActionIds tests passed')
 }

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -4035,8 +4035,8 @@ async function testFieldOptionsSyncRoute() {
   assert.equal(res.statusCode, 422)
   assert.equal(res.body.error.code, 'OPTION_SYNC_CONFIG_INVALID')
 
-  // action bindings fail closed on the generic route (stock-prep-only concept) → 422.
-  // Even a VALID predefined actionId is rejected, not silently dropped.
+  // FOS-4b-2: action bindings are DRY-RUN-ONLY. Non-dry-run + action bindings → fail-closed (apply not
+  // enabled), no patch — even a VALID predefined actionId.
   const patchCountBeforeActionReject = findCalls(provisioning.calls, 'patchObjectFieldProperty').length
   res = await invoke(routes, 'POST', '/api/integration/field-options/sync', {
     user: ADMIN_USER,
@@ -4046,12 +4046,45 @@ async function testFieldOptionsSyncRoute() {
     },
   })
   assert.equal(res.statusCode, 422)
-  assert.equal(res.body.error.code, 'FIELD_OPTION_SYNC_ACTIONS_NOT_SUPPORTED')
+  assert.equal(res.body.error.code, 'FIELD_OPTION_SYNC_ACTIONS_DRY_RUN_ONLY')
   assert.equal(
     findCalls(provisioning.calls, 'patchObjectFieldProperty').length,
     patchCountBeforeActionReject,
-    'rejected action-binding request does not patch',
+    'non-dry-run action-binding request does not patch',
   )
+
+  // FOS-4b-2 dry-run path: dryRun + a permitted action (with-actions preset) → values-free preview, NO write.
+  const patchCountBeforeDryRun = findCalls(provisioning.calls, 'patchObjectFieldProperty').length
+  res = await invoke(routes, 'POST', '/api/integration/field-options/sync', {
+    user: ADMIN_USER,
+    body: {
+      presetId: 'preset.stock-preparation.with-actions.v1',
+      dryRun: true,
+      optionSets: { material_type: [{ value: 'plate', actionBindings: [{ actionId: PLM_STOCK_PREPARATION_ACTION_ID, parameterBindings: { projectNo: 'projectNo' } }] }] },
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.dryRun, true)
+  assert.equal(res.body.data.written, false, 'dry-run writes nothing')
+  assert.equal(findCalls(provisioning.calls, 'patchObjectFieldProperty').length, patchCountBeforeDryRun, 'dry-run issues ZERO patch calls')
+  assert.equal(res.body.data.preview.actionBindings.length, 1, 'dry-run previews the validated action binding')
+  assert.equal(res.body.data.preview.actionBindings[0].actionId, PLM_STOCK_PREPARATION_ACTION_ID)
+  assert.equal(res.body.data.preview.actionBindings[0].requiresDryRun, true, 'gating copied from the registry')
+  assert.equal(res.body.data.preview.actionBindings[0].parameterBindingCount, 1, 'param COUNT only, not values')
+  assert.equal(JSON.stringify(res.body.data.preview).includes('projectNo'), false, 'preview is values-free (no param keys/values)')
+
+  // dryRun + an action NOT permitted by the preset (v1 permits none) → fail-closed, no write.
+  const patchCountBeforeDenied = findCalls(provisioning.calls, 'patchObjectFieldProperty').length
+  res = await invoke(routes, 'POST', '/api/integration/field-options/sync', {
+    user: ADMIN_USER,
+    body: {
+      presetId: STOCK_PREP_PRESET_ID,
+      dryRun: true,
+      optionSets: { material_type: [{ value: 'plate', actionBindings: [{ actionId: PLM_STOCK_PREPARATION_ACTION_ID }] }] },
+    },
+  })
+  assert.equal(res.statusCode, 422, 'dry-run with an action the preset does not permit fails closed')
+  assert.equal(findCalls(provisioning.calls, 'patchObjectFieldProperty').length, patchCountBeforeDenied, 'denied dry-run issues no patch')
 
   // nothing mapped supplied → no-fields-synced 422 (kernel error-if-none via generic factory)
   res = await invoke(routes, 'POST', '/api/integration/field-options/sync', {

--- a/plugins/plugin-integration-core/lib/field-option-sync-contract.cjs
+++ b/plugins/plugin-integration-core/lib/field-option-sync-contract.cjs
@@ -205,6 +205,24 @@ const FIELD_OPTION_SYNC_PRESETS = Object.freeze([
     conflictPolicy: 'update_from_source',
     triggerMode: 'manual',
   }),
+  // FOS-4b-2 (action dry-run path): a preset that PERMITS the registered stock-prep predefined action,
+  // so the generic route's action-binding DRY-RUN path is reachable (validate + preview, NO write/execute;
+  // apply is a later gated sub-slice). Same stock-prep table; values-free.
+  Object.freeze({
+    presetId: 'preset.stock-preparation.with-actions.v1',
+    label: 'Stock-preparation option sync (with predefined actions)',
+    sourceKind: 'static-preset',
+    sourceObjectOrTable: 'operator-config',
+    targetKind: TARGET_KIND,
+    targetTable: 'plm_stock_preparation_main',
+    optionFields: Object.freeze([
+      Object.freeze({ valueField: 'material_type', targetField: 'materialType', targetFieldType: 'single_select' }),
+    ]),
+    syncMode: 'replace',
+    conflictPolicy: 'update_from_source',
+    triggerMode: 'manual',
+    permittedActionIds: Object.freeze(['plm.stock-preparation.pull-bom.v1']), // ∈ FOS-4b-1 registry
+  }),
 ])
 
 // Returns deep, validated copies of the catalog (asserts values-free first; never mutates the frozen consts).

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -146,6 +146,9 @@ const {
   FieldOptionSyncContractError,
   listFieldOptionSyncPresets,
 } = require('./field-option-sync-contract.cjs')
+// FOS-4b-2: validate action-binding REFERENCES (registry ∩ preset.permittedActionIds) for the dry-run path.
+// Used ONLY in dryRun mode — no apply/write/execution (that's a later, separately-gated sub-slice).
+const { normalizeFieldOptionActionBinding } = require('./field-option-action-registry.cjs')
 
 class HttpRouteError extends Error {
   constructor(status, code, message, details = {}) {
@@ -429,6 +432,7 @@ const VALID_FIELD_OPTION_SYNC_REQUEST_KEYS = new Set([
   'projectId',
   'presetId',
   'optionSets',
+  'dryRun', // FOS-4b-2: dry-run-only mode (validate + preview, NO write). Required to carry action bindings.
 ])
 
 function normalizeTableActionBody(body = {}, allowedKeys = VALID_TABLE_ACTION_DRY_RUN_BODY_KEYS) {
@@ -612,6 +616,7 @@ function normalizeFieldOptionSyncRequest(input = {}) {
     projectId: firstString(input.projectId),
     presetId,
     optionSets: isPlainObject(input.optionSets) ? input.optionSets : {},
+    dryRun: input.dryRun === true,
   }
 }
 
@@ -625,6 +630,7 @@ function fieldOptionSyncInput(req, rawInput = {}) {
     projectId,
     presetId: input.presetId,
     optionSets: input.optionSets,
+    dryRun: input.dryRun === true,
   }
 }
 
@@ -645,6 +651,21 @@ function fieldOptionSyncKernelFields(preset) {
     id: field.targetField,
     optionSource: { key: field.valueField, type: preset.sourceKind },
   }))
+}
+
+// FOS-4b-2: strip action bindings from option sets before the (option-only) normalizer. Action bindings
+// are validated separately via the FOS-4b-1 registry; this keeps the option normalizer free of them.
+function stripActionBindingsFromOptionSets(optionSets) {
+  const out = {}
+  for (const [key, value] of Object.entries(optionSets)) {
+    if (!Array.isArray(value)) { out[key] = value; continue }
+    out[key] = value.map((option) => {
+      if (!isPlainObject(option)) return option
+      const { actionBindings, actions, ...rest } = option
+      return rest
+    })
+  }
+  return out
 }
 
 // FOS-2: values-free per-field evidence for the generic route (no option values/labels, no sheetId).
@@ -2133,24 +2154,71 @@ function createHandlers(services, options = {}) {
         })
       }
 
-      // Fail closed on action bindings: actions are a stock-prep-specific concept (predefined action
-      // allowlist + dry-run gating). The generic route writes option metadata only, so it rejects
-      // them rather than silently dropping them through the shared per-option normalizer.
+      // FOS-4b-2: action bindings are DRY-RUN-ONLY. The generic route accepts them ONLY when dryRun:true,
+      // and even then NOTHING is written or executed — each binding is validated as a REFERENCE against the
+      // registry ∩ preset.permittedActionIds (FOS-4b-1) and previewed. Apply/execute is a separate, later,
+      // owner-gated sub-slice. Non-dry-run + action bindings → fail-closed (no write).
+      const actionBindingPreview = []
       for (const [sourceKey, rawOptions] of Object.entries(input.optionSets)) {
         if (!Array.isArray(rawOptions)) continue
-        const carriesActions = rawOptions.some((option) =>
-          isPlainObject(option) && (Array.isArray(option.actionBindings) || Array.isArray(option.actions)))
-        if (carriesActions) {
-          throw new HttpRouteError(422, 'FIELD_OPTION_SYNC_ACTIONS_NOT_SUPPORTED', 'generic field-option-sync does not support action bindings', {
-            presetId: preset.presetId,
-            sourceKey,
-          })
+        for (const option of rawOptions) {
+          if (!isPlainObject(option)) continue
+          const bindings = Array.isArray(option.actionBindings)
+            ? option.actionBindings
+            : (Array.isArray(option.actions) ? option.actions : null)
+          if (!bindings || bindings.length === 0) continue
+          if (!input.dryRun) {
+            throw new HttpRouteError(422, 'FIELD_OPTION_SYNC_ACTIONS_DRY_RUN_ONLY', 'action bindings are dry-run-only (set dryRun:true); apply is not yet enabled', {
+              presetId: preset.presetId,
+              sourceKey,
+            })
+          }
+          for (const binding of bindings) {
+            // validates registry-membership + preset-permission + param allowlist; throws (fail-closed) on any miss.
+            const normalized = normalizeFieldOptionActionBinding(binding, {
+              field: `${sourceKey}.actionBindings`,
+              permittedActionIds: preset.permittedActionIds,
+            })
+            actionBindingPreview.push({
+              sourceKey,
+              actionId: normalized.actionId,
+              kind: normalized.kind,
+              requiresDryRun: normalized.requiresDryRun,
+              requiredPermission: normalized.requiredPermission,
+              parameterBindingCount: Object.keys(normalized.parameterBindings).length,
+            })
+          }
         }
       }
 
       // Reuse the per-option safety normalization (executable-key / secret / placeholder rejection,
       // color/order/label/disabled, dedup, max-options). Throws OPTION_SYNC_* (422, values-free).
-      const optionSets = optionSetsFromInput(input.optionSets)
+      // dry-run strips action bindings first (actions are validated above via the FOS-4b-1 registry, not
+      // the stock-prep path); non-dry-run uses the raw input unchanged (zero-drift).
+      const optionSets = optionSetsFromInput(
+        input.dryRun ? stripActionBindingsFromOptionSets(input.optionSets) : input.optionSets,
+      )
+
+      // FOS-4b-2: dry-run mode validates everything (options above + action references) and PREVIEWS what
+      // WOULD sync — writing NOTHING (no patchObjectFieldProperty). Apply is a separate gated sub-slice.
+      if (input.dryRun) {
+        return sendOk(res, {
+          ok: true,
+          dryRun: true,
+          written: false,
+          target: { presetId: preset.presetId, targetTable: preset.targetTable },
+          preview: {
+            fields: optionFields
+              .filter((field) => optionSets[field.optionSource.key])
+              .map((field) => ({
+                field: field.id,
+                sourceKey: field.optionSource.key,
+                optionCount: optionSets[field.optionSource.key].options.length,
+              })),
+            actionBindings: actionBindingPreview, // values-free: actionId/kind/gating/param-count only
+          },
+        })
+      }
 
       const { synced, skipped, held } = await syncFieldOptions({
         provisioning,


### PR DESCRIPTION
## What (FOS-4b-2, per owner ratification — dry-run-only)

Wires action bindings through the generic field-option-sync route in **DRY-RUN ONLY**: validate + preview, **write/execute NOTHING** (先不执行写). Apply = separate later owner-gated sub-slice.

- **`dryRun` flag**: action bindings accepted **only** when `dryRun:true`; each validated as a REFERENCE via the **FOS-4b-1 registry** (actionId ∈ registry ∩ `preset.permittedActionIds`, params ⊆ allowlist, gating from registry) → added to a **values-free preview** (actionId/kind/gating/param-**count**, no values). The dry-run return happens **before any kernel/patch call** → `written:false`, zero patch calls.
- **Apply gated**: non-dry-run + action bindings → `FIELD_OPTION_SYNC_ACTIONS_DRY_RUN_ONLY` (422, no write).
- **Zero-drift**: pure-option non-dry-run sync unchanged; stock-prep untouched.
- **`with-actions` preset** permits the registered action so the path is reachable (un-dorm).

## Verification
Full plugin suite EXIT=0. Wire-tests: non-dry-run+action → fail-closed (no patch); dryRun+permitted → preview (0 patch calls, values-free); dryRun+non-permitted → fail-closed.

## Boundary
DRY-RUN writes/executes nothing; apply gated; references validated against the registry; values-free preview; pure-option sync zero-drift. **Apply (real execution) remains a future owner-gated sub-slice (FOS-4b-3).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)