### PR TITLE
feat(approval): C-1 contract — detail/sub-form (明细) field type + author-time validation

### DIFF
--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -36,6 +36,7 @@ export type FormFieldType =
   | 'multi-select'
   | 'user'
   | 'attachment'
+  | 'detail'
 
 export interface ApprovalNode {
   key: string
@@ -150,6 +151,12 @@ export interface FormField {
   options?: FormOption[]
   props?: Record<string, unknown>
   visibilityRule?: FormFieldVisibilityRule
+  // detail / sub-form (明细/子表单) — present only when type === 'detail'. `columns` is the
+  // ordered row schema of LEAF sub-fields (no nested `detail`); a `detail` value is an array
+  // of row objects keyed by sub-field id.
+  columns?: FormField[]
+  minRows?: number
+  maxRows?: number
 }
 
 export interface FormSchema {

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -563,6 +563,7 @@ function fieldTypeLabel(type: FormFieldType) {
     'multi-select': '多选',
     user: '用户',
     attachment: '附件',
+    detail: '明细',
   }
   return map[type] ?? type
 }

--- a/docs/development/approval-detail-subform-todo-20260623.md
+++ b/docs/development/approval-detail-subform-todo-20260623.md
@@ -10,18 +10,19 @@
 - ✅ Decisions finalized via §8 defaults (a–e) under the /goal autonomy directive
   (owner-override-welcome). **C-1 unblocked.**
 
-## Phase C-1 — contract (⬜ — D accepted via §8 defaults; not wired to runtime)
-- ⬜ `FormFieldType += 'detail'` in FE (`types/approval.ts`) + BE (`approval-product.ts`) +
-  server allow-list `FORM_FIELD_TYPES` (`ApprovalProductService.ts:261`).
-- ⬜ Sub-schema types: `DetailColumn` (leaf-only) + `minRows`/`maxRows` on the detail field.
-- ⬜ Author-time schema validation in `normalizeFormField`/`assertFormSchema`: non-empty
-  `columns`; each sub-field a valid **leaf** type (reject `detail` = no nesting, reject
-  unknown); sub-field id uniqueness within the group; `minRows ≤ maxRows`; reject a
-  `form_field_user` source pointing at a sub-field (assignee sources top-level-only); reject a
-  sub-field `visibilityRule` crossing row scope or a top-level rule targeting a `detail`.
-- ⬜ Frozen-columns read shape (§5) defined in the contract (version `form_schema` or a
-  projected `detailColumns` on the instance read DTO).
-- ⬜ Contract + OpenAPI-parity tests; **no createApproval/runtime wiring**.
+## Phase C-1 — contract ✅ (shipped; types + author-time validation + tests; not wired to runtime)
+- ✅ `FormFieldType += 'detail'` in FE (`types/approval.ts`) + BE (`approval-product.ts`) +
+  server allow-list `FORM_FIELD_TYPES` + derived `DETAIL_LEAF_FIELD_TYPES`.
+- ✅ Sub-schema: `columns?: FormField[]` (reused `FormField` for sub-fields) + `minRows?` / `maxRows?`.
+- ✅ Author-time validation (`normalizeFormField` / `assertFormSchema` /
+  `validateFormFieldVisibilityRules`): non-empty leaf-only columns (no nesting), unique sub-ids,
+  `minRows ≤ maxRows` (non-negative ints), detail-only keys rejected on a non-detail field,
+  top-level rule can't target a `detail`, sub-field rule stays in-group, and the
+  `form_field_user`-can't-target-a-sub-field invariant (locked by test + a code comment).
+- ✅ Contract tests (11) in `approval-product-service.test.ts` — 8 reject + assignee-source +
+  negative-bound + accept round-trip (columns / minRows / maxRows + sibling rule preserved).
+- ➡️ Frozen-columns READ shape (§5) folded into **C-2** (the instance read-DTO change *is* the
+  runtime read path; the type-level contract — `columns` on the frozen formSchema — ships here).
 
 ## Phase C-2 — runtime (🔒 until C-1 merged)
 - 🔒 Submit-time row validation: extend `validateApprovalFormData`/`validateFieldType`/

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -273,7 +273,15 @@ const FORM_FIELD_TYPES = new Set([
   'multi-select',
   'user',
   'attachment',
+  'detail',
 ])
+
+// Leaf sub-field types allowed inside a `detail` group's columns (everything except `detail`
+// itself — one nesting level only). `attachment` is permitted at the type/contract layer;
+// the authoring UI (C-3) governs which are offered.
+const DETAIL_LEAF_FIELD_TYPES = new Set(
+  [...FORM_FIELD_TYPES].filter((type) => type !== 'detail'),
+)
 
 const APPROVAL_NODE_TYPES = new Set(['start', 'approval', 'cc', 'condition', 'parallel', 'end'])
 const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'])
@@ -451,6 +459,9 @@ function validateApprovalAssigneeSourcesAgainstFormSchema(
   formSchema: FormSchema,
   context: ValidationContext,
 ): void {
+  // Top-level fields only — detail sub-fields are intentionally NOT resolvable here, so a
+  // form_field_user source can never point at a sub-field (a sub-field has N row-values and
+  // would be ambiguous as a single approver). See approval-detail-subform-design-lock §1.
   const fieldById = new Map(formSchema.fields.map((field) => [field.id, field]))
   approvalGraph.nodes.forEach((node) => {
     if (node.type !== 'approval') return
@@ -497,6 +508,7 @@ function normalizeFormField(
   value: unknown,
   index: number,
   context: ValidationContext,
+  nested = false,
 ): FormSchema['fields'][number] {
   if (!isRecord(value)) {
     failValidation(context, `formSchema.fields[${index}] must be an object`)
@@ -534,6 +546,7 @@ function normalizeFormField(
   }
 
   const visibilityRule = normalizeFormFieldVisibilityRule(value.visibilityRule, index, context)
+  const detail = normalizeDetailFieldParts(value, index, context, nested)
 
   return {
     id: value.id.trim(),
@@ -552,7 +565,61 @@ function normalizeFormField(
       : {}),
     ...(isRecord(value.props) ? { props: { ...value.props } } : {}),
     ...(visibilityRule ? { visibilityRule } : {}),
+    ...detail,
   } as FormSchema['fields'][number]
+}
+
+// detail / sub-form (明细/子表单) author-time validation. Returns the normalized
+// columns/minRows/maxRows for a `detail` field, or {} for a non-detail field. Rejects: a
+// nested detail (one level only), a non-detail field carrying detail-only keys, an empty or
+// non-array `columns`, a non-leaf / unknown sub-field type, duplicate sub-field ids, and
+// minRows/maxRows that are not non-negative integers with minRows <= maxRows.
+function normalizeDetailFieldParts(
+  value: Record<string, unknown>,
+  index: number,
+  context: ValidationContext,
+  nested: boolean,
+): Pick<FormSchema['fields'][number], 'columns' | 'minRows' | 'maxRows'> {
+  if (value.type !== 'detail') {
+    if (value.columns !== undefined || value.minRows !== undefined || value.maxRows !== undefined) {
+      failValidation(context, `formSchema.fields[${index}].columns/minRows/maxRows are only valid on a detail field`)
+    }
+    return {}
+  }
+  if (nested) {
+    failValidation(context, `formSchema.fields[${index}] of type detail cannot be nested inside a detail group`)
+  }
+  if (!Array.isArray(value.columns) || value.columns.length === 0) {
+    failValidation(context, `formSchema.fields[${index}].columns must be a non-empty array for a detail field`)
+  }
+  const columns = value.columns.map((column, columnIndex) => {
+    const normalized = normalizeFormField(column, columnIndex, context, true)
+    if (!DETAIL_LEAF_FIELD_TYPES.has(normalized.type)) {
+      failValidation(context, `formSchema.fields[${index}].columns[${columnIndex}].type is not a valid leaf sub-field`)
+    }
+    return normalized
+  })
+  if (new Set(columns.map((column) => column.id)).size !== columns.length) {
+    failValidation(context, `formSchema.fields[${index}].columns ids must be unique within the detail group`)
+  }
+  const minRows = normalizeOptionalRowBound(value.minRows, `formSchema.fields[${index}].minRows`, context)
+  const maxRows = normalizeOptionalRowBound(value.maxRows, `formSchema.fields[${index}].maxRows`, context)
+  if (minRows !== undefined && maxRows !== undefined && minRows > maxRows) {
+    failValidation(context, `formSchema.fields[${index}].minRows must be <= maxRows`)
+  }
+  return {
+    columns,
+    ...(minRows !== undefined ? { minRows } : {}),
+    ...(maxRows !== undefined ? { maxRows } : {}),
+  }
+}
+
+function normalizeOptionalRowBound(value: unknown, path: string, context: ValidationContext): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    failValidation(context, `${path} must be a non-negative integer`)
+  }
+  return value
 }
 
 function assertFormSchema(value: unknown, context: ValidationContext = REQUEST_VALIDATION_CONTEXT): FormSchema {
@@ -635,7 +702,8 @@ function validateFormFieldVisibilityRules(
     const rule = field.visibilityRule
     if (!rule) return
 
-    if (!fieldMap.has(rule.fieldId)) {
+    const target = fieldMap.get(rule.fieldId)
+    if (!target) {
       failValidation(
         context,
         `formSchema.fields[${index}].visibilityRule.fieldId must reference an existing field`,
@@ -643,6 +711,12 @@ function validateFormFieldVisibilityRules(
     }
     if (rule.fieldId === field.id) {
       failValidation(context, `formSchema.fields[${index}].visibilityRule cannot reference itself`)
+    }
+    if (target.type === 'detail') {
+      failValidation(
+        context,
+        `formSchema.fields[${index}].visibilityRule.fieldId cannot reference a detail field (its value is a list)`,
+      )
     }
   })
 
@@ -664,6 +738,15 @@ function validateFormFieldVisibilityRules(
   }
 
   fields.forEach((field) => visit(field.id, []))
+
+  // Sub-field visibility rules are validated WITHIN their detail group: a sub-field rule may
+  // only reference a sibling sub-field (same row), never a top-level field — the recursive
+  // call's field map is the group's columns, so a cross-scope fieldId fails "existing field".
+  fields.forEach((field) => {
+    if (field.type === 'detail' && field.columns && field.columns.length > 0) {
+      validateFormFieldVisibilityRules(field.columns, context)
+    }
+  })
 }
 
 /**

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -61,6 +61,7 @@ export type FormFieldType =
   | 'multi-select'
   | 'user'
   | 'attachment'
+  | 'detail'
 
 export interface ApprovalNode {
   key: string
@@ -223,6 +224,12 @@ export interface FormField {
   options?: FormOption[]
   props?: Record<string, unknown>
   visibilityRule?: FormFieldVisibilityRule
+  // detail / sub-form (明细/子表单) — present only when type === 'detail'. `columns` is the
+  // ordered row schema of LEAF sub-fields (no nested `detail`, enforced at author-time);
+  // a `detail` value is submitted as an array of row objects keyed by sub-field id.
+  columns?: FormField[]
+  minRows?: number
+  maxRows?: number
 }
 
 export interface FormSchema {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1162,6 +1162,138 @@ describe('ApprovalProductService', () => {
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
+  describe('detail / sub-form (明细) field contract (C-1 author-time validation)', () => {
+    // assertFormSchema runs BEFORE pool.connect(), so reject cases throw without any query mock.
+    const wrap = (field: Record<string, unknown>, extra: Record<string, unknown>[] = []) => ({
+      key: 'detail-tpl',
+      name: 'Detail Tpl',
+      visibilityScope: { type: 'all', ids: [] },
+      formSchema: { fields: [field, ...extra] },
+      approvalGraph: buildRuntimeGraph(),
+    })
+    const create = async (request: unknown) => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      return new ApprovalProductService().createTemplate(request as never)
+    }
+
+    it('rejects a detail field with empty columns', async () => {
+      await expect(create(wrap({ id: 'items', type: 'detail', label: '明细', columns: [] })))
+        .rejects.toThrow(/columns must be a non-empty array/)
+    })
+
+    it('rejects a detail nested inside a detail (one level only)', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细',
+        columns: [{ id: 'sub', type: 'detail', label: 'sub', columns: [{ id: 'x', type: 'text', label: 'x' }] }],
+      }))).rejects.toThrow(/detail cannot be nested inside a detail group/)
+    })
+
+    it('rejects an unknown sub-field type', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细', columns: [{ id: 'x', type: 'bogus', label: 'x' }],
+      }))).rejects.toThrow(/type is invalid/)
+    })
+
+    it('rejects duplicate sub-field ids within a group', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细',
+        columns: [{ id: 'x', type: 'text', label: 'x' }, { id: 'x', type: 'number', label: 'x2' }],
+      }))).rejects.toThrow(/ids must be unique within the detail group/)
+    })
+
+    it('rejects minRows > maxRows', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细', minRows: 5, maxRows: 2,
+        columns: [{ id: 'x', type: 'text', label: 'x' }],
+      }))).rejects.toThrow(/minRows must be <= maxRows/)
+    })
+
+    it('rejects a negative row bound', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细', minRows: -1,
+        columns: [{ id: 'x', type: 'text', label: 'x' }],
+      }))).rejects.toThrow(/minRows must be a non-negative integer/)
+    })
+
+    it('rejects detail-only keys (columns) on a non-detail field', async () => {
+      await expect(create(wrap({ id: 'x', type: 'text', label: 'x', columns: [{ id: 'y', type: 'text', label: 'y' }] })))
+        .rejects.toThrow(/only valid on a detail field/)
+    })
+
+    it('rejects a top-level visibilityRule targeting a detail field', async () => {
+      await expect(create(wrap(
+        { id: 'items', type: 'detail', label: '明细', columns: [{ id: 'product', type: 'text', label: '品名' }] },
+        [{ id: 'note', type: 'text', label: 'note', visibilityRule: { fieldId: 'items', operator: 'notEmpty' } }],
+      ))).rejects.toThrow(/cannot reference a detail field/)
+    })
+
+    it('rejects a sub-field visibilityRule referencing a top-level (cross-scope) field', async () => {
+      await expect(create(wrap({
+        id: 'items', type: 'detail', label: '明细',
+        columns: [
+          { id: 'product', type: 'text', label: '品名' },
+          { id: 'note', type: 'text', label: 'note', visibilityRule: { fieldId: 'topLevelOnly', operator: 'notEmpty' } },
+        ],
+      }))).rejects.toThrow(/must reference an existing field/)
+    })
+
+    it('rejects a form_field_user assignee source pointing at a detail sub-field (sources stay top-level)', async () => {
+      // `approver` is a user-typed SUB-FIELD of `items`, not a top-level field — the assignee
+      // validator resolves form_field_user.fieldId against top-level fields only, so it rejects.
+      const request = {
+        key: 'detail-assignee',
+        name: 'Detail Assignee',
+        visibilityScope: { type: 'all', ids: [] },
+        formSchema: { fields: [{ id: 'items', type: 'detail', label: '明细', columns: [{ id: 'approver', type: 'user', label: '审批人' }] }] },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'approval_1', type: 'approval', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver' }] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+            { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+          ],
+          policy: { allowRevoke: true },
+        },
+      }
+      await expect(create(request)).rejects.toThrow(/must reference a user field/)
+    })
+
+    it('accepts a valid detail and round-trips columns / minRows / maxRows + a sibling sub-field rule', async () => {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const s = normalize(sql)
+        if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (s.startsWith('INSERT INTO approval_templates')) {
+          return { rows: [{ id: 'tpl-d', key: String(params?.[0]), name: String(params?.[1]), description: null, category: null, visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: null, created_at: new Date('2026-04-11T00:00:00.000Z'), updated_at: new Date('2026-04-11T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (s.startsWith('INSERT INTO approval_template_versions')) {
+          return { rows: [{ id: 'ver-d', template_id: 'tpl-d', version: 1, status: 'draft', form_schema: JSON.parse(String(params?.[1])), approval_graph: JSON.parse(String(params?.[2])), created_at: new Date('2026-04-11T00:00:00.000Z'), updated_at: new Date('2026-04-11T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (s.startsWith('UPDATE approval_templates')) {
+          return { rows: [{ id: 'tpl-d', key: 'detail-tpl', name: 'Detail Tpl', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft', active_version_id: 'ver-d', latest_version_id: 'ver-d', created_at: new Date('2026-04-11T00:00:00.000Z'), updated_at: new Date('2026-04-11T00:00:00.000Z') }], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${s}`)
+      })
+
+      const result = await create(wrap({
+        id: 'items', type: 'detail', label: '明细', required: true, minRows: 1, maxRows: 50,
+        columns: [
+          { id: 'product', type: 'text', label: '品名', required: true },
+          { id: 'qty', type: 'number', label: '数量', required: true },
+          { id: 'note', type: 'text', label: '备注', visibilityRule: { fieldId: 'product', operator: 'notEmpty' } },
+        ],
+      }))
+      const field = result.formSchema.fields[0]
+      expect(field.type).toBe('detail')
+      expect(field.minRows).toBe(1)
+      expect(field.maxRows).toBe(50)
+      expect(field.columns?.map((column) => column.id)).toEqual(['product', 'qty', 'note'])
+      expect(field.columns?.[2].visibilityRule).toEqual({ fieldId: 'product', operator: 'notEmpty' })
+    })
+  })
+
   it('accepts authoring-MVP form-field-user assignee sources when creating a template', async () => {
     const request = {
       key: 'expense-authoring',


### PR DESCRIPTION
First implementation slice of the **C 明细/子表单** arc (design-lock #3082, accepted via §8 defaults). **CONTRACT ONLY** — adds the field type + author-time schema validation; **not wired** to `createApproval`/runtime (that's C-2).

## Changes
- **Types (FE + BE):** `FormFieldType += 'detail'`; `FormField` gains `columns?: FormField[]` (sub-fields reuse `FormField`, leaf-only enforced at author-time) + `minRows?` / `maxRows?`.
- **Allow-list:** `FORM_FIELD_TYPES += 'detail'` + derived `DETAIL_LEAF_FIELD_TYPES`.
- **Author-time validation** (`normalizeFormField` / `assertFormSchema` / `validateFormFieldVisibilityRules`):
  - non-empty **leaf-only** columns (no nesting — one level), unique sub-ids within a group, `minRows ≤ maxRows` (non-negative ints), detail-only keys rejected on a non-detail field;
  - a top-level `visibilityRule` can't target a `detail` (array value); a sub-field rule resolves **within its group** (same-row scope);
  - `form_field_user` assignee sources stay **top-level-only** — a `user`-typed sub-field is *not* an approver source (the advisor-caught ambiguity), locked by a test + a comment; holds by construction since the validator maps top-level fields only.

## Tests
11 contract tests in `approval-product-service.test.ts`: 8 reject (empty/nested/unknown-type/dup-id/min>max/negative-bound/detail-keys-on-scalar/top-level→detail/cross-scope) + assignee-source rejection + accept round-trip (columns/minRows/maxRows + sibling sub-field rule preserved).

## Safety
Additive — the new validations fire only for `detail` fields/keys, which **no existing template has**, so existing schemas are unaffected. `tsc` (BE + FE vue-tsc) + lint clean; **58/58** service unit tests (47 existing + 11 new). TODO: C-1 ✅.

Next: **C-2** runtime (submit-time row validation + snapshot freeze + read exposes frozen columns) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)