### PR TITLE
feat(approval): G-5 sentinel UI hint — surface the placeholder role in the editor

### DIFF
--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -680,6 +680,18 @@
                   @update:model-value="(value: number) => setApprovalSourceLevel(node.key, value ?? 1)"
                 />
               </el-form-item>
+              <!-- G-5 sentinel hint: a starter preset's placeholder role surfaces HERE, in the editor,
+                   so the admin replaces it before publish (rather than hitting the publish-time 400). -->
+              <el-alert
+                v-if="approvalSourceIsPlaceholder(node.key)"
+                type="warning"
+                :closable="false"
+                show-icon
+                class="template-authoring__placeholder-hint"
+                data-testid="approval-node-placeholder-hint"
+                title="此为占位审批角色，发布前请替换为真实角色 ID"
+                description="占位角色无人可认领，未替换将无法发布该模板。"
+              />
             </div>
 
             <!-- approval (legacy / no edit) / other — read-only summary. -->
@@ -890,6 +902,7 @@ import {
   COMMON_APPROVAL_TEMPLATE_PRESETS,
   type CommonApprovalTemplatePresetId,
 } from '../../approvals/commonTemplatePresets'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../../types/approval'
 import type {
   ApprovalAssigneeSource,
   ApprovalAssigneeSourceKind,
@@ -1128,6 +1141,13 @@ function approvalSourceIds(nodeKey: string): string[] {
   if (source?.kind === 'static_user') return source.userIds
   if (source?.kind === 'static_role') return source.roleIds
   return []
+}
+// G-5 sentinel hint: true when the source is a static_role still carrying the starter-preset
+// placeholder (APPROVAL_ROLE_CONFIGURE_SENTINEL). The backend blocks publish on it; this surfaces it
+// in the editor so the admin replaces it first. Non-blocking — the draft still saves.
+function approvalSourceIsPlaceholder(nodeKey: string): boolean {
+  return approvalSourceKind(nodeKey) === 'static_role'
+    && approvalSourceIds(nodeKey).includes(APPROVAL_ROLE_CONFIGURE_SENTINEL)
 }
 function setApprovalSourceIds(nodeKey: string, ids: string[]): void {
   const kind = approvalSourceKind(nodeKey)

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
 import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
 import type { ApprovalNodeConfig, ApprovalTemplateDetailDTO, AutoApprovalPolicy } from '../src/types/approval'
+import { APPROVAL_ROLE_CONFIGURE_SENTINEL } from '../src/types/approval'
 import {
   buildApprovalGraph,
   buildCreateTemplatePayload,
@@ -801,6 +802,26 @@ describe('TemplateAuthoringView', () => {
     expect(container!.querySelector('[data-approval-node="approval_1"]')).toBeNull() // no editor for a legacy node
     expect(container!.querySelector('[data-testid="approval-graph-readonly-list"]')).not.toBeNull() // graph still renders (legacy keys are allowlisted)
     expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')).toBeNull() // not fail-closed
+  })
+
+  it('G-5 sentinel hint: an approval node whose static_role carries the placeholder sentinel shows the in-editor hint', async () => {
+    routeParams = { id: 'tpl_sentinel' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildG5ComplexGraph({ assigneeSources: [{ kind: 'static_role', roleIds: [APPROVAL_ROLE_CONFIGURE_SENTINEL] }], approvalMode: 'single', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="approval-node-placeholder-hint"]')).not.toBeNull() // surfaced in the editor, before publish
+  })
+
+  it('G-5 sentinel hint: a normal static_role (real role id) shows NO placeholder hint', async () => {
+    routeParams = { id: 'tpl_realrole' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      approvalGraph: buildG5ComplexGraph({ assigneeSources: [{ kind: 'static_role', roleIds: ['finance-approvers'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' }),
+    }))
+    await mountView()
+    await flushUi()
+    expect(container!.querySelector('[data-testid="approval-node-placeholder-hint"]')).toBeNull()
   })
 
   it('dept_head reads back editable: a saved dept_head template is NOT fail-closed (no unsupported alert, save enabled, sourceKind hydrated)', async () => {


### PR DESCRIPTION
UX follow-up to #3132 (the amount-tier preset sentinel). When a starter preset's approval node still carries the `APPROVAL_ROLE_CONFIGURE_SENTINEL` placeholder `static_role`, the G-5 approval-node editor now shows an **inline warning** right at the source control — so the admin replaces it *in the editor*, not at the publish-time 400.

- **Non-blocking by design:** the draft still saves; the backend publish guard remains the hard gate. This is only a visible nudge.
- `approvalSourceIsPlaceholder(nodeKey)` = a `static_role` whose ids include the sentinel, imported from `types/approval` — the **same mirrored constant** the backend guard checks, so the hint and the guard can't disagree.
- 2 mounted tests: hint renders for a sentinel-carrying role, and does **not** for a real role id.

vue-tsc + lint clean; `approvalTemplateAuthoring` 37/37 (runs under `approval-web-guard`). Low-risk UX-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)