### PR TITLE
fix(onprem): harden multitable package archives

### DIFF
--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -513,6 +513,46 @@ function Expand-PackageArchive {
   throw "Unsupported package extension (expected .zip, .tgz, or .tar.gz): $ArchivePath"
 }
 
+function Test-OnPremPackageRoot {
+  param([string]$Candidate)
+
+  if ([string]::IsNullOrWhiteSpace($Candidate)) {
+    return $false
+  }
+  return (
+    (Test-Path -LiteralPath (Join-Path $Candidate 'pnpm-lock.yaml')) -and
+    (Test-Path -LiteralPath (Join-Path $Candidate 'PACKAGE-METADATA.json')) -and
+    (Test-Path -LiteralPath (Join-Path $Candidate 'scripts\ops\multitable-onprem-apply-package.ps1'))
+  )
+}
+
+function Resolve-ExtractedPackageRoot {
+  param([string]$ExtractRoot)
+
+  $rootItem = Get-Item -LiteralPath $ExtractRoot -ErrorAction Stop
+  $candidates = @()
+  if (Test-OnPremPackageRoot -Candidate $rootItem.FullName) {
+    $candidates += $rootItem
+  }
+  $candidates += @(
+    Get-ChildItem -LiteralPath $ExtractRoot -Directory -Recurse -ErrorAction Stop |
+      Where-Object { Test-OnPremPackageRoot -Candidate $_.FullName }
+  )
+
+  if ($candidates.Count -lt 1) {
+    throw "Failed to locate extracted package root under $ExtractRoot (missing pnpm-lock.yaml / PACKAGE-METADATA.json / apply helper markers)"
+  }
+  if ($candidates.Count -eq 1) {
+    return $candidates[0].FullName
+  }
+
+  $preferred = @($candidates) | Where-Object { $_.Name -like 'metasheet-multitable-onprem-*' }
+  if (@($preferred).Count -eq 1) {
+    return @($preferred)[0].FullName
+  }
+  throw "Ambiguous extracted package roots under ${ExtractRoot}: $(@($candidates | ForEach-Object { $_.FullName }) -join '; ')"
+}
+
 function Invoke-HealthcheckOnce {
   param([string]$Url)
 
@@ -595,12 +635,10 @@ try {
 
   Expand-PackageArchive -ArchivePath $resolvedArchive -TargetDir $extractRoot
 
-  $packageRoot = Get-ChildItem -LiteralPath $extractRoot -Directory | Select-Object -First 1
-  if (-not $packageRoot) {
-    throw "Failed to locate extracted package root in $extractRoot"
-  }
+  $packageRoot = Resolve-ExtractedPackageRoot -ExtractRoot $extractRoot
+  Write-Info "Extracted package root: $packageRoot"
 
-  foreach ($item in Get-ChildItem -LiteralPath $packageRoot.FullName -Force) {
+  foreach ($item in Get-ChildItem -LiteralPath $packageRoot -Force) {
     Copy-Item -LiteralPath $item.FullName -Destination $resolvedRoot -Recurse -Force
   }
 

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -105,16 +105,35 @@ function Expand-StagingArchive {
 function Resolve-StagedPackageRoot {
   param([string]$Stage)
 
-  $children = Get-ChildItem -LiteralPath $Stage -Directory -ErrorAction Stop
-  if ($null -eq $children -or @($children).Count -lt 1) {
-    throw "No package root directory found inside staging extraction at $Stage"
+  $stageItem = Get-Item -LiteralPath $Stage -ErrorAction Stop
+  $candidates = @()
+  if (
+    (Test-Path -LiteralPath (Join-Path $stageItem.FullName 'pnpm-lock.yaml')) -and
+    (Test-Path -LiteralPath (Join-Path $stageItem.FullName 'PACKAGE-METADATA.json')) -and
+    (Test-Path -LiteralPath (Join-Path $stageItem.FullName 'scripts\ops\multitable-onprem-apply-package.ps1'))
+  ) {
+    $candidates += $stageItem
   }
+  $candidates += @(
+    Get-ChildItem -LiteralPath $Stage -Directory -Recurse -ErrorAction Stop |
+      Where-Object {
+        (Test-Path -LiteralPath (Join-Path $_.FullName 'pnpm-lock.yaml')) -and
+        (Test-Path -LiteralPath (Join-Path $_.FullName 'PACKAGE-METADATA.json')) -and
+        (Test-Path -LiteralPath (Join-Path $_.FullName 'scripts\ops\multitable-onprem-apply-package.ps1'))
+      }
+  )
 
-  $preferred = @($children) | Where-Object { $_.Name -like 'metasheet-multitable-onprem-*' } | Select-Object -First 1
-  if ($null -ne $preferred) {
-    return $preferred.FullName
+  if ($candidates.Count -lt 1) {
+    throw "No package root with pnpm-lock.yaml / PACKAGE-METADATA.json / apply helper markers found inside staging extraction at $Stage"
   }
-  return @($children)[0].FullName
+  if ($candidates.Count -eq 1) {
+    return $candidates[0].FullName
+  }
+  $preferred = @($candidates) | Where-Object { $_.Name -like 'metasheet-multitable-onprem-*' }
+  if (@($preferred).Count -eq 1) {
+    return @($preferred)[0].FullName
+  }
+  throw "Ambiguous package roots inside staging extraction at ${Stage}: $(@($candidates | ForEach-Object { $_.FullName }) -join '; ')"
 }
 
 $resolvedArchive = Resolve-LauncherPath -Candidate $PackageArchive -Label 'PackageArchive'

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export COPYFILE_DISABLE=1
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/output/releases/multitable-onprem}"
 INSTALL_DEPS="${INSTALL_DEPS:-0}"
@@ -228,6 +230,33 @@ function prune_node_modules() {
   while IFS= read -r -d '' path; do
     rm -rf "$path"
   done < <(find "$root" -name node_modules -prune -print0)
+}
+
+function assert_no_macos_metadata_entries() {
+  local archive="$1"
+  local archive_type="$2"
+  local label="$3"
+  local matches
+  case "$archive_type" in
+    tgz)
+      matches="$(tar -tzf "$archive" | LC_ALL=C grep -E '(^|/)(\._[^/]+|__MACOSX)(/|$)' | head -20 || true)"
+      ;;
+    zip)
+      if command -v zipinfo >/dev/null 2>&1; then
+        matches="$(zipinfo -1 "$archive" | LC_ALL=C grep -E '(^|/)(\._[^/]+|__MACOSX)(/|$)' | head -20 || true)"
+      elif command -v unzip >/dev/null 2>&1; then
+        matches="$(unzip -Z -1 "$archive" | LC_ALL=C grep -E '(^|/)(\._[^/]+|__MACOSX)(/|$)' | head -20 || true)"
+      else
+        die "zipinfo or unzip is required to inspect zip package entries"
+      fi
+      ;;
+    *)
+      die "Unknown archive type for macOS metadata check: ${archive_type}"
+      ;;
+  esac
+  if [[ -n "$matches" ]]; then
+    die "${label} must not contain macOS AppleDouble/resource-fork metadata entries. First entries: ${matches//$'\n'/, }"
+  fi
 }
 
 function write_windows_entrypoints() {
@@ -594,8 +623,11 @@ Windows staging root:
 EOF
 
 run rm -f "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_TGZ_SHA_TMP_PATH" "$ARCHIVE_ZIP_SHA_TMP_PATH" "$METADATA_JSON_TMP_PATH"
-run tar -czf "$ARCHIVE_TGZ_TMP_PATH" -C "$BUILD_ROOT" "$PACKAGE_NAME"
-run bash -lc "cd \"$BUILD_ROOT\" && zip -qr \"$ARCHIVE_ZIP_TMP_PATH\" \"$PACKAGE_NAME\""
+find "$PACKAGE_ROOT" \( -name '._*' -o -name '__MACOSX' \) -prune -exec rm -rf {} +
+run env COPYFILE_DISABLE=1 tar --no-xattrs -czf "$ARCHIVE_TGZ_TMP_PATH" -C "$BUILD_ROOT" "$PACKAGE_NAME"
+run bash -lc "cd \"$BUILD_ROOT\" && COPYFILE_DISABLE=1 zip -X -qr \"$ARCHIVE_ZIP_TMP_PATH\" \"$PACKAGE_NAME\""
+assert_no_macos_metadata_entries "$ARCHIVE_TGZ_TMP_PATH" tgz "tgz package"
+assert_no_macos_metadata_entries "$ARCHIVE_ZIP_TMP_PATH" zip "zip package"
 write_sha_file "$ARCHIVE_TGZ_TMP_PATH"
 write_sha_file "$ARCHIVE_ZIP_TMP_PATH"
 

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -12,18 +12,19 @@ const verifyScriptPath = path.join(repoRoot, 'scripts/ops/multitable-onprem-pack
 const buildScript = fs.readFileSync(buildScriptPath, 'utf8')
 const verifyScript = fs.readFileSync(verifyScriptPath, 'utf8')
 
-function runVerifierListCheck(listEntries) {
+function runVerifierFunction(functionName, listEntries) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-package-list-'))
   const listPath = path.join(dir, 'archive-list.txt')
   fs.writeFileSync(listPath, `${listEntries.join('\n')}\n`)
   const result = spawnSync(
     'bash',
-    ['-lc', 'source "$VERIFY"; verify_no_bundled_node_modules "$LIST"'],
+    ['-lc', 'source "$VERIFY"; "$VERIFY_FUNCTION" "$LIST"'],
     {
       cwd: repoRoot,
       env: {
         ...process.env,
         VERIFY: verifyScriptPath,
+        VERIFY_FUNCTION: functionName,
         LIST: listPath,
       },
       encoding: 'utf8',
@@ -31,6 +32,14 @@ function runVerifierListCheck(listEntries) {
   )
   fs.rmSync(dir, { recursive: true, force: true })
   return result
+}
+
+function runVerifierListCheck(listEntries) {
+  return runVerifierFunction('verify_no_bundled_node_modules', listEntries)
+}
+
+function runVerifierMacMetadataCheck(listEntries) {
+  return runVerifierFunction('verify_no_macos_metadata_entries', listEntries)
 }
 
 test('on-prem package build prunes copied workspace node_modules before archiving', () => {
@@ -81,6 +90,60 @@ test('on-prem verifier rejects archive lists that contain node_modules entries',
   )
 })
 
+test('on-prem package build and verifier reject macOS AppleDouble metadata entries', () => {
+  assert.match(
+    buildScript,
+    /export COPYFILE_DISABLE=1/,
+    'the build script should disable macOS resource-fork sidecar generation',
+  )
+  assert.ok(
+    buildScript.includes('find "$PACKAGE_ROOT" \\( -name \'._*\' -o -name \'__MACOSX\' \\) -prune -exec rm -rf {} +'),
+    'the build script should prune copied AppleDouble metadata before archiving',
+  )
+  assert.match(
+    buildScript,
+    /tar --no-xattrs -czf "\$ARCHIVE_TGZ_TMP_PATH"/,
+    'tgz creation should suppress extended attributes',
+  )
+  assert.match(
+    buildScript,
+    /zip -X -qr/,
+    'zip creation should exclude extra file attributes',
+  )
+  assert.match(
+    buildScript,
+    /assert_no_macos_metadata_entries "\$ARCHIVE_TGZ_TMP_PATH" tgz "tgz package"/,
+    'tgz archives should be inspected before publish',
+  )
+  assert.match(
+    buildScript,
+    /assert_no_macos_metadata_entries "\$ARCHIVE_ZIP_TMP_PATH" zip "zip package"/,
+    'zip archives should be inspected before publish',
+  )
+
+  const clean = runVerifierMacMetadataCheck([
+    'package/package.json',
+    'package/packages/core-backend/migrations/057_create_integration_core_tables.sql',
+  ])
+  assert.equal(clean.status, 0, clean.stderr)
+
+  const badAppleDouble = runVerifierMacMetadataCheck([
+    'package/package.json',
+    'package/packages/core-backend/migrations/._057_create_integration_core_tables.sql',
+  ])
+  assert.notEqual(badAppleDouble.status, 0, 'AppleDouble entries must fail package verification')
+  assert.match(badAppleDouble.stderr, /AppleDouble\/resource-fork metadata entries/)
+  assert.match(badAppleDouble.stderr, /migrations\/\._057_create_integration_core_tables\.sql/)
+
+  const badMacosx = runVerifierMacMetadataCheck([
+    'package/package.json',
+    'package/__MACOSX/package/._package.json',
+  ])
+  assert.notEqual(badMacosx.status, 0, '__MACOSX entries must fail package verification')
+  assert.match(badMacosx.stderr, /AppleDouble\/resource-fork metadata entries/)
+  assert.match(badMacosx.stderr, /__MACOSX/)
+})
+
 test('on-prem zip verifier fallback lists full archive depth', () => {
   assert.match(
     verifyScript,
@@ -91,5 +154,38 @@ test('on-prem zip verifier fallback lists full archive depth', () => {
     verifyScript,
     /find "\$EXTRACT_ROOT" -mindepth 1 -maxdepth 3/,
     'zip fallback must not stop before nested workspace node_modules paths',
+  )
+})
+
+test('on-prem zip verifier smokes Windows Expand-Archive package-root layout', () => {
+  assert.match(
+    verifyScript,
+    /function verify_windows_zip_expand_archive_smoke\(\)/,
+    'zip verification should include a Windows Expand-Archive smoke',
+  )
+  assert.match(
+    verifyScript,
+    /Expand-Archive -LiteralPath \$env:PACKAGE_ARCHIVE -DestinationPath \$env:EXTRACT_ROOT -Force/,
+    'the smoke should use the same PowerShell extraction primitive as Windows deploy',
+  )
+  assert.match(
+    verifyScript,
+    /Expected exactly one Windows-expanded package root/,
+    'the smoke should fail when package-root marker detection is ambiguous or absent',
+  )
+  assert.match(
+    verifyScript,
+    /pnpm-lock\.yaml/,
+    'package-root detection should require pnpm-lock.yaml',
+  )
+  assert.match(
+    verifyScript,
+    /PACKAGE-METADATA\.json/,
+    'package-root detection should require package metadata',
+  )
+  assert.match(
+    verifyScript,
+    /multitable-onprem-apply-package\.ps1/,
+    'package-root detection should require the apply helper from the package',
   )
 })

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -662,6 +662,57 @@ function verify_no_bundled_node_modules() {
   rm -f "$matches"
 }
 
+function verify_no_macos_metadata_entries() {
+  local archive_list_file="$1"
+  local matches
+  matches="$(mktemp)"
+  if LC_ALL=C grep -E '(^|/)(\._[^/]+|__MACOSX)(/|$)' "$archive_list_file" > "$matches"; then
+    local sample
+    sample="$(head -n 5 "$matches" | tr '\n' '; ')"
+    rm -f "$matches"
+    die "Package must not contain macOS AppleDouble/resource-fork metadata entries. First entries: ${sample}"
+  fi
+  rm -f "$matches"
+}
+
+function verify_windows_zip_expand_archive_smoke() {
+  local archive="$1"
+  local smoke_root
+  [[ "$archive" == *.zip ]] || return 0
+  command -v pwsh >/dev/null 2>&1 || die "pwsh is required to smoke Windows Expand-Archive behavior for zip packages"
+  smoke_root="$(mktemp -d)"
+  PACKAGE_ARCHIVE="$(cd "$(dirname "$archive")" && pwd)/$(basename "$archive")" \
+  EXTRACT_ROOT="$smoke_root" \
+  pwsh -NoProfile -NonInteractive -Command '
+    $ErrorActionPreference = "Stop"
+    Expand-Archive -LiteralPath $env:PACKAGE_ARCHIVE -DestinationPath $env:EXTRACT_ROOT -Force
+    $root = Get-Item -LiteralPath $env:EXTRACT_ROOT
+    $candidates = @()
+    if (
+      (Test-Path -LiteralPath (Join-Path $root.FullName "pnpm-lock.yaml")) -and
+      (Test-Path -LiteralPath (Join-Path $root.FullName "PACKAGE-METADATA.json")) -and
+      (Test-Path -LiteralPath (Join-Path $root.FullName "scripts/ops/multitable-onprem-apply-package.ps1"))
+    ) {
+      $candidates += $root
+    }
+    $candidates += @(
+      Get-ChildItem -LiteralPath $env:EXTRACT_ROOT -Directory -Recurse -ErrorAction Stop |
+        Where-Object {
+          (Test-Path -LiteralPath (Join-Path $_.FullName "pnpm-lock.yaml")) -and
+          (Test-Path -LiteralPath (Join-Path $_.FullName "PACKAGE-METADATA.json")) -and
+          (Test-Path -LiteralPath (Join-Path $_.FullName "scripts/ops/multitable-onprem-apply-package.ps1"))
+        }
+    )
+    if ($candidates.Count -ne 1) {
+      throw ("Expected exactly one Windows-expanded package root, got {0}: {1}" -f $candidates.Count, (($candidates | ForEach-Object { $_.FullName }) -join "; "))
+    }
+  ' || {
+    rm -rf "$smoke_root" || true
+    die "Windows Expand-Archive smoke failed for zip package"
+  }
+  rm -rf "$smoke_root"
+}
+
 # When sourced (e.g. by the focused test), define functions only — do not run the
 # package verification main flow. Direct execution (BASH_SOURCE[0] == $0) runs normally.
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
@@ -699,6 +750,7 @@ case "$PACKAGE_FILE" in
     archive_type="zip"
     command -v unzip >/dev/null 2>&1 || die "unzip is required to verify zip packages"
     unzip -q "$PACKAGE_FILE" -d "$EXTRACT_ROOT"
+    verify_windows_zip_expand_archive_smoke "$PACKAGE_FILE"
     if command -v zipinfo >/dev/null 2>&1; then
       zipinfo -1 "$PACKAGE_FILE" > "$list_file"
     else
@@ -712,6 +764,7 @@ esac
 
 pkg_name="$(head -n 1 "$list_file" | cut -d/ -f1)"
 pkg_root="${EXTRACT_ROOT}/${pkg_name}"
+verify_no_macos_metadata_entries "$list_file"
 verify_no_bundled_node_modules "$list_file"
 
 required=(

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -43,6 +43,40 @@ test('Windows apply helper retries post-PM2 healthcheck during warmup and remain
   assert.doesNotMatch(script, oldSingleProbe)
 })
 
+test('Windows apply helper resolves extracted package root by package markers, not first child directory', () => {
+  const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
+
+  assert.match(script, /function Test-OnPremPackageRoot/)
+  assert.match(script, /function Resolve-ExtractedPackageRoot/)
+  assert.match(script, /pnpm-lock\.yaml/)
+  assert.match(script, /PACKAGE-METADATA\.json/)
+  assert.match(script, /scripts\\ops\\multitable-onprem-apply-package\.ps1/)
+  assert.match(script, /Failed to locate extracted package root/)
+  assert.match(script, /Ambiguous extracted package roots/)
+  assert.match(script, /Extracted package root: \$packageRoot/)
+  assert.doesNotMatch(
+    script,
+    /Get-ChildItem -LiteralPath \$extractRoot -Directory\s*\|\s*Select-Object -First 1/,
+    'the extracted root must not be chosen by first child directory',
+  )
+})
+
+test('Windows deploy launcher resolves staged package root by package markers, not first child directory', () => {
+  const script = readScript('scripts/ops/multitable-onprem-deploy-launcher.ps1')
+
+  assert.match(script, /function Resolve-StagedPackageRoot/)
+  assert.match(script, /pnpm-lock\.yaml/)
+  assert.match(script, /PACKAGE-METADATA\.json/)
+  assert.match(script, /scripts\\ops\\multitable-onprem-apply-package\.ps1/)
+  assert.match(script, /No package root with pnpm-lock\.yaml \/ PACKAGE-METADATA\.json \/ apply helper markers/)
+  assert.match(script, /Ambiguous package roots inside staging extraction/)
+  assert.doesNotMatch(
+    script,
+    /Get-ChildItem -LiteralPath \$Stage -Directory[^\n]*\n[^\n]*Select-Object -First 1/,
+    'the staged root must not be chosen by first child directory',
+  )
+})
+
 test('PM2 startup helper initializes SYSTEM profile env before invoking PM2', () => {
   const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
 


### PR DESCRIPTION
## Summary

Fixes the #3093 package/deploy blocker by hardening the multitable on-prem archive and Windows package-root handling. This is packaging/deploy tooling only: it does not run sandbox validation, does not change FOS runtime behavior, and does not open production apply.

Changes:
- Build packages with `COPYFILE_DISABLE=1`, `tar --no-xattrs`, and `zip -X`.
- Prune and fail-closed on macOS AppleDouble/resource-fork metadata entries (`._*`, `__MACOSX`) before publish and during package verification.
- Add a zip verification smoke that runs PowerShell `Expand-Archive` and asserts exactly one package root with real markers (`pnpm-lock.yaml`, `PACKAGE-METADATA.json`, package apply helper).
- Update Windows deploy/apply helpers to resolve the extracted package root by those markers instead of choosing the first child directory.
- Add regression coverage for the metadata gate and package-root marker resolution.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh`
- `pwsh -NoProfile -NonInteractive -Command '$ErrorActionPreference="Stop"; [scriptblock]::Create((Get-Content -Raw scripts/ops/multitable-onprem-apply-package.ps1)) | Out-Null; [scriptblock]::Create((Get-Content -Raw scripts/ops/multitable-onprem-deploy-launcher.ps1)) | Out-Null; "ok"'`
- `node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs scripts/ops/onprem-windows-system-hardening.test.mjs`
- `INSTALL_DEPS=1 BUILD_WEB=1 BUILD_BACKEND=1 PACKAGE_TAG=fos-4b3-sandbox-target-archivefix-local scripts/ops/multitable-onprem-package-build.sh`
- `VERIFY_REPORT_JSON=output/releases/multitable-onprem/archivefix-local-tgz.verify.json VERIFY_REPORT_MD=output/releases/multitable-onprem/archivefix-local-tgz.verify.md scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-fos-4b3-sandbox-target-archivefix-local.tgz`
- `VERIFY_REPORT_JSON=output/releases/multitable-onprem/archivefix-local-zip.verify.json VERIFY_REPORT_MD=output/releases/multitable-onprem/archivefix-local-zip.verify.md scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-fos-4b3-sandbox-target-archivefix-local.zip`
- `! tar -tzf output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-fos-4b3-sandbox-target-archivefix-local.tgz | rg '(^|/)(\._|__MACOSX)(/|$)'`
- `! zipinfo -1 output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-fos-4b3-sandbox-target-archivefix-local.zip | rg '(^|/)(\._|__MACOSX)(/|$)'`

## Notes

- I downloaded the prior GitHub release artifacts named in #3093 as a sanity check, but they did not reproduce the AppleDouble listing locally, so I am not using that as proof. The regression suite includes synthetic negative controls, and the newly built package verifies cleanly.
- After merge, this needs a refreshed on-prem package/release and entity-machine deployment retry. Sandbox validation remains pending; production apply remains closed.
