### PR TITLE
feat(approval): G-5 — complex-graph approval-node source editing (topology-preserving)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -20,6 +20,7 @@ on:
       - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/ccEdit.ts'
+      - 'apps/web/src/approvals/approvalNodeEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
@@ -34,6 +35,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -41,6 +43,7 @@ on:
       - 'apps/web/src/approvals/conditionEdit.ts'
       - 'apps/web/src/approvals/parallelEdit.ts'
       - 'apps/web/src/approvals/ccEdit.ts'
+      - 'apps/web/src/approvals/approvalNodeEdit.ts'
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
@@ -55,6 +58,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-condition-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -111,4 +115,4 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit --reporter=dot

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -1,0 +1,150 @@
+import type {
+  ApprovalAssigneeSource,
+  ApprovalGraph,
+  ApprovalNode,
+  ApprovalNodeConfig,
+} from '../types/approval'
+
+// G-5 — approval-node editing inside a preserved complex graph. SCOPE: the approver SOURCE only
+// (`assigneeSources`). `approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy` / any other
+// config key are PRESERVED verbatim, NOT yet editable (a later slice). The node's edges/position
+// are TOPOLOGY — preserved byte-for-byte (G-1 anti-flatten floor). Every OTHER node/edge —
+// condition (G-2), parallel (G-3), cc (G-4), start/end — is preserved verbatim. No .vue / Element
+// Plus import, so this runs under the approval-web-guard vitest gate.
+//
+// PRE-CHECK FINDING (backend approval-node assignee rule, ApprovalProductService.ts):
+//   - `validateApprovalAssigneeSourcesAgainstFormSchema` (:457-480): a `form_field_user` source's
+//     `fieldId` MUST reference a TOP-LEVEL field of `type: 'user'` — detail sub-fields are
+//     intentionally unresolvable (a sub-field has N row-values, ambiguous as a single approver).
+//   - assignee source kinds: ApprovalAssigneeSource union (approval.ts:74-82).
+// The editor + `validateApprovalNodeEdits` mirror this (backend `normalizeApprovalGraph` stays the
+// sole arbiter; the preview never relaxes it).
+
+/**
+ * Editable model for one approval node — the approver `assigneeSources` array ONLY, keyed by node
+ * `key`, seeded 1:1 from the preserved approval nodes' existing config. The node's place in the
+ * graph (edges), its `approvalMode`, `emptyAssigneePolicy`, and `autoApprovalPolicy` are NOT carried
+ * here (preserved verbatim by `applyApprovalNodeEditsToGraph`).
+ */
+export interface ApprovalNodeSourceEdit {
+  nodeKey: string
+  assigneeSources: ApprovalAssigneeSource[]
+}
+
+/** Map of approval-node source edits keyed by node key, seeded from a preserved graph. */
+export type ApprovalNodeEdits = Record<string, ApprovalNodeSourceEdit>
+
+// Deep clone for the preserved-graph pass-through — same rationale as ccEdit/parallelEdit/
+// conditionEdit: pure JSON data, and a JSON round-trip works on the Vue reactive Proxy the draft
+// is wrapped in.
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+/**
+ * True only for an approval node whose config carries an `assigneeSources` ARRAY. A legacy node
+ * (`assigneeType`/`assigneeIds`, no `assigneeSources`) returns false, so it is never seeded and
+ * `applyApprovalNodeEditsToGraph` clones it byte-identical (read-only-preserved, never flattened).
+ */
+function hasAssigneeSources(config: ApprovalNode['config']): config is ApprovalNodeConfig & { assigneeSources: ApprovalAssigneeSource[] } {
+  return Boolean(config) && Array.isArray((config as ApprovalNodeConfig).assigneeSources)
+}
+
+/**
+ * Seed the editable model from a (preserved) graph — one entry per `approval` node THAT HAS an
+ * `assigneeSources` array, carrying a clone of it. Non-approval and legacy (no-`assigneeSources`)
+ * nodes are skipped (preserved verbatim). Seeding is identity: an untouched edit reproduces the
+ * original `assigneeSources`, so a round-trip is byte-identical (no spurious diff).
+ */
+export function approvalNodeEditsFromGraph(graph: ApprovalGraph | undefined): ApprovalNodeEdits {
+  const edits: ApprovalNodeEdits = {}
+  if (!graph) return edits
+  for (const node of graph.nodes) {
+    if (node.type !== 'approval' || !hasAssigneeSources(node.config)) continue
+    edits[node.key] = { nodeKey: node.key, assigneeSources: cloneJson(node.config.assigneeSources) }
+  }
+  return edits
+}
+
+/**
+ * Replace ONLY the `assigneeSources` of each edited approval node, leaving EVERY other node and ALL
+ * edges byte-identical (deep-cloned so the input is never mutated). Spread-original-first keeps the
+ * other config keys (`approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy`) and byte-stable
+ * key order, so an UNTOUCHED node reproduces its config exactly (the guard requires `assigneeSources`
+ * already present, so the spread never adds a key). A legacy node (no `assigneeSources`) has no edit
+ * and is cloned verbatim.
+ *
+ * Composition with G-2/G-3/G-4: approval / condition / parallel / cc are DISJOINT node types and
+ * each pass deep-clones everything else, so composing the four lands all edits while every
+ * non-targeted node/edge stays byte-identical.
+ */
+export function applyApprovalNodeEditsToGraph(graph: ApprovalGraph, edits: ApprovalNodeEdits): ApprovalGraph {
+  const nodes: ApprovalNode[] = graph.nodes.map((node) => {
+    if (node.type !== 'approval' || !hasAssigneeSources(node.config)) return cloneJson(node)
+    const edit = edits[node.key]
+    if (!edit) return cloneJson(node)
+    const originalConfig = cloneJson(node.config)
+    const config: ApprovalNodeConfig = { ...originalConfig, assigneeSources: cloneJson(edit.assigneeSources) }
+    return { ...cloneJson(node), config }
+  })
+  return {
+    nodes,
+    edges: graph.edges.map((edge) => cloneJson(edge)),
+  }
+}
+
+/** True when an assignee source is well-formed for its kind (mirrors what the backend accepts). */
+function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserFieldIds: Set<string> | null): boolean {
+  switch (source.kind) {
+    case 'static_user':
+      return source.userIds.some((id) => id.trim().length > 0)
+    case 'static_role':
+      return source.roleIds.some((id) => id.trim().length > 0)
+    case 'form_field_user':
+      // backend: fieldId must reference a TOP-LEVEL `user` field (sub-fields unresolvable).
+      if (source.fieldId.trim().length === 0) return false
+      return topLevelUserFieldIds ? topLevelUserFieldIds.has(source.fieldId.trim()) : true
+    case 'continuous_managers':
+      return source.levels >= 1
+    case 'manager_at_level':
+      return source.level >= 1
+    case 'requester':
+    case 'direct_manager':
+    case 'dept_head':
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * FE validation PREVIEW for approval-node source edits (UX only — the backend
+ * `normalizeApprovalGraph` + `validateApprovalAssigneeSourcesAgainstFormSchema` stay the sole
+ * arbiter). Each edited node needs at least one assignee source, every source must be well-formed,
+ * and a `form_field_user` source must reference a top-level `user` field (when `fields` is given).
+ */
+export function validateApprovalNodeEdits(
+  edits: ApprovalNodeEdits,
+  fields?: Array<{ id: string; type: string }>,
+): string[] {
+  const errors: string[] = []
+  const topLevelUserFieldIds = fields
+    ? new Set(fields.filter((f) => f.type === 'user').map((f) => f.id.trim()))
+    : null
+  for (const edit of Object.values(edits)) {
+    if (edit.assigneeSources.length === 0) {
+      errors.push(`审批节点 ${edit.nodeKey} 至少需要一个审批人来源`)
+      continue
+    }
+    for (const source of edit.assigneeSources) {
+      if (!isAssigneeSourceValid(source, topLevelUserFieldIds)) {
+        if (source.kind === 'form_field_user') {
+          errors.push(`审批节点 ${edit.nodeKey} 的表单字段审批人必须引用顶层用户字段`)
+        } else {
+          errors.push(`审批节点 ${edit.nodeKey} 的审批人来源（${source.kind}）配置无效`)
+        }
+      }
+    }
+  }
+  return errors
+}

--- a/apps/web/src/approvals/approvalNodeEdit.ts
+++ b/apps/web/src/approvals/approvalNodeEdit.ts
@@ -104,10 +104,13 @@ function isAssigneeSourceValid(source: ApprovalAssigneeSource, topLevelUserField
       // backend: fieldId must reference a TOP-LEVEL `user` field (sub-fields unresolvable).
       if (source.fieldId.trim().length === 0) return false
       return topLevelUserFieldIds ? topLevelUserFieldIds.has(source.fieldId.trim()) : true
+    // PREVIEW only: integer ≥ 1. The backend additionally enforces a manager-chain level CAP
+    // (MAX_MANAGER_CHAIN_LEVELS) which is NOT mirrored here — the UI input caps at 10 and the
+    // backend `normalizeApprovalGraph` is the final arbiter on the ceiling.
     case 'continuous_managers':
-      return source.levels >= 1
+      return Number.isInteger(source.levels) && source.levels >= 1
     case 'manager_at_level':
-      return source.level >= 1
+      return Number.isInteger(source.level) && source.level >= 1
     case 'requester':
     case 'direct_manager':
     case 'dept_head':

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -476,10 +476,10 @@ const RECOGNISED_GRAPH_NODE_TYPES = new Set([
  * Returns `null` when the template is editable OR complex-but-preservable.
  */
 // The approval-node config keys the BACKEND `normalizeApprovalGraph` re-emits for a COMPLEX graph
-// (ApprovalProductService.ts:899-911). Any other key is silently dropped on save. NB: this is the
-// COMPLEX path's allowlist ONLY — the linear path reconstructs via `buildStepConfig`, which does NOT
-// preserve `fieldPermissions`, so the two allowlists must stay SEPARATE (sharing would let a linear
-// node's `fieldPermissions` through, then flatten it — the same bug on the other path).
+// (ApprovalProductService.ts:899-911). Any other key — TOP-LEVEL or NESTED — is silently dropped on
+// save. NB: this is the COMPLEX path's allowlist ONLY — the linear path reconstructs via
+// `buildStepConfig`, which does NOT preserve `fieldPermissions`, so the two allowlists must stay
+// SEPARATE (sharing would let a linear node's `fieldPermissions` through, then flatten it).
 const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
   'assigneeType',
   'assigneeIds',
@@ -489,6 +489,57 @@ const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
   'autoApprovalPolicy',
   'fieldPermissions',
 ]
+// The backend ALSO rebuilds the NESTED shapes from fixed fields, silently dropping any other — so the
+// allowlist must be shape-level, not just top-level:
+//   - assigneeSources[] per kind (ApprovalProductService.ts:408-453)
+//   - autoApprovalPolicy (:371-376) — 4 fields
+//   - fieldPermissions[] (:786-799) — { fieldId, access }
+// All three bottom out in primitives / string-arrays (no deeper objects), so this 2-level check is complete.
+const BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND: Record<string, string[]> = {
+  static_user: ['kind', 'userIds'],
+  static_role: ['kind', 'roleIds'],
+  requester: ['kind'],
+  direct_manager: ['kind'],
+  dept_head: ['kind'],
+  continuous_managers: ['kind', 'levels'],
+  manager_at_level: ['kind', 'level'],
+  form_field_user: ['kind', 'fieldId'],
+}
+const BACKEND_AUTO_APPROVAL_POLICY_KEYS = ['mergeWithRequester', 'mergeAdjacentApprover', 'dedupeHistoricalApprover', 'actorMode']
+const BACKEND_FIELD_PERMISSION_KEYS = ['fieldId', 'access']
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+function hasKeyOutside(value: unknown, allowed: string[]): boolean {
+  return isPlainRecord(value) && Object.keys(value).some((key) => !allowed.includes(key))
+}
+
+/**
+ * True when a COMPLEX approval node's config carries a key — TOP-LEVEL or NESTED in assigneeSources[]
+ * / autoApprovalPolicy / fieldPermissions[] — that the backend `normalizeApprovalGraph` does NOT
+ * re-emit (and silently DROPS on save). The FE preserves config verbatim, so without this the
+ * deep-equal round-trip looks clean while the real save flattens the unknown key.
+ */
+function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): boolean {
+  if (hasKeyOutside(config, BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS)) return true
+  const sources = config.assigneeSources
+  if (Array.isArray(sources)) {
+    for (const source of sources) {
+      if (!isPlainRecord(source)) return true
+      const allowed = BACKEND_ASSIGNEE_SOURCE_KEYS_BY_KIND[source.kind as string]
+      if (!allowed || hasKeyOutside(source, allowed)) return true
+    }
+  }
+  if (hasKeyOutside(config.autoApprovalPolicy, BACKEND_AUTO_APPROVAL_POLICY_KEYS)) return true
+  const perms = config.fieldPermissions
+  if (Array.isArray(perms)) {
+    for (const perm of perms) {
+      if (!isPlainRecord(perm) || hasKeyOutside(perm, BACKEND_FIELD_PERMISSION_KEYS)) return true
+    }
+  }
+  return false
+}
 
 export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
   const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
@@ -517,9 +568,7 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     const unsupportedComplexApproval = template.approvalGraph.nodes.find(
       (node) =>
         node.type === 'approval'
-        && Object.keys(node.config as Record<string, unknown>).some(
-          (key) => !BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS.includes(key),
-        ),
+        && complexApprovalConfigHasBackendDrop(node.config as Record<string, unknown>),
     )
     if (unsupportedComplexApproval) {
       return `审批节点含后端不会保留的配置（保存将丢失），已锁定为只读：${unsupportedComplexApproval.name || unsupportedComplexApproval.key}`

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -40,6 +40,12 @@ import {
   validateCcEdits,
   type CcEdits,
 } from './ccEdit'
+import {
+  applyApprovalNodeEditsToGraph,
+  approvalNodeEditsFromGraph,
+  validateApprovalNodeEdits,
+  type ApprovalNodeEdits,
+} from './approvalNodeEdit'
 
 export type { DetailColumnDraft } from './detailField'
 export { createEmptyDetailColumnDraft, DETAIL_LEAF_FIELD_TYPES } from './detailField'
@@ -55,6 +61,7 @@ export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
 export { PARALLEL_JOIN_MODES } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
 export { CC_TARGET_TYPES } from './ccEdit'
+export type { ApprovalNodeEdits, ApprovalNodeSourceEdit } from './approvalNodeEdit'
 
 export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
 export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
@@ -165,6 +172,7 @@ export interface TemplateAuthoringDraft {
   // G-4 cc editor: editable targetType/targetIds for each `cc` node in `preservedGraph`, seeded
   // 1:1. Topology (edges) + every non-cc node stay byte-identical. Empty {} when no cc node.
   ccEdits?: CcEdits
+  approvalNodeEdits?: ApprovalNodeEdits
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -579,6 +587,7 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
           // Empty {} when the complex graph has no parallel node (condition/cc-only).
           parallelEdits: parallelEditsFromGraph(template.approvalGraph),
           ccEdits: ccEditsFromGraph(template.approvalGraph),
+          approvalNodeEdits: approvalNodeEditsFromGraph(template.approvalGraph),
         }
       : {}),
     fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
@@ -701,7 +710,10 @@ export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph
   if (draft.preservedGraph) {
     const withConditionEdits = applyConditionEditsToGraph(draft.preservedGraph, draft.conditionEdits ?? {})
     const withParallelEdits = applyParallelEditsToGraph(withConditionEdits, draft.parallelEdits ?? {})
-    return applyCcEditsToGraph(withParallelEdits, draft.ccEdits ?? {})
+    const withCcEdits = applyCcEditsToGraph(withParallelEdits, draft.ccEdits ?? {})
+    // G-5: replace ONLY each edited approval node's `assigneeSources` (approver source); approvalMode /
+    // emptyAssigneePolicy / autoApprovalPolicy + every other node + ALL edges stay byte-identical.
+    return applyApprovalNodeEditsToGraph(withCcEdits, draft.approvalNodeEdits ?? {})
   }
   const approvalNodes = draft.steps.map((step, index) => ({
     key: `approval_${index + 1}`,
@@ -835,6 +847,9 @@ export function validateTemplateDraft(
   }
   if (draft.ccEdits && Object.keys(draft.ccEdits).length > 0) {
     errors.push(...validateCcEdits(draft.ccEdits))
+  }
+  if (draft.approvalNodeEdits && Object.keys(draft.approvalNodeEdits).length > 0) {
+    errors.push(...validateApprovalNodeEdits(draft.approvalNodeEdits, draft.fields))
   }
   const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
   draft.steps.forEach((step, index) => {

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -475,6 +475,21 @@ const RECOGNISED_GRAPH_NODE_TYPES = new Set([
  *    rather than projected to `steps`.
  * Returns `null` when the template is editable OR complex-but-preservable.
  */
+// The approval-node config keys the BACKEND `normalizeApprovalGraph` re-emits for a COMPLEX graph
+// (ApprovalProductService.ts:899-911). Any other key is silently dropped on save. NB: this is the
+// COMPLEX path's allowlist ONLY — the linear path reconstructs via `buildStepConfig`, which does NOT
+// preserve `fieldPermissions`, so the two allowlists must stay SEPARATE (sharing would let a linear
+// node's `fieldPermissions` through, then flatten it — the same bug on the other path).
+const BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS = [
+  'assigneeType',
+  'assigneeIds',
+  'assigneeSources',
+  'approvalMode',
+  'emptyAssigneePolicy',
+  'autoApprovalPolicy',
+  'fieldPermissions',
+]
+
 export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
   const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
   if (unsupportedField) {
@@ -493,10 +508,22 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
     return `包含暂不支持编辑的审批节点：${unknownNode.name || unknownNode.key} (${unknownNode.type})`
   }
 
-  // Complex graphs (cc/condition/parallel or non-linear) are load-preserved verbatim — the linear
-  // `steps` projection (and its per-approval-node config allowlist below) does NOT apply, so they
-  // are never "unsupported" here. They open read-only via `graphReadOnlyReason` and save unchanged.
+  // Complex graphs (cc/condition/parallel or non-linear) are load-preserved verbatim via
+  // spread-original-first — BUT the backend `normalizeApprovalGraph` rebuilds each approval node's
+  // config from a fixed allowlist and silently DROPS any other key on save. The FE deep-equal
+  // round-trip can't see that drop, so fail-closed: a complex approval node carrying a config key the
+  // backend won't preserve is unsupported (read-only, save disabled), never silently flattened.
   if (isComplexApprovalGraph(template.approvalGraph)) {
+    const unsupportedComplexApproval = template.approvalGraph.nodes.find(
+      (node) =>
+        node.type === 'approval'
+        && Object.keys(node.config as Record<string, unknown>).some(
+          (key) => !BACKEND_PRESERVED_COMPLEX_APPROVAL_CONFIG_KEYS.includes(key),
+        ),
+    )
+    if (unsupportedComplexApproval) {
+      return `审批节点含后端不会保留的配置（保存将丢失），已锁定为只读：${unsupportedComplexApproval.name || unsupportedComplexApproval.key}`
+    }
     return null
   }
 

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -50,13 +50,13 @@
       data-testid="approval-template-unsupported-alert"
     />
 
-    <!-- G-1..G-4: a complex graph is preserved, not unsupported — informational, save stays enabled.
-         G-2 condition rules, G-3 parallel joinMode, and G-4 cc targets are all editable; branches /
-         join target / all edges are preserved topology. -->
+    <!-- G-1..G-5: a complex graph is preserved, not unsupported — informational, save stays enabled.
+         G-2 condition rules, G-3 parallel joinMode, G-4 cc targets, and G-5 approval-node source are
+         all editable; branches / join target / all edges are preserved topology. -->
     <el-alert
       v-if="!unsupportedReason && graphReadOnlyMessage"
       :title="graphReadOnlyMessage"
-      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象。分支拓扑与连线在保存时原样保留。"
+      description="表单与基本信息可编辑；条件分支节点可编辑分支规则，并行节点可编辑汇聚模式，抄送节点可编辑抄送对象，审批节点可编辑审批人来源。分支拓扑与连线在保存时原样保留。"
       type="info"
       show-icon
       :closable="false"
@@ -607,7 +607,82 @@
               </el-form-item>
             </div>
 
-            <!-- approval / other — read-only summary (G-4: cc is editable above). -->
+            <!-- G-5: editable approval node — approver SOURCE only (assigneeSources[0]). The node's
+                 approvalMode / emptyAssigneePolicy / autoApprovalPolicy + edges are preserved. Legacy
+                 nodes (no assigneeSources) aren't seeded → fall to the read-only summary below. -->
+            <div
+              v-else-if="node.type === 'approval' && approvalNodeEditFor(node.key)"
+              class="template-authoring__approval-node"
+              data-testid="approval-node-editor"
+              :data-approval-node="node.key"
+            >
+              <el-form-item label="审批人来源">
+                <el-select
+                  :model-value="approvalSourceKind(node.key)"
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 240px"
+                  data-testid="approval-node-source-kind"
+                  @update:model-value="(kind: ApprovalAssigneeSourceKind) => setApprovalSourceKind(node.key, kind)"
+                >
+                  <el-option
+                    v-for="opt in APPROVAL_NODE_SOURCE_KINDS"
+                    :key="opt.value"
+                    :label="opt.label"
+                    :value="opt.value"
+                  />
+                </el-select>
+              </el-form-item>
+              <el-form-item
+                v-if="approvalSourceKind(node.key) === 'static_user' || approvalSourceKind(node.key) === 'static_role'"
+                :label="approvalSourceKind(node.key) === 'static_user' ? '用户 ID' : '角色 ID'"
+              >
+                <el-select
+                  :model-value="approvalSourceIds(node.key)"
+                  multiple
+                  filterable
+                  allow-create
+                  default-first-option
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 360px"
+                  placeholder="输入 ID 后回车"
+                  data-testid="approval-node-source-ids"
+                  @update:model-value="(ids: string[]) => setApprovalSourceIds(node.key, ids)"
+                />
+              </el-form-item>
+              <el-form-item
+                v-else-if="approvalSourceKind(node.key) === 'form_field_user'"
+                label="表单用户字段 ID"
+              >
+                <el-input
+                  :model-value="approvalSourceFieldId(node.key)"
+                  size="small"
+                  :disabled="readOnly"
+                  style="width: 240px"
+                  placeholder="顶层 user 字段 ID"
+                  data-testid="approval-node-source-field"
+                  @update:model-value="(fieldId: string) => setApprovalSourceFieldId(node.key, fieldId)"
+                />
+              </el-form-item>
+              <el-form-item
+                v-else-if="approvalSourceKind(node.key) === 'manager_at_level' || approvalSourceKind(node.key) === 'continuous_managers'"
+                :label="approvalSourceKind(node.key) === 'manager_at_level' ? '指定上级层级' : '上级层级数'"
+              >
+                <el-input-number
+                  :model-value="approvalSourceLevel(node.key)"
+                  :min="1"
+                  :max="10"
+                  :step="1"
+                  size="small"
+                  :disabled="readOnly"
+                  data-testid="approval-node-source-level"
+                  @update:model-value="(value: number) => setApprovalSourceLevel(node.key, value ?? 1)"
+                />
+              </el-form-item>
+            </div>
+
+            <!-- approval (legacy / no edit) / other — read-only summary. -->
             <template v-else>
               <ul v-if="nodeConfigSummary(node).length" class="template-authoring__node-summary">
                 <li v-for="(line, lineIndex) in nodeConfigSummary(node)" :key="lineIndex">{{ line }}</li>
@@ -807,6 +882,7 @@ import {
   type FieldAuthoringDraft,
   type ParallelNodeEdit,
   type CcNodeEdit,
+  type ApprovalNodeSourceEdit,
   type TemplateAuthoringDraft,
 } from '../../approvals/templateAuthoring'
 import {
@@ -816,6 +892,7 @@ import {
 } from '../../approvals/commonTemplatePresets'
 import type {
   ApprovalAssigneeSource,
+  ApprovalAssigneeSourceKind,
   ApprovalAssigneeType,
   ApprovalNode,
   CcNodeConfig,
@@ -1002,6 +1079,78 @@ function ccEditFor(nodeKey: string): CcNodeEdit | undefined {
 }
 function ccTargetTypeLabel(targetType: ApprovalAssigneeType): string {
   return targetType === 'role' ? '角色' : '用户'
+}
+
+// ── G-5 approval-node editor (approver SOURCE only; the node's mode/policy + edges are preserved) ──
+// Edits the FIRST assignee source of an approval node in a preserved complex graph; the edit model
+// (`draft.approvalNodeEdits[nodeKey].assigneeSources`) is seeded 1:1 + carried through
+// `applyApprovalNodeEditsToGraph` (every other node + all edges byte-identical). Any extra sources
+// (index 1+) are preserved verbatim. approvalMode / emptyAssigneePolicy / autoApprovalPolicy are
+// NOT editable here (a later slice) — they ride through untouched. Legacy nodes (no `assigneeSources`)
+// aren't seeded, so they fall to the read-only summary below.
+const APPROVAL_NODE_SOURCE_KINDS: { value: ApprovalAssigneeSourceKind; label: string }[] = [
+  { value: 'static_user', label: '指定用户' },
+  { value: 'static_role', label: '指定角色' },
+  { value: 'requester', label: '发起人' },
+  { value: 'direct_manager', label: '直属上级' },
+  { value: 'dept_head', label: '部门主管' },
+  { value: 'continuous_managers', label: '连续多级上级' },
+  { value: 'manager_at_level', label: '指定层级上级' },
+  { value: 'form_field_user', label: '表单用户字段' },
+]
+function approvalNodeEditFor(nodeKey: string): ApprovalNodeSourceEdit | undefined {
+  return draft.value.approvalNodeEdits?.[nodeKey]
+}
+function approvalNodeFirstSource(nodeKey: string): ApprovalAssigneeSource | undefined {
+  return approvalNodeEditFor(nodeKey)?.assigneeSources[0]
+}
+// Replace ONLY the primary (first) source; preserve any extra sources verbatim (no flatten).
+function setApprovalNodeSource(nodeKey: string, source: ApprovalAssigneeSource): void {
+  const edit = approvalNodeEditFor(nodeKey)
+  if (!edit) return
+  edit.assigneeSources = [source, ...edit.assigneeSources.slice(1)]
+}
+function approvalSourceKind(nodeKey: string): ApprovalAssigneeSourceKind {
+  return approvalNodeFirstSource(nodeKey)?.kind ?? 'requester'
+}
+function setApprovalSourceKind(nodeKey: string, kind: ApprovalAssigneeSourceKind): void {
+  const next: ApprovalAssigneeSource =
+    kind === 'static_user' ? { kind, userIds: [] }
+      : kind === 'static_role' ? { kind, roleIds: [] }
+        : kind === 'form_field_user' ? { kind, fieldId: '' }
+          : kind === 'continuous_managers' ? { kind, levels: 1 }
+            : kind === 'manager_at_level' ? { kind, level: 1 }
+              : { kind }
+  setApprovalNodeSource(nodeKey, next)
+}
+function approvalSourceIds(nodeKey: string): string[] {
+  const source = approvalNodeFirstSource(nodeKey)
+  if (source?.kind === 'static_user') return source.userIds
+  if (source?.kind === 'static_role') return source.roleIds
+  return []
+}
+function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
+  const kind = approvalSourceKind(nodeKey)
+  if (kind === 'static_user') setApprovalNodeSource(nodeKey, { kind, userIds: ids })
+  else if (kind === 'static_role') setApprovalNodeSource(nodeKey, { kind, roleIds: ids })
+}
+function approvalSourceFieldId(nodeKey: string): string {
+  const source = approvalNodeFirstSource(nodeKey)
+  return source?.kind === 'form_field_user' ? source.fieldId : ''
+}
+function setApprovalSourceFieldId(nodeKey: string, fieldId: string): void {
+  setApprovalNodeSource(nodeKey, { kind: 'form_field_user', fieldId })
+}
+function approvalSourceLevel(nodeKey: string): number {
+  const source = approvalNodeFirstSource(nodeKey)
+  if (source?.kind === 'manager_at_level') return source.level
+  if (source?.kind === 'continuous_managers') return source.levels
+  return 1
+}
+function setApprovalSourceLevel(nodeKey: string, value: number): void {
+  const kind = approvalSourceKind(nodeKey)
+  if (kind === 'manager_at_level') setApprovalNodeSource(nodeKey, { kind, level: value })
+  else if (kind === 'continuous_managers') setApprovalNodeSource(nodeKey, { kind, levels: value })
 }
 
 const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -3,6 +3,7 @@ import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/appr
 import {
   buildApprovalGraph,
   draftFromTemplate,
+  unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
   type TemplateAuthoringDraft,
 } from '../src/approvals/templateAuthoring'
@@ -188,5 +189,38 @@ describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)'
     const draft = draftFromTemplate(buildTemplate(APPROVAL_GRAPH))
     draft.approvalNodeEdits!.approval_1.assigneeSources = []
     expect(validateTemplateDraft(draft).some((e) => /审批人来源/.test(e))).toBe(true)
+  })
+})
+
+describe('G-5 fail-closed — complex approval-node config must stay within the BACKEND allowlist', () => {
+  // The backend `normalizeApprovalGraph` rebuilds approval config from {assigneeType, assigneeIds,
+  // assigneeSources, approvalMode, emptyAssigneePolicy, autoApprovalPolicy, fieldPermissions} and
+  // silently DROPS any other key on save. The FE deep-equal round-trip can't see that drop, so a
+  // complex approval node (cc node forces the preserved path) carrying an unknown key must be
+  // UNSUPPORTED — read-only + save disabled — not silently flattened on save.
+  const complexWith = (approvalConfig: Record<string, unknown>): ApprovalGraph => ({
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '主管', config: approvalConfig },
+      { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'cc_1' },
+      { key: 'e3', source: 'cc_1', target: 'end' },
+    ],
+  })
+  it('flags a complex approval node carrying an unknown config key (backend would drop it → save disabled)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], customRoutingHint: 'x' })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+  it('ALLOWS fieldPermissions — the backend DOES preserve it on the complex path (not over-strict)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
+  it('allows a complex approval node with only backend-preserved keys', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true } })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
   })
 })

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -223,4 +223,32 @@ describe('G-5 fail-closed — complex approval-node config must stay within the 
     const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true } })
     expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
   })
+
+  // NESTED unknown keys: the backend rebuilds assigneeSources[] / autoApprovalPolicy / fieldPermissions[]
+  // from fixed fields too, so a nested unknown key is ALSO silently dropped on save — must be fail-closed,
+  // not just top-level keys.
+  it('flags a nested unknown key in an assigneeSources entry (backend drops it)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager', futureFlag: true }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+  it('flags a nested unknown key in autoApprovalPolicy (backend drops it)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], autoApprovalPolicy: { mergeWithRequester: true, futureFlag: true } })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+  it('flags a nested unknown key in a fieldPermissions entry (backend drops it)', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'direct_manager' }], fieldPermissions: [{ fieldId: 'amount', access: 'hidden', futureFlag: true }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+  it('flags an unknown assignee source KIND', () => {
+    const graph = complexWith({ assigneeSources: [{ kind: 'future_kind' }] })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).not.toBeNull()
+  })
+  it('ALLOWS fully-known nested shapes (per-kind fields + all 4 policy fields + fieldPermissions {fieldId,access})', () => {
+    const graph = complexWith({
+      assigneeSources: [{ kind: 'static_user', userIds: ['u1'] }, { kind: 'manager_at_level', level: 2 }],
+      autoApprovalPolicy: { mergeWithRequester: true, mergeAdjacentApprover: false, dedupeHistoricalApprover: true, actorMode: 'system' },
+      fieldPermissions: [{ fieldId: 'amount', access: 'hidden' }],
+    })
+    expect(unsupportedTemplateAuthoringReason(buildTemplate(graph))).toBeNull()
+  })
 })

--- a/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-approval-node-edit.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildApprovalGraph,
+  draftFromTemplate,
+  validateTemplateDraft,
+  type TemplateAuthoringDraft,
+} from '../src/approvals/templateAuthoring'
+import {
+  applyApprovalNodeEditsToGraph,
+  approvalNodeEditsFromGraph,
+  validateApprovalNodeEdits,
+} from '../src/approvals/approvalNodeEdit'
+
+// G-5 — approval-node editing (approver SOURCE only: `assigneeSources`). PURE-LOGIC tests (no .vue)
+// so they run under approval-web-guard. The GATE is topology + cross-phase + WITHIN-NODE
+// preservation: editing one approval node's source must leave every OTHER node + the FULL edge list
+// byte-identical, must COMPOSE with condition/parallel/cc edits, must keep that node's OWN
+// approvalMode/emptyAssigneePolicy/autoApprovalPolicy byte-identical, and a legacy node
+// (assigneeType/assigneeIds, no assigneeSources) must round-trip byte-identical + get NO editor.
+// PRE-CHECK: backend `validateApprovalAssigneeSourcesAgainstFormSchema` (ApprovalProductService.ts
+// :457-480) requires a form_field_user source's fieldId to be a TOP-LEVEL `user` field.
+
+function buildTemplate(approvalGraph: ApprovalGraph, fields = [{ id: 'mgr_field', type: 'user' as const, label: '经理', required: false }]): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1', key: 'expense', name: '费用审批', description: null, category: null,
+    visibilityScope: { type: 'all', ids: [] }, slaHours: null, status: 'draft',
+    activeVersionId: null, latestVersionId: 'ver_1',
+    createdAt: '2026-06-23T00:00:00Z', updatedAt: '2026-06-23T00:00:00Z',
+    formSchema: { fields }, approvalGraph,
+  }
+}
+
+// An approval node carrying autoApprovalPolicy + approvalMode + emptyAssigneePolicy (the within-node
+// preservation case) inside a condition graph (so we also prove cross-node preservation).
+const APPROVAL_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    {
+      key: 'approval_1', type: 'approval', name: '主管',
+      config: {
+        assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }],
+        approvalMode: 'single', emptyAssigneePolicy: 'error',
+        autoApprovalPolicy: { mergeWithRequester: true },
+      },
+    },
+    { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'edge-cond_1-high', rules: [{ fieldId: 'amount', operator: 'gt', value: 1000 }] }], defaultEdgeKey: 'edge-cond_1-low' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+    { key: 'edge-approval_1-cond_1', source: 'approval_1', target: 'cond_1' },
+    { key: 'edge-cond_1-high', source: 'cond_1', target: 'end' },
+    { key: 'edge-cond_1-low', source: 'cond_1', target: 'end' },
+  ],
+}
+
+// Legacy approval node (assigneeType/assigneeIds, NO assigneeSources) inside a COMPLEX graph — the cc
+// node forces the preserved-graph path (a linear graph would project to steps, a different code path
+// that pre-dates G-5). This is the path G-5 governs: the legacy node is cloned verbatim, not seeded.
+const LEGACY_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'approval_legacy', type: 'approval', name: '旧式', config: { assigneeType: 'role', assigneeIds: ['legacy_role'], approvalMode: 'single' } },
+    { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'edge-start-approval_legacy', source: 'start', target: 'approval_legacy' },
+    { key: 'edge-approval_legacy-cc_1', source: 'approval_legacy', target: 'cc_1' },
+    { key: 'edge-cc_1-end', source: 'cc_1', target: 'end' },
+  ],
+}
+
+// One node of EACH editable type + an approval node — proves the FOUR passes compose disjointly.
+const FOUR_TYPE_GRAPH: ApprovalGraph = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'cond_1', type: 'condition', name: '判断', config: { branches: [{ edgeKey: 'e2', rules: [{ fieldId: 'amount', operator: 'gt', value: 1000 }] }], defaultEdgeKey: 'e3' } },
+    { key: 'approval_1', type: 'approval', name: '主管', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'parallel_1', type: 'parallel', name: '并行', config: { branches: ['e4', 'e5'], joinMode: 'all', joinNodeKey: 'join_1' } },
+    { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'cond_1' },
+    { key: 'e2', source: 'cond_1', target: 'approval_1' },
+    { key: 'e3', source: 'cond_1', target: 'end' },
+    { key: 'e4', source: 'approval_1', target: 'parallel_1' },
+    { key: 'e5', source: 'parallel_1', target: 'cc_1' },
+    { key: 'e6', source: 'cc_1', target: 'end' },
+  ],
+}
+
+const clone = (g: ApprovalGraph): ApprovalGraph => JSON.parse(JSON.stringify(g))
+const nonApproval = (g: ApprovalGraph) => g.nodes.filter((n) => n.type !== 'approval')
+const node = (g: ApprovalGraph, key: string) => g.nodes.find((n) => n.key === key)!
+
+describe('approvalNodeEditsFromGraph (seed)', () => {
+  it('seeds one entry per approval node that HAS assigneeSources', () => {
+    expect(approvalNodeEditsFromGraph(APPROVAL_GRAPH)).toEqual({
+      approval_1: { nodeKey: 'approval_1', assigneeSources: [{ kind: 'static_role', roleIds: ['mgr'] }] },
+    })
+  })
+  it('does NOT seed a legacy approval node (no assigneeSources array) — stays read-only', () => {
+    expect(approvalNodeEditsFromGraph(LEGACY_GRAPH)).toEqual({})
+  })
+})
+
+describe('G-5 topology-preservation — editing an approver source keeps everything else byte-identical', () => {
+  it('changes ONLY the edited approval node assigneeSources; all other nodes + full edges byte-identical', () => {
+    const original = clone(APPROVAL_GRAPH)
+    const edits = approvalNodeEditsFromGraph(APPROVAL_GRAPH)
+    edits.approval_1.assigneeSources = [{ kind: 'direct_manager' }]
+    const rebuilt = applyApprovalNodeEditsToGraph(APPROVAL_GRAPH, edits)
+    expect(nonApproval(rebuilt)).toEqual(nonApproval(original)) // start / condition / end untouched
+    expect(rebuilt.edges).toEqual(original.edges) // topology untouched
+    expect((node(rebuilt, 'approval_1').config as { assigneeSources: unknown }).assigneeSources).toEqual([{ kind: 'direct_manager' }])
+  })
+  it('WITHIN-NODE: the edited node keeps its OWN approvalMode / emptyAssigneePolicy / autoApprovalPolicy byte-identical', () => {
+    const edits = approvalNodeEditsFromGraph(APPROVAL_GRAPH)
+    edits.approval_1.assigneeSources = [{ kind: 'dept_head' }]
+    const cfg = node(applyApprovalNodeEditsToGraph(APPROVAL_GRAPH, edits), 'approval_1').config as Record<string, unknown>
+    expect(cfg.approvalMode).toBe('single')
+    expect(cfg.emptyAssigneePolicy).toBe('error')
+    expect(cfg.autoApprovalPolicy).toEqual({ mergeWithRequester: true }) // preserved, not dropped
+    expect(cfg.assigneeSources).toEqual([{ kind: 'dept_head' }])
+  })
+  it('does not mutate the input graph', () => {
+    const before = clone(APPROVAL_GRAPH)
+    const edits = approvalNodeEditsFromGraph(APPROVAL_GRAPH)
+    edits.approval_1.assigneeSources = [{ kind: 'requester' }]
+    applyApprovalNodeEditsToGraph(APPROVAL_GRAPH, edits)
+    expect(APPROVAL_GRAPH).toEqual(before)
+  })
+})
+
+describe('G-5 untouched round-trip — G-1 floor holds (incl. legacy nodes)', () => {
+  it('an approval+condition graph round-trips byte-identical through draftFromTemplate → buildApprovalGraph', () => {
+    const original = clone(APPROVAL_GRAPH)
+    expect(buildApprovalGraph(draftFromTemplate(buildTemplate(APPROVAL_GRAPH)))).toEqual(original)
+  })
+  it('a LEGACY approval node round-trips byte-identical (not seeded, cloned verbatim)', () => {
+    const original = clone(LEGACY_GRAPH)
+    expect(buildApprovalGraph(draftFromTemplate(buildTemplate(LEGACY_GRAPH)))).toEqual(original)
+  })
+})
+
+describe('G-5 four-phase compose — condition + parallel + cc + approval-node edits all land', () => {
+  it('all four edits land; start/end + every non-edited field + all edges byte-identical', () => {
+    const draft: TemplateAuthoringDraft = draftFromTemplate(buildTemplate(FOUR_TYPE_GRAPH))
+    draft.conditionEdits!.cond_1.branches[0].rules[0].value = 9999
+    draft.parallelEdits!.parallel_1.joinMode = 'any'
+    draft.ccEdits!.cc_1.targetIds = ['treasury']
+    draft.approvalNodeEdits!.approval_1.assigneeSources = [{ kind: 'manager_at_level', level: 2 }]
+    const rebuilt = buildApprovalGraph(draft)
+    expect((node(rebuilt, 'cond_1').config as { branches: { rules: { value: unknown }[] }[] }).branches[0].rules[0].value).toBe(9999)
+    expect((node(rebuilt, 'parallel_1').config as { joinMode: string }).joinMode).toBe('any')
+    expect((node(rebuilt, 'cc_1').config as { targetIds: string[] }).targetIds).toEqual(['treasury'])
+    expect((node(rebuilt, 'approval_1').config as { assigneeSources: unknown }).assigneeSources).toEqual([{ kind: 'manager_at_level', level: 2 }])
+    expect(rebuilt.edges).toEqual(FOUR_TYPE_GRAPH.edges) // topology untouched
+    expect(node(rebuilt, 'start')).toEqual(node(FOUR_TYPE_GRAPH, 'start'))
+    expect(node(rebuilt, 'end')).toEqual(node(FOUR_TYPE_GRAPH, 'end'))
+  })
+})
+
+describe('validateApprovalNodeEdits (preview mirrors the backend assignee rule)', () => {
+  it('passes a valid source edit', () => {
+    expect(validateApprovalNodeEdits({ a: { nodeKey: 'a', assigneeSources: [{ kind: 'direct_manager' }] } })).toEqual([])
+  })
+  it('flags an empty assigneeSources', () => {
+    expect(validateApprovalNodeEdits({ a: { nodeKey: 'a', assigneeSources: [] } })[0]).toMatch(/至少需要一个审批人来源/)
+  })
+  it('flags a form_field_user pointing at a NON-top-level-user field', () => {
+    const errs = validateApprovalNodeEdits(
+      { a: { nodeKey: 'a', assigneeSources: [{ kind: 'form_field_user', fieldId: 'amount' }] } },
+      [{ id: 'amount', type: 'number' }, { id: 'mgr_field', type: 'user' }],
+    )
+    expect(errs[0]).toMatch(/顶层用户字段/)
+  })
+  it('passes a form_field_user pointing at a top-level user field', () => {
+    expect(validateApprovalNodeEdits(
+      { a: { nodeKey: 'a', assigneeSources: [{ kind: 'form_field_user', fieldId: 'mgr_field' }] } },
+      [{ id: 'mgr_field', type: 'user' }],
+    )).toEqual([])
+  })
+  it('surfaces an approval-node preview error through validateTemplateDraft', () => {
+    const draft = draftFromTemplate(buildTemplate(APPROVAL_GRAPH))
+    draft.approvalNodeEdits!.approval_1.assigneeSources = []
+    expect(validateTemplateDraft(draft).some((e) => /审批人来源/.test(e))).toBe(true)
+  })
+})

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -735,6 +735,74 @@ describe('TemplateAuthoringView', () => {
     expect((container!.querySelector('[data-testid="approval-step-source-kind"]') as HTMLSelectElement).value).toBe('direct_manager') // hydrated back
   })
 
+  // G-5 wiring (mounted SFC): helper tests prove the edit logic; these prove the COMPLEX-graph
+  // approval-node SOURCE control actually writes the changed source through @update:model-value →
+  // edit model → save payload (the wire a pure-helper test can't see), and that a legacy node shows
+  // no editor. cc node forces the preserved-graph (complex) path so the structured editor renders.
+  function buildG5ComplexGraph(approval1Config: Record<string, unknown>) {
+    return {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'approval_1', type: 'approval', name: '主管', config: approval1Config },
+        { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['finance'] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e1', source: 'start', target: 'approval_1' },
+        { key: 'e2', source: 'approval_1', target: 'cc_1' },
+        { key: 'e3', source: 'cc_1', target: 'end' },
+      ],
+    }
+  }
+
+  it('G-5 wiring: changing an approval-node source via the SFC control writes it to the save payload; mode/policy/autoApprovalPolicy + cc + edges preserved', async () => {
+    routeParams = { id: 'tpl_g5' }
+    const graph = buildG5ComplexGraph({ assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error', autoApprovalPolicy: { mergeWithRequester: true } })
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    // editor renders for the seeded approval node, hydrated to its current source
+    expect(container!.querySelector('[data-approval-node="approval_1"]')).not.toBeNull()
+    const kindSelect = container!.querySelector('[data-testid="approval-node-source-kind"]') as HTMLSelectElement
+    expect(kindSelect).not.toBeNull()
+    expect(kindSelect.value).toBe('direct_manager')
+
+    // change the source kind through the REAL control (direct_manager → dept_head — both valid
+    // no-ID kinds; a static_* target would need IDs the multi-select stub can't drive, and that ID
+    // logic is helper-covered. Note: switching to an EMPTY static_role correctly BLOCKS save via the
+    // validation preview — proving validation is wired too), then save.
+    kindSelect.value = 'dept_head'
+    kindSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const approval1 = payload.approvalGraph.nodes.find((n: any) => n.key === 'approval_1')
+    expect(approval1.config.assigneeSources).toEqual([{ kind: 'dept_head' }]) // CHANGED via the control
+    expect(approval1.config.approvalMode).toBe('single') // preserved on the edited node
+    expect(approval1.config.emptyAssigneePolicy).toBe('error') // preserved
+    expect(approval1.config.autoApprovalPolicy).toEqual({ mergeWithRequester: true }) // preserved
+    // cc node + ALL edges byte-identical
+    expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cc_1').config).toEqual({ targetType: 'role', targetIds: ['finance'] })
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
+  })
+
+  it('G-5 wiring: a LEGACY approval node (assigneeType/assigneeIds, no assigneeSources) shows NO source editor but still renders read-only', async () => {
+    routeParams = { id: 'tpl_g5_legacy' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildG5ComplexGraph({ assigneeType: 'role', assigneeIds: ['legacy_role'], approvalMode: 'single' }),
+    }))
+    await mountView()
+    await flushUi()
+
+    expect(container!.querySelector('[data-approval-node="approval_1"]')).toBeNull() // no editor for a legacy node
+    expect(container!.querySelector('[data-testid="approval-graph-readonly-list"]')).not.toBeNull() // graph still renders (legacy keys are allowlisted)
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // not fail-closed
+  })
+
   it('dept_head reads back editable: a saved dept_head template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {
     routeParams = { id: 'tpl_dh' }
     getTemplateSpy.mockResolvedValue(buildTemplate({

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -115,3 +115,11 @@
   doc's deferral premise was factually wrong. Re-scoped OUT of "out of scope" — pending owner
   ratification (see the G-3 PR body). The OTHER parallel limits (nested parallel, editing
   branches/joinNodeKey topology) remain out of scope.
+- 🔜 **FOLLOW-UP (G-5 review, NAMED not fixed): cc / condition / parallel config unknown-key
+  fail-closed.** G-5 added `complexApprovalConfigHasBackendDrop` (top-level + nested) for `approval`
+  nodes ONLY. The SAME latent gap exists for cc/condition/parallel: the backend rebuilds those configs
+  from fixed shapes (e.g. cc → `{targetType, targetIds}`, ApprovalProductService.ts:920-923) and
+  silently drops any other key, while the FE spread-preserves it → save-flatten the FE round-trip
+  can't see. Pre-existing since G-2/3/4, outside G-5's stated scope; needs a sibling shape-check pass
+  (their nested shapes — condition `branches[].rules[]`, parallel `branches[]` — are deeper, so size
+  it separately). Tracked here as a declared boundary.

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -93,6 +93,19 @@
 - ✅ 13 cc tests (topology-preservation + condition×cc compose + untouched round-trip + validation),
   wired into approval-web-guard. The complex-graph author UI render+edit set is complete.
 
+## Phase G-5 — approval-node editor ✅ (post-arc slice; unlocks #3114 amount-tier preset runtime)
+- ✅ approval node's **approver SOURCE only** (`assigneeSources`) editable in a preserved complex
+  graph; pure logic in `approvalNodeEdit.ts` (`applyApprovalNodeEditsToGraph` = the FOURTH disjoint
+  pass after condition/parallel/cc — every other node + all edges byte-identical; spread-original-first
+  so the edited node's own `approvalMode` / `emptyAssigneePolicy` / `autoApprovalPolicy` survive).
+  Legacy nodes (no `assigneeSources`) aren't seeded → cloned verbatim, read-only.
+- ✅ **SCOPE (honest):** approver-source editing only; `approvalMode` / `emptyAssigneePolicy` are
+  PRESERVED, not yet editable (a later slice). View is a compact per-kind source control (ID-typed,
+  not the rich directory picker yet); multi-source nodes edit the primary source + preserve extras.
+- ✅ 13 tests (topology + WITHIN-NODE preservation + legacy round-trip + FOUR-phase compose +
+  form_field_user→top-level-user validation), wired into approval-web-guard. This is the #3114
+  Decision-4 prerequisite (admins can now tune "which role/person approves at a threshold").
+
 ## Out of scope (v1 — reopen-only, see design-lock §7)
 - 🔒 Free-canvas / drag-edge editor · new node types · runtime/validator changes · nested
   parallel · any flatten of unsupported constructs · W7 approval-result write-back (own scope-doc,


### PR DESCRIPTION
Makes an `approval` node inside a **preserved complex graph** editable for its approver **source** (`assigneeSources`) — the **#3114 Decision-4 prerequisite** the amount-tier preset runtime depends on ("admins must tune which role/person approves at a threshold").

## Changes
- **`approvalNodeEdit.ts`** (pure, no `.vue`): `applyApprovalNodeEditsToGraph` is the **fourth disjoint edit pass** after condition/parallel/cc. The `assigneeSources`-present guard + spread-original-first means an untouched node is **byte-identical by construction**, a **legacy** node (`assigneeType`/`assigneeIds`, no `assigneeSources`) is never seeded → cloned verbatim + read-only, and the edited node's own `approvalMode`/`emptyAssigneePolicy`/`autoApprovalPolicy` **survive**. `validateApprovalNodeEdits` mirrors the backend (`ApprovalProductService.ts:457-480`): a `form_field_user` source must reference a **top-level user field**.
- **View**: a compact per-kind source control on complex-graph approval nodes; condition/parallel/cc keep their editors; topology read-only.

## Scope (deliberately honest)
- **Approver-source editing only.** `approvalMode` / `emptyAssigneePolicy` are **preserved, not yet editable** (a later slice).
- View is a **compact ID-typed control**, not the rich directory picker the linear editor uses.
- Multi-source nodes: edit the **primary** source, preserve extras.

So **G-5 ≠ "approval-node editing done"** — it's the source-editing unlock #3114 needs, with the rest scoped to follow-ups.

## Tests
13 tests — topology-preservation, **within-node** config survival on the edited node, **legacy-node** round-trip byte-identical, **four-phase compose** (condition+parallel+cc+approval all land), `form_field_user`→top-level-user validation. Wired into `approval-web-guard` (**168/168**). vue-tsc + lint clean.

UI-only — no runtime/validator/type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)