### PR TITLE
feat(automation): validate W7 writeback target fields

### DIFF
--- a/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
+++ b/docs/development/approval-automation-w7-result-backwrite-design-verification-20260624.md
@@ -58,11 +58,28 @@ silently left — both now closed:
 - **Verification:** a W7-1a integration test asserts a tail `send_webhook`'s `recordData` carries the
   backwrite AND that `multitable.record.updated` fired with the change — start-approval suite 12/12.
 
+## W7-1b — target field schema validation (shipped follow-up)
+The core write originally JSONB-merged whatever mapped field id the action declared. W7-1b closes that
+misconfiguration hole at the runtime seam, immediately before the write:
+
+- The mapped target field must exist on the source sheet's current `meta_fields` schema.
+- The target field type must be compatible with the system value being written:
+  - `statusField`: `string` / `longText` / `select`; `select` must include the terminal outcome option
+    being written (currently `approved` on the approved branch).
+  - `approverField`: `string` / `longText` only. Native `person` fields intentionally remain closed
+    because they store `userId[]`, while W7-1 writes one actor id string; supporting person writeback
+    needs an explicit person-shaped writer plus membership guard.
+  - `completedAtField`: `string` / `longText` / `dateTime`.
+- Failure remains fail-closed for the write and consistent with W7-1's best-effort resume semantics:
+  the invalid backwrite is skipped/logged, and W6 continues the approved-tail resume rather than treating
+  schema drift as a second approval-completion failure path.
+- **Verification:** real-DB integration now covers the positive path with real fields (`approval_status`
+  as a select containing `approved`, `approved_by` as string, `approved_at` as dateTime), plus missing-field
+  and incompatible-type cases that prove no schemaless JSONB key is written while the tail still resumes.
+
 ## Named follow-ups (gated, not silently skipped)
 - **Rejection backwrite** — write `status='rejected'` on the non-approved path. That path currently
   fails the automation by design (fingerprint + bridge governance); resume-and-write on rejection is a
   real behavior change with its own governance implications.
 - **Cross-base backwrite** — write to a different base's record (today: the same-base source record).
   Would route through the existing `evaluateCrossBaseWrite` gate, like `update_record`.
-- **Field-exists validation** against the target sheet schema (today the write is schemaless `jsonb`
-  merge, so any field id is accepted — consistent with `update_record`).

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -5,6 +5,7 @@ import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
 import { ensureRecordNotLocked } from './record-lock'
 import { publishMultitableSheetRealtime } from './realtime-publish'
+import { extractSelectOptions } from './field-codecs'
 import {
   ConditionGroupValidationError,
   normalizeConditionGroupInput,
@@ -74,6 +75,11 @@ const SAFE_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
 const PARALLEL_BRANCH_ACTION_TYPES = new Set(['update_record', 'send_notification'])
 const MAX_PARALLEL_BRANCHES = 10
 const MAX_PARALLEL_BRANCH_ACTIONS = 20
+const RESULT_WRITEBACK_FIELDS = ['statusField', 'approverField', 'completedAtField'] as const
+type ResultWritebackField = typeof RESULT_WRITEBACK_FIELDS[number]
+const TEXT_RESULT_WRITEBACK_TYPES = new Set(['string', 'longText'])
+const STATUS_RESULT_WRITEBACK_TYPES = new Set([...TEXT_RESULT_WRITEBACK_TYPES, 'select'])
+const COMPLETED_AT_RESULT_WRITEBACK_TYPES = new Set([...TEXT_RESULT_WRITEBACK_TYPES, 'dateTime'])
 
 // A6-1 opt-in (#2130 runtime): a rule may persist one C1 WorkflowJob row per action.
 // `null`/`'legacy'` both mean the legacy fire-and-forget path (no job rows); only
@@ -152,9 +158,8 @@ function validateStartApprovalConfig(config: Record<string, unknown>, path: stri
   // resume-time action-fingerprint drift guard (cannot be swapped after the approval suspends).
   if (config.resultWriteback !== undefined) {
     if (!isRecord(config.resultWriteback)) return `${path}.resultWriteback must be an object`
-    const fields = ['statusField', 'approverField', 'completedAtField'] as const
     let mapped = 0
-    for (const field of fields) {
+    for (const field of RESULT_WRITEBACK_FIELDS) {
       const value = config.resultWriteback[field]
       if (value === undefined) continue
       if (typeof value !== 'string' || value.trim().length === 0) return `${path}.resultWriteback.${field} must be a non-empty string`
@@ -195,6 +200,63 @@ function parseConditionGroupInput(value: unknown): ConditionGroup {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function resultWritebackFieldId(writeback: Record<string, unknown>, field: ResultWritebackField): string | null {
+  const value = writeback[field]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+type ResultWritebackTargetField = {
+  id: string
+  type: string
+  property?: Record<string, unknown>
+}
+
+function normalizeFieldProperty(value: unknown): Record<string, unknown> | undefined {
+  if (isRecord(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return isRecord(parsed) ? parsed : undefined
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+function resultWritebackFieldTypeError(
+  field: ResultWritebackField,
+  target: ResultWritebackTargetField,
+  outcome: string,
+): string | null {
+  if (field === 'statusField') {
+    if (!STATUS_RESULT_WRITEBACK_TYPES.has(target.type)) {
+      return `resultWriteback.statusField target ${target.id} must be string/longText/select, got ${target.type}`
+    }
+    if (target.type === 'select') {
+      const options = new Set((extractSelectOptions(target.property) ?? []).map((option) => option.value))
+      if (!options.has(outcome)) {
+        return `resultWriteback.statusField select ${target.id} does not include option ${outcome}`
+      }
+    }
+    return null
+  }
+  if (field === 'approverField') {
+    if (!TEXT_RESULT_WRITEBACK_TYPES.has(target.type)) {
+      // Native person fields store userId[], while W7-1 writes a single actor id string. Keep this
+      // closed until the writer intentionally emits person-shaped values and reuses the member guard.
+      return `resultWriteback.approverField target ${target.id} must be string/longText, got ${target.type}`
+    }
+    return null
+  }
+  if (!COMPLETED_AT_RESULT_WRITEBACK_TYPES.has(target.type)) {
+    return `resultWriteback.completedAtField target ${target.id} must be string/longText/dateTime, got ${target.type}`
+  }
+  return null
 }
 
 /**
@@ -1450,10 +1512,14 @@ export class AutomationService {
   ): Promise<Record<string, unknown> | null> {
     const writeback = isRecord(startApprovalConfig.resultWriteback) ? startApprovalConfig.resultWriteback : null
     if (!writeback || !bridge.recordId || !bridge.sheetId) return null
+    await this.assertResultWritebackFields(bridge.sheetId, writeback, event.transition.toStatus)
     const patch: Record<string, unknown> = {}
-    if (typeof writeback.statusField === 'string') patch[writeback.statusField] = event.transition.toStatus
-    if (typeof writeback.approverField === 'string') patch[writeback.approverField] = event.actor?.id ?? null
-    if (typeof writeback.completedAtField === 'string') patch[writeback.completedAtField] = event.occurredAt
+    const statusField = resultWritebackFieldId(writeback, 'statusField')
+    const approverField = resultWritebackFieldId(writeback, 'approverField')
+    const completedAtField = resultWritebackFieldId(writeback, 'completedAtField')
+    if (statusField) patch[statusField] = event.transition.toStatus
+    if (approverField) patch[approverField] = event.actor?.id ?? null
+    if (completedAtField) patch[completedAtField] = event.occurredAt
     if (Object.keys(patch).length === 0) return null
 
     const lockRes = await this.queryFn(
@@ -1497,6 +1563,39 @@ export class AutomationService {
       // publishMultitableSheetRealtime swallows its own errors; belt-and-suspenders.
     }
     return patch
+  }
+
+  private async assertResultWritebackFields(
+    sheetId: string,
+    writeback: Record<string, unknown>,
+    outcome: string,
+  ): Promise<void> {
+    const mapped = RESULT_WRITEBACK_FIELDS
+      .map((field) => ({ field, id: resultWritebackFieldId(writeback, field) }))
+      .filter((entry): entry is { field: ResultWritebackField; id: string } => !!entry.id)
+    if (mapped.length === 0) return
+
+    const uniqueIds = Array.from(new Set(mapped.map((entry) => entry.id)))
+    const res = await this.queryFn(
+      'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
+      [sheetId, uniqueIds],
+    )
+    const byId = new Map<string, ResultWritebackTargetField>()
+    for (const row of res.rows as Array<Record<string, unknown>>) {
+      const id = typeof row.id === 'string' ? row.id : ''
+      const type = typeof row.type === 'string' ? row.type : ''
+      if (!id || !type) continue
+      byId.set(id, { id, type, property: normalizeFieldProperty(row.property) })
+    }
+
+    for (const entry of mapped) {
+      const target = byId.get(entry.id)
+      if (!target) {
+        throw new Error(`resultWriteback.${entry.field} target field not found: ${entry.id}`)
+      }
+      const typeError = resultWritebackFieldTypeError(entry.field, target, outcome)
+      if (typeError) throw new Error(typeError)
+    }
   }
 
   private async failApprovalBridgeExecution(

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -203,12 +203,94 @@ async function seedSheetRecord(title: string): Promise<void> {
   )
 }
 
+async function seedWritebackFields(fields: Array<{ id: string; name: string; type: string; property?: Record<string, unknown>; order: number }>): Promise<void> {
+  for (const field of fields) {
+    await q(
+      `INSERT INTO meta_fields (id, sheet_id, name, type, property, "order")
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+       ON CONFLICT (id) DO UPDATE
+          SET name = EXCLUDED.name,
+              type = EXCLUDED.type,
+              property = EXCLUDED.property,
+              "order" = EXCLUDED."order"`,
+      [field.id, SHEET, field.name, field.type, JSON.stringify(field.property ?? {}), field.order],
+    )
+  }
+}
+
+async function seedDefaultWritebackFields(): Promise<void> {
+  await seedWritebackFields([
+    {
+      id: 'approval_status',
+      name: 'Approval Status',
+      type: 'select',
+      property: { options: [{ value: 'approved' }, { value: 'rejected' }] },
+      order: 10,
+    },
+    { id: 'approved_by', name: 'Approved By', type: 'string', order: 11 },
+    { id: 'approved_at', name: 'Approved At', type: 'dateTime', order: 12 },
+  ])
+}
+
 async function waitForExecutionStatus(svc: AutomationService, id: string, status: string) {
   await vi.waitFor(async () => {
     const execution = await svc.logs.getById(id)
     expect(execution?.status, JSON.stringify(execution)).toBe(status)
   }, { timeout: 5000, interval: 50 })
   return (await svc.logs.getById(id))!
+}
+
+async function executeAndApprove(
+  svc: AutomationService,
+  resultWriteback: Record<string, string>,
+  title = 'Q4 plan',
+): Promise<{ executionId: string; approvalInstanceId: string }> {
+  const templateId = await createPublishedTemplate()
+  const ruleId = await createStartApprovalRule(svc, templateId, resultWriteback)
+  await seedSheetRecord(title)
+  const execRule = {
+    id: ruleId,
+    name: 'W6 start approval',
+    sheetId: SHEET,
+    trigger: { type: 'record.created', config: {} },
+    actions: [
+      {
+        type: 'start_approval',
+        config: {
+          templateId,
+          formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+          requester: { mode: 'trigger_actor' },
+          resultWriteback,
+        },
+      },
+      { type: 'send_webhook', config: { url: 'https://example.test/w6-tail' } },
+    ],
+    enabled: true,
+    createdBy: REQUESTER,
+    createdAt: new Date(TS).toISOString(),
+    executionMode: 'workflow_job_v1',
+  }
+  const execution = await svc.executeRule(execRule as never, {
+    sheetId: SHEET,
+    recordId: RECORD,
+    data: { title },
+    actorId: REQUESTER,
+  })
+  executionIds.push(execution.id)
+  const bridge = await q(
+    `SELECT approval_instance_id FROM multitable_automation_approval_bridges WHERE execution_id = $1`,
+    [execution.id],
+  )
+  const approvalInstanceId = bridge.rows[0].approval_instance_id as string
+  approvalIds.push(approvalInstanceId)
+  const approvals = new ApprovalProductService()
+  await approvals.dispatchAction(
+    approvalInstanceId,
+    { action: 'approve', comment: 'go' },
+    { userId: APPROVER, userName: APPROVER },
+  )
+  await waitForExecutionStatus(svc, execution.id, 'success')
+  return { executionId: execution.id, approvalInstanceId }
 }
 
 describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)', () => {
@@ -233,6 +315,7 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       await q('DELETE FROM automation_rules WHERE id = $1', [id])
     }
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET])
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET])
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE])
     for (const id of templateIds) {
@@ -357,6 +440,7 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       const templateId = await createPublishedTemplate()
       const ruleId = await createStartApprovalRule(svc, templateId, RW)
       await seedSheetRecord('Q4 plan')
+      await seedDefaultWritebackFields()
       const execRule = {
         id: ruleId,
         name: 'W6 start approval',
@@ -427,6 +511,7 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       const templateId = await createPublishedTemplate()
       const ruleId = await createStartApprovalRule(svc, templateId, RW)
       await seedSheetRecord('Q4 plan')
+      await seedDefaultWritebackFields()
       const execRule = {
         id: ruleId,
         name: 'W6 start approval',
@@ -457,6 +542,49 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(updatedEvents.some((e) => (e.changes as Record<string, unknown> | undefined)?.approval_status === 'approved' && e.recordId === RECORD)).toBe(true)
     } finally {
       eventBus.unsubscribe(subId)
+      svc.shutdown()
+    }
+  })
+
+  test('W7-1b: resultWriteback skips writes when the mapped target field is missing', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      await executeAndApprove(svc, { statusField: 'missing_approval_status' }, 'Missing writeback field')
+
+      const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
+      const data = rec.rows[0].data as Record<string, unknown>
+      expect(data.title).toBe('Missing writeback field')
+      expect(data).not.toHaveProperty('missing_approval_status')
+      // Field-validation failure is fail-closed for the write, not a second way to block W6 resume.
+      expect(calls).toEqual(['https://example.test/w6-tail'])
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('W7-1b: resultWriteback skips writes when the mapped target type is incompatible', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      await seedSheetRecord('Wrong writeback type')
+      await seedWritebackFields([
+        { id: 'approval_status_number', name: 'Approval Status Number', type: 'number', order: 30 },
+      ])
+      await executeAndApprove(svc, { statusField: 'approval_status_number' }, 'Wrong writeback type')
+
+      const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
+      const data = rec.rows[0].data as Record<string, unknown>
+      expect(data.title).toBe('Wrong writeback type')
+      expect(data).not.toHaveProperty('approval_status_number')
+      expect(calls).toEqual(['https://example.test/w6-tail'])
+    } finally {
       svc.shutdown()
     }
   })


### PR DESCRIPTION
## Summary
- validate W7 resultWriteback mapped field ids against the source sheet schema before writing
- require compatible target types: status -> string/longText/select(with outcome option), approver -> string/longText, completedAt -> string/longText/dateTime
- add real-DB W7 regression coverage for valid fields, missing fields, and incompatible field types; update the W7 verification record

## Verification
- pnpm --filter @metasheet/core-backend type-check
- pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-automation-start-approval.test.ts (local DATABASE_URL absent: 14 skipped; CI plugin-tests Postgres lane runs this file)

## Scope
- W7-1b field-exists/type validation only
- no rejection backwrite, no cross-base writeback, no person-field approver writer