### PR TITLE
feat(multitable): BS-4 UX follow-up — off-page record titles + Advanced copy

### DIFF
--- a/apps/web/src/multitable/components/RestoreBatchDialog.vue
+++ b/apps/web/src/multitable/components/RestoreBatchDialog.vue
@@ -25,6 +25,7 @@
               @keyup.enter="onVersionChange"
             />
           </label>
+          <p v-if="advancedOpen" class="restore-batch__version-hint" data-test="batch-restore-version-hint">{{ l('record.batchRestoreVersionHint') }}</p>
         </div>
 
         <div class="restore-batch__body">
@@ -202,6 +203,11 @@ function onDone(): void {
   padding: 4px 6px;
   border: 1px solid var(--border, #cbd5e1);
   border-radius: 6px;
+}
+.restore-batch__version-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary, #64748b);
 }
 .restore-batch__body {
   padding: 16px;

--- a/apps/web/src/multitable/utils/batch-restore-labels.ts
+++ b/apps/web/src/multitable/utils/batch-restore-labels.ts
@@ -1,0 +1,24 @@
+/**
+ * BS-4 UX follow-up: resolve batch-restore record titles AT SELECTION TIME. A record can only be selected while it
+ * is loaded, so its primary-field value is in the loaded rows when the selection changes. Capturing it then means
+ * the batch-restore dialog can show a real title even if the row later scrolls off or a view reset clears the grid
+ * (off-page resolution) — without any fetch and without touching the restore wire/identity.
+ *
+ * Pure: given the current selection, the loaded rows, the primary field id, and the previously-captured labels,
+ * returns the new label map. A fresh on-page title wins; otherwise a previously-captured title is kept (the record
+ * has since scrolled off / a reset cleared it); otherwise the entry is empty and the caller falls back to the id.
+ */
+export function resolveSelectionLabels(
+  recordIds: string[],
+  rows: ReadonlyArray<{ id: string; data?: Record<string, unknown> }>,
+  primaryFieldId: string | undefined,
+  prev: Record<string, string>,
+): Record<string, string> {
+  const next: Record<string, string> = {}
+  for (const id of recordIds) {
+    const row = rows.find((r) => r.id === id)
+    const fresh = row && primaryFieldId ? row.data?.[primaryFieldId] : undefined
+    next[id] = fresh != null && fresh !== '' ? String(fresh) : (prev[id] ?? '')
+  }
+  return next
+}

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -48,7 +48,7 @@ export type MetaRecordLabelKey =
   | 'record.restorePreviewLoading' | 'record.restorePreviewSet' | 'record.restorePreviewUnset'
   // --- BS-4 scoped (multi-record) batch restore ---
   | 'record.batchRestoreTitle' | 'record.batchRestoreRevertOriginal' | 'record.batchRestoreAdvanced'
-  | 'record.batchRestoreVersionLabel' | 'record.batchRestoreSummaryRestorable' | 'record.batchRestoreSummarySkipped'
+  | 'record.batchRestoreVersionLabel' | 'record.batchRestoreVersionHint' | 'record.batchRestoreSummaryRestorable' | 'record.batchRestoreSummarySkipped'
   | 'record.batchRestoreLoading' | 'record.batchRestoreNoneRestorable' | 'record.batchRestoreConfirm'
   | 'record.batchRestoreCancel' | 'record.batchRestoreDone' | 'record.batchRestoreResultTitle'
   | 'record.batchRestoreRestored'
@@ -134,6 +134,7 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.batchRestoreRevertOriginal': { en: 'Revert selected records to their original version', zh: '将所选记录恢复到初始版本' },
   'record.batchRestoreAdvanced': { en: 'Advanced', zh: '高级' },
   'record.batchRestoreVersionLabel': { en: 'Restore to version', zh: '恢复到版本' },
+  'record.batchRestoreVersionHint': { en: 'Each record is restored to its own version of that number; records without it are skipped.', zh: '每条记录恢复到它自己的该版本号；没有该版本的记录会被跳过。' },
   'record.batchRestoreSummaryRestorable': { en: 'will be restored', zh: '将被恢复' },
   'record.batchRestoreSummarySkipped': { en: 'skipped', zh: '跳过' },
   'record.batchRestoreLoading': { en: 'Previewing…', zh: '预览中…' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -607,6 +607,7 @@ import RestorePreviewDialog from '../components/RestorePreviewDialog.vue'
 import RestoreBatchDialog from '../components/RestoreBatchDialog.vue'
 import type { RestorePreviewChange, RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../api/client'
 import { buildBatchExpectedVersions } from '../utils/batch-restore-expected-versions'
+import { resolveSelectionLabels } from '../utils/batch-restore-labels'
 import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaNotificationBell from '../components/MetaNotificationBell.vue'
@@ -1988,7 +1989,18 @@ const batchRestore = ref<{
   restoredCount: number
 }>({ visible: false, phase: 'preview', loading: false, targetVersion: 1, recordIds: [], records: [], scope: [], restorableCount: 0, skippedCount: 0, executable: false, identity: null, resultRecords: [], restoredCount: 0 })
 
+// Off-page record titles (UX follow-up): a record can only be SELECTED while it is loaded, so its title is in
+// grid.rows AT SELECTION TIME. Capture it then (no fetch, no restore-wire touch) so the label survives the row
+// later scrolling off / a view reset — the batch dialog then shows a real title instead of the bare recordId.
+const gridSelectionLabels = ref<Record<string, string>>({})
+function captureSelectionLabels(recordIds: string[]): void {
+  const pf = grid.visibleFields.value[0] as { id: string } | undefined
+  gridSelectionLabels.value = resolveSelectionLabels(recordIds, grid.rows.value as ReadonlyArray<{ id: string; data?: Record<string, unknown> }>, pf?.id, gridSelectionLabels.value)
+}
 const batchRecordLabel = (recordId: string): string => {
+  const captured = gridSelectionLabels.value[recordId]
+  if (captured) return captured
+  // belt-and-suspenders live lookup (dialog opened without a fresh capture); else the bare id
   const row = grid.rows.value.find((r: { id: string }) => r.id === recordId) as { data?: Record<string, unknown> } | undefined
   const pf = grid.visibleFields.value[0] as { id: string } | undefined
   const val = row && pf ? row.data?.[pf.id] : undefined
@@ -3302,6 +3314,7 @@ const exportInitialFormat = ref<'csv' | 'xlsx'>('xlsx')
 const exportSelectedRecordIds = ref<Set<string>>(new Set())
 function onGridSelectionChange(recordIds: string[]) {
   exportSelectedRecordIds.value = new Set(recordIds)
+  captureSelectionLabels(recordIds) // capture batch-restore titles while the rows are still loaded (off-page resolution)
 }
 
 // --- Export (A2: column/row selection via MetaExportDialog) ---

--- a/apps/web/tests/multitable-restore-batch-dialog.spec.ts
+++ b/apps/web/tests/multitable-restore-batch-dialog.spec.ts
@@ -11,7 +11,25 @@ import { createApp, nextTick } from 'vue'
 
 import RestoreBatchDialog from '../src/multitable/components/RestoreBatchDialog.vue'
 import { buildBatchExpectedVersions } from '../src/multitable/utils/batch-restore-expected-versions'
+import { resolveSelectionLabels } from '../src/multitable/utils/batch-restore-labels'
 import type { RestoreBatchPreviewRecord, RestoreBatchExecuteRecord } from '../src/multitable/api/client'
+
+describe('resolveSelectionLabels — BS-4 off-page title capture', () => {
+  const rows = [{ id: 'A', data: { f1: 'Alpha' } }, { id: 'B', data: { f1: 'Beta' } }]
+  it('captures the primary-field title for loaded (on-page) records', () => {
+    expect(resolveSelectionLabels(['A', 'B'], rows, 'f1', {})).toEqual({ A: 'Alpha', B: 'Beta' })
+  })
+  it('KEEPS a previously-captured title for a record no longer loaded (off-page / post-reset) — the key property', () => {
+    // C is selected but not in the (reset) rows; its title was captured earlier → retained, not lost to the id.
+    expect(resolveSelectionLabels(['A', 'C'], rows, 'f1', { C: 'Gamma' })).toEqual({ A: 'Alpha', C: 'Gamma' })
+  })
+  it('a fresh on-page title OVERRIDES a stale captured one (the live grid wins when loaded)', () => {
+    expect(resolveSelectionLabels(['A'], rows, 'f1', { A: 'OldAlpha' })).toEqual({ A: 'Alpha' })
+  })
+  it('empty (caller falls back to the id) when neither loaded nor previously captured', () => {
+    expect(resolveSelectionLabels(['Z'], rows, 'f1', {})).toEqual({ Z: '' })
+  })
+})
 
 describe('buildBatchExpectedVersions — BS-4 wire-drift guard', () => {
   it('maps ONLY scope records to their previewVersion (skipped records excluded; current version never used)', () => {
@@ -96,6 +114,8 @@ describe('RestoreBatchDialog — BS-4 panel', () => {
     await nextTick()
     const input = q('[data-test="batch-restore-version"]') as HTMLInputElement
     expect(input).toBeTruthy()
+    expect(q('[data-test="batch-restore-version-hint"]')).toBeTruthy() // the per-record version-N semantic is explained
+    expect(document.body.textContent).toContain('its own version') // the clearer copy
     input.value = '3'
     input.dispatchEvent(new Event('change'))
     expect(props.onPreviewVersion).toHaveBeenCalledWith(3)


### PR DESCRIPTION
The tight UX follow-up you scoped — **presentational only, no batch-restore wire/identity** (no fetch, no preview/execute call, no scopeHash). Nothing to re-review on the security front.

**1. Off-page record titles.** A record can only be selected while it's loaded, so its primary-field title is in the grid rows **at selection time**. `captureSelectionLabels` (via the pure `resolveSelectionLabels` helper) records it on every selection-change and **keeps it** if the row later scrolls off or a view reset clears the grid — so the dialog shows a real title instead of the bare `recordId`. **No backend call.**

**2. Advanced version copy.** A hint under the version-N picker: *"each record is restored to its own version of that number; records without it are skipped"* — so the power-user control isn't confusing.

## Verification
`resolveSelectionLabels` pure util + **4 unit tests** (on-page capture · **off-page retention** = the key property · fresh-overrides-stale · empty fallback) + the Advanced-hint dialog assertion. batch-dialog **12/12**; `vue-tsc -b` 0; regression set **52/52** — no restore wire/identity touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)