### PR TITLE
docs(multitable): drop 'Time Machine' brand wording from merged docs (review fix-forward)

### DIFF
--- a/docs/development/multitable-global-history-remaining-dev-pass2-design-verification-20260624.md
+++ b/docs/development/multitable-global-history-remaining-dev-pass2-design-verification-20260624.md
@@ -1,4 +1,4 @@
-# Time Machine remaining-dev (pass 2) — design & verification
+# Global History remaining-dev (pass 2) — design & verification
 
 ## 🚫 BLOCKED ON EXPLICIT SIGN-OFF (not built — by design)
 
@@ -55,7 +55,7 @@ This pass closed the [P1] review findings on the prior pass, then completed the 
 this doc follow. Each new write path is mutation/trigger-proven, allow-and-deny.
 
 ## The honest bottom line
-The read/preview/scoped-write/non-destructive arcs of the Time Machine line are complete and hardened. The **only**
+The read/preview/scoped-write/non-destructive arcs of the Global History / point-in-time restore line are complete and hardened. The **only**
 remaining development is the **destructive Reset (T8-2)** and the **irreversible data-loss config ops** — and those are
 deliberately held at your sign-off, with their decisions resolved and a build plan ready. Say yes to D1–D5 and I build
 T8-2 behind the default-off flag with the full PIT-2 / ceiling / atomicity golden suite.

--- a/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
+++ b/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
@@ -7,7 +7,7 @@
 
 ## Why this is gated and not auto-built
 
-Reset is the one genuinely destructive capability in the whole Time Machine line: it **deletes records created after
+Reset is the one genuinely destructive capability in the whole Global History / point-in-time restore line: it **deletes records created after
 T** (Revert keeps them). A bug here loses data. The line's discipline — and the [P1] review that just caught a T8-1
 gate miss — say the destructive path gets an explicit, deliberate sign-off, not a broad "complete it." So this is
 presented for decision, with the safe half (T8-1 Revert) already shipped (#3165).


### PR DESCRIPTION
Fix-forward for the #3170 [P2]: the same banned 'Time Machine' competitor-brand wording shipped via #3178 in two merged docs. Renames the pass-2 MD to `multitable-global-history-remaining-dev-pass2-*` and rewords 'Time Machine line' → 'Global History / point-in-time restore line' in it + the readiness doc. Committed docs state own principles, not competitor brand terms. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)