### PR TITLE
fix(integration): seed sandbox stock-prep select options

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -3763,6 +3763,90 @@ async function testStockPreparationTargetProvisioningRoutes() {
   assert.equal(res.body.error.details.reason, 'prod_canonical')
   assert.equal(provisioning.calls.length, 0, 'canonical objectId is rejected before sandbox provisioning')
 
+  let callCountBefore = provisioning.calls.length
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'customer_real_table',
+    },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'TARGET_SANDBOX_OBJECT_ID_INVALID')
+  assert.equal(res.body.error.details.reason, 'not_sandbox_namespace')
+  assert.equal(provisioning.calls.length, callCountBefore, 'non-sandbox objectId is rejected before sandbox provisioning')
+
+  callCountBefore = provisioning.calls.length
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'plm_stock_preparation_sandbox_validation',
+      optionSets: {
+        material_type: [{
+          value: 'plate',
+          rawSQL: 'select * from private_table',
+          functionBody: 'return 1',
+          payloadTemplate: { value: 'hidden' },
+        }],
+      },
+    },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'OPTION_SYNC_EXECUTABLE_REJECTED')
+  assert.equal(provisioning.calls.length, callCountBefore, 'invalid sandbox option seed is rejected before provisioning')
+  assert.equal(JSON.stringify(res.body).includes('private_table'), false, 'invalid option seed response hides raw values')
+
+  callCountBefore = provisioning.calls.length
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'plm_stock_preparation_sandbox_validation',
+      optionSets: {},
+      configInfo: { rawSQL: [{ value: 'secret' }] },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID')
+  assert.equal(provisioning.calls.length, callCountBefore, 'conflicting sandbox option aliases are rejected before provisioning')
+  assert.equal(JSON.stringify(res.body).includes('secret'), false, 'conflicting alias response hides ignored option values')
+
+  callCountBefore = provisioning.calls.length
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'plm_stock_preparation_sandbox_validation',
+      optionSets: {},
+      optionSources: { typo_source: [{ value: 'plate' }] },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID')
+  assert.equal(provisioning.calls.length, callCountBefore, 'conflicting sandbox optionSources alias is rejected before provisioning')
+
+  callCountBefore = provisioning.calls.length
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/sandbox-target/ensure', {
+    user: ADMIN_USER,
+    body: {
+      projectId: 'tenant_1:integration-core',
+      baseId: 'base_stock',
+      objectId: 'plm_stock_preparation_sandbox_validation',
+      optionSets: {
+        typo_source: [{ value: 'plate' }],
+      },
+    },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'OPTION_SYNC_UNKNOWN_SOURCE')
+  assert.ok(res.body.error.details.targetObjectIdHash)
+  assert.equal(provisioning.calls.length, callCountBefore, 'unknown sandbox option source is rejected before provisioning')
+
   res = await invoke(routes, 'GET', '/api/integration/stock-preparation/target/readiness', {
     user: ADMIN_USER,
     query: { projectId: 'tenant_1:integration-core' },
@@ -3845,6 +3929,11 @@ async function testStockPreparationTargetProvisioningRoutes() {
       baseId: 'base_stock',
       objectId: sandboxObjectId,
       label: 'Sandbox Stock Preparation',
+      optionSets: {
+        material_type: [{ value: 'plate', label: 'Plate' }],
+        blank_type: [{ value: 'casting', label: 'Casting' }],
+        stock_preparation_status: [{ value: 'pending', label: 'Pending' }],
+      },
     },
   })
   assertOkResponse(res, 201)
@@ -3855,8 +3944,14 @@ async function testStockPreparationTargetProvisioningRoutes() {
   assert.equal(res.body.data.evidence.fieldMapMode, 'sandbox')
   assert.equal(res.body.data.evidence.target.fieldIdMapEmpty, false)
   assert.ok(res.body.data.evidence.objectIdHash, 'sandbox route returns object hash evidence')
+  assert.equal(res.body.data.optionSync.ok, true)
+  assert.ok(res.body.data.optionSync.target.objectIdHash, 'sandbox option sync returns target hash evidence')
+  assert.equal(Object.prototype.hasOwnProperty.call(res.body.data.optionSync.target, 'objectId'), false)
+  assert.equal(res.body.data.optionSync.evidence.fields.length, 4, 'sandbox route seeds contract + three config_info option fields')
   assert.equal(JSON.stringify(res.body.data).includes(sandboxObjectId), false, 'sandbox route response hides object id')
   assert.equal(JSON.stringify(res.body.data).includes('sheet_stock_canonical_created'), false, 'sandbox route response hides sheet id')
+  assert.equal(JSON.stringify(res.body.data).includes('plate'), false, 'sandbox route response hides option values')
+  assert.equal(JSON.stringify(res.body.data).includes('Casting'), false, 'sandbox route response hides option labels')
   const sandboxEnsureCall = findCalls(sandboxProvisioning.calls, 'ensureObject')[0]
   assert.equal(sandboxEnsureCall[1].projectId, 'tenant_1:integration-core')
   assert.equal(sandboxEnsureCall[1].baseId, 'base_stock')
@@ -3867,6 +3962,19 @@ async function testStockPreparationTargetProvisioningRoutes() {
     STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id),
     'sandbox ensure descriptor keeps the stock-prep manifest fields',
   )
+  const sandboxOptionPatches = findCalls(sandboxProvisioning.calls, 'patchObjectFieldProperty')
+  assert.equal(sandboxOptionPatches.length, 4, 'sandbox ensure seeds select options through the option-sync kernel')
+  assert.ok(
+    sandboxOptionPatches.every((call) => call[1].objectId === sandboxObjectId),
+    'sandbox option seeding patches only the sandbox object id',
+  )
+  assert.equal(
+    sandboxOptionPatches.some((call) => call[1].objectId === STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId),
+    false,
+    'sandbox option seeding never patches the canonical object',
+  )
+  const materialPatch = sandboxOptionPatches.find((call) => call[1].fieldId === 'materialType')
+  assert.deepEqual(materialPatch[1].propertyPatch.options, [{ value: 'plate', label: 'Plate' }])
 
   const leakySandbox = createStockPreparationTargetProvisioningApi()
   leakySandbox.api.ensureObject = async (input) => {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-option-sync.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-option-sync.test.cjs
@@ -13,6 +13,7 @@ const {
   StockPreparationOptionSyncError,
   optionSetsFromInput,
   syncStockPreparationOptions,
+  syncStockPreparationSandboxOptions,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-option-sync.cjs'))
 
 const FIELD_IDS = STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id)
@@ -166,6 +167,53 @@ async function main() {
   assert.ok(!evidenceText.includes('Casting'), 'evidence must not include option labels')
   assert.ok(!evidenceText.includes('sheet_stock_preparation'), 'evidence must not include sheet id')
 
+  const sandboxObjectId = 'plm_stock_preparation_sandbox_validation'
+  const { context: sandboxContext, calls: sandboxCalls } = createContext({ ready: true })
+  const sandboxResult = await syncStockPreparationSandboxOptions({
+    context: sandboxContext,
+    projectId: 'tenant_1:integration-core',
+    objectId: sandboxObjectId,
+    permission: 'admin',
+    optionSets: {
+      material_type: [{ value: 'plate', label: 'Plate' }],
+      blank_type: [{ value: 'casting', label: 'Casting' }],
+      stock_preparation_status: [{ value: 'pending', label: 'Pending' }],
+    },
+  })
+  assert.equal(sandboxResult.ok, true)
+  assert.ok(sandboxResult.target.objectIdHash, 'sandbox option sync returns only an object hash')
+  assert.equal(Object.prototype.hasOwnProperty.call(sandboxResult.target, 'objectId'), false)
+  assert.equal(sandboxCalls.patchObjectFieldProperty.length, 4, 'sandbox sync seeds contract + three config_info fields')
+  assert.ok(
+    sandboxCalls.patchObjectFieldProperty.every((call) => call.objectId === sandboxObjectId),
+    'sandbox option sync patches only the sandbox object id',
+  )
+  const sandboxEvidence = JSON.stringify(sandboxResult.evidence)
+  assert.equal(sandboxEvidence.includes(sandboxObjectId), false, 'sandbox option evidence hides object id')
+  assert.equal(sandboxEvidence.includes('sheet_stock_preparation'), false, 'sandbox option evidence hides sheet id')
+  assert.equal(sandboxEvidence.includes('plate'), false, 'sandbox option evidence hides option values')
+  assert.equal(sandboxEvidence.includes('Casting'), false, 'sandbox option evidence hides option labels')
+
+  const { context: sandboxDefaultContext, calls: sandboxDefaultCalls } = createContext({ ready: true })
+  const sandboxDefaultResult = await syncStockPreparationSandboxOptions({
+    context: sandboxDefaultContext,
+    projectId: 'tenant_1:integration-core',
+    objectId: sandboxObjectId,
+    permission: 'admin',
+  })
+  assert.equal(sandboxDefaultResult.ok, true)
+  assert.equal(
+    sandboxDefaultCalls.patchObjectFieldProperty.length,
+    1,
+    'sandbox sync without config_info still seeds the contract decision options only',
+  )
+  assert.equal(sandboxDefaultCalls.patchObjectFieldProperty[0].fieldId, 'lastPlmRefreshDecision')
+  assert.equal(sandboxDefaultResult.evidence.skipped.length, 3, 'sandbox sync records config_info fields as skipped when not supplied')
+  assert.ok(
+    sandboxDefaultResult.evidence.skipped.every((entry) => entry.reason === 'config_info_not_supplied'),
+    'sandbox sync skip evidence is reason/count metadata only',
+  )
+
   const notReady = createContext({ ready: false })
   await rejectsWith(
     () => syncStockPreparationOptions({
@@ -229,6 +277,27 @@ async function main() {
     }),
     'OPTION_SYNC_CONFIG_INVALID',
   )
+
+  const executableKeyContext = createContext()
+  const executableKeyError = await rejectsWith(
+    () => syncStockPreparationSandboxOptions({
+      context: executableKeyContext.context,
+      projectId: 'tenant_1:integration-core',
+      objectId: sandboxObjectId,
+      permission: 'admin',
+      optionSets: {
+        material_type: [{
+          value: 'plate',
+          rawSQL: 'select * from private_table',
+          functionBody: 'return 1',
+          payloadTemplate: { value: 'hidden' },
+        }],
+      },
+    }),
+    'OPTION_SYNC_EXECUTABLE_REJECTED',
+  )
+  assert.equal(executableKeyContext.calls.patchObjectFieldProperty.length, 0, 'executable-like option keys fail before patching metadata')
+  assert.equal(JSON.stringify(executableKeyError.details).includes('private_table'), false, 'executable-key error details hide raw values')
 
   await rejectsWith(
     () => syncStockPreparationOptions({

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
@@ -318,6 +318,20 @@ async function main() {
   assert.equal(sandboxRejectCalls.findObjectSheet.length, 0, 'canonical objectId is rejected before provisioning reads')
   assert.equal(sandboxRejectCalls.ensureObject.length, 0, 'canonical objectId is never provisioned as sandbox')
 
+  const { context: nonSandboxRejectCtx, calls: nonSandboxRejectCalls } = createContext({ sheetExists: false })
+  const nonSandboxError = await rejectsWith(
+    () => ensureStockPreparationSandboxTarget({
+      context: nonSandboxRejectCtx,
+      projectId: 'tenant:proj',
+      objectId: 'customer_real_table',
+      permission: 'admin',
+    }),
+    'TARGET_SANDBOX_OBJECT_ID_INVALID',
+  )
+  assert.deepEqual(nonSandboxError.details, { reason: 'not_sandbox_namespace' })
+  assert.equal(nonSandboxRejectCalls.findObjectSheet.length, 0, 'non-sandbox objectId is rejected before provisioning reads')
+  assert.equal(nonSandboxRejectCalls.ensureObject.length, 0, 'non-sandbox objectId is never provisioned as sandbox')
+
   const { context: sandboxCreateCtx, calls: sandboxCreateCalls } = createContext({ sheetExists: false })
   const sandboxCreated = await ensureStockPreparationSandboxTarget({
     context: sandboxCreateCtx,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -132,14 +132,17 @@ const {
 } = require('./stock-preparation-conflict-planner.cjs')
 const {
   StockPreparationTargetProvisioningError,
+  hashEvidenceValue,
   inspectStockPreparationCanonicalTarget,
   ensureStockPreparationCanonicalTarget,
   inspectStockPreparationSandboxTarget,
   ensureStockPreparationSandboxTarget,
+  sandboxStockPreparationTemplate,
 } = require('./stock-preparation-target-provisioning.cjs')
 const {
   StockPreparationOptionSyncError,
   syncStockPreparationOptions,
+  syncStockPreparationSandboxOptions,
   optionSetsFromInput,
 } = require('./stock-preparation-option-sync.cjs')
 // FOS-4: canonical stock-prep objectId — readiness is bound per TARGET, so any preset targeting this
@@ -423,7 +426,7 @@ const VALID_C6_WRITE_APPLY_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'conf
 const VALID_TEMPLATE_INSTANTIATE_BODY_KEYS = new Set(['tenantId', 'workspaceId', 'targetSystemId', 'sourceSystemId', 'pipelineName'])
 const VALID_C6_WRITE_APPLY_CONFIRM_KEYS = new Set(['dryRunToken'])
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
-const VALID_STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId', 'objectId', 'label'])
+const VALID_STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId', 'objectId', 'label', 'optionSets', 'optionSources', 'configInfo'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
   'tenantId',
   'workspaceId',
@@ -576,6 +579,16 @@ function stockPreparationTargetInput(req, rawInput = {}) {
   }
 }
 
+function optionSetAliasValue(input, errorCode) {
+  const aliases = ['optionSets', 'optionSources', 'configInfo'].filter((key) =>
+    Object.prototype.hasOwnProperty.call(input, key),
+  )
+  if (aliases.length > 1) {
+    throw new HttpRouteError(400, errorCode, 'use only one option set request field alias', { fields: aliases.sort() })
+  }
+  return aliases.length === 1 ? input[aliases[0]] : {}
+}
+
 function normalizeStockPreparationSandboxTargetRequest(input = {}) {
   if (!isPlainObject(input)) {
     throw new HttpRouteError(400, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID', 'request must be an object')
@@ -592,6 +605,7 @@ function normalizeStockPreparationSandboxTargetRequest(input = {}) {
     baseId: firstString(input.baseId),
     objectId: firstString(input.objectId),
     label: firstString(input.label),
+    optionSets: optionSetAliasValue(input, 'STOCK_PREPARATION_SANDBOX_TARGET_REQUEST_INVALID'),
   }
 }
 
@@ -606,6 +620,24 @@ function stockPreparationSandboxTargetInput(req, rawInput = {}) {
     baseId: input.baseId,
     objectId: input.objectId,
     label: input.label,
+    optionSets: input.optionSets,
+  }
+}
+
+function validateStockPreparationSandboxOptionSeedInput(input = {}) {
+  const template = sandboxStockPreparationTemplate({ objectId: input.objectId, label: input.label })
+  const optionSets = optionSetsFromInput(input.optionSets || {})
+  const allowedSourceKeys = new Set(
+    template.fields
+      .filter((field) => field.type === 'select' && field.optionSource)
+      .map((field) => field.optionSource.key),
+  )
+  const unknownSourceKey = Object.keys(optionSets).find((sourceKey) => !allowedSourceKeys.has(sourceKey))
+  if (unknownSourceKey) {
+    throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_UNKNOWN_SOURCE', 'option set source key is not declared by the stock-preparation sandbox template', {
+      sourceKey: unknownSourceKey,
+      targetObjectIdHash: hashEvidenceValue(template.objectId),
+    })
   }
 }
 
@@ -622,7 +654,7 @@ function normalizeStockPreparationOptionSyncRequest(input = {}) {
     tenantId: firstString(input.tenantId),
     workspaceId: firstString(input.workspaceId),
     projectId: firstString(input.projectId),
-    optionSets: input.optionSets || input.optionSources || input.configInfo || {},
+    optionSets: optionSetAliasValue(input, 'STOCK_PREPARATION_OPTION_SYNC_REQUEST_INVALID'),
   }
 }
 
@@ -742,6 +774,7 @@ function publicStockPreparationSandboxTargetResult(result) {
     mode: result.mode,
     targetBindingAvailable: result.target != null,
     evidence: result.evidence,
+    ...(result.optionSync ? { optionSync: result.optionSync } : {}),
   }
 }
 
@@ -763,6 +796,14 @@ function sandboxTargetRouteError(error) {
         error.details || {},
       )
     }
+  }
+  if (error instanceof StockPreparationOptionSyncError) {
+    return new HttpRouteError(
+      Number.isInteger(error.status) ? error.status : 422,
+      error.code || 'TARGET_SANDBOX_OPTION_SYNC_FAILED',
+      error.message || 'sandbox stock-preparation target option sync failed',
+      error.details || {},
+    )
   }
   return new HttpRouteError(
     503,
@@ -2207,6 +2248,7 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'admin')
       const input = stockPreparationSandboxTargetInput(req, requestBody(req))
       try {
+        validateStockPreparationSandboxOptionSeedInput(input)
         const result = await ensureStockPreparationSandboxTarget({
           context,
           projectId: input.projectId,
@@ -2215,6 +2257,19 @@ function createHandlers(services, options = {}) {
           label: input.label,
           permission: 'admin',
         })
+        const optionSync = await syncStockPreparationSandboxOptions({
+          context,
+          projectId: input.projectId,
+          objectId: input.objectId,
+          label: input.label,
+          permission: 'admin',
+          optionSets: input.optionSets,
+        })
+        result.optionSync = {
+          ok: optionSync.ok === true,
+          target: optionSync.target,
+          evidence: optionSync.evidence,
+        }
         return sendOk(res, publicStockPreparationSandboxTargetResult(result), result.mode === 'sandbox_create' ? 201 : 200)
       } catch (error) {
         throw sandboxTargetRouteError(error)

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -2248,6 +2248,10 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'admin')
       const input = stockPreparationSandboxTargetInput(req, requestBody(req))
       try {
+        // Ordering rationale: validate (alias + sandbox objectId + option key/source) catches bad inputs
+        // BEFORE ensure, so no provisioning happens on bad input. A sync failure AFTER ensure leaves a
+        // structure-only sandbox target, which is acceptable: this is sandbox-only and ensure+sync is
+        // idempotent on retry.
         validateStockPreparationSandboxOptionSeedInput(input)
         const result = await ensureStockPreparationSandboxTarget({
           context,

--- a/plugins/plugin-integration-core/lib/stock-preparation-option-sync.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-option-sync.cjs
@@ -11,7 +11,10 @@ const {
   normalizeStockPreparationTemplate,
 } = require('./stock-preparation-templates.cjs')
 const {
+  hashEvidenceValue,
   inspectStockPreparationCanonicalTarget,
+  inspectStockPreparationSandboxTarget,
+  sandboxStockPreparationTemplate,
 } = require('./stock-preparation-target-provisioning.cjs')
 const {
   PLM_STOCK_PREPARATION_ACTION_ID,
@@ -34,6 +37,31 @@ const FORBIDDEN_EXECUTABLE_KEYS = Object.freeze([
   'payload',
   'query',
   'rawSql',
+  'script',
+  'sql',
+  'url',
+])
+
+const ALLOWED_OPTION_KEYS = Object.freeze([
+  'actionBindings',
+  'actions',
+  'color',
+  'enabled',
+  'label',
+  'order',
+  'value',
+])
+
+const FORBIDDEN_EXECUTABLE_KEY_PATTERNS = Object.freeze([
+  'body',
+  'command',
+  'endpoint',
+  'function',
+  'handler',
+  'javascript',
+  'payload',
+  'query',
+  'rawsql',
   'script',
   'sql',
   'url',
@@ -89,6 +117,16 @@ function isRedactedMarker(value) {
   return /\[redacted[^\]]*\]|<redacted[^>]*>/i.test(value)
 }
 
+function normalizedKeyFingerprint(key) {
+  return String(key).toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function isForbiddenExecutableKey(key) {
+  const fingerprint = normalizedKeyFingerprint(key)
+  return FORBIDDEN_EXECUTABLE_KEYS.some((forbidden) => normalizedKeyFingerprint(forbidden) === fingerprint) ||
+    FORBIDDEN_EXECUTABLE_KEY_PATTERNS.some((pattern) => fingerprint.includes(pattern))
+}
+
 function assertSafeString(value, field) {
   const str = requiredString(value, field)
   if (isRedactedMarker(str) || /<[^>]+>/.test(str)) {
@@ -102,8 +140,8 @@ function assertSafeString(value, field) {
 
 function assertNoExecutableKeys(value, field) {
   if (!isPlainObject(value)) return
-  for (const key of FORBIDDEN_EXECUTABLE_KEYS) {
-    if (key in value) {
+  for (const key of Object.keys(value)) {
+    if (isForbiddenExecutableKey(key)) {
       throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_EXECUTABLE_REJECTED', `${field} must not carry executable key ${key}`, {
         field: `${field}.${key}`,
       })
@@ -177,6 +215,13 @@ function normalizeOption(input, index, sourceKey) {
     throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_CONFIG_INVALID', `${field} must be an object`, { field })
   }
   assertNoExecutableKeys(input, field)
+  for (const key of Object.keys(input)) {
+    if (!ALLOWED_OPTION_KEYS.includes(key)) {
+      throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_CONFIG_INVALID', `${field}.${key} is not supported`, {
+        field: `${field}.${key}`,
+      })
+    }
+  }
   const value = assertSafeString(input.value, `${field}.value`)
   const option = { value }
   const label = optionalString(input.label)
@@ -253,9 +298,12 @@ function templateOptionFields(template) {
   return template.fields.filter((field) => field.type === 'select' && field.optionSource)
 }
 
-function summarizeOptionSyncEvidence({ template, synced, skipped }) {
+function summarizeOptionSyncEvidence({ template, synced, skipped, includeObjectId = true }) {
+  const targetIdentity = includeObjectId
+    ? { objectId: template.objectId }
+    : { objectIdHash: hashEvidenceValue(template.objectId) }
   return {
-    objectId: template.objectId,
+    ...targetIdentity,
     fields: synced.map((entry) => ({
       field: entry.field,
       optionSource: { ...entry.optionSource },
@@ -310,22 +358,28 @@ function publicOptionSyncConfig(input = {}) {
   }
 }
 
-async function syncStockPreparationOptions(input = {}) {
+async function syncStockPreparationOptionsForTarget(input = {}) {
   const context = input.context || {}
   const provisioning = getOptionSyncProvisioningApi(context)
   assertAdminPermission(input.permission)
   const projectId = assertSafeString(input.projectId, 'projectId')
   const template = normalizeStockPreparationTemplate(input.template || STOCK_PREPARATION_MAIN_TABLE_TEMPLATE)
-  const inspected = await inspectStockPreparationCanonicalTarget({
-    context,
-    projectId,
-    permission: REQUIRED_PERMISSION,
-    template,
-  })
+  const includeObjectId = input.includeObjectId !== false
+  const inspectTarget = typeof input.inspectTarget === 'function'
+    ? input.inspectTarget
+    : () => inspectStockPreparationCanonicalTarget({
+        context,
+        projectId,
+        permission: REQUIRED_PERMISSION,
+        template,
+      })
+  const inspected = await inspectTarget()
   if (!inspected.ready) {
     throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_TARGET_NOT_READY', 'stock-preparation target must be ready before option sync', {
       mode: inspected.mode,
-      targetObjectId: template.objectId,
+      ...(includeObjectId
+        ? { targetObjectId: template.objectId }
+        : { targetObjectIdHash: hashEvidenceValue(template.objectId) }),
       missingFields: inspected.evidence && inspected.evidence.missingFields,
     })
   }
@@ -336,7 +390,9 @@ async function syncStockPreparationOptions(input = {}) {
   if (unknownSourceKey) {
     throw new StockPreparationOptionSyncError(422, 'OPTION_SYNC_UNKNOWN_SOURCE', 'option set source key is not declared by the stock-preparation template', {
       sourceKey: unknownSourceKey,
-      targetObjectId: template.objectId,
+      ...(includeObjectId
+        ? { targetObjectId: template.objectId }
+        : { targetObjectIdHash: hashEvidenceValue(template.objectId) }),
     })
   }
   // FOS-2: delegate the loop / skip / patch / error-if-none to the shared kernel. The patch body,
@@ -378,7 +434,9 @@ async function syncStockPreparationOptions(input = {}) {
         }),
       noFieldsSynced: ({ targetObjectId, skipped: skippedEntries }) =>
         new StockPreparationOptionSyncError(422, 'OPTION_SYNC_NO_FIELDS', 'no stock-preparation option fields were synchronized', {
-          targetObjectId,
+          ...(includeObjectId
+            ? { targetObjectId }
+            : { targetObjectIdHash: hashEvidenceValue(targetObjectId) }),
           skipped: skippedEntries.map((entry) => ({ field: entry.field, reason: entry.reason })),
         }),
     },
@@ -393,11 +451,40 @@ async function syncStockPreparationOptions(input = {}) {
   return {
     ok: true,
     target: {
-      objectId: template.objectId,
+      ...(includeObjectId
+        ? { objectId: template.objectId }
+        : { objectIdHash: hashEvidenceValue(template.objectId) }),
       fieldCount: synced.length,
     },
-    evidence: summarizeOptionSyncEvidence({ template, synced, skipped }),
+    evidence: summarizeOptionSyncEvidence({ template, synced, skipped, includeObjectId }),
   }
+}
+
+async function syncStockPreparationOptions(input = {}) {
+  return syncStockPreparationOptionsForTarget(input)
+}
+
+async function syncStockPreparationSandboxOptions(input = {}) {
+  const context = input.context || {}
+  const projectId = assertSafeString(input.projectId, 'projectId')
+  const template = sandboxStockPreparationTemplate({
+    objectId: input.objectId,
+    label: input.label,
+  })
+  return syncStockPreparationOptionsForTarget({
+    ...input,
+    context,
+    projectId,
+    template,
+    includeObjectId: false,
+    inspectTarget: () => inspectStockPreparationSandboxTarget({
+      context,
+      projectId,
+      objectId: input.objectId,
+      label: input.label,
+      permission: REQUIRED_PERMISSION,
+    }),
+  })
 }
 
 module.exports = {
@@ -407,6 +494,7 @@ module.exports = {
   StockPreparationOptionSyncError,
   optionSetsFromInput,
   syncStockPreparationOptions,
+  syncStockPreparationSandboxOptions,
   summarizeOptionSyncEvidence,
   __internals: {
     isPlainObject,

--- a/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
@@ -64,6 +64,14 @@ function assertSandboxObjectId(value, field = 'objectId') {
       { reason: 'prod_canonical' },
     )
   }
+  if (!/^plm_stock_preparation_sandbox(?:$|[_-])/.test(objectId)) {
+    throw new StockPreparationTargetProvisioningError(
+      422,
+      'TARGET_SANDBOX_OBJECT_ID_INVALID',
+      'sandbox stock-preparation target objectId must use the stock-preparation sandbox namespace',
+      { reason: 'not_sandbox_namespace' },
+    )
+  }
   return objectId
 }
 
@@ -423,6 +431,8 @@ module.exports = {
   StockPreparationTargetProvisioningError,
   buildStockPreparationTargetDescriptor,
   summarizeStockPreparationTargetReadiness,
+  hashEvidenceValue,
+  sandboxStockPreparationTemplate,
   inspectStockPreparationCanonicalTarget,
   inspectStockPreparationSandboxTarget,
   ensureStockPreparationCanonicalTarget,


### PR DESCRIPTION
## Summary
This is the #3093 sandbox target completeness unblocker. It does **not** unlock production apply and does **not** write business rows.

- extend the stock-prep sandbox target ensure route to seed select-field options from the existing option-source machinery
- seed the built-in contract option set plus supplied config_info option sets on the sandbox target only
- keep sandbox responses/evidence values-free: objectId is hashed, sheetId and option values/labels are not returned
- harden the sandbox boundary: reject canonical targets, require the stock-prep sandbox objectId namespace, reject executable-like option keys, and reject conflicting optionSet aliases before provisioning

## Boundary
- admin-only
- sandbox target only
- metadata field-property patch only
- no apply unlock
- no production canonical write
- no business row write
- no external/K3 write

## Verification
- node plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
- node plugins/plugin-integration-core/__tests__/stock-preparation-option-sync.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- node --check plugins/plugin-integration-core/lib/stock-preparation-option-sync.cjs && node --check plugins/plugin-integration-core/lib/http-routes.cjs && node --check plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
- git diff --check
- pnpm --filter plugin-integration-core test

Adversarial sub-agent review: first pass found sandbox namespace, executable-key, pre-provision validation, and alias-shadowing gaps; all were fixed and re-reviewed APPROVE.