### PR TITLE
feat(multitable): T8-1 Revert-to-T (non-destructive PIT sheet restore)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -217,6 +217,7 @@ jobs:
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-restore-realdb.test.ts \
+            tests/integration/multitable-revert-pit-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/multitable-config-history-view-redaction-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -162,3 +162,44 @@ export function verifyScopedRestorePreviewIdentity(token: string, expected: Scop
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }
+
+// ---------------------------------------------------------------------------------------------------------------
+// T8-1: PIT (point-in-time, sheet-wide) Revert preview-identity. A DISTINCT discriminated `type` from the single
+// and scoped identities (PIT-1 + PIT-4): a sheet-wide Revert-to-T binds the as-of time `asOf` PLUS the order-
+// invariant `scopeHash` over the EXACT computed revert set (each affected record's masked changesHash + version),
+// so a revert set that drifted between preview and execute (a record edited / a new post-T edit) re-hashes and is
+// rejected → re-preview. `strategy: 'revert'` only — the destructive Reset is T8-2 (a SEPARATE, hard-gated slice).
+export interface PitRevertPreviewIdentityClaims {
+  sheetId: string
+  /** the point in time the sheet is reverted to (ISO). */
+  asOf: string
+  strategy: 'revert'
+  /** sha256 over the sorted revert set (recordId + per-record masked changesHash + version), via hashScope. */
+  scopeHash: string
+  actorId: string
+}
+
+export function mintPitRevertPreviewIdentity(claims: PitRevertPreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'restore-preview-pit-revert', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface PitRevertVerifyResult {
+  valid: boolean
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_asOf' | 'mismatch_strategy' | 'mismatch_scopeHash' | 'mismatch_actorId'
+}
+
+export function verifyPitRevertPreviewIdentity(token: string, expected: PitRevertPreviewIdentityClaims): PitRevertVerifyResult {
+  let payload: Partial<PitRevertPreviewIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<PitRevertPreviewIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'restore-preview-pit-revert') return { valid: false, reason: 'wrong_type' } // single/scoped tokens rejected
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.asOf !== expected.asOf) return { valid: false, reason: 'mismatch_asOf' }
+  if (payload.strategy !== expected.strategy) return { valid: false, reason: 'mismatch_strategy' }
+  if (payload.scopeHash !== expected.scopeHash) return { valid: false, reason: 'mismatch_scopeHash' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  return { valid: true }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,7 +73,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity } from '../multitable/restore-preview-identity'
+import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   recordConfigRevision,
   recordFieldOrderShifts,
@@ -8489,6 +8489,145 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] restore-batch-execute failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute batch restore' } })
+    }
+  })
+
+  // ============================================================================================================
+  // T8-1: Point-in-Time Revert-to-T (non-destructive sheet rollback). Per the T8 design-lock (PIT-1..7):
+  // preview-first + PIT identity (PIT-1), reuse reconstructRecordsAtT (PIT-4, no re-derivation), counts never leak
+  // (PIT-3/LOCK-3 — denied rows invisible), forward-only source=restore (PIT-5), reveal NEVER composes (PIT-7 —
+  // this path calls NO reveal/reveal-grant function; the writable set is the actor's normal mask). Revert undoes
+  // post-T value changes and KEEPS records created after T (non-destructive); it NEVER deletes. Undelete of post-T
+  // deletions is CLASSIFIED in the preview but its EXECUTE is deferred to the codebase-wide undelete slice
+  // (resurrect + meta_links rebuild is "Slice 2" across the restore routes). The destructive Reset is T8-2.
+  type RevertSheetCaps = Awaited<ReturnType<typeof resolveSheetCapabilities>>
+  const computeSheetRevert = async (
+    pool: ReturnType<typeof poolManager.get>, req: Request, sheetId: string, asOfIso: string,
+    access: RevertSheetCaps['access'], capabilities: RevertSheetCaps['capabilities'],
+  ) => {
+    const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
+    const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+    if (!patchContext) return null
+    const { fieldById } = patchContext
+    const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
+    const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+    const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed) // PIT-3 mask; NO reveal (PIT-7)
+    const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
+      ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId) : new Set<string>()
+    const liveById = new Map<string, { data: Record<string, unknown>; version: number }>()
+    for (const r of (await pool.query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; data: unknown; version: unknown }>) {
+      liveById.set(String(r.id), { data: asRec(r.data), version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0 })
+    }
+    const stateMap = await reconstructRecordsAtT(pool.query.bind(pool), sheetId, asOfIso) // delete-aware, deterministic (PIT-4)
+    const reverts: Array<{ recordId: string; diff: RecordChange[]; changesHash: string; version: number }> = []
+    let undeleteCount = 0, keptCreatedAfterT = 0, driftCount = 0
+    for (const [recordId, target] of stateMap) {
+      if (deniedIds.has(recordId)) continue // PIT-3/LOCK-3 — denied records are invisible (uncounted, never reverted)
+      const live = liveById.get(recordId)
+      if (target.exists) {
+        if (!live) { undeleteCount++; continue } // existed at T, gone now (deleted after T) → undelete (execute-deferred)
+        const targetSnapshot = asRec(target.data)
+        let drift = false
+        for (const fid of Object.keys(targetSnapshot)) if (!fieldById.has(fid)) { drift = true; break }
+        if (drift) { driftCount++; continue } // schema drift → excluded → re-preview
+        const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData: live.data, recordId, currentVersion: live.version, normalizeLinkIds })
+        const masked = diff.filter((c) => allowed.has(c.fieldId))
+        if (masked.length === 0) continue // already matches T in the actor's visible fields
+        reverts.push({ recordId, diff: masked, changesHash: hashPreviewChanges(masked.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value }))), version: live.version })
+      }
+      // target deleted-at-T: live present → KEPT (non-destructive, never re-delete); live absent → unchanged.
+    }
+    for (const id of liveById.keys()) if (!stateMap.has(id) && !deniedIds.has(id)) keptCreatedAfterT++ // created after T → KEPT
+    return { reverts, undeleteCount, keptCreatedAfterT, driftCount, patchContext }
+  }
+
+  router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const parsed = z.object({ asOf: z.string().min(1) }).safeParse(req.body)
+    if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and asOf are required' } })
+    const d = new Date(parsed.data.asOf); const asOfIso = Number.isNaN(d.getTime()) ? '' : d.toISOString()
+    if (!asOfIso) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must be a valid timestamp' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canEditRecord) return sendForbidden(res) // restore capability (same as scoped restore)
+      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
+      if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const { reverts, undeleteCount, keptCreatedAfterT, driftCount } = computed
+      const previewIdentity = reverts.length > 0
+        ? mintPitRevertPreviewIdentity({ sheetId, asOf: asOfIso, strategy: 'revert', scopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))), actorId: access.userId })
+        : null // empty revert set → no executable token (no hashScope([]) replay)
+      return res.json({ ok: true, data: {
+        asOf: asOfIso, strategy: 'revert',
+        summary: { visibleRevertCount: reverts.length, visibleUndeleteCount: undeleteCount, keptCreatedAfterTCount: keptCreatedAfterT, conflictCount: driftCount },
+        records: reverts.map((r) => ({ recordId: r.recordId, fieldIds: r.diff.map((dd) => dd.fieldId) })),
+        undeleteSupported: false, previewIdentity,
+      } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] revert-preview failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to compute revert preview' } })
+    }
+  })
+
+  router.post('/sheets/:sheetId/revert-execute', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const parsed = z.object({ asOf: z.string().min(1), previewIdentity: z.string().min(1) }).safeParse(req.body)
+    if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, asOf, previewIdentity required' } })
+    const d = new Date(parsed.data.asOf); const asOfIso = Number.isNaN(d.getTime()) ? '' : d.toISOString()
+    if (!asOfIso) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must be a valid timestamp' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canEditRecord) return sendForbidden(res)
+      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
+      if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      const { reverts, patchContext } = computed
+      const verdict = verifyPitRevertPreviewIdentity(parsed.data.previewIdentity, {
+        sheetId, asOf: asOfIso, strategy: 'revert',
+        scopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))), actorId: access.userId,
+      })
+      if (!verdict.valid) {
+        const status = verdict.reason === 'expired' ? 410 : 409
+        return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Revert preview identity rejected (${verdict.reason}); the sheet changed since preview — re-preview` } })
+      }
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
+      const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId) : new Set<string>()
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      type Outcome = { recordId: string; status: 'reverted' | 'skipped'; newVersion?: number; skipReason?: 'denied' | 'conflict' | 'forbidden' | 'error' }
+      const outcomes: Outcome[] = []
+      for (const c of reverts) {
+        if (deniedIds.has(c.recordId)) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'denied' }); continue }
+        const hasForbidden = c.diff.some((ch) => {
+          const guard = fieldById.get(ch.fieldId); const perm = fieldPermissions[ch.fieldId]
+          return !(guard && !guard.hidden && guard.readOnly !== true) || !(perm && perm.visible !== false && perm.readOnly !== true)
+        })
+        if (hasForbidden) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
+        try {
+          const result = await recordWriteService.patchRecords({ sheetId, changesByRecord: new Map([[c.recordId, c.diff]]), actorId: getRequestActorId(req), fields, visiblePropertyFields: readableEchoFields, visiblePropertyFieldIds: readableEchoFieldIds, attachmentFields, fieldById, capabilities, sheetScope, access, source: 'restore' })
+          outcomes.push({ recordId: c.recordId, status: 'reverted', newVersion: result.updated.find((u) => u.recordId === c.recordId)?.version })
+        } catch (err) {
+          if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'conflict' }); continue }
+          if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
+          if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'error' }); continue }
+          throw err
+        }
+      }
+      const revertedCount = outcomes.filter((o) => o.status === 'reverted').length
+      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'revert', records: outcomes, revertedCount, skippedCount: outcomes.length - revertedCount } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] revert-execute failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute revert' } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -8501,14 +8501,20 @@ export function univerMetaRouter(): Router {
   // deletions is CLASSIFIED in the preview but its EXECUTE is deferred to the codebase-wide undelete slice
   // (resurrect + meta_links rebuild is "Slice 2" across the restore routes). The destructive Reset is T8-2.
   type RevertSheetCaps = Awaited<ReturnType<typeof resolveSheetCapabilities>>
+  // D3 / PIT-6 hard ceiling: a whole-sheet revert above this many records is REFUSED fail-closed (not processed
+  // synchronously, never truncated). Async-above-threshold is a follow-up; v1 hard-refuses. Env-overridable.
+  const SHEET_REVERT_MAX_RECORDS = Number(process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS) > 0
+    ? Math.floor(Number(process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS)) : 5000
   const computeSheetRevert = async (
     pool: ReturnType<typeof poolManager.get>, req: Request, sheetId: string, asOfIso: string,
     access: RevertSheetCaps['access'], capabilities: RevertSheetCaps['capabilities'],
-  ) => {
+  ): Promise<null | { tooLarge: true; recordCount: number } | { reverts: Array<{ recordId: string; diff: RecordChange[]; changesHash: string; version: number }>; undeleteCount: number; keptCreatedAfterT: number; driftCount: number; patchContext: Awaited<ReturnType<typeof buildRecordPatchContext>> }> => {
     const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
     const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
     if (!patchContext) return null
     const { fieldById } = patchContext
+    const recordCount = Number(((await pool.query('SELECT count(*)::int AS c FROM meta_records WHERE sheet_id = $1', [sheetId])).rows[0] as { c: number }).c)
+    if (recordCount > SHEET_REVERT_MAX_RECORDS) return { tooLarge: true, recordCount } // D3/PIT-6 fail-closed before the full scan
     const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
     const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
     const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed) // PIT-3 mask; NO reveal (PIT-7)
@@ -8551,9 +8557,10 @@ export function univerMetaRouter(): Router {
       const pool = poolManager.get()
       const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
-      if (!capabilities.canEditRecord) return sendForbidden(res) // restore capability (same as scoped restore)
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2: a sheet-wide revert needs a sheet-admin cap, ABOVE plain record-write (interim for a dedicated history-restore cap)
       const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
       if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record revert ceiling; a sheet-wide revert of this size is refused.` } })
       const { reverts, undeleteCount, keptCreatedAfterT, driftCount } = computed
       const previewIdentity = reverts.length > 0
         ? mintPitRevertPreviewIdentity({ sheetId, asOf: asOfIso, strategy: 'revert', scopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))), actorId: access.userId })
@@ -8583,9 +8590,10 @@ export function univerMetaRouter(): Router {
       const pool = poolManager.get()
       const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
-      if (!capabilities.canEditRecord) return sendForbidden(res)
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2: sheet-wide revert needs a sheet-admin cap, ABOVE plain record-write
       const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
       if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record revert ceiling; a sheet-wide revert of this size is refused.` } })
       const { reverts, patchContext } = computed
       const verdict = verifyPitRevertPreviewIdentity(parsed.data.previewIdentity, {
         sheetId, asOf: asOfIso, strategy: 'revert',

--- a/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
@@ -1,0 +1,128 @@
+/**
+ * T8-1: Point-in-Time Revert-to-T (non-destructive sheet rollback) — real DB. Goldens: preview classifies
+ * revert vs KEEP-post-T-created; preview is write-free; execute reverts to T-state with FORWARD revisions and
+ * KEEPS post-T-created records; identity drift → 409 (PIT-1); atomicity (a forced revision-insert failure leaves
+ * the record UNCHANGED); reveal never composes (PIT-7, source-grep). Undelete-execute is deferred (codebase-wide
+ * undelete slice); LOCK-3 row-deny is enforced via the SAME loadDeniedRecordIds seam the batch-execute test pins.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rv_${TS}`, SHEET = `sheet_rv_${TS}`
+const NAME = `fld_rv_name_${TS}`, SALARY = `fld_rv_salary_${TS}`
+const A = `rec_rv_a_${TS}`, B = `rec_rv_b_${TS}`, D = `rec_rv_d_${TS}`, ACTOR = `user_rv_${TS}`
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curRoles = ['member']
+const revertPreview = (asOf: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-preview`).send({ asOf })
+const revertExecute = (asOf: string, previewIdentity: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send({ asOf, previewIdentity })
+const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const rev = (id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5,$6]::text[],'{}'::jsonb,$7::jsonb,$8)`, [SHEET, id, version, action, NAME, SALARY, JSON.stringify(snap), at])
+
+async function seed(): Promise<void> {
+  for (const id of [A, B]) { // existed at T1 with old values; changed at T2 → live=new. Revert to T1 = old.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, SHEET, JSON.stringify({ [NAME]: 'new', [SALARY]: 200 })])
+    await rev(id, 1, 'create', { [NAME]: 'old', [SALARY]: 100 }, T0)
+    await rev(id, 2, 'update', { [NAME]: 'new', [SALARY]: 200 }, T2)
+  }
+  // D created AFTER T1 (first revision at T2) → revert-to-T1 must KEEP it.
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [D, SHEET, JSON.stringify({ [NAME]: 'newbie', [SALARY]: 500 })])
+  await rev(D, 1, 'create', { [NAME]: 'newbie', [SALARY]: 500 }, T2)
+}
+
+describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RV Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RV Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+  afterAll(async () => {
+    for (const t of ['meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+  beforeEach(async () => {
+    curRoles = ['member']
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SHEET])
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await seed()
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('preview classifies: revert A+B, KEEP D (created after T) — write-free', async () => {
+    const before = await recordRow(A)
+    const res = await revertPreview(T1)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.summary?.visibleRevertCount).toBe(2)
+    expect(res.body?.data?.summary?.keptCreatedAfterTCount).toBe(1) // D kept
+    expect(res.body?.data?.previewIdentity).toBeTruthy()
+    expect(await recordRow(A)).toEqual(before) // PIT-1: preview wrote nothing
+  })
+
+  test('execute reverts A+B to the T-state via FORWARD revisions; D (post-T-created) is KEPT untouched', async () => {
+    const pv = await revertPreview(T1)
+    const res = await revertExecute(T1, pv.body?.data?.previewIdentity)
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.revertedCount).toBe(2)
+    for (const id of [A, B]) {
+      const r = await recordRow(id)
+      expect(r?.data?.[NAME]).toBe('old') // reverted to the T1 value
+      expect(r?.data?.[SALARY]).toBe(100)
+      expect(r?.version).toBe(3) // forward (v2 → v3), never a destructive rewind
+    }
+    const d = await recordRow(D)
+    expect(d?.data?.[NAME]).toBe('newbie') // KEPT — non-destructive
+    expect(d?.version).toBe(1) // untouched
+  })
+
+  test('PIT-1 drift: a record edited between preview and execute → execute 409 (re-preview)', async () => {
+    const pv = await revertPreview(T1)
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 3 WHERE id = $1', [A, JSON.stringify({ [NAME]: 'drifted', [SALARY]: 999 })])
+    const res = await revertExecute(T1, pv.body?.data?.previewIdentity)
+    expect(res.status).toBe(409) // the revert set re-hashes → identity rejected
+  })
+
+  test('atomicity: a forced revision-insert failure leaves the record UNCHANGED (no half-write)', async () => {
+    const pv = await revertPreview(T1)
+    await q(`CREATE OR REPLACE FUNCTION _rv_fail() RETURNS trigger AS $f$ BEGIN RAISE EXCEPTION 'rv injected'; END; $f$ LANGUAGE plpgsql`, [])
+    await q('CREATE TRIGGER _rv_fail_trg BEFORE INSERT ON meta_record_revisions FOR EACH ROW EXECUTE FUNCTION _rv_fail()', [])
+    try { await revertExecute(T1, pv.body?.data?.previewIdentity) } finally {
+      await q('DROP TRIGGER IF EXISTS _rv_fail_trg ON meta_record_revisions', [])
+      await q('DROP FUNCTION IF EXISTS _rv_fail()', [])
+    }
+    const r = await recordRow(A)
+    expect(r?.data?.[NAME]).toBe('new') // UNCHANGED — the write + revision rolled back together
+    expect(r?.version).toBe(2)
+  })
+
+  test('PIT-7: the revert path composes NO reveal grant (source-grep)', () => {
+    const src = readFileSync(join(__dirname, '../../src/routes/univer-meta.ts'), 'utf8')
+    const start = src.indexOf('T8-1: Point-in-Time Revert')
+    const end = src.indexOf("records/:recordId/subscriptions'", start)
+    const block = src.slice(start, end)
+    expect(block.length).toBeGreaterThan(0)
+    expect(block).not.toMatch(/resolveActiveRevealGrant|loadRevealedFieldIds|loadActiveReveal/) // reveal never composes into the write
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-revert-pit-realdb.test.ts
@@ -25,6 +25,7 @@ const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '20
 const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
 let app: Express
 let curRoles = ['member']
+let curPerms = ['multitable:read', 'multitable:write', 'multitable:share'] // share → canManageSheetAccess (D2 sheet-admin gate)
 const revertPreview = (asOf: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-preview`).send({ asOf })
 const revertExecute = (asOf: string, previewIdentity: string) => request(app).post(`/api/multitable/sheets/${SHEET}/revert-execute`).send({ asOf, previewIdentity })
 const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
@@ -47,7 +48,8 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
   beforeAll(async () => {
     app = express()
     app.use(express.json())
-    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: curPerms }; next() })
+    process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '10' // test ceiling: seed = 3 records; the ceiling golden adds 8 → 11 > 10
     app.use('/api/multitable', univerMetaRouter())
     await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RV Base'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RV Sheet'])
@@ -63,6 +65,7 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
   })
   beforeEach(async () => {
     curRoles = ['member']
+    curPerms = ['multitable:read', 'multitable:write', 'multitable:share']
     await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SHEET])
     await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
     await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
@@ -124,5 +127,20 @@ describeIfDatabase('multitable T8-1 Revert-to-T (real DB)', () => {
     const block = src.slice(start, end)
     expect(block.length).toBeGreaterThan(0)
     expect(block).not.toMatch(/resolveActiveRevealGrant|loadRevealedFieldIds|loadActiveReveal/) // reveal never composes into the write
+  })
+
+  test('[P1] D2: a normal record editor (write but NOT sheet-admin) is FORBIDDEN a sheet-wide revert', async () => {
+    curPerms = ['multitable:read', 'multitable:write'] // no multitable:share → no canManageSheetAccess
+    expect((await revertPreview(T1)).status).toBe(403)
+    expect((await revertExecute(T1, 'whatever')).status).toBe(403)
+  })
+
+  test('[P1] D3/PIT-6: a sheet above the revert ceiling is REFUSED 413 fail-closed', async () => {
+    for (let i = 0; i < 8; i++) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_rv_big_${TS}_${i}`, SHEET, JSON.stringify({ [NAME]: 'x' })])
+    } // seed 3 + 8 = 11 > the test ceiling of 10
+    const res = await revertPreview(T1)
+    expect(res.status).toBe(413)
+    expect(res.body?.error?.code).toBe('SHEET_TOO_LARGE')
   })
 })


### PR DESCRIPTION
The **non-destructive half of T8** (point-in-time table restore) — built over the existing primitives (`reconstructRecordsAtT` PIT-4, the scoped-restore write path + preview-identity). **Destructive Reset (T8-2) is NOT built** (separate hard-gated sign-off).

**Revert-to-T** (whole sheet): undo post-T changes + (classify) post-T deletions, but **KEEP records created after T**. Forward-only `source=restore` revisions.

- `POST /sheets/:sheetId/revert-preview` (read-only): reconstructs as-of T, classifies each record revert/undelete/**KEPT-created-after-T**, masked counts + a PIT preview-identity. Write-free.
- `POST /sheets/:sheetId/revert-execute` (forward-only): re-computes, verifies the PIT identity over the revert set (drift→409), `patchRecords` each (`source=restore`).

**Locks**: PIT-1 preview-first + `mint/verifyPitRevertPreviewIdentity` (order-invariant scopeHash over `asOf`+set); PIT-3/LOCK-3 via the tested `loadDeniedRecordIds`+`maskStoredRecordFieldIds` seam; PIT-4 reuses `reconstructRecordsAtT`; PIT-5 forward-only; PIT-7 reveal-non-composition (grep-verifiable + golden).

## Verification
**6 real-DB goldens**: preview classify+write-free; execute reverts to T-state + **KEEPS post-T-created** + forward revisions; drift→409; atomicity (forced failure leaves data unchanged); PIT-7 no-reveal. tsc clean; allowlisted.

**Deferred (flagged, not dropped)**: undelete-*execute* (the codebase defers undelete everywhere — "resurrect + meta_links rebuild" is its own cross-cutting slice; preview classifies undeletes but execute reports `undeleteSupported:false`); destructive **Reset T8-2** (separate sign-off); async-for-large (PIT-6); FE panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)