### PR TITLE
feat(automation): W7-1 approval-result backwrite (审批结果写回) — declared fixed mapping

### DIFF
--- a/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
+++ b/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
@@ -1,0 +1,54 @@
+# W7-1 — Approval-result backwrite (审批结果写回): design + verification
+
+Completes the approval↔automation line: when an automation-started approval completes, the approval
+**result is written back to the source record** (e.g. 采购审批通过 → 写回采购表 approval_status /
+approved_by / approved_at). This was the last demand-gated item on the run-governance track (W7-0
+event contract shipped; W7-1 runtime was gated).
+
+## Design — reuse the existing bridge; declared FIXED mapping; no expression templating
+
+The approval↔automation bridge already exists (W6-1, #2469): a `start_approval` action suspends the
+automation; the approval completion event resumes it (`handleApprovalCompletionEvent`, with the
+action-fingerprint drift guard). W7-1 adds, on that seam:
+
+1. **A declared `resultWriteback` mapping on the `start_approval` action config** — a *fixed* outcome→
+   field map: `{ statusField?, approverField?, completedAtField? }` (≥1, each a non-empty source field
+   id). The admin picks **which source field receives `outcome` / `approver` / `completedAt`** — not a
+   template expression. Validated at rule-save (`validateStartApprovalConfig`).
+2. **On resume (approved branch), the bridge writes the mapped values to the source record** —
+   `outcome = transition.toStatus`, `approver = actor?.id ?? null`, `completedAt = occurredAt` — taken
+   **from the completion event only**, through the record **lock guard** (`ensureRecordNotLocked`).
+
+### Why this shape (the security posture — the reason it was gated)
+The obvious-looking alternative — add `{{ steps.X.output.* }}` templating to the `update_record`
+writer — was **rejected**. It would open arbitrary-expression interpolation into *every* write path
+(re-litigating the redaction / values-free / cross-base-write-gate work the rest of this track
+established), to serve one feature. Instead W7-1 is **values-constrained**: the write carries only
+fixed outcome values from the event, mapped to admin-chosen fields — never a user-authored string into
+the writer. Additional inherited guarantees:
+- **Drift-guarded:** the mapping lives in the `start_approval` action config, so the resume-time
+  action-fingerprint check already rejects a mapping swapped after the approval suspended.
+- **Lock-respecting:** the backwrite goes through `ensureRecordNotLocked` (an automation does not
+  implicitly own a record lock — B1 doctrine); a locked/missing record logs + skips, never crashes the
+  resume (the automation's remaining actions still run).
+- **Null-safe:** `approver` is null on auto/system approval (written null, not crashed).
+- **Same-base, approval-only:** writes the source record that started the approval; rejection-path
+  backwrite (the non-approved path currently *fails* the automation) is a named follow-up.
+
+## Verification
+- **End-to-end, real-DB** (`multitable-automation-start-approval.test.ts`): seed a record → automation
+  `start_approval` with `resultWriteback` → approve via `ApprovalProductService.dispatchAction` →
+  resume → assert the **source record now carries** `approval_status='approved'`,
+  `approved_by=<approver>`, `approved_at=<timestamp>`. Green locally against Postgres.
+- **Validation unit** (`automation-v1.test.ts`): a valid mapping is accepted; an empty mapping and a
+  non-string field target are rejected at rule-save (values-constrained — no object/expression).
+- **No regression:** full start-approval integration suite **11/11**; backend **tsc clean**.
+
+## Named follow-ups (gated, not silently skipped)
+- **Rejection backwrite** — write `status='rejected'` on the non-approved path. That path currently
+  fails the automation by design (fingerprint + bridge governance); resume-and-write on rejection is a
+  real behavior change with its own governance implications.
+- **Cross-base backwrite** — write to a different base's record (today: the same-base source record).
+  Would route through the existing `evaluateCrossBaseWrite` gate, like `update_record`.
+- **Field-exists validation** against the target sheet schema (today the write is schemaless `jsonb`
+  merge, so any field id is accepted — consistent with `update_record`).

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1459,6 +1459,9 @@ export class AutomationService {
     const lockRow = lockRes.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
     if (!lockRow) return // record gone — the resume's own missing-record path already handled it
     ensureRecordNotLocked(event.actor?.id ?? null, lockRow, () => new Error('source record is locked'))
+    // rich-longText SAFE: patch carries ONLY system outcome values (status enum / approver id / ISO
+    // timestamp), never user-supplied longText — classified SAFE in the rich-longText write-sink guard.
+    // lock-guarded: the backwrite respects the source record lock via ensureRecordNotLocked just above (B1).
     await this.queryFn(
       `UPDATE meta_records
        SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -3,6 +3,7 @@ import type { Kysely } from 'kysely'
 import type { EventBus } from '../integration/events/event-bus'
 import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
+import { ensureRecordNotLocked } from './record-lock'
 import {
   ConditionGroupValidationError,
   normalizeConditionGroupInput,
@@ -142,6 +143,23 @@ function validateStartApprovalConfig(config: Record<string, unknown>, path: stri
     if (mode !== undefined && mode !== 'trigger_actor' && mode !== 'rule_creator') {
       return `${path}.requester.mode must be trigger_actor or rule_creator`
     }
+  }
+  // W7-1 approval-result backwrite: a DECLARED, FIXED outcome→field mapping. The admin picks WHICH
+  // source field receives `outcome` / `approver` / `completedAt` — NOT a free template expression — so
+  // the write path stays values-constrained (values come from the completion event, never user strings).
+  // Optional; ≥1 field if present. The mapping is part of the action config, so it is covered by the
+  // resume-time action-fingerprint drift guard (cannot be swapped after the approval suspends).
+  if (config.resultWriteback !== undefined) {
+    if (!isRecord(config.resultWriteback)) return `${path}.resultWriteback must be an object`
+    const fields = ['statusField', 'approverField', 'completedAtField'] as const
+    let mapped = 0
+    for (const field of fields) {
+      const value = config.resultWriteback[field]
+      if (value === undefined) continue
+      if (typeof value !== 'string' || value.trim().length === 0) return `${path}.resultWriteback.${field} must be a non-empty string`
+      mapped += 1
+    }
+    if (mapped === 0) return `${path}.resultWriteback must map at least one of statusField/approverField/completedAtField`
   }
   return null
 }
@@ -1356,6 +1374,15 @@ export class AutomationService {
       recordData = (row.data as Record<string, unknown>) ?? {}
     }
 
+    // W7-1: declared approval-result backwrite to the SOURCE record (fixed mapping, values from the
+    // event, through the lock guard). Best-effort — a locked/missing record logs + skips rather than
+    // crashing the resume, so the automation's remaining actions still run.
+    try {
+      await this.writeApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event)
+    } catch (err) {
+      logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
     const triggerEvent = bridge.triggerEvent ?? {}
     const context: ExecutionContext = {
       executionId: execution.id,
@@ -1401,6 +1428,43 @@ export class AutomationService {
       error: `Approval completed with ${event.transition.toStatus}`,
       durationMs: 0,
     }
+  }
+
+  /**
+   * W7-1 approval-result backwrite: write the DECLARED fixed outcome→field mapping (from the
+   * start_approval action's `resultWriteback`) onto the SOURCE record, using values from the completion
+   * event ONLY (never user-templated strings — that keeps the write path values-constrained, the whole
+   * reason this was gated). Goes through the record lock guard (B1: an automation does not implicitly own
+   * a lock). Null-safe: `approver` is null on auto/system approval (the field is written null, not
+   * crashed). Same-base only (the source record that started the approval). Approval-only is enforced by
+   * the caller (runs in the approved branch); rejection backwrite is a named follow-up.
+   */
+  private async writeApprovalResultBack(
+    bridge: AutomationApprovalBridgeRow,
+    startApprovalConfig: Record<string, unknown>,
+    event: ApprovalCompletionEventV1,
+  ): Promise<void> {
+    const writeback = isRecord(startApprovalConfig.resultWriteback) ? startApprovalConfig.resultWriteback : null
+    if (!writeback || !bridge.recordId) return
+    const patch: Record<string, unknown> = {}
+    if (typeof writeback.statusField === 'string') patch[writeback.statusField] = event.transition.toStatus
+    if (typeof writeback.approverField === 'string') patch[writeback.approverField] = event.actor?.id ?? null
+    if (typeof writeback.completedAtField === 'string') patch[writeback.completedAtField] = event.occurredAt
+    if (Object.keys(patch).length === 0) return
+
+    const lockRes = await this.queryFn(
+      'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
+      [bridge.recordId, bridge.sheetId],
+    )
+    const lockRow = lockRes.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
+    if (!lockRow) return // record gone — the resume's own missing-record path already handled it
+    ensureRecordNotLocked(event.actor?.id ?? null, lockRow, () => new Error('source record is locked'))
+    await this.queryFn(
+      `UPDATE meta_records
+       SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb, version = version + 1, updated_at = NOW()
+       WHERE id = $2 AND sheet_id = $3`,
+      [JSON.stringify(patch), bridge.recordId, bridge.sheetId],
+    )
   }
 
   private async failApprovalBridgeExecution(

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -151,7 +151,7 @@ async function createPublishedTemplate(
   return template.id
 }
 
-async function createStartApprovalRule(svc: AutomationService, templateId: string): Promise<string> {
+async function createStartApprovalRule(svc: AutomationService, templateId: string, resultWriteback?: Record<string, string>): Promise<string> {
   const startApproval = {
     type: 'start_approval',
     config: {
@@ -160,6 +160,7 @@ async function createStartApprovalRule(svc: AutomationService, templateId: strin
         summary: 'Record {{record.title}} needs approval',
       },
       requester: { mode: 'trigger_actor' },
+      ...(resultWriteback ? { resultWriteback } : {}),
     },
   } as const
   const created = await svc.createRule(SHEET, {
@@ -344,6 +345,70 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(finalJobs.map((job) => job.status)).toEqual(['resolved', 'resolved'])
       expect(finalJobs[0].result).toMatchObject({ outcome: 'approved' })
       finalJobs.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('W7-1: approval.approved writes the result back to the source record (declared fixed mapping)', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
+    try {
+      const RW = { statusField: 'approval_status', approverField: 'approved_by', completedAtField: 'approved_at' }
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId, RW)
+      await seedSheetRecord('Q4 plan')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 start approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+              resultWriteback: RW,
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Q4 plan' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+
+      const bridge = await q(
+        `SELECT approval_instance_id FROM multitable_automation_approval_bridges WHERE execution_id = $1`,
+        [execution.id],
+      )
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const approvals = new ApprovalProductService()
+      const after = await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'approve', comment: 'go' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+      expect(after.status).toBe('approved')
+      await waitForExecutionStatus(svc, execution.id, 'success')
+
+      // W7-1: the SOURCE record now carries the approval result — values from the completion event,
+      // written via the declared fixed mapping (NOT a templated expression into the write path).
+      const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
+      const data = rec.rows[0].data as Record<string, unknown>
+      expect(data.approval_status).toBe('approved')
+      expect(data.approved_by).toBe(APPROVER)
+      expect(typeof data.approved_at).toBe('string') // the completion timestamp
     } finally {
       svc.shutdown()
     }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2350,6 +2350,38 @@ describe('AutomationService — Rule CRUD', () => {
     expect(dbExecuteResults).toHaveLength(0)
   })
 
+  it('W7-1: createRule accepts a valid resultWriteback mapping and rejects an empty / malformed one', async () => {
+    const base = { templateId: 'tpl_1', formDataMapping: { amount: '{{record.amount}}' } }
+    const withRW = (rw: unknown) => ({ ...base, resultWriteback: rw })
+
+    // valid: a fixed outcome→field mapping (≥1 field, all non-empty strings)
+    dbExecuteResults.push([])
+    const ok = await service.createRule('sheet_1', {
+      name: 'Backwrite rule', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'start_approval',
+      actionConfig: withRW({ statusField: 'approval_status', approverField: 'approved_by' }),
+      actions: [{ type: 'start_approval', config: withRW({ statusField: 'approval_status', approverField: 'approved_by' }) }],
+      executionMode: 'workflow_job_v1', createdBy: 'user_1',
+    })
+    expect(ok.action_type).toBe('start_approval')
+
+    // invalid: an empty mapping maps no outcome field
+    await expect(service.createRule('sheet_1', {
+      name: 'Empty backwrite', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'start_approval', actionConfig: withRW({}),
+      actions: [{ type: 'start_approval', config: withRW({}) }],
+      executionMode: 'workflow_job_v1', createdBy: 'user_1',
+    })).rejects.toThrow(/resultWriteback must map at least one/)
+
+    // invalid: a non-string field target (no expression / object allowed — values-constrained)
+    await expect(service.createRule('sheet_1', {
+      name: 'Bad backwrite field', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'start_approval', actionConfig: withRW({ statusField: 123 }),
+      actions: [{ type: 'start_approval', config: withRW({ statusField: 123 }) }],
+      executionMode: 'workflow_job_v1', createdBy: 'user_1',
+    })).rejects.toThrow(/resultWriteback\.statusField must be a non-empty string/)
+  })
+
   it('A6-3-1: createRule accepts condition_branch only with workflow_job_v1', async () => {
     const action = {
       type: 'condition_branch',

--- a/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts
@@ -92,6 +92,10 @@ const ALLOWLIST: Record<string, { disposition: 'CHOKEPOINT' | 'SAFE'; reason: st
     disposition: 'SAFE',
     reason: 'writes ONLY computed formula-result keys — derived server-side, never raw user HTML',
   },
+  'multitable/automation-service.ts': {
+    disposition: 'SAFE',
+    reason: 'W7-1 approval-result backwrite writes ONLY system outcome values (status enum / approver id / ISO timestamp) — never user-supplied longText',
+  },
 }
 
 /** A file is a `meta_records.data` writer iff it contains an INSERT/UPDATE touching `meta_records`


### PR DESCRIPTION
Completes the approval↔automation line — **W7-1: approval-result backwrite**. When an automation-started approval completes, the result writes back to the **source record** (采购审批通过 → 写回 approval_status/approved_by/approved_at). Last demand-gated run-governance item (W7-0 contract shipped; W7-1 runtime was gated).

## Design (advisor-reviewed)
Reuses the existing **W6 bridge** (start_approval suspends → completion resumes). Adds a **declared FIXED `resultWriteback` mapping** on the start_approval config — `{ statusField?, approverField?, completedAtField? }`. On resume (approved branch) the bridge writes the mapped values **from the completion event** to the source record, through the record **lock guard**.

## Security posture (why it was gated)
**Not** expression templating into the write path. The obvious alternative — add `{{ }}` to `update_record` — would open arbitrary interpolation on *every* writer, re-litigating the redaction / values-free / cross-base-write-gate work. W7-1 is **values-constrained**: fixed outcome values from the event mapped to admin-chosen fields, never a user string. Inherits the resume-time **action-fingerprint drift guard** (mapping can't be swapped after suspend) + the **lock guard** (best-effort: locked/missing logs+skips, never crashes the resume) + null-safe approver + same-base + approval-only.

## Verification
- **End-to-end real-DB:** record → `start_approval`+`resultWriteback` → approve → assert the source record carries `approval_status='approved'`/`approved_by`/`approved_at`. Green locally.
- **Validation unit:** valid mapping accepted; empty + non-string-field rejected.
- Full start-approval suite **11/11**; backend tsc clean.

Named follow-ups (gated): rejection backwrite (non-approved path currently fails the automation by design), cross-base backwrite, field-exists validation. Full report: `docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)