### PR TITLE
fix(plm-embed): load persisted PLM data sources

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -5,17 +5,40 @@ import { PostgresAdapter } from './PostgresAdapter'
 import { HTTPAdapter } from './HTTPAdapter'
 import { MSSQLAdapter } from './MSSQLAdapter'
 import { MySQLAdapter } from './MySQLAdapter'
+import { PLMAdapter } from './PLMAdapter'
 import { encryptStoredSecretValue, decryptStoredSecretValue, isEncryptedSecretValue } from '../security/encrypted-secrets'
+import type { IConfigService, ILogger } from '../di/identifiers'
 
 // Credential fields that hold secrets and are encrypted at rest. Identifiers
 // like `username` are left as-is (matching the codebase's encrypt-secrets-only
 // convention).
 const SENSITIVE_CREDENTIAL_KEYS = ['password', 'apiKey', 'token']
-export const SUPPORTED_DATA_SOURCE_TYPES = ['postgresql', 'postgres', 'http', 'sqlserver', 'mysql'] as const
+export const SUPPORTED_DATA_SOURCE_TYPES = ['postgresql', 'postgres', 'http', 'sqlserver', 'mysql', 'plm'] as const
 export const DATA_SOURCE_C6_WRITE_TARGET_QUERY_DISABLED_CODE = 'DATA_SOURCE_C6_WRITE_TARGET_QUERY_DISABLED'
 export const DATA_SOURCE_C6_WRITE_TARGET_DELETE_UNSUPPORTED_CODE = 'DATA_SOURCE_C6_WRITE_TARGET_DELETE_UNSUPPORTED'
 
 type AdapterConstructor = new (config: DataSourceConfig) => BaseDataAdapter
+
+const emptyConfigService: IConfigService = {
+  get: async () => undefined,
+  set: async () => undefined,
+  getAll: async () => ({}),
+  reload: async () => undefined,
+  validate: async () => ({ valid: true, errors: [] }),
+}
+
+const consoleLogger: ILogger = {
+  info: (...args: unknown[]) => console.info(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+  error: (...args: unknown[]) => console.error(...args),
+  debug: (...args: unknown[]) => console.debug(...args),
+}
+
+class ManagedPLMAdapter extends PLMAdapter {
+  constructor(config: DataSourceConfig) {
+    super(emptyConfigService, consoleLogger, config)
+  }
+}
 
 function optionIsTrue(options: AdapterOptions | undefined, key: string): boolean {
   return options?.[key] === true
@@ -240,6 +263,7 @@ export class DataSourceManager extends EventEmitter {
     this.registerAdapterType('http', HTTPAdapter as unknown as AdapterConstructor)
     this.registerAdapterType('sqlserver', MSSQLAdapter as unknown as AdapterConstructor)
     this.registerAdapterType('mysql', MySQLAdapter as unknown as AdapterConstructor)
+    this.registerAdapterType('plm', ManagedPLMAdapter as unknown as AdapterConstructor)
   }
 
   registerAdapterType(type: string, adapterClass: AdapterConstructor): void {

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -44,7 +44,12 @@ const DataSourceCreateSchema = z.object({
     readOnly: z.boolean().optional(),
     // C6 external-write target marker. When set, raw /query is disabled even if readOnly=false.
     c6WriteTarget: z.boolean().optional(),
-    genericQueryDisabled: z.boolean().optional()
+    genericQueryDisabled: z.boolean().optional(),
+    // PLMAdapter runtime options for persisted Yuantus PLM sources.
+    apiMode: z.string().optional(),
+    tenantId: z.string().optional(),
+    orgId: z.string().optional(),
+    itemType: z.string().optional()
   }).optional(),
   credentials: z.object({
     username: z.string().optional(),
@@ -71,7 +76,12 @@ const DataSourceUpdateSchema = z.object({
     readOnly: z.boolean().optional(),
     // C6 external-write target marker. When set, raw /query is disabled even if readOnly=false.
     c6WriteTarget: z.boolean().optional(),
-    genericQueryDisabled: z.boolean().optional()
+    genericQueryDisabled: z.boolean().optional(),
+    // PLMAdapter runtime options for persisted Yuantus PLM sources.
+    apiMode: z.string().optional(),
+    tenantId: z.string().optional(),
+    orgId: z.string().optional(),
+    itemType: z.string().optional()
   }).optional(),
   poolConfig: z.object({
     min: z.number().min(0).optional(),

--- a/packages/core-backend/tests/unit/data-source-scope.test.ts
+++ b/packages/core-backend/tests/unit/data-source-scope.test.ts
@@ -314,6 +314,35 @@ describe('data-sources route ownership scope (A0.1)', () => {
 })
 
 describe('DataSourceManager persistence round-trip (A0)', () => {
+  it('loads persisted PLM sources with the PLM adapter surface required by the embed relay', async () => {
+    const m = new DataSourceManager()
+    await m.initialize(fakeDb([
+      {
+        ...dbRecord('plm-v12-staging', 'alice', null, 'plm'),
+        config: {
+          connection: {
+            url: 'http://plm.example.local',
+            headers: { Authorization: 'Bearer token', 'x-tenant-id': 'tenant-demo', 'x-org-id': 'org-demo' },
+          },
+          options: { apiMode: 'yuantus', tenantId: 'tenant-demo', orgId: 'org-demo', itemType: 'Part' },
+        },
+      },
+    ]) as never)
+
+    const adapter = m.getDataSource('plm-v12-staging') as {
+      connect: () => Promise<void>
+      getBomMultitableContext?: unknown
+      getEffectiveTenantId?: () => string | undefined
+      getConfig: () => DataSourceConfig
+    }
+    expect(typeof adapter.getBomMultitableContext).toBe('function')
+    expect(typeof adapter.getEffectiveTenantId).toBe('function')
+
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId?.()).toBe('tenant-demo')
+    expect(adapter.getConfig().type).toBe('plm')
+  })
+
   it('a source recreated with the same id after deletion still loads after a restart', async () => {
     const { db } = statefulFakeDb()
     const m1 = new DataSourceManager({ db: db as never })


### PR DESCRIPTION
## Summary
- register a managed `plm` adapter type in `DataSourceManager` so persisted PLM data sources can be loaded after restart
- preserve PLM-specific data-source options (`apiMode`, `tenantId`, `orgId`, `itemType`) through the data-source route schemas
- add a regression test for the V1.2 embed relay runtime path: persisted `type=plm` loads with the PLM adapter surface required by `/api/plm-embed/bom-review/context`

## Why
V1.2 two-origin staging exposed a real runtime gap: the MetaSheet2 embed route uses the shared `DataSourceManager`, but persisted `type='plm'` rows were skipped at startup with `Unsupported persisted data source type: plm`, making the real embed context path return `503 EMBED_UNAVAILABLE` even though token verification and origin config were correct.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/core-backend test:unit -- tests/unit/data-source-scope.test.ts` (script runs the package unit suite: 303 files / 3949 tests passed)
