### PR TITLE
feat(multitable): R4 config-history polish — diff-render depth + mount→fetch wire test

### DIFF
--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -127,10 +127,29 @@ const ACTION_KEY: Record<string, MetaRecordLabelKey> = {
 const filterLabel = (opt: string): string => (opt === '' ? l('record.configHistoryFilterAll') : entityLabel(opt))
 const entityLabel = (t: string): string => (ENTITY_KEY[t] ? l(ENTITY_KEY[t]) : t)
 const actionLabel = (a: string): string => (ACTION_KEY[a] ? l(ACTION_KEY[a]) : a)
-function display(value: unknown): string {
+// Render a config value (a view filter/sort/group, a permission grant, a hidden-field list, a scalar) as a compact
+// human summary instead of a raw JSON blob — objects become `k: v` pairs, primitive arrays join, and anything deeper
+// than two levels falls back to JSON (safe). These are CONFIG values (never record data), so no value-masking is
+// needed. No translatable strings are introduced (the separators/markers are structural).
+function summarizeConfigValue(value: unknown, depth = 0): string {
   if (value === null || value === undefined) return '∅'
   if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    const allPrimitive = value.every((v) => v === null || typeof v !== 'object')
+    return allPrimitive ? value.map((v) => summarizeConfigValue(v, depth + 1)).join('; ') : `[${value.length}]`
+  }
+  if (typeof value === 'object') {
+    if (depth >= 2) return JSON.stringify(value) // deep nesting → safe JSON fallback
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return '{}'
+    return entries.map(([k, v]) => `${k}: ${summarizeConfigValue(v, depth + 1)}`).join(', ')
+  }
   return JSON.stringify(value)
+}
+function display(value: unknown): string {
+  return summarizeConfigValue(value)
 }
 
 // --- T9-W revert flow (the gate stays server-side; this only shows the server's preview + confirms) ---

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -36,6 +36,12 @@ function mountModal(over: Partial<Props>) {
 }
 const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
 const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
+// Poll until a condition holds (CI-robust): the real client's fetch→text→parse→render chain takes a variable number
+// of ticks, so a fixed `flush()` count races in CI. Retry-with-flush until the predicate is true (or time out).
+const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
+  for (let i = 0; i < tries; i++) { if (pred()) return; await flush() }
+  throw new Error('waitUntil: condition not met in time')
+}
 afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
 
 describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
@@ -135,9 +141,9 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     })
     await nextTick()
     ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
-    await flush(); await flush() // the real client adds fetch→text→parse awaits; let the preview resolve + render
+    await waitUntil(() => !!q('[data-test="config-restore-confirm-btn"]')) // poll until the async preview rendered the confirm panel (CI-robust, not a fixed tick count)
     ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
-    await flush(); await flush()
+    await waitUntil(() => fetchFn.mock.calls.length >= 2 && onReverted.mock.calls.length >= 1) // poll until the execute fetch fired + reverted emitted
     // the two real fetches happened, in order
     expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')
     expect(fetchFn.mock.calls[1][0]).toContain('/config-restore-execute')

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -52,6 +52,16 @@ describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
     expect(document.body.querySelectorAll('.cfg-history__row').length).toBe(2) // BOTH rendered — the FE doesn't drop rows
   })
 
+  it('renders config objects as a compact k: v summary, not a raw JSON blob (diff-rendering depth)', async () => {
+    mountModal({ items: [
+      rev({ id: 'a', entityType: 'permission', entityId: 'fld_1', action: 'update', changedKeys: ['grant'],
+        before: { grant: { visible: true, readOnly: false } }, after: { grant: { visible: false, readOnly: true } } }),
+    ] })
+    await nextTick()
+    expect(document.body.textContent).toContain('visible: false, readOnly: true') // compact human summary
+    expect(document.body.textContent).not.toContain('{"visible"') // NOT the raw JSON blob
+  })
+
   it('the entity-type filter EMITS filter-change (server re-fetches; the FE never client-filters for security)', async () => {
     const props = mountModal({ items: [rev({})] })
     await nextTick()
@@ -101,6 +111,40 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
     await flush()
     expect(executeRevert).toHaveBeenCalledWith('a', 'tok1') // the server-minted previewToken, NOT a client hash
+    expect(onReverted).toHaveBeenCalledTimes(1)
+  })
+
+  it('END-TO-END wire: Revert button → real client → config-restore-preview then -execute with the SERVER previewToken', async () => {
+    // The FULL mount→button→fetch path through a real MultitableApiClient (mocked fetchFn) — not the callback shim —
+    // so the token actually flows preview→execute over the wire and execute carries the server token, not a client hash.
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('config-restore-preview')) {
+        return new Response(JSON.stringify({ ok: true, data: {
+          preview: { revisionId: 'a', entityType: 'field', entityId: 'fld_1', changedKeys: ['name'], current: { name: 'New' }, target: { name: 'Old' }, driftConflict: false, opKind: 'safe', baselineHash: 'h-server' },
+          previewToken: 'server-token-xyz',
+        } }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ ok: true, data: { restored: { revisionId: 'a' } } }), { status: 200 }) // execute
+    })
+    const client = new MultitableApiClient({ fetchFn })
+    const onReverted = vi.fn()
+    mountModal({
+      items: [updateRev()], onReverted,
+      previewRevert: (id: string) => client.getConfigRestorePreview('sheet_1', id),
+      executeRevert: (id: string, token: string) => client.executeConfigRestore('sheet_1', id, token),
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await flush(); await flush() // the real client adds fetch→text→parse awaits; let the preview resolve + render
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await flush(); await flush()
+    // the two real fetches happened, in order
+    expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')
+    expect(fetchFn.mock.calls[1][0]).toContain('/config-restore-execute')
+    // the execute body carries the SERVER-minted token (not a client hash) — preview-first can't be bypassed via the UI
+    const execBody = JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string)
+    expect(execBody.previewToken).toBe('server-token-xyz')
+    expect(execBody.baselineHash).toBeUndefined()
     expect(onReverted).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
Two deferred R4 items (based on #3169 — the revert panel it touches isn't on main yet; lands after #3169). Diff-rendering depth: `summarizeConfigValue()` renders config objects as compact `k: v` (e.g. a permission grant shows `visible: false, readOnly: true`) instead of a raw JSON blob, config-only (no value masking). End-to-end **mount→button→fetch wire test**: wires the modal to a real `MultitableApiClient` (mocked fetch), clicks Revert→confirm, asserts `/config-restore-preview` then `/config-restore-execute` fire with the server `previewToken` (baselineHash undefined) — closing the gap you flagged. vue-tsc 0; spec 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)