### PR TITLE
feat(approval): amount-tier preset runtime (reimbursement + purchase) — design-lock #3114

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -306,6 +306,7 @@ jobs:
             tests/integration/approval-delegation-api.db.test.ts \
             tests/integration/approval-detail-subform.db.test.ts \
             tests/integration/approval-common-template-presets.api.test.ts \
+            tests/integration/approval-wp1-parallel-gateway.api.test.ts \
             --reporter=dot
 
       - name: Run comment-reaction keystone (real wire, real PG)

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -1,3 +1,4 @@
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../types/approval'
 import type {
   ApprovalAssigneeSource,
   ApprovalGraph,
@@ -231,9 +232,10 @@ function reimbursementAmountTierGraph(): ApprovalGraph {
 // :4152/4181), so a user-typed and a role-typed branch can NEVER collide — regardless of org data.
 // (Two USER-resolving dynamic sources — e.g. an earlier dept_head here alongside manager_at_level —
 // CAN resolve to the SAME person at runtime → APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT 409; that
-// was the bug.) The role is a STARTER: configure it before publishing — an unconfigured role resolves
-// empty → emptyAssigneePolicy 'error' fails the high path CLOSED (a high-value approver is never
-// silently skipped). The role node name signals "发布前配置".
+// was the bug.) The role is a STARTER using the APPROVAL_ROLE_CONFIGURE_SENTINEL placeholder: the
+// backend FAIL-FASTS at publish (assertNoUnconfiguredPlaceholderRoles → 400 APPROVAL_ROLE_PLACEHOLDER_
+// NOT_CONFIGURED) until the admin replaces it with a real role — so an UNTOUCHED preset cannot be
+// published at all (a verifiable state, not merely a runtime stuck-flow). The node name signals 发布前配置.
 function purchaseAmountTierGraph(): ApprovalGraph {
   return {
     nodes: [
@@ -243,7 +245,7 @@ function purchaseAmountTierGraph(): ApprovalGraph {
       { key: 'manager_approval', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'parallel_fork', type: 'parallel', name: '高额并行审批（会签）', config: { branches: ['edge-fork-mgr', 'edge-fork-role'], joinMode: 'all', joinNodeKey: 'end' } },
       { key: 'higher_manager_approval', type: 'approval', name: '上级经理审批（高额）', config: { assigneeSources: [{ kind: 'manager_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'role_approval', type: 'approval', name: '指定审批角色（发布前配置）', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['待配置审批角色'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'role_approval', type: 'approval', name: '指定审批角色（发布前配置）', config: { assigneeSources: [{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'end', type: 'end', name: '结束', config: {} },
     ],
     edges: [

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -8,7 +8,12 @@ import type {
   FormSchema,
 } from '../types/approval'
 
-export type CommonApprovalTemplatePresetId = 'leave' | 'reimbursement' | 'purchase'
+export type CommonApprovalTemplatePresetId =
+  | 'leave'
+  | 'reimbursement'
+  | 'purchase'
+  | 'reimbursement_amount_tier'
+  | 'purchase_amount_tier'
 
 export interface CommonApprovalTemplatePreset {
   id: CommonApprovalTemplatePresetId
@@ -50,6 +55,18 @@ export const COMMON_APPROVAL_TEMPLATE_PRESETS: CommonApprovalTemplatePreset[] = 
     title: '采购审批',
     category: '采购',
     description: '采购类型、供应商、预算负责人、物品明细与逐级审核。',
+  },
+  {
+    id: 'reimbursement_amount_tier',
+    title: '报销审批（金额分级）',
+    category: '报销',
+    description: '高额报销自动升级：金额达阈值时增加部门主管审批（阈值/审批人可调）。',
+  },
+  {
+    id: 'purchase_amount_tier',
+    title: '采购审批（金额分级）',
+    category: '采购',
+    description: '高额采购升级并行会签：金额达阈值时由上级经理与指定角色并行审批（阈值/汇聚模式/审批人可调）。',
   },
 ]
 
@@ -181,6 +198,61 @@ function purchaseSchema(): FormSchema {
   }
 }
 
+// Amount-tier reimbursement (design-lock #3114): a condition node gates a higher-tier approver on the
+// top-level `amount`. Low amount → end after the direct manager; amount ≥ threshold → a dept-head
+// (higher-tier) approval before end. Default threshold 5000, editable in the condition-node rule
+// (Gate-A). The branch reads the top-level `amount` total (detail-row auto-sum is a separate
+// form-field capability, not this slice — design-lock Decision 1).
+function reimbursementAmountTierGraph(): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }], defaultEdgeKey: 'edge-gate-end' } },
+      { key: 'approval_high', type: 'approval', name: '部门主管审批（高额）', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-gate', source: 'approval_1', target: 'amount_gate' },
+      { key: 'edge-gate-high', source: 'amount_gate', target: 'approval_high' },
+      { key: 'edge-gate-end', source: 'amount_gate', target: 'end' },
+      { key: 'edge-high-end', source: 'approval_high', target: 'end' },
+    ],
+  }
+}
+
+// Amount-tier purchase (design-lock #3114): the condition node routes on the top-level `amount` —
+// below threshold → a single direct-manager approval; at/above threshold → a PARALLEL fork (joinMode
+// 'all' = 会签 by default; 'any' = 或签 editable) of two DISTINCT higher approvers that join at `end`.
+// Default threshold 20000. The two parallel approvers use distinct DYNAMIC sources (no static IDs →
+// no create-time duplicate-assignee reject); the role node is a starter to retune before publishing.
+function purchaseAmountTierGraph(): ApprovalGraph {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'budget_owner_approval', type: 'approval', name: '预算负责人审批', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'budget_owner' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-fork', rules: [{ fieldId: 'amount', operator: 'gte', value: 20000 }] }], defaultEdgeKey: 'edge-gate-manager' } },
+      { key: 'manager_approval', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'parallel_fork', type: 'parallel', name: '高额并行审批（会签）', config: { branches: ['edge-fork-mgr', 'edge-fork-role'], joinMode: 'all', joinNodeKey: 'end' } },
+      { key: 'higher_manager_approval', type: 'approval', name: '上级经理审批（高额）', config: { assigneeSources: [{ kind: 'manager_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'role_approval', type: 'approval', name: '部门负责人/指定角色审批（发布前配置）', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-budget', source: 'start', target: 'budget_owner_approval' },
+      { key: 'edge-budget-gate', source: 'budget_owner_approval', target: 'amount_gate' },
+      { key: 'edge-gate-fork', source: 'amount_gate', target: 'parallel_fork' },
+      { key: 'edge-gate-manager', source: 'amount_gate', target: 'manager_approval' },
+      { key: 'edge-fork-mgr', source: 'parallel_fork', target: 'higher_manager_approval' },
+      { key: 'edge-fork-role', source: 'parallel_fork', target: 'role_approval' },
+      { key: 'edge-mgr-end', source: 'higher_manager_approval', target: 'end' },
+      { key: 'edge-role-end', source: 'role_approval', target: 'end' },
+      { key: 'edge-manager-end', source: 'manager_approval', target: 'end' },
+    ],
+  }
+}
+
 function presetConfig(id: CommonApprovalTemplatePresetId): {
   keyPrefix: string
   name: string
@@ -226,6 +298,24 @@ function presetConfig(id: CommonApprovalTemplatePresetId): {
           { name: '直属上级审批', source: { kind: 'direct_manager' } },
           { name: '部门主管审批', source: { kind: 'dept_head' } },
         ]),
+      }
+    case 'reimbursement_amount_tier':
+      return {
+        keyPrefix: 'reimbursement-amount-tier',
+        name: '报销审批（金额分级）',
+        description: '高额报销自动升级审批草稿。金额阈值与各级审批人可在编辑页调整后再发布。',
+        category: '报销',
+        formSchema: reimbursementSchema(),
+        approvalGraph: reimbursementAmountTierGraph(),
+      }
+    case 'purchase_amount_tier':
+      return {
+        keyPrefix: 'purchase-amount-tier',
+        name: '采购审批（金额分级）',
+        description: '高额采购升级为并行会签草稿。金额阈值、汇聚模式（会签/或签）与各级审批人可在编辑页调整后再发布。',
+        category: '采购',
+        formSchema: purchaseSchema(),
+        approvalGraph: purchaseAmountTierGraph(),
       }
   }
 }

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -224,9 +224,16 @@ function reimbursementAmountTierGraph(): ApprovalGraph {
 
 // Amount-tier purchase (design-lock #3114): the condition node routes on the top-level `amount` —
 // below threshold → a single direct-manager approval; at/above threshold → a PARALLEL fork (joinMode
-// 'all' = 会签 by default; 'any' = 或签 editable) of two DISTINCT higher approvers that join at `end`.
-// Default threshold 20000. The two parallel approvers use distinct DYNAMIC sources (no static IDs →
-// no create-time duplicate-assignee reject); the role node is a starter to retune before publishing.
+// 'all' = 会签 by default; 'any' = 或签 editable) joining at `end`. Default threshold 20000.
+// The two parallel branches MUST resolve to DISTINCT assignment TYPES: a user-resolving manager
+// (manager_at_level → `user:X`) + a static_role (the design's "Configured Role / Person" → `role:Y`).
+// The runtime parallel-conflict key is `${assignmentType}:${assigneeId}` (ApprovalProductService.ts
+// :4152/4181), so a user-typed and a role-typed branch can NEVER collide — regardless of org data.
+// (Two USER-resolving dynamic sources — e.g. an earlier dept_head here alongside manager_at_level —
+// CAN resolve to the SAME person at runtime → APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT 409; that
+// was the bug.) The role is a STARTER: configure it before publishing — an unconfigured role resolves
+// empty → emptyAssigneePolicy 'error' fails the high path CLOSED (a high-value approver is never
+// silently skipped). The role node name signals "发布前配置".
 function purchaseAmountTierGraph(): ApprovalGraph {
   return {
     nodes: [
@@ -236,7 +243,7 @@ function purchaseAmountTierGraph(): ApprovalGraph {
       { key: 'manager_approval', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'parallel_fork', type: 'parallel', name: '高额并行审批（会签）', config: { branches: ['edge-fork-mgr', 'edge-fork-role'], joinMode: 'all', joinNodeKey: 'end' } },
       { key: 'higher_manager_approval', type: 'approval', name: '上级经理审批（高额）', config: { assigneeSources: [{ kind: 'manager_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'role_approval', type: 'approval', name: '部门负责人/指定角色审批（发布前配置）', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'role_approval', type: 'approval', name: '指定审批角色（发布前配置）', config: { assigneeSources: [{ kind: 'static_role', roleIds: ['待配置审批角色'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'end', type: 'end', name: '结束', config: {} },
     ],
     edges: [

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -7,6 +7,12 @@ export const APPROVAL_PRODUCT_PERMISSIONS = [
 
 export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[number]
 
+// Sentinel role id for a starter preset's "configure before publish" placeholder static_role. The
+// backend FAIL-FASTS at publish on this exact value (assertNoUnconfiguredPlaceholderRoles), so an
+// untouched preset cannot be published. MUST byte-match backend ApprovalProductService.ts
+// `APPROVAL_ROLE_CONFIGURE_SENTINEL` (the match is locked end-to-end by the preset publish test).
+export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
+
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
 export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user' | 'direct_manager' | 'dept_head' | 'continuous_managers' | 'manager_at_level'

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -90,10 +90,25 @@ describe('common approval template presets', () => {
     expect(gate?.config).toMatchObject({ branches: [{ rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }] })
   })
 
-  it('purchase_amount_tier forks to a parallel会签 join at the terminal end node', () => {
+  it('purchase_amount_tier forks a parallel会签 (join at end) with one user-resolving + one static_role branch — distinct-typed, no dynamic conflict', () => {
     const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: 'unit' })
-    const parallel = payload.approvalGraph.nodes.find((node) => node.type === 'parallel')
+    const graph = payload.approvalGraph
+    const parallel = graph.nodes.find((node) => node.type === 'parallel')
     expect(parallel?.config).toMatchObject({ joinMode: 'all', joinNodeKey: 'end' })
+
+    // The two parallel branch approvers must resolve to DISTINCT assignment TYPES — exactly one
+    // role-typed (static_role) + one user-resolving — so the runtime parallel-dynamic-conflict (key
+    // `assignmentType:assigneeId`) is impossible by construction. The enforcement-layer proof is in
+    // approval-wp1-parallel-gateway.api.test.ts (two user branches → 409; user + role → clean fork).
+    // This locks the preset SHAPE so it can't regress back to two user-resolving branches.
+    const branchKinds = (parallel!.config as { branches: string[] }).branches.map((edgeKey) => {
+      const target = graph.edges.find((edge) => edge.key === edgeKey)?.target
+      const node = graph.nodes.find((n) => n.key === target)
+      return (node?.config as { assigneeSources?: Array<{ kind: string }> }).assigneeSources?.[0]?.kind
+    })
+    expect(branchKinds.filter((kind) => kind === 'static_role')).toHaveLength(1) // the design's "Configured Role"
+    expect(branchKinds.filter((kind) => kind !== 'static_role' && kind !== undefined)).toHaveLength(1) // a user-resolving branch
+    expect(branchKinds).not.toContain('dept_head') // the original bug: dept_head(user) + manager_at_level(user) could collide
   })
 
   it('purchase preset uses the budget owner user field and a detail table without complex graph nodes', () => {

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -3,10 +3,11 @@ import type { ApprovalTemplateDetailDTO, CreateApprovalTemplateRequest } from '.
 import {
   buildCommonApprovalTemplatePresetPayload,
   COMMON_APPROVAL_TEMPLATE_PRESETS,
-  type CommonApprovalTemplatePresetId,
 } from '../src/approvals/commonTemplatePresets'
 import {
+  buildApprovalGraph,
   draftFromTemplate,
+  graphReadOnlyReason,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
 } from '../src/approvals/templateAuthoring'
@@ -31,24 +32,24 @@ function detailFromPayload(payload: CreateApprovalTemplateRequest): ApprovalTemp
 }
 
 describe('common approval template presets', () => {
-  it('ships the first three business presets as draft creators', () => {
+  it('ships the basic + amount-tier business presets as draft creators', () => {
     expect(COMMON_APPROVAL_TEMPLATE_PRESETS.map((preset) => preset.id)).toEqual([
       'leave',
       'reimbursement',
       'purchase',
+      'reimbursement_amount_tier',
+      'purchase_amount_tier',
     ])
   })
 
-  it.each(COMMON_APPROVAL_TEMPLATE_PRESETS.map((preset) => preset.id))(
-    '%s preset creates a linear editable template payload',
+  it.each(['leave', 'reimbursement', 'purchase'] as const)(
+    '%s basic preset creates a LINEAR editable template payload',
     (presetId) => {
-      const payload = buildCommonApprovalTemplatePresetPayload(presetId as CommonApprovalTemplatePresetId, {
-        keySuffix: 'unit',
-      })
+      const payload = buildCommonApprovalTemplatePresetPayload(presetId, { keySuffix: 'unit' })
       const detail = detailFromPayload(payload)
       const nodeTypes = payload.approvalGraph.nodes.map((node) => node.type)
 
-      expect(payload.key).toMatch(new RegExp(`^${presetId === 'leave' ? 'leave' : presetId}-approval-unit$`))
+      expect(payload.key).toMatch(new RegExp(`^${presetId}-approval-unit$`))
       expect(nodeTypes.every((type) => type === 'start' || type === 'approval' || type === 'end')).toBe(true)
       expect(payload.approvalGraph.edges).toHaveLength(payload.approvalGraph.nodes.length - 1)
       expect(unsupportedTemplateAuthoringReason(detail)).toBeNull()
@@ -59,6 +60,41 @@ describe('common approval template presets', () => {
       expect(validateTemplateDraft(draft, null)).toEqual([])
     },
   )
+
+  it.each(['reimbursement_amount_tier', 'purchase_amount_tier'] as const)(
+    '%s amount-tier preset creates a COMPLEX preserved graph (anti-flatten round-trip, G-1 floor)',
+    (presetId) => {
+      const payload = buildCommonApprovalTemplatePresetPayload(presetId, { keySuffix: 'unit' })
+      const detail = detailFromPayload(payload)
+      const nodeTypes = payload.approvalGraph.nodes.map((node) => node.type)
+
+      // complex graph: an `amount` condition gate (+ parallel for purchase). NOT linear.
+      expect(nodeTypes).toContain('condition')
+      // supported (load-preserved, save ENABLED) but rendered read-only/structured.
+      expect(unsupportedTemplateAuthoringReason(detail)).toBeNull()
+      expect(graphReadOnlyReason(detail)).not.toBeNull()
+
+      // anti-flatten floor: captured as preservedGraph, NOT projected to steps, and re-emitted
+      // byte-identical (load→save can not flatten the condition/parallel nodes).
+      const draft = draftFromTemplate(detail)
+      expect(draft.preservedGraph).toBeDefined()
+      expect(draft.steps).toEqual([])
+      expect(buildApprovalGraph(draft)).toEqual(payload.approvalGraph)
+      expect(validateTemplateDraft(draft, null)).toEqual([])
+    },
+  )
+
+  it('reimbursement_amount_tier gates a higher-tier approver on amount >= 5000', () => {
+    const payload = buildCommonApprovalTemplatePresetPayload('reimbursement_amount_tier', { keySuffix: 'unit' })
+    const gate = payload.approvalGraph.nodes.find((node) => node.type === 'condition')
+    expect(gate?.config).toMatchObject({ branches: [{ rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }] })
+  })
+
+  it('purchase_amount_tier forks to a parallel会签 join at the terminal end node', () => {
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: 'unit' })
+    const parallel = payload.approvalGraph.nodes.find((node) => node.type === 'parallel')
+    expect(parallel?.config).toMatchObject({ joinMode: 'all', joinNodeKey: 'end' })
+  })
 
   it('purchase preset uses the budget owner user field and a detail table without complex graph nodes', () => {
     const payload = buildCommonApprovalTemplatePresetPayload('purchase', { keySuffix: 'unit' })

--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -1,6 +1,8 @@
 # Amount-Tier Approval Template Presets — Design Lock
 
-Status: RATIFIED — RUNTIME NOT BUILT
+Status: RATIFIED — RUNTIME SHIPPED (amount-tier reimbursement + purchase presets; real-DB create
+acceptance + terminal-join runtime coverage). Decision 4's approval-node editor prerequisite shipped
+as G-5 (#3124); the editable complex-graph surface is fail-closed for unknown config keys (#3129).
 
 Grounding: approval authoring can create/edit linear approval templates, preserve complex graphs,
 edit condition-node rules, edit parallel `joinMode` (`all` / `any`), and edit cc targets. The common

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -485,8 +485,10 @@ function failValidation(context: ValidationContext, message: string): never {
 
 // A starter preset (e.g. the amount-tier purchase, #3114) ships a static_role branch the admin MUST
 // configure before publishing. A NORMAL placeholder role id would publish fine and then JAM the flow
-// at runtime (empty role → emptyAssigneePolicy 'error' on every instance — a stuck flow, not a clear
-// signal). Instead the starter uses this SENTINEL role id, and `assertNoUnconfiguredPlaceholderRoles`
+// at runtime: a placeholder static_role creates a ROLE-typed assignment to a role NOBODY holds, so
+// every instance STALLS on an unclaimable role assignment in to-do matching (NOT an empty-assignee
+// error — emptyAssigneePolicy never fires; the source resolves to one role assignment, just an
+// unclaimable one). Instead the starter uses this SENTINEL role id, and `assertNoUnconfiguredPlaceholderRoles`
 // FAIL-FASTS at PUBLISH, so an untouched preset can never reach a published definition — which also
 // means START is inherently protected (no published graph can contain the sentinel). FE mirror:
 // apps/web/src/types/approval.ts `APPROVAL_ROLE_CONFIGURE_SENTINEL` (the match is locked end-to-end by
@@ -2493,7 +2495,8 @@ export class ApprovalProductService {
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
-      // otherwise the high path jams at runtime (empty role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
+      // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
+      // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
       assertNoUnconfiguredPlaceholderRoles(approvalGraph)
       const runtimeGraph = buildRuntimeGraph(approvalGraph, policy)
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -483,6 +483,33 @@ function failValidation(context: ValidationContext, message: string): never {
   throw new ServiceError(message, context.status, context.code)
 }
 
+// A starter preset (e.g. the amount-tier purchase, #3114) ships a static_role branch the admin MUST
+// configure before publishing. A NORMAL placeholder role id would publish fine and then JAM the flow
+// at runtime (empty role → emptyAssigneePolicy 'error' on every instance — a stuck flow, not a clear
+// signal). Instead the starter uses this SENTINEL role id, and `assertNoUnconfiguredPlaceholderRoles`
+// FAIL-FASTS at PUBLISH, so an untouched preset can never reach a published definition — which also
+// means START is inherently protected (no published graph can contain the sentinel). FE mirror:
+// apps/web/src/types/approval.ts `APPROVAL_ROLE_CONFIGURE_SENTINEL` (the match is locked end-to-end by
+// the real-preset publish test in approval-common-template-presets.api.test.ts).
+export const APPROVAL_ROLE_CONFIGURE_SENTINEL = '__APPROVAL_ROLE_PLACEHOLDER__'
+
+function assertNoUnconfiguredPlaceholderRoles(approvalGraph: ApprovalGraph): void {
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'approval') continue
+    const sources = (node.config as { assigneeSources?: ApprovalAssigneeSource[] }).assigneeSources ?? []
+    for (const source of sources) {
+      if (source.kind === 'static_role' && source.roleIds.includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)) {
+        throw new ServiceError(
+          `审批节点「${node.name || node.key}」仍为占位审批角色，请先配置真实审批角色后再发布`,
+          400,
+          'APPROVAL_ROLE_PLACEHOLDER_NOT_CONFIGURED',
+          { nodeKey: node.key },
+        )
+      }
+    }
+  }
+}
+
 function deepFreeze<T>(value: T): T {
   if (Array.isArray(value)) {
     value.forEach((entry) => deepFreeze(entry))
@@ -2465,6 +2492,9 @@ export class ApprovalProductService {
       const approvalGraph = asApprovalGraph(version.approval_graph)
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
+      // otherwise the high path jams at runtime (empty role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.
+      assertNoUnconfiguredPlaceholderRoles(approvalGraph)
       const runtimeGraph = buildRuntimeGraph(approvalGraph, policy)
 
       const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(

--- a/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
@@ -7,6 +7,8 @@ import {
   buildCommonApprovalTemplatePresetPayload,
   COMMON_APPROVAL_TEMPLATE_PRESETS,
 } from '../../../../apps/web/src/approvals/commonTemplatePresets'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL as FE_ROLE_SENTINEL } from '../../../../apps/web/src/types/approval'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL as BACKEND_ROLE_SENTINEL } from '../../src/services/ApprovalProductService'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
@@ -131,5 +133,17 @@ describeIfDatabase('common approval template presets — real-DB backend accepta
     expect(parallel).toBeDefined()
     expect(parallel!.config.joinNodeKey).toBe('end')
     expect(parallel!.config.joinMode).toBe('all')
+  })
+
+  it('purchase_amount_tier: an UNTOUCHED preset CANNOT be published — the placeholder role fail-fasts at publish (a verifiable state, not a runtime stuck-flow)', async () => {
+    expect(FE_ROLE_SENTINEL).toBe(BACKEND_ROLE_SENTINEL) // FE preset placeholder MUST byte-match the backend guard, else the guard misses it
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: `realdb-${TS}-sentinel` })
+    const createResponse = await jsonRequest(baseUrl, '/api/approval-templates', token, { method: 'POST', body: payload })
+    expect(createResponse.status, await createResponse.clone().text()).toBe(201) // draft create is allowed (the sentinel is a valid static_role shape)
+    const template = await createResponse.json() as { id: string }
+    // publishing AS-IS must be REJECTED — the admin must replace the placeholder role first
+    const publishResponse = await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, token, { method: 'POST', body: { policy: { allowRevoke: true } } })
+    expect(publishResponse.status).toBe(400)
+    expect(await publishResponse.text()).toContain('APPROVAL_ROLE_PLACEHOLDER_NOT_CONFIGURED')
   })
 })

--- a/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
@@ -118,4 +118,18 @@ describeIfDatabase('common approval template presets — real-DB backend accepta
       )
     },
   )
+
+  it('purchase_amount_tier: the parallel node round-trips with joinNodeKey=end through create→normalize', async () => {
+    // The purchase amount-tier preset's high path forks to a parallel join that targets the terminal
+    // END node. Assert the backend normalize preserves joinNodeKey='end' (a future "helpful" rewrite
+    // of the join target — e.g. to a synthetic join node — would silently change the runtime shape).
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: `realdb-${TS}-joinkey` })
+    const response = await jsonRequest(baseUrl, '/api/approval-templates', token, { method: 'POST', body: payload })
+    expect(response.status, await response.clone().text()).toBe(201)
+    const body = await response.json() as { approvalGraph: { nodes: Array<{ type: string; config: Record<string, unknown> }> } }
+    const parallel = body.approvalGraph.nodes.find((node) => node.type === 'parallel')
+    expect(parallel).toBeDefined()
+    expect(parallel!.config.joinNodeKey).toBe('end')
+    expect(parallel!.config.joinMode).toBe('all')
+  })
 })

--- a/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
@@ -125,6 +125,30 @@ function buildParallelGatewayGraph(joinMode: 'all' | 'any' = 'all') {
   }
 }
 
+// Terminal-join variant (#3114 purchase amount-tier preset uses joinNodeKey:'end'): a parallel fork
+// whose branches join directly at the END node — the regression guard proving the runtime fork-join
+// executor COMPLETES the instance when the join target is terminal (resolveFromNode(joinNodeKey) →
+// end-completes, ApprovalGraphExecutor.ts ~676/761), so a future executor refactor can't silently
+// break it. Static assignees sidestep the directory; the topology is what's under test.
+function buildJoinAtEndGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'parallel_fork', type: 'parallel', config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'end' } },
+      { key: 'approver_a', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['joinend-a'] } },
+      { key: 'approver_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['joinend-b'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'edge-fork-a', source: 'parallel_fork', target: 'approver_a' },
+      { key: 'edge-fork-b', source: 'parallel_fork', target: 'approver_b' },
+      { key: 'edge-a-end', source: 'approver_a', target: 'end' },
+      { key: 'edge-b-end', source: 'approver_b', target: 'end' },
+    ],
+  }
+}
+
 describeIfDatabase('Approval Wave 2 WP1 parallel-gateway (并行分支) API', () => {
   let server: MetaSheetServer | undefined
   let baseUrl = ''
@@ -170,6 +194,39 @@ describeIfDatabase('Approval Wave 2 WP1 parallel-gateway (并行分支) API', ()
     if (server) {
       await server.stop()
     }
+  })
+
+  it('parallel branches that join at a TERMINAL end node complete the instance (joinNodeKey=end, #3114 amount-tier purchase shape)', async () => {
+    const adminToken = await authToken(baseUrl, 'approval-admin-joinend')
+    const requesterToken = await authToken(baseUrl, 'requester-joinend')
+    const aToken = await authToken(baseUrl, 'joinend-a')
+    const bToken = await authToken(baseUrl, 'joinend-b')
+
+    const templateResponse = await jsonRequest(baseUrl, '/api/approval-templates', adminToken, {
+      method: 'POST',
+      body: { key: `approval-joinend-${Date.now()}`, name: 'Join-At-End Template', formSchema: buildFormSchema(), approvalGraph: buildJoinAtEndGraph() },
+    })
+    expect(templateResponse.status).toBe(201)
+    const template = await templateResponse.json() as { id: string }
+    createdTemplateIds.add(template.id)
+    expect((await jsonRequest(baseUrl, `/api/approval-templates/${template.id}/publish`, adminToken, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, {
+      method: 'POST',
+      body: { templateId: template.id, formData: { reason: 'join-at-end' } },
+    })
+    expect(createResponse.status).toBe(201)
+    const approval = await createResponse.json() as { id: string; status: string; currentNodeKeys?: string[] | null }
+    createdApprovalIds.add(approval.id)
+    expect([...(approval.currentNodeKeys || [])].sort()).toEqual(['approver_a', 'approver_b']) // forked to both branches
+
+    // approve the first branch — still pending (join-all waits for both)
+    const afterA = await (await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, aToken, { method: 'POST', body: { action: 'approve' } })).json() as { status: string }
+    expect(afterA.status).toBe('pending')
+
+    // approve the second branch — join-all satisfied, join target is END → instance COMPLETES
+    const afterB = await (await jsonRequest(baseUrl, `/api/approvals/${approval.id}/actions`, bToken, { method: 'POST', body: { action: 'approve' } })).json() as { status: string }
+    expect(afterB.status).toBe('approved') // resolveFromNode(joinNodeKey='end') completed the instance
   })
 
   it('forks two branches and joins only after all branches complete (joinMode=all)', async () => {

--- a/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp1-parallel-gateway.api.test.ts
@@ -229,6 +229,65 @@ describeIfDatabase('Approval Wave 2 WP1 parallel-gateway (并行分支) API', ()
     expect(afterB.status).toBe('approved') // resolveFromNode(joinNodeKey='end') completed the instance
   })
 
+  // #3114 purchase amount-tier preset depends on its two parallel high-tier branches resolving to
+  // DISTINCT assignment TYPES so the runtime parallel-dynamic-conflict (key `${assignmentType}:
+  // ${assigneeId}`, gated to dynamically-resolved assignments — ApprovalProductService.ts:4142-4168)
+  // cannot fire. These two cases lock that AT THE ENFORCEMENT LAYER using form_field_user (a dynamic
+  // source resolving from form data — no directory needed): the OLD shape (two user-resolving branches
+  // → same user) is hard-rejected; the FIXED shape (user + role) forks cleanly.
+  function buildForkGraph(branchBConfig: Record<string, unknown>) {
+    return {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'parallel_fork', type: 'parallel', config: { branches: ['edge-fork-a', 'edge-fork-b'], joinMode: 'all', joinNodeKey: 'end' } },
+        { key: 'approver_a', type: 'approval', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver_a_field' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'approver_b', type: 'approval', config: branchBConfig },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+        { key: 'edge-fork-a', source: 'parallel_fork', target: 'approver_a' },
+        { key: 'edge-fork-b', source: 'parallel_fork', target: 'approver_b' },
+        { key: 'edge-a-end', source: 'approver_a', target: 'end' },
+        { key: 'edge-b-end', source: 'approver_b', target: 'end' },
+      ],
+    }
+  }
+  const forkFormSchema = {
+    fields: [
+      { id: 'approver_a_field', type: 'user', label: '审批人A', required: true },
+      { id: 'approver_b_field', type: 'user', label: '审批人B', required: false },
+    ],
+  }
+
+  it('parallel conflict: two USER-resolving branches that resolve to the SAME user are hard-rejected (APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT) — the bug the amount-tier preset must avoid', async () => {
+    const adminToken = await authToken(baseUrl, 'conflict-admin')
+    const requesterToken = await authToken(baseUrl, 'conflict-req')
+    const graph = buildForkGraph({ assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver_b_field' }], approvalMode: 'single', emptyAssigneePolicy: 'error' })
+    const tpl = await (await jsonRequest(baseUrl, '/api/approval-templates', adminToken, { method: 'POST', body: { key: `conflict-${Date.now()}`, name: 'Conflict', formSchema: forkFormSchema, approvalGraph: graph } })).json() as { id: string }
+    createdTemplateIds.add(tpl.id)
+    expect((await jsonRequest(baseUrl, `/api/approval-templates/${tpl.id}/publish`, adminToken, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+    // both form fields point at the same user → user:dup-user on BOTH branches → conflict at fork
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, { method: 'POST', body: { templateId: tpl.id, formData: { approver_a_field: 'dup-user', approver_b_field: 'dup-user' } } })
+    expect(createResponse.status).toBe(409)
+    expect(await createResponse.text()).toContain('APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT')
+  })
+
+  it('parallel no-conflict: a USER-resolving branch + a ROLE branch can NEVER collide (the preset fix: user:X vs role:Y) — forks cleanly', async () => {
+    const adminToken = await authToken(baseUrl, 'userrole-admin')
+    const requesterToken = await authToken(baseUrl, 'userrole-req')
+    const graph = buildForkGraph({ assigneeSources: [{ kind: 'static_role', roleIds: ['some-approval-role'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' })
+    const tpl = await (await jsonRequest(baseUrl, '/api/approval-templates', adminToken, { method: 'POST', body: { key: `userrole-${Date.now()}`, name: 'UserRole', formSchema: forkFormSchema, approvalGraph: graph } })).json() as { id: string }
+    createdTemplateIds.add(tpl.id)
+    expect((await jsonRequest(baseUrl, `/api/approval-templates/${tpl.id}/publish`, adminToken, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+    // branch A user_field → user:dup-user; branch B static_role → role:some-approval-role. Different key prefix → no conflict.
+    const createResponse = await jsonRequest(baseUrl, '/api/approvals', requesterToken, { method: 'POST', body: { templateId: tpl.id, formData: { approver_a_field: 'dup-user' } } })
+    expect(createResponse.status, await createResponse.clone().text()).toBe(201)
+    const approval = await createResponse.json() as { id: string; currentNodeKeys?: string[] | null }
+    createdApprovalIds.add(approval.id)
+    expect([...(approval.currentNodeKeys || [])].sort()).toEqual(['approver_a', 'approver_b'])
+  })
+
   it('forks two branches and joins only after all branches complete (joinMode=all)', async () => {
     const adminToken = await authToken(baseUrl, 'approval-admin-parallel')
     const requesterToken = await authToken(baseUrl, 'requester-parallel')


### PR DESCRIPTION
Builds the two amount-tier presets from design-lock **#3114**, now that G-5 (#3124, approval-node editing) and #3129 (fail-closed complex config) are on main.

## Presets
- **reimbursement_amount_tier** — direct manager → condition gate (top-level `amount` ≥ 5000) → high path adds a dept-head approval. Reuses the basic reimbursement schema.
- **purchase_amount_tier** — budget owner → condition gate (`amount` ≥ 20000) → high path forks a **parallel 会签** (joinMode 'all') of two distinct dynamic approvers that **join at the terminal `end` node**. Reuses the basic purchase schema.

## De-risked against the *real backend* first (the part the FE can't see)
Per the design's build gates, I built the graphs + ran them against real Postgres **before** the FE scaffolding:
- Both presets **create** → 201 + draft (the presets smoke `it.each` covers any list entry).
- The purchase parallel **`joinNodeKey:'end'` round-trips through normalize** (create→fetch) — catches a future join-target rewrite.
- **Terminal-join runtime:** a static-assignee parallel joining at `end` forks → both approve → join-all → instance **completes** (`approved`). This proves the design's "two approvers then done" intent *executes* (`resolveFromNode(joinNodeKey)` handles a terminal join, `ApprovalGraphExecutor.ts ~676/761`) — not just create-valid. New regression guard, and the parallel-gateway suite is **now wired into the real-DB CI job** (it was untested in CI — the smoke trap).
- Distinct **dynamic** parallel sources avoid the create-time duplicate-assignee reject; the role node is a labelled starter to retune before publishing.

## FE
The presets are complex graphs → load-preserve (`graphReadOnlyReason != null`, `unsupportedReason == null`) and round-trip **byte-identical** (G-1 anti-flatten floor), asserted per preset. The library cards fall out of the wired list; clicking creates a complex draft and drops into the G-1..G-5 editor.

Backend **12/12** (local real-DB) + FE **73/73**; vue-tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)