### PR TITLE
fix(approval): preserve amountConsistencyCheck through the authoring save (#3161 §1)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -174,6 +174,10 @@ export interface TemplateAuthoringDraft {
   // 1:1. Topology (edges) + every non-cc node stay byte-identical. Empty {} when no cc node.
   ccEdits?: CcEdits
   approvalNodeEdits?: ApprovalNodeEdits
+  // Server-side amount total-check mapping (design-lock #3161, shipped by #3176; on the presets via
+  // #3183). The editor does NOT author it yet — it is carried hydrate→save VERBATIM so an
+  // authoring-page save cannot silently drop a preset-shipped control (the #3161 §1 exposure).
+  amountConsistencyCheck?: FormSchema['amountConsistencyCheck']
 }
 
 // Complex node types the v1 LINEAR steps editor can't author. They are NOT "unsupported" — a
@@ -702,6 +706,11 @@ export function draftFromTemplate(template: ApprovalTemplateDetailDTO): Template
     visibilityIdsText: formatIds(template.visibilityScope?.ids),
     slaHoursText: template.slaHours == null ? '' : String(template.slaHours),
     allowRevoke: true,
+    // Hydrate side of the #3161 §1 preserve: carry the amount total-check mapping through verbatim
+    // (shallow clone, never alias the source schema). Absent → no key (no phantom on round-trip).
+    ...(template.formSchema.amountConsistencyCheck
+      ? { amountConsistencyCheck: { ...template.formSchema.amountConsistencyCheck } }
+      : {}),
     ...(complex
       ? {
           preservedGraph: template.approvalGraph,
@@ -769,6 +778,9 @@ export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
       }
       return next
     }),
+    // Preserve side of the #3161 §1 fix: re-emit the amount total-check mapping verbatim. The editor
+    // doesn't author it, so a rebuild that dropped it would silently kill a preset-shipped control.
+    ...(draft.amountConsistencyCheck ? { amountConsistencyCheck: { ...draft.amountConsistencyCheck } } : {}),
   }
 }
 

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -791,6 +791,49 @@ describe('TemplateAuthoringView', () => {
     expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 
+  // #3161 §1 — FE authoring preserve. The editor does not author amountConsistencyCheck, so the
+  // load→rebuild it runs on every save must carry it through verbatim or a preset-shipped control
+  // (#3183) is silently dropped on the first authoring-page save.
+  const amtFields = [
+    { id: 'amount', type: 'number', label: '总额', required: true },
+    { id: 'expense_items', type: 'detail', label: '明细', required: false, columns: [{ id: 'amount', type: 'number', label: '金额', required: true }] },
+  ]
+  const amtMapping = { totalFieldId: 'amount', detailFieldId: 'expense_items', amountColumnId: 'amount' }
+  // A graph consistent with amtFields (direct_manager — references no form field), so the mounted
+  // template is valid + editable + saveable (the default buildTemplate graph references a `reviewer`
+  // field amtFields omits).
+  const amtGraph = {
+    nodes: [
+      { key: 'start', type: 'start', name: '发起', config: {} },
+      { key: 'approval_1', type: 'approval', name: '审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', name: '结束', config: {} },
+    ],
+    edges: [
+      { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+      { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+    ],
+  }
+
+  it('§1 round-trip (unit): draftFromTemplate→buildFormSchema preserves amountConsistencyCheck; absent stays absent', () => {
+    const mapped = buildTemplate({ formSchema: { fields: amtFields, amountConsistencyCheck: amtMapping } as any })
+    expect(buildFormSchema(draftFromTemplate(mapped)).amountConsistencyCheck).toEqual(amtMapping)
+    const plain = buildTemplate({ formSchema: { fields: amtFields } as any })
+    expect(buildFormSchema(draftFromTemplate(plain)).amountConsistencyCheck).toBeUndefined()
+  })
+
+  it('§1 active-exposure guard (mounted): opening a mapped (preset-shipped) template and saving keeps amountConsistencyCheck in the payload', async () => {
+    routeParams = { id: 'tpl_amt' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ formSchema: { fields: amtFields, amountConsistencyCheck: amtMapping } as any, approvalGraph: amtGraph as any }))
+    await mountView()
+    await flushUi()
+    // No edits — just the load→save an admin does. Before the fix, buildFormSchema dropped the mapping.
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    expect(payload.formSchema.amountConsistencyCheck).toEqual(amtMapping)
+  })
+
   it('G-5 wiring: a LEGACY approval node (assigneeType/assigneeIds, no assigneeSources) shows NO source editor but still renders read-only', async () => {
     routeParams = { id: 'tpl_g5_legacy' }
     getTemplateSpy.mockResolvedValue(buildTemplate({


### PR DESCRIPTION
## What

Closes **#3161 Remaining-gaps §1** — the **active exposure** surfaced in the #3161 review.

#3176 shipped the server-side amount total-check at `formSchema.amountConsistencyCheck`, and **#3183 put real mappings on the amount-tier presets**. But the FE authoring editor dropped the mapping on save: `draftFromTemplate` read only `formSchema.fields` and `buildFormSchema()` returned `{ fields }`. So **opening a preset-created template in the authoring editor and saving silently killed the shipped control** — the inversion exposure (presets landed before this preserve).

## Fix (3 spots in `templateAuthoring.ts`, +12)
The editor does **not** author the mapping, so it's carried through **verbatim**:
- `TemplateAuthoringDraft` gains `amountConsistencyCheck?: FormSchema['amountConsistencyCheck']` (no new import);
- `draftFromTemplate` hydrates it (shallow clone, never aliases the source schema);
- `buildFormSchema` re-emits it (absent → no key, so no phantom on round-trip).

(The FE `FormSchema` type already carried the field; only the hydrate/save path was missing.)

## Tests (+43)
- **Unit round-trip** — `draftFromTemplate → buildFormSchema` preserves the mapping; a template without it stays without it.
- **Mounted save round-trip** — load a mapped (preset-shipped) template, click save with no edits, assert `payload.formSchema.amountConsistencyCheck` survives. This is the regression guard for the exposure.

All 96 approval-authoring tests pass; `vue-tsc` clean.

Does not touch the visibility policy (#3161 §3) — that stays deferred behind this fix per the agreed order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
