### PR TITLE
fix(multitable): layer-3 per-subject write gate on single-record restore-execute (T6-2 P1)

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7849,7 +7849,7 @@ export function univerMetaRouter(): Router {
 
       const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
       if (!patchContext) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
-      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById } = patchContext
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
       const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
 
       // Schema drift: a snapshot field absent from the current schema can't be faithfully reproduced. The preview
@@ -7880,6 +7880,19 @@ export function univerMetaRouter(): Router {
       // identity for an empty diff, so a forged/arbitrary token 409s at the verify above; a success ALWAYS
       // consumes a valid preview identity, never an empty-selection bypass.
       if (selectedDiff.length === 0) return res.json({ ok: true, data: { recordId, newVersion: currentVersion, noop: true, restoredFieldIds: [] } })
+      // Layer-3 per-subject WRITE gate (parity with the legacy /restore + the BS-3 batch fan-out): `allowed` is a
+      // READ mask (visible) and patchRecords enforces only FIELD-DEFINITION readonly — so a per-subject
+      // visible-but-readOnly field would otherwise be written. Gate the selected diff on the SAME derive
+      // (fieldPermissions) and reject before any write. The field ids are NOT echoed (server-derived from the
+      // unmasked snapshot — echoing would leak hidden-field metadata), matching the legacy /restore's message.
+      const hasForbidden = selectedDiff.some((ch) => {
+        const guard = fieldById.get(ch.fieldId)
+        const perm = fieldPermissions[ch.fieldId]
+        const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
+        const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
+        return !staticOk || !layer3Ok
+      })
+      if (hasForbidden) return res.status(403).json({ ok: false, error: { code: 'RESTORE_FORBIDDEN', message: 'Not permitted to restore one or more fields in this revision' } })
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
       if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])

--- a/packages/core-backend/tests/integration/multitable-restore-execute-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-execute-realdb.test.ts
@@ -75,6 +75,18 @@ describeIfDatabase('multitable scoped restore execute — T6-2 (real DB)', () =>
     expect(await recordData(REC)).toMatchObject({ [NAME]: 'a', [SALARY]: 100 }) // restored to v1
   })
 
+  test('layer-3 write gate: a VISIBLE+readOnly field in the restore → 403 RESTORE_FORBIDDEN, nothing written', async () => {
+    // SALARY: visible=true, read_only=true for the actor (per-subject layer-3 write-deny). patchRecords does NOT
+    // enforce this; only the route can. SALARY is VISIBLE so it is in the previewed diff + the identity — the gate
+    // must reject the WRITE (parity with the legacy /restore + the BS-3 batch fan-out). Closes the shipped T6-2 gap.
+    await q(`INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,'user',$3,true,true) ON CONFLICT DO NOTHING`, [SHEET, SALARY, VIEWER])
+    const identity = (await preview(REC, { targetVersion: 1 })).body?.data?.previewIdentity as string
+    const ex = await execute(REC, { targetVersion: 1, expectedVersion: 2, previewIdentity: identity })
+    expect(ex.status).toBe(403)
+    expect(ex.body?.error?.code).toBe('RESTORE_FORBIDDEN')
+    expect(await recordData(REC)).toMatchObject({ [NAME]: 'b', [SALARY]: 200 }) // NOT restored — gated before any write
+  })
+
   test('identity required: a missing identity is 400; a tampered identity is rejected (the route enforces verify)', async () => {
     expect((await execute(REC, { targetVersion: 1, expectedVersion: 2 })).status).toBe(400) // missing
     const identity = (await preview(REC, { targetVersion: 1 })).body?.data?.previewIdentity as string


### PR DESCRIPTION
The separate **P1 follow-up** flagged during the #3085 review: the **shipped** single-record `restore-execute` (T6-2) had the **same** layer-3 write gap that BS-3 fixed — pre-existing, not a BS-3 regression.

## The gap
It masked the diff with `allowed` (a **read** mask: visible ∧ field_permissions-visible) and relied on `patchRecords`, which enforces only **field-definition** readonly, **not** per-subject `field_permissions.read_only`. So a **visible-but-readOnly** field was folded into the diff and **written**.

## Fix
Destructure `fieldPermissions` from `buildRecordPatchContext` + gate the selected diff **before the write** with the *exact* legacy `/restore` derive (`staticOk = !hidden ∧ !field-def-readOnly`; `layer3Ok = perm.visible !== false ∧ perm.readOnly !== true`) → **403 RESTORE_FORBIDDEN** (forbidden ids not echoed — server-derived from the unmasked snapshot). Runs after the identity verify + empty-noop, before `patchRecords`.

## Verification
Real-DB golden: a visible+readOnly field in the restore → **403 RESTORE_FORBIDDEN**, record **not** written. **Mutation-proven** (disable the gate → golden fails, residue 0). 8/8 single-execute goldens; `tsc` clean.

Parity now holds across all three restore write paths (legacy `/restore`, single `restore-execute`, BS-3 batch fan-out). The single *preview* still offers readonly fields (read-only misleading-preview nit, not a write vuln) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)