### PR TITLE
fix(integration): bind table action source workspace scope

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5046,6 +5046,65 @@ async function testTableActionRoutesSupportExplicitBridgeSource() {
   assert.equal(findCalls(mismatch.calls, 'mismatchCreateAdapter').length, 0, 'kind mismatch fails before adapter creation')
 }
 
+async function testTableActionRoutesUseConfiguredSourceWorkspaceScope() {
+  const adapterCalls = []
+  const records = createTableActionRecordsApi()
+  const action = tableActionConfig({
+    source: {
+      externalSystemId: 'plm_sql_source',
+      workspaceId: 'workspace_source',
+    },
+  })
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        if (input.workspaceId !== 'workspace_source') {
+          const error = new Error('external system not found')
+          error.name = 'ExternalSystemNotFoundError'
+          throw error
+        }
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Scoped PLM SQL',
+          kind: 'data-source:sql-readonly',
+          role: 'source',
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', system, deps])
+        adapterCalls.push({ system, deps })
+        return createTableActionSourceAdapter(tableActionPlmData(), calls)
+      },
+    },
+  })
+  const { routes } = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    config: {
+      stockPreparationTableActions: [action],
+    },
+  })
+
+  const res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/dry-run', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    query: { workspaceId: 'wrong_workspace' },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'ready')
+  const lookup = findCall(calls, 'getExternalSystemForAdapter')
+  assert.equal(lookup[1].workspaceId, 'workspace_source', 'action source.workspaceId wins over request query for source lookup')
+  assert.equal(adapterCalls[0].system.workspaceId, 'workspace_source', 'adapter is created with the configured source workspace')
+  assert.equal(adapterCalls[0].deps.principal, 'user_read', 'dry-run source read still runs as the request user')
+  assert.equal(findCalls(calls, 'sourceRead').length > 0, true, 'configured workspace lookup reaches the source adapter')
+}
+
 async function testTableActionTargetPreflightBeforeSourceAdapter() {
   const { calls, services } = createMockServices({
     externalSystemRegistry: {
@@ -5349,6 +5408,7 @@ async function main() {
   await testLargeBomDurableStorageFailureIsValuesFree()
   await testTableActionConflictPolicyRoutes()
   await testTableActionRoutesSupportExplicitBridgeSource()
+  await testTableActionRoutesUseConfiguredSourceWorkspaceScope()
   await testTableActionTargetPreflightBeforeSourceAdapter()
   await testTableActionUnconfiguredFailsClosed()
   await testTemplatePreviewReferenceMappingResolution()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -294,11 +294,13 @@ async function testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun(
   const action = normalizeStockPreparationActionConfig(baseAction({
     source: {
       externalSystemId: 'bridge_source_1',
+      workspaceId: 'workspace_source',
       kind: 'bridge:legacy-sql-readonly',
     },
   }))
 
   assert.equal(action.source.kind, 'bridge:legacy-sql-readonly')
+  assert.equal(action.source.workspaceId, 'workspace_source', 'source workspace binding is preserved for route lookup')
   assert.equal(action.source.readPlan.sourceKind, 'bridge:legacy-sql-readonly', 'omitted readPlan sourceKind inherits the explicit Bridge source kind')
 
   const dryRun = await dryRunStockPreparationAction({

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1430,7 +1430,9 @@ function createHandlers(services, options = {}) {
     const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
       ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
       : externalSystems.getExternalSystem.bind(externalSystems)
-    const system = await loadSystem(scopedInput(req, { id: action.source.externalSystemId }))
+    const sourceScope = { id: action.source.externalSystemId }
+    if (action.source.workspaceId) sourceScope.workspaceId = action.source.workspaceId
+    const system = await loadSystem(scopedInput(req, sourceScope))
     if (!system || system.kind !== action.source.kind) {
       throw new HttpRouteError(422, 'TABLE_ACTION_SOURCE_INVALID', `table action source must be ${action.source.kind}`, {
         actionId: action.actionId,

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -143,6 +143,7 @@ function normalizeSource(input = {}) {
   }
   return {
     externalSystemId: requiredString(input.externalSystemId, 'source.externalSystemId'),
+    workspaceId: optionalString(input.workspaceId) || undefined,
     kind,
     readPlan,
   }
@@ -413,6 +414,7 @@ function buildRevision({ action, parameters, expansion, existingRows, conflictPo
     parameters,
     source: {
       externalSystemId: action.source.externalSystemId,
+      workspaceId: action.source.workspaceId,
       readPlan: action.source.readPlan,
     },
     target: action.target,


### PR DESCRIPTION
## Summary
- preserve optional table-action source.workspaceId through stock-prep action normalization
- use the configured source workspace when loading the action source adapter, before falling back to request query/params
- include source.workspaceId in the dry-run revision hash so source-scope changes invalidate old tokens

## Why
#3093 proved public external-system GET/list could resolve the configured source with workspace scope, while table-action dry-run still failed before adapter creation with EXTERNAL_SYSTEM_NOT_FOUND. The route was still dependent on request scope for source lookup because the action source binding dropped workspaceId.

## Verification
- node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- pnpm --filter plugin-integration-core test
- adversarial sub-agent review: APPROVE, no blocking findings; tenant scope still goes through scopedInput, workspace is server-configured, values-free evidence unchanged

## Boundary
- no sandbox apply authorization
- no production apply authorization
- no external write / K3 Save / Submit / Audit / BOM write
- this only fixes source lookup scope for table-action dry-run/apply/large-BOM paths that share loadTableActionSourceAdapter