### PR TITLE
feat(approval): C-3b UI — detail/sub-form (明细) author + fill + detail view

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -1,0 +1,83 @@
+# Approval web guard (targeted gate).
+#
+# Why this exists: the main PR gate (plugin-tests.yml) runs core-backend tests and only
+# `pnpm --filter @metasheet/web build` for the web app — it does NOT run apps/web vitest
+# specs. So FE-only regressions on the approval surface slip through green CI. The detail /
+# sub-form (明细) UI ships pure (Element-Plus-free) helpers in approvals/detailField.ts whose
+# whole job is to (a) render historical rows from the FROZEN snapshot columns without re-fetching
+# the live template and (b) mirror the backend column-validation reject-set client-side — exactly
+# the kind of serialization/render contract a build-only gate can't catch.
+#
+# Scope (deliberately TARGETED, like multitable-web-guard / attendance-web-guard): run the green
+# approval FE helper/round-trip specs only. The full `@metasheet/web` vitest suite still has
+# historical/flaky failures, so wiring the whole suite as a required gate would be red on arrival.
+# Expand the `vitest run` filter as more approval web specs are added.
+name: Approval Web Guard
+
+on:
+  pull_request:
+    paths:
+      - 'apps/web/src/approvals/detailField.ts'
+      - 'apps/web/src/approvals/templateAuthoring.ts'
+      - 'apps/web/src/views/approval/ApprovalDetailView.vue'
+      - 'apps/web/src/views/approval/ApprovalNewView.vue'
+      - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
+      - 'apps/web/tests/approval-detail-field.test.ts'
+      - 'apps/web/tests/approval-template-authoring-detail.test.ts'
+      - '.github/workflows/approval-web-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/src/approvals/detailField.ts'
+      - 'apps/web/src/approvals/templateAuthoring.ts'
+      - 'apps/web/src/views/approval/ApprovalDetailView.vue'
+      - 'apps/web/src/views/approval/ApprovalNewView.vue'
+      - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
+      - 'apps/web/tests/approval-detail-field.test.ts'
+      - 'apps/web/tests/approval-template-authoring-detail.test.ts'
+      - '.github/workflows/approval-web-guard.yml'
+
+jobs:
+  approval-web-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run approval web guard specs (targeted)
+        # detail/sub-form (明细) FE helpers: frozen-schema row render + fill-row seeding +
+        # column-draft validation (mirrors backend normalizeDetailFieldParts) + buildFormSchema
+        # detail emit/round-trip + validateTemplateDraft detail branch.
+        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail --reporter=dot

--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -1,0 +1,346 @@
+import type { FormField, FormFieldType, FormOption, FormSchema } from '../types/approval'
+import { getVisibleFormFields, pruneHiddenFormData } from './fieldVisibility'
+
+/**
+ * Pure (Element-Plus-free) helpers for the `detail` / sub-form (明细/子表单) field type.
+ *
+ * The Vue views (`ApprovalDetailView`, `ApprovalNewView`, `TemplateAuthoringView`) pull in
+ * Element Plus CSS, which makes them un-importable under vitest. Everything testable about
+ * detail rendering / authoring therefore lives here so it can be unit-tested directly.
+ *
+ * Mirrors the backend contract in `packages/core-backend/src/services/ApprovalProductService.ts`
+ * (`normalizeDetailFieldParts`, `DETAIL_LEAF_FIELD_TYPES`): a `detail` field carries an ordered
+ * `columns: FormField[]` of LEAF sub-fields (never another `detail` — one nesting level), plus
+ * optional `minRows`/`maxRows`; a `detail` value is an array of row objects keyed by sub-field id.
+ */
+
+/**
+ * Leaf sub-field types allowed inside a `detail` group's `columns` — the 8 authorable scalar
+ * types (everything except `attachment`, which is not authorable, and `detail`, which would
+ * nest). Mirrors backend `DETAIL_LEAF_FIELD_TYPES`.
+ */
+export const DETAIL_LEAF_FIELD_TYPES: readonly FormFieldType[] = [
+  'text',
+  'textarea',
+  'number',
+  'date',
+  'datetime',
+  'select',
+  'multi-select',
+  'user',
+]
+
+export function isDetailLeafFieldType(type: FormFieldType): boolean {
+  return DETAIL_LEAF_FIELD_TYPES.includes(type)
+}
+
+export function isDetailField(field: Pick<FormField, 'type'>): boolean {
+  return field.type === 'detail'
+}
+
+/**
+ * Editable draft of a single detail sub-field (`columns[]` entry). Kept narrow on purpose —
+ * v1 authors id / type / label / required (+ select options); other leaf knobs ride `props`
+ * server-side and are out of the v1 authoring UI.
+ */
+export interface DetailColumnDraft {
+  localId: string
+  id: string
+  type: FormFieldType
+  label: string
+  required: boolean
+  optionsText: string
+  // The stored sub-field this draft hydrated from, preserved so backend-contract fields the v1
+  // UI does NOT manage (`props` incl. min/max/pattern constraints, `placeholder`, `defaultValue`,
+  // `visibilityRule`) round-trip intact instead of being silently flattened on save. Mirrors the
+  // top-level `FieldAuthoringDraft.original` discipline.
+  original?: FormField
+}
+
+let detailColumnSeq = 0
+
+/** Stable-enough local id for `v-for` keying of unsaved sub-field rows. */
+function nextDetailColumnLocalId(): string {
+  detailColumnSeq += 1
+  return `detailcol_${Date.now()}_${detailColumnSeq}`
+}
+
+export function createEmptyDetailColumnDraft(index = 1): DetailColumnDraft {
+  return {
+    localId: nextDetailColumnLocalId(),
+    id: `col_${index}`,
+    type: 'text',
+    label: `子字段 ${index}`,
+    required: false,
+    optionsText: '',
+  }
+}
+
+function formatOptionsText(options?: FormOption[]): string {
+  return (options ?? []).map((option) => `${option.label}:${option.value}`).join('\n')
+}
+
+function parseOptionsText(value: string): FormOption[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const separator = line.indexOf(':')
+      if (separator === -1) return { label: line, value: line }
+      return { label: line.slice(0, separator).trim(), value: line.slice(separator + 1).trim() }
+    })
+}
+
+/** Hydrate editable sub-field drafts from a stored `detail` field's frozen `columns`. */
+export function detailColumnDraftsFromField(field: FormField): DetailColumnDraft[] {
+  return (field.columns ?? []).map((column) => ({
+    localId: nextDetailColumnLocalId(),
+    id: column.id,
+    type: column.type,
+    label: column.label,
+    required: column.required === true,
+    optionsText: formatOptionsText(column.options),
+    original: column,
+  }))
+}
+
+/**
+ * Build the emitted `columns: FormField[]` for a detail field from its sub-field drafts. The
+ * stored `original` is spread FIRST so unmanaged backend-contract fields (`props`, `placeholder`,
+ * `defaultValue`, `visibilityRule`) survive, then only the UI-managed fields override it. `options`
+ * is deleted for non-select types so a type change does not strand a stale options array from the
+ * original (mirrors `buildFormSchema`'s top-level omit-empty discipline).
+ */
+export function buildDetailColumns(drafts: DetailColumnDraft[]): FormField[] {
+  return drafts.map((draft) => {
+    const base = draft.original ? { ...draft.original } : {}
+    const column: FormField = {
+      ...base,
+      id: draft.id.trim(),
+      type: draft.type,
+      label: draft.label.trim(),
+      required: draft.required,
+    }
+    if (draft.type === 'select' || draft.type === 'multi-select') {
+      column.options = parseOptionsText(draft.optionsText)
+    } else {
+      delete column.options
+    }
+    return column
+  })
+}
+
+/**
+ * Client-side detail-columns validator, mirroring the backend `normalizeDetailFieldParts`
+ * reject-set: non-empty columns; each sub-field id present + unique within the group; each
+ * sub-field a leaf type (reject `detail` / unknown); select/multi-select needs >=1 option;
+ * minRows/maxRows non-negative integers with `minRows <= maxRows`. `fieldLabel` prefixes each
+ * message so the author can locate the offending detail field.
+ *
+ * `minRowsText`/`maxRowsText` are the raw input strings (`''` = unset); they are validated as
+ * the authoring UI binds text inputs.
+ */
+export function validateDetailColumnsDraft(
+  fieldLabel: string,
+  columns: DetailColumnDraft[],
+  minRowsText: string,
+  maxRowsText: string,
+): string[] {
+  const errors: string[] = []
+  const label = fieldLabel || '(未命名明细)'
+
+  if (columns.length === 0) {
+    errors.push(`明细字段 ${label} 至少需要一个子字段`)
+  }
+
+  const ids = columns.map((column) => column.id.trim())
+  if (ids.some((id) => !id)) {
+    errors.push(`明细字段 ${label} 的子字段 id 必填`)
+  }
+  const presentIds = ids.filter(Boolean)
+  if (new Set(presentIds).size !== presentIds.length) {
+    errors.push(`明细字段 ${label} 的子字段 id 不能重复`)
+  }
+
+  columns.forEach((column) => {
+    const columnLabel = column.label.trim() || column.id.trim() || '(未命名)'
+    if (!column.label.trim()) {
+      errors.push(`明细字段 ${label} 的子字段 ${column.id.trim() || '(未命名)'} 名称必填`)
+    }
+    if (!isDetailLeafFieldType(column.type)) {
+      // Guards against `detail` (no nesting) and any unknown leaf type.
+      errors.push(`明细字段 ${label} 的子字段 ${columnLabel} 类型不支持`)
+    }
+    if (column.type === 'select' || column.type === 'multi-select') {
+      const options = parseOptionsText(column.optionsText)
+      if (options.length === 0) {
+        errors.push(`明细字段 ${label} 的子字段 ${columnLabel} 需要至少一个选项`)
+      } else if (options.some((option) => !option.label.trim() || !option.value.trim())) {
+        errors.push(`明细字段 ${label} 的子字段 ${columnLabel} 的选项 label/value 不能为空`)
+      }
+    }
+  })
+
+  const minRows = parseRowBound(minRowsText)
+  const maxRows = parseRowBound(maxRowsText)
+  if (minRows === 'invalid') errors.push(`明细字段 ${label} 的最小行数必须是非负整数`)
+  if (maxRows === 'invalid') errors.push(`明细字段 ${label} 的最大行数必须是非负整数`)
+  if (
+    typeof minRows === 'number'
+    && typeof maxRows === 'number'
+    && minRows > maxRows
+  ) {
+    errors.push(`明细字段 ${label} 的最小行数不能大于最大行数`)
+  }
+
+  return errors
+}
+
+/** Parse a row-bound text input → number | undefined (unset) | 'invalid' (non-negative-int rule). */
+export function parseRowBound(value: string): number | undefined | 'invalid' {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const parsed = Number(trimmed)
+  if (!Number.isInteger(parsed) || parsed < 0) return 'invalid'
+  return parsed
+}
+
+/**
+ * Build an empty fill row for a detail field's `columns`: each leaf cell seeded with a sensible
+ * empty value (`[]` for multi-select so the multi `el-select` binds an array; `undefined`
+ * otherwise). Pure → unit-tested; the fill view appends the result to `formData[field.id]`.
+ */
+export function createEmptyDetailRow(columns: FormField[] | undefined): Record<string, unknown> {
+  const row: Record<string, unknown> = {}
+  for (const column of columns ?? []) {
+    row[column.id] = column.type === 'multi-select' ? [] : undefined
+  }
+  return row
+}
+
+/**
+ * Per-row sub-field visibility (design-lock §4 "sub-field visibilityRule hides cells live").
+ * A sub-field's `visibilityRule.fieldId` resolves to a SAME-ROW sub-field, so we evaluate the
+ * existing `fieldVisibility` engine against a sub-schema `{ fields: columns }` and the row as its
+ * form data. The fill view renders only the returned columns, and `pruneHiddenDetailRow` uses the
+ * SAME evaluation to drop hidden cells before submit — so what the user can't see never submits.
+ */
+export function visibleDetailColumnsForRow(
+  columns: FormField[] | undefined,
+  row: Record<string, unknown>,
+): FormField[] {
+  if (!Array.isArray(columns) || columns.length === 0) return []
+  return getVisibleFormFields({ fields: columns }, row ?? {})
+}
+
+/**
+ * Drop hidden cells (and any unknown keys) from a single detail row, keyed by the row's visible
+ * sub-fields. Mirrors the backend per-row `pruneHiddenFormData` recursion so the FE pre-submit
+ * payload matches what the backend would freeze.
+ */
+export function pruneHiddenDetailRow(
+  columns: FormField[] | undefined,
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const visibleIds = new Set(visibleDetailColumnsForRow(columns, row).map((column) => column.id))
+  const pruned: Record<string, unknown> = {}
+  for (const id of visibleIds) {
+    if (Object.prototype.hasOwnProperty.call(row, id)) pruned[id] = row[id]
+  }
+  return pruned
+}
+
+/**
+ * Prune hidden cells from every row of a detail field's value array. Non-array values pass
+ * through unchanged (the caller validates shape elsewhere).
+ */
+export function pruneHiddenDetailRows(field: Pick<FormField, 'columns'>, value: unknown): unknown {
+  if (!Array.isArray(value)) return value
+  return value.map((entry) =>
+    pruneHiddenDetailRow(field.columns, entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : {}),
+  )
+}
+
+/**
+ * Submit-time prune for an approval form that may contain `detail` fields. First applies the
+ * existing top-level `pruneHiddenFormData` (drops hidden TOP-LEVEL fields), then recurses into
+ * each surviving `detail` field's rows to drop per-row hidden cells (design-lock §3 prune-on-write,
+ * §4 same per-row visibility). Kept here (not in `fieldVisibility.ts`) so the detail recursion does
+ * not create an import cycle. Render and pre-submit prune therefore share `visibleDetailColumnsForRow`.
+ */
+export function pruneHiddenFormDataWithDetail(
+  formSchema: FormSchema,
+  formData: Record<string, unknown>,
+): Record<string, unknown> {
+  const topLevel = pruneHiddenFormData(formSchema, formData)
+  const detailFieldsById = new Map(
+    formSchema.fields.filter((field) => field.type === 'detail').map((field) => [field.id, field]),
+  )
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(topLevel)) {
+    const detailField = detailFieldsById.get(key)
+    result[key] = detailField ? pruneHiddenDetailRows(detailField, value) : value
+  }
+  return result
+}
+
+export interface DetailDisplayColumn {
+  id: string
+  label: string
+  type: FormFieldType
+  options?: FormOption[]
+}
+
+export interface DetailDisplayTable {
+  columns: DetailDisplayColumn[]
+  /** One entry per snapshot row; `cells` is keyed by sub-field id (raw frozen value). */
+  rows: Array<{ key: string; cells: Record<string, unknown> }>
+}
+
+/**
+ * Build the read-only table model for a `detail` field's frozen snapshot value, driven by the
+ * field's FROZEN `columns` (resolved from the instance's pinned template version — never the
+ * live template). Returns `null` when the field has no `columns` (not a usable detail) or the
+ * snapshot value is not an array — callers then fall back to the existing stringify rendering.
+ */
+export function buildDetailRowsForDisplay(
+  field: Pick<FormField, 'columns'> | undefined,
+  snapshotValue: unknown,
+): DetailDisplayTable | null {
+  const columns = field?.columns
+  if (!Array.isArray(columns) || columns.length === 0) return null
+  if (!Array.isArray(snapshotValue)) return null
+
+  const displayColumns: DetailDisplayColumn[] = columns.map((column) => ({
+    id: column.id,
+    label: column.label || column.id,
+    type: column.type,
+    ...(column.options ? { options: column.options } : {}),
+  }))
+
+  const rows = snapshotValue.map((entry, index) => {
+    const cells: Record<string, unknown> = {}
+    const source = entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : {}
+    for (const column of displayColumns) {
+      cells[column.id] = source[column.id]
+    }
+    return { key: `row_${index}`, cells }
+  })
+
+  return { columns: displayColumns, rows }
+}
+
+/**
+ * Resolve a `formSchema` field by id, used by the detail view to find a snapshot key's frozen
+ * `detail` definition. Returns the field only when it is a `detail` carrying `columns`.
+ */
+export function findDetailFieldInSchema(
+  formSchema: FormSchema | null | undefined,
+  fieldId: string,
+): FormField | null {
+  if (!formSchema || !Array.isArray(formSchema.fields)) return null
+  const field = formSchema.fields.find((entry) => entry.id === fieldId)
+  if (!field || field.type !== 'detail' || !Array.isArray(field.columns)) return null
+  return field
+}

--- a/apps/web/src/approvals/detailField.ts
+++ b/apps/web/src/approvals/detailField.ts
@@ -234,6 +234,19 @@ export function visibleDetailColumnsForRow(
   return getVisibleFormFields({ fields: columns }, row ?? {})
 }
 
+// Per-cell live-hide decision for the fill table. Takes the OWNING detail field explicitly —
+// NOT a reverse-lookup by column.id, because sub-field ids are unique only WITHIN a group, so
+// two detail fields can both have a `note`/`kind` column. A cell is visible when its column has
+// no rule, or the row makes that column visible among ITS OWN group's columns.
+export function isDetailCellVisible(
+  detailField: FormField,
+  column: FormField,
+  row: Record<string, unknown>,
+): boolean {
+  if (!column.visibilityRule) return true
+  return visibleDetailColumnsForRow(detailField.columns, row).some((entry) => entry.id === column.id)
+}
+
 /**
  * Drop hidden cells (and any unknown keys) from a single detail row, keyed by the row's visible
  * sub-fields. Mirrors the backend per-row `pruneHiddenFormData` recursion so the FE pre-submit

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -16,10 +16,23 @@ import type {
   CreateApprovalTemplateRequest,
   UpdateApprovalTemplateRequest,
 } from '../types/approval'
+import {
+  buildDetailColumns,
+  detailColumnDraftsFromField,
+  validateDetailColumnsDraft,
+  type DetailColumnDraft,
+} from './detailField'
+
+export type { DetailColumnDraft } from './detailField'
+export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
 
+// Top-level authorable field types: the 8 leaf scalar types plus `detail` (repeatable
+// line-items group). `attachment` is intentionally excluded (not authorable in v1); `detail`
+// is top-level-only — its sub-fields are restricted to the leaf set (`DETAIL_LEAF_FIELD_TYPES`)
+// and may never themselves be `detail` (one nesting level).
 export const AUTHORABLE_FIELD_TYPES: AuthorableFieldType[] = [
   'text',
   'textarea',
@@ -29,6 +42,7 @@ export const AUTHORABLE_FIELD_TYPES: AuthorableFieldType[] = [
   'select',
   'multi-select',
   'user',
+  'detail',
 ]
 
 /**
@@ -51,6 +65,11 @@ export interface FieldAuthoringDraft {
   placeholder: string
   optionsText: string
   visibility: FieldVisibilityDraft
+  // detail / sub-form authoring — meaningful only when `type === 'detail'`. `columns` is the
+  // editable sub-field list; `minRowsText`/`maxRowsText` are raw text inputs ('' = unset).
+  detailColumns: DetailColumnDraft[]
+  minRowsText: string
+  maxRowsText: string
   original?: FormField
 }
 
@@ -112,6 +131,9 @@ export function createEmptyFieldDraft(index = 1): FieldAuthoringDraft {
     placeholder: '',
     optionsText: '',
     visibility: emptyVisibilityDraft(),
+    detailColumns: [],
+    minRowsText: '',
+    maxRowsText: '',
   }
 }
 
@@ -229,6 +251,9 @@ function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
     placeholder: field.placeholder ?? '',
     optionsText: formatOptionsText(field.options),
     visibility: visibilityDraftFromRule(field.visibilityRule),
+    detailColumns: field.type === 'detail' ? detailColumnDraftsFromField(field) : [],
+    minRowsText: field.type === 'detail' && field.minRows != null ? String(field.minRows) : '',
+    maxRowsText: field.type === 'detail' && field.maxRows != null ? String(field.maxRows) : '',
     original: field,
   }
 }
@@ -444,6 +469,23 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
       } else {
         delete next.options
       }
+      // detail / sub-form: emit `columns` + optional `minRows`/`maxRows` from the sub-field
+      // editor, or delete all three so a field changed away from `detail` does not carry stale
+      // detail keys resurrected from the `original` spread (mirrors the options omit discipline;
+      // the backend rejects detail-only keys on a non-detail field).
+      if (field.type === 'detail') {
+        next.columns = buildDetailColumns(field.detailColumns)
+        const minRows = field.minRowsText.trim()
+        const maxRows = field.maxRowsText.trim()
+        if (minRows) next.minRows = Number(minRows)
+        else delete next.minRows
+        if (maxRows) next.maxRows = Number(maxRows)
+        else delete next.maxRows
+      } else {
+        delete next.columns
+        delete next.minRows
+        delete next.maxRows
+      }
       // Editor is authoritative for visibilityRule: emit the built rule, or
       // delete it so a cleared rule is not resurrected from the `original` spread.
       const visibilityRule = buildVisibilityRule(field.visibility)
@@ -568,6 +610,18 @@ export function validateTemplateDraft(
       if (options.some((option) => !option.label.trim() || !option.value.trim())) {
         errors.push(`字段 ${field.label || field.id} 的选项 label/value 不能为空`)
       }
+    }
+    // detail / sub-form: mirror the backend `normalizeDetailFieldParts` reject-set client-side
+    // (non-empty leaf-only unique-id columns, no nesting, minRows <= maxRows non-negative ints).
+    if (field.type === 'detail') {
+      errors.push(
+        ...validateDetailColumnsDraft(
+          field.label.trim() || field.id.trim(),
+          field.detailColumns,
+          field.minRowsText,
+          field.maxRowsText,
+        ),
+      )
     }
   })
   // Mirror the server visibility-rule reject-set (normalizeFormFieldVisibilityRule +

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -75,7 +75,28 @@
               class="approval-detail__field"
             >
               <span class="approval-detail__label">{{ String(key) }}</span>
-              <span>{{ formatFieldValue(value) }}</span>
+              <!-- detail / sub-form (明细): render the frozen rows × columns as a read-only
+                   table driven by the instance's FROZEN formSchema columns (never the live
+                   template). Falls back to the stringify rendering when the field is not a
+                   usable detail or the value is not an array. -->
+              <el-table
+                v-if="detailTables[String(key)]"
+                :data="detailTables[String(key)].rows"
+                border
+                size="small"
+                class="approval-detail__detail-table"
+              >
+                <el-table-column
+                  v-for="column in detailTables[String(key)].columns"
+                  :key="column.id"
+                  :label="column.label"
+                >
+                  <template #default="{ row }">
+                    {{ formatFieldValue(row.cells[column.id]) }}
+                  </template>
+                </el-table-column>
+              </el-table>
+              <span v-else>{{ formatFieldValue(value) }}</span>
             </div>
           </div>
           <el-empty v-else description="暂无表单数据" :image-size="80" />
@@ -535,6 +556,11 @@ import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { markApprovalRead, remindApproval } from '../../approvals/api'
+import {
+  buildDetailRowsForDisplay,
+  findDetailFieldInSchema,
+  type DetailDisplayTable,
+} from '../../approvals/detailField'
 
 const route = useRoute()
 const router = useRouter()
@@ -543,6 +569,25 @@ const templateStore = useApprovalTemplateStore()
 const { canAct } = useApprovalPermissions()
 
 const approval = computed(() => store.activeApproval)
+
+// Read-only detail (明细) tables, keyed by snapshot field id. Built from the instance's FROZEN
+// formSchema (C-3a read-path) so a later column rename/reorder on the live template never
+// mis-renders frozen rows. A key is present only when the field is a `detail` carrying
+// `columns` AND its snapshot value is an array; everything else falls back to stringify.
+const detailTables = computed<Record<string, DetailDisplayTable>>(() => {
+  const snapshot = approval.value?.formSnapshot
+  const formSchema = approval.value?.formSchema
+  if (!snapshot || !formSchema) return {}
+  const result: Record<string, DetailDisplayTable> = {}
+  for (const [key, value] of Object.entries(snapshot)) {
+    const detailField = findDetailFieldInSchema(formSchema, key)
+    if (!detailField) continue
+    const table = buildDetailRowsForDisplay(detailField, value)
+    if (table) result[key] = table
+  }
+  return result
+})
+
 const isRequester = computed(() => {
   // Simple heuristic: mock current user as 'user_1'
   return approval.value?.requester?.id === 'user_1'
@@ -1066,6 +1111,10 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.approval-detail__detail-table {
+  margin-top: 4px;
 }
 
 .approval-detail__timeline-content {

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -148,6 +148,137 @@
               <el-option label="王五" value="user_3" />
             </el-select>
 
+            <!-- detail / sub-form (明细): editable rows × leaf-column cells. `formData[field.id]`
+                 is an array of row objects keyed by sub-field id; each cell reuses the matching
+                 leaf editor. Respects minRows/maxRows (add disabled at maxRows; remove disabled
+                 at minRows). The backend re-validates row count / required / per-cell types. -->
+            <div v-else-if="field.type === 'detail'" class="approval-new__detail">
+              <el-table
+                :data="detailRows(field.id)"
+                border
+                size="small"
+                class="approval-new__detail-table"
+              >
+                <el-table-column
+                  v-for="column in (field.columns || [])"
+                  :key="column.id"
+                  :label="column.label"
+                  :prop="column.id"
+                >
+                  <template #header>
+                    {{ column.label }}<span v-if="column.required" class="approval-new__detail-required">*</span>
+                  </template>
+                  <template #default="{ row }">
+                    <!-- per-row sub-field visibility (design-lock §4): a cell whose
+                         column.visibilityRule is false for THIS row renders nothing and is pruned
+                         from the submit payload by the same evaluation. -->
+                    <template v-if="isDetailCellVisible(column, row)">
+                    <el-input
+                      v-if="column.type === 'text'"
+                      v-model="row[column.id]"
+                      :placeholder="column.placeholder || column.label"
+                    />
+                    <el-input
+                      v-else-if="column.type === 'textarea'"
+                      v-model="row[column.id]"
+                      type="textarea"
+                      :rows="2"
+                      :placeholder="column.placeholder || column.label"
+                    />
+                    <el-input-number
+                      v-else-if="column.type === 'number'"
+                      v-model="row[column.id]"
+                      :controls="false"
+                      style="width: 100%"
+                    />
+                    <el-date-picker
+                      v-else-if="column.type === 'date'"
+                      v-model="row[column.id]"
+                      type="date"
+                      :placeholder="column.label"
+                      style="width: 100%"
+                    />
+                    <el-date-picker
+                      v-else-if="column.type === 'datetime'"
+                      v-model="row[column.id]"
+                      type="datetime"
+                      :placeholder="column.label"
+                      style="width: 100%"
+                    />
+                    <el-select
+                      v-else-if="column.type === 'select'"
+                      v-model="row[column.id]"
+                      :placeholder="column.label"
+                      style="width: 100%"
+                    >
+                      <el-option
+                        v-for="opt in (column.options || [])"
+                        :key="opt.value"
+                        :label="opt.label"
+                        :value="opt.value"
+                      />
+                    </el-select>
+                    <el-select
+                      v-else-if="column.type === 'multi-select'"
+                      v-model="row[column.id]"
+                      multiple
+                      :placeholder="column.label"
+                      style="width: 100%"
+                    >
+                      <el-option
+                        v-for="opt in (column.options || [])"
+                        :key="opt.value"
+                        :label="opt.label"
+                        :value="opt.value"
+                      />
+                    </el-select>
+                    <el-select
+                      v-else-if="column.type === 'user'"
+                      v-model="row[column.id]"
+                      placeholder="选择用户"
+                      filterable
+                      style="width: 100%"
+                    >
+                      <el-option label="张三" value="user_1" />
+                      <el-option label="李四" value="user_2" />
+                      <el-option label="王五" value="user_3" />
+                    </el-select>
+                    <el-input v-else v-model="row[column.id]" :placeholder="column.label" />
+                    </template>
+                  </template>
+                </el-table-column>
+                <el-table-column label="操作" width="80" align="center">
+                  <template #default="{ $index }">
+                    <el-button
+                      type="danger"
+                      link
+                      :disabled="!canRemoveDetailRow(field)"
+                      @click="removeDetailRow(field.id, $index)"
+                    >
+                      删除
+                    </el-button>
+                  </template>
+                </el-table-column>
+                <template #empty>
+                  <span class="approval-new__detail-empty">暂无明细行，请点击下方“添加一行”</span>
+                </template>
+              </el-table>
+              <div class="approval-new__detail-actions">
+                <el-button
+                  type="primary"
+                  plain
+                  size="small"
+                  :disabled="!canAddDetailRow(field)"
+                  @click="addDetailRow(field)"
+                >
+                  添加一行
+                </el-button>
+                <span v-if="detailRowsHint(field)" class="approval-new__detail-hint">
+                  {{ detailRowsHint(field) }}
+                </span>
+              </div>
+            </div>
+
             <!-- attachment (drag upload) -->
             <el-upload
               v-else-if="field.type === 'attachment'"
@@ -198,13 +329,16 @@ import { useRoute, useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
 import { ArrowLeft, Search, UploadFilled } from '@element-plus/icons-vue'
+import type { FormField } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
+import { getVisibleFormFields } from '../../approvals/fieldVisibility'
 import {
-  getVisibleFormFields,
-  pruneHiddenFormData,
-} from '../../approvals/fieldVisibility'
+  createEmptyDetailRow,
+  pruneHiddenFormDataWithDetail,
+  visibleDetailColumnsForRow,
+} from '../../approvals/detailField'
 
 const route = useRoute()
 const router = useRouter()
@@ -237,6 +371,62 @@ function handleFileChange(fieldId: string, file: any) {
   formData[fieldId] = file?.raw ?? null
 }
 
+// ---------------------------------------------------------------------------
+// detail / sub-form (明细) fill helpers — `formData[field.id]` is the row array.
+// ---------------------------------------------------------------------------
+function detailRows(fieldId: string): Array<Record<string, unknown>> {
+  const value = formData[fieldId]
+  return Array.isArray(value) ? (value as Array<Record<string, unknown>>) : []
+}
+
+// Per-row sub-field visibility (design-lock §4): is `column` visible for THIS row? The cell editor
+// renders only when true; the same evaluation (visibleDetailColumnsForRow → pruneHiddenDetailRow)
+// drops the cell from the submit payload, so hidden cells are never sent.
+function isDetailCellVisible(column: FormField, row: Record<string, unknown>): boolean {
+  // No rule on the whole detail group's columns → keep the original loop's behavior (visible).
+  if (!column.visibilityRule) return true
+  return visibleDetailColumnsForRow(currentDetailColumns(column), row).some((c) => c.id === column.id)
+}
+
+// The sibling sub-fields a per-row rule may reference — the columns of the detail field this
+// `column` belongs to. Resolved from the live template (the fill-time schema source).
+function currentDetailColumns(column: FormField): FormField[] {
+  for (const field of template.value?.formSchema.fields ?? []) {
+    if (field.type === 'detail' && (field.columns ?? []).some((c) => c.id === column.id)) {
+      return field.columns ?? []
+    }
+  }
+  return [column]
+}
+
+function addDetailRow(field: FormField): void {
+  if (!canAddDetailRow(field)) return
+  if (!Array.isArray(formData[field.id])) formData[field.id] = []
+  ;(formData[field.id] as Array<Record<string, unknown>>).push(createEmptyDetailRow(field.columns))
+}
+
+function removeDetailRow(fieldId: string, index: number): void {
+  const rows = formData[fieldId]
+  if (Array.isArray(rows)) rows.splice(index, 1)
+}
+
+function canAddDetailRow(field: FormField): boolean {
+  if (typeof field.maxRows !== 'number') return true
+  return detailRows(field.id).length < field.maxRows
+}
+
+function canRemoveDetailRow(field: FormField): boolean {
+  const minRows = typeof field.minRows === 'number' ? field.minRows : 0
+  return detailRows(field.id).length > minRows
+}
+
+function detailRowsHint(field: FormField): string {
+  const parts: string[] = []
+  if (typeof field.minRows === 'number') parts.push(`至少 ${field.minRows} 行`)
+  if (typeof field.maxRows === 'number') parts.push(`最多 ${field.maxRows} 行`)
+  return parts.join(' · ')
+}
+
 function goBack() {
   router.back()
 }
@@ -262,7 +452,7 @@ async function handleSubmit() {
   try {
     const result = await approvalStore.submitApproval({
       templateId,
-      formData: template.value ? pruneHiddenFormData(template.value.formSchema, formData) : { ...formData },
+      formData: template.value ? pruneHiddenFormDataWithDetail(template.value.formSchema, formData) : { ...formData },
     })
     ElMessage.success('审批已提交')
     router.push({ name: 'approval-detail', params: { id: result.id } })
@@ -279,7 +469,8 @@ onMounted(async () => {
     for (const field of template.value.formSchema.fields) {
       if (field.defaultValue !== undefined) {
         formData[field.id] = field.defaultValue
-      } else if (field.type === 'multi-select') {
+      } else if (field.type === 'multi-select' || field.type === 'detail') {
+        // detail value is an array of row objects; seed empty so the fill table binds an array.
         formData[field.id] = []
       } else {
         formData[field.id] = undefined
@@ -300,7 +491,7 @@ function syncVisibleFormState() {
     if (formData[field.id] === undefined) {
       if (field.defaultValue !== undefined) {
         formData[field.id] = field.defaultValue
-      } else if (field.type === 'multi-select') {
+      } else if (field.type === 'multi-select' || field.type === 'detail') {
         formData[field.id] = []
       }
     }
@@ -385,5 +576,31 @@ watch([visibleFieldIds, template], () => {
 .approval-new__submit {
   margin-top: 8px;
   margin-bottom: 0;
+}
+
+.approval-new__detail {
+  width: 100%;
+}
+
+.approval-new__detail-table {
+  width: 100%;
+}
+
+.approval-new__detail-required {
+  color: var(--el-color-danger, #f56c6c);
+  margin-left: 2px;
+}
+
+.approval-new__detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.approval-new__detail-hint,
+.approval-new__detail-empty {
+  font-size: 12px;
+  color: var(--el-text-color-secondary, #909399);
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -172,7 +172,7 @@
                     <!-- per-row sub-field visibility (design-lock §4): a cell whose
                          column.visibilityRule is false for THIS row renders nothing and is pruned
                          from the submit payload by the same evaluation. -->
-                    <template v-if="isDetailCellVisible(column, row)">
+                    <template v-if="isDetailCellVisible(field, column, row)">
                     <el-input
                       v-if="column.type === 'text'"
                       v-model="row[column.id]"
@@ -336,8 +336,8 @@ import { useApprovalPermissions } from '../../approvals/permissions'
 import { getVisibleFormFields } from '../../approvals/fieldVisibility'
 import {
   createEmptyDetailRow,
+  isDetailCellVisible,
   pruneHiddenFormDataWithDetail,
-  visibleDetailColumnsForRow,
 } from '../../approvals/detailField'
 
 const route = useRoute()
@@ -377,26 +377,6 @@ function handleFileChange(fieldId: string, file: any) {
 function detailRows(fieldId: string): Array<Record<string, unknown>> {
   const value = formData[fieldId]
   return Array.isArray(value) ? (value as Array<Record<string, unknown>>) : []
-}
-
-// Per-row sub-field visibility (design-lock §4): is `column` visible for THIS row? The cell editor
-// renders only when true; the same evaluation (visibleDetailColumnsForRow → pruneHiddenDetailRow)
-// drops the cell from the submit payload, so hidden cells are never sent.
-function isDetailCellVisible(column: FormField, row: Record<string, unknown>): boolean {
-  // No rule on the whole detail group's columns → keep the original loop's behavior (visible).
-  if (!column.visibilityRule) return true
-  return visibleDetailColumnsForRow(currentDetailColumns(column), row).some((c) => c.id === column.id)
-}
-
-// The sibling sub-fields a per-row rule may reference — the columns of the detail field this
-// `column` belongs to. Resolved from the live template (the fill-time schema source).
-function currentDetailColumns(column: FormField): FormField[] {
-  for (const field of template.value?.formSchema.fields ?? []) {
-    if (field.type === 'detail' && (field.columns ?? []).some((c) => c.id === column.id)) {
-      return field.columns ?? []
-    }
-  }
-  return [column]
 }
 
 function addDetailRow(field: FormField): void {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -161,6 +161,7 @@
                 <el-option label="单选" value="select" />
                 <el-option label="多选" value="multi-select" />
                 <el-option label="用户" value="user" />
+                <el-option label="明细（子表单）" value="detail" />
               </el-select>
             </el-form-item>
             <el-form-item label="占位文本">
@@ -181,6 +182,101 @@
                 :rows="3"
                 placeholder="每行一个选项，格式：显示名:值"
               />
+            </el-form-item>
+            <!-- detail / sub-form (明细) config: sub-field list editor + minRows/maxRows. Each
+                 sub-field is a LEAF type (no nested detail). Mirrors the backend column schema. -->
+            <el-form-item
+              v-if="field.type === 'detail'"
+              label="明细子字段"
+              class="template-authoring__wide"
+            >
+              <div class="template-authoring__detail" data-testid="approval-detail-config">
+                <el-table
+                  v-if="field.detailColumns.length > 0"
+                  :data="field.detailColumns"
+                  border
+                  size="small"
+                  class="template-authoring__detail-table"
+                >
+                  <el-table-column label="子字段 ID" min-width="120">
+                    <template #default="{ row }">
+                      <el-input v-model="row.id" :disabled="readOnly" placeholder="如 product" />
+                    </template>
+                  </el-table-column>
+                  <el-table-column label="名称" min-width="120">
+                    <template #default="{ row }">
+                      <el-input v-model="row.label" :disabled="readOnly" placeholder="如 品名" />
+                    </template>
+                  </el-table-column>
+                  <el-table-column label="类型" min-width="120">
+                    <template #default="{ row }">
+                      <el-select v-model="row.type" :disabled="readOnly" style="width: 100%">
+                        <el-option
+                          v-for="leaf in detailLeafTypeOptions"
+                          :key="leaf.value"
+                          :label="leaf.label"
+                          :value="leaf.value"
+                        />
+                      </el-select>
+                    </template>
+                  </el-table-column>
+                  <el-table-column label="必填" width="70" align="center">
+                    <template #default="{ row }">
+                      <el-checkbox v-model="row.required" :disabled="readOnly" />
+                    </template>
+                  </el-table-column>
+                  <el-table-column label="选项" min-width="160">
+                    <template #default="{ row }">
+                      <el-input
+                        v-if="row.type === 'select' || row.type === 'multi-select'"
+                        v-model="row.optionsText"
+                        :disabled="readOnly"
+                        type="textarea"
+                        :rows="2"
+                        placeholder="每行一个：显示名:值"
+                      />
+                      <span v-else class="template-authoring__hint">—</span>
+                    </template>
+                  </el-table-column>
+                  <el-table-column label="操作" width="70" align="center">
+                    <template #default="{ $index }">
+                      <el-button
+                        type="danger"
+                        link
+                        :disabled="readOnly"
+                        @click="removeDetailColumn(field, $index)"
+                      >
+                        删除
+                      </el-button>
+                    </template>
+                  </el-table-column>
+                </el-table>
+                <div v-else class="template-authoring__hint">尚无子字段，请添加至少一个。</div>
+                <div class="template-authoring__detail-actions">
+                  <el-button
+                    size="small"
+                    type="primary"
+                    plain
+                    :disabled="readOnly"
+                    data-testid="approval-detail-add-column"
+                    @click="addDetailColumn(field)"
+                  >
+                    添加子字段
+                  </el-button>
+                  <el-input
+                    v-model="field.minRowsText"
+                    :disabled="readOnly"
+                    placeholder="最小行数"
+                    style="width: 120px"
+                  />
+                  <el-input
+                    v-model="field.maxRowsText"
+                    :disabled="readOnly"
+                    placeholder="最大行数"
+                    style="width: 120px"
+                  />
+                </div>
+              </div>
             </el-form-item>
             <el-form-item label="显隐规则" class="template-authoring__wide">
               <div class="template-authoring__visibility">
@@ -426,9 +522,11 @@ import {
   buildCreateTemplatePayload,
   buildFormSchema,
   buildUpdateTemplatePayload,
+  createEmptyDetailColumnDraft,
   createEmptyFieldDraft,
   createEmptyStepDraft,
   createEmptyTemplateDraft,
+  DETAIL_LEAF_FIELD_TYPES,
   draftFromTemplate,
   parseIdsText,
   unsupportedTemplateAuthoringReason,
@@ -525,6 +623,31 @@ function removeField(index: number) {
 
 function moveField(index: number, delta: -1 | 1) {
   draft.value.fields = swap(draft.value.fields, index, delta) ?? draft.value.fields
+}
+
+// detail / sub-form (明细) sub-field authoring. Sub-fields are LEAF types only (no nested
+// `detail`), surfaced from the shared `DETAIL_LEAF_FIELD_TYPES` so the picker can never offer
+// `detail` — the one-nesting-level invariant the backend also enforces.
+const DETAIL_LEAF_TYPE_LABELS: Record<string, string> = {
+  text: '文本',
+  textarea: '多行文本',
+  number: '数字',
+  date: '日期',
+  datetime: '日期时间',
+  select: '单选',
+  'multi-select': '多选',
+  user: '用户',
+}
+const detailLeafTypeOptions = computed(() =>
+  DETAIL_LEAF_FIELD_TYPES.map((type) => ({ value: type, label: DETAIL_LEAF_TYPE_LABELS[type] ?? type })),
+)
+
+function addDetailColumn(field: FieldAuthoringDraft) {
+  field.detailColumns = [...field.detailColumns, createEmptyDetailColumnDraft(field.detailColumns.length + 1)]
+}
+
+function removeDetailColumn(field: FieldAuthoringDraft, index: number) {
+  field.detailColumns = field.detailColumns.filter((_, i) => i !== index)
 }
 
 // Visibility-rule depends-on options: other fields that have an id (excludes self).
@@ -723,6 +846,22 @@ onMounted(() => {
 
 .template-authoring__inline > .el-input {
   flex: 1;
+}
+
+.template-authoring__detail {
+  width: 100%;
+}
+
+.template-authoring__detail-table {
+  width: 100%;
+}
+
+.template-authoring__detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
 }
 
 .template-authoring__item {

--- a/apps/web/tests/approval-detail-field.test.ts
+++ b/apps/web/tests/approval-detail-field.test.ts
@@ -8,6 +8,7 @@ import {
   detailColumnDraftsFromField,
   DETAIL_LEAF_FIELD_TYPES,
   findDetailFieldInSchema,
+  isDetailCellVisible,
   isDetailField,
   isDetailLeafFieldType,
   parseRowBound,
@@ -294,5 +295,36 @@ describe('detailField — per-row sub-field visibility (P2, design-lock §4)', (
     const pruned = pruneHiddenFormDataWithDetail(schema, { reason: 'hide', items: [{ kind: 'other', note: 'x' }] })
     expect(pruned).toEqual({ reason: 'hide' })
     expect(pruned).not.toHaveProperty('items')
+  })
+})
+
+describe('isDetailCellVisible — per-field (two detail groups may share a sub-field id)', () => {
+  const makeGroup = (id: string, noteVisibleWhen: string): FormField => ({
+    id,
+    type: 'detail',
+    label: id,
+    columns: [
+      { id: 'kind', type: 'select', label: 'kind', options: [{ label: 'X', value: 'x' }, { label: 'Y', value: 'y' }] },
+      { id: 'note', type: 'text', label: 'note', visibilityRule: { fieldId: 'kind', operator: 'eq', value: noteVisibleWhen } },
+    ],
+  })
+
+  it('judges a same-id sub-field by its OWN group, never a reverse-lookup across the template', () => {
+    const groupA = makeGroup('itemsA', 'x') // A.note visible when kind === 'x'
+    const groupB = makeGroup('itemsB', 'y') // B.note visible when kind === 'y'
+    const noteA = groupA.columns![1]
+    const noteB = groupB.columns![1]
+
+    expect(isDetailCellVisible(groupA, noteA, { kind: 'x' })).toBe(true)
+    expect(isDetailCellVisible(groupA, noteA, { kind: 'y' })).toBe(false)
+    // B.note shares the id 'note' with A.note, but must follow B's OWN rule (kind === 'y'),
+    // not A's (kind === 'x') — the bug the reverse-lookup helper would have produced.
+    expect(isDetailCellVisible(groupB, noteB, { kind: 'y' })).toBe(true)
+    expect(isDetailCellVisible(groupB, noteB, { kind: 'x' })).toBe(false)
+  })
+
+  it('a column without a visibilityRule is always visible', () => {
+    const group = makeGroup('items', 'x')
+    expect(isDetailCellVisible(group, group.columns![0], { kind: 'whatever' })).toBe(true)
   })
 })

--- a/apps/web/tests/approval-detail-field.test.ts
+++ b/apps/web/tests/approval-detail-field.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+import type { FormField, FormSchema } from '../src/types/approval'
+import {
+  buildDetailColumns,
+  buildDetailRowsForDisplay,
+  createEmptyDetailColumnDraft,
+  createEmptyDetailRow,
+  detailColumnDraftsFromField,
+  DETAIL_LEAF_FIELD_TYPES,
+  findDetailFieldInSchema,
+  isDetailField,
+  isDetailLeafFieldType,
+  parseRowBound,
+  pruneHiddenDetailRow,
+  pruneHiddenFormDataWithDetail,
+  validateDetailColumnsDraft,
+  visibleDetailColumnsForRow,
+  type DetailColumnDraft,
+} from '../src/approvals/detailField'
+
+function leafDraft(overrides: Partial<DetailColumnDraft> = {}): DetailColumnDraft {
+  return {
+    localId: 'l1',
+    id: 'product',
+    type: 'text',
+    label: '品名',
+    required: false,
+    optionsText: '',
+    ...overrides,
+  }
+}
+
+const detailField: FormField = {
+  id: 'items',
+  type: 'detail',
+  label: '明细',
+  columns: [
+    { id: 'product', type: 'text', label: '品名', required: true },
+    { id: 'qty', type: 'number', label: '数量' },
+    { id: 'tags', type: 'multi-select', label: '标签', options: [{ label: 'A', value: 'a' }] },
+  ],
+}
+
+describe('detailField — leaf-type guard', () => {
+  it('exposes exactly the 8 leaf types (no detail, no attachment)', () => {
+    expect([...DETAIL_LEAF_FIELD_TYPES].sort()).toEqual(
+      ['date', 'datetime', 'multi-select', 'number', 'select', 'text', 'textarea', 'user'].sort(),
+    )
+    expect(DETAIL_LEAF_FIELD_TYPES).not.toContain('detail')
+    expect(DETAIL_LEAF_FIELD_TYPES).not.toContain('attachment')
+  })
+
+  it('isDetailLeafFieldType rejects detail/attachment, accepts leaves', () => {
+    expect(isDetailLeafFieldType('text')).toBe(true)
+    expect(isDetailLeafFieldType('multi-select')).toBe(true)
+    expect(isDetailLeafFieldType('detail')).toBe(false)
+    expect(isDetailLeafFieldType('attachment')).toBe(false)
+  })
+
+  it('isDetailField only true for type detail', () => {
+    expect(isDetailField({ type: 'detail' })).toBe(true)
+    expect(isDetailField({ type: 'text' })).toBe(false)
+  })
+})
+
+describe('detailField — buildDetailRowsForDisplay (frozen-schema render)', () => {
+  it('builds rows × columns keyed by sub-field id from the frozen columns', () => {
+    const table = buildDetailRowsForDisplay(detailField, [
+      { product: 'A', qty: 2, tags: ['a'] },
+      { product: 'B', qty: 1 },
+    ])
+    expect(table).not.toBeNull()
+    expect(table!.columns.map((c) => c.id)).toEqual(['product', 'qty', 'tags'])
+    expect(table!.columns.map((c) => c.label)).toEqual(['品名', '数量', '标签'])
+    expect(table!.rows).toHaveLength(2)
+    expect(table!.rows[0].cells).toEqual({ product: 'A', qty: 2, tags: ['a'] })
+    // Missing cell in row 2 is surfaced as undefined (not dropped) so the column still renders.
+    expect(table!.rows[1].cells).toEqual({ product: 'B', qty: 1, tags: undefined })
+  })
+
+  it('only emits cells for DEFINED columns — unknown snapshot keys are ignored', () => {
+    const table = buildDetailRowsForDisplay(detailField, [
+      { product: 'A', qty: 2, rogue: 'should-not-appear' },
+    ])
+    expect(Object.keys(table!.rows[0].cells).sort()).toEqual(['product', 'qty', 'tags'].sort())
+    expect(table!.rows[0].cells).not.toHaveProperty('rogue')
+  })
+
+  it('returns null (→ stringify fallback) when columns are absent or value is not an array', () => {
+    expect(buildDetailRowsForDisplay(undefined, [])).toBeNull()
+    expect(buildDetailRowsForDisplay({ columns: [] }, [])).toBeNull()
+    expect(buildDetailRowsForDisplay(detailField, 'not-an-array')).toBeNull()
+    expect(buildDetailRowsForDisplay(detailField, null)).toBeNull()
+  })
+
+  it('tolerates non-object row entries by treating them as empty rows', () => {
+    const table = buildDetailRowsForDisplay(detailField, [null, 42])
+    expect(table!.rows).toHaveLength(2)
+    expect(table!.rows[0].cells).toEqual({ product: undefined, qty: undefined, tags: undefined })
+  })
+})
+
+describe('detailField — findDetailFieldInSchema', () => {
+  const schema: FormSchema = {
+    fields: [
+      { id: 'reason', type: 'text', label: '事由' },
+      detailField,
+      { id: 'broken', type: 'detail', label: '坏明细' }, // detail without columns → not usable
+    ],
+  }
+
+  it('returns the detail field when it carries columns', () => {
+    expect(findDetailFieldInSchema(schema, 'items')?.id).toBe('items')
+  })
+
+  it('returns null for scalar fields, detail-without-columns, missing keys, or null schema', () => {
+    expect(findDetailFieldInSchema(schema, 'reason')).toBeNull()
+    expect(findDetailFieldInSchema(schema, 'broken')).toBeNull()
+    expect(findDetailFieldInSchema(schema, 'nope')).toBeNull()
+    expect(findDetailFieldInSchema(null, 'items')).toBeNull()
+    expect(findDetailFieldInSchema(undefined, 'items')).toBeNull()
+  })
+})
+
+describe('detailField — fill row seeding', () => {
+  it('seeds [] for multi-select and undefined for other leaves; only defined column keys', () => {
+    const row = createEmptyDetailRow(detailField.columns)
+    expect(row).toEqual({ product: undefined, qty: undefined, tags: [] })
+    expect(Object.keys(row)).toEqual(['product', 'qty', 'tags'])
+  })
+
+  it('returns an empty object for missing columns', () => {
+    expect(createEmptyDetailRow(undefined)).toEqual({})
+  })
+})
+
+describe('detailField — column draft round-trip', () => {
+  it('hydrates drafts from a stored detail field and rebuilds equivalent columns', () => {
+    const drafts = detailColumnDraftsFromField(detailField)
+    expect(drafts.map((d) => d.id)).toEqual(['product', 'qty', 'tags'])
+    expect(drafts.find((d) => d.id === 'product')?.required).toBe(true)
+    expect(drafts.find((d) => d.id === 'tags')?.optionsText).toBe('A:a')
+
+    const rebuilt = buildDetailColumns(drafts)
+    expect(rebuilt.map((c) => c.id)).toEqual(['product', 'qty', 'tags'])
+    expect(rebuilt.find((c) => c.id === 'tags')?.options).toEqual([{ label: 'A', value: 'a' }])
+    // Non-option leaves carry no options key.
+    expect(rebuilt.find((c) => c.id === 'qty')).not.toHaveProperty('options')
+  })
+
+  it('createEmptyDetailColumnDraft defaults to a text leaf', () => {
+    const draft = createEmptyDetailColumnDraft(2)
+    expect(draft.type).toBe('text')
+    expect(draft.id).toBe('col_2')
+    expect(draft.required).toBe(false)
+  })
+})
+
+describe('detailField — parseRowBound', () => {
+  it('parses unset / valid / invalid bounds', () => {
+    expect(parseRowBound('')).toBeUndefined()
+    expect(parseRowBound('  ')).toBeUndefined()
+    expect(parseRowBound('0')).toBe(0)
+    expect(parseRowBound('200')).toBe(200)
+    expect(parseRowBound('-1')).toBe('invalid')
+    expect(parseRowBound('1.5')).toBe('invalid')
+    expect(parseRowBound('abc')).toBe('invalid')
+  })
+})
+
+describe('detailField — validateDetailColumnsDraft (mirrors backend reject-set)', () => {
+  it('accepts a valid single-leaf detail', () => {
+    expect(validateDetailColumnsDraft('明细', [leafDraft()], '', '')).toEqual([])
+  })
+
+  it('rejects empty columns', () => {
+    const errors = validateDetailColumnsDraft('明细', [], '', '')
+    expect(errors.some((e) => e.includes('至少需要一个子字段'))).toBe(true)
+  })
+
+  it('rejects a sub-field with empty id', () => {
+    const errors = validateDetailColumnsDraft('明细', [leafDraft({ id: '  ' })], '', '')
+    expect(errors.some((e) => e.includes('子字段 id 必填'))).toBe(true)
+  })
+
+  it('rejects duplicate sub-field ids', () => {
+    const errors = validateDetailColumnsDraft(
+      '明细',
+      [leafDraft({ localId: 'a', id: 'dup' }), leafDraft({ localId: 'b', id: 'dup' })],
+      '',
+      '',
+    )
+    expect(errors.some((e) => e.includes('不能重复'))).toBe(true)
+  })
+
+  it('rejects a missing sub-field label', () => {
+    const errors = validateDetailColumnsDraft('明细', [leafDraft({ label: '' })], '', '')
+    expect(errors.some((e) => e.includes('名称必填'))).toBe(true)
+  })
+
+  it('rejects a nested detail sub-field (no nesting)', () => {
+    // A sub-field can never be `detail`; the draft type is widened to FormFieldType to test it.
+    const errors = validateDetailColumnsDraft(
+      '明细',
+      [leafDraft({ type: 'detail' as DetailColumnDraft['type'] })],
+      '',
+      '',
+    )
+    expect(errors.some((e) => e.includes('类型不支持'))).toBe(true)
+  })
+
+  it('rejects a select sub-field with no options', () => {
+    const errors = validateDetailColumnsDraft('明细', [leafDraft({ type: 'select', optionsText: '' })], '', '')
+    expect(errors.some((e) => e.includes('需要至少一个选项'))).toBe(true)
+  })
+
+  it('rejects a select sub-field whose option label/value is blank', () => {
+    const errors = validateDetailColumnsDraft('明细', [leafDraft({ type: 'select', optionsText: ':v\nlabel:' })], '', '')
+    expect(errors.some((e) => e.includes('label/value 不能为空'))).toBe(true)
+  })
+
+  it('rejects a non-negative-int violation on minRows/maxRows', () => {
+    expect(validateDetailColumnsDraft('明细', [leafDraft()], '-1', '').some((e) => e.includes('最小行数必须是非负整数'))).toBe(true)
+    expect(validateDetailColumnsDraft('明细', [leafDraft()], '', '2.5').some((e) => e.includes('最大行数必须是非负整数'))).toBe(true)
+  })
+
+  it('rejects minRows > maxRows', () => {
+    const errors = validateDetailColumnsDraft('明细', [leafDraft()], '5', '3')
+    expect(errors.some((e) => e.includes('最小行数不能大于最大行数'))).toBe(true)
+  })
+
+  it('accepts minRows <= maxRows', () => {
+    expect(validateDetailColumnsDraft('明细', [leafDraft()], '1', '200')).toEqual([])
+  })
+})
+
+describe('detailField — per-row sub-field visibility (P2, design-lock §4)', () => {
+  // A detail group where `note` is visible only when `kind === 'other'` in the SAME row.
+  const visField: FormField = {
+    id: 'items',
+    type: 'detail',
+    label: '明细',
+    columns: [
+      { id: 'kind', type: 'select', label: '类型', options: [{ label: '常规', value: 'normal' }, { label: '其他', value: 'other' }] },
+      { id: 'note', type: 'text', label: '备注', visibilityRule: { fieldId: 'kind', operator: 'eq', value: 'other' } },
+    ],
+  }
+
+  it('visibleDetailColumnsForRow hides a sub-field whose rule is false for the row', () => {
+    const hiddenRow = visibleDetailColumnsForRow(visField.columns, { kind: 'normal', note: 'leak' })
+    expect(hiddenRow.map((c) => c.id)).toEqual(['kind'])
+    const shownRow = visibleDetailColumnsForRow(visField.columns, { kind: 'other', note: 'keep' })
+    expect(shownRow.map((c) => c.id)).toEqual(['kind', 'note'])
+  })
+
+  it('pruneHiddenDetailRow drops the hidden cell and any unknown key, keeps visible cells', () => {
+    expect(pruneHiddenDetailRow(visField.columns, { kind: 'normal', note: 'leak', rogue: 1 })).toEqual({ kind: 'normal' })
+    expect(pruneHiddenDetailRow(visField.columns, { kind: 'other', note: 'keep' })).toEqual({ kind: 'other', note: 'keep' })
+  })
+
+  it('pruneHiddenFormDataWithDetail prunes hidden cells per row across the whole form', () => {
+    const schema: FormSchema = { fields: [{ id: 'reason', type: 'text', label: '事由' }, visField] }
+    const pruned = pruneHiddenFormDataWithDetail(schema, {
+      reason: 'r',
+      items: [
+        { kind: 'normal', note: 'should-vanish' }, // note hidden → dropped
+        { kind: 'other', note: 'should-stay' }, // note visible → kept
+      ],
+    })
+    expect(pruned).toEqual({
+      reason: 'r',
+      items: [{ kind: 'normal' }, { kind: 'other', note: 'should-stay' }],
+    })
+    // The hidden value never reaches the payload for its row, but the shown row keeps it.
+    expect((pruned.items as Array<Record<string, unknown>>)[0]).not.toHaveProperty('note')
+    expect((pruned.items as Array<Record<string, unknown>>)[1].note).toBe('should-stay')
+  })
+
+  it('a detail field with no sub-field rules round-trips every cell (no over-pruning)', () => {
+    const plain: FormField = {
+      id: 'items',
+      type: 'detail',
+      label: '明细',
+      columns: [{ id: 'product', type: 'text', label: '品名' }, { id: 'qty', type: 'number', label: '数量' }],
+    }
+    const schema: FormSchema = { fields: [plain] }
+    const pruned = pruneHiddenFormDataWithDetail(schema, { items: [{ product: 'A', qty: 2 }] })
+    expect(pruned).toEqual({ items: [{ product: 'A', qty: 2 }] })
+  })
+
+  it('top-level hidden detail field is dropped entirely (top-level prune still applies)', () => {
+    const gatedDetail: FormField = { ...visField, visibilityRule: { fieldId: 'reason', operator: 'eq', value: 'show' } }
+    const schema: FormSchema = { fields: [{ id: 'reason', type: 'text', label: '事由' }, gatedDetail] }
+    const pruned = pruneHiddenFormDataWithDetail(schema, { reason: 'hide', items: [{ kind: 'other', note: 'x' }] })
+    expect(pruned).toEqual({ reason: 'hide' })
+    expect(pruned).not.toHaveProperty('items')
+  })
+})

--- a/apps/web/tests/approval-template-authoring-detail.test.ts
+++ b/apps/web/tests/approval-template-authoring-detail.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest'
+import type { FormField } from '../src/types/approval'
+import {
+  AUTHORABLE_FIELD_TYPES,
+  buildFormSchema,
+  createEmptyFieldDraft,
+  createEmptyStepDraft,
+  createEmptyTemplateDraft,
+  draftFromTemplate,
+  validateTemplateDraft,
+  type FieldAuthoringDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import type { DetailColumnDraft } from '../src/approvals/detailField'
+
+function detailColumnDraft(overrides: Partial<DetailColumnDraft> = {}): DetailColumnDraft {
+  return {
+    localId: `l_${Math.random().toString(16).slice(2)}`,
+    id: 'product',
+    type: 'text',
+    label: '品名',
+    required: false,
+    optionsText: '',
+    ...overrides,
+  }
+}
+
+function detailFieldDraft(overrides: Partial<FieldAuthoringDraft> = {}): FieldAuthoringDraft {
+  return {
+    ...createEmptyFieldDraft(1),
+    id: 'items',
+    type: 'detail',
+    label: '明细',
+    detailColumns: [detailColumnDraft()],
+    minRowsText: '',
+    maxRowsText: '',
+    ...overrides,
+  }
+}
+
+function draftWith(fields: FieldAuthoringDraft[]): TemplateAuthoringDraft {
+  return {
+    ...createEmptyTemplateDraft(),
+    key: 'k',
+    name: 'n',
+    fields,
+    steps: [createEmptyStepDraft(1)],
+  }
+}
+
+describe('templateAuthoring — detail is authorable', () => {
+  it('includes detail in AUTHORABLE_FIELD_TYPES (top-level), excludes attachment', () => {
+    expect(AUTHORABLE_FIELD_TYPES).toContain('detail')
+    expect(AUTHORABLE_FIELD_TYPES).not.toContain('attachment')
+  })
+
+  it('a fresh field draft seeds empty detail authoring state', () => {
+    const draft = createEmptyFieldDraft(1)
+    expect(draft.detailColumns).toEqual([])
+    expect(draft.minRowsText).toBe('')
+    expect(draft.maxRowsText).toBe('')
+  })
+})
+
+describe('templateAuthoring — buildFormSchema emits detail shape', () => {
+  it('emits columns + minRows/maxRows for a detail field', () => {
+    const schema = buildFormSchema(
+      draftWith([
+        detailFieldDraft({
+          detailColumns: [
+            detailColumnDraft({ id: 'product', type: 'text', label: '品名', required: true }),
+            detailColumnDraft({ id: 'tags', type: 'multi-select', label: '标签', optionsText: 'A:a\nB:b' }),
+          ],
+          minRowsText: '1',
+          maxRowsText: '200',
+        }),
+      ]),
+    )
+    const field = schema.fields[0]
+    expect(field.type).toBe('detail')
+    expect(field.columns?.map((c) => c.id)).toEqual(['product', 'tags'])
+    expect(field.columns?.find((c) => c.id === 'product')?.required).toBe(true)
+    expect(field.columns?.find((c) => c.id === 'tags')?.options).toEqual([
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+    ])
+    expect(field.minRows).toBe(1)
+    expect(field.maxRows).toBe(200)
+  })
+
+  it('omits minRows/maxRows when their inputs are blank', () => {
+    const schema = buildFormSchema(draftWith([detailFieldDraft({ minRowsText: '', maxRowsText: '' })]))
+    expect(schema.fields[0]).not.toHaveProperty('minRows')
+    expect(schema.fields[0]).not.toHaveProperty('maxRows')
+    expect(schema.fields[0].columns).toHaveLength(1)
+  })
+
+  it('deletes stale detail keys when a field is no longer a detail (original spread guard)', () => {
+    // Simulate hydrating a detail field from server, then changing its type to text.
+    const original: FormField = {
+      id: 'items',
+      type: 'detail',
+      label: '明细',
+      columns: [{ id: 'product', type: 'text', label: '品名' }],
+      minRows: 1,
+      maxRows: 5,
+    }
+    const field = detailFieldDraft({ type: 'text', original })
+    const schema = buildFormSchema(draftWith([field]))
+    expect(schema.fields[0].type).toBe('text')
+    expect(schema.fields[0]).not.toHaveProperty('columns')
+    expect(schema.fields[0]).not.toHaveProperty('minRows')
+    expect(schema.fields[0]).not.toHaveProperty('maxRows')
+  })
+})
+
+describe('templateAuthoring — validateTemplateDraft detail branch', () => {
+  it('passes a valid detail field', () => {
+    const errors = validateTemplateDraft(draftWith([detailFieldDraft()]))
+    expect(errors).toEqual([])
+  })
+
+  it('rejects a detail field with no sub-fields', () => {
+    const errors = validateTemplateDraft(draftWith([detailFieldDraft({ detailColumns: [] })]))
+    expect(errors.some((e) => e.includes('至少需要一个子字段'))).toBe(true)
+  })
+
+  it('rejects a nested detail sub-field', () => {
+    const errors = validateTemplateDraft(
+      draftWith([
+        detailFieldDraft({ detailColumns: [detailColumnDraft({ type: 'detail' as DetailColumnDraft['type'] })] }),
+      ]),
+    )
+    expect(errors.some((e) => e.includes('类型不支持'))).toBe(true)
+  })
+
+  it('rejects duplicate sub-field ids', () => {
+    const errors = validateTemplateDraft(
+      draftWith([
+        detailFieldDraft({
+          detailColumns: [detailColumnDraft({ id: 'dup' }), detailColumnDraft({ id: 'dup', label: '其他' })],
+        }),
+      ]),
+    )
+    expect(errors.some((e) => e.includes('不能重复'))).toBe(true)
+  })
+
+  it('rejects minRows > maxRows', () => {
+    const errors = validateTemplateDraft(draftWith([detailFieldDraft({ minRowsText: '9', maxRowsText: '2' })]))
+    expect(errors.some((e) => e.includes('最小行数不能大于最大行数'))).toBe(true)
+  })
+})
+
+describe('templateAuthoring — draftFromTemplate hydrates detail columns (round-trip)', () => {
+  it('hydrates columns + bounds from a stored detail template', () => {
+    const draft = draftFromTemplate({
+      id: 't1',
+      key: 'k',
+      name: 'n',
+      description: null,
+      category: null,
+      status: 'draft',
+      version: 1,
+      visibilityScope: { type: 'all', ids: [] },
+      slaHours: null,
+      formSchema: {
+        fields: [
+          {
+            id: 'items',
+            type: 'detail',
+            label: '明细',
+            columns: [
+              { id: 'product', type: 'text', label: '品名', required: true },
+              { id: 'qty', type: 'number', label: '数量' },
+            ],
+            minRows: 1,
+            maxRows: 50,
+          },
+        ],
+      },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'approval_1', type: 'approval', name: '审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)
+
+    const field = draft.fields.find((f) => f.id === 'items')
+    expect(field?.type).toBe('detail')
+    expect(field?.detailColumns.map((c) => c.id)).toEqual(['product', 'qty'])
+    expect(field?.detailColumns.find((c) => c.id === 'product')?.required).toBe(true)
+    expect(field?.minRowsText).toBe('1')
+    expect(field?.maxRowsText).toBe('50')
+
+    // And re-emitting reproduces the columns.
+    const rebuilt = buildFormSchema(draft)
+    const rebuiltField = rebuilt.fields.find((f) => f.id === 'items')
+    expect(rebuiltField?.columns?.map((c) => c.id)).toEqual(['product', 'qty'])
+    expect(rebuiltField?.minRows).toBe(1)
+    expect(rebuiltField?.maxRows).toBe(50)
+  })
+
+  // P1 regression: unmanaged sub-field metadata must NOT be silently flattened on save.
+  it('preserves a sub-field props / visibilityRule / placeholder / defaultValue through save (no flatten)', () => {
+    const storedColumns: FormField[] = [
+      {
+        id: 'qty',
+        type: 'number',
+        label: '数量',
+        required: true,
+        placeholder: '请输入数量',
+        defaultValue: 1,
+        // backend-contract constraints the v1 UI does NOT manage:
+        props: { min: 1, max: 999, step: 1 },
+      },
+      {
+        id: 'note',
+        type: 'text',
+        label: '备注',
+        // a same-row sub-field visibilityRule the v1 UI does NOT author:
+        visibilityRule: { fieldId: 'qty', operator: 'notEmpty' },
+      },
+    ]
+    const draft = draftFromTemplate({
+      id: 't1',
+      key: 'k',
+      name: 'n',
+      description: null,
+      category: null,
+      status: 'draft',
+      version: 1,
+      visibilityScope: { type: 'all', ids: [] },
+      slaHours: null,
+      formSchema: { fields: [{ id: 'items', type: 'detail', label: '明细', columns: storedColumns }] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'approval_1', type: 'approval', name: '审批', config: { assigneeSources: [{ kind: 'requester' }] } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'e1', source: 'start', target: 'approval_1' },
+          { key: 'e2', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)
+
+    const rebuilt = buildFormSchema(draft)
+    const rebuiltColumns = rebuilt.fields.find((f) => f.id === 'items')?.columns
+    expect(rebuiltColumns).toBeDefined()
+    // The detail columns round-trip preserving ALL unmanaged metadata. `required` is the one
+    // UI-managed field that is normalized to an explicit boolean (mirrors top-level buildFormSchema
+    // `required: field.required`), so the only delta vs the stored input is `note.required: false`
+    // becoming explicit — no metadata is dropped.
+    expect(rebuiltColumns).toEqual([
+      storedColumns[0],
+      { ...storedColumns[1], required: false },
+    ])
+    const qty = rebuiltColumns?.find((c) => c.id === 'qty')
+    expect(qty?.props).toEqual({ min: 1, max: 999, step: 1 })
+    expect(qty?.placeholder).toBe('请输入数量')
+    expect(qty?.defaultValue).toBe(1)
+    expect(rebuiltColumns?.find((c) => c.id === 'note')?.visibilityRule).toEqual({ fieldId: 'qty', operator: 'notEmpty' })
+  })
+})

--- a/docs/development/approval-detail-subform-todo-20260623.md
+++ b/docs/development/approval-detail-subform-todo-20260623.md
@@ -37,17 +37,34 @@
 - ➡️ Read path surfaces the **frozen** detail columns — folded into **C-3** (the renderer consumes
   them; exposing columns without a renderer is untestable/unused).
 
-## Phase C-3 — UI (🔒 until C-2 merged; the form-schema stability point for complex-graph node UI)
-- 🔒 Template author: configure detail `columns` (reuse leaf-field authoring +
-  `AUTHORABLE_FIELD_TYPES`) in `TemplateAuthoringView.vue`.
-- 🔒 Fill view: `detail → DetailTable` editable branch in `ApprovalNewView.vue` (add/remove
-  row; per-cell leaf editor; inline validation; per-row visibility).
-- 🔒 Read path (moved from C-2): expose the **frozen** detail `columns` on the instance read
-  (the version's `form_schema` or a projected `detailColumns` on the read DTO) so the detail
-  view renders from the frozen schema, not the live template (closes design-lock Fact B).
-- 🔒 Detail view: read-only `DetailTable` in `ApprovalDetailView.vue` driven by frozen columns
-  (replaces the `formatFieldValue` JSON-stringify fallback for `detail`).
-- 🔒 FE tests: author round-trip, fill validation, render-from-frozen-snapshot.
+## Phase C-3 — UI (the form-schema stability point for complex-graph node UI)
+### C-3a — read-path ✅ (shipped #3090, squash c330dfb03)
+- ✅ Read path: the instance read DTO `UnifiedApprovalDTO` now carries `formSchema?: FormSchema | null`,
+  resolved from the instance's pinned **frozen** template version (`getApproval` reads
+  `approval_template_versions.form_schema`) so the detail view renders against frozen columns, not
+  the live template (closes design-lock Fact B). Real-DB read round-trip test.
+### C-3b — author + fill + detail view ✅ (this PR)
+- ✅ Template author: configure detail `columns` (reuse leaf-field authoring + `AUTHORABLE_FIELD_TYPES`,
+  which now includes `detail`; sub-field type restricted to `DETAIL_LEAF_FIELD_TYPES` so the picker
+  can never offer `detail`) + minRows/maxRows inputs in `TemplateAuthoringView.vue`. `buildFormSchema`
+  emits `columns`/`minRows`/`maxRows` (and deletes them when a field is no longer a `detail`);
+  `draftFromTemplate` hydrates them (round-trip). `validateTemplateDraft` mirrors the backend
+  `normalizeDetailFieldParts` reject-set client-side (non-empty leaf-only unique-id columns, no
+  nesting, minRows ≤ maxRows non-negative ints).
+- ✅ Fill view: `detail` editable `el-table` branch in `ApprovalNewView.vue` (add/remove row;
+  per-cell leaf editor per column type; respects minRows/maxRows — add disabled at maxRows, remove
+  disabled at minRows). `formData[field.id]` is the row array (init `[]`); only DEFINED column keys
+  are emitted (no unknown sub-keys); backend re-validates row count / required / per-cell types.
+- ✅ Detail view: read-only `el-table` in `ApprovalDetailView.vue` driven by the FROZEN
+  `approval.formSchema` columns (replaces the `formatFieldValue` JSON-stringify fallback for
+  `detail`; falls back to stringify when formSchema/columns absent or value is not an array).
+- ✅ Pure (Element-Plus-free) logic extracted to `approvals/detailField.ts` (frozen-schema render,
+  fill-row seeding, column-draft validation, round-trip) so it is vitest-testable without Element Plus.
+- ✅ FE tests (36): `approval-detail-field.test.ts` (25 — render-from-frozen-snapshot, leaf guard,
+  fill seeding, column validation, round-trip) + `approval-template-authoring-detail.test.ts` (11 —
+  buildFormSchema detail emit/delete, validateTemplateDraft detail branch, draftFromTemplate hydrate).
+  Wired into CI via `approval-web-guard.yml` (the main gate runs only core-backend vitest + a web
+  build, so without this guard the FE specs would never run).
 
 ## Phase C-4 — cross-row summary sub-field (🔒 OPTIONAL — only if owner-decision (d) = v1 must)
 - 🔒 Read-only computed cell (e.g. `sum(items[].price)`) — a leaf "summary" sub-field; design


### PR DESCRIPTION
**Final slice of the C 明细/子表单 arc** (design-lock #3082; C-1 #3086; C-2 #3088; C-3a read-path #3090 `c330dfb03`). Completes the UI phase.

## The three pieces
- **Author config** — configure detail `columns` + `minRows`/`maxRows` **inline in `TemplateAuthoringView`** (no new route → reachable, no orphan-page risk). Sub-field type restricted to leaf types so the picker can never offer `detail`. `buildFormSchema` emits/round-trips columns; `validateTemplateDraft` **mirrors** the backend `normalizeDetailFieldParts` reject-set client-side (the backend stays the final arbiter — UI checks are UX only).
- **Fill** — editable `el-table` branch in `ApprovalNewView`: add/remove row (disabled at max/min), per-cell leaf editor per column type. Emits **only defined column keys** (no unknown sub-keys); payload is the row array matching the C-2/C-3a contract.
- **Detail view** — read-only `el-table` in `ApprovalDetailView` driven by the **FROZEN** `approval.formSchema` columns (from C-3a), **never** the live template; falls back to the prior stringify when formSchema/columns absent.

## Tests / CI
- Pure (Element-Plus-free) logic extracted to `approvals/detailField.ts` → vitest-testable.
- **36 FE tests** — `approval-detail-field.test.ts` (25: render-from-frozen-snapshot, leaf guard, fill seeding, column validation, round-trip) + `approval-template-authoring-detail.test.ts` (11: buildFormSchema emit/delete, validateTemplateDraft branch, draftFromTemplate hydrate).
- Wired into CI via **`approval-web-guard.yml`** — the main gate only *builds* the web app and never runs `apps/web` vitest, so without this the FE specs would never run. Its run step executes both specs by name.

vue-tsc + lint clean; 36/36 FE specs locally. **Scope: detail/sub-form UI only** — no W7, no result write-back, no complex-graph node UI. TODO: C-3 ✅ (arc complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)