### PR TITLE
feat(attendance): v1-1a OvertimeBankPolicy latent config + normalizer (加班银行)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -8665,6 +8665,36 @@ attendanceIntegrationDescribe(
       return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
     }
 
+    it('round-trips overtimeBankPolicy (wire lock): PUT→GET full shape, partial PUT preserves siblings, statutory_holiday → 400', async () => {
+      if (!baseUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-otbank-wire-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const headers = { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' }
+      const putSettings = (body: Record<string, unknown>) =>
+        requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify(body) })
+      const originalSettings = await loadSettingsForTest(adminToken)
+      try {
+        // (1) full PUT → GET returns the full shape — locks the whole wire: DEFAULT_SETTINGS + normalizeSettings
+        // + the settings zod schema + mergeSettings. (Normalizer unit tests do NOT cover this wire.)
+        expect((await putSettings({ overtimeBankPolicy: { enabled: true, pooledSources: ['restday', 'workday'], maxMinutesPerPeriod: 600, validityDays: 90 } })).status).toBe(200)
+        expect((await loadSettingsForTest(adminToken)).overtimeBankPolicy).toEqual({
+          enabled: true, pooledSources: ['restday', 'workday'], maxMinutesPerPeriod: 600, validityDays: 90,
+        })
+        // (2) partial PUT preserves siblings — PUT only { enabled:false }; pooledSources/cap/validity must NOT be
+        // cleared (this is the exact mergeSettings-whitelist gap the advisor caught).
+        expect((await putSettings({ overtimeBankPolicy: { enabled: false } })).status).toBe(200)
+        expect((await loadSettingsForTest(adminToken)).overtimeBankPolicy).toEqual({
+          enabled: false, pooledSources: ['restday', 'workday'], maxMinutesPerPeriod: 600, validityDays: 90,
+        })
+        // (3) API-layer compliance reject (not just the normalizer drop): statutory_holiday → 400 at PUT.
+        expect((await putSettings({ overtimeBankPolicy: { pooledSources: ['statutory_holiday'] } })).status).toBe(400)
+      } finally {
+        await putSettings({ overtimeBankPolicy: originalSettings.overtimeBankPolicy }).catch(() => undefined)
+      }
+    })
+
     it('round-trips auto-write settings including auto mode while rejecting invalid bounds', async () => {
       if (!baseUrl) return
       const runSuffix = Date.now().toString(36)

--- a/packages/core-backend/tests/unit/attendance-overtime-bank-policy.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-bank-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceOvertimeBankForTests as {
+  OVERTIME_BANK_POOLABLE_SOURCES: readonly string[]
+  normalizeOvertimeBankPolicySetting: (raw: unknown) => {
+    enabled: boolean
+    pooledSources: string[]
+    maxMinutesPerPeriod: number
+    validityDays: number | null
+  }
+}
+
+describe('#8/加班银行 v1-1a — OvertimeBankPolicy normalizer (LATENT, compliance-floor)', () => {
+  const norm = helpers.normalizeOvertimeBankPolicySetting
+  const DORMANT = { enabled: false, pooledSources: [], maxMinutesPerPeriod: 0, validityDays: null }
+
+  it('default dormant: empty / garbage → enabled false, empty pool, no cap, no expiry', () => {
+    expect(norm(undefined)).toEqual(DORMANT)
+    expect(norm({})).toEqual(DORMANT)
+    expect(norm('nope')).toEqual(DORMANT)
+    expect(norm(null)).toEqual(DORMANT)
+  })
+
+  it('keeps the poolable allowlist sources, de-duped, preserving order', () => {
+    const r = norm({ pooledSources: ['restday', 'workday', 'restday', 'special_hours', 'adjusted_rest_day', 'company_holiday'] })
+    expect(r.pooledSources).toEqual(['restday', 'workday', 'special_hours', 'adjusted_rest_day', 'company_holiday'])
+  })
+
+  it('COMPLIANCE FLOOR: statutory_holiday is dropped from pooledSources (法定节假日不可入池, 劳动法 §44)', () => {
+    expect(norm({ pooledSources: ['statutory_holiday'] }).pooledSources).toEqual([])
+    expect(norm({ pooledSources: ['restday', 'statutory_holiday', 'workday'] }).pooledSources).toEqual(['restday', 'workday'])
+    // the allowlist itself must never contain statutory_holiday.
+    expect(helpers.OVERTIME_BANK_POOLABLE_SOURCES).not.toContain('statutory_holiday')
+    expect([...helpers.OVERTIME_BANK_POOLABLE_SOURCES].sort()).toEqual(
+      ['adjusted_rest_day', 'company_holiday', 'restday', 'special_hours', 'workday'],
+    )
+  })
+
+  it('drops unknown / non-string sources (fail-closed)', () => {
+    expect(norm({ pooledSources: ['restday', 'bogus', 42, null, ''] }).pooledSources).toEqual(['restday'])
+    expect(norm({ pooledSources: 'restday' }).pooledSources).toEqual([]) // not an array → empty
+  })
+
+  it('enabled toggle + maxMinutesPerPeriod clamp ≥ 0', () => {
+    expect(norm({ enabled: true }).enabled).toBe(true)
+    expect(norm({ enabled: 'yes' }).enabled).toBe(true) // parseBoolean truthy
+    expect(norm({ maxMinutesPerPeriod: -5 }).maxMinutesPerPeriod).toBe(0)
+    expect(norm({ maxMinutesPerPeriod: 600 }).maxMinutesPerPeriod).toBe(600)
+  })
+
+  it('validityDays: null = no expiry; positive kept; 0 / negative → null', () => {
+    expect(norm({ validityDays: null }).validityDays).toBeNull()
+    expect(norm({ validityDays: 90 }).validityDays).toBe(90)
+    expect(norm({ validityDays: 0 }).validityDays).toBeNull()
+    expect(norm({ validityDays: -3 }).validityDays).toBeNull()
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -212,6 +212,16 @@ const DEFAULT_SETTINGS = {
   overtimeSegmentation: {
     enabled: false,
   },
+  // 加班银行 (overtime bank) — OvertimeBankPolicy v1-1a LATENT config (design-lock
+  // attendance-overtime-bank-settlement-designlock-20260624, §3/§6/§11). Default OFF; nothing enforces it
+  // yet (v1-1b source-tagged lots + later slices consume it). pooledSources is an allowlist that CANNOT
+  // contain statutory_holiday — 法定节假日加班按《劳动法》§44 必须支付、不得调休抵扣 (compliance floor §6).
+  overtimeBankPolicy: {
+    enabled: false,
+    pooledSources: [],
+    maxMinutesPerPeriod: 0,
+    validityDays: null,
+  },
   // 自动对班 (auto shift matching) — A1 preview/manual apply plus A2 scheduler auto-write.
   // Runtime still requires env flags in addition to these org settings.
   autoShiftMatching: {
@@ -11860,6 +11870,7 @@ function normalizeSettings(raw) {
     compTimeFromOvertime: normalizeCompTimeFromOvertimeSetting(raw.compTimeFromOvertime),
     annualLeavePolicy: normalizeAnnualLeavePolicySetting(raw.annualLeavePolicy),
     overtimeSegmentation: normalizeOvertimeSegmentationSetting(raw.overtimeSegmentation),
+    overtimeBankPolicy: normalizeOvertimeBankPolicySetting(raw.overtimeBankPolicy),
     autoShiftMatching: normalizeAutoShiftMatchingSetting(raw.autoShiftMatching),
   }
 }
@@ -11987,6 +11998,38 @@ function normalizeAnnualLeaveTiers(raw, fallbackTiers) {
   }
   if (tiers.length > 0 && tiers[tiers.length - 1].maxYears !== null) return clone()
   return tiers
+}
+
+// 加班银行可入池来源白名单 (OvertimeBankPolicy.pooledSources allowlist). statutory_holiday 故意缺席:§6 合规
+// 下限 —— 法定节假日加班按《劳动法》§44 必须支付、不得进调休池,无论管理员怎么配。adjusted_rest_day /
+// company_holiday 可配;workday 默认不入池(§11)但企业显式 opt-in 时允许。
+const OVERTIME_BANK_POOLABLE_SOURCES = Object.freeze([
+  'workday', 'restday', 'adjusted_rest_day', 'company_holiday', 'special_hours',
+])
+
+// OvertimeBankPolicy v1-1a LATENT normalizer. Fail-closed enum-strict: only the allowlist survives in
+// pooledSources (statutory_holiday + unknowns dropped = compliance floor §6). Default dormant (enabled
+// false). Nothing enforces this yet; v1-1b source-tagged lots + later slices consume it.
+function normalizeOvertimeBankPolicySetting(raw) {
+  const value = raw && typeof raw === 'object' ? raw : {}
+  const seen = new Set()
+  const pooledSources = []
+  for (const item of Array.isArray(value.pooledSources) ? value.pooledSources : []) {
+    if (typeof item === 'string' && OVERTIME_BANK_POOLABLE_SOURCES.includes(item) && !seen.has(item)) {
+      seen.add(item)
+      pooledSources.push(item)
+    }
+  }
+  const validityRaw = value.validityDays
+  const validityDays = validityRaw === null || validityRaw === undefined
+    ? null
+    : (Math.max(0, parseNumber(validityRaw, 0)) || null)
+  return {
+    enabled: parseBoolean(value.enabled, false),
+    pooledSources,
+    maxMinutesPerPeriod: Math.max(0, parseNumber(value.maxMinutesPerPeriod, 0)),
+    validityDays,
+  }
 }
 
 function normalizeOvertimeSegmentationSetting(raw) {
@@ -18296,6 +18339,10 @@ module.exports = {
     bucketOvertimeSegmentationWindowAtMidnight,
     maybeBuildOvertimeSegmentationSnapshot,
   },
+  __attendanceOvertimeBankForTests: {
+    OVERTIME_BANK_POOLABLE_SOURCES,
+    normalizeOvertimeBankPolicySetting,
+  },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
     ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
@@ -19388,6 +19435,15 @@ module.exports = {
       compTimeFromOvertime: z.object({
         enabled: z.boolean().optional(),
         expiresInDays: z.number().int().positive().nullable().optional(),
+      }).optional(),
+      // 加班银行 (overtime bank) — OvertimeBankPolicy v1-1a latent config. Round-trips through PUT/GET; no
+      // runtime enforces it yet. pooledSources enum EXCLUDES statutory_holiday (compliance floor §6 — 法定
+      // 节假日加班 must be paid, not poolable), so a PUT including it is rejected at the API.
+      overtimeBankPolicy: z.object({
+        enabled: z.boolean().optional(),
+        pooledSources: z.array(z.enum(['workday', 'restday', 'adjusted_rest_day', 'company_holiday', 'special_hours'])).optional(),
+        maxMinutesPerPeriod: z.number().int().min(0).optional(),
+        validityDays: z.number().int().positive().nullable().optional(),
       }).optional(),
       // 年假/法定假余额引擎 — L0 latent config (design-lock #2622). Round-trips through PUT/GET; no
       // runtime reads it until L2 (accrual). tiers = org-configurable statutory bands.

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -12191,6 +12191,11 @@ function mergeSettings(base, update) {
       ...(base?.overtimeSegmentation || {}),
       ...(update?.overtimeSegmentation || {}),
     },
+    // pooledSources is an array → replaced wholesale when an update provides it (partial merges meaningless).
+    overtimeBankPolicy: {
+      ...(base?.overtimeBankPolicy || {}),
+      ...(update?.overtimeBankPolicy || {}),
+    },
     autoShiftMatching: {
       ...(base?.autoShiftMatching || {}),
       ...(update?.autoShiftMatching || {}),


### PR DESCRIPTION
First build slice of the ratified **加班调休抵扣与周期结算规则** design-lock. **Split v1-1** into **v1-1a** (this — dormant config + normalizer, no migration, no runtime change, proven C5-0/A2-0 dormant-first pattern) and **v1-1b** (账1 source-tagged lots + migration, next gated slice).

- `DEFAULT_SETTINGS.overtimeBankPolicy` — **LATENT, default OFF**; nothing enforces it yet.
- `normalizeOvertimeBankPolicySetting` — fail-closed enum-strict; pooledSources from allowlist `{workday, restday, adjusted_rest_day, company_holiday, special_hours}`; unknowns dropped; deduped; cap≥0; validityDays null|positive.
- **COMPLIANCE FLOOR (§6)**: `statutory_holiday` intentionally absent from the allowlist (劳动法 §44 — must be paid, not poolable) → can never enter the pool. Enforced **twice**: normalizer drop (defense) + PUT /settings zod enum reject (API).

Unit **6/6** (incl. statutory_holiday-drop), tsc 0. No migration, no behavior change. v1-1b is next.