### PR TITLE
fix(attendance): escape upload cleanup size awk field

### DIFF
--- a/scripts/ops/attendance-clean-uploads.sh
+++ b/scripts/ops/attendance-clean-uploads.sh
@@ -235,7 +235,7 @@ if [[ "${CONFIRM_DELETE}" != "true" ]]; then
   die "Refusing to delete without CONFIRM_DELETE=true"
 fi
 
-size_kb_cmd="find \"${target_path}\" -type f -mtime +${mtime_threshold} -exec du -k {} + 2>/dev/null | awk '{s+=$1} END {print s+0}'"
+size_kb_cmd="find \"${target_path}\" -type f -mtime +${mtime_threshold} -exec du -k {} + 2>/dev/null | awk '{s+=\$1} END {print s+0}'"
 stale_kb_total="$(run_cmd "$size_kb_cmd" | tail -n 1 | tr -d '[:space:]' || true)"
 if ! is_integer "$stale_kb_total"; then
   die "Failed to compute stale_kb_total"

--- a/scripts/ops/attendance-clean-uploads.test.mjs
+++ b/scripts/ops/attendance-clean-uploads.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+
+const repoRoot = process.cwd()
+const cleanupScript = path.join(repoRoot, 'scripts/ops/attendance-clean-uploads.sh')
+
+function runBash(scriptPath, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+
+    child.on('error', (error) => reject(error))
+    child.on('close', (code) => {
+      resolve({ status: code, stdout, stderr })
+    })
+  })
+}
+
+test('attendance-clean-uploads deletes stale bind-mount files without expanding awk fields under nounset', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'attendance-clean-uploads-'))
+  const uploadDir = path.join(dir, 'uploads')
+  const binDir = path.join(dir, 'bin')
+  const composeFile = path.join(dir, 'docker-compose.app.yml')
+  const envFile = path.join(dir, 'app.env')
+  const oldFile = path.join(uploadDir, 'old.csv')
+  const freshFile = path.join(uploadDir, 'fresh.csv')
+  const dockerStub = path.join(binDir, 'docker')
+
+  try {
+    mkdirSync(uploadDir, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(oldFile, 'old import payload\n', 'utf8')
+    writeFileSync(freshFile, 'fresh import payload\n', 'utf8')
+    writeFileSync(dockerStub, '#!/usr/bin/env bash\nexit 1\n', 'utf8')
+    chmodSync(dockerStub, 0o755)
+
+    const oldDate = new Date(Date.now() - 16 * 24 * 60 * 60 * 1000)
+    utimesSync(oldFile, oldDate, oldDate)
+
+    writeFileSync(
+      composeFile,
+      [
+        'services:',
+        '  backend:',
+        '    volumes:',
+        `      - ${uploadDir}:/app/uploads/attendance-import`,
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+    writeFileSync(envFile, 'ATTENDANCE_IMPORT_UPLOAD_DIR=/app/uploads/attendance-import\n', 'utf8')
+    chmodSync(cleanupScript, 0o755)
+
+    const result = await runBash(cleanupScript, {
+      COMPOSE_FILE: composeFile,
+      ENV_FILE: envFile,
+      MAX_FILE_AGE_DAYS: '14',
+      DELETE: 'true',
+      CONFIRM_DELETE: 'true',
+      MAX_DELETE_FILES: '10',
+      MAX_DELETE_GB: '1',
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+    })
+
+    assert.equal(result.status, 0, `stderr:\n${result.stderr}`)
+    assert.match(result.stderr, /stale_count=1/)
+    assert.match(result.stderr, /stale_kb_total=/)
+    assert.match(result.stderr, /Delete completed/)
+    assert.equal(existsSync(oldFile), false)
+    assert.equal(existsSync(freshFile), true)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- escape the awk $1 field in attendance upload cleanup size estimation so bash nounset does not expand it locally
- add a Node regression test for the DELETE=true + CONFIRM_DELETE=true bind-mount cleanup path

## Production context
- Fixes #161
- Unblocks #159 remediation after this lands on main
- Cleanup run 28001716629 failed with scripts/ops/attendance-clean-uploads.sh: line 238: $1: unbound variable
- Prior dry-run 28001666676 showed stale_count=1 for /app/uploads/attendance-import/default/cac25ee6-c5e8-4cb4-ae51-28f716951cf2.csv

## Validation
- node --test scripts/ops/attendance-clean-uploads.test.mjs
- bash -n scripts/ops/attendance-clean-uploads.sh
- git diff --check