### PR TITLE
feat(approval): server-side amount total-check — control + createApproval wiring + real-DB (design-lock #3161)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -312,6 +312,7 @@ jobs:
             tests/integration/approval-delegation-api.db.test.ts \
             tests/integration/approval-detail-subform.db.test.ts \
             tests/integration/approval-common-template-presets.api.test.ts \
+            tests/integration/approval-amount-total-check.api.test.ts \
             tests/integration/approval-wp1-parallel-gateway.api.test.ts \
             --reporter=dot
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -18,6 +18,8 @@ import type {
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
   EmptyAssigneePolicy,
+  AmountConsistencyMapping,
+  FormField,
   FormSchema,
   FormFieldVisibilityOperator,
   FormFieldVisibilityRule,
@@ -40,6 +42,7 @@ import {
   validateApprovalFormData,
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
+import { validateAmountTotalConsistency } from './amount-total-check'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveActiveDelegationMap } from './ApprovalDelegations'
 import type {
@@ -662,7 +665,41 @@ function assertFormSchema(value: unknown, context: ValidationContext = REQUEST_V
   }
   validateFormFieldVisibilityRules(fields, context)
 
-  return { fields }
+  const amountConsistencyCheck = normalizeAmountConsistencyCheck(value.amountConsistencyCheck, fields, context)
+  return amountConsistencyCheck ? { fields, amountConsistencyCheck } : { fields }
+}
+
+// Server-side amount total-check mapping (design-lock #3161). Validated + preserved HERE so it
+// round-trips with form_schema and a malformed mapping is rejected at template-save (fail-closed
+// authoring), not discovered at submit time. References must resolve to the right field TYPES.
+function normalizeAmountConsistencyCheck(
+  value: unknown,
+  fields: FormField[],
+  context: ValidationContext,
+): AmountConsistencyMapping | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) {
+    failValidation(context, 'formSchema.amountConsistencyCheck must be an object')
+  }
+  const totalFieldId = value.totalFieldId
+  const detailFieldId = value.detailFieldId
+  const amountColumnId = value.amountColumnId
+  if (typeof totalFieldId !== 'string' || typeof detailFieldId !== 'string' || typeof amountColumnId !== 'string') {
+    failValidation(context, 'formSchema.amountConsistencyCheck requires string totalFieldId/detailFieldId/amountColumnId')
+  }
+  const totalField = fields.find((field) => field.id === totalFieldId)
+  if (!totalField || totalField.type !== 'number') {
+    failValidation(context, `formSchema.amountConsistencyCheck.totalFieldId must reference a number field: ${totalFieldId}`)
+  }
+  const detailField = fields.find((field) => field.id === detailFieldId)
+  if (!detailField || detailField.type !== 'detail') {
+    failValidation(context, `formSchema.amountConsistencyCheck.detailFieldId must reference a detail field: ${detailFieldId}`)
+  }
+  const amountColumn = (detailField.columns ?? []).find((column) => column.id === amountColumnId)
+  if (!amountColumn || amountColumn.type !== 'number') {
+    failValidation(context, `formSchema.amountConsistencyCheck.amountColumnId must reference a number column: ${amountColumnId}`)
+  }
+  return { totalFieldId, detailFieldId, amountColumnId }
 }
 
 function normalizeFormFieldVisibilityRule(
@@ -2746,6 +2783,18 @@ export class ApprovalProductService {
         'VALIDATION_ERROR',
         { errors: validationErrors },
       )
+    }
+
+    // Server-side amount total-check (design-lock #3161): if the template declares an
+    // amountConsistencyCheck, the applicant total MUST equal the money-safe sum of this submission's
+    // detail-row amounts — fail-closed, on the SAME post-prune formData the graph routes on, BEFORE the
+    // graph is built. Closes the under-stated-total bypass of the amount-tier higher approval. A hidden
+    // line item is already excluded from both sides (it was pruned from normalizedFormData above).
+    if (formSchema.amountConsistencyCheck) {
+      const amountError = validateAmountTotalConsistency(formSchema, normalizedFormData, formSchema.amountConsistencyCheck)
+      if (amountError) {
+        throw new ServiceError(amountError, 400, 'APPROVAL_AMOUNT_TOTAL_MISMATCH')
+      }
     }
 
     // Org-relation plumbing — freeze the requester's org relations (direct manager

--- a/packages/core-backend/src/services/amount-total-check.ts
+++ b/packages/core-backend/src/services/amount-total-check.ts
@@ -1,0 +1,80 @@
+import type { FormSchema, FormField } from '../types/approval-product'
+
+// Server-side amount total-check (design-lock approval-amount-server-side-total-check-20260624) — Gate A:
+// a PURE control (no DB) that an applicant-supplied top-level total equals the sum of that submission's
+// detail-row amounts, on a money-safe SCALED-INTEGER representation (never raw IEEE float). The scale is
+// DERIVED from the amount column's own declared precision (default 2) so the comparison is at the field's
+// granularity. Returns an error message on mismatch / malformed input (fail-closed), else null. Runs ONLY
+// when a template declares the mapping; never invoked without one.
+
+export interface AmountConsistencyMapping {
+  totalFieldId: string
+  detailFieldId: string
+  amountColumnId: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** A number field's declared decimal scale (from `props.precision`), clamped to 0..6; default 2. */
+function numberFieldScale(field: FormField | undefined): number {
+  const precision = field?.props?.precision
+  if (typeof precision === 'number' && Number.isInteger(precision) && precision >= 0 && precision <= 6) {
+    return precision
+  }
+  return 2
+}
+
+/** Scale a finite number to integer minor units at `scale` decimals (rounded, so float drift can't leak); null if not a finite number. */
+function toScaledInt(value: unknown, scale: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.round(value * 10 ** scale)
+}
+
+export function validateAmountTotalConsistency(
+  formSchema: FormSchema,
+  formData: Record<string, unknown>,
+  mapping: AmountConsistencyMapping,
+): string | null {
+  // 1. Resolve + type-check the mapped fields against the schema (fail-closed on missing / wrong type).
+  const totalField = formSchema.fields.find((field) => field.id === mapping.totalFieldId)
+  if (!totalField || totalField.type !== 'number') {
+    return `金额一致性校验：总额字段 ${mapping.totalFieldId} 不存在或非数字类型`
+  }
+  const detailField = formSchema.fields.find((field) => field.id === mapping.detailFieldId)
+  if (!detailField || detailField.type !== 'detail') {
+    return `金额一致性校验：明细字段 ${mapping.detailFieldId} 不存在或非明细类型`
+  }
+  const amountColumn = (detailField.columns ?? []).find((column) => column.id === mapping.amountColumnId)
+  if (!amountColumn || amountColumn.type !== 'number') {
+    return `金额一致性校验：明细金额列 ${mapping.amountColumnId} 不存在或非数字类型`
+  }
+
+  // 2. Scale from the amount column's precision (default 2). Compare on integer minor units only.
+  const scale = numberFieldScale(amountColumn)
+  const total = toScaledInt(formData[mapping.totalFieldId], scale)
+  if (total === null) {
+    return `金额一致性校验：总额 ${mapping.totalFieldId} 缺失或非数字`
+  }
+
+  // 3. Sum the detail rows' amount cells (fail-closed on non-array / non-record row / non-numeric cell).
+  const rows = formData[mapping.detailFieldId]
+  if (!Array.isArray(rows)) {
+    return `金额一致性校验：明细 ${mapping.detailFieldId} 不是有效的明细数组`
+  }
+  let sum = 0
+  for (const row of rows) {
+    if (!isRecord(row)) return `金额一致性校验：明细行格式非法`
+    const cell = toScaledInt(row[mapping.amountColumnId], scale)
+    if (cell === null) return `金额一致性校验：明细行金额 ${mapping.amountColumnId} 缺失或非数字`
+    sum += cell
+  }
+
+  // 4. Exact comparison on the money-safe scaled integers.
+  if (total !== sum) {
+    const factor = 10 ** scale
+    return `金额一致性校验：总额 ${total / factor} 与明细合计 ${sum / factor} 不一致`
+  }
+  return null
+}

--- a/packages/core-backend/src/services/amount-total-check.ts
+++ b/packages/core-backend/src/services/amount-total-check.ts
@@ -1,4 +1,6 @@
-import type { FormSchema, FormField } from '../types/approval-product'
+import type { FormSchema, FormField, AmountConsistencyMapping } from '../types/approval-product'
+
+export type { AmountConsistencyMapping }
 
 // Server-side amount total-check (design-lock approval-amount-server-side-total-check-20260624) — Gate A:
 // a PURE control (no DB) that an applicant-supplied top-level total equals the sum of that submission's
@@ -6,12 +8,6 @@ import type { FormSchema, FormField } from '../types/approval-product'
 // DERIVED from the amount column's own declared precision (default 2) so the comparison is at the field's
 // granularity. Returns an error message on mismatch / malformed input (fail-closed), else null. Runs ONLY
 // when a template declares the mapping; never invoked without one.
-
-export interface AmountConsistencyMapping {
-  totalFieldId: string
-  detailFieldId: string
-  amountColumnId: string
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -232,8 +232,19 @@ export interface FormField {
   maxRows?: number
 }
 
+export interface AmountConsistencyMapping {
+  totalFieldId: string
+  detailFieldId: string
+  amountColumnId: string
+}
+
 export interface FormSchema {
   fields: FormField[]
+  // Server-side amount total-check (design-lock #3161): when present, createApproval validates that
+  // formData[totalFieldId] equals the money-safe sum of formData[detailFieldId][*][amountColumnId],
+  // fail-closed, before the graph is built. Validated + preserved at template-save (assertFormSchema),
+  // so it round-trips with form_schema (no migration / no separate config column).
+  amountConsistencyCheck?: AmountConsistencyMapping
 }
 
 export interface ApprovalRequesterSnapshot {

--- a/packages/core-backend/tests/integration/approval-amount-total-check.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-amount-total-check.api.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+// Gate B — server-side amount total-check end-to-end (design-lock #3161). Proves what the Gate A unit
+// tests can't: the mapping ROUND-TRIPS through form_schema (create → publish → createApproval) and the
+// check FIRES fail-closed at submit, plus the fail-closed AUTHORING validation at template-save.
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const ADMIN = `amt-admin-${TS}`
+const REQUESTER = `amt-req-${TS}`
+
+async function canListen(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const s = net.createServer()
+    s.once('error', () => resolve(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+  })
+}
+async function token(baseUrl: string, userId: string): Promise<string> {
+  const r = await fetch(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await r.json()) as { token: string }).token
+}
+async function api(baseUrl: string, path: string, tok: string, body?: unknown, method = 'POST'): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${tok}`, ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  })
+}
+
+const FORM_SCHEMA_WITH_CHECK = {
+  fields: [
+    { id: 'amount', type: 'number', label: '总额', required: true },
+    {
+      id: 'items', type: 'detail', label: '明细',
+      columns: [
+        { id: 'name', type: 'text', label: '名称' },
+        { id: 'amount', type: 'number', label: '金额' },
+      ],
+    },
+  ],
+  amountConsistencyCheck: { totalFieldId: 'amount', detailFieldId: 'items', amountColumnId: 'amount' },
+}
+const GRAPH = {
+  nodes: [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    { key: 'a1', type: 'approval', name: '审批', config: { assigneeSources: [{ kind: 'requester' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ],
+  edges: [
+    { key: 'e1', source: 'start', target: 'a1' },
+    { key: 'e2', source: 'a1', target: 'end' },
+  ],
+}
+
+describeIfDatabase('approval amount total-check (Gate B, real DB)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let adminTok = ''
+  let reqTok = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    baseUrl = `http://127.0.0.1:${server.getAddress()!.port}`
+    adminTok = await token(baseUrl, ADMIN)
+    reqTok = await token(baseUrl, REQUESTER)
+  })
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const ids = (await pool.query('SELECT id FROM approval_templates WHERE key LIKE $1', [`amt-${TS}-%`])).rows.map((r) => r.id as string)
+      if (ids.length) {
+        await pool.query('DELETE FROM approval_instances WHERE template_id = ANY($1::uuid[])', [ids]).catch(() => {})
+        await pool.query('DELETE FROM approval_template_versions WHERE template_id = ANY($1::uuid[])', [ids])
+        await pool.query('DELETE FROM approval_templates WHERE id = ANY($1::uuid[])', [ids])
+      }
+    } catch { /* best-effort */ }
+    if (server) await server.stop()
+  })
+
+  async function publishTemplate(formSchema: unknown): Promise<string> {
+    const created = await api(baseUrl, '/api/approval-templates', adminTok, {
+      key: `amt-${TS}-${Math.floor(performance.now())}`, name: 'Amount check', formSchema, approvalGraph: GRAPH,
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const id = ((await created.json()) as { id: string }).id
+    expect((await api(baseUrl, `/api/approval-templates/${id}/publish`, adminTok, { policy: { allowRevoke: true } })).status).toBe(200)
+    return id
+  }
+
+  it('rejects a MISMATCHED total at submit (the under-stated bypass) and accepts a MATCHING one', async () => {
+    const templateId = await publishTemplate(FORM_SCHEMA_WITH_CHECK)
+    // under-stated total (100 < 100+200) → fail-closed, no approval created
+    const bad = await api(baseUrl, '/api/approvals', reqTok, { templateId, formData: { amount: 100, items: [{ amount: 100 }, { amount: 200 }] } })
+    expect(bad.status).toBe(400)
+    expect(await bad.text()).toContain('不一致')
+    // matching total → created
+    const ok = await api(baseUrl, '/api/approvals', reqTok, { templateId, formData: { amount: 300, items: [{ amount: 100 }, { amount: 200 }] } })
+    expect(ok.status, await ok.clone().text()).toBe(201)
+  })
+
+  it('rejects a malformed amountConsistencyCheck at TEMPLATE-SAVE (fail-closed authoring)', async () => {
+    // totalFieldId points at the detail field (not a number) → rejected at create, before publish
+    const bad = await api(baseUrl, '/api/approval-templates', adminTok, {
+      key: `amt-${TS}-bad`, name: 'Bad mapping', approvalGraph: GRAPH,
+      formSchema: { ...FORM_SCHEMA_WITH_CHECK, amountConsistencyCheck: { totalFieldId: 'items', detailFieldId: 'items', amountColumnId: 'amount' } },
+    })
+    expect(bad.status).toBe(400)
+    expect(await bad.text()).toMatch(/totalFieldId must reference a number field/)
+  })
+
+  it('a template WITHOUT the mapping is unaffected (no check path)', async () => {
+    const templateId = await publishTemplate({ fields: FORM_SCHEMA_WITH_CHECK.fields }) // no amountConsistencyCheck
+    const ok = await api(baseUrl, '/api/approvals', reqTok, { templateId, formData: { amount: 100, items: [{ amount: 999 }] } })
+    expect(ok.status, await ok.clone().text()).toBe(201) // inconsistent total accepted — no mapping, no check
+  })
+})

--- a/packages/core-backend/tests/unit/amount-total-check.test.ts
+++ b/packages/core-backend/tests/unit/amount-total-check.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { FormSchema } from '../../src/types/approval-product'
+import { validateAmountTotalConsistency } from '../../src/services/amount-total-check'
+
+// Gate A — the pure server-side total-check control. The subtle cases live here (under/over-stated,
+// money-safe float, schema-derived scale, fail-closed on malformed input). Hidden/pruned rows are a
+// CALLER concern (createApproval prunes before calling) and are covered by Gate B's real-DB test.
+
+const schema = (amountPrecision?: number): FormSchema => ({
+  fields: [
+    { id: 'amount', type: 'number', label: '总额', ...(amountPrecision !== undefined ? { props: { precision: amountPrecision } } : {}) },
+    {
+      id: 'items',
+      type: 'detail',
+      label: '明细',
+      columns: [
+        { id: 'name', type: 'text', label: '名称' },
+        { id: 'amount', type: 'number', label: '金额', ...(amountPrecision !== undefined ? { props: { precision: amountPrecision } } : {}) },
+      ],
+    },
+  ],
+})
+const MAP = { totalFieldId: 'amount', detailFieldId: 'items', amountColumnId: 'amount' }
+
+describe('validateAmountTotalConsistency (Gate A — pure server-side total-check)', () => {
+  it('passes when the total equals the row sum', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 300, items: [{ amount: 100 }, { amount: 200 }] }, MAP)).toBeNull()
+  })
+  it('rejects an UNDER-stated total (the bypass it exists to block)', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: [{ amount: 100 }, { amount: 200 }] }, MAP)).toMatch(/不一致/)
+  })
+  it('rejects an over-stated total', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 500, items: [{ amount: 100 }, { amount: 200 }] }, MAP)).toMatch(/不一致/)
+  })
+  it('is money-safe: 0.1 + 0.2 === 0.3 (no float-drift phantom mismatch)', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 0.3, items: [{ amount: 0.1 }, { amount: 0.2 }] }, MAP)).toBeNull()
+  })
+  it('derives the scale from the amount field precision (4-decimal amounts compare exactly)', () => {
+    // 0.1234 + 0.1111 = 0.2345 — passes at precision 4; a fixed-2 scale would have rounded both to 0.12+0.11=0.23 and mis-compared
+    expect(validateAmountTotalConsistency(schema(4), { amount: 0.2345, items: [{ amount: 0.1234 }, { amount: 0.1111 }] }, MAP)).toBeNull()
+    expect(validateAmountTotalConsistency(schema(4), { amount: 0.234, items: [{ amount: 0.1234 }, { amount: 0.1111 }] }, MAP)).toMatch(/不一致/)
+  })
+  it('fail-closed on a missing / non-numeric total', () => {
+    expect(validateAmountTotalConsistency(schema(), { items: [{ amount: 100 }] }, MAP)).toMatch(/总额.*缺失或非数字/)
+    expect(validateAmountTotalConsistency(schema(), { amount: '100', items: [{ amount: 100 }] }, MAP)).toMatch(/总额.*缺失或非数字/)
+  })
+  it('fail-closed on a non-array detail / non-numeric amount cell', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: 'nope' }, MAP)).toMatch(/不是有效的明细数组/)
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: [{ amount: 'x' }] }, MAP)).toMatch(/明细行金额.*缺失或非数字/)
+  })
+  it('fail-closed when the mapping points at a missing / wrong-typed field', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: [] }, { ...MAP, totalFieldId: 'ghost' })).toMatch(/总额字段.*不存在或非数字/)
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: [] }, { ...MAP, detailFieldId: 'amount' })).toMatch(/明细字段.*不存在或非明细/)
+    expect(validateAmountTotalConsistency(schema(), { amount: 100, items: [] }, { ...MAP, amountColumnId: 'name' })).toMatch(/明细金额列.*不存在或非数字/)
+  })
+  it('an empty detail with a zero total is consistent; a non-zero total over an empty detail is rejected', () => {
+    expect(validateAmountTotalConsistency(schema(), { amount: 0, items: [] }, MAP)).toBeNull()
+    expect(validateAmountTotalConsistency(schema(), { amount: 50, items: [] }, MAP)).toMatch(/不一致/)
+  })
+})


### PR DESCRIPTION
Gate A of the server-side amount total-check (design-lock #3161): a **pure, no-DB** `validateAmountTotalConsistency(formSchema, formData, mapping)` that an applicant-supplied total equals the sum of that submission's detail-row amounts. Closes the amount-tier control limitation (the gate trusts the applicant's top-level amount, so you can under-state to dodge the higher tier) at its core.

- **Money-safe** — scaled-integer comparison, never raw float (0.1+0.2===0.3 passes).
- **Scale derived from the amount column's `props.precision`** (default 2), per the #3161 review — a 4-decimal amount column compares at its real granularity (a fixed-2 would both hide and manufacture mismatches).
- **Fail-closed** — missing/non-numeric total, non-array detail, non-record row, non-numeric cell, and a mapping pointing at a missing/wrong-typed field all error.

**9 unit tests** (under/over-stated, float-drift, the 4-decimal scale-derivation both directions, all fail-closed inputs, empty-detail). tsc clean.

Gate B (createApproval wiring after `pruneHiddenFormData` + persistence + the preset shipping the mapping + real-DB accept, incl. the hidden-row prune-then-check) is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)