### PR TITLE
feat(approval): G-1 — complex-graph load-preserve + read-only structured render (anti-flatten)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -24,6 +24,7 @@ on:
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
+      - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -35,6 +36,7 @@ on:
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
+      - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -80,4 +82,6 @@ jobs:
         # detail/sub-form (明细) FE helpers: frozen-schema row render + fill-row seeding +
         # column-draft validation (mirrors backend normalizeDetailFieldParts) + buildFormSchema
         # detail emit/round-trip + validateTemplateDraft detail branch.
-        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail --reporter=dot
+        # G-1 complex-graph load-preserve: anti-flatten round-trip (condition/parallel/cc save
+        # byte-identical) + isComplexApprovalGraph + graphReadOnlyReason vs unsupportedReason split.
+        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve --reporter=dot

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -525,7 +525,9 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     allowRevoke: true,
     ...(complex ? { preservedGraph: template.approvalGraph } : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
-    steps: steps.length > 0 ? steps : [createEmptyStepDraft(1)],
+    // A complex graph round-trips via `preservedGraph` and has no editable steps — keep
+    // `steps: []` (no phantom step). Linear drafts seed an empty step for the editor.
+    steps: complex ? steps : (steps.length > 0 ? steps : [createEmptyStepDraft(1)]),
   }
 }
 
@@ -752,7 +754,9 @@ export function validateTemplateDraft(
     cycleState.set(fieldId, 2)
   }
   visibilityDeps.forEach((_dependsOn, fieldId) => visitVisibility(fieldId))
-  if (draft.steps.length === 0) errors.push('至少需要一个审批步骤')
+  // A complex graph (preservedGraph) carries no editable steps — the step requirement only
+  // applies to linear drafts that build their graph from `steps`.
+  if (!draft.preservedGraph && draft.steps.length === 0) errors.push('至少需要一个审批步骤')
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {
     const label = step.name.trim() || `审批步骤 ${index + 1}`

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -113,9 +113,29 @@ export interface TemplateAuthoringDraft {
   allowRevoke: boolean
   fields: FieldAuthoringDraft[]
   steps: ApprovalStepDraft[]
+  // G-1 anti-flatten keystone: a COMPLEX graph (any cc/condition/parallel node, or any
+  // non-linear shape) is captured here verbatim at hydrate and emitted UNCHANGED by
+  // `buildApprovalGraph` — the linear `steps` projection is NEVER applied to it, so save can
+  // not drop/reorder complex nodes/edges/config. `undefined` for plain linear templates (which
+  // keep the editable `steps` round-trip). The graph editor (G-2+) replaces this pass-through.
+  preservedGraph?: ApprovalGraph
 }
 
-const UNSUPPORTED_GRAPH_NODE_TYPES = new Set(['cc', 'condition', 'parallel'])
+// Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
+// graph containing them is load-preserved verbatim (read-only graph view), never flattened.
+const COMPLEX_GRAPH_NODE_TYPES = new Set(['cc', 'condition', 'parallel'])
+
+/**
+ * True when a graph can't be edited through the linear `steps` model and so must be
+ * preserved verbatim: any `cc` / `condition` / `parallel` node is present, OR the topology is
+ * not a single linear start→approval*→end chain (`orderedLinearNodes` returns null). This is the
+ * G-1 anti-flatten gate — its truth means `draftFromTemplate` captures `preservedGraph` and the
+ * view renders the graph read-only.
+ */
+export function isComplexApprovalGraph(graph: ApprovalGraph): boolean {
+  if (graph.nodes.some((node) => COMPLEX_GRAPH_NODE_TYPES.has(node.type))) return true
+  return orderedLinearNodes(graph) === null
+}
 
 function nextLocalId(prefix: string): string {
   return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`
@@ -377,24 +397,59 @@ function orderedLinearNodes(graph: ApprovalGraph): ApprovalGraph['nodes'] | null
   return ordered
 }
 
+// The full set of node types the runtime recognises. A node whose type is outside this set is
+// genuinely un-authorable (data corruption / a newer schema) → the whole template stays read-only
+// and save is blocked, never flattened. `cc`/`condition`/`parallel` ARE recognised (G-1
+// load-preserves them) and are deliberately included here.
+const RECOGNISED_GRAPH_NODE_TYPES = new Set([
+  'start',
+  'approval',
+  'cc',
+  'condition',
+  'parallel',
+  'end',
+])
+
+/**
+ * Reason the WHOLE template must open read-only with SAVE DISABLED (truly-unsupported, distinct
+ * from a complex-but-save-preserving graph — see `graphReadOnlyReason`). Returns a message for:
+ *  - an un-authorable FIELD type (e.g. `attachment`), or
+ *  - a node carrying EXTRA keys beyond key/type/name/config, or a node whose `type` is not
+ *    recognised by the runtime, or
+ *  - (LINEAR graphs only) an approval node whose `config` has keys/sources the linear editor
+ *    can't represent — for COMPLEX graphs this is skipped because the graph is preserved verbatim
+ *    rather than projected to `steps`.
+ * Returns `null` when the template is editable OR complex-but-preservable.
+ */
 export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
   const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
   if (unsupportedField) {
     return `包含暂不支持编辑的字段类型：${unsupportedField.label || unsupportedField.id} (${unsupportedField.type})`
   }
 
+  // A node carrying extra keys, or an unrecognised node type, is genuinely un-authorable and
+  // blocks save. NOTE: cc/condition/parallel are RECOGNISED (load-preserved) and do NOT trip
+  // this — they are surfaced read-only via `graphReadOnlyReason`, never flattened.
   const unknownNode = template.approvalGraph.nodes.find((node) => {
     const nodeKeys = Object.keys(node as unknown as Record<string, unknown>)
     return nodeKeys.some((key) => !['key', 'type', 'name', 'config'].includes(key))
-      || UNSUPPORTED_GRAPH_NODE_TYPES.has(node.type)
-      || !['start', 'approval', 'end'].includes(node.type)
+      || !RECOGNISED_GRAPH_NODE_TYPES.has(node.type)
   })
   if (unknownNode) {
     return `包含暂不支持编辑的审批节点：${unknownNode.name || unknownNode.key} (${unknownNode.type})`
   }
 
+  // Complex graphs (cc/condition/parallel or non-linear) are load-preserved verbatim — the linear
+  // `steps` projection (and its per-approval-node config allowlist below) does NOT apply, so they
+  // are never "unsupported" here. They open read-only via `graphReadOnlyReason` and save unchanged.
+  if (isComplexApprovalGraph(template.approvalGraph)) {
+    return null
+  }
+
   const ordered = orderedLinearNodes(template.approvalGraph)
   if (!ordered) {
+    // Unreachable in practice (a non-linear graph is already complex above), but keeps the
+    // linear path total: an unexpected non-linear shape stays read-only rather than projecting.
     return '审批流程不是 MVP 支持的线性结构'
   }
 
@@ -425,14 +480,38 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
   return null
 }
 
+/**
+ * G-1 — reason the GRAPH (not the whole template) must render READ-ONLY: the graph is complex
+ * (any cc/condition/parallel node, or non-linear) so the v1 linear `steps` editor can't author
+ * it. Distinct from `unsupportedTemplateAuthoringReason`: a complex graph is NOT unsupported — the
+ * form/metadata stay EDITABLE and SAVE stays enabled (it preserves the graph verbatim via
+ * `draftFromTemplate`→`preservedGraph`→`buildApprovalGraph`). Returns `null` for a linear graph
+ * (the steps editor is live) and for a truly-unsupported template (that path is fully read-only
+ * via `unsupportedTemplateAuthoringReason`; the graph view never opens). The G-2+ editors will
+ * narrow this to only genuinely-unrepresentable constructs.
+ */
+export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
+  if (unsupportedTemplateAuthoringReason(template)) return null
+  if (!isComplexApprovalGraph(template.approvalGraph)) return null
+  return '该审批流程包含条件 / 并行 / 抄送等复杂节点，当前版本以只读结构展示，保存时原样保留，不会被改写。'
+}
+
 export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
+  // G-1 anti-flatten keystone: a complex graph is captured VERBATIM and never projected to the
+  // linear `steps` model. `buildApprovalGraph` re-emits it byte-identical, so load→save can not
+  // drop or reorder its cc/condition/parallel nodes/edges/config.
+  const complex = isComplexApprovalGraph(template.approvalGraph)
   const ordered = orderedLinearNodes(template.approvalGraph) ?? template.approvalGraph.nodes
   const fields = template.formSchema.fields
     .map(fieldDraftFromField)
     .filter((field): field is FieldAuthoringDraft => field !== null)
-  const steps = ordered
-    .map(stepDraftFromApprovalNode)
-    .filter((step): step is ApprovalStepDraft => step !== null)
+  // Skip the approval-only step projection for complex graphs — they round-trip via
+  // `preservedGraph`, and projecting would discard the non-approval nodes (the flatten risk).
+  const steps = complex
+    ? []
+    : ordered
+        .map(stepDraftFromApprovalNode)
+        .filter((step): step is ApprovalStepDraft => step !== null)
 
   return {
     templateId: template.id,
@@ -444,6 +523,7 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     visibilityIdsText: formatIds(template.visibilityScope?.ids),
     slaHoursText: template.slaHours == null ? '' : String(template.slaHours),
     allowRevoke: true,
+    ...(complex ? { preservedGraph: template.approvalGraph } : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
     steps: steps.length > 0 ? steps : [createEmptyStepDraft(1)],
   }
@@ -551,6 +631,12 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
 }
 
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
+  // G-1 anti-flatten keystone: a preserved complex graph is emitted UNCHANGED — no rebuild from
+  // `steps`, so its cc/condition/parallel nodes/edges/config survive save byte-identical. Only
+  // linear drafts (no `preservedGraph`) take the start→approval*→end build below.
+  if (draft.preservedGraph) {
+    return draft.preservedGraph
+  }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
     type: 'approval' as const,

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -50,6 +50,18 @@
       data-testid="approval-template-unsupported-alert"
     />
 
+    <!-- G-1: a complex graph is preserved, not unsupported — informational, save stays enabled. -->
+    <el-alert
+      v-if="!unsupportedReason && graphReadOnlyMessage"
+      :title="graphReadOnlyMessage"
+      description="表单与基本信息可编辑；审批流程以只读结构展示，保存时原样保留。复杂节点的可视化编辑将在后续版本提供。"
+      type="info"
+      show-icon
+      :closable="false"
+      class="template-authoring__alert"
+      data-testid="approval-template-graph-readonly-alert"
+    />
+
     <el-alert
       v-if="loadError || validationErrors.length"
       :title="loadError || '请修正后再保存'"
@@ -341,8 +353,9 @@
       <el-card class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
-            <strong>审批步骤</strong>
+            <strong>{{ graphReadOnly ? '审批流程（只读）' : '审批步骤' }}</strong>
             <el-button
+              v-if="!graphReadOnly"
               size="small"
               :disabled="readOnly"
               data-testid="approval-template-add-step"
@@ -354,8 +367,32 @@
           </div>
         </template>
 
+        <!-- G-1: read-only structured render of a preserved complex graph. Covers ALL three
+             complex node types (condition / parallel / cc) plus approval, so nothing renders as a
+             bare "unsupported" — authors see the flow they are preserving. No editing yet (G-2+). -->
+        <div v-if="graphReadOnly" data-testid="approval-graph-readonly-list">
+          <div
+            v-for="node in graphPreviewNodes"
+            :key="node.key"
+            class="template-authoring__item"
+            data-testid="approval-graph-node-row"
+          >
+            <div class="template-authoring__item-toolbar">
+              <strong>{{ node.name || node.key }}</strong>
+              <span class="template-authoring__node-type" :data-node-type="node.type">
+                {{ nodeTypeLabel(node.type) }}
+              </span>
+            </div>
+            <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
+              <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
+            </ul>
+            <div v-else class="template-authoring__hint">（无可编辑配置）</div>
+          </div>
+        </div>
+
         <div
           v-for="(step, index) in draft.steps"
+          v-show="!graphReadOnly"
           :key="step.localId"
           class="template-authoring__item"
           data-testid="approval-template-step-row"
@@ -528,6 +565,7 @@ import {
   createEmptyTemplateDraft,
   DETAIL_LEAF_FIELD_TYPES,
   draftFromTemplate,
+  graphReadOnlyReason,
   parseIdsText,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
@@ -535,6 +573,13 @@ import {
   type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
+import type {
+  ApprovalAssigneeSource,
+  ApprovalNode,
+  CcNodeConfig,
+  ConditionNodeConfig,
+  ParallelNodeConfig,
+} from '../../types/approval'
 import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
 
 const route = useRoute()
@@ -547,12 +592,87 @@ const publishing = ref(false)
 const loadError = ref<string | null>(null)
 const validationErrors = ref<string[]>([])
 const unsupportedReason = ref<string | null>(null)
+// G-1: a COMPLEX (condition/parallel/cc/non-linear) graph renders read-only but is NOT
+// unsupported — the form/metadata stay editable and save preserves the graph verbatim.
+const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
 
 const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
 const isEditMode = computed(() => templateId.value.length > 0)
+// Truly-unsupported (attachment field / unknown node / extra config keys) locks the WHOLE form.
 const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupportedReason.value))
+// A complex graph is shown via the read-only structured node list (`graphPreviewNodes`); the
+// linear steps editor is hidden. The graph is preserved on save, so this does NOT disable save.
+const graphReadOnly = computed(() => Boolean(graphReadOnlyMessage.value))
 const canSave = computed(() => canManageTemplates.value && !unsupportedReason.value && !loading.value)
+
+// G-1 read-only structured render of a preserved complex graph: a per-node summary of the
+// config the v1 editor doesn't yet author, so authors can SEE the flow they're preserving.
+const graphPreviewNodes = computed<ApprovalNode[]>(() => draft.value.preservedGraph?.nodes ?? [])
+
+const NODE_TYPE_LABELS: Record<string, string> = {
+  start: '发起',
+  approval: '审批',
+  cc: '抄送',
+  condition: '条件分支',
+  parallel: '并行分支',
+  end: '结束',
+}
+function nodeTypeLabel(type: string): string {
+  return NODE_TYPE_LABELS[type] ?? type
+}
+
+function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
+  switch (source.kind) {
+    case 'static_user': return `指定用户：${source.userIds.join('、') || '（无）'}`
+    case 'static_role': return `指定角色：${source.roleIds.join('、') || '（无）'}`
+    case 'requester': return '发起人'
+    case 'form_field_user': return `表单用户字段：${source.fieldId}`
+    case 'direct_manager': return '直属上级'
+    case 'dept_head': return '部门主管'
+    case 'continuous_managers': return `连续多级上级（${source.levels} 级）`
+    case 'manager_at_level': return `指定层级上级（第 ${source.level} 级）`
+    default: return JSON.stringify(source)
+  }
+}
+
+// One read-only descriptor per node config, covering ALL three complex types (condition / parallel
+// / cc) plus approval — so no type silently renders as "unsupported". Returns `[]` for nodes
+// without summarisable config (start/end).
+function nodeConfigSummary(node: ApprovalNode): string[] {
+  const config = node.config as Record<string, unknown>
+  if (node.type === 'condition') {
+    const cfg = config as unknown as ConditionNodeConfig
+    const lines = (cfg.branches ?? []).map((branch) => {
+      const rules = (branch.rules ?? [])
+        .map((rule) => `${rule.fieldId} ${rule.operator}${rule.value === undefined ? '' : ` ${JSON.stringify(rule.value)}`}`)
+        .join(` ${branch.conjunction ?? 'and'} `)
+      return `分支 → ${branch.edgeKey}：${rules || '（无规则）'}`
+    })
+    if (cfg.defaultEdgeKey) lines.push(`默认分支 → ${cfg.defaultEdgeKey}`)
+    return lines
+  }
+  if (node.type === 'parallel') {
+    const cfg = config as unknown as ParallelNodeConfig
+    return [
+      `并行分支：${(cfg.branches ?? []).join('、') || '（无）'}`,
+      `汇聚节点：${cfg.joinNodeKey ?? '（无）'}`,
+      `汇聚模式：${cfg.joinMode ?? '（无）'}`,
+    ]
+  }
+  if (node.type === 'cc') {
+    const cfg = config as unknown as CcNodeConfig
+    return [
+      `抄送类型：${cfg.targetType === 'role' ? '角色' : '用户'}`,
+      `抄送对象：${(cfg.targetIds ?? []).join('、') || '（无）'}`,
+    ]
+  }
+  if (node.type === 'approval') {
+    const sources = Array.isArray(config.assigneeSources) ? config.assigneeSources as ApprovalAssigneeSource[] : []
+    return sources.map((source) => `审批人：${assigneeSourceSummary(source)}`)
+  }
+  return []
+}
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
 const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
 const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
@@ -674,6 +794,7 @@ async function loadTemplateForEdit() {
   if (!isEditMode.value) {
     draft.value = createEmptyTemplateDraft()
     unsupportedReason.value = null
+    graphReadOnlyMessage.value = null
     return
   }
   loading.value = true
@@ -681,6 +802,7 @@ async function loadTemplateForEdit() {
   try {
     const template = await getTemplate(templateId.value)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
+    graphReadOnlyMessage.value = graphReadOnlyReason(template)
     draft.value = draftFromTemplate(template)
     syncAllStepOptions()
   } catch (error: any) {
@@ -707,11 +829,13 @@ async function persistDraft() {
       const updated = await updateTemplate(draft.value.templateId, buildUpdateTemplatePayload(draft.value))
       draft.value = draftFromTemplate(updated)
       unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
+      graphReadOnlyMessage.value = graphReadOnlyReason(updated)
       return updated
     }
     const created = await createTemplate(buildCreateTemplatePayload(draft.value))
     draft.value = draftFromTemplate(created)
     unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
+    graphReadOnlyMessage.value = graphReadOnlyReason(created)
     await router.replace({ path: `/approval-templates/${created.id}/edit` })
     return created
   } catch (error: any) {
@@ -876,6 +1000,22 @@ onMounted(() => {
 
 .template-authoring__item-toolbar {
   margin-bottom: 12px;
+}
+
+.template-authoring__node-type {
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--el-fill-color-light, #f5f7fa);
+  color: var(--el-text-color-secondary, #606266);
+}
+
+.template-authoring__node-summary {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--el-text-color-regular, #606266);
 }
 
 .template-authoring__error-list {

--- a/apps/web/tests/approval-template-authoring-graph-preserve.test.ts
+++ b/apps/web/tests/approval-template-authoring-graph-preserve.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  graphReadOnlyReason,
+  isComplexApprovalGraph,
+  unsupportedTemplateAuthoringReason,
+} from '../src/approvals/templateAuthoring'
+
+// G-1 — complex-graph load-preserve + anti-flatten. These are PURE-LOGIC tests (no .vue / no
+// Element Plus import) so they run under the approval-web-guard CI gate; the .vue render path is
+// covered in approvalTemplateAuthoring.spec.ts. The keystone is the round-trip: load a complex
+// graph → save → byte-identical (no node/edge/config dropped or reordered).
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z',
+    updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        { id: 'kind', type: 'select', label: '类型', options: [{ label: 'A', value: 'a' }] },
+      ],
+    },
+    approvalGraph,
+  }
+}
+
+const LINEAR_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'approval_1',
+      type: 'approval',
+      name: '审批人 1',
+      config: {
+        assigneeSources: [{ kind: 'requester' }],
+        approvalMode: 'single',
+        emptyAssigneePolicy: 'error',
+      },
+    },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+  ],
+}
+
+// A graph with a CONDITION node (branches + rules + defaultEdgeKey) and two downstream approval
+// arms — non-linear, so the linear projection would lose the condition + the second arm.
+const CONDITION_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '金额判断',
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }],
+            conjunction: 'and',
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    },
+    {
+      key: 'approval_high',
+      type: 'approval',
+      name: '大额审批',
+      config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_low',
+      type: 'approval',
+      name: '小额审批',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' },
+    },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond_1', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval_high-end', source: 'approval_high', target: 'end' },
+    { key: 'edge-approval_low-end', source: 'approval_low', target: 'end' },
+  ],
+}
+
+// A graph with a PARALLEL fork (branches + joinNodeKey + joinMode) and a join node.
+const PARALLEL_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'fork_1',
+      type: 'parallel',
+      name: '并行会签',
+      config: { branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' },
+    },
+    {
+      key: 'approval_a',
+      type: 'approval',
+      name: '财务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['finance'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_b',
+      type: 'approval',
+      name: '法务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-fork_1', source: 'start', target: 'fork_1' },
+    { key: 'edge-fork_1-a', source: 'fork_1', target: 'approval_a' },
+    { key: 'edge-fork_1-b', source: 'fork_1', target: 'approval_b' },
+    { key: 'edge-approval_a-join', source: 'approval_a', target: 'join_1' },
+    { key: 'edge-approval_b-join', source: 'approval_b', target: 'join_1' },
+    { key: 'edge-join_1-end', source: 'join_1', target: 'end' },
+  ],
+}
+
+// A graph with a CC (抄送) node — targetType + targetIds.
+const CC_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'approval_1',
+      type: 'approval',
+      name: '审批人 1',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'cc_1', type: 'cc', name: '抄送 HR', config: { targetType: 'role', targetIds: ['hr', 'admin'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-cc_1', source: 'approval_1', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+  ],
+}
+
+describe('G-1 isComplexApprovalGraph', () => {
+  it('is true for a condition graph', () => {
+    expect(isComplexApprovalGraph(CONDITION_GRAPH)).toBe(true)
+  })
+
+  it('is true for a parallel graph', () => {
+    expect(isComplexApprovalGraph(PARALLEL_GRAPH)).toBe(true)
+  })
+
+  it('is true for a cc graph', () => {
+    expect(isComplexApprovalGraph(CC_GRAPH)).toBe(true)
+  })
+
+  it('is true for a non-linear graph that branches without a complex node type', () => {
+    // start fans out to two approval nodes (out-degree 2) — not a single linear chain even though
+    // every node type is start/approval/end. `orderedLinearNodes` returns null → complex.
+    const nonLinear: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'approval_1', type: 'approval', name: 'A', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'approval_2', type: 'approval', name: 'B', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'start', target: 'approval_2' },
+        { key: 'e3', source: 'approval_1', target: 'end' },
+        { key: 'e4', source: 'approval_2', target: 'end' },
+      ],
+    }
+    expect(isComplexApprovalGraph(nonLinear)).toBe(true)
+  })
+
+  it('is false for a plain linear start→approval→end graph', () => {
+    expect(isComplexApprovalGraph(LINEAR_GRAPH)).toBe(false)
+  })
+})
+
+describe('G-1 anti-flatten round-trip (load → save is byte-identical, nothing flattened)', () => {
+  it('round-trips a CONDITION graph unchanged through draftFromTemplate → buildApprovalGraph', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    // byte-identical: the condition node, both arms, every edge and rule survive verbatim.
+    expect(rebuilt).toEqual(original)
+    expect(rebuilt.nodes.map((node) => node.key)).toEqual(original.nodes.map((node) => node.key))
+    expect(rebuilt.edges).toEqual(original.edges)
+  })
+
+  it('round-trips a PARALLEL graph unchanged through draftFromTemplate → buildApprovalGraph', () => {
+    const template = buildTemplate(PARALLEL_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+    // the fork's branches + joinNodeKey + joinMode are preserved (not collapsed to a chain).
+    const fork = rebuilt.nodes.find((node) => node.type === 'parallel')
+    expect(fork?.config).toEqual({ branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' })
+    expect(rebuilt.edges).toEqual(original.edges)
+  })
+
+  it('round-trips a CC graph unchanged through draftFromTemplate → buildApprovalGraph', () => {
+    const template = buildTemplate(CC_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+    const cc = rebuilt.nodes.find((node) => node.type === 'cc')
+    expect(cc?.config).toEqual({ targetType: 'role', targetIds: ['hr', 'admin'] })
+  })
+
+  it('captures the full graph verbatim in preservedGraph for a complex template', () => {
+    const draft = draftFromTemplate(buildTemplate(CONDITION_GRAPH))
+    expect(draft.preservedGraph).toEqual(CONDITION_GRAPH)
+    // the linear `steps` projection is NOT applied to a complex graph (would drop the condition
+    // + the second arm) — preservedGraph is the sole source for buildApprovalGraph.
+    expect(draft.preservedGraph?.nodes.some((node) => node.type === 'condition')).toBe(true)
+  })
+
+  it('leaves preservedGraph undefined for a linear template (steps editor stays live)', () => {
+    const draft = draftFromTemplate(buildTemplate(LINEAR_GRAPH))
+    expect(draft.preservedGraph).toBeUndefined()
+    // the linear builder still emits the deterministic start→approval_1→end chain.
+    expect(buildApprovalGraph(draft).nodes.map((node) => node.key)).toEqual(['start', 'approval_1', 'end'])
+  })
+})
+
+describe('G-1 unsupportedTemplateAuthoringReason — complex graphs are save-able, not unsupported', () => {
+  it('returns null for a CONDITION graph (now save-preserving, no longer blocked)', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(CONDITION_GRAPH))).toBeNull()
+  })
+
+  it('returns null for a PARALLEL graph (now save-preserving, no longer blocked)', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(PARALLEL_GRAPH))).toBeNull()
+  })
+
+  it('returns null for a CC graph (now save-preserving, no longer blocked)', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(CC_GRAPH))).toBeNull()
+  })
+
+  it('still returns a reason for an unauthorable attachment field type', () => {
+    const template = buildTemplate(LINEAR_GRAPH)
+    template.formSchema = { fields: [{ id: 'file', type: 'attachment', label: '附件' }] }
+    expect(unsupportedTemplateAuthoringReason(template)).toContain('暂不支持编辑的字段类型')
+  })
+
+  it('still returns a reason for an unknown node type (not in the recognised set)', () => {
+    const template = buildTemplate({
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        // `webhook` is not a recognised node type → genuinely un-authorable, stays read-only.
+        { key: 'hook', type: 'webhook' as never, name: '回调', config: {} },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'hook' },
+        { key: 'e2', source: 'hook', target: 'end' },
+      ],
+    })
+    expect(unsupportedTemplateAuthoringReason(template)).toContain('暂不支持编辑的审批节点')
+  })
+
+  it('still returns a reason for a node carrying EXTRA keys beyond key/type/name/config', () => {
+    const template = buildTemplate({
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['hr'] }, extra: 'x' } as never,
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'cc_1' },
+        { key: 'e2', source: 'cc_1', target: 'end' },
+      ],
+    })
+    expect(unsupportedTemplateAuthoringReason(template)).toContain('暂不支持编辑的审批节点')
+  })
+
+  it('still returns a reason for a LINEAR approval node carrying an unsupported config key', () => {
+    // fieldPermissions on a LINEAR approval node is outside the editor allowlist → fail-closed
+    // (the linear-path config check still runs; a complex graph would skip it and preserve).
+    const template = buildTemplate({
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: '审批人 1',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+            fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+          } as never,
+        },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    })
+    expect(unsupportedTemplateAuthoringReason(template)).toContain('暂不支持的配置')
+  })
+})
+
+describe('G-1 graphReadOnlyReason — complex graphs render read-only but stay save-able', () => {
+  it('returns a message for condition / parallel / cc graphs', () => {
+    expect(graphReadOnlyReason(buildTemplate(CONDITION_GRAPH))).not.toBeNull()
+    expect(graphReadOnlyReason(buildTemplate(PARALLEL_GRAPH))).not.toBeNull()
+    expect(graphReadOnlyReason(buildTemplate(CC_GRAPH))).not.toBeNull()
+  })
+
+  it('returns null for a plain linear graph (the steps editor is live)', () => {
+    expect(graphReadOnlyReason(buildTemplate(LINEAR_GRAPH))).toBeNull()
+  })
+
+  it('returns null for a truly-unsupported template (fully read-only via unsupportedReason instead)', () => {
+    // an unknown node type is unsupported, not merely complex — the graph read-only view never
+    // opens; the whole template is locked by unsupportedTemplateAuthoringReason.
+    const template = buildTemplate({
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'hook', type: 'webhook' as never, name: '回调', config: {} },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'hook' },
+        { key: 'e2', source: 'hook', target: 'end' },
+      ],
+    })
+    expect(graphReadOnlyReason(template)).toBeNull()
+    expect(unsupportedTemplateAuthoringReason(template)).not.toBeNull()
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -8,6 +8,7 @@ import {
   buildFormSchema,
   createEmptyTemplateDraft,
   draftFromTemplate,
+  graphReadOnlyReason,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
 } from '../src/approvals/templateAuthoring'
@@ -283,8 +284,12 @@ describe('approval template authoring helpers', () => {
     expect(schema.fields[0]?.label).toBe('报销金额')
   })
 
-  it('blocks unsupported graph constructs instead of flattening them', () => {
-    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+  it('G-1: load-PRESERVES a complex (parallel) graph instead of flattening — graph read-only, save-able, byte-identical round-trip', () => {
+    // Behaviour CHANGED at G-1: cc/condition/parallel are no longer "unsupported" (which blocked
+    // save). They are load-preserved verbatim — the graph renders read-only, the form stays
+    // editable, and save re-emits the SAME graph (no flatten). See the dedicated round-trip suite
+    // in approval-template-authoring-graph-preserve.test.ts.
+    const template = buildTemplate({
       approvalGraph: {
         nodes: [
           { key: 'start', type: 'start', name: '发起', config: {} },
@@ -296,9 +301,15 @@ describe('approval template authoring helpers', () => {
           { key: 'edge-fork-end', source: 'fork', target: 'end' },
         ],
       },
-    }))
+    })
 
-    expect(reason).toContain('暂不支持编辑的审批节点')
+    // no longer unsupported (save NOT blocked) — but the graph is flagged read-only.
+    expect(unsupportedTemplateAuthoringReason(template)).toBeNull()
+    expect(graphReadOnlyReason(template)).not.toBeNull()
+    // anti-flatten: save re-emits the parallel graph byte-identical, never the linear projection.
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(template.approvalGraph)
+    expect(rebuilt.nodes.some((node) => node.type === 'parallel')).toBe(true)
   })
 
   it('fails closed on a node carrying fieldPermissions (no node-field editor yet)', () => {
@@ -809,33 +820,54 @@ describe('TemplateAuthoringView', () => {
     expect(payload.approvalGraph.nodes[1].config.autoApprovalPolicy).toEqual({ mergeWithRequester: true })
   })
 
-  it('opens unsupported existing graphs read-only and refuses to save them', async () => {
+  it('G-1: opens a complex (parallel) graph READ-ONLY but save-able — preserves the graph on save, never flattens', async () => {
+    // Behaviour CHANGED at G-1: a complex graph is no longer fail-closed (save disabled). It opens
+    // with the form editable + the graph rendered read-only (structured node list), and SAVE is
+    // enabled — the save re-emits the SAME graph (anti-flatten), it does not project to a linear
+    // start→approval→end chain.
     routeParams = { id: 'tpl_parallel' }
-    getTemplateSpy.mockResolvedValue(buildTemplate({
-      id: 'tpl_parallel',
-      approvalGraph: {
-        nodes: [
-          { key: 'start', type: 'start', name: '发起', config: {} },
-          { key: 'parallel_1', type: 'parallel', name: '并行审批', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'end' } },
-          { key: 'end', type: 'end', name: '结束', config: {} },
-        ],
-        edges: [
-          { key: 'edge-start-parallel_1', source: 'start', target: 'parallel_1' },
-          { key: 'edge-parallel_1-end', source: 'parallel_1', target: 'end' },
-        ],
-      },
-    }))
+    const parallelGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'parallel_1', type: 'parallel', name: '并行审批', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'join_1' } },
+        { key: 'approval_a', type: 'approval', name: '财务', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approval_b', type: 'approval', name: '法务', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-parallel_1', source: 'start', target: 'parallel_1' },
+        { key: 'edge-parallel_1-a', source: 'parallel_1', target: 'approval_a' },
+        { key: 'edge-parallel_1-b', source: 'parallel_1', target: 'approval_b' },
+        { key: 'edge-approval_a-join', source: 'approval_a', target: 'join_1' },
+        { key: 'edge-approval_b-join', source: 'approval_b', target: 'join_1' },
+        { key: 'edge-join_1-end', source: 'join_1', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_parallel', approvalGraph: parallelGraph }))
 
     await mountView()
+    await flushUi()
 
-    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')?.textContent)
-      .toContain('暂不支持编辑')
+    // NOT fail-closed: no unsupported alert; the informational graph-read-only alert shows instead.
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull()
+    expect(container!.querySelector('[data-testid="approval-template-graph-readonly-alert"]')).not.toBeNull()
+    // the linear steps editor is hidden; the read-only structured node list renders the parallel node.
+    expect(container!.querySelector('[data-testid="approval-template-add-step"]')).toBeNull()
+    const nodeRows = container!.querySelectorAll('[data-testid="approval-graph-node-row"]')
+    expect(nodeRows.length).toBe(parallelGraph.nodes.length)
+    expect(container!.querySelector('[data-node-type="parallel"]')).not.toBeNull()
+
+    // save is ENABLED and preserves the graph byte-identical (anti-flatten through the real wire).
     const saveButton = container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement
-    expect(saveButton.disabled).toBe(true)
+    expect(saveButton.disabled).toBe(false)
     saveButton.click()
     await flushUi()
 
-    expect(updateTemplateSpy).not.toHaveBeenCalled()
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    expect(payload.approvalGraph).toEqual(parallelGraph)
+    expect(payload.approvalGraph.nodes.some((node: any) => node.type === 'parallel')).toBe(true)
   })
 
   it('T8: disables the self-approver toggle when the template opens read-only', async () => {

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -8,17 +8,26 @@
 > 不支持的构造一律 read-only,**永不拍平**。
 
 ## Phase G — design-lock
-- ⬜ Land the design-lock doc (this PR, docs-only).
-- 🔒 Owner ACCEPT of the §1 editable set + the 4 §8 decisions. **Gate for G-1.**
+- ✅ Land the design-lock doc (landed in #3102, docs-only).
+- ✅ Owner ACCEPT of the §1 editable set + the 4 §8 decisions (G-1 opted in 2026-06-23). **Gate
+  for G-1 — opened.** G-2..G-4 remain separate per-phase opt-ins (still 🔒 below).
 
-## Phase G-1 — load-preserve + read-only structured view (🔒 until G accepted)
-- 🔒 Authoring draft model carries the FULL graph (all nodes + edges + every config), not the
-  linear `steps` projection; complex types pass through byte-for-byte (spread-original-first).
-- 🔒 Render a complex graph as a READ-ONLY structured node list (condition/parallel/cc shown,
-  not just "unsupported"). No editing yet.
-- 🔒 Anti-flatten test: load a condition / parallel / cc template → save untouched → the
-  `approvalGraph` is byte-identical (no node/edge/config dropped). Keep the existing
-  "blocks unsupported / refuses to save / opens read-only" tests green.
+## Phase G-1 — load-preserve + read-only structured view (✅ shipped)
+- ✅ Authoring draft model carries the FULL graph (`TemplateAuthoringDraft.preservedGraph`), not
+  the linear `steps` projection; complex types pass through byte-for-byte — `draftFromTemplate`
+  captures `preservedGraph` when `isComplexApprovalGraph`, `buildApprovalGraph` re-emits it
+  UNCHANGED (no rebuild from `steps`).
+- ✅ Render a complex graph as a READ-ONLY structured node list (condition branches+rules /
+  parallel branches+joinNodeKey+joinMode / cc targetType+targetIds / approval assignees shown,
+  not just "unsupported"). No editing yet. New `graphReadOnlyReason` flags the read-only graph
+  while keeping the form/metadata editable and SAVE enabled; truly-unsupported (attachment field
+  / unknown node type / extra config keys) still fully read-only + save-disabled.
+- ✅ Anti-flatten round-trip test: load a condition / parallel / cc template → save untouched → the
+  `approvalGraph` is byte-identical (no node/edge/config dropped) —
+  `apps/web/tests/approval-template-authoring-graph-preserve.test.ts` (one round-trip per complex
+  type; wired into `approval-web-guard.yml`). Existing "blocks unsupported / refuses to save /
+  opens read-only" tests updated for the changed cc/condition/parallel behaviour (now
+  save-preserving, graph read-only); the attachment / extra-key fail-closed tests stay green.
 
 ## Phase G-2 — condition editor (🔒 until G-1)
 - 🔒 Author condition `branches` (rules `{fieldId, operator, value}` + `conjunction`) +


### PR DESCRIPTION
## Phase G-1 — load-preserve + read-only structured view

Implements **G-1** of the approval complex-graph author UI (design-lock `docs/design/approval-complex-graph-author-ui-design-lock-20260623.md`, tracker `docs/development/approval-complex-graph-author-ui-todo-20260623.md`). **The safety floor before any editing**: load, read-only structured-render, and **SAVE** complex approval graphs (condition / parallel / cc) **WITHOUT flattening** them to the MVP linear `start→approval*→end`.

### The flatten risk this closes
The linear authoring path projects the graph to approval-only `steps` — `draftFromTemplate` drops non-approval nodes, `buildApprovalGraph` rebuilds a linear chain. A complex template reaching save through that path would lose its condition/parallel/cc nodes + edges. Until now this was mitigated by opening such templates fully read-only (save disabled); G-1 keeps that guarantee while letting the form/metadata stay editable and the graph save unchanged.

### Preserve mechanism (2 lines)
- `draftFromTemplate` captures the FULL graph verbatim into a new `TemplateAuthoringDraft.preservedGraph` when `isComplexApprovalGraph(graph)` (any cc/condition/parallel node, or a non-linear topology); the linear `steps` projection is skipped for complex graphs.
- `buildApprovalGraph` returns `preservedGraph` **UNCHANGED** when set (no rebuild from `steps`) → load→save is **byte-identical**. Linear drafts keep the existing editable linear build.

### Read-only split
- `unsupportedTemplateAuthoringReason` no longer treats cc/condition/parallel (or non-linear) as unsupported. It STILL blocks the whole template read-only + save-disabled for a truly-unsupported case: an un-authorable field type (attachment), an UNKNOWN node type (outside start/approval/cc/condition/parallel/end), or a node with EXTRA keys beyond key/type/name/config (the per-approval-node config allowlist runs on the LINEAR path only).
- New `graphReadOnlyReason` flags a complex graph → the view renders the graph **READ-ONLY** (structured node list) while form/metadata stay editable and **SAVE stays enabled** (preserving the graph).
- `TemplateAuthoringView` renders a read-only structured node list covering **all three** complex types plus approval: condition branches+rules / parallel branches+joinNodeKey+joinMode / cc targetType+targetIds / approval assignees; hides the linear steps editor; keeps save enabled. The truly-unsupported path stays fully read-only + save-disabled.

### Round-trip tests (the keystone — pure-logic `.ts` spec, no `.vue`)
New `apps/web/tests/approval-template-authoring-graph-preserve.test.ts` (**20 tests**), wired into `approval-web-guard.yml` (the main gate doesn't run apps/web vitest):
- **Anti-flatten round-trip, one per complex type** — `buildApprovalGraph(draftFromTemplate(template))` deepEquals the original `approvalGraph` byte-identical:
  - `round-trips a CONDITION graph unchanged …`
  - `round-trips a PARALLEL graph unchanged …`
  - `round-trips a CC graph unchanged …`
- `isComplexApprovalGraph` true for condition / parallel / cc / non-linear, false for linear.
- `unsupportedTemplateAuthoringReason` null for condition/parallel/cc; still blocks attachment field, unknown node type, extra-key node, and a linear approval node with an unsupported config key.
- `graphReadOnlyReason` non-null for complex, null for linear and for truly-unsupported.

**Existing flatten tests updated (not deleted):** the cc/condition/parallel cases in `approvalTemplateAuthoring.spec.ts` now assert save-preserving + graph read-only (the `.vue` render asserts the read-only node list, save enabled, and that the saved payload's `approvalGraph` equals the loaded parallel graph — anti-flatten through the real wire). The attachment / extra-key fail-closed tests stay green.

### Scope / boundaries
- **No graph editing yet (G-2+).** UI-only: no change to `ApprovalGraphExecutor`, `normalizeApprovalGraph`, or the graph types.
- Brand-neutral (no vendor names in code/docs).

### Verification
- `pnpm --filter @metasheet/web run type-check` — clean (vue-tsc -b).
- New + updated + detail specs: **96 tests pass** (20 new in the graph-preserve spec).
- eslint clean on changed source + new test (the 23 warnings in `approvalTemplateAuthoring.spec.ts` are pre-existing test-stub warnings, confirmed unchanged vs base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)