### PR TITLE
feat(approval): G-2 — condition branch editing (topology-preserving)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -17,6 +17,7 @@ name: Approval Web Guard
 on:
   pull_request:
     paths:
+      - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -25,10 +26,12 @@ on:
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
+      - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
     paths:
+      - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -37,6 +40,7 @@ on:
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
+      - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -84,4 +88,7 @@ jobs:
         # detail emit/round-trip + validateTemplateDraft detail branch.
         # G-1 complex-graph load-preserve: anti-flatten round-trip (condition/parallel/cc save
         # byte-identical) + isComplexApprovalGraph + graphReadOnlyReason vs unsupportedReason split.
-        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve --reporter=dot
+        # G-2 condition editor: topology-preserving edit (rule/conjunction/defaultEdgeKey change →
+        # only the condition node config changes; all other nodes + edges byte-identical; parallel/cc
+        # untouched) + seeding round-trip + validation preview (fieldId / outgoing default edge).
+        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit --reporter=dot

--- a/apps/web/src/approvals/conditionEdit.ts
+++ b/apps/web/src/approvals/conditionEdit.ts
@@ -1,0 +1,229 @@
+import type {
+  ApprovalGraph,
+  ApprovalNode,
+  ConditionBranch,
+  ConditionNodeConfig,
+  ConditionRule,
+  FormSchema,
+} from '../types/approval'
+
+// G-2 — condition node editing (LOGIC ONLY; no .vue / Element Plus import so this runs under the
+// approval-web-guard vitest gate). The scope is the condition *logic* — each branch's `rules`,
+// `conjunction`, and the node's `defaultEdgeKey`. Branch/edge TOPOLOGY (which branches exist, their
+// edgeKeys, their targets) and every OTHER node/edge are PRESERVED byte-for-byte (G-1 anti-flatten
+// floor). parallel / cc nodes stay read-only (G-3 / G-4).
+
+/** The condition-rule operator union the runtime + backend `normalizeApprovalGraph` recognise. */
+export const CONDITION_RULE_OPERATORS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'isEmpty'] as const
+export type ConditionRuleOperator = ConditionRule['operator']
+const CONDITION_RULE_OPERATOR_SET = new Set<string>(CONDITION_RULE_OPERATORS)
+
+/**
+ * Editable model for one condition node. `branches` mirrors the node config's branches 1:1 — the
+ * editor may change each branch's `rules` / `conjunction` but NOT add/remove a branch or change its
+ * `edgeKey` (topology, a later slice). `defaultEdgeKey` is editable: it is the FALL-THROUGH edge
+ * (taken when no branch matches), and must be an existing OUTGOING edge of the node — NOT one of the
+ * branch `edgeKey`s (see `validateConditionEdits`). The edit model is keyed by node `key`.
+ */
+export interface ConditionNodeEdit {
+  nodeKey: string
+  branches: ConditionBranchEdit[]
+  defaultEdgeKey: string
+}
+
+export interface ConditionBranchEdit {
+  // Topology — preserved verbatim; the editor never mutates these.
+  edgeKey: string
+  conjunction: 'and' | 'or'
+  rules: ConditionRuleEdit[]
+}
+
+export interface ConditionRuleEdit {
+  fieldId: string
+  operator: ConditionRuleOperator
+  // The raw rule value. Carried as `unknown` so a seeded value round-trips identically; the editor
+  // surface (text input) writes a string. `undefined` ⇒ the emitted rule omits `value` (matching
+  // `isEmpty` and the backend's omit-when-undefined discipline).
+  value: unknown
+}
+
+/** Map of condition edits keyed by node key, seeded from a preserved graph and edited in place. */
+export type ConditionEdits = Record<string, ConditionNodeEdit>
+
+// Deep clone for the preserved-graph pass-through. The graph is pure JSON-serialisable data (the
+// backend persists it as JSON), and — unlike `structuredClone` — a JSON round-trip works on the
+// Vue reactive Proxy the authoring view wraps the draft in (`structuredClone` throws DATA_CLONE_ERR
+// on a Proxy). JSON dropping `undefined`-valued keys is fine: a backend-normalised graph carries
+// none, so this is identity for the preserved nodes/edges we pass through unchanged.
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function isConditionConfig(config: ApprovalNode['config']): config is ConditionNodeConfig {
+  return Boolean(config) && Array.isArray((config as ConditionNodeConfig).branches)
+}
+
+/** True when a rule operator is one the editor's select offers (and the backend accepts). */
+export function isConditionRuleOperator(value: unknown): value is ConditionRuleOperator {
+  return typeof value === 'string' && CONDITION_RULE_OPERATOR_SET.has(value)
+}
+
+/**
+ * Seed the editable condition model from a (preserved) graph. One entry per `condition` node,
+ * branches captured 1:1 (edgeKey + conjunction default 'and' + rules). Non-condition nodes are
+ * ignored here — they are preserved verbatim by `applyConditionEditsToGraph`.
+ */
+export function conditionEditsFromGraph(graph: ApprovalGraph | undefined): ConditionEdits {
+  const edits: ConditionEdits = {}
+  if (!graph) return edits
+  for (const node of graph.nodes) {
+    if (node.type !== 'condition' || !isConditionConfig(node.config)) continue
+    const config = node.config
+    edits[node.key] = {
+      nodeKey: node.key,
+      branches: (config.branches ?? []).map((branch) => ({
+        edgeKey: branch.edgeKey,
+        conjunction: branch.conjunction === 'or' ? 'or' : 'and',
+        rules: (branch.rules ?? []).map((rule) => ({
+          fieldId: rule.fieldId,
+          operator: rule.operator,
+          // Preserve `value` verbatim. A branch may legitimately omit it (isEmpty / no value);
+          // capture that as `undefined` so the rebuilt rule omits the key too (byte-identical).
+          value: 'value' in rule ? rule.value : undefined,
+        })),
+      })),
+      defaultEdgeKey: config.defaultEdgeKey ?? '',
+    }
+  }
+  return edits
+}
+
+/**
+ * Build one persisted `ConditionRule` from a rule edit, mirroring the backend
+ * `normalizeApprovalGraph` rule shape: `fieldId` trimmed, `operator` verbatim, and `value` emitted
+ * only when defined (omitted for `isEmpty` / no-value rules) so an untouched rule is byte-identical.
+ */
+function buildConditionRule(rule: ConditionRuleEdit): ConditionRule {
+  return {
+    fieldId: rule.fieldId.trim(),
+    operator: rule.operator,
+    ...(rule.value !== undefined ? { value: rule.value } : {}),
+  }
+}
+
+/**
+ * Replace the `config` of each condition node in `graph` with the edited config, leaving EVERY
+ * other node and ALL edges byte-identical (deep-cloned so the input is never mutated). This is the
+ * G-2 save path: topology (branches/edgeKeys/targets, all non-condition nodes, the full edge list)
+ * is preserved exactly; only the condition LOGIC (rules / conjunction / defaultEdgeKey) changes.
+ *
+ * Byte-identity for an UNTOUCHED graph: each rebuilt condition branch carries `conjunction` only
+ * when the ORIGINAL branch did (threaded from `originalGraph`), `value` only when present, and
+ * `defaultEdgeKey` only when non-empty — matching the backend-normalised shape the graph was loaded
+ * with. Branches the edit model doesn't cover (none, by construction) or nodes with no edit entry
+ * are passed through verbatim.
+ */
+export function applyConditionEditsToGraph(
+  graph: ApprovalGraph,
+  edits: ConditionEdits,
+): ApprovalGraph {
+  const nodes: ApprovalNode[] = graph.nodes.map((node) => {
+    if (node.type !== 'condition') {
+      // Non-condition node — preserve byte-for-byte (deep clone so we never alias the input).
+      return cloneJson(node)
+    }
+    const edit = edits[node.key]
+    if (!edit || !isConditionConfig(node.config)) {
+      // No edit entry (shouldn't happen for a seeded condition node) — preserve verbatim.
+      return cloneJson(node)
+    }
+    const originalConfig = node.config
+    const originalBranchByEdge = new Map(
+      (originalConfig.branches ?? []).map((branch) => [branch.edgeKey, branch]),
+    )
+    const branches: ConditionBranch[] = edit.branches.map((branchEdit) => {
+      const original = originalBranchByEdge.get(branchEdit.edgeKey)
+      // Emit `conjunction` only when the original branch carried one, OR the editor set a value
+      // that differs from the original's absent/value — i.e. always emit when the current value is
+      // 'or', and emit 'and' only if the original explicitly had a conjunction. This keeps an
+      // untouched branch byte-identical (no spurious `conjunction: 'and'`).
+      const originalHadConjunction = original?.conjunction !== undefined
+      const emitConjunction = originalHadConjunction || branchEdit.conjunction === 'or'
+      return {
+        edgeKey: branchEdit.edgeKey,
+        ...(emitConjunction ? { conjunction: branchEdit.conjunction } : {}),
+        rules: branchEdit.rules.map(buildConditionRule),
+      }
+    })
+    const config: ConditionNodeConfig = {
+      branches,
+      ...(edit.defaultEdgeKey.trim() ? { defaultEdgeKey: edit.defaultEdgeKey.trim() } : {}),
+    }
+    return {
+      ...cloneJson(node),
+      config,
+    }
+  })
+  return {
+    nodes,
+    // Edges are pure topology — preserved byte-for-byte (deep clone, never aliased/reordered).
+    edges: graph.edges.map((edge) => cloneJson(edge)),
+  }
+}
+
+/**
+ * FE validation PREVIEW for the condition edits (UX only — the backend `normalizeApprovalGraph`
+ * stays the sole arbiter; this never relaxes it). Mirrors the high-value checks:
+ *  - every rule `fieldId` must reference an existing form field,
+ *  - every rule `operator` must be in the union,
+ *  - `defaultEdgeKey` (when set) must be an OUTGOING edge of the condition node.
+ *
+ * On `defaultEdgeKey`: the runtime (`ApprovalGraphExecutor.resolveConditionTarget`) resolves it via
+ * `targetForEdge`, which looks the key up in the GRAPH EDGE LIST — it is the FALL-THROUGH edge taken
+ * when no branch matches, and is deliberately a SEPARATE edge from the branch `edgeKey`s (the
+ * canonical fixture's default edge is `cond → low`, distinct from the branch's `cond → high`). So
+ * the correct invariant is "an existing outgoing edge of this node", NOT "a branch edgeKey". The
+ * node's outgoing edges come from the preserved graph (G-2 never changes topology). When `graph` is
+ * omitted the edge check is skipped (the field check still runs).
+ */
+export function validateConditionEdits(
+  edits: ConditionEdits,
+  formSchema: FormSchema,
+  graph?: ApprovalGraph,
+): string[] {
+  const errors: string[] = []
+  const fieldIds = new Set(formSchema.fields.map((field) => field.id))
+  // Outgoing edge keys per node key (edges whose `source` is that node) — the legal targets for a
+  // branch/default edge of that condition node.
+  const outgoingByNode = new Map<string, Set<string>>()
+  for (const edge of graph?.edges ?? []) {
+    const set = outgoingByNode.get(edge.source) ?? new Set<string>()
+    set.add(edge.key)
+    outgoingByNode.set(edge.source, set)
+  }
+  for (const edit of Object.values(edits)) {
+    const nodeLabel = edit.nodeKey
+    edit.branches.forEach((branch, branchIndex) => {
+      branch.rules.forEach((rule, ruleIndex) => {
+        const ruleLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 规则 ${ruleIndex + 1}`
+        const fieldId = rule.fieldId.trim()
+        if (!fieldId) {
+          errors.push(`${ruleLabel} 需要选择字段`)
+        } else if (!fieldIds.has(fieldId)) {
+          errors.push(`${ruleLabel} 引用的字段 ${fieldId} 不存在`)
+        }
+        if (!isConditionRuleOperator(rule.operator)) {
+          errors.push(`${ruleLabel} 的运算符无效`)
+        }
+      })
+    })
+    const defaultEdgeKey = edit.defaultEdgeKey.trim()
+    if (defaultEdgeKey && graph) {
+      const outgoing = outgoingByNode.get(edit.nodeKey) ?? new Set<string>()
+      if (!outgoing.has(defaultEdgeKey)) {
+        errors.push(`条件节点 ${nodeLabel} 的默认分支 ${defaultEdgeKey} 不是该节点的出边`)
+      }
+    }
+  }
+  return errors
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -22,9 +22,23 @@ import {
   validateDetailColumnsDraft,
   type DetailColumnDraft,
 } from './detailField'
+import {
+  applyConditionEditsToGraph,
+  conditionEditsFromGraph,
+  validateConditionEdits,
+  type ConditionEdits,
+} from './conditionEdit'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
+export type {
+  ConditionEdits,
+  ConditionNodeEdit,
+  ConditionBranchEdit,
+  ConditionRuleEdit,
+  ConditionRuleOperator,
+} from './conditionEdit'
+export { CONDITION_RULE_OPERATORS } from './conditionEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -119,6 +133,12 @@ export interface TemplateAuthoringDraft {
   // not drop/reorder complex nodes/edges/config. `undefined` for plain linear templates (which
   // keep the editable `steps` round-trip). The graph editor (G-2+) replaces this pass-through.
   preservedGraph?: ApprovalGraph
+  // G-2 condition editor: editable LOGIC for each `condition` node in `preservedGraph`, keyed by
+  // node key (seeded 1:1 from the preserved condition nodes). Only a condition node's rules /
+  // conjunction / defaultEdgeKey are editable here; branch/edge TOPOLOGY and every non-condition
+  // node/edge stay byte-identical-preserved (G-1 floor). `buildApprovalGraph` applies these onto a
+  // COPY of `preservedGraph`. Empty/absent for linear or non-condition complex graphs.
+  conditionEdits?: ConditionEdits
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -493,7 +513,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
 export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
   if (unsupportedTemplateAuthoringReason(template)) return null
   if (!isComplexApprovalGraph(template.approvalGraph)) return null
-  return '该审批流程包含条件 / 并行 / 抄送等复杂节点，当前版本以只读结构展示，保存时原样保留，不会被改写。'
+  return '该审批流程包含复杂节点：条件分支可在下方编辑分支规则，并行 / 抄送节点以只读结构展示；未改动的节点与连线在保存时原样保留，不会被改写。'
 }
 
 export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
@@ -523,7 +543,14 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     visibilityIdsText: formatIds(template.visibilityScope?.ids),
     slaHoursText: template.slaHours == null ? '' : String(template.slaHours),
     allowRevoke: true,
-    ...(complex ? { preservedGraph: template.approvalGraph } : {}),
+    ...(complex
+      ? {
+          preservedGraph: template.approvalGraph,
+          // G-2: seed the editable condition logic from the preserved condition nodes (1:1).
+          // Empty {} when the complex graph has no condition node (parallel/cc-only).
+          conditionEdits: conditionEditsFromGraph(template.approvalGraph),
+        }
+      : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
     // A complex graph round-trips via `preservedGraph` and has no editable steps — keep
     // `steps: []` (no phantom step). Linear drafts seed an empty step for the editor.
@@ -633,11 +660,14 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
 }
 
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
-  // G-1 anti-flatten keystone: a preserved complex graph is emitted UNCHANGED — no rebuild from
-  // `steps`, so its cc/condition/parallel nodes/edges/config survive save byte-identical. Only
-  // linear drafts (no `preservedGraph`) take the start→approval*→end build below.
+  // G-1/G-2 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`, so its
+  // cc/condition/parallel nodes/edges survive save. G-2 replaces ONLY each condition node's config
+  // with the edited logic (rules / conjunction / defaultEdgeKey) onto a COPY of the graph — every
+  // other node and ALL edges stay byte-identical (an untouched graph round-trips unchanged because
+  // `applyConditionEditsToGraph` reproduces the backend-normalised condition shape). parallel/cc
+  // nodes are passed through verbatim (G-3/G-4). Only linear drafts take the build below.
   if (draft.preservedGraph) {
-    return draft.preservedGraph
+    return applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
   }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
@@ -757,6 +787,13 @@ export function validateTemplateDraft(
   // A complex graph (preservedGraph) carries no editable steps — the step requirement only
   // applies to linear drafts that build their graph from `steps`.
   if (!draft.preservedGraph && draft.steps.length === 0) errors.push('至少需要一个审批步骤')
+  // G-2 condition-editor PREVIEW: rule fieldId must reference a form field, operator must be in the
+  // union, and defaultEdgeKey must be an OUTGOING edge of the condition node (the fall-through edge;
+  // checked against `preservedGraph`'s edges). UX-only — the backend `normalizeApprovalGraph`
+  // re-validates and is the final arbiter (we never relax it here).
+  if (draft.conditionEdits && Object.keys(draft.conditionEdits).length > 0) {
+    errors.push(...validateConditionEdits(draft.conditionEdits, buildFormSchema(draft), draft.preservedGraph))
+  }
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {
     const label = step.name.trim() || `审批步骤 ${index + 1}`

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -50,11 +50,12 @@
       data-testid="approval-template-unsupported-alert"
     />
 
-    <!-- G-1: a complex graph is preserved, not unsupported — informational, save stays enabled. -->
+    <!-- G-1/G-2: a complex graph is preserved, not unsupported — informational, save stays enabled.
+         G-2 makes condition nodes editable; parallel / cc stay read-only (G-3 / G-4). -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；审批流程以只读结构展示，保存时原样保留。复杂节点的可视化编辑将在后续版本提供。"
+      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行 / 抄送节点暂以只读结构展示。未改动的节点与连线在保存时原样保留。"
       type="info"
       show-icon
       :closable="false"
@@ -353,7 +354,7 @@
       <el-card class="template-authoring__panel" shadow="never">
         <template #header>
           <div class="template-authoring__panel-header">
-            <strong>{{ graphReadOnly ? '审批流程（只读）' : '审批步骤' }}</strong>
+            <strong>{{ graphReadOnly ? '审批流程（结构）' : '审批步骤' }}</strong>
             <el-button
               v-if="!graphReadOnly"
               size="small"
@@ -367,9 +368,10 @@
           </div>
         </template>
 
-        <!-- G-1: read-only structured render of a preserved complex graph. Covers ALL three
-             complex node types (condition / parallel / cc) plus approval, so nothing renders as a
-             bare "unsupported" — authors see the flow they are preserving. No editing yet (G-2+). -->
+        <!-- G-1/G-2: structured render of a preserved complex graph. condition nodes are EDITABLE
+             (G-2 — branch rules / conjunction / default edge); parallel / cc / approval stay
+             READ-ONLY summaries (G-3 / G-4), and every non-condition node + all edges are preserved
+             byte-for-byte on save. Nothing renders as a bare "unsupported". -->
         <div v-if="graphReadOnly" data-testid="approval-graph-readonly-list">
           <div
             v-for="node in graphPreviewNodes"
@@ -383,10 +385,126 @@
                 {{ nodeTypeLabel(node.type) }}
               </span>
             </div>
-            <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
-              <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
-            </ul>
-            <div v-else class="template-authoring__hint">（无可编辑配置）</div>
+
+            <!-- G-2: editable condition node (rules / conjunction / default fall-through edge).
+                 Topology (which branches exist, their edgeKeys/targets) is NOT editable here — only
+                 the matching LOGIC. Branch add/remove is a later slice. -->
+            <div
+              v-if="node.type === 'condition' && conditionEditFor(node.key)"
+              class="template-authoring__condition"
+              data-testid="approval-condition-editor"
+              :data-condition-node="node.key"
+            >
+              <div
+                v-for="branch in conditionEditFor(node.key)!.branches"
+                :key="branch.edgeKey"
+                class="template-authoring__condition-branch"
+                data-testid="approval-condition-branch"
+              >
+                <div class="template-authoring__condition-branch-head">
+                  <span>分支 → {{ branch.edgeKey }}</span>
+                  <el-select
+                    v-model="branch.conjunction"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 110px"
+                    data-testid="approval-condition-conjunction"
+                  >
+                    <el-option label="全部满足 (AND)" value="and" />
+                    <el-option label="任一满足 (OR)" value="or" />
+                  </el-select>
+                </div>
+                <div
+                  v-for="(rule, ruleIndex) in branch.rules"
+                  :key="ruleIndex"
+                  class="template-authoring__condition-rule"
+                  data-testid="approval-condition-rule"
+                >
+                  <el-select
+                    v-model="rule.fieldId"
+                    size="small"
+                    filterable
+                    placeholder="字段"
+                    :disabled="readOnly"
+                    style="width: 160px"
+                    data-testid="approval-condition-rule-field"
+                  >
+                    <el-option
+                      v-for="field in conditionFieldOptions"
+                      :key="field.id"
+                      :label="field.label"
+                      :value="field.id"
+                    />
+                  </el-select>
+                  <el-select
+                    v-model="rule.operator"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 120px"
+                    data-testid="approval-condition-rule-operator"
+                  >
+                    <el-option
+                      v-for="operator in CONDITION_RULE_OPERATORS"
+                      :key="operator"
+                      :label="conditionOperatorLabel(operator)"
+                      :value="operator"
+                    />
+                  </el-select>
+                  <el-input
+                    v-if="rule.operator !== 'isEmpty'"
+                    :model-value="conditionRuleValueText(rule)"
+                    size="small"
+                    placeholder="比较值"
+                    :disabled="readOnly"
+                    style="width: 160px"
+                    data-testid="approval-condition-rule-value"
+                    @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
+                  />
+                  <el-button
+                    size="small"
+                    type="danger"
+                    :disabled="readOnly || branch.rules.length === 1"
+                    data-testid="approval-condition-rule-remove"
+                    @click="removeConditionRule(branch, ruleIndex)"
+                  >删除</el-button>
+                </div>
+                <el-button
+                  size="small"
+                  :disabled="readOnly"
+                  data-testid="approval-condition-rule-add"
+                  @click="addConditionRule(branch)"
+                >
+                  <el-icon><Plus /></el-icon>
+                  添加规则
+                </el-button>
+              </div>
+              <el-form-item label="默认分支（无匹配时）" class="template-authoring__condition-default">
+                <el-select
+                  v-model="conditionEditFor(node.key)!.defaultEdgeKey"
+                  size="small"
+                  clearable
+                  :disabled="readOnly"
+                  style="width: 220px"
+                  placeholder="（无默认分支）"
+                  data-testid="approval-condition-default-edge"
+                >
+                  <el-option
+                    v-for="edgeKey in conditionOutgoingEdgeKeys(node.key)"
+                    :key="edgeKey"
+                    :label="edgeKey"
+                    :value="edgeKey"
+                  />
+                </el-select>
+              </el-form-item>
+            </div>
+
+            <!-- parallel / cc / approval — read-only summary (G-3 / G-4). -->
+            <template v-else>
+              <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
+                <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
+              </ul>
+              <div v-else class="template-authoring__hint">（无可编辑配置）</div>
+            </template>
           </div>
         </div>
 
@@ -569,7 +687,12 @@ import {
   parseIdsText,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  CONDITION_RULE_OPERATORS,
   type ApprovalStepDraft,
+  type ConditionBranchEdit,
+  type ConditionNodeEdit,
+  type ConditionRuleEdit,
+  type ConditionRuleOperator,
   type FieldAuthoringDraft,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
@@ -673,6 +796,62 @@ function nodeConfigSummary(node: ApprovalNode): string[] {
   }
   return []
 }
+
+// ── G-2 condition editor (logic-only; topology is preserved from `preservedGraph`) ──────────────
+// The editable model lives on `draft.conditionEdits[nodeKey]`, seeded 1:1 from the preserved
+// condition nodes. The controls below mutate ONLY rules / conjunction / defaultEdgeKey;
+// `buildApprovalGraph` re-applies them onto a COPY of the graph (all other nodes + edges untouched).
+function conditionEditFor(nodeKey: string): ConditionNodeEdit | undefined {
+  return draft.value.conditionEdits?.[nodeKey]
+}
+
+// Field options for a rule's fieldId picker — the draft's authorable form fields (id + label).
+const conditionFieldOptions = computed(() =>
+  draft.value.fields
+    .filter((field) => field.id.trim())
+    .map((field) => ({ id: field.id.trim(), label: field.label.trim() || field.id.trim() })),
+)
+
+const CONDITION_OPERATOR_LABELS: Record<ConditionRuleOperator, string> = {
+  eq: '等于',
+  neq: '不等于',
+  gt: '大于',
+  gte: '大于等于',
+  lt: '小于',
+  lte: '小于等于',
+  in: '包含于',
+  isEmpty: '为空',
+}
+function conditionOperatorLabel(operator: ConditionRuleOperator): string {
+  return CONDITION_OPERATOR_LABELS[operator] ?? operator
+}
+
+// The rule value is carried as `unknown` (round-trips a seeded value verbatim). The text input
+// reads/writes a string; `isEmpty` carries no value (handled in the template by hiding the input).
+function conditionRuleValueText(rule: ConditionRuleEdit): string {
+  if (rule.value === undefined || rule.value === null) return ''
+  return typeof rule.value === 'string' ? rule.value : String(rule.value)
+}
+function setConditionRuleValue(rule: ConditionRuleEdit, text: string): void {
+  rule.value = text === '' ? undefined : text
+}
+
+function addConditionRule(branch: ConditionBranchEdit): void {
+  branch.rules.push({ fieldId: '', operator: 'eq', value: undefined })
+}
+function removeConditionRule(branch: ConditionBranchEdit, ruleIndex: number): void {
+  if (branch.rules.length === 1) return
+  branch.rules.splice(ruleIndex, 1)
+}
+
+// Outgoing edge keys of a condition node (from the preserved graph) — the legal default fall-through
+// targets. Topology is read-only here, so these come straight from `preservedGraph.edges`.
+function conditionOutgoingEdgeKeys(nodeKey: string): string[] {
+  return (draft.value.preservedGraph?.edges ?? [])
+    .filter((edge) => edge.source === nodeKey)
+    .map((edge) => edge.key)
+}
+
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
 const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
 const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
@@ -1016,6 +1195,40 @@ onMounted(() => {
   font-size: 13px;
   line-height: 1.7;
   color: var(--el-text-color-regular, #606266);
+}
+
+/* G-2 condition editor */
+.template-authoring__condition {
+  margin-top: 8px;
+}
+
+.template-authoring__condition-branch {
+  border: 1px dashed var(--el-border-color, #dcdfe6);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+}
+
+.template-authoring__condition-branch-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: var(--el-text-color-regular, #606266);
+}
+
+.template-authoring__condition-rule {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.template-authoring__condition-default {
+  margin: 4px 0 0;
 }
 
 .template-authoring__error-list {

--- a/apps/web/tests/approval-template-authoring-condition-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-condition-edit.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  validateTemplateDraft,
+  type ConditionEdits,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import {
+  applyConditionEditsToGraph,
+  conditionEditsFromGraph,
+  validateConditionEdits,
+} from '../src/approvals/conditionEdit'
+
+// G-2 — condition branch editing. PURE-LOGIC tests (no .vue / no Element Plus) so they run under
+// the approval-web-guard CI gate. The GATE is topology-preservation: editing a condition node's
+// LOGIC (rules / conjunction / defaultEdgeKey) must leave every OTHER node and ALL edges
+// byte-identical, and an untouched complex graph must still round-trip byte-identical (G-1 floor).
+// parallel / cc stay read-only (G-3 / G-4) — unaffected here.
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z',
+    updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        { id: 'kind', type: 'select', label: '类型', options: [{ label: 'A', value: 'a' }] },
+      ],
+    },
+    approvalGraph,
+  }
+}
+
+// A condition graph: one condition node with a single explicit branch (rules + conjunction) + a
+// defaultEdgeKey, fanning out to two approval arms. This is the same shape the G-1 round-trip uses.
+const CONDITION_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '金额判断',
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }],
+            conjunction: 'and',
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    },
+    {
+      key: 'approval_high',
+      type: 'approval',
+      name: '大额审批',
+      config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_low',
+      type: 'approval',
+      name: '小额审批',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' },
+    },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond_1', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval_high-end', source: 'approval_high', target: 'end' },
+    { key: 'edge-approval_low-end', source: 'approval_low', target: 'end' },
+  ],
+}
+
+// A condition node with NO conjunction on its branch (backend omits it) — proves seeding+rebuild do
+// not resurrect a spurious `conjunction: 'and'`.
+const CONDITION_GRAPH_NO_CONJUNCTION: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '类型判断',
+      config: {
+        branches: [
+          { edgeKey: 'edge-cond_1-a', rules: [{ fieldId: 'kind', operator: 'eq', value: 'a' }] },
+          { edgeKey: 'edge-cond_1-b', rules: [{ fieldId: 'amount', operator: 'isEmpty' }] },
+        ],
+      },
+    },
+    {
+      key: 'approval_a',
+      type: 'approval',
+      name: 'A',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_b',
+      type: 'approval',
+      name: 'B',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond_1', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond_1-a', source: 'cond_1', target: 'approval_a' },
+    { key: 'edge-cond_1-b', source: 'cond_1', target: 'approval_b' },
+    { key: 'edge-approval_a-end', source: 'approval_a', target: 'end' },
+    { key: 'edge-approval_b-end', source: 'approval_b', target: 'end' },
+  ],
+}
+
+// A PARALLEL graph (no condition node) — G-2 must leave it byte-identical (parallel stays read-only).
+const PARALLEL_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'fork_1',
+      type: 'parallel',
+      name: '并行会签',
+      config: { branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' },
+    },
+    {
+      key: 'approval_a',
+      type: 'approval',
+      name: '财务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['finance'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_b',
+      type: 'approval',
+      name: '法务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-fork_1', source: 'start', target: 'fork_1' },
+    { key: 'edge-fork_1-a', source: 'fork_1', target: 'approval_a' },
+    { key: 'edge-fork_1-b', source: 'fork_1', target: 'approval_b' },
+    { key: 'edge-approval_a-join', source: 'approval_a', target: 'join_1' },
+    { key: 'edge-approval_b-join', source: 'approval_b', target: 'join_1' },
+    { key: 'edge-join_1-end', source: 'join_1', target: 'end' },
+  ],
+}
+
+// A CC graph (no condition node) — G-2 must leave it byte-identical (cc stays read-only).
+const CC_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'approval_1',
+      type: 'approval',
+      name: '审批人 1',
+      config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'cc_1', type: 'cc', name: '抄送 HR', config: { targetType: 'role', targetIds: ['hr', 'admin'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-cc_1', source: 'approval_1', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+  ],
+}
+
+/** Assert the two graphs agree on EVERY non-condition node + the FULL edge list (topology gate). */
+function expectTopologyByteIdentical(rebuilt: ApprovalGraph, original: ApprovalGraph): void {
+  const nonCond = (graph: ApprovalGraph) => graph.nodes.filter((node) => node.type !== 'condition')
+  // every non-condition node byte-identical (start / approval arms / parallel / cc / end)
+  expect(nonCond(rebuilt)).toEqual(nonCond(original))
+  // the FULL edge array byte-identical (no edge dropped / added / reordered / retargeted)
+  expect(rebuilt.edges).toEqual(original.edges)
+  // node identity + ORDER preserved (no reordering even of the condition node)
+  expect(rebuilt.nodes.map((node) => node.key)).toEqual(original.nodes.map((node) => node.key))
+}
+
+describe('G-2 conditionEditsFromGraph — seed from preserved condition nodes', () => {
+  it('captures one entry per condition node, branches 1:1', () => {
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH)
+    expect(Object.keys(edits)).toEqual(['cond_1'])
+    expect(edits.cond_1.branches.map((branch) => branch.edgeKey)).toEqual(['edge-cond_1-high'])
+    expect(edits.cond_1.branches[0].rules).toEqual([{ fieldId: 'amount', operator: 'gte', value: 1000 }])
+    expect(edits.cond_1.defaultEdgeKey).toBe('edge-cond_1-low')
+  })
+
+  it('is empty for a parallel / cc graph (no condition node)', () => {
+    expect(conditionEditsFromGraph(PARALLEL_GRAPH)).toEqual({})
+    expect(conditionEditsFromGraph(CC_GRAPH)).toEqual({})
+  })
+
+  it('defaults a missing branch conjunction to "and" in the edit model', () => {
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH_NO_CONJUNCTION)
+    expect(edits.cond_1.branches.every((branch) => branch.conjunction === 'and')).toBe(true)
+  })
+})
+
+describe('G-2 topology-preservation — editing a condition rule keeps everything else byte-identical', () => {
+  it('edit a rule → buildApprovalGraph → ONLY the condition node config changes; all other nodes + edges byte-identical', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    // change the rule's value 1000 → 5000 (logic edit, no topology change)
+    draft.conditionEdits!.cond_1.branches[0].rules[0].value = 5000
+    const rebuilt = buildApprovalGraph(draft)
+
+    // GATE: every non-condition node + the full edge array are byte-identical to the original.
+    expectTopologyByteIdentical(rebuilt, original)
+    // the ONE condition node reflects the edit (and nothing else about it changed).
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')!
+    expect(cond.config).toEqual({
+      branches: [
+        { edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] },
+      ],
+      defaultEdgeKey: 'edge-cond_1-low',
+    })
+    // the original condition node still said 1000 (we did not mutate the input graph).
+    const origCond = original.nodes.find((node) => node.key === 'cond_1')! as { config: { branches: { rules: { value: unknown }[] }[] } }
+    expect(origCond.config.branches[0].rules[0].value).toBe(1000)
+  })
+
+  it('changing a branch conjunction and defaultEdgeKey keeps all other nodes + edges byte-identical', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    draft.conditionEdits!.cond_1.branches[0].conjunction = 'or'
+    draft.conditionEdits!.cond_1.defaultEdgeKey = 'edge-cond_1-high'
+    const rebuilt = buildApprovalGraph(draft)
+
+    expectTopologyByteIdentical(rebuilt, original)
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')!
+    expect(cond.config).toEqual({
+      branches: [
+        { edgeKey: 'edge-cond_1-high', conjunction: 'or', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] },
+      ],
+      defaultEdgeKey: 'edge-cond_1-high',
+    })
+  })
+
+  it('adding/removing a RULE (not a branch) preserves topology byte-identical', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    // add a second rule to the existing branch — still no topology change.
+    draft.conditionEdits!.cond_1.branches[0].rules.push({ fieldId: 'kind', operator: 'eq', value: 'a' })
+    const rebuilt = buildApprovalGraph(draft)
+
+    expectTopologyByteIdentical(rebuilt, original)
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')! as { config: { branches: { rules: unknown[] }[] } }
+    expect(cond.config.branches[0].rules).toEqual([
+      { fieldId: 'amount', operator: 'gte', value: 1000 },
+      { fieldId: 'kind', operator: 'eq', value: 'a' },
+    ])
+  })
+})
+
+describe('G-2 untouched round-trip — no spurious diffs from seeding (G-1 floor holds)', () => {
+  it('an UNTOUCHED condition graph round-trips byte-identical through draftFromTemplate → buildApprovalGraph', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+  })
+
+  it('an UNTOUCHED condition graph WITHOUT branch conjunctions round-trips byte-identical (no resurrected conjunction)', () => {
+    const template = buildTemplate(CONDITION_GRAPH_NO_CONJUNCTION)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+    // explicit: the branches still carry NO conjunction key.
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')! as { config: { branches: Record<string, unknown>[] } }
+    expect(cond.config.branches.every((branch) => !('conjunction' in branch))).toBe(true)
+    // and the isEmpty rule still carries NO value key.
+    const isEmptyRule = (cond.config.branches[1] as { rules: Record<string, unknown>[] }).rules[0]
+    expect('value' in isEmptyRule).toBe(false)
+  })
+
+  it('applyConditionEditsToGraph with the seeded edits is identity for the condition graph', () => {
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH)
+    expect(applyConditionEditsToGraph(CONDITION_GRAPH, edits)).toEqual(CONDITION_GRAPH)
+  })
+})
+
+describe('G-2 parallel / cc unaffected — still byte-identical-preserved (G-3/G-4 read-only)', () => {
+  it('a PARALLEL graph round-trips byte-identical (G-2 leaves it untouched, no condition edits)', () => {
+    const template = buildTemplate(PARALLEL_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    // no condition node ⇒ no condition edits seeded.
+    expect(draft.conditionEdits).toEqual({})
+    const rebuilt = buildApprovalGraph(draft)
+    expect(rebuilt).toEqual(original)
+    const fork = rebuilt.nodes.find((node) => node.type === 'parallel')
+    expect(fork?.config).toEqual({ branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' })
+  })
+
+  it('a CC graph round-trips byte-identical (G-2 leaves it untouched)', () => {
+    const template = buildTemplate(CC_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+    const cc = rebuilt.nodes.find((node) => node.type === 'cc')
+    expect(cc?.config).toEqual({ targetType: 'role', targetIds: ['hr', 'admin'] })
+  })
+
+  it('applyConditionEditsToGraph passes a parallel/cc graph through byte-identical with empty edits', () => {
+    expect(applyConditionEditsToGraph(PARALLEL_GRAPH, {})).toEqual(PARALLEL_GRAPH)
+    expect(applyConditionEditsToGraph(CC_GRAPH, {})).toEqual(CC_GRAPH)
+  })
+})
+
+describe('G-2 input is never mutated', () => {
+  it('applyConditionEditsToGraph does not mutate the source graph', () => {
+    const before = structuredClone(CONDITION_GRAPH)
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH)
+    edits.cond_1.branches[0].rules[0].value = 9999
+    applyConditionEditsToGraph(CONDITION_GRAPH, edits)
+    expect(CONDITION_GRAPH).toEqual(before)
+  })
+})
+
+describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is final arbiter)', () => {
+  const formSchema = buildTemplate(CONDITION_GRAPH).formSchema
+
+  it('flags a rule fieldId that is NOT a form field', () => {
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'ghost', operator: 'gte', value: 1 }] }],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+    const errors = validateConditionEdits(edits, formSchema, CONDITION_GRAPH)
+    expect(errors.some((message) => message.includes('ghost') && message.includes('不存在'))).toBe(true)
+  })
+
+  it('flags a defaultEdgeKey that is NOT an outgoing edge of the condition node', () => {
+    // `edge-start-cond_1` exists in the graph but its source is `start`, not `cond_1` — so it is not
+    // a legal fall-through edge for this node. (The runtime resolves defaultEdgeKey via the edge
+    // list; an edge that doesn't leave this node would route to the wrong place.)
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 1 }] }],
+        defaultEdgeKey: 'edge-start-cond_1',
+      },
+    }
+    const errors = validateConditionEdits(edits, formSchema, CONDITION_GRAPH)
+    expect(errors.some((message) => message.includes('edge-start-cond_1') && message.includes('默认分支'))).toBe(true)
+  })
+
+  it('accepts a defaultEdgeKey that IS an outgoing fall-through edge (distinct from the branch edge)', () => {
+    // canonical valid shape: branch edge `edge-cond_1-high`, fall-through default `edge-cond_1-low`
+    // — both outgoing from cond_1, NOT the same edge. Must NOT be flagged.
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH)
+    expect(edits.cond_1.defaultEdgeKey).toBe('edge-cond_1-low')
+    expect(validateConditionEdits(edits, formSchema, CONDITION_GRAPH)).toEqual([])
+  })
+
+  it('flags an empty rule fieldId (needs a field chosen)', () => {
+    const edits: ConditionEdits = {
+      cond_1: {
+        nodeKey: 'cond_1',
+        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: '', operator: 'gte', value: 1 }] }],
+        defaultEdgeKey: '',
+      },
+    }
+    const errors = validateConditionEdits(edits, formSchema, CONDITION_GRAPH)
+    expect(errors.some((message) => message.includes('需要选择字段'))).toBe(true)
+  })
+
+  it('passes a valid seeded edit (fieldId exists, defaultEdgeKey is a real outgoing edge)', () => {
+    const edits = conditionEditsFromGraph(CONDITION_GRAPH)
+    expect(validateConditionEdits(edits, formSchema, CONDITION_GRAPH)).toEqual([])
+  })
+
+  it('surfaces the rule-fieldId error through validateTemplateDraft when the draft carries condition edits', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(CONDITION_GRAPH))
+    draft.conditionEdits!.cond_1.branches[0].rules[0].fieldId = 'ghost'
+    const errors = validateTemplateDraft(draft, null)
+    expect(errors.some((message) => message.includes('ghost'))).toBe(true)
+  })
+
+  it('surfaces the defaultEdgeKey error through validateTemplateDraft (checked against preservedGraph edges)', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(CONDITION_GRAPH))
+    draft.conditionEdits!.cond_1.defaultEdgeKey = 'edge-start-cond_1'
+    const errors = validateTemplateDraft(draft, null)
+    expect(errors.some((message) => message.includes('edge-start-cond_1') && message.includes('默认分支'))).toBe(true)
+  })
+
+  it('an untouched condition draft produces NO validation errors (G-1 floor: valid graph stays valid)', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(CONDITION_GRAPH))
+    // only condition-edit errors are asserted absent; key/name are seeded so the draft is complete.
+    expect(validateTemplateDraft(draft, null).filter((message) => message.includes('条件节点'))).toEqual([])
+  })
+})

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -29,12 +29,29 @@
   opens read-only" tests updated for the changed cc/condition/parallel behaviour (now
   save-preserving, graph read-only); the attachment / extra-key fail-closed tests stay green.
 
-## Phase G-2 — condition editor (🔒 until G-1)
-- 🔒 Author condition `branches` (rules `{fieldId, operator, value}` + `conjunction`) +
-  `defaultEdgeKey`; build the full graph; FE validation preview (branch needs an edgeKey;
-  rule fieldId must reference a form field). Backend `normalizeApprovalGraph` stays arbiter.
+## Phase G-2 — condition editor (✅ shipped)
+- ✅ Author condition `branches` LOGIC (each branch's `rules` `{fieldId, operator, value}` add/remove
+  + `conjunction` and/or) and the node `defaultEdgeKey`, in a structured editable panel
+  (`TemplateAuthoringView` condition rows reuse Element Plus selects/inputs). Branch/edge TOPOLOGY
+  (which branches exist, their edgeKeys/targets) is NOT editable — that is a later slice. parallel /
+  cc stay READ-ONLY summaries (G-3 / G-4). The whole structured render was already there from G-1.
+- ✅ Edit model: `TemplateAuthoringDraft.conditionEdits: Record<nodeKey, ConditionNodeEdit>`, seeded
+  1:1 from `preservedGraph`'s condition nodes (`conditionEditsFromGraph`). On save,
+  `buildApprovalGraph` calls `applyConditionEditsToGraph(preservedGraph, conditionEdits)` — returns a
+  COPY of the graph with ONLY each condition node's `config` rebuilt from the edits; every other node
+  + the full edge list are deep-cloned byte-for-byte. Pure logic in `approvals/conditionEdit.ts` (no
+  `.vue` import — runs under the vitest gate).
+- ✅ Topology-preservation tests (the gate): edit a rule/conjunction/defaultEdgeKey → only the one
+  condition node config changes, all other nodes + ALL edges byte-identical (deepEqual asserted);
+  an UNTOUCHED condition graph (with and without branch conjunctions) round-trips byte-identical (no
+  spurious seed diffs); parallel/cc graphs unaffected (still byte-identical-preserved). Validation
+  preview: rule `fieldId` must reference a form field; `defaultEdgeKey` (when set) must be an
+  OUTGOING edge of the node (the fall-through edge — runtime resolves it via the graph edge list, NOT
+  a branch edgeKey). `apps/web/tests/approval-template-authoring-condition-edit.test.ts` (wired into
+  `approval-web-guard.yml`). Backend `normalizeApprovalGraph` stays the sole arbiter (FE never
+  relaxes it). G-1 round-trip + `approvalTemplateAuthoring.spec` stay green.
 
-## Phase G-3 — parallel editor (🔒 until G-2)
+## Phase G-3 — parallel editor (🔒 — G-2 done; needs its own opt-in)
 - 🔒 Author parallel `branches` + `joinNodeKey` (v1 `joinMode='all'`); preview enforces the
   backend rules (no nested parallel, no cross-branch assignee dupes) before save.
 


### PR DESCRIPTION
## G-2 — condition node editing only (topology-preserving)

Phase G-2 of the approval complex-graph author UI. Makes `condition` nodes **editable** in the structured authoring editor while every **other** node/edge stays **byte-identical-preserved** (the G-1 anti-flatten floor). `parallel` / `cc` nodes remain **READ-ONLY** summaries (G-3 / G-4). Brand-neutral. UI-only — no change to `ApprovalGraphExecutor`, `normalizeApprovalGraph`, or the graph types.

Design-lock: `docs/design/approval-complex-graph-author-ui-design-lock-20260623.md` · TODO ticked G-2 ✅.

### Edit model + build mechanism (2 lines)
- **Seed:** `TemplateAuthoringDraft.conditionEdits: Record<nodeKey, ConditionNodeEdit>` is seeded 1:1 from `preservedGraph`'s condition nodes at hydrate (`conditionEditsFromGraph`); the editor mutates **only** each branch's `rules` (add/remove; `fieldId` / `operator` / `value`), the branch `conjunction` (and/or), and the node `defaultEdgeKey` — never branch/edge topology.
- **Build:** on save, `buildApprovalGraph` calls `applyConditionEditsToGraph(preservedGraph, conditionEdits)` — returns a **copy** of the graph with **only** each condition node's `config` rebuilt from the edits; every non-condition node + the full edge list are deep-cloned byte-for-byte. Pure logic in `apps/web/src/approvals/conditionEdit.ts` (no `.vue` import → runs under the approval-web-guard vitest gate).

### Validation preview (UX-only; backend `normalizeApprovalGraph` stays the sole arbiter)
- Rule `fieldId` must reference an existing form field; operator must be in the union; `defaultEdgeKey` (when set) must be an **outgoing** edge of the condition node.
- Note: `defaultEdgeKey` is the **fall-through** edge the runtime resolves via the graph edge list (`ApprovalGraphExecutor.resolveConditionTarget` → `targetForEdge`) — a **separate** edge from the branch edgeKeys, not one of them. The check mirrors the runtime (the canonical fixture's default edge is `cond → low`, distinct from the branch's `cond → high`); flagging it as "must be a branch edgeKey" would have falsely errored on a valid graph.

### Topology-preservation tests (the gate) — `apps/web/tests/approval-template-authoring-condition-edit.test.ts` (21 tests)
- **`G-2 topology-preservation — editing a condition rule keeps everything else byte-identical`** (3): edit a rule / conjunction+defaultEdgeKey / add a rule → only the one condition node config changes; **all other nodes + ALL edges byte-identical** (deepEqual on the non-condition nodes + the full edges array); input graph never mutated.
- **`G-2 untouched round-trip — no spurious diffs from seeding`** (3): an untouched condition graph (with **and** without branch conjunctions) round-trips byte-identical; `applyConditionEditsToGraph` with the seeded edits is identity.
- **`G-2 parallel / cc unaffected — still byte-identical-preserved`** (3): parallel and cc graphs round-trip byte-identical (no condition edits seeded); empty-edits pass-through is identity.
- **`G-2 conditionEditsFromGraph`** (3) · **`G-2 input is never mutated`** (1) · **`G-2 validation preview`** (8: fieldId-not-a-field / defaultEdgeKey-not-an-outgoing-edge / empty-fieldId / valid seeded edit / `validateTemplateDraft` surfacing).

Wired into `.github/workflows/approval-web-guard.yml` (paths + vitest filter). **G-1 round-trip + `approvalTemplateAuthoring.spec` stay green.**

### parallel / cc still read-only (G-3 / G-4)
parallel and cc nodes render unchanged read-only summaries and pass through `buildApprovalGraph` **byte-identical-preserved** — no regression to the G-1 floor (asserted by the unaffected-graph tests above).

### Verify
- `pnpm --filter @metasheet/web run type-check` clean (`vue-tsc -b`, incl. `--force`).
- eslint clean on all changed files.
- Full approval-web-guard gate green: 85 tests across the 4 guard specs.
- Web production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)