### PR TITLE
feat(approval): derive line subtotals in amount-tier forms

### DIFF
--- a/.github/workflows/approval-web-guard.yml
+++ b/.github/workflows/approval-web-guard.yml
@@ -28,6 +28,7 @@ on:
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/approvals/amountAutoSum.ts'
       - 'apps/web/src/approvals/useAutoSumTotal.ts'
+      - 'apps/web/src/approvals/lineDerivation.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -45,6 +46,7 @@ on:
       - 'apps/web/tests/approval-graph-layout.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
+      - 'apps/web/tests/lineDerivation.test.ts'
       - '.github/workflows/approval-web-guard.yml'
   push:
     branches: [main]
@@ -60,6 +62,7 @@ on:
       - 'apps/web/src/approvals/templateAuthoring.ts'
       - 'apps/web/src/approvals/amountAutoSum.ts'
       - 'apps/web/src/approvals/useAutoSumTotal.ts'
+      - 'apps/web/src/approvals/lineDerivation.ts'
       - 'apps/web/src/views/approval/ApprovalDetailView.vue'
       - 'apps/web/src/views/approval/ApprovalNewView.vue'
       - 'apps/web/src/views/approval/TemplateAuthoringView.vue'
@@ -77,6 +80,7 @@ on:
       - 'apps/web/tests/approval-graph-layout.test.ts'
       - 'apps/web/tests/amountAutoSum.test.ts'
       - 'apps/web/tests/useAutoSumTotal.test.ts'
+      - 'apps/web/tests/lineDerivation.test.ts'
       - '.github/workflows/approval-web-guard.yml'
 
 jobs:
@@ -133,4 +137,4 @@ jobs:
         # changes; branches/joinNodeKey + all other nodes + edges byte-identical) + cross-phase
         # compose (condition G-2 + parallel G-3 both land) + seeding round-trip + validation preview
         # (joinMode in backend-accepted {'all','any'}; cc untouched / G-4).
-        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -195,7 +195,11 @@ function purchaseSchema(): FormSchema {
         field('spec', 'text', '规格'),
         field('quantity', 'number', '数量', { required: true, props: { min: 1 } }),
         field('unit_price', 'number', '单价', { required: true, props: { min: 0 } }),
-        field('amount', 'number', '小计', { props: { min: 0 } }),
+        // 小计 = 数量 × 单价, derived read-only in the fill UI (design-lock #3203); it then feeds the
+        // amount-tier total auto-sum (#3198) + the backend total-check (#3176).
+        field('amount', 'number', '小计', {
+          props: { min: 0, derivedFrom: { operandColumnIds: ['quantity', 'unit_price'], operation: 'product' } },
+        }),
         field('note', 'text', '备注'),
       ]),
       field('reason', 'textarea', '采购说明', { required: true, placeholder: '请说明采购必要性' }),

--- a/apps/web/src/approvals/lineDerivation.ts
+++ b/apps/web/src/approvals/lineDerivation.ts
@@ -1,0 +1,89 @@
+import type { FormField, FormSchema } from '../types/approval'
+import { getVisibleFormFields } from './fieldVisibility'
+import { numberFieldScale } from './amountAutoSum'
+
+// Per-row line-subtotal derivation (design-lock #3203, Gate A). The declaration rides on the TARGET
+// column's props (`props.derivedFrom`), which round-trips through the backend wholesale (no backend
+// change). Because the backend does NOT validate this key, the FE is the sole validator: a malformed /
+// partial / wrong-typed declaration parses to null and the column stays a normal manual column.
+
+export interface RowDerivation {
+  operandColumnIds: string[]
+  operation: 'product'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Parse a column's `props.derivedFrom`. Defensive: returns null (→ manual column) on anything invalid. */
+export function columnDerivation(column: FormField | undefined): RowDerivation | null {
+  const decl = column?.props?.derivedFrom
+  if (!isRecord(decl)) return null
+  const ops = decl.operandColumnIds
+  if (!Array.isArray(ops) || ops.length === 0 || !ops.every((op) => typeof op === 'string' && op.length > 0)) {
+    return null
+  }
+  if (decl.operation !== 'product') return null
+  return { operandColumnIds: ops as string[], operation: 'product' }
+}
+
+/** True iff the column declares a valid derivation → rendered read-only in the fill UI. */
+export function isDerivedColumn(column: FormField | undefined): boolean {
+  return columnDerivation(column) !== null
+}
+
+/** Compute a row's derived value: the product of the operand cells, rounded to the target column scale.
+ *  That scale is the amount column's precision — the SAME scale that governs the total chain — so the
+ *  derived value composes exactly with computeConsistentTotal. Returns null if ANY operand is
+ *  non-numeric / missing (→ leave the cell manual; never derive from a partial operand set). */
+export function computeRowDerivation(row: Record<string, unknown>, decl: RowDerivation, scale: number): number | null {
+  let product = 1
+  for (const columnId of decl.operandColumnIds) {
+    const value = row[columnId]
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null
+    product *= value
+  }
+  return Math.round(product * 10 ** scale) / 10 ** scale
+}
+
+/** A declared target is active for a row only when the target and ALL operands are visible for that
+ *  row. This is the shared guard for both mutation and UI read-only: hidden operands mean "manual
+ *  row", visible-but-empty operands mean "read-only until the user fills the operands". */
+export function isRowDerivationActive(
+  columns: FormField[] | undefined,
+  targetColumn: FormField | undefined,
+  row: Record<string, unknown>,
+): boolean {
+  if (!columns || !targetColumn) return false
+  const decl = columnDerivation(targetColumn)
+  if (!decl) return false
+  const visibleIds = new Set(getVisibleFormFields({ fields: columns }, row).map((column) => column.id))
+  return visibleIds.has(targetColumn.id) && decl.operandColumnIds.every((id) => visibleIds.has(id))
+}
+
+/** Derive every row's amount column IN-PLACE from its operands, for one declared detail field. No-op if
+ *  the amount column declares no derivation. Reuses the detail table's own per-row column visibility:
+ *  hidden target / hidden operand rows stay manual, and visible-but-not-yet-numeric operands leave the
+ *  current amount untouched until the operands are filled. */
+export function applyRowDerivations(
+  formSchema: FormSchema,
+  formData: Record<string, unknown>,
+  detailFieldId: string,
+  amountColumnId: string,
+): void {
+  const detailField = formSchema.fields.find((field) => field.id === detailFieldId)
+  const columns = detailField?.columns
+  const amountColumn = columns?.find((column) => column.id === amountColumnId)
+  const decl = columnDerivation(amountColumn)
+  if (!decl) return
+  const scale = numberFieldScale(amountColumn)
+  const rows = formData[detailFieldId]
+  if (!Array.isArray(rows)) return
+  for (const row of rows) {
+    if (!isRecord(row)) continue
+    if (!isRowDerivationActive(columns, amountColumn, row)) continue
+    const derived = computeRowDerivation(row, decl, scale)
+    if (derived !== null) row[amountColumnId] = derived
+  }
+}

--- a/apps/web/src/approvals/useAutoSumTotal.ts
+++ b/apps/web/src/approvals/useAutoSumTotal.ts
@@ -1,6 +1,7 @@
 import { computed, watch, type Ref } from 'vue'
 import type { ApprovalTemplateDetailDTO } from '../types/approval'
 import { autoSumTotalFromMapping } from './amountAutoSum'
+import { applyRowDerivations } from './lineDerivation'
 
 // Detail-row auto-sum wiring (design-lock #3189, Gate B). Extracted from ApprovalNewView so the watch is
 // unit-testable in isolation. When the active template declares `amountConsistencyCheck`, the total field
@@ -27,6 +28,15 @@ export function useAutoSumTotal(
     () => {
       const mapping = amountConsistency.value
       if (!mapping || !template.value) return
+      // ONE pass (design-lock #3203, dimension 5): derive each row's amount from its operands FIRST, then
+      // sum the now-derived amounts into the total — same composable, no two-watch stale-transient hazard.
+      // (When the amount column declares no derivedFrom, applyRowDerivations is a no-op and this is the
+      // plain total auto-sum.)
+      // TERMINATION: applyRowDerivations mutates row[amount], which IS inside this deep-watched source, so
+      // it re-fires once and converges ONLY because computeRowDerivation is IDEMPOTENT (same operands →
+      // same amount → Vue hasChanged stops the re-fire). A future non-idempotent operation MUST preserve
+      // that invariant, or this must watch the operand columns instead of mutating in-place.
+      applyRowDerivations(template.value.formSchema, formData, mapping.detailFieldId, mapping.amountColumnId)
       formData[mapping.totalFieldId] = autoSumTotalFromMapping(template.value.formSchema, formData, mapping)
     },
     { deep: true, immediate: true },

--- a/apps/web/src/views/approval/ApprovalNewView.vue
+++ b/apps/web/src/views/approval/ApprovalNewView.vue
@@ -191,6 +191,7 @@
                       v-else-if="column.type === 'number'"
                       v-model="row[column.id]"
                       :controls="false"
+                      :disabled="isDetailDerivedColumnReadOnly(field, column, row)"
                       style="width: 100%"
                     />
                     <el-date-picker
@@ -341,6 +342,7 @@ import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { getVisibleFormFields } from '../../approvals/fieldVisibility'
 import { useAutoSumTotal } from '../../approvals/useAutoSumTotal'
+import { isRowDerivationActive } from '../../approvals/lineDerivation'
 import {
   createEmptyDetailRow,
   isDetailCellVisible,
@@ -417,6 +419,14 @@ function detailRowsHint(field: FormField): string {
   if (typeof field.minRows === 'number') parts.push(`至少 ${field.minRows} 行`)
   if (typeof field.maxRows === 'number') parts.push(`最多 ${field.maxRows} 行`)
   return parts.join(' · ')
+}
+
+function isDetailDerivedColumnReadOnly(
+  detailField: FormField,
+  column: FormField,
+  row: Record<string, unknown>,
+): boolean {
+  return isRowDerivationActive(detailField.columns, column, row)
 }
 
 function goBack() {

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -142,6 +142,12 @@ describe('amount-tier presets ship the server-side total-check mapping (#3161)',
       totalFieldId: 'amount', detailFieldId: 'purchase_items', amountColumnId: 'amount',
     })
   })
+  it('purchase_amount_tier declares derivedFrom (qty × unit_price) on purchase_items.amount (#3203)', () => {
+    const { formSchema } = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier')
+    const detail = formSchema.fields.find((field) => field.id === 'purchase_items')
+    const amount = detail?.columns?.find((column) => column.id === 'amount')
+    expect(amount?.props?.derivedFrom).toEqual({ operandColumnIds: ['quantity', 'unit_price'], operation: 'product' })
+  })
   it('reimbursement_amount_tier carries amountConsistencyCheck → expense_items.amount', () => {
     const { formSchema } = buildCommonApprovalTemplatePresetPayload('reimbursement_amount_tier')
     expect(formSchema.amountConsistencyCheck).toEqual({

--- a/apps/web/tests/lineDerivation.test.ts
+++ b/apps/web/tests/lineDerivation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { FormField } from '../src/types/approval'
+import {
+  applyRowDerivations,
+  columnDerivation,
+  computeRowDerivation,
+  isDerivedColumn,
+  isRowDerivationActive,
+} from '../src/approvals/lineDerivation'
+
+const col = (derivedFrom?: unknown): FormField =>
+  ({ id: 'amount', type: 'number', label: '小计', props: { precision: 2, ...(derivedFrom !== undefined ? { derivedFrom } : {}) } } as FormField)
+
+describe('columnDerivation — defensive parse of props.derivedFrom (FE is the sole validator)', () => {
+  it('parses a valid product declaration', () => {
+    expect(columnDerivation(col({ operandColumnIds: ['quantity', 'unit_price'], operation: 'product' })))
+      .toEqual({ operandColumnIds: ['quantity', 'unit_price'], operation: 'product' })
+  })
+  it('returns null (→ manual column) for malformed / partial / wrong-typed declarations', () => {
+    expect(columnDerivation(col())).toBeNull()
+    expect(columnDerivation(col({ operandColumnIds: [], operation: 'product' }))).toBeNull()
+    expect(columnDerivation(col({ operandColumnIds: ['quantity', 2], operation: 'product' }))).toBeNull()
+    expect(columnDerivation(col({ operandColumnIds: ['quantity'], operation: 'sum' }))).toBeNull()
+    expect(columnDerivation(col({ operation: 'product' }))).toBeNull()
+    expect(columnDerivation(col('nope'))).toBeNull()
+    expect(columnDerivation({ id: 'x', type: 'number', label: 'x' } as FormField)).toBeNull()
+    expect(columnDerivation(undefined)).toBeNull()
+  })
+  it('isDerivedColumn reflects validity', () => {
+    expect(isDerivedColumn(col({ operandColumnIds: ['quantity', 'unit_price'], operation: 'product' }))).toBe(true)
+    expect(isDerivedColumn(col())).toBe(false)
+  })
+})
+
+describe('computeRowDerivation — product of operands, rounded to the target scale', () => {
+  const decl = { operandColumnIds: ['quantity', 'unit_price'], operation: 'product' as const }
+  it('multiplies the operands', () => {
+    expect(computeRowDerivation({ quantity: 3, unit_price: 100 }, decl, 2)).toBe(300)
+  })
+  it('rounds the product to the target column scale', () => {
+    expect(computeRowDerivation({ quantity: 3, unit_price: 1.333 }, decl, 2)).toBe(4) // 3.999 → 4.00
+    expect(computeRowDerivation({ quantity: 3, unit_price: 1.333 }, decl, 4)).toBe(3.999) // keeps 4-dp precision
+  })
+  it('partial / non-numeric operands → null (leave the cell manual)', () => {
+    expect(computeRowDerivation({ quantity: 3 }, decl, 2)).toBeNull()
+    expect(computeRowDerivation({ quantity: 3, unit_price: '' }, decl, 2)).toBeNull()
+    expect(computeRowDerivation({ quantity: 3, unit_price: null }, decl, 2)).toBeNull()
+  })
+  it('a single-operand product is that operand', () => {
+    expect(computeRowDerivation({ x: 5 }, { operandColumnIds: ['x'], operation: 'product' }, 2)).toBe(5)
+  })
+})
+
+describe('row derivation visibility — hidden operands stay manual (#3203 dimension 4)', () => {
+  const columns: FormField[] = [
+    { id: 'use_quantity', type: 'select', label: '使用数量' },
+    {
+      id: 'quantity',
+      type: 'number',
+      label: '数量',
+      visibilityRule: { fieldId: 'use_quantity', operator: 'eq', value: true },
+    },
+    { id: 'unit_price', type: 'number', label: '单价' },
+    {
+      id: 'amount',
+      type: 'number',
+      label: '小计',
+      props: { precision: 2, derivedFrom: { operandColumnIds: ['quantity', 'unit_price'], operation: 'product' } },
+    },
+  ]
+  const amount = columns.find((column) => column.id === 'amount')
+
+  it('activates only when target and every operand are visible for that row', () => {
+    expect(isRowDerivationActive(columns, amount, { use_quantity: true })).toBe(true)
+    expect(isRowDerivationActive(columns, amount, { use_quantity: false })).toBe(false)
+  })
+
+  it('applies derived amounts only to rows whose operands are visible', () => {
+    const formData = {
+      items: [
+        { use_quantity: true, quantity: 3, unit_price: 100 },
+        { use_quantity: false, quantity: 3, unit_price: 100, amount: 999 },
+      ],
+    }
+    applyRowDerivations(
+      { fields: [{ id: 'items', type: 'detail', label: '明细', columns }] },
+      formData,
+      'items',
+      'amount',
+    )
+    expect(formData.items[0].amount).toBe(300)
+    expect(formData.items[1].amount).toBe(999)
+  })
+})

--- a/apps/web/tests/useAutoSumTotal.test.ts
+++ b/apps/web/tests/useAutoSumTotal.test.ts
@@ -84,3 +84,70 @@ describe('useAutoSumTotal (Gate B — auto-fill wiring)', () => {
     app.unmount()
   })
 })
+
+function makeDerivedTemplate(withHiddenOperand = false): ApprovalTemplateDetailDTO {
+  return {
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '总额' },
+        {
+          id: 'items', type: 'detail', label: '明细', columns: [
+            ...(withHiddenOperand ? [{ id: 'use_quantity', type: 'select' as const, label: '使用数量' }] : []),
+            { id: 'quantity', type: 'number', label: '数量' },
+            { id: 'unit_price', type: 'number', label: '单价' },
+            { id: 'amount', type: 'number', label: '小计', props: { derivedFrom: { operandColumnIds: ['quantity', 'unit_price'], operation: 'product' } } },
+          ],
+        },
+      ],
+      amountConsistencyCheck: { totalFieldId: 'amount', detailFieldId: 'items', amountColumnId: 'amount' },
+    },
+  } as unknown as ApprovalTemplateDetailDTO
+}
+
+describe('useAutoSumTotal — derive-then-sum one pass (line-subtotal #3203)', () => {
+  it('derives each row amount from its operands AND sums the total, in one flush', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ quantity: 3, unit_price: 100 }, { quantity: 2, unit_price: 50 }] })
+    const { app } = harness(ref(makeDerivedTemplate()), formData)
+    await nextTick()
+    expect((formData.items as Array<Record<string, unknown>>)[0].amount).toBe(300)
+    expect((formData.items as Array<Record<string, unknown>>)[1].amount).toBe(100)
+    expect(formData.amount).toBe(400)
+    // edit an operand → that row re-derives + the total updates (same chain)
+    ;(formData.items as Array<Record<string, unknown>>)[0].unit_price = 200
+    await nextTick()
+    expect((formData.items as Array<Record<string, unknown>>)[0].amount).toBe(600)
+    expect(formData.amount).toBe(700)
+    app.unmount()
+  })
+
+  it('a row with a partial operand is left manual (not derived); the total uses its manual amount', async () => {
+    const formData = reactive<Record<string, unknown>>({ items: [{ quantity: 3, unit_price: 100 }, { quantity: 2, amount: 999 }] })
+    const { app } = harness(ref(makeDerivedTemplate()), formData)
+    await nextTick()
+    expect((formData.items as Array<Record<string, unknown>>)[0].amount).toBe(300) // derived
+    expect((formData.items as Array<Record<string, unknown>>)[1].amount).toBe(999) // partial (no unit_price) → manual
+    expect(formData.amount).toBe(1299)
+    app.unmount()
+  })
+
+  it('a row with a hidden operand is left manual; the total uses its manual amount', async () => {
+    const template = makeDerivedTemplate(true)
+    const detail = template.formSchema.fields.find((field) => field.id === 'items')
+    const quantity = detail?.columns?.find((column) => column.id === 'quantity')
+    if (quantity) {
+      quantity.visibilityRule = { fieldId: 'use_quantity', operator: 'eq', value: true }
+    }
+    const formData = reactive<Record<string, unknown>>({
+      items: [
+        { use_quantity: true, quantity: 3, unit_price: 100 },
+        { use_quantity: false, quantity: 2, unit_price: 50, amount: 999 },
+      ],
+    })
+    const { app } = harness(ref(template), formData)
+    await nextTick()
+    expect((formData.items as Array<Record<string, unknown>>)[0].amount).toBe(300)
+    expect((formData.items as Array<Record<string, unknown>>)[1].amount).toBe(999)
+    expect(formData.amount).toBe(1299)
+    app.unmount()
+  })
+})


### PR DESCRIPTION
## Summary\n- add FE-only line subtotal derivation from target-column props.derivedFrom (qty × unit_price → amount)\n- run derivation before existing amount total auto-sum, so line amount feeds the existing backend total-check chain\n- render declared line amount read-only only when the row target and operands are visible; hidden operand rows stay manual\n- enable the purchase amount-tier preset declaration and add the new approval-web guard tests\n\n## Boundary\n- frontend-only runtime for #3203\n- backend total-check unchanged: still enforces total = sum(amount), not amount = qty × price\n- malformed/dangling declarations fall back to manual/no-op\n\n## Verification\n- pnpm --filter @metasheet/web exec vitest run tests/lineDerivation.test.ts tests/useAutoSumTotal.test.ts --watch=false\n- pnpm --filter @metasheet/web exec vitest run approval-common-template-presets amountAutoSum useAutoSumTotal lineDerivation --reporter=dot\n- pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot\n- pnpm --filter @metasheet/web exec vue-tsc -b --pretty false\n- pnpm --filter @metasheet/web exec eslint src/approvals/lineDerivation.ts src/approvals/useAutoSumTotal.ts src/views/approval/ApprovalNewView.vue tests/lineDerivation.test.ts tests/useAutoSumTotal.test.ts tests/approval-common-template-presets.test.ts --max-warnings=0