### PR TITLE
feat(approval): D-5 canvas validity hardening — duplicate-key / cannot-reach-end / cycle

### DIFF
--- a/apps/web/src/approvals/graphLayout.ts
+++ b/apps/web/src/approvals/graphLayout.ts
@@ -80,6 +80,24 @@ export function computeLayout(graph: ApprovalGraph): GraphLayout {
 export function graphValidityIssues(graph: ApprovalGraph): string[] {
   const issues: string[] = []
   const keys = new Set(graph.nodes.map((n) => n.key))
+
+  // D-5: duplicate node / edge keys (a canvas add could collide a key; the backend rejects it on save).
+  if (keys.size !== graph.nodes.length) {
+    const seenKeys = new Set<string>()
+    for (const node of graph.nodes) {
+      if (seenKeys.has(node.key)) issues.push(`节点 key 重复：${node.key}`)
+      seenKeys.add(node.key)
+    }
+  }
+  const edgeKeySet = new Set(graph.edges.map((e) => e.key))
+  if (edgeKeySet.size !== graph.edges.length) {
+    const seenEdge = new Set<string>()
+    for (const edge of graph.edges) {
+      if (seenEdge.has(edge.key)) issues.push(`连线 key 重复：${edge.key}`)
+      seenEdge.add(edge.key)
+    }
+  }
+
   for (const edge of graph.edges) {
     if (!keys.has(edge.source) || !keys.has(edge.target)) {
       issues.push(`连线 ${edge.key} 指向不存在的节点（${edge.source} → ${edge.target}）`)
@@ -110,6 +128,62 @@ export function graphValidityIssues(graph: ApprovalGraph): string[] {
         issues.push(`节点「${node.name || node.key}」没有后继连线（流程会卡住）`)
       }
     }
+    // D-5: every reachable node must be able to REACH an end node (backward reachability). A node that
+    // can't (trapped in a cycle, or a dead-end sub-graph) means the flow can stall before finishing.
+    const endKeys = graph.nodes.filter((n) => n.type === 'end').map((n) => n.key)
+    if (endKeys.length) {
+      const radj = new Map<string, string[]>()
+      for (const e of graph.edges) {
+        if (!keys.has(e.source) || !keys.has(e.target)) continue
+        if (!radj.has(e.target)) radj.set(e.target, [])
+        radj.get(e.target)!.push(e.source)
+      }
+      const canReachEnd = new Set<string>(endKeys)
+      const rq = [...endKeys]
+      while (rq.length) {
+        const cur = rq.shift()!
+        for (const pred of radj.get(cur) ?? []) if (!canReachEnd.has(pred)) { canReachEnd.add(pred); rq.push(pred) }
+      }
+      for (const node of graph.nodes) {
+        if (node.type !== 'end' && seen.has(node.key) && !canReachEnd.has(node.key)) {
+          issues.push(`节点「${node.name || node.key}」无法到达结束节点（流程不会结束）`)
+        }
+      }
+    }
   }
+
+  // D-5: cycle detection (an approval graph must be a DAG; a back-edge means the flow can loop forever).
+  if (graphHasCycle(graph)) issues.push('审批流程存在环（节点回路），流程可能无法结束')
+
   return issues
+}
+
+/** Iterative DFS back-edge detection (no recursion → safe on any graph size). */
+function graphHasCycle(graph: ApprovalGraph): boolean {
+  const adj = new Map<string, string[]>()
+  for (const e of graph.edges) {
+    if (!adj.has(e.source)) adj.set(e.source, [])
+    adj.get(e.source)!.push(e.target)
+  }
+  const state = new Map<string, 0 | 1 | 2>() // 0/undefined = unvisited, 1 = on-stack, 2 = done
+  for (const root of graph.nodes.map((n) => n.key)) {
+    if (state.get(root)) continue
+    const stack: Array<{ node: string; idx: number }> = [{ node: root, idx: 0 }]
+    state.set(root, 1)
+    while (stack.length) {
+      const top = stack[stack.length - 1]
+      const neighbors = adj.get(top.node) ?? []
+      if (top.idx < neighbors.length) {
+        const next = neighbors[top.idx]
+        top.idx += 1
+        const s = state.get(next) ?? 0
+        if (s === 1) return true // back-edge into a node still on the stack → cycle
+        if (s === 0) { state.set(next, 1); stack.push({ node: next, idx: 0 }) }
+      } else {
+        state.set(top.node, 2)
+        stack.pop()
+      }
+    }
+  }
+  return false
 }

--- a/apps/web/tests/approval-graph-layout.test.ts
+++ b/apps/web/tests/approval-graph-layout.test.ts
@@ -80,4 +80,38 @@ describe('graphValidityIssues (D-5 preview)', () => {
     }
     expect(graphValidityIssues(stuck).some((i) => /没有后继连线/.test(i))).toBe(true)
   })
+
+  it('D-5: flags duplicate node keys and duplicate edge keys (a canvas key collision)', () => {
+    const dupNode: ApprovalGraph = {
+      nodes: [...LINEAR.nodes, { key: 'a1', type: 'approval', config: {} }], // 'a1' duplicated
+      edges: LINEAR.edges,
+    }
+    expect(graphValidityIssues(dupNode).some((i) => /节点 key 重复：a1/.test(i))).toBe(true)
+    const dupEdge: ApprovalGraph = {
+      nodes: LINEAR.nodes,
+      edges: [...LINEAR.edges, { key: 'e1', source: 'a1', target: 'end' }], // 'e1' duplicated
+    }
+    expect(graphValidityIssues(dupEdge).some((i) => /连线 key 重复：e1/.test(i))).toBe(true)
+  })
+
+  it('D-5: flags a cycle AND the nodes trapped in it (cannot reach end, but not "no-successor")', () => {
+    const cycle: ApprovalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'a', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'b', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'e-s-a', source: 'start', target: 'a' },
+        { key: 'e-s-e', source: 'start', target: 'end' }, // start can still reach end
+        { key: 'e-a-b', source: 'a', target: 'b' },
+        { key: 'e-b-a', source: 'b', target: 'a' }, // a ↔ b cycle
+      ],
+    }
+    const issues = graphValidityIssues(cycle)
+    expect(issues.some((i) => /存在环/.test(i))).toBe(true) // cycle detected
+    expect(issues.some((i) => /无法到达结束节点/.test(i))).toBe(true) // a, b trapped (can't reach end)
+    expect(issues.some((i) => /没有后继连线/.test(i))).toBe(false) // a/b have out-edges → NOT flagged as stuck
+  })
 })

--- a/docs/development/approval-visual-authoring-canvas-todo-20260624.md
+++ b/docs/development/approval-visual-authoring-canvas-todo-20260624.md
@@ -26,9 +26,10 @@ predecessor lands; ✅ = shipped. Nothing past D-0 starts without the design-loc
 - ✅ `moveItemToIndex` drag-to-position logic + native-drag wiring (logic unit-covered).
 - 🔒 The drag GESTURE (manual/E2E QA) · field-type palette · sections.
 
-## D-5 — live validation preview  ✅
-- ✅ `graphValidityIssues` (dangling edge / unreachable / no-successor) surfaced as a live canvas alert;
-  backend stays final arbiter on save. Unit + mounted (no-false-positive) tested.
+## D-5 — live validation preview  ✅ (hardened)
+- ✅ `graphValidityIssues` (dangling edge / unreachable / no-successor / duplicate node+edge key /
+  cannot-reach-end / cycle) surfaced as a live canvas alert; backend stays final arbiter on save.
+  Unit (incl. the 3 hardening checks) + mounted (no-false-positive) tested.
 
 ## D-6 — canvas ⇄ list parity  ✅
 - ✅ 结构列表 ⇄ 画布视图 toggle on one template; fail-closed (#3129) + sentinel hint (#3141) unchanged.

--- a/docs/development/approval-visual-authoring-dev-verification-20260624.md
+++ b/docs/development/approval-visual-authoring-dev-verification-20260624.md
@@ -63,8 +63,9 @@ chosen so the render / operations / layout / validity ARE unit-verifiable in the
   + SVG edges. A `nodePositions` sidecar holds drag overrides and **never reaches the saved graph**
   (the design-lock §6 layout-sidecar decision). The same topology toolbar (add branch / insert /
   remove) sits on the canvas nodes, wired to the same engine + bridge.
-- **D-5 live validity** — `graphValidityIssues` (pure: dangling edge / unreachable node / no-successor)
-  surfaced as a live canvas alert; the backend stays the final arbiter on save.
+- **D-5 live validity** — `graphValidityIssues` (pure: dangling edge / unreachable node / no-successor /
+  **duplicate node+edge key / cannot-reach-end / cycle** — the D-5 hardening pass) surfaced as a live
+  canvas alert; the backend stays the final arbiter on save.
 - **D-6 canvas ⇄ list toggle** — 结构列表 ⇄ 画布视图 on one template; the fail-closed surface (#3129) +
   sentinel hint (#3141) are unchanged (node config is edited in the list view).
 


### PR DESCRIPTION
Closes the D-5 canvas-validity hardening the closeout left open. The live-validity preview caught dangling-edge / unreachable / no-successor; this adds the three a drag canvas can introduce:
- **duplicate node key + duplicate edge key** (a canvas add can collide a key; backend rejects on save)
- **cannot-reach-end** (backward reachability from end — a reachable node trapped in a cycle / dead-end never finishes; flagged only for start-reachable nodes to avoid double-noise)
- **cycle** (iterative-DFS back-edge detection — an approval graph must be a DAG)

Pure in `graphLayout.ts`; the canvas surfaces them in the live alert (backend stays final arbiter on save). +2 unit tests (duplicate node+edge; cycle + cannot-reach-end, asserting the cycle case is *not* mis-flagged as no-successor). `approval-graph-layout` **8/8**; vue-tsc + lint clean; clean-graph no-false-positive test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)