### PR TITLE
feat(attendance): team-availability admin UI section (#6 TA-3)

### DIFF
--- a/apps/web/src/services/attendance/teamAvailability.ts
+++ b/apps/web/src/services/attendance/teamAvailability.ts
@@ -1,0 +1,121 @@
+import { apiFetch } from '../../utils/api'
+
+// #6 TA-2/TA-3 (design-lock #3056): team-availability read surface. Mirrors fetchEffectiveCalendar's
+// apiFetch/{ok,data}/error pattern, but a DISTINCT response shape (per-member state + per-date summary).
+
+export type TeamAvailabilityState =
+  | 'scheduled'
+  | 'rest'
+  | 'approved_leave'
+  | 'pending_leave'
+  | 'unscheduled'
+
+export interface TeamAvailabilityItem {
+  date: string
+  userId: string
+  state: TeamAvailabilityState
+}
+
+export interface TeamAvailabilityDaySummary {
+  date: string
+  scheduled: number
+  rest: number
+  approvedLeave: number
+  pendingLeaveTentative: number
+  unscheduled: number
+  /** §3a: scheduled + pendingLeaveTentative — pending does NOT reduce the formal available headcount. */
+  availableFormal: number
+}
+
+export interface TeamAvailabilityResponse {
+  groupId: string
+  range: { from: string; to: string }
+  members: number
+  items: TeamAvailabilityItem[]
+  summary: TeamAvailabilityDaySummary[]
+}
+
+export interface FetchTeamAvailabilityOptions {
+  groupId: string
+  from: string
+  to: string
+  suppressUnauthorizedRedirect?: boolean
+  signal?: AbortSignal
+}
+
+export class TeamAvailabilityFetchError extends Error {
+  status: number
+  code?: string
+  constructor(message: string, status: number, code?: string) {
+    super(message)
+    this.name = 'TeamAvailabilityFetchError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export async function fetchTeamAvailability(
+  options: FetchTeamAvailabilityOptions,
+): Promise<TeamAvailabilityResponse> {
+  const { groupId, from, to, suppressUnauthorizedRedirect, signal } = options
+  if (!groupId) {
+    throw new Error('fetchTeamAvailability: "groupId" is required (v1 is group-only).')
+  }
+  if (!from || !to) {
+    throw new Error('fetchTeamAvailability: "from" and "to" are required.')
+  }
+
+  const query = new URLSearchParams({ groupId, from, to })
+  const response = await apiFetch(`/api/attendance/team-availability?${query.toString()}`, {
+    suppressUnauthorizedRedirect: suppressUnauthorizedRedirect ?? true,
+    signal,
+  })
+  let data: any = null
+  try {
+    data = await response.json()
+  } catch {
+    data = null
+  }
+  if (!response.ok || data?.ok === false) {
+    const message = data?.error?.message
+      ?? `Failed to load team availability (HTTP ${response.status}).`
+    throw new TeamAvailabilityFetchError(message, response.status, data?.error?.code)
+  }
+  return data?.data as TeamAvailabilityResponse
+}
+
+// §3c state → presentation. pending_leave is PROVISIONAL: visually + semantically distinct from
+// approved_leave, carries the "待审批，未生效" tooltip, and is NEVER treated as a deduction (it stays in
+// availableFormal, §3a). Pure function — unit-tested without a DOM.
+export interface TeamAvailabilityStateMeta {
+  state: TeamAvailabilityState
+  className: string
+  provisional: boolean
+  zhShort: string
+  zhLabel: string
+  enLabel: string
+  /** §3c — only pending carries the not-yet-effective note. */
+  zhTooltip?: string
+  enTooltip?: string
+}
+
+const STATE_META: Record<TeamAvailabilityState, TeamAvailabilityStateMeta> = {
+  scheduled: { state: 'scheduled', className: 'ta-state--scheduled', provisional: false, zhShort: '班', zhLabel: '排班', enLabel: 'Scheduled' },
+  rest: { state: 'rest', className: 'ta-state--rest', provisional: false, zhShort: '休', zhLabel: '休息', enLabel: 'Rest' },
+  approved_leave: { state: 'approved_leave', className: 'ta-state--approved-leave', provisional: false, zhShort: '假', zhLabel: '已批请假', enLabel: 'Approved leave' },
+  pending_leave: {
+    state: 'pending_leave',
+    className: 'ta-state--pending-leave',
+    provisional: true,
+    zhShort: '待',
+    zhLabel: '待审批请假',
+    enLabel: 'Pending leave',
+    zhTooltip: '待审批，未生效',
+    enTooltip: 'Pending approval, not yet effective',
+  },
+  unscheduled: { state: 'unscheduled', className: 'ta-state--unscheduled', provisional: false, zhShort: '—', zhLabel: '未排班', enLabel: 'Unscheduled' },
+}
+
+export function teamAvailabilityStateMeta(state: TeamAvailabilityState): TeamAvailabilityStateMeta {
+  return STATE_META[state] ?? STATE_META.unscheduled
+}

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5508,6 +5508,14 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.teamAvailability)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.teamAvailability)"
+            >
+              <AttendanceTeamAvailabilitySection :tr="tr" />
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.reportFields)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.reportFields)"
@@ -8277,6 +8285,7 @@ import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
 import AttendanceCalendarPolicyQuickAdd from './attendance/AttendanceCalendarPolicyQuickAdd.vue'
 import AttendanceCalendarPolicyPreviewPanel from './attendance/AttendanceCalendarPolicyPreviewPanel.vue'
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
+import AttendanceTeamAvailabilitySection from './attendance/AttendanceTeamAvailabilitySection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'
 import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'

--- a/apps/web/src/views/attendance/AttendanceTeamAvailabilitySection.vue
+++ b/apps/web/src/views/attendance/AttendanceTeamAvailabilitySection.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="attendance__admin-section" data-attendance-team-availability>
+    <div class="attendance__admin-section-header">
+      <h4>{{ tr('Team availability', '团队可用性') }}</h4>
+      <div class="attendance__admin-actions">
+        <button class="attendance__btn attendance__btn--primary" :disabled="loading || !canLoad" @click="reload">
+          {{ loading ? tr('Loading...', '加载中...') : tr('Load', '加载') }}
+        </button>
+      </div>
+    </div>
+
+    <p class="attendance__hint">
+      {{ tr(
+        'Read-only view of a group’s availability (scheduled / rest / approved-leave / pending-leave / unscheduled). Pending leave is shown as tentative — it is NOT subtracted from the available headcount.',
+        '某考勤组可用性的只读视图（排班 / 休息 / 已批请假 / 待审批请假 / 未排班）。待审批请假以“暂定”呈现 — 不从可用人数中扣减。',
+      ) }}
+    </p>
+
+    <div class="attendance__admin-grid">
+      <label class="attendance__field" for="attendance-ta-group">
+        <span>{{ tr('Group ID', '考勤组 ID') }}</span>
+        <input id="attendance-ta-group" v-model.trim="groupId" type="text" :placeholder="tr('attendance group UUID', '考勤组 UUID')" @keydown.enter.prevent="reload" />
+      </label>
+      <label class="attendance__field" for="attendance-ta-from">
+        <span>{{ tr('From', '起') }}</span>
+        <input id="attendance-ta-from" v-model="from" type="date" />
+      </label>
+      <label class="attendance__field" for="attendance-ta-to">
+        <span>{{ tr('To', '止') }}</span>
+        <input id="attendance-ta-to" v-model="to" type="date" />
+      </label>
+    </div>
+
+    <p v-if="errorText" class="attendance__error" data-attendance-team-availability-error>{{ errorText }}</p>
+
+    <template v-if="data">
+      <!-- §3a summary: availableFormal counts scheduled + pending; pending is tentative, never a deduction. -->
+      <table class="attendance__table" data-attendance-team-availability-summary>
+        <thead>
+          <tr>
+            <th>{{ tr('Date', '日期') }}</th>
+            <th>{{ tr('Available (formal)', '可用（正式）') }}</th>
+            <th>{{ tr('Scheduled', '排班') }}</th>
+            <th class="attendance-ta__col--provisional">{{ tr('Pending (tentative)', '待审批（暂定）') }}</th>
+            <th>{{ tr('Approved leave', '已批请假') }}</th>
+            <th>{{ tr('Rest', '休息') }}</th>
+            <th>{{ tr('Unscheduled', '未排班') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in data.summary" :key="row.date">
+            <td>{{ row.date }}</td>
+            <td><strong>{{ row.availableFormal }}</strong></td>
+            <td>{{ row.scheduled }}</td>
+            <td class="attendance-ta__col--provisional" :title="pendingTooltip">{{ row.pendingLeaveTentative }}</td>
+            <td>{{ row.approvedLeave }}</td>
+            <td>{{ row.rest }}</td>
+            <td>{{ row.unscheduled }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- member × date matrix; each cell is a state chip (pending = provisional style + tooltip). -->
+      <div class="attendance-ta__matrix-wrap">
+        <table class="attendance__table attendance-ta__matrix" data-attendance-team-availability-matrix>
+          <thead>
+            <tr>
+              <th>{{ tr('Member', '成员') }}</th>
+              <th v-for="d in dates" :key="d">{{ d }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="member in memberIds" :key="member">
+              <td class="attendance-ta__member">{{ member }}</td>
+              <td v-for="d in dates" :key="d">
+                <span
+                  v-if="metaAt(member, d)"
+                  class="attendance-ta__chip"
+                  :class="[metaAt(member, d)!.className, { 'attendance-ta__chip--provisional': metaAt(member, d)!.provisional }]"
+                  :title="chipTitle(metaAt(member, d)!)"
+                >{{ tr(metaAt(member, d)!.enLabel, metaAt(member, d)!.zhLabel) }}</span>
+                <span v-else class="attendance-ta__chip attendance-ta__chip--none">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- legend -->
+      <p class="attendance__hint attendance-ta__legend">
+        <span class="attendance-ta__chip attendance-ta__chip--provisional ta-state--pending-leave" :title="pendingTooltip">{{ tr('Pending leave', '待审批请假') }}</span>
+        {{ tr('= pending approval, not yet effective (shown distinct from approved leave).', '= 待审批，未生效（与已批请假明确区分）。') }}
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { TranslateFn } from './useAttendanceAdminRail'
+import { useTeamAvailability } from './useTeamAvailability'
+import { teamAvailabilityStateMeta, type TeamAvailabilityStateMeta } from '../../services/attendance/teamAvailability'
+
+const props = defineProps<{ tr: TranslateFn }>()
+const tr = props.tr
+
+const groupId = ref('')
+const from = ref('')
+const to = ref('')
+
+const { data, loading, errorStatus, errorMessage, load } = useTeamAvailability()
+
+const canLoad = computed(() => Boolean(groupId.value && from.value && to.value))
+const pendingTooltip = computed(() => tr('Pending approval, not yet effective', '待审批，未生效'))
+
+const errorText = computed(() => {
+  if (errorStatus.value === null && !errorMessage.value) return ''
+  if (errorStatus.value === 403) return tr('You do not have permission to view this group.', '你没有查看该考勤组的权限。')
+  if (errorStatus.value === 404) return tr('Attendance group not found.', '考勤组不存在。')
+  return errorMessage.value ?? tr('Failed to load team availability.', '加载团队可用性失败。')
+})
+
+// unique sorted dates (from the summary) + unique members (from items).
+const dates = computed(() => (data.value?.summary ?? []).map((s) => s.date))
+const memberIds = computed(() => {
+  const seen = new Set<string>()
+  for (const it of data.value?.items ?? []) seen.add(it.userId)
+  return Array.from(seen).sort()
+})
+
+const metaIndex = computed(() => {
+  const map = new Map<string, TeamAvailabilityStateMeta>()
+  for (const it of data.value?.items ?? []) map.set(`${it.userId}|${it.date}`, teamAvailabilityStateMeta(it.state))
+  return map
+})
+function metaAt(member: string, date: string): TeamAvailabilityStateMeta | undefined {
+  return metaIndex.value.get(`${member}|${date}`)
+}
+function chipTitle(meta: TeamAvailabilityStateMeta): string {
+  const note = tr(meta.enTooltip ?? '', meta.zhTooltip ?? '')
+  const label = tr(meta.enLabel, meta.zhLabel)
+  return note ? `${label} — ${note}` : label
+}
+
+async function reload(): Promise<void> {
+  if (!canLoad.value) return
+  await load(groupId.value, from.value, to.value)
+}
+</script>
+
+<style scoped>
+.attendance-ta__matrix-wrap { overflow-x: auto; }
+.attendance-ta__member { font-family: var(--font-mono, monospace); font-size: 0.85em; white-space: nowrap; }
+.attendance-ta__col--provisional { color: #b45309; }
+.attendance-ta__chip {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8em;
+  line-height: 1.4;
+  border-left: 3px solid transparent;
+}
+.attendance-ta__chip--none { color: var(--text-muted, #6e7681); }
+.ta-state--scheduled { background: #e6f4ea; border-left-color: #2e7d32; }
+.ta-state--rest { background: #f1f3f5; border-left-color: #6e7681; }
+.ta-state--approved-leave { background: #fdecea; border-left-color: #d73a4a; }
+.ta-state--unscheduled { background: #f8f9fa; border-left-color: #ced4da; color: #6e7681; }
+/* §3c: pending is PROVISIONAL — a distinct dashed, amber, lower-emphasis style, never the approved red. */
+.ta-state--pending-leave,
+.attendance-ta__chip--provisional {
+  background: #fff8e1;
+  border-left-color: #f59e0b;
+  border-left-style: dashed;
+  color: #92400e;
+  font-style: italic;
+}
+</style>

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -21,6 +21,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   ruleTemplateLibrary: 'attendance-admin-rule-template-library',
   attendanceGroups: 'attendance-admin-groups',
   groupMembers: 'attendance-admin-group-members',
+  teamAvailability: 'attendance-admin-team-availability',
   import: 'attendance-admin-import',
   importBatches: 'attendance-admin-import-batches',
   reportFields: 'attendance-admin-report-fields',
@@ -174,6 +175,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.ruleTemplateLibrary, label: tr('Rule Template Library', '规则模板库') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.attendanceGroups, label: tr('Attendance groups', '考勤组') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.groupMembers, label: tr('Group members', '分组成员') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.teamAvailability, label: tr('Team availability', '团队可用性') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.import, label: tr('Import', '导入') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.importBatches, label: tr('Import batches', '导入批次') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.reportFields, label: tr('Report fields', '统计字段') },
@@ -227,6 +229,7 @@ export function useAttendanceAdminRail({
       itemIds: [
         ATTENDANCE_ADMIN_SECTION_IDS.attendanceGroups,
         ATTENDANCE_ADMIN_SECTION_IDS.groupMembers,
+        ATTENDANCE_ADMIN_SECTION_IDS.teamAvailability,
       ],
     },
     {

--- a/apps/web/src/views/attendance/useTeamAvailability.ts
+++ b/apps/web/src/views/attendance/useTeamAvailability.ts
@@ -17,6 +17,9 @@ export function useTeamAvailability() {
     loading.value = true
     errorStatus.value = null
     errorMessage.value = null
+    // Clear stale results at the START of a new load (owner review of #3095 §P2): while the request is in
+    // flight, the section must NOT render the previous group's matrix under the new form values.
+    data.value = null
     try {
       data.value = await fetchTeamAvailability({ groupId, from, to })
     } catch (e) {

--- a/apps/web/src/views/attendance/useTeamAvailability.ts
+++ b/apps/web/src/views/attendance/useTeamAvailability.ts
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+import {
+  fetchTeamAvailability,
+  TeamAvailabilityFetchError,
+  type TeamAvailabilityResponse,
+} from '../../services/attendance/teamAvailability'
+
+// #6 TA-3: load-and-clear state for the team-availability section. The clear-on-failure invariant is the
+// acceptance criterion "403/404/failed query clears old data" — a stale group's table must never linger.
+export function useTeamAvailability() {
+  const data = ref<TeamAvailabilityResponse | null>(null)
+  const loading = ref(false)
+  const errorStatus = ref<number | null>(null)
+  const errorMessage = ref<string | null>(null)
+
+  async function load(groupId: string, from: string, to: string): Promise<void> {
+    loading.value = true
+    errorStatus.value = null
+    errorMessage.value = null
+    try {
+      data.value = await fetchTeamAvailability({ groupId, from, to })
+    } catch (e) {
+      // CLEAR old results on any failure (403/404/network) — never show the previous group's table.
+      data.value = null
+      errorStatus.value = e instanceof TeamAvailabilityFetchError ? e.status : null
+      errorMessage.value = e instanceof Error ? e.message : 'Failed to load team availability.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function reset(): void {
+    data.value = null
+    errorStatus.value = null
+    errorMessage.value = null
+  }
+
+  return { data, loading, errorStatus, errorMessage, load, reset }
+}

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,7 +124,7 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Annual leave', 'Data & Payroll'])
-    expect(labels).toHaveLength(30)
+    expect(labels).toHaveLength(31)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Annual leave balance',
@@ -135,6 +135,7 @@ describe('Attendance admin anchor navigation', () => {
         'Notification deliveries',
         'Advanced scheduling',
         'Comprehensive hours',
+        'Team availability',
         'Import',
         'Import batches',
         'Report fields',
@@ -830,7 +831,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(30)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(31)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/teamAvailability.spec.ts
+++ b/apps/web/tests/teamAvailability.spec.ts
@@ -12,8 +12,17 @@ import {
   type TeamAvailabilityResponse,
 } from '../src/services/attendance/teamAvailability'
 import { useTeamAvailability } from '../src/views/attendance/useTeamAvailability'
+import { createApp, nextTick } from 'vue'
+import AttendanceTeamAvailabilitySection from '../src/views/attendance/AttendanceTeamAvailabilitySection.vue'
 
 const apiFetchMock = vi.mocked(apiFetch)
+
+async function flushUi(cycles = 8): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -98,5 +107,67 @@ describe('useTeamAvailability — clear-on-failure invariant (403/404/failure cl
     await ta.load('ghost', '2026-09-21', '2026-09-21')
     expect(ta.data.value).toBeNull()
     expect(ta.errorStatus.value).toBe(404)
+  })
+})
+
+describe('AttendanceTeamAvailabilitySection — RENDER (the owner-enumerated §3c vitest criterion)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  function mountSection() {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    // ZH locale so the rendered tooltip is the §3c "待审批，未生效".
+    const app = createApp(AttendanceTeamAvailabilitySection, { tr: (_en: string, zh: string) => zh })
+    app.mount(container)
+    const fillForm = () => {
+      for (const [sel, value] of [['#attendance-ta-group', 'grp_1'], ['#attendance-ta-from', '2026-09-21'], ['#attendance-ta-to', '2026-09-21']] as const) {
+        const el = container.querySelector(sel) as HTMLInputElement
+        el.value = value
+        el.dispatchEvent(new Event('input'))
+      }
+    }
+    const clickLoad = () => (container.querySelector('.attendance__btn--primary') as HTMLButtonElement).click()
+    return { container, app, fillForm, clickLoad }
+  }
+
+  it('a mocked pending_leave item renders a PROVISIONAL matrix cell carrying the "待审批，未生效" tooltip; scheduled does not', async () => {
+    const { container, app, fillForm, clickLoad } = mountSection()
+    await flushUi()
+    fillForm()
+    await flushUi()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload())) // u1 pending_leave + u2 scheduled
+    clickLoad()
+    await flushUi()
+
+    const matrix = container.querySelector('[data-attendance-team-availability-matrix]')
+    expect(matrix, 'matrix renders after a successful load').toBeTruthy()
+    const provisional = matrix!.querySelectorAll('.attendance-ta__chip--provisional')
+    expect(provisional.length).toBe(1) // ONLY the pending_leave member's cell is provisional
+    expect((provisional[0] as HTMLElement).getAttribute('title')).toContain('待审批，未生效')
+    // 1 date × 2 members = 2 state cells; exactly one provisional → the scheduled cell is NOT provisional.
+    expect(matrix!.querySelectorAll('.attendance-ta__chip:not(.attendance-ta__chip--none)').length).toBe(2)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('a failed (404) load clears the rendered table — no stale matrix, error shown', async () => {
+    const { container, app, fillForm, clickLoad } = mountSection()
+    await flushUi()
+    fillForm()
+    await flushUi()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload()))
+    clickLoad()
+    await flushUi()
+    expect(container.querySelector('[data-attendance-team-availability-matrix]')).toBeTruthy()
+
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(404, { ok: false, error: { code: 'NOT_FOUND', message: 'gone' } }))
+    clickLoad()
+    await flushUi()
+    expect(container.querySelector('[data-attendance-team-availability-matrix]')).toBeNull()
+    expect(container.querySelector('[data-attendance-team-availability-error]')).toBeTruthy()
+
+    app.unmount()
+    container.remove()
   })
 })

--- a/apps/web/tests/teamAvailability.spec.ts
+++ b/apps/web/tests/teamAvailability.spec.ts
@@ -1,0 +1,102 @@
+// #6 TA-3 — team-availability service + §3c state presentation + clear-on-failure composable.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '../src/utils/api'
+import {
+  fetchTeamAvailability,
+  teamAvailabilityStateMeta,
+  type TeamAvailabilityResponse,
+} from '../src/services/attendance/teamAvailability'
+import { useTeamAvailability } from '../src/views/attendance/useTeamAvailability'
+
+const apiFetchMock = vi.mocked(apiFetch)
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function okPayload(): { ok: true; data: TeamAvailabilityResponse } {
+  return {
+    ok: true,
+    data: {
+      groupId: 'grp_1',
+      range: { from: '2026-09-21', to: '2026-09-21' },
+      members: 2,
+      items: [
+        { date: '2026-09-21', userId: 'u1', state: 'pending_leave' },
+        { date: '2026-09-21', userId: 'u2', state: 'scheduled' },
+      ],
+      summary: [
+        { date: '2026-09-21', scheduled: 1, rest: 0, approvedLeave: 0, pendingLeaveTentative: 1, unscheduled: 0, availableFormal: 2 },
+      ],
+    },
+  }
+}
+
+describe('fetchTeamAvailability', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+  afterEach(() => vi.clearAllMocks())
+
+  it('builds the group-only URL with groupId/from/to + suppressUnauthorizedRedirect default true', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload()))
+    await fetchTeamAvailability({ groupId: 'grp_1', from: '2026-09-21', to: '2026-09-22' })
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const [path, options] = apiFetchMock.mock.calls[0]
+    expect(path).toBe('/api/attendance/team-availability?groupId=grp_1&from=2026-09-21&to=2026-09-22')
+    expect((options as any)?.suppressUnauthorizedRedirect).toBe(true)
+  })
+
+  it('requires groupId (v1 group-only)', async () => {
+    await expect(fetchTeamAvailability({ groupId: '', from: '2026-09-21', to: '2026-09-21' })).rejects.toThrow(/groupId/)
+  })
+
+  it('throws TeamAvailabilityFetchError carrying status/code on 403 and 404', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(403, { ok: false, error: { code: 'FORBIDDEN', message: 'no' } }))
+    await expect(fetchTeamAvailability({ groupId: 'g', from: '2026-09-21', to: '2026-09-21' }))
+      .rejects.toMatchObject({ name: 'TeamAvailabilityFetchError', status: 403, code: 'FORBIDDEN' })
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(404, { ok: false, error: { code: 'NOT_FOUND', message: 'gone' } }))
+    await expect(fetchTeamAvailability({ groupId: 'g', from: '2026-09-21', to: '2026-09-21' }))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' })
+  })
+})
+
+describe('teamAvailabilityStateMeta (§3c — provisional, distinct from approved)', () => {
+  it('pending_leave is PROVISIONAL with the "待审批，未生效" tooltip', () => {
+    const m = teamAvailabilityStateMeta('pending_leave')
+    expect(m.provisional).toBe(true)
+    expect(m.zhTooltip).toBe('待审批，未生效')
+    expect(m.enTooltip).toBe('Pending approval, not yet effective')
+  })
+  it('pending_leave is NOT equated with approved_leave (distinct class, not provisional, no not-yet-effective tooltip)', () => {
+    const pending = teamAvailabilityStateMeta('pending_leave')
+    const approved = teamAvailabilityStateMeta('approved_leave')
+    expect(pending.className).not.toBe(approved.className)
+    expect(approved.provisional).toBe(false)
+    expect(approved.zhTooltip).toBeUndefined()
+  })
+})
+
+describe('useTeamAvailability — clear-on-failure invariant (403/404/failure clears old data)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('load success sets data; a subsequent failed query CLEARS the stale table + records the status', async () => {
+    const ta = useTeamAvailability()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload()))
+    await ta.load('grp_1', '2026-09-21', '2026-09-21')
+    expect(ta.data.value?.members).toBe(2)
+    expect(ta.errorStatus.value).toBeNull()
+
+    // a 404 (e.g. a typo'd / deleted group) must NOT keep the previous group's table.
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(404, { ok: false, error: { code: 'NOT_FOUND', message: 'gone' } }))
+    await ta.load('ghost', '2026-09-21', '2026-09-21')
+    expect(ta.data.value).toBeNull()
+    expect(ta.errorStatus.value).toBe(404)
+  })
+})

--- a/apps/web/tests/teamAvailability.spec.ts
+++ b/apps/web/tests/teamAvailability.spec.ts
@@ -108,6 +108,22 @@ describe('useTeamAvailability — clear-on-failure invariant (403/404/failure cl
     expect(ta.data.value).toBeNull()
     expect(ta.errorStatus.value).toBe(404)
   })
+
+  it('clears the old table at the START of a new load — no stale group while the request is in flight', async () => {
+    const ta = useTeamAvailability()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload()))
+    await ta.load('grp_1', '2026-09-21', '2026-09-21')
+    expect(ta.data.value?.members).toBe(2)
+
+    // a second load whose request never resolves in this tick → the old data must be gone synchronously.
+    let resolveSecond: (r: Response) => void = () => {}
+    apiFetchMock.mockReturnValueOnce(new Promise<Response>((res) => { resolveSecond = res }))
+    const pending = ta.load('grp_b', '2026-09-22', '2026-09-22') // NOT awaited
+    expect(ta.data.value).toBeNull() // group A's table cleared the instant group B's load begins
+    expect(ta.loading.value).toBe(true)
+    resolveSecond(jsonResponse(200, okPayload()))
+    await pending
+  })
 })
 
 describe('AttendanceTeamAvailabilitySection — RENDER (the owner-enumerated §3c vitest criterion)', () => {
@@ -166,6 +182,26 @@ describe('AttendanceTeamAvailabilitySection — RENDER (the owner-enumerated §3
     await flushUi()
     expect(container.querySelector('[data-attendance-team-availability-matrix]')).toBeNull()
     expect(container.querySelector('[data-attendance-team-availability-error]')).toBeTruthy()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('starting a NEW load immediately removes the previous matrix (no stale table in-flight)', async () => {
+    const { container, app, fillForm, clickLoad } = mountSection()
+    await flushUi()
+    fillForm()
+    await flushUi()
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, okPayload()))
+    clickLoad()
+    await flushUi()
+    expect(container.querySelector('[data-attendance-team-availability-matrix]')).toBeTruthy()
+
+    // a second load whose request never resolves → the matrix must vanish the instant the load starts.
+    apiFetchMock.mockReturnValueOnce(new Promise<Response>(() => { /* never resolves */ }))
+    clickLoad()
+    await flushUi()
+    expect(container.querySelector('[data-attendance-team-availability-matrix]')).toBeNull()
 
     app.unmount()
     container.remove()


### PR DESCRIPTION
## #6 TA-3 — team-availability admin UI section

Per design-lock #3056 §3c + the owner's locked TA-3 scope. A **new read-only team-availability section** that makes the just-landed TA-2 endpoint visible — deliberately **not** a retrofit of the shared calendar chip (which would touch personal-calendar / scheduling-preview / multitable consumers). `calendarChipDisplay` / `CalendarEffectiveOverlayKind` are **untouched**.

### What's built
- **`services/attendance/teamAvailability.ts`** — `fetchTeamAvailability` (mirrors `fetchEffectiveCalendar`'s `apiFetch`/`{ok,data}`/error pattern, group-only) + `teamAvailabilityStateMeta`: §3c presentation where `pending_leave` is **provisional** (distinct class, the "待审批，未生效" tooltip), never equated with approved.
- **`views/attendance/useTeamAvailability.ts`** — load-and-clear composable: **403/404/failure clears the stale table** (never shows a prior group's results).
- **`views/attendance/AttendanceTeamAvailabilitySection.vue`** — group/date form → summary (**§3a** `availableFormal = scheduled + pendingLeaveTentative`, pending **not** a deduction) + a member×date matrix where pending renders dashed/amber/italic with the tooltip, **distinct from approved's red**.
- Registered in `useAttendanceAdminRail` (Organization group) + rendered in `AttendanceView`.

### Acceptance criteria (all met)
1. `pending_leave` provisional, **not** equated with `approved_leave` ✓ · 2. "待审批，未生效" text ✓ · 3. `availableFormal` includes pending (no deduction) ✓ · 4. 403/404/failure clears old data ✓ · 5. vitest: mapper provisional/tooltip · clear-on-failure · anchor-nav count ✓

### Tests (local vitest green, vue-tsc 0 errors)
`teamAvailability.spec.ts` (service URL/error + §3c mapper + clear-on-failure composable). **anchor-nav gate updated 30→31** (both count assertions) + asserts 'Team availability' present — that spec **mounts the full AttendanceView**, so it integration-checks the section renders.

> ⚠️ `tests/useAttendanceAdminRail.spec.ts` "persists focused mode" fails on **clean main too** (verified by stashing this change) — **pre-existing**, not introduced here.

Follow-ups (not v1): group **dropdown** (v1 uses a groupId input), TA-4 staging smoke, and — only if needed — extending the shared chip to show pending on personal/scheduling calendars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
