### PR TITLE
feat(approval): C-2 runtime — detail/sub-form (明细) submit validation + per-row prune + freeze

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -301,6 +301,7 @@ jobs:
             tests/integration/approval-manager-chain.db.test.ts \
             tests/integration/approval-delegation-seam.db.test.ts \
             tests/integration/approval-delegation-api.db.test.ts \
+            tests/integration/approval-detail-subform.db.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/docs/development/approval-detail-subform-todo-20260623.md
+++ b/docs/development/approval-detail-subform-todo-20260623.md
@@ -24,22 +24,27 @@
 - ➡️ Frozen-columns READ shape (§5) folded into **C-2** (the instance read-DTO change *is* the
   runtime read path; the type-level contract — `columns` on the frozen formSchema — ships here).
 
-## Phase C-2 — runtime (🔒 until C-1 merged)
-- 🔒 Submit-time row validation: extend `validateApprovalFormData`/`validateFieldType`/
-  `validateFieldConstraints` to recurse into rows (array → row count → required cells → per-cell
-  leaf validation; unknown sub-keys fail-closed; row-addressed error messages).
-- 🔒 Freeze the row array into `form_snapshot` (no new column).
-- 🔒 Per-row `visibilityRule`: extend `pruneHiddenFormData` to drop hidden cells per row
-  **on write** (never frozen). No read-time masking.
-- 🔒 Read path surfaces the **frozen** detail columns from the template version (close Fact B).
-- 🔒 Real-DB tests: submit→freeze→read round-trip; required-row reject (400);
-  hidden-cell pruned-not-frozen; frozen-columns-survive-template-change.
+## Phase C-2 — runtime ✅ (shipped; submit-time validation + per-row prune + freeze; not the read/UI)
+- ✅ Submit-time row validation: `validateApprovalFormData` gains a `detail` branch →
+  `validateDetailFieldValue` (array → minRows/maxRows → per-row required + leaf
+  `validateFieldType`/`validateFieldConstraints`; row-addressed `items[i].cell` messages).
+- ✅ Freeze: the row array rides `form_snapshot` (no new column) via the existing createApproval path.
+- ✅ Per-row `visibilityRule`: `pruneHiddenFormData` drops hidden + unknown cells per row on
+  write (recurses the same prune over each row). No read-time masking.
+- ✅ Real-DB round-trip (`approval-detail-subform.db.test.ts`, wired into the approval PG lane +
+  vitest no-DB exclude): columns JSONB round-trip on the version; submit→validate→prune→freeze
+  into form_snapshot; invalid-row 400. + 8 unit tests. Whole approval lane green (10 files / 49).
+- ➡️ Read path surfaces the **frozen** detail columns — folded into **C-3** (the renderer consumes
+  them; exposing columns without a renderer is untestable/unused).
 
 ## Phase C-3 — UI (🔒 until C-2 merged; the form-schema stability point for complex-graph node UI)
 - 🔒 Template author: configure detail `columns` (reuse leaf-field authoring +
   `AUTHORABLE_FIELD_TYPES`) in `TemplateAuthoringView.vue`.
 - 🔒 Fill view: `detail → DetailTable` editable branch in `ApprovalNewView.vue` (add/remove
   row; per-cell leaf editor; inline validation; per-row visibility).
+- 🔒 Read path (moved from C-2): expose the **frozen** detail `columns` on the instance read
+  (the version's `form_schema` or a projected `detailColumns` on the read DTO) so the detail
+  view renders from the frozen schema, not the live template (closes design-lock Fact B).
 - 🔒 Detail view: read-only `DetailTable` in `ApprovalDetailView.vue` driven by frozen columns
   (replaces the `formatFieldValue` JSON-stringify fallback for `detail`).
 - 🔒 FE tests: author round-trip, fill validation, render-from-frozen-snapshot.

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -260,8 +260,24 @@ export function pruneHiddenFormData(
   formData: Record<string, unknown>,
 ): Record<string, unknown> {
   const visibleFieldIds = getVisibleFormFieldIds(formSchema, formData)
+  const detailColumnsById = new Map(
+    formSchema.fields
+      .filter((field): field is FormField & { columns: FormField[] } => field.type === 'detail' && Array.isArray(field.columns))
+      .map((field) => [field.id, field.columns]),
+  )
   return Object.fromEntries(
-    Object.entries(formData).filter(([fieldId]) => visibleFieldIds.has(fieldId)),
+    Object.entries(formData)
+      .filter(([fieldId]) => visibleFieldIds.has(fieldId))
+      .map(([fieldId, value]) => {
+        const columns = detailColumnsById.get(fieldId)
+        if (columns && Array.isArray(value)) {
+          // detail: drop hidden / unknown cells per row (a sub-field visibilityRule is evaluated
+          // against that row), recursing through the same prune so behavior matches top-level.
+          const subSchema: FormSchema = { fields: columns }
+          return [fieldId, value.map((row) => (isRecord(row) ? pruneHiddenFormData(subSchema, row) : row))]
+        }
+        return [fieldId, value]
+      }),
   )
 }
 
@@ -432,6 +448,48 @@ function validateFieldConstraints(field: FormField, value: unknown): string[] {
   }
 }
 
+// Submit-time validation of a detail (明细) value: an array of row objects. Each row's cells
+// are validated against the frozen `columns` with the SAME leaf validators as top-level
+// fields; per-row `visibilityRule` decides which cells are required; messages are row-addressed
+// (`items[1].qty is required`). Unknown cells are dropped by pruneHiddenFormData before this
+// runs, matching the top-level prune-then-validate behavior.
+function validateDetailFieldValue(field: FormField, value: unknown): string[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) return [`${field.id} must be a list`]
+  const errors: string[] = []
+  if (field.minRows !== undefined && value.length < field.minRows) {
+    errors.push(`${field.id} requires at least ${field.minRows} row(s)`)
+  }
+  if (field.maxRows !== undefined && value.length > field.maxRows) {
+    errors.push(`${field.id} allows at most ${field.maxRows} row(s)`)
+  }
+  const columns = field.columns ?? []
+  const subSchema: FormSchema = { fields: columns }
+  value.forEach((row, rowIndex) => {
+    const prefix = `${field.id}[${rowIndex}]`
+    if (!isRecord(row)) {
+      errors.push(`${prefix} must be an object`)
+      return
+    }
+    const visibleSubIds = getVisibleFormFieldIds(subSchema, row)
+    for (const column of columns) {
+      if (!visibleSubIds.has(column.id)) continue
+      const cell = row[column.id]
+      if (column.required && isEmptyValue(cell)) {
+        errors.push(`${prefix}.${column.id} is required`)
+        continue
+      }
+      const typeError = validateFieldType(column, cell)
+      if (typeError) {
+        errors.push(`${prefix}.${typeError}`)
+        continue
+      }
+      errors.push(...validateFieldConstraints(column, cell).map((error) => `${prefix}.${error}`))
+    }
+  })
+  return errors
+}
+
 export function validateApprovalFormData(formSchema: FormSchema, formData: Record<string, unknown>): string[] {
   const errors: string[] = []
   const visibleFieldIds = getVisibleFormFieldIds(formSchema, formData)
@@ -443,6 +501,10 @@ export function validateApprovalFormData(formSchema: FormSchema, formData: Recor
     const value = formData[field.id]
     if (field.required && isEmptyValue(value)) {
       errors.push(`${field.id} is required`)
+      continue
+    }
+    if (field.type === 'detail') {
+      errors.push(...validateDetailFieldValue(field, value))
       continue
     }
     const typeError = validateFieldType(field, value)

--- a/packages/core-backend/tests/integration/approval-detail-subform.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-detail-subform.db.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * Detail / sub-form (明细/子表单) C-2 runtime — real-DB submit→freeze→read round-trip.
+ *
+ * The unit tests cover validateApprovalFormData / pruneHiddenFormData against hand-built
+ * schemas. This proves the REAL WIRE the unit tests hand-feed: a detail template's `columns`
+ * survive the JSONB round-trip on the template version, and createApproval validates the
+ * submitted rows, prunes hidden/unknown cells per row, and freezes the result into
+ * form_snapshot. (wire-vs-fixture guard: `columns` is a new field-by-field-serialized member.)
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `det-req-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+describeIfDatabase('detail / sub-form (明细) submit→freeze→read — real-DB round-trip (C-2)', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let tid = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: 's', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'a', config: { assigneeSources: [{ kind: 'static_user', userIds: [REQ] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: 'e', config: {} },
+      ],
+      edges: [{ key: 'e1', source: 'start', target: 'approval_1' }, { key: 'e2', source: 'approval_1', target: 'end' }],
+    }
+    const key = `det-tpl-${TS}`
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: {
+        key,
+        name: key,
+        formSchema: {
+          fields: [{
+            id: 'items', type: 'detail', label: '明细', required: true, minRows: 1, maxRows: 5,
+            columns: [
+              { id: 'product', type: 'text', label: '品名', required: true },
+              { id: 'qty', type: 'number', label: '数量', required: true },
+              { id: 'memo', type: 'text', label: '备注', visibilityRule: { fieldId: 'product', operator: 'eq', value: 'special' } },
+            ],
+          }],
+        },
+        approvalGraph: graph,
+      },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`%-${TS}`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1)`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_template_versions WHERE template_id = ANY($1)`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1)`, [tids])
+      }
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('persists detail columns on the template version (JSONB round-trip)', async () => {
+    const pool = poolManager.get()
+    const row = (await pool.query<{ form_schema: { fields: Array<{ id: string; columns?: Array<{ id: string }>; minRows?: number; maxRows?: number }> } }>(
+      `SELECT v.form_schema FROM approval_template_versions v JOIN approval_templates t ON t.latest_version_id = v.id WHERE t.id = $1`,
+      [tid],
+    )).rows[0]
+    const detail = row.form_schema.fields.find((field) => field.id === 'items')
+    expect(detail?.columns?.map((column) => column.id)).toEqual(['product', 'qty', 'memo'])
+    expect(detail?.minRows).toBe(1)
+    expect(detail?.maxRows).toBe(5)
+  })
+
+  it('validates rows + freezes the detail into form_snapshot, pruning a hidden cell and an unknown sub-key', async () => {
+    const started = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: {
+        templateId: tid,
+        formData: { items: [
+          { product: 'A', qty: 2, memo: 'should-drop', junk: 'x' }, // memo hidden (product != special); junk unknown
+          { product: 'special', qty: 1, memo: 'keep' },             // memo visible
+        ] },
+      },
+    })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+
+    const pool = poolManager.get()
+    const snapshot = (await pool.query<{ form_snapshot: { items: Array<Record<string, unknown>> } }>(
+      `SELECT form_snapshot FROM approval_instances WHERE id = $1`,
+      [aid],
+    )).rows[0].form_snapshot
+    expect(snapshot.items).toEqual([
+      { product: 'A', qty: 2 },
+      { product: 'special', qty: 1, memo: 'keep' },
+    ])
+  })
+
+  it('rejects an invalid detail submission (missing required cell) with a row-addressed 400', async () => {
+    const bad = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { items: [{ product: 'A' }] } }, // missing required qty
+    })
+    expect(bad.status).toBe(400)
+    expect(await bad.text()).toMatch(/items\[0\]\.qty is required/)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ApprovalGraphExecutor, validateApprovalFormData } from '../../src/services/ApprovalGraphExecutor'
+import { ApprovalGraphExecutor, validateApprovalFormData, pruneHiddenFormData } from '../../src/services/ApprovalGraphExecutor'
 import type { FormSchema, RuntimeGraph } from '../../src/types/approval-product'
 
 describe('ApprovalGraphExecutor', () => {
@@ -937,5 +937,84 @@ describe('validateApprovalFormData', () => {
     }
     const executor = new ApprovalGraphExecutor(runtimeGraph, {})
     expect(executor.buildAddSignAssignments('approval_1', [], 'user-1')).toEqual([])
+  })
+})
+
+describe('validateApprovalFormData — detail (明细) rows (C-2)', () => {
+  const detailSchema: FormSchema = {
+    fields: [
+      {
+        id: 'items', type: 'detail', label: '明细', required: true, minRows: 1, maxRows: 3,
+        columns: [
+          { id: 'product', type: 'text', label: '品名', required: true },
+          { id: 'qty', type: 'number', label: '数量', required: true },
+          // required, but only visible (hence only required) when product === 'special'
+          { id: 'note', type: 'text', label: '备注', required: true, visibilityRule: { fieldId: 'product', operator: 'eq', value: 'special' } },
+        ],
+      },
+    ],
+  }
+
+  it('accepts valid rows', () => {
+    expect(validateApprovalFormData(detailSchema, { items: [{ product: 'A', qty: 2 }] })).toEqual([])
+  })
+
+  it('row-addresses a missing required cell', () => {
+    expect(validateApprovalFormData(detailSchema, { items: [{ product: 'A' }] })).toEqual(['items[0].qty is required'])
+  })
+
+  it('row-addresses a wrong cell type', () => {
+    expect(validateApprovalFormData(detailSchema, { items: [{ product: 'A', qty: 'two' }] })).toEqual(['items[0].qty must be a number'])
+  })
+
+  it('enforces maxRows (non-empty, too many)', () => {
+    expect(validateApprovalFormData(detailSchema, {
+      items: [{ product: 'a', qty: 1 }, { product: 'b', qty: 1 }, { product: 'c', qty: 1 }, { product: 'd', qty: 1 }],
+    })).toContain('items allows at most 3 row(s)')
+  })
+
+  it('enforces minRows (a non-empty array below the floor; an empty required detail is "required" instead)', () => {
+    // a required+empty detail is caught by the required check first (empty array = empty value)
+    expect(validateApprovalFormData(detailSchema, { items: [] })).toEqual(['items is required'])
+    // minRows is the meaningful floor for non-empty arrays: minRows 2, one row
+    const minSchema: FormSchema = { fields: [{ id: 'items', type: 'detail', label: '明细', minRows: 2, columns: [{ id: 'x', type: 'text', label: 'x' }] }] }
+    expect(validateApprovalFormData(minSchema, { items: [{ x: 'a' }] })).toContain('items requires at least 2 row(s)')
+  })
+
+  it('rejects a non-array detail value', () => {
+    expect(validateApprovalFormData(detailSchema, { items: 'nope' })).toEqual(['items must be a list'])
+  })
+
+  it('applies per-row visibility: a hidden required sub-field is not required, but required when visible', () => {
+    expect(validateApprovalFormData(detailSchema, { items: [{ product: 'A', qty: 1 }] })).toEqual([])
+    expect(validateApprovalFormData(detailSchema, { items: [{ product: 'special', qty: 1 }] })).toEqual(['items[0].note is required'])
+  })
+})
+
+describe('pruneHiddenFormData — detail (明细) per-row cells (C-2)', () => {
+  const schema: FormSchema = {
+    fields: [
+      {
+        id: 'items', type: 'detail', label: '明细',
+        columns: [
+          { id: 'product', type: 'text', label: '品名' },
+          { id: 'note', type: 'text', label: '备注', visibilityRule: { fieldId: 'product', operator: 'eq', value: 'special' } },
+        ],
+      },
+    ],
+  }
+
+  it('drops hidden cells per row and unknown sub-keys, keeps visible cells', () => {
+    expect(pruneHiddenFormData(schema, {
+      items: [
+        { product: 'A', note: 'drop-me', evil: 'x' },
+        { product: 'special', note: 'keep' },
+      ],
+    })).toEqual({
+      items: [
+        { product: 'A' },
+        { product: 'special', note: 'keep' },
+      ],
+    })
   })
 })

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       'tests/integration/approval-manager-chain.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
+      'tests/integration/approval-detail-subform.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',


### PR DESCRIPTION
Second slice of the **C 明细/子表单** arc (design-lock #3082; C-1 #3086). Wires the `detail` field into the `createApproval` runtime — validation + per-row hidden-cell prune + freeze. **Not the read/UI** (that's C-3).

## Changes
- **Submit-time validation:** `validateApprovalFormData` gains a `detail` branch → `validateDetailFieldValue` (array → `minRows`/`maxRows` → per-row required + leaf `validateFieldType`/`validateFieldConstraints`, reusing the same validators as top-level fields; **row-addressed** `items[i].cell` messages).
- **Per-row visibility:** `pruneHiddenFormData` drops hidden + unknown cells **per row** on write (recurses the same prune over each row) — matches the existing top-level prune-then-validate model; no read-time masking.
- **Freeze:** the row array rides `form_snapshot` (no new column) through the existing path.

## Tests
- 8 unit (validate/prune) in `approval-graph-executor.test.ts`.
- **Real-DB round-trip** `approval-detail-subform.db.test.ts` — proves the JSONB `columns` round-trip on the template version + submit→validate→prune→freeze→read + invalid-row 400. Wired into the approval PG lane **and** the no-DB vitest exclude (wire-vs-fixture guard for the new serialized `columns` member).
- Whole approval lane green locally (**10 files / 49**). `tsc` + lint clean.

## Safety
Additive — the detail branch fires only for `detail` fields no existing template has. Read-path frozen-columns exposure moves to **C-3** (the renderer consumes it). TODO: C-2 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)