### PR TITLE
feat(multitable): T9-R3 config-history read API (gated per-entity-type + view-literal redaction)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -216,6 +216,7 @@ jobs:
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
+            tests/integration/multitable-config-history-read-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-t9-r3-config-history-read-verification-20260624.md
+++ b/docs/development/multitable-t9-r3-config-history-read-verification-20260624.md
@@ -55,7 +55,8 @@ fully-allowed reader does; a non-filter key (the view name) survives.
 ## Verification (all green)
 
 - **Unit** — `tests/unit/config-history-read.spec.ts` (9): every entity_type, all 3 permission
-  subtypes, and fail-closed (unknown type → DENY; malformed/empty/unknown-scope permission id → DENY).
+  subtypes, and fail-closed (unknown type → DENY; malformed/empty/unknown-scope permission id → DENY,
+  including a COLONLESS scope-looking id like a bare `'field'` — a real `scope:` boundary is required).
 - **Real-DB goldens** — `tests/integration/multitable-config-history-read-realdb.test.ts` (8):
   - each surface returns only its entity_type/scope rows;
   - **cross-cap 403**: a write-only user (no share) is 403 on `/sheet-config` + `/permissions/sheet`,

--- a/docs/development/multitable-t9-r3-config-history-read-verification-20260624.md
+++ b/docs/development/multitable-t9-r3-config-history-read-verification-20260624.md
@@ -1,0 +1,80 @@
+# T9-R3 — config-history READ API — design + verification — 2026-06-24
+
+> Implements the read API over `meta_config_revisions` (recorded by R1/R2) per the design-lock
+> `docs/development/multitable-t9-r3-config-history-read-api-design-lock-20260624.md`. Backend
+> only; the unified timeline + any FE surface remain deferred (separate opt-ins).
+
+## What shipped
+
+- **Gate predicate** — `packages/core-backend/src/multitable/config-history-read.ts`:
+  `configHistoryRequiredCapability(entityType, entityId)` → the config-manage capability that
+  gates reading that row's history, or `null` = DENY. Pure, fail-closed, unit-tested.
+- **Six read endpoints** — `packages/core-backend/src/routes/univer-meta.ts`, each a single
+  structural capability gate, mirroring the record-history endpoint's shape (pagination
+  `created_at DESC, id DESC`, actor-name enrichment via `resolveUserDisplayNames`):
+  `GET /sheets/:sheetId/config-history/{fields,views,sheet-config}` and
+  `GET /sheets/:sheetId/config-history/permissions/{sheet,view,field}`.
+- **View payload redaction** — the `/views` endpoint redacts `before`/`after.filterInfo`
+  literals via the requester's `loadAllowedFieldIds` + the existing `redactViewConfigFilterLiterals`.
+
+## Design — the gate口径 (symmetric with the write routes)
+
+The access gate (which ROWS a caller may read) is the EXACT capability that gates WRITING that
+config — never the record-history mask. Grounded on current main:
+
+| history rows | read gate = write gate |
+|---|---|
+| `field` | `canManageFields` |
+| `view` | `canManageViews` |
+| `sheet_config` | `canManageSheetAccess` |
+| `permission` / scope `sheet` | `canManageSheetAccess` |
+| `permission` / scope `view` | `canManageViews` |
+| `permission` / scope `field` | `canManageFields` |
+
+The permission subtype is parsed from `entity_id` (`${scope}:…`, scope ∈ field|sheet|view). The
+predicate **fails closed**: an unknown `entity_type` or an unparseable permission scope → DENY.
+Belt-and-suspenders: each returned row is re-checked against the predicate, so a mis-prefixed
+permission row cannot slip an endpoint (the predicate is the single source of truth, also used by
+the SQL scope filter).
+
+> Capability note (grounding): `canManageFields == canManageViews == canWrite` (both derive from
+> `multitable:write`), while `canManageSheetAccess` derives from `multitable:share`/admin. So the
+> real separable axis is **write vs share vs read-only** — the cross-cap tests exercise exactly that.
+
+## The view payload exception — proven END-TO-END (not fixture-deep)
+
+A view's `filterInfo.conditions[].value` literals are field-read-sensitive (#2052/R9): the live
+view read redacts them per-requester, and `canManageViews` does NOT imply field-read. R3 returns
+historical view config, so it MUST redact those literals too. **Verified against R2's real
+recorded shape**, not a hand-built fixture: a view filtered on a denied field is created+patched
+through the real routes (so R2 records it), the raw recorded row is asserted to hold the secret
+literal in `filterInfo.conditions[].value` (the path the redactor walks — R2's camelCase shape
+matches), and a field-denied view-manager reading `/config-history/views` does NOT see it, while a
+fully-allowed reader does; a non-filter key (the view name) survives.
+
+## Verification (all green)
+
+- **Unit** — `tests/unit/config-history-read.spec.ts` (9): every entity_type, all 3 permission
+  subtypes, and fail-closed (unknown type → DENY; malformed/empty/unknown-scope permission id → DENY).
+- **Real-DB goldens** — `tests/integration/multitable-config-history-read-realdb.test.ts` (8):
+  - each surface returns only its entity_type/scope rows;
+  - **cross-cap 403**: a write-only user (no share) is 403 on `/sheet-config` + `/permissions/sheet`,
+    200 on fields/views/perm-view/perm-field; a read-only user is 403 on every endpoint;
+  - **view redaction (fixture)**: a field-denied view-manager doesn't see the secret literal, a
+    fully-allowed reader does, VISIBLE stays;
+  - **view redaction (END-TO-END, real recorder)**: as above but via the real view route → R2
+    record → read, with a raw-recorded-row sanity check + a non-filter-key survival assertion;
+  - **fail-closed**: a malformed `permission` entity_id is returned by no permission endpoint;
+  - **deterministic pagination** (`created_at DESC, id DESC`).
+- `tsc` 0; R1/R2 recording goldens unaffected (`multitable-config-revisions-realdb.test.ts` 20/20).
+- Real-DB test registered in `.github/workflows/plugin-tests.yml`.
+
+## Scope
+
+**IN:** the six gated, paginated, actor-enriched read endpoints + view-row redaction + the goldens.
+**OUT (deferred, separate opt-in):** a unified sheet-level timeline (row-gates via the SAME
+predicate); any FE surface; cross-sheet/base history; and all write-side restore/rollback (parked).
+
+## Commits (branch `claude/multitable-t9-r3-config-history-read-impl-20260624`)
+- `e7a332a4b` feat — predicate + 6 endpoints + view redaction + unit + real-DB golden + CI registration
+- `4251b84f0` test — end-to-end view-redaction golden against R2's real recorded shape

--- a/packages/core-backend/src/multitable/config-history-read.ts
+++ b/packages/core-backend/src/multitable/config-history-read.ts
@@ -17,10 +17,13 @@ export type ConfigManageCapKey = 'canManageFields' | 'canManageViews' | 'canMana
 /**
  * Permission rows store `entity_id = `${scope}:${JSON.stringify(parts)}`` (R2's
  * `permissionConfigEntityId`); scope ∈ {field, sheet, view}. We read the scope as the substring
- * before the FIRST `:` (the scope is a fixed enum and never contains `:`).
+ * before the FIRST `:` and REQUIRE a real `scope:` boundary — a colonless value (e.g. a bare
+ * `'field'`) is malformed and yields `''` → DENY (fail-closed). The scope is a fixed enum and
+ * never contains `:`.
  */
 function permissionScope(entityId: string): string {
-  return entityId.split(':', 1)[0] ?? ''
+  const idx = entityId.indexOf(':')
+  return idx > 0 ? entityId.slice(0, idx) : '' // no colon, or colon at position 0 → malformed → ''
 }
 
 /**

--- a/packages/core-backend/src/multitable/config-history-read.ts
+++ b/packages/core-backend/src/multitable/config-history-read.ts
@@ -1,0 +1,55 @@
+/**
+ * T9-R3 — config-history READ-side gating (the gate口径, fail-closed).
+ *
+ * Maps a `meta_config_revisions` row's (entity_type, entity_id) to the config-manage capability
+ * that gates READING its history — the SAME capability that gates WRITING that config (symmetric
+ * access). Returns `null` = DENY (fail-closed) for an unknown entity_type or an unparseable
+ * permission scope. See
+ * docs/development/multitable-t9-r3-config-history-read-api-design-lock-20260624.md.
+ *
+ * This is the ACCESS gate (which ROWS a caller may read). The view-row PAYLOAD redaction (view
+ * filter literals are field-read-sensitive) is a SEPARATE concern, applied at the endpoint via
+ * `redactViewConfigFilterLiterals` — not here.
+ */
+
+export type ConfigManageCapKey = 'canManageFields' | 'canManageViews' | 'canManageSheetAccess'
+
+/**
+ * Permission rows store `entity_id = `${scope}:${JSON.stringify(parts)}`` (R2's
+ * `permissionConfigEntityId`); scope ∈ {field, sheet, view}. We read the scope as the substring
+ * before the FIRST `:` (the scope is a fixed enum and never contains `:`).
+ */
+function permissionScope(entityId: string): string {
+  return entityId.split(':', 1)[0] ?? ''
+}
+
+/**
+ * The config-manage capability required to read this row's history, or `null` to DENY.
+ * FAIL-CLOSED: anything not explicitly mapped → `null`.
+ */
+export function configHistoryRequiredCapability(
+  entityType: string,
+  entityId: string,
+): ConfigManageCapKey | null {
+  switch (entityType) {
+    case 'field':
+      return 'canManageFields'
+    case 'view':
+      return 'canManageViews'
+    case 'sheet_config':
+      return 'canManageSheetAccess'
+    case 'permission':
+      switch (permissionScope(entityId)) {
+        case 'sheet':
+          return 'canManageSheetAccess'
+        case 'view':
+          return 'canManageViews'
+        case 'field':
+          return 'canManageFields'
+        default:
+          return null // FAIL CLOSED — unknown / unparseable permission scope
+      }
+    default:
+      return null // FAIL CLOSED — unknown entity_type
+  }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -84,6 +84,7 @@ import {
   fieldUpdateDiff,
   fieldDeleteDiff,
 } from '../multitable/config-revision-recorder'
+import { configHistoryRequiredCapability, type ConfigManageCapKey } from '../multitable/config-history-read'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
@@ -7462,6 +7463,90 @@ export function univerMetaRouter(): Router {
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record history' } })
     }
   })
+
+  // ---------------------------------------------------------------------------
+  // T9-R3 — config-history READ API (per-entity-type, write-gate-symmetric, fail-closed).
+  // Design-lock: docs/development/multitable-t9-r3-config-history-read-api-design-lock-20260624.md.
+  // The ACCESS gate (which rows) = the EXACT capability that gates WRITING that config. VIEW rows
+  // additionally redact field-read-sensitive filter literals in before/after (payload projection,
+  // #2052/R9) — canManageViews does NOT imply field-read.
+  const readConfigHistoryRows = async (
+    sheetId: string, entityType: string, scopePrefix: string | null, limit: number, offset: number,
+  ): Promise<Array<Record<string, unknown>>> => {
+    const pool = poolManager.get()
+    const params: unknown[] = [sheetId, entityType]
+    let sql = `SELECT id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, created_at
+               FROM meta_config_revisions WHERE sheet_id = $1 AND entity_type = $2`
+    if (scopePrefix) { params.push(`${scopePrefix}:%`); sql += ` AND entity_id LIKE $${params.length}` }
+    params.push(limit); const limIdx = params.length
+    params.push(offset); const offIdx = params.length
+    sql += ` ORDER BY created_at DESC, id DESC LIMIT $${limIdx} OFFSET $${offIdx}`
+    return ((await pool.query(sql, params)).rows as Array<Record<string, unknown>>)
+  }
+
+  const serializeConfigRevision = (row: Record<string, unknown>) => ({
+    id: String(row.id),
+    entityType: String(row.entity_type),
+    entityId: String(row.entity_id),
+    action: String(row.action),
+    before: (row.before ?? null) as Record<string, unknown> | null,
+    after: (row.after ?? null) as Record<string, unknown> | null,
+    changedKeys: Array.isArray(row.changed_keys) ? (row.changed_keys as unknown[]).map(String) : [],
+    batchId: row.batch_id ? String(row.batch_id) : null,
+    actorId: row.actor_id ? String(row.actor_id) : null,
+    createdAt: row.created_at ?? null,
+  })
+
+  const configHistoryHandler = (
+    entityType: string, scopePrefix: string | null, capKey: ConfigManageCapKey, redactViewLiterals = false,
+  ) => async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
+    const offsetParam = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+    const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 200) : 50
+    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0
+    if (!sheetId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      if (!capabilities[capKey]) return sendForbidden(res)
+      const rows = await readConfigHistoryRows(sheetId, entityType, scopePrefix, limit, offset)
+      // Fail-closed belt-and-suspenders: only rows whose OWN (entity_type, entity_id) require
+      // EXACTLY this endpoint's capability are returned (a mis-prefixed permission row can't slip).
+      const gated = rows.filter((r) => configHistoryRequiredCapability(String(r.entity_type), String(r.entity_id)) === capKey)
+      let revisions = gated.map(serializeConfigRevision)
+      if (redactViewLiterals) {
+        // VIEW payload projection: filter literals are field-read-sensitive (#2052/R9). Redact
+        // before/after.filterInfo for fields the REQUESTER can't read.
+        const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+        revisions = revisions.map((rev) => ({
+          ...rev,
+          before: rev.before ? redactViewConfigFilterLiterals(rev.before, allowedFieldIds) : rev.before,
+          after: rev.after ? redactViewConfigFilterLiterals(rev.after, allowedFieldIds) : rev.after,
+        }))
+      }
+      const names = await resolveUserDisplayNames(
+        pool.query.bind(pool),
+        revisions.map((r) => r.actorId).filter((x): x is string => !!x),
+      )
+      const enriched = revisions.map((r) => ({ ...r, actorName: r.actorId ? (names.get(r.actorId) ?? null) : null }))
+      return res.json({ ok: true, data: { revisions: enriched, limit, offset } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_config_revisions')) return res.json({ ok: true, data: { revisions: [], limit, offset } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list config history failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list config history' } })
+    }
+  }
+
+  router.get('/sheets/:sheetId/config-history/fields', configHistoryHandler('field', null, 'canManageFields'))
+  router.get('/sheets/:sheetId/config-history/views', configHistoryHandler('view', null, 'canManageViews', true))
+  router.get('/sheets/:sheetId/config-history/sheet-config', configHistoryHandler('sheet_config', null, 'canManageSheetAccess'))
+  router.get('/sheets/:sheetId/config-history/permissions/sheet', configHistoryHandler('permission', 'sheet', 'canManageSheetAccess'))
+  router.get('/sheets/:sheetId/config-history/permissions/view', configHistoryHandler('permission', 'view', 'canManageViews'))
+  router.get('/sheets/:sheetId/config-history/permissions/field', configHistoryHandler('permission', 'field', 'canManageFields'))
 
   // ---------------------------------------------------------------------------
   // History Field-Audit Permission — A1 grant management (issue / list / revoke).

--- a/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
@@ -1,0 +1,177 @@
+/**
+ * T9-R3 — config-history READ API (real DB). Proves the gate口径 + view payload redaction:
+ *  - each endpoint returns only its entity_type/scope rows;
+ *  - the read gate = the write-symmetric capability (write-user 403 on sheet-config + sheet-perm;
+ *    read-only 403 on everything);
+ *  - VIEW rows redact field-read-sensitive filter literals (a canManageViews + field-denied caller
+ *    does NOT see the denied literal; a fully-allowed caller does) — #2052/R9 reused;
+ *  - fail-closed: a malformed `permission` entity_id is returned by no endpoint;
+ *  - deterministic pagination (created_at DESC, id DESC).
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_chr_${TS}`
+const SHEET = `sheet_chr_${TS}`
+const FLD_VISIBLE = `fld_chr_visible_${TS}`
+const FLD_SECRET = `fld_chr_secret_${TS}`
+const VIEW_ID = `view_chr_${TS}`
+const SEED_ACTOR = `user_chr_actor_${TS}`
+const SUBJECT = `user_chr_subject_${TS}`
+// distinct, unambiguous literals for the leak canary
+const VISIBLE_LIT = 'chr-visible-literal-keepme'
+const SECRET_LIT = 'chr-secret-literal-do-not-leak'
+// users (caps via base perms — deriveCapabilities: write→canManageFields/Views; share→canManageSheetAccess)
+const U_FULL = `user_chr_full_${TS}`
+const U_WRITE = `user_chr_write_${TS}`
+const U_READ = `user_chr_read_${TS}`
+const U_FIELDDENIED = `user_chr_fdenied_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const bodyStr = (res: { body: unknown }) => JSON.stringify(res.body)
+let app: Express
+let testUserId = U_FULL
+let testPerms: string[] = ['multitable:read', 'multitable:write', 'multitable:share']
+const as = (id: string, perms: string[]) => { testUserId = id; testPerms = perms }
+const get = (path: string) => request(app).get(`/api/multitable${path}`)
+const revisions = (res: { body: any }): Array<Record<string, any>> => (res.body?.data?.revisions ?? [])
+
+const insertRev = (
+  entityType: string, entityId: string, action: string,
+  before: unknown, after: unknown, createdAt?: string,
+) => q(
+  `INSERT INTO meta_config_revisions
+     (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id${createdAt ? ', created_at' : ''})
+   VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::text[],$8,$9${createdAt ? ',$10' : ''})`,
+  [SHEET, entityType, entityId, action, JSON.stringify(before ?? null), JSON.stringify(after ?? null), [], null, SEED_ACTOR, ...(createdAt ? [createdAt] : [])],
+)
+const permId = (scope: 'field' | 'sheet' | 'view', parts: string[]) => `${scope}:${JSON.stringify(parts)}`
+
+describeIfDatabase('multitable config-history READ API — T9-R3 (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: testUserId, roles: [], perms: testPerms }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CHR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CHR Sheet'])
+    for (const [fid, name, order] of [[FLD_VISIBLE, 'Visible', 1], [FLD_SECRET, 'Secret', 2]] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET, name, 'string', '{}', order])
+    }
+    await q('INSERT INTO meta_views (id, sheet_id, name, type) VALUES ($1,$2,$3,$4)', [VIEW_ID, SHEET, 'CHR View', 'grid'])
+    for (const u of [U_FULL, U_WRITE, U_READ, U_FIELDDENIED, SEED_ACTOR, SUBJECT]) {
+      await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    }
+    // FLD_SECRET denied to the field-denied user ONLY (layer-3); FULL keeps field read.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET, FLD_SECRET, 'user', U_FIELDDENIED, false, false])
+
+    // Seed config-revision rows — one per entity type / permission subtype + a malformed permission row.
+    await insertRev('field', FLD_VISIBLE, 'create', null, { name: 'Visible', type: 'string', order: 1 })
+    await insertRev('sheet_config', SHEET, 'update', { rowLevelReadPermissionsEnabled: false }, { rowLevelReadPermissionsEnabled: true })
+    await insertRev('permission', permId('sheet', ['user', SUBJECT]), 'create', null, { subjectType: 'user', subjectId: SUBJECT, accessLevel: 'read' })
+    await insertRev('permission', permId('view', [VIEW_ID, 'user', SUBJECT]), 'create', null, { viewId: VIEW_ID, subjectType: 'user', subjectId: SUBJECT, permission: 'read' })
+    await insertRev('permission', permId('field', [FLD_VISIBLE, 'user', SUBJECT]), 'create', null, { fieldId: FLD_VISIBLE, subjectType: 'user', subjectId: SUBJECT, visible: true, readOnly: false })
+    // MALFORMED permission row (no scope prefix) — fail-closed: returned by NO endpoint.
+    await insertRev('permission', 'garbage-no-scope-prefix', 'create', null, { x: 1 })
+    // VIEW row whose after.filterInfo carries a literal on the SECRET field + the VISIBLE field.
+    await insertRev('view', VIEW_ID, 'update', null, {
+      filterInfo: { conjunction: 'and', conditions: [
+        { fieldId: FLD_VISIBLE, operator: 'is', value: VISIBLE_LIT },
+        { fieldId: FLD_SECRET, operator: 'is', value: SECRET_LIT },
+      ] },
+    })
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [U_FULL, U_WRITE, U_READ, U_FIELDDENIED, SEED_ACTOR, SUBJECT]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('FULL reads each surface; rows are scoped to the endpoint entity_type/scope', async () => {
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    const f = await get(`/sheets/${SHEET}/config-history/fields`)
+    expect(f.status).toBe(200)
+    expect(revisions(f).length).toBeGreaterThanOrEqual(1)
+    expect(revisions(f).every((r) => r.entityType === 'field')).toBe(true)
+
+    const sc = await get(`/sheets/${SHEET}/config-history/sheet-config`)
+    expect(sc.status).toBe(200)
+    expect(revisions(sc).every((r) => r.entityType === 'sheet_config')).toBe(true)
+
+    const ps = await get(`/sheets/${SHEET}/config-history/permissions/sheet`)
+    expect(ps.status).toBe(200)
+    expect(revisions(ps).length).toBe(1)
+    expect(revisions(ps).every((r) => r.entityType === 'permission' && String(r.entityId).startsWith('sheet:'))).toBe(true)
+
+    const pv = await get(`/sheets/${SHEET}/config-history/permissions/view`)
+    expect(revisions(pv).every((r) => String(r.entityId).startsWith('view:'))).toBe(true)
+    const pf = await get(`/sheets/${SHEET}/config-history/permissions/field`)
+    expect(revisions(pf).every((r) => String(r.entityId).startsWith('field:'))).toBe(true)
+  })
+
+  test('cross-cap: a WRITE-only user (no share) is 403 on sheet-config + permissions/sheet, 200 on fields/views/perm-view/perm-field', async () => {
+    as(U_WRITE, ['multitable:read', 'multitable:write'])
+    expect((await get(`/sheets/${SHEET}/config-history/sheet-config`)).status).toBe(403)
+    expect((await get(`/sheets/${SHEET}/config-history/permissions/sheet`)).status).toBe(403)
+    expect((await get(`/sheets/${SHEET}/config-history/fields`)).status).toBe(200)
+    expect((await get(`/sheets/${SHEET}/config-history/views`)).status).toBe(200)
+    expect((await get(`/sheets/${SHEET}/config-history/permissions/view`)).status).toBe(200)
+    expect((await get(`/sheets/${SHEET}/config-history/permissions/field`)).status).toBe(200)
+  })
+
+  test('cross-cap: a READ-only user is 403 on every config-history endpoint', async () => {
+    as(U_READ, ['multitable:read'])
+    for (const p of ['fields', 'views', 'sheet-config', 'permissions/sheet', 'permissions/view', 'permissions/field']) {
+      expect((await get(`/sheets/${SHEET}/config-history/${p}`)).status).toBe(403)
+    }
+  })
+
+  test('VIEW redaction: FULL sees the SECRET filter literal; a field-denied view-manager does NOT (VISIBLE stays)', async () => {
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    const full = await get(`/sheets/${SHEET}/config-history/views`)
+    expect(full.status).toBe(200)
+    expect(bodyStr(full)).toContain(SECRET_LIT)
+    expect(bodyStr(full)).toContain(VISIBLE_LIT)
+
+    as(U_FIELDDENIED, ['multitable:read', 'multitable:write']) // canManageViews, but FLD_SECRET denied
+    const denied = await get(`/sheets/${SHEET}/config-history/views`)
+    expect(denied.status).toBe(200)
+    expect(bodyStr(denied)).not.toContain(SECRET_LIT) // the keystone — no leak through history
+    expect(bodyStr(denied)).toContain(VISIBLE_LIT) // no over-redaction
+  })
+
+  test('fail-closed: a malformed permission entity_id is returned by NO permission endpoint', async () => {
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    for (const sub of ['sheet', 'view', 'field']) {
+      const r = await get(`/sheets/${SHEET}/config-history/permissions/${sub}`)
+      expect(r.status).toBe(200)
+      expect(bodyStr(r)).not.toContain('garbage-no-scope-prefix')
+    }
+  })
+
+  test('pagination is deterministic (created_at DESC, id DESC)', async () => {
+    const older = `fld_chr_pg_old_${TS}`
+    const newer = `fld_chr_pg_new_${TS}`
+    await insertRev('field', older, 'create', null, { name: 'old' }, '2026-01-01T00:00:00Z')
+    await insertRev('field', newer, 'create', null, { name: 'new' }, '2026-01-02T00:00:00Z')
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    const r = await get(`/sheets/${SHEET}/config-history/fields?limit=200`)
+    const ids = revisions(r).map((x) => x.entityId)
+    expect(ids.indexOf(newer)).toBeLessThan(ids.indexOf(older)) // newer first
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
@@ -79,8 +79,10 @@ describeIfDatabase('multitable config-history READ API — T9-R3 (real DB)', () 
     await insertRev('permission', permId('sheet', ['user', SUBJECT]), 'create', null, { subjectType: 'user', subjectId: SUBJECT, accessLevel: 'read' })
     await insertRev('permission', permId('view', [VIEW_ID, 'user', SUBJECT]), 'create', null, { viewId: VIEW_ID, subjectType: 'user', subjectId: SUBJECT, permission: 'read' })
     await insertRev('permission', permId('field', [FLD_VISIBLE, 'user', SUBJECT]), 'create', null, { fieldId: FLD_VISIBLE, subjectType: 'user', subjectId: SUBJECT, visible: true, readOnly: false })
-    // MALFORMED permission row (no scope prefix) — fail-closed: returned by NO endpoint.
+    // MALFORMED permission rows — fail-closed: returned by NO endpoint. Two shapes: no prefix at
+    // all, and a COLONLESS scope-LOOKING id (a bare 'field') that must still DENY (no `scope:` boundary).
     await insertRev('permission', 'garbage-no-scope-prefix', 'create', null, { x: 1 })
+    await insertRev('permission', 'field', 'create', null, { canary: 'COLONLESS-FIELD-CANARY' })
     // VIEW row whose after.filterInfo carries a literal on the SECRET field + the VISIBLE field.
     await insertRev('view', VIEW_ID, 'update', null, {
       filterInfo: { conjunction: 'and', conditions: [
@@ -200,6 +202,7 @@ describeIfDatabase('multitable config-history READ API — T9-R3 (real DB)', () 
       const r = await get(`/sheets/${SHEET}/config-history/permissions/${sub}`)
       expect(r.status).toBe(200)
       expect(bodyStr(r)).not.toContain('garbage-no-scope-prefix')
+      expect(bodyStr(r)).not.toContain('COLONLESS-FIELD-CANARY') // colonless 'field' must DENY (no scope boundary)
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-read-realdb.test.ts
@@ -155,6 +155,45 @@ describeIfDatabase('multitable config-history READ API — T9-R3 (real DB)', () 
     expect(bodyStr(denied)).toContain(VISIBLE_LIT) // no over-redaction
   })
 
+  test('VIEW redaction END-TO-END (REAL recorder shape): a view filtered on a denied field is written via the route, recorded by R2, and the denied manager does NOT see the literal (non-filter config survives)', async () => {
+    // Create + patch a view THROUGH the real routes so R2 records the actual shape (not a fixture).
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    const created = await request(app).post('/api/multitable/views').send({ sheetId: SHEET, name: 'E2E Redact View', type: 'grid' })
+    expect(created.status).toBe(201)
+    const e2eViewId = created.body?.data?.view?.id as string
+    expect(e2eViewId).toBeTruthy()
+    const patched = await request(app).patch(`/api/multitable/views/${e2eViewId}`).send({
+      filterInfo: { conjunction: 'and', conditions: [
+        { fieldId: FLD_VISIBLE, operator: 'is', value: VISIBLE_LIT },
+        { fieldId: FLD_SECRET, operator: 'is', value: SECRET_LIT },
+      ] },
+    })
+    expect(patched.status).toBe(200)
+
+    // Sanity: the RAW recorded row holds the secret literal in the path the redactor must walk
+    // (if this is absent, R2 stores a different shape and the redaction proof would be vacuous).
+    const recorded = (await q(
+      `SELECT after FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='view' AND entity_id=$2 ORDER BY created_at DESC, id DESC LIMIT 1`,
+      [SHEET, e2eViewId],
+    )).rows[0] as { after: any } | undefined
+    expect(JSON.stringify(recorded?.after)).toContain(SECRET_LIT)
+
+    // KEYSTONE: the field-denied view-manager reads it back through the API → literal redacted.
+    as(U_FIELDDENIED, ['multitable:read', 'multitable:write'])
+    const denied = await get(`/sheets/${SHEET}/config-history/views?limit=200`)
+    expect(denied.status).toBe(200)
+    const deniedRow = revisions(denied).find((r) => r.entityId === e2eViewId && r.action === 'update')
+    expect(deniedRow).toBeTruthy()
+    expect(JSON.stringify(deniedRow)).not.toContain(SECRET_LIT) // no leak through REAL-recorded history
+    expect(JSON.stringify(deniedRow)).toContain(VISIBLE_LIT) // no over-redaction
+
+    // Non-filter config survives redaction (the create revision's name round-trips, not stripped).
+    as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
+    const all = await get(`/sheets/${SHEET}/config-history/views?limit=200`)
+    const createRow = revisions(all).find((r) => r.entityId === e2eViewId && r.action === 'create')
+    expect(JSON.stringify(createRow?.after)).toContain('E2E Redact View')
+  })
+
   test('fail-closed: a malformed permission entity_id is returned by NO permission endpoint', async () => {
     as(U_FULL, ['multitable:read', 'multitable:write', 'multitable:share'])
     for (const sub of ['sheet', 'view', 'field']) {

--- a/packages/core-backend/tests/unit/config-history-read.spec.ts
+++ b/packages/core-backend/tests/unit/config-history-read.spec.ts
@@ -40,4 +40,9 @@ describe('configHistoryRequiredCapability — T9-R3 gate口径 (fail-closed)', (
     expect(configHistoryRequiredCapability('permission', 'noscopehere')).toBeNull()
     expect(configHistoryRequiredCapability('permission', ':[]')).toBeNull()
   })
+  test('permission with a COLONLESS scope-looking entity_id → null (DENY) — a real `scope:` boundary is required', () => {
+    expect(configHistoryRequiredCapability('permission', 'field')).toBeNull()
+    expect(configHistoryRequiredCapability('permission', 'view')).toBeNull()
+    expect(configHistoryRequiredCapability('permission', 'sheet')).toBeNull()
+  })
 })

--- a/packages/core-backend/tests/unit/config-history-read.spec.ts
+++ b/packages/core-backend/tests/unit/config-history-read.spec.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from 'vitest'
+
+import { configHistoryRequiredCapability } from '../../src/multitable/config-history-read'
+
+// T9-R3 gate口径: read gate = the write gate, per entity type AND per permission subtype.
+// FAIL-CLOSED on anything not explicitly mapped.
+describe('configHistoryRequiredCapability — T9-R3 gate口径 (fail-closed)', () => {
+  test('field → canManageFields', () => {
+    expect(configHistoryRequiredCapability('field', 'fld_abc')).toBe('canManageFields')
+  })
+  test('view → canManageViews', () => {
+    expect(configHistoryRequiredCapability('view', 'view_abc')).toBe('canManageViews')
+  })
+  test('sheet_config → canManageSheetAccess', () => {
+    expect(configHistoryRequiredCapability('sheet_config', 'sheet_abc')).toBe('canManageSheetAccess')
+  })
+
+  test('permission/sheet → canManageSheetAccess', () => {
+    expect(configHistoryRequiredCapability('permission', 'sheet:["role","r1"]')).toBe('canManageSheetAccess')
+  })
+  test('permission/view → canManageViews (NOT canManageSheetAccess)', () => {
+    expect(configHistoryRequiredCapability('permission', 'view:["v1","role","r1"]')).toBe('canManageViews')
+  })
+  test('permission/field → canManageFields (NOT canManageSheetAccess)', () => {
+    expect(configHistoryRequiredCapability('permission', 'field:["f1","role","r1"]')).toBe('canManageFields')
+  })
+
+  // ── FAIL CLOSED ──────────────────────────────────────────────────────────
+  test('unknown entity_type → null (DENY)', () => {
+    expect(configHistoryRequiredCapability('automation', 'x')).toBeNull()
+    expect(configHistoryRequiredCapability('record', 'rec_x')).toBeNull()
+    expect(configHistoryRequiredCapability('', 'x')).toBeNull()
+  })
+  test('permission with unknown scope → null (DENY)', () => {
+    expect(configHistoryRequiredCapability('permission', 'base:["x"]')).toBeNull()
+    expect(configHistoryRequiredCapability('permission', 'record:["x"]')).toBeNull()
+  })
+  test('permission with malformed / empty entity_id → null (DENY)', () => {
+    expect(configHistoryRequiredCapability('permission', '')).toBeNull()
+    expect(configHistoryRequiredCapability('permission', 'noscopehere')).toBeNull()
+    expect(configHistoryRequiredCapability('permission', ':[]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## T9-R3 — config-history READ API

Implements the read API over `meta_config_revisions` (recorded by R1 #3126 / R2 #3130) per the design-lock **#3139**. Backend only; unified timeline + FE deferred.

### Gate口径 (symmetric with the write routes; fail-closed)
One predicate (`config-history-read.ts`): field→canManageFields, view→canManageViews, sheet_config→canManageSheetAccess, permission/{sheet→canManageSheetAccess, view→canManageViews, field→canManageFields}; unknown type / unparseable permission scope → **DENY**. Never the record-history mask.

### Six read endpoints (each a single structural cap gate)
`GET /sheets/:sheetId/config-history/{fields,views,sheet-config}` + `…/permissions/{sheet,view,field}` — mirroring the record-history endpoint's shape (pagination `created_at DESC,id DESC`, actor enrichment). Belt-and-suspenders: each row re-checked against the predicate.

### View payload redaction — proven END-TO-END (data-deep, not fixture-deep)
The `/views` endpoint redacts `before/after.filterInfo` literals via the requester's `loadAllowedFieldIds` + `redactViewConfigFilterLiterals` (#2052/R9 — `canManageViews` ≠ field-read). The golden creates+patches a view filtered on a denied field **through the real routes** (so R2 records it), asserts the raw recorded row holds the literal in `filterInfo.conditions[].value`, then asserts a field-denied view-manager does **not** see it through the API (and a non-filter key survives).

### Verification (all green)
- Unit (9): every entity_type, all permission subtypes, fail-closed.
- Real-DB goldens (8): per-surface scoping; cross-cap 403 (write-only → 403 on sheet-config + sheet-perm; read-only → 403 on all); view redaction (fixture **and** end-to-end real-recorder); fail-closed; deterministic pagination.
- `tsc` 0; R1/R2 recording goldens unaffected (20/20); real-DB test registered in `plugin-tests.yml`.

Design + verification doc: `docs/development/multitable-t9-r3-config-history-read-verification-20260624.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)