### PR TITLE
feat(approval): G-4 — cc node editing + complex-graph editor close-out

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/parallelEdit.ts'
+      - 'apps/web/src/approvals/ccEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -29,12 +30,14 @@ on:
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
     paths:
       - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/parallelEdit.ts'
+      - 'apps/web/src/approvals/ccEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
@@ -45,6 +48,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -99,4 +103,4 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot

--- a/apps/web/src/approvals/ccEdit.ts
+++ b/apps/web/src/approvals/ccEdit.ts
@@ -1,0 +1,117 @@
+import type {
+  ApprovalAssigneeType,
+  ApprovalGraph,
+  ApprovalNode,
+  CcNodeConfig,
+} from '../types/approval'
+
+// G-4 — cc node editing (TARGETS ONLY; no .vue / Element Plus import so this runs under the
+// approval-web-guard vitest gate). Scope: each cc node's `targetType` ('user'|'role') and
+// `targetIds` (string[]). The cc node's edges/position are TOPOLOGY — preserved byte-for-byte
+// (G-1 anti-flatten floor). Every OTHER node/edge — condition (G-2) and parallel (G-3) included —
+// is preserved verbatim. condition stays editable via `conditionEdit.ts`, parallel via `parallelEdit.ts`.
+//
+// PRE-CHECK FINDING (the backend-accepted cc shape): `normalizeApprovalGraph`'s cc validation
+// (`ApprovalProductService.ts:914-922`) requires `config.targetType` ∈ {'user','role'} and
+// `config.targetIds` an array of NON-EMPTY strings, and writes them back trimmed. The editor +
+// preview match exactly (backend stays the sole arbiter).
+
+/** The cc target types the backend `normalizeApprovalGraph` accepts (the editor's select offers these). */
+export const CC_TARGET_TYPES: readonly ApprovalAssigneeType[] = ['user', 'role'] as const
+const CC_TARGET_TYPE_SET = new Set<string>(CC_TARGET_TYPES)
+
+/**
+ * Editable model for one cc node — `targetType` + `targetIds`. Keyed by node `key`, seeded 1:1
+ * from the preserved cc nodes' existing config. The cc node's place in the graph (edges) is
+ * topology and is NOT carried here (preserved verbatim by `applyCcEditsToGraph`).
+ */
+export interface CcNodeEdit {
+  nodeKey: string
+  targetType: ApprovalAssigneeType
+  targetIds: string[]
+}
+
+/** Map of cc edits keyed by node key, seeded from a preserved graph and edited in place. */
+export type CcEdits = Record<string, CcNodeEdit>
+
+// Deep clone for the preserved-graph pass-through — same rationale as parallelEdit/conditionEdit:
+// pure JSON data, and a JSON round-trip works on the Vue reactive Proxy the draft is wrapped in.
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function isCcConfig(config: ApprovalNode['config']): config is CcNodeConfig {
+  return Boolean(config) && Array.isArray((config as CcNodeConfig).targetIds)
+}
+
+/** True when a target type is one the editor offers (and the backend accepts). */
+export function isCcTargetType(value: unknown): value is ApprovalAssigneeType {
+  return typeof value === 'string' && CC_TARGET_TYPE_SET.has(value)
+}
+
+/**
+ * Seed the editable cc model from a (preserved) graph — one entry per `cc` node, carrying its
+ * existing `targetType` + `targetIds`. Non-cc nodes are ignored (preserved verbatim by
+ * `applyCcEditsToGraph`). Seeding is identity: an untouched edit reproduces the original config,
+ * so a round-trip is byte-identical (no spurious diff).
+ */
+export function ccEditsFromGraph(graph: ApprovalGraph | undefined): CcEdits {
+  const edits: CcEdits = {}
+  if (!graph) return edits
+  for (const node of graph.nodes) {
+    if (node.type !== 'cc' || !isCcConfig(node.config)) continue
+    edits[node.key] = {
+      nodeKey: node.key,
+      targetType: isCcTargetType(node.config.targetType) ? node.config.targetType : 'user',
+      targetIds: [...node.config.targetIds],
+    }
+  }
+  return edits
+}
+
+/**
+ * Replace the config (`targetType` + `targetIds`) of each cc node in `graph` with the edited value,
+ * leaving EVERY other node and ALL edges byte-identical (deep-cloned so the input is never mutated).
+ * `targetIds` are trimmed + empties dropped to match the backend's write shape. Spread-original-first
+ * keeps key order byte-stable, so an UNTOUCHED cc node reproduces its config exactly.
+ *
+ * Composition with G-2/G-3: cc / condition / parallel are DISJOINT node types and each pass
+ * deep-clones everything else, so composing the three lands all edits while every non-targeted
+ * node/edge stays byte-identical.
+ */
+export function applyCcEditsToGraph(graph: ApprovalGraph, edits: CcEdits): ApprovalGraph {
+  const nodes: ApprovalNode[] = graph.nodes.map((node) => {
+    if (node.type !== 'cc') return cloneJson(node)
+    const edit = edits[node.key]
+    if (!edit || !isCcConfig(node.config)) return cloneJson(node)
+    const originalConfig = cloneJson(node.config)
+    const config: CcNodeConfig = {
+      ...originalConfig,
+      targetType: edit.targetType,
+      targetIds: edit.targetIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0),
+    }
+    return { ...cloneJson(node), config }
+  })
+  return {
+    nodes,
+    edges: graph.edges.map((edge) => cloneJson(edge)),
+  }
+}
+
+/**
+ * FE validation PREVIEW for the cc edits (UX only — the backend `normalizeApprovalGraph` stays the
+ * sole arbiter). Mirrors the backend cc rule: `targetType` ∈ {'user','role'} and at least one
+ * non-empty `targetId`.
+ */
+export function validateCcEdits(edits: CcEdits): string[] {
+  const errors: string[] = []
+  for (const edit of Object.values(edits)) {
+    if (!isCcTargetType(edit.targetType)) {
+      errors.push(`抄送节点 ${edit.nodeKey} 的抄送对象类型无效`)
+    }
+    if (edit.targetIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0).length === 0) {
+      errors.push(`抄送节点 ${edit.nodeKey} 至少需要一个抄送对象`)
+    }
+  }
+  return errors
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -34,6 +34,12 @@ import {
   validateParallelEdits,
   type ParallelEdits,
 } from './parallelEdit'
+import {
+  applyCcEditsToGraph,
+  ccEditsFromGraph,
+  validateCcEdits,
+  type CcEdits,
+} from './ccEdit'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
@@ -47,6 +53,8 @@ export type {
 export { CONDITION_RULE_OPERATORS } from './conditionEdit'
 export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
 export { PARALLEL_JOIN_MODES } from './parallelEdit'
+export type { CcEdits, CcNodeEdit } from './ccEdit'
+export { CC_TARGET_TYPES } from './ccEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -154,6 +162,9 @@ export interface TemplateAuthoringDraft {
   // with the condition edits onto a COPY of `preservedGraph`. Empty/absent for linear or
   // non-parallel complex graphs.
   parallelEdits?: ParallelEdits
+  // G-4 cc editor: editable targetType/targetIds for each `cc` node in `preservedGraph`, seeded
+  // 1:1. Topology (edges) + every non-cc node stay byte-identical. Empty {} when no cc node.
+  ccEdits?: CcEdits
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -567,6 +578,7 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
           // G-3: seed the editable parallel joinMode from the preserved parallel nodes (1:1).
           // Empty {} when the complex graph has no parallel node (condition/cc-only).
           parallelEdits: parallelEditsFromGraph(template.approvalGraph),
+          ccEdits: ccEditsFromGraph(template.approvalGraph),
         }
       : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
@@ -680,15 +692,16 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
   // G-1/G-2/G-3 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`, so
   // its cc/condition/parallel nodes/edges survive save. Two disjoint edit passes COMPOSE onto a COPY
-  // of the graph: G-2 (`applyConditionEditsToGraph`) replaces ONLY each condition node's config with
-  // the edited logic, then G-3 (`applyParallelEditsToGraph`) replaces ONLY each parallel node's
-  // `joinMode`. The passes touch disjoint node types and each deep-clones everything else, so both
-  // edits land while every other node + ALL edges (cc included — G-4 read-only) stay byte-identical;
-  // an untouched graph round-trips unchanged (both apply-fns reproduce the backend-normalised shape).
+  // of the graph: G-2 (`applyConditionEditsToGraph`) replaces ONLY each condition node's config, G-3
+  // (`applyParallelEditsToGraph`) replaces ONLY each parallel node's `joinMode`, and G-4
+  // (`applyCcEditsToGraph`) replaces ONLY each cc node's targetType/targetIds. The three passes touch
+  // disjoint node types and each deep-clones everything else, so all edits land while every other
+  // node + ALL edges stay byte-identical; an untouched graph round-trips unchanged.
   // Only linear drafts take the build below.
   if (draft.preservedGraph) {
     const withConditionEdits = applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
-    return applyParallelEditsToGraph(withConditionEdits, draft.parallelEdits ?? {})
+    const withParallelEdits = applyParallelEditsToGraph(withConditionEdits, draft.parallelEdits ?? {})
+    return applyCcEditsToGraph(withParallelEdits, draft.ccEdits ?? {})
   }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
@@ -819,6 +832,9 @@ export function validateTemplateDraft(
   // UX-only — the backend `normalizeApprovalGraph` re-validates and is the final arbiter.
   if (draft.parallelEdits && Object.keys(draft.parallelEdits).length > 0) {
     errors.push(...validateParallelEdits(draft.parallelEdits))
+  }
+  if (draft.ccEdits && Object.keys(draft.ccEdits).length > 0) {
+    errors.push(...validateCcEdits(draft.ccEdits))
   }
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -50,13 +50,13 @@
       data-testid="approval-template-unsupported-alert"
     />
 
-    <!-- G-1/G-2: a complex graph is preserved, not unsupported — informational, save stays enabled.
-         G-2 makes condition nodes editable; G-3 makes a parallel node's joinMode editable; cc stays
-         read-only (G-4). branches / join target / all edges are preserved topology. -->
+    <!-- G-1..G-4: a complex graph is preserved, not unsupported — informational, save stays enabled.
+         G-2 condition rules, G-3 parallel joinMode, and G-4 cc targets are all editable; branches /
+         join target / all edges are preserved topology. -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点暂以只读结构展示。分支拓扑与连线在保存时原样保留。"
+      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象。分支拓扑与连线在保存时原样保留。"
       type="info"
       show-icon
       :closable="false"
@@ -531,7 +531,47 @@
               </ul>
             </div>
 
-            <!-- cc / approval — read-only summary (G-4). -->
+            <!-- G-4: editable cc node — targetType (用户/角色) + targetIds. The cc node's edges /
+                 position are TOPOLOGY: preserved byte-for-byte on save. -->
+            <div
+              v-else-if="node.type === 'cc' && ccEditFor(node.key)"
+              class="template-authoring__cc"
+              data-testid="approval-cc-editor"
+              :data-cc-node="node.key"
+            >
+              <el-form-item label="抄送类型">
+                <el-select
+                  v-model="ccEditFor(node.key)!.targetType"
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 240px"
+                  data-testid="approval-cc-target-type"
+                >
+                  <el-option
+                    v-for="targetType in CC_TARGET_TYPES"
+                    :key="targetType"
+                    :label="ccTargetTypeLabel(targetType)"
+                    :value="targetType"
+                  />
+                </el-select>
+              </el-form-item>
+              <el-form-item label="抄送对象">
+                <el-select
+                  v-model="ccEditFor(node.key)!.targetIds"
+                  multiple
+                  filterable
+                  allow-create
+                  default-first-option
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 360px"
+                  placeholder="输入用户/角色 ID 后回车"
+                  data-testid="approval-cc-target-ids"
+                />
+              </el-form-item>
+            </div>
+
+            <!-- approval / other — read-only summary (G-4: cc is editable above). -->
             <template v-else>
               <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
                 <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
@@ -722,6 +762,7 @@ import {
   validateTemplateDraft,
   CONDITION_RULE_OPERATORS,
   PARALLEL_JOIN_MODES,
+  CC_TARGET_TYPES,
   type ApprovalStepDraft,
   type ConditionBranchEdit,
   type ConditionNodeEdit,
@@ -729,10 +770,12 @@ import {
   type ConditionRuleOperator,
   type FieldAuthoringDraft,
   type ParallelNodeEdit,
+  type CcNodeEdit,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
 import type {
   ApprovalAssigneeSource,
+  ApprovalAssigneeType,
   ApprovalNode,
   CcNodeConfig,
   ConditionNodeConfig,
@@ -904,6 +947,17 @@ const PARALLEL_JOIN_MODE_LABELS: Record<ParallelJoinMode, string> = {
 }
 function parallelJoinModeLabel(mode: ParallelJoinMode): string {
   return PARALLEL_JOIN_MODE_LABELS[mode] ?? mode
+}
+
+// ── G-4 cc editor (targetType + targetIds; the cc node's edges/position are preserved topology) ──
+// Editable model on `draft.ccEdits[nodeKey]`, seeded 1:1 from the preserved cc nodes. The controls
+// mutate ONLY targetType/targetIds; `buildApprovalGraph` re-applies onto a COPY (every non-cc node +
+// all edges untouched). Matches the backend cc rule (targetType ∈ {user,role}, non-empty targetIds).
+function ccEditFor(nodeKey: string): CcNodeEdit | undefined {
+  return draft.value.ccEdits?.[nodeKey]
+}
+function ccTargetTypeLabel(targetType: ApprovalAssigneeType): string {
+  return targetType === 'role' ? '角色' : '用户'
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))

--- a/apps/web/tests/approval-template-authoring-cc-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-cc-edit.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  validateTemplateDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import { applyCcEditsToGraph, ccEditsFromGraph, validateCcEdits, CC_TARGET_TYPES } from '../src/approvals/ccEdit'
+import { applyConditionEditsToGraph, conditionEditsFromGraph } from '../src/approvals/conditionEdit'
+
+// G-4 — cc node editing (targetType + targetIds). PURE-LOGIC tests (no .vue / no Element Plus) so
+// they run under the approval-web-guard CI gate. The GATE is topology + cross-phase preservation:
+// editing a cc node's targets must leave every OTHER node (start/approval/condition/parallel/end) and
+// the FULL edge list byte-identical, cc edits must COMPOSE with condition/parallel edits, and an
+// untouched complex graph must still round-trip byte-identical (G-1 floor). PRE-CHECK: the backend
+// `normalizeApprovalGraph` cc rule (ApprovalProductService.ts:914-922) = targetType ∈ {'user','role'}
+// + a non-empty targetIds string[] (trimmed). The editor + validateCcEdits mirror exactly.
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1', key: 'expense', name: '费用审批', description: null, category: null,
+    visibilityScope: { type: 'all', ids: [] }, slaHours: null, status: 'draft',
+    activeVersionId: null, latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z', updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: { fields: [{ id: 'amount', type: 'number', label: '金额', required: true }] },
+    approvalGraph,
+  }
+}
+
+// A graph with a cc node: start → approval_1 → cc_1 → end.
+const CC_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'approval_1', type: 'approval', name: '主管', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'cc_1', type: 'cc', name: '抄送财务', config: { targetType: 'role', targetIds: ['finance', 'audit'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-cc_1', source: 'approval_1', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+  ],
+}
+
+// A graph with BOTH a condition node and a cc node — proves G-2 (condition) + G-4 (cc) edits compose.
+const CONDITION_PLUS_CC_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'edge-cond_1-high', rules: [{ fieldId: 'amount', operator: 'gt', value: 1000 }] }], defaultEdgeKey: 'edge-cond_1-low' } },
+    { key: 'approval_high', type: 'approval', name: '高额', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['vp'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'user', targetIds: ['u1'] } },
+    { key: 'approval_low', type: 'approval', name: '低额', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond_1', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval_high-cc_1', source: 'approval_high', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+    { key: 'edge-approval_low-end', source: 'approval_low', target: 'end' },
+  ],
+}
+
+const clone = (g: ApprovalGraph): ApprovalGraph => JSON.parse(JSON.stringify(g))
+const nonCc = (g: ApprovalGraph) => g.nodes.filter((n) => n.type !== 'cc')
+
+describe('ccEditsFromGraph (seed)', () => {
+  it('seeds one entry per cc node with its existing targetType/targetIds', () => {
+    expect(ccEditsFromGraph(CC_GRAPH)).toEqual({ cc_1: { nodeKey: 'cc_1', targetType: 'role', targetIds: ['finance', 'audit'] } })
+  })
+  it('is empty for a graph with no cc node', () => {
+    expect(ccEditsFromGraph({ nodes: [{ key: 'start', type: 'start', config: {} }], edges: [] })).toEqual({})
+  })
+})
+
+describe('G-4 topology-preservation — editing a cc target keeps everything else byte-identical', () => {
+  it('changes ONLY the cc node config; all other nodes + the full edge list byte-identical', () => {
+    const original = clone(CC_GRAPH)
+    const edits = ccEditsFromGraph(CC_GRAPH)
+    edits.cc_1.targetType = 'user'
+    edits.cc_1.targetIds = ['  u9  ', '', 'u10']
+    const rebuilt = applyCcEditsToGraph(CC_GRAPH, edits)
+    expect(nonCc(rebuilt)).toEqual(nonCc(original)) // start / approval / end untouched
+    expect(rebuilt.edges).toEqual(original.edges) // full topology untouched
+    expect(rebuilt.nodes.find((n) => n.key === 'cc_1')!.config).toEqual({ targetType: 'user', targetIds: ['u9', 'u10'] }) // trimmed + empties dropped
+  })
+  it('does not mutate the input graph', () => {
+    const before = clone(CC_GRAPH)
+    const edits = ccEditsFromGraph(CC_GRAPH)
+    edits.cc_1.targetIds = ['x']
+    applyCcEditsToGraph(CC_GRAPH, edits)
+    expect(CC_GRAPH).toEqual(before)
+  })
+})
+
+describe('G-4 untouched round-trip — no spurious diffs from seeding (G-1 floor holds)', () => {
+  it('a cc graph round-trips byte-identical through draftFromTemplate → buildApprovalGraph', () => {
+    const original = clone(CC_GRAPH)
+    expect(buildApprovalGraph(draftFromTemplate(buildTemplate(CC_GRAPH)))).toEqual(original)
+  })
+  it('a condition+cc graph round-trips byte-identical untouched', () => {
+    const original = clone(CONDITION_PLUS_CC_GRAPH)
+    expect(buildApprovalGraph(draftFromTemplate(buildTemplate(CONDITION_PLUS_CC_GRAPH)))).toEqual(original)
+  })
+})
+
+describe('G-4 cross-phase — cc + condition edits compose; nothing else drifts', () => {
+  it('editing a condition rule AND a cc target both land; all other nodes + edges byte-identical', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(CONDITION_PLUS_CC_GRAPH))
+    // edit the condition rule value + the cc target
+    draft.conditionEdits!.cond_1.branches[0].rules[0].value = 5000
+    draft.ccEdits!.cc_1.targetIds = ['u2']
+    const rebuilt = buildApprovalGraph(draft)
+    // condition + cc reflect the edits
+    expect((rebuilt.nodes.find((n) => n.key === 'cond_1')!.config as { branches: { rules: { value: unknown }[] }[] }).branches[0].rules[0].value).toBe(5000)
+    expect(rebuilt.nodes.find((n) => n.key === 'cc_1')!.config).toEqual({ targetType: 'user', targetIds: ['u2'] })
+    // everything else byte-identical
+    const other = (g: ApprovalGraph) => g.nodes.filter((n) => n.type !== 'cc' && n.type !== 'condition')
+    expect(other(rebuilt)).toEqual(other(CONDITION_PLUS_CC_GRAPH))
+    expect(rebuilt.edges).toEqual(CONDITION_PLUS_CC_GRAPH.edges)
+  })
+  it('applying cc edits leaves condition nodes byte-identical (disjoint passes)', () => {
+    const condEdits = conditionEditsFromGraph(CONDITION_PLUS_CC_GRAPH)
+    const afterCond = applyConditionEditsToGraph(CONDITION_PLUS_CC_GRAPH, condEdits)
+    const afterCc = applyCcEditsToGraph(afterCond, ccEditsFromGraph(CONDITION_PLUS_CC_GRAPH))
+    expect(afterCc).toEqual(CONDITION_PLUS_CC_GRAPH) // seeded (untouched) compose is identity
+  })
+})
+
+describe('validateCcEdits (preview mirrors the backend cc rule)', () => {
+  it('offers exactly [user, role]', () => {
+    expect([...CC_TARGET_TYPES]).toEqual(['user', 'role'])
+  })
+  it('passes a valid cc edit', () => {
+    expect(validateCcEdits({ cc_1: { nodeKey: 'cc_1', targetType: 'user', targetIds: ['u1'] } })).toEqual([])
+  })
+  it('flags an empty targetIds', () => {
+    expect(validateCcEdits({ cc_1: { nodeKey: 'cc_1', targetType: 'user', targetIds: ['', '  '] } })[0]).toMatch(/至少需要一个抄送对象/)
+  })
+  it('flags an invalid targetType', () => {
+    expect(validateCcEdits({ cc_1: { nodeKey: 'cc_1', targetType: 'dept' as never, targetIds: ['u1'] } })[0]).toMatch(/类型无效/)
+  })
+  it('surfaces a cc preview error through validateTemplateDraft', () => {
+    const draft = draftFromTemplate(buildTemplate(CC_GRAPH))
+    draft.ccEdits!.cc_1.targetIds = []
+    expect(validateTemplateDraft(draft).some((e) => /抄送/.test(e))).toBe(true)
+  })
+})

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -84,9 +84,14 @@
   `approval-web-guard.yml`). Backend `normalizeApprovalGraph` stays the sole arbiter (FE never
   relaxes it). G-1 round-trip + G-2 + `approvalTemplateAuthoring.spec` stay green.
 
-## Phase G-4 — cc editor (🔒 until G-3 ratified)
-- 🔒 Author cc `targetType` + `targetIds` (reuse the approval user/role picker). **cc stays
-  READ-ONLY** until this phase is opted in.
+## Phase G-4 — cc editor + close-out ✅ (shipped; this PR)
+- ✅ cc `targetType` (user/role) + `targetIds` editable in TemplateAuthoringView; pure logic in
+  `ccEdit.ts` (`applyCcEditsToGraph` composes after condition + parallel — three disjoint passes,
+  every non-cc node + all edges byte-identical). Matches the backend cc rule (targetType ∈
+  {user,role}, non-empty targetIds). Close-out: all three complex node types now editable in one
+  structured view; the FE preview surfaces all three edit types; topology stays read-only.
+- ✅ 13 cc tests (topology-preservation + condition×cc compose + untouched round-trip + validation),
+  wired into approval-web-guard. The complex-graph author UI render+edit set is complete.
 
 ## Out of scope (v1 — reopen-only, see design-lock §7)
 - 🔒 Free-canvas / drag-edge editor · new node types · runtime/validator changes · nested


### PR DESCRIPTION
**Final slice of the complex-graph author UI** (design-lock → G-1 load-preserve → G-2 condition → G-3 parallel → **G-4 cc**). Makes `cc` nodes editable, completing the render+edit set.

## Changes
- **cc editing** — `ccEdit.ts` (pure, no `.vue`): `ccEditsFromGraph` seeds `{targetType, targetIds}` 1:1 from preserved cc nodes; `applyCcEditsToGraph` replaces ONLY each cc node's config (spread-original-first), deep-cloning every other node + all edges. `buildApprovalGraph` now composes **three disjoint passes** — condition → parallel → cc — so all edits land while topology + non-target nodes stay **byte-identical**.
- **Backend-matched** — the cc rule (`normalizeApprovalGraph` ApprovalProductService.ts:914-922) is `targetType ∈ {user,role}` + non-empty `targetIds` (trimmed); `validateCcEdits` mirrors it (preview only; backend stays sole arbiter).
- **View** — editable cc `targetType` (用户/角色) + `targetIds`; condition/parallel keep their editors; start/approval/end + topology read-only. **Close-out:** all three complex node types now editable in one structured view.

## Tests
13 cc tests — topology-preservation (a cc edit leaves all other nodes + the full edge list byte-identical), **condition×cc compose**, untouched round-trip byte-identical, validation. Wired into `approval-web-guard`. **105 FE specs** green; vue-tsc + lint clean.

UI-only — no runtime/validator/type changes. Completes the complex-graph author UI arc's render+edit set. (Implemented directly after the delegate hit a transient stream timeout pre-commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)