### PR TITLE
feat(attendance): v1-2a LeaveOffsetPolicy latent config + normalizer (加班银行 §4 账2)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -8665,6 +8665,34 @@ attendanceIntegrationDescribe(
       return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
     }
 
+    it('round-trips leaveBalanceDeductionPolicy (wire lock): PUT→GET full shape, partial PUT preserves rules, bad pool → 400', async () => {
+      if (!baseUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-leaveoffset-wire-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const headers = { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' }
+      const putSettings = (body: Record<string, unknown>) =>
+        requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify(body) })
+      const originalSettings = await loadSettingsForTest(adminToken)
+      try {
+        const rules = [
+          { requestLeaveType: 'annual', deductFrom: ['annual'], insufficient: 'block' },
+          { requestLeaveType: 'personal_leave', deductFrom: ['comp_time'], insufficient: 'partial_unpaid_absence' },
+        ]
+        // (1) full PUT → GET returns the full shape (locks DEFAULT_SETTINGS + normalizeSettings + zod + mergeSettings).
+        expect((await putSettings({ leaveBalanceDeductionPolicy: { enabled: true, rules } })).status).toBe(200)
+        expect((await loadSettingsForTest(adminToken)).leaveBalanceDeductionPolicy).toEqual({ enabled: true, rules })
+        // (2) partial PUT preserves rules: PUT only { enabled:false } → rules NOT cleared (mergeSettings whitelist).
+        expect((await putSettings({ leaveBalanceDeductionPolicy: { enabled: false } })).status).toBe(200)
+        expect((await loadSettingsForTest(adminToken)).leaveBalanceDeductionPolicy).toEqual({ enabled: false, rules })
+        // (3) API enum reject: an unknown deductFrom pool → 400.
+        expect((await putSettings({ leaveBalanceDeductionPolicy: { rules: [{ requestLeaveType: 'x', deductFrom: ['bogus'] }] } })).status).toBe(400)
+      } finally {
+        await putSettings({ leaveBalanceDeductionPolicy: originalSettings.leaveBalanceDeductionPolicy }).catch(() => undefined)
+      }
+    })
+
     it('round-trips overtimeBankPolicy (wire lock): PUT→GET full shape, partial PUT preserves siblings, statutory_holiday → 400', async () => {
       if (!baseUrl) return
       const runSuffix = Date.now().toString(36)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -8688,6 +8688,8 @@ attendanceIntegrationDescribe(
         expect((await loadSettingsForTest(adminToken)).leaveBalanceDeductionPolicy).toEqual({ enabled: false, rules })
         // (3) API enum reject: an unknown deductFrom pool → 400.
         expect((await putSettings({ leaveBalanceDeductionPolicy: { rules: [{ requestLeaveType: 'x', deductFrom: ['bogus'] }] } })).status).toBe(400)
+        // (4) §P2 single-pool lock: a multi-pool deductFrom is rejected at the API (>1 element). Cross-pool is v2.
+        expect((await putSettings({ leaveBalanceDeductionPolicy: { rules: [{ requestLeaveType: 'personal_leave', deductFrom: ['comp_time', 'annual'] }] } })).status).toBe(400)
       } finally {
         await putSettings({ leaveBalanceDeductionPolicy: originalSettings.leaveBalanceDeductionPolicy }).catch(() => undefined)
       }

--- a/packages/core-backend/tests/unit/attendance-leave-offset-policy.test.ts
+++ b/packages/core-backend/tests/unit/attendance-leave-offset-policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceLeaveOffsetForTests as {
+  LEAVE_DEDUCTION_POOLS: readonly string[]
+  LEAVE_DEDUCTION_INSUFFICIENT_MODES: readonly string[]
+  normalizeLeaveBalanceDeductionPolicySetting: (raw: unknown) => {
+    enabled: boolean
+    rules: Array<{ requestLeaveType: string; deductFrom: string[]; insufficient: string }>
+  }
+}
+
+describe('#加班银行 v1-2a — LeaveOffsetPolicy normalizer (LATENT, enum-strict)', () => {
+  const norm = helpers.normalizeLeaveBalanceDeductionPolicySetting
+
+  it('default dormant: empty/garbage → { enabled:false, rules:[] }', () => {
+    expect(norm(undefined)).toEqual({ enabled: false, rules: [] })
+    expect(norm({})).toEqual({ enabled: false, rules: [] })
+    expect(norm('x')).toEqual({ enabled: false, rules: [] })
+  })
+
+  it('keeps valid rules; deductFrom enum-strict + de-duped; insufficient defaults to block', () => {
+    const r = norm({ enabled: true, rules: [
+      { requestLeaveType: 'annual', deductFrom: ['annual'], insufficient: 'block' },
+      { requestLeaveType: 'comp_time', deductFrom: ['comp_time'] },
+      { requestLeaveType: 'personal_leave', deductFrom: ['comp_time', 'annual', 'comp_time'], insufficient: 'partial_unpaid_absence' },
+    ] })
+    expect(r.enabled).toBe(true)
+    expect(r.rules).toEqual([
+      { requestLeaveType: 'annual', deductFrom: ['annual'], insufficient: 'block' },
+      { requestLeaveType: 'comp_time', deductFrom: ['comp_time'], insufficient: 'block' },
+      { requestLeaveType: 'personal_leave', deductFrom: ['comp_time', 'annual'], insufficient: 'partial_unpaid_absence' },
+    ])
+  })
+
+  it('drops invalid rules (no requestLeaveType, no valid pool, unknown pool/insufficient → defaults)', () => {
+    const r = norm({ rules: [
+      { deductFrom: ['comp_time'] },                                  // no requestLeaveType → dropped
+      { requestLeaveType: 'x', deductFrom: ['bogus'] },               // no valid pool → dropped
+      { requestLeaveType: 'y', deductFrom: ['unpaid', 42, 'bogus'] }, // keeps only 'unpaid'
+      { requestLeaveType: 'z', deductFrom: ['annual'], insufficient: 'nope' }, // bad insufficient → block
+    ] })
+    expect(r.rules).toEqual([
+      { requestLeaveType: 'y', deductFrom: ['unpaid'], insufficient: 'block' },
+      { requestLeaveType: 'z', deductFrom: ['annual'], insufficient: 'block' },
+    ])
+  })
+
+  it('the pool + insufficient vocabularies are the bounded enums', () => {
+    expect([...helpers.LEAVE_DEDUCTION_POOLS].sort()).toEqual(['annual', 'comp_time', 'unpaid'])
+    expect([...helpers.LEAVE_DEDUCTION_INSUFFICIENT_MODES].sort()).toEqual(['block', 'partial_unpaid_absence'])
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-leave-offset-policy.test.ts
+++ b/packages/core-backend/tests/unit/attendance-leave-offset-policy.test.ts
@@ -29,8 +29,17 @@ describe('#加班银行 v1-2a — LeaveOffsetPolicy normalizer (LATENT, enum-str
     expect(r.rules).toEqual([
       { requestLeaveType: 'annual', deductFrom: ['annual'], insufficient: 'block' },
       { requestLeaveType: 'comp_time', deductFrom: ['comp_time'], insufficient: 'block' },
-      { requestLeaveType: 'personal_leave', deductFrom: ['comp_time', 'annual'], insufficient: 'partial_unpaid_absence' },
+      // §P2: v1 single-pool — only the FIRST valid pool persists; the multi-pool order is NOT kept (that's v2).
+      { requestLeaveType: 'personal_leave', deductFrom: ['comp_time'], insufficient: 'partial_unpaid_absence' },
     ])
+  })
+
+  it('§P2 single-pool lock: a multi-pool deductFrom is truncated to the first valid pool (cross-pool is v2)', () => {
+    expect(norm({ rules: [{ requestLeaveType: 'personal_leave', deductFrom: ['comp_time', 'annual'] }] }).rules)
+      .toEqual([{ requestLeaveType: 'personal_leave', deductFrom: ['comp_time'], insufficient: 'block' }])
+    // a leading invalid pool is skipped; the first VALID pool wins.
+    expect(norm({ rules: [{ requestLeaveType: 'x', deductFrom: ['bogus', 'annual', 'comp_time'] }] }).rules)
+      .toEqual([{ requestLeaveType: 'x', deductFrom: ['annual'], insufficient: 'block' }])
   })
 
   it('drops invalid rules (no requestLeaveType, no valid pool, unknown pool/insufficient → defaults)', () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -12055,15 +12055,16 @@ function normalizeLeaveBalanceDeductionPolicySetting(raw) {
       ? rule.requestLeaveType.trim()
       : null
     if (!requestLeaveType) continue
-    const seen = new Set()
-    const deductFrom = []
+    // §P2 (owner review): v1 LOCKS single-pool — only the FIRST valid pool persists. The array SHAPE is kept
+    // forward-compatible (v2 will use the full ordered list for cross-pool deduction), but v1-2a must NOT
+    // persist a multi-pool order, or the customer's config would diverge from the v1-2b wiring (which deducts
+    // from one pool). Cross-pool order unlocks in v2. (The PUT zod also rejects >1 element — defense in depth.)
+    let firstPool = null
     for (const pool of Array.isArray(rule.deductFrom) ? rule.deductFrom : []) {
-      if (typeof pool === 'string' && LEAVE_DEDUCTION_POOLS.includes(pool) && !seen.has(pool)) {
-        seen.add(pool)
-        deductFrom.push(pool)
-      }
+      if (typeof pool === 'string' && LEAVE_DEDUCTION_POOLS.includes(pool)) { firstPool = pool; break }
     }
-    if (deductFrom.length === 0) continue // a rule must name ≥1 valid pool; unknown pools are dropped (fail-closed)
+    if (!firstPool) continue // a rule must name ≥1 valid pool; unknown pools are dropped (fail-closed)
+    const deductFrom = [firstPool]
     const insufficient = LEAVE_DEDUCTION_INSUFFICIENT_MODES.includes(rule.insufficient) ? rule.insufficient : 'block'
     rules.push({ requestLeaveType, deductFrom, insufficient })
   }
@@ -19504,7 +19505,7 @@ module.exports = {
         enabled: z.boolean().optional(),
         rules: z.array(z.object({
           requestLeaveType: z.string().min(1),
-          deductFrom: z.array(z.enum(['comp_time', 'annual', 'unpaid'])).min(1),
+          deductFrom: z.array(z.enum(['comp_time', 'annual', 'unpaid'])).min(1).max(1), // §P2: v1 single-pool; v2 unlocks >1
           insufficient: z.enum(['block', 'partial_unpaid_absence']).optional(),
         })).optional(),
       }).optional(),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -222,6 +222,12 @@ const DEFAULT_SETTINGS = {
     maxMinutesPerPeriod: 0,
     validityDays: null,
   },
+  // 加班银行 v1-2a (design-lock §4 账2): LeaveOffsetPolicy LATENT config. Default OFF / no rules → existing
+  // hardcoded per-type deduction unchanged. v1-2b wiring consumes it.
+  leaveBalanceDeductionPolicy: {
+    enabled: false,
+    rules: [],
+  },
   // 自动对班 (auto shift matching) — A1 preview/manual apply plus A2 scheduler auto-write.
   // Runtime still requires env flags in addition to these org settings.
   autoShiftMatching: {
@@ -11871,6 +11877,7 @@ function normalizeSettings(raw) {
     annualLeavePolicy: normalizeAnnualLeavePolicySetting(raw.annualLeavePolicy),
     overtimeSegmentation: normalizeOvertimeSegmentationSetting(raw.overtimeSegmentation),
     overtimeBankPolicy: normalizeOvertimeBankPolicySetting(raw.overtimeBankPolicy),
+    leaveBalanceDeductionPolicy: normalizeLeaveBalanceDeductionPolicySetting(raw.leaveBalanceDeductionPolicy),
     autoShiftMatching: normalizeAutoShiftMatchingSetting(raw.autoShiftMatching),
   }
 }
@@ -12030,6 +12037,37 @@ function normalizeOvertimeBankPolicySetting(raw) {
     maxMinutesPerPeriod: Math.max(0, parseNumber(value.maxMinutesPerPeriod, 0)),
     validityDays,
   }
+}
+
+// 加班银行 v1-2a (design-lock §4 账2 LeaveOffsetPolicy): the configurable leave-balance deduction policy —
+// which余额池 each leave type deducts from, in what order, and how to handle insufficiency. LATENT: default
+// { enabled:false, rules:[] } → the existing hardcoded per-type deduction (comp_time→comp_time, annual→annual)
+// is unchanged. The v1-2b wiring consumes it; v1 LOCKS single-pool (deductFrom[0]); cross-pool order is v2.
+const LEAVE_DEDUCTION_POOLS = Object.freeze(['comp_time', 'annual', 'unpaid'])
+const LEAVE_DEDUCTION_INSUFFICIENT_MODES = Object.freeze(['block', 'partial_unpaid_absence'])
+
+function normalizeLeaveBalanceDeductionPolicySetting(raw) {
+  const value = raw && typeof raw === 'object' ? raw : {}
+  const rules = []
+  for (const rule of Array.isArray(value.rules) ? value.rules : []) {
+    if (!rule || typeof rule !== 'object') continue
+    const requestLeaveType = typeof rule.requestLeaveType === 'string' && rule.requestLeaveType.trim()
+      ? rule.requestLeaveType.trim()
+      : null
+    if (!requestLeaveType) continue
+    const seen = new Set()
+    const deductFrom = []
+    for (const pool of Array.isArray(rule.deductFrom) ? rule.deductFrom : []) {
+      if (typeof pool === 'string' && LEAVE_DEDUCTION_POOLS.includes(pool) && !seen.has(pool)) {
+        seen.add(pool)
+        deductFrom.push(pool)
+      }
+    }
+    if (deductFrom.length === 0) continue // a rule must name ≥1 valid pool; unknown pools are dropped (fail-closed)
+    const insufficient = LEAVE_DEDUCTION_INSUFFICIENT_MODES.includes(rule.insufficient) ? rule.insufficient : 'block'
+    rules.push({ requestLeaveType, deductFrom, insufficient })
+  }
+  return { enabled: parseBoolean(value.enabled, false), rules }
 }
 
 function normalizeOvertimeSegmentationSetting(raw) {
@@ -12195,6 +12233,11 @@ function mergeSettings(base, update) {
     overtimeBankPolicy: {
       ...(base?.overtimeBankPolicy || {}),
       ...(update?.overtimeBankPolicy || {}),
+    },
+    // rules is an array → replaced wholesale when an update provides it (partial rule merges are meaningless).
+    leaveBalanceDeductionPolicy: {
+      ...(base?.leaveBalanceDeductionPolicy || {}),
+      ...(update?.leaveBalanceDeductionPolicy || {}),
     },
     autoShiftMatching: {
       ...(base?.autoShiftMatching || {}),
@@ -18348,6 +18391,11 @@ module.exports = {
     OVERTIME_BANK_POOLABLE_SOURCES,
     normalizeOvertimeBankPolicySetting,
   },
+  __attendanceLeaveOffsetForTests: {
+    LEAVE_DEDUCTION_POOLS,
+    LEAVE_DEDUCTION_INSUFFICIENT_MODES,
+    normalizeLeaveBalanceDeductionPolicySetting,
+  },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
     ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
@@ -19449,6 +19497,16 @@ module.exports = {
         pooledSources: z.array(z.enum(['workday', 'restday', 'adjusted_rest_day', 'company_holiday', 'special_hours'])).optional(),
         maxMinutesPerPeriod: z.number().int().min(0).optional(),
         validityDays: z.number().int().positive().nullable().optional(),
+      }).optional(),
+      // 加班银行 v1-2a — LeaveOffsetPolicy latent config. Round-trips through PUT/GET; v1-2b wiring consumes it.
+      // deductFrom enum = the余额池; v1 locks single-pool (deductFrom[0]), cross-pool order is v2.
+      leaveBalanceDeductionPolicy: z.object({
+        enabled: z.boolean().optional(),
+        rules: z.array(z.object({
+          requestLeaveType: z.string().min(1),
+          deductFrom: z.array(z.enum(['comp_time', 'annual', 'unpaid'])).min(1),
+          insufficient: z.enum(['block', 'partial_unpaid_absence']).optional(),
+        })).optional(),
       }).optional(),
       // 年假/法定假余额引擎 — L0 latent config (design-lock #2622). Round-trips through PUT/GET; no
       // runtime reads it until L2 (accrual). tiers = org-configurable statutory bands.


### PR DESCRIPTION
Third slice — 账2 foundation. Split v1-2 into **v1-2a** (this: dormant config + normalizer + wire, no behavior change, v1-1a pattern) + **v1-2b** (the deduction-order wiring on the existing `deductLeaveBalance`, gated). Off main (independent of v1-1b). **Held for review.**

- `leaveBalanceDeductionPolicy` LATENT { enabled:false, rules:[] } → existing per-type deduction unchanged.
- enum-strict normalizer (deductFrom ∈ {comp_time, annual, unpaid}, insufficient ∈ {block, partial_unpaid_absence}; invalid rules dropped). v1 locks single-pool in v1-2b; cross-pool = v2.
- Wired DEFAULT_SETTINGS + normalizeSettings + **mergeSettings** + zod. Unit 4/4 + **real-DB wire regression** (full shape · partial-preserve · bad-pool→400).