### PR TITLE
feat(multitable): T9-W config-restore — design-lock + safe-subset (preview + execute)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -216,6 +216,7 @@ jobs:
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
+            tests/integration/multitable-config-restore-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \

--- a/docs/development/multitable-t9w-config-restore-design-lock-20260624.md
+++ b/docs/development/multitable-t9w-config-restore-design-lock-20260624.md
@@ -1,0 +1,101 @@
+# T9-W — Config / Schema-Change RESTORE (WRITE-SIDE) — DESIGN-LOCK
+
+> Status: **DESIGN-LOCK, docs-only. Runtime GATED behind ratification of §6 (D1–D6) + an explicit owner opt-in per
+> slice.** This is the **write half** of T9, deferred out of the read-side lock
+> (`multitable-t9-config-history-readside-designlock-20260623.md`) exactly as the record line deferred the restore
+> write (T6/BS) behind the read+preview (T5/T7). The read side (R1–R4: record + display config history) is shipped;
+> this locks **mutating config back toward a prior recorded state**.
+>
+> Mirror of the record-restore discipline: **preview (read-only) → execute (forward-only write) → FE**, with the
+> destructive subset hard-gated behind a separate sign-off (as T8 Reset is to T8 Revert).
+
+## 1. Scope — what a config-restore does (and does NOT do)
+
+A config-restore takes a recorded `meta_config_revisions` entry (or an entity's state as-of a prior revision) and
+**re-applies that config forward** as a new change — never rewriting history. It operates on the same four entity
+types the read side records: **field**, **view**, **permission**, **sheet_config**.
+
+- **Revert a field property change** — restore a renamed/retyped/reconfigured field's prior config (name, options,
+  formula expression, link/rollup config, read-only, hidden). **← v1 candidate (safe subset).**
+- **Revert a view config change** — restore a view's prior filters / sorts / groups / hidden-fields / type. **← v1
+  candidate (safe subset).**
+- **Revert a permission change** — restore a prior `field_permissions` / sheet-access / view-permission / row-deny
+  grant. **← R-W2 (after the field/view safe subset).**
+- **Revert a sheet_config change** — restore a prior row-deny / conditional-rules / settings toggle. **← R-W2.**
+
+**Explicitly OUT of scope (hard boundary):**
+- **No mixed config+data restore (T9-W-L2).** A config-restore touches ONLY config. Restoring a *deleted field* does
+  NOT resurrect its cell data; restoring a *retype* does NOT recover values the retype dropped. Data history is the
+  record line's (T1–T8) job; the two never compose in one operation.
+- **Data-loss config operations are a separate, hard-gated slice (T9-W-L6)** — field-delete *undelete*, retype that
+  would reinterpret/lose values. Like T8 Reset, these need their own explicit owner sign-off after the safe subset is
+  proven. v1 ships the *non-data-loss* reverts only.
+
+## 2. Why this is dangerous (the threat model the locks address)
+
+1. **Schema drift.** The live entity may have changed *since* the target revision. Blindly writing the old config
+   overwrites intervening edits and can re-introduce a config that no longer matches the data (e.g. revert a field to
+   `number` after rows were typed as text). → **T9-W-L5: schema-drift is a conflict, not a silent overwrite.**
+2. **Restore is a NEW permission surface.** The read side gates *viewing* history per entity type; restore *writes*.
+   The write must re-apply the same per-entity config-manage capability at execute time. → **T9-W-L3: read-gate ≡
+   write-gate ≡ restore-gate.**
+3. **Irreversibility illusion.** Undeleting a field looks like "undo" but the column data is gone — the restore can't
+   honestly reverse it. → **T9-W-L2 + L6: no data resurrection; data-loss ops hard-gated.**
+4. **History divergence.** If restore rewrote `meta_config_revisions` it would corrupt the audit trail. → **T9-W-L1:
+   forward-only, append a new revision (`source=restore`), never rewrite.**
+
+## 3. The LOCKS (T9-W-L1 … L7)
+
+| Lock | Statement | Enforced by |
+|---|---|---|
+| **T9-W-L1** | **Forward-only, append-only.** Restore writes the new config + appends a `meta_config_revisions` row with `source=restore` (and a back-reference to the source revision/batch). It NEVER deletes/rewrites prior config-revisions. | Recorder writes a new row; no UPDATE/DELETE on `meta_config_revisions`. |
+| **T9-W-L2** | **No mixed config+data restore.** A config-restore mutates only config tables (`meta_fields` / `meta_views` / `field_permissions` / `meta_sheets`). It never touches `meta_records` / `meta_record_revisions`. Restoring a deleted field does NOT restore cell data. | Grep-verifiable: the restore write path has no record-table writes. |
+| **T9-W-L3** | **Read-gate ≡ write-gate ≡ restore-gate.** Restore re-checks, per entity type at execute time, the SAME capability the mutation route checks: field/field-perm → `canManageFields`; view/view-perm → `canManageViews`; sheet_config/sheet-perm → `canManageSheetAccess`. Not admin-bypassed silently. | Reuse the R3 gate mapping (shared helper). |
+| **T9-W-L4** | **Preview-first + preview-identity.** Every execute is preceded by a read-only preview; a server-verifiable identity binds the executed change to the previewed diff (scope + before/after hash + actor). A stale/forged identity is rejected. | Mint at preview, verify at execute (reuse `restore-preview-identity.ts` pattern). |
+| **T9-W-L5** | **Schema-drift is a conflict.** If the live entity's current config ≠ the target revision's `before` baseline (someone changed it since), restore does NOT blind-overwrite — preview flags it as a conflict and execute refuses until re-previewed. | Compare live config to the target revision's recorded baseline at preview + re-verify at execute. |
+| **T9-W-L6** | **Data-loss ops hard-gated.** Field-delete undelete and lossy retype are a SEPARATE slice behind a SEPARATE explicit owner sign-off (post safe-subset). v1 restore refuses them with an explicit "not supported in this slice" error, never a partial attempt. | Allowlist of safe op kinds; everything else fail-closed. |
+| **T9-W-L7** | **Atomic + idempotent.** The config write + the `source=restore` revision commit in ONE transaction. Re-submitting the same preview identity does not double-apply. | `pool.transaction` + idempotency key = preview identity. |
+
+Cross-arc reuse (already-proven locks this inherits): LOCK-3 no-existence-oracle (restore-preview counts/visibility are
+post-permission), field-audit LOCK-7 reveal-never-composes (a reveal grant never widens what restore writes),
+deterministic order LOCK-11 (the "as-of revision" pick).
+
+## 4. Restore semantics per entity type (v1 safe subset)
+
+| Entity | Safe revert (v1) | Hard-gated (T9-W-L6, later) |
+|---|---|---|
+| **field** | name, options, formula expression, link/rollup config, read-only, hidden, **non-lossy** retype | **delete→undelete**, **lossy retype** |
+| **view** | filters, sorts, groups, hidden fields, type, frozen columns, form-share config | view **delete→undelete** (recreate) |
+| **permission** | `field_permissions` / sheet-access / view-permission grant, row-deny toggle | — (revert is inherently non-lossy) → **R-W2** |
+| **sheet_config** | row-deny enabled, conditional-rules, settings | — → **R-W2** |
+
+"Revert one change" (undo a single recorded revision) is v1's unit. "Restore an entity to its full config as-of T"
+(compose multiple revisions) is a follow-up (D1).
+
+## 6. Decisions to ratify (D1–D6)
+
+- **D1 — scope unit.** Revert a single recorded revision (undo *this* change) vs restore an entity to its as-of-T
+  config (compose revisions). **Recommend: single-revision revert first**; as-of-T entity restore is a follow-up
+  (heavier; needs a config reconstructor analogous to the record reconstructor).
+- **D2 — entity coverage v1.** **Recommend: field + view safe reverts first** (highest value, non-lossy, clearest
+  semantics); permission + sheet_config reverts as R-W2; data-loss ops (undelete / lossy retype) hard-gated (L6).
+- **D3 — schema-drift policy.** **Recommend: reject-and-re-preview** (safest; matches the record line's conflict
+  policy) over apply-anyway-on-non-conflicting-keys.
+- **D4 — restore capability.** **Recommend: the same per-entity config-manage capability** (read-gate ≡ write-gate ≡
+  restore-gate, L3) — do not invent a new cap; restoring a field config needs `canManageFields`, same as editing it.
+- **D5 — preview identity.** **Recommend: a signed short-lived payload** binding {entity, target revision, before/after
+  hash, actor} — stateless, mirrors the record restore-preview-identity.
+- **D6 — confirmation + audit.** **Recommend: explicit confirmation for any restore + an audit trail** (the
+  `source=restore` revision already records actor/target/time; never logs record values).
+
+## 7. Gated TODO (T9-W-0 … T9-W-3)
+
+| Slice | What | Gate |
+|---|---|---|
+| **T9-W-0** | Ratify this lock (D1–D6) + opt-in. | Owner. |
+| 🔒 **T9-W-1** | **Config-restore PREVIEW** (read-only): given an entity + target revision, compute the would-be config diff, the schema-drift conflict flag (L5), and the safe-vs-gated op classification (L6). Write-free (asserted). Real-DB goldens. | T9-W-0. |
+| 🔒 **T9-W-2** | **Config-restore EXECUTE** (forward-only write): verify preview identity (L4) → re-gate per entity (L3) → schema-drift re-check (L5) → atomic forward write + `source=restore` revision (L1, L7). Refuses data-loss ops (L6). Real-DB goldens incl. **rollback/consistency** (a failed revision insert rolls back the config write) + **gate-deny** + **drift-reject** + **idempotency**, each mutation-proven. | T9-W-1. |
+| 🔒 **T9-W-3** | **FE config-restore panel**: from the R4 config-history view, "revert this change" → preview → confirm → execute. Faithful client. | T9-W-2. |
+| 🔒 **(separate)** | **Data-loss restore** (field undelete / lossy retype) — separate slice, separate sign-off. | Post-T9-W-2, owner re-ratify. |
+
+**Out of scope for T9-W:** record-data restore (T1–T8) · destructive table PIT (T8) · any config+data joint restore.

--- a/packages/core-backend/src/db/migrations/zzzz20260624200000_add_config_revision_source.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260624200000_add_config_revision_source.ts
@@ -1,0 +1,19 @@
+import { sql, type Kysely } from 'kysely'
+
+// T9-W-L1: a config-restore is forward-only — it appends a NEW meta_config_revisions row marked `source='restore'`
+// with a back-reference (`restored_from_id`) to the revision it reverted, so a restore is distinguishable from an
+// ordinary edit in the history and is itself inspectable. Existing rows + all current recording default to
+// `source='mutation'`. This never rewrites prior rows.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE meta_config_revisions
+      ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'mutation'
+        CHECK (source IN ('mutation', 'restore')),
+      ADD COLUMN IF NOT EXISTS restored_from_id uuid
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_config_revisions DROP COLUMN IF EXISTS restored_from_id`.execute(db)
+  await sql`ALTER TABLE meta_config_revisions DROP COLUMN IF EXISTS source`.execute(db)
+}

--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -1,0 +1,148 @@
+/**
+ * T9-W — config/schema-change RESTORE engine (write half of T9). Reverts a recorded `meta_config_revisions` change
+ * FORWARD (re-applies its `before` state as a new change), drift-guarded (T9-W-L5) and forward-only (T9-W-L1).
+ *
+ * v1 SAFE subset (T9-W-L6): field `name`/`order` reverts + all view config reverts (display-only, non-lossy).
+ * Everything else — field `type`/`property` (potentially lossy), create/delete (undelete), permission, sheet_config —
+ * is GATED in this slice and refused fail-closed. No record-data is ever touched (T9-W-L2).
+ */
+import { createHash } from 'node:crypto'
+
+type QueryFn = (text: string, params: unknown[]) => Promise<{ rows: unknown[] }>
+
+export interface ConfigRevisionRow {
+  id: string
+  sheet_id: string
+  entity_type: 'field' | 'permission' | 'view' | 'sheet_config'
+  entity_id: string
+  action: 'create' | 'update' | 'delete'
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changed_keys: string[]
+}
+
+export type RevertOpKind = 'safe' | 'gated'
+
+const SAFE_FIELD_KEYS = new Set(['name', 'order'])
+
+/** T9-W-L6: which reverts this slice supports. Everything not provably non-lossy is gated. */
+export function classifyRevert(rev: Pick<ConfigRevisionRow, 'entity_type' | 'action' | 'changed_keys'>): { kind: RevertOpKind; reason?: string } {
+  if (rev.action !== 'update') return { kind: 'gated', reason: 'only update reverts are supported in this slice (create/delete = undelete, gated)' }
+  if (rev.entity_type === 'view') return { kind: 'safe' } // view config is display-only, non-lossy
+  if (rev.entity_type === 'field') {
+    const unsafe = rev.changed_keys.filter((k) => !SAFE_FIELD_KEYS.has(k))
+    if (unsafe.length > 0) return { kind: 'gated', reason: `field ${unsafe.join('/')} reverts are not supported in this slice (potentially lossy)` }
+    return { kind: 'safe' }
+  }
+  return { kind: 'gated', reason: `${rev.entity_type} reverts are not supported in this slice` }
+}
+
+const stable = (v: unknown): string => JSON.stringify(v ?? null)
+function pick(snapshot: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const k of keys) out[k] = snapshot[k]
+  return out
+}
+
+/** A short stable hash of the entity's current config over the changed keys — binds execute to the previewed state. */
+export function configBaselineHash(snapshot: Record<string, unknown>, keys: string[]): string {
+  const picked: Record<string, unknown> = {}
+  for (const k of [...keys].sort()) picked[k] = snapshot[k] ?? null
+  return createHash('sha256').update(JSON.stringify(picked)).digest('hex').slice(0, 32)
+}
+
+export interface RevertPreview {
+  revisionId: string
+  entityType: string
+  entityId: string
+  changedKeys: string[]
+  current: Record<string, unknown>
+  /** the `before` state this revert would restore the changed keys to. */
+  target: Record<string, unknown>
+  /** T9-W-L5: the live config for the changed keys no longer matches what this change produced (`after`). */
+  driftConflict: boolean
+  opKind: RevertOpKind
+  gatedReason?: string
+  baselineHash: string
+}
+
+export function computeRevertPreview(rev: ConfigRevisionRow, currentSnapshot: Record<string, unknown>): RevertPreview {
+  const keys = rev.changed_keys
+  const before = rev.before ?? {}
+  const after = rev.after ?? {}
+  const current = pick(currentSnapshot, keys)
+  const driftConflict = keys.some((k) => stable(current[k]) !== stable(after[k]))
+  const { kind, reason } = classifyRevert(rev)
+  return {
+    revisionId: rev.id,
+    entityType: rev.entity_type,
+    entityId: rev.entity_id,
+    changedKeys: keys,
+    current,
+    target: pick(before, keys),
+    driftConflict,
+    opKind: kind,
+    ...(reason ? { gatedReason: reason } : {}),
+    baselineHash: configBaselineHash(currentSnapshot, keys),
+  }
+}
+
+// --- entity config snapshot loaders (current live config) ---
+
+export async function loadFieldConfigSnapshot(query: QueryFn, fieldId: string): Promise<Record<string, unknown> | null> {
+  const res = await query('SELECT name, type, property, "order" FROM meta_fields WHERE id = $1', [fieldId])
+  const row = res.rows[0] as { name: string; type: string; property: unknown; order: number } | undefined
+  if (!row) return null
+  return { name: row.name, type: row.type, property: row.property, order: row.order }
+}
+
+export async function loadViewConfigSnapshot(query: QueryFn, viewId: string): Promise<Record<string, unknown> | null> {
+  const res = await query('SELECT name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1', [viewId])
+  const row = res.rows[0] as Record<string, unknown> | undefined
+  if (!row) return null
+  return {
+    name: String(row.name),
+    type: String(row.type ?? 'grid'),
+    filterInfo: row.filter_info ?? null,
+    sortInfo: row.sort_info ?? null,
+    groupInfo: row.group_info ?? null,
+    hiddenFieldIds: row.hidden_field_ids ?? [],
+    config: row.config ?? null,
+  }
+}
+
+export async function loadEntityConfigSnapshot(query: QueryFn, rev: ConfigRevisionRow): Promise<Record<string, unknown> | null> {
+  if (rev.entity_type === 'field') return loadFieldConfigSnapshot(query, rev.entity_id)
+  if (rev.entity_type === 'view') return loadViewConfigSnapshot(query, rev.entity_id)
+  return null
+}
+
+// --- the revert WRITE (forward-only): set the changed keys back to `before` ---
+
+interface ColumnMap { col: string; jsonb?: boolean }
+const FIELD_COLUMN: Record<string, ColumnMap> = { name: { col: 'name' }, order: { col: '"order"' } }
+const VIEW_COLUMN: Record<string, ColumnMap> = {
+  name: { col: 'name' }, type: { col: 'type' },
+  filterInfo: { col: 'filter_info', jsonb: true }, sortInfo: { col: 'sort_info', jsonb: true },
+  groupInfo: { col: 'group_info', jsonb: true }, hiddenFieldIds: { col: 'hidden_field_ids', jsonb: true },
+  config: { col: 'config', jsonb: true },
+}
+
+/** Apply the revert: UPDATE the entity's changed columns to the revision's `before` values. Safe-op only (caller gates). */
+export async function applyConfigRevert(query: QueryFn, rev: ConfigRevisionRow): Promise<void> {
+  const map = rev.entity_type === 'field' ? FIELD_COLUMN : rev.entity_type === 'view' ? VIEW_COLUMN : null
+  const table = rev.entity_type === 'field' ? 'meta_fields' : rev.entity_type === 'view' ? 'meta_views' : null
+  if (!map || !table) throw new Error(`config revert not supported for entity_type=${rev.entity_type}`)
+  const before = rev.before ?? {}
+  const sets: string[] = []
+  const params: unknown[] = []
+  for (const k of rev.changed_keys) {
+    const m = map[k]
+    if (!m) throw new Error(`config revert not supported for key=${k}`)
+    params.push(m.jsonb ? JSON.stringify(before[k] ?? null) : before[k])
+    sets.push(`${m.col} = $${params.length}${m.jsonb ? '::jsonb' : ''}`)
+  }
+  if (sets.length === 0) return
+  params.push(rev.entity_id)
+  await query(`UPDATE ${table} SET ${sets.join(', ')} WHERE id = $${params.length}`, params)
+}

--- a/packages/core-backend/src/multitable/config-revision-recorder.ts
+++ b/packages/core-backend/src/multitable/config-revision-recorder.ts
@@ -25,12 +25,16 @@ export interface ConfigRevisionInput {
   /** groups a mutation with its cascaded derived changes (T9-L7); per-request. */
   batchId: string | null
   actorId: string | null
+  /** T9-W-L1: 'restore' marks a forward-only config-restore (default 'mutation' = an ordinary edit). */
+  source?: 'mutation' | 'restore'
+  /** T9-W-L1: when source='restore', the id of the meta_config_revisions row that was reverted (back-reference). */
+  restoredFromId?: string | null
 }
 
 export async function recordConfigRevision(query: QueryFn, input: ConfigRevisionInput): Promise<void> {
   await query(
-    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id)
-     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::text[], $8, $9)`,
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, source, restored_from_id)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::text[], $8, $9, $10, $11)`,
     [
       input.sheetId,
       input.entityType,
@@ -41,6 +45,8 @@ export async function recordConfigRevision(query: QueryFn, input: ConfigRevision
       input.changedKeys,
       input.batchId,
       input.actorId,
+      input.source ?? 'mutation',
+      input.restoredFromId ?? null,
     ],
   )
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -84,6 +84,13 @@ import {
   fieldUpdateDiff,
   fieldDeleteDiff,
 } from '../multitable/config-revision-recorder'
+import {
+  type ConfigRevisionRow,
+  classifyRevert,
+  computeRevertPreview,
+  loadEntityConfigSnapshot,
+  applyConfigRevert,
+} from '../multitable/config-restore'
 import { computeRecordRestoreDiff } from '../multitable/record-restore-diff'
 import {
   HISTORY_FIELD_AUDIT_GRANT_PERMISSION,
@@ -7591,6 +7598,85 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] config-history list failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to list config history' } })
+    }
+  })
+
+  // T9-W-1: config-restore PREVIEW (read-only). Given a recorded config revision, compute the would-be revert diff,
+  // the schema-drift conflict flag (T9-W-L5), and the safe-vs-gated classification (T9-W-L6). Writes nothing.
+  // Gated per entity type by the SAME capability that authored the change (read-gate ≡ write-gate ≡ restore-gate, L3).
+  router.post('/sheets/:sheetId/config-restore-preview', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const revisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId.trim() : ''
+    if (!sheetId || !revisionId) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and revisionId are required' } })
+    try {
+      const pool = poolManager.get()
+      const revRes = await pool.query('SELECT id, sheet_id, entity_type, entity_id, action, before, after, changed_keys FROM meta_config_revisions WHERE id = $1 AND sheet_id = $2', [revisionId, sheetId])
+      const rev = revRes.rows[0] as ConfigRevisionRow | undefined
+      if (!rev) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Config revision not found: ${revisionId}` } })
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      const cap = rev.entity_type === 'field' ? capabilities.canManageFields
+        : rev.entity_type === 'view' ? capabilities.canManageViews
+        : rev.entity_type === 'sheet_config' ? capabilities.canManageSheetAccess
+        : (capabilities.canManageFields || capabilities.canManageViews || capabilities.canManageSheetAccess)
+      if (!cap) return sendForbidden(res)
+      const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
+      if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
+      return res.json({ ok: true, data: { preview: computeRevertPreview(rev, snapshot) } })
+    } catch (err: unknown) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] config-restore preview failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to preview config restore' } })
+    }
+  })
+
+  // T9-W-2: config-restore EXECUTE (forward-only write). Re-gate (L3) → classify (L6, gated → 422) → atomic txn:
+  // re-read current, baseline-match (L4, stale → 409) + drift re-check (L5, drift → 409), apply the revert, and record
+  // a source=restore revision back-referencing the reverted one (L1). Config write + restore revision commit together
+  // (L7). Idempotent: after a revert the state no longer matches the preview's baseline hash, so a replay is rejected.
+  router.post('/sheets/:sheetId/config-restore-execute', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const revisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId.trim() : ''
+    const baselineHash = typeof req.body?.baselineHash === 'string' ? req.body.baselineHash : ''
+    if (!sheetId || !revisionId || !baselineHash) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, revisionId and baselineHash are required' } })
+    try {
+      const pool = poolManager.get()
+      const revRes = await pool.query('SELECT id, sheet_id, entity_type, entity_id, action, before, after, changed_keys FROM meta_config_revisions WHERE id = $1 AND sheet_id = $2', [revisionId, sheetId])
+      const rev = revRes.rows[0] as ConfigRevisionRow | undefined
+      if (!rev) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Config revision not found: ${revisionId}` } })
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      const cap = rev.entity_type === 'field' ? capabilities.canManageFields
+        : rev.entity_type === 'view' ? capabilities.canManageViews
+        : rev.entity_type === 'sheet_config' ? capabilities.canManageSheetAccess
+        : (capabilities.canManageFields || capabilities.canManageViews || capabilities.canManageSheetAccess)
+      if (!cap) return sendForbidden(res)
+      const classify = classifyRevert(rev)
+      if (classify.kind === 'gated') return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
+
+      // null = applied; a failure object = a guard tripped (the txn made no write either way).
+      const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {
+        const snapshot = await loadEntityConfigSnapshot(query, rev)
+        if (!snapshot) return { status: 409, code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot restore.' }
+        const preview = computeRevertPreview(rev, snapshot)
+        if (preview.baselineHash !== baselineHash) return { status: 409, code: 'PREVIEW_STALE', message: 'The config changed since preview; re-preview before restoring.' }
+        if (preview.driftConflict) return { status: 409, code: 'CONFIG_DRIFT', message: 'The config was changed after this revision; cannot safely revert without re-previewing.' }
+        await applyConfigRevert(query, rev)
+        await recordConfigRevision(query, {
+          sheetId, entityType: rev.entity_type, entityId: rev.entity_id, action: 'update',
+          before: preview.current, after: preview.target, changedKeys: rev.changed_keys,
+          batchId: randomUUID(), actorId: getRequestActorId(req), source: 'restore', restoredFromId: rev.id,
+        })
+        return null
+      })
+      if (failure) return res.status(failure.status).json({ ok: false, error: { code: failure.code, message: failure.message } })
+      return res.json({ ok: true, data: { restored: { revisionId, entityType: rev.entity_type, entityId: rev.entity_id, changedKeys: rev.changed_keys } } })
+    } catch (err: unknown) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] config-restore execute failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL', message: 'Failed to execute config restore' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-config-restore-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-restore-realdb.test.ts
@@ -1,0 +1,151 @@
+/**
+ * T9-W — config-restore (write half) — real DB. Verifies: preview is write-free; a safe revert restores the prior
+ * config AND records a source=restore revision (L1); the per-entity gate (L3); gated ops refused (L6); drift (L5) +
+ * stale-preview (L4) + idempotency rejected; and atomicity (L7 — a failed restore-revision insert rolls the config
+ * write back). Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_cw_${TS}`
+const SHEET = `sheet_cw_${TS}`
+const FIELD = `fld_cw_${TS}`
+const VIEW = `view_cw_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let currentActor: { id: string; roles: string[]; perms: string[] }
+const ADMIN = { id: `u_admin_${TS}`, roles: ['admin'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+const READER = { id: `u_reader_${TS}`, roles: ['member'], perms: ['multitable:read'] }
+
+const preview = (as: typeof ADMIN, revisionId: string) => { currentActor = as; return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId }) }
+const execute = (as: typeof ADMIN, body: Record<string, unknown>) => { currentActor = as; return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-execute`).send(body) }
+const fieldName = async () => String(((await q('SELECT name FROM meta_fields WHERE id = $1', [FIELD])).rows[0] as { name: string }).name)
+const insertRev = async (entityType: string, entityId: string, before: unknown, after: unknown, changedKeys: string[]) =>
+  String(((await q(
+    `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, actor_id)
+     VALUES ($1,$2,$3,'update',$4::jsonb,$5::jsonb,$6::text[],$7) RETURNING id`,
+    [SHEET, entityType, entityId, JSON.stringify(before), JSON.stringify(after), changedKeys, ADMIN.id],
+  )).rows[0] as { id: string }).id)
+
+let REV_FIELD = '' // a recorded field rename Old→New
+let REV_VIEW = '' // a recorded view filter change
+let REV_GATED = '' // a recorded field RETYPE (gated in this slice)
+
+describeIfDatabase('multitable config-restore — T9-W (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentActor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CW Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CW Sheet'])
+    // field currently named 'New' (post-rename); the revision records Old→New
+    await q(`INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,'New','string','{}'::jsonb,0)`, [FIELD, SHEET])
+    REV_FIELD = await insertRev('field', FIELD, { name: 'Old' }, { name: 'New' }, ['name'])
+    // view currently filtered {q:'new'}; the revision records {q:'old'}→{q:'new'}
+    await q(`INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
+             VALUES ($1,$2,'V','grid','{"q":"new"}'::jsonb,'{}'::jsonb,'{}'::jsonb,'[]'::jsonb,'{}'::jsonb)`, [VIEW, SHEET])
+    REV_VIEW = await insertRev('view', VIEW, { filterInfo: { q: 'old' } }, { filterInfo: { q: 'new' } }, ['filterInfo'])
+    REV_GATED = await insertRev('field', FIELD, { type: 'string' }, { type: 'number' }, ['type'])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('preview is WRITE-FREE and shows the revert target + safe classification', async () => {
+    const before = await fieldName()
+    const res = await preview(ADMIN, REV_FIELD)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.preview).toMatchObject({ entityType: 'field', entityId: FIELD, opKind: 'safe', driftConflict: false })
+    expect(res.body.data.preview.current).toMatchObject({ name: 'New' })
+    expect(res.body.data.preview.target).toMatchObject({ name: 'Old' })
+    expect(res.body.data.preview.baselineHash).toBeTruthy()
+    expect(await fieldName()).toBe(before) // nothing written
+  })
+
+  test('execute reverts the field rename AND records a source=restore revision (L1)', async () => {
+    const pv = await preview(ADMIN, REV_FIELD)
+    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })
+    expect(res.status).toBe(200)
+    expect(await fieldName()).toBe('Old') // reverted
+    const restoreRevs = await q(`SELECT before, after, source, restored_from_id FROM meta_config_revisions WHERE source = 'restore' AND restored_from_id = $1`, [REV_FIELD])
+    expect(restoreRevs.rows.length).toBe(1)
+    expect(restoreRevs.rows[0]).toMatchObject({ source: 'restore', restored_from_id: REV_FIELD })
+    expect((restoreRevs.rows[0] as any).after).toMatchObject({ name: 'Old' }) // the restore moved New→Old
+    // reset for later tests
+    await q(`UPDATE meta_fields SET name = 'New' WHERE id = $1`, [FIELD])
+    await q(`DELETE FROM meta_config_revisions WHERE source = 'restore'`, [])
+  })
+
+  test('a non-manager (canManageFields=false) is FORBIDDEN to preview or execute (L3)', async () => {
+    expect((await preview(READER, REV_FIELD)).status).toBe(403)
+    expect((await execute(READER, { revisionId: REV_FIELD, baselineHash: 'x' })).status).toBe(403)
+  })
+
+  test('a gated op (field RETYPE) is refused 422, not partially attempted (L6)', async () => {
+    const before = await fieldName()
+    const res = await execute(ADMIN, { revisionId: REV_GATED, baselineHash: 'whatever' })
+    expect(res.status).toBe(422)
+    expect(res.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
+    expect(await fieldName()).toBe(before) // untouched
+  })
+
+  test('a wrong baselineHash is rejected PREVIEW_STALE (L4)', async () => {
+    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: 'definitely-not-the-hash' })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('PREVIEW_STALE')
+  })
+
+  test('drift + idempotency: after a revert, replaying the same revision is rejected (L5/L7)', async () => {
+    const pv = await preview(ADMIN, REV_FIELD)
+    expect((await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(200)
+    expect(await fieldName()).toBe('Old')
+    // replay with the SAME (now-stale) hash → stale
+    expect((await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(409)
+    // a FRESH preview now flags drift (current 'Old' != the revision's after 'New') → execute rejected CONFIG_DRIFT
+    const pv2 = await preview(ADMIN, REV_FIELD)
+    expect(pv2.body.data.preview.driftConflict).toBe(true)
+    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv2.body.data.preview.baselineHash })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('CONFIG_DRIFT')
+    await q(`UPDATE meta_fields SET name = 'New' WHERE id = $1`, [FIELD])
+    await q(`DELETE FROM meta_config_revisions WHERE source = 'restore'`, [])
+  })
+
+  test('view config revert restores the prior filter', async () => {
+    const pv = await preview(ADMIN, REV_VIEW)
+    expect(pv.body.data.preview.opKind).toBe('safe')
+    expect((await execute(ADMIN, { revisionId: REV_VIEW, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(200)
+    const filter = (await q('SELECT filter_info FROM meta_views WHERE id = $1', [VIEW])).rows[0] as { filter_info: unknown }
+    expect(JSON.stringify(filter.filter_info)).toBe(JSON.stringify({ q: 'old' }))
+    await q(`UPDATE meta_views SET filter_info = '{"q":"new"}'::jsonb WHERE id = $1`, [VIEW])
+    await q(`DELETE FROM meta_config_revisions WHERE source = 'restore'`, [])
+  })
+
+  test('ATOMICITY (L7): a failing restore-revision insert rolls the config write back', async () => {
+    await q(`CREATE OR REPLACE FUNCTION _t9w_fail() RETURNS trigger AS $f$ BEGIN RAISE EXCEPTION 't9w injected'; END; $f$ LANGUAGE plpgsql`, [])
+    await q('CREATE TRIGGER _t9w_fail_trg BEFORE INSERT ON meta_config_revisions FOR EACH ROW EXECUTE FUNCTION _t9w_fail()', [])
+    try {
+      const pv = await preview(ADMIN, REV_FIELD)
+      const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })
+      expect(res.status).not.toBe(200) // the recording threw → whole txn rolled back
+      expect(await fieldName()).toBe('New') // the field name did NOT revert — config write rolled back with it
+    } finally {
+      await q('DROP TRIGGER IF EXISTS _t9w_fail_trg ON meta_config_revisions', [])
+      await q('DROP FUNCTION IF EXISTS _t9w_fail()', [])
+    }
+  })
+})


### PR DESCRIPTION
The **write half of T9** (config-history restore) — and the first time the config line writes. Includes the **design-lock** for review (`multitable-t9w-config-restore-design-lock-20260624.md`) and the **safe-subset v1** impl.

A config-restore reverts a recorded `meta_config_revisions` change **forward** (re-applies its `before` state as a new change) — never rewriting history (T9-W-L1).

**v1 safe subset** (T9-W-L6): field `name`/`order` reverts + all view config reverts (display-only, non-lossy). Everything else — field `type`/`property` (potentially lossy), create/delete (undelete), permission, sheet_config — is **gated and refused 422** in this slice. No record data is ever touched (T9-W-L2).

- migration: `meta_config_revisions` += `source` (`mutation`|`restore`) + `restored_from_id`
- `config-restore.ts`: classify (safe/gated), compute revert preview (drift flag L5 + baseline hash L4), apply forward
- `POST /sheets/:sheetId/config-restore-preview` (read-only) + `/config-restore-execute` (atomic forward write + source=restore revision), per-entity gate (read≡write≡restore-gate, L3)

## Verification
**9 real-DB goldens**: preview write-free; revert restores prior config + records source=restore (L1); gate-deny (L3, **mutation-proven** — neuter the gate → it fails); gated-op 422 (L6); stale-preview (L4); drift+idempotency (L5/L7); view config revert; **ATOMICITY** (a failed restore-revision insert rolls the config write back, L7). tsc clean; allowlisted.

**Gated for follow-up** (per the design-lock): data-loss ops (field undelete / lossy retype — separate sign-off), permission + sheet_config reverts (R-W2), the FE panel (T9-W-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)