### PR TITLE
feat(attendance): v1-4 账4 settlement export — per-source remaining + must-pay marker (加班银行 §4)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6067,6 +6067,53 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④ 加班银行 v1-4 — overtimeSettlement on GET /summary when bank ON (convertible by source + must-pay); ABSENT when OFF', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-v14-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    let token: string | undefined
+    let originalSettings: Record<string, unknown> = {}
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      token = (tokenRes.body as { token?: string } | undefined)?.token
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+      const putSettings = (body: Record<string, unknown>) => requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify(body) })
+      originalSettings = ((await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })).body as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+      const getSummary = async () => {
+        const r = await requestJson(`${baseUrl}/api/attendance/summary?from=2026-09-01&to=2026-09-30`, { headers: { Authorization: `Bearer ${token}` } })
+        expect(r.status).toBe(200)
+        return ((r.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      }
+      // a banked restday comp_time lot (overtime_source) → should appear under convertibleBySource.restday.
+      await pool.query(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+         VALUES ('default', $1, 'comp_time', 90, 90, 'overtime_conversion', $2, 'active', '2026-01-01', 'restday')`,
+        [userId, `v14:${runSuffix}`],
+      )
+      // (1) bank OFF (default) → no overtimeSettlement field (dormant-clean: response byte-identical).
+      await putSettings({ overtimeBankPolicy: { enabled: false } })
+      expect('overtimeSettlement' in (await getSummary())).toBe(false)
+      // (2) bank ON → overtimeSettlement present; convertibleBySource.restday reflects the banked lot; must-pay present.
+      await putSettings({ overtimeBankPolicy: { enabled: true, pooledSources: ['restday'] } })
+      const s = await getSummary()
+      expect('overtimeSettlement' in s).toBe(true)
+      const settlement = s.overtimeSettlement as { convertibleBySource?: Record<string, number>; mustPayBySource?: Record<string, number> }
+      expect(settlement.convertibleBySource?.restday).toBe(90)
+      expect(settlement.mustPayBySource).toHaveProperty('statutory_holiday')
+    } finally {
+      if (token && Object.keys(originalSettings).length > 0) await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS; else process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
   it('加班三段 O3/O4 — records, report fields, and summary expose approved overtime segment buckets from request snapshots', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/packages/core-backend/tests/unit/attendance-settlement-export.test.ts
+++ b/packages/core-backend/tests/unit/attendance-settlement-export.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceOvertimeBankForTests as {
+  buildOvertimeSettlementExport: (
+    summary: Record<string, unknown>,
+    compTimeRemainingBySource: Record<string, number>,
+    overtimeBankPolicy: { enabled?: boolean } | undefined,
+  ) => { convertibleBySource: { workday: number; restday: number }; mustPayBySource: { statutory_holiday: number } } | null
+}
+
+describe('#加班银行 v1-4 — buildOvertimeSettlementExport (账4 各来源剩余 + 可折算/直付, no amounts)', () => {
+  const f = helpers.buildOvertimeSettlementExport
+  const ON = { enabled: true }
+
+  it('DORMANT: policy off / missing → null (no field → summary response byte-identical)', () => {
+    expect(f({ holiday_overtime_minutes: 300 }, { workday: 120 }, undefined)).toBeNull()
+    expect(f({ holiday_overtime_minutes: 300 }, { workday: 120 }, { enabled: false })).toBeNull()
+  })
+
+  it('ENABLED: convertible = comp_time remaining by source; must-pay = statutory_holiday OT total (§6)', () => {
+    const r = f({ holiday_overtime_minutes: 300, workday_overtime_minutes: 600 }, { workday: 120, restday: 60, unsourced: 999 }, ON)
+    expect(r).toEqual({
+      // banked comp_time REMAINING by source; the NULL-source legacy bucket ('unsourced') is NOT exported.
+      convertibleBySource: { workday: 120, restday: 60 },
+      // statutory_holiday OT total = must-pay (v1-1b never banks it; §6 legal floor — must be paid).
+      mustPayBySource: { statutory_holiday: 300 },
+    })
+  })
+
+  it('clamps to ≥0 integers; missing inputs → 0', () => {
+    expect(f({}, {}, ON)).toEqual({ convertibleBySource: { workday: 0, restday: 0 }, mustPayBySource: { statutory_holiday: 0 } })
+    expect(f({ holiday_overtime_minutes: -5 }, { workday: -3, restday: 90.7 }, ON)).toEqual({
+      convertibleBySource: { workday: 0, restday: 90 }, mustPayBySource: { statutory_holiday: 0 },
+    })
+  })
+
+  it('NO amounts (rates/money = payroll): only minutes split by convertible vs must-pay disposition', () => {
+    const r = f({ holiday_overtime_minutes: 300 }, { workday: 120 }, ON)!
+    expect(Object.keys(r).sort()).toEqual(['convertibleBySource', 'mustPayBySource'])
+    expect(JSON.stringify(r)).not.toMatch(/amount|rate|salary|wage|金额|倍率/i)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11633,6 +11633,48 @@ function resolveFullAttendanceEligible(summary, policy) {
   return true
 }
 
+// 加班银行 v1-4 (design-lock §4 账4 PayrollSettlementPolicy 导出契约): the period-end settlement FACTS —
+// 各来源剩余可折算分钟 + 可折算/必须直付标记, NO amounts (倍率/金额 = payroll). Returns null when
+// overtimeBankPolicy is OFF (dormant — the caller omits the field, response byte-identical). The must-pay
+// marker is an ATTENDANCE fact (§6 legal floor: statutory_holiday OT must be paid, never banked), computed
+// from facts we already have — NOT a payroll inference:
+//   • convertibleBySource = the still-bankable comp_time lot REMAINING by overtime_source (workday/restday,
+//     the v1-1b-poolable sources). disposition = 折算.
+//   • mustPayBySource = OT that must be paid directly. statutory_holiday = the holiday OT total (never banked
+//     by v1-1b → all must-pay). disposition = 直付. (Un-banked workday/restday over-cap must-pay is a later
+//     refinement once cap accounting lands.)
+function buildOvertimeSettlementExport(summary, compTimeRemainingBySource, overtimeBankPolicy) {
+  if (!overtimeBankPolicy || overtimeBankPolicy.enabled !== true) return null
+  const s = summary && typeof summary === 'object' ? summary : {}
+  const banked = compTimeRemainingBySource && typeof compTimeRemainingBySource === 'object' ? compTimeRemainingBySource : {}
+  const minutes = (value) => Math.max(0, Math.floor(Number(value) || 0))
+  return {
+    convertibleBySource: {
+      workday: minutes(banked.workday),
+      restday: minutes(banked.restday),
+    },
+    mustPayBySource: {
+      statutory_holiday: minutes(s.holiday_overtime_minutes),
+    },
+  }
+}
+
+// 加班银行 v1-4: the still-bankable comp_time lot remaining grouped by OT source (workday/restday). A lot's
+// overtime_source is NULL for the dormant/legacy single-lot path → bucketed under 'unsourced' (ignored by the
+// export's known-source keys). statutory_holiday never appears here (v1-1b never banks it).
+async function loadCompTimeRemainingBySource(db, orgId, userId) {
+  const rows = await db.query(
+    `SELECT COALESCE(overtime_source, 'unsourced') AS source, COALESCE(SUM(remaining_minutes), 0)::int AS remaining
+       FROM attendance_leave_balances
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = 'comp_time' AND status = 'active'
+      GROUP BY COALESCE(overtime_source, 'unsourced')`,
+    [orgId, userId]
+  )
+  const bySource = {}
+  for (const row of rows) bySource[row.source] = Number(row.remaining) || 0
+  return bySource
+}
+
 async function loadAttendanceSummary(db, orgId, userId, from, to) {
   const countedDaySql = buildAttendanceSummaryCountedDaySql()
   const rows = await db.query(
@@ -18511,6 +18553,7 @@ module.exports = {
     normalizeOvertimeBankPolicySetting,
     resolveOvertimeBankSourceMinutes,
     partitionOvertimeBankGrantLots,
+    buildOvertimeSettlementExport,
   },
   __attendanceLeaveOffsetForTests: {
     LEAVE_DEDUCTION_POOLS,
@@ -23034,6 +23077,15 @@ module.exports = {
           // report-summary table is untouched (that path is not dormant-safe for new fields).
           const fullAttendanceEligible = resolveFullAttendanceEligible(summary, (await getSettings(db))?.attendanceBonusPolicy)
           if (fullAttendanceEligible !== null) data.fullAttendanceEligible = fullAttendanceEligible
+          // 加班银行 v1-4 (§4 账4): surface the period-end settlement FACTS (各来源剩余 + 可折算/直付标记, no
+          // amounts) on this LIVE read, gated on overtimeBankPolicy. DORMANT-CLEAN: the field is OMITTED (and
+          // the lots query is skipped) when the bank is off → byte-identical response; cached report untouched.
+          // must-pay is an attendance fact (§6 legal floor), not a payroll inference.
+          const overtimeBankPolicy = (await getSettings(db))?.overtimeBankPolicy
+          if (overtimeBankPolicy?.enabled === true) {
+            const overtimeSettlement = buildOvertimeSettlementExport(summary, await loadCompTimeRemainingBySource(db, orgId, targetUserId), overtimeBankPolicy)
+            if (overtimeSettlement) data.overtimeSettlement = overtimeSettlement
+          }
 	          res.json({ ok: true, success: true, data })
         } catch (error) {
           if (isDatabaseSchemaError(error)) {


### PR DESCRIPTION
The 账4 export contract on the landed v1-3b summary surface. **Money-path — held for review.** Per advisor + §4 literal contract (各来源剩余 + 可折算/必须直付标记, **no amounts**).

- **`buildOvertimeSettlementExport`** → null (dormant) | { `convertibleBySource` {workday,restday} = comp_time lot **remaining** by `overtime_source`; `mustPayBySource` {statutory_holiday} = holiday OT total (never banked → must-pay, §6) }. **must-pay is an attendance fact, not a payroll inference** — computed from facts we already have. No amounts (倍率/金额 = payroll).
- **DORMANT-CLEAN**: on the LIVE GET /summary read, gated on overtimeBankPolicy; field **omitted + lots query skipped when off** → byte-identical; cached report untouched (same constraint as v1-3b).
- Tests: unit **4/4** + real-DB (OFF → absent; ON → present, banked restday lot → convertibleBySource.restday=90, must-pay has statutory_holiday).

real-absence stays out (账3 result). node -c, tsc 0.