### PR TITLE
feat(multitable): T9-R3 config-history read API (per-entity-type gate)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -216,6 +216,7 @@ jobs:
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
+            tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7543,6 +7543,57 @@ export function univerMetaRouter(): Router {
     }
   })
 
+  // T9-R3: config/schema-change history READ API. Lists meta_config_revisions for the sheet, gated PER ENTITY TYPE
+  // by the SAME capability the corresponding mutation route checks (read-gate ≡ write-gate): field/field-permission
+  // → canManageFields, view/view-permission → canManageViews, sheet_config/sheet-permission → canManageSheetAccess.
+  // The gate is applied IN THE WHERE CLAUSE (so pagination/has-more never lie), NOT after LIMIT/OFFSET. These rows
+  // are config-only (no record values) and this is its OWN gate — never the record-history mask.
+  router.get('/sheets/:sheetId/config-history', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
+    const offsetParam = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+    const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 50
+    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0
+    const entityTypeFilter = typeof req.query.entityType === 'string' && req.query.entityType.trim() ? req.query.entityType.trim() : null
+    if (!sheetId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    try {
+      const pool = poolManager.get()
+      const sheetCheck = await pool.query('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL', [sheetId])
+      if (sheetCheck.rows.length === 0) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+
+      // Per-entity-type gate IN the WHERE clause. Condition strings are STATIC (no user input) — safe to interpolate;
+      // every value (sheetId, entityType, limit, offset) is parameterized. A `permission` row's kind is its entity_id
+      // scope prefix (field:/view:/sheet:), routed to the same capability that authored it.
+      const allowed: string[] = []
+      if (capabilities.canManageFields) allowed.push("entity_type = 'field'", "(entity_type = 'permission' AND entity_id LIKE 'field:%')")
+      if (capabilities.canManageViews) allowed.push("entity_type = 'view'", "(entity_type = 'permission' AND entity_id LIKE 'view:%')")
+      if (capabilities.canManageSheetAccess) allowed.push("entity_type = 'sheet_config'", "(entity_type = 'permission' AND entity_id LIKE 'sheet:%')")
+      if (allowed.length === 0) return res.json({ ok: true, data: { items: [], limit, offset } }) // manages no config → empty
+
+      const params: unknown[] = [sheetId]
+      let where = `sheet_id = $1 AND (${allowed.join(' OR ')})`
+      if (entityTypeFilter) { params.push(entityTypeFilter); where += ` AND entity_type = $${params.length}` }
+      params.push(limit, offset)
+      const rows = (await pool.query(
+        `SELECT id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, created_at
+         FROM meta_config_revisions WHERE ${where} ORDER BY created_at DESC, id DESC LIMIT $${params.length - 1} OFFSET $${params.length}`,
+        params,
+      )).rows as Array<Record<string, unknown>>
+      return res.json({ ok: true, data: { items: rows.map((r) => ({
+        id: String(r.id), entityType: String(r.entity_type), entityId: String(r.entity_id), action: String(r.action),
+        before: r.before ?? null, after: r.after ?? null, changedKeys: r.changed_keys ?? [],
+        batchId: r.batch_id ?? null, actorId: r.actor_id ?? null, createdAt: r.created_at,
+      })), limit, offset } })
+    } catch (err: unknown) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] config-history list failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to list config history' } })
+    }
+  })
+
   router.get('/bases/:baseId/history-audit-grants', async (req: Request, res: Response) => {
     try {
       const access = await requireHistoryAuditGrantAuthority(req, res)

--- a/packages/core-backend/tests/integration/multitable-config-history-api-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-api-realdb.test.ts
@@ -1,0 +1,117 @@
+/**
+ * T9-R3: config/schema-change history READ API — real DB. The load-bearing property is the PER-ENTITY-TYPE gate
+ * (read-gate ≡ write-gate), applied IN the WHERE clause: field/field-perm → canManageFields(=write), view/view-perm
+ * → canManageViews(=write), sheet_config/sheet-perm → canManageSheetAccess(=share). Caps: field/view = multitable:write,
+ * sheet-config/sheet-access = multitable:share (independent), so the meaningful DENY case is write-but-not-share.
+ * Tests BOTH allow and deny (not allow-only). Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_ch_${TS}`
+const SHEET = `sheet_ch_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let currentActor: { id: string; roles: string[]; perms: string[] }
+const ADMIN = { id: `u_admin_${TS}`, roles: ['admin'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+const WRITER = { id: `u_writer_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:write'] } // NOT share
+const SHARER = { id: `u_sharer_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:share'] } // NOT write
+const READER = { id: `u_reader_${TS}`, roles: ['member'], perms: ['multitable:read'] } // no manage caps
+
+const list = (as: typeof ADMIN, qs = '') => { currentActor = as; return request(app).get(`/api/multitable/sheets/${SHEET}/config-history${qs}`) }
+const ids = (res: { body?: any }) => (res.body?.data?.items ?? []).map((i: { entityId: string }) => i.entityId)
+
+// Insert one revision of a given entity_type/entity_id (the R3 read API reads the table; recording is R2's goldens).
+const seedRev = (entityType: string, entityId: string) => q(
+  `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, after, changed_keys, actor_id)
+   VALUES ($1,$2,$3,'create','{}'::jsonb, ARRAY['x']::text[], $4)`,
+  [SHEET, entityType, entityId, ADMIN.id],
+)
+
+describeIfDatabase('multitable config-history read API — T9-R3 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentActor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CH Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CH Sheet'])
+    // one revision per gated bucket
+    await seedRev('field', 'fld_ch')
+    await seedRev('view', 'view_ch')
+    await seedRev('sheet_config', SHEET)
+    await seedRev('permission', `field:["fld_ch","user","s1"]`)
+    await seedRev('permission', `view:["view_ch","user","s1"]`)
+    await seedRev('permission', `sheet:["user","s1"]`)
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('admin sees ALL six revisions, deterministic order (created_at DESC, id DESC)', async () => {
+    const res = await list(ADMIN)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.items?.length).toBe(6)
+    // most-recent first: the seeds were inserted in order, so the last (sheet-perm) is first
+    expect(ids(res)[0]).toBe('sheet:["user","s1"]')
+  })
+
+  test('DENY: a write-but-not-share actor sees field/view (+ their perms) but NOT sheet_config / sheet-perm', async () => {
+    const res = await list(WRITER)
+    expect(res.status).toBe(200)
+    const seen = ids(res)
+    expect(seen).toContain('fld_ch') // field
+    expect(seen).toContain('view_ch') // view
+    expect(seen).toContain('field:["fld_ch","user","s1"]') // field-perm
+    expect(seen).toContain('view:["view_ch","user","s1"]') // view-perm
+    expect(seen).not.toContain(SHEET) // sheet_config DENIED
+    expect(seen).not.toContain('sheet:["user","s1"]') // sheet-perm DENIED
+    expect(seen.length).toBe(4)
+  })
+
+  test('inverse DENY: a share-but-not-write actor sees sheet_config / sheet-perm but NOT field / view', async () => {
+    const res = await list(SHARER)
+    const seen = ids(res)
+    expect(seen).toContain(SHEET) // sheet_config
+    expect(seen).toContain('sheet:["user","s1"]') // sheet-perm
+    expect(seen).not.toContain('fld_ch')
+    expect(seen).not.toContain('view_ch')
+    expect(seen).not.toContain('field:["fld_ch","user","s1"]')
+    expect(seen.length).toBe(2)
+  })
+
+  test('a read-only actor (manages no config) gets an empty list, not a leak', async () => {
+    const res = await list(READER)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.items).toEqual([])
+  })
+
+  test('entityType filter narrows within the allowed set (writer ?entityType=field → only the field rev)', async () => {
+    const res = await list(WRITER, '?entityType=field')
+    expect(ids(res)).toEqual(['fld_ch'])
+  })
+
+  test('entityType filter cannot bypass the gate (writer ?entityType=sheet_config → still empty)', async () => {
+    const res = await list(WRITER, '?entityType=sheet_config')
+    expect(res.body?.data?.items).toEqual([]) // gate is in the WHERE; the filter only narrows within it
+  })
+
+  test('pagination is honored (limit/offset on the gated set)', async () => {
+    const first = await list(ADMIN, '?limit=2&offset=0')
+    const second = await list(ADMIN, '?limit=2&offset=2')
+    expect(first.body?.data?.items?.length).toBe(2)
+    expect(second.body?.data?.items?.length).toBe(2)
+    expect(ids(first)).not.toEqual(ids(second)) // distinct pages, gated in the WHERE (no short pages)
+  })
+})


### PR DESCRIPTION
The **read half** of T9 config history (R3). `GET /sheets/:sheetId/config-history` lists `meta_config_revisions`, gated **per entity type by the same capability the mutation route checks** (read-gate ≡ write-gate):
- field / field-permission → `canManageFields` (= `multitable:write`)
- view / view-permission → `canManageViews` (= write)
- sheet_config / sheet-permission → `canManageSheetAccess` (= `multitable:share`)

A `permission` row's kind is routed by its `entity_id` scope prefix (`field:`/`view:`/`sheet:`). **The gate is in the WHERE clause** (so pagination/has-more never lie) — not after LIMIT/OFFSET. Config-only, its **own** gate, never the record-history mask. Deterministic order (`created_at DESC, id DESC`); optional `entityType` filter (narrows within the allowed set, can't bypass the gate); limit/offset.

## Verification (ALLOW *and* DENY — not allow-only)
8 real-DB goldens: admin sees all 6; **write-but-not-share sees field/view(+perms) but NOT sheet_config/sheet-perm**; share-but-not-write the inverse; read-only → empty; entityType filter narrows + can't bypass; pagination on the gated set. **Mutation-proven** (drop the `canManageSheetAccess` guard → the DENY golden fails). Added to the plugin-tests allowlist; tsc clean.

R4 (FE config-history view) + the design/verification MD follow as separate items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)