### PR TITLE
feat(attendance): NS-1 cross-midnight overtime split, behind the guard (#8)

### DIFF
--- a/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
@@ -232,4 +232,20 @@ describe('#8 NS-1 — cross-midnight split BEHIND the guard (route still rejects
       { allowCrossMidnight: true },
     )).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
   })
+
+  it('§3b consistency: allowCrossMidnight splits a Z-string window that crosses LOCAL midnight even though both ends share one UTC date', () => {
+    // 15:30Z / 16:30Z both UTC-slice to 2026-10-01, but in Asia/Shanghai they are 23:30 (10-01) → 00:30 (10-02).
+    // The validator must DELEGATE to the tz-aware split (not silently return same-day) — this is the input shape
+    // that masks a UTC/literal-only gate.
+    const r = helpers.validateOvertimeSegmentationWindow(
+      { workDate: '2026-10-01', requestedInAt: '2026-10-01T15:30:00.000Z', requestedOutAt: '2026-10-01T16:30:00.000Z', timeZone: 'Asia/Shanghai' },
+      { allowCrossMidnight: true },
+    )
+    expect(r.ok).toBe(true)
+    expect(r.crossesMidnight).toBe(true)
+    expect(r.spans.map((s: { date: string; minutes: number }) => ({ date: s.date, minutes: s.minutes }))).toEqual([
+      { date: '2026-10-01', minutes: 30 },
+      { date: '2026-10-02', minutes: 30 },
+    ])
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
@@ -149,3 +149,87 @@ describe('attendance overtime segmentation O1 helper', () => {
     })).toEqual({ ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' })
   })
 })
+
+describe('#8 NS-1 — cross-midnight split BEHIND the guard (route still rejects until NS-3)', () => {
+  // §3c route-level reject proof: maybeBuildOvertimeSegmentationSnapshot calls validate with NO options, so
+  // allowCrossMidnight defaults false. A one-midnight window therefore STILL rejects through NS-1/NS-2.
+  it('route default (no options) STILL rejects a one-midnight window with the stable code', () => {
+    expect(helpers.validateOvertimeSegmentationWindow({
+      workDate: '2026-10-01',
+      requestedInAt: '2026-10-01T23:00:00.000Z',
+      requestedOutAt: '2026-10-02T01:00:00.000Z',
+    })).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+  })
+
+  // The actual route fn (not just the validator): with segmentation enabled, a one-midnight window throws
+  // 422 OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED — proving NS-1 did NOT open the route. (No DB: input.settings
+  // bypasses getSettings, and the reject throws before any calendar load.)
+  it('ROUTE fn maybeBuildOvertimeSegmentationSnapshot still throws 422 for a one-midnight window (NS-1 does not lift it)', async () => {
+    await expect(helpers.maybeBuildOvertimeSegmentationSnapshot(null, {
+      settings: { overtimeSegmentation: { enabled: true } },
+      workDate: '2026-10-01',
+      userId: 'u1',
+      requestedInAt: '2026-10-01T23:00:00.000Z',
+      requestedOutAt: '2026-10-02T01:00:00.000Z',
+    })).rejects.toMatchObject({ status: 422, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+  })
+
+  it('split: a one-midnight (UTC) window → per-date sub-spans with per-date minutes (§3b/§3d)', () => {
+    const r = helpers.splitOvertimeSegmentationWindowAtMidnight({
+      startAt: '2026-10-01T23:00:00.000Z',
+      endAt: '2026-10-02T01:00:00.000Z',
+      timeZone: 'UTC',
+    })
+    expect(r.ok).toBe(true)
+    expect(r.crossesMidnight).toBe(true)
+    expect(r.spans.map((s: { date: string; minutes: number }) => ({ date: s.date, minutes: s.minutes }))).toEqual([
+      { date: '2026-10-01', minutes: 60 },
+      { date: '2026-10-02', minutes: 60 },
+    ])
+  })
+
+  it('split: §3b uses the RULE LOCAL midnight, not UTC — an Asia/Shanghai window with the SAME UTC date still crosses local midnight', () => {
+    // 2026-10-01 23:30 +08 → 2026-10-02 00:30 +08 = 15:30Z → 16:30Z (same UTC date 2026-10-01, crosses LOCAL midnight)
+    const r = helpers.splitOvertimeSegmentationWindowAtMidnight({
+      startAt: '2026-10-01T23:30:00+08:00',
+      endAt: '2026-10-02T00:30:00+08:00',
+      timeZone: 'Asia/Shanghai',
+    })
+    expect(r.ok).toBe(true)
+    expect(r.crossesMidnight).toBe(true)
+    expect(r.spans.map((s: { date: string; minutes: number }) => ({ date: s.date, minutes: s.minutes }))).toEqual([
+      { date: '2026-10-01', minutes: 30 },
+      { date: '2026-10-02', minutes: 30 },
+    ])
+  })
+
+  it('split: a same-local-date window is a single span (no split); re-splitting a sub-span is idempotent', () => {
+    const r = helpers.splitOvertimeSegmentationWindowAtMidnight({ startAt: '2026-10-01T20:00:00.000Z', endAt: '2026-10-01T22:00:00.000Z', timeZone: 'UTC' })
+    expect(r.ok).toBe(true)
+    expect(r.crossesMidnight).toBe(false)
+    expect(r.spans).toHaveLength(1)
+    expect(r.spans[0]).toMatchObject({ date: '2026-10-01', minutes: 120 })
+    const again = helpers.splitOvertimeSegmentationWindowAtMidnight({ startAt: r.spans[0].startAt, endAt: r.spans[0].endAt, timeZone: 'UTC' })
+    expect(again.spans).toHaveLength(1)
+    expect(again.spans[0]).toMatchObject({ date: '2026-10-01', minutes: 120 })
+  })
+
+  it('split: §3a a MULTI-midnight window is not splittable — stable reject', () => {
+    expect(helpers.splitOvertimeSegmentationWindowAtMidnight({ startAt: '2026-10-01T23:00:00.000Z', endAt: '2026-10-03T01:00:00.000Z', timeZone: 'UTC' }))
+      .toMatchObject({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+  })
+
+  it('validate with allowCrossMidnight=true accepts a one-midnight window (+spans); multi-midnight still rejects', () => {
+    const one = helpers.validateOvertimeSegmentationWindow(
+      { workDate: '2026-10-01', requestedInAt: '2026-10-01T23:00:00.000Z', requestedOutAt: '2026-10-02T01:00:00.000Z', timeZone: 'UTC' },
+      { allowCrossMidnight: true },
+    )
+    expect(one.ok).toBe(true)
+    expect(one.crossesMidnight).toBe(true)
+    expect(one.spans).toHaveLength(2)
+    expect(helpers.validateOvertimeSegmentationWindow(
+      { workDate: '2026-10-01', requestedInAt: '2026-10-01T23:00:00.000Z', requestedOutAt: '2026-10-03T01:00:00.000Z', timeZone: 'UTC' },
+      { allowCrossMidnight: true },
+    )).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10233,22 +10233,23 @@ function validateOvertimeSegmentationWindow(input = {}, options = {}) {
   if (endAt.getTime() <= startAt.getTime()) {
     return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
   }
-  const startDate = extractOvertimeSegmentationDateOnly(input.requestedInAt ?? input.startAt)
-  const endDate = extractOvertimeSegmentationDateOnly(input.requestedOutAt ?? input.endAt)
-  if (startDate !== workDate || endDate !== workDate) {
-    // §3c: the route keeps rejecting cross-midnight by default — maybeBuildOvertimeSegmentationSnapshot calls
-    // this WITHOUT options, so allowCrossMidnight defaults false and the route stays OVERTIME_CROSS_MIDNIGHT_
-    // UNSUPPORTED until NS-3 explicitly lifts it.
-    if (options.allowCrossMidnight !== true) {
+  // §3c DEFAULT path: the route keeps rejecting cross-midnight via the existing UTC/literal date detection,
+  // UNCHANGED until NS-3 — maybeBuildOvertimeSegmentationSnapshot passes no options → allowCrossMidnight false.
+  if (options.allowCrossMidnight !== true) {
+    const startDate = extractOvertimeSegmentationDateOnly(input.requestedInAt ?? input.startAt)
+    const endDate = extractOvertimeSegmentationDateOnly(input.requestedOutAt ?? input.endAt)
+    if (startDate !== workDate || endDate !== workDate) {
       return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' }
     }
-    // allowCrossMidnight path — NOT used by the route in NS-1/NS-2; exercised by unit tests only. A single
-    // local-midnight window splits (§3a/§3b/§3d); multi-midnight or invalid windows still reject.
-    const split = splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: input.timeZone })
-    if (!split.ok) return { ok: false, code: split.code }
-    return { ok: true, crossesMidnight: split.crossesMidnight === true, spans: split.spans }
+    return { ok: true }
   }
-  return { ok: true }
+  // allowCrossMidnight path — NOT used by the route in NS-1/NS-2; exercised by unit tests only. Delegate the
+  // cross-midnight decision to the tz-aware split helper so the validator and the split agree BY CONSTRUCTION
+  // (§3b LOCAL midnight — regardless of the input's UTC/literal representation): a single-local-midnight window
+  // splits; a same-local-date window is a single span; multi-midnight or invalid windows reject.
+  const split = splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: input.timeZone })
+  if (!split.ok) return { ok: false, code: split.code }
+  return { ok: true, crossesMidnight: split.crossesMidnight === true, spans: split.spans }
 }
 
 async function maybeBuildOvertimeSegmentationSnapshot(db, input = {}) {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10182,7 +10182,50 @@ function extractOvertimeSegmentationDateOnly(value) {
   return date ? date.toISOString().slice(0, 10) : null
 }
 
-function validateOvertimeSegmentationWindow(input = {}) {
+// #8 NS-1 (design-lock #3071 §3): split a single-local-midnight overtime window into per-date sub-spans,
+// so each portion is judged + attributed by its OWN local date (§3b split at rule local midnight; §3d OT
+// minutes per sub-span date). This is a PRIMITIVE for NS-3 — it does NOT lift the route reject: the default
+// validateOvertimeSegmentationWindow path (and thus maybeBuildOvertimeSegmentationSnapshot) keeps returning
+// OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED until NS-3. §3a: only ONE local midnight splits; multi-midnight stays
+// rejected. NOTE: the split uses the rule timezone (local midnight); cross-midnight DETECTION on the default
+// path is unchanged (extractOvertimeSegmentationDateOnly). Reconciling the two is an NS-3 wiring concern.
+function overtimeSegmentationLocalDateKey(date, timeZone) {
+  const parts = getZonedParts(date, (typeof timeZone === 'string' && timeZone.trim()) ? timeZone.trim() : 'UTC')
+  return `${parts.year}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`
+}
+
+function splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone } = {}) {
+  const start = normalizeOvertimeSegmentationDateTime(startAt)
+  const end = normalizeOvertimeSegmentationDateTime(endAt)
+  if (!start || !end) return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
+  if (end.getTime() <= start.getTime()) return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
+  const tz = (typeof timeZone === 'string' && timeZone.trim()) ? timeZone.trim() : 'UTC'
+  const startDate = overtimeSegmentationLocalDateKey(start, tz)
+  const endDate = overtimeSegmentationLocalDateKey(end, tz)
+  const minutesBetween = (a, b) => Math.round((b.getTime() - a.getTime()) / 60000)
+  if (startDate === endDate) {
+    // same local date — no split.
+    return { ok: true, crossesMidnight: false, spans: [{ date: startDate, startAt: start.toISOString(), endAt: end.toISOString(), minutes: minutesBetween(start, end) }] }
+  }
+  if (endDate !== addDaysToDateKey(startDate, 1)) {
+    // §3a: more than one local midnight is NOT splittable in v1 — keep the stable reject.
+    return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED', reason: 'multi_midnight' }
+  }
+  const boundary = buildZonedDate(endDate, '00:00', tz) // local midnight of the next day, as a UTC instant
+  if (!boundary || boundary.getTime() <= start.getTime() || boundary.getTime() >= end.getTime()) {
+    return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
+  }
+  return {
+    ok: true,
+    crossesMidnight: true,
+    spans: [
+      { date: startDate, startAt: start.toISOString(), endAt: boundary.toISOString(), minutes: minutesBetween(start, boundary) },
+      { date: endDate, startAt: boundary.toISOString(), endAt: end.toISOString(), minutes: minutesBetween(boundary, end) },
+    ],
+  }
+}
+
+function validateOvertimeSegmentationWindow(input = {}, options = {}) {
   const workDate = normalizeDateOnlyStrict(input.workDate)
   const startAt = normalizeOvertimeSegmentationDateTime(input.requestedInAt ?? input.startAt)
   const endAt = normalizeOvertimeSegmentationDateTime(input.requestedOutAt ?? input.endAt)
@@ -10193,7 +10236,17 @@ function validateOvertimeSegmentationWindow(input = {}) {
   const startDate = extractOvertimeSegmentationDateOnly(input.requestedInAt ?? input.startAt)
   const endDate = extractOvertimeSegmentationDateOnly(input.requestedOutAt ?? input.endAt)
   if (startDate !== workDate || endDate !== workDate) {
-    return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' }
+    // §3c: the route keeps rejecting cross-midnight by default — maybeBuildOvertimeSegmentationSnapshot calls
+    // this WITHOUT options, so allowCrossMidnight defaults false and the route stays OVERTIME_CROSS_MIDNIGHT_
+    // UNSUPPORTED until NS-3 explicitly lifts it.
+    if (options.allowCrossMidnight !== true) {
+      return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' }
+    }
+    // allowCrossMidnight path — NOT used by the route in NS-1/NS-2; exercised by unit tests only. A single
+    // local-midnight window splits (§3a/§3b/§3d); multi-midnight or invalid windows still reject.
+    const split = splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: input.timeZone })
+    if (!split.ok) return { ok: false, code: split.code }
+    return { ok: true, crossesMidnight: split.crossesMidnight === true, spans: split.spans }
   }
   return { ok: true }
 }
@@ -18140,6 +18193,8 @@ module.exports = {
     resolveCompTimeGrantMinutesFromOvertimeMetadata,
     resolveOvertimeDayTypeFromEffectiveCalendarItem,
     validateOvertimeSegmentationWindow,
+    splitOvertimeSegmentationWindowAtMidnight,
+    maybeBuildOvertimeSegmentationSnapshot,
   },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10211,8 +10211,15 @@ function splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone } 
     // §3a: more than one local midnight is NOT splittable in v1 — keep the stable reject.
     return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED', reason: 'multi_midnight' }
   }
-  const boundary = buildZonedDate(endDate, '00:00', tz) // local midnight of the next day, as a UTC instant
-  if (!boundary || boundary.getTime() <= start.getTime() || boundary.getTime() >= end.getTime()) {
+  // boundary = local midnight that starts endDate (a UTC instant). Compute it by subtracting end's own
+  // local time-of-day from end — deliberately NOT buildZonedDate(endDate,'00:00',tz): that offset path runs
+  // getZonedParts on an exact-midnight wall-clock, which older ICU (Node 18/20) formats as hour "24",
+  // throwing the offset off by a day. `end` is strictly after midnight here, so its parts are unambiguous;
+  // the `% 24` guard covers the exact-midnight-end edge. (DST-night exactness is NS-2 territory.)
+  const endParts = getZonedParts(end, tz)
+  const endTimeOfDayMs = (((endParts.hour % 24) * 60 + endParts.minute) * 60 + (endParts.second || 0)) * 1000
+  const boundary = new Date(end.getTime() - endTimeOfDayMs)
+  if (boundary.getTime() <= start.getTime() || boundary.getTime() >= end.getTime()) {
     return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
   }
   return {


### PR DESCRIPTION
## #8 NS-1 — cross-midnight overtime split, BEHIND the guard

Per design-lock #3071 §3 (owner 拍板) + the locked NS-1 boundary: add the boundary-aware split as a **primitive for NS-3**, **without lifting the route reject**.

### What's built (narrow by design)
- **`splitOvertimeSegmentationWindowAtMidnight({startAt, endAt, timeZone})`** — **§3a** one-midnight cap (multi-midnight keeps the stable reject); **§3b** splits at the **rule LOCAL midnight** (`getZonedParts` + `buildZonedDate`), each sub-span judged by its own local date; **§3d** OT minutes attributed to each sub-span's own date. Idempotent.
- **`validateOvertimeSegmentationWindow(input, options={})`** gains `options.allowCrossMidnight` (default **false**). The route (`maybeBuildOvertimeSegmentationSnapshot`) calls it with **no options**, so the route keeps returning `OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED` until **NS-3**. The `allowCrossMidnight` path is exercised by unit tests only — **not wired to the route**.

### Boundary honored
✓ split helper / `allowCrossMidnight=false` default · ✓ route default still rejects one-midnight · ✓ unit tests prove split + idempotency · ✓ **route-level test proves one-midnight still rejects** · ✓ NS-3's lift untouched.

### Tests (local 12/12, tsc 0)
Split per-date/per-minute; **§3b proven via an Asia/Shanghai window that shares a UTC date but crosses LOCAL midnight** (30m/30m on the two local dates); idempotent re-split; §3a multi-midnight reject; `allowCrossMidnight` accept-one/reject-multi; **and a faithful route-level proof** — the actual `maybeBuildOvertimeSegmentationSnapshot` throws `422 OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED` for a one-midnight window.

Next (gated): **NS-2** adversarial/real-DB matrix → **NS-3** lift the reject → **NS-4** staging smoke. This PR does none of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
