### PR TITLE
feat(integration): provision stock-prep sandbox targets

### DIFF
--- a/docs/development/data-factory-fos-4b-3-sandbox-validation-runbook-20260623.md
+++ b/docs/development/data-factory-fos-4b-3-sandbox-validation-runbook-20260623.md
@@ -19,6 +19,27 @@
 ☐ 记录沙箱 objectId(下面记为 <SANDBOX_OBJECT_ID>)与 sheetId(仅本地记录,证据中不外泄)
 ```
 
+### 1.1 如果沙箱目标表不存在
+
+> **不要**使用 `POST /api/integration/stock-preparation/target/ensure`。该 canonical ensure 入口只会创建/绑定
+> `plm_stock_preparation_main`,不是沙箱目标。缺沙箱表时,使用下面的 admin-only sandbox provisioning 入口。
+
+```text
+POST /api/integration/stock-preparation/sandbox-target/ensure
+{
+  "projectId": "<PROJECT_ID>",
+  "baseId": "<SANDBOX_BASE_ID>",
+  "objectId": "<SANDBOX_OBJECT_ID>",
+  "label": "<SANDBOX_LABEL>"
+}
+
+期望:
+☐ objectId ≠ plm_stock_preparation_main;若误传 canonical objectId → 422 TARGET_SANDBOX_OBJECT_ID_INVALID
+☐ 响应 mode = sandbox_create 或 sandbox_existing
+☐ 响应只返回 targetBindingAvailable + values-free evidence(objectIdHash / field counts / field names);不返回 targetBinding / sheetId / 明文 objectId
+☐ evidence 可贴 issue;明文 <SANDBOX_OBJECT_ID> / sheetId 仅本地记录,不要贴出
+```
+
 ## 2. Step 1 — 配置并验证 sandbox gate(开关 + fail-closed)
 
 ```text

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -3705,6 +3705,14 @@ async function testStockPreparationTargetProvisioningRoutes() {
     registered.includes('POST /api/integration/stock-preparation/target/ensure'),
     'stock-preparation target ensure route registered',
   )
+  assert.ok(
+    registered.includes('GET /api/integration/stock-preparation/sandbox-target/readiness'),
+    'stock-preparation sandbox target readiness route registered',
+  )
+  assert.ok(
+    registered.includes('POST /api/integration/stock-preparation/sandbox-target/ensure'),
+    'stock-preparation sandbox target ensure route registered',
+  )
 
   let res = await invoke(routes, 'GET', '/api/integration/stock-preparation/target/readiness', {
     user: WRITE_USER,
@@ -3720,6 +3728,40 @@ async function testStockPreparationTargetProvisioningRoutes() {
   assert.equal(res.statusCode, 400)
   assert.equal(res.body.error.code, 'STOCK_PREPARATION_TARGET_REQUEST_INVALID')
   assert.equal(provisioning.calls.length, 0, 'client-supplied sheetId/permission is rejected before provisioning')
+
+  res = await invoke(routes, 'GET', '/api/integration/stock-preparation/sandbox-target/readiness', {
+    user: WRITE_USER,
+    query: { projectId: 'tenant_1:integration-core', objectId: 'plm_stock_preparation_sandbox_validation' },
+  })
+  assert.equal(res.statusCode, 403, 'write user cannot inspect sandbox target readiness')
+  assert.equal(provisioning.calls.length, 0, 'non-admin sandbox request does not reach provisioning API')
+
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'plm_stock_preparation_sandbox_validation',
+      sheetId: 'evil_sheet',
+      permission: 'admin',
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID')
+  assert.equal(provisioning.calls.length, 0, 'sandbox client-supplied sheetId/permission is rejected before provisioning')
+
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
+    },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'TARGET_SANDBOX_OBJECT_ID_INVALID')
+  assert.equal(res.body.error.details.reason, 'prod_canonical')
+  assert.equal(provisioning.calls.length, 0, 'canonical objectId is rejected before sandbox provisioning')
 
   res = await invoke(routes, 'GET', '/api/integration/stock-preparation/target/readiness', {
     user: ADMIN_USER,
@@ -3789,6 +3831,73 @@ async function testStockPreparationTargetProvisioningRoutes() {
   assert.deepEqual(res.body.error.details.missingFields, ['path'])
   assert.equal(JSON.stringify(res.body.error).includes('sheet_stock_canonical_private'), false, 'incomplete error hides sheet id')
   assert.equal(findCalls(incomplete.calls, 'ensureObject').length, 0, 'incomplete existing target is not repaired in place')
+
+  const sandboxObjectId = 'plm_stock_preparation_sandbox_validation'
+  const sandboxProvisioning = createStockPreparationTargetProvisioningApi()
+  const sandboxMount = mountRoutes(createMockServices().services, {
+    provisioningApi: sandboxProvisioning.api,
+    recordsApi: createTableActionRecordsApi().recordsApi,
+  })
+  res = await invoke(sandboxMount.routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: sandboxObjectId,
+      label: 'Sandbox Stock Preparation',
+    },
+  })
+  assertOkResponse(res, 201)
+  assert.equal(res.body.data.ready, true)
+  assert.equal(res.body.data.mode, 'sandbox_create')
+  assert.equal(res.body.data.targetBindingAvailable, true)
+  assert.equal(Object.prototype.hasOwnProperty.call(res.body.data, 'targetBinding'), false, 'sandbox route never exposes target binding')
+  assert.equal(res.body.data.evidence.fieldMapMode, 'sandbox')
+  assert.equal(res.body.data.evidence.target.fieldIdMapEmpty, false)
+  assert.ok(res.body.data.evidence.objectIdHash, 'sandbox route returns object hash evidence')
+  assert.equal(JSON.stringify(res.body.data).includes(sandboxObjectId), false, 'sandbox route response hides object id')
+  assert.equal(JSON.stringify(res.body.data).includes('sheet_stock_canonical_created'), false, 'sandbox route response hides sheet id')
+  const sandboxEnsureCall = findCalls(sandboxProvisioning.calls, 'ensureObject')[0]
+  assert.equal(sandboxEnsureCall[1].projectId, 'tenant_1:integration-core')
+  assert.equal(sandboxEnsureCall[1].baseId, 'base_stock')
+  assert.equal(sandboxEnsureCall[1].descriptor.id, sandboxObjectId)
+  assert.notEqual(sandboxEnsureCall[1].descriptor.id, STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId)
+  assert.deepEqual(
+    sandboxEnsureCall[1].descriptor.fields.map((field) => field.id),
+    STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id),
+    'sandbox ensure descriptor keeps the stock-prep manifest fields',
+  )
+
+  const leakySandbox = createStockPreparationTargetProvisioningApi()
+  leakySandbox.api.ensureObject = async (input) => {
+    leakySandbox.calls.push(['ensureObject', clone(input)])
+    const err = new Error(`cannot provision ${input.descriptor.id} in sheet_sandbox_private`)
+    err.status = 500
+    err.code = 'HOST_PROVISIONING_FAILED'
+    err.details = {
+      objectId: input.descriptor.id,
+      sheetId: 'sheet_sandbox_private',
+    }
+    throw err
+  }
+  const leakyMount = mountRoutes(createMockServices().services, {
+    provisioningApi: leakySandbox.api,
+    recordsApi: createTableActionRecordsApi().recordsApi,
+  })
+  res = await invoke(leakyMount.routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: sandboxObjectId,
+    },
+  })
+  assert.equal(res.statusCode, 503)
+  assert.equal(res.body.error.code, 'TARGET_SANDBOX_PROVISIONING_FAILED')
+  assert.equal(res.body.error.message, 'sandbox stock-preparation target provisioning failed')
+  assert.equal(res.body.error.details.reason, 'provisioning_failed')
+  assert.equal(JSON.stringify(res.body).includes(sandboxObjectId), false, 'sandbox host error response hides object id')
+  assert.equal(JSON.stringify(res.body).includes('sheet_sandbox_private'), false, 'sandbox host error response hides sheet id')
 }
 
 async function testStockPreparationOptionSyncRoute() {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
@@ -11,11 +11,14 @@ const {
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 const {
+  SANDBOX_FIELD_MAP_MODE,
   StockPreparationTargetProvisioningError,
   buildStockPreparationTargetDescriptor,
   summarizeStockPreparationTargetReadiness,
   inspectStockPreparationCanonicalTarget,
+  inspectStockPreparationSandboxTarget,
   ensureStockPreparationCanonicalTarget,
+  ensureStockPreparationSandboxTarget,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-target-provisioning.cjs'))
 
 const LOGICAL_FIELD_IDS = STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id)
@@ -290,6 +293,87 @@ async function main() {
   )
   assert.deepEqual(badCreateError.details.missingFields, ['path'])
   assert.equal(badCreateCalls.records.length, 0, 'failed create verification never uses records API')
+
+  const sandboxObjectId = 'plm_stock_preparation_sandbox_validation'
+  const sandboxDescriptor = buildStockPreparationTargetDescriptor({
+    template: { ...STOCK_PREPARATION_MAIN_TABLE_TEMPLATE, objectId: sandboxObjectId, label: 'Sandbox Stock Preparation' },
+    description: 'Sandbox target descriptor',
+  })
+  assert.equal(sandboxDescriptor.id, sandboxObjectId)
+  assert.equal(sandboxDescriptor.name, 'Sandbox Stock Preparation')
+  assert.equal(sandboxDescriptor.description, 'Sandbox target descriptor')
+  assert.deepEqual(sandboxDescriptor.fields.map((field) => field.id), LOGICAL_FIELD_IDS)
+
+  const { context: sandboxRejectCtx, calls: sandboxRejectCalls } = createContext({ sheetExists: false })
+  const canonicalSandboxError = await rejectsWith(
+    () => ensureStockPreparationSandboxTarget({
+      context: sandboxRejectCtx,
+      projectId: 'tenant:proj',
+      objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
+      permission: 'admin',
+    }),
+    'TARGET_SANDBOX_OBJECT_ID_INVALID',
+  )
+  assert.deepEqual(canonicalSandboxError.details, { reason: 'prod_canonical' })
+  assert.equal(sandboxRejectCalls.findObjectSheet.length, 0, 'canonical objectId is rejected before provisioning reads')
+  assert.equal(sandboxRejectCalls.ensureObject.length, 0, 'canonical objectId is never provisioned as sandbox')
+
+  const { context: sandboxCreateCtx, calls: sandboxCreateCalls } = createContext({ sheetExists: false })
+  const sandboxCreated = await ensureStockPreparationSandboxTarget({
+    context: sandboxCreateCtx,
+    projectId: 'tenant:proj',
+    baseId: 'base_sandbox',
+    objectId: sandboxObjectId,
+    permission: 'admin',
+  })
+  assert.equal(sandboxCreated.ready, true)
+  assert.equal(sandboxCreated.mode, 'sandbox_create')
+  assert.equal(sandboxCreated.target.objectId, sandboxObjectId, 'internal binding keeps the real sandbox object id')
+  assert.equal(sandboxCreated.target.sheetId, 'sheet_created_stock_target')
+  assert.equal(sandboxCreated.evidence.fieldMapMode, SANDBOX_FIELD_MAP_MODE)
+  assert.equal(sandboxCreated.evidence.target.fieldIdMapEmpty, false)
+  assert.ok(sandboxCreated.evidence.objectIdHash, 'sandbox evidence carries a deterministic object hash')
+  assert.equal(JSON.stringify(sandboxCreated.evidence).includes(sandboxObjectId), false, 'sandbox evidence hides object id')
+  assert.equal(JSON.stringify(sandboxCreated.evidence).includes('sheet_created_stock_target'), false, 'sandbox evidence hides sheet id')
+  assert.equal(sandboxCreateCalls.findObjectSheet[0].objectId, sandboxObjectId)
+  assert.equal(sandboxCreateCalls.ensureObject.length, 1)
+  assert.equal(sandboxCreateCalls.ensureObject[0].descriptor.id, sandboxObjectId)
+  assert.equal(sandboxCreateCalls.records.length, 0, 'sandbox create path never uses records API')
+
+  const { context: sandboxExistingCtx, calls: sandboxExistingCalls } = createContext({ sheetExists: true })
+  const sandboxExisting = await inspectStockPreparationSandboxTarget({
+    context: sandboxExistingCtx,
+    projectId: 'tenant:proj',
+    objectId: sandboxObjectId,
+    permission: 'admin',
+  })
+  assert.equal(sandboxExisting.ready, true)
+  assert.equal(sandboxExisting.mode, 'sandbox_existing')
+  assert.equal(sandboxExisting.evidence.fieldMapMode, SANDBOX_FIELD_MAP_MODE)
+  assert.equal(sandboxExisting.evidence.target.fieldIdMapEmpty, false)
+  assert.equal(JSON.stringify(sandboxExisting.evidence).includes(sandboxObjectId), false, 'sandbox existing evidence hides object id')
+  assert.equal(sandboxExistingCalls.findObjectSheet[0].objectId, sandboxObjectId)
+  assert.equal(sandboxExistingCalls.ensureObject.length, 0, 'sandbox existing path does not create')
+
+  const { context: sandboxIncompleteCtx, calls: sandboxIncompleteCalls } = createContext({
+    sheetExists: true,
+    missingFields: ['rawQuantity'],
+  })
+  const sandboxIncompleteError = await rejectsWith(
+    () => ensureStockPreparationSandboxTarget({
+      context: sandboxIncompleteCtx,
+      projectId: 'tenant:proj',
+      objectId: sandboxObjectId,
+      permission: 'admin',
+    }),
+    'TARGET_SCHEMA_INCOMPLETE',
+  )
+  assert.deepEqual(sandboxIncompleteError.details.missingFields, ['rawQuantity'])
+  assert.equal(sandboxIncompleteError.details.fieldMapMode, SANDBOX_FIELD_MAP_MODE)
+  assert.ok(sandboxIncompleteError.details.targetObjectIdHash)
+  assert.equal(JSON.stringify(sandboxIncompleteError.details).includes(sandboxObjectId), false, 'sandbox incomplete error hides object id')
+  assert.equal(sandboxIncompleteCalls.ensureObject.length, 0, 'incomplete sandbox target is not repaired in place')
+  assert.equal(sandboxIncompleteCalls.records.length, 0, 'incomplete sandbox path never uses records API')
 
   console.log('stock-preparation-target-provisioning.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -41,6 +41,8 @@ const ROUTES = [
   ['DELETE', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesDelete'],
   ['GET', '/api/integration/stock-preparation/target/readiness', 'stockPreparationTargetReadiness'],
   ['POST', '/api/integration/stock-preparation/target/ensure', 'stockPreparationTargetEnsure'],
+  ['GET', '/api/integration/stock-preparation/sandbox-target/readiness', 'stockPreparationSandboxTargetReadiness'],
+  ['POST', '/api/integration/stock-preparation/sandbox-target/ensure', 'stockPreparationSandboxTargetEnsure'],
   ['POST', '/api/integration/stock-preparation/options/sync', 'stockPreparationOptionsSync'],
   // FOS-2: generic field-option-sync (preset-driven). Stock-prep route above is a compat alias.
   ['POST', '/api/integration/field-options/sync', 'fieldOptionsSync'],
@@ -129,8 +131,11 @@ const {
   duplicateExpandedKeyDiagnosticsForRows,
 } = require('./stock-preparation-conflict-planner.cjs')
 const {
+  StockPreparationTargetProvisioningError,
   inspectStockPreparationCanonicalTarget,
   ensureStockPreparationCanonicalTarget,
+  inspectStockPreparationSandboxTarget,
+  ensureStockPreparationSandboxTarget,
 } = require('./stock-preparation-target-provisioning.cjs')
 const {
   StockPreparationOptionSyncError,
@@ -418,6 +423,7 @@ const VALID_C6_WRITE_APPLY_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'conf
 const VALID_TEMPLATE_INSTANTIATE_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'targetSystemId', 'sourceSystemId', 'pipelineName'])
 const VALID_C6_WRITE_APPLY_CONFIRM_KEYS = new Set(['dryRunToken'])
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
+const VALID_STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId', 'objectId', 'label'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
   'tenantId',
   'workspaceId',
@@ -570,6 +576,39 @@ function stockPreparationTargetInput(req, rawInput = {}) {
   }
 }
 
+function normalizeStockPreparationSandboxTargetRequest(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new HttpRouteError(400, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID', 'request must be an object')
+  }
+  for (const key of Object.keys(input)) {
+    if (!VALID_STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_KEYS.has(key)) {
+      throw new HttpRouteError(400, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID', `unsupported request field: ${key}`, { field: key })
+    }
+  }
+  return {
+    tenantId: firstString(input.tenantId),
+    workspaceId: firstString(input.workspaceId),
+    projectId: firstString(input.projectId),
+    baseId: firstString(input.baseId),
+    objectId: firstString(input.objectId),
+    label: firstString(input.label),
+  }
+}
+
+function stockPreparationSandboxTargetInput(req, rawInput = {}) {
+  const input = normalizeStockPreparationSandboxTargetRequest(rawInput)
+  const tenantId = resolveTenantId(req, input)
+  const projectId = resolveIntegrationStagingProjectId(tenantId, input.projectId)
+  return {
+    tenantId,
+    workspaceId: input.workspaceId,
+    projectId,
+    baseId: input.baseId,
+    objectId: input.objectId,
+    label: input.label,
+  }
+}
+
 function normalizeStockPreparationOptionSyncRequest(input = {}) {
   if (!isPlainObject(input)) {
     throw new HttpRouteError(400, 'STOCK_PREPARATION_OPTION_SYNC_REQUEST_INVALID', 'request must be an object')
@@ -695,6 +734,42 @@ function publicStockPreparationTargetResult(result) {
     targetBinding: result.target ? cloneJson(result.target) : null,
     evidence: result.evidence,
   }
+}
+
+function publicStockPreparationSandboxTargetResult(result) {
+  return {
+    ready: result.ready === true,
+    mode: result.mode,
+    targetBindingAvailable: result.target != null,
+    evidence: result.evidence,
+  }
+}
+
+function sandboxTargetRouteError(error) {
+  if (error instanceof HttpRouteError) return error
+  if (error instanceof StockPreparationTargetProvisioningError) {
+    const code = error.code || 'TARGET_SANDBOX_PROVISIONING_FAILED'
+    if (
+      code === 'TARGET_SANDBOX_OBJECT_ID_INVALID' ||
+      code === 'TARGET_PROVISIONING_CONFIG_INVALID' ||
+      code === 'TARGET_PROVISIONING_PERMISSION_DENIED' ||
+      code === 'TARGET_PROVISIONING_API_UNAVAILABLE' ||
+      code === 'TARGET_SCHEMA_INCOMPLETE'
+    ) {
+      return new HttpRouteError(
+        Number.isInteger(error.status) ? error.status : 422,
+        code,
+        error.message || 'sandbox stock-preparation target provisioning failed',
+        error.details || {},
+      )
+    }
+  }
+  return new HttpRouteError(
+    503,
+    'TARGET_SANDBOX_PROVISIONING_FAILED',
+    'sandbox stock-preparation target provisioning failed',
+    { reason: 'provisioning_failed' },
+  )
 }
 
 function largeBomExpansionOptionsForAction(action = {}) {
@@ -2107,6 +2182,41 @@ function createHandlers(services, options = {}) {
         permission: 'admin',
       })
       return sendOk(res, publicStockPreparationTargetResult(result), result.mode === 'canonical_create' ? 201 : 200)
+    },
+
+    async stockPreparationSandboxTargetReadiness(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationSandboxTargetInput(req, requestQuery(req))
+      try {
+        const result = await inspectStockPreparationSandboxTarget({
+          context,
+          projectId: input.projectId,
+          objectId: input.objectId,
+          label: input.label,
+          permission: 'admin',
+        })
+        return sendOk(res, publicStockPreparationSandboxTargetResult(result))
+      } catch (error) {
+        throw sandboxTargetRouteError(error)
+      }
+    },
+
+    async stockPreparationSandboxTargetEnsure(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationSandboxTargetInput(req, requestBody(req))
+      try {
+        const result = await ensureStockPreparationSandboxTarget({
+          context,
+          projectId: input.projectId,
+          baseId: input.baseId,
+          objectId: input.objectId,
+          label: input.label,
+          permission: 'admin',
+        })
+        return sendOk(res, publicStockPreparationSandboxTargetResult(result), result.mode === 'sandbox_create' ? 201 : 200)
+      } catch (error) {
+        throw sandboxTargetRouteError(error)
+      }
     },
 
     async stockPreparationOptionsSync(req, res) {

--- a/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
@@ -5,6 +5,8 @@
 // the host provisioning API, never reads PLM, never writes MetaSheet rows, and
 // never calls K3/external DB write paths.
 
+const crypto = require('node:crypto')
+
 const {
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
   normalizeStockPreparationTemplate,
@@ -12,6 +14,7 @@ const {
 } = require('./stock-preparation-templates.cjs')
 
 const CANONICAL_FIELD_MAP_MODE = 'canonical'
+const SANDBOX_FIELD_MAP_MODE = 'sandbox'
 const CANONICAL_KEY_FIELD = 'idempotencyKey'
 const REQUIRED_PERMISSION = 'admin'
 
@@ -45,6 +48,23 @@ function requiredString(value, field) {
     })
   }
   return normalized
+}
+
+function hashEvidenceValue(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 16)
+}
+
+function assertSandboxObjectId(value, field = 'objectId') {
+  const objectId = requiredString(value, field)
+  if (objectId === STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId) {
+    throw new StockPreparationTargetProvisioningError(
+      422,
+      'TARGET_SANDBOX_OBJECT_ID_INVALID',
+      'sandbox stock-preparation target objectId must not be the production canonical target',
+      { reason: 'prod_canonical' },
+    )
+  }
+  return objectId
 }
 
 function assertAdminPermission(permission) {
@@ -103,6 +123,25 @@ function buildFieldProperty(templateField, structureField) {
   return property
 }
 
+function stockPreparationTemplateForObject(input = {}) {
+  const objectId = requiredString(input.objectId, 'objectId')
+  const label = optionalString(input.label) || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.label
+  return normalizeStockPreparationTemplate({
+    ...STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
+    id: input.id || `${STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.id}.${hashEvidenceValue(objectId)}`,
+    objectId,
+    label,
+  })
+}
+
+function sandboxStockPreparationTemplate(input = {}) {
+  const objectId = assertSandboxObjectId(input.objectId)
+  return stockPreparationTemplateForObject({
+    objectId,
+    label: optionalString(input.label) || 'PLM Stock Preparation Sandbox',
+  })
+}
+
 function buildStockPreparationTargetDescriptor(input = {}) {
   const template = normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE)
   const structure = buildSheetStructureFromTemplate(template)
@@ -110,7 +149,7 @@ function buildStockPreparationTargetDescriptor(input = {}) {
   return {
     id: structure.objectId,
     name: structure.label,
-    description: 'Canonical PLM stock-preparation target generated from the C1 manifest.',
+    description: optionalString(input.description) || 'Canonical PLM stock-preparation target generated from the C1 manifest.',
     fields: structure.fields.map((field) => {
       const templateField = templateById.get(field.id)
       return {
@@ -140,11 +179,12 @@ function summarizeStockPreparationTargetReadiness(input = {}) {
     : []
   const mode = optionalString(input.mode) || (missingFields.length ? 'canonical_incomplete' : 'canonical_unchecked')
   const status = optionalString(input.status) || 'not_ready'
+  const includeObjectId = input.includeObjectId !== false
   return {
     status,
     mode,
-    objectId: template.objectId,
-    fieldMapMode: CANONICAL_FIELD_MAP_MODE,
+    ...(includeObjectId ? { objectId: template.objectId } : { objectIdHash: hashEvidenceValue(template.objectId) }),
+    fieldMapMode: optionalString(input.fieldMapMode) || CANONICAL_FIELD_MAP_MODE,
     keyField: CANONICAL_KEY_FIELD,
     fieldCounts: templateFieldCounts(template),
     missingFields,
@@ -156,7 +196,7 @@ function summarizeStockPreparationTargetReadiness(input = {}) {
         key: field.optionSource.key,
       })),
     target: {
-      objectId: template.objectId,
+      ...(includeObjectId ? { objectId: template.objectId } : { objectIdHash: hashEvidenceValue(template.objectId) }),
       keyField: CANONICAL_KEY_FIELD,
       fieldIdMapEmpty: input.fieldIdMapEmpty !== false,
     },
@@ -168,22 +208,47 @@ function missingLogicalFields(template, resolvedFieldIds = {}) {
 }
 
 async function inspectStockPreparationCanonicalTarget(input = {}) {
+  return inspectStockPreparationTarget({
+    ...input,
+    template: normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE),
+    modePrefix: 'canonical',
+    fieldMapMode: CANONICAL_FIELD_MAP_MODE,
+    includeObjectId: true,
+  })
+}
+
+async function inspectStockPreparationSandboxTarget(input = {}) {
+  return inspectStockPreparationTarget({
+    ...input,
+    template: sandboxStockPreparationTemplate(input),
+    modePrefix: 'sandbox',
+    fieldMapMode: SANDBOX_FIELD_MAP_MODE,
+    includeObjectId: false,
+  })
+}
+
+async function inspectStockPreparationTarget(input = {}) {
   const context = input.context || {}
   const provisioning = getProvisioningApi(context)
   assertAdminPermission(input.permission)
   const projectId = requiredString(input.projectId, 'projectId')
   const template = normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE)
+  const modePrefix = optionalString(input.modePrefix) || 'canonical'
+  const fieldMapMode = optionalString(input.fieldMapMode) || CANONICAL_FIELD_MAP_MODE
+  const includeObjectId = input.includeObjectId !== false
   const sheet = await provisioning.findObjectSheet({ projectId, objectId: template.objectId })
   if (!sheet) {
     return {
       ready: false,
-      mode: 'canonical_missing',
+      mode: `${modePrefix}_missing`,
       target: null,
       evidence: summarizeStockPreparationTargetReadiness({
         template,
-        mode: 'canonical_missing',
+        mode: `${modePrefix}_missing`,
         status: 'missing',
         missingFields: templateFieldIds(template),
+        fieldMapMode,
+        includeObjectId,
       }),
     }
   }
@@ -196,61 +261,123 @@ async function inspectStockPreparationCanonicalTarget(input = {}) {
   if (missingFields.length) {
     return {
       ready: false,
-      mode: 'canonical_incomplete',
+      mode: `${modePrefix}_incomplete`,
       target: null,
       evidence: summarizeStockPreparationTargetReadiness({
         template,
-        mode: 'canonical_incomplete',
+        mode: `${modePrefix}_incomplete`,
         status: 'not_ready',
         missingFields,
+        fieldMapMode,
+        includeObjectId,
       }),
     }
   }
   return {
     ready: true,
-    mode: 'canonical_existing',
+    mode: `${modePrefix}_existing`,
     target: buildCanonicalTargetBinding({ sheetId: sheet.id, objectId: template.objectId, fieldIdMap: resolved }),
     evidence: summarizeStockPreparationTargetReadiness({
       template,
-      mode: 'canonical_existing',
+      mode: `${modePrefix}_existing`,
       status: 'ready',
       missingFields: [],
       fieldIdMapEmpty: false,
+      fieldMapMode,
+      includeObjectId,
     }),
   }
 }
 
 async function ensureStockPreparationCanonicalTarget(input = {}) {
+  return ensureStockPreparationTarget({
+    ...input,
+    template: normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE),
+    modePrefix: 'canonical',
+    fieldMapMode: CANONICAL_FIELD_MAP_MODE,
+    includeObjectId: true,
+    description: 'Canonical PLM stock-preparation target generated from the C1 manifest.',
+    incompleteMessage: 'canonical stock-preparation target is missing manifest fields',
+    createdIncompleteMessage: 'created stock-preparation target is missing manifest fields',
+    incompleteDetails: (template, inspected) => ({
+      targetObjectId: template.objectId,
+      fieldMapMode: CANONICAL_FIELD_MAP_MODE,
+      missingFields: inspected.evidence.missingFields,
+      requiredFields: templateFieldIds(template),
+    }),
+    createdIncompleteDetails: (template, missingFields) => ({
+      targetObjectId: template.objectId,
+      fieldMapMode: CANONICAL_FIELD_MAP_MODE,
+      missingFields,
+      requiredFields: templateFieldIds(template),
+    }),
+  })
+}
+
+async function ensureStockPreparationSandboxTarget(input = {}) {
+  const template = sandboxStockPreparationTemplate(input)
+  return ensureStockPreparationTarget({
+    ...input,
+    template,
+    modePrefix: 'sandbox',
+    fieldMapMode: SANDBOX_FIELD_MAP_MODE,
+    includeObjectId: false,
+    description: 'Sandbox PLM stock-preparation target for validation only.',
+    incompleteMessage: 'sandbox stock-preparation target is missing manifest fields',
+    createdIncompleteMessage: 'created sandbox stock-preparation target is missing manifest fields',
+    incompleteDetails: (normalizedTemplate, inspected) => ({
+      targetObjectIdHash: hashEvidenceValue(normalizedTemplate.objectId),
+      fieldMapMode: SANDBOX_FIELD_MAP_MODE,
+      missingFields: inspected.evidence.missingFields,
+      requiredFields: templateFieldIds(normalizedTemplate),
+    }),
+    createdIncompleteDetails: (normalizedTemplate, missingFields) => ({
+      targetObjectIdHash: hashEvidenceValue(normalizedTemplate.objectId),
+      fieldMapMode: SANDBOX_FIELD_MAP_MODE,
+      missingFields,
+      requiredFields: templateFieldIds(normalizedTemplate),
+    }),
+  })
+}
+
+async function ensureStockPreparationTarget(input = {}) {
   const context = input.context || {}
   const provisioning = getProvisioningApi(context)
   assertAdminPermission(input.permission)
   const projectId = requiredString(input.projectId, 'projectId')
   const template = normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE)
-  const inspected = await inspectStockPreparationCanonicalTarget({
+  const modePrefix = optionalString(input.modePrefix) || 'canonical'
+  const fieldMapMode = optionalString(input.fieldMapMode) || CANONICAL_FIELD_MAP_MODE
+  const includeObjectId = input.includeObjectId !== false
+  const inspected = await inspectStockPreparationTarget({
     context,
     projectId,
     permission: input.permission,
     template,
+    modePrefix,
+    fieldMapMode,
+    includeObjectId,
   })
   if (inspected.ready) return inspected
-  if (inspected.mode === 'canonical_incomplete') {
+  if (inspected.mode === `${modePrefix}_incomplete`) {
     throw new StockPreparationTargetProvisioningError(
       422,
       'TARGET_SCHEMA_INCOMPLETE',
-      'canonical stock-preparation target is missing manifest fields',
-      {
-        targetObjectId: template.objectId,
-        fieldMapMode: CANONICAL_FIELD_MAP_MODE,
-        missingFields: inspected.evidence.missingFields,
-        requiredFields: templateFieldIds(template),
-      },
+      input.incompleteMessage || 'stock-preparation target is missing manifest fields',
+      typeof input.incompleteDetails === 'function'
+        ? input.incompleteDetails(template, inspected)
+        : {
+            fieldMapMode,
+            missingFields: inspected.evidence.missingFields,
+            requiredFields: templateFieldIds(template),
+          },
     )
   }
 
   const ensured = await provisioning.ensureObject({
     projectId,
     baseId: input.baseId || null,
-    descriptor: buildStockPreparationTargetDescriptor({ template }),
+    descriptor: buildStockPreparationTargetDescriptor({ template, description: input.description }),
   })
   const resolvedAfterCreate = await provisioning.resolveFieldIds({
     projectId,
@@ -262,44 +389,52 @@ async function ensureStockPreparationCanonicalTarget(input = {}) {
     throw new StockPreparationTargetProvisioningError(
       422,
       'TARGET_SCHEMA_INCOMPLETE',
-      'created stock-preparation target is missing manifest fields',
-      {
-        targetObjectId: template.objectId,
-        fieldMapMode: CANONICAL_FIELD_MAP_MODE,
-        missingFields,
-        requiredFields: templateFieldIds(template),
-      },
+      input.createdIncompleteMessage || 'created stock-preparation target is missing manifest fields',
+      typeof input.createdIncompleteDetails === 'function'
+        ? input.createdIncompleteDetails(template, missingFields)
+        : {
+            fieldMapMode,
+            missingFields,
+            requiredFields: templateFieldIds(template),
+          },
     )
   }
   return {
     ready: true,
-    mode: 'canonical_create',
+    mode: `${modePrefix}_create`,
     target: buildCanonicalTargetBinding({ sheetId: ensured.sheet.id, objectId: template.objectId, fieldIdMap: resolvedAfterCreate }),
     evidence: summarizeStockPreparationTargetReadiness({
       template,
-      mode: 'canonical_create',
+      mode: `${modePrefix}_create`,
       status: 'ready',
       missingFields: [],
       fieldIdMapEmpty: false,
+      fieldMapMode,
+      includeObjectId,
     }),
   }
 }
 
 module.exports = {
   CANONICAL_FIELD_MAP_MODE,
+  SANDBOX_FIELD_MAP_MODE,
   CANONICAL_KEY_FIELD,
   REQUIRED_PERMISSION,
   StockPreparationTargetProvisioningError,
   buildStockPreparationTargetDescriptor,
   summarizeStockPreparationTargetReadiness,
   inspectStockPreparationCanonicalTarget,
+  inspectStockPreparationSandboxTarget,
   ensureStockPreparationCanonicalTarget,
+  ensureStockPreparationSandboxTarget,
   __internals: {
     isPlainObject,
     templateFieldIds,
     templateFieldCounts,
     missingLogicalFields,
     buildCanonicalTargetBinding,
+    hashEvidenceValue,
+    sandboxStockPreparationTemplate,
     assertAdminPermission,
     getProvisioningApi,
   },


### PR DESCRIPTION
## Summary

Adds an admin-only sandbox stock-preparation target provisioning path for the FOS-4b-3 sandbox validation runbook.

This is the missing precondition surfaced in #3093: the existing canonical ensure route only creates/binds `plm_stock_preparation_main`, so it must not be used to prepare a sandbox apply target.

## What changed

- Adds:
  - `GET /api/integration/stock-preparation/sandbox-target/readiness`
  - `POST /api/integration/stock-preparation/sandbox-target/ensure`
- Reuses the stock-prep manifest fields, but requires a caller-provided non-canonical sandbox `objectId`.
- Rejects `plm_stock_preparation_main` fail-closed with `TARGET_SANDBOX_OBJECT_ID_INVALID` before provisioning reads/writes.
- Public sandbox responses expose only:
  - `ready`
  - `mode`
  - `targetBindingAvailable`
  - values-free evidence with `objectIdHash`
- Does not expose `targetBinding`, `sheetId`, or the plaintext sandbox `objectId`.
- Updates the sandbox validation runbook to direct operators to the sandbox route when the sandbox target is absent.

## Boundaries

- No apply execution.
- No production canonical write/unlock.
- No source read.
- No records API row writes.
- No K3 / external write.
- Admin-only metadata provisioning for a non-canonical sandbox target.

## Review hardening

Adversarial review caught a real failure-path leak: host provisioning errors could include the raw sandbox `objectId` or `sheetId` in `error.message`. This PR now wraps sandbox helper failures at the route boundary:

- expected validation errors keep safe code/details;
- unknown host provisioning errors become coarse `TARGET_SANDBOX_PROVISIONING_FAILED`;
- tests include a leaky `ensureObject` negative control proving the response does not contain the sandbox object id or sheet id.

## Verification

- `node -c plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs`
- `node -c plugins/plugin-integration-core/lib/http-routes.cjs`
- `pnpm --filter plugin-integration-core test:stock-preparation-target-provisioning`
- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter plugin-integration-core test`

## Next after merge

Cut a refreshed on-prem package, then rerun #3093 from the sandbox-target precondition:

- create/bind the sandbox target via the new route;
- configure `STOCK_PREP_SANDBOX_MODE=true` + allowlist;
- continue the runbook sandbox apply / re-pull / human-field-preservation validation.

Production apply remains closed.
