### PR TITLE
fix(approval): fail-closed complex node config allowlist (cc / condition / parallel + start/end)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -36,6 +36,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -59,6 +60,7 @@ on:
       - 'apps/web/tests/approval-template-authoring-parallel-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-cc-edit.test.ts'
       - 'apps/web/tests/approval-template-authoring-approval-node-edit.test.ts'
+      - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -115,4 +117,4 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist --reporter=dot

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -2,6 +2,7 @@ import type {
   ApprovalAssigneeSource,
   ApprovalGraph,
   ApprovalMode,
+  ApprovalNode,
   ApprovalNodeConfig,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateVisibilityScope,
@@ -541,6 +542,58 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
   return false
 }
 
+// The COMPLEX-path config shapes the backend re-emits for the OTHER node types (same silent-drop
+// risk as approval): cc → {targetType, targetIds} (ApprovalProductService.ts:920-923); parallel →
+// {branches, joinMode, joinNodeKey} (:946-950); condition → {branches, defaultEdgeKey} with each
+// branch {edgeKey, conjunction?, rules} and each rule {fieldId, operator, value?} (:956-985 — the
+// rule `value` is a free leaf, NOT shape-checked); start/end → {} (default, :988).
+const BACKEND_CC_CONFIG_KEYS = ['targetType', 'targetIds']
+const BACKEND_PARALLEL_CONFIG_KEYS = ['branches', 'joinMode', 'joinNodeKey']
+const BACKEND_CONDITION_CONFIG_KEYS = ['branches', 'defaultEdgeKey']
+const BACKEND_CONDITION_BRANCH_KEYS = ['edgeKey', 'conjunction', 'rules']
+const BACKEND_CONDITION_RULE_KEYS = ['fieldId', 'operator', 'value']
+
+/**
+ * True when a complex node's config carries a key the backend `normalizeApprovalGraph` does NOT
+ * re-emit (and silently drops on save) — generalises the approval-node shape-check to EVERY node
+ * type. cc/parallel are flat; condition recurses config → branches[] → rules[]; start/end re-emit
+ * {} so any config key is dropped. Without this a save flattens the unknown key while the FE
+ * deep-equal round-trip looks clean.
+ */
+function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
+  const config = (node.config ?? {}) as Record<string, unknown>
+  switch (node.type) {
+    case 'approval':
+      return complexApprovalConfigHasBackendDrop(config)
+    case 'cc':
+      return hasKeyOutside(config, BACKEND_CC_CONFIG_KEYS)
+    case 'parallel':
+      return hasKeyOutside(config, BACKEND_PARALLEL_CONFIG_KEYS)
+    case 'condition': {
+      if (hasKeyOutside(config, BACKEND_CONDITION_CONFIG_KEYS)) return true
+      const branches = config.branches
+      if (Array.isArray(branches)) {
+        for (const branch of branches) {
+          if (!isPlainRecord(branch) || hasKeyOutside(branch, BACKEND_CONDITION_BRANCH_KEYS)) return true
+          const rules = branch.rules
+          if (Array.isArray(rules)) {
+            for (const rule of rules) {
+              if (!isPlainRecord(rule) || hasKeyOutside(rule, BACKEND_CONDITION_RULE_KEYS)) return true
+            }
+          }
+        }
+      }
+      return false
+    }
+    case 'start':
+    case 'end':
+      // backend re-emits {} for these — any config key would be silently dropped.
+      return Object.keys(config).length > 0
+    default:
+      return false
+  }
+}
+
 export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
   const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
   if (unsupportedField) {
@@ -560,18 +613,14 @@ export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDet
   }
 
   // Complex graphs (cc/condition/parallel or non-linear) are load-preserved verbatim via
-  // spread-original-first — BUT the backend `normalizeApprovalGraph` rebuilds each approval node's
-  // config from a fixed allowlist and silently DROPS any other key on save. The FE deep-equal
-  // round-trip can't see that drop, so fail-closed: a complex approval node carrying a config key the
-  // backend won't preserve is unsupported (read-only, save disabled), never silently flattened.
+  // spread-original-first — BUT the backend `normalizeApprovalGraph` rebuilds EVERY node's config
+  // from a fixed per-type allowlist and silently DROPS any other key (top-level or nested) on save.
+  // The FE deep-equal round-trip can't see that drop, so fail-closed: ANY node carrying a config key
+  // the backend won't preserve is unsupported (read-only, save disabled), never silently flattened.
   if (isComplexApprovalGraph(template.approvalGraph)) {
-    const unsupportedComplexApproval = template.approvalGraph.nodes.find(
-      (node) =>
-        node.type === 'approval'
-        && complexApprovalConfigHasBackendDrop(node.config as Record<string, unknown>),
-    )
-    if (unsupportedComplexApproval) {
-      return `审批节点含后端不会保留的配置（保存将丢失），已锁定为只读：${unsupportedComplexApproval.name || unsupportedComplexApproval.key}`
+    const unsupportedNode = template.approvalGraph.nodes.find((node) => complexNodeConfigHasBackendDrop(node))
+    if (unsupportedNode) {
+      return `节点含后端不会保留的配置（保存将丢失），已锁定为只读：${unsupportedNode.name || unsupportedNode.key}（${unsupportedNode.type}）`
     }
     return null
   }

--- a/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
+++ b/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { ApprovalGraph, ApprovalTemplateDetailDTO } from '../src/types/approval'
+import { unsupportedTemplateAuthoringReason } from '../src/approvals/templateAuthoring'
+
+// Follow-up to the G-5 approval-node fail-closed (#3124): the SAME backend silent-drop applies to
+// cc / condition / parallel (and start/end) node configs. The backend `normalizeApprovalGraph`
+// rebuilds each from a fixed per-type shape (ApprovalProductService.ts) and DROPS any other key —
+// top-level OR nested (condition branches[].rules[]). `complexNodeConfigHasBackendDrop` now fails
+// closed for EVERY node type, so an unknown key can't silently flatten on save while the FE
+// deep-equal round-trip looks clean. Pure helper test (no .vue) → runs under approval-web-guard.
+
+function tpl(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1', key: 'k', name: 'n', description: null, category: null,
+    visibilityScope: { type: 'all', ids: [] }, slaHours: null, status: 'draft',
+    activeVersionId: null, latestVersionId: 'v1',
+    createdAt: '2026-06-24T00:00:00Z', updatedAt: '2026-06-24T00:00:00Z',
+    formSchema: { fields: [{ id: 'amount', type: 'number', label: '金额', required: true }] },
+    approvalGraph,
+  }
+}
+// start → [node] → end — the node's type (cc/condition/parallel) makes the graph complex (preserved path).
+function reasonFor(node: { key: string; type: string; name?: string; config: Record<string, unknown> }): string | null {
+  return unsupportedTemplateAuthoringReason(tpl({
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      node as never,
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: node.key },
+      { key: 'e2', source: node.key, target: 'end' },
+    ],
+  }))
+}
+
+describe('complex node config fail-closed — cc (backend re-emits {targetType, targetIds})', () => {
+  it('flags an unknown cc config key', () => {
+    expect(reasonFor({ key: 'cc_1', type: 'cc', config: { targetType: 'role', targetIds: ['r1'], futureFlag: true } })).not.toBeNull()
+  })
+  it('allows a known cc config', () => {
+    expect(reasonFor({ key: 'cc_1', type: 'cc', config: { targetType: 'role', targetIds: ['r1'] } })).toBeNull()
+  })
+})
+
+describe('complex node config fail-closed — parallel (backend re-emits {branches, joinMode, joinNodeKey})', () => {
+  it('flags an unknown parallel config key', () => {
+    expect(reasonFor({ key: 'p1', type: 'parallel', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'j', futureFlag: true } })).not.toBeNull()
+  })
+  it('allows a known parallel config', () => {
+    expect(reasonFor({ key: 'p1', type: 'parallel', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'j' } })).toBeNull()
+  })
+})
+
+describe('complex node config fail-closed — condition (recurses config → branches[] → rules[])', () => {
+  const cond = (branch: Record<string, unknown>, top: Record<string, unknown> = {}) =>
+    reasonFor({ key: 'c1', type: 'condition', config: { branches: [branch], defaultEdgeKey: 'd', ...top } })
+  it('flags an unknown top-level condition key', () => {
+    expect(cond({ edgeKey: 'e', rules: [] }, { futureFlag: true })).not.toBeNull()
+  })
+  it('flags an unknown branch key', () => {
+    expect(cond({ edgeKey: 'e', rules: [], futureFlag: true })).not.toBeNull()
+  })
+  it('flags an unknown rule key', () => {
+    expect(cond({ edgeKey: 'e', rules: [{ fieldId: 'amount', operator: 'gt', value: 1, futureFlag: true }] })).not.toBeNull()
+  })
+  it('allows a known condition (conjunction + a FREE-FORM rule value — value is a leaf, not shape-checked)', () => {
+    expect(cond({ edgeKey: 'e', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'in', value: { complex: ['object', 'leaf'] } }] })).toBeNull()
+  })
+})
+
+describe('complex node config fail-closed — start/end re-emit {} (any config key is dropped)', () => {
+  it('flags a stray config key on a start node in a complex graph', () => {
+    const graph: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: { stray: true } as never },
+        { key: 'cc_1', type: 'cc', name: '抄送', config: { targetType: 'role', targetIds: ['r1'] } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [{ key: 'e1', source: 'start', target: 'cc_1' }, { key: 'e2', source: 'cc_1', target: 'end' }],
+    }
+    expect(unsupportedTemplateAuthoringReason(tpl(graph))).not.toBeNull()
+  })
+})

--- a/docs/development/approval-complex-graph-author-ui-todo-20260623.md
+++ b/docs/development/approval-complex-graph-author-ui-todo-20260623.md
@@ -115,11 +115,10 @@
   doc's deferral premise was factually wrong. Re-scoped OUT of "out of scope" — pending owner
   ratification (see the G-3 PR body). The OTHER parallel limits (nested parallel, editing
   branches/joinNodeKey topology) remain out of scope.
-- 🔜 **FOLLOW-UP (G-5 review, NAMED not fixed): cc / condition / parallel config unknown-key
-  fail-closed.** G-5 added `complexApprovalConfigHasBackendDrop` (top-level + nested) for `approval`
-  nodes ONLY. The SAME latent gap exists for cc/condition/parallel: the backend rebuilds those configs
-  from fixed shapes (e.g. cc → `{targetType, targetIds}`, ApprovalProductService.ts:920-923) and
-  silently drops any other key, while the FE spread-preserves it → save-flatten the FE round-trip
-  can't see. Pre-existing since G-2/3/4, outside G-5's stated scope; needs a sibling shape-check pass
-  (their nested shapes — condition `branches[].rules[]`, parallel `branches[]` — are deeper, so size
-  it separately). Tracked here as a declared boundary.
+- ✅ **FOLLOW-UP DONE — cc / condition / parallel config unknown-key fail-closed.**
+  `complexNodeConfigHasBackendDrop` generalises the approval shape-check to EVERY node type: cc →
+  `{targetType, targetIds}`, parallel → `{branches, joinMode, joinNodeKey}`, condition → recurses
+  config → `branches[].{edgeKey, conjunction, rules}` → `rules[].{fieldId, operator, value}` (the
+  rule `value` is a free leaf, NOT shape-checked), start/end → `{}`. Any unknown key — top-level or
+  nested — on ANY complex node now → unsupported (read-only, save disabled), never silently flattened
+  on save. 11 tests; the whole complex graph-save surface is fail-closed for unknown keys.


### PR DESCRIPTION
Closes the **named boundary** from the #3124 review: the unknown-key silent-drop the G-5 P1 surfaced for `approval` nodes applies to **every** complex node type. The backend `normalizeApprovalGraph` rebuilds each node's config from a fixed per-type shape and drops any other key, while the FE spread-preserves it — so a complex graph could save and silently flatten an unknown key the deep-equal round-trip can't see.

## Change
`complexNodeConfigHasBackendDrop` generalises the G-5 approval shape-check to all node types, mirroring the exact backend shapes:
- **cc** → `{targetType, targetIds}` (`ApprovalProductService.ts:920-923`)
- **parallel** → `{branches, joinMode, joinNodeKey}` (`:946-950`)
- **condition** → `{branches, defaultEdgeKey}`, recursing `branches[].{edgeKey, conjunction, rules}` → `rules[].{fieldId, operator, value}` (`:956-985`); the rule **`value` is a free leaf** (backend re-emits it verbatim) so it's deliberately **not** shape-checked — proven by an allowed-free-form-value test
- **start/end** → `{}` (`:988`) — any config key is dropped

Any unknown key (top-level or nested) on any complex node → unsupported (read-only via `graphReadOnly=false`, save disabled), never silently flattened.

## Why this can't false-lock a valid template
The check makes the FE stricter, so the risk flips to wrongly locking a *valid* complex template. Two things rule that out: (1) the condition/parallel/cc/graph-preserve suites assert `graphReadOnlyReason(...) !== null` on **normal** complex graphs — a false-flag would turn them red; they're green (**187/187**). (2) A loaded prod template was already backend-normalized on its prior save, so it only contains backend-preserved keys by construction — the check only trips on non-normalized data (manual seed / future schema), which is exactly when fail-closed is wanted.

## Known non-goal (on record, not fixed)
A stray config key on start/end in a **linear** graph isn't checked (the linear path is approval-only). It's theoretical (start/end are auto-created `{}`), pre-existing, and out of this fix's scope.

11 tests; approval-web-guard **187/187**, vue-tsc + lint clean. UI-only — no runtime/backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)