### PR TITLE
feat(multitable): R4 config-history diff polish follow-up

### DIFF
--- a/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
+++ b/apps/web/src/multitable/components/MetaConfigHistoryModal.vue
@@ -127,10 +127,28 @@ const ACTION_KEY: Record<string, MetaRecordLabelKey> = {
 const filterLabel = (opt: string): string => (opt === '' ? l('record.configHistoryFilterAll') : entityLabel(opt))
 const entityLabel = (t: string): string => (ENTITY_KEY[t] ? l(ENTITY_KEY[t]) : t)
 const actionLabel = (a: string): string => (ACTION_KEY[a] ? l(ACTION_KEY[a]) : a)
-function display(value: unknown): string {
+
+// Render config values as compact summaries instead of raw JSON blobs. These are CONFIG values (not record data), so
+// no value masking is applied here; sensitive projection/redaction remains server-owned.
+function summarizeConfigValue(value: unknown, depth = 0): string {
   if (value === null || value === undefined) return '∅'
   if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    const allPrimitive = value.every((v) => v === null || typeof v !== 'object')
+    return allPrimitive ? value.map((v) => summarizeConfigValue(v, depth + 1)).join('; ') : `[${value.length}]`
+  }
+  if (typeof value === 'object') {
+    if (depth >= 2) return JSON.stringify(value)
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) return '{}'
+    return entries.map(([k, v]) => `${k}: ${summarizeConfigValue(v, depth + 1)}`).join(', ')
+  }
   return JSON.stringify(value)
+}
+function display(value: unknown): string {
+  return summarizeConfigValue(value)
 }
 
 // --- T9-W revert flow (the gate stays server-side; this only shows the server's preview + confirms) ---

--- a/apps/web/tests/multitable-config-history-modal.spec.ts
+++ b/apps/web/tests/multitable-config-history-modal.spec.ts
@@ -36,6 +36,13 @@ function mountModal(over: Partial<Props>) {
 }
 const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
 const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
+const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
+  for (let i = 0; i < tries; i++) {
+    if (pred()) return
+    await flush()
+  }
+  throw new Error('waitUntil: condition not met in time')
+}
 afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
 
 describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
@@ -50,6 +57,23 @@ describe('MetaConfigHistoryModal — T9-R4 config-history view', () => {
     expect(document.body.textContent).toContain('Old') // before
     expect(document.body.textContent).toContain('New') // after
     expect(document.body.querySelectorAll('.cfg-history__row').length).toBe(2) // BOTH rendered — the FE doesn't drop rows
+  })
+
+  it('renders config objects as a compact k: v summary, not a raw JSON blob (diff-rendering depth)', async () => {
+    mountModal({ items: [
+      rev({
+        id: 'a',
+        entityType: 'permission',
+        entityId: 'fld_1',
+        action: 'update',
+        changedKeys: ['grant'],
+        before: { grant: { visible: true, readOnly: false } },
+        after: { grant: { visible: false, readOnly: true } },
+      }),
+    ] })
+    await nextTick()
+    expect(document.body.textContent).toContain('visible: false, readOnly: true')
+    expect(document.body.textContent).not.toContain('{"visible"')
   })
 
   it('the entity-type filter EMITS filter-change (server re-fetches; the FE never client-filters for security)', async () => {
@@ -119,6 +143,51 @@ describe('MetaConfigHistoryModal — T9-W revert action (server-gated, FE render
     await nextTick(); (q('[data-test="config-history-revert"]') as HTMLButtonElement).click(); await flush()
     expect(q('[data-test="config-restore-drift"]')).toBeTruthy()
     expect((q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('END-TO-END wire: Revert button → real client → config-restore-preview then -execute with the SERVER previewToken', async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes('config-restore-preview')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            preview: {
+              revisionId: 'a',
+              entityType: 'field',
+              entityId: 'fld_1',
+              changedKeys: ['name'],
+              current: { name: 'New' },
+              target: { name: 'Old' },
+              driftConflict: false,
+              opKind: 'safe',
+              baselineHash: 'h-server',
+            },
+            previewToken: 'server-token-xyz',
+          },
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ ok: true, data: { restored: { revisionId: 'a' } } }), { status: 200 })
+    })
+    const client = new MultitableApiClient({ fetchFn })
+    const onReverted = vi.fn()
+    mountModal({
+      items: [updateRev()],
+      onReverted,
+      previewRevert: (id: string) => client.getConfigRestorePreview('sheet_1', id),
+      executeRevert: (id: string, token: string) => client.executeConfigRestore('sheet_1', id, token),
+    })
+    await nextTick()
+    ;(q('[data-test="config-history-revert"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="config-restore-confirm-btn"]'))
+    ;(q('[data-test="config-restore-confirm-btn"]') as HTMLButtonElement).click()
+    await waitUntil(() => fetchFn.mock.calls.length >= 2 && onReverted.mock.calls.length >= 1)
+
+    expect(fetchFn.mock.calls[0][0]).toContain('/config-restore-preview')
+    expect(fetchFn.mock.calls[1][0]).toContain('/config-restore-execute')
+    const execBody = JSON.parse((fetchFn.mock.calls[1][1] as RequestInit).body as string)
+    expect(execBody.previewToken).toBe('server-token-xyz')
+    expect(execBody.baselineHash).toBeUndefined()
+    expect(onReverted).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

This is the collision-free follow-up for the useful additive pieces from #3177, without rebasing or touching the agent-held #3177 branch.

- render config-history diff values as compact `k: v` summaries instead of raw JSON blobs
- add a diff-rendering regression test for object config values
- add a real `MultitableApiClient` wire test for Revert -> preview -> execute, proving execute sends the server `previewToken` and not a stale client hash

After this lands, #3177 can be closed as superseded by this focused follow-up.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-config-history-modal.spec.ts --reporter=dot`
- `pnpm --filter @metasheet/web exec vue-tsc -b`
