### PR TITLE
fix(attendance): align reversed overtime route error with NS-4

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5968,6 +5968,12 @@ attendanceIntegrationDescribe(
       const multiRes = await createOvertime({ minutes: 200, requestedInAt: zonedUtcIso(workDate, '23:00', tz), requestedOutAt: zonedUtcIso(farDate, '01:00', tz) })
       expect(multiRes.status).toBe(422)
       expect((multiRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('OVERTIME_CROSS_MIDNIGHT_UNSUPPORTED')
+
+      // NS-4 staging contract: reversed overtime windows surface the overtime-specific code at the route layer,
+      // not the generic request VALIDATION_ERROR used by non-overtime request types.
+      const reversedRes = await createOvertime({ minutes: 60, requestedInAt: zonedUtcIso(workDate, '10:00', tz), requestedOutAt: zonedUtcIso(workDate, '09:00', tz) })
+      expect(reversedRes.status).toBe(422)
+      expect((reversedRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('OVERTIME_INVALID_TIME_WINDOW')
     } finally {
       // §P2: restore the GLOBAL segmentation setting so later tests don't run under enabled=true.
       if (token && Object.keys(originalSettings).length > 0) {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -23922,6 +23922,14 @@ module.exports = {
       const requestedOutAt = parseDateInput(requestedOutSource)
 
       if (requestedInAt && requestedOutAt && requestedOutAt <= requestedInAt) {
+        if (requestType === 'overtime') {
+          throw new HttpError(
+            422,
+            'OVERTIME_INVALID_TIME_WINDOW',
+            'Invalid overtime time window',
+            singleValidationDetail('requestedOutAt', 'Must be after requestedInAt')
+          )
+        }
         throw new HttpError(
           400,
           'VALIDATION_ERROR',


### PR DESCRIPTION
## Summary
- return the overtime-specific `422 OVERTIME_INVALID_TIME_WINDOW` when an overtime request has `requestedOutAt <= requestedInAt`
- preserve the existing generic `400 VALIDATION_ERROR` path for non-overtime request types
- add a route-level real-DB integration assertion in the NS-3/NS-4 cross-midnight matrix

## Why
The NS-4 staging smoke on deploy `44c29ce43da77b0fdc25a3058e2663856b5eb939` passed the cross-midnight acceptance/bucketing/record/report/summary/residue checks, but reversed overtime returned generic `400 VALIDATION_ERROR` before reaching the overtime segmentation validator. The runbook expects the stable overtime code `OVERTIME_INVALID_TIME_WINDOW`.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-overtime-segmentation.test.ts --watch=false` — 25 passed
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot --watch=false` — collected locally but skipped without local DB; CI attendance integration is the real Postgres gate

## Review
- subagent review: APPROVE
