### PR TITLE
fix(multitable): [P1] T9-W execute requires a server-minted preview identity (D5)

### DIFF
--- a/docs/development/multitable-t9w-config-restore-design-lock-20260624.md
+++ b/docs/development/multitable-t9w-config-restore-design-lock-20260624.md
@@ -1,10 +1,13 @@
 # T9-W — Config / Schema-Change RESTORE (WRITE-SIDE) — DESIGN-LOCK
 
-> Status: **DESIGN-LOCK, docs-only. Runtime GATED behind ratification of §6 (D1–D6) + an explicit owner opt-in per
-> slice.** This is the **write half** of T9, deferred out of the read-side lock
-> (`multitable-t9-config-history-readside-designlock-20260623.md`) exactly as the record line deferred the restore
-> write (T6/BS) behind the read+preview (T5/T7). The read side (R1–R4: record + display config history) is shipped;
-> this locks **mutating config back toward a prior recorded state**.
+> Status: **DESIGN-LOCK + IMPLEMENTED THROUGH THE SAFE SUBSET.** T9-W-1/2 (preview + execute) shipped in #3164;
+> the **signed preview identity (D5 / T9-W-L4)** was a follow-up fix (#review-fix) after an initial pass shipped only
+> a client-computable baseline hash — execute now REQUIRES a server-minted token. The **gated subset stays deferred**
+> behind separate sign-off: data-loss ops (field undelete / lossy retype, L6) and permission + sheet_config reverts
+> (R-W2). This is the **write half** of T9, mirroring the record line's read+preview→write discipline.
+>
+> (Historical note: this file was authored as a docs-only lock; runtime landed in the same arc. The §7 TODO markers
+> below are kept as the original plan — T9-W-1/2/3 are now DONE; the `(separate) data-loss` row remains gated.)
 >
 > Mirror of the record-restore discipline: **preview (read-only) → execute (forward-only write) → FE**, with the
 > destructive subset hard-gated behind a separate sign-off (as T8 Reset is to T8 Revert).

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -203,3 +203,47 @@ export function verifyPitRevertPreviewIdentity(token: string, expected: PitRever
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }
+
+// ── T9-W: config-restore preview-identity (D5 / T9-W-L4) ──────────────────────────────────────────────────────
+// A config-restore PREVIEW (T9-W-1) mints an identity binding {sheetId, revisionId, entityType, entityId,
+// baselineHash, actorId}; EXECUTE (T9-W-2) REQUIRES + verifies it. Without this, the baselineHash alone is
+// client-computable (sha256 over the current changed-key config), so a caller could skip the preview entirely —
+// breaking the preview-first contract. `type: 'config-restore-preview'` keeps it disjoint from record/scoped
+// identities. Stateless JWT/HS256: signature defeats forgery, `exp` bounds the window, and the baselineHash claim
+// defeats stale replay (drift since preview → the execute's re-hash diverges → reject → re-preview).
+export interface ConfigRestorePreviewIdentityClaims {
+  sheetId: string
+  revisionId: string
+  entityType: string
+  entityId: string
+  /** the baseline config hash the preview saw (config-restore.ts `configBaselineHash`). */
+  baselineHash: string
+  /** the actor the preview was minted for — a preview minted for A is unusable by B. */
+  actorId: string
+}
+
+export function mintConfigRestorePreviewIdentity(claims: ConfigRestorePreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'config-restore-preview', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface ConfigRestoreVerifyResult {
+  valid: boolean
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_revisionId' | 'mismatch_entityType' | 'mismatch_entityId' | 'mismatch_baselineHash' | 'mismatch_actorId'
+}
+
+export function verifyConfigRestorePreviewIdentity(token: string, expected: ConfigRestorePreviewIdentityClaims): ConfigRestoreVerifyResult {
+  let payload: Partial<ConfigRestorePreviewIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<ConfigRestorePreviewIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'config-restore-preview') return { valid: false, reason: 'wrong_type' }
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.revisionId !== expected.revisionId) return { valid: false, reason: 'mismatch_revisionId' }
+  if (payload.entityType !== expected.entityType) return { valid: false, reason: 'mismatch_entityType' }
+  if (payload.entityId !== expected.entityId) return { valid: false, reason: 'mismatch_entityId' }
+  if (payload.baselineHash !== expected.baselineHash) return { valid: false, reason: 'mismatch_baselineHash' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  return { valid: true }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,7 +73,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity } from '../multitable/restore-preview-identity'
+import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   recordConfigRevision,
   recordFieldOrderShifts,
@@ -7638,17 +7638,23 @@ export function univerMetaRouter(): Router {
       const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
       if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
       const preview = computeRevertPreview(rev, snapshot)
-      // T9-W-L7: a VIEW revert preview shows `current`/`target` filterInfo, whose literals are
-      // field-read-sensitive (#2052/R9). canManageViews does NOT imply field-read, so redact them
-      // per the requester before returning (the same projection the /config-history read applies).
-      // EXECUTE re-computes the raw target server-side, so a field-denied restorer reverts correctly
-      // without ever seeing the denied literal.
+      // T9-W-L7: a VIEW revert preview shows `current`/`target` filterInfo, whose literals are field-read-sensitive
+      // (#2052/R9). canManageViews does NOT imply field-read, so redact them per the requester before returning.
+      // EXECUTE re-computes the raw target server-side, so a field-denied restorer reverts correctly without ever
+      // seeing the denied literal. The redaction is display-only — it runs AFTER computeRevertPreview, so it does
+      // not affect the baselineHash the token binds (that hash is over the raw config, consistent with execute).
       if (rev.entity_type === 'view') {
         const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
         preview.current = redactViewConfigFilterLiterals(preview.current as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
         preview.target = redactViewConfigFilterLiterals(preview.target as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
       }
-      return res.json({ ok: true, data: { preview } })
+      // T9-W-L4/D5: mint a server-signed identity binding this preview to execute. The baselineHash alone is
+      // client-computable, so execute REQUIRES this token — a caller cannot skip the preview by computing the hash.
+      const previewToken = mintConfigRestorePreviewIdentity({
+        sheetId, revisionId, entityType: rev.entity_type, entityId: rev.entity_id,
+        baselineHash: preview.baselineHash, actorId: access.userId,
+      })
+      return res.json({ ok: true, data: { preview, previewToken } })
     } catch (err: unknown) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7664,8 +7670,8 @@ export function univerMetaRouter(): Router {
   router.post('/sheets/:sheetId/config-restore-execute', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const revisionId = typeof req.body?.revisionId === 'string' ? req.body.revisionId.trim() : ''
-    const baselineHash = typeof req.body?.baselineHash === 'string' ? req.body.baselineHash : ''
-    if (!sheetId || !revisionId || !baselineHash) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, revisionId and baselineHash are required' } })
+    const previewToken = typeof req.body?.previewToken === 'string' ? req.body.previewToken : ''
+    if (!sheetId || !revisionId || !previewToken) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, revisionId and previewToken are required' } })
     try {
       const pool = poolManager.get()
       const revRes = await pool.query('SELECT id, sheet_id, entity_type, entity_id, action, before, after, changed_keys FROM meta_config_revisions WHERE id = $1 AND sheet_id = $2', [revisionId, sheetId])
@@ -7686,7 +7692,18 @@ export function univerMetaRouter(): Router {
         const snapshot = await loadEntityConfigSnapshot(query, rev)
         if (!snapshot) return { status: 409, code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot restore.' }
         const preview = computeRevertPreview(rev, snapshot)
-        if (preview.baselineHash !== baselineHash) return { status: 409, code: 'PREVIEW_STALE', message: 'The config changed since preview; re-preview before restoring.' }
+        // T9-W-L4/D5: REQUIRE + verify the server-minted preview identity. It binds revision/entity/actor, and its
+        // baselineHash claim must equal the CURRENT state — so a forged/absent token fails (no preview-skip) and a
+        // stale token (drift since preview) fails mismatch_baselineHash.
+        const verdict = verifyConfigRestorePreviewIdentity(previewToken, {
+          sheetId, revisionId, entityType: rev.entity_type, entityId: rev.entity_id,
+          baselineHash: preview.baselineHash, actorId: access.userId,
+        })
+        if (!verdict.valid) {
+          return verdict.reason === 'mismatch_baselineHash'
+            ? { status: 409, code: 'PREVIEW_STALE', message: 'The config changed since preview; re-preview before restoring.' }
+            : { status: 401, code: 'PREVIEW_IDENTITY_INVALID', message: 'A valid server-minted preview identity is required; preview before restoring.' }
+        }
         if (preview.driftConflict) return { status: 409, code: 'CONFIG_DRIFT', message: 'The config was changed after this revision; cannot safely revert without re-previewing.' }
         await applyConfigRevert(query, rev)
         await recordConfigRevision(query, {

--- a/packages/core-backend/tests/integration/multitable-config-restore-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-restore-realdb.test.ts
@@ -78,7 +78,7 @@ describeIfDatabase('multitable config-restore — T9-W (real DB)', () => {
 
   test('execute reverts the field rename AND records a source=restore revision (L1)', async () => {
     const pv = await preview(ADMIN, REV_FIELD)
-    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })
+    const res = await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv.body.data.previewToken })
     expect(res.status).toBe(200)
     expect(await fieldName()).toBe('Old') // reverted
     const restoreRevs = await q(`SELECT before, after, source, restored_from_id FROM meta_config_revisions WHERE source = 'restore' AND restored_from_id = $1`, [REV_FIELD])
@@ -92,33 +92,46 @@ describeIfDatabase('multitable config-restore — T9-W (real DB)', () => {
 
   test('a non-manager (canManageFields=false) is FORBIDDEN to preview or execute (L3)', async () => {
     expect((await preview(READER, REV_FIELD)).status).toBe(403)
-    expect((await execute(READER, { revisionId: REV_FIELD, baselineHash: 'x' })).status).toBe(403)
+    expect((await execute(READER, { revisionId: REV_FIELD, previewToken: 'x' })).status).toBe(403)
   })
 
   test('a gated op (field RETYPE) is refused 422, not partially attempted (L6)', async () => {
     const before = await fieldName()
-    const res = await execute(ADMIN, { revisionId: REV_GATED, baselineHash: 'whatever' })
+    const res = await execute(ADMIN, { revisionId: REV_GATED, previewToken: 'whatever' })
     expect(res.status).toBe(422)
     expect(res.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
     expect(await fieldName()).toBe(before) // untouched
   })
 
-  test('a wrong baselineHash is rejected PREVIEW_STALE (L4)', async () => {
-    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: 'definitely-not-the-hash' })
-    expect(res.status).toBe(409)
-    expect(res.body?.error?.code).toBe('PREVIEW_STALE')
+  test('execute REQUIRES a server-minted preview identity — a client-computed hash cannot skip preview (L4/D5)', async () => {
+    const pv = await preview(ADMIN, REV_FIELD)
+    // no token → 400 (cannot execute without previewing)
+    expect((await execute(ADMIN, { revisionId: REV_FIELD })).status).toBe(400)
+    // a forged / non-server token → 401 (signature fails)
+    const forged = await execute(ADMIN, { revisionId: REV_FIELD, previewToken: 'not.a.valid.jwt' })
+    expect(forged.status).toBe(401)
+    expect(forged.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    // the load-bearing golden: knowing the correct (client-computable) baselineHash is NOT enough — without the
+    // server-minted token, execute still fails. Preview-first cannot be bypassed.
+    const hashOnly = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash } as Record<string, unknown>)
+    expect(hashOnly.status).toBe(400)
+    expect(await fieldName()).toBe('New') // nothing reverted by any of the rejected attempts
+    // the genuine server token works
+    expect((await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv.body.data.previewToken })).status).toBe(200)
+    await q(`UPDATE meta_fields SET name = 'New' WHERE id = $1`, [FIELD])
+    await q(`DELETE FROM meta_config_revisions WHERE source = 'restore'`, [])
   })
 
   test('drift + idempotency: after a revert, replaying the same revision is rejected (L5/L7)', async () => {
     const pv = await preview(ADMIN, REV_FIELD)
-    expect((await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(200)
+    expect((await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv.body.data.previewToken })).status).toBe(200)
     expect(await fieldName()).toBe('Old')
     // replay with the SAME (now-stale) hash → stale
-    expect((await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(409)
+    expect((await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv.body.data.previewToken })).status).toBe(409)
     // a FRESH preview now flags drift (current 'Old' != the revision's after 'New') → execute rejected CONFIG_DRIFT
     const pv2 = await preview(ADMIN, REV_FIELD)
     expect(pv2.body.data.preview.driftConflict).toBe(true)
-    const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv2.body.data.preview.baselineHash })
+    const res = await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv2.body.data.previewToken })
     expect(res.status).toBe(409)
     expect(res.body?.error?.code).toBe('CONFIG_DRIFT')
     await q(`UPDATE meta_fields SET name = 'New' WHERE id = $1`, [FIELD])
@@ -128,7 +141,7 @@ describeIfDatabase('multitable config-restore — T9-W (real DB)', () => {
   test('view config revert restores the prior filter', async () => {
     const pv = await preview(ADMIN, REV_VIEW)
     expect(pv.body.data.preview.opKind).toBe('safe')
-    expect((await execute(ADMIN, { revisionId: REV_VIEW, baselineHash: pv.body.data.preview.baselineHash })).status).toBe(200)
+    expect((await execute(ADMIN, { revisionId: REV_VIEW, previewToken: pv.body.data.previewToken })).status).toBe(200)
     const filter = (await q('SELECT filter_info FROM meta_views WHERE id = $1', [VIEW])).rows[0] as { filter_info: unknown }
     expect(JSON.stringify(filter.filter_info)).toBe(JSON.stringify({ q: 'old' }))
     await q(`UPDATE meta_views SET filter_info = '{"q":"new"}'::jsonb WHERE id = $1`, [VIEW])
@@ -140,7 +153,7 @@ describeIfDatabase('multitable config-restore — T9-W (real DB)', () => {
     await q('CREATE TRIGGER _t9w_fail_trg BEFORE INSERT ON meta_config_revisions FOR EACH ROW EXECUTE FUNCTION _t9w_fail()', [])
     try {
       const pv = await preview(ADMIN, REV_FIELD)
-      const res = await execute(ADMIN, { revisionId: REV_FIELD, baselineHash: pv.body.data.preview.baselineHash })
+      const res = await execute(ADMIN, { revisionId: REV_FIELD, previewToken: pv.body.data.previewToken })
       expect(res.status).not.toBe(200) // the recording threw → whole txn rolled back
       expect(await fieldName()).toBe('New') // the field name did NOT revert — config write rolled back with it
     } finally {


### PR DESCRIPTION
Review fix-forward on the merged T9-W (#3164), addressing **[P1]** + **[P2]**.

**[P1] preview-first was bypassable.** Execute trusted a client-supplied `baselineHash` (sha256 over the current changed-key config — client-computable), so a restore-capable caller could skip `/config-restore-preview` and call execute directly. The design-lock D5 / T9-W-L4 specify a **signed** identity.

Fix: `mint/verifyConfigRestorePreviewIdentity` (JWT/HS256, type-discriminated) binding `{sheetId, revisionId, entityType, entityId, baselineHash, actorId}` + TTL. Preview mints + returns `previewToken`; **execute requires it** (400 absent) and verifies it (401 forged; 409 `PREVIEW_STALE` when the baseline claim ≠ current). The raw `baselineHash` param is removed.

**Golden** (owner-requested): a computed `baselineHash` *without* the server token fails — preview-first cannot be bypassed. Forged → 401; genuine → 200. **9/9; tsc clean.**

**[P2]** design-lock status header corrected from "docs-only / gated" to "implemented through the safe subset; D5 signed identity wired" (it had merged with runtime but still read docs-only — a stale-ledger trap).

Follow-ups in this review pass: FE token plumbing (#3169) + the T8-1 gate/ceiling [P1] (#3165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)