### PR TITLE
feat(multitable): reconcile orphaned AI bulk-fill jobs after hard restart (B-4 BJ-5 follow-up)

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -32,6 +32,8 @@ import type {
 } from './types/plugin'
 import type { User } from './auth/AuthService'
 import { poolManager } from './integration/db/connection-pool'
+import { reconcileOrphanedBulkJobs } from './services/ai-bulk-job-service'
+import type { AiUsageQueryFn } from './services/ai-usage-ledger'
 import { eventBus } from './integration/events/event-bus'
 import { initializeEventBusService } from './integration/events/event-bus-service'
 import { messageBus } from './integration/messaging/message-bus'
@@ -2169,6 +2171,20 @@ export class MetaSheetServer {
       )
     } catch (e) {
       this.logger.error('AI usage ledger retention scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // B-4 BJ-5 follow-up: reconcile ORPHANED AI bulk-fill jobs at boot. A hard
+    // restart drops the in-process worker + plan registry, so a job left
+    // `queued`/`running` can never progress yet keeps blocking a fresh start for
+    // its (actor, sheet, field) scope (the BJ-7 active-job index) until expires_at
+    // GC. Flip the stale ones to `errored`. The UPDATE is idempotent and
+    // age-guarded, so it is safe to run on every instance (no leader election).
+    try {
+      const bulkPool = poolManager.get()
+      const reconciled = await reconcileOrphanedBulkJobs(bulkPool.query.bind(bulkPool) as AiUsageQueryFn)
+      this.logger.info(`AI bulk-fill orphaned-job reconcile: ${reconciled} job(s) marked errored`)
+    } catch (e) {
+      this.logger.error('AI bulk-fill orphaned-job reconcile failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/services/ai-bulk-job-service.ts
+++ b/packages/core-backend/src/services/ai-bulk-job-service.ts
@@ -463,7 +463,10 @@ export async function reconcileOrphanedBulkJobs(
   query: AiUsageQueryFn,
   opts: { staleAfterMs?: number } = {},
 ): Promise<number> {
-  const staleAfterSeconds = Math.max(0, Math.round((opts.staleAfterMs ?? DEFAULT_BULK_JOB_RECONCILE_STALE_MS) / 1000))
+  const staleMs = opts.staleAfterMs ?? DEFAULT_BULK_JOB_RECONCILE_STALE_MS
+  // Floor at 30s: this is an exported helper, so guard against a misuse that passes
+  // a tiny/zero window and would reconcile a just-claimed, still-live job.
+  const staleAfterSeconds = Math.max(30, Math.round(staleMs / 1000))
   const res = await query(
     `UPDATE ${AI_BULK_JOB_TABLE}
         SET status = 'errored', suspend_reason = NULL, updated_at = NOW()

--- a/packages/core-backend/src/services/ai-bulk-job-service.ts
+++ b/packages/core-backend/src/services/ai-bulk-job-service.ts
@@ -438,6 +438,43 @@ async function markErroredIfRunning(query: AiUsageQueryFn, jobId: string): Promi
   )
 }
 
+/** Default quiet window before a `queued`/`running` job is treated as orphaned (ms). */
+export const DEFAULT_BULK_JOB_RECONCILE_STALE_MS = 10 * 60 * 1000
+
+/**
+ * B-4 follow-up to BJ-5 — reconcile ORPHANED jobs (the hard-process-restart case
+ * that markErroredIfRunning explicitly does NOT cover).
+ *
+ * `runJob` is an in-process worker (QueueService); a hard restart drops the queue
+ * and the in-process plan registry, so any job still `queued`/`running` has no live
+ * worker and can never progress — yet it stays "active" (the BJ-7 partial unique
+ * index counts queued/running/suspended), blocking a fresh start for its
+ * (actor, sheet, field) until expires_at GC. Flip those orphans to `errored`
+ * (header-only, mirroring markErroredIfRunning; already-`generated` rows stay
+ * committable).
+ *
+ * `suspended` jobs are EXCLUDED — they are intentionally paused awaiting review,
+ * not orphaned. The `staleAfterMs` age guard avoids racing a just-claimed job in a
+ * multi-instance deploy: only jobs whose `updated_at` has been quiet longer than
+ * the guard are reconciled (a live worker advances `updated_at` per row). Run at
+ * startup and/or on a periodic sweep. Returns the number of jobs reconciled.
+ */
+export async function reconcileOrphanedBulkJobs(
+  query: AiUsageQueryFn,
+  opts: { staleAfterMs?: number } = {},
+): Promise<number> {
+  const staleAfterSeconds = Math.max(0, Math.round((opts.staleAfterMs ?? DEFAULT_BULK_JOB_RECONCILE_STALE_MS) / 1000))
+  const res = await query(
+    `UPDATE ${AI_BULK_JOB_TABLE}
+        SET status = 'errored', suspend_reason = NULL, updated_at = NOW()
+      WHERE status IN ('queued', 'running')
+        AND updated_at < NOW() - ($1::int * INTERVAL '1 second')
+      RETURNING job_id`,
+    [staleAfterSeconds],
+  )
+  return Array.isArray(res.rows) ? res.rows.length : 0
+}
+
 /** Write a per-row commit outcome back to job-rows (BJ-10). `committed` is terminal-success. */
 export async function setRowCommitOutcome(
   query: AiUsageQueryFn,

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-job.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-job.test.ts
@@ -45,6 +45,7 @@ import {
   cancelBulkJob,
   setHeaderRunning,
   insertBulkJobHeader,
+  reconcileOrphanedBulkJobs,
 } from '../../src/services/ai-bulk-job-service'
 import { QueueServiceImpl } from '../../src/services/QueueService'
 import type { PoolLike } from '../../src/services/ai-bulk-shared'
@@ -636,6 +637,48 @@ describeIfDatabase('B-4 AI bulk-fill async job (real DB)', () => {
     expect(commit.body.state).toBe('resolved')
     expect(commit.body.counts.committed).toBe(1)
     expect(await recordValue(String(generated[0].record_id), FLD_TARGET)).toBe('AI OUT')
+  })
+
+  // ── HARD-RESTART RECONCILE (B-4 follow-up to BJ-5) ─────────────────────────
+  test('hard-restart reconcile: a stale orphaned queued/running job → errored; recent + suspended jobs untouched', async () => {
+    // markErroredIfRunning covers only the IN-PROCESS crash path. A HARD restart
+    // drops the in-process worker + queue, so a job left queued/running has no live
+    // worker and can never progress — it must be reconciled at boot. Seed four
+    // headers on DISTINCT fields (the BJ-7 active-job unique index is
+    // (actor, sheet, field), so several active headers for one target collide):
+    // a stale-running orphan, a stale-queued orphan, a just-updated running job (a
+    // live worker on another instance), and a suspended job (intentionally paused).
+    const queryFn = q as unknown as AiUsageQueryFn
+    const mk = async (suffix: string, status: string, ageMinutes: number) => {
+      const jid = `aibulkjob_recon_${suffix}_${TS}`
+      await insertBulkJobHeader(queryFn, {
+        jobId: jid,
+        actorId: ACTOR,
+        sheetId: SHEET_ID,
+        fieldId: `${FLD_TARGET}_recon_${suffix}`,
+        scopeFingerprint: `fp_recon_${suffix}`,
+        total: 3,
+      })
+      await q(
+        `UPDATE ${AI_BULK_JOB_TABLE} SET status = $2, updated_at = NOW() - ($3::int * INTERVAL '1 minute') WHERE job_id = $1`,
+        [jid, status, ageMinutes],
+      )
+      return jid
+    }
+    const staleRunning = await mk('stale_running', 'running', 5)
+    const staleQueued = await mk('stale_queued', 'queued', 5)
+    const recentRunning = await mk('recent_running', 'running', 0)
+    const suspendedOld = await mk('suspended_old', 'suspended', 5)
+
+    // Quiet window 60s: the 5-min-stale active jobs are orphaned; the just-updated
+    // one is a live worker; the suspended one is excluded by STATUS regardless of age.
+    const reconciled = await reconcileOrphanedBulkJobs(queryFn, { staleAfterMs: 60_000 })
+
+    expect((await dbJobHeader(staleRunning))!.status).toBe('errored')
+    expect((await dbJobHeader(staleQueued))!.status).toBe('errored')
+    expect((await dbJobHeader(recentRunning))!.status).toBe('running')
+    expect((await dbJobHeader(suspendedOld))!.status).toBe('suspended')
+    expect(reconciled).toBeGreaterThanOrEqual(2)
   })
 
   // ── DURABILITY KEYSTONE (BJ-9) ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Narrow follow-up to **#3075** closing the one non-blocking gap from its review: **stale `queued`/`running` job reconciliation after a hard restart**.

`runJob` is the in-process worker. `markErroredIfRunning` only covers the in-process exception path — its own comment notes a **hard process restart is a B-4 follow-up**. On restart the queue + in-process plan registry are gone, so a job left `queued`/`running` has no live worker and can never progress, yet it stays "active" (the BJ-7 partial unique index counts `queued/running/suspended`) and **blocks a fresh start for that `(actor, sheet, field)` until `expires_at` GC**.

## Change (3 files, +96)

- **`reconcileOrphanedBulkJobs(query, { staleAfterMs })`** — flips stale `queued`/`running` headers → `errored` (header-only, mirroring `markErroredIfRunning`; already-`generated` rows stay committable). **Excludes `suspended`** (intentionally paused for review). An **age guard** avoids racing a just-claimed job in a multi-instance deploy; the `UPDATE` is idempotent + race-safe, so **no leader election** is needed.
- **Startup wiring** (`index.ts`) — best-effort, mirroring the ledger-retention scheduler. Degrades gracefully on a DB error (verified: `server-lifecycle.test` exercises it, logs degraded-mode, and the server continues).
- **Hard-restart golden** (real-DB integration) — a 5-min-stale `running` **and** a stale `queued` job → `errored`; a just-updated `running` job and a `suspended` job are **untouched**.

## Validation
- `tsc --noEmit` passes; integration file parses + collects (the golden runs under `DATABASE_URL` in CI).
- Full `core-backend` **unit suite: 298 files / 3896 pass**, including `server-lifecycle` which runs the new startup path and degrades cleanly.

Does **not** touch any #3075 code — purely additive.
