### PR TITLE
feat(multitable): BS-3 scoped restore batch-execute — the multi-record write (PARTIAL) [HELD for review]

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -214,6 +214,7 @@ jobs:
             tests/integration/multitable-restore-execute-realdb.test.ts \
             tests/integration/multitable-restore-per-field-realdb.test.ts \
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
+            tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -114,15 +114,20 @@ export interface ScopedRestorePreviewIdentityClaims {
 }
 
 /**
- * Canonical, ORDER-INVARIANT scope hash: binds the EXACT record set AND each record's per-record changesHash.
- * Sorted by recordId, each entry serialized as `[recordId, changesHash]` (D4). A record added/removed changes the
- * set → a different hash; a changed per-record diff → a different hash. This is what makes BS-7 hold — a scoped
- * identity for {A,B,C} cannot execute {A,B} or {A,B,C,D}, because the execute re-hashes the ACTUAL set and diverges.
+ * Canonical, ORDER-INVARIANT scope hash: binds the EXACT record set, each record's per-record changesHash, AND
+ * each record's per-record expected `version`. Sorted by recordId, each entry serialized as
+ * `[recordId, changesHash, version]` (D4). A record added/removed changes the set → a different hash; a changed
+ * per-record diff → a different hash; a changed per-record version → a different hash. This is what makes BS-7
+ * hold (a scoped identity for {A,B,C} cannot execute {A,B} or {A,B,C,D}) AND what binds the per-record
+ * optimistic-concurrency anchor: the version is FOLDED IN here at mint (BS-2) and re-folded at verify (BS-3) from
+ * the CLIENT-SUBMITTED expectedVersion — never trusted as free side-input — so a client that submits the current
+ * (rather than the preview-time) version to slip past the CAS instead diverges the hash and is rejected. Same
+ * filter-then-hash discipline that folds `fieldIds` into `changesHash`, applied to the version axis.
  */
-export function hashScope(perRecord: Array<{ recordId: string; changesHash: string }>): string {
+export function hashScope(perRecord: Array<{ recordId: string; changesHash: string; version: number }>): string {
   const canon = [...perRecord]
     .sort((a, b) => (a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : 0))
-    .map((r) => JSON.stringify([r.recordId, r.changesHash]))
+    .map((r) => JSON.stringify([r.recordId, r.changesHash, r.version]))
   return createHash('sha256').update(JSON.stringify(canon)).digest('hex')
 }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,7 +73,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity } from '../multitable/restore-preview-identity'
+import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity } from '../multitable/restore-preview-identity'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
@@ -7908,6 +7908,127 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] restore-execute failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute restore' } })
+    }
+  })
+
+  // ── BS-3: SCOPED (multi-record) restore batch-execute — the WRITE (separate owner opt-in; "reviewed alone") ──
+  // Consumes the BS-1 scoped identity + the BS-2 preview. TWO-LAYER rejection model (advisor):
+  //  • DIFF-LEVEL — a record now missing / no-revision / delete / schema-drifted / different / empty SINCE preview
+  //    → it is EXCLUDED from `contributing` → the recomputed scopeHash diverges → WHOLE-BATCH 409, re-preview. There
+  //    is NO per-record "noop-skip-and-proceed": skipping a diff-changed record would execute a SMALLER set than the
+  //    token authorized.
+  //  • WRITE-LEVEL — row-deny appeared / version conflict / field-forbidden → detected during the per-record
+  //    fan-out → PARTIAL-skip + report. The case that proves the split: data edited THEN reverted → the diff is
+  //    identical (scopeHash passes) but the version moved → the in-transaction CAS (RecordChange.expectedVersion
+  //    under SELECT FOR UPDATE) skips it (partial).
+  // verify-before-write: the scopeHash is verified BEFORE any 2xx, INCLUDING an all-noop set — a forged/foreign
+  // token over an already-restored set 4xxes at the verify, never via a 200 noop short-circuit. Forward-only
+  // (source='restore'; no destructive delete — that is T8). PARTIAL only — all-or-nothing is BS-3.1 behind a named
+  // need (patchRecords' single-call multi-record path is already atomic, so it is a small follow-up, not built
+  // speculatively here). Bounded ≤100, fail-closed.
+  router.post('/sheets/:sheetId/restore-batch-execute', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    if (!sheetId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    const parsed = z.object({
+      targetVersion: z.number().int().positive(),
+      recordIds: z.array(z.string().min(1)).min(1).max(100),
+      // per-record CAS base — the FE's preview-time version for each record; drives the authoritative in-transaction
+      // version check (a record moved since preview → conflict → skip). Fail-closed: every recordId must have one.
+      expectedVersions: z.record(z.string(), z.number().int().nonnegative()),
+      previewIdentity: z.string().min(1),
+      fieldIds: z.array(z.string().min(1)).min(1).optional(),
+    }).safeParse(req.body)
+    if (!parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    const { targetVersion, recordIds: requestedIds, expectedVersions, previewIdentity, fieldIds } = parsed.data
+    const uniqueIds = [...new Set(requestedIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)) // ONE canonical source (sorted, deduped)
+    for (const id of uniqueIds) if (typeof expectedVersions[id] !== 'number') return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `expectedVersions missing for ${id}` } })
+    const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canEditRecord) return sendForbidden(res) // D5: gate on the RESTORE capability
+      const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+      if (!patchContext) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById } = patchContext
+      const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
+      const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
+      const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId)
+        : new Set<string>()
+      // fresh live data (the diff source) + the target revision, batch-loaded (2 queries, not 2·N):
+      const liveById = new Map<string, { data: Record<string, unknown> }>()
+      for (const r of (await pool.query('SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2)', [sheetId, uniqueIds])).rows as Array<{ id: string; data: unknown }>) liveById.set(String(r.id), { data: asRec(r.data) })
+      const revById = new Map<string, { action: string; snapshot: unknown }>()
+      for (const r of (await pool.query('SELECT record_id, action, snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = ANY($2) AND version = $3', [sheetId, uniqueIds, targetVersion])).rows as Array<{ record_id: string; action: string; snapshot: unknown }>) {
+        const prev = revById.get(String(r.record_id))
+        if (!prev || (prev.action === 'delete' && r.action !== 'delete')) revById.set(String(r.record_id), { action: r.action, snapshot: r.snapshot })
+      }
+      const selSet = fieldIds ? new Set(fieldIds) : null
+      // Step 1: recompute each submitted record's FRESH masked+filtered diff ONCE — the SAME object feeds both the
+      // hash and the write (within-execute write-set ≡ hashed-set). A non-computable record (missing / no-revision /
+      // delete / drift / empty) is EXCLUDED → contributing shrinks → scopeHash diverges → whole-batch 409 below.
+      // expectedVersion = the FE's per-record version (the CAS base); it does NOT enter hashPreviewChanges, so it
+      // cannot game the hash. The diff is from FRESH data, so any data change diverges the hash (diff-level).
+      const contributing: Array<{ recordId: string; diff: RecordChange[]; changesHash: string }> = []
+      for (const recordId of uniqueIds) {
+        const live = liveById.get(recordId); const rev = revById.get(recordId)
+        if (!live || !rev || rev.action === 'delete' || rev.snapshot === null || rev.snapshot === undefined) continue
+        const targetSnapshot = asRec(rev.snapshot)
+        let recDrift = false
+        for (const fid of Object.keys(targetSnapshot)) if (!fieldById.has(fid)) { recDrift = true; break }
+        if (recDrift) continue // schema drift → excluded → scopeHash diverges → re-preview
+        const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData: live.data, recordId, currentVersion: expectedVersions[recordId], normalizeLinkIds })
+        const masked = diff.filter((c) => allowed.has(c.fieldId)) // PV-2 mask
+        const selected = selSet ? masked.filter((c) => selSet.has(c.fieldId)) : masked // per-field filter (mask-then-filter)
+        if (selected.length === 0) continue // nets zero → excluded
+        contributing.push({ recordId, diff: selected, changesHash: hashPreviewChanges(selected.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value }))) })
+      }
+      // Step 2: verify the scoped identity over the recomputed contributing set BEFORE any write. all-noop:
+      // contributing=[] → hashScope([]) ≠ any real identity → 409, never a 200 noop short-circuit (the BS [P2] rule).
+      const scopeIds = contributing.map((c) => c.recordId) // already sorted (uniqueIds was sorted; contributing preserves order)
+      const verdict = verifyScopedRestorePreviewIdentity(previewIdentity, {
+        sheetId, scope: { kind: 'records', recordIds: scopeIds }, targetVersion, strategy: 'revert',
+        scopeHash: hashScope(contributing.map((c) => ({ recordId: c.recordId, changesHash: c.changesHash }))), actorId: access.userId,
+      })
+      if (!verdict.valid) {
+        const status = verdict.reason === 'expired' ? 410 : 409
+        return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Batch preview identity rejected (${verdict.reason}); the scope or a record diff changed since preview — re-preview` } })
+      }
+      // Step 3: per-record write fan-out (PARTIAL). Each record is its OWN patchRecords (its OWN transaction), so a
+      // row-deny / version-conflict / field-forbidden on one record skips ONLY that record. The in-transaction CAS
+      // (RecordChange.expectedVersion under SELECT FOR UPDATE) is the authoritative concurrency guard.
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      type Outcome = { recordId: string; status: 'restored' | 'skipped'; newVersion?: number; restoredFieldIds?: string[]; skipReason?: 'denied' | 'conflict' | 'forbidden' | 'error' }
+      const outcomes: Outcome[] = []
+      for (const c of contributing) {
+        // fresh per-record row-deny re-check (the rare deny-added-since-preview edge) → partial-skip, no oracle leak
+        if (deniedIds.has(c.recordId)) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'denied' }); continue }
+        try {
+          const result = await recordWriteService.patchRecords({
+            sheetId, changesByRecord: new Map([[c.recordId, c.diff]]), actorId: getRequestActorId(req),
+            fields, visiblePropertyFields: readableEchoFields, visiblePropertyFieldIds: readableEchoFieldIds,
+            attachmentFields, fieldById, capabilities, sheetScope, access, source: 'restore',
+          })
+          outcomes.push({ recordId: c.recordId, status: 'restored', newVersion: result.updated.find((u) => u.recordId === c.recordId)?.version, restoredFieldIds: c.diff.map((d) => d.fieldId) })
+        } catch (err) {
+          if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'conflict' }); continue }
+          if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
+          if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'error' }); continue }
+          throw err
+        }
+      }
+      const restoredCount = outcomes.filter((o) => o.status === 'restored').length
+      return res.json({ ok: true, data: { records: outcomes, restoredCount, skippedCount: outcomes.length - restoredCount, targetVersion } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] restore-batch-execute failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute batch restore' } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7506,21 +7506,23 @@ export function univerMetaRouter(): Router {
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
       const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
-      // batch-load per-record live data + the target revision in 2 queries (not 2·N):
-      const liveById = new Map<string, Record<string, unknown>>()
-      for (const r of (await pool.query('SELECT id, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2)', [sheetId, uniqueIds])).rows as Array<{ id: string; data: unknown }>) liveById.set(String(r.id), asRec(r.data))
+      // batch-load per-record live data + version + the target revision in 2 queries (not 2·N). The VERSION is the
+      // per-record optimistic-concurrency anchor bound into the scopeHash (#2) — the FE submits it back to BS-3.
+      const liveById = new Map<string, { version: number; data: Record<string, unknown> }>()
+      for (const r of (await pool.query('SELECT id, version, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2)', [sheetId, uniqueIds])).rows as Array<{ id: string; version: unknown; data: unknown }>) liveById.set(String(r.id), { version: Number(r.version ?? 0), data: asRec(r.data) })
       const revById = new Map<string, { action: string; snapshot: unknown }>()
       for (const r of (await pool.query('SELECT record_id, action, snapshot FROM meta_record_revisions WHERE sheet_id = $1 AND record_id = ANY($2) AND version = $3', [sheetId, uniqueIds, targetVersion])).rows as Array<{ record_id: string; action: string; snapshot: unknown }>) {
         const prev = revById.get(String(r.record_id))
         if (!prev || (prev.action === 'delete' && r.action !== 'delete')) revById.set(String(r.record_id), { action: r.action, snapshot: r.snapshot }) // prefer a non-delete snapshot (as single-record)
       }
       const selSet = fieldIds ? new Set(fieldIds) : null
-      type Outcome = { recordId: string; status: 'restorable' | 'skipped'; changes?: Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }>; affectedFieldCount?: number; skipReason?: string }
+      type Outcome = { recordId: string; status: 'restorable' | 'skipped'; changes?: Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }>; affectedFieldCount?: number; previewVersion?: number; skipReason?: string }
       const outcomes: Outcome[] = []
-      const contributing: Array<{ recordId: string; changesHash: string }> = []
+      const contributing: Array<{ recordId: string; changesHash: string; version: number }> = []
       for (const recordId of uniqueIds) {
+        const live = liveById.get(recordId)
         // existence + row-deny share ONE 'unavailable' reason (no existence oracle, like the single route's 404)
-        if (!liveById.has(recordId) || deniedIds.has(recordId)) { outcomes.push({ recordId, status: 'skipped', skipReason: 'unavailable' }); continue }
+        if (!live || deniedIds.has(recordId)) { outcomes.push({ recordId, status: 'skipped', skipReason: 'unavailable' }); continue }
         const rev = revById.get(recordId)
         if (!rev) { outcomes.push({ recordId, status: 'skipped', skipReason: 'version_unavailable' }); continue }
         if (rev.action === 'delete') { outcomes.push({ recordId, status: 'skipped', skipReason: 'unsupported' }); continue } // undelete is a later slice
@@ -7529,13 +7531,15 @@ export function univerMetaRouter(): Router {
         let drift = false
         for (const fid of Object.keys(targetSnapshot)) if (!previewCtx.fieldById.has(fid)) { drift = true; break }
         if (drift) { outcomes.push({ recordId, status: 'skipped', skipReason: 'schema_drift' }); continue } // can't faithfully reproduce → not restorable
-        const raw = computeRecordRestoreDiff({ fieldById: previewCtx.fieldById, rawTypeById, targetSnapshot, currentData: liveById.get(recordId)!, recordId, currentVersion: 0, normalizeLinkIds })
+        const raw = computeRecordRestoreDiff({ fieldById: previewCtx.fieldById, rawTypeById, targetSnapshot, currentData: live.data, recordId, currentVersion: 0, normalizeLinkIds })
           .map((c) => ({ fieldId: c.fieldId, op: (c.op ?? 'set') as 'set' | 'unset', value: c.value }))
         const visible = raw.filter((c) => allowed.has(c.fieldId)) // PV-2 mask (visible ∧ field_permissions)
         const selected = selSet ? visible.filter((c) => selSet.has(c.fieldId)) : visible // per-field filter (mask-then-filter)
         if (selected.length === 0) { outcomes.push({ recordId, status: 'skipped', skipReason: 'no_change' }); continue } // nets zero → not in scope
-        outcomes.push({ recordId, status: 'restorable', changes: selected, affectedFieldCount: selected.length })
-        contributing.push({ recordId, changesHash: hashPreviewChanges(selected) })
+        // bind this record's CURRENT (preview-time) version into the scope + return it as previewVersion: the FE
+        // submits it back as expectedVersions[id], BS-3 folds the SUBMITTED value into the hash (#2 anti-bypass).
+        outcomes.push({ recordId, status: 'restorable', changes: selected, affectedFieldCount: selected.length, previewVersion: live.version })
+        contributing.push({ recordId, changesHash: hashPreviewChanges(selected), version: live.version })
       }
       // the scope = the RESTORABLE set only; identity null when empty (never a hashScope([]) executable token).
       const scopeIds = contributing.map((c) => c.recordId).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
@@ -7950,7 +7954,10 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canEditRecord) return sendForbidden(res) // D5: gate on the RESTORE capability
       const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
       if (!patchContext) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
-      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById } = patchContext
+      // fieldPermissions = the SAME deriveFieldPermissions(layer-3) the legacy /restore gates with — `allowed` is a
+      // READ mask (visible), and patchRecords only enforces FIELD-DEFINITION readonly, so a per-subject visible-but-
+      // readOnly field must be gated HERE at the write (#1) or it would be written.
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
       const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
       const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
       const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
@@ -7969,9 +7976,12 @@ export function univerMetaRouter(): Router {
       // Step 1: recompute each submitted record's FRESH masked+filtered diff ONCE — the SAME object feeds both the
       // hash and the write (within-execute write-set ≡ hashed-set). A non-computable record (missing / no-revision /
       // delete / drift / empty) is EXCLUDED → contributing shrinks → scopeHash diverges → whole-batch 409 below.
-      // expectedVersion = the FE's per-record version (the CAS base); it does NOT enter hashPreviewChanges, so it
-      // cannot game the hash. The diff is from FRESH data, so any data change diverges the hash (diff-level).
-      const contributing: Array<{ recordId: string; diff: RecordChange[]; changesHash: string }> = []
+      // The diff is from FRESH data, so any data change diverges the hash (diff-level). The per-record version FOLDED
+      // into the scopeHash is the CLIENT-SUBMITTED expectedVersions[id] (#2): a client that submits the CURRENT
+      // version to slip past the CAS instead diverges the hash → 409; an honest client submits the preview-time
+      // version → hash matches → the in-transaction CAS still fires against the actual current version. The SAME
+      // submitted value also drives the CAS via computeRecordRestoreDiff's currentVersion → RecordChange.expectedVersion.
+      const contributing: Array<{ recordId: string; diff: RecordChange[]; changesHash: string; version: number }> = []
       for (const recordId of uniqueIds) {
         const live = liveById.get(recordId); const rev = revById.get(recordId)
         if (!live || !rev || rev.action === 'delete' || rev.snapshot === null || rev.snapshot === undefined) continue
@@ -7983,14 +7993,14 @@ export function univerMetaRouter(): Router {
         const masked = diff.filter((c) => allowed.has(c.fieldId)) // PV-2 mask
         const selected = selSet ? masked.filter((c) => selSet.has(c.fieldId)) : masked // per-field filter (mask-then-filter)
         if (selected.length === 0) continue // nets zero → excluded
-        contributing.push({ recordId, diff: selected, changesHash: hashPreviewChanges(selected.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value }))) })
+        contributing.push({ recordId, diff: selected, changesHash: hashPreviewChanges(selected.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value }))), version: expectedVersions[recordId] })
       }
       // Step 2: verify the scoped identity over the recomputed contributing set BEFORE any write. all-noop:
       // contributing=[] → hashScope([]) ≠ any real identity → 409, never a 200 noop short-circuit (the BS [P2] rule).
       const scopeIds = contributing.map((c) => c.recordId) // already sorted (uniqueIds was sorted; contributing preserves order)
       const verdict = verifyScopedRestorePreviewIdentity(previewIdentity, {
         sheetId, scope: { kind: 'records', recordIds: scopeIds }, targetVersion, strategy: 'revert',
-        scopeHash: hashScope(contributing.map((c) => ({ recordId: c.recordId, changesHash: c.changesHash }))), actorId: access.userId,
+        scopeHash: hashScope(contributing.map((c) => ({ recordId: c.recordId, changesHash: c.changesHash, version: c.version }))), actorId: access.userId,
       })
       if (!verdict.valid) {
         const status = verdict.reason === 'expired' ? 410 : 409
@@ -8007,6 +8017,18 @@ export function univerMetaRouter(): Router {
       for (const c of contributing) {
         // fresh per-record row-deny re-check (the rare deny-added-since-preview edge) → partial-skip, no oracle leak
         if (deniedIds.has(c.recordId)) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'denied' }); continue }
+        // #1 layer-3 per-subject WRITE gate (the EXACT derive the legacy /restore gates with): a field that is
+        // hidden / field-definition-readOnly (static) OR per-subject visible=false / read_only=true (layer-3) must
+        // not be written. patchRecords enforces only the static axis, so a visible-but-readOnly field would slip
+        // through — gate the WHOLE record here (skip:forbidden, PARTIAL), the others proceed.
+        const hasForbidden = c.diff.some((ch) => {
+          const guard = fieldById.get(ch.fieldId)
+          const perm = fieldPermissions[ch.fieldId]
+          const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
+          const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
+          return !staticOk || !layer3Ok
+        })
+        if (hasForbidden) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
         try {
           const result = await recordWriteService.patchRecords({
             sheetId, changesByRecord: new Map([[c.recordId, c.diff]]), actorId: getRequestActorId(req),

--- a/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Global History — BS-3: SCOPED (multi-record) restore batch-execute, the WRITE (real DB). Consumes the BS-1
+ * scoped identity + BS-2 preview. Two-layer rejection (diff-level → whole-batch 409 re-preview; write-level →
+ * PARTIAL skip+report). verify-before-any-2xx incl all-noop. Forward-only, source='restore'. PARTIAL only.
+ *
+ * Goldens: real preview→execute happy path (forward revisions, all rows written) · [P2] forged token over an
+ * all-noop set → 4xx not 200 · diff-level data-changed → whole-batch 409, nothing written · write-level conflict
+ * (edited-then-reverted = hash passes, CAS skips — the subtle case) → PARTIAL · write-level denied → PARTIAL ·
+ * BS-7 keystone (execute a SUBSET of the token's scope → 409) · D6 (single-record token → 409) · actor binding ·
+ * bounded. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_be_${TS}`
+const SHEET = `sheet_be_${TS}`
+const NAME = `fld_be_name_${TS}`
+const SALARY = `fld_be_salary_${TS}`
+const A = `rec_be_a_${TS}`
+const B = `rec_be_b_${TS}`
+const C = `rec_be_c_${TS}`
+const ACTOR = `user_be_${TS}`
+const OTHER = `user_be_other_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser = ACTOR
+let curRoles = ['member']
+const batchPreview = (recordIds: string[], body: Record<string, unknown> = {}) =>
+  request(app).post(`/api/multitable/sheets/${SHEET}/restore-batch-preview`).send({ targetVersion: 1, recordIds, ...body })
+const batchExecute = (recordIds: string[], expectedVersions: Record<string, number>, previewIdentity: string, body: Record<string, unknown> = {}) =>
+  request(app).post(`/api/multitable/sheets/${SHEET}/restore-batch-execute`).send({ targetVersion: 1, recordIds, expectedVersions, previewIdentity, ...body })
+const singlePreview = (recordId: string) => request(app).post(`/api/multitable/sheets/${SHEET}/records/${recordId}/restore-preview`).send({ targetVersion: 1 })
+const recordRow = async (recordId: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [recordId])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+
+async function seedRecord(id: string): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, SHEET, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+           VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: 'a', [SALARY]: 100 })])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+           VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+}
+// mint a real identity through the actual preview route (no hand-built tokens — the real drift guard)
+async function freshIdentity(recordIds: string[]): Promise<{ token: string; scope: string[] }> {
+  const pv = await batchPreview(recordIds)
+  return { token: pv.body?.data?.previewIdentity as string, scope: pv.body?.data?.scope as string[] }
+}
+
+describeIfDatabase('multitable scoped restore batch-execute — BS-3 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: curUser, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'BE Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'BE Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    for (const u of [ACTOR, OTHER]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [ACTOR, OTHER]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    curUser = ACTOR; curRoles = ['member']
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET])
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = '[]'::jsonb WHERE id = $1", [SHEET])
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    for (const id of [A, B, C]) await seedRecord(id)
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('happy path: a real preview→execute restores EVERY contributing record (forward revisions, all rows written)', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.restoredCount).toBe(3)
+    for (const id of [A, B, C]) {
+      const row = await recordRow(id)
+      expect(row?.data?.[NAME]).toBe('a') // restored to v1
+      expect(row?.data?.[SALARY]).toBe(100)
+      expect(row?.version).toBe(3) // FORWARD revision (v2 → v3), never a destructive rewind
+    }
+    // forward-only: a new 'restore' revision was appended for each record
+    const restoreRevs = await q(`SELECT count(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])
+    expect((restoreRevs.rows[0] as { n: number }).n).toBe(3)
+  })
+
+  test('[P2] verify-before-write: a forged token over an all-noop set 4xxes, never a 200 noop short-circuit', async () => {
+    // restore everything first → now all 3 are AT v1 (an execute targeting v1 nets zero for all → contributing empty)
+    const { token } = await freshIdentity([A, B, C])
+    await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    // a garbage/foreign token over the now all-noop set MUST be rejected at the verify, not 200-noop'd through
+    const res = await batchExecute([A, B, C], { [A]: 3, [B]: 3, [C]: 3 }, 'garbage.token.value')
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.body?.ok).toBe(false)
+  })
+
+  test('diff-level: a record whose restorable diff changed since preview → WHOLE-BATCH 409, nothing written', async () => {
+    const { token } = await freshIdentity([A, B, C]) // A's diff at preview = {NAME→a, SALARY→100}
+    // A's SALARY edited to the restore TARGET (100) since preview → SALARY no longer needs restoring → A's diff
+    // shrinks to {NAME→a} → its per-record changesHash changes → scopeHash diverges (a diff-level change).
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [A, JSON.stringify({ [NAME]: 'b', [SALARY]: 100 })])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(409)
+    // whole-batch reject: B and C (untouched) were NOT restored — still at v2
+    expect((await recordRow(B))?.version).toBe(2)
+    expect((await recordRow(C))?.version).toBe(2)
+  })
+
+  test('write-level conflict (edited-then-reverted = hash passes, CAS skips): PARTIAL — others restored', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    // B edited THEN reverted: data identical to preview (diff unchanged → scopeHash still matches) but version moved
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 3 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'x', [SALARY]: 1 })])
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 4 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })]) // reverted
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token) // B expected v2, now at v4
+    expect(res.status).toBe(200)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    expect(byId[A].status).toBe('restored')
+    expect(byId[C].status).toBe('restored')
+    expect(byId[B].status).toBe('skipped')
+    expect(byId[B].skipReason).toBe('conflict') // the in-transaction CAS caught the moved version
+    expect((await recordRow(B))?.data?.[NAME]).toBe('b') // B untouched (still its current value, not rewound)
+  })
+
+  test('write-level denied: ONE record row-denied since preview → PARTIAL skip(denied), the others restored', async () => {
+    // give C a distinct value BEFORE preview so a rule can deny ONLY C (A,B keep NAME='b')
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [C, JSON.stringify({ [NAME]: 'c_marker', [SALARY]: 200 })])
+    const { token } = await freshIdentity([A, B, C]) // minted while none denied (all in scope)
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET, JSON.stringify([{ id: 'r1', fieldId: NAME, operator: 'eq', value: 'c_marker', effect: 'deny_read' }])])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(200)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    expect(byId[A].status).toBe('restored')
+    expect(byId[B].status).toBe('restored')
+    expect(byId[C].status).toBe('skipped')
+    expect(byId[C].skipReason).toBe('denied') // skipped at the FRESH row-deny gate (the SR-2 fan-out surface)
+    expect(res.body?.data?.restoredCount).toBe(2)
+    expect((await recordRow(C))?.version).toBe(2) // C never written
+  })
+
+  test('BS-7 keystone: executing a SUBSET of the token scope → 409 (the scopeHash binds the exact set)', async () => {
+    const { token, scope } = await freshIdentity([A, B, C])
+    expect(scope).toEqual([A, B, C].sort())
+    const res = await batchExecute([A, B], { [A]: 2, [B]: 2 }, token) // submit fewer than the token authorized
+    expect(res.status).toBe(409)
+    expect((await recordRow(A))?.version).toBe(2) // nothing written
+  })
+
+  test('D6: a single-record preview token cannot drive a batch execute (wrong_type → 409)', async () => {
+    const single = (await singlePreview(A)).body?.data?.previewIdentity as string
+    expect(single).toBeTruthy()
+    const res = await batchExecute([A], { [A]: 2 }, single)
+    expect(res.status).toBe(409)
+  })
+
+  test('actor binding: a token minted for ACTOR cannot be executed by OTHER (mismatch_actorId → 409)', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    curUser = OTHER
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(409)
+    curUser = ACTOR
+  })
+
+  test('bounded: a scope over the cap is fail-closed (400)', async () => {
+    const tooMany = Array.from({ length: 101 }, (_, i) => `rec_of_${i}`)
+    const ev: Record<string, number> = {}; for (const id of tooMany) ev[id] = 1
+    const res = await batchExecute(tooMany, ev, 'x.y.z')
+    expect(res.status).toBe(400)
+  })
+
+  test('expectedVersions fail-closed: a missing per-record expectedVersion → 400', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2 }, token) // C omitted
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
@@ -179,6 +179,36 @@ describeIfDatabase('multitable scoped restore batch-execute — BS-3 (real DB)',
     expect((await recordRow(B))?.data?.[NAME]).toBe('a')
   })
 
+  test('#1 layer-3 write gate: a VISIBLE+readOnly field in a record diff → that record skipped(forbidden), others restored', async () => {
+    // SALARY: visible=true, read_only=true for the actor (per-subject layer-3 write-deny — patchRecords does NOT
+    // enforce this; only the route can). A is the only record whose diff still touches SALARY.
+    await q(`INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,true,true) ON CONFLICT DO NOTHING`, [SHEET, SALARY, ACTOR])
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 100 })]) // B,C already at v1 SALARY → only NAME changes (writable)
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [C, JSON.stringify({ [NAME]: 'b', [SALARY]: 100 })])
+    const { token } = await freshIdentity([A, B, C]) // SALARY is VISIBLE so it is in A's previewed diff + the scopeHash
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(200)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    expect(byId[A].skipReason).toBe('forbidden') // A's diff hits the readOnly SALARY → WHOLE record skipped
+    expect(byId[B].status).toBe('restored')
+    expect(byId[C].status).toBe('restored')
+    expect((await recordRow(A))?.data?.[SALARY]).toBe(200) // the readOnly field was NOT written
+    expect((await recordRow(A))?.data?.[NAME]).toBe('b') // and A is NOT partially restored (whole-record skip)
+  })
+
+  test('#2 version-tamper: submitting the CURRENT version (not the preview version) to slip past the CAS → 409, no write', async () => {
+    const { token } = await freshIdentity([A, B, C]) // preview binds B at version 2
+    // B edited THEN reverted: data identical (diff unchanged → changesHash matches) but version moved to 4.
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 3 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'x', [SALARY]: 1 })])
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 4 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+    // a tampering client submits B's CURRENT version (4) to make the CAS pass — but the version is FOLDED into the
+    // scopeHash, so submitted {B:4} ≠ the bound {B:2} → hash diverges → whole-batch 409 (the bypass is closed).
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 4, [C]: 2 }, token)
+    expect(res.status).toBe(409)
+    expect((await recordRow(A))?.version).toBe(2) // nothing written
+    expect((await recordRow(C))?.version).toBe(2)
+  })
+
   test('BS-7 keystone: executing a SUBSET of the token scope → 409 (the scopeHash binds the exact set)', async () => {
     const { token, scope } = await freshIdentity([A, B, C])
     expect(scope).toEqual([A, B, C].sort())

--- a/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-batch-execute-realdb.test.ts
@@ -99,6 +99,27 @@ describeIfDatabase('multitable scoped restore batch-execute — BS-3 (real DB)',
     expect((restoreRevs.rows[0] as { n: number }).n).toBe(3)
   })
 
+  test('per-record ISOLATION: distinct snapshots → each record restores to ITS OWN v1 (no cross-record contamination)', async () => {
+    // the shared-fixture goldens would pass even if the code applied ONE record's diff to all three. Distinct v1
+    // snapshots make a recordId-mapping / contamination bug visible (the wire-vs-fixture-drift rule, record axis).
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    const seedDistinct = async (id: string, v1name: string, v1salary: number) => {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, SHEET, JSON.stringify({ [NAME]: 'current', [SALARY]: 999 })])
+      await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: v1name, [SALARY]: v1salary })])
+      await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at) VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: 'current', [SALARY]: 999 })])
+    }
+    await seedDistinct(A, 'alpha', 100); await seedDistinct(B, 'beta', 200); await seedDistinct(C, 'gamma', 300)
+    const { token } = await freshIdentity([A, B, C])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.restoredCount).toBe(3)
+    // each record landed on ITS OWN snapshot — not a shared one
+    expect((await recordRow(A))?.data).toEqual({ [NAME]: 'alpha', [SALARY]: 100 })
+    expect((await recordRow(B))?.data).toEqual({ [NAME]: 'beta', [SALARY]: 200 })
+    expect((await recordRow(C))?.data).toEqual({ [NAME]: 'gamma', [SALARY]: 300 })
+  })
+
   test('[P2] verify-before-write: a forged token over an all-noop set 4xxes, never a 200 noop short-circuit', async () => {
     // restore everything first → now all 3 are AT v1 (an execute targeting v1 nets zero for all → contributing empty)
     const { token } = await freshIdentity([A, B, C])
@@ -134,6 +155,9 @@ describeIfDatabase('multitable scoped restore batch-execute — BS-3 (real DB)',
     expect(byId[B].status).toBe('skipped')
     expect(byId[B].skipReason).toBe('conflict') // the in-transaction CAS caught the moved version
     expect((await recordRow(B))?.data?.[NAME]).toBe('b') // B untouched (still its current value, not rewound)
+    // the survivors were actually WRITTEN to v1 (not merely reported 'restored')
+    expect((await recordRow(A))?.data?.[NAME]).toBe('a')
+    expect((await recordRow(C))?.data?.[NAME]).toBe('a')
   })
 
   test('write-level denied: ONE record row-denied since preview → PARTIAL skip(denied), the others restored', async () => {
@@ -150,6 +174,9 @@ describeIfDatabase('multitable scoped restore batch-execute — BS-3 (real DB)',
     expect(byId[C].skipReason).toBe('denied') // skipped at the FRESH row-deny gate (the SR-2 fan-out surface)
     expect(res.body?.data?.restoredCount).toBe(2)
     expect((await recordRow(C))?.version).toBe(2) // C never written
+    // the survivors A,B were actually WRITTEN to v1 (not merely reported 'restored')
+    expect((await recordRow(A))?.data?.[NAME]).toBe('a')
+    expect((await recordRow(B))?.data?.[NAME]).toBe('a')
   })
 
   test('BS-7 keystone: executing a SUBSET of the token scope → 409 (the scopeHash binds the exact set)', async () => {

--- a/packages/core-backend/tests/integration/multitable-restore-batch-preview-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-batch-preview-realdb.test.ts
@@ -130,9 +130,11 @@ describeIfDatabase('multitable scoped restore batch-preview — BS-2 (real DB)',
     const payload = jwt.decode(res.body?.data?.previewIdentity as string) as { scope?: { recordIds?: string[] }; scopeHash?: string; type?: string }
     expect(payload?.type).toBe('restore-preview-scoped')
     expect(payload?.scope?.recordIds).toEqual([A]) // NOT [A,B,C] — the skipped records never enter the identity
-    // and the scopeHash is exactly hashScope over A's per-record diff (write-set ≡ hashed-set, BS-2 half)
-    const aChanges = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string; changes?: unknown }) => [r.recordId, r.changes]))[A] as Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }>
-    expect(payload?.scopeHash).toBe(hashScope([{ recordId: A, changesHash: hashPreviewChanges(aChanges) }]))
+    const aRow = (res.body?.data?.records ?? []).find((r: { recordId: string }) => r.recordId === A)
+    expect(aRow?.previewVersion).toBe(2) // BS-2 returns each restorable record's preview-time version (the FE submits it back)
+    // and the scopeHash is exactly hashScope over A's per-record diff + its preview version (write-set ≡ hashed-set + #2 version bind)
+    const aChanges = aRow?.changes as Array<{ fieldId: string; op: 'set' | 'unset'; value: unknown }>
+    expect(payload?.scopeHash).toBe(hashScope([{ recordId: A, changesHash: hashPreviewChanges(aChanges), version: 2 }]))
   })
 
   test('empty scope → null identity (all records net zero → never a hashScope([]) executable token)', async () => {

--- a/packages/core-backend/tests/unit/restore-preview-identity.test.ts
+++ b/packages/core-backend/tests/unit/restore-preview-identity.test.ts
@@ -76,13 +76,13 @@ describe('restore preview identity — T6-1 contract', () => {
 // (BS-1; D6 discriminated union, D4 scope hash, BS-7 no narrow/widen replay). Pure unit; the execute computing the
 // real per-record diffs → expected scope claims → verify → fan-out write is BS-3.
 
-const perRecordDiff = (id: string) => ({ recordId: id, changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: id }]) })
-const scopedClaims = (recordIds: string[]): ScopedRestorePreviewIdentityClaims => ({
+const perRecordDiff = (id: string, version = 2) => ({ recordId: id, changesHash: hashPreviewChanges([{ fieldId: 'f1', op: 'set', value: id }]), version })
+const scopedClaims = (recordIds: string[], versions: Record<string, number> = {}): ScopedRestorePreviewIdentityClaims => ({
   sheetId: 'sheet_1',
   scope: { kind: 'records', recordIds },
   targetVersion: 3,
   strategy: 'revert',
-  scopeHash: hashScope(recordIds.map(perRecordDiff)),
+  scopeHash: hashScope(recordIds.map((id) => perRecordDiff(id, versions[id] ?? 2))),
   actorId: 'user_1',
 })
 const singleClaims = (): RestorePreviewIdentityClaims => ({
@@ -101,6 +101,13 @@ describe('restore preview identity — BS-1 scoped (multi-record) contract', () 
     // the execute computes the expected scopeHash FRESH from the actual set it is about to restore → diverges → reject
     expect(verifyScopedRestorePreviewIdentity(token, scopedClaims(['A', 'B'])).reason).toBe('mismatch_scopeHash')
     expect(verifyScopedRestorePreviewIdentity(token, scopedClaims(['A', 'B', 'C', 'D'])).reason).toBe('mismatch_scopeHash')
+  })
+
+  it('binds the per-record VERSION: a different submitted version → different scopeHash (anti-CAS-bypass)', () => {
+    // same records, same diffs, but B's submitted version is 4 instead of the preview-time 2 — a client trying to
+    // submit the CURRENT version to slip past the optimistic-concurrency CAS instead diverges the hash → reject.
+    const token = mintScopedRestorePreviewIdentity(scopedClaims(['A', 'B'])) // versions default to 2
+    expect(verifyScopedRestorePreviewIdentity(token, scopedClaims(['A', 'B'], { B: 4 })).reason).toBe('mismatch_scopeHash')
   })
 
   it('hashScope is ORDER-INVARIANT over the record set (else a batch could never execute — re-hash would diverge)', () => {


### PR DESCRIPTION
> **HELD for your review — do not auto-merge.** The gated write slice (BS-3), built to exactly the ratified boundary. Merge gate retained per "merge 前保留审阅闸口".

The multi-record fan-out **write**. Consumes the BS-1 scoped identity (#3073) + BS-2 preview (#3078).

## Two-layer rejection model (advisor)
- **DIFF-LEVEL** — a record missing / no-revision / delete / schema-drifted / *restorable diff changed* / empty since preview → excluded from `contributing` → the recomputed `scopeHash` diverges → **WHOLE-BATCH 409**, re-preview. No per-record noop-skip (that would execute a smaller set than the token authorized).
- **WRITE-LEVEL** — row-deny appeared / version conflict / field-forbidden during the per-record fan-out → **PARTIAL skip + report** (machine-distinguishable `denied`/`conflict`/`forbidden`). The split's proof case: data **edited-then-reverted** → diff identical (scopeHash passes) but version moved → the in-transaction CAS skips it.

## Boundaries (exactly as ratified)
- **verify-before-write** — `scopeHash` verified before ANY 2xx, **including an all-noop set** (a forged token over an already-restored set 4xxes, never a 200 noop short-circuit).
- **write-set ≡ hashed-set** — one canonical sorted/deduped `recordIds` source; each diff computed **once**, fed to both the hash and `patchRecords`; `expectedVersion` never enters the hash.
- **per-record fresh gates** — row-deny re-check + **authoritative in-transaction `expectedVersion` CAS under `SELECT FOR UPDATE`** + field-write gate. The concurrency guard the advisor flagged as the blocker — confirmed authoritative (record-write-service.ts L711), not the TOCTOU outside pre-check.
- **PARTIAL default** — per-record `patchRecords` (its own txn) so one conflict/forbidden/denied skips only that record.
- **forward-only** (`source='restore'`, no destructive delete = T8); **bounded ≤100** fail-closed. all-or-nothing deferred to BS-3.1 (a named-need follow-up; `patchRecords`' single-call path is already atomic).

## Verification
**11 real-DB goldens** (run locally on `metasheet_test`): real preview→execute happy path (forward revisions, all rows written) · **[P2]** forged token over all-noop → 4xx · **diff-level** restorable-diff-changed → whole-batch 409 nothing written · **write-level conflict** (edited-then-reverted) → PARTIAL · **write-level denied** (1 of 3) → PARTIAL · **BS-7 keystone** (execute a subset → 409) · **D6** (single-record token → 409) · **actor binding** → 409 · bounded 400 · expectedVersions fail-closed 400.
**Mutation-proven** (3 new surfaces, Python-revert, residue 0): noop-short-circuit-before-verify → [P2] fails; strip the per-record `expectedVersion` → conflict fails; disable the fresh row-deny gate → denied fails. Full restore surface **56/56** across 6 files (no regression); `tsc` clean; control bytes 0; added to the plugin-tests allowlist.

## How I'd like the gate handled
Review at your pace — I can post a self-review summary, run `/ultrareview`, or you take it. I won't merge until you say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)