### PR TITLE
feat(approval): edit approval nodes in complex graphs

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -34,6 +34,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -55,6 +56,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -111,4 +113,6 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot
+        # G-4 cc editor + G-5 approval-node editor: config-only edits preserve every edge and every
+        # untouched node byte-identical; unsupported approval-node config fails closed.
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit --reporter=dot

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -1,0 +1,254 @@
+import type {
+  ApprovalAssigneeSource,
+  ApprovalGraph,
+  ApprovalMode,
+  ApprovalNode,
+  ApprovalNodeConfig,
+  AutoApprovalPolicy,
+  EmptyAssigneePolicy,
+  FormSchema,
+} from '../types/approval'
+
+// G-5 — approval node editing inside a preserved complex graph. This is config-only:
+// assignee source, approvalMode, emptyAssigneePolicy, and mergeWithRequester. Node keys, node
+// order, and every edge remain topology and are preserved byte-for-byte.
+
+export type ApprovalNodeSourceKind = ApprovalAssigneeSource['kind']
+
+export interface ApprovalNodeEdit {
+  nodeKey: string
+  name: string
+  sourceKind: ApprovalNodeSourceKind
+  idsText: string
+  fieldId: string
+  levels: number
+  level: number
+  approvalMode: ApprovalMode
+  emptyAssigneePolicy: EmptyAssigneePolicy
+  mergeWithRequester: boolean
+  originalAutoApprovalPolicy?: AutoApprovalPolicy
+}
+
+export type ApprovalNodeEdits = Record<string, ApprovalNodeEdit>
+
+export const APPROVAL_NODE_SOURCE_KINDS: readonly ApprovalNodeSourceKind[] = [
+  'static_user',
+  'static_role',
+  'requester',
+  'direct_manager',
+  'dept_head',
+  'continuous_managers',
+  'manager_at_level',
+  'form_field_user',
+] as const
+
+const APPROVAL_NODE_SOURCE_KIND_SET = new Set<string>(APPROVAL_NODE_SOURCE_KINDS)
+const APPROVAL_MODES: readonly ApprovalMode[] = ['single', 'all', 'any'] as const
+const APPROVAL_MODE_SET = new Set<string>(APPROVAL_MODES)
+const EMPTY_ASSIGNEE_POLICIES: readonly EmptyAssigneePolicy[] = ['error', 'auto-approve'] as const
+const EMPTY_ASSIGNEE_POLICY_SET = new Set<string>(EMPTY_ASSIGNEE_POLICIES)
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function parseIdsText(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,，]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+function formatIds(ids?: string[]): string {
+  return (ids ?? []).join(', ')
+}
+
+export function isApprovalNodeSourceKind(value: unknown): value is ApprovalNodeSourceKind {
+  return typeof value === 'string' && APPROVAL_NODE_SOURCE_KIND_SET.has(value)
+}
+
+function sourceFromConfig(config: ApprovalNodeConfig): ApprovalAssigneeSource | undefined {
+  return Array.isArray(config.assigneeSources)
+    ? config.assigneeSources[0] as ApprovalAssigneeSource | undefined
+    : undefined
+}
+
+function editFromApprovalNode(node: ApprovalNode, index: number): ApprovalNodeEdit | null {
+  if (node.type !== 'approval') return null
+  const config = node.config as ApprovalNodeConfig
+  const source = sourceFromConfig(config)
+  if (!source || !isApprovalNodeSourceKind(source.kind)) return null
+
+  let idsText = ''
+  let fieldId = ''
+  let levels = 2
+  let level = 1
+  if (source.kind === 'static_user') {
+    idsText = formatIds(source.userIds)
+  } else if (source.kind === 'static_role') {
+    idsText = formatIds(source.roleIds)
+  } else if (source.kind === 'form_field_user') {
+    fieldId = source.fieldId
+  } else if (source.kind === 'continuous_managers') {
+    levels = source.levels
+  } else if (source.kind === 'manager_at_level') {
+    level = source.level
+  }
+
+  const autoApprovalPolicy = config.autoApprovalPolicy
+  return {
+    nodeKey: node.key,
+    name: node.name ?? `审批节点 ${index + 1}`,
+    sourceKind: source.kind,
+    idsText,
+    fieldId,
+    levels,
+    level,
+    approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
+    emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
+    mergeWithRequester: autoApprovalPolicy?.mergeWithRequester === true,
+    ...(autoApprovalPolicy ? { originalAutoApprovalPolicy: cloneJson(autoApprovalPolicy) } : {}),
+  }
+}
+
+export function approvalNodeEditsFromGraph(graph: ApprovalGraph | undefined): ApprovalNodeEdits {
+  const edits: ApprovalNodeEdits = {}
+  if (!graph) return edits
+  graph.nodes.forEach((node, index) => {
+    const edit = editFromApprovalNode(node, index)
+    if (edit) edits[node.key] = edit
+  })
+  return edits
+}
+
+function sourceFromEdit(edit: ApprovalNodeEdit): ApprovalAssigneeSource {
+  if (edit.sourceKind === 'static_user') {
+    return { kind: 'static_user', userIds: parseIdsText(edit.idsText) }
+  }
+  if (edit.sourceKind === 'static_role') {
+    return { kind: 'static_role', roleIds: parseIdsText(edit.idsText) }
+  }
+  if (edit.sourceKind === 'form_field_user') {
+    return { kind: 'form_field_user', fieldId: edit.fieldId.trim() }
+  }
+  if (edit.sourceKind === 'direct_manager') {
+    return { kind: 'direct_manager' }
+  }
+  if (edit.sourceKind === 'dept_head') {
+    return { kind: 'dept_head' }
+  }
+  if (edit.sourceKind === 'continuous_managers') {
+    return { kind: 'continuous_managers', levels: edit.levels }
+  }
+  if (edit.sourceKind === 'manager_at_level') {
+    return { kind: 'manager_at_level', level: edit.level }
+  }
+  return { kind: 'requester' }
+}
+
+function buildApprovalNodeConfig(original: ApprovalNodeConfig, edit: ApprovalNodeEdit): ApprovalNodeConfig {
+  const autoApprovalPolicy: AutoApprovalPolicy = {
+    ...cloneJson(edit.originalAutoApprovalPolicy ?? {}),
+    ...(edit.mergeWithRequester ? { mergeWithRequester: true } : {}),
+  }
+  if (!edit.mergeWithRequester) {
+    delete autoApprovalPolicy.mergeWithRequester
+  }
+  const config: ApprovalNodeConfig = {
+    ...cloneJson(original),
+    assigneeSources: [sourceFromEdit(edit)],
+    approvalMode: edit.approvalMode,
+    emptyAssigneePolicy: edit.emptyAssigneePolicy,
+  }
+  delete config.assigneeType
+  delete config.assigneeIds
+  if (Object.keys(autoApprovalPolicy).length > 0) {
+    config.autoApprovalPolicy = autoApprovalPolicy
+  } else {
+    delete config.autoApprovalPolicy
+  }
+  return config
+}
+
+export function applyApprovalNodeEditsToGraph(
+  graph: ApprovalGraph,
+  edits: ApprovalNodeEdits,
+): ApprovalGraph {
+  const nodes: ApprovalNode[] = graph.nodes.map((node) => {
+    if (node.type !== 'approval') return cloneJson(node)
+    const edit = edits[node.key]
+    if (!edit) return cloneJson(node)
+    return {
+      ...cloneJson(node),
+      config: buildApprovalNodeConfig(node.config as ApprovalNodeConfig, edit),
+    }
+  })
+  return {
+    nodes,
+    edges: graph.edges.map((edge) => cloneJson(edge)),
+  }
+}
+
+export function validateApprovalNodeEdits(edits: ApprovalNodeEdits, formSchema: FormSchema): string[] {
+  const errors: string[] = []
+  const userFieldIds = new Set(
+    formSchema.fields
+      .filter((field) => field.type === 'user')
+      .map((field) => field.id),
+  )
+  for (const edit of Object.values(edits)) {
+    const label = edit.name.trim() || edit.nodeKey
+    if (!isApprovalNodeSourceKind(edit.sourceKind)) {
+      errors.push(`审批节点 ${label} 的审批人来源无效`)
+    }
+    if (!APPROVAL_MODE_SET.has(edit.approvalMode)) {
+      errors.push(`审批节点 ${label} 的审批模式无效`)
+    }
+    if (!EMPTY_ASSIGNEE_POLICY_SET.has(edit.emptyAssigneePolicy)) {
+      errors.push(`审批节点 ${label} 的空审批人策略无效`)
+    }
+    if ((edit.sourceKind === 'static_user' || edit.sourceKind === 'static_role') && parseIdsText(edit.idsText).length === 0) {
+      errors.push(`审批节点 ${label} 需要填写用户/角色 id`)
+    }
+    if (edit.sourceKind === 'form_field_user' && !userFieldIds.has(edit.fieldId.trim())) {
+      errors.push(`审批节点 ${label} 的表单用户字段无效`)
+    }
+    if (edit.sourceKind === 'continuous_managers' && (!Number.isInteger(edit.levels) || edit.levels < 1 || edit.levels > 10)) {
+      errors.push(`审批节点 ${label} 的连续上级层级数必须在 1 到 10 之间`)
+    }
+    if (edit.sourceKind === 'manager_at_level' && (!Number.isInteger(edit.level) || edit.level < 1 || edit.level > 10)) {
+      errors.push(`审批节点 ${label} 的指定上级层级必须在 1 到 10 之间`)
+    }
+  }
+  return errors
+}
+
+export function unsupportedComplexApprovalNodeConfigReason(graph: ApprovalGraph): string | null {
+  const allowedConfigKeys = new Set([
+    'assigneeSources',
+    'approvalMode',
+    'emptyAssigneePolicy',
+    'autoApprovalPolicy',
+    'fieldPermissions',
+  ])
+  for (const node of graph.nodes) {
+    if (node.type !== 'approval') continue
+    const config = node.config as ApprovalNodeConfig
+    const configKeys = Object.keys(config as Record<string, unknown>)
+    if (configKeys.some((key) => !allowedConfigKeys.has(key))) {
+      return `审批节点含暂不支持的配置：${node.name || node.key}`
+    }
+    if (!Array.isArray(config.assigneeSources) || config.assigneeSources.length !== 1) {
+      return `审批节点含暂不支持的审批人来源：${node.name || node.key}`
+    }
+    const source = config.assigneeSources[0]
+    if (!isApprovalNodeSourceKind(source?.kind)) {
+      return `审批节点含暂不支持的审批人来源：${node.name || node.key}`
+    }
+  }
+  return null
+}

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -40,6 +40,13 @@ import {
   validateCcEdits,
   type CcEdits,
 } from './ccEdit'
+import {
+  applyApprovalNodeEditsToGraph,
+  approvalNodeEditsFromGraph,
+  unsupportedComplexApprovalNodeConfigReason,
+  validateApprovalNodeEdits,
+  type ApprovalNodeEdits,
+} from './approvalNodeEdit'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
@@ -55,6 +62,8 @@ export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
 export { PARALLEL_JOIN_MODES } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
+export type { ApprovalNodeEdits, ApprovalNodeEdit } from './approvalNodeEdit'
+export { APPROVAL_NODE_SOURCE_KINDS } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -165,6 +174,11 @@ export interface TemplateAuthoringDraft {
   // G-4 cc editor: editable targetType/targetIds for each `cc` node in `preservedGraph`, seeded
   // 1:1. Topology (edges) + every non-cc node stay byte-identical. Empty {} when no cc node.
   ccEdits?: CcEdits
+  // G-5 approval-node editor: editable approval config for each approval node in a preserved graph.
+  // It mutates ONLY assignee source / approvalMode / emptyAssigneePolicy / mergeWithRequester on
+  // that approval node. `fieldPermissions` and other preserved siblings remain intact; every
+  // non-edited node and every edge stay byte-identical.
+  approvalNodeEdits?: ApprovalNodeEdits
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -485,11 +499,11 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     return `包含暂不支持编辑的审批节点：${unknownNode.name || unknownNode.key} (${unknownNode.type})`
   }
 
-  // Complex graphs (cc/condition/parallel or non-linear) are load-preserved verbatim — the linear
-  // `steps` projection (and its per-approval-node config allowlist below) does NOT apply, so they
-  // are never "unsupported" here. They open read-only via `graphReadOnlyReason` and save unchanged.
+  // Complex graphs (cc/condition/parallel or non-linear) are load-preserved and partially editable.
+  // G-5 opens approval-node config editing inside that graph, so approval nodes whose config cannot
+  // be represented by the structured editor must fail closed rather than being flattened.
   if (isComplexApprovalGraph(template.approvalGraph)) {
-    return null
+    return unsupportedComplexApprovalNodeConfigReason(template.approvalGraph)
   }
 
   const ordered = orderedLinearNodes(template.approvalGraph)
@@ -539,7 +553,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
 export function graphReadOnlyReason(template: ApprovalTemplateDetailDTO): string | null {
   if (unsupportedTemplateAuthoringReason(template)) return null
   if (!isComplexApprovalGraph(template.approvalGraph)) return null
-  return '该审批流程包含复杂节点：条件分支可在下方编辑分支规则，并行 / 抄送节点以只读结构展示；未改动的节点与连线在保存时原样保留，不会被改写。'
+  return '该审批流程包含复杂节点：可编辑条件分支规则、并行汇聚模式、抄送对象和审批节点配置；未改动的节点与连线在保存时原样保留，不会被改写。'
 }
 
 export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
@@ -579,6 +593,7 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
           // Empty {} when the complex graph has no parallel node (condition/cc-only).
           parallelEdits: parallelEditsFromGraph(template.approvalGraph),
           ccEdits: ccEditsFromGraph(template.approvalGraph),
+          approvalNodeEdits: approvalNodeEditsFromGraph(template.approvalGraph),
         }
       : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
@@ -690,18 +705,16 @@ function buildStepConfig(step: ApprovalStepDraft): ApprovalNodeConfig {
 }
 
 export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
-  // G-1/G-2/G-3 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`, so
-  // its cc/condition/parallel nodes/edges survive save. Two disjoint edit passes COMPOSE onto a COPY
-  // of the graph: G-2 (`applyConditionEditsToGraph`) replaces ONLY each condition node's config, G-3
-  // (`applyParallelEditsToGraph`) replaces ONLY each parallel node's `joinMode`, and G-4
-  // (`applyCcEditsToGraph`) replaces ONLY each cc node's targetType/targetIds. The three passes touch
-  // disjoint node types and each deep-clones everything else, so all edits land while every other
-  // node + ALL edges stay byte-identical; an untouched graph round-trips unchanged.
+  // G-1..G-5 anti-flatten keystone: a preserved complex graph is NEVER rebuilt from `steps`.
+  // Disjoint edit passes COMPOSE onto a COPY of the graph: condition logic, parallel joinMode, cc
+  // targets, and approval-node config. Each pass touches only its node type and deep-clones
+  // everything else, so all topology and every untouched node remain byte-identical.
   // Only linear drafts take the build below.
   if (draft.preservedGraph) {
     const withConditionEdits = applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
     const withParallelEdits = applyParallelEditsToGraph(withConditionEdits, draft.parallelEdits ?? {})
-    return applyCcEditsToGraph(withParallelEdits, draft.ccEdits ?? {})
+    const withCcEdits = applyCcEditsToGraph(withParallelEdits, draft.ccEdits ?? {})
+    return applyApprovalNodeEditsToGraph(withCcEdits, draft.approvalNodeEdits ?? {})
   }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
@@ -835,6 +848,9 @@ export function validateTemplateDraft(
   }
   if (draft.ccEdits && Object.keys(draft.ccEdits).length > 0) {
     errors.push(...validateCcEdits(draft.ccEdits))
+  }
+  if (draft.approvalNodeEdits && Object.keys(draft.approvalNodeEdits).length > 0) {
+    errors.push(...validateApprovalNodeEdits(draft.approvalNodeEdits, buildFormSchema(draft)))
   }
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -7,7 +7,7 @@
       </el-button>
       <div>
         <h1>{{ isEditMode ? '编辑审批模板' : '新建审批模板' }}</h1>
-        <p>面向模板管理员的线性审批模板编辑器</p>
+        <p>面向模板管理员的审批模板编辑器</p>
       </div>
       <div class="template-authoring__actions">
         <el-button
@@ -50,13 +50,13 @@
       data-testid="approval-template-unsupported-alert"
     />
 
-    <!-- G-1..G-4: a complex graph is preserved, not unsupported — informational, save stays enabled.
-         G-2 condition rules, G-3 parallel joinMode, and G-4 cc targets are all editable; branches /
-         join target / all edges are preserved topology. -->
+    <!-- G-1..G-5: a complex graph is preserved, not unsupported — informational, save stays
+         enabled. G-2 condition rules, G-3 parallel joinMode, G-4 cc targets, and G-5 approval-node
+         config are editable; branches / join target / all edges are preserved topology. -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象。分支拓扑与连线在保存时原样保留。"
+      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象，审批节点可编辑审批人来源与策略。分支拓扑与连线在保存时原样保留。"
       type="info"
       show-icon
       :closable="false"
@@ -405,10 +405,9 @@
           </div>
         </template>
 
-        <!-- G-1/G-2: structured render of a preserved complex graph. condition nodes are EDITABLE
-             (G-2 — branch rules / conjunction / default edge); parallel / cc / approval stay
-             READ-ONLY summaries (G-3 / G-4), and every non-condition node + all edges are preserved
-             byte-for-byte on save. Nothing renders as a bare "unsupported". -->
+        <!-- G-1..G-5: structured render of a preserved complex graph. condition / parallel / cc /
+             approval-node config are editable in place; topology (node keys, edges, branch edgeKeys,
+             join target) stays byte-for-byte preserved. Nothing renders as a bare "unsupported". -->
         <div v-if="graphReadOnly" data-testid="approval-graph-readonly-list">
           <div
             v-for="node in graphPreviewNodes"
@@ -535,6 +534,160 @@
               </el-form-item>
             </div>
 
+            <!-- G-5: editable approval node config. Node key/order and all edges are topology;
+                 config siblings such as fieldPermissions are preserved by the builder. -->
+            <div
+              v-else-if="node.type === 'approval' && approvalNodeEditFor(node.key)"
+              class="template-authoring__approval-node"
+              data-testid="approval-node-editor"
+              :data-approval-node="node.key"
+            >
+              <div class="template-authoring__grid">
+                <el-form-item label="审批人来源">
+                  <el-select
+                    v-model="approvalNodeEditFor(node.key)!.sourceKind"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    data-testid="approval-node-source-kind"
+                    @change="syncApprovalNodeOptions(approvalNodeEditFor(node.key)!)"
+                  >
+                    <el-option label="指定用户" value="static_user" />
+                    <el-option label="指定角色" value="static_role" />
+                    <el-option label="发起人" value="requester" />
+                    <el-option label="直属上级" value="direct_manager" />
+                    <el-option label="部门主管" value="dept_head" />
+                    <el-option label="连续多级上级" value="continuous_managers" />
+                    <el-option label="指定层级上级" value="manager_at_level" />
+                    <el-option label="表单用户字段" value="form_field_user" />
+                  </el-select>
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'continuous_managers'" label="上级层级数">
+                  <el-input-number
+                    v-model="approvalNodeEditFor(node.key)!.levels"
+                    :min="1"
+                    :max="10"
+                    :step="1"
+                    size="small"
+                    :disabled="readOnly"
+                    data-testid="approval-node-levels"
+                  />
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'manager_at_level'" label="指定上级层级">
+                  <el-input-number
+                    v-model="approvalNodeEditFor(node.key)!.level"
+                    :min="1"
+                    :max="10"
+                    :step="1"
+                    size="small"
+                    :disabled="readOnly"
+                    data-testid="approval-node-level"
+                  />
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'static_user'" label="选择用户">
+                  <el-select
+                    :model-value="approvalNodeIds(approvalNodeEditFor(node.key)!)"
+                    multiple
+                    filterable
+                    remote
+                    :remote-method="onUserSearch"
+                    :loading="directory.usersLoading.value"
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    placeholder="搜索用户名 / 邮箱 / ID"
+                    data-testid="approval-node-user-picker"
+                    @update:model-value="(ids: string[]) => setApprovalNodeIds(approvalNodeEditFor(node.key)!, ids)"
+                    @visible-change="(visible: boolean) => visible && onUserSearch('')"
+                  >
+                    <el-option
+                      v-for="user in directory.users.value"
+                      :key="user.id"
+                      :label="directory.formatUserLabel(user)"
+                      :value="user.id"
+                    />
+                  </el-select>
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'static_role'" label="选择角色">
+                  <el-select
+                    :model-value="approvalNodeIds(approvalNodeEditFor(node.key)!)"
+                    multiple
+                    filterable
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    placeholder="选择角色"
+                    data-testid="approval-node-role-picker"
+                    @update:model-value="(ids: string[]) => setApprovalNodeIds(approvalNodeEditFor(node.key)!, ids)"
+                  >
+                    <el-option
+                      v-for="role in directory.roles.value"
+                      :key="role.id"
+                      :label="directory.formatRoleLabel(role)"
+                      :value="role.id"
+                    />
+                  </el-select>
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'static_user' || approvalNodeEditFor(node.key)!.sourceKind === 'static_role'" label="手动输入 ID（高级）">
+                  <el-input
+                    v-model="approvalNodeEditFor(node.key)!.idsText"
+                    size="small"
+                    :disabled="readOnly"
+                    placeholder="逗号或换行分隔"
+                    data-testid="approval-node-ids-text"
+                  />
+                </el-form-item>
+                <el-form-item v-if="approvalNodeEditFor(node.key)!.sourceKind === 'form_field_user'" label="表单用户字段">
+                  <el-select
+                    v-model="approvalNodeEditFor(node.key)!.fieldId"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    data-testid="approval-node-form-field"
+                  >
+                    <el-option
+                      v-for="field in userFields"
+                      :key="field.id"
+                      :label="`${field.label} (${field.id})`"
+                      :value="field.id"
+                    />
+                  </el-select>
+                </el-form-item>
+                <el-form-item label="审批模式">
+                  <el-select
+                    v-model="approvalNodeEditFor(node.key)!.approvalMode"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    data-testid="approval-node-approval-mode"
+                  >
+                    <el-option label="单人通过" value="single" />
+                    <el-option label="全部通过" value="all" />
+                    <el-option label="任一通过" value="any" />
+                  </el-select>
+                </el-form-item>
+                <el-form-item label="空审批人策略">
+                  <el-select
+                    v-model="approvalNodeEditFor(node.key)!.emptyAssigneePolicy"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 100%"
+                    data-testid="approval-node-empty-policy"
+                  >
+                    <el-option label="报错" value="error" />
+                    <el-option label="自动通过" value="auto-approve" />
+                  </el-select>
+                </el-form-item>
+                <el-form-item label="自审策略">
+                  <el-checkbox
+                    v-model="approvalNodeEditFor(node.key)!.mergeWithRequester"
+                    :disabled="readOnly"
+                    data-testid="approval-node-merge-with-requester"
+                  >
+                    发起人自动通过（自审合并）
+                  </el-checkbox>
+                </el-form-item>
+              </div>
+            </div>
+
             <!-- G-3: editable parallel node — `joinMode` ONLY (会签 all / 或签 any, both
                  backend-accepted). `branches` (fork edges) + `joinNodeKey` are TOPOLOGY: shown
                  read-only, preserved byte-for-byte on save. -->
@@ -607,7 +760,7 @@
               </el-form-item>
             </div>
 
-            <!-- approval / other — read-only summary (G-4: cc is editable above). -->
+            <!-- approval fallback / other: summary only. Editable approval nodes render above. -->
             <template v-else>
               <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
                 <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
@@ -800,6 +953,7 @@ import {
   PARALLEL_JOIN_MODES,
   CC_TARGET_TYPES,
   type ApprovalStepDraft,
+  type ApprovalNodeEdit,
   type ConditionBranchEdit,
   type ConditionNodeEdit,
   type ConditionRuleEdit,
@@ -836,8 +990,9 @@ const creatingPresetId = ref<CommonApprovalTemplatePresetId | null>(null)
 const loadError = ref<string | null>(null)
 const validationErrors = ref<string[]>([])
 const unsupportedReason = ref<string | null>(null)
-// G-1: a COMPLEX (condition/parallel/cc/non-linear) graph renders read-only but is NOT
-// unsupported — the form/metadata stay editable and save preserves the graph verbatim.
+// G-1..G-5: a COMPLEX (condition/parallel/cc/non-linear) graph renders through the structured
+// graph surface, not the linear steps editor. The form/metadata stay editable and save preserves
+// untouched topology verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
 
@@ -847,13 +1002,13 @@ const commonTemplatePresets = COMMON_APPROVAL_TEMPLATE_PRESETS
 const showPresetLibrary = computed(() => !isEditMode.value && canManageTemplates.value)
 // Truly-unsupported (attachment field / unknown node / extra config keys) locks the WHOLE form.
 const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupportedReason.value))
-// A complex graph is shown via the read-only structured node list (`graphPreviewNodes`); the
-// linear steps editor is hidden. The graph is preserved on save, so this does NOT disable save.
+// A complex graph is shown via the structured node list (`graphPreviewNodes`); the linear steps
+// editor is hidden. The graph is preserved on save, so this does NOT disable save.
 const graphReadOnly = computed(() => Boolean(graphReadOnlyMessage.value))
 const canSave = computed(() => canManageTemplates.value && !unsupportedReason.value && !loading.value)
 
-// G-1 read-only structured render of a preserved complex graph: a per-node summary of the
-// config the v1 editor doesn't yet author, so authors can SEE the flow they're preserving.
+// G-1 structured render of a preserved complex graph: a per-node summary plus the editable
+// config panels added in later G slices.
 const graphPreviewNodes = computed<ApprovalNode[]>(() => draft.value.preservedGraph?.nodes ?? [])
 
 const NODE_TYPE_LABELS: Record<string, string> = {
@@ -882,8 +1037,8 @@ function assigneeSourceSummary(source: ApprovalAssigneeSource): string {
   }
 }
 
-// One read-only descriptor per node config, covering ALL three complex types (condition / parallel
-// / cc) plus approval — so no type silently renders as "unsupported". Returns `[]` for nodes
+// One descriptor per node config, covering ALL three complex types (condition / parallel / cc)
+// plus approval — so no type silently renders as "unsupported". Returns `[]` for nodes
 // without summarisable config (start/end).
 function nodeConfigSummary(node: ApprovalNode): string[] {
   const config = node.config as Record<string, unknown>
@@ -1004,6 +1159,11 @@ function ccTargetTypeLabel(targetType: ApprovalAssigneeType): string {
   return targetType === 'role' ? '角色' : '用户'
 }
 
+// ── G-5 approval node editor (config-only; graph topology preserved) ──────────────────────────
+function approvalNodeEditFor(nodeKey: string): ApprovalNodeEdit | undefined {
+  return draft.value.approvalNodeEdits?.[nodeKey]
+}
+
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
 const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
 const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
@@ -1021,12 +1181,24 @@ function setStepIds(step: ApprovalStepDraft, ids: string[]): void {
   step.idsText = ids.join(', ')
 }
 
+function approvalNodeIds(edit: ApprovalNodeEdit): string[] {
+  return parseIdsText(edit.idsText)
+}
+
+function setApprovalNodeIds(edit: ApprovalNodeEdit, ids: string[]): void {
+  edit.idsText = ids.join(', ')
+}
+
 async function onUserSearch(query: string): Promise<void> {
   await directory.searchUsers(query)
   // Keep already-selected ids visible as chips even if the new search page omits them.
   for (const step of draft.value.steps) {
     if (step.sourceKind !== 'static_user') continue
     for (const id of parseIdsText(step.idsText)) directory.ensureUserOptionVisible(id)
+  }
+  for (const edit of Object.values(draft.value.approvalNodeEdits ?? {})) {
+    if (edit.sourceKind !== 'static_user') continue
+    for (const id of parseIdsText(edit.idsText)) directory.ensureUserOptionVisible(id)
   }
 }
 
@@ -1040,8 +1212,17 @@ function syncStepOptions(step: ApprovalStepDraft): void {
   }
 }
 
+function syncApprovalNodeOptions(edit: ApprovalNodeEdit): void {
+  if (edit.sourceKind === 'static_user') {
+    for (const id of parseIdsText(edit.idsText)) directory.ensureUserOptionVisible(id)
+  } else if (edit.sourceKind === 'static_role') {
+    for (const id of parseIdsText(edit.idsText)) directory.ensureRoleOptionVisible(id)
+  }
+}
+
 function syncAllStepOptions(): void {
   for (const step of draft.value.steps) syncStepOptions(step)
+  for (const edit of Object.values(draft.value.approvalNodeEdits ?? {})) syncApprovalNodeOptions(edit)
 }
 
 function clearErrors() {

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  unsupportedTemplateAuthoringReason,
+  validateTemplateDraft,
+} from '../src/approvals/templateAuthoring'
+import {
+  applyApprovalNodeEditsToGraph,
+  approvalNodeEditsFromGraph,
+  validateApprovalNodeEdits,
+} from '../src/approvals/approvalNodeEdit'
+
+// G-5 — approval node editing inside a preserved complex graph. PURE-LOGIC tests (no .vue /
+// Element Plus) so they run under approval-web-guard. The gate is topology preservation: editing one
+// approval node changes only that node's editable config; every condition/parallel/cc node, every
+// non-edited approval node, and the full edge list remain byte-identical.
+
+function buildTemplate(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'amount_tier',
+    name: '金额分级审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-24T00:00:00Z',
+    updatedAt: '2026-06-24T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        { id: 'budget_owner', type: 'user', label: '预算负责人' },
+      ],
+    },
+    approvalGraph,
+  }
+}
+
+const COMPLEX_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'cond_1',
+      type: 'condition',
+      name: '金额判断',
+      config: {
+        branches: [{ edgeKey: 'edge-cond-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }], conjunction: 'and' }],
+        defaultEdgeKey: 'edge-cond-low',
+      },
+    },
+    {
+      key: 'approval_high',
+      type: 'approval',
+      name: '高额审批',
+      config: {
+        assigneeSources: [{ kind: 'manager_at_level', level: 2 }],
+        approvalMode: 'single',
+        emptyAssigneePolicy: 'error',
+        autoApprovalPolicy: { mergeWithRequester: true, mergeAdjacentApprover: true },
+        fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+      },
+    },
+    {
+      key: 'approval_low',
+      type: 'approval',
+      name: '普通审批',
+      config: {
+        assigneeSources: [{ kind: 'direct_manager' }],
+        approvalMode: 'single',
+        emptyAssigneePolicy: 'auto-approve',
+      },
+    },
+    { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+    {
+      key: 'fork_1',
+      type: 'parallel',
+      name: '并行',
+      config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'join_1' },
+    },
+    { key: 'join_1', type: 'approval', name: '汇聚', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-cond', source: 'start', target: 'cond_1' },
+    { key: 'edge-cond-high', source: 'cond_1', target: 'approval_high' },
+    { key: 'edge-cond-low', source: 'cond_1', target: 'approval_low' },
+    { key: 'edge-approval-high-cc', source: 'approval_high', target: 'cc_1' },
+    { key: 'edge-cc-fork', source: 'cc_1', target: 'fork_1' },
+    { key: 'edge-fork-a', source: 'fork_1', target: 'approval_low' },
+    { key: 'edge-fork-b', source: 'fork_1', target: 'join_1' },
+    { key: 'edge-approval-low-join', source: 'approval_low', target: 'join_1' },
+    { key: 'edge-join-end', source: 'join_1', target: 'end' },
+  ],
+}
+
+const clone = (graph: ApprovalGraph): ApprovalGraph => JSON.parse(JSON.stringify(graph))
+
+function nonEditedApprovalNodes(graph: ApprovalGraph, editedKey: string): ApprovalGraph['nodes'] {
+  return graph.nodes.filter((node) => node.type !== 'approval' || node.key !== editedKey)
+}
+
+describe('G-5 approvalNodeEditsFromGraph', () => {
+  it('seeds one edit per approval node with source and policy fields', () => {
+    const edits = approvalNodeEditsFromGraph(COMPLEX_GRAPH)
+    expect(Object.keys(edits)).toEqual(['approval_high', 'approval_low', 'join_1'])
+    expect(edits.approval_high.sourceKind).toBe('manager_at_level')
+    expect(edits.approval_high.level).toBe(2)
+    expect(edits.approval_high.mergeWithRequester).toBe(true)
+    expect(edits.approval_low.emptyAssigneePolicy).toBe('auto-approve')
+  })
+})
+
+describe('G-5 untouched round-trip', () => {
+  it('keeps a complex graph byte-identical when approval node edits are untouched', () => {
+    const original = clone(COMPLEX_GRAPH)
+    expect(buildApprovalGraph(draftFromTemplate(buildTemplate(COMPLEX_GRAPH)))).toEqual(original)
+  })
+})
+
+describe('G-5 topology preservation', () => {
+  it('editing one approval source changes only that approval node config; every edge and other node is byte-identical', () => {
+    const original = clone(COMPLEX_GRAPH)
+    const draft = draftFromTemplate(buildTemplate(COMPLEX_GRAPH))
+    draft.approvalNodeEdits!.approval_high.sourceKind = 'static_role'
+    draft.approvalNodeEdits!.approval_high.idsText = 'finance, cfo'
+    draft.approvalNodeEdits!.approval_high.approvalMode = 'all'
+    draft.approvalNodeEdits!.approval_high.emptyAssigneePolicy = 'auto-approve'
+    const rebuilt = buildApprovalGraph(draft)
+
+    expect(nonEditedApprovalNodes(rebuilt, 'approval_high')).toEqual(nonEditedApprovalNodes(original, 'approval_high'))
+    expect(rebuilt.edges).toEqual(original.edges)
+    expect(rebuilt.nodes.map((node) => node.key)).toEqual(original.nodes.map((node) => node.key))
+    expect(rebuilt.nodes.find((node) => node.key === 'approval_high')!.config).toEqual({
+      assigneeSources: [{ kind: 'static_role', roleIds: ['finance', 'cfo'] }],
+      approvalMode: 'all',
+      emptyAssigneePolicy: 'auto-approve',
+      autoApprovalPolicy: { mergeWithRequester: true, mergeAdjacentApprover: true },
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
+  })
+
+  it('preserves config siblings while the mergeWithRequester toggle owns only that flag', () => {
+    const draft = draftFromTemplate(buildTemplate(COMPLEX_GRAPH))
+    draft.approvalNodeEdits!.approval_high.sourceKind = 'static_user'
+    draft.approvalNodeEdits!.approval_high.idsText = 'u2'
+    draft.approvalNodeEdits!.approval_high.mergeWithRequester = false
+    const rebuilt = buildApprovalGraph(draft)
+    expect(rebuilt.nodes.find((node) => node.key === 'approval_high')!.config).toEqual({
+      assigneeSources: [{ kind: 'static_user', userIds: ['u2'] }],
+      approvalMode: 'single',
+      emptyAssigneePolicy: 'error',
+      autoApprovalPolicy: { mergeAdjacentApprover: true },
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
+  })
+
+  it('applyApprovalNodeEditsToGraph does not mutate the input graph', () => {
+    const before = clone(COMPLEX_GRAPH)
+    const edits = approvalNodeEditsFromGraph(COMPLEX_GRAPH)
+    edits.approval_high.sourceKind = 'requester'
+    applyApprovalNodeEditsToGraph(COMPLEX_GRAPH, edits)
+    expect(COMPLEX_GRAPH).toEqual(before)
+  })
+})
+
+describe('G-5 preview validation', () => {
+  it('requires static user/role ids and valid form_field_user field ids', () => {
+    const edits = approvalNodeEditsFromGraph(COMPLEX_GRAPH)
+    edits.approval_high.sourceKind = 'static_user'
+    edits.approval_high.idsText = ''
+    edits.approval_low.sourceKind = 'form_field_user'
+    edits.approval_low.fieldId = 'amount'
+    const errors = validateApprovalNodeEdits(edits, buildTemplate(COMPLEX_GRAPH).formSchema)
+    expect(errors.some((error) => /需要填写用户\/角色 id/.test(error))).toBe(true)
+    expect(errors.some((error) => /表单用户字段无效/.test(error))).toBe(true)
+  })
+
+  it('surfaces approval-node preview errors through validateTemplateDraft', () => {
+    const draft = draftFromTemplate(buildTemplate(COMPLEX_GRAPH))
+    draft.approvalNodeEdits!.approval_high.sourceKind = 'form_field_user'
+    draft.approvalNodeEdits!.approval_high.fieldId = 'amount'
+    expect(validateTemplateDraft(draft).some((error) => /表单用户字段无效/.test(error))).toBe(true)
+  })
+})
+
+describe('G-5 fail-closed boundary', () => {
+  it('keeps a complex graph editable when approval node fieldPermissions are representable and preserved', () => {
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(COMPLEX_GRAPH))).toBeNull()
+  })
+
+  it('fails closed for a complex approval node with multiple assigneeSources, rather than flattening to the first', () => {
+    const graph = clone(COMPLEX_GRAPH)
+    const approval = graph.nodes.find((node) => node.key === 'approval_high')!
+    approval.config = {
+      assigneeSources: [{ kind: 'requester' }, { kind: 'dept_head' }],
+      approvalMode: 'single',
+      emptyAssigneePolicy: 'error',
+    }
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toContain('暂不支持的审批人来源')
+  })
+
+  it('fails closed for complex approval-node config keys outside the G-5 editable/preserved allowlist', () => {
+    const graph = clone(COMPLEX_GRAPH)
+    const approval = graph.nodes.find((node) => node.key === 'approval_high')!
+    approval.config = { ...approval.config, customEscalation: true } as never
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toContain('暂不支持的配置')
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -85,7 +85,7 @@ const ElButton = defineComponent({
 
 const ElInput = defineComponent({
   name: 'ElInput',
-  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String },
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String, size: String },
   emits: ['update:modelValue'],
   render() {
     return h('input', {
@@ -99,7 +99,7 @@ const ElInput = defineComponent({
 
 const ElInputNumber = defineComponent({
   name: 'ElInputNumber',
-  props: { modelValue: Number, disabled: Boolean, min: Number, max: Number, step: Number },
+  props: { modelValue: Number, disabled: Boolean, min: Number, max: Number, step: Number, size: String },
   emits: ['update:modelValue'],
   render() {
     return h('input', {
@@ -114,7 +114,7 @@ const ElInputNumber = defineComponent({
 
 const ElSelect = defineComponent({
   name: 'ElSelect',
-  props: { modelValue: [String, Array], disabled: Boolean },
+  props: { modelValue: [String, Array], disabled: Boolean, size: String },
   emits: ['update:modelValue', 'change'],
   render() {
     return h('select', {
@@ -908,6 +908,89 @@ describe('TemplateAuthoringView', () => {
     const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
     expect(payload.approvalGraph).toEqual(parallelGraph)
     expect(payload.approvalGraph.nodes.some((node: any) => node.type === 'parallel')).toBe(true)
+  })
+
+  it('G-5: wires a complex-graph approval node editor into the saved payload without changing topology', async () => {
+    routeParams = { id: 'tpl_amount_tier' }
+    const complexGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        {
+          key: 'cond_1',
+          type: 'condition',
+          name: '金额判断',
+          config: { branches: [{ edgeKey: 'edge-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }], conjunction: 'and' }], defaultEdgeKey: 'edge-low' },
+        },
+        {
+          key: 'approval_high',
+          type: 'approval',
+          name: '高额审批',
+          config: {
+            assigneeSources: [{ kind: 'direct_manager' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+            autoApprovalPolicy: { mergeWithRequester: true, mergeAdjacentApprover: true },
+            fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+          },
+        },
+        {
+          key: 'approval_low',
+          type: 'approval',
+          name: '普通审批',
+          config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'auto-approve' },
+        },
+        { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-cond', source: 'start', target: 'cond_1' },
+        { key: 'edge-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'edge-low', source: 'cond_1', target: 'approval_low' },
+        { key: 'edge-approval-high-cc', source: 'approval_high', target: 'cc_1' },
+        { key: 'edge-cc-end', source: 'cc_1', target: 'end' },
+        { key: 'edge-approval-low-end', source: 'approval_low', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ id: 'tpl_amount_tier', approvalGraph: complexGraph }))
+
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull()
+    const highEditor = container!.querySelector('[data-approval-node="approval_high"]') as HTMLElement
+    expect(highEditor).not.toBeNull()
+    const sourceSelect = highEditor.querySelector('[data-testid="approval-node-source-kind"]') as HTMLSelectElement
+    expect(sourceSelect.value).toBe('direct_manager')
+    sourceSelect.value = 'static_role'
+    sourceSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    const idsInput = highEditor.querySelector('[data-testid="approval-node-ids-text"]') as HTMLInputElement
+    idsInput.value = 'finance, cfo'
+    idsInput.dispatchEvent(new Event('input'))
+    const approvalMode = highEditor.querySelector('[data-testid="approval-node-approval-mode"]') as HTMLSelectElement
+    approvalMode.value = 'all'
+    approvalMode.dispatchEvent(new Event('change'))
+    const mergeToggle = highEditor.querySelector('[data-testid="approval-node-merge-with-requester"]') as HTMLInputElement
+    mergeToggle.checked = false
+    mergeToggle.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    expect(payload.approvalGraph.edges).toEqual(complexGraph.edges)
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'cond_1')).toEqual(complexGraph.nodes[1])
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_low')).toEqual(complexGraph.nodes[3])
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'cc_1')).toEqual(complexGraph.nodes[4])
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_high').config).toEqual({
+      assigneeSources: [{ kind: 'static_role', roleIds: ['finance', 'cfo'] }],
+      approvalMode: 'all',
+      emptyAssigneePolicy: 'error',
+      autoApprovalPolicy: { mergeAdjacentApprover: true },
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
   })
 
   it('T8: disables the self-approver toggle when the template opens read-only', async () => {

--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -1,11 +1,12 @@
 # Amount-Tier Approval Template Presets — Design Lock
 
-Status: RATIFIED — RUNTIME NOT BUILT
+Status: RATIFIED — PRESET RUNTIME NOT BUILT
 
 Grounding: approval authoring can create/edit linear approval templates, preserve complex graphs,
-edit condition-node rules, edit parallel `joinMode` (`all` / `any`), and edit cc targets. The common
-template preset slice creates basic reimbursement/purchase drafts. This design locks the next
-advanced preset family: amount-tier reimbursement and amount-tier purchase.
+edit condition-node rules, edit parallel `joinMode` (`all` / `any`), edit cc targets, and edit
+approval-node sources/strategy inside preserved complex graphs. The common template preset slice
+creates basic reimbursement/purchase drafts. This design locks the next advanced preset family:
+amount-tier reimbursement and amount-tier purchase.
 
 ## Goal
 
@@ -51,10 +52,9 @@ approval-result write-back.
 
 4. The advanced presets require editable approval nodes inside preserved complex graphs.
 
-   Current complex-graph authoring can edit condition rules and parallel join mode, but approval
-   nodes inside a complex graph are displayed as read-only summaries. That is not enough for a
-   reusable amount-tier preset because administrators must be able to tune "which role/person/source
-   approves at this threshold".
+   The G-5 complex-graph follow-up satisfies this gate: approval nodes inside a preserved graph can
+   now edit their assignee source and approval strategy without topology changes. That unlocks the
+   preset implementation, but it does not mean the amount-tier preset payloads themselves are built.
 
    Therefore implementation order is:
 
@@ -134,6 +134,9 @@ Default threshold proposal: `20000`. `joinMode` defaults to `all` for purchase c
 ## Build Gates
 
 ### Gate A — Complex Approval-Node Editor
+
+Status: satisfied by the G-5 complex-graph approval-node editor follow-up. The advanced preset
+payloads remain unbuilt until Gate B/C and the preset slice land.
 
 Before shipping the advanced presets, the authoring UI must let an admin edit approval-node sources
 inside preserved complex graphs without changing topology.

--- a/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
+++ b/docs/design/approval-complex-graph-author-ui-design-lock-20260623.md
@@ -1,13 +1,17 @@
 # Design-lock: Approval complex-graph node author UI (复杂图节点作者 UI)
 
-**Status:** RATIFIED + SHIPPED (2026-06-23). The arc is complete on main — design-lock #3102,
-G-1 load-preserve #3103, G-2 condition #3104, G-3 parallel join-mode #3105, G-4 cc #3106.
+**Status:** RATIFIED + SHIPPED (2026-06-23). The initial arc is complete on main — design-lock
+#3102, G-1 load-preserve #3103, G-2 condition #3104, G-3 parallel join-mode #3105, G-4 cc #3106.
+The G-5 follow-up adds approval-node config editing inside preserved complex graphs, satisfying
+the amount-tier preset Gate A without changing graph topology.
 **As-built scope** (refined from the original proposal below): the editor edits **condition
 logic** (branch rules / conjunction / default edge), **parallel `joinMode`** (`all`/`any` — both
-backend-accepted), and **cc targets** (`targetType` / `targetIds`). All graph **topology**
-(parallel branch edgeKeys + `joinNodeKey`, condition branch edges, every edge) is **read-only,
-preserved byte-identical**; **parallel topology / branch add-remove editing is explicitly OUT of
-scope** (a later slice). Brand-neutral (external OA / mainstream approval platforms; no vendor names).
+backend-accepted), **cc targets** (`targetType` / `targetIds`), and **approval-node config**
+(`assigneeSources`, `approvalMode`, `emptyAssigneePolicy`, and
+`autoApprovalPolicy.mergeWithRequester`). All graph **topology** (parallel branch edgeKeys +
+`joinNodeKey`, condition branch edges, every edge) is **read-only, preserved byte-identical**;
+**parallel topology / branch add-remove editing is explicitly OUT of scope** (a later slice).
+Brand-neutral (external OA / mainstream approval platforms; no vendor names).
 
 ---
 
@@ -22,6 +26,9 @@ scope** (a later slice). Brand-neutral (external OA / mainstream approval platfo
 > - **(2) `joinMode='any'` shipped** (not fail-closed) — see the §7/§8c RATIFIED notes.
 > - **(3) A complex graph is load-preserved + save-ENABLED.** The "Current authoring …
 >   `UNSUPPORTED_GRAPH_NODE_TYPES` … save disabled" line below describes the **pre-G-1** state.
+> - **(4) Approval-node config is editable in the G-5 follow-up.** §1's "Plus the existing
+>   approval node config (unchanged)" line described the pre-G-5 state. G-5 edits approval-node
+>   sources and strategy fields while preserving topology and unsupported config fail-closed.
 >
 > The runtime / validator / node-model facts below remain accurate.
 
@@ -61,8 +68,9 @@ Grounded in code (explorer-verified 2026-06-23):
 - **Editable (all runtime-ready):** `condition` (branches: rules `{fieldId, operator, value}` +
   `conjunction` and/or, + `defaultEdgeKey`), `parallel` (**`joinMode` only** — `all`/`any`;
   branch edgeKeys + `joinNodeKey` are topology, preserved read-only **[as-built]**), `cc`
-  (`targetType` user/role + `targetIds`). Plus the existing `approval` node
-  config (unchanged).
+  (`targetType` user/role + `targetIds`), and `approval` node config
+  (`assigneeSources`, `approvalMode`, `emptyAssigneePolicy`,
+  `autoApprovalPolicy.mergeWithRequester`) **[as-built G-5 follow-up]**.
 - **Read-only / structural (never hand-edited):** `start` / `end` (auto-managed), and node
   `key`s / `edge`s identity (the editor manages topology through structured controls, not raw
   key editing). Legacy `assigneeType`/`assigneeIds` config is shown read-only (the editor
@@ -80,8 +88,9 @@ Grounded in code (explorer-verified 2026-06-23):
   cc → target picker reusing the existing approval user/role picker) + a **validation preview**
   (inline errors/warnings before save). No drag canvas, no free edge drawing — topology is
   expressed through structured controls (~~add branch, set join target~~ **[as-built: parallel
-  topology is read-only; only joinMode/condition-rules/cc-targets are editable]**), which the builder turns
-  into nodes + edges. This fits TemplateAuthoringView's evolution and is far more testable.
+  topology is read-only; only joinMode/condition-rules/cc-targets/approval-node config are
+  editable]**), which the builder turns into nodes + edges. This fits TemplateAuthoringView's
+  evolution and is far more testable.
 
 ## 3. Anti-flatten — full-graph round-trip (the keystone)
 - The editor's draft model carries the **whole graph** (all nodes + edges + every node's
@@ -120,6 +129,10 @@ Grounded in code (explorer-verified 2026-06-23):
 - **G-3 · parallel editor.** Author parallel `joinMode` (`all`/`any`, both backend-accepted);
   branch edgeKeys + `joinNodeKey` are topology, read-only **[as-built — branch add/remove deferred].**
 - **G-4 · cc editor.** Author cc targets (reuse the approval picker).
+- **G-5 · approval-node config editor.** Author approval-node assignee source + approval mode +
+  empty-assignee policy + merge-with-requester inside preserved complex graphs. All node keys,
+  all edges, condition configs, parallel configs, cc configs, and non-edited approval nodes remain
+  deep-equal; unsupported legacy / multi-source / unknown approval-node config stays fail-closed.
 - The structured-graph editor is the form-schema-adjacent surface the detail arc stabilized
   first (goal sequencing: C 明细 done → graph UI now).
 


### PR DESCRIPTION
## Summary

- add the G-5 complex-graph approval-node editor for preserved approval graphs
- edit approval-node assignee source, approval mode, empty-assignee policy, and merge-with-requester without changing graph topology
- fail closed on complex approval-node configs the structured editor cannot represent, instead of flattening them
- update the amount-tier and complex-graph design locks so Gate A is marked satisfied while amount-tier presets remain unbuilt

## Scope

- UI/docs/guard only: no backend runtime, migrations, or approval-result write-back
- implements the approval-node editor prerequisite for amount-tier presets; does not add the amount-tier preset payloads
- preserves all node keys, all edges, and untouched condition/parallel/cc/approval nodes byte-identical

## Verification

- pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit --reporter=dot (166/166)
- pnpm --filter @metasheet/web exec vue-tsc -b
- pnpm --filter @metasheet/web exec eslint src/approvals/approvalNodeEdit.ts src/approvals/templateAuthoring.ts src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts tests/approval-template-authoring-approval-node-edit.test.ts
- node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/approval-web-guard.yml','utf8')); console.log('yaml ok')"
- git diff --check