### PR TITLE
fix(onprem): add first-hop Windows deploy bootstrap sidecar

### DIFF
--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -281,9 +281,29 @@ The packaged root now also includes Windows-native wrappers:
 - `bootstrap-admin.bat <admin-email> <admin-password> [admin-name]`: create or repair the initial admin user on a pure Windows host
 - `bootstrap-admin-runXX.bat <admin-email> <admin-password> [admin-name]`: same helper with the packaged run label baked in
 
-These wrappers now call `scripts/ops/multitable-onprem-apply-package.ps1`, so a plain Windows Server 2022 host does not need bash or WSL just to apply a corrective package reroll.
+These wrappers now call `scripts/ops/multitable-onprem-deploy-launcher.ps1`,
+which extracts the supplied package, finds the apply helper inside that staged
+package, and then invokes the fresh helper against the installed root. A plain
+Windows Server 2022 host does not need bash or WSL just to apply a corrective
+package reroll.
 
 The PowerShell helper extracts the incoming archive into a short staging root. By default on Windows it uses `C:\ms-tmp` when `METASHEET_ONPREM_STAGING_ROOT` is unset; set that environment variable only if you need a different short local directory. Zip packages are extracted through `.NET ZipFile` instead of `Expand-Archive`, so the default deploy path avoids the prior `Expand-Archive` cleanup/path failure class as well as deep `%TEMP%` / `MAX_PATH` failures.
+
+If the already-installed `deploy.bat` / launcher is too old to reach the new
+package's launcher (for example it still stages under `%TEMP%` or still uses
+`Expand-Archive` before the new package can take over), use the release sidecar
+bootstrap assets instead of the installed launcher:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\metasheet-multitable-onprem-v<version>-<tag>-deploy-bootstrap.ps1 `
+  -RootDir C:\path\to\installed\metasheet `
+  -PackageArchive .\metasheet-multitable-onprem-v<version>-<tag>.zip
+```
+
+The sidecar is generated next to the release `.zip` / `.tgz` files and reuses
+the current launcher code immediately, so the first hop also defaults to
+`C:\ms-tmp` and `.NET ZipFile`.
 
 The package intentionally does **not** bundle `node_modules`. `deploy.bat`
 defaults to `InstallDeps=1` and refreshes dependencies with
@@ -354,11 +374,10 @@ subsection documents the **scheduled-task** path specifically — the synchronou
    - run a single synchronous `deploy.bat <new-package.zip>` from the
      installed root first (the new wrappers land, the next scheduled-task
      invocation then uses them), or
-   - manually copy `deploy.bat`, `deploy-remote.bat`,
-     `deploy-runXX.bat`, and
-     `scripts\ops\multitable-onprem-deploy-launcher.ps1` from the new
-     package zip into the installed root before letting the scheduled task
-     fire.
+   - if that installed first hop is itself too old to stage the new package,
+     run the release sidecar `*-deploy-bootstrap.ps1` / `.bat` next to the
+     downloaded package archive. The sidecar bypasses the installed launcher
+     and stages through the current launcher logic immediately.
 
    Either path leaves a `>=584dbc88a` `deploy-remote.bat` on disk before the
    first scheduled-task run that is expected to report a real

--- a/docs/development/multitable-onprem-windows-first-hop-bootstrap-20260624.md
+++ b/docs/development/multitable-onprem-windows-first-hop-bootstrap-20260624.md
@@ -1,0 +1,64 @@
+# Multitable On-Prem Windows First-Hop Bootstrap Follow-Up (2026-06-24)
+
+## Context
+
+#3137 changed the current Windows deploy launcher and apply helper so default
+staging uses `C:\ms-tmp` and zip extraction uses `.NET ZipFile` instead of
+`Expand-Archive`. The entity-machine retest showed a remaining upgrade gap:
+when an already-installed root still has an old `deploy.bat` / launcher, that
+old first hop runs before the new package can take over. The observed staging
+root stayed under the user temp directory and the zip first hop still used
+`Expand-Archive`.
+
+This slice addresses only that first-hop bootstrap gap.
+
+## Implementation
+
+- The package build now emits release sidecar assets next to the `.zip` and
+  `.tgz` archives:
+  - `<package>-deploy-bootstrap.ps1`
+  - `<package>-deploy-bootstrap.bat`
+- The PowerShell sidecar reuses the current
+  `scripts/ops/multitable-onprem-deploy-launcher.ps1` implementation, so it
+  gets the same `C:\ms-tmp` default, marker-based package-root detection, and
+  `.NET ZipFile` extraction.
+- The batch sidecar is a thin Windows wrapper with a parseable
+  `[multitable-onprem-deploy-bootstrap] apply exit=N` marker.
+- Both sidecars get `.sha256` files and entries in `SHA256SUMS`.
+- Package metadata records the sidecar names.
+
+## Boundary
+
+This is deploy tooling only. It does not touch FOS apply logic, Path 2 apply,
+production/canonical writes, K3, external writes, plugin runtime, database
+schema, or option-sync semantics.
+
+## Entity-Machine Retest
+
+Use the sidecar only when the installed first hop is too old to reach the new
+package's launcher:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\<package>-deploy-bootstrap.ps1 `
+  -RootDir C:\path\to\installed\metasheet `
+  -PackageArchive .\<package>.zip
+```
+
+Expected values-free evidence:
+
+```text
+bootstrapSidecarUsed=true
+observedStagingRoot=C:\ms-tmp
+zipObservedExpandArchiveAbsent=true
+zipBootstrapDeployExit=0
+tgzBootstrapDeployExit=0
+apiHealthStatus=200
+productionApplyExecuted=false
+path2ApplyExecuted=false
+k3Save=false
+k3Submit=false
+k3Audit=false
+k3BomWrite=false
+valuesFreeEvidence=true
+```

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -21,6 +21,12 @@ ARCHIVE_TGZ_TMP_PATH="${TMP_OUTPUT_DIR}/${PACKAGE_NAME}.tgz"
 ARCHIVE_ZIP_TMP_PATH="${TMP_OUTPUT_DIR}/${PACKAGE_NAME}.zip"
 ARCHIVE_TGZ_SHA_TMP_PATH="${ARCHIVE_TGZ_TMP_PATH}.sha256"
 ARCHIVE_ZIP_SHA_TMP_PATH="${ARCHIVE_ZIP_TMP_PATH}.sha256"
+BOOTSTRAP_PS1_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}-deploy-bootstrap.ps1"
+BOOTSTRAP_BAT_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}-deploy-bootstrap.bat"
+BOOTSTRAP_PS1_TMP_PATH="${TMP_OUTPUT_DIR}/${PACKAGE_NAME}-deploy-bootstrap.ps1"
+BOOTSTRAP_BAT_TMP_PATH="${TMP_OUTPUT_DIR}/${PACKAGE_NAME}-deploy-bootstrap.bat"
+BOOTSTRAP_PS1_SHA_TMP_PATH="${BOOTSTRAP_PS1_TMP_PATH}.sha256"
+BOOTSTRAP_BAT_SHA_TMP_PATH="${BOOTSTRAP_BAT_TMP_PATH}.sha256"
 METADATA_JSON_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}.json"
 METADATA_JSON_TMP_PATH="${TMP_OUTPUT_DIR}/${PACKAGE_NAME}.json"
 CHECKSUM_FILE="${OUTPUT_DIR}/SHA256SUMS"
@@ -333,6 +339,29 @@ exit /b %ERRORLEVEL%
 EOF
 }
 
+function write_windows_first_hop_bootstrap_assets() {
+  cp "${ROOT_DIR}/scripts/ops/multitable-onprem-deploy-launcher.ps1" "$BOOTSTRAP_PS1_TMP_PATH"
+
+  cat > "$BOOTSTRAP_BAT_TMP_PATH" <<EOF
+@echo off
+setlocal
+if "%~1"=="" (
+  echo Usage: ${PACKAGE_NAME}-deploy-bootstrap.bat ^<package.zip^|package.tgz^> [installed-root]
+  exit /b 64
+)
+set "INSTALL_ROOT=%~2"
+if "%INSTALL_ROOT%"=="" set "INSTALL_ROOT=%cd%"
+REM First-hop bootstrap sidecar. Use this from a release download when the
+REM already-installed deploy.bat/launcher is too old to stage the new package
+REM under C:\ms-tmp. It intentionally bypasses the installed launcher and runs
+REM the fresh launcher sidecar next to this .bat file.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0${PACKAGE_NAME}-deploy-bootstrap.ps1" -RootDir "%INSTALL_ROOT%" -PackageArchive "%~1"
+set "APPLY_EXIT=%ERRORLEVEL%"
+echo [multitable-onprem-deploy-bootstrap] apply exit=%APPLY_EXIT%
+exit /b %APPLY_EXIT%
+EOF
+}
+
 function write_deployment_guides() {
   cat > "${PACKAGE_ROOT}/DEPLOYMENT.txt" <<EOF
 MetaSheet Multitable On-Prem Deployable Package
@@ -401,6 +430,8 @@ EOF
   "nodeModulesBundled": false,
   "dependencyInstallMode": "refresh-on-apply",
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+  "windowsFirstHopBootstrap": "release sidecar: ${PACKAGE_NAME}-deploy-bootstrap.ps1",
+  "windowsFirstHopBootstrapWrapper": "release sidecar: ${PACKAGE_NAME}-deploy-bootstrap.bat",
   "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
   "windowsDefaultStagingRoot": "C:\\\\ms-tmp",
   "linuxEntryPoint": "scripts/ops/multitable-onprem-package-install.sh",
@@ -570,6 +601,15 @@ which extracts the supplied package to a staging temp dir and invokes the
 apply helper *from inside the new package*. This avoids the prior
 "first apply uses the stale installed helper" issue on upgrades.
 
+First-hop bootstrap sidecar:
+  If an existing Windows install still has an old deploy.bat / launcher that
+  fails before the new package can take over, download the release sidecar
+  ${PACKAGE_NAME}-deploy-bootstrap.ps1 (or the .bat wrapper) next to the package
+  archive and run it from the existing install root:
+    powershell -NoProfile -ExecutionPolicy Bypass -File .\${PACKAGE_NAME}-deploy-bootstrap.ps1 -RootDir . -PackageArchive .\${PACKAGE_NAME}.zip
+  The sidecar uses the current launcher logic immediately, defaults staging to
+  C:\ms-tmp on Windows, and invokes the staged package's fresh apply helper.
+
 K3 WISE PoC operator tools (Node only; no Docker needed to run these):
   Runtime plugin:
     plugins/plugin-integration-core
@@ -624,7 +664,8 @@ Windows staging root:
     deploy.bat <downloaded-package.zip>
 EOF
 
-run rm -f "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_TGZ_SHA_TMP_PATH" "$ARCHIVE_ZIP_SHA_TMP_PATH" "$METADATA_JSON_TMP_PATH"
+run rm -f "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_TGZ_SHA_TMP_PATH" "$ARCHIVE_ZIP_SHA_TMP_PATH" "$BOOTSTRAP_PS1_TMP_PATH" "$BOOTSTRAP_BAT_TMP_PATH" "$BOOTSTRAP_PS1_SHA_TMP_PATH" "$BOOTSTRAP_BAT_SHA_TMP_PATH" "$METADATA_JSON_TMP_PATH"
+write_windows_first_hop_bootstrap_assets
 find "$PACKAGE_ROOT" \( -name '._*' -o -name '__MACOSX' \) -prune -exec rm -rf {} +
 run env COPYFILE_DISABLE=1 tar --no-xattrs -czf "$ARCHIVE_TGZ_TMP_PATH" -C "$BUILD_ROOT" "$PACKAGE_NAME"
 run bash -lc "cd \"$BUILD_ROOT\" && COPYFILE_DISABLE=1 zip -X -qr \"$ARCHIVE_ZIP_TMP_PATH\" \"$PACKAGE_NAME\""
@@ -632,15 +673,25 @@ assert_no_macos_metadata_entries "$ARCHIVE_TGZ_TMP_PATH" tgz "tgz package"
 assert_no_macos_metadata_entries "$ARCHIVE_ZIP_TMP_PATH" zip "zip package"
 write_sha_file "$ARCHIVE_TGZ_TMP_PATH"
 write_sha_file "$ARCHIVE_ZIP_TMP_PATH"
+write_sha_file "$BOOTSTRAP_PS1_TMP_PATH"
+write_sha_file "$BOOTSTRAP_BAT_TMP_PATH"
 
 checksum_tmp="$(mktemp)"
 if [[ -f "$CHECKSUM_FILE" ]]; then
-  awk -v tgz="${PACKAGE_NAME}.tgz" -v zip="${PACKAGE_NAME}.zip" '$2 != tgz && $2 != zip { print }' "$CHECKSUM_FILE" > "$checksum_tmp"
+  awk \
+    -v tgz="${PACKAGE_NAME}.tgz" \
+    -v zip="${PACKAGE_NAME}.zip" \
+    -v ps1="${PACKAGE_NAME}-deploy-bootstrap.ps1" \
+    -v bat="${PACKAGE_NAME}-deploy-bootstrap.bat" \
+    '$2 != tgz && $2 != zip && $2 != ps1 && $2 != bat { print }' \
+    "$CHECKSUM_FILE" > "$checksum_tmp"
 else
   : > "$checksum_tmp"
 fi
 add_checksum_entry "$ARCHIVE_TGZ_TMP_PATH" >> "$checksum_tmp"
 add_checksum_entry "$ARCHIVE_ZIP_TMP_PATH" >> "$checksum_tmp"
+add_checksum_entry "$BOOTSTRAP_PS1_TMP_PATH" >> "$checksum_tmp"
+add_checksum_entry "$BOOTSTRAP_BAT_TMP_PATH" >> "$checksum_tmp"
 
 cat > "${METADATA_JSON_TMP_PATH}" <<EOF
 {
@@ -652,6 +703,8 @@ cat > "${METADATA_JSON_TMP_PATH}" <<EOF
   "directReplaceSafe": false,
   "nodeModulesBundled": false,
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+  "windowsFirstHopBootstrap": "$(basename "$BOOTSTRAP_PS1_PATH")",
+  "windowsFirstHopBootstrapWrapper": "$(basename "$BOOTSTRAP_BAT_PATH")",
   "windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT",
   "windowsDefaultStagingRoot": "C:\\\\ms-tmp",
   "attendanceOnly": false,
@@ -668,6 +721,10 @@ mv "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_TGZ_PATH"
 mv "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_ZIP_PATH"
 mv "$ARCHIVE_TGZ_SHA_TMP_PATH" "${ARCHIVE_TGZ_PATH}.sha256"
 mv "$ARCHIVE_ZIP_SHA_TMP_PATH" "${ARCHIVE_ZIP_PATH}.sha256"
+mv "$BOOTSTRAP_PS1_TMP_PATH" "$BOOTSTRAP_PS1_PATH"
+mv "$BOOTSTRAP_BAT_TMP_PATH" "$BOOTSTRAP_BAT_PATH"
+mv "$BOOTSTRAP_PS1_SHA_TMP_PATH" "${BOOTSTRAP_PS1_PATH}.sha256"
+mv "$BOOTSTRAP_BAT_SHA_TMP_PATH" "${BOOTSTRAP_BAT_PATH}.sha256"
 mv "$checksum_tmp" "$CHECKSUM_FILE"
 checksum_tmp=""
 mv "${METADATA_JSON_TMP_PATH}" "${METADATA_JSON_PATH}"
@@ -678,5 +735,9 @@ info "  archive_tgz: ${ARCHIVE_TGZ_PATH}"
 info "  archive_zip: ${ARCHIVE_ZIP_PATH}"
 info "  checksum_tgz: ${ARCHIVE_TGZ_PATH}.sha256"
 info "  checksum_zip: ${ARCHIVE_ZIP_PATH}.sha256"
+info "  bootstrap_ps1: ${BOOTSTRAP_PS1_PATH}"
+info "  bootstrap_bat: ${BOOTSTRAP_BAT_PATH}"
+info "  checksum_bootstrap_ps1: ${BOOTSTRAP_PS1_PATH}.sha256"
+info "  checksum_bootstrap_bat: ${BOOTSTRAP_BAT_PATH}.sha256"
 info "  index: ${CHECKSUM_FILE}"
 info "  metadata_json: ${METADATA_JSON_PATH}"

--- a/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
+++ b/scripts/ops/multitable-onprem-package-no-node-modules.test.mjs
@@ -189,3 +189,46 @@ test('on-prem zip verifier smokes Windows ZipFile package-root layout', () => {
     'package-root detection should require the apply helper from the package',
   )
 })
+
+test('on-prem package build emits first-hop Windows bootstrap sidecar assets', () => {
+  assert.match(
+    buildScript,
+    /BOOTSTRAP_PS1_PATH="\$\{OUTPUT_DIR\}\/\$\{PACKAGE_NAME\}-deploy-bootstrap\.ps1"/,
+    'the build should emit a release-sidecar PowerShell bootstrap',
+  )
+  assert.match(
+    buildScript,
+    /BOOTSTRAP_BAT_PATH="\$\{OUTPUT_DIR\}\/\$\{PACKAGE_NAME\}-deploy-bootstrap\.bat"/,
+    'the build should emit a release-sidecar batch wrapper',
+  )
+  assert.match(
+    buildScript,
+    /cp "\$\{ROOT_DIR\}\/scripts\/ops\/multitable-onprem-deploy-launcher\.ps1" "\$BOOTSTRAP_PS1_TMP_PATH"/,
+    'the bootstrap PowerShell sidecar should reuse the current launcher implementation',
+  )
+  assert.match(
+    buildScript,
+    /multitable-onprem-deploy-bootstrap/,
+    'the bootstrap wrapper should emit its own parseable apply-exit marker',
+  )
+  assert.match(
+    buildScript,
+    /write_sha_file "\$BOOTSTRAP_PS1_TMP_PATH"/,
+    'the PowerShell sidecar should get a sha256 file',
+  )
+  assert.match(
+    buildScript,
+    /add_checksum_entry "\$BOOTSTRAP_BAT_TMP_PATH" >> "\$checksum_tmp"/,
+    'the batch sidecar should be listed in SHA256SUMS',
+  )
+  assert.match(
+    buildScript,
+    /"windowsFirstHopBootstrap": "\$\(basename "\$BOOTSTRAP_PS1_PATH"\)"/,
+    'external metadata should name the first-hop bootstrap sidecar',
+  )
+  assert.match(
+    verifyScript,
+    /first-hop bootstrap release sidecar/,
+    'package verifier should require the package metadata to describe the bootstrap sidecar',
+  )
+})

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -238,6 +238,8 @@ function verify_deployable_artifact_contract() {
   search_fixed_string '"nodeModulesBundled": false' "$metadata_json" || die "PACKAGE-METADATA.json must document node_modules policy"
   search_fixed_string '"dependencyInstallMode": "refresh-on-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document dependency refresh policy"
   search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
+  search_fixed_string '"windowsFirstHopBootstrap": "release sidecar:' "$metadata_json" || die "PACKAGE-METADATA.json must document the first-hop bootstrap release sidecar"
+  search_fixed_string '"windowsFirstHopBootstrapWrapper": "release sidecar:' "$metadata_json" || die "PACKAGE-METADATA.json must document the first-hop bootstrap wrapper release sidecar"
   search_fixed_string '"windowsStagingRootEnv": "METASHEET_ONPREM_STAGING_ROOT"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows staging root environment override"
   search_fixed_string '"windowsDefaultStagingRoot": "C:\\ms-tmp"' "$metadata_json" || die "PACKAGE-METADATA.json must document the built-in short Windows staging default"
 }


### PR DESCRIPTION
## Summary

Adds release-sidecar Windows bootstrap assets for on-prem packages:

- emits a package-named deploy-bootstrap.ps1 next to the zip and tgz release assets by reusing the current multitable-onprem-deploy-launcher.ps1 implementation;
- emits a thin package-named deploy-bootstrap.bat wrapper with a parseable multitable-onprem-deploy-bootstrap apply-exit marker;
- adds sha256 files and SHA256SUMS entries for both sidecars;
- records the sidecar names in package metadata and operator docs.

## Why

Issue #3093 showed that #3137 package-internal launcher hardening was correct but could not close an upgrade whose already-installed first hop was still stale. The old installed deploy.bat / launcher ran before the new package could take over, so staging still resolved to user TEMP and zip still used Expand-Archive.

This PR gives operators a first-hop bootstrap asset downloaded from the new release, so they can bypass the stale installed launcher and immediately stage through the current launcher logic: C:\ms-tmp, .NET ZipFile, and the staged fresh apply helper.

## Boundary

Deploy tooling only. This does not touch FOS apply logic, Path 2 apply, production or canonical writes, K3, external writes, plugin runtime, database schema, or option-sync semantics.

## Verification

- bash syntax check for multitable-onprem-package-build.sh and multitable-onprem-package-verify.sh
- node test: scripts/ops/onprem-windows-system-hardening.test.mjs, 8 pass
- node test: scripts/ops/multitable-onprem-package-no-node-modules.test.mjs, 6 pass
- git diff check for the final commit
- full package smoke with BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=0 PACKAGE_TAG=first-hop-bootstrap-smoke-20260624
- package verifier passed for both generated zip and tgz
- generated metadata contains windowsFirstHopBootstrap, windowsFirstHopBootstrapWrapper, and windowsDefaultStagingRoot=C:\ms-tmp
- SHA256SUMS contains both bootstrap sidecars

## Entity-machine close condition

After merge and package release, entity-machine retest should use the sidecar path and report values-free:

- bootstrapSidecarUsed=true
- observedStagingRoot=C:\ms-tmp
- zipObservedExpandArchiveAbsent=true
- zipBootstrapDeployExit=0
- tgzBootstrapDeployExit=0
- no Path 2 apply, production apply, canonical write, or K3 write opened.