### PR TITLE
feat(multitable): T9-R4 config-history view (dedicated, faithful client)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -38,6 +38,7 @@ on:
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
       - 'apps/web/src/multitable/components/RestoreBatchDialog.vue'
+      - 'apps/web/src/multitable/components/MetaConfigHistoryModal.vue'
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
@@ -84,6 +85,7 @@ on:
       - 'apps/web/src/multitable/views/MultitableWorkbench.vue'
       - 'apps/web/src/multitable/components/RestorePreviewDialog.vue'
       - 'apps/web/src/multitable/components/RestoreBatchDialog.vue'
+      - 'apps/web/src/multitable/components/MetaConfigHistoryModal.vue'
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
@@ -150,4 +152,4 @@ jobs:
         # accumulation/loadMore) added so the grid virtualization ACTIVATION has real CI enforcement —
         # the guard already triggers on MetaGridTable.vue / useMultitableGrid.ts / MultitableWorkbench.vue
         # edits but, before this, ran none of those specs (and plugin-tests.yml only build-checks web).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-workbench-restore-wiring --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring --reporter=dot

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1009,6 +1009,20 @@ export interface RestoreBatchExecuteResult {
   targetVersion: number
 }
 
+// T9-R4: a config/schema-change history entry (server-gated per entity type; the FE renders it as-is).
+export interface MetaConfigRevision {
+  id: string
+  entityType: 'field' | 'permission' | 'view' | 'sheet_config'
+  entityId: string
+  action: 'create' | 'update' | 'delete'
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changedKeys: string[]
+  batchId: string | null
+  actorId: string | null
+  createdAt: string
+}
+
 export interface AiShortcutPreviewData {
   status: 'succeeded'
   action: 'preview'
@@ -1863,6 +1877,14 @@ export class MultitableApiClient {
     )
     const data = await this.parseJson<{ items?: Array<Partial<MetaRecordRevision>> }>(res)
     return normalizeRecordHistoryEntries(data)
+  }
+
+  // T9-R4: config/schema-change history (read-only). The server gates per entity type (read-gate ≡ write-gate); the
+  // FE is a FAITHFUL CLIENT — it renders exactly what the server returns and never filters for security.
+  async getConfigHistory(sheetId: string, params?: { entityType?: string; limit?: number; offset?: number }): Promise<MetaConfigRevision[]> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-history${qs(params ?? {})}`)
+    const data = await this.parseJson<{ items?: MetaConfigRevision[] }>(res)
+    return Array.isArray(data.items) ? data.items : []
   }
 
   // --- Global History & Point-in-Time Restore (read-only) ---

--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="cfg-history-overlay" data-test="config-history" @click.self="$emit('close')">
+      <div class="cfg-history-modal" role="dialog" :aria-label="l('record.configHistoryTitle')">
+        <div class="cfg-history__header">
+          <strong>{{ l('record.configHistoryTitle') }}</strong>
+          <button class="cfg-history__close" :aria-label="l('record.configHistoryClose')" @click="$emit('close')">&times;</button>
+        </div>
+
+        <!-- Entity-type filter (server still gates; this only narrows within what the server returned). -->
+        <div class="cfg-history__filters" data-test="config-history-filters">
+          <button
+            v-for="opt in FILTERS"
+            :key="opt"
+            type="button"
+            class="cfg-history__chip"
+            :class="{ 'cfg-history__chip--active': entityType === opt }"
+            :data-test="`config-history-filter-${opt || 'all'}`"
+            @click="$emit('filter-change', opt)"
+          >{{ filterLabel(opt) }}</button>
+        </div>
+
+        <div class="cfg-history__body">
+          <p v-if="loading" class="cfg-history__hint" data-test="config-history-loading">{{ l('record.configHistoryLoading') }}</p>
+          <p v-else-if="items.length === 0" class="cfg-history__hint" data-test="config-history-empty">{{ l('record.configHistoryEmpty') }}</p>
+          <ul v-else class="cfg-history__list" data-test="config-history-list">
+            <li v-for="rev in items" :key="rev.id" class="cfg-history__row" :data-entity-type="rev.entityType">
+              <div class="cfg-history__row-head">
+                <span class="cfg-history__action" :class="`cfg-history__action--${rev.action}`">{{ actionLabel(rev.action) }}</span>
+                <span class="cfg-history__entity">{{ entityLabel(rev.entityType) }}</span>
+                <span class="cfg-history__entity-id">{{ recordLabelOf(rev.entityId) }}</span>
+              </div>
+              <ul v-if="rev.action === 'update' && rev.changedKeys.length" class="cfg-history__changes">
+                <li v-for="k in rev.changedKeys" :key="k" class="cfg-history__change">
+                  <span class="cfg-history__key">{{ k }}</span>
+                  <span class="cfg-history__before">{{ display(rev.before?.[k]) }}</span>
+                  <span class="cfg-history__arrow">→</span>
+                  <span class="cfg-history__after">{{ display(rev.after?.[k]) }}</span>
+                </li>
+              </ul>
+              <div class="cfg-history__meta">
+                <span v-if="rev.actorId">{{ l('record.configHistoryBy') }} {{ rev.actorId }}</span>
+                <span class="cfg-history__time">{{ rev.createdAt }}</span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import type { MetaConfigRevision } from '../api/client'
+import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
+
+const props = defineProps<{
+  visible: boolean
+  items: MetaConfigRevision[]
+  loading: boolean
+  /** current entity-type filter ('' = all). */
+  entityType: string
+  /** resolve an entity id to a display label (the workbench owns the field/view name map). */
+  recordLabelOf: (entityId: string) => string
+  isZh: boolean
+}>()
+
+defineEmits<{ (e: 'close'): void; (e: 'filter-change', entityType: string): void }>()
+
+const FILTERS = ['', 'field', 'view', 'permission', 'sheet_config'] as const
+const l = (key: MetaRecordLabelKey): string => recordLabel(key, props.isZh)
+const ENTITY_KEY: Record<string, MetaRecordLabelKey> = {
+  field: 'record.configHistoryEntityField', view: 'record.configHistoryEntityView',
+  permission: 'record.configHistoryEntityPermission', sheet_config: 'record.configHistoryEntitySheetConfig',
+}
+const ACTION_KEY: Record<string, MetaRecordLabelKey> = {
+  create: 'record.configHistoryActionCreate', update: 'record.configHistoryActionUpdate', delete: 'record.configHistoryActionDelete',
+}
+const filterLabel = (opt: string): string => (opt === '' ? l('record.configHistoryFilterAll') : entityLabel(opt))
+const entityLabel = (t: string): string => (ENTITY_KEY[t] ? l(ENTITY_KEY[t]) : t)
+const actionLabel = (a: string): string => (ACTION_KEY[a] ? l(ACTION_KEY[a]) : a)
+function display(value: unknown): string {
+  if (value === null || value === undefined) return '∅'
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+</script>
+
+<style scoped>
+.cfg-history-overlay { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+.cfg-history-modal { background: var(--surface, #fff); border-radius: 10px; width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 64px); display: flex; flex-direction: column; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2); }
+.cfg-history__header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border, #e2e8f0); }
+.cfg-history__close { border: none; background: none; font-size: 20px; line-height: 1; cursor: pointer; color: var(--text-secondary, #64748b); }
+.cfg-history__filters { display: flex; gap: 6px; flex-wrap: wrap; padding: 10px 16px 0; }
+.cfg-history__chip { padding: 3px 10px; border-radius: 999px; border: 1px solid var(--border, #cbd5e1); background: var(--surface, #fff); cursor: pointer; font-size: 12px; }
+.cfg-history__chip--active { background: var(--primary, #2563eb); color: #fff; border-color: var(--primary, #2563eb); }
+.cfg-history__body { padding: 12px 16px 16px; overflow-y: auto; }
+.cfg-history__hint { margin: 0; color: var(--text-secondary, #64748b); }
+.cfg-history__list { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 10px; }
+.cfg-history__row { padding: 8px 10px; background: var(--surface-muted, #f1f5f9); border-radius: 8px; }
+.cfg-history__row-head { display: flex; gap: 8px; align-items: baseline; }
+.cfg-history__action { font-size: 11px; font-weight: 600; text-transform: uppercase; }
+.cfg-history__action--create { color: var(--success, #15803d); }
+.cfg-history__action--update { color: var(--primary, #2563eb); }
+.cfg-history__action--delete { color: var(--danger, #b91c1c); }
+.cfg-history__entity { font-size: 12px; color: var(--text-secondary, #64748b); }
+.cfg-history__entity-id { font-weight: 600; word-break: break-word; }
+.cfg-history__changes { margin: 6px 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 3px; }
+.cfg-history__change { display: flex; gap: 6px; align-items: baseline; font-size: 12px; }
+.cfg-history__key { font-weight: 600; }
+.cfg-history__before { color: var(--text-secondary, #64748b); text-decoration: line-through; word-break: break-word; }
+.cfg-history__arrow { color: var(--text-secondary, #64748b); }
+.cfg-history__after { word-break: break-word; }
+.cfg-history__meta { display: flex; gap: 10px; margin-top: 6px; font-size: 11px; color: var(--text-secondary, #64748b); }
+.cfg-history__time { margin-left: auto; }
+</style>

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -55,6 +55,11 @@ export type MetaRecordLabelKey =
   | 'record.batchReasonUnavailable' | 'record.batchReasonVersionUnavailable' | 'record.batchReasonUnsupported'
   | 'record.batchReasonSnapshotUnavailable' | 'record.batchReasonSchemaDrift' | 'record.batchReasonNoChange'
   | 'record.batchReasonDenied' | 'record.batchReasonConflict' | 'record.batchReasonForbidden' | 'record.batchReasonError'
+  // --- T9-R4 config-history view ---
+  | 'record.configHistoryTitle' | 'record.configHistoryClose' | 'record.configHistoryFilterAll'
+  | 'record.configHistoryEntityField' | 'record.configHistoryEntityView' | 'record.configHistoryEntityPermission'
+  | 'record.configHistoryEntitySheetConfig' | 'record.configHistoryActionCreate' | 'record.configHistoryActionUpdate'
+  | 'record.configHistoryActionDelete' | 'record.configHistoryEmpty' | 'record.configHistoryLoading' | 'record.configHistoryBy'
   // FE-owned static fallback strings (the `error?.message ?? l(...)`
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
@@ -154,6 +159,19 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.batchReasonConflict': { en: 'Version conflict', zh: '版本冲突' },
   'record.batchReasonForbidden': { en: 'Field write-denied', zh: '字段不可写' },
   'record.batchReasonError': { en: 'Error', zh: '错误' },
+  'record.configHistoryTitle': { en: 'Config history', zh: '配置历史' },
+  'record.configHistoryClose': { en: 'Close', zh: '关闭' },
+  'record.configHistoryFilterAll': { en: 'All', zh: '全部' },
+  'record.configHistoryEntityField': { en: 'Field', zh: '字段' },
+  'record.configHistoryEntityView': { en: 'View', zh: '视图' },
+  'record.configHistoryEntityPermission': { en: 'Permission', zh: '权限' },
+  'record.configHistoryEntitySheetConfig': { en: 'Sheet config', zh: '表配置' },
+  'record.configHistoryActionCreate': { en: 'Created', zh: '新建' },
+  'record.configHistoryActionUpdate': { en: 'Updated', zh: '更新' },
+  'record.configHistoryActionDelete': { en: 'Deleted', zh: '删除' },
+  'record.configHistoryEmpty': { en: 'No config changes', zh: '暂无配置变更' },
+  'record.configHistoryLoading': { en: 'Loading…', zh: '加载中…' },
+  'record.configHistoryBy': { en: 'by', zh: '操作人' },
   'record.errorRestore': { en: 'Restore failed', zh: '恢复失败' },
   'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -63,6 +63,7 @@
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; {{ wb('toolbar.apiWebhooks', isZh) }}</button>
       <button v-if="caps.canDeleteRecord.value" class="mt-workbench__mgr-btn" @click="showTrash = true">&#x1F5D1; {{ wb('toolbar.trash', isZh) }}</button>
       <button v-if="activeBaseId" class="mt-workbench__mgr-btn" data-action="open-history" @click="showHistory = true">&#x1F570; {{ isZh ? '历史' : 'History' }}</button>
+      <button v-if="workbench.activeSheetId.value" class="mt-workbench__mgr-btn" data-action="open-config-history" @click="openConfigHistory">&#x2699; {{ isZh ? '配置历史' : 'Config history' }}</button>
     </div>
     <div v-if="showTemplateLibrary" class="mt-template-library" data-testid="multitable-template-library">
       <div class="mt-template-library__header">
@@ -522,6 +523,16 @@
       :fields="propertyVisibleGridFields"
       @close="showHistory = false"
     />
+    <MetaConfigHistoryModal
+      :visible="configHistory.visible"
+      :items="configHistory.items"
+      :loading="configHistory.loading"
+      :entity-type="configHistory.entityType"
+      :record-label-of="configHistoryLabelOf"
+      :is-zh="isZh"
+      @close="closeConfigHistory"
+      @filter-change="onConfigHistoryFilter"
+    />
   </div>
 </template>
 
@@ -621,6 +632,8 @@ import MetaAiBulkFillDialog from '../components/MetaAiBulkFillDialog.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
 import TrashModal from '../components/TrashModal.vue'
 import HistoryCenterModal from '../components/HistoryCenterModal.vue'
+import MetaConfigHistoryModal from '../components/MetaConfigHistoryModal.vue'
+import type { MetaConfigRevision } from '../api/client'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
 import MetaAutomationManager from '../components/MetaAutomationManager.vue'
 import MetaFormShareManager from '../components/MetaFormShareManager.vue'
@@ -860,6 +873,36 @@ const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
 const showTrash = ref(false)
 const showHistory = ref(false)
+
+// T9-R4: config/schema-change history view. The server gates per entity type — the FE renders what it returns
+// (faithful client; no client-side security filtering). The entity-type filter only narrows within the gated set.
+const configHistory = ref<{ visible: boolean; items: MetaConfigRevision[]; loading: boolean; entityType: string }>({ visible: false, items: [], loading: false, entityType: '' })
+const configHistoryLabelOf = (entityId: string): string => {
+  const f = scopedAllFields.value.find((x) => x.id === entityId)
+  if (f) return f.name
+  const v = (workbench.views.value as Array<{ id: string; name?: string }>).find((x) => x.id === entityId)
+  return v?.name ?? entityId
+}
+async function loadConfigHistory(entityType: string) {
+  const sheetId = workbench.activeSheetId.value
+  if (!sheetId) return
+  configHistory.value = { ...configHistory.value, loading: true, entityType }
+  try {
+    const items = await workbench.client.getConfigHistory(sheetId, entityType ? { entityType } : {})
+    configHistory.value = { ...configHistory.value, loading: false, items }
+  } catch (error) {
+    configHistory.value = { ...configHistory.value, loading: false, items: [] }
+    showError((error as Error)?.message ?? recordLabel('record.errorHistoryLoad', isZh.value))
+  }
+}
+function openConfigHistory() {
+  if (!workbench.activeSheetId.value) return
+  configHistory.value = { visible: true, items: [], loading: true, entityType: '' }
+  void loadConfigHistory('')
+}
+function onConfigHistoryFilter(entityType: string) { void loadConfigHistory(entityType) }
+function closeConfigHistory() { configHistory.value = { ...configHistory.value, visible: false } }
+
 // After an undelete, the restored record is back in the sheet → refresh the current page so it appears.
 function onTrashRestored(): void {
   void grid.reloadCurrentPage()

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/**
+ * T9-R4 — MetaConfigHistoryModal: the dedicated config-history view. The server gates per entity type (R3); the FE
+ * is a FAITHFUL CLIENT — it renders exactly the items the server returned and never filters for security. The
+ * entity-type filter only emits a re-fetch (server re-applies the gate). Mounted via createApp + jsdom (Teleport).
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import MetaConfigHistoryModal from '../src/multitable/components/MetaConfigHistoryModal.vue'
+import type { MetaConfigRevision } from '../src/multitable/api/client'
+
+const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
+  id: 'r1', entityType: 'field', entityId: 'fld_1', action: 'create', before: null, after: { name: 'X' },
+  changedKeys: [], batchId: null, actorId: 'u1', createdAt: '2026-06-24T00:00:00Z', ...over,
+})
+
+type Props = {
+  visible: boolean; items: MetaConfigRevision[]; loading: boolean; entityType: string
+  recordLabelOf: (id: string) => string; isZh: boolean; onClose: () => void; onFilterChange: (t: string) => void
+}
+const mounted: Array<{ unmount: () => void }> = []
+function mountModal(over: Partial<Props>) {
+  const props: Props = {
+    visible: true, items: [], loading: false, entityType: '', recordLabelOf: (id) => `name:${id}`, isZh: false,
+    onClose: vi.fn(), onFilterChange: vi.fn(), ...over,
+  }
+  const app = createApp(MetaConfigHistoryModal, props as unknown as Record<string, unknown>)
+  const c = document.createElement('div'); document.body.appendChild(c); app.mount(c); mounted.push(app); return props
+}
+const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+
+describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
+  it('renders the server revisions FAITHFULLY (action, entity, changed before→after) — no client-side filtering', async () => {
+    mountModal({ items: [
+      rev({ id: 'a', entityType: 'field', entityId: 'fld_1', action: 'update', changedKeys: ['name'], before: { name: 'Old' }, after: { name: 'New' } }),
+      rev({ id: 'b', entityType: 'view', entityId: 'view_1', action: 'create' }),
+    ] })
+    await nextTick()
+    expect(q('[data-test="config-history-list"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('name:fld_1') // recordLabelOf resolved
+    expect(document.body.textContent).toContain('Old') // before
+    expect(document.body.textContent).toContain('New') // after
+    expect(document.body.querySelectorAll('.cfg-history__row').length).toBe(2) // BOTH rendered — the FE doesn't drop rows
+  })
+
+  it('the entity-type filter EMITS filter-change (server re-fetches; the FE never client-filters for security)', async () => {
+    const props = mountModal({ items: [rev({})] })
+    await nextTick()
+    ;(q('[data-test="config-history-filter-view"]') as HTMLButtonElement).click()
+    expect(props.onFilterChange).toHaveBeenCalledWith('view')
+    // the list still shows the (unchanged) items — filtering is the server's job on the next load, not a client cull
+    expect(document.body.querySelectorAll('.cfg-history__row').length).toBe(1)
+  })
+
+  it('shows the loading state', async () => {
+    mountModal({ loading: true }); await nextTick()
+    expect(q('[data-test="config-history-loading"]')).toBeTruthy()
+    expect(q('[data-test="config-history-list"]')).toBeFalsy()
+  })
+
+  it('shows the empty state when the server returns nothing (e.g. an actor who manages no config)', async () => {
+    mountModal({ items: [] }); await nextTick()
+    expect(q('[data-test="config-history-empty"]')).toBeTruthy()
+  })
+
+  it('close emits close', async () => {
+    const props = mountModal({ items: [rev({})] }); await nextTick()
+    ;(q('.cfg-history__close') as HTMLButtonElement).click()
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi, afterEach } from 'vitest'
 import { createApp, nextTick } from 'vue'
 
 import MetaConfigHistoryModal from '../src/multitable/components/MetaConfigHistoryModal.vue'
-import type { MetaConfigRevision } from '../src/multitable/api/client'
+import { MultitableApiClient, type MetaConfigRevision } from '../src/multitable/api/client'
 
 const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
   id: 'r1', entityType: 'field', entityId: 'fld_1', action: 'create', before: null, after: { name: 'X' },
@@ -69,5 +69,28 @@ describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
     const props = mountModal({ items: [rev({})] }); await nextTick()
     ;(q('.cfg-history__close') as HTMLButtonElement).click()
     expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getConfigHistory — T9-R3↔R4 wire (drift lock)', () => {
+  it('round-trips the REAL R3 {ok,data:{items}} envelope (not a fixture) — never silently returns []', async () => {
+    // The R3↔R4 seam is drift-prone (cf. dayIndex). R3 returns { ok, data: { items, limit, offset } }; the client's
+    // parseJson unwraps .data, so getConfigHistory reads .items off the unwrapped body. Assert against a real-shaped
+    // envelope so a future envelope change can't make getConfigHistory always-empty while every isolated test stays green.
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      data: { items: [
+        { id: 'cr_1', entityType: 'field', entityId: 'fld_1', action: 'update', before: { name: 'A' }, after: { name: 'B' }, changedKeys: ['name'], batchId: null, actorId: 'u1', createdAt: '2026-06-24T00:00:00Z' },
+      ], limit: 50, offset: 0 },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const items = await client.getConfigHistory('sheet_1', { entityType: 'field' })
+
+    expect(items).toHaveLength(1) // NOT [] — the envelope was unwrapped
+    expect(items[0].entityId).toBe('fld_1')
+    expect(items[0].changedKeys).toEqual(['name'])
+    expect(fetchFn).toHaveBeenCalledWith(expect.stringContaining('/api/multitable/sheets/sheet_1/config-history')) // GET passes the URL only
+    expect(fetchFn.mock.calls[0][0]).toContain('entityType=field')
   })
 })


### PR DESCRIPTION
The **FE half** of T9 config history (R4) — pairs with the R3 read API (#3153).

A dedicated sheet-level **Config history** modal (`MetaConfigHistoryModal`): a timeline of config/schema changes with an **entity-type filter** (all / field / view / permission / sheet_config) and **before→after** display, opened from a workbench toolbar button (shown when a sheet is active).

**Faithful client of R3** (the BS-4 wire-drift lesson): `getConfigHistory` renders exactly what the server's per-entity-type gate returns; the entity-type filter only **emits a re-fetch** (server re-applies the gate) — never a client-side security cull.

## Verification
5 jsdom specs: faithful render (incl. before→after, both rows kept — no client drop), filter-emits-refetch (not a client cull), loading, empty (an actor who manages no config), close. 14 strict-zero i18n keys. Added to the multitable-web-guard. `vue-tsc -b` 0.

Runtime depends on R3 (#3153) for the `/config-history` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)