### PR TITLE
docs(approval): §1 closed by #3197 + §3 visibilityRule ratified as-built (amount total-check)

### DIFF
--- a/docs/development/approval-amount-total-check-dev-verification-20260624.md
+++ b/docs/development/approval-amount-total-check-dev-verification-20260624.md
@@ -70,6 +70,31 @@ equal the sum of that submission's detail-row amounts:
   behavior** (record what save vs submit actually does today), NOT a rushed backend save-time reject —
   handled separately from §1.
 
+## §3 — `visibilityRule` save-vs-submit policy (ratified as-built; doc-only)
+
+**Shipped behavior (as-built, ratified for v1 — verified on `origin/main`):**
+- **Save** (`ApprovalProductService` `normalizeFormFieldVisibilityRule`, ~580 + the `failValidation` block
+  ~714–744): a field's `visibilityRule` is **structurally validated + normalized** to a canonical shape.
+  `failValidation` rejects a malformed shape — missing `fieldId`, invalid `operator`, `values` only allowed
+  for `in` (and must be a non-empty array), `value` required otherwise. The canonical rule persists on the
+  versioned `formSchema`.
+- **Submit** (`ApprovalGraphExecutor` `evaluateVisibilityRule`, ~238 + the detail per-row drop ~274): the
+  rule is **evaluated against the submitted `formData`** — hidden fields are dropped, and a detail sub-field's
+  `visibilityRule` is evaluated per row (hidden cells dropped) before processing.
+
+**Policy (ratified):** **structural validation at save + semantic evaluation at submit.** A rule that is
+structurally valid at save but semantically problematic *at submit time* (e.g. references a field that no
+longer exists, or hides a field) is resolved at submit by the evaluation (hidden → dropped), NOT rejected at
+save. This is symmetric with the amount total-check's posture: **fail-closed at the runtime/submit chokepoint,
+lenient at save** — the server is the sole arbiter at the moment that matters.
+
+**Deferred (NOT rushed — per owner: do not pre-build a backend save-time reject):** a save-time SEMANTIC reject
+(reject a `visibilityRule` at save when its `fieldId` is unknown in the schema, or when it could hide a
+required / total / amount field) is a P2 hardening. It is NOT built here because a save-time reject changes the
+authoring contract and a wrong one blocks valid saves — it needs the same explicit-semantics care this line
+gives money-path changes, as its own gated slice. This section ratifies the shipped behavior and records the
+gap; it does not change runtime.
+
 ## Deferred (need explicit business semantics — per the plan, do not pre-build)
 - **W7 rejection backwrite** — write `status='rejected'` on the non-approved path (which currently fails
   the automation by design).

--- a/docs/development/approval-amount-total-check-dev-verification-20260624.md
+++ b/docs/development/approval-amount-total-check-dev-verification-20260624.md
@@ -40,6 +40,12 @@ equal the sum of that submission's detail-row amounts:
 - No regression (approval-product-service unit suite unchanged); backend tsc clean.
 
 ## Shipped as the rest of this line (separate PRs, all on main)
+- **FE authoring preserve (§1 — the active exposure) → #3197.** The authoring editor does NOT author
+  `amountConsistencyCheck`, but the load→rebuild-on-save path now carries it through VERBATIM (hydrate +
+  re-emit), so a preset-shipped control (#3183) is no longer silently dropped on the first authoring-page
+  save. Tests: §1 round-trip unit (`draftFromTemplate`→`buildFormSchema` preserves it; absent stays absent) +
+  the **active-exposure mounted guard** (open a mapped template + save with no edits → the mapping stays in
+  the PUT payload). FE-only; backend remains the sole arbiter.
 - **Preset enablement → #3183.** `purchase_amount_tier` ships `{amount, purchase_items, amount}` and
   `reimbursement_amount_tier` ships `{amount, expense_items, amount}` (via a `withAmountConsistency`
   helper); the basic presets (leave/reimbursement/purchase) keep no mapping. The FE
@@ -57,8 +63,12 @@ equal the sum of that submission's detail-row amounts:
     result (`backwriteSkipped`), not only `logger.warn`. 14/14 start_approval integration; automation-v1 186/186.
 
 ## Still a follow-up (not built)
-- **Detail-row auto-sum** — the heavier of the two #3161 fixes (compute/auto-fill the total, removing
-  the gameable separate total) — its own later lock; pulls in a computed/rollup form-field capability.
+- **Detail-row auto-sum** — the heavier of the two #3161 fixes (the lighter — §1, the FE authoring
+  silent-drop — is now **closed by #3197**); compute/auto-fill the total, removing the gameable separate
+  total — its own later lock; pulls in a computed/rollup form-field capability.
+- **§3 — `visibilityRule` save-vs-submit policy (P2).** Next move is **doc-only ratify of the shipped
+  behavior** (record what save vs submit actually does today), NOT a rushed backend save-time reject —
+  handled separately from §1.
 
 ## Deferred (need explicit business semantics — per the plan, do not pre-build)
 - **W7 rejection backwrite** — write `status='rejected'` on the non-approved path (which currently fails


### PR DESCRIPTION
Syncs the amount-total-check record after #3197 merged, per your sequence.

- **§1** (preset-shipped `amountConsistencyCheck` silently dropped on first authoring save) → **CLOSED by #3197** (verbatim passthrough + round-trip + active-exposure mounted guard). Moved to 'shipped'.
- **§3** `visibilityRule` save-vs-submit → **ratified as-built (doc-only)**: SAVE = structural validate/normalize (failValidation on malformed); SUBMIT = evaluate (hidden fields/cells dropped). Policy = structural-at-save + semantic-at-submit (fail-closed at submit, lenient at save). A **save-time semantic reject stays a deferred P2** — not rushed, per your call.

Docs-only, no runtime change.