### PR TITLE
docs(approval): server-side amount total-check design-lock

### DIFF
--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -56,9 +56,13 @@ rows.
 3. **Exact comparison on a money-safe representation.**
    Compare `total` against `sum(rows[*][amountColumnId])` in integer minor units
    (or a fixed-scale decimal), NEVER raw IEEE float — `0.1 + 0.2` drift must not
-   create a phantom mismatch. The implementation scales each value to a fixed number
-   of decimal places (default 2), sums, and compares exactly. No tolerance band in
-   v1 (a money control is exact); a configurable epsilon is out of scope.
+   create a phantom mismatch. The scale is derived from the mapped number fields'
+   declared precision (approval `FormField.props`, aligned with the multitable
+   `property.decimals` convention where present), not hard-coded to "currency = 2".
+   When no precision is declared, the helper must preserve the submitted decimal
+   precision with an exact decimal parser/normalizer rather than rounding both
+   sides to two places. It then sums and compares exactly. No tolerance band in v1
+   (a money control is exact); a configurable epsilon is out of scope.
 
 4. **Mapped fields must be unconditionally visible; value gaps fail closed.**
    `pruneHiddenFormData` (`ApprovalGraphExecutor`) prunes at TWO granularities —
@@ -86,18 +90,19 @@ rows.
 
 6. **`amountConsistencyCheck` needs an explicit persisted home + an allowlisted
    re-emit — or it is silently dropped (the G-5 lesson).**
-   The mapping is a NEW persisted template field, and the exact audit that drove
-   G-5 applies: the template save/normalization path rebuilds its output from a
-   FIXED set of keys and drops anything it does not re-emit. So the mapping must
-   live in a dedicated, explicitly-normalized slot — a nullable
-   `amount_consistency_check` column on the template (parallel to `form_schema` /
-   `approval_graph`), NOT tucked inside `form_schema` or graph `metadata` where a
-   different normalizer owns the shape and would flatten it. Build scope therefore
-   includes a migration (new nullable column), the create/update-template DTO, and
-   an explicit normalize-and-re-emit of the mapping in the save path (validated per
-   "Mapping shape"). Without this, the control config is dropped on the first save
-   and the check silently never runs — fail-OPEN, the precise failure mode this lock
-   exists to prevent.
+   This is a TEMPLATE-LEVEL field, not a node config. It sits outside the #3129
+   complex-node config allowlist entirely, and the exact audit that drove G-5 still
+   applies: the template save/normalization path rebuilds its output from a FIXED
+   set of keys and drops anything it does not re-emit. So the mapping must live in a
+   dedicated, explicitly-normalized slot — a nullable `amount_consistency_check`
+   column on the template (parallel to `form_schema` / `approval_graph`), NOT tucked
+   inside `form_schema`, approval-node config, or graph `metadata` where a different
+   normalizer owns the shape and would flatten it. Build scope therefore includes a
+   migration (new nullable column), the create/update-template DTO, and an explicit
+   normalize-and-re-emit of the mapping in the save path (validated per "Mapping
+   shape"). Without this, the control config is dropped on the first save and the
+   check silently never runs — fail-OPEN, the precise failure mode this lock exists
+   to prevent.
 
 ## Mapping shape and authoring-time validation
 
@@ -112,11 +117,19 @@ the assignee-source allowlist discipline:
   `columns` (leaf sub-fields; the model already forbids nested `detail`).
 - none of the three referenced fields carries a `visibilityRule` — they must be
   unconditionally present so the check always has its inputs (Decision 4).
+- the comparison scale is derived from the mapped number fields' declared precision;
+  a missing precision declaration does NOT imply "round to two places".
 
 A mapping that points at a missing or wrong-typed field is REJECTED at save — the
 unsupported-config gate, not a runtime surprise. A template carrying an
 `amountConsistencyCheck` whose shape the backend does not re-emit is fail-closed in
 the authoring UI exactly as G-5 handles unknown approval-node keys.
+
+The amount-tier presets that motivated this lock MUST declare the mapping when the
+runtime slice lands. In particular, the shipped purchase amount-tier preset needs
+`{ totalFieldId: 'amount', detailFieldId: 'purchase_items', amountColumnId: 'amount' }`
+so the high-tier route is actually controlled by the line-item total. Presets that
+omit the mapping remain valid drafts, but they do NOT get this control.
 
 ## Build Gates
 
@@ -126,9 +139,11 @@ helper (no DB), unit-tested both directions:
 - matching total ↔ row sum → passes;
 - under-stated total (the bypass) → rejected;
 - over-stated total → rejected;
-- a hidden/pruned row drops out of BOTH sides → still consistent (no false reject);
+- mapped fields with any `visibilityRule` → rejected at template-save (the submit
+  helper never has to guess whether a pruned value should count);
+- decimal precision cases: `0.1 + 0.2` vs `0.3` passes, and a higher-precision
+  mapped amount (for example four decimal places) is not rounded to two places;
 - non-numeric total / non-array detail / non-numeric amount cell → rejected;
-- float-drift case (`0.1 + 0.2` vs `0.3`) → passes (money-safe scaling);
 - no mapping → no check (the helper is never invoked).
 
 ### Gate B — real-DB acceptance
@@ -140,6 +155,7 @@ smoke:
   written;
 - same template + a matching submission → `201` + created;
 - a mapping referencing a `visibilityRule`-bearing field → REJECTED at template-save;
+- the amount-tier preset mapping is persisted on create and survives readback;
 - template WITHOUT the mapping → unaffected (no check path executed).
 
 ### Gate C — no scope creep

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -13,16 +13,26 @@ fixes — the heavier one, detail-row auto-sum, is a separate later lock.
 
 ## Goal
 
-Make amount-tier routing tamper-resistant. When a template declares an
-amount-consistency mapping, the backend validates at SUBMIT time that the
-applicant-entered total equals the sum of that submission's detail-row amounts, and
-**rejects a mismatch fail-closed** before the approval graph is built. A total that
-does not match its own line items can no longer slip a request under the
-higher-tier threshold.
+**Bind the number that drives tier routing to the line items the approver actually
+sees.** When a template declares an amount-consistency mapping, the backend
+validates at SUBMIT time that the applicant-entered total equals the sum of that
+submission's detail-row amounts, and **rejects a mismatch fail-closed** before the
+approval graph is built.
 
-This is a CONTROL, not a convenience. It does NOT compute or auto-fill the total
-(that is detail-row auto-sum, a separate lock). It validates an applicant-supplied
-total against the applicant-supplied rows.
+Scope of the guarantee, stated precisely (this is a control, not magic):
+
+- It CLOSES the decouple — routing on a top-level `4000` while the line items sum
+  to `8000` (under-stating only the routing field to dodge the tier) is rejected.
+- It does NOT make amounts truthful. A submitter who under-states the total AND the
+  line items *consistently* still routes low — that is a truthfulness problem
+  (approver review, downstream reconciliation), outside this control's reach. Do
+  not describe this as "tamper-proof"; it binds routing to the visible line items,
+  it does not verify the line items are honest.
+
+It does NOT compute or auto-fill the total (that is detail-row auto-sum — a separate
+lock delivering the SAME routing guarantee with different ergonomics; see
+Non-Goals). It validates an applicant-supplied total against the applicant-supplied
+rows.
 
 ## Decisions
 
@@ -50,21 +60,44 @@ total against the applicant-supplied rows.
    of decimal places (default 2), sums, and compares exactly. No tolerance band in
    v1 (a money control is exact); a configurable epsilon is out of scope.
 
-4. **Hidden/pruned rows and empty states are handled consistently and fail closed.**
-   - The check runs on the SAME post-`pruneHiddenFormData` `formData` the graph
-     sees, so a conditionally hidden line item is excluded from BOTH the total
-     interpretation and the row sum — it can neither manufacture a false mismatch
-     nor open a hidden bypass.
-   - A missing or non-numeric total, a missing detail field, a non-array detail
-     value, or a non-numeric amount cell → fail-closed (reject), never silently
-     skipped. The form-schema validation already enforces field TYPES; this check
-     enforces VALUE consistency on top of a type-valid submission.
+4. **Mapped fields must be unconditionally visible; value gaps fail closed.**
+   `pruneHiddenFormData` (`ApprovalGraphExecutor`) prunes at TWO granularities —
+   whole top-level fields (by visibility), and individual CELLS within each detail
+   row (a sub-field `visibilityRule` evaluated per row, recursing the sub-schema).
+   It does NOT drop whole rows — the row-array length is preserved. So the dangerous
+   edge is a mapped field/cell being pruned AWAY, not a row vanishing.
+   - To remove that ambiguity entirely, the mapping REQUIRES its three referenced
+     fields — the total field, the detail field, and the amount column — to carry NO
+     `visibilityRule` (unconditionally visible), enforced at template-save
+     (fail-closed authoring). They can then never be pruned, so the check always has
+     well-defined inputs and reads the SAME post-prune `formData` the graph routes
+     on.
+   - With that guaranteed, value gaps still fail closed: a non-numeric/absent total,
+     a non-array detail value, or a row whose amount cell is empty/non-numeric →
+     reject (the control cannot verify a row it cannot read). The form-schema layer
+     enforces field TYPES; this check enforces VALUE consistency on a type-valid
+     submission.
 
 5. **One total ↔ one detail column, v1.**
    v1 maps exactly one top-level total to exactly one `number` column of one
    `detail` field. Multi-detail roll-ups, nested details (the model is one nesting
    level regardless), cross-field arithmetic, and currency conversion are out of
    scope.
+
+6. **`amountConsistencyCheck` needs an explicit persisted home + an allowlisted
+   re-emit — or it is silently dropped (the G-5 lesson).**
+   The mapping is a NEW persisted template field, and the exact audit that drove
+   G-5 applies: the template save/normalization path rebuilds its output from a
+   FIXED set of keys and drops anything it does not re-emit. So the mapping must
+   live in a dedicated, explicitly-normalized slot — a nullable
+   `amount_consistency_check` column on the template (parallel to `form_schema` /
+   `approval_graph`), NOT tucked inside `form_schema` or graph `metadata` where a
+   different normalizer owns the shape and would flatten it. Build scope therefore
+   includes a migration (new nullable column), the create/update-template DTO, and
+   an explicit normalize-and-re-emit of the mapping in the save path (validated per
+   "Mapping shape"). Without this, the control config is dropped on the first save
+   and the check silently never runs — fail-OPEN, the precise failure mode this lock
+   exists to prevent.
 
 ## Mapping shape and authoring-time validation
 
@@ -77,6 +110,8 @@ the assignee-source allowlist discipline:
 - `detailFieldId` references a top-level field of `type: 'detail'`.
 - `amountColumnId` references a `type: 'number'` entry in that detail field's
   `columns` (leaf sub-fields; the model already forbids nested `detail`).
+- none of the three referenced fields carries a `visibilityRule` — they must be
+  unconditionally present so the check always has its inputs (Decision 4).
 
 A mapping that points at a missing or wrong-typed field is REJECTED at save — the
 unsupported-config gate, not a runtime surprise. A template carrying an
@@ -97,10 +132,14 @@ helper (no DB), unit-tested both directions:
 - no mapping → no check (the helper is never invoked).
 
 ### Gate B — real-DB acceptance
-A real-DB `createApproval`, mirroring the create-template smoke:
+A real-DB `createApproval` + create/update-template, mirroring the create-template
+smoke:
+- the `amount_consistency_check` mapping survives a template save→reload round-trip,
+  NOT dropped by normalization (the Decision 6 silent-drop regression);
 - template WITH the mapping + a mismatched submission → REJECTED, no approval row
   written;
 - same template + a matching submission → `201` + created;
+- a mapping referencing a `visibilityRule`-bearing field → REJECTED at template-save;
 - template WITHOUT the mapping → unaffected (no check path executed).
 
 ### Gate C — no scope creep
@@ -108,9 +147,13 @@ The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that 
 the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
 
 ## Non-Goals
-- Detail-row auto-sum (computing/auto-filling the total) — separate later lock; it
-  is the stronger fix and removes the gameable separate total entirely, but it
-  pulls in a computed/rollup form-field capability and is the larger surface.
+- Detail-row auto-sum (computing/auto-filling the total) — separate later lock. It
+  delivers the SAME routing guarantee as this check (bind the routing total to the
+  visible line items), NOT a stronger one — a consistent low-baller defeats both
+  identically. It differs in ERGONOMICS (compute-and-lock the total vs
+  validate-and-reject) and is the larger surface (a computed/rollup form-field
+  capability). "Check first" is an ordering-by-cost call, not a claim auto-sum is
+  weaker.
 - Currency conversion / multi-currency arithmetic.
 - Multi-detail roll-ups or cross-field arithmetic.
 - A tolerance/epsilon band (v1 is exact).

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -1,6 +1,6 @@
 # Amount Server-Side Total Check — Design Lock
 
-Status: IMPLEMENTED BY #3176; FOLLOW-UP GAPS TRACKED
+Status: IMPLEMENTED BY #3176; FOLLOW-UP GAPS RESOLVED (§1 #3197 · §2 #3183 · §3 #3207)
 
 Grounding: the amount-tier approval line — design-lock
 `approval-amount-tier-template-presets-design-lock-20260624.md` plus the Gate-A

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -1,6 +1,6 @@
 # Amount Server-Side Total Check — Design Lock
 
-Status: RATIFIED — RUNTIME NOT BUILT
+Status: IMPLEMENTED BY #3176; FOLLOW-UP GAPS TRACKED
 
 Grounding: the amount-tier approval line — design-lock
 `approval-amount-tier-template-presets-design-lock-20260624.md` plus the Gate-A
@@ -88,28 +88,29 @@ rows.
    level regardless), cross-field arithmetic, and currency conversion are out of
    scope.
 
-6. **`amountConsistencyCheck` needs an explicit persisted home + an allowlisted
-   re-emit — or it is silently dropped (the G-5 lesson).**
-   This is a TEMPLATE-LEVEL field, not a node config. It sits outside the #3129
-   complex-node config allowlist entirely, and the exact audit that drove G-5 still
-   applies: the template save/normalization path rebuilds its output from a FIXED
-   set of keys and drops anything it does not re-emit. So the mapping must live in a
-   dedicated, explicitly-normalized slot — a nullable `amount_consistency_check`
-   column on the template (parallel to `form_schema` / `approval_graph`), NOT tucked
-   inside `form_schema`, approval-node config, or graph `metadata` where a different
-   normalizer owns the shape and would flatten it. Build scope therefore includes a
-   migration (new nullable column), the create/update-template DTO, and an explicit
-   normalize-and-re-emit of the mapping in the save path (validated per "Mapping
-   shape"). Without this, the control config is dropped on the first save and the
-   check silently never runs — fail-OPEN, the precise failure mode this lock exists
-   to prevent.
+6. **Persistence: versioned `formSchema.amountConsistencyCheck` (as built in #3176) —
+   the dedicated-column requirement is WITHDRAWN.**
+   An earlier draft of this decision required a dedicated `amount_consistency_check`
+   column on the parent template and argued AGAINST putting it in `form_schema`. That
+   was wrong: `form_schema` (and `approval_graph`) live on
+   `approval_template_versions`, not the parent `approval_templates`, so a
+   parent-template column would DRIFT from the version a running instance is pinned
+   to. #3176 instead put the mapping at `formSchema.amountConsistencyCheck`,
+   normalized + re-emitted in `assertFormSchema` (`normalizeAmountConsistencyCheck`)
+   and read in `createApproval` — version-pinned and explicitly allowlisted (not an
+   un-allowlisted key the form-schema normalizer would drop). This lock adopts that
+   home. The G-5 silent-drop risk does NOT disappear — it MOVES to the FRONTEND save
+   path: the `apps/web` `FormSchema` type and `buildFormSchema()` must carry
+   `amountConsistencyCheck` through, or the editing page rebuilds the schema without
+   it and drops the mapping on first save (Remaining gaps §1).
 
 ## Mapping shape and authoring-time validation
 
 `amountConsistencyCheck?: { totalFieldId: string; detailFieldId: string; amountColumnId: string }`
-sits on the template alongside `formSchema` / `approvalGraph`, is persisted
-verbatim, and is validated at TEMPLATE-SAVE time (fail-closed authoring), mirroring
-the assignee-source allowlist discipline:
+sits at `formSchema.amountConsistencyCheck` (version-pinned with the rest of the
+form schema), is normalized + re-emitted in `assertFormSchema`, and is validated at
+TEMPLATE-SAVE time (fail-closed authoring), mirroring the assignee-source allowlist
+discipline:
 
 - `totalFieldId` references a top-level field of `type: 'number'`.
 - `detailFieldId` references a top-level field of `type: 'detail'`.
@@ -149,8 +150,9 @@ helper (no DB), unit-tested both directions:
 ### Gate B — real-DB acceptance
 A real-DB `createApproval` + create/update-template, mirroring the create-template
 smoke:
-- the `amount_consistency_check` mapping survives a template save→reload round-trip,
-  NOT dropped by normalization (the Decision 6 silent-drop regression);
+- `formSchema.amountConsistencyCheck` survives a template save→reload round-trip AND
+  a FRONTEND editing-page save, NOT dropped by normalization (the Remaining-gaps §1
+  silent-drop regression);
 - template WITH the mapping + a mismatched submission → REJECTED, no approval row
   written;
 - same template + a matching submission → `201` + created;
@@ -161,6 +163,32 @@ smoke:
 ### Gate C — no scope creep
 The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that is
 the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
+
+## Remaining gaps (open follow-ups — #3176 shipped the capability, the gap is NOT fully closed)
+
+Tracked here, none in #3176. Sequence matters: FE preserve FIRST (it is the base
+save-path fix the rest depends on), THEN the preset mapping (a mapping added before
+the FE preserve would be dropped by the editing page on the next save), then the
+visibility policy.
+
+1. **[P1] FE authoring save silently drops the mapping.** The backend type carries
+   `FormSchema.amountConsistencyCheck`, but `apps/web/src/types/approval.ts`
+   `FormSchema` still has only `fields` and `buildFormSchema()` returns `{ fields }`
+   — so a template saved through the editing page loses the mapping (the G-5
+   silent-drop, now on the FE side). Fix: FE `FormSchema` type + `draftFromTemplate`
+   hydrate + `buildFormSchema` preserve + a mounted round-trip test.
+2. **[P1] Amount-tier presets do not declare the mapping.** `commonTemplatePresets.ts`
+   carries no `amountConsistencyCheck`, so the capability ships unused and the
+   amount-tier preset gap stays open. Wire reimbursement
+   `{ totalFieldId: 'amount', detailFieldId: 'expense_items', amountColumnId: 'amount' }`
+   and purchase `{ totalFieldId: 'amount', detailFieldId: 'purchase_items', amountColumnId: 'amount' }`,
+   with shape + real-DB coverage. DEPENDS on §1 (else an edited preset loses the mapping).
+3. **[P2] `visibilityRule` policy mismatch.** This lock (Decision 4 / Mapping shape /
+   Gate B) asserts a SAVE-TIME reject of `visibilityRule`-bearing mapped fields, but
+   `normalizeAmountConsistencyCheck` validates existence + type only — the shipped
+   behavior is fail-closed at SUBMIT (a pruned mapped field → absent value → reject),
+   not at save. Align one way: add the save-time reject, OR ratify "submit-time
+   fail-closed" and drop the save-time claim from those three places.
 
 ## Non-Goals
 - Detail-row auto-sum (computing/auto-filling the total) — separate later lock. It

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -164,23 +164,19 @@ smoke:
 The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that is
 the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
 
-## Remaining gaps (#3176 shipped the capability; §2 since closed by #3183; §1 and §3 open)
+## Remaining gaps (#3176 shipped the capability; §1 closed by #3197, §2 by #3183; §3 open)
 
-Status: #3183 landed the preset mapping (§2) BEFORE the FE preserve (§1), INVERTING
-the intended order — so the exposure §1 warned about is now live on shipped preset
-templates. FE preserve (§1) is the active first priority; the auto-sum lock (#3189,
-design-only) rides the same save path and is also blocked on it. Visibility (§3) last.
+Status: #3183 landed the preset mapping (§2) BEFORE the FE preserve (§1), inverting the
+intended order and briefly exposing shipped preset templates to a save-time drop — now
+CLOSED by #3197 (the §1 exposure is resolved). The auto-sum lock (#3189, design-only)
+rides the same save path and inherits this preserve. Only §3 (visibility) remains.
 
-1. **[P1 — ACTIVE EXPOSURE] FE authoring save silently drops the mapping on a
-   now-SHIPPED control.** With #3183 putting real mappings on the amount-tier presets
-   (§2), this is no longer hypothetical: a preset-created template carries
-   `formSchema.amountConsistencyCheck` (backend-persisted), but `templateAuthoring.ts`
-   has no hydrate/preserve — `draftFromTemplate` reads only `template.formSchema.fields`
-   and `buildFormSchema()` returns `{ fields }`. So the first time an admin opens such
-   a template in the authoring editor and saves, the mapping is silently dropped and
-   the control fails. The FE `FormSchema` TYPE already carries the field; the fix is
-   `draftFromTemplate` hydrate + `buildFormSchema` preserve + a mounted save round-trip
-   test. FIRST PRIORITY.
+1. **[CLOSED — #3197] FE authoring save preserves the mapping.** Closed by #3197
+   (merge `fd17ad2e7`): `TemplateAuthoringDraft` now carries `amountConsistencyCheck`,
+   `draftFromTemplate` hydrates it, and `buildFormSchema` re-emits it — so opening a
+   preset-created template in the authoring editor and saving no longer drops the
+   control. Guarded by a unit round-trip and a mounted save round-trip test. The active
+   exposure (a shipped preset control lost on the first authoring-page save) is resolved.
 2. **[DONE — #3183] Amount-tier presets declare the mapping.** Closed by `4f6cd83b2`
    (#3183): `commonTemplatePresets.ts` `withAmountConsistency()` wires reimbursement
    `{ amount, expense_items, amount }` and purchase `{ amount, purchase_items, amount }`,

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -64,23 +64,20 @@ rows.
    sides to two places. It then sums and compares exactly. No tolerance band in v1
    (a money control is exact); a configurable epsilon is out of scope.
 
-4. **Mapped fields must be unconditionally visible; value gaps fail closed.**
-   `pruneHiddenFormData` (`ApprovalGraphExecutor`) prunes at TWO granularities —
-   whole top-level fields (by visibility), and individual CELLS within each detail
-   row (a sub-field `visibilityRule` evaluated per row, recursing the sub-schema).
-   It does NOT drop whole rows — the row-array length is preserved. So the dangerous
-   edge is a mapped field/cell being pruned AWAY, not a row vanishing.
-   - To remove that ambiguity entirely, the mapping REQUIRES its three referenced
-     fields — the total field, the detail field, and the amount column — to carry NO
-     `visibilityRule` (unconditionally visible), enforced at template-save
-     (fail-closed authoring). They can then never be pruned, so the check always has
-     well-defined inputs and reads the SAME post-prune `formData` the graph routes
-     on.
-   - With that guaranteed, value gaps still fail closed: a non-numeric/absent total,
-     a non-array detail value, or a row whose amount cell is empty/non-numeric →
-     reject (the control cannot verify a row it cannot read). The form-schema layer
-     enforces field TYPES; this check enforces VALUE consistency on a type-valid
-     submission.
+4. **Structural validity at save; semantic / pruned absence fails closed at submit (as built, #3207).**
+   `pruneHiddenFormData` (`ApprovalGraphExecutor`) prunes at TWO granularities — whole
+   top-level fields (by visibility), and individual CELLS within each detail row (a
+   sub-field `visibilityRule` evaluated per row, recursing the sub-schema). It does NOT
+   drop whole rows — the row-array length is preserved.
+   - SAVE-time is STRUCTURAL: `normalizeAmountConsistencyCheck` validates that the
+     mapped fields exist and have the right types. Mapped fields MAY carry a
+     `visibilityRule` — they are NOT required to be unconditionally visible.
+   - SUBMIT-time is SEMANTIC and fail-closed: the check runs on the same post-prune
+     `formData` the graph routes on, so a `visibilityRule`-hidden mapped field/cell is
+     pruned → its value is absent → reject. A non-numeric/absent total, a non-array
+     detail value, or an empty/non-numeric amount cell likewise rejects (the control
+     cannot verify a field it cannot read). The control can never silently run on data
+     it can't see.
 
 5. **One total ↔ one detail column, v1.**
    v1 maps exactly one top-level total to exactly one `number` column of one
@@ -116,8 +113,6 @@ discipline:
 - `detailFieldId` references a top-level field of `type: 'detail'`.
 - `amountColumnId` references a `type: 'number'` entry in that detail field's
   `columns` (leaf sub-fields; the model already forbids nested `detail`).
-- none of the three referenced fields carries a `visibilityRule` — they must be
-  unconditionally present so the check always has its inputs (Decision 4).
 - the comparison scale is derived from the mapped number fields' declared precision;
   a missing precision declaration does NOT imply "round to two places".
 
@@ -140,8 +135,8 @@ helper (no DB), unit-tested both directions:
 - matching total ↔ row sum → passes;
 - under-stated total (the bypass) → rejected;
 - over-stated total → rejected;
-- mapped fields with any `visibilityRule` → rejected at template-save (the submit
-  helper never has to guess whether a pruned value should count);
+- a `visibilityRule`-hidden mapped field/cell → pruned to absent at submit → rejected
+  (semantic fail-closed; NOT a save-time reject);
 - decimal precision cases: `0.1 + 0.2` vs `0.3` passes, and a higher-precision
   mapped amount (for example four decimal places) is not rounded to two places;
 - non-numeric total / non-array detail / non-numeric amount cell → rejected;
@@ -156,7 +151,7 @@ smoke:
 - template WITH the mapping + a mismatched submission → REJECTED, no approval row
   written;
 - same template + a matching submission → `201` + created;
-- a mapping referencing a `visibilityRule`-bearing field → REJECTED at template-save;
+- a submission whose mapped field is `visibilityRule`-hidden (pruned → absent) → REJECTED at submit;
 - the amount-tier preset mapping is persisted on create and survives readback;
 - template WITHOUT the mapping → unaffected (no check path executed).
 
@@ -164,12 +159,13 @@ smoke:
 The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that is
 the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
 
-## Remaining gaps (#3176 shipped the capability; §1 closed by #3197, §2 by #3183; §3 open)
+## Remaining gaps (all resolved — §1 #3197, §2 #3183, §3 ratified by #3207)
 
-Status: #3183 landed the preset mapping (§2) BEFORE the FE preserve (§1), inverting the
-intended order and briefly exposing shipped preset templates to a save-time drop — now
-CLOSED by #3197 (the §1 exposure is resolved). The auto-sum lock (#3189, design-only)
-rides the same save path and inherits this preserve. Only §3 (visibility) remains.
+Status: §1 (FE preserve) closed by #3197, §2 (preset mapping) by #3183, and §3
+(visibility policy) ratified as-built by #3207 — this lock is now consistent with that
+verification record and has no open gap. The auto-sum lock (#3189, design-only) rides
+the same save path and inherits the §1 preserve. A save-time semantic visibility reject
+remains a deferred P2 hardening (§3 below), not a gap.
 
 1. **[CLOSED — #3197] FE authoring save preserves the mapping.** Closed by #3197
    (merge `fd17ad2e7`): `TemplateAuthoringDraft` now carries `amountConsistencyCheck`,
@@ -183,12 +179,13 @@ rides the same save path and inherits this preserve. Only §3 (visibility) remai
    with preset coverage. Retained as a record — the capability is shipped; its
    durability through the authoring editor depends on §1 (which landed AFTER it, hence
    the live exposure above).
-3. **[P2] `visibilityRule` policy mismatch.** This lock (Decision 4 / Mapping shape /
-   Gate B) asserts a SAVE-TIME reject of `visibilityRule`-bearing mapped fields, but
-   `normalizeAmountConsistencyCheck` validates existence + type only — the shipped
-   behavior is fail-closed at SUBMIT (a pruned mapped field → absent value → reject),
-   not at save. Align one way: add the save-time reject, OR ratify "submit-time
-   fail-closed" and drop the save-time claim from those three places.
+3. **[CLOSED — ratified as-built by #3207] `visibilityRule` policy.** Ratified doc-only
+   (no backend change): SAVE-time is STRUCTURAL (existence + type, via
+   `normalizeAmountConsistencyCheck`); SUBMIT-time is SEMANTIC and fail-closed (a
+   `visibilityRule`-hidden mapped field is pruned → absent → reject). Decision 4 /
+   Mapping shape / Gate A / Gate B above are aligned to that split. A SAVE-time semantic
+   reject of `visibilityRule`-bearing fields is left as a deferred P2 hardening (an
+   earlier authoring-time signal), NOT pursued now. Verification record: #3207.
 
 ## Non-Goals
 - Detail-row auto-sum (computing/auto-filling the total) — separate later lock. It

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -164,25 +164,29 @@ smoke:
 The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that is
 the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
 
-## Remaining gaps (open follow-ups — #3176 shipped the capability, the gap is NOT fully closed)
+## Remaining gaps (#3176 shipped the capability; §2 since closed by #3183; §1 and §3 open)
 
-Tracked here, none in #3176. Sequence matters: FE preserve FIRST (it is the base
-save-path fix the rest depends on), THEN the preset mapping (a mapping added before
-the FE preserve would be dropped by the editing page on the next save), then the
-visibility policy.
+Status: #3183 landed the preset mapping (§2) BEFORE the FE preserve (§1), INVERTING
+the intended order — so the exposure §1 warned about is now live on shipped preset
+templates. FE preserve (§1) is the active first priority; the auto-sum lock (#3189,
+design-only) rides the same save path and is also blocked on it. Visibility (§3) last.
 
-1. **[P1] FE authoring save silently drops the mapping.** The backend type carries
-   `FormSchema.amountConsistencyCheck`, but `apps/web/src/types/approval.ts`
-   `FormSchema` still has only `fields` and `buildFormSchema()` returns `{ fields }`
-   — so a template saved through the editing page loses the mapping (the G-5
-   silent-drop, now on the FE side). Fix: FE `FormSchema` type + `draftFromTemplate`
-   hydrate + `buildFormSchema` preserve + a mounted round-trip test.
-2. **[P1] Amount-tier presets do not declare the mapping.** `commonTemplatePresets.ts`
-   carries no `amountConsistencyCheck`, so the capability ships unused and the
-   amount-tier preset gap stays open. Wire reimbursement
-   `{ totalFieldId: 'amount', detailFieldId: 'expense_items', amountColumnId: 'amount' }`
-   and purchase `{ totalFieldId: 'amount', detailFieldId: 'purchase_items', amountColumnId: 'amount' }`,
-   with shape + real-DB coverage. DEPENDS on §1 (else an edited preset loses the mapping).
+1. **[P1 — ACTIVE EXPOSURE] FE authoring save silently drops the mapping on a
+   now-SHIPPED control.** With #3183 putting real mappings on the amount-tier presets
+   (§2), this is no longer hypothetical: a preset-created template carries
+   `formSchema.amountConsistencyCheck` (backend-persisted), but `templateAuthoring.ts`
+   has no hydrate/preserve — `draftFromTemplate` reads only `template.formSchema.fields`
+   and `buildFormSchema()` returns `{ fields }`. So the first time an admin opens such
+   a template in the authoring editor and saves, the mapping is silently dropped and
+   the control fails. The FE `FormSchema` TYPE already carries the field; the fix is
+   `draftFromTemplate` hydrate + `buildFormSchema` preserve + a mounted save round-trip
+   test. FIRST PRIORITY.
+2. **[DONE — #3183] Amount-tier presets declare the mapping.** Closed by `4f6cd83b2`
+   (#3183): `commonTemplatePresets.ts` `withAmountConsistency()` wires reimbursement
+   `{ amount, expense_items, amount }` and purchase `{ amount, purchase_items, amount }`,
+   with preset coverage. Retained as a record — the capability is shipped; its
+   durability through the authoring editor depends on §1 (which landed AFTER it, hence
+   the live exposure above).
 3. **[P2] `visibilityRule` policy mismatch.** This lock (Decision 4 / Mapping shape /
    Gate B) asserts a SAVE-TIME reject of `visibilityRule`-bearing mapped fields, but
    `normalizeAmountConsistencyCheck` validates existence + type only — the shipped

--- a/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
+++ b/docs/design/approval-amount-server-side-total-check-design-lock-20260624.md
@@ -1,0 +1,118 @@
+# Amount Server-Side Total Check — Design Lock
+
+Status: RATIFIED — RUNTIME NOT BUILT
+
+Grounding: the amount-tier approval line — design-lock
+`approval-amount-tier-template-presets-design-lock-20260624.md` plus the Gate-A
+approval-node source editor (#3124) — shipped with a written KNOWN CONTROL
+LIMITATION (Decision 1 of that lock): the amount gate reads the applicant-entered
+top-level `amount`, so a submitter can **under-state the total to route around the
+higher-amount approval tier**. That line is closed; this is a NEW, narrow lock that
+closes only that one gap, server-side. It is the lighter of the two documented
+fixes — the heavier one, detail-row auto-sum, is a separate later lock.
+
+## Goal
+
+Make amount-tier routing tamper-resistant. When a template declares an
+amount-consistency mapping, the backend validates at SUBMIT time that the
+applicant-entered total equals the sum of that submission's detail-row amounts, and
+**rejects a mismatch fail-closed** before the approval graph is built. A total that
+does not match its own line items can no longer slip a request under the
+higher-tier threshold.
+
+This is a CONTROL, not a convenience. It does NOT compute or auto-fill the total
+(that is detail-row auto-sum, a separate lock). It validates an applicant-supplied
+total against the applicant-supplied rows.
+
+## Decisions
+
+1. **Explicit declared mapping — never inferred.**
+   The check runs ONLY when the template config declares an `amountConsistencyCheck`
+   mapping `{ totalFieldId, detailFieldId, amountColumnId }`. No field-name
+   convention, no "find the amount field" heuristic — both are brittle and fail
+   OPEN. A template without the mapping is unaffected (no check). This mirrors the
+   G-5 discipline: the editor offers only what the backend explicitly accepts; the
+   control engages only on an explicit, validated declaration.
+
+2. **Server-side, fail-closed, at submit time.**
+   The check lives in `createApproval` (`ApprovalProductService`), AFTER
+   `pruneHiddenFormData` and BEFORE the runtime graph is built, so it sees exactly
+   the normalized `formData` the graph will route on. On a mismatch it raises a
+   validation error (HTTP 400, precise but non-leaking message) and the approval is
+   never created. A FE preview MAY mirror it for UX, but — as with
+   `normalizeApprovalGraph` — the backend is the SOLE arbiter and the preview never
+   relaxes it.
+
+3. **Exact comparison on a money-safe representation.**
+   Compare `total` against `sum(rows[*][amountColumnId])` in integer minor units
+   (or a fixed-scale decimal), NEVER raw IEEE float — `0.1 + 0.2` drift must not
+   create a phantom mismatch. The implementation scales each value to a fixed number
+   of decimal places (default 2), sums, and compares exactly. No tolerance band in
+   v1 (a money control is exact); a configurable epsilon is out of scope.
+
+4. **Hidden/pruned rows and empty states are handled consistently and fail closed.**
+   - The check runs on the SAME post-`pruneHiddenFormData` `formData` the graph
+     sees, so a conditionally hidden line item is excluded from BOTH the total
+     interpretation and the row sum — it can neither manufacture a false mismatch
+     nor open a hidden bypass.
+   - A missing or non-numeric total, a missing detail field, a non-array detail
+     value, or a non-numeric amount cell → fail-closed (reject), never silently
+     skipped. The form-schema validation already enforces field TYPES; this check
+     enforces VALUE consistency on top of a type-valid submission.
+
+5. **One total ↔ one detail column, v1.**
+   v1 maps exactly one top-level total to exactly one `number` column of one
+   `detail` field. Multi-detail roll-ups, nested details (the model is one nesting
+   level regardless), cross-field arithmetic, and currency conversion are out of
+   scope.
+
+## Mapping shape and authoring-time validation
+
+`amountConsistencyCheck?: { totalFieldId: string; detailFieldId: string; amountColumnId: string }`
+sits on the template alongside `formSchema` / `approvalGraph`, is persisted
+verbatim, and is validated at TEMPLATE-SAVE time (fail-closed authoring), mirroring
+the assignee-source allowlist discipline:
+
+- `totalFieldId` references a top-level field of `type: 'number'`.
+- `detailFieldId` references a top-level field of `type: 'detail'`.
+- `amountColumnId` references a `type: 'number'` entry in that detail field's
+  `columns` (leaf sub-fields; the model already forbids nested `detail`).
+
+A mapping that points at a missing or wrong-typed field is REJECTED at save — the
+unsupported-config gate, not a runtime surprise. A template carrying an
+`amountConsistencyCheck` whose shape the backend does not re-emit is fail-closed in
+the authoring UI exactly as G-5 handles unknown approval-node keys.
+
+## Build Gates
+
+### Gate A — submit-time check + fail-closed unit tests
+A pure `validateAmountTotalConsistency(formSchema, normalizedFormData, mapping)`
+helper (no DB), unit-tested both directions:
+- matching total ↔ row sum → passes;
+- under-stated total (the bypass) → rejected;
+- over-stated total → rejected;
+- a hidden/pruned row drops out of BOTH sides → still consistent (no false reject);
+- non-numeric total / non-array detail / non-numeric amount cell → rejected;
+- float-drift case (`0.1 + 0.2` vs `0.3`) → passes (money-safe scaling);
+- no mapping → no check (the helper is never invoked).
+
+### Gate B — real-DB acceptance
+A real-DB `createApproval`, mirroring the create-template smoke:
+- template WITH the mapping + a mismatched submission → REJECTED, no approval row
+  written;
+- same template + a matching submission → `201` + created;
+- template WITHOUT the mapping → unaffected (no check path executed).
+
+### Gate C — no scope creep
+The check only ever REJECTS; it NEVER mutates `formData` (no auto-fill — that is
+the auto-sum lock). No currency conversion, no multi-detail, no tolerance band.
+
+## Non-Goals
+- Detail-row auto-sum (computing/auto-filling the total) — separate later lock; it
+  is the stronger fix and removes the gameable separate total entirely, but it
+  pulls in a computed/rollup form-field capability and is the larger surface.
+- Currency conversion / multi-currency arithmetic.
+- Multi-detail roll-ups or cross-field arithmetic.
+- A tolerance/epsilon band (v1 is exact).
+- Inferring the total/amount fields by name or heuristic.
+- `job_title` / `rank` resolver and W7 approval-result write-back (their own locks).


### PR DESCRIPTION
## What

Docs-only design/verification record for the server-side amount total-check line, reconciled to the current main state.

The runtime capability has already landed in #3176. This PR records the as-built design and the remaining follow-up gaps rather than claiming runtime is still unbuilt.

## Current status

- Implemented by #3176: backend `formSchema.amountConsistencyCheck` normalization + `createApproval` submit-time check + unit/real-DB coverage.
- Persistence home: versioned `formSchema.amountConsistencyCheck`, not a separate parent-template column. The earlier dedicated-column idea is withdrawn because `form_schema` / `approval_graph` live on `approval_template_versions`.
- Remaining gaps tracked in the doc: **§1 FE authoring silent-drop — CLOSED by #3197** (the authoring save now carries `amountConsistencyCheck` through verbatim — round-trip unit + active-exposure mounted guard); **§2 amount-tier preset mappings — DONE by #3183** (`4f6cd83b2`); §3 the visibilityRule save-vs-submit policy — **ratified as-built (doc-only, see #3207)**: structural-at-save + semantic-at-submit; a save-time semantic reject stays a deferred P2 (not rushed).

## Key decisions

- Explicit declared mapping, never inferred.
- Server-side, fail-closed, at submit.
- Exact money-safe comparison using declared precision / exact decimal handling.
- One total field to one detail amount column in v1.
- No auto-fill / auto-sum in this lock.

## Validation

- Docs-only diff.
- CI green on #3161.
- #3176 is the runtime implementation PR; follow-up code PRs should be split from this doc record.




