### PR TITLE
fix(onprem): harden default Windows deploy staging paths

### DIFF
--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -283,7 +283,7 @@ The packaged root now also includes Windows-native wrappers:
 
 These wrappers now call `scripts/ops/multitable-onprem-apply-package.ps1`, so a plain Windows Server 2022 host does not need bash or WSL just to apply a corrective package reroll.
 
-The PowerShell helper extracts the incoming archive into a short-lived system temp directory instead of a deep deploy-root subdirectory, which avoids common Windows long-path failures during `Expand-Archive`.
+The PowerShell helper extracts the incoming archive into a short staging root. By default on Windows it uses `C:\ms-tmp` when `METASHEET_ONPREM_STAGING_ROOT` is unset; set that environment variable only if you need a different short local directory. Zip packages are extracted through `.NET ZipFile` instead of `Expand-Archive`, so the default deploy path avoids the prior `Expand-Archive` cleanup/path failure class as well as deep `%TEMP%` / `MAX_PATH` failures.
 
 The package intentionally does **not** bundle `node_modules`. `deploy.bat`
 defaults to `InstallDeps=1` and refreshes dependencies with

--- a/docs/development/multitable-onprem-windows-default-deploy-path-hardening-20260624.md
+++ b/docs/development/multitable-onprem-windows-default-deploy-path-hardening-20260624.md
@@ -1,0 +1,80 @@
+# Multitable on-prem Windows default deploy-path hardening (2026-06-24)
+
+## Scope
+
+This slice addresses the deployment-path caveat reported during the FOS-4b-3
+sandbox validation on the entity machine:
+
+- default `.zip` deploy failed before dependency refresh in the PowerShell
+  extraction step;
+- default `.tgz` deploy failed under the default staging path with a Windows
+  path-length issue;
+- the short-staging launcher workaround succeeded.
+
+This is deployment tooling only. It does not change FOS apply behavior, K3
+behavior, external writes, production writes, option sync semantics, or database
+schema.
+
+## Change
+
+Windows PowerShell deploy helpers now default to a short local staging root when
+no explicit staging override is supplied:
+
+```text
+C:\ms-tmp
+```
+
+`METASHEET_ONPREM_STAGING_ROOT` remains the explicit override for hosts that
+need a different short local path.
+
+Zip extraction in both Windows deploy helper layers now uses
+`System.IO.Compression.ZipFile.ExtractToDirectory(...)` instead of
+`Expand-Archive`, matching the package verifier's Windows zip smoke. `.tgz` /
+`.tar.gz` extraction continues to use `tar`, but now benefits from the same
+short default staging base.
+
+## Guardrails
+
+- The self-bootstrapping launcher still invokes the apply helper from inside
+  the staged package, not the installed root.
+- The apply helper still refreshes dependencies, runs migrations, restarts PM2,
+  and performs healthchecks exactly as before.
+- The package verifier now rejects packages whose Windows helpers fall back to
+  `Expand-Archive` or omit the built-in short staging default.
+- Package metadata records both the override env
+  (`METASHEET_ONPREM_STAGING_ROOT`) and the default staging root (`C:\ms-tmp`).
+
+## Verification
+
+Run:
+
+```text
+node --test scripts/ops/onprem-windows-system-hardening.test.mjs
+node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+```
+
+For a full package proof, build a package and verify both archive types:
+
+```text
+BUILD_WEB=0 BUILD_BACKEND=0 INSTALL_DEPS=0 PACKAGE_TAG=windows-default-staging-smoke \
+  scripts/ops/multitable-onprem-package-build.sh
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-windows-default-staging-smoke.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-windows-default-staging-smoke.tgz
+```
+
+Entity-machine verification is still required to close the operational caveat on
+the exact Windows host. The expected result is:
+
+```text
+zipDefaultDeployExit=0
+tgzDefaultStagingDeployExit=0
+shortStagingWorkaroundNoLongerRequired=true
+```
+
+This follow-up is independent of the FOS-4b-3 production apply gate. Production
+apply remains closed.

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -89,7 +89,12 @@ function Resolve-StagingBase {
     $tempBase = $env:METASHEET_ONPREM_STAGING_ROOT
   }
   if ([string]::IsNullOrWhiteSpace($tempBase)) {
-    $tempBase = [System.IO.Path]::GetTempPath()
+    if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+      $tempBase = 'C:\ms-tmp'
+      Write-Info "No staging root override set; defaulting to short Windows staging root $tempBase"
+    } else {
+      $tempBase = [System.IO.Path]::GetTempPath()
+    }
   }
   if ([string]::IsNullOrWhiteSpace($tempBase)) {
     throw 'Staging root is unavailable. Set METASHEET_ONPREM_STAGING_ROOT to a short local path such as C:\ms-tmp.'
@@ -498,7 +503,9 @@ function Expand-PackageArchive {
 
   $archiveLower = $ArchivePath.ToLowerInvariant()
   if ($archiveLower.EndsWith('.zip')) {
-    Expand-Archive -LiteralPath $ArchivePath -DestinationPath $TargetDir -Force
+    Write-Info "Extract package archive via System.IO.Compression.ZipFile ($ArchivePath)"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($ArchivePath, $TargetDir)
     return
   }
 

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -56,7 +56,12 @@ function Resolve-StagingBase {
     $base = $env:METASHEET_ONPREM_STAGING_ROOT
   }
   if ([string]::IsNullOrWhiteSpace($base)) {
-    $base = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+    if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+      $base = 'C:\ms-tmp'
+      Write-LauncherInfo "No staging root override set; defaulting to short Windows staging root $base"
+    } else {
+      $base = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+    }
   }
   if ([string]::IsNullOrWhiteSpace($base)) {
     throw 'No staging root is available. Set METASHEET_ONPREM_STAGING_ROOT to a short local path such as C:\ms-tmp.'
@@ -82,8 +87,9 @@ function Expand-StagingArchive {
 
   $lower = $Archive.ToLowerInvariant()
   if ($lower.EndsWith('.zip')) {
-    Write-LauncherInfo "Extracting zip via Expand-Archive"
-    Expand-Archive -LiteralPath $Archive -DestinationPath $Stage -Force
+    Write-LauncherInfo "Extracting zip via System.IO.Compression.ZipFile"
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $Stage)
     return
   }
 

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -367,8 +367,9 @@ Upgrade / corrective reroll:
   deploy root, run:
     deploy.bat <downloaded-package.zip>
 
-  On Windows hosts whose default %TEMP% path is deep or redirected, pin staging
-  to a short local root before running deploy.bat:
+  Windows deploy defaults staging to C:\ms-tmp when no override is supplied, so
+  .zip and .tgz applies avoid deep %TEMP% / MAX_PATH failures by default. You
+  can still pin a different short local root before running deploy.bat:
     mkdir C:\ms-tmp 2>NUL
     set "METASHEET_ONPREM_STAGING_ROOT=C:\ms-tmp"
     deploy.bat <downloaded-package.zip>
@@ -401,6 +402,7 @@ EOF
   "dependencyInstallMode": "refresh-on-apply",
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
   "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
+  "windowsDefaultStagingRoot": "C:\\\\ms-tmp",
   "linuxEntryPoint": "scripts/ops/multitable-onprem-package-install.sh",
   "includedRuntimeRoots": [
     "apps/web/dist",
@@ -614,8 +616,8 @@ Runtime dependencies:
   from the package root before migrations/bootstrap.
 
 Windows staging root:
-  If the host's default %TEMP% path is deep, redirected, or fails package
-  staging, create a short local directory and set METASHEET_ONPREM_STAGING_ROOT
+  The Windows helpers default staging to C:\ms-tmp when no override is supplied.
+  If you need a different short local directory, set METASHEET_ONPREM_STAGING_ROOT
   before running deploy.bat:
     mkdir C:\ms-tmp 2>NUL
     set "METASHEET_ONPREM_STAGING_ROOT=C:\ms-tmp"
@@ -651,6 +653,7 @@ cat > "${METADATA_JSON_TMP_PATH}" <<EOF
   "nodeModulesBundled": false,
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
   "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
+  "windowsDefaultStagingRoot": "C:\\\\ms-tmp",
   "attendanceOnly": false,
   "productMode": "platform",
   "includedPlugins": ["plugin-attendance", "plugin-integration-core"],

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -157,15 +157,15 @@ test('on-prem zip verifier fallback lists full archive depth', () => {
   )
 })
 
-test('on-prem zip verifier smokes Windows Expand-Archive package-root layout', () => {
+test('on-prem zip verifier smokes Windows ZipFile package-root layout', () => {
   assert.match(
     verifyScript,
-    /function verify_windows_zip_expand_archive_smoke\(\)/,
-    'zip verification should include a Windows Expand-Archive smoke',
+    /function verify_windows_zip_zipfile_smoke\(\)/,
+    'zip verification should include a Windows ZipFile smoke',
   )
   assert.match(
     verifyScript,
-    /Expand-Archive -LiteralPath \$env:PACKAGE_ARCHIVE -DestinationPath \$env:EXTRACT_ROOT -Force/,
+    /\[System\.IO\.Compression\.ZipFile\]::ExtractToDirectory\(\$env:PACKAGE_ARCHIVE, \$env:EXTRACT_ROOT\)/,
     'the smoke should use the same PowerShell extraction primitive as Windows deploy',
   )
   assert.match(

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -67,6 +67,13 @@ function verify_windows_entrypoints() {
   fi
   search_fixed_string '[multitable-onprem-deploy-launcher]' "$launcher_helper" || die "launcher must self-identify in its logs"
   search_fixed_string 'Expand-StagingArchive' "$launcher_helper" || die "launcher must extract the supplied package into a staging directory before invoking the apply helper"
+  search_fixed_string "defaulting to short Windows staging root" "$launcher_helper" || die "launcher must default to a short Windows staging root when METASHEET_ONPREM_STAGING_ROOT is unset"
+  search_fixed_string "C:\ms-tmp" "$launcher_helper" || die "launcher must use C:\\ms-tmp as the built-in short Windows staging default"
+  search_fixed_string 'System.IO.Compression.ZipFile' "$launcher_helper" || die "launcher must use .NET ZipFile for zip extraction instead of Expand-Archive"
+  search_fixed_string 'ExtractToDirectory' "$launcher_helper" || die "launcher must extract zip archives with ZipFile.ExtractToDirectory"
+  if search_fixed_string 'Expand-Archive' "$launcher_helper"; then
+    die "launcher must not use Expand-Archive for zip deploy extraction; use .NET ZipFile so default zip deploy avoids Expand-Archive cleanup/path failures"
+  fi
   search_fixed_string 'Resolve-StagedPackageRoot' "$launcher_helper" || die "launcher must resolve the staged package root before invoking the apply helper"
   search_fixed_string 'METASHEET_ONPREM_STAGING_ROOT' "$launcher_helper" || die "launcher must support METASHEET_ONPREM_STAGING_ROOT for short Windows staging paths"
   search_fixed_string '-StagingRoot $stagingBase' "$launcher_helper" || die "launcher must pass its resolved staging base to the staged apply helper"
@@ -84,6 +91,13 @@ function verify_windows_entrypoints() {
 
   local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
   search_fixed_string 'Refresh dependencies (cmd.exe /c pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply through cmd.exe"
+  search_fixed_string "defaulting to short Windows staging root" "$apply_helper" || die "PowerShell apply helper must default to a short Windows staging root when METASHEET_ONPREM_STAGING_ROOT is unset"
+  search_fixed_string "C:\ms-tmp" "$apply_helper" || die "PowerShell apply helper must use C:\\ms-tmp as the built-in short Windows staging default"
+  search_fixed_string 'System.IO.Compression.ZipFile' "$apply_helper" || die "PowerShell apply helper must use .NET ZipFile for zip extraction instead of Expand-Archive"
+  search_fixed_string 'ExtractToDirectory' "$apply_helper" || die "PowerShell apply helper must extract zip archives with ZipFile.ExtractToDirectory"
+  if search_fixed_string 'Expand-Archive' "$apply_helper"; then
+    die "PowerShell apply helper must not use Expand-Archive for zip deploy extraction; use .NET ZipFile so default zip deploy avoids Expand-Archive cleanup/path failures"
+  fi
   search_fixed_string 'DependencyRefreshTimeoutSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh timeout"
   search_fixed_string 'DependencyRefreshHeartbeatSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh heartbeat"
   search_fixed_string 'METASHEET_ONPREM_STAGING_ROOT' "$apply_helper" || die "PowerShell apply helper must support METASHEET_ONPREM_STAGING_ROOT for short Windows extraction paths"
@@ -225,6 +239,7 @@ function verify_deployable_artifact_contract() {
   search_fixed_string '"dependencyInstallMode": "refresh-on-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document dependency refresh policy"
   search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
   search_fixed_string '"windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows staging root environment override"
+  search_fixed_string '"windowsDefaultStagingRoot": "C:\\ms-tmp"' "$metadata_json" || die "PACKAGE-METADATA.json must document the built-in short Windows staging default"
 }
 
 function verify_build_provenance() {
@@ -675,17 +690,18 @@ function verify_no_macos_metadata_entries() {
   rm -f "$matches"
 }
 
-function verify_windows_zip_expand_archive_smoke() {
+function verify_windows_zip_zipfile_smoke() {
   local archive="$1"
   local smoke_root
   [[ "$archive" == *.zip ]] || return 0
-  command -v pwsh >/dev/null 2>&1 || die "pwsh is required to smoke Windows Expand-Archive behavior for zip packages"
+  command -v pwsh >/dev/null 2>&1 || die "pwsh is required to smoke Windows ZipFile extraction behavior for zip packages"
   smoke_root="$(mktemp -d)"
   PACKAGE_ARCHIVE="$(cd "$(dirname "$archive")" && pwd)/$(basename "$archive")" \
   EXTRACT_ROOT="$smoke_root" \
   pwsh -NoProfile -NonInteractive -Command '
     $ErrorActionPreference = "Stop"
-    Expand-Archive -LiteralPath $env:PACKAGE_ARCHIVE -DestinationPath $env:EXTRACT_ROOT -Force
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($env:PACKAGE_ARCHIVE, $env:EXTRACT_ROOT)
     $root = Get-Item -LiteralPath $env:EXTRACT_ROOT
     $candidates = @()
     if (
@@ -708,7 +724,7 @@ function verify_windows_zip_expand_archive_smoke() {
     }
   ' || {
     rm -rf "$smoke_root" || true
-    die "Windows Expand-Archive smoke failed for zip package"
+    die "Windows ZipFile extraction smoke failed for zip package"
   }
   rm -rf "$smoke_root"
 }
@@ -750,7 +766,7 @@ case "$PACKAGE_FILE" in
     archive_type="zip"
     command -v unzip >/dev/null 2>&1 || die "unzip is required to verify zip packages"
     unzip -q "$PACKAGE_FILE" -d "$EXTRACT_ROOT"
-    verify_windows_zip_expand_archive_smoke "$PACKAGE_FILE"
+    verify_windows_zip_zipfile_smoke "$PACKAGE_FILE"
     if command -v zipinfo >/dev/null 2>&1; then
       zipinfo -1 "$PACKAGE_FILE" > "$list_file"
     else

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -46,6 +46,11 @@ test('Windows apply helper retries post-PM2 healthcheck during warmup and remain
 test('Windows apply helper resolves extracted package root by package markers, not first child directory', () => {
   const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
 
+  assert.match(script, /defaulting to short Windows staging root \$tempBase/)
+  assert.match(script, /C:\\ms-tmp/)
+  assert.match(script, /System\.IO\.Compression\.ZipFile/)
+  assert.match(script, /ExtractToDirectory\(\$ArchivePath, \$TargetDir\)/)
+  assert.doesNotMatch(script, /Expand-Archive/)
   assert.match(script, /function Test-OnPremPackageRoot/)
   assert.match(script, /function Resolve-ExtractedPackageRoot/)
   assert.match(script, /pnpm-lock\.yaml/)
@@ -64,6 +69,11 @@ test('Windows apply helper resolves extracted package root by package markers, n
 test('Windows deploy launcher resolves staged package root by package markers, not first child directory', () => {
   const script = readScript('scripts/ops/multitable-onprem-deploy-launcher.ps1')
 
+  assert.match(script, /defaulting to short Windows staging root \$base/)
+  assert.match(script, /C:\\ms-tmp/)
+  assert.match(script, /System\.IO\.Compression\.ZipFile/)
+  assert.match(script, /ExtractToDirectory\(\$Archive, \$Stage\)/)
+  assert.doesNotMatch(script, /Expand-Archive/)
   assert.match(script, /function Resolve-StagedPackageRoot/)
   assert.match(script, /pnpm-lock\.yaml/)
   assert.match(script, /PACKAGE-METADATA\.json/)


### PR DESCRIPTION
## Summary

Hardens the default Windows on-prem deploy path that #3093 exposed during FOS-4b-3 sandbox validation:

- Windows deploy launcher and apply helper now default staging to `C:\ms-tmp` when `METASHEET_ONPREM_STAGING_ROOT` / `-StagingRoot` is not supplied.
- Zip extraction in both Windows PowerShell extraction layers now uses `.NET ZipFile` instead of `Expand-Archive`.
- Package metadata records the built-in short Windows staging default, with JSON escaping verified.
- Package verifier and static tests now reject regressions back to `Expand-Archive` / missing short-default metadata.
- Adds a verification note for the deploy-hardening slice and updates the Windows easy-start doc.

This is deployment tooling only. It does not change FOS apply behavior, K3 behavior, external writes, production writes, option sync semantics, or DB schema.

## Why

Entity-machine #3093 proved the FOS Path 1 sandbox apply, but also showed two independent Windows deployment caveats:

- default zip deploy failed before dependency refresh in `Expand-Archive` cleanup/path handling;
- default tgz staging hit Windows path-length behavior;
- the short-staging workaround succeeded.

This PR turns the short-staging workaround into the default and removes `Expand-Archive` from the package deploy extraction path.

## Verification

Passed locally:

```text
node --test scripts/ops/onprem-windows-system-hardening.test.mjs
node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=0 PACKAGE_TAG=windows-default-staging-smoke scripts/ops/multitable-onprem-package-build.sh
scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-windows-default-staging-smoke.zip
scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-windows-default-staging-smoke.tgz
node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-windows-default-staging-smoke.json','utf8')); console.log('metadata-json-ok')"
```

Additional checks:

- package-internal `PACKAGE-METADATA.json` parsed from both generated `.zip` and `.tgz`, with `windowsDefaultStagingRoot = C:\ms-tmp`;
- adversarial subagent review: APPROVE, no blocking findings.

## Remaining operator validation

Entity-machine validation is still required for the exact Windows host:

```text
zipDefaultDeployExit=0
tgzDefaultStagingDeployExit=0
shortStagingWorkaroundNoLongerRequired=true
```

This PR does not authorize Path 2 large-BOM apply and does not open production apply.
