### PR TITLE
docs(multitable): remaining-dev pass-2 + T8-2 Reset HELD for sign-off (decisions resolved)

### DIFF
--- a/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
+++ b/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
@@ -1,0 +1,64 @@
+# T8-2 Reset-to-T (destructive PIT restore) — build-readiness + decisions for sign-off
+
+> Status: **AWAITING EXPLICIT OWNER SIGN-OFF — NOT built.** The T8 design-lock (§5) requires Reset to have a *separate
+> rollback-semantics sign-off, not just doc approval*. A re-issued `/goal` is not that sign-off. This doc resolves the
+> §5 decisions (D1–D5) and proposes a flag-gated build, so the sign-off is a concrete yes/no rather than an open
+> question. Nothing destructive ships until you approve this.
+
+## Why this is gated and not auto-built
+
+Reset is the one genuinely destructive capability in the whole Time Machine line: it **deletes records created after
+T** (Revert keeps them). A bug here loses data. The line's discipline — and the [P1] review that just caught a T8-1
+gate miss — say the destructive path gets an explicit, deliberate sign-off, not a broad "complete it." So this is
+presented for decision, with the safe half (T8-1 Revert) already shipped (#3165).
+
+## Reset = Revert + delete-post-T-created
+
+Reset reuses everything T8-1 Revert built (the `reconstructRecordsAtT` target, the forward-revision write,
+`source=restore` batch, the `canManageSheetAccess` gate, the size ceiling, PIT-3/LOCK-3 masking, PIT-7 reveal-non-
+composition). It **adds one thing**: enumerating the records created after T and deleting them, under an all-or-nothing
+preflight.
+
+## Decisions to ratify (T8 design-lock §5)
+
+- **D1 — ship Reset at all?** Recommend **yes** — it's the natural capstone. **There is no destructive code yet; the
+  build awaits THIS sign-off.** On your yes I build it, and the runtime ships behind a default-OFF flag
+  (`MULTITABLE_ENABLE_PIT_RESET`) as belt-and-suspenders so it's inert even post-build until explicitly enabled — but
+  the flag is the *operational* gate *after* authorization, not a substitute for it. Revert stays the default,
+  always-on path.
+- **D2 — who may execute?** Recommend **`canManageSheetAccess`** (the sheet-admin cap T8-1 now uses), *plus* the flag.
+  A dedicated `multitable:history-restore` capability is the eventual target but not a v1 blocker.
+- **D3 — size ceiling + async?** Recommend **reuse the T8-1 `SHEET_REVERT_MAX_RECORDS` ceiling** (fail-closed `413`
+  above it); **no async in v1** (async-above-threshold is a follow-up). Reset over the ceiling is refused, never
+  truncated.
+- **D4 — confirmation?** Recommend **a typed two-step confirm**: the execute body must carry an explicit
+  `confirm: 'reset'` (or the deleted-count echoed back), so Reset cannot be triggered by a stray Revert call. Audit via
+  the `source=restore` batch (actor / T / scope; never values).
+- **D5 — scope?** Recommend **whole-sheet only** in v1 (a permission-filtered subset is a follow-up).
+
+## The load-bearing lock (PIT-2) and how it's proven
+
+**All-or-nothing permission preflight:** before ANY delete, EVERY post-T-created record to be deleted AND every record
+to be reverted is permission-checked; if a SINGLE one is denied, the **entire Reset is rejected and nothing is
+written** (no partial skip, no fail-halfway — unlike Revert, which may partial-skip). The proving golden is a
+**mutation check**: drop one preflight check → a denied target slips into the destructive set → the test fails.
+
+## Proposed verification (what the build would ship with)
+
+Real-DB goldens: flag-off → Reset refused (inert); flag-on + whole-sheet Reset → post-T-created **deleted**,
+pre-T-state reverted, forward revisions + `source=restore` batch written; **PIT-2 all-or-nothing blocks on any single
+denial, zero writes** (+ the mutation check); above-ceiling → `413`; `confirm`-absent → refused; PIT-3 no count/
+existence leak; PIT-7 reveal-non-composition. Plus a destructive-delete atomicity golden (a forced mid-write failure
+leaves the sheet untouched).
+
+## What I need from you
+
+A yes/no on **D1–D5 as recommended** (or your amendments). On a yes, I build T8-2 behind the default-off flag with the
+goldens above, on the T8-1 branch/its successor, and present it for review before the flag is ever enabled in any real
+environment.
+
+## Adjacent destructive/irreversible items (same gate, same ask)
+
+- **T9-W data-loss config ops** — field *undelete* (the column data is gone; honest "undo" is impossible) and *lossy
+  retype*. Refused `422` today. These need the same explicit sign-off + likely the codebase-wide undelete slice first.
+- **T8-1 undelete-execute** — pending that same cross-cutting undelete slice (resurrect + link-rebuild).

--- a/docs/development/multitable-timemachine-remaining-dev-pass2-design-verification-20260624.md
+++ b/docs/development/multitable-timemachine-remaining-dev-pass2-design-verification-20260624.md
@@ -1,0 +1,52 @@
+# Time Machine remaining-dev (pass 2) — design & verification
+
+## 🚫 BLOCKED ON EXPLICIT SIGN-OFF (not built — by design)
+
+- **T8-2 Reset-to-T** (destructive PIT restore — *deletes* records created after T). Decisions resolved + flag-gated
+  build plan in `multitable-t8-2-reset-build-readiness-20260624.md`; awaiting your **yes/no on D1–D5** (the T8
+  design-lock §5 requires a separate rollback-semantics sign-off, which a re-issued `/goal` is not). **No destructive
+  code was written.**
+- **T9-W data-loss config ops** (field *undelete* / *lossy retype*) + **T8-1 undelete-execute** — same gate, same ask;
+  also need the codebase-wide undelete slice first. Refused `422` today.
+
+These are the one part of "the remaining dev" that the line's discipline says I must not self-authorize — especially
+one turn after the [P1] review caught a T8 gate miss. They are presented for decision, not shipped.
+
+## What this pass DID complete (safe, non-destructive)
+
+This pass closed the [P1] review findings on the prior pass, then completed the safe remaining items.
+
+### Review fixes (the [P1]/[P2] from your review)
+- **[P1] T9-W signed preview identity** (#3172): execute now requires a server-minted `previewToken` (JWT/HS256, binds
+  sheet/revision/entity/baselineHash/actor + TTL) — a client-computable hash can no longer skip preview. 9 goldens
+  incl. *computed-hash-without-token fails*. FE plumbs the token (#3169). *(Resolved a 3-way merge with main's view
+  filterInfo redaction — the redaction is display-only and does not affect the token's raw baselineHash.)*
+- **[P1] T8-1 gate + ceiling** (#3165, merged): gate `canManageSheetAccess` (above record-write, D2) + a hard
+  `SHEET_REVERT_MAX_RECORDS` ceiling (`413` fail-closed, D3/PIT-6). Deny goldens: normal editor `403`, over-ceiling
+  `413`.
+- **[P2]** design-lock status corrected (#3172); the closeout MD records both fixes (#3170).
+
+### Safe completions
+- **R4 config-history polish** (#3177): diff-rendering depth (`summarizeConfigValue` — compact `k: v` for config
+  objects instead of raw JSON, config-only so no value masking) + an **end-to-end mount→button→fetch wire test**
+  (clicks Revert→confirm, asserts the real `config-restore-preview` then `config-restore-execute` fetches fire with the
+  server `previewToken`) — closing the wire-coverage gap flagged earlier. vue-tsc 0; spec 13/13.
+- **BS-3.1 all-or-nothing batch restore** (agent-built, landing): an opt-in `allOrNothing` mode on the scoped
+  batch-restore execute — if ANY target is denied/conflicted, the whole batch is rejected and nothing is written
+  (vs the default partial-skip). Real-DB goldens incl. zero-write-on-block.
+
+## Deferred (smaller, non-blocking — noted, not silently dropped)
+- **Record-history projection `hasMore`** — needs the in-app LOCK-3 filter restructured (security-sensitive); left as a
+  perf follow-up rather than rushed.
+- **Base-level config history** — no base-config mutation chokepoints exist to wire today; needs its own investigation.
+- cross-base data-sync, dashboards — parked off this line.
+
+## Landing status
+[P1]#2 #3165 + sub-features #3168 **merged**. Landing dependency-gated: #3172 (identity) → #3169 (FE) → #3177
+(R4 polish) → #3170 (MD); BS-3.1 + this doc follow. Each new write path is mutation/trigger-proven, allow-and-deny.
+
+## The honest bottom line
+The read/preview/scoped-write/non-destructive arcs of the Time Machine line are complete and hardened. The **only**
+remaining development is the **destructive Reset (T8-2)** and the **irreversible data-loss config ops** — and those are
+deliberately held at your sign-off, with their decisions resolved and a build plan ready. Say yes to D1–D5 and I build
+T8-2 behind the default-off flag with the full PIT-2 / ceiling / atomicity golden suite.


### PR DESCRIPTION
Closeout for the /goal pass. **The held status is loud, not buried:** T8-2 Reset (destructive) + T9-W data-loss ops are presented for an explicit sign-off (D1–D5 resolved in the readiness doc), NOT built — the line's discipline says the destructive path needs a separate rollback-semantics sign-off, which a re-issued /goal is not. Safe work this pass: the [P1] review fixes + R4 polish + BS-3.1. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)