### PR TITLE
feat(multitable): T9-R1 config history — field create/update/delete recording

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -215,6 +215,7 @@ jobs:
             tests/integration/multitable-restore-per-field-realdb.test.ts \
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
+            tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/packages/core-backend/src/db/migrations/zzzz20260624120000_create_meta_config_revisions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260624120000_create_meta_config_revisions.ts
@@ -1,0 +1,44 @@
+import { sql, type Kysely } from 'kysely'
+
+// T9-R1: config/schema-change history. Append-only history of CONFIG entities (v1 records only `field`; permissions
+// / views / sheet_config are R2). Parallels meta_record_revisions but for STRUCTURE, not record values.
+//
+// IMPORTANT: meta_config_revisions rows are NOT record data. A future read API (T9-R3) MUST apply its own
+// per-entity-type config-manage gate (field → canManageFields, etc.) and MUST NOT reuse the record-history
+// projection / record mask — that mask is for record values; this table holds config.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_config_revisions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      entity_type text NOT NULL CHECK (entity_type IN ('field', 'permission', 'view', 'sheet_config')),
+      entity_id text NOT NULL,
+      action text NOT NULL CHECK (action IN ('create', 'update', 'delete')),
+      before jsonb,
+      after jsonb,
+      changed_keys text[] NOT NULL DEFAULT ARRAY[]::text[],
+      batch_id uuid,
+      actor_id text,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  // T9-L6 deterministic order: the sheet-level timeline reads (sheet_id, created_at DESC, id DESC).
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_config_revisions_sheet_created
+    ON meta_config_revisions(sheet_id, created_at DESC, id DESC)
+  `.execute(db)
+  // per-entity drill-down.
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_config_revisions_entity
+    ON meta_config_revisions(sheet_id, entity_type, entity_id, created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_config_revisions_entity`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_config_revisions_sheet_created`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_config_revisions`.execute(db)
+}

--- a/packages/core-backend/src/multitable/config-revision-recorder.ts
+++ b/packages/core-backend/src/multitable/config-revision-recorder.ts
@@ -74,6 +74,29 @@ export function fieldCreateDiff(after: FieldConfigSnapshot): FieldDiff {
 export function fieldDeleteDiff(before: FieldConfigSnapshot): FieldDiff {
   return { before: { ...before }, after: null, changedKeys: [...FIELD_CONFIG_KEYS] }
 }
+/**
+ * Record the order-only side-effect of a bulk reorder: a field mutation (insert-in-middle / reorder / delete)
+ * shifts OTHER fields' `order`, and each of those is a real config change. The caller passes the rows the shift
+ * `UPDATE … RETURNING id, "order"` returned (the NEW order) + the `delta` applied (+1 or -1), and the SHARED
+ * per-request `batchId` so the whole reorder reads as one logical operation. Old order = newOrder − delta.
+ */
+export async function recordFieldOrderShifts(
+  query: QueryFn,
+  sheetId: string,
+  shifted: Array<{ id: string; newOrder: number }>,
+  delta: number,
+  batchId: string,
+  actorId: string | null,
+): Promise<void> {
+  for (const f of shifted) {
+    await recordConfigRevision(query, {
+      sheetId, entityType: 'field', entityId: f.id, action: 'update',
+      before: { order: f.newOrder - delta }, after: { order: f.newOrder }, changedKeys: ['order'],
+      batchId, actorId,
+    })
+  }
+}
+
 /** Update diff — only the changed config keys. Returns null on a no-op (caller records nothing). */
 export function fieldUpdateDiff(before: FieldConfigSnapshot, after: FieldConfigSnapshot): FieldDiff | null {
   const changedKeys: string[] = []

--- a/packages/core-backend/src/multitable/config-revision-recorder.ts
+++ b/packages/core-backend/src/multitable/config-revision-recorder.ts
@@ -1,0 +1,91 @@
+/**
+ * T9-R1 — config/schema-change history recorder (FIELDS only in v1).
+ *
+ * `recordConfigRevision` appends one `meta_config_revisions` row using the MUTATION'S OWN transaction `query`, so a
+ * config change and its history row commit or roll back together — the history can never diverge from live config
+ * (T9-L4). It is append-only and never restores (T9-L1). The field-diff helpers below are diff-first (T9-L /D2):
+ * create → after = the field's own config; delete → before = the config; update → the changed keys only (empty diff
+ * → null, the caller records nothing — no rename-to-same spam).
+ *
+ * NOT in R1: read API, permissions, views, sheet-config, cascade recording. This module only RECORDS field changes.
+ */
+
+type QueryFn = (text: string, params: unknown[]) => Promise<unknown>
+
+export type ConfigEntityType = 'field' | 'permission' | 'view' | 'sheet_config'
+export type ConfigAction = 'create' | 'update' | 'delete'
+
+export interface ConfigRevisionInput {
+  sheetId: string
+  entityType: ConfigEntityType
+  entityId: string
+  action: ConfigAction
+  /** the diff endpoints (NOT a full snapshot, D2) — null on the create/delete side. */
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changedKeys: string[]
+  /** groups a mutation with its cascaded derived changes (T9-L7); per-request. */
+  batchId: string | null
+  actorId: string | null
+}
+
+export async function recordConfigRevision(query: QueryFn, input: ConfigRevisionInput): Promise<void> {
+  await query(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::text[], $8, $9)`,
+    [
+      input.sheetId,
+      input.entityType,
+      input.entityId,
+      input.action,
+      JSON.stringify(input.before ?? null),
+      JSON.stringify(input.after ?? null),
+      input.changedKeys,
+      input.batchId,
+      input.actorId,
+    ],
+  )
+}
+
+/** The config-relevant keys of a field (identity keys id/sheet_id are excluded — they are not config changes). */
+export interface FieldConfigSnapshot {
+  name: string
+  type: string
+  property: unknown
+  order: number
+}
+const FIELD_CONFIG_KEYS: ReadonlyArray<keyof FieldConfigSnapshot> = ['name', 'type', 'property', 'order']
+
+// Stable equality for a config key (property is an object; name/type/order scalar). A field's property is written
+// wholesale, so a serialized compare reliably detects a change.
+function sameConfigValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null)
+}
+
+export interface FieldDiff {
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changedKeys: string[]
+}
+
+export function fieldCreateDiff(after: FieldConfigSnapshot): FieldDiff {
+  return { before: null, after: { ...after }, changedKeys: [...FIELD_CONFIG_KEYS] }
+}
+export function fieldDeleteDiff(before: FieldConfigSnapshot): FieldDiff {
+  return { before: { ...before }, after: null, changedKeys: [...FIELD_CONFIG_KEYS] }
+}
+/** Update diff — only the changed config keys. Returns null on a no-op (caller records nothing). */
+export function fieldUpdateDiff(before: FieldConfigSnapshot, after: FieldConfigSnapshot): FieldDiff | null {
+  const changedKeys: string[] = []
+  const b: Record<string, unknown> = {}
+  const a: Record<string, unknown> = {}
+  for (const k of FIELD_CONFIG_KEYS) {
+    if (!sameConfigValue(before[k], after[k])) {
+      changedKeys.push(k)
+      b[k] = before[k]
+      a[k] = after[k]
+    }
+  }
+  if (changedKeys.length === 0) return null
+  return { before: b, after: a, changedKeys }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,7 +74,7 @@ import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity } from '../multitable/restore-preview-identity'
-import { recordConfigRevision, recordFieldOrderShifts, fieldCreateDiff, fieldUpdateDiff, fieldDeleteDiff, type FieldConfigSnapshot } from '../multitable/config-revision-recorder'
+import { recordConfigRevision, recordFieldOrderShifts, fieldCreateDiff, fieldUpdateDiff, fieldDeleteDiff } from '../multitable/config-revision-recorder'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,6 +74,7 @@ import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity } from '../multitable/restore-preview-identity'
+import { recordConfigRevision, fieldCreateDiff, fieldUpdateDiff, fieldDeleteDiff, type FieldConfigSnapshot } from '../multitable/config-revision-recorder'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
@@ -8468,6 +8469,13 @@ export function univerMetaRouter(): Router {
         if (type === 'autoNumber') {
           await backfillAutoNumberField(query, sheetId, fieldId, property)
         }
+
+        // T9-R1: record the field creation in the SAME transaction (config history can't diverge from live config).
+        await recordConfigRevision(query, {
+          sheetId, entityType: 'field', entityId: fieldId, action: 'create',
+          ...fieldCreateDiff({ name: String(row.name), type: String(row.type), property: row.property, order: Number(row.order) }),
+          batchId: randomUUID(), actorId: getRequestActorId(req),
+        })
       })
 
       const fieldRes = await pool.query(
@@ -8892,6 +8900,19 @@ export function univerMetaRouter(): Router {
           await syncFormulaDependencies(query, sheetId, fieldId, refs)
         }
 
+        // T9-R1: record the field update — only the CHANGED config keys; a no-op (nothing changed) records nothing.
+        const updateDiff = fieldUpdateDiff(
+          { name: String(row.name), type: String(row.type), property: row.property, order: Number(row.order) },
+          { name: String(updatedRow.name), type: String(updatedRow.type), property: updatedRow.property, order: Number(updatedRow.order) },
+        )
+        if (updateDiff) {
+          await recordConfigRevision(query, {
+            sheetId, entityType: 'field', entityId: fieldId, action: 'update',
+            before: updateDiff.before, after: updateDiff.after, changedKeys: updateDiff.changedKeys,
+            batchId: randomUUID(), actorId: getRequestActorId(req),
+          })
+        }
+
         return serializeFieldRow(updatedRow)
       })
 
@@ -8952,7 +8973,7 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageFields) return sendForbidden(res)
       const result = await pool.transaction(async ({ query }) => {
-        const existing = await query('SELECT id, sheet_id, "order" FROM meta_fields WHERE id = $1', [fieldId])
+        const existing = await query('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1', [fieldId])
         if ((existing as any).rows.length === 0) throw new NotFoundError(`Field not found: ${fieldId}`)
         const row = (existing as any).rows[0]
         const sheetId = String(row.sheet_id)
@@ -8960,6 +8981,14 @@ export function univerMetaRouter(): Router {
 
         await query('DELETE FROM meta_fields WHERE id = $1', [fieldId])
         await query('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [fieldId])
+
+        // T9-R1: record the field deletion (before = the deleted field's config). The cascade view-config cleanup
+        // below is NOT recorded in R1 (view recording is R2); it will group under this batchId once R2 lands (T9-L7).
+        await recordConfigRevision(query, {
+          sheetId, entityType: 'field', entityId: fieldId, action: 'delete',
+          ...fieldDeleteDiff({ name: String(row.name), type: String(row.type), property: row.property, order }),
+          batchId: randomUUID(), actorId: getRequestActorId(req),
+        })
 
         try {
           await query('DELETE FROM meta_links WHERE field_id = $1', [fieldId])

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -74,7 +74,7 @@ import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity } from '../multitable/restore-preview-identity'
-import { recordConfigRevision, fieldCreateDiff, fieldUpdateDiff, fieldDeleteDiff, type FieldConfigSnapshot } from '../multitable/config-revision-recorder'
+import { recordConfigRevision, recordFieldOrderShifts, fieldCreateDiff, fieldUpdateDiff, fieldDeleteDiff, type FieldConfigSnapshot } from '../multitable/config-revision-recorder'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
@@ -8407,6 +8407,7 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageFields) return sendForbidden(res)
       await pool.transaction(async ({ query }) => {
+        const configBatchId = randomUUID() // T9-R1: one batchId per request — the new field + any shifted fields share it
         const { type, property } = await normalizeFieldWriteInput(
           query as unknown as QueryFn,
           sheetId,
@@ -8446,7 +8447,9 @@ export function univerMetaRouter(): Router {
           const maxOrder = Number((maxRes as any).rows?.[0]?.max_order ?? -1)
           order = Number.isFinite(maxOrder) ? maxOrder + 1 : 0
         } else {
-          await query('UPDATE meta_fields SET "order" = "order" + 1 WHERE sheet_id = $1 AND "order" >= $2', [sheetId, order])
+          // T9-R1: insert-in-middle shifts existing fields +1 — record each shifted field's order change too.
+          const shifted = ((await query('UPDATE meta_fields SET "order" = "order" + 1 WHERE sheet_id = $1 AND "order" >= $2 RETURNING id, "order"', [sheetId, order])) as any).rows as Array<{ id: string; order: number }>
+          await recordFieldOrderShifts(query, sheetId, shifted.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), 1, configBatchId, getRequestActorId(req))
         }
 
         const insert = await query(
@@ -8474,7 +8477,7 @@ export function univerMetaRouter(): Router {
         await recordConfigRevision(query, {
           sheetId, entityType: 'field', entityId: fieldId, action: 'create',
           ...fieldCreateDiff({ name: String(row.name), type: String(row.type), property: row.property, order: Number(row.order) }),
-          batchId: randomUUID(), actorId: getRequestActorId(req),
+          batchId: configBatchId, actorId: getRequestActorId(req),
         })
       })
 
@@ -8750,6 +8753,7 @@ export function univerMetaRouter(): Router {
           typeof parsed.data.property !== 'undefined' ? parsed.data.property : row.property,
         )
         const desiredOrder = parsed.data.order
+        const configBatchId = randomUUID() // T9-R1: one batchId per request — the updated field + any shifted fields share it
 
         // Rich-longText backward-compat gate (§4) — shared with the plugin-SDK provisioning
         // property write so BOTH boundaries reject flipping a POPULATED field to rich (whose old
@@ -8859,16 +8863,19 @@ export function univerMetaRouter(): Router {
         }
 
         if (typeof desiredOrder === 'number' && desiredOrder !== currentOrder) {
+          // T9-R1: a reorder shifts the fields BETWEEN old and new position — record each shifted field's order too.
           if (desiredOrder < currentOrder) {
-            await query(
-              'UPDATE meta_fields SET "order" = "order" + 1 WHERE sheet_id = $1 AND "order" >= $2 AND "order" < $3 AND id <> $4',
+            const shifted = ((await query(
+              'UPDATE meta_fields SET "order" = "order" + 1 WHERE sheet_id = $1 AND "order" >= $2 AND "order" < $3 AND id <> $4 RETURNING id, "order"',
               [sheetId, desiredOrder, currentOrder, fieldId],
-            )
+            )) as any).rows as Array<{ id: string; order: number }>
+            await recordFieldOrderShifts(query, sheetId, shifted.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), 1, configBatchId, getRequestActorId(req))
           } else {
-            await query(
-              'UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2 AND "order" <= $3 AND id <> $4',
+            const shifted = ((await query(
+              'UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2 AND "order" <= $3 AND id <> $4 RETURNING id, "order"',
               [sheetId, currentOrder, desiredOrder, fieldId],
-            )
+            )) as any).rows as Array<{ id: string; order: number }>
+            await recordFieldOrderShifts(query, sheetId, shifted.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), -1, configBatchId, getRequestActorId(req))
           }
         }
 
@@ -8909,7 +8916,7 @@ export function univerMetaRouter(): Router {
           await recordConfigRevision(query, {
             sheetId, entityType: 'field', entityId: fieldId, action: 'update',
             before: updateDiff.before, after: updateDiff.after, changedKeys: updateDiff.changedKeys,
-            batchId: randomUUID(), actorId: getRequestActorId(req),
+            batchId: configBatchId, actorId: getRequestActorId(req),
           })
         }
 
@@ -8978,6 +8985,7 @@ export function univerMetaRouter(): Router {
         const row = (existing as any).rows[0]
         const sheetId = String(row.sheet_id)
         const order = Number(row.order ?? 0)
+        const configBatchId = randomUUID() // T9-R1: one batchId — the deleted field + the order-shift of later fields share it
 
         await query('DELETE FROM meta_fields WHERE id = $1', [fieldId])
         await query('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [fieldId])
@@ -8987,7 +8995,7 @@ export function univerMetaRouter(): Router {
         await recordConfigRevision(query, {
           sheetId, entityType: 'field', entityId: fieldId, action: 'delete',
           ...fieldDeleteDiff({ name: String(row.name), type: String(row.type), property: row.property, order }),
-          batchId: randomUUID(), actorId: getRequestActorId(req),
+          batchId: configBatchId, actorId: getRequestActorId(req),
         })
 
         try {
@@ -8998,7 +9006,9 @@ export function univerMetaRouter(): Router {
 
         // lock-exempt: field-delete schema op — drops the deleted field's key sheet-wide; not a per-record user edit.
         await query('UPDATE meta_records SET data = data - $1 WHERE sheet_id = $2', [fieldId, sheetId])
-        await query('UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2', [sheetId, order])
+        // T9-R1: deleting a field shifts later fields' order -1 — record each shifted field under the same batchId.
+        const shiftedDel = ((await query('UPDATE meta_fields SET "order" = "order" - 1 WHERE sheet_id = $1 AND "order" > $2 RETURNING id, "order"', [sheetId, order])) as any).rows as Array<{ id: string; order: number }>
+        await recordFieldOrderShifts(query, sheetId, shiftedDel.map((r) => ({ id: String(r.id), newOrder: Number(r.order) })), -1, configBatchId, getRequestActorId(req))
 
         const views = await query(
           'SELECT id, filter_info, sort_info, group_info, hidden_field_ids FROM meta_views WHERE sheet_id = $1',

--- a/packages/core-backend/tests/integration/config-revision-mock.ts
+++ b/packages/core-backend/tests/integration/config-revision-mock.ts
@@ -1,0 +1,8 @@
+// T9-R1: field create/update/delete now append a meta_config_revisions row in the SAME transaction. Mock route
+// tests whose queryHandler throws on unrecognized SQL must accept that insert as a no-op so the route doesn't 500.
+// Shared so the no-op lives in ONE place across the mock route tests.
+export type ConfigRevisionMockResult = { rows: never[]; rowCount: number }
+
+export function configRevisionNoop(sql: string): ConfigRevisionMockResult | null {
+  return /meta_config_revisions/i.test(sql) ? { rows: [], rowCount: 0 } : null
+}

--- a/packages/core-backend/tests/integration/config-revision-mock.ts
+++ b/packages/core-backend/tests/integration/config-revision-mock.ts
@@ -3,6 +3,8 @@
 // Shared so the no-op lives in ONE place across the mock route tests.
 export type ConfigRevisionMockResult = { rows: never[]; rowCount: number }
 
+// Match ONLY the T9-R1 insert — not an accidental SELECT/UPDATE/DELETE on the table, which a future mock route test
+// might legitimately want to handle itself rather than have silently swallowed.
 export function configRevisionNoop(sql: string): ConfigRevisionMockResult | null {
-  return /meta_config_revisions/i.test(sql) ? { rows: [], rowCount: 0 } : null
+  return /^\s*INSERT\s+INTO\s+meta_config_revisions\b/i.test(sql) ? { rows: [], rowCount: 0 } : null
 }

--- a/packages/core-backend/tests/integration/multitable-config-revisions-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-revisions-realdb.test.ts
@@ -1,0 +1,118 @@
+/**
+ * T9-R1: config/schema-change history recording (FIELDS only) — real DB. A field create/update/delete appends a
+ * meta_config_revisions row IN the mutation's transaction (diff-first; no-op records nothing). Read-only: this slice
+ * only RECORDS — no read API, no gate, no permissions/views/cascade. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_cr_${TS}`
+const SHEET = `sheet_cr_${TS}`
+const ACTOR = `user_cr_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+const createField = (body: Record<string, unknown>) => request(app).post('/api/multitable/fields').send({ sheetId: SHEET, ...body })
+const updateField = (fieldId: string, body: Record<string, unknown>) => request(app).patch(`/api/multitable/fields/${fieldId}`).send(body)
+const deleteField = (fieldId: string) => request(app).delete(`/api/multitable/fields/${fieldId}`)
+const configRevs = async (entityId?: string) => (await q(
+  `SELECT entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id
+   FROM meta_config_revisions WHERE sheet_id = $1 ${entityId ? 'AND entity_id = $2' : ''} ORDER BY created_at DESC, id DESC`,
+  entityId ? [SHEET, entityId] : [SHEET],
+)).rows as Array<{ entity_type: string; entity_id: string; action: string; before: any; after: any; changed_keys: string[]; batch_id: string | null; actor_id: string | null }>
+
+describeIfDatabase('multitable config-revisions recording — T9-R1 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: ['owner'], perms: ['multitable:read', 'multitable:write', 'multitable:manage'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CR Sheet'])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    for (const t of ['meta_fields', 'meta_records']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  beforeEach(async () => { await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]); await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]) })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('field CREATE → one config-revision (entity field, action create, after=config, all keys, actor)', async () => {
+    const res = await createField({ name: 'Title', type: 'string' })
+    expect(res.status).toBe(201)
+    const fid = res.body?.data?.field?.id
+    const revs = await configRevs(fid)
+    expect(revs.length).toBe(1)
+    expect(revs[0]).toMatchObject({ entity_type: 'field', entity_id: fid, action: 'create', actor_id: ACTOR })
+    expect(revs[0].before).toBeNull()
+    expect(revs[0].after).toMatchObject({ name: 'Title', type: 'string' })
+    expect(revs[0].changed_keys.sort()).toEqual(['name', 'order', 'property', 'type'])
+    expect(revs[0].batch_id).toBeTruthy()
+  })
+
+  test('field RENAME → action update, changed_keys=[name] only, before/after the name', async () => {
+    const fid = (await createField({ name: 'Old', type: 'string' })).body?.data?.field?.id
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]) // isolate the update
+    const res = await updateField(fid, { name: 'New' })
+    expect(res.status).toBe(200)
+    const revs = await configRevs(fid)
+    expect(revs.length).toBe(1)
+    expect(revs[0]).toMatchObject({ action: 'update' })
+    expect(revs[0].changed_keys).toEqual(['name'])
+    expect(revs[0].before).toMatchObject({ name: 'Old' })
+    expect(revs[0].after).toMatchObject({ name: 'New' })
+  })
+
+  test('field RETYPE → action update, changed_keys includes type', async () => {
+    const fid = (await createField({ name: 'Num', type: 'string' })).body?.data?.field?.id
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    await updateField(fid, { type: 'number' })
+    const revs = await configRevs(fid)
+    expect(revs.length).toBe(1)
+    expect(revs[0].action).toBe('update')
+    expect(revs[0].changed_keys).toContain('type')
+  })
+
+  test('field NO-OP update (rename to the same name) records NOTHING', async () => {
+    const fid = (await createField({ name: 'Same', type: 'string' })).body?.data?.field?.id
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    await updateField(fid, { name: 'Same' })
+    expect((await configRevs(fid)).length).toBe(0) // empty diff → no spam
+  })
+
+  test('field DELETE → action delete, before=config, after=null, batch_id (for the R2 cascade)', async () => {
+    const fid = (await createField({ name: 'Gone', type: 'string' })).body?.data?.field?.id
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    await deleteField(fid)
+    const revs = await configRevs(fid)
+    expect(revs.length).toBe(1)
+    expect(revs[0].action).toBe('delete')
+    expect(revs[0].before).toMatchObject({ name: 'Gone', type: 'string' })
+    expect(revs[0].after).toBeNull()
+    expect(revs[0].batch_id).toBeTruthy()
+  })
+
+  test('deterministic order + no record-value leakage (config-only columns)', async () => {
+    const a = (await createField({ name: 'A', type: 'string' })).body?.data?.field?.id
+    const b = (await createField({ name: 'B', type: 'string' })).body?.data?.field?.id
+    const revs = await configRevs()
+    expect(revs.length).toBe(2)
+    expect(revs[0].entity_id).toBe(b) // most-recent first (created_at DESC, id DESC)
+    expect(revs[1].entity_id).toBe(a)
+    // structure-only: the row carries config keys, never a record-data column
+    for (const r of revs) expect(Object.keys(r.after ?? {}).sort()).toEqual(['name', 'order', 'property', 'type'])
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-config-revisions-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-revisions-realdb.test.ts
@@ -115,4 +115,49 @@ describeIfDatabase('multitable config-revisions recording — T9-R1 (real DB)', 
     // structure-only: the row carries config keys, never a record-data column
     for (const r of revs) expect(Object.keys(r.after ?? {}).sort()).toEqual(['name', 'order', 'property', 'type'])
   })
+
+  test('MIDDLE INSERT: create at order 0 shifts existing fields — each shift recorded under ONE batchId', async () => {
+    const a = (await createField({ name: 'A', type: 'string' })).body?.data?.field?.id // order 0
+    const b = (await createField({ name: 'B', type: 'string' })).body?.data?.field?.id // order 1
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    const c = (await createField({ name: 'C', type: 'string', order: 0 })).body?.data?.field?.id // insert at front → A,B shift +1
+    const revs = await configRevs()
+    expect(revs.length).toBe(3) // C create + A,B order shifts (previously only C was recorded — the [P2] gap)
+    const byId = Object.fromEntries(revs.map((r) => [r.entity_id, r]))
+    expect(byId[c].action).toBe('create')
+    expect(byId[a]).toMatchObject({ action: 'update' }); expect(byId[a].changed_keys).toEqual(['order'])
+    expect(byId[a].before).toMatchObject({ order: 0 }); expect(byId[a].after).toMatchObject({ order: 1 })
+    expect(byId[b].before).toMatchObject({ order: 1 }); expect(byId[b].after).toMatchObject({ order: 2 })
+    expect(new Set(revs.map((r) => r.batch_id)).size).toBe(1) // one logical operation = one batchId
+  })
+
+  test('REORDER: moving a field shifts the fields between it — each recorded under ONE batchId', async () => {
+    const a = (await createField({ name: 'A', type: 'string' })).body?.data?.field?.id // 0
+    const b = (await createField({ name: 'B', type: 'string' })).body?.data?.field?.id // 1
+    const c = (await createField({ name: 'C', type: 'string' })).body?.data?.field?.id // 2
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    await updateField(a, { order: 2 }) // A 0→2 ; B,C shift -1
+    const revs = await configRevs()
+    expect(revs.length).toBe(3) // A update + B,C shifts
+    const byId = Object.fromEntries(revs.map((r) => [r.entity_id, r]))
+    expect(byId[a].action).toBe('update'); expect(byId[a].changed_keys).toContain('order')
+    expect(byId[b].changed_keys).toEqual(['order']); expect(byId[c].changed_keys).toEqual(['order'])
+    expect(new Set(revs.map((r) => r.batch_id)).size).toBe(1)
+  })
+
+  test('DELETE shift: deleting a middle field shifts later fields -1 — recorded under ONE batchId', async () => {
+    const a = (await createField({ name: 'A', type: 'string' })).body?.data?.field?.id // 0
+    const b = (await createField({ name: 'B', type: 'string' })).body?.data?.field?.id // 1
+    const c = (await createField({ name: 'C', type: 'string' })).body?.data?.field?.id // 2
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET])
+    await deleteField(b) // B deleted (order 1) ; C shifts 2→1
+    const revs = await configRevs()
+    expect(revs.length).toBe(2) // B delete + C shift
+    const byId = Object.fromEntries(revs.map((r) => [r.entity_id, r]))
+    expect(byId[b].action).toBe('delete')
+    expect(byId[c].changed_keys).toEqual(['order'])
+    expect(byId[c].before).toMatchObject({ order: 2 }); expect(byId[c].after).toMatchObject({ order: 1 })
+    expect(new Set(revs.map((r) => r.batch_id)).size).toBe(1)
+    void a // a unused beyond setup
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -2,6 +2,8 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+import { configRevisionNoop } from './config-revision-mock'
+
 type QueryResult = {
   rows: any[]
   rowCount?: number
@@ -146,6 +148,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -263,6 +266,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -334,6 +338,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -406,6 +411,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -503,6 +509,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -544,6 +551,7 @@ describe('Multitable context API', () => {
         if (sql.includes('INSERT INTO meta_views')) {
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -574,6 +582,7 @@ describe('Multitable context API', () => {
           viewInsert = params
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -696,6 +705,7 @@ describe('Multitable context API', () => {
           const [viewId] = params as [string]
           return { rows: views.filter((view) => view.id === viewId) }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -784,6 +794,7 @@ describe('Multitable context API', () => {
           const [viewId] = params as [string]
           return { rows: views.filter((view) => view.id === viewId) }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -876,6 +887,7 @@ describe('Multitable context API', () => {
         if (sql.includes('INSERT INTO meta_views')) {
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -907,6 +919,7 @@ describe('Multitable context API', () => {
             rows: [{ id: 'base_ops', owner_id: 'someone_else' }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -934,6 +947,7 @@ describe('Multitable context API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -958,6 +972,7 @@ describe('Multitable context API', () => {
           expect(params).toEqual(['sheet_missing'])
           return { rows: [], rowCount: 0 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1032,6 +1047,7 @@ describe('Multitable context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1104,6 +1120,7 @@ describe('Multitable context API', () => {
           })
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1177,6 +1194,7 @@ describe('Multitable context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1252,6 +1270,7 @@ describe('Multitable context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1364,6 +1383,7 @@ describe('Multitable context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1484,6 +1504,7 @@ describe('Multitable context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })

--- a/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-form.api.test.ts
@@ -2,6 +2,8 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+import { configRevisionNoop } from './config-revision-mock'
+
 type QueryResult = {
   rows: any[]
   rowCount?: number
@@ -161,6 +163,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -265,6 +268,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -365,6 +369,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -429,6 +434,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -475,6 +481,7 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual(['sheet_public'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -523,6 +530,7 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual(['sheet_public'])
           return { rows: [{ id: 'sheet_public', base_id: 'base_public', name: 'Public', description: 'Public intake' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -635,6 +643,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -776,6 +785,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -873,6 +883,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -958,6 +969,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1086,6 +1098,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1222,6 +1235,7 @@ describe('Multitable record and form context API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1281,6 +1295,7 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual(['rec_missing', 'sheet_ops'])
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1363,6 +1378,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1457,6 +1473,7 @@ describe('Multitable record and form context API', () => {
           expect(params).toEqual([['rec_1']])
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1535,6 +1552,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1588,6 +1606,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1620,6 +1639,7 @@ describe('Multitable record and form context API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -2,6 +2,8 @@ import express from 'express'
 import request from 'supertest'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+import { configRevisionNoop } from './config-revision-mock'
+
 type QueryResult = {
   rows: any[]
   rowCount?: number
@@ -186,6 +188,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'rec_1', sheet_id: 'sheet_ops', version: 3, data: { fld_name: 'Order A' } }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -283,6 +286,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -351,6 +355,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -398,6 +403,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -436,6 +442,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -496,6 +503,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'rec_owned', sheet_id: 'sheet_ops', version: 3, data: { fld_name: 'Mine' }, created_by: 'user_sheet_acl_1' }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -547,6 +555,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'rec_1', sheet_id: 'sheet_ops', version: 1, data: { fld_name: 'Blocked' }, created_by: 'user_sheet_acl_2' }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -597,6 +606,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['rec_1'])
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -687,6 +697,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -775,6 +786,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -974,6 +986,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           records.delete('rec_owned')
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1068,6 +1081,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['view_grid'])
           return { rows: [{ id: 'view_grid', sheet_id: 'sheet_ops' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1125,6 +1139,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1328,6 +1343,7 @@ describe('Multitable sheet-scoped permissions API', () => {
         if (sql.includes('SELECT id, email, name, avatar_url') && sql.includes('FROM users')) {
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1502,6 +1518,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['role_ops_writer'])
           return { rows: [{ permission_code: 'multitable:write' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1621,6 +1638,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1682,6 +1700,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1771,6 +1790,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           if (params?.[0] === 'role_scope_only') return { rows: [] }
           throw new Error(`Unexpected role permission lookup: ${params?.[0]}`)
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1886,6 +1906,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -1987,6 +2008,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2071,6 +2093,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2177,6 +2200,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2235,6 +2259,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['role_ops_writer'])
           return { rows: [{ id: 'role_ops_writer' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2262,6 +2287,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
           return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:write-own', subject_type: 'user' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2293,6 +2319,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
           return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:write', subject_type: 'user' }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2352,6 +2379,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2413,6 +2441,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [], rowCount: 1 }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2441,6 +2470,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ sheet_id: 'sheet_locked', perm_code: 'spreadsheet:comment' }],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2484,6 +2514,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2533,6 +2564,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['sheet_target'])
           return { rows: [{ id: 'sheet_target', base_id: 'base_ops', name: 'Vendors', description: null }] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2596,6 +2628,7 @@ describe('Multitable sheet-scoped permissions API', () => {
         if (sql.includes('field_permissions')) {
           return { rows: [] }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2677,6 +2710,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             return { rows: [{ sheet_id: 'sheet_vendors', perm_code: 'spreadsheet:write-own' }] }
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2755,6 +2789,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             return { rows: [{ sheet_id: 'sheet_vendors', perm_code: 'spreadsheet:comment' }] }
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2812,6 +2847,7 @@ describe('Multitable sheet-scoped permissions API', () => {
         if (sql.includes('INSERT INTO meta_fields')) {
           throw new Error('field insert should not run when foreign sheet is unreadable')
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2854,6 +2890,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2903,6 +2940,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -2957,6 +2995,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -3011,6 +3050,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -3063,6 +3103,7 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -3101,6 +3142,7 @@ describe('Multitable sheet-scoped permissions API', () => {
         if (sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g')) {
           throw undefinedTableError('platform_member_groups')
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -3131,6 +3173,7 @@ describe('Multitable sheet-scoped permissions API', () => {
         if (sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g')) {
           throw undefinedTableError('platform_member_groups')
         }
+        { const cr = configRevisionNoop(sql); if (cr) return cr }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })


### PR DESCRIPTION
> **HELD for your implementation review** (you caught 3 real gaps in the design-lock pass; same diligence wanted on the wiring). The ratified first T9 slice — read-side, **fields only**.

## What
- **Migration** `meta_config_revisions` — append-only config-history table (per-entity-type CHECK, deterministic index, `batch_id`). Comment pins: **NOT record data; R3 needs its own per-entity-type gate, not the record mask.**
- **`recordConfigRevision` + field-diff helpers** (`config-revision-recorder.ts`) — wired into the **existing** field `pool.transaction`s (create/update/delete), so the config change + history row commit/roll back together (T9-L4).
- **Diff-first** (D2): create → `after`=the field's config; delete → `before`=config; update → the changed keys only (name/type/property/order); **a no-op PATCH records nothing**.
- **Read-only** (T9-L1): records only — **no read API, no gate, no permissions/views/sheet-config/cascade in R1**. Field-delete allocates a `batch_id` so the R2 view-config cascade can group under it.

## Verification
7 real-DB goldens: create (one rev, `after`+all-keys+actor) · rename (`changed_keys=[name]` only) · retype · **no-op records nothing** · delete (`before`+null+`batch_id`) · deterministic order + **config-only, no record-value leakage**. **Mutation-proven** (no-op the recorder → CREATE golden fails). `tsc` clean; added to the plugin-tests allowlist.

Per the ratified scope, R2 (permissions+views+sheet-config, with their transaction-ization + the cascade) and R3/R4 (read API + FE view) are separate gated slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)