### PR TITLE
feat(approval): C-3a read-path — expose frozen detail columns on the instance read

### DIFF
--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -209,6 +209,9 @@ export interface UnifiedApprovalDTO {
   publishedDefinitionId?: string | null
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
+  // Frozen form schema from the instance's pinned template version (detail `columns` included),
+  // so the detail view renders rows from the FROZEN schema, not the live template.
+  formSchema?: FormSchema | null
   currentNodeKey?: string | null
   /**
    * Parallel gateway (并行分支) — surfaced only when the instance is inside

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -12,6 +12,7 @@ import {
   toPlatformApprovalBridgeRecord,
   type PlmApprovalBridgeSource,
 } from '../federation/plm-approval-bridge'
+import type { FormSchema } from '../types/approval-product'
 import type {
   ApprovalActionRequest,
   ApprovalAssignmentRow,
@@ -511,11 +512,22 @@ export class ApprovalBridgeService {
 
     const assignmentsByInstance = await this.loadAssignments([id])
     const runtimeGraphsByDefinition = await this.loadRuntimeGraphs([row.published_definition_id])
-    return toUnifiedDTO(
+    const dto = toUnifiedDTO(
       row,
       assignmentsByInstance.get(id) || [],
       row.published_definition_id ? runtimeGraphsByDefinition.get(row.published_definition_id) ?? null : null,
     )
+    // Attach the FROZEN form schema (detail `columns` included) from the instance's pinned
+    // template version so the read renders detail rows from the frozen schema (design-lock Fact B).
+    if (dto && row.template_version_id) {
+      const versionResult = await pool.query<{ form_schema: Record<string, unknown> }>(
+        `SELECT form_schema FROM approval_template_versions WHERE id = $1`,
+        [row.template_version_id],
+      )
+      const frozen = versionResult.rows[0]?.form_schema
+      if (frozen) dto.formSchema = frozen as unknown as FormSchema
+    }
+    return dto
   }
 
   async getApprovalHistory(id: string): Promise<UnifiedApprovalHistoryDTO[]> {

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1190,6 +1190,7 @@ function toApprovalTemplateVersionDetailDTO(bundle: TemplateBundle): ApprovalTem
 function toUnifiedApprovalDTO(
   row: ApprovalInstanceRow,
   assignments: ApprovalAssignmentDTO[],
+  frozenFormSchema?: FormSchema | null,
 ): UnifiedApprovalDTO {
   // Surface `currentNodeKeys` when the instance is inside a parallel region so
   // consumers (frontend timeline, callers checking `.length > 1`) can detect
@@ -1221,6 +1222,9 @@ function toUnifiedApprovalDTO(
     publishedDefinitionId: row.published_definition_id,
     requestNo: row.request_no,
     formSnapshot: toNullableRecord(row.form_snapshot),
+    // Frozen form schema (incl. detail `columns`) from the instance's pinned template version,
+    // so consumers render detail rows from the FROZEN schema, not the live template (Fact B).
+    ...(frozenFormSchema ? { formSchema: frozenFormSchema } : {}),
     currentNodeKey: row.current_node_key,
     ...(currentNodeKeys ? { currentNodeKeys } : {}),
     assignments,
@@ -3947,6 +3951,17 @@ export class ApprovalProductService {
       [id],
     )
 
+    // Resolve the FROZEN form schema from the instance's pinned template version so detail
+    // columns travel with the instance read (the live template may have changed since).
+    let frozenFormSchema: FormSchema | null = null
+    if (row.template_version_id) {
+      const versionResult = await pool.query<{ form_schema: Record<string, unknown> }>(
+        `SELECT form_schema FROM approval_template_versions WHERE id = $1`,
+        [row.template_version_id],
+      )
+      if (versionResult.rows[0]) frozenFormSchema = asFormSchema(versionResult.rows[0].form_schema)
+    }
+
     return toUnifiedApprovalDTO(
       row,
       assignmentsResult.rows.map((assignment) => ({
@@ -3958,6 +3973,7 @@ export class ApprovalProductService {
         isActive: assignment.is_active,
         metadata: assignment.metadata || {},
       })),
+      frozenFormSchema,
     )
   }
 

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -7,6 +7,7 @@
 
 import type { QueryResult } from '../data-adapters/BaseAdapter'
 import type { ApprovalHistoryEntry, ApprovalRequest } from '../data-adapters/PLMAdapter'
+import type { FormSchema } from '../types/approval-product'
 
 // ── Unified Approval DTO (API response shape) ──
 
@@ -28,6 +29,9 @@ export interface UnifiedApprovalDTO {
   publishedDefinitionId?: string | null
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
+  // Frozen form schema (detail `columns` included) from the instance's pinned template version,
+  // so the read renders detail rows from the FROZEN schema, not the live template.
+  formSchema?: FormSchema | null
   currentNodeKey?: string | null
   /**
    * Parallel gateway (并行分支) — populated only when the instance is in a

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -313,6 +313,9 @@ export interface UnifiedApprovalDTO {
   publishedDefinitionId?: string | null
   requestNo?: string | null
   formSnapshot?: Record<string, unknown> | null
+  // Frozen form schema from the instance's pinned template version (detail `columns` included),
+  // so the read renders detail rows from the FROZEN schema, not the live template.
+  formSchema?: FormSchema | null
   currentNodeKey?: string | null
   /**
    * Parallel gateway (并行分支) — populated only when the instance is in

--- a/packages/core-backend/tests/integration/approval-detail-subform.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-detail-subform.db.test.ts
@@ -153,4 +153,22 @@ describeIfDatabase('detail / sub-form (明细) submit→freeze→read — real-D
     expect(bad.status).toBe(400)
     expect(await bad.text()).toMatch(/items\[0\]\.qty is required/)
   })
+
+  it('exposes the frozen detail columns on the instance read (GET /api/approvals/:id — closes Fact B) [C-3a]', async () => {
+    const started = await req(base, '/api/approvals', reqTok, {
+      method: 'POST',
+      body: { templateId: tid, formData: { items: [{ product: 'A', qty: 1 }] } },
+    })
+    const body = (await started.json()) as { id?: string; data?: { id: string } }
+    const aid = body.id ?? body.data?.id
+    const read = await req(base, `/api/approvals/${aid}`, reqTok)
+    expect(read.status).toBe(200)
+    const dto = (await read.json()) as {
+      formSchema?: { fields: Array<{ id: string; columns?: Array<{ id: string }> }> }
+      data?: { formSchema?: { fields: Array<{ id: string; columns?: Array<{ id: string }> }> } }
+    }
+    const schema = dto.formSchema ?? dto.data?.formSchema
+    const detail = schema?.fields.find((field) => field.id === 'items')
+    expect(detail?.columns?.map((column) => column.id)).toEqual(['product', 'qty', 'memo'])
+  })
 })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1857,6 +1857,9 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
         return { rows: [buildInstanceRow({ status: 'approved', current_node_key: null })], rowCount: 1 }
       }
+      if (statement.startsWith('SELECT form_schema FROM approval_template_versions WHERE id = $1')) {
+        return { rows: [{ form_schema: { fields: [] } }], rowCount: 1 }
+      }
       if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
         return { rows: [], rowCount: 0 }
       }


### PR DESCRIPTION
Third slice of the **C 明细/子表单** arc (design-lock #3082; C-1 #3086; C-2 #3088). Surfaces the **frozen** form schema (detail `columns` included) on the approval instance read so consumers render detail rows from the pinned template version, **not** the live template (closes design-lock **Fact B**). Prereq for the C-3 detail-view renderer.

## Changes
- `UnifiedApprovalDTO` gains `formSchema?: FormSchema | null` on all three shapes (product, bridge, FE).
- The route reads via `ApprovalBridgeService.getApproval` → attaches the version's `form_schema` by the instance's pinned `template_version_id`; product `getApproval` / `toUnifiedApprovalDTO` mirror it for consistency. **Null** for external/versionless instances.

## Tests
Real-DB test (extends `approval-detail-subform.db.test.ts`): `GET /api/approvals/:id` returns the frozen detail `columns`. Whole detail file green (5/5). tsc (BE + FE) + lint clean.

Additive + read-only. The detail-view **renderer** that consumes this is the next C-3 slice (UI). TODO: C-3a done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)