### PR TITLE
feat(multitable): T9-W-3 config-restore FE panel (faithful client)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1023,6 +1023,20 @@ export interface MetaConfigRevision {
   createdAt: string
 }
 
+// T9-W: the would-be revert of a recorded config change (server-computed; the FE renders it as-is).
+export interface ConfigRestorePreview {
+  revisionId: string
+  entityType: string
+  entityId: string
+  changedKeys: string[]
+  current: Record<string, unknown>
+  target: Record<string, unknown>
+  driftConflict: boolean
+  opKind: 'safe' | 'gated'
+  gatedReason?: string
+  baselineHash: string
+}
+
 export interface AiShortcutPreviewData {
   status: 'succeeded'
   action: 'preview'
@@ -1885,6 +1899,27 @@ export class MultitableApiClient {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-history${qs(params ?? {})}`)
     const data = await this.parseJson<{ items?: MetaConfigRevision[] }>(res)
     return Array.isArray(data.items) ? data.items : []
+  }
+
+  // T9-W: preview a config-restore (read-only) — server computes the revert + drift/gated decision; FE renders as-is.
+  async getConfigRestorePreview(sheetId: string, revisionId: string): Promise<ConfigRestorePreview> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-restore-preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ revisionId }),
+    })
+    const data = await this.parseJson<{ preview: ConfigRestorePreview }>(res)
+    return data.preview
+  }
+
+  // T9-W: execute a config-restore (forward-only write). baselineHash binds it to the previewed state (stale → 409).
+  async executeConfigRestore(sheetId: string, revisionId: string, baselineHash: string): Promise<void> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-restore-execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ revisionId, baselineHash }),
+    })
+    await this.parseJson<{ restored: unknown }>(res)
   }
 
   // --- Global History & Point-in-Time Restore (read-only) ---

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1035,6 +1035,8 @@ export interface ConfigRestorePreview {
   opKind: 'safe' | 'gated'
   gatedReason?: string
   baselineHash: string
+  /** the server-minted preview identity, REQUIRED by execute (preview-first; a client-computed hash is rejected). */
+  previewToken: string
 }
 
 export interface AiShortcutPreviewData {
@@ -1908,16 +1910,17 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ revisionId }),
     })
-    const data = await this.parseJson<{ preview: ConfigRestorePreview }>(res)
-    return data.preview
+    const data = await this.parseJson<{ preview: ConfigRestorePreview; previewToken: string }>(res)
+    return { ...data.preview, previewToken: data.previewToken } // fold the server-minted token into the preview the modal holds
   }
 
-  // T9-W: execute a config-restore (forward-only write). baselineHash binds it to the previewed state (stale → 409).
-  async executeConfigRestore(sheetId: string, revisionId: string, baselineHash: string): Promise<void> {
+  // T9-W: execute a config-restore (forward-only write). The server-minted previewToken binds it to the preview and
+  // is REQUIRED — a client-computed hash alone is rejected (preview-first); a stale token → 409.
+  async executeConfigRestore(sheetId: string, revisionId: string, previewToken: string): Promise<void> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/config-restore-execute`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ revisionId, baselineHash }),
+      body: JSON.stringify({ revisionId, previewToken }),
     })
     await this.parseJson<{ restored: unknown }>(res)
   }

--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -110,7 +110,7 @@ const props = defineProps<{
   isZh: boolean
   /** T9-W: when provided, an update row gets a Revert action wired through these (the workbench owns the client). */
   previewRevert?: (revisionId: string) => Promise<ConfigRestorePreview>
-  executeRevert?: (revisionId: string, baselineHash: string) => Promise<void>
+  executeRevert?: (revisionId: string, previewToken: string) => Promise<void>
 }>()
 
 const emit = defineEmits<{ (e: 'close'): void; (e: 'filter-change', entityType: string): void; (e: 'reverted'): void }>()
@@ -153,7 +153,7 @@ async function confirmRevert(): Promise<void> {
   if (!preview || !props.executeRevert) return
   revert.value = { ...revert.value, executing: true, error: '' }
   try {
-    await props.executeRevert(preview.revisionId, preview.baselineHash)
+    await props.executeRevert(preview.revisionId, preview.previewToken)
     revert.value = { visible: false, loading: false, executing: false, error: '', preview: null }
     emit('reverted')
   } catch (e) {

--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -29,6 +29,13 @@
                 <span class="cfg-history__action" :class="`cfg-history__action--${rev.action}`">{{ actionLabel(rev.action) }}</span>
                 <span class="cfg-history__entity">{{ entityLabel(rev.entityType) }}</span>
                 <span class="cfg-history__entity-id">{{ recordLabelOf(rev.entityId) }}</span>
+                <button
+                  v-if="canRevert(rev)"
+                  type="button"
+                  class="cfg-history__revert"
+                  data-test="config-history-revert"
+                  @click="openRevert(rev)"
+                >{{ l('record.configRestoreAction') }}</button>
               </div>
               <ul v-if="rev.action === 'update' && rev.changedKeys.length" class="cfg-history__changes">
                 <li v-for="k in rev.changedKeys" :key="k" class="cfg-history__change">
@@ -45,13 +52,51 @@
             </li>
           </ul>
         </div>
+
+        <!-- T9-W revert confirm. The safe/gated/drift decision is the SERVER's (the preview) — rendered as-is. -->
+        <div v-if="revert.visible" class="cfg-restore-overlay" data-test="config-restore-confirm" @click.self="cancelRevert">
+          <div class="cfg-restore-panel" role="dialog" :aria-label="l('record.configRestoreTitle')">
+            <strong>{{ l('record.configRestoreTitle') }}</strong>
+            <p v-if="revert.loading" class="cfg-history__hint" data-test="config-restore-loading">{{ l('record.configHistoryLoading') }}</p>
+            <p v-else-if="revert.error" class="cfg-restore-error" data-test="config-restore-error">{{ revert.error }}</p>
+            <template v-else-if="revert.preview">
+              <p v-if="revert.preview.opKind === 'gated'" class="cfg-restore-gated" data-test="config-restore-gated">
+                {{ revert.preview.gatedReason || l('record.configRestoreGated') }}
+              </p>
+              <template v-else>
+                <p v-if="revert.preview.driftConflict" class="cfg-restore-drift" data-test="config-restore-drift">{{ l('record.configRestoreDrift') }}</p>
+                <p class="cfg-restore-summary">{{ l('record.configRestoreWillRevert') }}</p>
+                <ul class="cfg-restore-changes" data-test="config-restore-changes">
+                  <li v-for="k in revert.preview.changedKeys" :key="k" class="cfg-history__change">
+                    <span class="cfg-history__key">{{ k }}</span>
+                    <span class="cfg-history__before">{{ display(revert.preview.current[k]) }}</span>
+                    <span class="cfg-history__arrow">→</span>
+                    <span class="cfg-history__after">{{ display(revert.preview.target[k]) }}</span>
+                  </li>
+                </ul>
+              </template>
+            </template>
+            <div class="cfg-restore-actions">
+              <button type="button" data-test="config-restore-cancel" @click="cancelRevert">{{ l('record.configRestoreCancel') }}</button>
+              <button
+                v-if="revert.preview && revert.preview.opKind === 'safe'"
+                type="button"
+                data-test="config-restore-confirm-btn"
+                :disabled="revert.preview.driftConflict || revert.executing"
+                @click="confirmRevert"
+              >{{ l('record.configRestoreConfirm') }}</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import type { MetaConfigRevision } from '../api/client'
+import { ref } from 'vue'
+
+import type { MetaConfigRevision, ConfigRestorePreview } from '../api/client'
 import { recordLabel, type MetaRecordLabelKey } from '../utils/meta-record-labels'
 
 const props = defineProps<{
@@ -63,9 +108,12 @@ const props = defineProps<{
   /** resolve an entity id to a display label (the workbench owns the field/view name map). */
   recordLabelOf: (entityId: string) => string
   isZh: boolean
+  /** T9-W: when provided, an update row gets a Revert action wired through these (the workbench owns the client). */
+  previewRevert?: (revisionId: string) => Promise<ConfigRestorePreview>
+  executeRevert?: (revisionId: string, baselineHash: string) => Promise<void>
 }>()
 
-defineEmits<{ (e: 'close'): void; (e: 'filter-change', entityType: string): void }>()
+const emit = defineEmits<{ (e: 'close'): void; (e: 'filter-change', entityType: string): void; (e: 'reverted'): void }>()
 
 const FILTERS = ['', 'field', 'view', 'permission', 'sheet_config'] as const
 const l = (key: MetaRecordLabelKey): string => recordLabel(key, props.isZh)
@@ -84,11 +132,40 @@ function display(value: unknown): string {
   if (typeof value === 'string') return value
   return JSON.stringify(value)
 }
+
+// --- T9-W revert flow (the gate stays server-side; this only shows the server's preview + confirms) ---
+interface RevertState { visible: boolean; loading: boolean; executing: boolean; error: string; preview: ConfigRestorePreview | null }
+const revert = ref<RevertState>({ visible: false, loading: false, executing: false, error: '', preview: null })
+const canRevert = (rev: MetaConfigRevision): boolean => typeof props.previewRevert === 'function' && rev.action === 'update'
+
+async function openRevert(rev: MetaConfigRevision): Promise<void> {
+  if (!props.previewRevert) return
+  revert.value = { visible: true, loading: true, executing: false, error: '', preview: null }
+  try {
+    const preview = await props.previewRevert(rev.id)
+    revert.value = { visible: true, loading: false, executing: false, error: '', preview }
+  } catch (e) {
+    revert.value = { visible: true, loading: false, executing: false, error: (e as Error)?.message ?? l('record.configRestoreError'), preview: null }
+  }
+}
+async function confirmRevert(): Promise<void> {
+  const preview = revert.value.preview
+  if (!preview || !props.executeRevert) return
+  revert.value = { ...revert.value, executing: true, error: '' }
+  try {
+    await props.executeRevert(preview.revisionId, preview.baselineHash)
+    revert.value = { visible: false, loading: false, executing: false, error: '', preview: null }
+    emit('reverted')
+  } catch (e) {
+    revert.value = { ...revert.value, executing: false, error: (e as Error)?.message ?? l('record.configRestoreError') }
+  }
+}
+function cancelRevert(): void { revert.value = { visible: false, loading: false, executing: false, error: '', preview: null } }
 </script>
 
 <style scoped>
 .cfg-history-overlay { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.45); display: flex; align-items: center; justify-content: center; z-index: 1000; }
-.cfg-history-modal { background: var(--surface, #fff); border-radius: 10px; width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 64px); display: flex; flex-direction: column; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2); }
+.cfg-history-modal { position: relative; background: var(--surface, #fff); border-radius: 10px; width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 64px); display: flex; flex-direction: column; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.2); }
 .cfg-history__header { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; border-bottom: 1px solid var(--border, #e2e8f0); }
 .cfg-history__close { border: none; background: none; font-size: 20px; line-height: 1; cursor: pointer; color: var(--text-secondary, #64748b); }
 .cfg-history__filters { display: flex; gap: 6px; flex-wrap: wrap; padding: 10px 16px 0; }
@@ -105,6 +182,7 @@ function display(value: unknown): string {
 .cfg-history__action--delete { color: var(--danger, #b91c1c); }
 .cfg-history__entity { font-size: 12px; color: var(--text-secondary, #64748b); }
 .cfg-history__entity-id { font-weight: 600; word-break: break-word; }
+.cfg-history__revert { margin-left: auto; padding: 1px 8px; border-radius: 6px; border: 1px solid var(--border, #cbd5e1); background: var(--surface, #fff); cursor: pointer; font-size: 11px; }
 .cfg-history__changes { margin: 6px 0 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 3px; }
 .cfg-history__change { display: flex; gap: 6px; align-items: baseline; font-size: 12px; }
 .cfg-history__key { font-weight: 600; }
@@ -113,4 +191,14 @@ function display(value: unknown): string {
 .cfg-history__after { word-break: break-word; }
 .cfg-history__meta { display: flex; gap: 10px; margin-top: 6px; font-size: 11px; color: var(--text-secondary, #64748b); }
 .cfg-history__time { margin-left: auto; }
+.cfg-restore-overlay { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.35); display: flex; align-items: center; justify-content: center; border-radius: 10px; }
+.cfg-restore-panel { background: var(--surface, #fff); border-radius: 8px; padding: 14px 16px; width: min(420px, calc(100% - 32px)); box-shadow: 0 8px 28px rgba(15, 23, 42, 0.2); display: flex; flex-direction: column; gap: 8px; }
+.cfg-restore-error { margin: 0; color: var(--danger, #b91c1c); font-size: 13px; }
+.cfg-restore-gated { margin: 0; color: var(--text-secondary, #64748b); font-size: 13px; }
+.cfg-restore-drift { margin: 0; color: var(--warning, #b45309); font-size: 12px; }
+.cfg-restore-summary { margin: 0; font-size: 12px; color: var(--text-secondary, #64748b); }
+.cfg-restore-changes { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 3px; }
+.cfg-restore-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }
+.cfg-restore-actions button { padding: 4px 12px; border-radius: 6px; border: 1px solid var(--border, #cbd5e1); background: var(--surface, #fff); cursor: pointer; font-size: 13px; }
+.cfg-restore-actions button[disabled] { opacity: 0.5; cursor: not-allowed; }
 </style>

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -60,6 +60,10 @@ export type MetaRecordLabelKey =
   | 'record.configHistoryEntityField' | 'record.configHistoryEntityView' | 'record.configHistoryEntityPermission'
   | 'record.configHistoryEntitySheetConfig' | 'record.configHistoryActionCreate' | 'record.configHistoryActionUpdate'
   | 'record.configHistoryActionDelete' | 'record.configHistoryEmpty' | 'record.configHistoryLoading' | 'record.configHistoryBy'
+  // --- T9-W config-restore (revert a config change) ---
+  | 'record.configRestoreAction' | 'record.configRestoreTitle' | 'record.configRestoreWillRevert'
+  | 'record.configRestoreDrift' | 'record.configRestoreGated' | 'record.configRestoreConfirm'
+  | 'record.configRestoreCancel' | 'record.configRestoreError'
   // FE-owned static fallback strings (the `error?.message ?? l(...)`
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
@@ -172,6 +176,14 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.configHistoryEmpty': { en: 'No config changes', zh: '暂无配置变更' },
   'record.configHistoryLoading': { en: 'Loading…', zh: '加载中…' },
   'record.configHistoryBy': { en: 'by', zh: '操作人' },
+  'record.configRestoreAction': { en: 'Revert', zh: '撤销' },
+  'record.configRestoreTitle': { en: 'Revert this change', zh: '撤销此变更' },
+  'record.configRestoreWillRevert': { en: 'This will revert:', zh: '将撤销为：' },
+  'record.configRestoreDrift': { en: 'The config changed since this revision — re-preview before reverting.', zh: '此后配置已变更 — 请重新预览后再撤销。' },
+  'record.configRestoreGated': { en: "This change can't be reverted in this version.", zh: '此变更暂不支持撤销。' },
+  'record.configRestoreConfirm': { en: 'Revert', zh: '确认撤销' },
+  'record.configRestoreCancel': { en: 'Cancel', zh: '取消' },
+  'record.configRestoreError': { en: 'Revert failed', zh: '撤销失败' },
   'record.errorRestore': { en: 'Restore failed', zh: '恢复失败' },
   'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -902,8 +902,8 @@ async function loadConfigHistory(entityType: string) {
 function configRestorePreview(revisionId: string) {
   return workbench.client.getConfigRestorePreview(workbench.activeSheetId.value, revisionId)
 }
-function configRestoreExecute(revisionId: string, baselineHash: string) {
-  return workbench.client.executeConfigRestore(workbench.activeSheetId.value, revisionId, baselineHash)
+function configRestoreExecute(revisionId: string, previewToken: string) {
+  return workbench.client.executeConfigRestore(workbench.activeSheetId.value, revisionId, previewToken)
 }
 function onConfigReverted() {
   void loadConfigHistory(configHistory.value.entityType) // a revert added a source=restore row + changed the entity

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -530,8 +530,11 @@
       :entity-type="configHistory.entityType"
       :record-label-of="configHistoryLabelOf"
       :is-zh="isZh"
+      :preview-revert="configRestorePreview"
+      :execute-revert="configRestoreExecute"
       @close="closeConfigHistory"
       @filter-change="onConfigHistoryFilter"
+      @reverted="onConfigReverted"
     />
   </div>
 </template>
@@ -894,6 +897,16 @@ async function loadConfigHistory(entityType: string) {
     configHistory.value = { ...configHistory.value, loading: false, items: [] }
     showError((error as Error)?.message ?? recordLabel('record.errorHistoryLoad', isZh.value))
   }
+}
+// T9-W: the modal owns the revert UI; the workbench owns the client. The server gates — these just forward.
+function configRestorePreview(revisionId: string) {
+  return workbench.client.getConfigRestorePreview(workbench.activeSheetId.value, revisionId)
+}
+function configRestoreExecute(revisionId: string, baselineHash: string) {
+  return workbench.client.executeConfigRestore(workbench.activeSheetId.value, revisionId, baselineHash)
+}
+function onConfigReverted() {
+  void loadConfigHistory(configHistory.value.entityType) // a revert added a source=restore row + changed the entity
 }
 function openConfigHistory() {
   if (!workbench.activeSheetId.value) return

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -12,7 +12,7 @@ import { MultitableApiClient, type MetaConfigRevision, type ConfigRestorePreview
 
 const previewOf = (over: Partial<ConfigRestorePreview>): ConfigRestorePreview => ({
   revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'],
-  current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1', ...over,
+  current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1', previewToken: 'tok1', ...over,
 })
 
 const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
@@ -87,7 +87,7 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     expect(q('[data-test="config-history-revert"]')).toBeFalsy()
   })
 
-  it('SAFE: revert → preview → confirm → executeRevert(id, baselineHash) + reverted emitted', async () => {
+  it('SAFE: revert → preview → confirm → executeRevert(id, previewToken) + reverted emitted', async () => {
     const previewRevert = vi.fn(async () => previewOf({}))
     const executeRevert = vi.fn(async () => {})
     const onReverted = vi.fn()
@@ -100,7 +100,7 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     expect(document.body.textContent).toContain('Old') // target
     ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
     await flush()
-    expect(executeRevert).toHaveBeenCalledWith('a', 'h1') // the preview's baselineHash
+    expect(executeRevert).toHaveBeenCalledWith('a', 'tok1') // the server-minted previewToken, NOT a client hash
     expect(onReverted).toHaveBeenCalledTimes(1)
   })
 
@@ -147,13 +147,14 @@ describe('getConfigHistory — T9-R3↔R4 wire (drift lock)', () => {
   it('getConfigRestorePreview unwraps the REAL {ok,data:{preview}} envelope (not a fixture)', async () => {
     const fetchFn = vi.fn(async () => new Response(JSON.stringify({
       ok: true,
-      data: { preview: { revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'], current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1' } },
+      data: { preview: { revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'], current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1' }, previewToken: 'tok1' },
     }), { status: 200 }))
     const client = new MultitableApiClient({ fetchFn })
 
     const preview = await client.getConfigRestorePreview('sheet_1', 'a')
 
     expect(preview.baselineHash).toBe('h1') // unwrapped — NOT undefined
+    expect(preview.previewToken).toBe('tok1') // the server token folded in — the execute wire depends on it
     expect(preview.target).toEqual({ name: 'Old' })
     expect(preview.opKind).toBe('safe')
     expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -8,7 +8,12 @@ import { describe, expect, it, vi, afterEach } from 'vitest'
 import { createApp, nextTick } from 'vue'
 
 import MetaConfigHistoryModal from '../src/multitable/components/MetaConfigHistoryModal.vue'
-import { MultitableApiClient, type MetaConfigRevision } from '../src/multitable/api/client'
+import { MultitableApiClient, type MetaConfigRevision, type ConfigRestorePreview } from '../src/multitable/api/client'
+
+const previewOf = (over: Partial<ConfigRestorePreview>): ConfigRestorePreview => ({
+  revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'],
+  current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1', ...over,
+})
 
 const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
   id: 'r1', entityType: 'field', entityId: 'fld_1', action: 'create', before: null, after: { name: 'X' },
@@ -18,6 +23,7 @@ const rev = (over: Partial<MetaConfigRevision>): MetaConfigRevision => ({
 type Props = {
   visible: boolean; items: MetaConfigRevision[]; loading: boolean; entityType: string
   recordLabelOf: (id: string) => string; isZh: boolean; onClose: () => void; onFilterChange: (t: string) => void
+  previewRevert?: (id: string) => Promise<ConfigRestorePreview>; executeRevert?: (id: string, h: string) => Promise<void>; onReverted?: () => void
 }
 const mounted: Array<{ unmount: () => void }> = []
 function mountModal(over: Partial<Props>) {
@@ -29,6 +35,7 @@ function mountModal(over: Partial<Props>) {
   const c = document.createElement('div'); document.body.appendChild(c); app.mount(c); mounted.push(app); return props
 }
 const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
+const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
 afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
 
 describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
@@ -72,6 +79,49 @@ describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
   })
 })
 
+describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE renders the decision)', () => {
+  const updateRev = () => rev({ id: 'a', action: 'update', changedKeys: ['name'], before: { name: 'Old' }, after: { name: 'New' } })
+
+  it('no revert button when previewRevert is not provided (read-only mode)', async () => {
+    mountModal({ items: [updateRev()] }); await nextTick()
+    expect(q('[data-test="config-history-revert"]')).toBeFalsy()
+  })
+
+  it('SAFE: revert → preview → confirm → executeRevert(id, baselineHash) + reverted emitted', async () => {
+    const previewRevert = vi.fn(async () => previewOf({}))
+    const executeRevert = vi.fn(async () => {})
+    const onReverted = vi.fn()
+    mountModal({ items: [updateRev()], previewRevert, executeRevert, onReverted })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await flush()
+    expect(previewRevert).toHaveBeenCalledWith('a')
+    expect(q('[data-test="config-restore-confirm"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('Old') // target
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await flush()
+    expect(executeRevert).toHaveBeenCalledWith('a', 'h1') // the preview's baselineHash
+    expect(onReverted).toHaveBeenCalledTimes(1)
+  })
+
+  it('GATED: the server says opKind=gated → shows the reason, NO confirm button (FE renders, never overrides)', async () => {
+    const previewRevert = vi.fn(async () => previewOf({ opKind: 'gated', gatedReason: 'field type reverts are not supported in this slice' }))
+    mountModal({ items: [updateRev()], previewRevert, executeRevert: vi.fn() })
+    await nextTick(); (q('[data-test="config-history-revert"]') as HTMLButtonElement).click(); await flush()
+    expect(q('[data-test="config-restore-gated"]')).toBeTruthy()
+    expect(document.body.textContent).toContain('not supported')
+    expect(q('[data-test="config-restore-confirm-btn"]')).toBeFalsy()
+  })
+
+  it('DRIFT: the server flags driftConflict → warning shown + confirm disabled', async () => {
+    const previewRevert = vi.fn(async () => previewOf({ driftConflict: true }))
+    mountModal({ items: [updateRev()], previewRevert, executeRevert: vi.fn() })
+    await nextTick(); (q('[data-test="config-history-revert"]') as HTMLButtonElement).click(); await flush()
+    expect(q('[data-test="config-restore-drift"]')).toBeTruthy()
+    expect((q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+})
+
 describe('getConfigHistory — T9-R3↔R4 wire (drift lock)', () => {
   it('round-trips the REAL R3 {ok,data:{items}} envelope (not a fixture) — never silently returns []', async () => {
     // The R3↔R4 seam is drift-prone (cf. dayIndex). R3 returns { ok, data: { items, limit, offset } }; the client's
@@ -92,5 +142,20 @@ describe('getConfigHistory — T9-R3↔R4 wire (drift lock)', () => {
     expect(items[0].changedKeys).toEqual(['name'])
     expect(fetchFn).toHaveBeenCalledWith(expect.stringContaining('/api/multitable/sheets/sheet_1/config-history')) // GET passes the URL only
     expect(fetchFn.mock.calls[0][0]).toContain('entityType=field')
+  })
+
+  it('getConfigRestorePreview unwraps the REAL {ok,data:{preview}} envelope (not a fixture)', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      data: { preview: { revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'], current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h1' } },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const preview = await client.getConfigRestorePreview('sheet_1', 'a')
+
+    expect(preview.baselineHash).toBe('h1') // unwrapped — NOT undefined
+    expect(preview.target).toEqual({ name: 'Old' })
+    expect(preview.opKind).toBe('safe')
+    expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')
   })
 })


### PR DESCRIPTION
The FE panel for T9-W config-restore (pairs with backend #3164). Each *update* row in the config-history view gets a **Revert** action → `getConfigRestorePreview` → a confirm panel rendering `target←current` per changed key. The **server's** decision is rendered as-is: `opKind==='gated'` shows the reason and offers no confirm; `driftConflict` shows a warning and disables confirm; on confirm `executeConfigRestore(id, baselineHash)` → reload. Faithful client — no client cull.

## Verification
**11 jsdom specs** (5 existing R4 + 4 revert: hidden-when-read-only / safe preview→confirm→execute / gated-disabled-with-reason / drift-disabled-with-warning + a client wire-lock asserting `getConfigRestorePreview` unwraps the real `{ok,data:{preview}}` envelope). `vue-tsc -b` 0. In the web-guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)