### PR TITLE
feat(approval): enable the amount total-check on the amount-tier presets

### DIFF
--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -199,6 +199,19 @@ function purchaseSchema(): FormSchema {
   }
 }
 
+// Server-side amount total-check (design-lock #3161): attach the consistency mapping so the amount-tier
+// presets are protected by default — the backend rejects a submission whose top-level total ≠ the sum of
+// the detail-row amounts (closing the under-stated-total bypass of the higher tier). The basic presets
+// keep no mapping. The backend validates + persists it; the FE just declares it.
+function withAmountConsistency(
+  schema: FormSchema,
+  totalFieldId: string,
+  detailFieldId: string,
+  amountColumnId: string,
+): FormSchema {
+  return { ...schema, amountConsistencyCheck: { totalFieldId, detailFieldId, amountColumnId } }
+}
+
 // Amount-tier reimbursement (design-lock #3114): a condition node gates a higher-tier approver on the
 // top-level `amount`. Low amount → end after the direct manager; amount ≥ threshold → a dept-head
 // (higher-tier) approval before end. Default threshold 5000, editable in the condition-node rule
@@ -314,7 +327,7 @@ function presetConfig(id: CommonApprovalTemplatePresetId): {
         name: '报销审批（金额分级）',
         description: '高额报销自动升级审批草稿。金额阈值与各级审批人可在编辑页调整后再发布。',
         category: '报销',
-        formSchema: reimbursementSchema(),
+        formSchema: withAmountConsistency(reimbursementSchema(), 'amount', 'expense_items', 'amount'),
         approvalGraph: reimbursementAmountTierGraph(),
       }
     case 'purchase_amount_tier':
@@ -323,7 +336,7 @@ function presetConfig(id: CommonApprovalTemplatePresetId): {
         name: '采购审批（金额分级）',
         description: '高额采购升级为并行会签草稿。金额阈值、汇聚模式（会签/或签）与各级审批人可在编辑页调整后再发布。',
         category: '采购',
-        formSchema: purchaseSchema(),
+        formSchema: withAmountConsistency(purchaseSchema(), 'amount', 'purchase_items', 'amount'),
         approvalGraph: purchaseAmountTierGraph(),
       }
   }

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -165,8 +165,18 @@ export interface FormField {
   maxRows?: number
 }
 
+export interface AmountConsistencyMapping {
+  totalFieldId: string
+  detailFieldId: string
+  amountColumnId: string
+}
+
 export interface FormSchema {
   fields: FormField[]
+  // Server-side amount total-check (design-lock #3161): when present, the backend rejects a create
+  // whose top-level total ≠ the sum of the detail-row amounts. Authored here / preserved by the backend
+  // assertFormSchema; the FE just carries it verbatim (the backend is the sole arbiter).
+  amountConsistencyCheck?: AmountConsistencyMapping
 }
 
 export interface ApprovalRequesterSnapshot {

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -134,3 +134,23 @@ describe('common approval template presets', () => {
     })
   })
 })
+
+describe('amount-tier presets ship the server-side total-check mapping (#3161)', () => {
+  it('purchase_amount_tier carries amountConsistencyCheck → purchase_items.amount', () => {
+    const { formSchema } = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier')
+    expect(formSchema.amountConsistencyCheck).toEqual({
+      totalFieldId: 'amount', detailFieldId: 'purchase_items', amountColumnId: 'amount',
+    })
+  })
+  it('reimbursement_amount_tier carries amountConsistencyCheck → expense_items.amount', () => {
+    const { formSchema } = buildCommonApprovalTemplatePresetPayload('reimbursement_amount_tier')
+    expect(formSchema.amountConsistencyCheck).toEqual({
+      totalFieldId: 'amount', detailFieldId: 'expense_items', amountColumnId: 'amount',
+    })
+  })
+  it('the basic (non-amount-tier) presets do NOT carry the mapping', () => {
+    for (const id of ['leave', 'reimbursement', 'purchase'] as const) {
+      expect(buildCommonApprovalTemplatePresetPayload(id).formSchema.amountConsistencyCheck).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
Turns the amount-total-check (#3176) ON by default for the amount-tier presets: `purchase_amount_tier` → `{amount, purchase_items, amount}`, `reimbursement_amount_tier` → `{amount, expense_items, amount}` (via a small `withAmountConsistency` helper). The basic presets (leave/reimbursement/purchase) keep no mapping. So under-stating the top-level total to dodge the higher tier is rejected by the backend out of the box. FE FormSchema gains `amountConsistencyCheck?` (carried verbatim — backend is sole arbiter). Preset test +3; vue-tsc clean. Depends on #3176 for the effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)