### PR TITLE
feat(multitable): B-4 Slice 2 — AI bulk-fill async-job FE (progress + paginated review + chunked commit)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1104,6 +1104,122 @@ export interface AiBulkCommitData {
   counts: Record<AiBulkCommitOutcome, number>
 }
 
+// AI BULK fill — ASYNC JOB (B-4). When a bulk-preview request exceeds the inline
+// cap the backend creates a job instead of generating inline and returns
+// `{ jobId }` (bare body — no `{ ok, data }` envelope: parseJson passes it through
+// as-is). These mirror the EXACT job-route wire 1:1 (multitable-ai.ts: poll
+// `bulk-job/:jobId` ~1238, paginated `bulk-job/:jobId/rows` ~1280, commit
+// `bulk-job/:jobId/commit` ~1431, cancel `bulk-job/:jobId/cancel` ~1316). Do NOT
+// reshape — the truthful-status UI depends on every distinct state surviving the
+// wire (the same fixture-drift rule as B-3).
+
+/**
+ * Job lifecycle status (the poll route's `state`, a WorkflowJobStatus). Job mode
+ * cares about: `queued`/`running` (the worker is still generating — keep polling)
+ * → `suspended` (generation done, AWAITING review — the diff is ready) /
+ * `resolved` (already committed — terminal success) / `rejected` (cancelled —
+ * already-generated rows stay committable) / `errored` (crashed mid-generate —
+ * the persisted partial is still committable).
+ */
+export type AiBulkJobStatus =
+  | 'queued'
+  | 'running'
+  | 'suspended'
+  | 'resolved'
+  | 'rejected'
+  | 'errored'
+
+/** A bulk-fill start either generated inline (≤ cap, B-3 path) or created a job (over cap). */
+export type AiBulkPreviewStart = AiBulkPreviewData | AiBulkJobStart
+
+export interface AiBulkJobStart {
+  jobId: string
+}
+
+/** True when the over-cap start created an async job (vs. the inline B-3 preview). */
+export function isAiBulkJobStart(start: AiBulkPreviewStart): start is AiBulkJobStart {
+  return 'jobId' in start
+}
+
+/**
+ * Poll header (multitable-ai.ts BJ-3 ~1238). The durable progress counters +
+ * per-state row counts + the commit aggregate. `state` drives the poll loop;
+ * `generated`/`total` the progress bar; `quotaPaused` the banner; `settledCost`
+ * the already-charged spend. Counts are the truthful per-bucket tallies.
+ */
+export interface AiBulkJobPoll {
+  jobId: string
+  state: AiBulkJobStatus
+  /** Why the job suspended (BJ-3) — e.g. `manual_task` (awaiting review). Display copy is by state, not this. */
+  suspendReason: string | null
+  /** Provider-bound denominator (NOT including skipped_no_perm rows). */
+  total: number
+  generated: number
+  skippedCount: number
+  failuresCount: number
+  committedCount: number
+  pendingNotGeneratedCount: number
+  /** Already-charged provider spend (USD) for this job so far. */
+  settledCost: number
+  /** true → generation paused on the per-tenant quota (BJ — partial; re-run to continue). */
+  quotaPaused: boolean
+  /** Durable commit aggregate ({ confirmed, attempted, counts }) once committed; null before. */
+  aggregate: unknown
+}
+
+/** Row review state (multitable-ai.ts BJ-9). ONLY `generated` is confirmable. */
+export type AiBulkJobRowState =
+  | 'pending'
+  | 'generated'
+  | 'skipped'
+  | 'failure'
+  | 'committed'
+  | 'pending_not_generated'
+
+/**
+ * One review row (multitable-ai.ts BJ-9 ~1280). `proposed` is the cached output
+ * (null until generated). `currentValue` is the server-read target value the
+ * write would overwrite (null = genuinely empty). `masked` flags a reduced
+ * context. `reason` carries the skipped/failure/pending_not_generated detail.
+ */
+export interface AiBulkJobRow {
+  recordId: string
+  ordinal: number
+  state: AiBulkJobRowState
+  currentValue: string | null
+  proposed: string | null
+  masked: boolean
+  reason: string | null
+}
+
+/** A paginated review page (multitable-ai.ts BJ-9). Follow `nextCursor` until null. */
+export interface AiBulkJobRowsPage {
+  rows: AiBulkJobRow[]
+  nextCursor: number | null
+}
+
+/** Job-commit per-row outcome — DIVERGES from B-2: `committed` (not `written`), no `not_in_cache`. */
+export type AiBulkJobCommitOutcome =
+  | 'committed'
+  | 'stale_reprev'
+  | 'write_conflict'
+  | 'skipped_no_perm'
+
+/** Commit response (multitable-ai.ts BJ-10 ~1431). The job resolves; counts is the truthful tally. */
+export interface AiBulkJobCommitData {
+  jobId: string
+  state: AiBulkJobStatus
+  counts: Record<AiBulkJobCommitOutcome, number>
+  attempted: number
+}
+
+/** Cancel response (multitable-ai.ts BJ-4 ~1316). `state` is `rejected` on success. */
+export interface AiBulkJobCancelData {
+  jobId: string
+  cancelled: boolean
+  state: AiBulkJobStatus
+}
+
 export interface AiUsageSummary {
   callerDayTokens: number
   callerWeekTokens: number
@@ -1599,7 +1715,11 @@ export class MultitableApiClient {
   // (NOT the loaded page); viewId is required for scope:'view'. The response
   // separates confirmable rows / uncharged skipped / CHARGED non-confirmable
   // failures / settled cost / a partial (capped) flag — preserved verbatim.
-  async aiBulkPreview(sheetId: string, input: AiBulkPreviewInput): Promise<AiBulkPreviewData> {
+  //
+  // OVER the inline cap the backend returns a bare `{ jobId }` instead of an
+  // inline preview (B-4 async job). The caller discriminates with
+  // `isAiBulkJobStart` and switches to the poll/review/commit job flow.
+  async aiBulkPreview(sheetId: string, input: AiBulkPreviewInput): Promise<AiBulkPreviewStart> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/bulk-preview`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1625,6 +1745,58 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ runId: input.runId, recordIds: input.recordIds }),
     })
+    return this.parseJson(res)
+  }
+
+  // AI BULK JOB poll (B-4 BJ-3) — durable progress header for an async over-cap
+  // job: state (queued|running while generating; suspended|resolved|rejected|
+  // errored terminal), generated/total, per-state counts, settledCost,
+  // quotaPaused, aggregate. A bare body (no envelope) — passed through verbatim.
+  async getBulkJob(sheetId: string, jobId: string): Promise<AiBulkJobPoll> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/bulk-job/${encodeURIComponent(jobId)}`,
+    )
+    return this.parseJson(res)
+  }
+
+  // AI BULK JOB rows (B-4 BJ-9) — paginated review page ordered by ordinal. Pass
+  // `cursor` (the previous page's `nextCursor`) to page forward; omit for the
+  // first page. Returns `{ rows, nextCursor }` (nextCursor null on the last page).
+  // Only `state === 'generated'` rows are confirmable; others are read-only.
+  async getBulkJobRows(sheetId: string, jobId: string, cursor?: number | null): Promise<AiBulkJobRowsPage> {
+    const query = typeof cursor === 'number' ? `?cursor=${encodeURIComponent(String(cursor))}` : ''
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/bulk-job/${encodeURIComponent(jobId)}/rows${query}`,
+    )
+    return this.parseJson(res)
+  }
+
+  // AI BULK JOB commit (B-4 BJ-10) — WRITE the confirmed `generated` rows. The FE
+  // sends the confirmed recordIds ONCE; the BACKEND chunks internally (never loop
+  // here). Returns `{ jobId, state:'resolved', counts, attempted }`. Outcomes
+  // DIVERGE from B-2: `committed` (not `written`), no `not_in_cache`. A row may
+  // still come back stale_reprev / write_conflict / skipped_no_perm (commit
+  // re-gates the live record). 409 if the job is not committable / already committing.
+  async commitBulkJob(sheetId: string, jobId: string, recordIds: string[]): Promise<AiBulkJobCommitData> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/bulk-job/${encodeURIComponent(jobId)}/commit`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recordIds }),
+      },
+    )
+    return this.parseJson(res)
+  }
+
+  // AI BULK JOB cancel (B-4 BJ-4) — stop the worker at the next row. Rows already
+  // `generated` stay charged + committable; ungenerated rows → pending_not_generated
+  // (uncharged); the job → `rejected`. NOT a refund. Returns `{ jobId, cancelled, state }`.
+  async cancelBulkJob(sheetId: string, jobId: string): Promise<AiBulkJobCancelData> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/bulk-job/${encodeURIComponent(jobId)}/cancel`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } },
+    )
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaAiBulkFillDialog.vue
+++ b/apps/web/src/multitable/components/MetaAiBulkFillDialog.vue
@@ -348,6 +348,13 @@
             </section>
           </template>
 
+          <!-- ───────────────────────── Phase: jobLoadError (review rows failed to load COMPLETELY) ───────────────────────── -->
+          <template v-else-if="ctrl.state.phase === 'jobLoadError'">
+            <p class="ai-bulk__alert ai-bulk__alert--error" data-test="ai-bulk-job-load-error">
+              {{ l('aibulk.jobLoadErrorBody') }}
+            </p>
+          </template>
+
           <!-- ───────────────────────── Phase: jobCommitting / jobDone ───────────────────────── -->
           <template v-else-if="ctrl.state.phase === 'jobCommitting' || ctrl.state.phase === 'jobDone'">
             <div v-if="jobCommitData" class="ai-bulk__result-head">
@@ -474,6 +481,19 @@
               @click="onJobConfirm"
             >
               {{ jobConfirmLabel }}
+            </button>
+          </template>
+
+          <!-- jobLoadError: retry the (fail-closed) review load, or cancel -->
+          <template v-else-if="ctrl.state.phase === 'jobLoadError'">
+            <button type="button" class="ai-bulk__btn" @click="onClose">{{ l('aibulk.cancel') }}</button>
+            <button
+              type="button"
+              class="ai-bulk__btn ai-bulk__btn--primary"
+              data-test="ai-bulk-job-load-retry"
+              @click="ctrl.retryJobLoad"
+            >
+              {{ l('aibulk.jobLoadRetry') }}
             </button>
           </template>
 

--- a/apps/web/src/multitable/components/MetaAiBulkFillDialog.vue
+++ b/apps/web/src/multitable/components/MetaAiBulkFillDialog.vue
@@ -180,6 +180,191 @@
             </section>
           </template>
 
+          <!-- ───────────────────────── Phase: polling (async job generating) ───────────────────────── -->
+          <template v-else-if="ctrl.state.phase === 'polling'">
+            <p class="ai-bulk__job-status" data-test="ai-bulk-job-status">
+              {{ ctrl.state.job && ctrl.state.job.state === 'running' ? l('aibulk.jobRunning') : l('aibulk.jobQueued') }}
+            </p>
+            <div
+              class="ai-bulk__progress"
+              role="progressbar"
+              :aria-label="l('aibulk.jobProgressAria')"
+              :aria-valuemin="0"
+              :aria-valuemax="job ? job.total : 0"
+              :aria-valuenow="job ? job.generated : 0"
+              data-test="ai-bulk-progress"
+            >
+              <div class="ai-bulk__progress-track">
+                <div class="ai-bulk__progress-fill" :style="{ width: jobProgressPct + '%' }"></div>
+              </div>
+              <div class="ai-bulk__progress-meta">
+                <span data-test="ai-bulk-progress-line">{{ jobProgress }}</span>
+                <span class="ai-bulk__cost" data-test="ai-bulk-cost">{{ costLine }}</span>
+              </div>
+            </div>
+            <p class="ai-bulk__quota-note ai-bulk__quota-note--compact" role="note">{{ l('aibulk.quotaNote') }}</p>
+          </template>
+
+          <!-- ───────────────────────── Phase: jobReview (async job awaiting commit) ───────────────────────── -->
+          <template v-else-if="ctrl.state.phase === 'jobReview'">
+            <!-- Cost + progress header (already charged). -->
+            <div class="ai-bulk__result-head">
+              <span class="ai-bulk__cost" data-test="ai-bulk-cost">{{ costLine }}</span>
+              <span class="ai-bulk__summary" data-test="ai-bulk-progress-line">{{ jobProgress }}</span>
+            </div>
+
+            <!-- Quota-paused banner — generation stopped on the per-tenant quota. -->
+            <p
+              v-if="ctrl.quotaPaused.value"
+              class="ai-bulk__alert ai-bulk__alert--warn"
+              role="alert"
+              data-test="ai-bulk-quota-paused"
+            >
+              {{ l('aibulk.jobQuotaPaused') }}
+            </p>
+
+            <!-- Terminal banner for a cancelled (rejected) / errored job. -->
+            <p
+              v-if="jobReviewBannerKey"
+              class="ai-bulk__alert ai-bulk__alert--warn"
+              role="alert"
+              data-test="ai-bulk-job-banner"
+            >
+              {{ l(jobReviewBannerKey) }}
+            </p>
+
+            <!-- Generated rows — the ONLY selectable rows (masked included, badged). -->
+            <template v-if="ctrl.jobGeneratedRows.value.length > 0">
+              <h4 class="ai-bulk__group-title">{{ l('aibulk.jobReviewHeading') }} ({{ ctrl.jobGeneratedRows.value.length }})</h4>
+              <table class="ai-bulk__table" data-test="ai-bulk-job-rows">
+                <thead>
+                  <tr>
+                    <th class="ai-bulk__col-select">
+                      <input
+                        type="checkbox"
+                        :aria-label="l('aibulk.selectAll')"
+                        :checked="ctrl.allConfirmableSelected.value"
+                        data-test="ai-bulk-job-select-all"
+                        @change="onToggleAll"
+                      />
+                    </th>
+                    <th>{{ l('aibulk.colRecord') }}</th>
+                    <th>{{ l('aibulk.colCurrent') }}</th>
+                    <th>{{ l('aibulk.colProposed') }}</th>
+                    <th>{{ l('aibulk.colJobState') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="row in ctrl.jobGeneratedRows.value"
+                    :key="row.recordId"
+                    class="ai-bulk__row"
+                    :data-record-id="row.recordId"
+                    data-test="ai-bulk-job-row"
+                  >
+                    <td class="ai-bulk__col-select">
+                      <input
+                        type="checkbox"
+                        :aria-label="l('aibulk.colSelect')"
+                        :checked="ctrl.selected.value.has(row.recordId)"
+                        :data-record-id="row.recordId"
+                        data-test="ai-bulk-job-row-select"
+                        @change="ctrl.toggleRow(row.recordId)"
+                      />
+                    </td>
+                    <td class="ai-bulk__cell-record">{{ recordName(row.recordId) }}</td>
+                    <td class="ai-bulk__cell-current">{{ displayCurrent(row.currentValue) }}</td>
+                    <td class="ai-bulk__cell-proposed">{{ row.proposed }}</td>
+                    <td class="ai-bulk__cell-state">
+                      <span
+                        v-if="row.masked"
+                        class="ai-bulk__badge ai-bulk__badge--masked"
+                        :title="l('aibulk.badgeMaskedTitle')"
+                        data-test="ai-bulk-job-badge-masked"
+                      >{{ l('aibulk.badgeMasked') }}</span>
+                      <span
+                        v-else
+                        class="ai-bulk__badge ai-bulk__badge--ready"
+                        data-test="ai-bulk-job-badge-ready"
+                      >{{ l('aibulk.stateGenerated') }}</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </template>
+            <p v-else class="ai-bulk__empty" data-test="ai-bulk-job-empty">{{ l('aibulk.emptyConfirmable') }}</p>
+
+            <!-- Skipped — UNCHARGED, NON-selectable. -->
+            <section v-if="ctrl.jobSkippedRows.value.length > 0" class="ai-bulk__group" data-test="ai-bulk-job-skipped">
+              <h4 class="ai-bulk__group-title">{{ l('aibulk.skippedHeading') }} ({{ ctrl.jobSkippedRows.value.length }})</h4>
+              <p class="ai-bulk__group-note">{{ l('aibulk.skippedNote') }}</p>
+              <ul class="ai-bulk__group-list">
+                <li
+                  v-for="s in ctrl.jobSkippedRows.value"
+                  :key="s.recordId"
+                  class="ai-bulk__group-item"
+                  :data-record-id="s.recordId"
+                  data-test="ai-bulk-job-skipped-item"
+                >
+                  <span class="ai-bulk__group-record">{{ recordName(s.recordId) }}</span>
+                  <span class="ai-bulk__group-reason">{{ skippedReason(s.reason ?? '') }}</span>
+                </li>
+              </ul>
+            </section>
+
+            <!-- Failures — CHARGED but non-confirmable, NON-selectable. -->
+            <section v-if="ctrl.jobFailureRows.value.length > 0" class="ai-bulk__group ai-bulk__group--charged" data-test="ai-bulk-job-failures">
+              <h4 class="ai-bulk__group-title">{{ l('aibulk.failuresHeading') }} ({{ ctrl.jobFailureRows.value.length }})</h4>
+              <p class="ai-bulk__group-note">{{ l('aibulk.failuresNote') }}</p>
+              <ul class="ai-bulk__group-list">
+                <li
+                  v-for="f in ctrl.jobFailureRows.value"
+                  :key="f.recordId"
+                  class="ai-bulk__group-item"
+                  :data-record-id="f.recordId"
+                  data-test="ai-bulk-job-failure-item"
+                >
+                  <span class="ai-bulk__group-record">{{ recordName(f.recordId) }}</span>
+                  <span class="ai-bulk__group-reason">{{ failureReason(f.reason ?? '') }}</span>
+                </li>
+              </ul>
+            </section>
+
+            <!-- Pending-not-generated — never generated (cancelled before reach), UNCHARGED. -->
+            <section v-if="ctrl.jobPendingNotGeneratedRows.value.length > 0" class="ai-bulk__group" data-test="ai-bulk-job-pending">
+              <h4 class="ai-bulk__group-title">{{ l('aibulk.statePendingNotGenerated') }} ({{ ctrl.jobPendingNotGeneratedRows.value.length }})</h4>
+              <p class="ai-bulk__group-note">{{ l('aibulk.statePendingNotGeneratedNote') }}</p>
+              <ul class="ai-bulk__group-list">
+                <li
+                  v-for="p in ctrl.jobPendingNotGeneratedRows.value"
+                  :key="p.recordId"
+                  class="ai-bulk__group-item"
+                  :data-record-id="p.recordId"
+                  data-test="ai-bulk-job-pending-item"
+                >
+                  <span class="ai-bulk__group-record">{{ recordName(p.recordId) }}</span>
+                </li>
+              </ul>
+            </section>
+          </template>
+
+          <!-- ───────────────────────── Phase: jobCommitting / jobDone ───────────────────────── -->
+          <template v-else-if="ctrl.state.phase === 'jobCommitting' || ctrl.state.phase === 'jobDone'">
+            <div v-if="jobCommitData" class="ai-bulk__result-head">
+              <span class="ai-bulk__summary ai-bulk__summary--strong" data-test="ai-bulk-job-commit-summary">{{ jobCommitSummary }}</span>
+            </div>
+
+            <!-- Stale guidance: any row needs a re-preview. -->
+            <p
+              v-if="jobCommitData && jobHasStale"
+              class="ai-bulk__alert ai-bulk__alert--warn"
+              role="alert"
+              data-test="ai-bulk-job-stale-guidance"
+            >
+              {{ l('aibulk.outcomeStaleGuidance') }}
+            </p>
+          </template>
+
           <!-- ───────────────────────── Phase: committing / done ───────────────────────── -->
           <template v-else-if="ctrl.state.phase === 'committing' || ctrl.state.phase === 'done'">
             <div v-if="commitData" class="ai-bulk__result-head">
@@ -266,6 +451,45 @@
             </button>
           </template>
 
+          <!-- polling (async job generating): cancel generation -->
+          <template v-else-if="ctrl.state.phase === 'polling'">
+            <button
+              type="button"
+              class="ai-bulk__btn"
+              data-test="ai-bulk-job-cancel"
+              @click="onJobCancel"
+            >
+              {{ l('aibulk.jobCancel') }}
+            </button>
+          </template>
+
+          <!-- jobReview (async job awaiting commit): write selected -->
+          <template v-else-if="ctrl.state.phase === 'jobReview'">
+            <button type="button" class="ai-bulk__btn" @click="onClose">{{ l('aibulk.cancel') }}</button>
+            <button
+              type="button"
+              class="ai-bulk__btn ai-bulk__btn--primary"
+              :disabled="ctrl.busy.value || ctrl.selectedCount.value === 0"
+              data-test="ai-bulk-job-confirm"
+              @click="onJobConfirm"
+            >
+              {{ jobConfirmLabel }}
+            </button>
+          </template>
+
+          <!-- jobCommitting/jobDone: done -->
+          <template v-else-if="ctrl.state.phase === 'jobCommitting' || ctrl.state.phase === 'jobDone'">
+            <button
+              type="button"
+              class="ai-bulk__btn ai-bulk__btn--primary"
+              :disabled="ctrl.state.phase === 'jobCommitting'"
+              data-test="ai-bulk-job-done"
+              @click="onClose"
+            >
+              {{ ctrl.state.phase === 'jobCommitting' ? l('aibulk.jobCommitting') : l('aibulk.done') }}
+            </button>
+          </template>
+
           <!-- committing/done: done -->
           <template v-else>
             <button
@@ -294,6 +518,9 @@ import {
   aiBulkCommitSummary,
   aiBulkCostLine,
   aiBulkFailureReason,
+  aiBulkJobCommitSummary,
+  aiBulkJobOutcomeLabel,
+  aiBulkJobProgressLine,
   aiBulkLabel,
   aiBulkOutcomeLabel,
   aiBulkPreviewSummary,
@@ -353,6 +580,7 @@ const previewSummary = computed(() =>
   aiBulkPreviewSummary(ctrl.confirmableCount.value, ctrl.skipped.value.length, ctrl.failures.value.length, props.isZh),
 )
 const confirmLabel = computed(() => `${l('aibulk.confirm')} (${ctrl.selectedCount.value})`)
+const jobConfirmLabel = computed(() => `${l('aibulk.jobConfirm')} (${ctrl.selectedCount.value})`)
 
 const commitData = computed(() => ctrl.state.commit)
 const commitSummary = computed(() => (commitData.value ? aiBulkCommitSummary(commitData.value.counts, props.isZh) : ''))
@@ -362,6 +590,46 @@ const allExpired = computed(() => {
   if (!c || c.outcomes.length === 0) return false
   return c.outcomes.every((o) => o.outcome === 'not_in_cache')
 })
+
+// --- B-4 async job ---
+const job = computed(() => ctrl.state.job)
+const jobProgress = computed(() =>
+  job.value ? aiBulkJobProgressLine(job.value.generated, job.value.total, props.isZh) : '',
+)
+const jobProgressPct = computed(() => {
+  const j = job.value
+  if (!j || j.total <= 0) return 0
+  return Math.min(100, Math.round((j.generated / j.total) * 100))
+})
+/** Terminal banner for a committable-but-not-clean job (cancelled / errored). null = no banner. */
+const jobReviewBannerKey = computed<MetaAiBulkLabelKey | null>(() => {
+  switch (job.value?.state) {
+    case 'rejected':
+      return 'aibulk.jobCancelledNotice'
+    case 'errored':
+      return 'aibulk.jobErroredNotice'
+    default:
+      return null
+  }
+})
+const jobCommitData = computed(() => ctrl.state.jobCommit)
+const jobCommitSummary = computed(() =>
+  jobCommitData.value ? aiBulkJobCommitSummary(jobCommitData.value.counts, props.isZh) : '',
+)
+const jobHasStale = computed(() => (jobCommitData.value?.counts.stale_reprev ?? 0) > 0)
+function jobOutcomeLabel(outcome: string): string {
+  return aiBulkJobOutcomeLabel(outcome, props.isZh)
+}
+function jobOutcomeBadgeClass(outcome: string): string {
+  return outcome === 'committed' ? 'ai-bulk__badge--ready' : 'ai-bulk__badge--warn'
+}
+function onJobConfirm(): void {
+  if (ctrl.busy.value || ctrl.selectedCount.value === 0) return
+  void ctrl.commitJob()
+}
+function onJobCancel(): void {
+  void ctrl.cancelJob()
+}
 
 function recordName(recordId: string): string {
   return props.recordName(recordId)
@@ -502,6 +770,35 @@ function onClose(): void {
   background: transparent;
   padding: 0;
   color: #b45309;
+}
+.ai-bulk__job-status {
+  font-size: 13px;
+  color: #334155;
+  margin: 0;
+}
+.ai-bulk__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ai-bulk__progress-track {
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.ai-bulk__progress-fill {
+  height: 100%;
+  background: #2563eb;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+.ai-bulk__progress-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: #475569;
 }
 .ai-bulk__alert {
   font-size: 13px;

--- a/apps/web/src/multitable/composables/useAiBulkFill.ts
+++ b/apps/web/src/multitable/composables/useAiBulkFill.ts
@@ -1,8 +1,8 @@
 /**
- * useAiBulkFill — B-3 review-before-write state machine for AI bulk/whole-column
+ * useAiBulkFill — review-before-write state machine for AI bulk/whole-column
  * fill. Drives MetaAiBulkFillDialog.vue. Design lock:
  * docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md
- * (§5 B-3).
+ * (§5 B-3) + the B-4 async-job extension (over-cap → job).
  *
  * THE CENTRAL REQUIREMENT (owner's flagged risk): TRUTHFUL STATUS. The user
  * must never be misled about what was or wasn't written. Every preview state and
@@ -15,6 +15,13 @@
  *  - cost honesty: preview already CHARGED (`settledCost`) is surfaced; abandon
  *    does not refund.
  *
+ * B-4 ASYNC JOB MODE: an over-cap start returns `{ jobId }` instead of an inline
+ * preview. The composable then DRIVES the job: poll progress (~2s, queued/
+ * running) → on a committable status (suspended / errored / rejected) fetch ALL
+ * review rows by following nextCursor → commit the user-selected `generated`
+ * subset ONCE (the backend chunks). Cancel stops the worker → `rejected`, whose
+ * already-generated rows stay committable (we transition INTO review, not close).
+ *
  * Error handling reuses the per-record A3 discipline (mapAiShortcutError): branch
  * STRICTLY on error.code. The burst-limiter RATE_LIMITED (429 + Retry-After)
  * starts a countdown that gates new sends on BOTH preview and commit;
@@ -24,50 +31,99 @@
 import { computed, getCurrentScope, onScopeDispose, reactive, ref } from 'vue'
 import type {
   AiBulkCommitData,
+  AiBulkJobCommitData,
+  AiBulkJobPoll,
+  AiBulkJobRow,
   AiBulkPreviewData,
   AiBulkPreviewInput,
+  AiBulkPreviewStart,
 } from '../api/client'
+import { isAiBulkJobStart } from '../api/client'
 import { mapAiShortcutError, type AiShortcutUiError } from './useAiShortcut'
 
-export type AiBulkFillPhase = 'idle' | 'previewing' | 'review' | 'committing' | 'done'
+export type AiBulkFillPhase =
+  // Inline (≤ cap, B-3) phases — UNCHANGED.
+  | 'idle'
+  | 'previewing'
+  | 'review'
+  | 'committing'
+  | 'done'
+  // Async job (over cap, B-4) phases.
+  | 'polling' // job created; worker generating (queued/running) — polling progress
+  | 'jobReview' // committable terminal (suspended/errored/rejected) — rows fetched
+  | 'jobCommitting'
+  | 'jobDone'
+
+/** Statuses on which the worker is done mutating the job → it's committable. */
+const COMMITTABLE_STATUSES = new Set<AiBulkJobPoll['state']>(['suspended', 'errored', 'rejected'])
+/** Statuses on which polling must STOP (terminal-for-this-session). */
+const POLL_STOP_STATUSES = new Set<AiBulkJobPoll['state']>(['suspended', 'resolved', 'rejected', 'errored'])
+/** Hard cap on row pages we will follow (defence against a non-advancing cursor). */
+const MAX_ROW_PAGES = 1000
 
 interface AiBulkClientLike {
-  aiBulkPreview(sheetId: string, input: AiBulkPreviewInput): Promise<AiBulkPreviewData>
+  aiBulkPreview(sheetId: string, input: AiBulkPreviewInput): Promise<AiBulkPreviewStart>
   aiBulkCommit(sheetId: string, input: { runId: string; recordIds: string[] }): Promise<AiBulkCommitData>
+  getBulkJob(sheetId: string, jobId: string): Promise<AiBulkJobPoll>
+  getBulkJobRows(sheetId: string, jobId: string, cursor?: number | null): Promise<{ rows: AiBulkJobRow[]; nextCursor: number | null }>
+  commitBulkJob(sheetId: string, jobId: string, recordIds: string[]): Promise<AiBulkJobCommitData>
+  cancelBulkJob(sheetId: string, jobId: string): Promise<{ jobId: string; cancelled: boolean; state: AiBulkJobPoll['state'] }>
 }
 
 export interface UseAiBulkFillOptions {
   client: AiBulkClientLike
   sheetId: () => string
+  /** Poll interval (ms) for an async job. Default 2000; tests override it. */
+  pollIntervalMs?: number
 }
 
 export interface AiBulkFillState {
   phase: AiBulkFillPhase
-  /** Last preview result (kept through the review + commit phases for the diff table). */
+  /** Last INLINE preview result (kept through the review + commit phases for the diff table). */
   preview: AiBulkPreviewData | null
-  /** Last commit result (set in the `done` phase). */
+  /** Last INLINE commit result (set in the `done` phase). */
   commit: AiBulkCommitData | null
+  // --- B-4 async job (distinct from the inline preview/commit above) ---
+  /** Async job id once an over-cap start created one. */
+  jobId: string | null
+  /** Latest poll header (progress + counts) — drives the progress bar + terminal banners. */
+  job: AiBulkJobPoll | null
+  /** ALL review rows for the job (accumulated across nextCursor pages). */
+  jobRows: AiBulkJobRow[]
+  /** Async job commit result (set in `jobDone`). */
+  jobCommit: AiBulkJobCommitData | null
   error: AiShortcutUiError | null
   /** RATE_LIMITED countdown (ms); null when no countdown is active. */
   retryRemainingMs: number | null
 }
 
 export function useAiBulkFill(opts: UseAiBulkFillOptions) {
+  const pollIntervalMs = opts.pollIntervalMs ?? 2000
   const state = reactive<AiBulkFillState>({
     phase: 'idle',
     preview: null,
     commit: null,
+    jobId: null,
+    job: null,
+    jobRows: [],
+    jobCommit: null,
     error: null,
     retryRemainingMs: null,
   })
 
-  // The set of recordIds the user has chosen to write. Only confirmable
-  // (rows[]) recordIds are ever admitted here — skipped/failures rows can never
-  // become selectable (they have no value to write). Default after a preview:
-  // ALL confirmable rows (including masked — masked rows ARE writable).
+  // The set of recordIds the user has chosen to write. Only SELECTABLE recordIds
+  // (inline confirmable rows[] OR job `generated` rows) are ever admitted here —
+  // skipped/failures/pending rows can never become selectable (no value to write).
   const selected = ref<Set<string>>(new Set())
 
   let countdownTimer: ReturnType<typeof setInterval> | null = null
+  // Async-job poll: a self-rescheduling setTimeout, NOT setInterval, so a slow
+  // poll never overlaps the next. `pollToken` defeats the zombie-continuation
+  // bug: clearPoll()/reset() bump it; every async continuation captures it at
+  // entry and bails after each await once it no longer matches (so a fetch that
+  // resolves AFTER the dialog closed can't resurrect the loop).
+  let pollTimer: ReturnType<typeof setTimeout> | null = null
+  let pollToken = 0
 
   function clearCountdown(): void {
     if (countdownTimer) {
@@ -75,6 +131,15 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
       countdownTimer = null
     }
     state.retryRemainingMs = null
+  }
+
+  function clearPoll(): void {
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+    // Invalidate any in-flight poll/rows/cancel continuation.
+    pollToken += 1
   }
 
   function startCountdown(ms: number): void {
@@ -98,28 +163,57 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
     return mapped
   }
 
-  /** true exactly when a new send would be refused (in-flight OR active countdown). */
+  /** true exactly when a new send (generate) would be refused (in-flight OR active countdown). */
   const busy = computed(
-    () => state.phase === 'previewing' || state.phase === 'committing' || state.retryRemainingMs !== null,
+    () =>
+      state.phase === 'previewing' ||
+      state.phase === 'committing' ||
+      state.phase === 'polling' ||
+      state.phase === 'jobCommitting' ||
+      state.retryRemainingMs !== null,
   )
 
-  // --- Derived, distinct preview buckets (never collapse them) ---
+  /** true when the current flow is an async job (vs the inline preview path). */
+  const isJob = computed(() => state.jobId !== null)
+
+  // --- Derived, distinct INLINE preview buckets (never collapse them) ---
   const rows = computed(() => state.preview?.rows ?? [])
   const skipped = computed(() => state.preview?.skipped ?? [])
   const failures = computed(() => state.preview?.failures ?? [])
-  /** Whether the preview broke early (partial). NOT the over-cap path (that's a 400). */
+  /** Whether the INLINE preview broke early (partial). NOT the over-cap path (that's a job). */
   const partial = computed(() => state.preview?.capped === true)
-  const settledCost = computed(() => state.preview?.settledCost ?? 0)
+  /** Already-charged cost — inline preview's settledCost, or the job's running settledCost. */
+  const settledCost = computed(() => (isJob.value ? state.job?.settledCost ?? 0 : state.preview?.settledCost ?? 0))
 
-  const confirmableCount = computed(() => rows.value.length)
+  // --- B-4 job-row buckets (distinct review states) ---
+  /** Confirmable job rows = state 'generated' ONLY. */
+  const jobGeneratedRows = computed(() => state.jobRows.filter((r) => r.state === 'generated'))
+  /** Already-committed job rows (terminal). */
+  const jobCommittedRows = computed(() => state.jobRows.filter((r) => r.state === 'committed'))
+  /** Skipped (UNCHARGED) job rows. */
+  const jobSkippedRows = computed(() => state.jobRows.filter((r) => r.state === 'skipped'))
+  /** Failure (CHARGED, non-confirmable) job rows. */
+  const jobFailureRows = computed(() => state.jobRows.filter((r) => r.state === 'failure'))
+  /** Never-generated (cancelled before reach — UNCHARGED) job rows. */
+  const jobPendingNotGeneratedRows = computed(() => state.jobRows.filter((r) => r.state === 'pending_not_generated'))
+  const quotaPaused = computed(() => state.job?.quotaPaused === true)
+
+  // --- Unified selection (the ONE source of "what is selectable") ---
+  // Inline mode: confirmable rows[] (masked included). Job mode: `generated` rows
+  // ONLY. Deriving everything from this makes "only generated rows selectable"
+  // structural, not a second hand-written guard.
+  const selectableIds = computed<string[]>(() =>
+    isJob.value ? jobGeneratedRows.value.map((r) => r.recordId) : rows.value.map((r) => r.recordId),
+  )
+  const confirmableCount = computed(() => selectableIds.value.length)
   const selectedCount = computed(() => selected.value.size)
   const allConfirmableSelected = computed(
     () => confirmableCount.value > 0 && selectedCount.value === confirmableCount.value,
   )
 
-  /** Toggle one confirmable row. A non-confirmable recordId is silently ignored. */
+  /** Toggle one selectable row. A non-selectable recordId is silently ignored. */
   function toggleRow(recordId: string): void {
-    if (!rows.value.some((r) => r.recordId === recordId)) return
+    if (!selectableIds.value.includes(recordId)) return
     const next = new Set(selected.value)
     if (next.has(recordId)) next.delete(recordId)
     else next.add(recordId)
@@ -127,7 +221,7 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
   }
 
   function selectAllConfirmable(): void {
-    selected.value = new Set(rows.value.map((r) => r.recordId))
+    selected.value = new Set(selectableIds.value)
   }
 
   function clearSelection(): void {
@@ -135,24 +229,44 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
   }
 
   /**
-   * Phase 1 — generate the preview (CHARGES the provider per row). Resolves the
-   * server-side scope; the response separates confirmable/skipped/failures.
-   * Returns the preview data, or null on a guarded no-op / error (state.error set).
+   * Phase 1 — start the bulk fill. ≤ cap → an INLINE preview (CHARGES the
+   * provider per row; the response separates confirmable/skipped/failures, B-3).
+   * OVER cap → the backend returns `{ jobId }` and we switch to the async job
+   * flow (poll → review → commit). Returns the preview data (inline), null
+   * (job mode entered — caller reads job state), or null on a guarded no-op /
+   * error (state.error set).
    */
   async function preview(input: AiBulkPreviewInput): Promise<AiBulkPreviewData | null> {
     if (busy.value) return null
+    // Cancel any stale poll loop from a prior run (bumps pollToken) BEFORE we
+    // capture the token this run will use.
+    clearPoll()
     state.phase = 'previewing'
     state.preview = null
     state.commit = null
+    state.jobId = null
+    state.job = null
+    state.jobRows = []
+    state.jobCommit = null
     state.error = null
+    selected.value = new Set()
     try {
-      const data = await opts.client.aiBulkPreview(opts.sheetId(), input)
-      state.preview = data
+      const start = await opts.client.aiBulkPreview(opts.sheetId(), input)
+      if (isAiBulkJobStart(start)) {
+        // Over cap → async job. Begin polling (first poll fires immediately).
+        state.jobId = start.jobId
+        state.phase = 'polling'
+        const token = pollToken // the token this poll run owns
+        await pollStep(token)
+        return null
+      }
+      // Inline path — UNCHANGED from B-3.
+      state.preview = start
       // Default selection: ALL confirmable rows (masked included — masked is a
       // flag on a writable row, never an exclusion). skipped/failures excluded.
-      selected.value = new Set(data.rows.map((r) => r.recordId))
+      selected.value = new Set(start.rows.map((r) => r.recordId))
       state.phase = 'review'
-      return data
+      return start
     } catch (err) {
       fail(err)
       state.phase = 'idle'
@@ -161,10 +275,92 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
   }
 
   /**
-   * Phase 2 — commit the SELECTED confirmable rows (writes the CACHED outputs;
-   * no new provider call / charge). Returns the per-row outcomes, or null on a
-   * guarded no-op / error. A row may come back stale/conflict/no-perm/not-in-cache
-   * even though it was confirmable at preview (commit re-gates the live record).
+   * One poll tick for the async job: read the header, render progress, and either
+   * reschedule (still queued/running) or transition to the committable review /
+   * done. Captures `token` at entry and bails after each await if it no longer
+   * matches (the dialog was closed / a new run started) — never resurrects.
+   */
+  async function pollStep(token: number): Promise<void> {
+    const jobId = state.jobId
+    if (!jobId) return
+    let header: AiBulkJobPoll
+    try {
+      header = await opts.client.getBulkJob(opts.sheetId(), jobId)
+    } catch (err) {
+      if (token !== pollToken) return
+      // A thrown poll STOPS (no reschedule — never an infinite error loop).
+      clearPoll()
+      fail(err)
+      state.phase = 'idle'
+      return
+    }
+    if (token !== pollToken) return
+    state.job = header
+
+    if (!POLL_STOP_STATUSES.has(header.state)) {
+      // Still generating → reschedule the next tick.
+      pollTimer = setTimeout(() => {
+        void pollStep(token)
+      }, pollIntervalMs)
+      return
+    }
+
+    // Terminal-for-this-session. No timer is pending for this tick (we only
+    // schedule when rescheduling), so there is nothing to clearPoll here — and
+    // bumping the token would invalidate THIS owning continuation. Resolve into
+    // review/done directly. (A later loadAllJobRows await is still token-safe
+    // because reset()/a new run bump the token, and we re-check below.)
+    if (header.state === 'resolved') {
+      // Defensive: a job that resolved without our commit (effectively
+      // unreachable in one dialog session) → straight to done with its counts.
+      state.phase = 'jobDone'
+      return
+    }
+    if (COMMITTABLE_STATUSES.has(header.state)) {
+      await loadAllJobRows(jobId, token)
+      return
+    }
+  }
+
+  /**
+   * Fetch ALL review rows by following nextCursor, accumulating, then default-
+   * select every `generated` row and enter jobReview. Guarded against a non-
+   * advancing cursor (MAX_ROW_PAGES). Token-aware: a dialog close mid-fetch
+   * (reset bumps the token) aborts before any state write.
+   */
+  async function loadAllJobRows(jobId: string, token: number): Promise<void> {
+    const all: AiBulkJobRow[] = []
+    let cursor: number | null = null
+    try {
+      for (let page = 0; page < MAX_ROW_PAGES; page += 1) {
+        const res = await opts.client.getBulkJobRows(opts.sheetId(), jobId, cursor)
+        if (token !== pollToken) return
+        all.push(...res.rows)
+        if (res.nextCursor == null) break
+        if (res.nextCursor === cursor) break // non-advancing cursor guard
+        cursor = res.nextCursor
+      }
+    } catch (err) {
+      if (token !== pollToken) return
+      fail(err)
+      // Keep whatever we got; if nothing, fall back to idle so the user can retry.
+      if (all.length === 0) {
+        state.phase = 'idle'
+        return
+      }
+    }
+    if (token !== pollToken) return
+    state.jobRows = all
+    // Default selection = ALL `generated` rows (the only confirmable ones).
+    selected.value = new Set(all.filter((r) => r.state === 'generated').map((r) => r.recordId))
+    state.phase = 'jobReview'
+  }
+
+  /**
+   * Phase 2 (INLINE) — commit the SELECTED confirmable rows (writes the CACHED
+   * outputs; no new provider call / charge). Returns the per-row outcomes, or
+   * null on a guarded no-op / error. A row may come back stale/conflict/no-perm/
+   * not-in-cache even though it was confirmable at preview (commit re-gates).
    */
   async function commit(): Promise<AiBulkCommitData | null> {
     if (busy.value) return null
@@ -186,17 +382,81 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
     }
   }
 
-  /** Reset to idle (e.g. dialog closed) — clears preview, selection, commit, error, countdown. */
+  /**
+   * Phase 2 (JOB) — commit the SELECTED `generated` rows. The FE sends the
+   * confirmed recordIds ONCE; the BACKEND chunks internally (never loop here).
+   * Returns the commit result (counts + state:'resolved'), or null on a guarded
+   * no-op / error. A 409 (not committable / already committing) surfaces and
+   * stays in jobReview.
+   */
+  async function commitJob(): Promise<AiBulkJobCommitData | null> {
+    if (busy.value) return null
+    const jobId = state.jobId
+    if (!jobId) return null
+    const recordIds = [...selected.value]
+    if (recordIds.length === 0) return null
+    state.phase = 'jobCommitting'
+    state.error = null
+    try {
+      const data = await opts.client.commitBulkJob(opts.sheetId(), jobId, recordIds)
+      state.jobCommit = data
+      state.phase = 'jobDone'
+      return data
+    } catch (err) {
+      fail(err)
+      // Stay in review so the user can retry the same selection.
+      state.phase = 'jobReview'
+      return null
+    }
+  }
+
+  /**
+   * Cancel an async job (BJ-4). Stops the worker at the next row; already-
+   * generated rows stay charged + committable, so on success we transition INTO
+   * the committable review (fetch rows + still offer commit), NOT close. Returns
+   * true on a successful cancel. Stops polling first.
+   */
+  async function cancelJob(): Promise<boolean> {
+    const jobId = state.jobId
+    if (!jobId) return false
+    clearPoll()
+    const token = pollToken
+    try {
+      await opts.client.cancelBulkJob(opts.sheetId(), jobId)
+    } catch (err) {
+      if (token !== pollToken) return false
+      fail(err)
+      return false
+    }
+    if (token !== pollToken) return false
+    // Read the post-cancel header for truthful counts, then load the committable
+    // (already-generated) rows into review.
+    try {
+      state.job = await opts.client.getBulkJob(opts.sheetId(), jobId)
+    } catch {
+      // Non-fatal — the rows fetch still drives review.
+    }
+    if (token !== pollToken) return false
+    await loadAllJobRows(jobId, token)
+    return true
+  }
+
+  /** Reset to idle (e.g. dialog closed) — clears everything + stops polling/countdown. */
   function reset(): void {
     clearCountdown()
+    clearPoll()
     state.phase = 'idle'
     state.preview = null
     state.commit = null
+    state.jobId = null
+    state.job = null
+    state.jobRows = []
+    state.jobCommit = null
     state.error = null
     selected.value = new Set()
   }
 
-  /** Dismiss only the error (keep the current phase/preview). */
+  /** Dismiss only the error (keep the current phase/preview/job). */
   function clearError(): void {
     state.error = null
   }
@@ -204,14 +464,17 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
   if (getCurrentScope()) {
     onScopeDispose(() => {
       if (countdownTimer) clearInterval(countdownTimer)
+      if (pollTimer) clearTimeout(pollTimer)
+      pollToken += 1
     })
   }
 
   return {
     state,
     busy,
+    isJob,
     selected,
-    // derived buckets
+    // inline derived buckets
     rows,
     skipped,
     failures,
@@ -220,9 +483,18 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
     confirmableCount,
     selectedCount,
     allConfirmableSelected,
+    // job derived buckets
+    jobGeneratedRows,
+    jobCommittedRows,
+    jobSkippedRows,
+    jobFailureRows,
+    jobPendingNotGeneratedRows,
+    quotaPaused,
     // actions
     preview,
     commit,
+    commitJob,
+    cancelJob,
     toggleRow,
     selectAllConfirmable,
     clearSelection,

--- a/apps/web/src/multitable/composables/useAiBulkFill.ts
+++ b/apps/web/src/multitable/composables/useAiBulkFill.ts
@@ -461,6 +461,13 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
     } catch (err) {
       if (token !== pollToken) return false
       fail(err)
+      // Resilience: the cancel did not land, so the worker may still be running. We
+      // cleared polling above — resume it so the UI shows LIVE progress instead of
+      // freezing on stale numbers until the user retries cancel. pollStep stops cleanly
+      // on its own if the backend is genuinely down; a later cancel re-clears via clearPoll().
+      if (state.phase === 'polling') {
+        await pollStep(token)
+      }
       return false
     }
     if (token !== pollToken) return false

--- a/apps/web/src/multitable/composables/useAiBulkFill.ts
+++ b/apps/web/src/multitable/composables/useAiBulkFill.ts
@@ -51,6 +51,7 @@ export type AiBulkFillPhase =
   // Async job (over cap, B-4) phases.
   | 'polling' // job created; worker generating (queued/running) — polling progress
   | 'jobReview' // committable terminal (suspended/errored/rejected) — rows fetched
+  | 'jobLoadError' // review rows failed to load COMPLETELY — fail-closed, NOT confirmable
   | 'jobCommitting'
   | 'jobDone'
 
@@ -324,36 +325,70 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
 
   /**
    * Fetch ALL review rows by following nextCursor, accumulating, then default-
-   * select every `generated` row and enter jobReview. Guarded against a non-
-   * advancing cursor (MAX_ROW_PAGES). Token-aware: a dialog close mid-fetch
-   * (reset bumps the token) aborts before any state write.
+   * select every `generated` row and enter jobReview.
+   *
+   * FAIL-CLOSED on incomplete pagination (BJ-9 — review-before-write MUST show the
+   * COMPLETE job-rows diff; otherwise the user could confirm what they think is the
+   * whole batch but is only the loaded prefix). The ONLY path into `jobReview` is a
+   * genuine completion (`nextCursor == null`). A page-load error (even after partial
+   * pages), a non-advancing cursor, or MAX_ROW_PAGES exhaustion all land in
+   * `jobLoadError` with NO selection and NO rows — never a confirmable review.
+   * cancelJob() reuses this loader, so it inherits the same guarantee. Token-aware:
+   * a dialog close mid-fetch (reset bumps the token) aborts before any state write.
    */
   async function loadAllJobRows(jobId: string, token: number): Promise<void> {
     const all: AiBulkJobRow[] = []
     let cursor: number | null = null
+    let completed = false
+    // Fail-closed: clear any prior rows/selection up front so no incomplete-load
+    // path can leave a confirmable selection or a stale diff behind.
+    state.jobRows = []
+    selected.value = new Set()
     try {
       for (let page = 0; page < MAX_ROW_PAGES; page += 1) {
         const res = await opts.client.getBulkJobRows(opts.sheetId(), jobId, cursor)
         if (token !== pollToken) return
         all.push(...res.rows)
-        if (res.nextCursor == null) break
-        if (res.nextCursor === cursor) break // non-advancing cursor guard
+        if (res.nextCursor == null) {
+          completed = true
+          break
+        }
+        if (res.nextCursor === cursor) break // non-advancing cursor → INCOMPLETE
         cursor = res.nextCursor
       }
     } catch (err) {
       if (token !== pollToken) return
+      // A page failed mid-pagination — NEVER review on a partial load. Surface the
+      // error and stop in the fail-closed state.
       fail(err)
-      // Keep whatever we got; if nothing, fall back to idle so the user can retry.
-      if (all.length === 0) {
-        state.phase = 'idle'
-        return
-      }
+      state.phase = 'jobLoadError'
+      return
     }
     if (token !== pollToken) return
+    if (!completed) {
+      // Non-advancing cursor or MAX_ROW_PAGES exhausted → the diff is truncated.
+      // Fail-closed rather than letting the user confirm an incomplete batch.
+      state.phase = 'jobLoadError'
+      return
+    }
+    // Pagination genuinely completed (nextCursor == null) → safe to review.
     state.jobRows = all
     // Default selection = ALL `generated` rows (the only confirmable ones).
     selected.value = new Set(all.filter((r) => r.state === 'generated').map((r) => r.recordId))
     state.phase = 'jobReview'
+  }
+
+  /**
+   * Retry a failed review load (from `jobLoadError`). Re-runs the fail-closed loader
+   * for the current job; on success it enters jobReview, on a repeat failure it
+   * stays in jobLoadError. Token-safe (a closed/reset dialog won't reload).
+   */
+  async function retryJobLoad(): Promise<void> {
+    const jobId = state.jobId
+    if (!jobId || state.phase !== 'jobLoadError') return
+    clearError()
+    state.phase = 'polling' // loading indicator while we re-fetch the rows
+    await loadAllJobRows(jobId, pollToken)
   }
 
   /**
@@ -495,6 +530,7 @@ export function useAiBulkFill(opts: UseAiBulkFillOptions) {
     commit,
     commitJob,
     cancelJob,
+    retryJobLoad,
     toggleRow,
     selectAllConfirmable,
     clearSelection,

--- a/apps/web/src/multitable/utils/meta-ai-bulk-labels.ts
+++ b/apps/web/src/multitable/utils/meta-ai-bulk-labels.ts
@@ -75,6 +75,28 @@ export type MetaAiBulkLabelKey =
   | 'aibulk.outcomeSkippedNoPerm'
   | 'aibulk.allExpired'
   | 'aibulk.done'
+  // ── B-4 async JOB mode (over the inline cap) ──
+  // Progress (queued/running — worker still generating)
+  | 'aibulk.jobQueued'
+  | 'aibulk.jobRunning'
+  | 'aibulk.jobProgressAria'
+  | 'aibulk.jobQuotaPaused'
+  // Review heading + the new pending_not_generated row state (cancel before reach)
+  | 'aibulk.jobReviewHeading'
+  | 'aibulk.colJobState'
+  | 'aibulk.stateGenerated'
+  | 'aibulk.statePendingNotGenerated'
+  | 'aibulk.statePendingNotGeneratedNote'
+  // Terminal banners for a committable-but-not-clean job
+  | 'aibulk.jobCancelledNotice'
+  | 'aibulk.jobErroredNotice'
+  | 'aibulk.jobResolvedNotice'
+  // Job action buttons
+  | 'aibulk.jobCancel'
+  | 'aibulk.jobConfirm'
+  | 'aibulk.jobCommitting'
+  // Job commit outcomes (DIVERGE from B-2: `committed` not `written`; no `not_in_cache`)
+  | 'aibulk.jobOutcomeCommitted'
 
 const LABELS: Record<MetaAiBulkLabelKey, LocaleText> = {
   'aibulk.trigger': { en: 'AI fill column', zh: 'AI 填充整列' },
@@ -162,6 +184,35 @@ const LABELS: Record<MetaAiBulkLabelKey, LocaleText> = {
     zh: '确认的行均无法写入——预览可能已过期。请再次运行 AI 填充以重新生成。',
   },
   'aibulk.done': { en: 'Done', zh: '完成' },
+  // ── B-4 async JOB mode ──
+  'aibulk.jobQueued': { en: 'Queued — starting…', zh: '排队中——即将开始…' },
+  'aibulk.jobRunning': { en: 'Generating in the background…', zh: '正在后台生成…' },
+  'aibulk.jobProgressAria': { en: 'Bulk-fill generation progress', zh: '批量填充生成进度' },
+  'aibulk.jobQuotaPaused': {
+    en: 'Generation paused — the per-tenant AI quota ran out before every row was generated. Write the rows already generated, then run AI fill again later to continue.',
+    zh: '生成已暂停——在全部行生成完成前，租户 AI 配额已用尽。可先写入已生成的行，稍后再次运行 AI 填充以继续。',
+  },
+  'aibulk.jobReviewHeading': { en: 'Review generated rows', zh: '审阅已生成的行' },
+  'aibulk.colJobState': { en: 'State', zh: '状态' },
+  'aibulk.stateGenerated': { en: 'Ready to write', zh: '可写入' },
+  'aibulk.statePendingNotGenerated': { en: 'Not generated', zh: '未生成' },
+  'aibulk.statePendingNotGeneratedNote': {
+    en: 'These rows were never generated (the job was cancelled before reaching them) and consumed no quota. Run AI fill again to generate them.',
+    zh: '这些行从未生成（任务在处理到它们之前已取消），未消耗配额。请再次运行 AI 填充以生成它们。',
+  },
+  'aibulk.jobCancelledNotice': {
+    en: 'This job was cancelled. The rows already generated below are still ready to write; the rest were not generated.',
+    zh: '此任务已取消。下方已生成的行仍可写入；其余行未生成。',
+  },
+  'aibulk.jobErroredNotice': {
+    en: 'Generation stopped on an error. The rows already generated below are still ready to write; run AI fill again to continue with the rest.',
+    zh: '生成因出错而中止。下方已生成的行仍可写入；请再次运行 AI 填充以继续处理其余行。',
+  },
+  'aibulk.jobResolvedNotice': { en: 'This job is complete. See the write results below.', zh: '此任务已完成。写入结果见下方。' },
+  'aibulk.jobCancel': { en: 'Cancel generation', zh: '取消生成' },
+  'aibulk.jobConfirm': { en: 'Write selected rows', zh: '写入所选行' },
+  'aibulk.jobCommitting': { en: 'Writing…', zh: '写入中…' },
+  'aibulk.jobOutcomeCommitted': { en: 'Written', zh: '已写入' },
 }
 
 export function aiBulkLabel(key: MetaAiBulkLabelKey, isZh: boolean): string {
@@ -270,4 +321,62 @@ export function aiBulkCommitSummary(counts: Record<string, number>, isZh: boolea
   if (notInCache > 0) parts.push(`${notInCache} expired/not-cached`)
   if (noPerm > 0) parts.push(`${noPerm} no-permission`)
   return parts.join(' · ') + ` (${written + stale + conflict + notInCache + noPerm} ${rowWord(written + stale + conflict + notInCache + noPerm)})`
+}
+
+// ── B-4 async JOB helpers (the inline helpers above are unchanged) ──
+
+/**
+ * Job generation progress line — "{generated} / {total} generated". The counts
+ * are numeric data interpolated raw; the surrounding word is localized. `total`
+ * is the provider-bound denominator (skipped_no_perm rows are NOT in it).
+ */
+export function aiBulkJobProgressLine(generated: number, total: number, isZh: boolean): string {
+  return isZh ? `已生成 ${generated} / ${total}` : `${generated} / ${total} generated`
+}
+
+/**
+ * Distinct copy for each JOB commit per-row OUTCOME. DIVERGES from the inline
+ * (B-2) vocabulary: the terminal success is `committed` (not `written`) and there
+ * is NO `not_in_cache`. stale_reprev / write_conflict / skipped_no_perm reuse the
+ * inline copy. Falls back to the raw outcome.
+ */
+export function aiBulkJobOutcomeLabel(outcome: string, isZh: boolean): string {
+  switch (outcome) {
+    case 'committed':
+      return aiBulkLabel('aibulk.jobOutcomeCommitted', isZh)
+    case 'stale_reprev':
+      return aiBulkLabel('aibulk.outcomeStale', isZh)
+    case 'write_conflict':
+      return aiBulkLabel('aibulk.outcomeConflict', isZh)
+    case 'skipped_no_perm':
+      return aiBulkLabel('aibulk.outcomeSkippedNoPerm', isZh)
+    default:
+      return outcome
+  }
+}
+
+/**
+ * Aggregate JOB commit summary — the headline truthful-status line for the job
+ * commit. Lists every non-zero outcome bucket (`committed` vocabulary; no
+ * not_in_cache). Mirrors aiBulkCommitSummary's row-count tail.
+ */
+export function aiBulkJobCommitSummary(counts: Record<string, number>, isZh: boolean): string {
+  const committed = counts.committed ?? 0
+  const stale = counts.stale_reprev ?? 0
+  const conflict = counts.write_conflict ?? 0
+  const noPerm = counts.skipped_no_perm ?? 0
+  const total = committed + stale + conflict + noPerm
+  const parts: string[] = []
+  if (isZh) {
+    parts.push(`已写入 ${committed} 行`)
+    if (stale > 0) parts.push(`需重新预览 ${stale} 行`)
+    if (conflict > 0) parts.push(`写入冲突 ${conflict} 行`)
+    if (noPerm > 0) parts.push(`无权限 ${noPerm} 行`)
+    return parts.join(' · ')
+  }
+  parts.push(`${committed} written`)
+  if (stale > 0) parts.push(`${stale} need re-preview`)
+  if (conflict > 0) parts.push(`${conflict} write-conflict`)
+  if (noPerm > 0) parts.push(`${noPerm} no-permission`)
+  return parts.join(' · ') + ` (${total} ${rowWord(total)})`
 }

--- a/apps/web/src/multitable/utils/meta-ai-bulk-labels.ts
+++ b/apps/web/src/multitable/utils/meta-ai-bulk-labels.ts
@@ -95,6 +95,8 @@ export type MetaAiBulkLabelKey =
   | 'aibulk.jobCancel'
   | 'aibulk.jobConfirm'
   | 'aibulk.jobCommitting'
+  | 'aibulk.jobLoadErrorBody'
+  | 'aibulk.jobLoadRetry'
   // Job commit outcomes (DIVERGE from B-2: `committed` not `written`; no `not_in_cache`)
   | 'aibulk.jobOutcomeCommitted'
 
@@ -213,6 +215,11 @@ const LABELS: Record<MetaAiBulkLabelKey, LocaleText> = {
   'aibulk.jobConfirm': { en: 'Write selected rows', zh: '写入所选行' },
   'aibulk.jobCommitting': { en: 'Writing…', zh: '写入中…' },
   'aibulk.jobOutcomeCommitted': { en: 'Written', zh: '已写入' },
+  'aibulk.jobLoadErrorBody': {
+    en: "The full review couldn't be loaded, so committing is disabled to avoid writing an incomplete batch. Retry, or cancel and start over.",
+    zh: '无法加载完整的审阅列表，为避免写入不完整的批次，已禁用提交。请重试，或取消后重新开始。',
+  },
+  'aibulk.jobLoadRetry': { en: 'Retry loading', zh: '重新加载' },
 }
 
 export function aiBulkLabel(key: MetaAiBulkLabelKey, isZh: boolean): string {

--- a/apps/web/src/multitable/utils/meta-api-error-labels.ts
+++ b/apps/web/src/multitable/utils/meta-api-error-labels.ts
@@ -26,6 +26,10 @@ export type MetaApiErrorLabelKey =
   | 'error.aiBulkViewFilterUnsupported'
   | 'error.aiBulkInlineConfigRejected'
   | 'error.aiBulkFieldForbidden'
+  // AI BULK async-JOB state copy (B-4) — job lifecycle conflicts keyed on error.code.
+  | 'error.aiBulkActiveJobExists'
+  | 'error.aiBulkJobNotCommittable'
+  | 'error.aiBulkJobCommitInProgress'
 
 const META_API_ERROR_LABELS: Record<MetaApiErrorLabelKey, LocaleText> = {
   'error.forbidden': { en: 'Insufficient permissions', zh: '权限不足' },
@@ -63,6 +67,19 @@ const META_API_ERROR_LABELS: Record<MetaApiErrorLabelKey, LocaleText> = {
   'error.aiBulkFieldForbidden': {
     en: 'This field is not editable, so it cannot be bulk-filled.',
     zh: '该字段不可编辑，无法进行批量填充。',
+  },
+  // AI bulk async-job conflicts (B-4).
+  'error.aiBulkActiveJobExists': {
+    en: 'An AI bulk-fill job for a different scope is already running on this field. Review or cancel it before starting another.',
+    zh: '该字段已有一个不同范围的 AI 批量填充任务在运行。请先审阅或取消后再开始新的任务。',
+  },
+  'error.aiBulkJobNotCommittable': {
+    en: 'This bulk-fill job is not ready to write yet. Wait for generation to finish, then try again.',
+    zh: '该批量填充任务尚未就绪，无法写入。请等待生成完成后重试。',
+  },
+  'error.aiBulkJobCommitInProgress': {
+    en: 'Another write for this bulk-fill job is already in progress.',
+    zh: '该批量填充任务已有另一次写入正在进行中。',
   },
 }
 
@@ -127,6 +144,10 @@ const AI_BULK_ERROR_KEY_BY_CODE: Record<string, MetaApiErrorLabelKey> = {
   AI_BULK_VIEW_FILTER_UNSUPPORTED: 'error.aiBulkViewFilterUnsupported',
   AI_INLINE_CONFIG_REJECTED: 'error.aiBulkInlineConfigRejected',
   FIELD_FORBIDDEN: 'error.aiBulkFieldForbidden',
+  // B-4 async-job conflicts.
+  ACTIVE_JOB_EXISTS: 'error.aiBulkActiveJobExists',
+  BULK_JOB_NOT_COMMITTABLE: 'error.aiBulkJobNotCommittable',
+  BULK_JOB_COMMIT_IN_PROGRESS: 'error.aiBulkJobCommitInProgress',
 }
 
 /**

--- a/apps/web/tests/meta-api-error-labels.spec.ts
+++ b/apps/web/tests/meta-api-error-labels.spec.ts
@@ -23,6 +23,16 @@ describe('meta-api-error-labels', () => {
       'error.aiUnsafeInput',
       'error.aiProviderError',
       'error.aiVersionConflict',
+      // B-3 AI bulk-fill state copy — bulk-specific error codes.
+      'error.aiBulkQuotaInsufficient',
+      'error.aiBulkScopeTooLarge',
+      'error.aiBulkViewFilterUnsupported',
+      'error.aiBulkInlineConfigRejected',
+      'error.aiBulkFieldForbidden',
+      // B-4 AI bulk async-job lifecycle conflicts.
+      'error.aiBulkActiveJobExists',
+      'error.aiBulkJobNotCommittable',
+      'error.aiBulkJobCommitInProgress',
     ])
 
     for (const key of META_API_ERROR_LABEL_KEYS) {

--- a/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
+++ b/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
@@ -1,0 +1,397 @@
+/**
+ * B-4 useAiBulkFill ASYNC-JOB mode + client wire fidelity — over-cap bulk fill.
+ * Design lock: B-3 review-before-write + the B-4 async-job extension
+ * (docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md).
+ *
+ * THE CENTRAL REQUIREMENT (owner's flagged risk): TRUTHFUL STATUS. These tests
+ * lock that the over-cap async flow keeps every distinct state distinct through
+ * the REAL wire: an over-cap start returns { jobId } (job mode); polling reaches
+ * a committable status; the diff rows accumulate across nextCursor; ONLY
+ * `generated` rows are selectable; commit sends the selected recordIds ONCE; and
+ * a terminal (errored/rejected) job still offers a commit of the generated subset.
+ *
+ * Wire fidelity: every job-route fixture is the BARE body the routes actually
+ * emit (multitable-ai.ts: poll/rows/commit/cancel return `res.json({...})` with
+ * NO { ok, data } envelope, and the over-cap start returns a bare { jobId }).
+ * parseJson passes a bare body through verbatim, so a fixture in the wrong
+ * (enveloped) shape would fail loudly. Zero real provider calls.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MultitableApiClient,
+  isAiBulkJobStart,
+  type AiBulkJobCommitData,
+  type AiBulkJobPoll,
+  type AiBulkJobRow,
+} from '../src/multitable/api/client'
+import { useAiBulkFill } from '../src/multitable/composables/useAiBulkFill'
+
+// BARE poll header (BJ-3 return). `suspended` = generation done, awaiting review.
+function pollHeader(overrides: Partial<AiBulkJobPoll> = {}): AiBulkJobPoll {
+  return {
+    jobId: 'aibulkjob_1',
+    state: 'suspended',
+    suspendReason: 'manual_task',
+    total: 3,
+    generated: 2,
+    skippedCount: 1,
+    failuresCount: 0,
+    committedCount: 0,
+    pendingNotGeneratedCount: 0,
+    settledCost: 0.0123,
+    quotaPaused: false,
+    aggregate: null,
+    ...overrides,
+  }
+}
+
+// BARE review rows (BJ-9). A MIXED set: 2 generated (one masked), 1 skipped, 1
+// failure, 1 pending_not_generated — only the `generated` rows are confirmable.
+const JOB_ROWS: AiBulkJobRow[] = [
+  { recordId: 'rec_g1', ordinal: 0, state: 'generated', currentValue: 'old1', proposed: 'NEW1', masked: false, reason: null },
+  { recordId: 'rec_g2', ordinal: 1, state: 'generated', currentValue: null, proposed: 'NEW2', masked: true, reason: null },
+  { recordId: 'rec_sk', ordinal: 2, state: 'skipped', currentValue: null, proposed: null, masked: false, reason: 'skipped_no_perm' },
+  { recordId: 'rec_fl', ordinal: 3, state: 'failure', currentValue: null, proposed: null, masked: false, reason: 'provider_error_charged' },
+  { recordId: 'rec_png', ordinal: 4, state: 'pending_not_generated', currentValue: null, proposed: null, masked: false, reason: null },
+]
+
+const JOB_COMMIT_WIRE: AiBulkJobCommitData = {
+  jobId: 'aibulkjob_1',
+  state: 'resolved',
+  counts: { committed: 1, stale_reprev: 1, write_conflict: 0, skipped_no_perm: 0 },
+  attempted: 2,
+}
+
+function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+}
+
+function setup(fetchFn: (input: string, init?: RequestInit) => Promise<Response>, pollIntervalMs = 2000) {
+  const client = new MultitableApiClient({ fetchFn })
+  const bulk = useAiBulkFill({ client, sheetId: () => 'sheet_1', pollIntervalMs })
+  return { bulk, client }
+}
+
+const previewInput = { fieldId: 'fld_t', scope: 'view' as const, viewId: 'view_1' }
+
+describe('AI bulk JOB client wire shape (bare bodies)', () => {
+  it('an over-cap start returns a bare { jobId } that isAiBulkJobStart detects', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ jobId: 'aibulkjob_1' }))
+    const { client } = setup(fetchFn as never)
+
+    const start = await client.aiBulkPreview('sheet_1', previewInput)
+    expect(isAiBulkJobStart(start)).toBe(true)
+    if (isAiBulkJobStart(start)) expect(start.jobId).toBe('aibulkjob_1')
+  })
+
+  it('getBulkJob returns the bare poll header verbatim (no envelope, key set pinned)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(pollHeader()))
+    const { client } = setup(fetchFn as never)
+
+    const header = await client.getBulkJob('sheet_1', 'aibulkjob_1')
+    const [url] = fetchFn.mock.calls[0] as [string]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/bulk-job/aibulkjob_1')
+    // FIXTURE-DRIFT GUARD: the header key set the FE consumes must not drift.
+    expect(Object.keys(header).sort()).toEqual([
+      'aggregate', 'committedCount', 'failuresCount', 'generated', 'jobId',
+      'pendingNotGeneratedCount', 'quotaPaused', 'settledCost', 'skippedCount',
+      'state', 'suspendReason', 'total',
+    ])
+  })
+
+  it('getBulkJobRows passes the cursor and returns { rows, nextCursor } verbatim', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 }))
+    const { client } = setup(fetchFn as never)
+
+    const page = await client.getBulkJobRows('sheet_1', 'aibulkjob_1', 5)
+    const [url] = fetchFn.mock.calls[0] as [string]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/bulk-job/aibulkjob_1/rows?cursor=5')
+    expect(page.nextCursor).toBe(1)
+    expect(Object.keys(page.rows[0]).sort()).toEqual(['currentValue', 'masked', 'ordinal', 'proposed', 'reason', 'recordId', 'state'])
+  })
+
+  it('getBulkJobRows omits the cursor on the first page', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ rows: [], nextCursor: null }))
+    const { client } = setup(fetchFn as never)
+    await client.getBulkJobRows('sheet_1', 'aibulkjob_1')
+    const [url] = fetchFn.mock.calls[0] as [string]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/bulk-job/aibulkjob_1/rows')
+  })
+
+  it('commitBulkJob posts { recordIds } ONCE and returns the bare commit result', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(JOB_COMMIT_WIRE))
+    const { client } = setup(fetchFn as never)
+
+    const data = await client.commitBulkJob('sheet_1', 'aibulkjob_1', ['rec_g1', 'rec_g2'])
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/bulk-job/aibulkjob_1/commit')
+    expect(JSON.parse(String(init.body))).toEqual({ recordIds: ['rec_g1', 'rec_g2'] })
+    expect(data.state).toBe('resolved')
+    // DIVERGENCE GUARD: job outcome counts use `committed`, not `written`, and have no `not_in_cache`.
+    expect(Object.keys(data.counts).sort()).toEqual(['committed', 'skipped_no_perm', 'stale_reprev', 'write_conflict'])
+  })
+
+  it('cancelBulkJob POSTs and returns the bare cancel result', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' }))
+    const { client } = setup(fetchFn as never)
+    const data = await client.cancelBulkJob('sheet_1', 'aibulkjob_1')
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/bulk-job/aibulkjob_1/cancel')
+    expect(init.method).toBe('POST')
+    expect(data).toEqual({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' })
+  })
+})
+
+describe('useAiBulkFill — async-job state machine', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Route the fetch to the right handler by URL — one stub for the whole flow. */
+  function router(handlers: {
+    start: () => Response
+    poll: (n: number) => Response
+    rows: (cursor: string | null) => Response
+    commit?: () => Response
+    cancel?: () => Response
+  }) {
+    let pollCount = 0
+    return vi.fn(async (input: string) => {
+      if (input.endsWith('/bulk-preview')) return handlers.start()
+      if (input.includes('/rows')) {
+        const m = input.match(/cursor=(\d+)/)
+        return handlers.rows(m ? m[1]! : null)
+      }
+      if (input.endsWith('/commit')) return (handlers.commit ?? (() => jsonResponse(JOB_COMMIT_WIRE)))()
+      if (input.endsWith('/cancel')) return (handlers.cancel ?? (() => jsonResponse({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' })))()
+      // bulk-job poll
+      pollCount += 1
+      return handlers.poll(pollCount)
+    })
+  }
+
+  it('an over-cap start enters job mode, polls to suspended, and loads ALL review rows', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never)
+
+    const result = await bulk.preview(previewInput)
+    expect(result).toBeNull() // job mode → no inline preview returned
+
+    expect(bulk.isJob.value).toBe(true)
+    expect(bulk.state.jobId).toBe('aibulkjob_1')
+    expect(bulk.state.phase).toBe('jobReview')
+    expect(bulk.state.job?.state).toBe('suspended')
+    // All 5 rows accumulated; buckets kept distinct.
+    expect(bulk.state.jobRows).toHaveLength(5)
+    expect(bulk.jobGeneratedRows.value.map((r) => r.recordId)).toEqual(['rec_g1', 'rec_g2'])
+    expect(bulk.jobSkippedRows.value.map((r) => r.recordId)).toEqual(['rec_sk'])
+    expect(bulk.jobFailureRows.value.map((r) => r.recordId)).toEqual(['rec_fl'])
+    expect(bulk.jobPendingNotGeneratedRows.value.map((r) => r.recordId)).toEqual(['rec_png'])
+    // Default selection = ALL generated rows (masked included).
+    expect([...bulk.selected.value].sort()).toEqual(['rec_g1', 'rec_g2'])
+    // Progress + cost surfaced from the poll header.
+    expect(bulk.settledCost.value).toBe(0.0123)
+  })
+
+  it('polls across multiple ticks (queued → running → suspended) before review', async () => {
+    vi.useFakeTimers()
+    const states: Array<AiBulkJobPoll['state']> = ['queued', 'running', 'suspended']
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: (n) => jsonResponse(pollHeader({ state: states[Math.min(n - 1, states.length - 1)]!, generated: n })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never, 2000)
+
+    await bulk.preview(previewInput) // first poll fires immediately → queued
+    expect(bulk.state.phase).toBe('polling')
+    expect(bulk.state.job?.state).toBe('queued')
+
+    await vi.advanceTimersByTimeAsync(2000) // second poll → running
+    expect(bulk.state.phase).toBe('polling')
+    expect(bulk.state.job?.state).toBe('running')
+
+    await vi.advanceTimersByTimeAsync(2000) // third poll → suspended → review
+    expect(bulk.state.phase).toBe('jobReview')
+    expect(bulk.state.jobRows).toHaveLength(5)
+  })
+
+  it('accumulates review rows across nextCursor pages (paginated review)', async () => {
+    const pages: Record<string, Response> = {}
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        // page 1 (no cursor) → first 2 + nextCursor 1; page 2 (cursor=1) → next 2 + nextCursor 3; page 3 (cursor=3) → last 1 + null
+        if (cursor === null) return jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 })
+        if (cursor === '1') return jsonResponse({ rows: JOB_ROWS.slice(2, 4), nextCursor: 3 })
+        return jsonResponse({ rows: JOB_ROWS.slice(4), nextCursor: null })
+      },
+    })
+    void pages
+    const { bulk } = setup(fetchFn as never)
+
+    await bulk.preview(previewInput)
+    expect(bulk.state.jobRows.map((r) => r.recordId)).toEqual(['rec_g1', 'rec_g2', 'rec_sk', 'rec_fl', 'rec_png'])
+    // 1 start + 1 poll + 3 row pages = 5 fetches
+    expect(fetchFn).toHaveBeenCalledTimes(5)
+  })
+
+  it('ONLY generated rows are selectable — toggling a skipped/failure/pending id is a no-op', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never)
+    await bulk.preview(previewInput)
+
+    bulk.clearSelection()
+    bulk.toggleRow('rec_sk') // skipped
+    bulk.toggleRow('rec_fl') // failure
+    bulk.toggleRow('rec_png') // pending_not_generated
+    expect(bulk.selected.value.size).toBe(0)
+
+    bulk.toggleRow('rec_g2') // generated masked row — CAN be selected
+    expect([...bulk.selected.value]).toEqual(['rec_g2'])
+  })
+
+  it('commit posts ONLY the selected generated rows ONCE and resolves to jobDone', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+      commit: () => jsonResponse(JOB_COMMIT_WIRE),
+    })
+    const { bulk } = setup(fetchFn as never)
+    await bulk.preview(previewInput)
+
+    // Deselect the masked row → only rec_g1 confirmed.
+    bulk.toggleRow('rec_g2')
+    const data = await bulk.commitJob()
+
+    const commitCall = (fetchFn.mock.calls as Array<[string, RequestInit]>).find(([u]) => u.endsWith('/commit'))!
+    expect(JSON.parse(String(commitCall[1].body))).toEqual({ recordIds: ['rec_g1'] })
+    // Exactly one commit fetch — the FE never loops (backend chunks).
+    expect((fetchFn.mock.calls as Array<[string]>).filter(([u]) => u.endsWith('/commit'))).toHaveLength(1)
+    expect(bulk.state.phase).toBe('jobDone')
+    expect(data?.counts.committed).toBe(1)
+    expect(data?.counts.stale_reprev).toBe(1)
+  })
+
+  it('commit with an empty selection is a guarded no-op (no commit fetch, stays in jobReview)', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never)
+    await bulk.preview(previewInput)
+    bulk.clearSelection()
+
+    const result = await bulk.commitJob()
+    expect(result).toBeNull()
+    expect((fetchFn.mock.calls as Array<[string]>).some(([u]) => u.endsWith('/commit'))).toBe(false)
+    expect(bulk.state.phase).toBe('jobReview')
+  })
+
+  it('a terminal ERRORED job is still committable (review of the generated subset)', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ state: 'errored', suspendReason: null, generated: 2, total: 4 })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never)
+    await bulk.preview(previewInput)
+
+    expect(bulk.state.job?.state).toBe('errored')
+    expect(bulk.state.phase).toBe('jobReview') // committable, NOT a dead end
+    expect(bulk.jobGeneratedRows.value).toHaveLength(2)
+    expect([...bulk.selected.value].sort()).toEqual(['rec_g1', 'rec_g2'])
+  })
+
+  it('cancel stops polling and transitions INTO review with the already-generated rows', async () => {
+    vi.useFakeTimers()
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ state: 'running', generated: 2, total: 4 })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+      cancel: () => jsonResponse({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' }),
+    })
+    const { bulk } = setup(fetchFn as never, 2000)
+
+    await bulk.preview(previewInput) // first poll → running, still polling
+    expect(bulk.state.phase).toBe('polling')
+
+    const ok = await bulk.cancelJob()
+    expect(ok).toBe(true)
+    expect(bulk.state.phase).toBe('jobReview')
+    // already-generated rows are committable.
+    expect(bulk.jobGeneratedRows.value).toHaveLength(2)
+    expect([...bulk.selected.value].sort()).toEqual(['rec_g1', 'rec_g2'])
+
+    // No further polling after cancel (the loop was stopped).
+    const callsBefore = fetchFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(fetchFn.mock.calls.length).toBe(callsBefore)
+  })
+
+  it('quotaPaused is surfaced for the progress banner', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ quotaPaused: true })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never)
+    await bulk.preview(previewInput)
+    expect(bulk.quotaPaused.value).toBe(true)
+  })
+
+  it('a poll error surfaces by code and stops the loop (no infinite retry)', async () => {
+    vi.useFakeTimers()
+    let polls = 0
+    const fetchFn = vi.fn(async (input: string) => {
+      if (input.endsWith('/bulk-preview')) return jsonResponse({ jobId: 'aibulkjob_1' })
+      polls += 1
+      return jsonResponse({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'boom' } }, { status: 500 })
+    })
+    const { bulk } = setup(fetchFn as never, 2000)
+
+    await bulk.preview(previewInput)
+    expect(bulk.state.error?.code).toBe('INTERNAL_ERROR')
+    expect(bulk.state.phase).toBe('idle')
+
+    await vi.advanceTimersByTimeAsync(8000)
+    expect(polls).toBe(1) // stopped after the first failed poll — no reschedule
+  })
+
+  it('reset clears job state + stops polling; a late poll cannot resurrect the loop', async () => {
+    vi.useFakeTimers()
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ state: 'running' })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { bulk } = setup(fetchFn as never, 2000)
+    await bulk.preview(previewInput)
+    expect(bulk.state.phase).toBe('polling')
+
+    bulk.reset()
+    expect(bulk.state.phase).toBe('idle')
+    expect(bulk.state.jobId).toBeNull()
+    expect(bulk.state.job).toBeNull()
+    expect(bulk.state.jobRows).toHaveLength(0)
+
+    const callsBefore = fetchFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(fetchFn.mock.calls.length).toBe(callsBefore) // no further polls
+    expect(bulk.state.phase).toBe('idle') // not resurrected
+  })
+})

--- a/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
+++ b/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
@@ -394,4 +394,88 @@ describe('useAiBulkFill — async-job state machine', () => {
     expect(fetchFn.mock.calls.length).toBe(callsBefore) // no further polls
     expect(bulk.state.phase).toBe('idle') // not resurrected
   })
+
+  // ── Pagination-completeness FAIL-CLOSED (BJ-9: review-before-write must show the COMPLETE diff) ──
+  // Each incomplete-load path must NOT enter the confirmable `jobReview` (else the user could
+  // commit what they think is the whole batch but is only the loaded prefix).
+
+  it('FAIL-CLOSED: a page-2 load error does NOT enter review (no truncated diff, no selection)', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        if (cursor === null) return jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 })
+        return jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }, { status: 500 }) // page 2 fails
+      },
+    })
+    const { bulk } = setup(fetchFn as never)
+
+    await bulk.preview(previewInput)
+
+    expect(bulk.state.phase).toBe('jobLoadError') // NOT jobReview
+    expect(bulk.state.jobRows).toHaveLength(0) // no truncated diff retained
+    expect(bulk.selected.value.size).toBe(0) // no committable selection
+    expect(bulk.state.error).not.toBeNull() // the page error is surfaced
+  })
+
+  it('FAIL-CLOSED: a non-advancing cursor does NOT enter review', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        if (cursor === null) return jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 })
+        return jsonResponse({ rows: JOB_ROWS.slice(2, 4), nextCursor: 1 }) // SAME cursor → non-advancing
+      },
+    })
+    const { bulk } = setup(fetchFn as never)
+
+    await bulk.preview(previewInput)
+
+    expect(bulk.state.phase).toBe('jobLoadError')
+    expect(bulk.state.jobRows).toHaveLength(0)
+    expect(bulk.selected.value.size).toBe(0)
+  })
+
+  it('FAIL-CLOSED: MAX_ROW_PAGES exhaustion does NOT enter review', async () => {
+    // Always advance the cursor and never return null → the loader exhausts the page cap.
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        const next = (cursor === null ? 0 : Number(cursor)) + 1
+        return jsonResponse({ rows: [JOB_ROWS[0]], nextCursor: next })
+      },
+    })
+    const { bulk } = setup(fetchFn as never)
+
+    await bulk.preview(previewInput)
+
+    expect(bulk.state.phase).toBe('jobLoadError')
+    expect(bulk.state.jobRows).toHaveLength(0)
+    expect(bulk.selected.value.size).toBe(0)
+  })
+
+  it('retryJobLoad re-runs the fail-closed loader: transient page error → jobLoadError → retry → jobReview', async () => {
+    let page2Attempts = 0
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        if (cursor === null) return jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 })
+        page2Attempts += 1
+        if (page2Attempts === 1) return jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }, { status: 500 })
+        return jsonResponse({ rows: JOB_ROWS.slice(2), nextCursor: null }) // retry: page 2 succeeds → complete
+      },
+    })
+    const { bulk } = setup(fetchFn as never)
+
+    await bulk.preview(previewInput)
+    expect(bulk.state.phase).toBe('jobLoadError')
+
+    await bulk.retryJobLoad()
+    expect(bulk.state.phase).toBe('jobReview') // now complete → confirmable
+    expect(bulk.state.jobRows).toHaveLength(5)
+    expect([...bulk.selected.value].sort()).toEqual(['rec_g1', 'rec_g2']) // default-select generated
+    expect(bulk.state.error).toBeNull() // cleared on retry
+  })
 })

--- a/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
+++ b/apps/web/tests/multitable-ai-bulk-fill-job-composable.spec.ts
@@ -478,4 +478,29 @@ describe('useAiBulkFill — async-job state machine', () => {
     expect([...bulk.selected.value].sort()).toEqual(['rec_g1', 'rec_g2']) // default-select generated
     expect(bulk.state.error).toBeNull() // cleared on retry
   })
+
+  // ── Resilience: a FAILED cancel must not freeze the UI in polling with stale progress ──
+  it('a failed cancel RESUMES polling (UI keeps live progress, not frozen) and surfaces the error', async () => {
+    vi.useFakeTimers()
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: (n) => jsonResponse(pollHeader({ state: 'running', generated: n })), // worker still running
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+      cancel: () => jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }, { status: 500 }), // cancel fails
+    })
+    const { bulk } = setup(fetchFn as never, 2000)
+
+    await bulk.preview(previewInput) // first poll → running
+    expect(bulk.state.phase).toBe('polling')
+
+    await bulk.cancelJob() // cancel API fails
+    expect(bulk.state.phase).toBe('polling') // RESUMED, not frozen
+    expect(bulk.state.error).not.toBeNull() // the cancel failure is surfaced
+
+    // Polling genuinely continues — a later tick fetches a fresh header.
+    const before = fetchFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(fetchFn.mock.calls.length).toBeGreaterThan(before)
+    expect(bulk.state.phase).toBe('polling')
+  })
 })

--- a/apps/web/tests/multitable-ai-bulk-fill-job-dialog.spec.ts
+++ b/apps/web/tests/multitable-ai-bulk-fill-job-dialog.spec.ts
@@ -295,4 +295,25 @@ describe('MetaAiBulkFillDialog — async-job (over-cap) rendering', () => {
     expect((q('[data-test="ai-bulk-job-confirm"]') as HTMLButtonElement).disabled).toBe(true)
     app.unmount()
   })
+
+  it('a page-load failure renders the fail-closed jobLoadError UI (error body + retry, NO commit / NO rows)', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ total: 5, generated: 2 })),
+      rows: (cursor) => {
+        if (cursor === null) return jsonResponse({ rows: JOB_ROWS.slice(0, 2), nextCursor: 1 })
+        return jsonResponse({ error: { code: 'INTERNAL_ERROR', message: 'boom' } }, { status: 500 }) // page 2 fails
+      },
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+
+    // Fail-closed UI: error body + retry button, and NO confirmable surface (no commit, no rows).
+    expect(q('[data-test="ai-bulk-job-load-error"]')).not.toBeNull()
+    expect(q('[data-test="ai-bulk-job-load-retry"]')).not.toBeNull()
+    expect(q('[data-test="ai-bulk-job-confirm"]')).toBeNull()
+    expect(qa('[data-test="ai-bulk-job-row"]')).toHaveLength(0)
+    app.unmount()
+  })
 })

--- a/apps/web/tests/multitable-ai-bulk-fill-job-dialog.spec.ts
+++ b/apps/web/tests/multitable-ai-bulk-fill-job-dialog.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * B-4 MetaAiBulkFillDialog ASYNC-JOB mode — over-cap review-before-write UI.
+ * Design lock: B-3 + the B-4 async-job extension
+ * (docs/development/multitable-ai-bulk-fill-review-before-write-designlock-20260621.md).
+ *
+ * THE CENTRAL REQUIREMENT (owner's flagged risk): TRUTHFUL STATUS. These tests
+ * lock that the over-cap job UI never misleads the user about what was or wasn't
+ * written:
+ *  - a generating job shows a progress bar (generated/total) + the already-charged cost;
+ *  - quotaPaused renders an explicit "generation paused" banner;
+ *  - the review table makes ONLY `generated` rows selectable; skipped / failure /
+ *    pending_not_generated are read-only sections with their reasons;
+ *  - a terminal (errored / rejected) job still offers a commit of the generated
+ *    subset (a cancelled/errored banner, NOT a dead end);
+ *  - the job commit summary uses the `committed` vocabulary.
+ *
+ * The dialog is driven by the REAL useAiBulkFill over a stubbed client, so the
+ * full job flow runs through the actual state machine + BARE wire shapes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaAiBulkFillDialog from '../src/multitable/components/MetaAiBulkFillDialog.vue'
+import { useAiBulkFill } from '../src/multitable/composables/useAiBulkFill'
+import { MultitableApiClient, type AiBulkJobCommitData, type AiBulkJobPoll, type AiBulkJobRow } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
+
+function pollHeader(overrides: Partial<AiBulkJobPoll> = {}): AiBulkJobPoll {
+  return {
+    jobId: 'aibulkjob_1',
+    state: 'suspended',
+    suspendReason: 'manual_task',
+    total: 3,
+    generated: 2,
+    skippedCount: 1,
+    failuresCount: 1,
+    committedCount: 0,
+    pendingNotGeneratedCount: 1,
+    settledCost: 0.0123,
+    quotaPaused: false,
+    aggregate: null,
+    ...overrides,
+  }
+}
+
+const JOB_ROWS: AiBulkJobRow[] = [
+  { recordId: 'rec_g1', ordinal: 0, state: 'generated', currentValue: 'old1', proposed: 'NEW1', masked: false, reason: null },
+  { recordId: 'rec_g2', ordinal: 1, state: 'generated', currentValue: null, proposed: 'NEW2', masked: true, reason: null },
+  { recordId: 'rec_sk', ordinal: 2, state: 'skipped', currentValue: null, proposed: null, masked: false, reason: 'skipped_no_perm' },
+  { recordId: 'rec_fl', ordinal: 3, state: 'failure', currentValue: null, proposed: null, masked: false, reason: 'provider_error_charged' },
+  { recordId: 'rec_png', ordinal: 4, state: 'pending_not_generated', currentValue: null, proposed: null, masked: false, reason: null },
+]
+
+const JOB_COMMIT_WIRE: AiBulkJobCommitData = {
+  jobId: 'aibulkjob_1',
+  state: 'resolved',
+  counts: { committed: 1, stale_reprev: 1, write_conflict: 0, skipped_no_perm: 0 },
+  attempted: 2,
+}
+
+function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+}
+
+/** Route the fetch to the right handler by URL — one stub for the whole flow. */
+function router(handlers: {
+  start: () => Response
+  poll: (n: number) => Response
+  rows: () => Response
+  commit?: () => Response
+  cancel?: () => Response
+}) {
+  let pollCount = 0
+  return vi.fn(async (input: string) => {
+    if (input.endsWith('/bulk-preview')) return handlers.start()
+    if (input.includes('/rows')) return handlers.rows()
+    if (input.endsWith('/commit')) return (handlers.commit ?? (() => jsonResponse(JOB_COMMIT_WIRE)))()
+    if (input.endsWith('/cancel')) return (handlers.cancel ?? (() => jsonResponse({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' })))()
+    pollCount += 1
+    return handlers.poll(pollCount)
+  })
+}
+
+function mountDialog(fetchFn: (input: string, init?: RequestInit) => Promise<Response>, pollIntervalMs = 2000): {
+  app: App
+  controller: ReturnType<typeof useAiBulkFill>
+} {
+  const client = new MultitableApiClient({ fetchFn })
+  const controller = useAiBulkFill({ client, sheetId: () => 'sheet_1', pollIntervalMs })
+  const app = createApp({
+    render() {
+      return h(MetaAiBulkFillDialog, {
+        visible: true,
+        controller,
+        fieldId: 'fld_t',
+        viewId: 'view_1',
+        selectedRecordIds: [],
+        fieldName: (id: string) => (id === 'fld_t' ? 'Summary' : id),
+        recordName: (id: string) => id,
+        isZh: false,
+      })
+    },
+  })
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  app.mount(host)
+  return { app, controller }
+}
+
+function q(sel: string): HTMLElement | null {
+  return document.body.querySelector(sel)
+}
+function qa(sel: string): HTMLElement[] {
+  return Array.from(document.body.querySelectorAll(sel))
+}
+
+// The job flow chains several sequential fetches (start → poll → rows pages),
+// each with an `await res.text()` microtask, so flush generously.
+async function flush(): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('MetaAiBulkFillDialog — async-job (over-cap) rendering', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+  })
+
+  it('shows a progress bar (generated/total) + already-charged cost while generating', async () => {
+    vi.useFakeTimers()
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ state: 'running', generated: 2, total: 3 })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { app } = mountDialog(fetchFn as never, 2000)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(q('[data-test="ai-bulk-progress"]')).not.toBeNull()
+    expect(q('[data-test="ai-bulk-progress-line"]')?.textContent).toContain('2 / 3 generated')
+    const bar = q('[data-test="ai-bulk-progress"]')!
+    expect(bar.getAttribute('aria-valuenow')).toBe('2')
+    expect(bar.getAttribute('aria-valuemax')).toBe('3')
+    // The cancel-generation button is available while polling.
+    expect(q('[data-test="ai-bulk-job-cancel"]')).not.toBeNull()
+    // Cost (already charged) surfaced.
+    expect(q('[data-test="ai-bulk-cost"]')?.textContent).toContain('0.0123')
+    app.unmount()
+  })
+
+  it('a MIXED job review renders generated rows selectable; skipped/failure/pending read-only', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+
+    // Generated rows: exactly 2, each selectable + default-checked.
+    const rows = qa('[data-test="ai-bulk-job-row"]')
+    expect(rows).toHaveLength(2)
+    const rowSelects = qa('[data-test="ai-bulk-job-row-select"]') as HTMLInputElement[]
+    expect(rowSelects).toHaveLength(2)
+    expect(rowSelects.every((c) => c.checked)).toBe(true)
+
+    // Masked generated row distinctly badged.
+    expect(q('[data-test="ai-bulk-job-badge-masked"]')?.textContent).toContain('May be incomplete')
+    expect(q('[data-test="ai-bulk-job-badge-ready"]')?.textContent).toContain('Ready to write')
+
+    // Skipped / failure / pending — read-only lists (no checkboxes), with reasons.
+    const skipped = q('[data-test="ai-bulk-job-skipped"]')
+    expect(skipped!.querySelectorAll('input[type="checkbox"]')).toHaveLength(0)
+    expect(q('[data-test="ai-bulk-job-skipped-item"] .ai-bulk__group-reason')?.textContent).toContain('No write permission')
+
+    const failures = q('[data-test="ai-bulk-job-failures"]')
+    expect(failures!.querySelectorAll('input[type="checkbox"]')).toHaveLength(0)
+    expect(q('[data-test="ai-bulk-job-failure-item"] .ai-bulk__group-reason')?.textContent).toContain('Provider error after charge')
+
+    const pending = q('[data-test="ai-bulk-job-pending"]')
+    expect(pending).not.toBeNull()
+    expect(pending!.querySelectorAll('input[type="checkbox"]')).toHaveLength(0)
+
+    // Confirm button counts the 2 default-selected generated rows.
+    expect((q('[data-test="ai-bulk-job-confirm"]') as HTMLButtonElement).textContent).toContain('(2)')
+    app.unmount()
+  })
+
+  it('quotaPaused renders the explicit "generation paused" banner in review', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ quotaPaused: true })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+    expect(q('[data-test="ai-bulk-quota-paused"]')?.textContent).toContain('Generation paused')
+    app.unmount()
+  })
+
+  it('a terminal ERRORED job shows a banner AND still offers a commit of the generated subset', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader({ state: 'errored', suspendReason: null })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(q('[data-test="ai-bulk-job-banner"]')?.textContent).toContain('Generation stopped on an error')
+    // Generated rows still selectable + a working confirm button.
+    expect(qa('[data-test="ai-bulk-job-row"]')).toHaveLength(2)
+    const confirm = q('[data-test="ai-bulk-job-confirm"]') as HTMLButtonElement
+    expect(confirm).not.toBeNull()
+    expect(confirm.disabled).toBe(false)
+    app.unmount()
+  })
+
+  it('a cancelled job (rejected) shows the cancelled banner with the generated subset still committable', async () => {
+    vi.useFakeTimers()
+    // After cancel, the post-cancel poll re-read reflects `rejected` (the worker
+    // stopped); before cancel it is `running`.
+    let cancelled = false
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () =>
+        jsonResponse(pollHeader({ state: cancelled ? 'rejected' : 'running', suspendReason: null, generated: 2, total: 4 })),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+      cancel: () => {
+        cancelled = true
+        return jsonResponse({ jobId: 'aibulkjob_1', cancelled: true, state: 'rejected' })
+      },
+    })
+    const { app } = mountDialog(fetchFn as never, 2000)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+    expect(q('[data-test="ai-bulk-progress"]')).not.toBeNull() // generating
+
+    ;(q('[data-test="ai-bulk-job-cancel"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(q('[data-test="ai-bulk-job-banner"]')?.textContent).toContain('cancelled')
+    expect(qa('[data-test="ai-bulk-job-row"]')).toHaveLength(2)
+    expect(q('[data-test="ai-bulk-job-confirm"]')).not.toBeNull()
+    app.unmount()
+  })
+
+  it('committing the job renders the commit summary (committed vocabulary) + stale guidance', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+      commit: () => jsonResponse(JOB_COMMIT_WIRE),
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+    ;(q('[data-test="ai-bulk-job-confirm"]') as HTMLButtonElement).click()
+    await flush()
+
+    const summary = q('[data-test="ai-bulk-job-commit-summary"]')?.textContent ?? ''
+    expect(summary).toContain('1 written')
+    expect(summary).toContain('1 need re-preview')
+    // Stale rows → explicit re-preview guidance.
+    expect(q('[data-test="ai-bulk-job-stale-guidance"]')?.textContent).toContain('re-preview')
+    // The done button is shown.
+    expect(q('[data-test="ai-bulk-job-done"]')?.textContent).toContain('Done')
+    app.unmount()
+  })
+
+  it('deselecting all generated rows disables the job confirm button', async () => {
+    const fetchFn = router({
+      start: () => jsonResponse({ jobId: 'aibulkjob_1' }),
+      poll: () => jsonResponse(pollHeader()),
+      rows: () => jsonResponse({ rows: JOB_ROWS, nextCursor: null }),
+    })
+    const { app } = mountDialog(fetchFn as never)
+    ;(q('[data-test="ai-bulk-generate"]') as HTMLButtonElement).click()
+    await flush()
+
+    ;(q('[data-test="ai-bulk-job-select-all"]') as HTMLInputElement).click()
+    await nextTick()
+    expect((q('[data-test="ai-bulk-job-confirm"]') as HTMLButtonElement).disabled).toBe(true)
+    app.unmount()
+  })
+})


### PR DESCRIPTION
## B-4 Slice 2 — async-job frontend

Drives the async job that Slice 1 (#3075) creates for over-cap bulk-fills: **start → poll progress → paginated review of the generated diff → commit a confirmed subset (or cancel).** The inline ≤cap path (B-3) is **untouched**.

### Contract (verified against the merged Slice-1 routes, not a paraphrase)
- `aiBulkPreview` returns a **union**: inline `{rows,skipped,failures}` (≤cap) or a bare `{jobId}` (over-cap) — discriminated by `isAiBulkJobStart`.
- Poll `GET …/bulk-job/:jobId` → `{ jobId, state, suspendReason, total, generated, skippedCount, failuresCount, committedCount, pendingNotGeneratedCount, settledCost, quotaPaused, aggregate }` (note: `state`, not `status`).
- Review `GET …/rows?cursor=N` → `{ rows:[{recordId,ordinal,state,currentValue,proposed,masked,reason}], nextCursor }` (wire field `proposed` ← `proposedValue`; FE type matches).
- Commit `POST …/commit {recordIds}` → `{ jobId, state:'resolved', counts, attempted }` — FE sends recordIds **once**; backend chunks (BJ-10).
- Committable statuses: `suspended | errored | rejected`.

### Key design
- **Poll**: a self-rescheduling `setTimeout` (not `setInterval`, so a slow poll never overlaps), first tick immediate, ~2s thereafter while `queued|running`. A `pollToken` (bumped by `clearPoll()`/`reset()`/`onScopeDispose`) defeats the zombie-continuation bug — a fetch resolving after the dialog closed can't resurrect the loop or timers.
- **Review**: on a committable status, accumulate **all** rows by following `nextCursor` (non-advancing-cursor + `MAX_ROW_PAGES` guards); default-select every `generated` row; `selectableIds` makes "only `generated` rows selectable" structural at both layers.
- **Cancel** → `rejected` then transitions **into** review (already-generated rows stay committable), not a silent close.

### Files
`api/client.ts` (job types + `getBulkJob`/`getBulkJobRows`/`commitBulkJob`/`cancelBulkJob`), `composables/useAiBulkFill.ts` (job state machine; inline path byte-identical), `components/MetaAiBulkFillDialog.vue` (progress/review/commit UI), `utils/meta-ai-bulk-labels.ts` (+`utils/meta-api-error-labels.ts`, 3 job-conflict codes) — strict-zero i18n (EN+ZH).

### Tests
24 new component/unit specs (17 composable + 7 dialog): job-mode detection, multi-tick poll→suspended (fake timers), `nextCursor` accumulation, only-`generated`-selectable, commit-sends-recordIds-once, progress + quota-paused rendering, errored/rejected-still-committable, poll-error-stops-loop, reset-can't-resurrect. B-3 regression (23) still green; type-check (`vue-tsc -b`) 0 errors. (Real browser/real-DB e2e is Slice 3.)

### Notes
- Inline ≤cap B-3 path unchanged.
- Hard-restart reconciliation remains a deferred B-4 follow-up (per the narrowed BJ-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)