### PR TITLE
docs(attendance): polish §0.5 intro — drop dangling arrow

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -137,7 +137,7 @@
 
 ## 0.5 下一阶段目标（2026-06-22 锁定）— 跨午夜加班放开 + 团队可用性 + 销假 + 报表分级（✅ 已闭环 2026-06-24）
 
-> owner-set 新目标（接 §2 line 185「另起新的 owner 目标」）：四条并行切片，各自按所需证据档位闭环（design-lock → runtime → owner review →）；**#6/#8 含 staging smoke，#5/#7 以 code + CI/real-DB 闭环**（详见 §收口）。全程稳妥 auto-merge、**未碰分支保护**（strict=true / 5 context）。
+> owner-set 新目标（接 §2 line 185「另起新的 owner 目标」）：四条并行切片，各自按所需证据档位闭环（design-lock → runtime → owner review）；**#6/#8 含 staging smoke，#5/#7 以 code + CI/real-DB 闭环**（详见 §收口）。全程稳妥 auto-merge、**未碰分支保护**（strict=true / 5 context）。
 
 | 项 | 内容 | 当前状态 | 完成口径 |
 |---|---|---|---|


### PR DESCRIPTION
Cosmetic-only polish (owner-flagged, non-blocking): removes the trailing arrow in `(design-lock → runtime → owner review →)` on the §0.5 intro. No fact change. Docs-only, 1 line.