### PR TITLE
feat(automation): W7 observability — rule-save fail-fast + step-result skip-reason

### DIFF
--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -773,6 +773,13 @@ export class AutomationService {
     )
     if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
 
+    // W7-obs (rule-save fail-fast): validate the resultWriteback target FIELDS exist + are type-
+    // compatible against the SOURCE sheet schema at save — the same check as the runtime backwrite
+    // (assertResultWritebackFields, outcome 'approved' for the approval-only path), hoisted earlier so a
+    // typo'd field id surfaces at rule-save, not as a silent backwrite skip at submit.
+    const writebackFieldError = await this.assertResultWritebackFieldsAtSave(sheetId, actionsForValidation)
+    if (writebackFieldError) throw new AutomationRuleValidationError(writebackFieldError)
+
     const row = {
       id: ruleId,
       sheet_id: sheetId,
@@ -1446,7 +1453,14 @@ export class AutomationService {
       // update_record / ...) see the just-written result, not the pre-approval record.
       if (backwritten) recordData = { ...recordData, ...backwritten }
     } catch (err) {
-      logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${err instanceof Error ? err.message : String(err)}`)
+      const reason = err instanceof Error ? err.message : String(err)
+      logger.warn(`approval-result backwrite skipped for bridge ${bridge.id}: ${reason}`)
+      // W7-obs: surface the skip on the start_approval step result so it shows in the run history —
+      // an admin shouldn't need log access to see a misconfigured/blocked backwrite.
+      ;(result as { output?: Record<string, unknown> }).output = {
+        ...((result as { output?: Record<string, unknown> }).output ?? {}),
+        backwriteSkipped: reason,
+      }
     }
 
     const triggerEvent = bridge.triggerEvent ?? {}
@@ -1596,6 +1610,46 @@ export class AutomationService {
       const typeError = resultWritebackFieldTypeError(entry.field, target, outcome)
       if (typeError) throw new Error(typeError)
     }
+  }
+
+  // W7-obs rule-save fail-fast: reuse the runtime resultWriteback field check at SAVE-time, against the
+  // rule's source sheet. Returns an error message (→ AutomationRuleValidationError) or null. 'approved'
+  // is the only outcome the backwrite writes (approval-only path), so it matches the runtime check.
+  private async assertResultWritebackFieldsAtSave(
+    sheetId: string,
+    actions: AutomationAction[] | null,
+  ): Promise<string | null> {
+    for (const action of actions ?? []) {
+      if (action.type !== 'start_approval' || !isRecord(action.config)) continue
+      const writeback = isRecord(action.config.resultWriteback) ? action.config.resultWriteback : null
+      if (!writeback) continue
+      const mapped = RESULT_WRITEBACK_FIELDS
+        .map((field) => ({ field, id: resultWritebackFieldId(writeback, field) }))
+        .filter((entry): entry is { field: ResultWritebackField; id: string } => !!entry.id)
+      if (mapped.length === 0) continue
+      const ids = Array.from(new Set(mapped.map((entry) => entry.id)))
+      const res = await this.queryFn(
+        'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
+        [sheetId, ids],
+      )
+      const byId = new Map<string, ResultWritebackTargetField>()
+      for (const row of res.rows as Array<Record<string, unknown>>) {
+        const id = typeof row.id === 'string' ? row.id : ''
+        const type = typeof row.type === 'string' ? row.type : ''
+        if (id && type) byId.set(id, { id, type, property: normalizeFieldProperty(row.property) })
+      }
+      for (const entry of mapped) {
+        const target = byId.get(entry.id)
+        // LENIENT on absence: a not-yet-defined target field is DEFERRED to the runtime check (the
+        // record data is schemaless and the field may be created after the rule — the runtime's
+        // skip-missing posture). We only fail-fast on a TYPE mismatch for a field that ALREADY exists,
+        // which is an unambiguous misconfiguration the admin should fix now.
+        if (!target) continue
+        const typeError = resultWritebackFieldTypeError(entry.field, target, 'approved')
+        if (typeError) return typeError
+      }
+    }
+    return null
   }
 
   private async failApprovalBridgeExecution(

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -553,7 +553,7 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       return new Response('OK', { status: 200 })
     }) as never)
     try {
-      await executeAndApprove(svc, { statusField: 'missing_approval_status' }, 'Missing writeback field')
+      const { executionId } = await executeAndApprove(svc, { statusField: 'missing_approval_status' }, 'Missing writeback field')
 
       const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
       const data = rec.rows[0].data as Record<string, unknown>
@@ -561,29 +561,34 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(data).not.toHaveProperty('missing_approval_status')
       // Field-validation failure is fail-closed for the write, not a second way to block W6 resume.
       expect(calls).toEqual(['https://example.test/w6-tail'])
+      // W7-obs: the skip reason is surfaced on the start_approval step result (run history), not just logs.
+      const resumed = await waitForExecutionStatus(svc, executionId, 'success')
+      const startStep = resumed.steps.find((step) => step.actionType === 'start_approval')
+      expect(startStep?.output).toMatchObject({ backwriteSkipped: expect.stringContaining('target field not found') })
     } finally {
       svc.shutdown()
     }
   })
 
-  test('W7-1b: resultWriteback skips writes when the mapped target type is incompatible', async () => {
-    const calls: string[] = []
-    const svc = makeAutomationService((async (url: string) => {
-      calls.push(url)
-      return new Response('OK', { status: 200 })
-    }) as never)
+  test('W7-obs: resultWriteback with an incompatible target type is rejected at rule-save (fail-fast)', async () => {
+    const svc = makeAutomationService((async () => new Response('OK', { status: 200 })) as never)
     try {
       await seedSheetRecord('Wrong writeback type')
       await seedWritebackFields([
         { id: 'approval_status_number', name: 'Approval Status Number', type: 'number', order: 30 },
       ])
-      await executeAndApprove(svc, { statusField: 'approval_status_number' }, 'Wrong writeback type')
+      // W7-obs rule-save fail-fast: a statusField mapped to a number column is an unambiguous misconfig
+      // for an EXISTING field, so it is caught at createRule rather than saved and silently skipped at
+      // submit. The runtime skip-don't-block posture (W7-1b) is preserved for MISSING fields (the test
+      // above — createRule stays lenient on absence) and for post-save schema changes.
+      await expect(
+        executeAndApprove(svc, { statusField: 'approval_status_number' }, 'Wrong writeback type'),
+      ).rejects.toThrow(/must be string\/longText\/select/)
 
+      // The rule was rejected, so nothing was written to the record.
       const rec = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [RECORD, SHEET])
       const data = rec.rows[0].data as Record<string, unknown>
-      expect(data.title).toBe('Wrong writeback type')
       expect(data).not.toHaveProperty('approval_status_number')
-      expect(calls).toEqual(['https://example.test/w6-tail'])
     } finally {
       svc.shutdown()
     }


### PR DESCRIPTION
Two operability補強 for the W7 approval-result backwrite (lower risk than rejection/cross-base, per the plan):

- **rule-save fail-fast** (`createRule`) — validate the `resultWriteback` target fields against the source sheet schema at SAVE (reusing #3157's existence/type check). **Lenient on absence** (a not-yet-defined field is deferred to the runtime skip — record data is schemaless, the field may be added after the rule), **fail-fast on a TYPE mismatch for a field that already exists** (unambiguous misconfig, e.g. statusField→number).
- **step-result skip-reason** — when the runtime backwrite skips, surface the reason on the `start_approval` step result output (`backwriteSkipped`), so it shows in run history, not only `logger.warn`.

**Behavior note:** the fail-fast changes the at-save incompatible-type case from "saved + skipped at runtime" to "rejected at rule-save" (the point of fail-fast). The W7-1b skip-don't-block posture is preserved for **missing fields** (lenient → runtime skip) and **post-save schema changes**. The W7-1b incompatible-type test is updated to assert the save-time rejection; the missing-field test now also asserts the step-result skip-reason.

**14/14** start_approval integration; automation-v1 186/186; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)