### PR TITLE
feat(multitable): BS-4 FE batch-restore panel (mix entry) [HELD for UX review]

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -37,6 +37,7 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
+      - 'apps/web/src/multitable/components/RestoreBatchDialog.vue'
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
@@ -82,6 +83,7 @@ on:
       - 'apps/web/src/multitable/components/MetaGridTable.vue'
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
+      - 'apps/web/src/multitable/components/RestoreBatchDialog.vue'
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
@@ -148,4 +150,4 @@ jobs:
         # accumulation/loadMore) added so the grid virtualization ACTIVATION has real CI enforcement —
         # the guard already triggers on MetaGridTable.vue / useMultitableGrid.ts / MultitableWorkbench.vue
         # edits but, before this, ran none of those specs (and plugin-tests.yml only build-checks web).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-workbench-restore-wiring --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-workbench-restore-wiring --reporter=dot

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -974,6 +974,41 @@ export interface RestorePreviewResult {
   previewIdentity: string | null
 }
 
+// BS-4: scoped (multi-record) restore preview/execute results — a faithful client of the BS-2/BS-3 wire.
+export interface RestoreBatchPreviewRecord {
+  recordId: string
+  status: 'restorable' | 'skipped'
+  changes?: RestorePreviewChange[]
+  affectedFieldCount?: number
+  /** the record's preview-time version — submitted back verbatim as expectedVersions[recordId] (the version bind). */
+  previewVersion?: number
+  /** why a record is not restorable: unavailable | version_unavailable | unsupported | snapshot_unavailable | schema_drift | no_change */
+  skipReason?: string
+}
+export interface RestoreBatchPreviewResult {
+  records: RestoreBatchPreviewRecord[]
+  /** the RESTORABLE record set the identity binds (sorted) — the FE executes exactly this set. */
+  scope: string[]
+  restorableCount: number
+  skippedCount: number
+  targetVersion: number
+  previewIdentity: string | null
+}
+export interface RestoreBatchExecuteRecord {
+  recordId: string
+  status: 'restored' | 'skipped'
+  newVersion?: number
+  restoredFieldIds?: string[]
+  /** write-level skip taxonomy (surfaced verbatim): denied | conflict | forbidden | error */
+  skipReason?: 'denied' | 'conflict' | 'forbidden' | 'error'
+}
+export interface RestoreBatchExecuteResult {
+  records: RestoreBatchExecuteRecord[]
+  restoredCount: number
+  skippedCount: number
+  targetVersion: number
+}
+
 export interface AiShortcutPreviewData {
   status: 'succeeded'
   action: 'preview'
@@ -1845,6 +1880,38 @@ export class MultitableApiClient {
       { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
     )
     return this.parseJson<RestoreRecordResult>(res)
+  }
+
+  // BS-4: preview a multi-record restore. Read-only — returns each record's restorable/skipped outcome + the scope
+  // identity. Pair with restoreBatchExecute; never batch-restore without showing the per-record preview.
+  async restoreBatchPreview(sheetId: string, recordIds: string[], targetVersion: number, fieldIds?: string[]): Promise<RestoreBatchPreviewResult> {
+    const body: { targetVersion: number; recordIds: string[]; fieldIds?: string[] } = { targetVersion, recordIds }
+    if (fieldIds && fieldIds.length > 0) body.fieldIds = fieldIds
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/restore-batch-preview`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+    )
+    return this.parseJson<RestoreBatchPreviewResult>(res)
+  }
+
+  // BS-4: execute a previewed batch restore. `expectedVersions` MUST be each record's previewVersion from the preview
+  // (the version bind — the server folds the submitted value into the scopeHash); `recordIds` MUST be the preview's
+  // `scope`. PARTIAL: per-record restored/skipped(denied|conflict|forbidden) in the result.
+  async restoreBatchExecute(
+    sheetId: string,
+    recordIds: string[],
+    targetVersion: number,
+    expectedVersions: Record<string, number>,
+    previewIdentity: string,
+    fieldIds?: string[],
+  ): Promise<RestoreBatchExecuteResult> {
+    const body: { targetVersion: number; recordIds: string[]; expectedVersions: Record<string, number>; previewIdentity: string; fieldIds?: string[] } = { targetVersion, recordIds, expectedVersions, previewIdentity }
+    if (fieldIds && fieldIds.length > 0) body.fieldIds = fieldIds
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/restore-batch-execute`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+    )
+    return this.parseJson<RestoreBatchExecuteResult>(res)
   }
 
   // --- Form submit ---

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -4,6 +4,7 @@
       <span class="meta-grid__bulk-count">{{ selectedCount(selectedIds.size, isZh) }}</span>
       <button v-if="canBulkEdit" class="meta-grid__bulk-btn" :aria-label="l('grid.setFieldAria')" @click="onBulkEdit('set')">{{ l('grid.setField') }}</button>
       <button v-if="canBulkEdit" class="meta-grid__bulk-btn" :aria-label="l('grid.clearFieldAria')" @click="onBulkEdit('clear')">{{ l('grid.clearField') }}</button>
+      <button v-if="canBulkRestore" class="meta-grid__bulk-btn" :aria-label="l('grid.batchRestoreAria')" data-test="grid-bulk-restore" @click="onBulkRestore">{{ l('grid.batchRestore') }}</button>
       <button v-if="canDelete" class="meta-grid__bulk-btn meta-grid__bulk-btn--danger" :aria-label="l('grid.deleteSelectedAria')" @click="onBulkDelete">{{ l('grid.deleteSelected') }}</button>
       <button class="meta-grid__bulk-btn" :aria-label="l('grid.clearSelection')" @click="selectedIds = new Set(); emit('selection-change', [])">{{ l('grid.clear') }}</button>
     </div>
@@ -426,6 +427,7 @@ const props = defineProps<{
   canEdit: boolean
   canDelete?: boolean
   canBulkEdit?: boolean
+  canBulkRestore?: boolean
   canCreate?: boolean
   frozenLeftColumnIds?: string[]
   rowActionOverrides?: Record<string, MetaRowActions>
@@ -513,6 +515,7 @@ const emit = defineEmits<{
   (e: 'selection-change', recordIds: string[]): void
   (e: 'bulk-delete', recordIds: string[]): void
   (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
+  (e: 'bulk-restore', recordIds: string[]): void
   // Duplicate / clone record (design 2026-06-16): right-click a row → request a duplicate. The native
   // context menu is suppressed so the row affordance is the menu; the workbench owns the create + clone-open.
   (e: 'duplicate-record', recordId: string): void
@@ -897,6 +900,13 @@ function toggleSelectRow(recordId: string) {
 function onBulkDelete() {
   const deletable = [...selectedIds.value].filter((id) => resolveRowActions(id).canDelete)
   if (deletable.length > 0) emit('bulk-delete', deletable)
+}
+
+// Batch restore (BS-4): emit the selected records the actor can edit (restore is a write). The server re-checks
+// per record (row-deny / write-gate / version) in the preview + execute, so this is a coarse pre-filter only.
+function onBulkRestore() {
+  const restorable = [...selectedIds.value].filter((id) => resolveRowActions(id).canEdit)
+  if (restorable.length > 0) emit('bulk-restore', restorable)
 }
 
 function onBulkEdit(mode: 'set' | 'clear') {

--- a/apps/web/src/multitable/components/RestoreBatchDialog.vue
+++ b/apps/web/src/multitable/components/RestoreBatchDialog.vue
@@ -1,0 +1,258 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="restore-batch-overlay" data-test="restore-batch" @click.self="onCancel">
+      <div class="restore-batch-modal" role="dialog" :aria-label="l('record.batchRestoreTitle')">
+        <div class="restore-batch__header">
+          <strong>{{ l('record.batchRestoreTitle') }}</strong>
+          <button class="restore-batch__close" :aria-label="l('record.batchRestoreCancel')" @click="onCancel">&times;</button>
+        </div>
+
+        <!-- Target control: default = revert to original (v1); Advanced reveals a version-N picker (the MIX entry). -->
+        <div v-if="phase === 'preview'" class="restore-batch__target">
+          <p class="restore-batch__revert">{{ l('record.batchRestoreRevertOriginal') }}</p>
+          <button type="button" class="restore-batch__advanced-toggle" data-test="batch-restore-advanced" @click="advancedOpen = !advancedOpen">
+            {{ l('record.batchRestoreAdvanced') }}
+          </button>
+          <label v-if="advancedOpen" class="restore-batch__version">
+            <span>{{ l('record.batchRestoreVersionLabel') }}</span>
+            <input
+              type="number"
+              min="1"
+              class="restore-batch__version-input"
+              data-test="batch-restore-version"
+              :value="versionInput"
+              @change="onVersionChange"
+              @keyup.enter="onVersionChange"
+            />
+          </label>
+        </div>
+
+        <div class="restore-batch__body">
+          <p v-if="loading" class="restore-batch__hint" data-test="batch-restore-loading">{{ l('record.batchRestoreLoading') }}</p>
+
+          <!-- Preview phase: per-record restorable / skipped(reason). -->
+          <template v-else-if="phase === 'preview'">
+            <ul class="restore-batch__list" data-test="batch-restore-preview-list">
+              <li v-for="rec in previewRecords" :key="rec.recordId" class="restore-batch__row" :data-status="rec.status">
+                <span class="restore-batch__rec">{{ recordLabelOf(rec.recordId) }}</span>
+                <span v-if="rec.status === 'restorable'" class="restore-batch__chip restore-batch__chip--ok" data-test="batch-restorable">
+                  {{ l('record.batchRestoreSummaryRestorable') }}
+                </span>
+                <span v-else class="restore-batch__chip restore-batch__chip--skip" data-test="batch-skipped">
+                  {{ skipReason(rec.skipReason) }}
+                </span>
+              </li>
+            </ul>
+            <p v-if="restorableCount === 0" class="restore-batch__hint restore-batch__hint--warn" role="alert" data-test="batch-restore-none">
+              {{ l('record.batchRestoreNoneRestorable') }}
+            </p>
+            <p v-else class="restore-batch__summary" data-test="batch-restore-summary">
+              {{ restorableCount }} {{ l('record.batchRestoreSummaryRestorable') }} · {{ skippedCount }} {{ l('record.batchRestoreSummarySkipped') }}
+            </p>
+          </template>
+
+          <!-- Result phase: per-record restored / skipped(reason). -->
+          <template v-else>
+            <p class="restore-batch__label">{{ l('record.batchRestoreResultTitle') }}</p>
+            <ul class="restore-batch__list" data-test="batch-restore-result-list">
+              <li v-for="rec in resultRecords" :key="rec.recordId" class="restore-batch__row" :data-status="rec.status">
+                <span class="restore-batch__rec">{{ recordLabelOf(rec.recordId) }}</span>
+                <span v-if="rec.status === 'restored'" class="restore-batch__chip restore-batch__chip--ok" data-test="batch-restored">
+                  {{ l('record.batchRestoreRestored') }}
+                </span>
+                <span v-else class="restore-batch__chip restore-batch__chip--skip" data-test="batch-result-skipped">
+                  {{ skipReason(rec.skipReason) }}
+                </span>
+              </li>
+            </ul>
+            <p class="restore-batch__summary" data-test="batch-restore-result-summary">
+              {{ restoredCount }} {{ l('record.batchRestoreRestored') }} · {{ skippedCount }} {{ l('record.batchRestoreSummarySkipped') }}
+            </p>
+          </template>
+        </div>
+
+        <div class="restore-batch__footer">
+          <template v-if="phase === 'preview'">
+            <button type="button" class="restore-batch__btn" @click="onCancel">{{ l('record.batchRestoreCancel') }}</button>
+            <button
+              type="button"
+              class="restore-batch__btn restore-batch__btn--primary"
+              :disabled="!canConfirm"
+              data-test="batch-restore-confirm"
+              @click="onConfirm"
+            >
+              {{ l('record.batchRestoreConfirm') }}
+            </button>
+          </template>
+          <button v-else type="button" class="restore-batch__btn restore-batch__btn--primary" data-test="batch-restore-done" @click="onDone">
+            {{ l('record.batchRestoreDone') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import type { RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../api/client'
+import { recordLabel, batchSkipReasonLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
+
+const props = defineProps<{
+  visible: boolean
+  phase: 'preview' | 'result'
+  loading: boolean
+  targetVersion: number
+  previewRecords: RestoreBatchPreviewRecord[]
+  restorableCount: number
+  skippedCount: number
+  /** false when the server withheld a scope identity (empty restorable set / drift) — confirm blocked. */
+  executable: boolean
+  resultRecords: RestoreBatchExecuteRecord[]
+  restoredCount: number
+  /** resolve a record id to a display label (the workbench owns the record map). */
+  recordLabelOf: (recordId: string) => string
+  isZh: boolean
+}>()
+
+const emit = defineEmits<{ (e: 'preview-version', version: number): void; (e: 'confirm'): void; (e: 'cancel'): void; (e: 'done'): void }>()
+
+const l = (key: MetaRecordLabelKey): string => recordLabel(key, props.isZh)
+const skipReason = (reason: string | undefined): string => batchSkipReasonLabel(reason, props.isZh)
+
+const advancedOpen = ref(false)
+const versionInput = computed(() => props.targetVersion)
+// Confirm only when the preview returned an executable identity over a non-empty restorable set.
+const canConfirm = computed(() => !props.loading && props.executable && props.restorableCount > 0)
+
+function onVersionChange(ev: Event): void {
+  const raw = Number((ev.target as HTMLInputElement).value)
+  if (Number.isFinite(raw) && raw >= 1) emit('preview-version', Math.floor(raw))
+}
+function onConfirm(): void {
+  if (canConfirm.value) emit('confirm')
+}
+function onCancel(): void {
+  emit('cancel')
+}
+function onDone(): void {
+  emit('done')
+}
+</script>
+
+<style scoped>
+.restore-batch-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.restore-batch-modal {
+  background: var(--surface, #fff);
+  border-radius: 10px;
+  width: min(480px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2);
+}
+.restore-batch__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, #e2e8f0);
+}
+.restore-batch__close {
+  border: none;
+  background: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-secondary, #64748b);
+}
+.restore-batch__target {
+  padding: 12px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.restore-batch__revert { margin: 0; font-weight: 600; }
+.restore-batch__advanced-toggle {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--primary, #2563eb);
+}
+.restore-batch__version {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.restore-batch__version-input {
+  width: 80px;
+  padding: 4px 6px;
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 6px;
+}
+.restore-batch__body {
+  padding: 16px;
+  overflow-y: auto;
+}
+.restore-batch__label { margin: 0 0 8px; font-weight: 600; }
+.restore-batch__hint { margin: 0; color: var(--text-secondary, #64748b); }
+.restore-batch__hint--warn { color: var(--danger, #b91c1c); }
+.restore-batch__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.restore-batch__row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 6px 8px;
+  background: var(--surface-muted, #f1f5f9);
+  border-radius: 6px;
+}
+.restore-batch__rec { font-weight: 600; word-break: break-word; }
+.restore-batch__chip { font-size: 12px; white-space: nowrap; }
+.restore-batch__chip--ok { color: var(--success, #15803d); }
+.restore-batch__chip--skip { color: var(--text-secondary, #64748b); }
+.restore-batch__summary { margin: 10px 0 0; color: var(--text-secondary, #64748b); font-size: 13px; }
+.restore-batch__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border, #e2e8f0);
+}
+.restore-batch__btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border, #cbd5e1);
+  background: var(--surface, #fff);
+  cursor: pointer;
+}
+.restore-batch__btn--primary {
+  background: var(--primary, #2563eb);
+  color: #fff;
+  border-color: var(--primary, #2563eb);
+}
+.restore-batch__btn--primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/web/src/multitable/utils/batch-restore-expected-versions.ts
+++ b/apps/web/src/multitable/utils/batch-restore-expected-versions.ts
@@ -1,0 +1,23 @@
+import type { RestoreBatchPreviewRecord } from '../api/client'
+
+/**
+ * BS-4 wire-drift guard. Build the `expectedVersions` map the batch execute submits: ONLY the records in `scope`
+ * (the restorable set the preview identity binds), each mapped to its preview-time `previewVersion`. A record not
+ * in `scope`, or one lacking a numeric `previewVersion`, is excluded.
+ *
+ * This is the version-bind contract (#2): the FE submits each record's PREVIEW-TIME version verbatim — never the
+ * current version — so the server folds the submitted value into the scopeHash and a stale/tampered version is
+ * rejected. The FE is a faithful client of the security model; it does not reinterpret it. The execute's `recordIds`
+ * must be the preview's `scope`, and these expectedVersions are keyed over exactly that scope.
+ */
+export function buildBatchExpectedVersions(
+  records: RestoreBatchPreviewRecord[],
+  scope: string[],
+): Record<string, number> {
+  const scopeSet = new Set(scope)
+  const out: Record<string, number> = {}
+  for (const r of records) {
+    if (scopeSet.has(r.recordId) && typeof r.previewVersion === 'number') out[r.recordId] = r.previewVersion
+  }
+  return out
+}

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -57,6 +57,7 @@ export type MetaCoreLabelKey =
   | 'grid.setField' | 'grid.setFieldAria'
   | 'grid.clearField' | 'grid.clearFieldAria'
   | 'grid.deleteSelected' | 'grid.deleteSelectedAria'
+  | 'grid.batchRestore' | 'grid.batchRestoreAria'
   | 'grid.clear' | 'grid.clearSelection'
   | 'grid.noRecordsTitle'
   | 'grid.noRecordsHintPrefix' | 'grid.noRecordsHintAction' | 'grid.noRecordsHintSuffix'
@@ -185,6 +186,8 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.clearFieldAria': { en: 'Clear field on selected records', zh: '清空所选记录的字段' },
   'grid.deleteSelected': { en: 'Delete selected', zh: '删除所选' },
   'grid.deleteSelectedAria': { en: 'Delete selected records', zh: '删除所选记录' },
+  'grid.batchRestore': { en: 'Restore', zh: '恢复' },
+  'grid.batchRestoreAria': { en: 'Restore selected records to an earlier version', zh: '将所选记录恢复到较早版本' },
   'grid.clear': { en: 'Clear', zh: '清除' },
   'grid.clearSelection': { en: 'Clear selection', zh: '清除选择' },
   'grid.noRecordsTitle': { en: 'No records yet', zh: '暂无记录' },

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -46,6 +46,15 @@ export type MetaRecordLabelKey =
   | 'record.restorePreviewTitle' | 'record.restorePreviewWillChange' | 'record.restorePreviewNoChanges'
   | 'record.restorePreviewConflict' | 'record.restorePreviewExecute' | 'record.restorePreviewCancel'
   | 'record.restorePreviewLoading' | 'record.restorePreviewSet' | 'record.restorePreviewUnset'
+  // --- BS-4 scoped (multi-record) batch restore ---
+  | 'record.batchRestoreTitle' | 'record.batchRestoreRevertOriginal' | 'record.batchRestoreAdvanced'
+  | 'record.batchRestoreVersionLabel' | 'record.batchRestoreSummaryRestorable' | 'record.batchRestoreSummarySkipped'
+  | 'record.batchRestoreLoading' | 'record.batchRestoreNoneRestorable' | 'record.batchRestoreConfirm'
+  | 'record.batchRestoreCancel' | 'record.batchRestoreDone' | 'record.batchRestoreResultTitle'
+  | 'record.batchRestoreRestored'
+  | 'record.batchReasonUnavailable' | 'record.batchReasonVersionUnavailable' | 'record.batchReasonUnsupported'
+  | 'record.batchReasonSnapshotUnavailable' | 'record.batchReasonSchemaDrift' | 'record.batchReasonNoChange'
+  | 'record.batchReasonDenied' | 'record.batchReasonConflict' | 'record.batchReasonForbidden' | 'record.batchReasonError'
   // FE-owned static fallback strings (the `error?.message ?? l(...)`
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
@@ -120,6 +129,30 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.restorePreviewLoading': { en: 'Loading preview…', zh: '正在加载预览…' },
   'record.restorePreviewSet': { en: 'set', zh: '设为' },
   'record.restorePreviewUnset': { en: 'clear', zh: '清空' },
+  // BS-4 batch restore
+  'record.batchRestoreTitle': { en: 'Batch restore', zh: '批量恢复' },
+  'record.batchRestoreRevertOriginal': { en: 'Revert selected records to their original version', zh: '将所选记录恢复到初始版本' },
+  'record.batchRestoreAdvanced': { en: 'Advanced', zh: '高级' },
+  'record.batchRestoreVersionLabel': { en: 'Restore to version', zh: '恢复到版本' },
+  'record.batchRestoreSummaryRestorable': { en: 'will be restored', zh: '将被恢复' },
+  'record.batchRestoreSummarySkipped': { en: 'skipped', zh: '跳过' },
+  'record.batchRestoreLoading': { en: 'Previewing…', zh: '预览中…' },
+  'record.batchRestoreNoneRestorable': { en: 'No selected records can be restored to this version', zh: '没有所选记录可恢复到该版本' },
+  'record.batchRestoreConfirm': { en: 'Restore', zh: '恢复' },
+  'record.batchRestoreCancel': { en: 'Cancel', zh: '取消' },
+  'record.batchRestoreDone': { en: 'Done', zh: '完成' },
+  'record.batchRestoreResultTitle': { en: 'Restore results', zh: '恢复结果' },
+  'record.batchRestoreRestored': { en: 'Restored', zh: '已恢复' },
+  'record.batchReasonUnavailable': { en: 'Unavailable', zh: '不可用' },
+  'record.batchReasonVersionUnavailable': { en: 'No such version', zh: '无该版本' },
+  'record.batchReasonUnsupported': { en: 'Not supported', zh: '不支持' },
+  'record.batchReasonSnapshotUnavailable': { en: 'No snapshot', zh: '无快照' },
+  'record.batchReasonSchemaDrift': { en: 'Schema changed', zh: '结构已变' },
+  'record.batchReasonNoChange': { en: 'No change', zh: '无变化' },
+  'record.batchReasonDenied': { en: 'Not permitted', zh: '无权限' },
+  'record.batchReasonConflict': { en: 'Version conflict', zh: '版本冲突' },
+  'record.batchReasonForbidden': { en: 'Field write-denied', zh: '字段不可写' },
+  'record.batchReasonError': { en: 'Error', zh: '错误' },
   'record.errorRestore': { en: 'Restore failed', zh: '恢复失败' },
   'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },
@@ -148,6 +181,27 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
 export function recordLabel(key: MetaRecordLabelKey, isZh: boolean): string {
   const entry = META_RECORD_LABELS[key]
   return isZh ? entry.zh : entry.en
+}
+
+// BS-4: map a wire skip-reason (preview: unavailable/version_unavailable/unsupported/snapshot_unavailable/
+// schema_drift/no_change · execute: denied/conflict/forbidden/error) to its typed label. Unknown → raw reason
+// (forward-compatible if the backend adds a reason). Keeps the FE a faithful client of the wire taxonomy.
+const BATCH_REASON_KEYS: Record<string, MetaRecordLabelKey> = {
+  unavailable: 'record.batchReasonUnavailable',
+  version_unavailable: 'record.batchReasonVersionUnavailable',
+  unsupported: 'record.batchReasonUnsupported',
+  snapshot_unavailable: 'record.batchReasonSnapshotUnavailable',
+  schema_drift: 'record.batchReasonSchemaDrift',
+  no_change: 'record.batchReasonNoChange',
+  denied: 'record.batchReasonDenied',
+  conflict: 'record.batchReasonConflict',
+  forbidden: 'record.batchReasonForbidden',
+  error: 'record.batchReasonError',
+}
+export function batchSkipReasonLabel(reason: string | undefined, isZh: boolean): string {
+  if (!reason) return ''
+  const key = BATCH_REASON_KEYS[reason]
+  return key ? recordLabel(key, isZh) : reason
 }
 
 // --- Interpolation helpers (not keys) ---

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1995,14 +1995,20 @@ const batchRecordLabel = (recordId: string): string => {
   return val != null && val !== '' ? String(val) : recordId
 }
 
+// Monotonic token: rapid Advanced version-switching (v3 → v4) can resolve out of order — only the LAST request's
+// response may land, or a slow v3 could overwrite v4's preview (wrong diff shown / identity mismatch at confirm).
+let batchPreviewSeq = 0
 async function runBatchPreview(version: number) {
   const sheetId = workbench.activeSheetId.value
   if (!sheetId) return
+  const seq = ++batchPreviewSeq
   batchRestore.value = { ...batchRestore.value, loading: true, targetVersion: version }
   try {
     const pv = await workbench.client.restoreBatchPreview(sheetId, batchRestore.value.recordIds, version)
+    if (seq !== batchPreviewSeq) return // a newer preview superseded this one → drop the stale response
     batchRestore.value = { ...batchRestore.value, loading: false, phase: 'preview', records: pv.records, scope: pv.scope, restorableCount: pv.restorableCount, skippedCount: pv.skippedCount, executable: pv.previewIdentity != null, identity: pv.previewIdentity }
   } catch (error) {
+    if (seq !== batchPreviewSeq) return // stale failure too — don't tear down a newer preview
     batchRestore.value = { ...batchRestore.value, visible: false }
     showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
   }
@@ -2024,8 +2030,9 @@ async function onConfirmBatchRestore() {
   if (!sheetId || !state.identity || state.scope.length === 0) { batchRestore.value = { ...state, visible: false }; return }
   const expectedVersions = buildBatchExpectedVersions(state.records, state.scope) // wire-drift guard
   // [P3] FE fail-closed: if any scope record lacks a previewVersion, expectedVersions would be incomplete and the
-  // server would 400 — surface a re-preview rather than that opaque error. (Can't happen with current BS-2, which
-  // always returns previewVersion for a restorable record; defensive against a future wire change.)
+  // server would 400 — block the execute and show a restore error (the user re-opens batch restore to retry) rather
+  // than sending incomplete expectedVersions. (Can't happen with current BS-2, which always returns previewVersion
+  // for a restorable record; defensive against a future wire change.)
   if (Object.keys(expectedVersions).length !== state.scope.length) {
     batchRestore.value = { ...state, visible: false }
     showError(recordLabel('record.errorRestore', isZh.value))

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -254,7 +254,7 @@
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
           :loading="grid.loading.value" :current-page="grid.currentPage.value" :total-pages="grid.totalPages.value"
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
-          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :aggregation-config="activeAggregationConfig" :aggregates="aggregateValues" :aggregate-too-large="aggregateTooLarge" :aggregate-groups="aggregateGroups" :field-read-only-ids="readOnlyFieldIds" :column-widths="activeColumnWidths" :collapsed-group-keys="activeCollapsedGroupKeys"
+          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-bulk-restore="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :aggregation-config="activeAggregationConfig" :aggregates="aggregateValues" :aggregate-too-large="aggregateTooLarge" :aggregate-groups="aggregateGroups" :field-read-only-ids="readOnlyFieldIds" :column-widths="activeColumnWidths" :collapsed-group-keys="activeCollapsedGroupKeys"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :person-summaries="grid.personSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
@@ -277,7 +277,7 @@
           @cursor-focus="onCellCursorFocus"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @load-more="grid.loadMore" @open-link-picker="onGridLinkPicker" @open-person-picker="onGridPersonPicker" @resize-column="onSetColumnWidth"
-          @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
+          @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @bulk-restore="onBulkRestoreRequest" @reorder-field="onReorderField"
           @create-record="onAddRecord"
           @duplicate-record="onDuplicateRecord"
           @set-frozen="onSetFrozen"
@@ -398,6 +398,24 @@
       :is-zh="isZh"
       @confirm="onConfirmRestore"
       @cancel="onCancelRestore"
+    />
+    <RestoreBatchDialog
+      :visible="batchRestore.visible"
+      :phase="batchRestore.phase"
+      :loading="batchRestore.loading"
+      :target-version="batchRestore.targetVersion"
+      :preview-records="batchRestore.records"
+      :restorable-count="batchRestore.restorableCount"
+      :skipped-count="batchRestore.skippedCount"
+      :executable="batchRestore.executable"
+      :result-records="batchRestore.resultRecords"
+      :restored-count="batchRestore.restoredCount"
+      :record-label-of="batchRecordLabel"
+      :is-zh="isZh"
+      @preview-version="onBatchPreviewVersion"
+      @confirm="onConfirmBatchRestore"
+      @cancel="onBatchRestoreCancel"
+      @done="onBatchRestoreDone"
     />
     <MetaLinkPicker
       :visible="linkPickerVisible"
@@ -586,7 +604,9 @@ import MetaToolbar from '../components/MetaToolbar.vue'
 import MetaGridTable from '../components/MetaGridTable.vue'
 import MetaExportDialog, { type ExportConfirmPayload } from '../components/MetaExportDialog.vue'
 import RestorePreviewDialog from '../components/RestorePreviewDialog.vue'
-import type { RestorePreviewChange } from '../api/client'
+import RestoreBatchDialog from '../components/RestoreBatchDialog.vue'
+import type { RestorePreviewChange, RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../api/client'
+import { buildBatchExpectedVersions } from '../utils/batch-restore-expected-versions'
 import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaNotificationBell from '../components/MetaNotificationBell.vue'
@@ -1947,6 +1967,79 @@ async function onConfirmRestore() {
 
 function onCancelRestore() {
   restorePreview.value = { ...restorePreview.value, visible: false }
+}
+
+// BS-4: scoped (multi-record) restore. Default entry = revert-to-original (v1); the dialog's Advanced picker
+// re-previews at any version. The FE is a faithful client of the BS-2/BS-3 wire — it submits each record's
+// previewVersion as expectedVersions over the identity's scope, and surfaces the skip-reason taxonomy verbatim.
+const batchRestore = ref<{
+  visible: boolean
+  phase: 'preview' | 'result'
+  loading: boolean
+  targetVersion: number
+  recordIds: string[]
+  records: RestoreBatchPreviewRecord[]
+  scope: string[]
+  restorableCount: number
+  skippedCount: number
+  executable: boolean
+  identity: string | null
+  resultRecords: RestoreBatchExecuteRecord[]
+  restoredCount: number
+}>({ visible: false, phase: 'preview', loading: false, targetVersion: 1, recordIds: [], records: [], scope: [], restorableCount: 0, skippedCount: 0, executable: false, identity: null, resultRecords: [], restoredCount: 0 })
+
+const batchRecordLabel = (recordId: string): string => {
+  const row = grid.rows.value.find((r: { id: string }) => r.id === recordId) as { data?: Record<string, unknown> } | undefined
+  const pf = grid.visibleFields.value[0] as { id: string } | undefined
+  const val = row && pf ? row.data?.[pf.id] : undefined
+  return val != null && val !== '' ? String(val) : recordId
+}
+
+async function runBatchPreview(version: number) {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  batchRestore.value = { ...batchRestore.value, loading: true, targetVersion: version }
+  try {
+    const pv = await workbench.client.restoreBatchPreview(sheetId, batchRestore.value.recordIds, version)
+    batchRestore.value = { ...batchRestore.value, loading: false, phase: 'preview', records: pv.records, scope: pv.scope, restorableCount: pv.restorableCount, skippedCount: pv.skippedCount, executable: pv.previewIdentity != null, identity: pv.previewIdentity }
+  } catch (error) {
+    batchRestore.value = { ...batchRestore.value, visible: false }
+    showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
+  }
+}
+
+function onBulkRestoreRequest(recordIds: string[]) {
+  if (!workbench.activeSheetId.value || recordIds.length === 0) return
+  batchRestore.value = { visible: true, phase: 'preview', loading: true, targetVersion: 1, recordIds, records: [], scope: [], restorableCount: 0, skippedCount: 0, executable: false, identity: null, resultRecords: [], restoredCount: 0 }
+  void runBatchPreview(1)
+}
+
+function onBatchPreviewVersion(version: number) {
+  void runBatchPreview(version)
+}
+
+async function onConfirmBatchRestore() {
+  const sheetId = workbench.activeSheetId.value
+  const state = batchRestore.value
+  if (!sheetId || !state.identity || state.scope.length === 0) { batchRestore.value = { ...state, visible: false }; return }
+  const expectedVersions = buildBatchExpectedVersions(state.records, state.scope) // wire-drift guard
+  batchRestore.value = { ...state, loading: true }
+  try {
+    const result = await workbench.client.restoreBatchExecute(sheetId, state.scope, state.targetVersion, expectedVersions, state.identity)
+    batchRestore.value = { ...batchRestore.value, loading: false, phase: 'result', resultRecords: result.records, restoredCount: result.restoredCount, skippedCount: result.skippedCount }
+    await grid.loadViewData(grid.page.value.offset)
+    showSuccess(`${result.restoredCount} ${recordLabel('record.batchRestoreRestored', isZh.value)} · ${result.skippedCount} ${recordLabel('record.batchRestoreSummarySkipped', isZh.value)}`)
+  } catch (error) {
+    batchRestore.value = { ...batchRestore.value, loading: false }
+    showError((error as Error)?.message ?? recordLabel('record.errorRestore', isZh.value))
+  }
+}
+
+function onBatchRestoreDone() {
+  batchRestore.value = { ...batchRestore.value, visible: false }
+}
+function onBatchRestoreCancel() {
+  batchRestore.value = { ...batchRestore.value, visible: false }
 }
 
 async function onReloadConflict() {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -2023,6 +2023,14 @@ async function onConfirmBatchRestore() {
   const state = batchRestore.value
   if (!sheetId || !state.identity || state.scope.length === 0) { batchRestore.value = { ...state, visible: false }; return }
   const expectedVersions = buildBatchExpectedVersions(state.records, state.scope) // wire-drift guard
+  // [P3] FE fail-closed: if any scope record lacks a previewVersion, expectedVersions would be incomplete and the
+  // server would 400 — surface a re-preview rather than that opaque error. (Can't happen with current BS-2, which
+  // always returns previewVersion for a restorable record; defensive against a future wire change.)
+  if (Object.keys(expectedVersions).length !== state.scope.length) {
+    batchRestore.value = { ...state, visible: false }
+    showError(recordLabel('record.errorRestore', isZh.value))
+    return
+  }
   batchRestore.value = { ...state, loading: true }
   try {
     const result = await workbench.client.restoreBatchExecute(sheetId, state.scope, state.targetVersion, expectedVersions, state.identity)

--- a/apps/web/tests/multitable-restore-batch-dialog.spec.ts
+++ b/apps/web/tests/multitable-restore-batch-dialog.spec.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * BS-4 — RestoreBatchDialog + the wire-drift guard. The dialog is the per-record batch-restore panel (preview →
+ * confirm → result). The load-bearing safety is twofold: `canConfirm` (only an executable, non-empty restorable
+ * set commits) and `buildBatchExpectedVersions` (the FE submits each record's PREVIEW-TIME version over the
+ * identity's scope — never the current version, never a record outside scope). Mounted via createApp + jsdom;
+ * the dialog Teleports to body.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import RestoreBatchDialog from '../src/multitable/components/RestoreBatchDialog.vue'
+import { buildBatchExpectedVersions } from '../src/multitable/utils/batch-restore-expected-versions'
+import type { RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../src/multitable/api/client'
+
+describe('buildBatchExpectedVersions — BS-4 wire-drift guard', () => {
+  it('maps ONLY scope records to their previewVersion (skipped records excluded; current version never used)', () => {
+    const records: RestoreBatchPreviewRecord[] = [
+      { recordId: 'A', status: 'restorable', previewVersion: 2 },
+      { recordId: 'B', status: 'skipped', skipReason: 'no_change' },
+      { recordId: 'C', status: 'restorable', previewVersion: 5 },
+    ]
+    expect(buildBatchExpectedVersions(records, ['A', 'C'])).toEqual({ A: 2, C: 5 }) // B (skipped) excluded
+  })
+  it('excludes a record not in scope even if it carries a previewVersion (scope is canonical)', () => {
+    const records: RestoreBatchPreviewRecord[] = [
+      { recordId: 'A', status: 'restorable', previewVersion: 2 },
+      { recordId: 'B', status: 'restorable', previewVersion: 3 },
+    ]
+    expect(buildBatchExpectedVersions(records, ['A'])).toEqual({ A: 2 }) // B in records but not scope → excluded
+  })
+  it('omits a scope record lacking a numeric previewVersion (fail-closed — never a guessed version)', () => {
+    const records: RestoreBatchPreviewRecord[] = [{ recordId: 'A', status: 'restorable' }]
+    expect(buildBatchExpectedVersions(records, ['A'])).toEqual({})
+  })
+})
+
+type Props = {
+  visible: boolean; phase: 'preview' | 'result'; loading: boolean; targetVersion: number
+  previewRecords: RestoreBatchPreviewRecord[]; restorableCount: number; skippedCount: number; executable: boolean
+  resultRecords: RestoreBatchExecuteRecord[]; restoredCount: number
+  recordLabelOf: (id: string) => string; isZh: boolean
+  onPreviewVersion: (v: number) => void; onConfirm: () => void; onCancel: () => void; onDone: () => void
+}
+
+const mounted: Array<{ unmount: () => void }> = []
+function mountDialog(overrides: Partial<Props>) {
+  const props: Props = {
+    visible: true, phase: 'preview', loading: false, targetVersion: 1,
+    previewRecords: [], restorableCount: 0, skippedCount: 0, executable: false,
+    resultRecords: [], restoredCount: 0, recordLabelOf: (id) => `rec:${id}`, isZh: false,
+    onPreviewVersion: vi.fn(), onConfirm: vi.fn(), onCancel: vi.fn(), onDone: vi.fn(), ...overrides,
+  }
+  const app = createApp(RestoreBatchDialog, props as unknown as Record<string, unknown>)
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  app.mount(container)
+  mounted.push(app)
+  return props
+}
+const q = (sel: string) => document.body.querySelector(sel) as HTMLElement | null
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+
+describe('RestoreBatchDialog — BS-4 panel', () => {
+  it('preview: renders per-record restorable/skipped(reason) + ENABLES confirm when executable & restorable>0', async () => {
+    const props = mountDialog({
+      executable: true, restorableCount: 1, skippedCount: 1,
+      previewRecords: [
+        { recordId: 'A', status: 'restorable', previewVersion: 2 },
+        { recordId: 'B', status: 'skipped', skipReason: 'no_change' },
+      ],
+    })
+    await nextTick()
+    expect(q('[data-test="batch-restore-preview-list"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('rec:A')
+    expect(q('[data-test="batch-restorable"]')).toBeTruthy()
+    expect(q('[data-test="batch-skipped"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('No change') // the skip-reason label resolved from the taxonomy
+    const confirm = q('[data-test="batch-restore-confirm"]') as HTMLButtonElement
+    expect(confirm.disabled).toBe(false)
+    confirm.click()
+    expect(props.onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('preview: BLOCKS confirm when restorableCount === 0 (none-restorable) and shows the hint', async () => {
+    mountDialog({ executable: false, restorableCount: 0, previewRecords: [{ recordId: 'A', status: 'skipped', skipReason: 'unavailable' }] })
+    await nextTick()
+    expect(q('[data-test="batch-restore-none"]')).toBeTruthy()
+    expect((q('[data-test="batch-restore-confirm"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('advanced: toggling reveals the version input and changing it emits preview-version', async () => {
+    const props = mountDialog({ executable: true, restorableCount: 1, previewRecords: [{ recordId: 'A', status: 'restorable', previewVersion: 2 }] })
+    await nextTick()
+    ;(q('[data-test="batch-restore-advanced"]') as HTMLButtonElement).click()
+    await nextTick()
+    const input = q('[data-test="batch-restore-version"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    input.value = '3'
+    input.dispatchEvent(new Event('change'))
+    expect(props.onPreviewVersion).toHaveBeenCalledWith(3)
+  })
+
+  it('result: renders restored/skipped(reason) and Done emits done', async () => {
+    const props = mountDialog({
+      phase: 'result', restoredCount: 1, skippedCount: 1,
+      resultRecords: [
+        { recordId: 'A', status: 'restored', newVersion: 3 },
+        { recordId: 'B', status: 'skipped', skipReason: 'conflict' },
+      ],
+    })
+    await nextTick()
+    expect(q('[data-test="batch-restore-result-list"]')).toBeTruthy()
+    expect(q('[data-test="batch-restored"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('Version conflict') // execute skip-reason label
+    const done = q('[data-test="batch-restore-done"]') as HTMLButtonElement
+    done.click()
+    expect(props.onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits cancel from the cancel button (preview)', async () => {
+    const props = mountDialog({ executable: true, restorableCount: 1, previewRecords: [{ recordId: 'A', status: 'restorable', previewVersion: 2 }] })
+    await nextTick()
+    ;(document.body.querySelectorAll('.restore-batch__btn')[0] as HTMLButtonElement).click()
+    expect(props.onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
@@ -13,9 +13,12 @@ import { computed, createApp, defineComponent, h, nextTick, ref, type App as Vue
 const showErrorSpy = vi.fn()
 const showSuccessSpy = vi.fn()
 
-// Capture the real listeners/props the workbench passes to MetaRecordDrawer + RestorePreviewDialog.
+// Capture the real listeners/props the workbench passes to MetaRecordDrawer + RestorePreviewDialog + (BS-4) the
+// MetaGridTable bulk bar + the RestoreBatchDialog.
 let capturedDrawerAttrs: Record<string, unknown> | null = null
 let capturedDialogAttrs: Record<string, unknown> | null = null
+let capturedGridAttrs: Record<string, unknown> | null = null
+let capturedBatchDialogAttrs: Record<string, unknown> | null = null
 
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
@@ -60,7 +63,17 @@ vi.mock('../src/multitable/import/bulk-import', () => ({ bulkImportRecords: vi.f
 
 vi.mock('../src/multitable/components/MetaViewTabBar.vue', () => ({ default: stubComponent('MetaViewTabBar') }))
 vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({ default: stubComponent('MetaToolbar') }))
-vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({ default: stubComponent('MetaGridTable') }))
+// Capturing stub for the grid — records the @bulk-restore listener (onBulkRestoreRequest), the BS-4 entry point.
+vi.mock('../src/multitable/components/MetaGridTable.vue', () => ({
+  default: defineComponent({
+    name: 'MetaGridTable',
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+      capturedGridAttrs = attrs as Record<string, unknown>
+      return () => h('div', { 'data-stub-MetaGridTable': 'true' })
+    },
+  }),
+}))
 vi.mock('../src/multitable/components/MetaFormView.vue', () => ({ default: stubComponent('MetaFormView') }))
 // Capturing stub for the drawer under wiring test — records the real listeners.
 vi.mock('../src/multitable/components/MetaRecordDrawer.vue', () => ({
@@ -82,6 +95,17 @@ vi.mock('../src/multitable/components/RestorePreviewDialog.vue', () => ({
     setup(_props, { attrs }) {
       capturedDialogAttrs = attrs as Record<string, unknown>
       return () => h('div', { 'data-stub-RestorePreviewDialog': 'true' })
+    },
+  }),
+}))
+// Capturing stub for the BS-4 batch panel — records visible/executable + the @preview-version/@confirm listeners.
+vi.mock('../src/multitable/components/RestoreBatchDialog.vue', () => ({
+  default: defineComponent({
+    name: 'RestoreBatchDialog',
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+      capturedBatchDialogAttrs = attrs as Record<string, unknown>
+      return () => h('div', { 'data-stub-RestoreBatchDialog': 'true' })
     },
   }),
 }))
@@ -130,6 +154,9 @@ function createWorkbenchMock() {
       // The functions under test (the slice-2 chain):
       restorePreviewRecord: vi.fn().mockResolvedValue({ ...PREVIEW_OK }),
       restoreExecuteRecord: vi.fn().mockResolvedValue({ recordId: 'rec_42', newVersion: 6, noop: false, restoredFieldIds: ['fld_title'] }),
+      // BS-4 batch chain: preview returns a RESTORABLE scope [A,C] (B skipped) + per-record previewVersion; execute echoes a result.
+      restoreBatchPreview: vi.fn().mockResolvedValue({ records: [{ recordId: 'A', status: 'restorable', previewVersion: 2 }, { recordId: 'B', status: 'skipped', skipReason: 'no_change' }, { recordId: 'C', status: 'restorable', previewVersion: 5 }], scope: ['A', 'C'], restorableCount: 2, skippedCount: 1, targetVersion: 1, previewIdentity: 'tok_batch' }),
+      restoreBatchExecute: vi.fn().mockResolvedValue({ records: [{ recordId: 'A', status: 'restored', newVersion: 3 }, { recordId: 'C', status: 'restored', newVersion: 6 }], restoredCount: 2, skippedCount: 0, targetVersion: 1 }),
     },
     sheets: ref([{ id: 'sheet_orders', baseId: 'base_ops', name: 'Orders', description: null }]),
     fields: ref([{ id: 'fld_title', name: 'Title', type: 'string' }]),
@@ -287,5 +314,91 @@ describe('MultitableWorkbench record-restore handler wiring (preview→execute, 
     expect(showErrorSpy.mock.calls[0][0]).toBe('Record is at version 6, expected 5')
     expect(gridMock.loadViewData).not.toHaveBeenCalled()
     expect(showSuccessSpy).not.toHaveBeenCalled()
+  })
+})
+
+// BS-4: the REAL workbench batch wire — the lock the helper + dialog specs don't provide. Mounts the workbench,
+// captures the grid's @bulk-restore + the batch dialog's @preview-version/@confirm, and asserts the EXACT client
+// call chain (so a future edit that executes the original selected ids, or builds expectedVersions from the wrong
+// list, or drifts the identity position, fails here).
+describe('MultitableWorkbench BATCH-restore handler wiring (bulk → preview → confirm → execute)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    workbenchMock = createWorkbenchMock()
+    gridMock = createGridMock()
+    capturedGridAttrs = null
+    capturedBatchDialogAttrs = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null; container = null
+    showErrorSpy.mockReset(); showSuccessSpy.mockReset()
+    vi.unstubAllGlobals(); vi.clearAllMocks()
+  })
+
+  async function mountAndGetBulkRestore(): Promise<(ids: string[]) => Promise<void> | void> {
+    const Host = defineComponent({ setup() { return () => h(MultitableWorkbench as Component) } })
+    app = createApp(Host)
+    app.mount(container!)
+    await flushUi()
+    expect(capturedGridAttrs).not.toBeNull()
+    const onBulkRestore = capturedGridAttrs!.onBulkRestore as (ids: string[]) => Promise<void> | void
+    expect(typeof onBulkRestore).toBe('function')
+    return onBulkRestore
+  }
+
+  it('locks the chain: preview(SELECTED, v1) → advanced re-preview(SELECTED, N) → execute(SCOPE, expectedVersions-from-previewVersion, identity)', async () => {
+    const onBulkRestore = await mountAndGetBulkRestore()
+    // 1. bulk restore previews the ORIGINAL selected ids at v1 (default revert-to-original).
+    await onBulkRestore(['A', 'B', 'C']); await flushUi()
+    expect(workbenchMock.client.restoreBatchPreview).toHaveBeenCalledWith('sheet_orders', ['A', 'B', 'C'], 1)
+    expect(capturedBatchDialogAttrs!.visible).toBe(true)
+    expect(capturedBatchDialogAttrs!.executable).toBe(true)
+    // 2. Advanced re-preview uses the target version N + the SAME original selected ids (not the scope).
+    await (capturedBatchDialogAttrs!.onPreviewVersion as (v: number) => void)(3); await flushUi()
+    expect(workbenchMock.client.restoreBatchPreview).toHaveBeenLastCalledWith('sheet_orders', ['A', 'B', 'C'], 3)
+    // 3. confirm executes over the preview's SCOPE (['A','C']) — NOT the selected ids; expectedVersions are exactly
+    //    each restorable record's previewVersion ({A:2,C:5}); targetVersion is the re-previewed 3; identity is the
+    //    5th positional arg. A reorder/wrong-source on ANY of these fails here.
+    await (capturedBatchDialogAttrs!.onConfirm as () => void)(); await flushUi()
+    expect(workbenchMock.client.restoreBatchExecute).toHaveBeenCalledTimes(1)
+    expect(workbenchMock.client.restoreBatchExecute).toHaveBeenCalledWith('sheet_orders', ['A', 'C'], 3, { A: 2, C: 5 }, 'tok_batch')
+    expect(showSuccessSpy).toHaveBeenCalledTimes(1)
+    expect(gridMock.loadViewData).toHaveBeenCalled()
+  })
+
+  it('confirm NEVER executes the original selected ids — the skipped record B is excluded (scope-not-selection lock)', async () => {
+    const onBulkRestore = await mountAndGetBulkRestore()
+    await onBulkRestore(['A', 'B', 'C']); await flushUi()
+    await (capturedBatchDialogAttrs!.onConfirm as () => void)(); await flushUi()
+    const call = (workbenchMock.client.restoreBatchExecute as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(call[1]).toEqual(['A', 'C']) // the scope, not ['A','B','C']
+    expect(call[1]).not.toContain('B') // the skipped record is never written
+    expect(call[3]).toEqual({ A: 2, C: 5 }) // expectedVersions has no B either
+  })
+
+  it('a non-executable preview (empty restorable scope → previewIdentity null) cannot execute even if confirm is forced', async () => {
+    workbenchMock.client.restoreBatchPreview.mockResolvedValueOnce({ records: [{ recordId: 'A', status: 'skipped', skipReason: 'no_change' }], scope: [], restorableCount: 0, skippedCount: 1, targetVersion: 1, previewIdentity: null })
+    const onBulkRestore = await mountAndGetBulkRestore()
+    await onBulkRestore(['A']); await flushUi()
+    expect(capturedBatchDialogAttrs!.executable).toBe(false)
+    await (capturedBatchDialogAttrs!.onConfirm as () => void)(); await flushUi()
+    expect(workbenchMock.client.restoreBatchExecute).not.toHaveBeenCalled()
+  })
+
+  it('[P3] FE fail-closed: a scope record missing previewVersion blocks execute (incomplete expectedVersions never sent)', async () => {
+    // executable (identity present) but a restorable scope record has NO previewVersion → expectedVersions would be
+    // incomplete → the FE guard blocks the execute (rather than letting the server 400).
+    workbenchMock.client.restoreBatchPreview.mockResolvedValueOnce({ records: [{ recordId: 'A', status: 'restorable' }], scope: ['A'], restorableCount: 1, skippedCount: 0, targetVersion: 1, previewIdentity: 'tok_batch' })
+    const onBulkRestore = await mountAndGetBulkRestore()
+    await onBulkRestore(['A']); await flushUi()
+    await (capturedBatchDialogAttrs!.onConfirm as () => void)(); await flushUi()
+    expect(workbenchMock.client.restoreBatchExecute).not.toHaveBeenCalled() // incomplete expectedVersions never sent
+    expect(showErrorSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
+++ b/apps/web/tests/multitable-workbench-restore-wiring.spec.ts
@@ -401,4 +401,21 @@ describe('MultitableWorkbench BATCH-restore handler wiring (bulk → preview →
     expect(workbenchMock.client.restoreBatchExecute).not.toHaveBeenCalled() // incomplete expectedVersions never sent
     expect(showErrorSpy).toHaveBeenCalledTimes(1)
   })
+
+  it('out-of-order Advanced previews: a stale earlier-version response never overwrites the latest (seq guard)', async () => {
+    const onBulkRestore = await mountAndGetBulkRestore()
+    await onBulkRestore(['A', 'B', 'C']); await flushUi() // initial v1 preview (default mock)
+    // race: v3 deferred, v4 resolves first → v3's late response must be dropped.
+    let resolveV3!: (v: unknown) => void
+    workbenchMock.client.restoreBatchPreview
+      .mockReturnValueOnce(new Promise((r) => { resolveV3 = r as (v: unknown) => void }))
+      .mockResolvedValueOnce({ records: [{ recordId: 'C', status: 'restorable', previewVersion: 5 }], scope: ['C'], restorableCount: 1, skippedCount: 0, targetVersion: 4, previewIdentity: 'tok_v4' })
+    await (capturedBatchDialogAttrs!.onPreviewVersion as (v: number) => void)(3)
+    await (capturedBatchDialogAttrs!.onPreviewVersion as (v: number) => void)(4); await flushUi() // v4 applies
+    resolveV3({ records: [{ recordId: 'A', status: 'restorable', previewVersion: 2 }, { recordId: 'B', status: 'restorable', previewVersion: 3 }], scope: ['A', 'B'], restorableCount: 2, skippedCount: 0, targetVersion: 3, previewIdentity: 'tok_v3' })
+    await flushUi() // the stale v3 now resolves — must be dropped, not overwrite v4
+    await (capturedBatchDialogAttrs!.onConfirm as () => void)(); await flushUi()
+    // confirm executes the v4 scope + identity, NOT the stale v3 (['A','B'] / tok_v3)
+    expect(workbenchMock.client.restoreBatchExecute).toHaveBeenCalledWith('sheet_orders', ['C'], 4, { C: 5 }, 'tok_v4')
+  })
 })


### PR DESCRIPTION
> **HELD for your UX review — not auto-landed.** UX is the named BS-4 risk and this is the first user-facing surface of the batch capability.

The FE for the shipped batch/scope backend (BS-1 #3073 / BS-2 #3078 / BS-3 #3085). The **mix** entry you chose:

**Flow:** grid multi-select → bulk-bar **Restore** button → `RestoreBatchDialog`:
- **Default: revert-to-original (v1)** — per-record **restorable** / **skipped(reason)** list + summary.
- **Advanced** toggle → a **version-N** input → re-previews at that version.
- Confirm → execute → **result phase**: per-record **restored** / **skipped(denied/conflict/forbidden)** + Done.

**Faithful client of the security model** (the wire-drift risk you named): submits each record's `previewVersion` as `expectedVersions` over the identity's `scope` (via `buildBatchExpectedVersions`, unit-tested), surfaces the skip-reason taxonomy verbatim, and gates confirm on an executable, non-empty restorable set. It never reinterprets the model.

## Pieces
`RestoreBatchDialog.vue` · client methods (`e1cec5897`) · `buildBatchExpectedVersions` util · `MetaGridTable` `@bulk-restore` button (`canBulkRestore`, canEdit-gated) · `MultitableWorkbench` wiring · 24 strict-zero `record.batch*` i18n keys + `batchSkipReasonLabel` + 2 `grid.batchRestore*` keys.

## Verification
8 specs (5 jsdom dialog: preview/result phases, confirm-gating, advanced version, cancel/done + 3 wire-drift unit: scope-only mapping, out-of-scope exclusion, fail-closed-on-missing-version). Added to **multitable-web-guard**. `vue-tsc -b` 0; guard set **43/43** (no regression).

## Known MVP edges (your call on follow-ups)
- Record labels in the dialog use the first-visible-field value, falling back to the **recordId** when the row isn't on the current page — a primary-field label resolver is a fast follow if you want it.
- `targetVersion` is per-record "version N" (BS-3 semantic); the default v1 sidesteps the awkwardness, the Advanced picker exposes it. A timestamp/batch-id "undo that bulk edit" entry is T-series, not this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)