### PR TITLE
fix(multitable): reconcile orphaned pending rows → pending_not_generated (B-4 truthful-status follow-up to #3097)

### DIFF
--- a/packages/core-backend/src/services/ai-bulk-job-service.ts
+++ b/packages/core-backend/src/services/ai-bulk-job-service.ts
@@ -449,9 +449,12 @@ export const DEFAULT_BULK_JOB_RECONCILE_STALE_MS = 10 * 60 * 1000
  * and the in-process plan registry, so any job still `queued`/`running` has no live
  * worker and can never progress — yet it stays "active" (the BJ-7 partial unique
  * index counts queued/running/suspended), blocking a fresh start for its
- * (actor, sheet, field) until expires_at GC. Flip those orphans to `errored`
- * (header-only, mirroring markErroredIfRunning; already-`generated` rows stay
- * committable).
+ * (actor, sheet, field) until expires_at GC. Flip those orphans to `errored` AND, in
+ * the SAME atomic statement, convert their still-`pending` rows to
+ * `pending_not_generated` so the header and its rows can never disagree. (Leaving rows
+ * in raw `pending` would hide them from the review breakdown — the poll count + FE
+ * buckets only surface `pending_not_generated`, not raw `pending` — violating
+ * truthful-status.) Already-`generated` rows are untouched and stay committable.
  *
  * `suspended` jobs are EXCLUDED — they are intentionally paused awaiting review,
  * not orphaned. The `staleAfterMs` age guard avoids racing a just-claimed job in a
@@ -467,12 +470,26 @@ export async function reconcileOrphanedBulkJobs(
   // Floor at 30s: this is an exported helper, so guard against a misuse that passes
   // a tiny/zero window and would reconcile a just-claimed, still-live job.
   const staleAfterSeconds = Math.max(30, Math.round(staleMs / 1000))
+  // ONE atomic statement: flip stale orphan HEADERS to `errored`, and in the same
+  // statement convert those jobs' still-`pending` ROWS to `pending_not_generated`, so a
+  // reconciled job's header and rows can never disagree. `generated` rows are untouched
+  // (committable); other row states (skipped/failure) are left as-is; `suspended` jobs
+  // are excluded by the header status filter.
   const res = await query(
-    `UPDATE ${AI_BULK_JOB_TABLE}
-        SET status = 'errored', suspend_reason = NULL, updated_at = NOW()
-      WHERE status IN ('queued', 'running')
-        AND updated_at < NOW() - ($1::int * INTERVAL '1 second')
-      RETURNING job_id`,
+    `WITH reconciled AS (
+       UPDATE ${AI_BULK_JOB_TABLE}
+          SET status = 'errored', suspend_reason = NULL, updated_at = NOW()
+        WHERE status IN ('queued', 'running')
+          AND updated_at < NOW() - ($1::int * INTERVAL '1 second')
+        RETURNING job_id
+     ), orphaned_rows AS (
+       UPDATE ${AI_BULK_JOB_ROWS_TABLE}
+          SET state = 'pending_not_generated', updated_at = NOW()
+        WHERE job_id IN (SELECT job_id FROM reconciled)
+          AND state = 'pending'
+        RETURNING 1
+     )
+     SELECT job_id FROM reconciled`,
     [staleAfterSeconds],
   )
   return Array.isArray(res.rows) ? res.rows.length : 0

--- a/packages/core-backend/tests/integration/multitable-ai-bulk-job.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-bulk-job.test.ts
@@ -45,6 +45,7 @@ import {
   cancelBulkJob,
   setHeaderRunning,
   insertBulkJobHeader,
+  insertBulkJobRowsPending,
   reconcileOrphanedBulkJobs,
 } from '../../src/services/ai-bulk-job-service'
 import { QueueServiceImpl } from '../../src/services/QueueService'
@@ -679,6 +680,54 @@ describeIfDatabase('B-4 AI bulk-fill async job (real DB)', () => {
     expect((await dbJobHeader(recentRunning))!.status).toBe('running')
     expect((await dbJobHeader(suspendedOld))!.status).toBe('suspended')
     expect(reconciled).toBeGreaterThanOrEqual(2)
+  })
+
+  test('hard-restart reconcile (TRUTHFUL ROWS): seeded rows → errored; generated stays charged, pending → pending_not_generated, skipped untouched, NO raw pending leaks', async () => {
+    const queryFn = q as unknown as AiUsageQueryFn
+    const jid = `aibulkjob_reconrows_${TS}`
+    await insertBulkJobHeader(queryFn, {
+      jobId: jid,
+      actorId: ACTOR,
+      sheetId: SHEET_ID,
+      fieldId: `${FLD_TARGET}_reconrows`,
+      scopeFingerprint: 'fp_reconrows',
+      total: 3,
+    })
+    // A PARTIAL pre-restart state: 1 generated (charged), 1 still pending (the worker
+    // never reached it), 1 skipped. A hard restart then orphaned the running header.
+    await insertBulkJobRowsPending(queryFn, jid, [
+      { recordId: 'rec_gen', ordinal: 0, state: 'pending', currentValue: 'old' },
+      { recordId: 'rec_pend', ordinal: 1, state: 'pending', currentValue: null },
+      { recordId: 'rec_skip', ordinal: 2, state: 'skipped', currentValue: null, reason: 'skipped_no_perm' },
+    ])
+    await q(
+      `UPDATE ${AI_BULK_JOB_ROWS_TABLE} SET state = 'generated', proposed_value = $2, usage_tokens = 30, cost_usd = 0.01 WHERE job_id = $1 AND record_id = 'rec_gen'`,
+      [jid, 'AI OUT'],
+    )
+    await q(`UPDATE ${AI_BULK_JOB_TABLE} SET status = 'running', updated_at = NOW() - INTERVAL '5 minutes' WHERE job_id = $1`, [jid])
+
+    const reconciled = await reconcileOrphanedBulkJobs(queryFn, { staleAfterMs: 60_000 })
+    expect(reconciled).toBeGreaterThanOrEqual(1)
+
+    // Header reconciled to errored (committable terminal).
+    expect((await dbJobHeader(jid))!.status).toBe('errored')
+
+    // ROWS stay truthful: generated stays generated + charged; the still-pending row is
+    // converted to pending_not_generated (NOT left as raw `pending`, which the poll count +
+    // FE buckets would hide); skipped is untouched.
+    const rows = await dbJobRows(jid)
+    const byId = (rid: string) => rows.find((r) => String(r.record_id) === rid)!
+    expect(byId('rec_gen').state).toBe('generated')
+    expect(Number(byId('rec_gen').usage_tokens)).toBe(30) // still charged
+    expect(byId('rec_gen').proposed_value).toBe('AI OUT')
+    expect(byId('rec_pend').state).toBe('pending_not_generated')
+    expect(byId('rec_skip').state).toBe('skipped')
+    // Truthful-status keystone: NO row is left in raw `pending` (the state the UI hides).
+    expect(rows.filter((r) => r.state === 'pending')).toHaveLength(0)
+
+    // The poll surfaces the converted row in pendingNotGeneratedCount (visible in the FE breakdown).
+    const poll = await pollJob(jid)
+    expect(poll.body.pendingNotGeneratedCount).toBe(1)
   })
 
   // ── DURABILITY KEYSTONE (BJ-9) ─────────────────────────────────────────────


### PR DESCRIPTION
## Follow-up to #3097 — truthful-status gap in hard-restart reconcile

Your REQUEST CHANGES on #3097 landed after auto-merge had already merged it, so this is the follow-up fix.

### The gap (High)
`reconcileOrphanedBulkJobs` flipped the stale orphan **header** to `errored` but left its seeded job-rows in raw `pending`. In a real hard restart the job already has seeded `multitable_ai_bulk_job_rows`; rows the worker never reached stay `pending`. But:
- the poll route reports only `pending_not_generated` (not raw `pending`) — `multitable-ai.ts`,
- the FE buckets render generated/skipped/failure/`pending_not_generated`, not raw `pending` — `useAiBulkFill.ts` / `MetaAiBulkFillDialog.vue`.

So after reconcile those `pending` rows **vanish from the review breakdown** instead of showing as not-generated — violating the truthful-status contract. #3097's golden seeded headers only, so it didn't catch it.

### Fix
`reconcileOrphanedBulkJobs` now flips the header to `errored` **and** converts the reconciled jobs' still-`pending` rows to `pending_not_generated` — in **one atomic CTE statement**, so a reconciled job's header and rows can never disagree:

```sql
WITH reconciled AS (
  UPDATE multitable_ai_bulk_job SET status='errored', suspend_reason=NULL, updated_at=NOW()
   WHERE status IN ('queued','running') AND updated_at < NOW() - ($1 * INTERVAL '1 second')
  RETURNING job_id
), orphaned_rows AS (
  UPDATE multitable_ai_bulk_job_rows SET state='pending_not_generated', updated_at=NOW()
   WHERE job_id IN (SELECT job_id FROM reconciled) AND state='pending'
  RETURNING 1
)
SELECT job_id FROM reconciled
```

`generated` rows are untouched (stay charged + committable); skipped/failure left as-is; `suspended` still excluded; the age guard + 30s floor are unchanged.

### Golden (real DB, seeded ROWS — the coverage #3097 lacked)
A stale orphan with **1 generated (charged) + 1 pending + 1 skipped** → reconcile → header `errored`, generated stays `generated`/charged, pending → `pending_not_generated`, skipped untouched, **no row left in raw `pending`**, and the poll's `pendingNotGeneratedCount` reflects it. 18 job goldens green; `tsc` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)