### PR TITLE
feat(attendance): NS-3 lift cross-midnight reject + wire bucketing into the snapshot (#8)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5879,6 +5879,96 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('加班三段 NS-3 — a one-midnight overtime window is ACCEPTED, bucketed per OWN date, conserved, replay-idempotent; multi-midnight rejects (real DB)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-ns3-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    const createdRequestIds: string[] = []
+    const workDate = '2037-06-12' // June → no DST transition in any tz, so the local-midnight offset is stable
+    const nextDate = '2037-06-13'
+    const farDate = '2037-06-14'
+    const holidayId = randomUUID()
+    let overtimeRuleId: string | undefined
+    // UTC ISO for a local wall-clock in tz (DST-safe here because the dates avoid transitions).
+    const zonedUtcIso = (dateStr: string, timeStr: string, tz: string): string => {
+      const guess = new Date(`${dateStr}T${timeStr}:00.000Z`)
+      const local = new Date(guess.toLocaleString('en-US', { timeZone: tz }))
+      return new Date(guess.getTime() + (guess.getTime() - local.getTime())).toISOString()
+    }
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`)
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+      const ruleRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, { method: 'POST', headers, body: JSON.stringify({ name: `ns3-ot-${runSuffix}`, minMinutes: 0, roundingMinutes: 1 }) })
+      expect([201, 409]).toContain(ruleRes.status)
+      overtimeRuleId = (ruleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      if (!overtimeRuleId) {
+        const listRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, { headers: { Authorization: `Bearer ${token}` } })
+        overtimeRuleId = ((listRes.body as { data?: { items?: { id?: string; name?: string }[] } } | undefined)?.data?.items ?? []).find(i => i.name === `ns3-ot-${runSuffix}`)?.id
+      }
+      if (!overtimeRuleId) return
+
+      // learn the user's work timezone so the window crosses LOCAL midnight regardless of the org default.
+      const calRes = await requestJson(`${baseUrl}/api/attendance/effective-calendar?from=${workDate}&to=${workDate}&userId=${encodeURIComponent(userId)}`, { headers: { Authorization: `Bearer ${token}` } })
+      const tz = ((calRes.body as { data?: { timezone?: string } } | undefined)?.data?.timezone) || 'UTC'
+
+      // holiday on the after-midnight date → its portion must bucket to holiday.
+      await pool.query(`INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin) VALUES ($1, 'default', $2, $3, false, 'national')`, [holidayId, nextDate, `NS3 Holiday ${runSuffix}`])
+      expect((await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ overtimeSegmentation: { enabled: true } }) })).status).toBe(200)
+
+      const createOvertime = async (body: Record<string, unknown>) => {
+        const res = await requestJson(`${baseUrl}/api/attendance/requests`, { method: 'POST', headers, body: JSON.stringify({ workDate, requestType: 'overtime', overtimeRuleId, ...body }) })
+        const id = (res.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+        if (id) createdRequestIds.push(id)
+        return res
+      }
+      const loadSeg = async (id: string) => ((await pool.query('SELECT metadata FROM attendance_requests WHERE id = $1', [id])).rows[0]?.metadata as { overtimeSegmentation?: any })?.overtimeSegmentation
+
+      // (1) one local midnight (workDate 23:00 → nextDate 01:00 local) → accepted + bucketed per own date.
+      const crossRes = await createOvertime({ minutes: 120, requestedInAt: zonedUtcIso(workDate, '23:00', tz), requestedOutAt: zonedUtcIso(nextDate, '01:00', tz) })
+      expect(crossRes.status, crossRes.raw).toBe(201)
+      const crossId = (crossRes.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id as string
+      const seg = await loadSeg(crossId)
+      expect(seg.crossesMidnight).toBe(true)
+      expect(seg.totalMinutes).toBe(120)
+      // conservation: buckets sum to total, no boundary double-count.
+      expect(seg.segments.workdayMinutes + seg.segments.restdayMinutes + seg.segments.holidayMinutes).toBe(120)
+      expect(seg.perDate).toHaveLength(2)
+      expect(seg.perDate.map((p: { date: string }) => p.date)).toEqual([workDate, nextDate])
+      // the after-midnight date is the holiday → 60 min in the holiday bucket, attributed to nextDate.
+      expect(seg.perDate[1]).toMatchObject({ date: nextDate, dayType: 'holiday', minutes: 60 })
+      expect(seg.segments.holidayMinutes).toBe(60)
+
+      // (2) replay idempotency: corrupt the draft snapshot, approve → recomputed identical inside the txn.
+      const before = JSON.stringify(seg)
+      await pool.query(`UPDATE attendance_requests SET metadata = jsonb_set(metadata, '{overtimeSegmentation,segments,holidayMinutes}', '999'::jsonb, true) WHERE id = $1`, [crossId])
+      expect((await requestJson(`${baseUrl}/api/attendance/requests/${crossId}/approve`, { method: 'POST', headers, body: JSON.stringify({ comment: 'approve ns3' }) })).status).toBe(200)
+      expect(JSON.stringify(await loadSeg(crossId))).toBe(before)
+
+      // (3) more than one midnight still rejects with the stable code.
+      const multiRes = await createOvertime({ minutes: 200, requestedInAt: zonedUtcIso(workDate, '23:00', tz), requestedOutAt: zonedUtcIso(farDate, '01:00', tz) })
+      expect(multiRes.status).toBe(422)
+      expect((multiRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED')
+    } finally {
+      if (createdRequestIds.length > 0) {
+        await pool.query('DELETE FROM attendance_events WHERE meta->>\'requestId\' = ANY($1::text[])', [createdRequestIds]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM attendance_holidays WHERE id = $1', [holidayId]).catch(() => undefined)
+      if (overtimeRuleId) await pool.query('DELETE FROM attendance_overtime_rules WHERE id = $1', [overtimeRuleId]).catch(() => undefined)
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('加班三段 O3/O4 — records, report fields, and summary expose approved overtime segment buckets from request snapshots', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5845,19 +5845,26 @@ attendanceIntegrationDescribe(
       })
       expect(metadata.resolution).toMatchObject({ action: 'approve', status: 'approved' })
 
+      // #8 NS-3 lifted the reject: a one-midnight overtime window is now ACCEPTED and bucketed per own date
+      // (was OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED pre-NS-3).
       const crossRes = await createOvertime(crossDate, {
         requestedInAt: `${crossDate}T23:00:00.000Z`,
         requestedOutAt: '2036-10-04T01:00:00.000Z',
       })
-      expect(crossRes.status, crossRes.raw).toBe(422)
-      expect((crossRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED')
-      const crossRows = await pool.query(
-        `SELECT COUNT(*)::int AS count
-         FROM attendance_requests
-         WHERE org_id = 'default' AND user_id = $1 AND work_date = $2 AND request_type = 'overtime'`,
-        [userId, crossDate],
-      )
-      expect(Number(crossRows.rows[0]?.count ?? 0)).toBe(0)
+      expect(crossRes.status, crossRes.raw).toBe(201)
+      const crossId = (crossRes.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id as string
+      expect(crossId).toBeTruthy()
+      const crossSeg = (await loadRequestMetadata(crossId)).overtimeSegmentation as {
+        crossesMidnight?: boolean; totalMinutes?: number
+        segments: { workdayMinutes: number; restdayMinutes: number; holidayMinutes: number }
+        perDate: { date: string; minutes: number }[]
+      }
+      expect(crossSeg.crossesMidnight).toBe(true)
+      expect(crossSeg.totalMinutes).toBe(120)
+      // conserved across the two dates (no boundary double-count) + attributed by own date.
+      expect(crossSeg.segments.workdayMinutes + crossSeg.segments.restdayMinutes + crossSeg.segments.holidayMinutes).toBe(120)
+      expect(crossSeg.perDate.map((p) => p.date)).toEqual([crossDate, '2036-10-04'])
+      expect(crossSeg.perDate.reduce((s, p) => s + p.minutes, 0)).toBe(120)
     } finally {
       if (token && Object.keys(originalSettings).length > 0) {
         await requestJson(`${baseUrl}/api/attendance/settings`, {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5895,6 +5895,8 @@ attendanceIntegrationDescribe(
     const previousRbacBypass = process.env.RBAC_BYPASS
     const pool = new Pool({ connectionString: dbUrl })
     const createdRequestIds: string[] = []
+    let originalSettings: Record<string, unknown> = {}
+    let token: string | undefined
     const workDate = '2037-06-12' // June → no DST transition in any tz, so the local-midnight offset is stable
     const nextDate = '2037-06-13'
     const farDate = '2037-06-14'
@@ -5909,7 +5911,7 @@ attendanceIntegrationDescribe(
     try {
       process.env.RBAC_BYPASS = 'true'
       const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`)
-      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      token = (tokenRes.body as { token?: string } | undefined)?.token
       if (!token) return
       const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
 
@@ -5928,6 +5930,9 @@ attendanceIntegrationDescribe(
 
       // holiday on the after-midnight date → its portion must bucket to holiday.
       await pool.query(`INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin) VALUES ($1, 'default', $2, $3, false, 'national')`, [holidayId, nextDate, `NS3 Holiday ${runSuffix}`])
+      // §P2: snapshot settings so finally can restore them (segmentation is a GLOBAL toggle — don't leak it).
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
       expect((await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ overtimeSegmentation: { enabled: true } }) })).status).toBe(200)
 
       const createOvertime = async (body: Record<string, unknown>) => {
@@ -5964,10 +5969,16 @@ attendanceIntegrationDescribe(
       expect(multiRes.status).toBe(422)
       expect((multiRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED')
     } finally {
+      // §P2: restore the GLOBAL segmentation setting so later tests don't run under enabled=true.
+      if (token && Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      }
       if (createdRequestIds.length > 0) {
         await pool.query('DELETE FROM attendance_events WHERE meta->>\'requestId\' = ANY($1::text[])', [createdRequestIds]).catch(() => undefined)
         await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
       }
+      // §P2: the approve step can write a record for the synthetic user/dates — clean it up.
+      await pool.query('DELETE FROM attendance_records WHERE user_id = $1 AND work_date::text = ANY($2::text[])', [userId, [workDate, nextDate, farDate]]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_holidays WHERE id = $1', [holidayId]).catch(() => undefined)
       if (overtimeRuleId) await pool.query('DELETE FROM attendance_overtime_rules WHERE id = $1', [overtimeRuleId]).catch(() => undefined)
       if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS

--- a/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
@@ -126,22 +126,28 @@ describe('attendance overtime segmentation O1 helper', () => {
     })).toBe(90)
   })
 
-  it('rejects cross-midnight overtime windows with the stable v1 code', () => {
+  it('NS-3: accepts a one-local-midnight window (lifted); same-day stays single-span; reversed still invalid', () => {
+    // same-day → ok, single span, not crossing midnight
     expect(helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
       requestedInAt: '2026-10-01T20:00:00.000Z',
       requestedOutAt: '2026-10-01T22:00:00.000Z',
-    })).toEqual({ ok: true })
+    })).toMatchObject({ ok: true, crossesMidnight: false })
     expect(helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
       requestedInAt: '2026-10-01T00:30:00+08:00',
       requestedOutAt: '2026-10-01T02:00:00+08:00',
-    })).toEqual({ ok: true })
-    expect(helpers.validateOvertimeSegmentationWindow({
+    })).toMatchObject({ ok: true, crossesMidnight: false })
+    // one local midnight → NOW ACCEPTED with per-date spans (pre-NS-3 was OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED)
+    const cross = helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
       requestedInAt: '2026-10-01T23:00:00.000Z',
       requestedOutAt: '2026-10-02T01:00:00.000Z',
-    })).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+    })
+    expect(cross.ok).toBe(true)
+    expect(cross.crossesMidnight).toBe(true)
+    expect(cross.spans).toHaveLength(2)
+    // reversed → still the stable invalid code
     expect(helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
       requestedInAt: '2026-10-01T23:00:00.000Z',
@@ -151,27 +157,18 @@ describe('attendance overtime segmentation O1 helper', () => {
 })
 
 describe('#8 NS-1 — cross-midnight split BEHIND the guard (route still rejects until NS-3)', () => {
-  // §3c route-level reject proof: maybeBuildOvertimeSegmentationSnapshot calls validate with NO options, so
-  // allowCrossMidnight defaults false. A one-midnight window therefore STILL rejects through NS-1/NS-2.
-  it('route default (no options) STILL rejects a one-midnight window with the stable code', () => {
-    expect(helpers.validateOvertimeSegmentationWindow({
+  // #8 NS-3 lifted the reject: the validator (which the route calls) now ACCEPTS a one-local-midnight window
+  // with per-date spans. reversed / multi-midnight keep the stable reject (asserted in the split tests below);
+  // the snapshot-level accept + reject are proven in the real-DB matrix (attendance-plugin.test.ts).
+  it('NS-3: the validator default ACCEPTS a one-midnight window with per-date spans (reject lifted)', () => {
+    const r = helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
       requestedInAt: '2026-10-01T23:00:00.000Z',
       requestedOutAt: '2026-10-02T01:00:00.000Z',
-    })).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
-  })
-
-  // The actual route fn (not just the validator): with segmentation enabled, a one-midnight window throws
-  // 422 OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED — proving NS-1 did NOT open the route. (No DB: input.settings
-  // bypasses getSettings, and the reject throws before any calendar load.)
-  it('ROUTE fn maybeBuildOvertimeSegmentationSnapshot still throws 422 for a one-midnight window (NS-1 does not lift it)', async () => {
-    await expect(helpers.maybeBuildOvertimeSegmentationSnapshot(null, {
-      settings: { overtimeSegmentation: { enabled: true } },
-      workDate: '2026-10-01',
-      userId: 'u1',
-      requestedInAt: '2026-10-01T23:00:00.000Z',
-      requestedOutAt: '2026-10-02T01:00:00.000Z',
-    })).rejects.toMatchObject({ status: 422, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+    })
+    expect(r.ok).toBe(true)
+    expect(r.crossesMidnight).toBe(true)
+    expect(r.spans).toHaveLength(2)
   })
 
   it('split: a one-midnight (UTC) window → per-date sub-spans with per-date minutes (§3b/§3d)', () => {
@@ -330,12 +327,87 @@ describe('#8 NS-2 — adversarial matrix pinning NS-1 split + per-own-date bucke
     expect(JSON.stringify(a)).toBe(JSON.stringify(b))
     expect(a.buckets.workdayMinutes + a.buckets.restdayMinutes + a.buckets.holidayMinutes).toBe(120)
   })
+})
 
-  it('NS-2 does NOT touch the route reject — maybeBuildOvertimeSegmentationSnapshot still throws 422 for one-midnight', async () => {
-    await expect(helpers.maybeBuildOvertimeSegmentationSnapshot(null, {
-      settings: { overtimeSegmentation: { enabled: true } },
-      workDate: '2026-10-01', userId: 'u1',
-      requestedInAt: '2026-10-01T23:00:00.000Z', requestedOutAt: '2026-10-02T01:00:00.000Z',
-    })).rejects.toMatchObject({ status: 422, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
+describe('#8 NS-3 — buildCrossMidnightOvertimeSegmentationSnapshot (rule-once, partition, per-own-date bucket)', () => {
+  const item = (isWorkingDay: boolean, holiday = false) => ({
+    effective: { isWorkingDay },
+    layers: holiday ? [{ kind: 'holiday', isWorkingDay: false, label: 'Holiday' }] : [],
+  })
+  const itemsByDate = (map: Record<string, ReturnType<typeof item>>) => new Map(Object.entries(map))
+  const splitOf = (startAt: string, endAt: string, tz = 'UTC') =>
+    helpers.splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: tz }).spans
+
+  it('partitions the RULE-NORMALIZED total by window weights, last date remainder, per-own-date bucket', () => {
+    const spans = splitOf('2026-10-01T23:00:00.000Z', '2026-10-02T01:00:00.000Z') // 60/60
+    const snap = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 120, overtimeRule: null, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(false) }),
+    })
+    expect(snap.crossesMidnight).toBe(true)
+    expect(snap.totalMinutes).toBe(120)
+    expect(snap.segments).toEqual({ workdayMinutes: 60, restdayMinutes: 60, holidayMinutes: 0 })
+    expect(snap.perDate.map((p: { date: string; dayType: string; minutes: number }) => ({ date: p.date, dayType: p.dayType, minutes: p.minutes }))).toEqual([
+      { date: '2026-10-01', dayType: 'workday', minutes: 60 },
+      { date: '2026-10-02', dayType: 'restday', minutes: 60 },
+    ])
+  })
+
+  it('applies the overtime rule ONCE to the aggregate then partitions (no per-sub-span double rounding)', () => {
+    // rule rounds UP to 60; raw 90 → normalized 120; partition by 60/60 weights → 60/60 (not 60→60 + 30→60).
+    const spans = splitOf('2026-10-01T23:00:00.000Z', '2026-10-02T01:00:00.000Z')
+    const snap = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 90, overtimeRule: { roundingMinutes: 60 }, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(true) }),
+    })
+    expect(snap.totalMinutes).toBe(120)
+    expect(snap.segments.workdayMinutes).toBe(120)
+    expect(snap.perDate[0].minutes + snap.perDate[1].minutes).toBe(120) // conservation
+  })
+
+  it('odd total: last date absorbs the remainder so Σ === total exactly (replay-deterministic)', () => {
+    const spans = splitOf('2026-10-01T23:00:00.000Z', '2026-10-02T01:00:00.000Z') // 60/60 weights
+    const snap = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 121, overtimeRule: null, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(true) }),
+    })
+    expect(snap.perDate[0].minutes).toBe(60) // floor(121*60/120)
+    expect(snap.perDate[1].minutes).toBe(61) // remainder
+    expect(snap.totalMinutes).toBe(121)
+    // idempotent: identical re-run
+    const snap2 = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 121, overtimeRule: null, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(true) }),
+    })
+    expect(JSON.stringify(snap)).toBe(JSON.stringify(snap2))
+  })
+
+  it('holiday-after-midnight buckets to holiday; makeup-workday (both flags) buckets to workday', () => {
+    const spans = splitOf('2026-10-01T23:00:00.000Z', '2026-10-02T01:00:00.000Z')
+    const holiday = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 120, overtimeRule: null, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(false, true) }),
+    })
+    expect(holiday.segments).toEqual({ workdayMinutes: 60, restdayMinutes: 0, holidayMinutes: 60 })
+    const makeup = helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate: '2026-10-01', minutes: 120, overtimeRule: null, spans,
+      itemsByDate: itemsByDate({ '2026-10-01': item(true), '2026-10-02': item(true, true) }),
+    })
+    expect(makeup.segments).toEqual({ workdayMinutes: 120, restdayMinutes: 0, holidayMinutes: 0 })
+  })
+
+  it('fails closed (OVERTIME_SEGMENTATION_UNRESOLVED, 422) if a spanned date has no calendar item', () => {
+    const spans = splitOf('2026-10-01T23:00:00.000Z', '2026-10-02T01:00:00.000Z')
+    let thrown: { status?: number; code?: string } | undefined
+    try {
+      helpers.buildCrossMidnightOvertimeSegmentationSnapshot({
+        workDate: '2026-10-01', minutes: 120, overtimeRule: null, spans,
+        itemsByDate: itemsByDate({ '2026-10-01': item(true) }), // D+1 missing → must NOT silently bucket as restday
+      })
+    } catch (e) {
+      thrown = e as { status?: number; code?: string }
+    }
+    expect(thrown?.status).toBe(422)
+    expect(thrown?.code).toBe('OVERTIME_SEGMENTATION_UNRESOLVED')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-segmentation.test.ts
@@ -135,8 +135,8 @@ describe('attendance overtime segmentation O1 helper', () => {
     })).toMatchObject({ ok: true, crossesMidnight: false })
     expect(helpers.validateOvertimeSegmentationWindow({
       workDate: '2026-10-01',
-      requestedInAt: '2026-10-01T00:30:00+08:00',
-      requestedOutAt: '2026-10-01T02:00:00+08:00',
+      requestedInAt: '2026-10-01T08:00:00.000Z',
+      requestedOutAt: '2026-10-01T10:00:00.000Z',
     })).toMatchObject({ ok: true, crossesMidnight: false })
     // one local midnight → NOW ACCEPTED with per-date spans (pre-NS-3 was OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED)
     const cross = helpers.validateOvertimeSegmentationWindow({
@@ -153,6 +153,13 @@ describe('attendance overtime segmentation O1 helper', () => {
       requestedInAt: '2026-10-01T23:00:00.000Z',
       requestedOutAt: '2026-10-01T22:00:00.000Z',
     })).toEqual({ ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' })
+    // §P1 workDate anchoring: a window whose first local date is NOT workDate (here both ends land on D+1
+    // while workDate=D) is REJECTED — it must not be silently snapshotted onto workDate.
+    expect(helpers.validateOvertimeSegmentationWindow({
+      workDate: '2026-10-01',
+      requestedInAt: '2026-10-02T09:00:00.000Z',
+      requestedOutAt: '2026-10-02T11:00:00.000Z',
+    })).toEqual({ ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' })
   })
 })
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10316,6 +10316,13 @@ function validateOvertimeSegmentationWindow(input = {}) {
   // UTC/literal date compare) so a Z-string that shares a UTC date but crosses local midnight is not masked.
   const split = splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: input.timeZone })
   if (!split.ok) return { ok: false, code: split.code }
+  // #8 NS-3 (owner review §P1): anchor to workDate. The window must START on workDate (a one-midnight window
+  // then naturally spans workDate → next day). A window whose first local date is NOT workDate — e.g. both ends
+  // land on D+1 while workDate=D — is rejected, restoring the anchoring the pre-NS-3 date compare enforced
+  // (else the snapshot's same-day path would attribute an off-workDate window onto workDate).
+  if (split.spans[0]?.date !== workDate) {
+    return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' }
+  }
   return { ok: true, crossesMidnight: split.crossesMidnight === true, spans: split.spans }
 }
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10099,6 +10099,61 @@ function buildOvertimeSegmentationSnapshot(input = {}) {
   }
 }
 
+// #8 NS-3 (design-lock #3071): build the snapshot for a one-local-midnight overtime window. The
+// rule-normalized total is computed ONCE (identical to the same-day path), then partitioned across the
+// per-date window weights — integer math, LAST date gets the remainder so Σ buckets === total exactly
+// (conservation + replay-determinism = "no boundary double-count"). Each date's portion is bucketed by
+// ITS OWN canonical day-type (resolveOvertimeDayTypeFromEffectiveCalendarItem on that date's item; an
+// effective working day wins over a holiday layer — 调休). The rule is NEVER re-applied per sub-span.
+// Fails closed (OVERTIME_SEGMENTATION_UNRESOLVED) if any spanned date's calendar item is missing.
+function buildCrossMidnightOvertimeSegmentationSnapshot(input = {}) {
+  const workDate = normalizeDateOnlyValue(input.workDate)
+  const spans = Array.isArray(input.spans) ? input.spans : []
+  const itemsByDate = input.itemsByDate instanceof Map ? input.itemsByDate : new Map()
+  const total = applyOvertimeRule(
+    normalizeOvertimeSegmentationMinutes(input.minutes),
+    input.overtimeRule ?? null,
+  )
+  const totalWeight = spans.reduce((sum, span) => sum + Math.max(0, Number(span.minutes) || 0), 0)
+  const segments = { workdayMinutes: 0, restdayMinutes: 0, holidayMinutes: 0 }
+  const perDate = []
+  let allocated = 0
+  spans.forEach((span, index) => {
+    const item = itemsByDate.get(span.date)
+    if (!item) {
+      throw new HttpError(422, 'OVERTIME_SEGMENTATION_UNRESOLVED', 'Unable to resolve overtime day type')
+    }
+    const isLast = index === spans.length - 1
+    // last date absorbs the remainder so the partition sums to `total` with no rounding loss.
+    const portion = isLast
+      ? Math.max(0, total - allocated)
+      : (totalWeight > 0 ? Math.floor((total * (Number(span.minutes) || 0)) / totalWeight) : 0)
+    allocated += portion
+    const dayTypeResult = resolveOvertimeDayTypeFromEffectiveCalendarItem(item)
+    const dayType = OVERTIME_DAY_TYPES.has(dayTypeResult.dayType) ? dayTypeResult.dayType : 'restday'
+    if (dayType === 'workday') segments.workdayMinutes += portion
+    else if (dayType === 'holiday') segments.holidayMinutes += portion
+    else segments.restdayMinutes += portion
+    perDate.push({ date: span.date, dayType, minutes: portion, calendar: dayTypeResult.decision })
+  })
+  // Backward-compatible shape: keep dayType/calendar (the primary workDate's) so existing consumers read a
+  // sane summary; add crossesMidnight + perDate for the full per-date breakdown. segments/totalMinutes are
+  // the conserved buckets/total.
+  const primary = perDate[0] ?? { dayType: 'restday', calendar: null }
+  return {
+    version: OVERTIME_SEGMENTATION_VERSION,
+    engine: OVERTIME_SEGMENTATION_ENGINE,
+    workDate,
+    crossesMidnight: true,
+    dayType: primary.dayType,
+    calendar: primary.calendar,
+    perDate,
+    segments,
+    totalMinutes: total,
+    compTimeGrantMinutes: total,
+  }
+}
+
 function createApprovedMinutesEntry() {
   return {
     leaveMinutes: 0,
@@ -10173,22 +10228,12 @@ function normalizeOvertimeSegmentationDateTime(value) {
   return date
 }
 
-function extractOvertimeSegmentationDateOnly(value) {
-  if (typeof value === 'string') {
-    const literalDate = normalizeDateOnlyStrict(value.trim().slice(0, 10))
-    if (literalDate) return literalDate
-  }
-  const date = normalizeOvertimeSegmentationDateTime(value)
-  return date ? date.toISOString().slice(0, 10) : null
-}
-
-// #8 NS-1 (design-lock #3071 §3): split a single-local-midnight overtime window into per-date sub-spans,
-// so each portion is judged + attributed by its OWN local date (§3b split at rule local midnight; §3d OT
-// minutes per sub-span date). This is a PRIMITIVE for NS-3 — it does NOT lift the route reject: the default
-// validateOvertimeSegmentationWindow path (and thus maybeBuildOvertimeSegmentationSnapshot) keeps returning
-// OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED until NS-3. §3a: only ONE local midnight splits; multi-midnight stays
-// rejected. NOTE: the split uses the rule timezone (local midnight); cross-midnight DETECTION on the default
-// path is unchanged (extractOvertimeSegmentationDateOnly). Reconciling the two is an NS-3 wiring concern.
+// #8 NS-1/NS-3 (design-lock #3071 §3): split a single-local-midnight overtime window into per-date sub-spans,
+// so each portion is judged + attributed by its OWN local date (§3b split at the work timezone's local
+// midnight; §3d OT minutes per sub-span date). §3a: only ONE local midnight splits; multi-midnight stays
+// rejected. Since NS-3 this split is the SINGLE source of cross-midnight detection inside
+// validateOvertimeSegmentationWindow (the old UTC/literal date compare is gone), so a Z-string that shares a
+// UTC date but crosses local midnight is not masked.
 function overtimeSegmentationLocalDateKey(date, timeZone) {
   const parts = getZonedParts(date, (typeof timeZone === 'string' && timeZone.trim()) ? timeZone.trim() : 'UTC')
   return `${parts.year}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`
@@ -10256,7 +10301,7 @@ function bucketOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone, 
   return { ok: true, crossesMidnight: split.crossesMidnight === true, perDate, buckets }
 }
 
-function validateOvertimeSegmentationWindow(input = {}, options = {}) {
+function validateOvertimeSegmentationWindow(input = {}) {
   const workDate = normalizeDateOnlyStrict(input.workDate)
   const startAt = normalizeOvertimeSegmentationDateTime(input.requestedInAt ?? input.startAt)
   const endAt = normalizeOvertimeSegmentationDateTime(input.requestedOutAt ?? input.endAt)
@@ -10264,20 +10309,11 @@ function validateOvertimeSegmentationWindow(input = {}, options = {}) {
   if (endAt.getTime() <= startAt.getTime()) {
     return { ok: false, code: 'OVERTIME_INVALID_TIME_WINDOW' }
   }
-  // §3c DEFAULT path: the route keeps rejecting cross-midnight via the existing UTC/literal date detection,
-  // UNCHANGED until NS-3 — maybeBuildOvertimeSegmentationSnapshot passes no options → allowCrossMidnight false.
-  if (options.allowCrossMidnight !== true) {
-    const startDate = extractOvertimeSegmentationDateOnly(input.requestedInAt ?? input.startAt)
-    const endDate = extractOvertimeSegmentationDateOnly(input.requestedOutAt ?? input.endAt)
-    if (startDate !== workDate || endDate !== workDate) {
-      return { ok: false, code: 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED' }
-    }
-    return { ok: true }
-  }
-  // allowCrossMidnight path — NOT used by the route in NS-1/NS-2; exercised by unit tests only. Delegate the
-  // cross-midnight decision to the tz-aware split helper so the validator and the split agree BY CONSTRUCTION
-  // (§3b LOCAL midnight — regardless of the input's UTC/literal representation): a single-local-midnight window
-  // splits; a same-local-date window is a single span; multi-midnight or invalid windows reject.
+  // #8 NS-3: the cross-midnight reject is LIFTED. The tz-aware split is the single source of truth — a window
+  // crossing exactly one LOCAL midnight (§3b) is ACCEPTED and returns per-date spans; reversed and
+  // multi-midnight windows keep the stable reject code; a same-local-date window returns one span (the
+  // snapshot then takes the byte-identical same-day path). Detection is delegated to the split (NOT the old
+  // UTC/literal date compare) so a Z-string that shares a UTC date but crosses local midnight is not masked.
   const split = splitOvertimeSegmentationWindowAtMidnight({ startAt, endAt, timeZone: input.timeZone })
   if (!split.ok) return { ok: false, code: split.code }
   return { ok: true, crossesMidnight: split.crossesMidnight === true, spans: split.spans }
@@ -10291,28 +10327,17 @@ async function maybeBuildOvertimeSegmentationSnapshot(db, input = {}) {
   const workDate = normalizeDateOnlyValue(input.workDate)
   if (!workDate || !input.userId) return null
 
-  const windowValidation = validateOvertimeSegmentationWindow({
-    workDate,
-    requestedInAt: input.requestedInAt,
-    requestedOutAt: input.requestedOutAt,
-  })
-  if (!windowValidation.ok) {
-    throw new HttpError(
-      422,
-      windowValidation.code,
-      windowValidation.code === 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED'
-        ? 'Cross-midnight overtime is not supported in v1'
-        : 'Invalid overtime time window',
-    )
-  }
-
+  // #8 NS-3: load workDate AND the next local date so a one-midnight window can bucket each date by its OWN
+  // calendar. resolveEffectiveCalendar also yields the work timezone for the split's local-midnight. A
+  // same-local-date window uses only the workDate item → byte-identical to the pre-#8 snapshot.
+  const nextDate = addDaysToDateKey(workDate, 1) ?? workDate
   let calendar
   try {
     calendar = await resolveEffectiveCalendar(db, {
       orgId: input.orgId,
       userId: input.userId,
       from: workDate,
-      to: workDate,
+      to: nextDate,
     })
   } catch (error) {
     if (isDatabaseSchemaError(error)) {
@@ -10320,11 +10345,45 @@ async function maybeBuildOvertimeSegmentationSnapshot(db, input = {}) {
     }
     throw error
   }
-  const effectiveCalendarItem = Array.isArray(calendar?.items) ? calendar.items[0] : null
+  const itemsByDate = new Map()
+  for (const item of (Array.isArray(calendar?.items) ? calendar.items : [])) {
+    const key = item && item.date ? String(item.date).slice(0, 10) : null
+    if (key) itemsByDate.set(key, item)
+  }
+
+  // #8 NS-3: one local midnight is now ACCEPTED; reversed / multi-midnight keep the stable reject code. The
+  // split uses the work timezone so detection matches the calendar's own local dates.
+  const windowValidation = validateOvertimeSegmentationWindow({
+    workDate,
+    requestedInAt: input.requestedInAt,
+    requestedOutAt: input.requestedOutAt,
+    timeZone: calendar?.timezone,
+  })
+  if (!windowValidation.ok) {
+    throw new HttpError(
+      422,
+      windowValidation.code,
+      windowValidation.code === 'OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED'
+        ? 'Cross-midnight overtime spanning more than one midnight is not supported'
+        : 'Invalid overtime time window',
+    )
+  }
+
+  if (windowValidation.crossesMidnight === true) {
+    return buildCrossMidnightOvertimeSegmentationSnapshot({
+      workDate,
+      minutes: input.minutes,
+      overtimeRule: input.overtimeRule ?? null,
+      spans: windowValidation.spans,
+      itemsByDate,
+    })
+  }
+
+  // same-local-date — byte-identical to the pre-#8 path: only the workDate item, the unchanged builder.
+  const effectiveCalendarItem = itemsByDate.get(workDate)
   if (!effectiveCalendarItem) {
     throw new HttpError(422, 'OVERTIME_SEGMENTATION_UNRESOLVED', 'Unable to resolve overtime day type')
   }
-
   return buildOvertimeSegmentationSnapshot({
     workDate,
     minutes: input.minutes,
@@ -18222,6 +18281,7 @@ module.exports = {
     OVERTIME_SEGMENTATION_ENGINE,
     OVERTIME_SEGMENTATION_VERSION,
     buildOvertimeSegmentationSnapshot,
+    buildCrossMidnightOvertimeSegmentationSnapshot,
     resolveCompTimeGrantMinutesFromOvertimeMetadata,
     resolveOvertimeDayTypeFromEffectiveCalendarItem,
     validateOvertimeSegmentationWindow,


### PR DESCRIPTION
## #8 NS-3 — lift the cross-midnight reject + wire bucketing into the snapshot

Per the owner's go (3 items): the route now **accepts** a one-local-midnight overtime window; reversed/multi-midnight keep the stable reject; NS-2 bucketing is wired into the **actual snapshot**; real-DB + replay matrix added; the old test-locks flip reject→accept. **NS-4/TA-4 staging are not in this PR.**

### Build (advisor recipe)
- **`validateOvertimeSegmentationWindow`** — the tz-aware split is now the **single source** of cross-midnight detection (the old UTC/literal compare is gone, so a Z-string sharing a UTC date but crossing local midnight is no longer masked). One local midnight → `ok` + per-date spans; reversed/multi-midnight → stable reject. Removed the orphaned `extractOvertimeSegmentationDateOnly`.
- **`maybeBuildOvertimeSegmentationSnapshot`** — loads `workDate` + the next local date (and the work timezone) once; **same-local-date → the UNCHANGED `buildOvertimeSegmentationSnapshot` (byte-identical)**; cross-midnight → the new builder.
- **`buildCrossMidnightOvertimeSegmentationSnapshot`** — rule-normalize the total **once** (identical to same-day), then **partition** across per-date window weights — integer, **last date gets the remainder** so `Σ buckets === total` (conservation + replay-determinism). Each date bucketed by its **own** canonical day-type (workday wins over a holiday layer — 调休). **Never** re-applies the rule per sub-span. **Fails closed** (`OVERTIME_SEGMENTATION_UNRESOLVED`) if any spanned date's calendar item is missing.

### Tests
- **Unit 25/25** — partition/rule-once/last-remainder/conservation, holiday-vs-makeup-workday precedence, fail-closed, and the flipped accept locks (`:144` + the NS-1 default).
- **Real-DB + replay matrix** — a one-midnight overtime request is accepted, bucketed per own date (after-midnight holiday portion = 60), conserved; corrupt-then-approve recomputes byte-identical; multi-midnight → 422. Learns the work tz so the window crosses **local** midnight regardless of the org default.

### Watch-items (NS-3 doc reconciliation, recorded for follow-up)
The `classifyDate` contract is converged onto `resolveOvertimeDayTypeFromEffectiveCalendarItem` (one day-type model). Same-day byte-identical is guaranteed by routing same-day to the untouched builder + the existing O2/O3/O4 real-DB tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
