### PR TITLE
feat(approval): detail-row auto-sum runtime (FE auto-fill + tamper-proof loop)

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -26,6 +26,8 @@ on:
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
+      - 'apps/web/src/approvals/amountAutoSum.ts'
+      - 'apps/web/src/approvals/useAutoSumTotal.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -41,6 +43,8 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
+      - 'apps/web/tests/amountAutoSum.test.ts'
+      - 'apps/web/tests/useAutoSumTotal.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -54,6 +58,8 @@ on:
       - 'apps/web/src/approvals/detailField.ts'
       - 'apps/web/src/approvals/commonTemplatePresets.ts'
       - 'apps/web/src/approvals/templateAuthoring.ts'
+      - 'apps/web/src/approvals/amountAutoSum.ts'
+      - 'apps/web/src/approvals/useAutoSumTotal.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -69,6 +75,8 @@ on:
       - 'apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts'
       - 'apps/web/tests/approval-graph-topology-edit.test.ts'
       - 'apps/web/tests/approval-graph-layout.test.ts'
+      - 'apps/web/tests/amountAutoSum.test.ts'
+      - 'apps/web/tests/useAutoSumTotal.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -125,4 +133,4 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal --reporter=dot

--- a/apps/web/src/approvals/amountAutoSum.ts
+++ b/apps/web/src/approvals/amountAutoSum.ts
@@ -1,0 +1,59 @@
+import type { FormField, FormSchema, AmountConsistencyMapping } from '../types/approval'
+
+// FE MIRROR of packages/core-backend/src/services/amount-total-check.ts (validateAmountTotalConsistency)
+// — design-lock approval-detail-autosum-design-lock-20260624 (#3189), Decisions 4–6.
+//
+// apps/web imports nothing from packages/core-backend (no shared boundary), so the backend's scaled-int
+// algorithm is DUPLICATED here. The duplication is kept honest by the parity tests in
+// amountAutoSum.test.ts, which assert the auto-filled total always clears the backend comparison
+// `round(total·10^scale) === Σ round(cell·10^scale)`. CRITICAL: this is round-each-cell-THEN-sum, never
+// sum-then-round — otherwise the backend backstop would reject the system's own auto-filled value
+// (e.g. 0.005 + 0.005 at scale 2 → 2 minor units, not the float 0.01 → 1). Any change to the backend's
+// comparison MUST be mirrored here.
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Mirror of the backend `numberFieldScale`: a number field's declared decimal scale (`props.precision`),
+ *  integer clamped to 0..6; default 2. */
+export function numberFieldScale(field: FormField | undefined): number {
+  const precision = field?.props?.precision
+  if (typeof precision === 'number' && Number.isInteger(precision) && precision >= 0 && precision <= 6) {
+    return precision
+  }
+  return 2
+}
+
+/** One cell → scaled-integer minor units (`Math.round(cell·10^scale)`), mirroring the backend `toScaledInt`.
+ *  A non-numeric / not-yet-filled cell counts as 0 so the LIVE total stays useful while the form is being
+ *  filled — the backend still rejects a non-numeric cell at submit; this only keeps the derived total live. */
+function cellToScaledInt(value: unknown, scale: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+  return Math.round(value * 10 ** scale)
+}
+
+/** Compute the top-level total from the detail rows so it is GUARANTEED to clear the backend total-check.
+ *  ROUND-EACH-CELL-THEN-SUM (identical to the backend's `Σ round(cell·10^scale)`), then divide back. */
+export function computeConsistentTotal(rows: unknown, amountColumnId: string, scale: number): number {
+  if (!Array.isArray(rows)) return 0
+  let scaledSum = 0
+  for (const row of rows) {
+    const cell = isRecord(row) ? row[amountColumnId] : undefined
+    scaledSum += cellToScaledInt(cell, scale)
+  }
+  return scaledSum / 10 ** scale
+}
+
+/** Resolve the amount-column scale from the schema (mirroring the backend's field resolution) and sum the
+ *  detail rows into the consistent total. Returns the number to write into `formData[totalFieldId]`. */
+export function autoSumTotalFromMapping(
+  formSchema: FormSchema,
+  formData: Record<string, unknown>,
+  mapping: AmountConsistencyMapping,
+): number {
+  const detailField = formSchema.fields.find((field) => field.id === mapping.detailFieldId)
+  const amountColumn = (detailField?.columns ?? []).find((column) => column.id === mapping.amountColumnId)
+  const scale = numberFieldScale(amountColumn)
+  return computeConsistentTotal(formData[mapping.detailFieldId], mapping.amountColumnId, scale)
+}

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -159,7 +159,9 @@ function reimbursementSchema(): FormSchema {
     fields: [
       selectField('expense_type', '费用类型', ['差旅', '交通', '餐饮', '办公', '其他']),
       field('expense_date', 'date', '费用日期', { required: true }),
-      // Preset v1 does not auto-sum detail rows; admins can keep this as the applicant-entered total.
+      // Amount-tier templates (those declaring amountConsistencyCheck) auto-sum this from the detail
+      // rows in the fill UI (read-only, design-lock #3189); a template without the mapping keeps it
+      // applicant-entered.
       field('amount', 'number', '报销金额', {
         required: true,
         props: { min: 0 },
@@ -180,7 +182,9 @@ function purchaseSchema(): FormSchema {
     fields: [
       selectField('purchase_type', '采购类型', ['办公用品', '设备', '服务', '软件', '其他']),
       field('supplier', 'text', '供应商', { required: true }),
-      // Preset v1 does not auto-sum detail rows; admins can keep this as the applicant-entered total.
+      // Amount-tier templates (those declaring amountConsistencyCheck) auto-sum this from the detail
+      // rows in the fill UI (read-only, design-lock #3189); a template without the mapping keeps it
+      // applicant-entered.
       field('amount', 'number', '预算金额', {
         required: true,
         props: { min: 0 },

--- a/apps/web/src/approvals/useAutoSumTotal.ts
+++ b/apps/web/src/approvals/useAutoSumTotal.ts
@@ -1,0 +1,36 @@
+import { computed, watch, type Ref } from 'vue'
+import type { ApprovalTemplateDetailDTO } from '../types/approval'
+import { autoSumTotalFromMapping } from './amountAutoSum'
+
+// Detail-row auto-sum wiring (design-lock #3189, Gate B). Extracted from ApprovalNewView so the watch is
+// unit-testable in isolation. When the active template declares `amountConsistencyCheck`, the total field
+// is DERIVED from the detail rows (read-only in the UI) — auto-fill (UX) closing the loop with the backend
+// total-check (tamper-proof). FE-only: this never calls the backend; it only maintains formData[total].
+export function useAutoSumTotal(
+  template: Ref<ApprovalTemplateDetailDTO | null>,
+  formData: Record<string, unknown>,
+) {
+  const amountConsistency = computed(() => template.value?.formSchema.amountConsistencyCheck ?? null)
+
+  /** True for the field that is auto-summed (→ rendered read-only). */
+  function isAutoSummedTotal(fieldId: string): boolean {
+    return amountConsistency.value?.totalFieldId === fieldId
+  }
+
+  // Watch BOTH the mapping itself AND (deep) the detail rows, recomputing the total via the
+  // backend-identical mirror so the auto-filled value always clears the backstop. Watching the mapping
+  // matters because `template` resolves async: this seeds the total to 0 the instant a mapped template
+  // loads — even if the detail field isn't array-initialized yet at that tick — rather than relying on
+  // watch-ordering vs the view's detail seeding. immediate: also seed on a synchronously-present mapping.
+  watch(
+    [amountConsistency, () => (amountConsistency.value ? formData[amountConsistency.value.detailFieldId] : undefined)],
+    () => {
+      const mapping = amountConsistency.value
+      if (!mapping || !template.value) return
+      formData[mapping.totalFieldId] = autoSumTotalFromMapping(template.value.formSchema, formData, mapping)
+    },
+    { deep: true, immediate: true },
+  )
+
+  return { isAutoSummedTotal }
+}

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -80,6 +80,8 @@
               v-else-if="field.type === 'number'"
               v-model="formData[field.id]"
               :placeholder="field.placeholder"
+              :disabled="isAutoSummedTotal(field.id)"
+              :controls="!isAutoSummedTotal(field.id)"
               style="width: 100%"
             />
 
@@ -300,6 +302,10 @@
               v-model="formData[field.id]"
               :placeholder="field.placeholder || `请输入${field.label}`"
             />
+
+            <span v-if="isAutoSummedTotal(field.id)" class="approval-new__field-hint">
+              由明细自动汇总，无需手填
+            </span>
           </el-form-item>
 
           <el-divider />
@@ -334,6 +340,7 @@ import { useApprovalStore } from '../../approvals/store'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { getVisibleFormFields } from '../../approvals/fieldVisibility'
+import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
 import {
   createEmptyDetailRow,
   isDetailCellVisible,
@@ -354,6 +361,11 @@ const visibleFields = computed(() => {
   return getVisibleFormFields(template.value.formSchema, formData)
 })
 const visibleFieldIds = computed(() => visibleFields.value.map((field) => field.id))
+
+// Detail-row auto-sum (design-lock #3189, Gate B): when the template declares amountConsistencyCheck the
+// total field is derived from the detail rows (read-only) — auto-fill (UX) + backend total-check
+// (tamper-proof). FE-only. See useAutoSumTotal for the watch + the backend-identical mirror.
+const { isAutoSummedTotal } = useAutoSumTotal(template, formData)
 
 const formRules = computed<FormRules>(() => {
   const rules: FormRules = {}

--- a/apps/web/tests/amountAutoSum.test.ts
+++ b/apps/web/tests/amountAutoSum.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { FormField } from '../src/types/approval'
+import { computeConsistentTotal, numberFieldScale, autoSumTotalFromMapping } from '../src/approvals/amountAutoSum'
+
+// The PARITY harness (design-lock #3189, Decision 6): apps/web cannot import the real backend
+// validateAmountTotalConsistency, so we re-state its ALL-NUMERIC accept branch here —
+// `round(total·10^scale) === Σ round(cell·10^scale)` — and assert the auto-filled total ALWAYS clears it.
+// NOTE: this is NOT a full mirror. The real backend REJECTS a non-numeric amount cell (returns an error;
+// it does not treat it as 0). `clearsBackstop` is therefore only ever fed numeric/empty rows, where the
+// re-statement is faithful and the assertion is the closed loop. The incomplete-row case
+// (cellToScaledInt → 0) keeps the LIVE total useful while typing, but at SUBMIT a non-numeric cell is a
+// backend reject — not a "total clears" path — so it is deliberately NOT asserted through clearsBackstop.
+function backendScaledSum(rows: Array<Record<string, unknown>>, col: string, scale: number): number {
+  return rows.reduce((sum, row) => {
+    const cell = row[col]
+    return sum + (typeof cell === 'number' && Number.isFinite(cell) ? Math.round(cell * 10 ** scale) : 0)
+  }, 0)
+}
+function clearsBackstop(rows: Array<Record<string, unknown>>, col: string, scale: number): boolean {
+  const total = computeConsistentTotal(rows, col, scale)
+  return Math.round(total * 10 ** scale) === backendScaledSum(rows, col, scale)
+}
+
+describe('computeConsistentTotal — parity with the backend total-check (closed loop)', () => {
+  it('round-each-then-sum, NOT sum-then-round: 0.005 + 0.005 at scale 2 → 0.02 (2 minor units), clears', () => {
+    const rows = [{ amount: 0.005 }, { amount: 0.005 }]
+    // sum-then-round would give 0.01 → backend round(0.01·100)=1 ≠ 2 → REJECT. round-each-then-sum gives 0.02.
+    expect(computeConsistentTotal(rows, 'amount', 2)).toBe(0.02)
+    expect(backendScaledSum(rows, 'amount', 2)).toBe(2)
+    expect(clearsBackstop(rows, 'amount', 2)).toBe(true)
+  })
+  it('0.1 + 0.2 = 0.3 — no float drift, clears the backstop', () => {
+    const rows = [{ amount: 0.1 }, { amount: 0.2 }]
+    expect(computeConsistentTotal(rows, 'amount', 2)).toBe(0.3)
+    expect(clearsBackstop(rows, 'amount', 2)).toBe(true)
+  })
+  it('4-decimal column: 0.1234 + 0.1111 = 0.2345 clears at scale 4', () => {
+    const rows = [{ amount: 0.1234 }, { amount: 0.1111 }]
+    expect(computeConsistentTotal(rows, 'amount', 4)).toBe(0.2345)
+    expect(clearsBackstop(rows, 'amount', 4)).toBe(true)
+  })
+  it('a realistic multi-row purchase clears the backstop', () => {
+    const rows = [{ amount: 1999.99 }, { amount: 0.01 }, { amount: 18000 }]
+    expect(computeConsistentTotal(rows, 'amount', 2)).toBe(20000)
+    expect(clearsBackstop(rows, 'amount', 2)).toBe(true)
+  })
+  it('empty / non-array detail → 0, and 0 clears the backstop', () => {
+    expect(computeConsistentTotal([], 'amount', 2)).toBe(0)
+    expect(computeConsistentTotal(undefined, 'amount', 2)).toBe(0)
+    expect(clearsBackstop([], 'amount', 2)).toBe(true)
+  })
+  it('incomplete rows: a not-yet-filled / non-numeric / missing amount cell counts as 0 for the live total', () => {
+    const rows = [{ amount: 100 }, { amount: '' }, { other: 1 }, { amount: 50 }, { amount: null }]
+    expect(computeConsistentTotal(rows, 'amount', 2)).toBe(150)
+  })
+})
+
+describe('numberFieldScale — mirrors the backend (props.precision, clamp 0..6, default 2)', () => {
+  const f = (precision?: unknown): FormField => ({ id: 'a', type: 'number', label: 'A', ...(precision !== undefined ? { props: { precision } } : {}) } as FormField)
+  it('reads an integer precision in 0..6', () => { expect(numberFieldScale(f(4))).toBe(4); expect(numberFieldScale(f(0))).toBe(0) })
+  it('defaults to 2 when absent / out-of-range / non-integer', () => {
+    expect(numberFieldScale(f())).toBe(2)
+    expect(numberFieldScale(f(9))).toBe(2)
+    expect(numberFieldScale(f(2.5))).toBe(2)
+    expect(numberFieldScale(undefined)).toBe(2)
+  })
+})
+
+describe('autoSumTotalFromMapping — resolves the amount-column scale from the schema', () => {
+  const schema = (precision?: number) => ({
+    fields: [
+      { id: 'amount', type: 'number', label: '总额' },
+      { id: 'items', type: 'detail', label: '明细', columns: [
+        { id: 'name', type: 'text', label: '名称' },
+        { id: 'amount', type: 'number', label: '金额', ...(precision !== undefined ? { props: { precision } } : {}) },
+      ] },
+    ],
+  }) as never
+  const MAP = { totalFieldId: 'amount', detailFieldId: 'items', amountColumnId: 'amount' }
+  it('sums at the amount column precision (4-decimal) from a real schema', () => {
+    expect(autoSumTotalFromMapping(schema(4), { items: [{ amount: 0.1234 }, { amount: 0.1111 }] }, MAP)).toBe(0.2345)
+  })
+  it('defaults to scale 2 when the amount column declares no precision', () => {
+    expect(autoSumTotalFromMapping(schema(), { items: [{ amount: 100 }, { amount: 200 }] }, MAP)).toBe(300)
+  })
+})

--- a/apps/web/tests/useAutoSumTotal.test.ts
+++ b/apps/web/tests/useAutoSumTotal.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { createApp, defineComponent, h, reactive, ref, nextTick } from 'vue'
+import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
+import { useAutoSumTotal } from '../src/approvals/useAutoSumTotal'
+
+function makeTemplate(withMapping: boolean, precision?: number): ApprovalTemplateDetailDTO {
+  return {
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '总额' },
+        {
+          id: 'items', type: 'detail', label: '明细', columns: [
+            { id: 'name', type: 'text', label: '名称' },
+            { id: 'amount', type: 'number', label: '金额', ...(precision !== undefined ? { props: { precision } } : {}) },
+          ],
+        },
+      ],
+      ...(withMapping ? { amountConsistencyCheck: { totalFieldId: 'amount', detailFieldId: 'items', amountColumnId: 'amount' } } : {}),
+    },
+  } as unknown as ApprovalTemplateDetailDTO
+
+}
+
+function harness(template: ReturnType<typeof ref<ApprovalTemplateDetailDTO | null>>, formData: Record<string, unknown>) {
+  let api!: ReturnType<typeof useAutoSumTotal>
+  const Comp = defineComponent({ setup() { api = useAutoSumTotal(template, formData); return () => h('div') } })
+  const app = createApp(Comp)
+  app.mount(document.createElement('div'))
+  return { api, app }
+}
+
+describe('useAutoSumTotal (Gate B — auto-fill wiring)', () => {
+  it('immediate: seeds the total from the detail rows on load', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ amount: 100 }, { amount: 200 }] })
+    const { app } = harness(ref(makeTemplate(true)), formData)
+    await nextTick()
+    expect(formData.amount).toBe(300)
+    app.unmount()
+  })
+
+  it('reactive: updates the total when a row is added and when a cell changes', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ amount: 100 }] })
+    const { app } = harness(ref(makeTemplate(true)), formData)
+    await nextTick()
+    expect(formData.amount).toBe(100)
+    ;(formData.items as Array<Record<string, unknown>>).push({ amount: 50 })
+    await nextTick()
+    expect(formData.amount).toBe(150)
+    ;(formData.items as Array<Record<string, unknown>>)[0].amount = 999
+    await nextTick()
+    expect(formData.amount).toBe(1049)
+    app.unmount()
+  })
+
+  it('money-safe: 0.005 + 0.005 auto-fills 0.02 (clears the backstop, not the float 0.01)', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ amount: 0.005 }, { amount: 0.005 }] })
+    const { app } = harness(ref(makeTemplate(true)), formData)
+    await nextTick()
+    expect(formData.amount).toBe(0.02)
+    app.unmount()
+  })
+
+  it('incomplete rows: a not-yet-filled amount cell counts as 0 in the live total', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ amount: 100 }, { name: 'x' }, { amount: 50 }] })
+    const { app } = harness(ref(makeTemplate(true)), formData)
+    await nextTick()
+    expect(formData.amount).toBe(150)
+    app.unmount()
+  })
+
+  it('isAutoSummedTotal: true for the total field, false otherwise', () => {
+    const { api, app } = harness(ref(makeTemplate(true)), reactive({}))
+    expect(api.isAutoSummedTotal('amount')).toBe(true)
+    expect(api.isAutoSummedTotal('items')).toBe(false)
+    app.unmount()
+  })
+
+  it('no mapping → no auto-fill, total untouched, isAutoSummedTotal false', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ amount: 100 }], amount: 7 })
+    const { api, app } = harness(ref(makeTemplate(false)), formData)
+    await nextTick()
+    expect(formData.amount).toBe(7)
+    expect(api.isAutoSummedTotal('amount')).toBe(false)
+    app.unmount()
+  })
+})


### PR DESCRIPTION
Step 3 of the amount-tier line — **FE-only**, strictly per the #3189 design-lock's three gates. Closes the loop: auto-fill (UX) + the shipped server-side total-check (tamper-proof).

- **Gate A — pure `computeConsistentTotal`** (amountAutoSum.ts): MIRRORS the backend's round-each-cell-then-sum (`Σ round(cell·10^scale)`, scale from `props.precision`) since `apps/web` can't import the backend helper. **10 parity tests** assert the auto-filled total always clears the backend comparison — incl. the **0.005+0.005 counter-example** (→ 0.02 / 2 minor units, not the float 0.01 the backstop would reject), 0.1+0.2, a 4-decimal column, empty/incomplete rows.
- **Gate B — read-only wiring** (`useAutoSumTotal` composable + `ApprovalNewView`): a deep watch derives the total from the detail rows (immediate + reactive) when the template declares `amountConsistencyCheck`; the total renders read-only with a "由明细自动汇总" hint. **6 tests** (immediate seed, row-add/cell-edit, money-safe, incomplete rows, read-only flag, no-mapping untouched). The watch also keys on the mapping so the total seeds deterministically when an async-loaded mapped template resolves.
- **Gate C — no backend touch** (diff is 100% `apps/web`); stale preset comment updated; both specs wired into approval-web-guard (paths + filter).

Read-only because the backend already enforces total=sum for mapped templates → auto-fill removes zero expressiveness and can never reject a previously-valid submission. **147/147** across the guard set + both e2e specs that mount ApprovalNewView (lifecycle + permissions); vue-tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)