### PR TITLE
feat(multitable): BS-1 scoped restore preview-identity contract (multi-record)

### DIFF
--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -15,9 +15,11 @@ import { resolveRuntimeJwtSecret } from '../security/auth-runtime-config'
  * A FIELD SUBSET of that record-version is NOT a separate scope — it is represented by the filtered `changesHash`:
  * preview + execute both filter the masked diff to the selected `fieldIds` and hash the FILTERED result, so a
  * different selection yields a different hash and cannot be replayed (the selection is folded into the hash, never
- * trusted as a side input). What this identity deliberately does NOT express is a MULTI-RECORD / batch / PIT
- * scope; that is a later slice that adds a `scope` claim (kind + recordIds/batchId) and binds a scope canonical
- * hash. Do not read this v1 identity as authorizing a MULTI-RECORD scope just because `changesHash` matches.
+ * trusted as a side input). What this SINGLE-record identity deliberately does NOT express is a MULTI-RECORD /
+ * batch / PIT scope: that is the SCOPED identity below (BS-1), a SEPARATE discriminated `type` that adds a `scope`
+ * claim (kind + recordIds) and binds an order-invariant `scopeHash`. The two are DISJOINT by `type` — a
+ * single-record token can never satisfy a scoped execute and vice versa — so do not read this single-record
+ * identity as authorizing a MULTI-RECORD scope just because `changesHash` matches (and vice versa).
  *
  * Stateless (JWT/HS256, same primitive as invite-tokens): signature defeats tampering, `exp` bounds the window,
  * and `changesHash` defeats stale replay (if the data — or the actor's field permissions — moved since preview,
@@ -87,6 +89,71 @@ export function verifyRestorePreviewIdentity(token: string, expected: RestorePre
   if (payload.targetVersion !== expected.targetVersion) return { valid: false, reason: 'mismatch_targetVersion' }
   if (payload.strategy !== expected.strategy) return { valid: false, reason: 'mismatch_strategy' }
   if (payload.changesHash !== expected.changesHash) return { valid: false, reason: 'mismatch_changesHash' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  return { valid: true }
+}
+
+// ── BS-1: SCOPED (multi-record) restore preview-identity ────────────────────────────────────────────────────
+// Per the batch/scope design-lock (BS-1; D1 recordIds[], D4 scope hash, D6 discriminated union). A SCOPED
+// identity binds a MULTI-record restore: the EXACT record set AND each record's per-record (masked, field-
+// filtered) `changesHash`, via an order-invariant `scopeHash`. The `type: 'restore-preview-scoped'` discriminator
+// makes single and scoped identities DISJOINT — a single-record token can never satisfy a scoped execute and
+// vice versa (BS-7 + D6). CONTRACT ONLY — not wired into any route, writes nothing (preview = BS-2, execute = BS-3).
+
+export interface ScopedRestorePreviewIdentityClaims {
+  sheetId: string
+  /** v1 (D1): an explicit record set. A `batchId` / PIT kind is a later slice. */
+  scope: { kind: 'records'; recordIds: string[] }
+  targetVersion: number
+  /** v1 = `revert` only (the destructive `reset` is T8, never here). */
+  strategy: 'revert'
+  /** sha256 over the sorted record set + each record's per-record changesHash — see hashScope. */
+  scopeHash: string
+  /** the actor the preview was minted for (no permission-skip replay by another actor). */
+  actorId: string
+}
+
+/**
+ * Canonical, ORDER-INVARIANT scope hash: binds the EXACT record set AND each record's per-record changesHash.
+ * Sorted by recordId, each entry serialized as `[recordId, changesHash]` (D4). A record added/removed changes the
+ * set → a different hash; a changed per-record diff → a different hash. This is what makes BS-7 hold — a scoped
+ * identity for {A,B,C} cannot execute {A,B} or {A,B,C,D}, because the execute re-hashes the ACTUAL set and diverges.
+ */
+export function hashScope(perRecord: Array<{ recordId: string; changesHash: string }>): string {
+  const canon = [...perRecord]
+    .sort((a, b) => (a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0))
+    .map((r) => JSON.stringify([r.recordId, r.changesHash]))
+  return createHash('sha256').update(JSON.stringify(canon)).digest('hex')
+}
+
+export function mintScopedRestorePreviewIdentity(claims: ScopedRestorePreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'restore-preview-scoped', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface ScopedVerifyResult {
+  valid: boolean
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_targetVersion' | 'mismatch_strategy' | 'mismatch_scopeKind' | 'mismatch_scopeHash' | 'mismatch_actorId'
+}
+
+/**
+ * Verify a SCOPED identity against claims the execute (BS-3) computes FRESH from the actual record set it is about
+ * to restore. The `scopeHash` binds the set + per-record diffs, so a narrowed / widened / altered scope diverges
+ * and is rejected (BS-7). The `restore-preview-scoped` type makes this DISJOINT from the single-record verify (D6):
+ * a single-record token presented here → `wrong_type`, and a scoped token presented to the single verify likewise.
+ */
+export function verifyScopedRestorePreviewIdentity(token: string, expected: ScopedRestorePreviewIdentityClaims): ScopedVerifyResult {
+  let payload: Partial<ScopedRestorePreviewIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<ScopedRestorePreviewIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'restore-preview-scoped') return { valid: false, reason: 'wrong_type' } // a single-record token is rejected here
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.targetVersion !== expected.targetVersion) return { valid: false, reason: 'mismatch_targetVersion' }
+  if (payload.strategy !== expected.strategy) return { valid: false, reason: 'mismatch_strategy' }
+  if (payload.scope?.kind !== expected.scope.kind) return { valid: false, reason: 'mismatch_scopeKind' }
+  if (payload.scopeHash !== expected.scopeHash) return { valid: false, reason: 'mismatch_scopeHash' }
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }

--- a/packages/core-backend/tests/unit/restore-preview-identity.test.ts
+++ b/packages/core-backend/tests/unit/restore-preview-identity.test.ts
@@ -9,9 +9,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   hashPreviewChanges,
+  hashScope,
   mintRestorePreviewIdentity,
+  mintScopedRestorePreviewIdentity,
   verifyRestorePreviewIdentity,
+  verifyScopedRestorePreviewIdentity,
   type RestorePreviewIdentityClaims,
+  type ScopedRestorePreviewIdentityClaims,
 } from '../../src/multitable/restore-preview-identity'
 
 const baseClaims = (): RestorePreviewIdentityClaims => ({
@@ -64,5 +68,76 @@ describe('restore preview identity — T6-1 contract', () => {
     const a = hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 1 }])
     const b = hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 2 }])
     expect(a).not.toBe(b)
+  })
+})
+
+// ── BS-1: scoped (multi-record) identity goldens ──────────────────────────────────────────────────────────────
+// The contract that will let the batch execute (BS-3) confirm "execution matches the preview" across a record SET
+// (BS-1; D6 discriminated union, D4 scope hash, BS-7 no narrow/widen replay). Pure unit; the execute computing the
+// real per-record diffs → expected scope claims → verify → fan-out write is BS-3.
+
+const perRecordDiff = (id: string) => ({ recordId: id, changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: id }]) })
+const scopedClaims = (recordIds: string[]): ScopedRestorePreviewIdentityClaims => ({
+  sheetId: 'sheet_1',
+  scope: { kind: 'records', recordIds },
+  targetVersion: 3,
+  strategy: 'revert',
+  scopeHash: hashScope(recordIds.map(perRecordDiff)),
+  actorId: 'user_1',
+})
+const singleClaims = (): RestorePreviewIdentityClaims => ({
+  sheetId: 'sheet_1', recordId: 'A', targetVersion: 3, strategy: 'revert',
+  changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 'A' }]), actorId: 'user_1',
+})
+
+describe('restore preview identity — BS-1 scoped (multi-record) contract', () => {
+  it('scoped mint → verify roundtrip is valid against the matching record set', () => {
+    const claims = scopedClaims(['A', 'B', 'C'])
+    expect(verifyScopedRestorePreviewIdentity(mintScopedRestorePreviewIdentity(claims), claims)).toEqual({ valid: true })
+  })
+
+  it('SCOPE KEYSTONE: an identity for {A,B,C} cannot execute a narrowed {A,B} or a widened {A,B,C,D} (BS-7)', () => {
+    const token = mintScopedRestorePreviewIdentity(scopedClaims(['A', 'B', 'C']))
+    // the execute computes the expected scopeHash FRESH from the actual set it is about to restore → diverges → reject
+    expect(verifyScopedRestorePreviewIdentity(token, scopedClaims(['A', 'B'])).reason).toBe('mismatch_scopeHash')
+    expect(verifyScopedRestorePreviewIdentity(token, scopedClaims(['A', 'B', 'C', 'D'])).reason).toBe('mismatch_scopeHash')
+  })
+
+  it('hashScope is ORDER-INVARIANT over the record set (else a batch could never execute — re-hash would diverge)', () => {
+    const a = hashScope([perRecordDiff('A'), perRecordDiff('B'), perRecordDiff('C')])
+    const b = hashScope([perRecordDiff('C'), perRecordDiff('A'), perRecordDiff('B')])
+    expect(a).toBe(b)
+  })
+
+  it('hashScope DISTINGUISHES a changed per-record diff (one record value moved → different scope hash)', () => {
+    const base = hashScope([perRecordDiff('A'), perRecordDiff('B')])
+    const moved = hashScope([perRecordDiff('A'), { recordId: 'B', changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: 'CHANGED' }]) }])
+    expect(base).not.toBe(moved)
+  })
+
+  it('every bound claim must match — a mismatch on any axis is rejected', () => {
+    const claims = scopedClaims(['A', 'B', 'C'])
+    const token = mintScopedRestorePreviewIdentity(claims)
+    expect(verifyScopedRestorePreviewIdentity(token, { ...claims, sheetId: 'other' }).reason).toBe('mismatch_sheetId')
+    expect(verifyScopedRestorePreviewIdentity(token, { ...claims, targetVersion: 99 }).reason).toBe('mismatch_targetVersion')
+    expect(verifyScopedRestorePreviewIdentity(token, { ...claims, strategy: 'reset' as unknown as 'revert' }).reason).toBe('mismatch_strategy')
+    // a future `batch`/PIT kind must never satisfy a `records` execute (the kind is bound independently of the hash)
+    expect(verifyScopedRestorePreviewIdentity(token, { ...claims, scope: { kind: 'batch' as unknown as 'records', recordIds: claims.scope.recordIds } }).reason).toBe('mismatch_scopeKind')
+    expect(verifyScopedRestorePreviewIdentity(token, { ...claims, actorId: 'user_2' }).reason).toBe('mismatch_actorId')
+  })
+
+  it('D6 DISJOINTNESS: a single-record token can never satisfy a scoped execute, nor a scoped token a single one', () => {
+    const single = mintRestorePreviewIdentity(singleClaims())
+    const scoped = mintScopedRestorePreviewIdentity(scopedClaims(['A', 'B', 'C']))
+    expect(verifyScopedRestorePreviewIdentity(single, scopedClaims(['A', 'B', 'C'])).reason).toBe('wrong_type')
+    expect(verifyRestorePreviewIdentity(scoped, singleClaims()).reason).toBe('wrong_type')
+  })
+
+  it('expired + tampered scoped tokens are rejected', () => {
+    const claims = scopedClaims(['A', 'B'])
+    expect(verifyScopedRestorePreviewIdentity(mintScopedRestorePreviewIdentity(claims, '-1s'), claims)).toEqual({ valid: false, reason: 'expired' })
+    const token = mintScopedRestorePreviewIdentity(claims)
+    const tampered = token.slice(0, -3) + (token.slice(-3) === 'AAA' ? 'BBB' : 'AAA')
+    expect(verifyScopedRestorePreviewIdentity(tampered, claims).valid).toBe(false)
   })
 })


### PR DESCRIPTION
First runtime slice of batch/scope (BS-0 ratified). **Contract only** — extends `restore-preview-identity.ts`; **not wired into any route, writes nothing** (preview = BS-2, execute = BS-3). Per the design-lock #3062 (D1 `recordIds[]`, D4 scope hash, D6 discriminated union).

## What
A **scoped** identity binds a MULTI-record restore: the EXACT record set AND each record's per-record (masked, field-filtered) `changesHash`, via an order-invariant `scopeHash`.
- `ScopedRestorePreviewIdentityClaims` + `hashScope` + `mintScopedRestorePreviewIdentity` + `verifyScopedRestorePreviewIdentity`.
- **D6 disjointness:** `type: 'restore-preview-scoped'` ≠ the single-record `'restore-preview'` — a single token can never satisfy a scoped execute and vice versa.
- **BS-7:** the execute re-hashes the actual set, so a narrowed `{A,B}` / widened `{A,B,C,D}` scope diverges → reject.

## Verification
13 goldens (7 new scoped): roundtrip · **SCOPE KEYSTONE** (narrow/widen → `mismatch_scopeHash`) · order-invariance · per-record-diff distinction · full claim-mismatch matrix · **D6 disjointness** · expired/tampered. **Mutation-proven:** skip the `scopeHash` bind → KEYSTONE fails; skip the `type` discriminator → DISJOINTNESS fails (Python-reverted, residue 0). `tsc` clean; control bytes 0.

The single-record path is unchanged; `strategy: 'revert'` only (no destructive `reset` — that's T8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)