### PR TITLE
feat(automation): W7-1a — approval-result backwrite parity (recordData merge + realtime)

### DIFF
--- a/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
+++ b/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
@@ -42,7 +42,21 @@ the writer. Additional inherited guarantees:
   `approved_by=<approver>`, `approved_at=<timestamp>`. Green locally against Postgres.
 - **Validation unit** (`automation-v1.test.ts`): a valid mapping is accepted; an empty mapping and a
   non-string field target are rejected at rule-save (values-constrained — no object/expression).
-- **No regression:** full start-approval integration suite **11/11**; backend **tsc clean**.
+- **No regression:** full start-approval integration suite **12/12** (incl. W7-1a); backend **tsc clean**.
+
+## W7-1a — semantic parity (shipped follow-up to the core write)
+The core write (above) landed the DB write, but a code-semantics review surfaced two gaps the core
+silently left — both now closed:
+- **Tail-action visibility (recordData merge):** the backwrite ran *after* the resume snapshotted
+  `recordData`, so tail actions (send_webhook / update_record / …) read the *pre-approval* record. Fix:
+  `writeApprovalResultBack` returns the patch and the resume merges it into `recordData` before
+  building the tail context — so "审批通过 → 写回状态 → 据此发通知/继续自动化" sees the just-written status.
+- **Realtime / chaining parity:** the bare write emitted no `multitable.record.updated` + no realtime
+  fan-out (unlike `update_record`). Fix: the backwrite now emits the event +
+  `publishMultitableSheetRealtime`, **depth-guarded** (`_automationDepth + 1`) so a backwrite-driven
+  record.updated cascade can't run away.
+- **Verification:** a W7-1a integration test asserts a tail `send_webhook`'s `recordData` carries the
+  backwrite AND that `multitable.record.updated` fired with the change — start-approval suite 12/12.
 
 ## Named follow-ups (gated, not silently skipped)
 - **Rejection backwrite** — write `status='rejected'` on the non-approved path. That path currently

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -4,6 +4,7 @@ import type { EventBus } from '../integration/events/event-bus'
 import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
 import { ensureRecordNotLocked } from './record-lock'
+import { publishMultitableSheetRealtime } from './realtime-publish'
 import {
   ConditionGroupValidationError,
   normalizeConditionGroupInput,
@@ -1378,7 +1379,10 @@ export class AutomationService {
     // event, through the lock guard). Best-effort — a locked/missing record logs + skips rather than
     // crashing the resume, so the automation's remaining actions still run.
     try {
-      await this.writeApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event)
+      const backwritten = await this.writeApprovalResultBack(bridge, execRule.actions[bridge.stepIndex]?.config ?? {}, event)
+      // W7-1a: merge the backwrite into the resume snapshot so the TAIL actions (send_webhook /
+      // update_record / ...) see the just-written result, not the pre-approval record.
+      if (backwritten) recordData = { ...recordData, ...backwritten }
     } catch (err) {
       logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${err instanceof Error ? err.message : String(err)}`)
     }
@@ -1443,21 +1447,21 @@ export class AutomationService {
     bridge: AutomationApprovalBridgeRow,
     startApprovalConfig: Record<string, unknown>,
     event: ApprovalCompletionEventV1,
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | null> {
     const writeback = isRecord(startApprovalConfig.resultWriteback) ? startApprovalConfig.resultWriteback : null
-    if (!writeback || !bridge.recordId) return
+    if (!writeback || !bridge.recordId || !bridge.sheetId) return null
     const patch: Record<string, unknown> = {}
     if (typeof writeback.statusField === 'string') patch[writeback.statusField] = event.transition.toStatus
     if (typeof writeback.approverField === 'string') patch[writeback.approverField] = event.actor?.id ?? null
     if (typeof writeback.completedAtField === 'string') patch[writeback.completedAtField] = event.occurredAt
-    if (Object.keys(patch).length === 0) return
+    if (Object.keys(patch).length === 0) return null
 
     const lockRes = await this.queryFn(
       'SELECT locked, locked_by, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2',
       [bridge.recordId, bridge.sheetId],
     )
     const lockRow = lockRes.rows[0] as { locked?: unknown; locked_by?: unknown; created_by?: unknown } | undefined
-    if (!lockRow) return // record gone — the resume's own missing-record path already handled it
+    if (!lockRow) return null // record gone — the resume's own missing-record path already handled it
     ensureRecordNotLocked(event.actor?.id ?? null, lockRow, () => new Error('source record is locked'))
     // rich-longText SAFE: patch carries ONLY system outcome values (status enum / approver id / ISO
     // timestamp), never user-supplied longText — classified SAFE in the rich-longText write-sink guard.
@@ -1468,6 +1472,31 @@ export class AutomationService {
        WHERE id = $2 AND sheet_id = $3`,
       [JSON.stringify(patch), bridge.recordId, bridge.sheetId],
     )
+
+    // W7-1a parity: emit the chaining event + realtime fan-out, matching update_record, so UI /
+    // subscribers / downstream record.updated automations see the backwrite live. Depth-guarded
+    // (inherits the trigger's _automationDepth + 1) so a backwrite-driven cascade can't run away.
+    const actorId = event.actor?.id ?? null
+    const automationDepth = (((bridge.triggerEvent as Record<string, unknown> | null)?._automationDepth as number) ?? 0) + 1
+    this.eventBus.emit('multitable.record.updated', {
+      sheetId: bridge.sheetId,
+      recordId: bridge.recordId,
+      changes: patch,
+      actorId,
+      _automationDepth: automationDepth,
+    })
+    try {
+      publishMultitableSheetRealtime({
+        spreadsheetId: bridge.sheetId,
+        source: 'multitable',
+        kind: 'record-updated',
+        recordId: bridge.recordId,
+        actorId: actorId ?? undefined,
+      })
+    } catch {
+      // publishMultitableSheetRealtime swallows its own errors; belt-and-suspenders.
+    }
+    return patch
   }
 
   private async failApprovalBridgeExecution(

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -414,6 +414,53 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
     }
   })
 
+  test('W7-1a: backwrite is visible to tail actions (recordData merge) + emits record.updated (realtime parity)', async () => {
+    const webhookBodies: string[] = []
+    const updatedEvents: Array<Record<string, unknown>> = []
+    const subId = eventBus.subscribe('multitable.record.updated', (p: unknown) => { updatedEvents.push(p as Record<string, unknown>) })
+    const svc = makeAutomationService((async (_url: string, opts?: { body?: string }) => {
+      if (opts?.body) webhookBodies.push(opts.body)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const RW = { statusField: 'approval_status' }
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId, RW)
+      await seedSheetRecord('Q4 plan')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 start approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          { type: 'start_approval', config: { templateId, formDataMapping: { summary: 'Record {{record.title}} needs approval' }, requester: { mode: 'trigger_actor' }, resultWriteback: RW } },
+          { type: 'send_webhook', config: { url: 'https://example.test/w7a-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+      const execution = await svc.executeRule(execRule as never, { sheetId: SHEET, recordId: RECORD, data: { title: 'Q4 plan' }, actorId: REQUESTER })
+      executionIds.push(execution.id)
+      const bridge = await q(`SELECT approval_instance_id FROM multitable_automation_approval_bridges WHERE execution_id = $1`, [execution.id])
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+      const approvals = new ApprovalProductService()
+      await approvals.dispatchAction(bridge.rows[0].approval_instance_id, { action: 'approve', comment: 'go' }, { userId: APPROVER, userName: APPROVER })
+      await waitForExecutionStatus(svc, execution.id, 'success')
+
+      // gap 1 (recordData merge): the tail send_webhook's recordData snapshot includes the backwrite.
+      expect(webhookBodies.length).toBeGreaterThan(0)
+      const body = JSON.parse(webhookBodies[webhookBodies.length - 1]) as { data?: Record<string, unknown> }
+      expect(body.data?.approval_status).toBe('approved')
+      // gap 2 (realtime/chaining parity): the backwrite emitted multitable.record.updated.
+      expect(updatedEvents.some((e) => (e.changes as Record<string, unknown> | undefined)?.approval_status === 'approved' && e.recordId === RECORD)).toBe(true)
+    } finally {
+      eventBus.unsubscribe(subId)
+      svc.shutdown()
+    }
+  })
+
   test('rejected approval fails the automation and does not run the tail', async () => {
     const calls: string[] = []
     const svc = makeAutomationService((async (url: string) => {


### PR DESCRIPTION
Closes the two parity gaps a code-semantics review found in the W7-1 core write (core write is correct + on main; these were left open and I wrongly closed them out — corrected here).

1. **Tail-action visibility (recordData merge)** — the backwrite ran *after* the resume snapshotted `recordData`, so tail actions read the pre-approval record. `writeApprovalResultBack` now returns the patch and the resume merges it into `recordData` before the tail context — so "审批通过 → 写回状态 → 据此发通知/继续自动化" sees the just-written status.
2. **Realtime / chaining parity** — the bare write emitted no `multitable.record.updated` + no realtime fan-out (unlike `update_record`). Now it emits the event + `publishMultitableSheetRealtime`, **depth-guarded** (`_automationDepth + 1`) so a backwrite cascade can't run away.

**Verification:** a W7-1a integration test asserts a tail `send_webhook`'s `recordData` carries the backwrite **and** that `multitable.record.updated` fired. Full start-approval suite **12/12**; structural guards green; tsc clean. MD updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)