### PR TITLE
feat(attendance): v1-1b OT-bank source-tagged lots (migration + gated per-source grant)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260624160000_add_overtime_source_to_leave_balances.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260624160000_add_overtime_source_to_leave_balances.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from 'kysely'
+import { addColumnIfNotExists, checkTableExists, dropColumnIfExists } from './_patterns'
+
+// 加班银行 v1-1b (design-lock attendance-overtime-bank-settlement-designlock-20260624, §3 账1): tag each
+// overtime-conversion comp_time lot with the OT day-type SOURCE (workday / restday / special_hours / ...) so
+// 账2 offset + 账4 settlement can treat sources differently (§6 — e.g. statutory_holiday must be paid, never
+// poolable). NULLABLE, default NULL: every existing lot keeps NULL, and the DORMANT overtimeBankPolicy path
+// (default, every current org) keeps writing a single NULL-source lot — byte-identical to pre-#8. Only when
+// an org enables overtimeBankPolicy does the grant write per-source tagged lots.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'attendance_leave_balances')
+  if (!exists) return
+  await addColumnIfNotExists(db, 'attendance_leave_balances', 'overtime_source', 'text', {})
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'attendance_leave_balances')
+  if (!exists) return
+  await dropColumnIfExists(db, 'attendance_leave_balances', 'overtime_source')
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5700,6 +5700,30 @@ attendanceIntegrationDescribe(
       )
       expect(replayLot.rows).toHaveLength(0)
       expect(await lotsFor(onId)).toHaveLength(1)
+
+      // (4) 加班银行 v1-1b: with overtimeBankPolicy ENABLED, an OT segmentation spanning workday+restday grants
+      // PER-SOURCE pooled comp_time lots (overtime_source tagged, keyed per-source), conserved to the total.
+      // (sections 1–3 above prove the DORMANT path is byte-identical: single overtime_conversion lot.)
+      expect((await putSettings({ compTimeFromOvertime: { enabled: true }, overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })).status).toBe(200)
+      const bankId = await createOvertime('2026-09-10', 120)
+      await pool.query(
+        `UPDATE attendance_requests SET metadata = jsonb_set(metadata, '{overtimeSegmentation}', $2::jsonb) WHERE id = $1`,
+        [bankId, JSON.stringify({ version: 1, engine: 'attendance_overtime_segmentation_v1', workDate: '2026-09-10', dayType: 'workday', segments: { workdayMinutes: 60, restdayMinutes: 60, holidayMinutes: 0 }, totalMinutes: 120, compTimeGrantMinutes: 120 })],
+      )
+      expect((await approve(bankId)).status).toBe(200)
+      const bankLots = (await pool.query(
+        `SELECT amount_minutes, source_key, overtime_source FROM attendance_leave_balances
+          WHERE org_id='default' AND source_id=$1 AND leave_type_code='comp_time' ORDER BY overtime_source`,
+        [bankId],
+      )).rows as { amount_minutes: number; source_key: string; overtime_source: string }[]
+      expect(bankLots).toEqual([
+        { amount_minutes: 60, source_key: `overtime_conversion:${bankId}:restday`, overtime_source: 'restday' },
+        { amount_minutes: 60, source_key: `overtime_conversion:${bankId}:workday`, overtime_source: 'workday' },
+      ])
+      expect(bankLots.reduce((s, l) => s + l.amount_minutes, 0)).toBe(120) // conservation: Σ per-source === total
+      // replay: re-approving is rejected and never adds extra lots.
+      expect((await approve(bankId)).status).toBe(400)
+      expect((await pool.query(`SELECT count(*)::int AS n FROM attendance_leave_balances WHERE source_id=$1 AND leave_type_code='comp_time'`, [bankId])).rows[0].n).toBe(2)
     } finally {
       if (token && Object.keys(originalSettings).length > 0) {
         await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)

--- a/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
@@ -62,4 +62,11 @@ describe('#加班银行 v1-1b — partitionOvertimeBankGrantLots (dormant byte-i
     expect(JSON.stringify(a)).toBe(JSON.stringify(b))
     expect(a.lots.map((l) => l.sourceKey)).toEqual(['overtime_conversion:rX:workday', 'overtime_conversion:rX:restday'])
   })
+
+  it('ENABLED but NO source breakdown (segments null / all-zero) → single NULL-source lot (grant never lost)', () => {
+    expect(part({ requestId: 'r6', totalMinutes: 90, segments: null, overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }).lots)
+      .toEqual([{ source: null, sourceKey: 'overtime_conversion:r6', minutes: 90 }])
+    expect(part({ requestId: 'r6', totalMinutes: 90, segments: segs(0, 0, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }).lots)
+      .toEqual([{ source: null, sourceKey: 'overtime_conversion:r6', minutes: 90 }])
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
@@ -63,10 +63,12 @@ describe('#加班银行 v1-1b — partitionOvertimeBankGrantLots (dormant byte-i
     expect(a.lots.map((l) => l.sourceKey)).toEqual(['overtime_conversion:rX:workday', 'overtime_conversion:rX:restday'])
   })
 
-  it('ENABLED but NO source breakdown (segments null / all-zero) → single NULL-source lot (grant never lost)', () => {
-    expect(part({ requestId: 'r6', totalMinutes: 90, segments: null, overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }).lots)
-      .toEqual([{ source: null, sourceKey: 'overtime_conversion:r6', minutes: 90 }])
-    expect(part({ requestId: 'r6', totalMinutes: 90, segments: segs(0, 0, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }).lots)
-      .toEqual([{ source: null, sourceKey: 'overtime_conversion:r6', minutes: 90 }])
+  it('§P1 ENABLED but NO source breakdown (segments null / all-zero) → FAIL CLOSED: pool NOTHING (must-pay)', () => {
+    // the NULL-source whole-lot fallback would bypass the §6 floor + pooledSources — so the enabled path pools
+    // nothing when the source is unresolvable (the OT is must-pay, not banked). NULL fallback is dormant-only.
+    expect(part({ requestId: 'r6', totalMinutes: 90, segments: null, overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }))
+      .toEqual({ lots: [], perSource: [] })
+    expect(part({ requestId: 'r6', totalMinutes: 90, segments: segs(0, 0, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } }))
+      .toEqual({ lots: [], perSource: [] })
   })
 })

--- a/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-bank-grant.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceOvertimeBankForTests as {
+  resolveOvertimeBankSourceMinutes: (segments: unknown) => { workday: number; restday: number; statutory_holiday: number }
+  partitionOvertimeBankGrantLots: (input: {
+    requestId: string; totalMinutes: number; segments?: unknown
+    overtimeBankPolicy?: { enabled?: boolean; pooledSources?: string[] }
+  }) => { lots: Array<{ source: string | null; sourceKey: string; minutes: number }>; perSource: Array<{ source: string; minutes: number }> }
+}
+
+const segs = (w: number, r: number, h: number) => ({ workdayMinutes: w, restdayMinutes: r, holidayMinutes: h })
+const sum = (xs: Array<{ minutes: number }>) => xs.reduce((s, x) => s + x.minutes, 0)
+
+describe('#加班银行 v1-1b — partitionOvertimeBankGrantLots (dormant byte-identical / enabled per-source)', () => {
+  const part = helpers.partitionOvertimeBankGrantLots
+
+  it('DORMANT (no policy / enabled=false): a single NULL-source lot of the whole total — byte-identical', () => {
+    expect(part({ requestId: 'r1', totalMinutes: 120, segments: segs(60, 60, 0), overtimeBankPolicy: undefined }))
+      .toEqual({ lots: [{ source: null, sourceKey: 'overtime_conversion:r1', minutes: 120 }], perSource: [] })
+    expect(part({ requestId: 'r1', totalMinutes: 120, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: false, pooledSources: ['workday', 'restday'] } }).lots)
+      .toEqual([{ source: null, sourceKey: 'overtime_conversion:r1', minutes: 120 }])
+  })
+
+  it('DORMANT zero total → no lots', () => {
+    expect(part({ requestId: 'r1', totalMinutes: 0, segments: segs(0, 0, 0) }).lots).toEqual([])
+  })
+
+  it('ENABLED: partition by source weights, pooled lots keyed per-source; Σ perSource === total (conservation)', () => {
+    const r = part({ requestId: 'r2', totalMinutes: 120, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    expect(r.perSource).toEqual([{ source: 'workday', minutes: 60 }, { source: 'restday', minutes: 60 }, { source: 'statutory_holiday', minutes: 0 }])
+    expect(sum(r.perSource)).toBe(120)
+    expect(r.lots).toEqual([
+      { source: 'workday', sourceKey: 'overtime_conversion:r2:workday', minutes: 60 },
+      { source: 'restday', sourceKey: 'overtime_conversion:r2:restday', minutes: 60 },
+    ])
+  })
+
+  it('ENABLED rule-normalized total ≠ raw segment sum: partition the TOTAL (rule applied ONCE upstream), not segments', () => {
+    // raw segments 60/60 (sum 120) but the rule-normalized comp-time total = 90 → partition 90 by 60/60 → 45/45.
+    const r = part({ requestId: 'r3', totalMinutes: 90, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    expect(sum(r.perSource)).toBe(90)
+    expect(r.lots.map((l) => l.minutes)).toEqual([45, 45])
+  })
+
+  it('COMPLIANCE: holiday OT → statutory_holiday, attributed but NEVER banked (must-pay); only workday/restday lots', () => {
+    const r = part({ requestId: 'r4', totalMinutes: 180, segments: segs(60, 60, 60), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    expect(r.perSource).toEqual([{ source: 'workday', minutes: 60 }, { source: 'restday', minutes: 60 }, { source: 'statutory_holiday', minutes: 60 }])
+    expect(sum(r.perSource)).toBe(180)
+    expect(r.lots.map((l) => l.source)).toEqual(['workday', 'restday']) // statutory_holiday not banked
+  })
+
+  it('odd total: the LAST NON-ZERO source absorbs the remainder; a 0-weight source gets exactly 0 (no mis-attribution)', () => {
+    const r = part({ requestId: 'r5', totalMinutes: 121, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    expect(r.perSource).toEqual([{ source: 'workday', minutes: 60 }, { source: 'restday', minutes: 61 }, { source: 'statutory_holiday', minutes: 0 }])
+    expect(sum(r.perSource)).toBe(121)
+  })
+
+  it('per-source sourceKey is deterministic (replay ON CONFLICT idempotency holds)', () => {
+    const a = part({ requestId: 'rX', totalMinutes: 120, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    const b = part({ requestId: 'rX', totalMinutes: 120, segments: segs(60, 60, 0), overtimeBankPolicy: { enabled: true, pooledSources: ['workday', 'restday'] } })
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+    expect(a.lots.map((l) => l.sourceKey)).toEqual(['overtime_conversion:rX:workday', 'overtime_conversion:rX:restday'])
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-overtime-bank-policy.test.ts
+++ b/packages/core-backend/tests/unit/attendance-overtime-bank-policy.test.ts
@@ -22,19 +22,19 @@ describe('#8/加班银行 v1-1a — OvertimeBankPolicy normalizer (LATENT, compl
     expect(norm(null)).toEqual(DORMANT)
   })
 
-  it('keeps the poolable allowlist sources, de-duped, preserving order', () => {
+  it('keeps the poolable allowlist sources, de-duped, preserving order; drops not-yet-producible sources', () => {
     const r = norm({ pooledSources: ['restday', 'workday', 'restday', 'special_hours', 'adjusted_rest_day', 'company_holiday'] })
-    expect(r.pooledSources).toEqual(['restday', 'workday', 'special_hours', 'adjusted_rest_day', 'company_holiday'])
+    // §P2: v1-1b only produces workday/restday — the holiday sub-types + special_hours are NOT yet in the
+    // allowlist (they'd silently never pool), so they're dropped here until the calendar exposes the dayType.
+    expect(r.pooledSources).toEqual(['restday', 'workday'])
   })
 
   it('COMPLIANCE FLOOR: statutory_holiday is dropped from pooledSources (法定节假日不可入池, 劳动法 §44)', () => {
     expect(norm({ pooledSources: ['statutory_holiday'] }).pooledSources).toEqual([])
     expect(norm({ pooledSources: ['restday', 'statutory_holiday', 'workday'] }).pooledSources).toEqual(['restday', 'workday'])
-    // the allowlist itself must never contain statutory_holiday.
+    // the allowlist itself must never contain statutory_holiday, and (§P2) only exposes what v1-1b produces.
     expect(helpers.OVERTIME_BANK_POOLABLE_SOURCES).not.toContain('statutory_holiday')
-    expect([...helpers.OVERTIME_BANK_POOLABLE_SOURCES].sort()).toEqual(
-      ['adjusted_rest_day', 'company_holiday', 'restday', 'special_hours', 'workday'],
-    )
+    expect([...helpers.OVERTIME_BANK_POOLABLE_SOURCES].sort()).toEqual(['restday', 'workday'])
   })
 
   it('drops unknown / non-string sources (fail-closed)', () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10206,6 +10206,60 @@ function resolveCompTimeGrantMinutesFromOvertimeMetadata(metadata) {
   return Math.floor(Number(meta.minutes) || 0)
 }
 
+// 加班银行 v1-1b (design-lock §3 账1/§6): map the overtime segmentation's per-day-type minutes to BANK
+// sources. workday→workday, restday→restday, holiday→statutory_holiday — CONSERVATIVE §6: the segmentation's
+// 'holiday' bucket does not yet distinguish statutory vs adjusted-rest vs company, so v1-1b treats holiday OT
+// as statutory_holiday (never poolable) rather than risk pooling a must-pay statutory day. Finer holiday
+// sub-typing + special_hours are later refinements (need the calendar to expose them).
+function resolveOvertimeBankSourceMinutes(segments) {
+  const s = segments && typeof segments === 'object' ? segments : {}
+  return {
+    workday: Math.max(0, Math.floor(Number(s.workdayMinutes) || 0)),
+    restday: Math.max(0, Math.floor(Number(s.restdayMinutes) || 0)),
+    statutory_holiday: Math.max(0, Math.floor(Number(s.holidayMinutes) || 0)),
+  }
+}
+
+// 加班银行 v1-1b (design-lock §3 账1): partition the rule-normalized comp-time total into per-source
+// comp_time lots, GATED on overtimeBankPolicy. DORMANT (default / not enabled) → a single NULL-source lot of
+// the whole total (caller keeps the byte-identical pre-v1-1b INSERT). ENABLED → partition `totalMinutes` by
+// the per-source weights (rule already applied ONCE upstream → never re-applied), last source absorbs the
+// remainder (exact conservation: Σ perSource === total); only sources in pooledSources become comp_time lots
+// (the rest is must-pay → 账4, not banked; statutory_holiday is never poolable, §6 floor). Each pooled lot
+// keyed `overtime_conversion:${requestId}:${source}` so per-source ON CONFLICT idempotency holds on replay.
+function partitionOvertimeBankGrantLots({ requestId, totalMinutes, segments, overtimeBankPolicy } = {}) {
+  const total = Math.max(0, Math.floor(Number(totalMinutes) || 0))
+  if (!overtimeBankPolicy || overtimeBankPolicy.enabled !== true) {
+    return {
+      lots: total > 0 ? [{ source: null, sourceKey: `overtime_conversion:${requestId}`, minutes: total }] : [],
+      perSource: [],
+    }
+  }
+  const sourceMinutes = resolveOvertimeBankSourceMinutes(segments)
+  const order = ['workday', 'restday', 'statutory_holiday']
+  const totalWeight = order.reduce((sum, src) => sum + sourceMinutes[src], 0)
+  // the LAST source WITH non-zero weight absorbs the rounding remainder; a zero-weight source must get exactly
+  // 0 (else the remainder could be mis-attributed to a source that had no OT — e.g. must-pay statutory_holiday).
+  const lastWeighted = [...order].reverse().find((src) => sourceMinutes[src] > 0) ?? null
+  const perSource = []
+  let allocated = 0
+  order.forEach((source) => {
+    let minutes = 0
+    if (sourceMinutes[source] > 0) {
+      minutes = source === lastWeighted
+        ? Math.max(0, total - allocated)
+        : (totalWeight > 0 ? Math.floor((total * sourceMinutes[source]) / totalWeight) : 0)
+    }
+    allocated += minutes
+    perSource.push({ source, minutes })
+  })
+  const pooled = new Set(Array.isArray(overtimeBankPolicy.pooledSources) ? overtimeBankPolicy.pooledSources : [])
+  const lots = perSource
+    .filter((p) => p.minutes > 0 && pooled.has(p.source))
+    .map((p) => ({ source: p.source, sourceKey: `overtime_conversion:${requestId}:${p.source}`, minutes: p.minutes }))
+  return { lots, perSource }
+}
+
 function applyOvertimeSegmentationSnapshotToApprovedEntry(entry, snapshot) {
   if (!entry || !snapshot) return
   entry.workdayOvertimeMinutes += snapshot.workdayOvertimeMinutes
@@ -18347,6 +18401,8 @@ module.exports = {
   __attendanceOvertimeBankForTests: {
     OVERTIME_BANK_POOLABLE_SOURCES,
     normalizeOvertimeBankPolicySetting,
+    resolveOvertimeBankSourceMinutes,
+    partitionOvertimeBankGrantLots,
   },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
@@ -25714,29 +25770,60 @@ module.exports = {
               if (compTimeSettings?.compTimeFromOvertime?.enabled === true) {
                 const amountMinutes = resolveCompTimeGrantMinutesFromOvertimeMetadata(nextMetadata)
                 if (amountMinutes > 0) {
-                  const compTimeSourceKey = `overtime_conversion:${requestId}`
                   // ④ C4 (#2267): when expiresInDays is configured (positive int), stamp the grant with
                   // expires_at = granted_at + N×24h — a FIXED 24h-per-day duration, computed in SQL from
                   // the statement's now() (granted_at also defaults to now() → exact). null = no expiry
                   // (unchanged C2 behaviour). The AttendanceExpiryService (C4-1) reaps these.
                   const expiresInDays = compTimeSettings.compTimeFromOvertime.expiresInDays ?? null
-                  const lotRows = await trx.query(
-                    `INSERT INTO attendance_leave_balances
-                       (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, expires_at)
-                     VALUES ($1, $2, 'comp_time', $3, $3, 'overtime_conversion', $4, $5, 'active',
-                             CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '24 hours') END)
-                     ON CONFLICT (org_id, source_key) DO NOTHING
-                     RETURNING id`,
-                    [orgId, requestRow.user_id, amountMinutes, requestId, compTimeSourceKey, expiresInDays]
-                  )
-                  const newLotId = lotRows[0]?.id
-                  if (newLotId) {
-                    await trx.query(
-                      `INSERT INTO attendance_leave_balance_events
-                         (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
-                       VALUES ($1, $2, $3, 'grant', $4, 'overtime_conversion', $5)`,
-                      [orgId, requestRow.user_id, newLotId, amountMinutes, requestId]
+                  // 加班银行 v1-1b (design-lock §3 账1): gate per-source tagging on overtimeBankPolicy. DORMANT
+                  // (default, every current org) keeps the EXISTING single overtime_conversion lot with
+                  // overtime_source NULL — byte-identical to pre-v1-1b. ENABLED splits the rule-normalized
+                  // total into per-source pooled lots (statutory_holiday never pooled, §6); non-pooled OT is
+                  // must-pay (账4), not banked.
+                  const bankPolicy = compTimeSettings?.overtimeBankPolicy
+                  if (!bankPolicy || bankPolicy.enabled !== true) {
+                    const compTimeSourceKey = `overtime_conversion:${requestId}`
+                    const lotRows = await trx.query(
+                      `INSERT INTO attendance_leave_balances
+                         (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, expires_at)
+                       VALUES ($1, $2, 'comp_time', $3, $3, 'overtime_conversion', $4, $5, 'active',
+                               CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '24 hours') END)
+                       ON CONFLICT (org_id, source_key) DO NOTHING
+                       RETURNING id`,
+                      [orgId, requestRow.user_id, amountMinutes, requestId, compTimeSourceKey, expiresInDays]
                     )
+                    const newLotId = lotRows[0]?.id
+                    if (newLotId) {
+                      await trx.query(
+                        `INSERT INTO attendance_leave_balance_events
+                           (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+                         VALUES ($1, $2, $3, 'grant', $4, 'overtime_conversion', $5)`,
+                        [orgId, requestRow.user_id, newLotId, amountMinutes, requestId]
+                      )
+                    }
+                  } else {
+                    const segments = readOvertimeSegmentationSnapshot(nextMetadata)?.segments
+                    const { lots } = partitionOvertimeBankGrantLots({ requestId, totalMinutes: amountMinutes, segments, overtimeBankPolicy: bankPolicy })
+                    for (const lot of lots) {
+                      const lotRows = await trx.query(
+                        `INSERT INTO attendance_leave_balances
+                           (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, expires_at, overtime_source)
+                         VALUES ($1, $2, 'comp_time', $3, $3, 'overtime_conversion', $4, $5, 'active',
+                                 CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '24 hours') END, $7)
+                         ON CONFLICT (org_id, source_key) DO NOTHING
+                         RETURNING id`,
+                        [orgId, requestRow.user_id, lot.minutes, requestId, lot.sourceKey, expiresInDays, lot.source]
+                      )
+                      const newLotId = lotRows[0]?.id
+                      if (newLotId) {
+                        await trx.query(
+                          `INSERT INTO attendance_leave_balance_events
+                             (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+                           VALUES ($1, $2, $3, 'grant', $4, 'overtime_conversion', $5)`,
+                          [orgId, requestRow.user_id, newLotId, lot.minutes, requestId]
+                        )
+                      }
+                    }
                   }
                 }
               }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10238,13 +10238,14 @@ function partitionOvertimeBankGrantLots({ requestId, totalMinutes, segments, ove
   const sourceMinutes = resolveOvertimeBankSourceMinutes(segments)
   const order = ['workday', 'restday', 'statutory_holiday']
   const totalWeight = order.reduce((sum, src) => sum + sourceMinutes[src], 0)
-  // enabled but NO source breakdown (no segmentation snapshot / segmentation off) → fall back to the single
-  // NULL-source lot of the whole total, so the comp-time grant is never LOST (can't tag without sources).
+  // §P1 (owner review): enabled bank but the OT source is UNRESOLVABLE (no segmentation snapshot — e.g. the
+  // org enabled overtimeBankPolicy but not overtimeSegmentation) → FAIL CLOSED: pool NOTHING (the OT is
+  // must-pay, 账4, not banked). The grant-never-lost NULL-source whole-lot fallback is ONLY valid on the
+  // DORMANT legacy path (above); using it here would pool ANY OT — incl. statutory_holiday — into a single
+  // untagged lot, bypassing the §6 legal floor AND the customer's pooledSources config. (Forcing segmentation
+  // when bank is enabled is the cleaner UX — a follow-up; this slice closes the bypass.)
   if (totalWeight <= 0) {
-    return {
-      lots: total > 0 ? [{ source: null, sourceKey: `overtime_conversion:${requestId}`, minutes: total }] : [],
-      perSource: [],
-    }
+    return { lots: [], perSource: [] }
   }
   // the LAST source WITH non-zero weight absorbs the rounding remainder; a zero-weight source must get exactly
   // 0 (else the remainder could be mis-attributed to a source that had no OT — e.g. must-pay statutory_holiday).
@@ -12063,10 +12064,14 @@ function normalizeAnnualLeaveTiers(raw, fallbackTiers) {
 }
 
 // 加班银行可入池来源白名单 (OvertimeBankPolicy.pooledSources allowlist). statutory_holiday 故意缺席:§6 合规
-// 下限 —— 法定节假日加班按《劳动法》§44 必须支付、不得进调休池,无论管理员怎么配。adjusted_rest_day /
-// company_holiday 可配;workday 默认不入池(§11)但企业显式 opt-in 时允许。
+// 下限 —— 法定节假日加班按《劳动法》§44 必须支付、不得进调休池,无论管理员怎么配。
+// §P2 (owner review): v1-1b 的 source classification 只产出 workday / restday / statutory_holiday(holiday 桶
+// 保守映射成 statutory_holiday）。所以白名单**只暴露 v1-1b 真能产出且可入池的 {workday, restday}** —— 否则
+// 客户配 adjusted_rest_day / company_holiday / special_hours 入池会永远不生效,与 §6「非 statutory 可配」口径
+// 不符。这三个来源等日历层能区分 dayType 子类(statutory / adjusted_rest_day / company_holiday）后的后续切片
+// 再放进来。workday 默认不入池(§11)但企业显式 opt-in 时允许。
 const OVERTIME_BANK_POOLABLE_SOURCES = Object.freeze([
-  'workday', 'restday', 'adjusted_rest_day', 'company_holiday', 'special_hours',
+  'workday', 'restday',
 ])
 
 // OvertimeBankPolicy v1-1a LATENT normalizer. Fail-closed enum-strict: only the allowlist survives in
@@ -19510,7 +19515,7 @@ module.exports = {
       // 节假日加班 must be paid, not poolable), so a PUT including it is rejected at the API.
       overtimeBankPolicy: z.object({
         enabled: z.boolean().optional(),
-        pooledSources: z.array(z.enum(['workday', 'restday', 'adjusted_rest_day', 'company_holiday', 'special_hours'])).optional(),
+        pooledSources: z.array(z.enum(['workday', 'restday'])).optional(),
         maxMinutesPerPeriod: z.number().int().min(0).optional(),
         validityDays: z.number().int().positive().nullable().optional(),
       }).optional(),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10238,6 +10238,14 @@ function partitionOvertimeBankGrantLots({ requestId, totalMinutes, segments, ove
   const sourceMinutes = resolveOvertimeBankSourceMinutes(segments)
   const order = ['workday', 'restday', 'statutory_holiday']
   const totalWeight = order.reduce((sum, src) => sum + sourceMinutes[src], 0)
+  // enabled but NO source breakdown (no segmentation snapshot / segmentation off) → fall back to the single
+  // NULL-source lot of the whole total, so the comp-time grant is never LOST (can't tag without sources).
+  if (totalWeight <= 0) {
+    return {
+      lots: total > 0 ? [{ source: null, sourceKey: `overtime_conversion:${requestId}`, minutes: total }] : [],
+      perSource: [],
+    }
+  }
   // the LAST source WITH non-zero weight absorbs the rounding remainder; a zero-weight source must get exactly
   // 0 (else the remainder could be mis-attributed to a source that had no OT — e.g. must-pay statutory_holiday).
   const lastWeighted = [...order].reverse().find((src) => sourceMinutes[src] > 0) ?? null
@@ -25802,7 +25810,12 @@ module.exports = {
                       )
                     }
                   } else {
-                    const segments = readOvertimeSegmentationSnapshot(nextMetadata)?.segments
+                    // readOvertimeSegmentationSnapshot reshapes segments → workday/restday/holidayOvertimeMinutes;
+                    // rebuild the {…Minutes} shape the partition helper expects (no snapshot → null → fallback lot).
+                    const snap = readOvertimeSegmentationSnapshot(nextMetadata)
+                    const segments = snap
+                      ? { workdayMinutes: snap.workdayOvertimeMinutes, restdayMinutes: snap.restdayOvertimeMinutes, holidayMinutes: snap.holidayOvertimeMinutes }
+                      : null
                     const { lots } = partitionOvertimeBankGrantLots({ requestId, totalMinutes: amountMinutes, segments, overtimeBankPolicy: bankPolicy })
                     for (const lot of lots) {
                       const lotRows = await trx.query(


### PR DESCRIPTION
Second slice of the ratified 加班银行 design-lock. **Money path — held for your review, not auto-merged** (per the per-slice review rigor; a CI-green-but-wrong grant = wrong pay).

- **Migration**: `attendance_leave_balances.overtime_source` TEXT NULLABLE → existing + dormant rows stay NULL (byte-identical).
- **`partitionOvertimeBankGrantLots`** (pure, 7 unit tests): DORMANT → single NULL-source lot of the whole total; ENABLED → partition the **rule-normalized total** by per-source weights (rule once; **last non-zero source** absorbs remainder — a 0-weight source can't be mis-attributed, caught in test); only `pooledSources` become comp_time lots (keyed `…:${source}` → per-source replay idempotency); non-pooled = must-pay (账4). `holiday → statutory_holiday` **conservatively** (never poolable §6; finer holiday sub-types + special_hours deferred until the calendar exposes them).
- **Grant**: DORMANT branch = the existing single-lot INSERT **literally untouched**; ENABLED = per-source loop. Existing C2 (sections 1–3) proves dormant byte-identical; new C2 **section (4)** proves ENABLED per-source lots + **conservation** + **replay no double-credit** on real DB.

Unit 13/13, tsc 0. NS-3 partition discipline reused. Migration `zzzz20260624160000`.