### PR TITLE
feat(approval): G-3 — parallel join-mode editing (topology-preserving)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     paths:
       - 'apps/web/src/approvals/conditionEdit.ts'
+      - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -27,11 +28,13 @@ on:
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
     paths:
       - 'apps/web/src/approvals/conditionEdit.ts'
+      - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -41,6 +44,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -91,4 +95,8 @@ jobs:
         # G-2 condition editor: topology-preserving edit (rule/conjunction/defaultEdgeKey change →
         # only the condition node config changes; all other nodes + edges byte-identical; parallel/cc
         # untouched) + seeding round-trip + validation preview (fieldId / outgoing default edge).
-        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit --reporter=dot
+        # G-3 parallel editor: topology-preserving joinMode edit (only that parallel node's joinMode
+        # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
+        # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
+        # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
+        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit --reporter=dot

--- a/apps/web/src/approvals/parallelEdit.ts
+++ b/apps/web/src/approvals/parallelEdit.ts
@@ -1,0 +1,142 @@
+import type {
+  ApprovalGraph,
+  ApprovalNode,
+  ParallelJoinMode,
+  ParallelNodeConfig,
+} from '../types/approval'
+
+// G-3 — parallel node editing (JOIN-MODE ONLY; no .vue / Element Plus import so this runs under the
+// approval-web-guard vitest gate). The scope is a single field: each parallel node's `joinMode`.
+// `branches` (the fork edgeKeys) and `joinNodeKey` are TOPOLOGY — preserved byte-for-byte (G-1
+// anti-flatten floor), NOT editable here. Every OTHER node/edge — including condition (G-2) and cc
+// — is preserved verbatim. condition stays editable via `conditionEdit.ts`; cc stays read-only (G-4).
+//
+// PRE-CHECK FINDING (backend accepts BOTH modes): `normalizeApprovalGraph`'s parallel validation
+// (`ApprovalProductService.ts:940`) checks `PARALLEL_JOIN_MODES.has(joinMode)` where
+// `PARALLEL_JOIN_MODES = new Set(['all', 'any'])` (`:289`) and writes `joinMode` VERBATIM (`:948`,
+// no coercion to 'all'). The runtime `ApprovalGraphExecutor` handles 'any' = first-wins
+// (`:3691`, plus `loadParallelState` accepts 'any' at `:1523`). So 'all' AND 'any' are both
+// accepted — the editor offers both. (This empirically SUPERSEDES design-lock §7/§8c's "'all' only,
+// validator/type say 'all'" deferral, whose premise is factually false: the set is {'all','any'}
+// and the FE/BE type union is 'all'|'any'. See the PR body / TODO for the ratification flag.)
+
+/** The join modes the backend `normalizeApprovalGraph` accepts (the editor's select offers these). */
+export const PARALLEL_JOIN_MODES: readonly ParallelJoinMode[] = ['all', 'any'] as const
+const PARALLEL_JOIN_MODE_SET = new Set<string>(PARALLEL_JOIN_MODES)
+
+/**
+ * Editable model for one parallel node — `joinMode` ONLY. `branches`/`joinNodeKey` are topology and
+ * are NOT carried here (they are preserved verbatim by `applyParallelEditsToGraph`). Keyed by node
+ * `key`, seeded 1:1 from the preserved parallel nodes' existing `joinMode`.
+ */
+export interface ParallelNodeEdit {
+  nodeKey: string
+  joinMode: ParallelJoinMode
+}
+
+/** Map of parallel edits keyed by node key, seeded from a preserved graph and edited in place. */
+export type ParallelEdits = Record<string, ParallelNodeEdit>
+
+// Deep clone for the preserved-graph pass-through. Same rationale as `conditionEdit.cloneJson`: the
+// graph is pure JSON-serialisable data, and a JSON round-trip (unlike `structuredClone`) works on
+// the Vue reactive Proxy the authoring view wraps the draft in. A backend-normalised graph carries
+// no `undefined`-valued keys, so JSON dropping them is identity for the nodes/edges we pass through.
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function isParallelConfig(config: ApprovalNode['config']): config is ParallelNodeConfig {
+  return Boolean(config) && Array.isArray((config as ParallelNodeConfig).branches)
+}
+
+/** True when a join mode is one the editor's select offers (and the backend accepts). */
+export function isParallelJoinMode(value: unknown): value is ParallelJoinMode {
+  return typeof value === 'string' && PARALLEL_JOIN_MODE_SET.has(value)
+}
+
+/**
+ * Seed the editable parallel model from a (preserved) graph. One entry per `parallel` node, carrying
+ * its existing `joinMode` (defaulted to 'all' only if a malformed graph lacks one — a normalised
+ * graph always has 'all' or 'any'). Non-parallel nodes are ignored here — they are preserved verbatim
+ * by `applyParallelEditsToGraph`. Seeding is identity: an untouched edit reproduces the original
+ * `joinMode`, so a round-trip is byte-identical (no spurious diff).
+ */
+export function parallelEditsFromGraph(graph: ApprovalGraph | undefined): ParallelEdits {
+  const edits: ParallelEdits = {}
+  if (!graph) return edits
+  for (const node of graph.nodes) {
+    if (node.type !== 'parallel' || !isParallelConfig(node.config)) continue
+    edits[node.key] = {
+      nodeKey: node.key,
+      joinMode: isParallelJoinMode(node.config.joinMode) ? node.config.joinMode : 'all',
+    }
+  }
+  return edits
+}
+
+/**
+ * Replace the `joinMode` of each parallel node in `graph` with the edited value, leaving EVERY other
+ * node and ALL edges byte-identical (deep-cloned so the input is never mutated). This is the G-3 save
+ * path: topology (each parallel node's `branches`/`joinNodeKey`, every non-parallel node, the full
+ * edge list) is preserved exactly; only `joinMode` changes.
+ *
+ * Byte-identity for an UNTOUCHED graph: spread-and-overwrite — `{ ...originalConfig, joinMode }` —
+ * keeps `joinMode`'s existing position (so key order stays `branches, joinMode, joinNodeKey`,
+ * matching the backend `normalizeApprovalGraph` shape the graph loaded with) and, when the edit's
+ * `joinMode` equals the original's, reproduces the config exactly. Nodes with no edit entry (none,
+ * by construction, for a seeded parallel node) are passed through verbatim.
+ *
+ * Composition with G-2: `applyParallelEditsToGraph` and `applyConditionEditsToGraph` touch DISJOINT
+ * node types (parallel vs condition) and each deep-clones everything else, so composing them
+ * (`applyParallelEditsToGraph(applyConditionEditsToGraph(g, ...), ...)`) lands both edits while every
+ * non-targeted node/edge — cc included — stays byte-identical.
+ */
+export function applyParallelEditsToGraph(
+  graph: ApprovalGraph,
+  edits: ParallelEdits,
+): ApprovalGraph {
+  const nodes: ApprovalNode[] = graph.nodes.map((node) => {
+    if (node.type !== 'parallel') {
+      // Non-parallel node (incl. condition / cc) — preserve byte-for-byte (deep clone, never alias).
+      return cloneJson(node)
+    }
+    const edit = edits[node.key]
+    if (!edit || !isParallelConfig(node.config)) {
+      // No edit entry (shouldn't happen for a seeded parallel node) — preserve verbatim.
+      return cloneJson(node)
+    }
+    const originalConfig = cloneJson(node.config)
+    const config: ParallelNodeConfig = {
+      // Spread the preserved topology first (branches + joinNodeKey, in their original positions),
+      // then overwrite ONLY joinMode (overwriting an existing key keeps its slot → byte-stable order).
+      ...originalConfig,
+      joinMode: edit.joinMode,
+    }
+    return {
+      ...cloneJson(node),
+      config,
+    }
+  })
+  return {
+    nodes,
+    // Edges are pure topology — preserved byte-for-byte (deep clone, never aliased/reordered).
+    edges: graph.edges.map((edge) => cloneJson(edge)),
+  }
+}
+
+/**
+ * FE validation PREVIEW for the parallel edits (UX only — the backend `normalizeApprovalGraph` stays
+ * the sole arbiter; this never relaxes it). The only editable field is `joinMode`, so the only check
+ * is that it is in the backend-accepted set ('all' | 'any'). An out-of-set value (only reachable via
+ * a corrupt/hand-built edit, never the UI select) is flagged so the FE never offers to save a
+ * backend-rejected graph.
+ */
+export function validateParallelEdits(edits: ParallelEdits): string[] {
+  const errors: string[] = []
+  for (const edit of Object.values(edits)) {
+    if (!isParallelJoinMode(edit.joinMode)) {
+      errors.push(`并行节点 ${edit.nodeKey} 的汇聚模式无效`)
+    }
+  }
+  return errors
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -28,6 +28,12 @@ import {
   validateConditionEdits,
   type ConditionEdits,
 } from './conditionEdit'
+import {
+  applyParallelEditsToGraph,
+  parallelEditsFromGraph,
+  validateParallelEdits,
+  type ParallelEdits,
+} from './parallelEdit'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
@@ -39,6 +45,8 @@ export type {
   ConditionRuleOperator,
 } from './conditionEdit'
 export { CONDITION_RULE_OPERATORS } from './conditionEdit'
+export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
+export { PARALLEL_JOIN_MODES } from './parallelEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -139,6 +147,13 @@ export interface TemplateAuthoringDraft {
   // node/edge stay byte-identical-preserved (G-1 floor). `buildApprovalGraph` applies these onto a
   // COPY of `preservedGraph`. Empty/absent for linear or non-condition complex graphs.
   conditionEdits?: ConditionEdits
+  // G-3 parallel editor: editable `joinMode` for each `parallel` node in `preservedGraph`, keyed by
+  // node key (seeded 1:1 from the preserved parallel nodes). ONLY `joinMode` ('all' | 'any' — both
+  // backend-accepted, see `parallelEdit.ts`) is editable; `branches`/`joinNodeKey` are topology and
+  // every non-parallel node/edge stay byte-identical-preserved. `buildApprovalGraph` composes these
+  // with the condition edits onto a COPY of `preservedGraph`. Empty/absent for linear or
+  // non-parallel complex graphs.
+  parallelEdits?: ParallelEdits
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -549,6 +564,9 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
           // G-2: seed the editable condition logic from the preserved condition nodes (1:1).
           // Empty {} when the complex graph has no condition node (parallel/cc-only).
           conditionEdits: conditionEditsFromGraph(template.approvalGraph),
+          // G-3: seed the editable parallel joinMode from the preserved parallel nodes (1:1).
+          // Empty {} when the complex graph has no parallel node (condition/cc-only).
+          parallelEdits: parallelEditsFromGraph(template.approvalGraph),
         }
       : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
@@ -660,14 +678,17 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
 }
 
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
-  // G-1/G-2 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`, so its
-  // cc/condition/parallel nodes/edges survive save. G-2 replaces ONLY each condition node's config
-  // with the edited logic (rules / conjunction / defaultEdgeKey) onto a COPY of the graph — every
-  // other node and ALL edges stay byte-identical (an untouched graph round-trips unchanged because
-  // `applyConditionEditsToGraph` reproduces the backend-normalised condition shape). parallel/cc
-  // nodes are passed through verbatim (G-3/G-4). Only linear drafts take the build below.
+  // G-1/G-2/G-3 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`, so
+  // its cc/condition/parallel nodes/edges survive save. Two disjoint edit passes COMPOSE onto a COPY
+  // of the graph: G-2 (`applyConditionEditsToGraph`) replaces ONLY each condition node's config with
+  // the edited logic, then G-3 (`applyParallelEditsToGraph`) replaces ONLY each parallel node's
+  // `joinMode`. The passes touch disjoint node types and each deep-clones everything else, so both
+  // edits land while every other node + ALL edges (cc included — G-4 read-only) stay byte-identical;
+  // an untouched graph round-trips unchanged (both apply-fns reproduce the backend-normalised shape).
+  // Only linear drafts take the build below.
   if (draft.preservedGraph) {
-    return applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
+    const withConditionEdits = applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
+    return applyParallelEditsToGraph(withConditionEdits, draft.parallelEdits ?? {})
   }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
@@ -793,6 +814,11 @@ export function validateTemplateDraft(
   // re-validates and is the final arbiter (we never relax it here).
   if (draft.conditionEdits && Object.keys(draft.conditionEdits).length > 0) {
     errors.push(...validateConditionEdits(draft.conditionEdits, buildFormSchema(draft), draft.preservedGraph))
+  }
+  // G-3 parallel-editor PREVIEW: joinMode must be in the backend-accepted set ('all' | 'any').
+  // UX-only — the backend `normalizeApprovalGraph` re-validates and is the final arbiter.
+  if (draft.parallelEdits && Object.keys(draft.parallelEdits).length > 0) {
+    errors.push(...validateParallelEdits(draft.parallelEdits))
   }
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -51,11 +51,12 @@
     />
 
     <!-- G-1/G-2: a complex graph is preserved, not unsupported — informational, save stays enabled.
-         G-2 makes condition nodes editable; parallel / cc stay read-only (G-3 / G-4). -->
+         G-2 makes condition nodes editable; G-3 makes a parallel node's joinMode editable; cc stays
+         read-only (G-4). branches / join target / all edges are preserved topology. -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行 / 抄送节点暂以只读结构展示。未改动的节点与连线在保存时原样保留。"
+      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点暂以只读结构展示。分支拓扑与连线在保存时原样保留。"
       type="info"
       show-icon
       :closable="false"
@@ -498,7 +499,39 @@
               </el-form-item>
             </div>
 
-            <!-- parallel / cc / approval — read-only summary (G-3 / G-4). -->
+            <!-- G-3: editable parallel node — `joinMode` ONLY (会签 all / 或签 any, both
+                 backend-accepted). `branches` (fork edges) + `joinNodeKey` are TOPOLOGY: shown
+                 read-only, preserved byte-for-byte on save. -->
+            <div
+              v-else-if="node.type === 'parallel' && parallelEditFor(node.key)"
+              class="template-authoring__parallel"
+              data-testid="approval-parallel-editor"
+              :data-parallel-node="node.key"
+            >
+              <el-form-item label="汇聚模式" class="template-authoring__parallel-join-mode">
+                <el-select
+                  v-model="parallelEditFor(node.key)!.joinMode"
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 240px"
+                  data-testid="approval-parallel-join-mode"
+                >
+                  <el-option
+                    v-for="mode in PARALLEL_JOIN_MODES"
+                    :key="mode"
+                    :label="parallelJoinModeLabel(mode)"
+                    :value="mode"
+                  />
+                </el-select>
+              </el-form-item>
+              <!-- branches + join target are preserved topology (not editable here). -->
+              <ul class="template-authoring__node-summary" data-testid="approval-parallel-topology">
+                <li>并行分支：{{ (node.config as ParallelNodeConfig).branches.join('、') || '（无）' }}</li>
+                <li>汇聚节点：{{ (node.config as ParallelNodeConfig).joinNodeKey || '（无）' }}</li>
+              </ul>
+            </div>
+
+            <!-- cc / approval — read-only summary (G-4). -->
             <template v-else>
               <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
                 <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
@@ -688,12 +721,14 @@ import {
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
   CONDITION_RULE_OPERATORS,
+  PARALLEL_JOIN_MODES,
   type ApprovalStepDraft,
   type ConditionBranchEdit,
   type ConditionNodeEdit,
   type ConditionRuleEdit,
   type ConditionRuleOperator,
   type FieldAuthoringDraft,
+  type ParallelNodeEdit,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
 import type {
@@ -701,6 +736,7 @@ import type {
   ApprovalNode,
   CcNodeConfig,
   ConditionNodeConfig,
+  ParallelJoinMode,
   ParallelNodeConfig,
 } from '../../types/approval'
 import { useApprovalDirectory } from '../../approvals/useApprovalDirectory'
@@ -850,6 +886,24 @@ function conditionOutgoingEdgeKeys(nodeKey: string): string[] {
   return (draft.value.preservedGraph?.edges ?? [])
     .filter((edge) => edge.source === nodeKey)
     .map((edge) => edge.key)
+}
+
+// ── G-3 parallel editor (joinMode ONLY; branches / joinNodeKey are preserved topology, read-only) ──
+// The editable model lives on `draft.parallelEdits[nodeKey]`, seeded 1:1 from the preserved parallel
+// nodes. The select below mutates ONLY `joinMode`; `buildApprovalGraph` re-applies it onto a COPY of
+// the graph (branches/joinNodeKey + every non-parallel node + all edges untouched). Both 'all' and
+// 'any' are offered because the backend `normalizeApprovalGraph` accepts both (`PARALLEL_JOIN_MODES`
+// = {'all','any'}, joinMode written verbatim) and the runtime executes 'any' (first-wins).
+function parallelEditFor(nodeKey: string): ParallelNodeEdit | undefined {
+  return draft.value.parallelEdits?.[nodeKey]
+}
+
+const PARALLEL_JOIN_MODE_LABELS: Record<ParallelJoinMode, string> = {
+  all: '全部完成（会签）',
+  any: '任一完成（或签 / 抢占）',
+}
+function parallelJoinModeLabel(mode: ParallelJoinMode): string {
+  return PARALLEL_JOIN_MODE_LABELS[mode] ?? mode
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))

--- a/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-parallel-edit.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  validateTemplateDraft,
+  type ParallelEdits,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import {
+  applyParallelEditsToGraph,
+  parallelEditsFromGraph,
+  validateParallelEdits,
+  PARALLEL_JOIN_MODES,
+} from '../src/approvals/parallelEdit'
+import { applyConditionEditsToGraph, conditionEditsFromGraph } from '../src/approvals/conditionEdit'
+
+// G-3 — parallel JOIN-MODE editing. PURE-LOGIC tests (no .vue / no Element Plus) so they run under
+// the approval-web-guard CI gate. The GATE is topology-preservation + cross-phase preservation:
+// editing a parallel node's `joinMode` must leave every OTHER node (start / approval / condition /
+// cc / end) and the FULL edge list byte-identical, condition (G-2) edits must compose with parallel
+// (G-3) edits, and an untouched complex graph must still round-trip byte-identical (G-1 floor).
+// PRE-CHECK: the backend `normalizeApprovalGraph` ACCEPTS both 'all' and 'any' (PARALLEL_JOIN_MODES
+// = {'all','any'}, joinMode written verbatim) so the editor offers both — these tests exercise both.
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z',
+    updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        { id: 'kind', type: 'select', label: '类型', options: [{ label: 'A', value: 'a' }] },
+      ],
+    },
+    approvalGraph,
+  }
+}
+
+// A PARALLEL graph: one fork (branches + joinNodeKey + joinMode 'all') fanning to two approval arms
+// that re-converge at a join node. Same shape the G-1/G-2 round-trips use.
+const PARALLEL_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'fork_1',
+      type: 'parallel',
+      name: '并行会签',
+      config: { branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' },
+    },
+    {
+      key: 'approval_a',
+      type: 'approval',
+      name: '财务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['finance'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    {
+      key: 'approval_b',
+      type: 'approval',
+      name: '法务',
+      config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' },
+    },
+    { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-fork_1', source: 'start', target: 'fork_1' },
+    { key: 'edge-fork_1-a', source: 'fork_1', target: 'approval_a' },
+    { key: 'edge-fork_1-b', source: 'fork_1', target: 'approval_b' },
+    { key: 'edge-approval_a-join', source: 'approval_a', target: 'join_1' },
+    { key: 'edge-approval_b-join', source: 'approval_b', target: 'join_1' },
+    { key: 'edge-join_1-end', source: 'join_1', target: 'end' },
+  ],
+}
+
+// A graph carrying BOTH a parallel fork AND a condition node (each arm of the fork routes through a
+// condition). Proves G-2 (condition) and G-3 (parallel) edits COMPOSE on the same graph and leave
+// the cc-free remainder byte-identical.
+const PARALLEL_PLUS_CONDITION_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'fork_1',
+      type: 'parallel',
+      name: '并行',
+      config: { branches: ['edge-fork_1-cond', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' },
+    },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '金额判断',
+      config: {
+        branches: [
+          { edgeKey: 'edge-cond_1-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    },
+    { key: 'approval_high', type: 'approval', name: '大额', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'approval_low', type: 'approval', name: '小额', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'approval_b', type: 'approval', name: '法务', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['legal'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-fork_1', source: 'start', target: 'fork_1' },
+    { key: 'edge-fork_1-cond', source: 'fork_1', target: 'cond_1' },
+    { key: 'edge-fork_1-b', source: 'fork_1', target: 'approval_b' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval_high-join', source: 'approval_high', target: 'join_1' },
+    { key: 'edge-approval_low-join', source: 'approval_low', target: 'join_1' },
+    { key: 'edge-approval_b-join', source: 'approval_b', target: 'join_1' },
+    { key: 'edge-join_1-end', source: 'join_1', target: 'end' },
+  ],
+}
+
+// A CONDITION-only graph (no parallel node) — G-3 must leave it byte-identical.
+const CONDITION_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '金额判断',
+      config: {
+        branches: [
+          { edgeKey: 'edge-cond_1-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }], conjunction: 'and' },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    },
+    { key: 'approval_high', type: 'approval', name: '大额审批', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'approval_low', type: 'approval', name: '小额审批', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond_1', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval_high-end', source: 'approval_high', target: 'end' },
+    { key: 'edge-approval_low-end', source: 'approval_low', target: 'end' },
+  ],
+}
+
+// A CC graph (no parallel node) — G-3 must leave it byte-identical (cc stays read-only / G-4).
+const CC_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'approval_1', type: 'approval', name: '审批人 1', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'cc_1', type: 'cc', name: '抄送 HR', config: { targetType: 'role', targetIds: ['hr', 'admin'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-cc_1', source: 'approval_1', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+  ],
+}
+
+/** Assert the two graphs agree on EVERY non-parallel node + the FULL edge list (topology gate). */
+function expectTopologyByteIdentical(rebuilt: ApprovalGraph, original: ApprovalGraph): void {
+  const nonParallel = (graph: ApprovalGraph) => graph.nodes.filter((node) => node.type !== 'parallel')
+  // every non-parallel node byte-identical (start / approval arms / condition / cc / join / end)
+  expect(nonParallel(rebuilt)).toEqual(nonParallel(original))
+  // the FULL edge array byte-identical (no edge dropped / added / reordered / retargeted)
+  expect(rebuilt.edges).toEqual(original.edges)
+  // node identity + ORDER preserved (no reordering even of the parallel node)
+  expect(rebuilt.nodes.map((node) => node.key)).toEqual(original.nodes.map((node) => node.key))
+}
+
+describe('G-3 parallelEditsFromGraph — seed from preserved parallel nodes', () => {
+  it('captures one entry per parallel node carrying its joinMode (1:1)', () => {
+    const edits = parallelEditsFromGraph(PARALLEL_GRAPH)
+    expect(Object.keys(edits)).toEqual(['fork_1'])
+    expect(edits.fork_1).toEqual({ nodeKey: 'fork_1', joinMode: 'all' })
+  })
+
+  it('is empty for a condition / cc graph (no parallel node)', () => {
+    expect(parallelEditsFromGraph(CONDITION_GRAPH)).toEqual({})
+    expect(parallelEditsFromGraph(CC_GRAPH)).toEqual({})
+  })
+
+  it('seeds joinMode "any" verbatim from an any-mode fork (backend accepts both)', () => {
+    const anyGraph: ApprovalGraph = JSON.parse(JSON.stringify(PARALLEL_GRAPH))
+    ;(anyGraph.nodes[1].config as { joinMode: string }).joinMode = 'any'
+    expect(parallelEditsFromGraph(anyGraph).fork_1.joinMode).toBe('any')
+  })
+})
+
+describe('G-3 topology-preservation — editing joinMode keeps everything else byte-identical', () => {
+  it('edit joinMode all → any → buildApprovalGraph → ONLY that parallel node config.joinMode changes; all other nodes + edges byte-identical', () => {
+    const template = buildTemplate(PARALLEL_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    draft.parallelEdits!.fork_1.joinMode = 'any'
+    const rebuilt = buildApprovalGraph(draft)
+
+    // GATE: every non-parallel node + the full edge array are byte-identical to the original.
+    expectTopologyByteIdentical(rebuilt, original)
+    // the ONE parallel node reflects ONLY the joinMode edit — branches + joinNodeKey unchanged, in
+    // their original key positions (key order stays branches, joinMode, joinNodeKey).
+    const fork = rebuilt.nodes.find((node) => node.key === 'fork_1')!
+    expect(fork.config).toEqual({ branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'any', joinNodeKey: 'join_1' })
+    expect(Object.keys(fork.config)).toEqual(['branches', 'joinMode', 'joinNodeKey'])
+    // the original fork still said 'all' (we did not mutate the input graph).
+    const origFork = original.nodes.find((node) => node.key === 'fork_1')! as { config: { joinMode: string } }
+    expect(origFork.config.joinMode).toBe('all')
+  })
+
+  it('editing joinMode any → all keeps branches + joinNodeKey + all edges byte-identical', () => {
+    const anyTemplate = buildTemplate(JSON.parse(JSON.stringify(PARALLEL_GRAPH)))
+    ;(anyTemplate.approvalGraph.nodes[1].config as { joinMode: string }).joinMode = 'any'
+    const original = structuredClone(anyTemplate.approvalGraph)
+    const draft = draftFromTemplate(anyTemplate)
+    draft.parallelEdits!.fork_1.joinMode = 'all'
+    const rebuilt = buildApprovalGraph(draft)
+
+    expectTopologyByteIdentical(rebuilt, original)
+    const fork = rebuilt.nodes.find((node) => node.key === 'fork_1')!
+    expect(fork.config).toEqual({ branches: ['edge-fork_1-a', 'edge-fork_1-b'], joinMode: 'all', joinNodeKey: 'join_1' })
+  })
+})
+
+describe('G-3 cross-phase — condition (G-2) AND parallel (G-3) edits compose; everything else byte-identical', () => {
+  it('editing a condition rule AND a parallel joinMode both land; all OTHER nodes + edges byte-identical', () => {
+    const template = buildTemplate(PARALLEL_PLUS_CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    // both edit models seeded from the one graph
+    draft.conditionEdits!.cond_1.branches[0].rules[0].value = 5000
+    draft.parallelEdits!.fork_1.joinMode = 'any'
+    const rebuilt = buildApprovalGraph(draft)
+
+    // the condition edit landed
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')! as { config: { branches: { rules: { value: unknown }[] }[] } }
+    expect(cond.config.branches[0].rules[0].value).toBe(5000)
+    // the parallel edit landed
+    const fork = rebuilt.nodes.find((node) => node.key === 'fork_1')! as { config: { joinMode: string } }
+    expect(fork.config.joinMode).toBe('any')
+
+    // EVERYTHING ELSE byte-identical: every node that is NOT cond_1 / fork_1, plus the full edge list.
+    const others = (graph: ApprovalGraph) => graph.nodes.filter((node) => node.key !== 'cond_1' && node.key !== 'fork_1')
+    expect(others(rebuilt)).toEqual(others(original))
+    expect(rebuilt.edges).toEqual(original.edges)
+    expect(rebuilt.nodes.map((node) => node.key)).toEqual(original.nodes.map((node) => node.key))
+    // input graph never mutated
+    const origFork = original.nodes.find((node) => node.key === 'fork_1')! as { config: { joinMode: string } }
+    expect(origFork.config.joinMode).toBe('all')
+  })
+
+  it('composing applyConditionEditsToGraph then applyParallelEditsToGraph with SEEDED edits is identity', () => {
+    const conditionEdits = conditionEditsFromGraph(PARALLEL_PLUS_CONDITION_GRAPH)
+    const parallelEdits = parallelEditsFromGraph(PARALLEL_PLUS_CONDITION_GRAPH)
+    const composed = applyParallelEditsToGraph(
+      applyConditionEditsToGraph(PARALLEL_PLUS_CONDITION_GRAPH, conditionEdits),
+      parallelEdits,
+    )
+    expect(composed).toEqual(PARALLEL_PLUS_CONDITION_GRAPH)
+  })
+})
+
+describe('G-3 untouched round-trip — no spurious diffs from seeding (G-1 floor holds)', () => {
+  it('an UNTOUCHED parallel graph round-trips byte-identical through draftFromTemplate → buildApprovalGraph', () => {
+    const template = buildTemplate(PARALLEL_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+  })
+
+  it('an UNTOUCHED parallel+condition graph round-trips byte-identical (both seedings are identity)', () => {
+    const template = buildTemplate(PARALLEL_PLUS_CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const rebuilt = buildApprovalGraph(draftFromTemplate(template))
+    expect(rebuilt).toEqual(original)
+  })
+
+  it('applyParallelEditsToGraph with the seeded edits is identity for the parallel graph', () => {
+    const edits = parallelEditsFromGraph(PARALLEL_GRAPH)
+    expect(applyParallelEditsToGraph(PARALLEL_GRAPH, edits)).toEqual(PARALLEL_GRAPH)
+  })
+})
+
+describe('G-3 condition / cc unaffected — still byte-identical-preserved', () => {
+  it('a CONDITION-only graph round-trips byte-identical (G-3 leaves it untouched, no parallel edits)', () => {
+    const template = buildTemplate(CONDITION_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    // no parallel node ⇒ no parallel edits seeded.
+    expect(draft.parallelEdits).toEqual({})
+    expect(buildApprovalGraph(draft)).toEqual(original)
+  })
+
+  it('a CC graph round-trips byte-identical (cc stays read-only / G-4)', () => {
+    const template = buildTemplate(CC_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    expect(draft.parallelEdits).toEqual({})
+    const rebuilt = buildApprovalGraph(draft)
+    expect(rebuilt).toEqual(original)
+    const cc = rebuilt.nodes.find((node) => node.type === 'cc')
+    expect(cc?.config).toEqual({ targetType: 'role', targetIds: ['hr', 'admin'] })
+  })
+
+  it('applyParallelEditsToGraph passes a condition/cc graph through byte-identical with empty edits', () => {
+    expect(applyParallelEditsToGraph(CONDITION_GRAPH, {})).toEqual(CONDITION_GRAPH)
+    expect(applyParallelEditsToGraph(CC_GRAPH, {})).toEqual(CC_GRAPH)
+  })
+})
+
+describe('G-3 input is never mutated', () => {
+  it('applyParallelEditsToGraph does not mutate the source graph', () => {
+    const before = structuredClone(PARALLEL_GRAPH)
+    const edits = parallelEditsFromGraph(PARALLEL_GRAPH)
+    edits.fork_1.joinMode = 'any'
+    applyParallelEditsToGraph(PARALLEL_GRAPH, edits)
+    expect(PARALLEL_GRAPH).toEqual(before)
+  })
+})
+
+describe('G-3 join-mode option set — backend accepts BOTH all and any (pre-check)', () => {
+  it('the editor offers exactly [all, any]', () => {
+    expect(PARALLEL_JOIN_MODES).toEqual(['all', 'any'])
+  })
+
+  it('both seeded all and seeded any pass the validation preview', () => {
+    expect(validateParallelEdits(parallelEditsFromGraph(PARALLEL_GRAPH))).toEqual([])
+    const anyGraph: ApprovalGraph = JSON.parse(JSON.stringify(PARALLEL_GRAPH))
+    ;(anyGraph.nodes[1].config as { joinMode: string }).joinMode = 'any'
+    expect(validateParallelEdits(parallelEditsFromGraph(anyGraph))).toEqual([])
+  })
+})
+
+describe('G-3 validation preview (UX-only; backend normalizeApprovalGraph is final arbiter)', () => {
+  it('flags an out-of-set joinMode (only reachable via a corrupt edit, never the UI select)', () => {
+    const edits: ParallelEdits = {
+      fork_1: { nodeKey: 'fork_1', joinMode: 'majority' as never },
+    }
+    const errors = validateParallelEdits(edits)
+    expect(errors.some((message) => message.includes('fork_1') && message.includes('汇聚模式无效'))).toBe(true)
+  })
+
+  it('surfaces the out-of-set joinMode error through validateTemplateDraft when the draft carries parallel edits', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(PARALLEL_GRAPH))
+    draft.parallelEdits!.fork_1.joinMode = 'majority' as never
+    const errors = validateTemplateDraft(draft, null)
+    expect(errors.some((message) => message.includes('汇聚模式无效'))).toBe(true)
+  })
+
+  it('an untouched parallel draft produces NO parallel validation errors (valid graph stays valid)', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(PARALLEL_GRAPH))
+    expect(validateTemplateDraft(draft, null).filter((message) => message.includes('汇聚模式'))).toEqual([])
+  })
+})

--- a/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
+++ b/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
@@ -98,6 +98,14 @@ Grounded in code (explorer-verified 2026-06-23):
 - **No new node types**, no runtime changes, no `normalizeApprovalGraph` changes.
 - **No nested parallel**, no `joinMode='any'` authoring in v1 (validator/type say 'all') — both
   stay fail-closed read-only.
+  > **CORRECTION (G-3, 2026-06-23):** the parenthetical "(validator/type say 'all')" is **factually
+  > wrong**. The backend `normalizeApprovalGraph` ACCEPTS both — `PARALLEL_JOIN_MODES =
+  > new Set(['all', 'any'])` (`ApprovalProductService.ts:289`), validated at `:940`, written
+  > verbatim at `:948`; the FE/BE type union is `'all' | 'any'`; and the runtime executes `'any'`
+  > (first-wins, `:3691`). G-3 therefore makes `joinMode` editable with BOTH options (the mandatory
+  > pre-check found 'any' is not backend-rejected, so per the "UI must not produce backend-rejected
+  > graphs" rule there is no reason to withhold it). Nested parallel and editing
+  > branches/joinNodeKey topology REMAIN out of scope. Pending owner ratification — see the G-3 PR.
 - **No flatten, ever** — unsupported constructs stay read-only, never dropped.
 - **No W7** approval-result write-back (its own gated scope-doc, pending a concrete scenario).
 
@@ -106,5 +114,8 @@ Grounded in code (explorer-verified 2026-06-23):
   G-1 load-preserve foundation. Override to a narrower first set if wanted.
 - (b) Phasing order — default condition → parallel → cc (most-common-first). Confirm or reorder.
 - (c) `parallel.joinMode='any'` authoring = deferred (default; v1 'all' only). Confirm.
+  > **SUPERSEDED (G-3, 2026-06-23):** the deferral rested on the §7 premise that the validator/type
+  > only allow 'all', which the code disproves (set `{'all','any'}`, accepted + runtime-executed).
+  > G-3 ships both modes; this decision now needs owner ratification rather than confirmation.
 - (d) Whether G-1 (load-preserve + read-only structured render) ships before any editor, or is
   folded into G-2 — default = G-1 standalone (proves anti-flatten before editing).

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -51,14 +51,49 @@
   `approval-web-guard.yml`). Backend `normalizeApprovalGraph` stays the sole arbiter (FE never
   relaxes it). G-1 round-trip + `approvalTemplateAuthoring.spec` stay green.
 
-## Phase G-3 — parallel editor (🔒 — G-2 done; needs its own opt-in)
-- 🔒 Author parallel `branches` + `joinNodeKey` (v1 `joinMode='all'`); preview enforces the
-  backend rules (no nested parallel, no cross-branch assignee dupes) before save.
+## Phase G-3 — parallel editor (✅ shipped — joinMode ONLY)
+- ✅ Author a parallel node's `joinMode` in a structured editable control. **PRE-CHECK SUPERSEDES
+  design-lock §8c/§7's `'all'`-only deferral:** the backend `normalizeApprovalGraph` ACCEPTS BOTH
+  `'all'` and `'any'` — `PARALLEL_JOIN_MODES = new Set(['all', 'any'])`
+  (`ApprovalProductService.ts:289`), the validation at `:940` only rejects values OUTSIDE that set
+  and writes `joinMode` VERBATIM (`:948`, no coercion to `'all'`), and the runtime
+  `ApprovalGraphExecutor` executes `'any'` = first-wins (`:3691`; `loadParallelState` accepts
+  `'any'` at `:1523`). The design-lock's premise "(validator/type say 'all')" is **factually false**
+  (the set is `{'all','any'}`, the FE/BE type union is `'all'|'any'`). So the editor offers **both**
+  modes — UI must not produce backend-rejected graphs, and here `'any'` is NOT rejected. **Owner
+  ratification flag:** §8(c) said 'any' deferred; this ships it because the empirical pre-check
+  overrides the stale doc-default. `branches` (fork edgeKeys) + `joinNodeKey` are TOPOLOGY: shown
+  read-only, preserved byte-for-byte on save (NOT editable — a later slice). condition stays
+  G-2-editable; cc stays read-only (G-4).
+- ✅ Edit model: `TemplateAuthoringDraft.parallelEdits: Record<nodeKey, ParallelNodeEdit>`, seeded
+  1:1 from `preservedGraph`'s parallel nodes (`parallelEditsFromGraph`). On save,
+  `buildApprovalGraph` COMPOSES `applyConditionEditsToGraph` (G-2) THEN
+  `applyParallelEditsToGraph` (G-3) onto a COPY of the graph — the two passes touch DISJOINT node
+  types (condition vs parallel) and each deep-clones everything else, so both edits land and every
+  other node + the full edge list stay byte-identical. `applyParallelEditsToGraph` spread-and-
+  overwrites ONLY `joinMode` (`{ ...originalConfig, joinMode }`) so an untouched edit is identity and
+  key order stays `branches, joinMode, joinNodeKey`. Pure logic in `approvals/parallelEdit.ts` (no
+  `.vue` import — runs under the vitest gate).
+- ✅ Topology + cross-phase preservation tests (the gate): edit joinMode → only that one parallel
+  node's `config.joinMode` changes, all other nodes + ALL edges byte-identical (deepEqual); editing a
+  condition rule (G-2) AND a parallel joinMode (G-3) in the same graph both land, everything else
+  byte-identical; an UNTOUCHED parallel / parallel+condition / condition / cc graph round-trips
+  byte-identical (no spurious seed diffs); validation preview = joinMode ∈ `{'all','any'}` (an
+  out-of-set value → preview error; both seeded 'all' and 'any' pass).
+  `apps/web/tests/approval-template-authoring-parallel-edit.test.ts` (wired into
+  `approval-web-guard.yml`). Backend `normalizeApprovalGraph` stays the sole arbiter (FE never
+  relaxes it). G-1 round-trip + G-2 + `approvalTemplateAuthoring.spec` stay green.
 
-## Phase G-4 — cc editor (🔒 until G-3)
-- 🔒 Author cc `targetType` + `targetIds` (reuse the approval user/role picker).
+## Phase G-4 — cc editor (🔒 until G-3 ratified)
+- 🔒 Author cc `targetType` + `targetIds` (reuse the approval user/role picker). **cc stays
+  READ-ONLY** until this phase is opted in.
 
 ## Out of scope (v1 — reopen-only, see design-lock §7)
 - 🔒 Free-canvas / drag-edge editor · new node types · runtime/validator changes · nested
-  parallel · `joinMode='any'` authoring · any flatten of unsupported constructs · W7
-  approval-result write-back (own scope-doc, pending a concrete scenario).
+  parallel · any flatten of unsupported constructs · W7 approval-result write-back (own scope-doc,
+  pending a concrete scenario).
+- ⚠️ **`joinMode='any'` authoring was listed here / in design-lock §7 as deferred, but G-3 SHIPS it**
+  because the empirical backend pre-check (above) shows `'any'` is accepted + runtime-executed; the
+  doc's deferral premise was factually wrong. Re-scoped OUT of "out of scope" — pending owner
+  ratification (see the G-3 PR body). The OTHER parallel limits (nested parallel, editing
+  branches/joinNodeKey topology) remain out of scope.


### PR DESCRIPTION
Phase **G-3** of the approval complex-graph author UI: make a `parallel` node's `joinMode` editable in the structured editor, while **every other node/edge — including condition (G-2) and cc — stays byte-identical-preserved** (the G-1 anti-flatten floor). Brand-neutral. Follows the G-2 pattern exactly.

Design-lock: `docs/design/approval-complex-graph-author-ui-design-lock-20260623.md` · TODO ticked: `docs/development/approval-complex-graph-author-ui-todo-20260623.md`.

## ⚠️ Pre-check finding — `joinMode='any'` is ACCEPTED by the backend (shipped both modes; needs owner ratification)

The mandatory pre-check on `normalizeApprovalGraph` found that **both `'all'` and `'any'` are accepted**:

- `PARALLEL_JOIN_MODES = new Set(['all', 'any'])` — `packages/core-backend/src/services/ApprovalProductService.ts:289`
- the parallel-node validation at **`ApprovalProductService.ts:940`** only fails values OUTSIDE that set (`!PARALLEL_JOIN_MODES.has(joinMode)`), and writes `joinMode` **verbatim** at `:948` (no coercion to `'all'`).
- runtime path for `'any'` exists: `ApprovalGraphExecutor` handles `joinMode === 'any'` = first-wins at **`:3691`** (cancels pending sibling assignments); `loadParallelState` accepts `'any'` at `:1523`.

Per the task rule "**IF it ACCEPTS 'all'|'any': make both selectable**", the editor offers **both**.

**This empirically supersedes design-lock §7 / §8(c)**, which deferred `'any'` on the premise "(validator/type say 'all')". That premise is **factually false** — the set is `{'all','any'}` and the FE/BE type union is `'all' | 'any'`. The pre-check exists precisely to stop the UI producing a backend-rejected graph; here `'any'` is *not* rejected, so withholding it has no basis. **Flagging for owner ratification** since §8(c) had marked it deferred. The contradiction is made loud, not silent, in all three artifacts:
- design-lock §7 + §8(c): a dated `CORRECTION`/`SUPERSEDED` note pointing here (the original prose is preserved, not silently rewritten inside an impl PR);
- TODO: G-3 ticked ✅ with the pre-check, and the out-of-scope `joinMode='any'` entry re-annotated (⚠️ shipped, pending ratification);
- this PR body (above).

Nested parallel and editing `branches`/`joinNodeKey` topology **remain out of scope**.

## Edit model (mirrors G-2)

- **`apps/web/src/approvals/parallelEdit.ts`** — pure logic, no `.vue` import (runs under the web-guard vitest gate):
  - `parallelEditsFromGraph(graph)` → `Record<nodeKey, { nodeKey, joinMode }>`, seeded **1:1** from `preservedGraph`'s parallel nodes (seeding is identity).
  - `applyParallelEditsToGraph(graph, edits)` → deep-cloned **copy** that overwrites **only** each parallel node's `joinMode` via spread-and-overwrite `{ ...originalConfig, joinMode }` (keeps key order `branches, joinMode, joinNodeKey`; an untouched edit is identity). `branches`/`joinNodeKey` + every non-parallel node + all edges are preserved byte-for-byte; the input is never mutated.
  - `validateParallelEdits(edits)` → preview error when `joinMode` ∉ `{'all','any'}`.
- **`buildApprovalGraph`** composes the two **disjoint** passes onto a copy of the preserved graph: `applyParallelEditsToGraph(applyConditionEditsToGraph(preservedGraph, conditionEdits), parallelEdits)`. Because condition and parallel passes touch different node types and each deep-clones the rest, **both edits land and everything else stays byte-identical**.
- **`TemplateAuthoringView.vue`** — each parallel node renders an editable `joinMode` `el-select` (会签 `all` / 或签 `any`) + **read-only** branches/join target. condition stays G-2-editable; cc stays read-only.
- **`validateTemplateDraft`** runs the parallel preview when the draft carries `parallelEdits` (UX only — `normalizeApprovalGraph` is the sole arbiter).

## Tests — topology + cross-phase preservation is the gate

`apps/web/tests/approval-template-authoring-parallel-edit.test.ts` (**19 tests**), wired into `.github/workflows/approval-web-guard.yml` (paths × pull_request + push, and the `vitest run` filter):

- **Topology-preservation** — `edit joinMode all → any → buildApprovalGraph → ONLY that parallel node config.joinMode changes; all other nodes + edges byte-identical`; `editing joinMode any → all keeps branches + joinNodeKey + all edges byte-identical` (asserts `expectTopologyByteIdentical`: every non-parallel node deep-equal, full edge array deep-equal, node order preserved; key order stays `branches, joinMode, joinNodeKey`).
- **Cross-phase (G-2 + G-3)** — `editing a condition rule AND a parallel joinMode both land; all OTHER nodes + edges byte-identical`; `composing applyConditionEditsToGraph then applyParallelEditsToGraph with SEEDED edits is identity`.
- **Untouched round-trips** — `an UNTOUCHED parallel graph round-trips byte-identical`; `an UNTOUCHED parallel+condition graph round-trips byte-identical (both seedings are identity)`; `applyParallelEditsToGraph with the seeded edits is identity`.
- **condition / cc unaffected** — `a CONDITION-only graph round-trips byte-identical`; `a CC graph round-trips byte-identical (cc stays read-only / G-4)`; pass-through with empty edits.
- **Validation / option set** — `the editor offers exactly [all, any]`; `both seeded all and seeded any pass the validation preview`; `flags an out-of-set joinMode`; `surfaces the out-of-set joinMode error through validateTemplateDraft`; `an untouched parallel draft produces NO parallel validation errors`.
- **Input never mutated.**

**cc still read-only (G-4)** — unchanged; the cc round-trip test confirms its config is byte-identical-preserved.

## Verify

- `pnpm --filter @metasheet/web run type-check` — clean (`vue-tsc -b`).
- All approval web-guard specs green: **136 passed** (19 new G-3 + 21 G-2 + 20 G-1/preserve + 12 detail + 32 detail-field + 32 `approvalTemplateAuthoring.spec`).
- eslint clean on all changed files. (2 unrelated lint errors exist on `origin/main` — `api.ts:213`, `useApprovalDirectory.ts:1` — neither touched here.)
- Condition (G-2) + cc unaffected: cross-phase + untouched tests assert byte-identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)