### PR TITLE
feat(approval): add common template presets

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -21,10 +21,13 @@ on:
       - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/ccEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
+      - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
+      - 'apps/web/tests/approval-common-template-presets.test.ts'
+      - 'apps/web/tests/approvalTemplateAuthoring.spec.ts'
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
@@ -39,10 +42,13 @@ on:
       - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/ccEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
+      - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
+      - 'apps/web/tests/approval-common-template-presets.test.ts'
+      - 'apps/web/tests/approvalTemplateAuthoring.spec.ts'
       - 'apps/web/tests/approval-detail-field.test.ts'
       - 'apps/web/tests/approval-template-authoring-detail.test.ts'
       - 'apps/web/tests/approval-template-authoring-graph-preserve.test.ts'
@@ -99,8 +105,10 @@ jobs:
         # G-2 condition editor: topology-preserving edit (rule/conjunction/defaultEdgeKey change →
         # only the condition node config changes; all other nodes + edges byte-identical; parallel/cc
         # untouched) + seeding round-trip + validation preview (fieldId / outgoing default edge).
+        # Common-template presets: the first three preset payloads stay linear/editable and the
+        # authoring page button creates a draft through the real createTemplate wrapper, never publish.
         # G-3 parallel editor: topology-preserving joinMode edit (only that parallel node's joinMode
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -283,7 +283,7 @@ jobs:
             tests/integration/data-source-test-ephemeral-realdb.test.ts \
             --reporter=dot
 
-      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk)
+      - name: Run approval real-DB integration (directory endpoints + P1-C field redaction + P1-B add_sign/reduce_sign + direct_manager create/start + A/E/B/D/G cross-lane acceptance + dept_head sync-plumbing carry-forward + continuous_managers chain walk + common template presets)
         # Lane A (directory endpoints) + Lane B (P1-C hidden field redaction) + Lane D (add_sign/reduce_sign). Wired as WHOLE FILE runs so the
         # gate is robust (a name filter that matches zero tests would exit green and hide
         # regressions). The file is describeIfDatabase-guarded + excluded from the no-DB
@@ -304,6 +304,7 @@ jobs:
             tests/integration/approval-delegation-seam.db.test.ts \
             tests/integration/approval-delegation-api.db.test.ts \
             tests/integration/approval-detail-subform.db.test.ts \
+            tests/integration/approval-common-template-presets.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -1,0 +1,249 @@
+import type {
+  ApprovalAssigneeSource,
+  ApprovalGraph,
+  ApprovalMode,
+  CreateApprovalTemplateRequest,
+  EmptyAssigneePolicy,
+  FormField,
+  FormSchema,
+} from '../types/approval'
+
+export type CommonApprovalTemplatePresetId = 'leave' | 'reimbursement' | 'purchase'
+
+export interface CommonApprovalTemplatePreset {
+  id: CommonApprovalTemplatePresetId
+  title: string
+  category: string
+  description: string
+}
+
+export interface BuildCommonApprovalTemplatePresetOptions {
+  /**
+   * Test hook / deterministic import hook. Runtime callers omit it so repeated clicks
+   * create distinct draft keys.
+   */
+  keySuffix?: string
+}
+
+interface CommonApprovalTemplateStep {
+  name: string
+  source: ApprovalAssigneeSource
+  approvalMode?: ApprovalMode
+  emptyAssigneePolicy?: EmptyAssigneePolicy
+}
+
+export const COMMON_APPROVAL_TEMPLATE_PRESETS: CommonApprovalTemplatePreset[] = [
+  {
+    id: 'leave',
+    title: '请假审批',
+    category: '请假',
+    description: '请假类型、起止日期、天数、事由与工作交接人。',
+  },
+  {
+    id: 'reimbursement',
+    title: '报销审批',
+    category: '报销',
+    description: '费用类型、金额、报销明细、事由与逐级审核。',
+  },
+  {
+    id: 'purchase',
+    title: '采购审批',
+    category: '采购',
+    description: '采购类型、供应商、预算负责人、物品明细与逐级审核。',
+  },
+]
+
+function nextPresetKeySuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+}
+
+function field(
+  id: string,
+  type: FormField['type'],
+  label: string,
+  options: Partial<FormField> = {},
+): FormField {
+  return { id, type, label, ...options }
+}
+
+function selectField(id: string, label: string, values: string[], options: Partial<FormField> = {}): FormField {
+  return field(id, 'select', label, {
+    required: true,
+    options: values.map((value) => ({ label: value, value })),
+    ...options,
+  })
+}
+
+function approvalStep(
+  index: number,
+  name: string,
+  source: ApprovalAssigneeSource,
+  options: {
+    approvalMode?: ApprovalMode
+    emptyAssigneePolicy?: EmptyAssigneePolicy
+  } = {},
+): ApprovalGraph['nodes'][number] {
+  return {
+    key: `approval_${index}`,
+    type: 'approval',
+    name,
+    config: {
+      assigneeSources: [source],
+      approvalMode: options.approvalMode ?? 'single',
+      emptyAssigneePolicy: options.emptyAssigneePolicy ?? 'error',
+    },
+  }
+}
+
+function linearGraph(steps: CommonApprovalTemplateStep[]): ApprovalGraph {
+  const nodes: ApprovalGraph['nodes'] = [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    ...steps.map((step, index) => approvalStep(index + 1, step.name, step.source, step)),
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ]
+  const keys = nodes.map((node) => node.key)
+  return {
+    nodes,
+    edges: keys.slice(0, -1).map((source, index) => ({
+      key: `edge-${source}-${keys[index + 1]}`,
+      source,
+      target: keys[index + 1],
+    })),
+  }
+}
+
+function detailField(id: string, label: string, columns: FormField[], minRows = 1): FormField {
+  return field(id, 'detail', label, {
+    required: true,
+    columns,
+    minRows,
+  })
+}
+
+function leaveSchema(): FormSchema {
+  return {
+    fields: [
+      selectField('leave_type', '请假类型', ['年假', '事假', '病假', '调休', '其他']),
+      field('start_date', 'date', '开始日期', { required: true }),
+      field('end_date', 'date', '结束日期', { required: true }),
+      field('leave_days', 'number', '请假天数', {
+        required: true,
+        props: { min: 0.5, step: 0.5 },
+      }),
+      field('reason', 'textarea', '请假事由', { required: true, placeholder: '请填写请假原因' }),
+      field('handover_user', 'user', '工作交接人'),
+    ],
+  }
+}
+
+function reimbursementSchema(): FormSchema {
+  return {
+    fields: [
+      selectField('expense_type', '费用类型', ['差旅', '交通', '餐饮', '办公', '其他']),
+      field('expense_date', 'date', '费用日期', { required: true }),
+      // Preset v1 does not auto-sum detail rows; admins can keep this as the applicant-entered total.
+      field('amount', 'number', '报销金额', {
+        required: true,
+        props: { min: 0 },
+      }),
+      detailField('expense_items', '报销明细', [
+        field('item', 'text', '项目', { required: true }),
+        selectField('category', '类别', ['交通', '住宿', '餐饮', '办公', '其他']),
+        field('amount', 'number', '金额', { required: true, props: { min: 0 } }),
+        field('note', 'text', '备注'),
+      ]),
+      field('reason', 'textarea', '报销说明', { placeholder: '请说明费用用途' }),
+    ],
+  }
+}
+
+function purchaseSchema(): FormSchema {
+  return {
+    fields: [
+      selectField('purchase_type', '采购类型', ['办公用品', '设备', '服务', '软件', '其他']),
+      field('supplier', 'text', '供应商', { required: true }),
+      // Preset v1 does not auto-sum detail rows; admins can keep this as the applicant-entered total.
+      field('amount', 'number', '预算金额', {
+        required: true,
+        props: { min: 0 },
+      }),
+      field('budget_owner', 'user', '预算负责人', { required: true }),
+      detailField('purchase_items', '采购明细', [
+        field('name', 'text', '物品/服务', { required: true }),
+        field('spec', 'text', '规格'),
+        field('quantity', 'number', '数量', { required: true, props: { min: 1 } }),
+        field('unit_price', 'number', '单价', { required: true, props: { min: 0 } }),
+        field('amount', 'number', '小计', { props: { min: 0 } }),
+        field('note', 'text', '备注'),
+      ]),
+      field('reason', 'textarea', '采购说明', { required: true, placeholder: '请说明采购必要性' }),
+    ],
+  }
+}
+
+function presetConfig(id: CommonApprovalTemplatePresetId): {
+  keyPrefix: string
+  name: string
+  description: string
+  category: string
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+} {
+  switch (id) {
+    case 'leave':
+      return {
+        keyPrefix: 'leave-approval',
+        name: '请假审批',
+        description: '常用请假审批草稿。发布前请按组织规则调整审批人。',
+        category: '请假',
+        formSchema: leaveSchema(),
+        approvalGraph: linearGraph([
+          { name: '直属上级审批', source: { kind: 'direct_manager' } },
+          { name: '部门主管审批', source: { kind: 'dept_head' } },
+        ]),
+      }
+    case 'reimbursement':
+      return {
+        keyPrefix: 'reimbursement-approval',
+        name: '报销审批',
+        description: '常用报销审批草稿。发布前请确认费用明细和审批层级。',
+        category: '报销',
+        formSchema: reimbursementSchema(),
+        approvalGraph: linearGraph([
+          { name: '直属上级审批', source: { kind: 'direct_manager' } },
+          { name: '上两级审批', source: { kind: 'manager_at_level', level: 2 } },
+        ]),
+      }
+    case 'purchase':
+      return {
+        keyPrefix: 'purchase-approval',
+        name: '采购审批',
+        description: '常用采购审批草稿。发布前请确认预算负责人和采购明细。',
+        category: '采购',
+        formSchema: purchaseSchema(),
+        approvalGraph: linearGraph([
+          { name: '预算负责人审批', source: { kind: 'form_field_user', fieldId: 'budget_owner' } },
+          { name: '直属上级审批', source: { kind: 'direct_manager' } },
+          { name: '部门主管审批', source: { kind: 'dept_head' } },
+        ]),
+      }
+  }
+}
+
+export function buildCommonApprovalTemplatePresetPayload(
+  id: CommonApprovalTemplatePresetId,
+  options: BuildCommonApprovalTemplatePresetOptions = {},
+): CreateApprovalTemplateRequest {
+  const config = presetConfig(id)
+  const keySuffix = options.keySuffix ?? nextPresetKeySuffix()
+  return {
+    key: `${config.keyPrefix}-${keySuffix}`,
+    name: config.name,
+    description: config.description,
+    category: config.category,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    formSchema: config.formSchema,
+    approvalGraph: config.approvalGraph,
+  }
+}

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -80,6 +80,42 @@
     </el-alert>
 
     <div v-loading="loading" class="template-authoring__body">
+      <el-card
+        v-if="showPresetLibrary"
+        class="template-authoring__panel"
+        shadow="never"
+        data-testid="approval-template-preset-library"
+      >
+        <template #header>
+          <div class="template-authoring__panel-header">
+            <strong>常用审批模板</strong>
+            <span class="template-authoring__hint">创建为草稿，发布前可继续调整字段和审批人。</span>
+          </div>
+        </template>
+        <div class="template-authoring__preset-grid">
+          <div
+            v-for="preset in commonTemplatePresets"
+            :key="preset.id"
+            class="template-authoring__preset"
+          >
+            <div>
+              <strong>{{ preset.title }}</strong>
+              <p>{{ preset.description }}</p>
+            </div>
+            <el-button
+              type="primary"
+              plain
+              :loading="creatingPresetId === preset.id"
+              :disabled="creatingPresetId !== null"
+              :data-testid="`approval-template-preset-${preset.id}`"
+              @click="createFromPreset(preset.id)"
+            >
+              使用模板
+            </el-button>
+          </div>
+        </div>
+      </el-card>
+
       <el-card class="template-authoring__panel" shadow="never">
         <template #header>
           <strong>基本信息</strong>
@@ -773,6 +809,11 @@ import {
   type CcNodeEdit,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
+import {
+  buildCommonApprovalTemplatePresetPayload,
+  COMMON_APPROVAL_TEMPLATE_PRESETS,
+  type CommonApprovalTemplatePresetId,
+} from '../../approvals/commonTemplatePresets'
 import type {
   ApprovalAssigneeSource,
   ApprovalAssigneeType,
@@ -791,6 +832,7 @@ const { canManageTemplates } = useApprovalPermissions()
 const loading = ref(false)
 const saving = ref(false)
 const publishing = ref(false)
+const creatingPresetId = ref<CommonApprovalTemplatePresetId | null>(null)
 const loadError = ref<string | null>(null)
 const validationErrors = ref<string[]>([])
 const unsupportedReason = ref<string | null>(null)
@@ -801,6 +843,8 @@ const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
 
 const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
 const isEditMode = computed(() => templateId.value.length > 0)
+const commonTemplatePresets = COMMON_APPROVAL_TEMPLATE_PRESETS
+const showPresetLibrary = computed(() => !isEditMode.value && canManageTemplates.value)
 // Truly-unsupported (attachment field / unknown node / extra config keys) locks the WHOLE form.
 const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupportedReason.value))
 // A complex graph is shown via the read-only structured node list (`graphPreviewNodes`); the
@@ -1133,6 +1177,25 @@ async function persistDraft() {
   }
 }
 
+async function createFromPreset(presetId: CommonApprovalTemplatePresetId) {
+  if (!canManageTemplates.value || creatingPresetId.value) return
+  creatingPresetId.value = presetId
+  loadError.value = null
+  try {
+    const created = await createTemplate(buildCommonApprovalTemplatePresetPayload(presetId))
+    draft.value = draftFromTemplate(created)
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
+    graphReadOnlyMessage.value = graphReadOnlyReason(created)
+    syncAllStepOptions()
+    await router.replace({ path: `/approval-templates/${created.id}/edit` })
+    ElMessage.success('模板草稿已创建')
+  } catch (error: any) {
+    loadError.value = error?.message ?? '创建常用模板失败'
+  } finally {
+    creatingPresetId.value = null
+  }
+}
+
 async function handleSave() {
   if (!canSave.value || saving.value) return
   const saved = await persistDraft()
@@ -1239,6 +1302,30 @@ onMounted(() => {
 
 .template-authoring__wide {
   grid-column: 1 / -1;
+}
+
+.template-authoring__preset-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.template-authoring__preset {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 148px;
+  padding: 14px;
+  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border-radius: 8px;
+}
+
+.template-authoring__preset p {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--el-text-color-secondary, #606266);
 }
 
 .template-authoring__visibility {
@@ -1358,6 +1445,10 @@ pre {
   }
 
   .template-authoring__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .template-authoring__preset-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalTemplateDetailDTO, CreateApprovalTemplateRequest } from '../src/types/approval'
+import {
+  buildCommonApprovalTemplatePresetPayload,
+  COMMON_APPROVAL_TEMPLATE_PRESETS,
+  type CommonApprovalTemplatePresetId,
+} from '../src/approvals/commonTemplatePresets'
+import {
+  draftFromTemplate,
+  unsupportedTemplateAuthoringReason,
+  validateTemplateDraft,
+} from '../src/approvals/templateAuthoring'
+
+function detailFromPayload(payload: CreateApprovalTemplateRequest): ApprovalTemplateDetailDTO {
+  return {
+    id: `tpl_${payload.key}`,
+    key: payload.key,
+    name: payload.name,
+    description: payload.description ?? null,
+    category: payload.category ?? null,
+    visibilityScope: payload.visibilityScope ?? { type: 'all', ids: [] },
+    slaHours: payload.slaHours ?? null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z',
+    updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: payload.formSchema,
+    approvalGraph: payload.approvalGraph,
+  }
+}
+
+describe('common approval template presets', () => {
+  it('ships the first three business presets as draft creators', () => {
+    expect(COMMON_APPROVAL_TEMPLATE_PRESETS.map((preset) => preset.id)).toEqual([
+      'leave',
+      'reimbursement',
+      'purchase',
+    ])
+  })
+
+  it.each(COMMON_APPROVAL_TEMPLATE_PRESETS.map((preset) => preset.id))(
+    '%s preset creates a linear editable template payload',
+    (presetId) => {
+      const payload = buildCommonApprovalTemplatePresetPayload(presetId as CommonApprovalTemplatePresetId, {
+        keySuffix: 'unit',
+      })
+      const detail = detailFromPayload(payload)
+      const nodeTypes = payload.approvalGraph.nodes.map((node) => node.type)
+
+      expect(payload.key).toMatch(new RegExp(`^${presetId === 'leave' ? 'leave' : presetId}-approval-unit$`))
+      expect(nodeTypes.every((type) => type === 'start' || type === 'approval' || type === 'end')).toBe(true)
+      expect(payload.approvalGraph.edges).toHaveLength(payload.approvalGraph.nodes.length - 1)
+      expect(unsupportedTemplateAuthoringReason(detail)).toBeNull()
+
+      const draft = draftFromTemplate(detail)
+      expect(draft.preservedGraph).toBeUndefined()
+      expect(draft.steps.length).toBeGreaterThan(0)
+      expect(validateTemplateDraft(draft, null)).toEqual([])
+    },
+  )
+
+  it('purchase preset uses the budget owner user field and a detail table without complex graph nodes', () => {
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase', { keySuffix: 'unit' })
+    const budgetOwner = payload.formSchema.fields.find((field) => field.id === 'budget_owner')
+    const detail = payload.formSchema.fields.find((field) => field.id === 'purchase_items')
+    const approvalSources = payload.approvalGraph.nodes
+      .filter((node) => node.type === 'approval')
+      .map((node) => node.config)
+
+    expect(budgetOwner?.type).toBe('user')
+    expect(detail?.type).toBe('detail')
+    expect(detail?.columns?.map((field) => field.id)).toEqual([
+      'name',
+      'spec',
+      'quantity',
+      'unit_price',
+      'amount',
+      'note',
+    ])
+    expect(approvalSources[0]).toMatchObject({
+      assigneeSources: [{ kind: 'form_field_user', fieldId: 'budget_owner' }],
+    })
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable vue/one-component-per-file, vue/require-default-prop */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
@@ -156,6 +157,24 @@ const ElCheckbox = defineComponent({
   },
 })
 
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array },
+  render() {
+    return h('div', {
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+    }, this.$slots.default?.())
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { label: String },
+  render() {
+    return h('div')
+  },
+})
+
 const passthrough = (name: string, tag = 'div') => defineComponent({
   name,
   render() {
@@ -188,6 +207,8 @@ function installStubs(app: VueApp<Element>) {
   app.component('ElOption', ElOption)
   app.component('ElCheckbox', ElCheckbox)
   app.component('ElAlert', ElAlert)
+  app.component('ElTable', ElTable)
+  app.component('ElTableColumn', ElTableColumn)
   app.component('ElCard', passthrough('ElCard', 'section'))
   app.component('ElForm', passthrough('ElForm', 'form'))
   app.component('ElFormItem', passthrough('ElFormItem', 'label'))
@@ -637,6 +658,25 @@ describe('TemplateAuthoringView', () => {
     expect(payload.key).toBe('travel')
     expect(payload.name).toBe('出差审批')
     expect(payload.approvalGraph.nodes.map((node: any) => node.key)).toEqual(['start', 'approval_1', 'end'])
+    expect(replaceSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created/edit' })
+  })
+
+  it('creates a common purchase template as a draft without publishing', async () => {
+    await mountView()
+
+    const button = container!.querySelector('[data-testid="approval-template-preset-purchase"]') as HTMLButtonElement
+    expect(button).not.toBeNull()
+    button.click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    expect(publishTemplateSpy).not.toHaveBeenCalled()
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.key).toMatch(/^purchase-approval-/)
+    expect(payload.name).toBe('采购审批')
+    expect(payload.category).toBe('采购')
+    expect(payload.formSchema.fields.some((field: any) => field.id === 'purchase_items' && field.type === 'detail')).toBe(true)
+    expect(payload.approvalGraph.nodes.filter((node: any) => node.type === 'approval')).toHaveLength(3)
     expect(replaceSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created/edit' })
   })
 

--- a/docs/design/approval-common-template-presets-design-lock-20260623.md
+++ b/docs/design/approval-common-template-presets-design-lock-20260623.md
@@ -1,0 +1,47 @@
+# Common Approval Template Presets — Design Lock
+
+Status: RATIFIED + IMPLEMENTED IN PR
+
+Grounding: origin/main after the detail/sub-form and complex-graph authoring arcs. The approval
+authoring surface can now edit linear approval steps, detail fields, org-derived assignee sources,
+and load-preserve complex graphs. This slice adds a common-template starting point; it does not add
+new runtime semantics.
+
+## Decisions
+
+1. Presets create drafts only.
+
+   Selecting a preset calls the existing template-create API and lands the user in the normal edit
+   page. It never publishes automatically and never bypasses the existing
+   `approval-templates:manage` gate.
+
+2. V1 presets are linear and fully editable.
+
+   The first presets are `leave`, `reimbursement`, and `purchase`. They intentionally use linear
+   approval graphs so the existing authoring UI can edit every approval step. Complex conditional
+   or parallel variants are future presets, not hidden in this first slice.
+
+3. Presets prefer portable assignee sources.
+
+   The shipped presets use existing org-derived/user-field sources such as direct manager,
+   department head, manager-at-level, and form user fields. They do not assume tenant-specific role
+   ids exist.
+
+4. The preset catalog is static product UI, not a new backend catalog.
+
+   No table, migration, seed job, or vendor-specific import is introduced. A future editable/admin
+   preset catalog can be designed separately if needed.
+
+5. No approval-result writeback.
+
+   These presets define approval forms and approval graphs only. They do not unlock W7 or any
+   record/table write-back behavior.
+
+## Verification Contract
+
+- Preset payloads must round-trip through the existing authoring helpers as editable linear drafts.
+- The purchase preset must prove the first user-field approver references an actual `user` field.
+- The mounted authoring page must prove the preset button calls the existing create wrapper and does
+  not call publish.
+- Approval web guard must run the preset tests because the main PR gate does not run web vitest by
+  default.

--- a/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+import {
+  buildCommonApprovalTemplatePresetPayload,
+  COMMON_APPROVAL_TEMPLATE_PRESETS,
+} from '../../../../apps/web/src/approvals/commonTemplatePresets'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQUESTER = `preset-admin-${TS}`
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function authToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  path: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: options.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+  })
+}
+
+describeIfDatabase('common approval template presets — real-DB backend acceptance', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let token = ''
+
+  beforeAll(async () => {
+    expect(await canListenOnEphemeralPort()).toBe(true)
+    await ensureApprovalSchemaReady()
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    if (!address) throw new Error('server did not bind')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    token = await authToken(baseUrl, REQUESTER)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const templateIds = (await pool.query(
+        'SELECT id FROM approval_templates WHERE key LIKE $1',
+        [`%-realdb-${TS}-%`],
+      )).rows.map((row) => row.id as string)
+      if (templateIds.length > 0) {
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [templateIds])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [templateIds])
+      }
+    } catch {
+      // Best-effort cleanup; do not mask the test failure.
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it.each(COMMON_APPROVAL_TEMPLATE_PRESETS)(
+    '$id preset posts through createTemplate and stays draft',
+    async (preset) => {
+      const payload = buildCommonApprovalTemplatePresetPayload(preset.id, {
+        keySuffix: `realdb-${TS}-${preset.id}`,
+      })
+
+      const response = await jsonRequest(baseUrl, '/api/approval-templates', token, {
+        method: 'POST',
+        body: payload,
+      })
+      expect(response.status, await response.clone().text()).toBe(201)
+      const body = await response.json() as {
+        key: string
+        name: string
+        category: string | null
+        status: string
+        formSchema: { fields: Array<{ id: string; type: string }> }
+        approvalGraph: { nodes: Array<{ type: string }> }
+      }
+
+      expect(body.key).toBe(payload.key)
+      expect(body.name).toBe(payload.name)
+      expect(body.category).toBe(payload.category)
+      expect(body.status).toBe('draft')
+      expect(body.formSchema.fields.length).toBe(payload.formSchema.fields.length)
+      expect(body.approvalGraph.nodes.map((node) => node.type)).toEqual(
+        payload.approvalGraph.nodes.map((node) => node.type),
+      )
+    },
+  )
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
+      'tests/integration/approval-common-template-presets.api.test.ts',
       'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',


### PR DESCRIPTION
## Summary

Adds a small common approval template preset library to the existing template authoring page:

- Leave request, reimbursement, and purchase approval presets.
- Presets create draft templates through the existing `createTemplate` path, then route to the normal edit page.
- Presets are linear and fully editable in the current authoring UI; no auto-publish, no backend catalog/migration, and no result write-back.
- Adds a design lock documenting the scope and non-goals.

## Verification

- `pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot` — 155/155
- `pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring --reporter=dot` — 38/38 after the real-DB smoke addition
- `pnpm --filter @metasheet/web exec vue-tsc -b`
- `pnpm --filter @metasheet/web exec eslint src/approvals/commonTemplatePresets.ts src/views/approval/TemplateAuthoringView.vue tests/approval-common-template-presets.test.ts tests/approvalTemplateAuthoring.spec.ts --max-warnings=0`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-common-template-presets.api.test.ts --reporter=dot` — no-DB local skip path; file is wired into the approval real-DB CI lane for actual POST/201 coverage
- `git diff --check`

## Notes

The preset shapes intentionally avoid tenant-specific role ids. They use existing org-derived/user-field assignee sources where possible, so admins can adapt and publish the generated drafts per tenant.

Review follow-up N1 is included: `approval-common-template-presets.api.test.ts` imports the same preset builder and posts each preset through the real backend create-template route, asserting 201 + draft in the Postgres approval integration lane.
