### PR TITLE
feat(integration): FOS-4b-3-prod P1 — production apply policy contract (LOCK-SAFE; no apply enabled)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
@@ -74,13 +74,25 @@ rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresA
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: 'not-a-date' })), 'invalid_expiry')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ requireFreshDryRun: false })), 'fresh_dry_run_required')
 
-// --- expiry check (caller supplies now; no module clock) ---
-const future = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2999-01-01T00:00:00.000Z' }))
-assert.doesNotThrow(() => assertProductionPolicyNotExpired(future, Date.parse('2026-06-25T00:00:00.000Z')))
+// --- strict ISO-8601 (reject loose forms Date.parse would otherwise accept) ---
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2999' })), 'invalid_expiry') // year-only → ~1000y window
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-25' })), 'invalid_expiry') // date-only, no time/zone
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-25T00:00:00' })), 'invalid_expiry') // no zone
+
+// --- expiry check (caller supplies now; no module clock; bounded authorization window = 7 days) ---
+const nowMs = Date.parse('2026-06-25T00:00:00.000Z')
+const nearFuture = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-26T00:00:00.000Z' })) // +1d, in window
+assert.doesNotThrow(() => assertProductionPolicyNotExpired(nearFuture, nowMs))
+const atWindow = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-07-02T00:00:00.000Z' })) // now + exactly 7d
+assert.doesNotThrow(() => assertProductionPolicyNotExpired(atWindow, nowMs)) // boundary is inclusive (> check)
+const justOverWindow = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-07-02T00:00:00.001Z' })) // +7d+1ms
+rejectsWith(() => assertProductionPolicyNotExpired(justOverWindow, nowMs), 'expiry_too_far')
+const tooFar = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2999-01-01T00:00:00.000Z' })) // valid ISO but distant
+rejectsWith(() => assertProductionPolicyNotExpired(tooFar, nowMs), 'expiry_too_far')
 const past = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2020-01-01T00:00:00.000Z' }))
-rejectsWith(() => assertProductionPolicyNotExpired(past, Date.parse('2026-06-25T00:00:00.000Z')), 'expired')
-rejectsWith(() => assertProductionPolicyNotExpired({}, Date.parse('2026-06-25T00:00:00.000Z')), 'not_normalized')
-rejectsWith(() => assertProductionPolicyNotExpired(future, Number.NaN), 'missing_now')
+rejectsWith(() => assertProductionPolicyNotExpired(past, nowMs), 'expired')
+rejectsWith(() => assertProductionPolicyNotExpired({}, nowMs), 'not_normalized')
+rejectsWith(() => assertProductionPolicyNotExpired(nearFuture, Number.NaN), 'missing_now')
 
 // --- non-vacuous: a fully valid policy still normalizes (the negatives aren't rejecting everything) ---
 assert.ok(normalizeStockPrepApplyProductionPolicy(validPolicy()), 'valid policy normalizes (non-vacuous)')

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
@@ -1,0 +1,88 @@
+'use strict'
+
+// FOS-4b-3-prod P1: production policy contract tests. Normalizer + negative controls + expiry + values-free.
+// LOCK-SAFE: this exercises the contract only; nothing here enables apply or touches the canonical.
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const {
+  PROD_CANONICAL_OBJECT_ID,
+  StockPreparationProductionPolicyError,
+  normalizeStockPrepApplyProductionPolicy,
+  assertProductionPolicyNotExpired,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-production-policy.cjs'))
+
+function validPolicy(overrides = {}) {
+  return {
+    enabled: true,
+    authorizedTargetObjectId: PROD_CANONICAL_OBJECT_ID,
+    authorizationId: 'auth-opaque-1',
+    allowedActionId: 'plm.stock-preparation.pull-bom.v1',
+    allowedRoute: 'both',
+    maxCleanRows: 500,
+    expiresAt: '2999-01-01T00:00:00.000Z',
+    requireFreshDryRun: true,
+    ...overrides,
+  }
+}
+
+function rejectsWith(fn, reason) {
+  try {
+    fn()
+  } catch (e) {
+    assert.ok(e instanceof StockPreparationProductionPolicyError, `expected policy error, got ${e && e.name}`)
+    assert.equal(e.status, 422)
+    assert.equal(e.code, 'STOCK_PREP_PRODUCTION_POLICY_INVALID')
+    assert.equal(e.details.reason, reason, `expected reason=${reason}, got ${e.details && e.details.reason}`)
+    // values-free: error details carry only a coarse reason (no target / authorization / values)
+    assert.deepEqual(Object.keys(e.details), ['reason'], 'error details must be reason-only (values-free)')
+    return e
+  }
+  assert.fail(`expected rejection with reason=${reason}`)
+}
+
+// --- happy path ---
+const ok = normalizeStockPrepApplyProductionPolicy(validPolicy())
+assert.equal(ok.enabled, true)
+assert.equal(ok.authorizedTargetObjectId, PROD_CANONICAL_OBJECT_ID)
+assert.equal(ok.allowedRoute, 'both')
+assert.equal(ok.maxCleanRows, 500)
+assert.equal(ok.requireFreshDryRun, true)
+assert.ok(Number.isFinite(ok.expiresAtMs))
+assert.ok(Object.isFrozen(ok), 'normalized policy is frozen')
+for (const route of ['small', 'large', 'both']) {
+  assert.equal(normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedRoute: route })).allowedRoute, route)
+}
+
+// --- negative controls (each fail-closed, values-free) ---
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(null), 'not_object')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy('x'), 'not_object')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy({ allowedTargetObjectIds: ['sandbox_x'], enabled: true }), 'sandbox_shape')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ enabled: false })), 'not_enabled')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ authorizedTargetObjectId: '' })), 'missing_target')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ authorizedTargetObjectId: 'some_sandbox_table' })), 'target_not_canonical')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ authorizationId: '' })), 'missing_authorization')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedActionId: '' })), 'missing_action')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedActionId: 'evil.action.v1' })), 'action_not_allowed')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedRoute: 'all' })), 'invalid_route')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedRoute: '' })), 'invalid_route')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ maxCleanRows: 0 })), 'invalid_max_clean_rows')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ maxCleanRows: -5 })), 'invalid_max_clean_rows')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ maxCleanRows: 1.5 })), 'invalid_max_clean_rows')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '' })), 'missing_expiry')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: 'not-a-date' })), 'invalid_expiry')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ requireFreshDryRun: false })), 'fresh_dry_run_required')
+
+// --- expiry check (caller supplies now; no module clock) ---
+const future = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2999-01-01T00:00:00.000Z' }))
+assert.doesNotThrow(() => assertProductionPolicyNotExpired(future, Date.parse('2026-06-25T00:00:00.000Z')))
+const past = normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2020-01-01T00:00:00.000Z' }))
+rejectsWith(() => assertProductionPolicyNotExpired(past, Date.parse('2026-06-25T00:00:00.000Z')), 'expired')
+rejectsWith(() => assertProductionPolicyNotExpired({}, Date.parse('2026-06-25T00:00:00.000Z')), 'not_normalized')
+rejectsWith(() => assertProductionPolicyNotExpired(future, Number.NaN), 'missing_now')
+
+// --- non-vacuous: a fully valid policy still normalizes (the negatives aren't rejecting everything) ---
+assert.ok(normalizeStockPrepApplyProductionPolicy(validPolicy()), 'valid policy normalizes (non-vacuous)')
+
+console.log('stock-preparation-production-policy.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-production-policy.test.cjs
@@ -59,6 +59,7 @@ for (const route of ['small', 'large', 'both']) {
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(null), 'not_object')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy('x'), 'not_object')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy({ allowedTargetObjectIds: ['sandbox_x'], enabled: true }), 'sandbox_shape')
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ allowedTargetObjectIds: ['sandbox_x'] })), 'sandbox_shape')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ enabled: false })), 'not_enabled')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ authorizedTargetObjectId: '' })), 'missing_target')
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ authorizedTargetObjectId: 'some_sandbox_table' })), 'target_not_canonical')
@@ -78,6 +79,8 @@ rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ requireF
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2999' })), 'invalid_expiry') // year-only → ~1000y window
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-25' })), 'invalid_expiry') // date-only, no time/zone
 rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-25T00:00:00' })), 'invalid_expiry') // no zone
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-02-31T00:00:00.000Z' })), 'invalid_expiry') // Date.parse rollover
+rejectsWith(() => normalizeStockPrepApplyProductionPolicy(validPolicy({ expiresAt: '2026-06-25T24:00:00.000Z' })), 'invalid_expiry') // Date.parse rollover
 
 // --- expiry check (caller supplies now; no module clock; bounded authorization window = 7 days) ---
 const nowMs = Date.parse('2026-06-25T00:00:00.000Z')

--- a/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
@@ -19,6 +19,10 @@ const {
 const PLM_STOCK_PREPARATION_ACTION_ID = 'plm.stock-preparation.pull-bom.v1'
 const PROD_CANONICAL_OBJECT_ID = STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId
 const ALLOWED_ROUTES = Object.freeze(['small', 'large', 'both'])
+// Bounded authorization window: a production policy may not be usable more than this far in the future,
+// enforced at apply time against the caller-supplied `now`. Keeps "bounded by time" real even when
+// expiresAt is a valid-but-distant ISO timestamp. Reviewed bound; tighten as needed.
+const MAX_PRODUCTION_POLICY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 
 class StockPreparationProductionPolicyError extends Error {
   constructor(status, code, message, details = {}) {
@@ -83,6 +87,11 @@ function normalizeStockPrepApplyProductionPolicy(input) {
 
   const expiresAt = optionalString(input.expiresAt)
   if (!expiresAt) reject('missing_expiry', 'expiresAt is required')
+  // Require strict ISO-8601 with explicit time + zone. Date.parse alone accepts loose forms (e.g. "2999"
+  // → a ~1000-year window), which defeats the bounded-time intent; demand the full timestamp.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(expiresAt)) {
+    reject('invalid_expiry', 'expiresAt must be a strict ISO-8601 timestamp with time and zone')
+  }
   const expiresAtMs = Date.parse(expiresAt)
   if (!Number.isFinite(expiresAtMs)) reject('invalid_expiry', 'expiresAt must be a valid timestamp')
 
@@ -111,11 +120,16 @@ function assertProductionPolicyNotExpired(policy, now) {
   }
   if (!Number.isFinite(now)) reject('missing_now', 'a current timestamp is required for the expiry check')
   if (now >= policy.expiresAtMs) reject('expired', 'production policy has expired')
+  // Bounded-time: reject a policy whose expiry is further out than the reviewed authorization window.
+  if (policy.expiresAtMs > now + MAX_PRODUCTION_POLICY_WINDOW_MS) {
+    reject('expiry_too_far', 'production policy expiry exceeds the bounded authorization window')
+  }
 }
 
 module.exports = {
   PROD_CANONICAL_OBJECT_ID,
   ALLOWED_ROUTES,
+  MAX_PRODUCTION_POLICY_WINDOW_MS,
   StockPreparationProductionPolicyError,
   normalizeStockPrepApplyProductionPolicy,
   assertProductionPolicyNotExpired,

--- a/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
@@ -1,0 +1,122 @@
+'use strict'
+
+// FOS-4b-3-prod P1 — production apply policy CONTRACT (normalize/validate + negative controls).
+//
+// LOCK-SAFE: this module is NOT wired into the apply path. The sandbox-only guard
+// (assertStockPrepApplySandboxAllowed) is unchanged and the production canonical target stays rejected by
+// default. P2 will wire a validated production policy into BOTH write entry points (small-BOM
+// applyStockPreparationAction and large-BOM tableActionLargeBomApplyJobRun) behind explicit owner
+// authorization, fail-closed by default. This file only defines + validates the policy shape so that the
+// future wiring has a strict contract. It does not open production apply, touch the canonical, or change
+// any runtime. See data-factory-fos-4b-3-prod-apply-gate-design-lock-20260625.md.
+
+const {
+  STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
+} = require('./stock-preparation-templates.cjs')
+
+// Mirrors PLM_STOCK_PREPARATION_ACTION_ID (defined in stock-preparation-table-actions.cjs); kept local to
+// avoid a future table-actions <-> production-policy import cycle when P2 wires this in.
+const PLM_STOCK_PREPARATION_ACTION_ID = 'plm.stock-preparation.pull-bom.v1'
+const PROD_CANONICAL_OBJECT_ID = STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId
+const ALLOWED_ROUTES = Object.freeze(['small', 'large', 'both'])
+
+class StockPreparationProductionPolicyError extends Error {
+  constructor(status, code, message, details = {}) {
+    super(message)
+    this.name = 'StockPreparationProductionPolicyError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function optionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+// Values-free reject: coarse reason only; never echoes target / authorization / action / values.
+function reject(reason, message) {
+  throw new StockPreparationProductionPolicyError(422, 'STOCK_PREP_PRODUCTION_POLICY_INVALID', message, { reason })
+}
+
+// Normalize/validate a production apply policy. Fail-closed: any missing/invalid field, a sandbox-shaped
+// object, a non-canonical target, or a non-true gating flag throws. Returns a frozen normalized policy on
+// success. This is the contract only — it grants nothing; P2 decides per-apply using it.
+function normalizeStockPrepApplyProductionPolicy(input) {
+  if (!isPlainObject(input)) reject('not_object', 'production policy must be an object')
+  // A sandbox policy is NOT a production policy — reject the sandbox allowlist shape outright so it can
+  // never be passed in as a production policy.
+  if (Object.prototype.hasOwnProperty.call(input, 'allowedTargetObjectIds') &&
+      !Object.prototype.hasOwnProperty.call(input, 'authorizedTargetObjectId')) {
+    reject('sandbox_shape', 'a sandbox policy must not be used as a production policy')
+  }
+  if (input.enabled !== true) reject('not_enabled', 'production policy must be explicitly enabled')
+
+  const authorizedTargetObjectId = optionalString(input.authorizedTargetObjectId)
+  if (!authorizedTargetObjectId) reject('missing_target', 'authorizedTargetObjectId is required')
+  // Production policy may only authorize the prod canonical target — never an arbitrary non-canonical one.
+  if (authorizedTargetObjectId !== PROD_CANONICAL_OBJECT_ID) {
+    reject('target_not_canonical', 'production policy may only authorize the production canonical target')
+  }
+
+  const authorizationId = optionalString(input.authorizationId)
+  if (!authorizationId) reject('missing_authorization', 'authorizationId is required')
+
+  const allowedActionId = optionalString(input.allowedActionId)
+  if (!allowedActionId) reject('missing_action', 'allowedActionId is required')
+  if (allowedActionId !== PLM_STOCK_PREPARATION_ACTION_ID) {
+    reject('action_not_allowed', 'allowedActionId is not a recognized stock-preparation action')
+  }
+
+  const allowedRoute = optionalString(input.allowedRoute)
+  if (!allowedRoute || !ALLOWED_ROUTES.includes(allowedRoute)) {
+    reject('invalid_route', 'allowedRoute must be one of small | large | both')
+  }
+
+  if (!Number.isInteger(input.maxCleanRows) || input.maxCleanRows <= 0) {
+    reject('invalid_max_clean_rows', 'maxCleanRows must be a positive integer')
+  }
+
+  const expiresAt = optionalString(input.expiresAt)
+  if (!expiresAt) reject('missing_expiry', 'expiresAt is required')
+  const expiresAtMs = Date.parse(expiresAt)
+  if (!Number.isFinite(expiresAtMs)) reject('invalid_expiry', 'expiresAt must be a valid timestamp')
+
+  // No blind apply: the policy must explicitly require a fresh dry-run/apply token at apply time.
+  if (input.requireFreshDryRun !== true) reject('fresh_dry_run_required', 'requireFreshDryRun must be true')
+
+  return Object.freeze({
+    enabled: true,
+    authorizedTargetObjectId,
+    authorizationId,
+    allowedActionId,
+    allowedRoute,
+    maxCleanRows: input.maxCleanRows,
+    expiresAt,
+    expiresAtMs,
+    requireFreshDryRun: true,
+  })
+}
+
+// Expiry check kept separate so the caller supplies `now` (no module-level clock). Fail-closed: a
+// normalized policy at/after expiry rejects; a missing/non-normalized policy or missing `now` rejects.
+// P2 calls this at apply time with the current timestamp.
+function assertProductionPolicyNotExpired(policy, now) {
+  if (!isPlainObject(policy) || !Number.isFinite(policy.expiresAtMs)) {
+    reject('not_normalized', 'production policy must be normalized before the expiry check')
+  }
+  if (!Number.isFinite(now)) reject('missing_now', 'a current timestamp is required for the expiry check')
+  if (now >= policy.expiresAtMs) reject('expired', 'production policy has expired')
+}
+
+module.exports = {
+  PROD_CANONICAL_OBJECT_ID,
+  ALLOWED_ROUTES,
+  StockPreparationProductionPolicyError,
+  normalizeStockPrepApplyProductionPolicy,
+  assertProductionPolicyNotExpired,
+}

--- a/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-production-policy.cjs
@@ -42,6 +42,28 @@ function optionalString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
+function parseStrictIsoTimestamp(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-])(\d{2}):(\d{2}))$/.exec(value)
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const hour = Number(match[4])
+  const minute = Number(match[5])
+  const second = Number(match[6])
+  const offsetHour = match[9] === undefined ? 0 : Number(match[9])
+  const offsetMinute = match[10] === undefined ? 0 : Number(match[10])
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  if (month < 1 || month > 12) return null
+  if (day < 1 || day > daysInMonth) return null
+  if (hour < 0 || hour > 23) return null
+  if (minute < 0 || minute > 59) return null
+  if (second < 0 || second > 59) return null
+  if (offsetHour < 0 || offsetHour > 23 || offsetMinute < 0 || offsetMinute > 59) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 // Values-free reject: coarse reason only; never echoes target / authorization / action / values.
 function reject(reason, message) {
   throw new StockPreparationProductionPolicyError(422, 'STOCK_PREP_PRODUCTION_POLICY_INVALID', message, { reason })
@@ -54,8 +76,7 @@ function normalizeStockPrepApplyProductionPolicy(input) {
   if (!isPlainObject(input)) reject('not_object', 'production policy must be an object')
   // A sandbox policy is NOT a production policy — reject the sandbox allowlist shape outright so it can
   // never be passed in as a production policy.
-  if (Object.prototype.hasOwnProperty.call(input, 'allowedTargetObjectIds') &&
-      !Object.prototype.hasOwnProperty.call(input, 'authorizedTargetObjectId')) {
+  if (Object.prototype.hasOwnProperty.call(input, 'allowedTargetObjectIds')) {
     reject('sandbox_shape', 'a sandbox policy must not be used as a production policy')
   }
   if (input.enabled !== true) reject('not_enabled', 'production policy must be explicitly enabled')
@@ -89,11 +110,10 @@ function normalizeStockPrepApplyProductionPolicy(input) {
   if (!expiresAt) reject('missing_expiry', 'expiresAt is required')
   // Require strict ISO-8601 with explicit time + zone. Date.parse alone accepts loose forms (e.g. "2999"
   // → a ~1000-year window), which defeats the bounded-time intent; demand the full timestamp.
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/.test(expiresAt)) {
+  const expiresAtMs = parseStrictIsoTimestamp(expiresAt)
+  if (!Number.isFinite(expiresAtMs)) {
     reject('invalid_expiry', 'expiresAt must be a strict ISO-8601 timestamp with time and zone')
   }
-  const expiresAtMs = Date.parse(expiresAt)
-  if (!Number.isFinite(expiresAtMs)) reject('invalid_expiry', 'expiresAt must be a valid timestamp')
 
   // No blind apply: the policy must explicitly require a fresh dry-run/apply token at apply time.
   if (input.requireFreshDryRun !== true) reject('fresh_dry_run_required', 'requireFreshDryRun must be true')


### PR DESCRIPTION
First slice of the FOS-4b-3-prod gate (design-lock §7-P1). **Production-policy contract only — does NOT enable production apply, wire the apply path, or touch the canonical.**

- New `lib/stock-preparation-production-policy.cjs`: `normalizeStockPrepApplyProductionPolicy` (fail-closed, enum-strict, values-free) + `assertProductionPolicyNotExpired` (caller-supplied `now`, no module clock).
- Fail-closed reasons (coarse, values-free): non-object · **sandbox-policy shape rejected** · not-enabled · missing/**non-canonical** target (production may only authorize the prod canonical) · missing authorizationId · missing/unrecognized action · invalid route · invalid maxCleanRows · missing/invalid expiry · `requireFreshDryRun!=true`.
- **LOCK-SAFE:** imported by **0 libs** — the sandbox-only guard is unchanged, canonical stays rejected by default. P2 (separate gated slice) wires a validated policy into both write entry points behind explicit owner authorization.

**Tests:** happy + 17 negative controls + expiry + values-free; non-vacuous (neuter → fails; restored). Full plugin suite green.

**Boundary:** production apply CLOSED; canonical not written; no external/K3; no runtime wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
