### PR TITLE
docs(multitable): correct pass-2 doc — #3177 is OPEN/web-guard-failing, not a safe completion

### DIFF
--- a/docs/development/multitable-timemachine-remaining-dev-pass2-design-verification-20260624.md
+++ b/docs/development/multitable-timemachine-remaining-dev-pass2-design-verification-20260624.md
@@ -27,7 +27,14 @@ This pass closed the [P1] review findings on the prior pass, then completed the 
 - **[P2]** design-lock status corrected (#3172); the closeout MD records both fixes (#3170).
 
 ### Safe completions
-- **R4 config-history polish** (#3177): diff-rendering depth (`summarizeConfigValue` — compact `k: v` for config
+
+> **Status correction (2026-06-25).** #3177 below was listed here prematurely — it is **NOT a completed/landed item.**
+> As of this correction **#3177 is still OPEN with `multitable-web-guard` FAILING**, and **#3169 (FE) is also still
+> OPEN** (with a blocking REQUEST-CHANGES: post-restore `onConfigReverted` doesn't reload sheet-meta/grid, so a revert
+> looks successful while the field name / view filter / grid stay stale). The "Landing status" section below describes
+> the *intended* dependency order, not what has actually merged.
+
+- **R4 config-history polish** (#3177) — **OPEN; `multitable-web-guard` FAILING; not yet landed.** diff-rendering depth (`summarizeConfigValue` — compact `k: v` for config
   objects instead of raw JSON, config-only so no value masking) + an **end-to-end mount→button→fetch wire test**
   (clicks Revert→confirm, asserts the real `config-restore-preview` then `config-restore-execute` fetches fire with the
   server `previewToken`) — closing the wire-coverage gap flagged earlier. vue-tsc 0; spec 13/13.
@@ -42,8 +49,10 @@ This pass closed the [P1] review findings on the prior pass, then completed the 
 - cross-base data-sync, dashboards — parked off this line.
 
 ## Landing status
-[P1]#2 #3165 + sub-features #3168 **merged**. Landing dependency-gated: #3172 (identity) → #3169 (FE) → #3177
-(R4 polish) → #3170 (MD); BS-3.1 + this doc follow. Each new write path is mutation/trigger-proven, allow-and-deny.
+[P1]#2 #3165 + sub-features #3168 **merged**. Landing dependency-gated (this is the **INTENDED** order — corrected
+2026-06-25 to live state, not all merged): #3172 (identity) → #3169 (FE — **OPEN**, blocking REQUEST-CHANGES) → #3177
+(R4 polish — **OPEN, `multitable-web-guard` failing**) → #3170 (MD — **closed as superseded** by #3178/#3181). BS-3.1 +
+this doc follow. Each new write path is mutation/trigger-proven, allow-and-deny.
 
 ## The honest bottom line
 The read/preview/scoped-write/non-destructive arcs of the Time Machine line are complete and hardened. The **only**


### PR DESCRIPTION
The merged **#3178** pass-2 doc lists **R4 polish (#3177)** under "Safe completions" and in the landing chain as if landed. Live state contradicts that:
- **#3177** — OPEN, `multitable-web-guard` **FAILING**.
- **#3169** (FE) — OPEN, with a blocking REQUEST-CHANGES (post-restore `onConfigReverted` doesn't reload sheet-meta/grid → revert looks successful but field name / view filter / grid stay stale).
- **#3170** (MD) — closed as superseded by #3178/#3181.

This is a focused status correction (a status-note + the landing-status line) so `main`'s record stops asserting a failing, unmerged PR is complete. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)