### PR TITLE
feat(multitable): T9 sub-features — config-revision retention (D4) + config-history hasMore

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -218,6 +218,7 @@ jobs:
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-restore-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \
+            tests/integration/multitable-config-revision-retention-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/multitable-config-history-view-redaction-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \

--- a/packages/core-backend/src/multitable/meta-revision-retention.ts
+++ b/packages/core-backend/src/multitable/meta-revision-retention.ts
@@ -130,6 +130,57 @@ export async function sweepMetaRevisionRetention(
   return result.rowCount ?? 0
 }
 
+export const META_CONFIG_REVISION_RETENTION_TABLE = 'meta_config_revisions'
+
+/**
+ * T9 D4 — prune old CONFIG/schema-change history (`meta_config_revisions`) by the SAME policy as record revisions
+ * (one knob set ages both; disabled by default). The latest revision per (sheet_id, entity_type, entity_id) is ALWAYS
+ * retained (row_number=1 over created_at DESC, id DESC), so the current config is always inspectable and the most
+ * recent change stays revertible (T9-W). Bounded per pass by batchSize.
+ */
+export async function sweepConfigRevisionRetention(
+  query: RetentionQueryFn,
+  config: MetaRevisionRetentionConfig,
+): Promise<number> {
+  if (!config.enabled) return 0
+  const batchSize = Math.max(1, Math.floor(config.batchSize))
+
+  if (config.policy === 'keep-days') {
+    const days = Math.max(META_REVISION_RETENTION_MIN_DAYS, Math.floor(config.retentionDays))
+    const result = await query(
+      `DELETE FROM ${META_CONFIG_REVISION_RETENTION_TABLE}
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id, created_at,
+                   row_number() OVER (PARTITION BY sheet_id, entity_type, entity_id ORDER BY created_at DESC, id DESC) AS rn
+            FROM ${META_CONFIG_REVISION_RETENTION_TABLE}
+          ) ranked
+          WHERE ranked.rn > 1
+            AND ranked.created_at < now() - ($1::int * interval '1 day')
+          LIMIT $2
+        )`,
+      [days, batchSize],
+    )
+    return result.rowCount ?? 0
+  }
+
+  const keepN = Math.max(META_REVISION_RETENTION_MIN_KEEP_N, Math.floor(config.keepN))
+  const result = await query(
+    `DELETE FROM ${META_CONFIG_REVISION_RETENTION_TABLE}
+      WHERE id IN (
+        SELECT id FROM (
+          SELECT id,
+                 row_number() OVER (PARTITION BY sheet_id, entity_type, entity_id ORDER BY created_at DESC, id DESC) AS rn
+          FROM ${META_CONFIG_REVISION_RETENTION_TABLE}
+        ) ranked
+        WHERE ranked.rn > $1
+        LIMIT $2
+      )`,
+    [keepN, batchSize],
+  )
+  return result.rowCount ?? 0
+}
+
 /** Default sweep cadence (24h), env-overridable, clamped to [1m, 24h]. */
 export const META_REVISION_RETENTION_DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000
 

--- a/packages/core-backend/tests/integration/multitable-config-revision-retention-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-revision-retention-realdb.test.ts
@@ -1,0 +1,64 @@
+/**
+ * T9 D4 — config-revision retention sweep (real DB). Mirrors the record-revision retention: same policy knobs, prunes
+ * meta_config_revisions per (sheet_id, entity_type, entity_id), ALWAYS keeps the latest per entity (so current config
+ * stays inspectable + revertible), disabled by default. Runs only with DATABASE_URL.
+ */
+import { afterAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { sweepConfigRevisionRetention, type MetaRevisionRetentionConfig } from '../../src/multitable/meta-revision-retention'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const SHEET = `sheet_crr_${TS}`
+const FIELD = `fld_crr_${TS}`
+const FIELD2 = `fld_crr2_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+const sweep = (cfg: Partial<MetaRevisionRetentionConfig>) => sweepConfigRevisionRetention(
+  (sql, params) => poolManager.get().query(sql, params ?? []),
+  { enabled: true, policy: 'keep-last-n', keepN: 2, retentionDays: 365, batchSize: 5000, ...cfg },
+)
+// insert one revision `minutesAgo` old for an entity
+const seed = (entityId: string, minutesAgo: number) => q(
+  `INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, changed_keys, created_at)
+   VALUES ($1, 'field', $2, 'update', ARRAY['name']::text[], now() - ($3 || ' minutes')::interval)`,
+  [SHEET, entityId, String(minutesAgo)],
+)
+const countFor = async (entityId: string) => Number(((await q('SELECT count(*)::int AS c FROM meta_config_revisions WHERE entity_id = $1', [entityId])).rows[0] as { c: number }).c)
+
+describeIfDatabase('config-revision retention — T9 D4 (real DB)', () => {
+  beforeEach(async () => { await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]) })
+  afterAll(async () => { await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {}) })
+
+  test('disabled (the default) is a no-op — deletes nothing', async () => {
+    await seed(FIELD, 100); await seed(FIELD, 50); await seed(FIELD, 1)
+    expect(await sweep({ enabled: false })).toBe(0)
+    expect(await countFor(FIELD)).toBe(3)
+  })
+
+  test('keep-last-n prunes older revisions per entity, ALWAYS keeps the latest', async () => {
+    // keepN is floored to MIN_KEEP_N=10 (the inherited safety floor), so an entity must exceed 10 to prune.
+    for (let i = 13; i >= 1; i--) await seed(FIELD, i) // 13 revisions
+    await seed(FIELD2, 3) // a second entity with one revision — must be untouched (its latest)
+    const deleted = await sweep({ keepN: 2 }) // floored to 10
+    expect(deleted).toBe(3) // FIELD: 13 → 10 kept; FIELD2: 1 (latest) kept
+    expect(await countFor(FIELD)).toBe(10)
+    expect(await countFor(FIELD2)).toBe(1) // latest-per-entity invariant
+  })
+
+  test('keep-days prunes old NON-latest rows but never the latest, even when the latest is old', async () => {
+    await seed(FIELD, 60 * 24 * 400) // ~400 days old (the only/latest revision)
+    await seed(FIELD2, 60 * 24 * 400); await seed(FIELD2, 60 * 24 * 10) // entity2: an old one + a 10-day one (latest)
+    const deleted = await sweep({ policy: 'keep-days', retentionDays: 365 })
+    expect(deleted).toBe(1) // only FIELD2's 400-day NON-latest pruned
+    expect(await countFor(FIELD)).toBe(1) // latest kept even though 400 days old
+    expect(await countFor(FIELD2)).toBe(1) // 10-day latest kept, 400-day non-latest pruned
+  })
+
+  test('batchSize bounds one pass', async () => {
+    for (let i = 15; i >= 1; i--) await seed(FIELD, i) // 15 revisions; keepN floored to 10 → 5 prunable
+    expect(await sweep({ keepN: 1, batchSize: 3 })).toBe(3) // one pass caps at 3 even though 5 are prunable
+    expect(await countFor(FIELD)).toBe(12) // 15 - 3
+  })
+})


### PR DESCRIPTION
Two deferred T9 sub-features from the line audit.

**Config-revision retention (D4)** — `sweepConfigRevisionRetention` mirrors the record-revision sweep: same policy knobs (one knob set ages both; disabled by default), prunes `meta_config_revisions` per `(sheet_id, entity_type, entity_id)`, **always keeps the latest per entity** (current config stays inspectable + revertible), bounded per pass. 4 real-DB goldens (disabled no-op; keep-last-n respecting the MIN_KEEP_N=10 floor; keep-days keeping the latest even when old; batchSize bound).

**Config-history hasMore** — the R3 list returns `hasMore` via a `limit+1` peek (cheap; the per-entity gate is in the WHERE clause, no in-app filtering), avoiding a COUNT over the gated set. The peek is gated too — no denied-row leak. Golden: hasMore true on a partial page, false when all fit, gate-respecting.

Both allowlisted; tsc clean. (The record-history projection's own hasMore estimate stays a separate perf follow-up — it needs the in-app LOCK-3 filter restructured.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)