### PR TITLE
fix(multitable): T9-R3.1 — redact view filter literals in /config-history (shipped-path leak hotfix)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -217,6 +217,7 @@ jobs:
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
+            tests/integration/multitable-config-history-view-redaction-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/docs/development/multitable-t9-config-history-readside-r3-r4-design-verification-20260624.md
+++ b/docs/development/multitable-t9-config-history-readside-r3-r4-design-verification-20260624.md
@@ -64,6 +64,23 @@ Deterministic order (`created_at DESC, id DESC`); `limit` clamped 1–100 (defau
 **narrows within** the allowed set and **cannot bypass** the gate (it is `AND`-ed onto the WHERE, so an actor filtering
 for a type they can't manage still gets empty). 401 if unauthenticated; 404 if the sheet doesn't exist.
 
+### 1.4 View payload projection — filter-literal redaction (T9-R3.1)
+
+The gate above decides which ROWS a caller sees; it does NOT decide which fields WITHIN a row. A
+`view` row's `before`/`after.filterInfo.conditions[].value` literals are **field-read-sensitive**
+(#2052/R9): the live view read already redacts them per-requester via
+`redactViewConfigFilterLiterals`, and `canManageViews` does **not** imply field-read. Config-history
+therefore MUST redact them too — otherwise a field-denied view-manager would read a denied field's
+filter literal through history (the gap this hotfix closes; R3 #3153 returned them raw). The single
+`/config-history` endpoint, for `view` rows, runs `before`/`after` through the requester's
+`loadAllowedFieldIds` + `redactViewConfigFilterLiterals` before returning. Other entity types
+(`field`, `permission`, `sheet_config`) are returned in full to the endpoint's cap-holder — config
+history has no per-record-value mask; this projection is view-filter-literal-specific. Proven
+end-to-end against R2's real recorded shape in
+`multitable-config-history-view-redaction-realdb.test.ts`: a view filtered on a denied field is
+written through the route (so R2 records the real shape), then a field-denied `canManageViews`
+reader does NOT see the literal while a fully-allowed reader does.
+
 ## 2. T9-R4 — FE config-history view
 
 A **dedicated** sheet-level **Config history** modal (`MetaConfigHistoryModal.vue`) — not folded into the per-record

--- a/docs/development/multitable-t9-readside-closeout-ledger-20260625.md
+++ b/docs/development/multitable-t9-readside-closeout-ledger-20260625.md
@@ -1,0 +1,40 @@
+# T9 (config-history) — read-side closeout + remaining-work ledger — 2026-06-25
+
+## Read side — COMPLETE (with this hotfix)
+
+| Slice | What | Status |
+|---|---|---|
+| T9-R1 | field config-revision recording | merged (#3126) + atomicity follow-up |
+| T9-R2 | permission / view / sheet_config recording + field-delete→view cascade | merged (#3130) + rollback goldens (#3138) |
+| T9-R3 | config-history READ API — single endpoint `GET /sheets/:sheetId/config-history?entityType=`, per-entity-type gate IN the WHERE clause (read-gate ≡ write-gate) | merged (#3153) |
+| **T9-R3.1** | **VIEW payload projection** — redact `before`/`after.filterInfo` literals on the single endpoint (field-read-sensitive, #2052/R9) | **this hotfix** — closes the shipped-path leak |
+| T9-R4 | dedicated FE config-history view (calls the single endpoint) | merged (#3155) |
+| docs | R3+R4 design & verification | merged (#3156), updated here with §1.4 (view payload projection) |
+
+After this hotfix the read side is **secure and complete**: revisions are gated per entity type by
+the authoring capability, and view filter literals are redacted per requester — verified end-to-end
+against R2's real recorded shape (`multitable-config-history-view-redaction-realdb.test.ts`).
+
+## Doc-consistency debt (low, no code impact)
+
+- **#3139** (merged design-lock, `e2a7d4578`) locked a **six-endpoint** R3 shape
+  (`/config-history/{fields,views,…}` + `/permissions/{…}`). Main shipped the **single** endpoint
+  (#3153) instead, and R4's FE uses it. **The authoritative R3 design is now #3156's doc** (single
+  endpoint + §1.4 redaction); #3139 is superseded as a design record. #3154 (the six-endpoint
+  implementation) was closed as superseded. No code divergence remains — only this historical note.
+
+## Remaining T9 work (each a separate, gated opt-in)
+
+- **T9-W — write side (restore / rollback of config).** The natural next main line, now that the
+  read side is closed. NOT started; it is design-heavy + security-sensitive (a config restore can
+  re-grant permissions, resurrect a deleted field, revert row-deny) and must be its own
+  **design-lock first** (capability gates per entity type, dry-run/preview, idempotency, and the
+  same write-gate symmetry as the read side). Open this last.
+- **Unified timeline** (one list across all entity types, row-gated through the same per-entity
+  capability) — deferred; the single endpoint already supports `entityType` filtering within the
+  gate, so this is a presentation enhancement, not a security item.
+- **FE polish** on the R4 view — out of scope here.
+
+## Discipline note
+T9-W is a separate explicit opt-in: design-lock → review → implement → review, the same cadence R1–R4
+followed. Do not begin T9-W implementation before its design-lock is reviewed.

--- a/docs/development/multitable-t9-readside-closeout-ledger-20260625.md
+++ b/docs/development/multitable-t9-readside-closeout-ledger-20260625.md
@@ -25,16 +25,25 @@ against R2's real recorded shape (`multitable-config-history-view-redaction-real
 
 ## Remaining T9 work (each a separate, gated opt-in)
 
-- **T9-W — write side (restore / rollback of config).** The natural next main line, now that the
-  read side is closed. NOT started; it is design-heavy + security-sensitive (a config restore can
-  re-grant permissions, resurrect a deleted field, revert row-deny) and must be its own
-  **design-lock first** (capability gates per entity type, dry-run/preview, idempotency, and the
-  same write-gate symmetry as the read side). Open this last.
+- **T9-W — write side (restore / rollback of config).** **Safe subset SHIPPED via #3164**
+  (design-lock + preview/execute): field name/order + view config-update revert; permission /
+  sheet_config / create / delete restore are GATED (deferred). Write-gate symmetry + dry-run
+  preview→execute + same-transaction recording are in place. **Remaining:**
+  - **preview-redaction follow-up — THIS PR:** #3164's `config-restore-preview` returned the view
+    `current`/`target` raw, leaking `filterInfo` literals to a field-denied `canManageViews` caller
+    (same class as the R3.1 `/config-history` leak, new entry point). Fixed here.
+  - **gated unsafe restore** (permission / sheet_config / create / delete) — each a later opt-in.
+  - **FE** for the restore flow.
 - **Unified timeline** (one list across all entity types, row-gated through the same per-entity
   capability) — deferred; the single endpoint already supports `entityType` filtering within the
   gate, so this is a presentation enhancement, not a security item.
 - **FE polish** on the R4 view — out of scope here.
 
+> Note: the **#3163** design-lock (PROPOSED) is superseded by #3164 (which shipped its own
+> design-lock + the narrower safe subset). Close #3163 or rewrite it as a post-#3164 *delta* design
+> for the still-gated unsafe-restore slices; do NOT land it as the current T9-W design-lock.
+
 ## Discipline note
-T9-W is a separate explicit opt-in: design-lock → review → implement → review, the same cadence R1–R4
+The still-gated T9-W slices (permission/sheet_config/create/delete restore, FE) are each a separate
+explicit opt-in: design-lock → review → implement → review, the same cadence R1–R4
 followed. Do not begin T9-W implementation before its design-lock is reviewed.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7581,11 +7581,26 @@ export function univerMetaRouter(): Router {
          FROM meta_config_revisions WHERE ${where} ORDER BY created_at DESC, id DESC LIMIT $${params.length - 1} OFFSET $${params.length}`,
         params,
       )).rows as Array<Record<string, unknown>>
-      return res.json({ ok: true, data: { items: rows.map((r) => ({
-        id: String(r.id), entityType: String(r.entity_type), entityId: String(r.entity_id), action: String(r.action),
-        before: r.before ?? null, after: r.after ?? null, changedKeys: r.changed_keys ?? [],
-        batchId: r.batch_id ?? null, actorId: r.actor_id ?? null, createdAt: r.created_at,
-      })), limit, offset } })
+      // T9-R3.1: VIEW rows carry filter literals (filterInfo.conditions[].value) that are
+      // field-read-sensitive (#2052/R9) — canManageViews does NOT imply field-read, so returning
+      // before/after.filterInfo raw would leak a denied field's literal through history. Redact per
+      // the requester's allowed fields, mirroring redactViewConfigFilterLiterals on the live view read.
+      const hasViewRow = rows.some((r) => String(r.entity_type) === 'view')
+      const allowedFieldIds = hasViewRow
+        ? await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+        : null
+      const redactViewPayload = (val: unknown): unknown =>
+        allowedFieldIds && val ? redactViewConfigFilterLiterals(val as { filterInfo?: unknown }, allowedFieldIds) : (val ?? null)
+      return res.json({ ok: true, data: { items: rows.map((r) => {
+        const isView = String(r.entity_type) === 'view'
+        return {
+          id: String(r.id), entityType: String(r.entity_type), entityId: String(r.entity_id), action: String(r.action),
+          before: isView ? redactViewPayload(r.before) : (r.before ?? null),
+          after: isView ? redactViewPayload(r.after) : (r.after ?? null),
+          changedKeys: r.changed_keys ?? [],
+          batchId: r.batch_id ?? null, actorId: r.actor_id ?? null, createdAt: r.created_at,
+        }
+      }), limit, offset } })
     } catch (err: unknown) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7637,7 +7637,18 @@ export function univerMetaRouter(): Router {
       if (!cap) return sendForbidden(res)
       const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
       if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
-      return res.json({ ok: true, data: { preview: computeRevertPreview(rev, snapshot) } })
+      const preview = computeRevertPreview(rev, snapshot)
+      // T9-W-L7: a VIEW revert preview shows `current`/`target` filterInfo, whose literals are
+      // field-read-sensitive (#2052/R9). canManageViews does NOT imply field-read, so redact them
+      // per the requester before returning (the same projection the /config-history read applies).
+      // EXECUTE re-computes the raw target server-side, so a field-denied restorer reverts correctly
+      // without ever seeing the denied literal.
+      if (rev.entity_type === 'view') {
+        const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+        preview.current = redactViewConfigFilterLiterals(preview.current as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
+        preview.target = redactViewConfigFilterLiterals(preview.target as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
+      }
+      return res.json({ ok: true, data: { preview } })
     } catch (err: unknown) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/integration/multitable-config-history-view-redaction-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-view-redaction-realdb.test.ts
@@ -1,0 +1,95 @@
+/**
+ * T9-R3.1 — VIEW filter-literal redaction on the SINGLE /config-history endpoint (real DB).
+ *
+ * Shipped-path security fix: the single endpoint (#3153) returned view `before`/`after` raw, so a
+ * view's `filterInfo.conditions[].value` literals — which are field-read-sensitive (#2052/R9) —
+ * leaked through config-history to a `canManageViews`-but-field-denied reader (`canManageViews`
+ * does NOT imply field-read). This proves the redaction against R2's REAL recorded shape: a view
+ * filtered on a denied field is written through the route (so R2 records it), then a field-denied
+ * reader does NOT see the denied literal while a fully-allowed reader does. Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_chvr_${TS}`
+const SHEET = `sheet_chvr_${TS}`
+const FLD_VISIBLE = `fld_chvr_visible_${TS}`
+const FLD_SECRET = `fld_chvr_secret_${TS}`
+const VISIBLE_LIT = 'chvr-visible-literal-keepme'
+const SECRET_LIT = 'chvr-secret-literal-do-not-leak'
+const U_FULL = `u_chvr_full_${TS}`
+const U_FIELDDENIED = `u_chvr_fdenied_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let actor: { id: string; roles: string[]; perms: string[] }
+const FULL = { id: U_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+// canManageViews (via write) but FLD_SECRET denied → must NOT see the secret filter literal.
+const FIELDDENIED = { id: U_FIELDDENIED, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+const listViews = (as: typeof FULL) => { actor = as; return request(app).get(`/api/multitable/sheets/${SHEET}/config-history?entityType=view`) }
+
+describeIfDatabase('multitable config-history — VIEW filter-literal redaction on the single endpoint (T9-R3.1, real DB)', () => {
+  let e2eViewId = ''
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = actor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CHVR Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CHVR Sheet'])
+    for (const [fid, name, order] of [[FLD_VISIBLE, 'Visible', 1], [FLD_SECRET, 'Secret', 2]] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET, name, 'string', '{}', order])
+    }
+    for (const u of [U_FULL, U_FIELDDENIED]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    // FLD_SECRET denied to the field-denied user (layer-3); FULL keeps field read.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET, FLD_SECRET, 'user', U_FIELDDENIED, false, false])
+    // Create + patch a view filtered on the denied field THROUGH the route → R2 records the real shape.
+    actor = FULL
+    const created = await request(app).post('/api/multitable/views').send({ sheetId: SHEET, name: 'CHVR View', type: 'grid' })
+    e2eViewId = created.body?.data?.view?.id
+    const patched = await request(app).patch(`/api/multitable/views/${e2eViewId}`).send({
+      filterInfo: { conjunction: 'and', conditions: [
+        { fieldId: FLD_VISIBLE, operator: 'is', value: VISIBLE_LIT },
+        { fieldId: FLD_SECRET, operator: 'is', value: SECRET_LIT },
+      ] },
+    })
+    if (!e2eViewId || patched.status !== 200) throw new Error(`view setup failed: create=${created.status} patch=${patched.status}`)
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [U_FULL, U_FIELDDENIED]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R2 recorded the view filter literal in the redactor path (sanity, pre-redaction)', async () => {
+    const rec = (await q(
+      `SELECT after FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='view' AND entity_id=$2 ORDER BY created_at DESC, id DESC LIMIT 1`,
+      [SHEET, e2eViewId],
+    )).rows[0] as { after: any } | undefined
+    expect(JSON.stringify(rec?.after)).toContain(SECRET_LIT)
+  })
+
+  test('field-denied canManageViews reader does NOT see the secret filter literal; fully-allowed DOES (VISIBLE stays)', async () => {
+    const denied = await listViews(FIELDDENIED)
+    expect(denied.status).toBe(200)
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_LIT) // shipped-path leak CLOSED
+    expect(JSON.stringify(denied.body)).toContain(VISIBLE_LIT) // no over-redaction
+
+    const full = await listViews(FULL)
+    expect(full.status).toBe(200)
+    expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it
+    expect(JSON.stringify(full.body)).toContain(VISIBLE_LIT)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-config-history-view-redaction-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-view-redaction-realdb.test.ts
@@ -92,4 +92,25 @@ describeIfDatabase('multitable config-history — VIEW filter-literal redaction 
     expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it
     expect(JSON.stringify(full.body)).toContain(VISIBLE_LIT)
   })
+
+  // T9-W preview path (same leak class via config-restore-preview): the view revert preview's
+  // current/target carries filterInfo — must be redacted for a field-denied canManageViews caller.
+  test('config-restore-preview redaction: field-denied canManageViews does NOT see the secret literal in current/target; fully-allowed DOES', async () => {
+    const rev = (await q(
+      `SELECT id FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='view' AND entity_id=$2 AND action='update' ORDER BY created_at DESC, id DESC LIMIT 1`,
+      [SHEET, e2eViewId],
+    )).rows[0] as { id: string } | undefined
+    expect(rev?.id).toBeTruthy()
+
+    actor = FIELDDENIED
+    const denied = await request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId: rev!.id })
+    expect(denied.status).toBe(200)
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_LIT) // preview leak CLOSED
+    expect(JSON.stringify(denied.body)).toContain(VISIBLE_LIT) // no over-redaction
+
+    actor = FULL
+    const full = await request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId: rev!.id })
+    expect(full.status).toBe(200)
+    expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it in the preview
+  })
 })


### PR DESCRIPTION
## Shipped-path security hotfix (against current origin/main)

R3 landed as a **single** endpoint `GET /sheets/:sheetId/config-history?entityType=` (#3153), and R4's FE (#3155) calls it. That endpoint returned config-history **view** rows' `before`/`after` **raw** — so a view's `filterInfo.conditions[].value` literals (field-read-sensitive, #2052/R9) leaked to a **`canManageViews`-but-field-denied** reader, bypassing the `redactViewConfigFilterLiterals` protection the live view read applies. `canManageViews` does not imply field-read.

(The per-entity-type WHERE-clause gate was correct — only the view **payload** leaked.)

### Fix
Keep the shipped single-endpoint shape; for **view rows only**, run `before`/`after` through the requester's `loadAllowedFieldIds` + `redactViewConfigFilterLiterals` before returning. Other entity types are returned in full to the endpoint's cap-holder (config history has no per-record mask).

### Verification
- New real-DB golden `multitable-config-history-view-redaction-realdb.test.ts` — **end-to-end against R2's real recorded shape**: a view filtered on a denied field is written through the route (R2 records it), the raw recorded row is asserted to hold the literal, then a field-denied `canManageViews` reader does **not** see it via `/config-history?entityType=view` while a fully-allowed reader does.
- Existing #3153 gate golden still 8/8; tsc 0; registered in `plugin-tests.yml`.
- #3156 verification doc updated — R3 (single endpoint) includes the view payload projection.

### Supersedes
**#3154** (the six-endpoint shape) is superseded — it diverged from the shipped single endpoint and wouldn't have fixed the live path (R4's UI uses the single endpoint). Closing it. The colonless-predicate hardening in #3154 isn't needed here — main's single endpoint gates via SQL `LIKE 'field:%'` (a real colon boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)