### PR TITLE
fix(onprem): keep launcher logs off success stream

### DIFF
--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -32,7 +32,10 @@ $ErrorActionPreference = 'Stop'
 
 function Write-LauncherInfo {
   param([string]$Message)
-  Write-Output ("[multitable-onprem-deploy-launcher] {0}" -f $Message)
+  # Use the host stream, not the success output stream. PowerShell functions
+  # return every success-stream object, so Write-Output inside helpers such as
+  # Resolve-StagingBase can pollute the caller's path value.
+  Write-Host ("[multitable-onprem-deploy-launcher] {0}" -f $Message)
 }
 
 function Resolve-LauncherPath {

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -66,6 +66,10 @@ function verify_windows_entrypoints() {
     die "PowerShell launcher script must be packaged for deploy.bat self-bootstrap"
   fi
   search_fixed_string '[multitable-onprem-deploy-launcher]' "$launcher_helper" || die "launcher must self-identify in its logs"
+  search_fixed_string 'Write-Host ("[multitable-onprem-deploy-launcher] {0}" -f $Message)' "$launcher_helper" || die "launcher must log through Write-Host so informational messages do not pollute helper return values"
+  if search_fixed_string 'Write-Output ("[multitable-onprem-deploy-launcher] {0}" -f $Message)' "$launcher_helper"; then
+    die "launcher must not log through Write-Output; PowerShell success-stream output pollutes helper return values such as the staging root"
+  fi
   search_fixed_string 'Expand-StagingArchive' "$launcher_helper" || die "launcher must extract the supplied package into a staging directory before invoking the apply helper"
   search_fixed_string "defaulting to short Windows staging root" "$launcher_helper" || die "launcher must default to a short Windows staging root when METASHEET_ONPREM_STAGING_ROOT is unset"
   search_fixed_string "C:\ms-tmp" "$launcher_helper" || die "launcher must use C:\\ms-tmp as the built-in short Windows staging default"
@@ -90,6 +94,10 @@ function verify_windows_entrypoints() {
   fi
 
   local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
+  search_fixed_string 'Write-Host "[multitable-onprem-apply-package] $Message"' "$apply_helper" || die "PowerShell apply helper must log through Write-Host so informational messages do not pollute helper return values"
+  if search_fixed_string 'Write-Output "[multitable-onprem-apply-package] $Message"' "$apply_helper"; then
+    die "PowerShell apply helper must not log through Write-Output; PowerShell success-stream output pollutes helper return values such as the staging root"
+  fi
   search_fixed_string 'Refresh dependencies (cmd.exe /c pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply through cmd.exe"
   search_fixed_string "defaulting to short Windows staging root" "$apply_helper" || die "PowerShell apply helper must default to a short Windows staging root when METASHEET_ONPREM_STAGING_ROOT is unset"
   search_fixed_string "C:\ms-tmp" "$apply_helper" || die "PowerShell apply helper must use C:\\ms-tmp as the built-in short Windows staging default"

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -46,6 +46,16 @@ test('Windows apply helper retries post-PM2 healthcheck during warmup and remain
 test('Windows apply helper resolves extracted package root by package markers, not first child directory', () => {
   const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
 
+  assert.match(
+    script,
+    /function Write-Info \{\s+param\(\[string\]\$Message\)\s+Write-Host "\[multitable-onprem-apply-package\] \$Message"\s+\}/,
+    'apply-helper logging must not use Write-Output because success-stream output pollutes helper return values',
+  )
+  assert.doesNotMatch(
+    script,
+    /Write-Output "\[multitable-onprem-apply-package\] \$Message"/,
+    'apply-helper logging must not emit informational lines on the success output stream',
+  )
   assert.match(script, /defaulting to short Windows staging root \$tempBase/)
   assert.match(script, /C:\\ms-tmp/)
   assert.match(script, /System\.IO\.Compression\.ZipFile/)
@@ -69,6 +79,16 @@ test('Windows apply helper resolves extracted package root by package markers, n
 test('Windows deploy launcher resolves staged package root by package markers, not first child directory', () => {
   const script = readScript('scripts/ops/multitable-onprem-deploy-launcher.ps1')
 
+  assert.match(
+    script,
+    /function Write-LauncherInfo \{\s+param\(\[string\]\$Message\)\s+# Use the host stream,[\s\S]+Write-Host \("\[multitable-onprem-deploy-launcher\] \{0\}" -f \$Message\)\s+\}/,
+    'launcher logging must not use Write-Output because success-stream output pollutes helper return values',
+  )
+  assert.doesNotMatch(
+    script,
+    /Write-Output \("\[multitable-onprem-deploy-launcher\] \{0\}" -f \$Message\)/,
+    'launcher logging must not emit informational lines on the success output stream',
+  )
   assert.match(script, /defaulting to short Windows staging root \$base/)
   assert.match(script, /C:\\ms-tmp/)
   assert.match(script, /System\.IO\.Compression\.ZipFile/)


### PR DESCRIPTION
## Summary

Fixes the smaller first-hop bootstrap bug found by the #3093 entity-machine retest after #3144.

The retest proved the sidecar is used and explicit `-StagingRoot C:\ms-tmp` succeeds for both zip and tgz, but the default sidecar path still failed before archive extraction. Root cause: launcher logging used `Write-Output`; PowerShell treats success-stream output from helper functions as return values, so the default-root informational line polluted `Resolve-StagingBase`'s returned path and `GetFullPath` rejected the combined string.

## Changes

- Change `Write-LauncherInfo` from `Write-Output` to `Write-Host`, keeping informational logs off the success output stream.
- Add package verifier guards so packaged launchers must use `Write-Host` and must not use the old launcher `Write-Output` logging shape.
- Add the symmetric apply-helper guard: `Write-Info` must use `Write-Host` and must reject the equivalent apply-helper `Write-Output` shape, even though the apply helper was already correct.
- Add static test coverage for both no-success-stream logging contracts.

## Boundary

Deploy tooling only:
- no FOS apply/runtime change;
- Path 2 sandbox checkpoint apply is not authorized here;
- production apply remains closed;
- no K3 / external / canonical write is opened.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-verify.sh scripts/ops/multitable-onprem-package-build.sh`
- `node --test scripts/ops/onprem-windows-system-hardening.test.mjs`
- `node --test scripts/ops/multitable-onprem-package-no-node-modules.test.mjs`
- `git diff --check`

## Next after merge

Cut a refreshed on-prem package from the merge commit and rerun the #3093 sidecar retest, expecting default sidecar path to reach the same shape already proven by the explicit-staging control:

- `bootstrapSidecarUsed=true`
- `observedStagingRoot=C:\ms-tmp`
- `zipObservedExpandArchiveAbsent=true`
- `zipBootstrapDeployExit=0`
- `tgzBootstrapDeployExit=0`
