### PR TITLE
feat(multitable): BS-3.1 all-or-nothing scoped batch restore (opt-in)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -215,6 +215,7 @@ jobs:
             tests/integration/multitable-restore-per-field-realdb.test.ts \
             tests/integration/multitable-restore-batch-preview-realdb.test.ts \
             tests/integration/multitable-restore-batch-execute-realdb.test.ts \
+            tests/integration/multitable-restore-batch-allornothing-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-restore-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -8379,9 +8379,14 @@ export function univerMetaRouter(): Router {
       expectedVersions: z.record(z.string(), z.number().int().nonnegative()),
       previewIdentity: z.string().min(1),
       fieldIds: z.array(z.string().min(1)).min(1).optional(),
+      // BS-3.1 (SR-5 / D2 opt-in): all-or-nothing mode. Default false = the back-compat PARTIAL behavior (each
+      // record restores or is skipped+reported). When true: any single denied/forbidden/conflicted record in scope
+      // blocks the ENTIRE batch (one transaction, ZERO writes) → 409 with the full blocker list. Transactional
+      // callers opt in; the surgical PARTIAL default is unchanged.
+      allOrNothing: z.boolean().optional().default(false),
     }).safeParse(req.body)
     if (!parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
-    const { targetVersion, recordIds: requestedIds, expectedVersions, previewIdentity, fieldIds } = parsed.data
+    const { targetVersion, recordIds: requestedIds, expectedVersions, previewIdentity, fieldIds, allOrNothing } = parsed.data
     const uniqueIds = [...new Set(requestedIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)) // ONE canonical source (sorted, deduped)
     for (const id of uniqueIds) if (typeof expectedVersions[id] !== 'number') return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `expectedVersions missing for ${id}` } })
     const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
@@ -8444,29 +8449,67 @@ export function univerMetaRouter(): Router {
         const status = verdict.reason === 'expired' ? 410 : 409
         return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Batch preview identity rejected (${verdict.reason}); the scope or a record diff changed since preview — re-preview` } })
       }
-      // Step 3: per-record write fan-out (PARTIAL). Each record is its OWN patchRecords (its OWN transaction), so a
-      // row-deny / version-conflict / field-forbidden on one record skips ONLY that record. The in-transaction CAS
-      // (RecordChange.expectedVersion under SELECT FOR UPDATE) is the authoritative concurrency guard.
+      // Shared per-record pre-write FORBIDDEN gate (#1 layer-3): a field that is hidden / field-definition-readOnly
+      // (static) OR per-subject visible=false / read_only=true (layer-3) must not be written. patchRecords enforces
+      // ONLY the static axis, so a visible-but-readOnly field would slip through — gate the WHOLE record here. ONE
+      // source of truth shared by BOTH the PARTIAL loop and the all-or-nothing preflight (no drift across modes).
+      const recordIsForbidden = (diff: RecordChange[]): boolean => diff.some((ch) => {
+        const guard = fieldById.get(ch.fieldId)
+        const perm = fieldPermissions[ch.fieldId]
+        const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
+        const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
+        return !staticOk || !layer3Ok
+      })
       const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
       if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
       type Outcome = { recordId: string; status: 'restored' | 'skipped'; newVersion?: number; restoredFieldIds?: string[]; skipReason?: 'denied' | 'conflict' | 'forbidden' | 'error' }
+
+      // BS-3.1 (SR-5 / D2 opt-in): ALL-OR-NOTHING. Any single denied/forbidden/conflicted record blocks the ENTIRE
+      // batch and writes NOTHING. denied (fresh row-deny) + forbidden (layer-3) are NOT enforced by patchRecords →
+      // preflight them in-route over EVERY contributing record and collect ALL blockers (no write attempted yet, so
+      // zero writes is structural). conflict is the in-transaction CAS: a SINGLE patchRecords over the whole map runs
+      // in ONE transaction (this.pool.transaction) and THROWS on any per-record version conflict / field-forbidden /
+      // validation → the whole transaction rolls back → ZERO writes (no preflight version-compare: that would
+      // duplicate the CAS + open a TOCTOU gap). The success path writes EVERY record atomically.
+      if (allOrNothing) {
+        const blockers: Array<{ recordId: string; reason: 'denied' | 'forbidden' }> = []
+        for (const c of contributing) {
+          if (deniedIds.has(c.recordId)) { blockers.push({ recordId: c.recordId, reason: 'denied' }); continue }
+          if (recordIsForbidden(c.diff)) { blockers.push({ recordId: c.recordId, reason: 'forbidden' }) }
+        }
+        if (blockers.length > 0) {
+          // distinct code from PREVIEW_IDENTITY_INVALID (re-preview) — this means "a record is denied/forbidden"
+          return res.status(409).json({ ok: false, error: { code: 'BATCH_RESTORE_BLOCKED', message: `All-or-nothing batch restore blocked: ${blockers.length} record(s) denied or forbidden; nothing written`, blockers } })
+        }
+        try {
+          const result = await recordWriteService.patchRecords({
+            sheetId, changesByRecord: new Map(contributing.map((c) => [c.recordId, c.diff])), actorId: getRequestActorId(req),
+            fields, visiblePropertyFields: readableEchoFields, visiblePropertyFieldIds: readableEchoFieldIds,
+            attachmentFields, fieldById, capabilities, sheetScope, access, source: 'restore',
+          })
+          const versionByRecord = new Map(result.updated.map((u) => [u.recordId, u.version]))
+          const records: Outcome[] = contributing.map((c) => ({ recordId: c.recordId, status: 'restored', newVersion: versionByRecord.get(c.recordId), restoredFieldIds: c.diff.map((d) => d.fieldId) }))
+          return res.json({ ok: true, data: { records, restoredCount: records.length, skippedCount: 0, targetVersion } })
+        } catch (err) {
+          // the WHOLE transaction rolled back → zero writes. The CAS aborts on the FIRST conflicting record, so the
+          // conflict blocker list is first-only BY DESIGN (a full version preflight would reintroduce the TOCTOU we
+          // deliberately avoid). denied/forbidden are reported in full above (those are preflighted, not thrown).
+          if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) return res.status(409).json({ ok: false, error: { code: 'BATCH_RESTORE_BLOCKED', message: 'All-or-nothing batch restore blocked: a record version conflicted; nothing written', blockers: [{ recordId: (err as ServiceVersionConflictError).recordId, reason: 'conflict' }] } })
+          if (err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) return res.status(409).json({ ok: false, error: { code: 'BATCH_RESTORE_BLOCKED', message: 'All-or-nothing batch restore blocked: a record field is forbidden; nothing written', blockers: [{ recordId: '', reason: 'forbidden' }] } })
+          if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError) return res.status(409).json({ ok: false, error: { code: 'BATCH_RESTORE_BLOCKED', message: `All-or-nothing batch restore blocked: ${(err as Error).message}; nothing written`, blockers: [{ recordId: '', reason: 'error' }] } })
+          throw err
+        }
+      }
+
+      // Step 3: per-record write fan-out (PARTIAL). Each record is its OWN patchRecords (its OWN transaction), so a
+      // row-deny / version-conflict / field-forbidden on one record skips ONLY that record. The in-transaction CAS
+      // (RecordChange.expectedVersion under SELECT FOR UPDATE) is the authoritative concurrency guard.
       const outcomes: Outcome[] = []
       for (const c of contributing) {
         // fresh per-record row-deny re-check (the rare deny-added-since-preview edge) → partial-skip, no oracle leak
         if (deniedIds.has(c.recordId)) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'denied' }); continue }
-        // #1 layer-3 per-subject WRITE gate (the EXACT derive the legacy /restore gates with): a field that is
-        // hidden / field-definition-readOnly (static) OR per-subject visible=false / read_only=true (layer-3) must
-        // not be written. patchRecords enforces only the static axis, so a visible-but-readOnly field would slip
-        // through — gate the WHOLE record here (skip:forbidden, PARTIAL), the others proceed.
-        const hasForbidden = c.diff.some((ch) => {
-          const guard = fieldById.get(ch.fieldId)
-          const perm = fieldPermissions[ch.fieldId]
-          const staticOk = !!guard && !guard.hidden && guard.readOnly !== true
-          const layer3Ok = !!perm && perm.visible !== false && perm.readOnly !== true
-          return !staticOk || !layer3Ok
-        })
-        if (hasForbidden) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
+        if (recordIsForbidden(c.diff)) { outcomes.push({ recordId: c.recordId, status: 'skipped', skipReason: 'forbidden' }); continue }
         try {
           const result = await recordWriteService.patchRecords({
             sheetId, changesByRecord: new Map([[c.recordId, c.diff]]), actorId: getRequestActorId(req),

--- a/packages/core-backend/tests/integration/multitable-restore-batch-allornothing-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-restore-batch-allornothing-realdb.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Global History — BS-3.1: SCOPED (multi-record) restore batch-execute, the ALL-OR-NOTHING opt-in (real DB).
+ * Per the SR-5 / D2 design-lock: `allOrNothing: true` makes any single denied/forbidden/conflicted record in scope
+ * block the ENTIRE batch (one transaction, ZERO writes) → 409 BATCH_RESTORE_BLOCKED; default (false) is the
+ * back-compat PARTIAL skip+report. Same per-record preflight gates as PARTIAL, re-applied before the atomic write.
+ *
+ * Goldens: (a) all-permitted → applies ALL (every row written, versions bumped) · (b) one row-DENIED → 409,
+ * NOTHING written (every version unchanged — preflight blocks before any write) · (c) one CONFLICT (version moved
+ * since preview) → 409, NOTHING written (the TRANSACTION-ROLLBACK keystone: the write phase started but rolled the
+ * whole batch back) · (d) default PARTIAL still skips-and-applies-the-rest (back-compat). Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_aon_${TS}`
+const SHEET = `sheet_aon_${TS}`
+const NAME = `fld_aon_name_${TS}`
+const SALARY = `fld_aon_salary_${TS}`
+const A = `rec_aon_a_${TS}`
+const B = `rec_aon_b_${TS}`
+const C = `rec_aon_c_${TS}`
+const ACTOR = `user_aon_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curUser = ACTOR
+let curRoles = ['member']
+const batchPreview = (recordIds: string[], body: Record<string, unknown> = {}) =>
+  request(app).post(`/api/multitable/sheets/${SHEET}/restore-batch-preview`).send({ targetVersion: 1, recordIds, ...body })
+const batchExecute = (recordIds: string[], expectedVersions: Record<string, number>, previewIdentity: string, body: Record<string, unknown> = {}) =>
+  request(app).post(`/api/multitable/sheets/${SHEET}/restore-batch-execute`).send({ targetVersion: 1, recordIds, expectedVersions, previewIdentity, ...body })
+const recordRow = async (recordId: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [recordId])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+
+async function seedRecord(id: string): Promise<void> {
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, SHEET, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+           VALUES (gen_random_uuid(), $1, $2, 1, 'create', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: 'a', [SALARY]: 100 })])
+  await q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+           VALUES (gen_random_uuid(), $1, $2, 2, 'update', 'rest', ARRAY[$3,$4]::text[], '{}'::jsonb, $5::jsonb, now())`, [SHEET, id, NAME, SALARY, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+}
+// mint a real identity through the actual preview route (no hand-built tokens — the real drift guard)
+async function freshIdentity(recordIds: string[]): Promise<{ token: string; scope: string[] }> {
+  const pv = await batchPreview(recordIds)
+  return { token: pv.body?.data?.previewIdentity as string, scope: pv.body?.data?.scope as string[] }
+}
+
+describeIfDatabase('multitable scoped restore batch-execute — BS-3.1 all-or-nothing (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: curUser, roles: curRoles, perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'AON Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'AON Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+
+  afterAll(async () => {
+    for (const t of ['field_permissions', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    curUser = ACTOR; curRoles = ['member']
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET])
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = false, conditional_read_rules = '[]'::jsonb WHERE id = $1", [SHEET])
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    for (const id of [A, B, C]) await seedRecord(id)
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) all-permitted → applies ALL atomically (every row restored, versions bumped, restoredCount=N, skipped=0)', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token, { allOrNothing: true })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.restoredCount).toBe(3)
+    expect(res.body?.data?.skippedCount).toBe(0)
+    for (const id of [A, B, C]) {
+      const row = await recordRow(id)
+      expect(row?.data?.[NAME]).toBe('a') // restored to v1
+      expect(row?.data?.[SALARY]).toBe(100)
+      expect(row?.version).toBe(3) // FORWARD revision (v2 → v3)
+    }
+    // every record marked restored (no skipped outcome in all-or-nothing success)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    for (const id of [A, B, C]) expect(byId[id].status).toBe('restored')
+  })
+
+  test('(b) one row-DENIED → 409 BATCH_RESTORE_BLOCKED, NOTHING written (every version unchanged at v2)', async () => {
+    // give C a distinct value BEFORE preview so a rule can deny ONLY C (A,B keep NAME='b')
+    await q('UPDATE meta_records SET data = $2::jsonb WHERE id = $1', [C, JSON.stringify({ [NAME]: 'c_marker', [SALARY]: 200 })])
+    const { token } = await freshIdentity([A, B, C]) // minted while none denied (all in scope, same scopeHash)
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET, JSON.stringify([{ id: 'r1', fieldId: NAME, operator: 'eq', value: 'c_marker', effect: 'deny_read' }])])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token, { allOrNothing: true })
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('BATCH_RESTORE_BLOCKED')
+    // the blocker list names C with reason denied (and ONLY C)
+    const blockers = (res.body?.error?.blockers ?? []) as Array<{ recordId: string; reason: string }>
+    expect(blockers).toEqual([{ recordId: C, reason: 'denied' }])
+    // ATOMIC: NOTHING written — A and B (which WOULD have been permitted) are still at v2, unchanged
+    for (const id of [A, B]) {
+      const row = await recordRow(id)
+      expect(row?.version).toBe(2)
+      expect(row?.data?.[NAME]).toBe('b') // not rewound to v1
+    }
+    expect((await recordRow(C))?.version).toBe(2)
+    // and zero forward 'restore' revisions were appended
+    const restoreRevs = await q(`SELECT count(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])
+    expect((restoreRevs.rows[0] as { n: number }).n).toBe(0)
+  })
+
+  test('(c) TRANSACTION ROLLBACK keystone: one CONFLICT (version moved since preview) → 409, NOTHING written (A NOT partially applied)', async () => {
+    // This is the dangerous-slice test: the write phase STARTS (preflight passes — no deny/forbidden), then the
+    // in-transaction CAS throws on B's moved version. Only a true single-transaction write rolls A back; a
+    // best-effort fan-out would have already written A. We assert A is UNCHANGED → proves atomic rollback.
+    const { token } = await freshIdentity([A, B, C]) // preview binds B at version 2
+    // B edited THEN reverted: data identical to preview (diff unchanged → scopeHash still matches) but version moved
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 3 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'x', [SALARY]: 1 })])
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 4 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })]) // reverted
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token, { allOrNothing: true }) // B expected v2, now at v4
+    expect(res.status).toBe(409)
+    expect(res.body?.error?.code).toBe('BATCH_RESTORE_BLOCKED')
+    const blockers = (res.body?.error?.blockers ?? []) as Array<{ recordId: string; reason: string }>
+    expect(blockers).toEqual([{ recordId: B, reason: 'conflict' }]) // the CAS named B
+    // ATOMIC ROLLBACK: A and C were NOT written — A is still v2 with its CURRENT value (never rewound to v1)
+    expect((await recordRow(A))?.version).toBe(2)
+    expect((await recordRow(A))?.data?.[NAME]).toBe('b')
+    expect((await recordRow(C))?.version).toBe(2)
+    expect((await recordRow(C))?.data?.[NAME]).toBe('b')
+    expect((await recordRow(B))?.data?.[NAME]).toBe('b') // B untouched
+    // zero forward 'restore' revisions (the whole transaction rolled back)
+    const restoreRevs = await q(`SELECT count(*)::int AS n FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])
+    expect((restoreRevs.rows[0] as { n: number }).n).toBe(0)
+  })
+
+  test('(d) BACK-COMPAT: default (no flag) is still PARTIAL — one conflict skips, the others apply', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    // B edited THEN reverted: data identical (diff unchanged → scopeHash matches) but version moved → CAS skips B only
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 3 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'x', [SALARY]: 1 })])
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 4 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })])
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token) // NO allOrNothing → default false
+    expect(res.status).toBe(200)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    expect(byId[A].status).toBe('restored')
+    expect(byId[C].status).toBe('restored')
+    expect(byId[B].status).toBe('skipped')
+    expect(byId[B].skipReason).toBe('conflict')
+    expect(res.body?.data?.restoredCount).toBe(2)
+    expect(res.body?.data?.skippedCount).toBe(1)
+    // the survivors A,C WERE written to v1; B left at its current value (partial = skip-and-apply-rest)
+    expect((await recordRow(A))?.data?.[NAME]).toBe('a')
+    expect((await recordRow(C))?.data?.[NAME]).toBe('a')
+    expect((await recordRow(B))?.data?.[NAME]).toBe('b')
+  })
+
+  test('(e) explicit allOrNothing:false is identical to default PARTIAL (the flag is genuinely opt-in)', async () => {
+    const { token } = await freshIdentity([A, B, C])
+    await q('UPDATE meta_records SET data = $2::jsonb, version = 4 WHERE id = $1', [B, JSON.stringify({ [NAME]: 'b', [SALARY]: 200 })]) // B version moved
+    const res = await batchExecute([A, B, C], { [A]: 2, [B]: 2, [C]: 2 }, token, { allOrNothing: false })
+    expect(res.status).toBe(200)
+    const byId = Object.fromEntries((res.body?.data?.records ?? []).map((r: { recordId: string }) => [r.recordId, r]))
+    expect(byId[B].skipReason).toBe('conflict')
+    expect(res.body?.data?.restoredCount).toBe(2) // A,C applied; B skipped
+  })
+})


### PR DESCRIPTION
Opt-in `allOrNothing` mode on `POST .../restore-batch-execute`. Default false = current partial-skip (back-compat). When true: any single denied/forbidden/conflict target blocks the WHOLE batch → 409 `BATCH_RESTORE_BLOCKED` with the blocker list, NOTHING written. Atomicity is structural — `patchRecords` runs the full set in one transaction (any per-record throw rolls back); denied/forbidden are preflighted in-route before any write. **6 new real-DB goldens** (incl. the transaction-rollback keystone: a mid-write conflict leaves the already-started record untouched) + 14 existing = 20/20; tsc clean; allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)