### PR TITLE
docs(approval): reconcile complex-graph design-lock to as-built (RATIFIED + SHIPPED)

### DIFF
--- a/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
+++ b/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
@@ -1,7 +1,14 @@
 # Design-lock: Approval complex-graph node author UI (复杂图节点作者 UI)
 
-**Status:** PROPOSED (owner-sequenced 2026-06-23 via /goal — design-lock first, then a v1
-**structured editor**, not a free canvas). The approval **runtime** already executes all six
+**Status:** RATIFIED + SHIPPED (2026-06-23). The arc is complete on main — design-lock #3102,
+G-1 load-preserve #3103, G-2 condition #3104, G-3 parallel join-mode #3105, G-4 cc #3106.
+**As-built scope** (refined from the original proposal below): the editor edits **condition
+logic** (branch rules / conjunction / default edge), **parallel `joinMode`** (`all`/`any` — both
+backend-accepted), and **cc targets** (`targetType` / `targetIds`). All graph **topology**
+(parallel branch edgeKeys + `joinNodeKey`, condition branch edges, every edge) is **read-only,
+preserved byte-identical**; **parallel topology / branch add-remove editing is explicitly OUT of
+scope** (a later slice). The original proposal (owner-sequenced via /goal — design-lock first,
+then a v1 **structured editor**, not a free canvas) follows. The approval **runtime** already executes all six
 node types (start / approval / cc / condition / parallel / end) including parallel fork-join,
 but the template-authoring UI is **linear-only** and **fail-closes** (read-only) on any
 cc / condition / parallel node. This locks the scope of a structured author UI that unlocks
@@ -34,8 +41,9 @@ Grounded in code (explorer-verified 2026-06-23):
 
 ## 1. v1 scope — which nodes are editable, which stay read-only
 - **Editable (all runtime-ready):** `condition` (branches: rules `{fieldId, operator, value}` +
-  `conjunction` and/or, + `defaultEdgeKey`), `parallel` (branch edgeKeys + `joinNodeKey` +
-  `joinMode`), `cc` (`targetType` user/role + `targetIds`). Plus the existing `approval` node
+  `conjunction` and/or, + `defaultEdgeKey`), `parallel` (**`joinMode` only** — `all`/`any`;
+  branch edgeKeys + `joinNodeKey` are topology, preserved read-only **[as-built]**), `cc`
+  (`targetType` user/role + `targetIds`). Plus the existing `approval` node
   config (unchanged).
 - **Read-only / structural (never hand-edited):** `start` / `end` (auto-managed), and node
   `key`s / `edge`s identity (the editor manages topology through structured controls, not raw
@@ -87,8 +95,8 @@ Grounded in code (explorer-verified 2026-06-23):
   save untouched → graph byte-identical.
 - **G-2 · condition editor.** Author condition branches/rules + default edge; full-graph build;
   FE preview. 
-- **G-3 · parallel editor.** Author parallel branches + join (v1 `joinMode='all'`); respect the
-  backend's no-nested / no-cross-branch-dupe rules in the preview.
+- **G-3 · parallel editor.** Author parallel `joinMode` (`all`/`any`, both backend-accepted);
+  branch edgeKeys + `joinNodeKey` are topology, read-only **[as-built — branch add/remove deferred].**
 - **G-4 · cc editor.** Author cc targets (reuse the approval picker).
 - The structured-graph editor is the form-schema-adjacent surface the detail arc stabilized
   first (goal sequencing: C 明细 done → graph UI now).
@@ -96,16 +104,14 @@ Grounded in code (explorer-verified 2026-06-23):
 ## 7. Boundaries / non-goals (v1 — all reopen-only)
 - **No free-canvas / drag-edge editor** (structured controls only).
 - **No new node types**, no runtime changes, no `normalizeApprovalGraph` changes.
-- **No nested parallel**, no `joinMode='any'` authoring in v1 (validator/type say 'all') — both
-  stay fail-closed read-only.
-  > **CORRECTION (G-3, 2026-06-23):** the parenthetical "(validator/type say 'all')" is **factually
-  > wrong**. The backend `normalizeApprovalGraph` ACCEPTS both — `PARALLEL_JOIN_MODES =
-  > new Set(['all', 'any'])` (`ApprovalProductService.ts:289`), validated at `:940`, written
-  > verbatim at `:948`; the FE/BE type union is `'all' | 'any'`; and the runtime executes `'any'`
-  > (first-wins, `:3691`). G-3 therefore makes `joinMode` editable with BOTH options (the mandatory
-  > pre-check found 'any' is not backend-rejected, so per the "UI must not produce backend-rejected
-  > graphs" rule there is no reason to withhold it). Nested parallel and editing
-  > branches/joinNodeKey topology REMAIN out of scope. Pending owner ratification — see the G-3 PR.
+- **No nested parallel**; **no parallel topology editing** (branch add/remove, `joinNodeKey`) — the
+  parallel editor edits `joinMode` only; branches/joinNodeKey are preserved read-only **[as-built]**.
+  > **RATIFIED (G-3, 2026-06-23 — shipped #3105):** `joinMode='any'` IS backend-accepted —
+  > `PARALLEL_JOIN_MODES = new Set(['all', 'any'])` (`ApprovalProductService.ts:289`), validated at
+  > `:940`, written verbatim at `:948`; the FE/BE type union is `'all' | 'any'`; the runtime executes
+  > `'any'` (first-wins, `:3691`). G-3 ships `joinMode` editable with BOTH options. The original
+  > §7/§8c "joinMode='any' deferred (validator/type say 'all')" premise was factually wrong and is
+  > superseded as-built. Branch / `joinNodeKey` topology editing REMAINS out of scope.
 - **No flatten, ever** — unsupported constructs stay read-only, never dropped.
 - **No W7** approval-result write-back (its own gated scope-doc, pending a concrete scenario).
 
@@ -113,9 +119,9 @@ Grounded in code (explorer-verified 2026-06-23):
 - (a) v1 editable set = `condition` + `parallel` + `cc` (default), phased G-2/G-3/G-4 after the
   G-1 load-preserve foundation. Override to a narrower first set if wanted.
 - (b) Phasing order — default condition → parallel → cc (most-common-first). Confirm or reorder.
-- (c) `parallel.joinMode='any'` authoring = deferred (default; v1 'all' only). Confirm.
-  > **SUPERSEDED (G-3, 2026-06-23):** the deferral rested on the §7 premise that the validator/type
-  > only allow 'all', which the code disproves (set `{'all','any'}`, accepted + runtime-executed).
-  > G-3 ships both modes; this decision now needs owner ratification rather than confirmation.
+- (c) `parallel.joinMode='any'` authoring = **RATIFIED + SHIPPED** (G-3 #3105). The original
+  "deferred" default rested on the §7 premise that the validator/type only allow 'all', which the
+  code disproves (set `{'all','any'}`, accepted + runtime-executed); the owner audit (2026-06-23)
+  ratified shipping both modes.
 - (d) Whether G-1 (load-preserve + read-only structured render) ships before any editor, or is
   folded into G-2 — default = G-1 standalone (proves anti-flatten before editing).

--- a/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
+++ b/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
@@ -7,13 +7,30 @@ logic** (branch rules / conjunction / default edge), **parallel `joinMode`** (`a
 backend-accepted), and **cc targets** (`targetType` / `targetIds`). All graph **topology**
 (parallel branch edgeKeys + `joinNodeKey`, condition branch edges, every edge) is **read-only,
 preserved byte-identical**; **parallel topology / branch add-remove editing is explicitly OUT of
-scope** (a later slice). The original proposal (owner-sequenced via /goal — design-lock first,
-then a v1 **structured editor**, not a free canvas) follows. The approval **runtime** already executes all six
-node types (start / approval / cc / condition / parallel / end) including parallel fork-join,
-but the template-authoring UI is **linear-only** and **fail-closes** (read-only) on any
-cc / condition / parallel node. This locks the scope of a structured author UI that unlocks
-those nodes without flattening existing complex templates. Brand-neutral (external OA /
-mainstream approval platforms; no vendor names).
+scope** (a later slice). Brand-neutral (external OA / mainstream approval platforms; no vendor names).
+
+---
+
+> **⟨HISTORICAL PROPOSAL — as-written 2026-06-23, superseded by the As-built status above⟩**
+> Everything below this line is the **original design proposal**, kept for rationale. Where it
+> differs from the As-built status, **the As-built status governs.** In particular, DO NOT read
+> these as current guidance:
+> - **(1) Parallel is `joinMode`-only.** §1's "`parallel.joinMode='any'` fail-closed (type says
+>   v1='all')", §2's "parallel → branch list + join target + mode" / "add branch, set join target",
+>   and §4's "a parallel join target that isn't reachable" preview are **NOT as-built** — branch
+>   edgeKeys, `joinNodeKey`, and ALL topology are read-only (G-3 edits `joinMode` only).
+> - **(2) `joinMode='any'` shipped** (not fail-closed) — see the §7/§8c RATIFIED notes.
+> - **(3) A complex graph is load-preserved + save-ENABLED.** The "Current authoring …
+>   `UNSUPPORTED_GRAPH_NODE_TYPES` … save disabled" line below describes the **pre-G-1** state.
+>
+> The runtime / validator / node-model facts below remain accurate.
+
+The original proposal (owner-sequenced via /goal — design-lock first, then a v1 **structured
+editor**, not a free canvas). The approval **runtime** already executes all six node types
+(start / approval / cc / condition / parallel / end) including parallel fork-join; the
+template-authoring UI **was** linear-only and fail-closed (read-only) on any cc / condition /
+parallel node — **the state BEFORE this arc** — which the design unlocked without flattening
+existing complex templates.
 
 Grounded in code (explorer-verified 2026-06-23):
 - Node model — `ApprovalNodeType` (6 types) + `ConditionNodeConfig` / `ParallelNodeConfig` /
@@ -25,7 +42,8 @@ Grounded in code (explorer-verified 2026-06-23):
   (no nested parallel, no cross-branch assignee dupes)** + reachability.
 - Runtime — `ApprovalGraphExecutor` executes ALL six types (condition eval, cc dispatch,
   parallel fork/join state machine). **Runtime is ready; the gap is purely UI.**
-- Current authoring — `templateAuthoring.ts:65` `UNSUPPORTED_GRAPH_NODE_TYPES = {cc, condition,
+- Current authoring **[pre-G-1 state — superseded; complex graphs now load-preserve + save]** —
+  `templateAuthoring.ts:65` `UNSUPPORTED_GRAPH_NODE_TYPES = {cc, condition,
   parallel}`; `unsupportedTemplateAuthoringReason()` opens such templates **read-only** (save
   disabled), tests lock "blocks unsupported constructs instead of flattening".
 
@@ -50,16 +68,19 @@ Grounded in code (explorer-verified 2026-06-23):
   key editing). Legacy `assigneeType`/`assigneeIds` config is shown read-only (the editor
   authors `assigneeSources`).
 - **Still fail-closed (read-only template) in v1:** any construct the structured editor does
-  not yet support — e.g. `parallel.joinMode='any'` (type says v1='all'), nested parallel
+  not yet support — e.g. ~~`parallel.joinMode='any'` (type says v1='all')~~ **[NOT as-built —
+  joinMode='any' shipped in G-3]**, nested parallel
   (the validator rejects it anyway), or a graph shape the structured model can't represent.
   Unsupported ⇒ the template stays viewable read-only, **never flattened** (§3).
 
 ## 2. The editor — structured, NOT a free canvas
 - A **node list** (ordered, with branch nesting shown as indentation/grouping) + a **per-node
-  config panel** (condition → branch/rule rows; parallel → branch list + join target + mode;
+  config panel** (condition → branch/rule rows; parallel → ~~branch list + join target +~~ mode
+  **[as-built: joinMode only — branch list / join target are read-only topology]**;
   cc → target picker reusing the existing approval user/role picker) + a **validation preview**
   (inline errors/warnings before save). No drag canvas, no free edge drawing — topology is
-  expressed through structured controls (add branch, set join target), which the builder turns
+  expressed through structured controls (~~add branch, set join target~~ **[as-built: parallel
+  topology is read-only; only joinMode/condition-rules/cc-targets are editable]**), which the builder turns
   into nodes + edges. This fits TemplateAuthoringView's evolution and is far more testable.
 
 ## 3. Anti-flatten — full-graph round-trip (the keystone)
@@ -79,7 +100,8 @@ Grounded in code (explorer-verified 2026-06-23):
   `normalizeApprovalGraph` stays the **sole arbiter** (node uniqueness, edge integrity, config
   shape, condition edgeKeys, parallel safety, reachability) — the FE never relaxes it.
 - A FE **validation preview** mirrors the high-value checks (dangling edges, a condition branch
-  with no edgeKey, a parallel join target that isn't reachable, an empty assignee) and blocks
+  with no edgeKey, ~~a parallel join target that isn't reachable~~ **[not as-built — parallel
+  topology isn't editable, so no such preview]**, an empty assignee) and blocks
   save with inline messages — UX only; the backend re-validates and is final.
 
 ## 5. Runtime-exists boundary


### PR DESCRIPTION
Owner audit of the shipped complex-graph arc (#3102–#3106) found the canonical design-lock still reads as the **as-written PROPOSED** version — it would mislead the next implementer about what "G complete" means. Docs-only reconciliation to **as-built**:

- **Status** `PROPOSED` → **RATIFIED + SHIPPED** with the five merged-PR SHAs + an as-built scope summary (condition logic + parallel `joinMode` + cc targets; all graph topology read-only). The original proposal prose is kept below the header as history, not authority.
- **§1 / §6** — parallel is **`joinMode`-only** editable; branch edgeKeys + `joinNodeKey` are **topology, preserved read-only** (the proposal implied "parallel branches + join" were editable; the shipped G-3 does not edit topology).
- **§7 / §8c** — **parallel topology editing (branch add/remove) explicitly OUT of scope**; the `joinMode='any'` correction flipped from "pending owner ratification" to **RATIFIED + SHIPPED (#3105)** per the owner audit.

No code/runtime change. Matches the shipped implementation + the TODO tracker. W7 stays gated on a concrete write-back scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)