### PR TITLE
feat(multitable): T8-2 Reset-to-T destructive PIT restore (default-OFF flag)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -219,6 +219,7 @@ jobs:
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-restore-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \
+            tests/integration/multitable-reset-pit-realdb.test.ts \
             tests/integration/multitable-config-revision-retention-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/multitable-config-history-view-redaction-realdb.test.ts \

--- a/docs/development/multitable-global-history-nondestructive-acceptance-runbook-20260625.md
+++ b/docs/development/multitable-global-history-nondestructive-acceptance-runbook-20260625.md
@@ -178,7 +178,8 @@ The non-destructive line is acceptable for pilot if:
 - all expected error/status semantics in section 4 are observed;
 - no masked field value, hidden field ID, denied record count, or denied record existence is visible to a restricted actor;
 - no write path accepts a client-computable identity in place of a server preview token;
-- T8-2 Reset-to-T and T9-W data-loss operations remain unavailable unless separately ratified.
+- T8-2 Reset-to-T remains unavailable unless `MULTITABLE_ENABLE_PIT_RESET` is explicitly enabled; T9-W data-loss
+  operations remain unavailable unless separately ratified.
 
 If this pass fails on UX only, file polish follow-ups against the owning surface.
 If it fails on permission, preview identity, drift, or atomicity, stop the pilot and fix before release.
@@ -187,7 +188,7 @@ If it fails on permission, preview identity, drift, or atomicity, stop the pilot
 
 | Item | Status | Required next action |
 |---|---|---|
-| T8-2 Reset-to-T | Gated destructive path | Explicit owner sign-off on D1-D5, then build behind a flag with PIT-2 / ceiling / atomicity goldens. |
+| T8-2 Reset-to-T | Runtime shipped default-OFF (#3214) | Enable only by explicit environment decision via `MULTITABLE_ENABLE_PIT_RESET`; async/subset reset remain follow-ups. |
 | T9-W data-loss config ops | Gated irreversible config path | Separate design/sign-off for field undelete and lossy retype; likely depends on the wider undelete story. |
 | T8-1 undelete-execute | Deferred | Needs the cross-cutting undelete/link-rebuild slice. |
 | Record-history keyset `hasMore` | Deferred | Resolve same-millisecond ordering semantics before implementing. |

--- a/docs/development/multitable-global-history-program-roadmap-20260621.md
+++ b/docs/development/multitable-global-history-program-roadmap-20260621.md
@@ -1,8 +1,12 @@
 # Multitable Global History — Program Roadmap (T5–T9)
 
 > The 规划 for "complete the remaining history-records + Global History development plan." It records the staged
-> execution, the build-vs-design-lock split, and the ratification gates. The read-only foundation is built; the
-> write/destructive slices are design-locked (the 设计 deliverable) and held for explicit owner ratification.
+> execution, the build-vs-design-lock split, and the ratification gates.
+>
+> **Status reconciliation (2026-06-25):** this roadmap's §3/§5 are retained history from the design-lock phase. Since
+> then, T6/T8/T9 have advanced. For T8 specifically, T8-1 Revert-to-T is shipped and T8-2 Reset-to-T is implemented by
+> #3214 behind `MULTITABLE_ENABLE_PIT_RESET` (default off). Treat
+> `multitable-t8-2-reset-dev-verification-20260625.md` and the T8 design-lock status block as the current T8 ledger.
 
 ## 0. Where the line already is (shipped)
 

--- a/docs/development/multitable-global-history-remaining-dev-pass2-design-verification-20260624.md
+++ b/docs/development/multitable-global-history-remaining-dev-pass2-design-verification-20260624.md
@@ -1,16 +1,15 @@
 # Global History remaining-dev (pass 2) — design & verification
 
-## 🚫 BLOCKED ON EXPLICIT SIGN-OFF (not built — by design)
+## Current status after T8-2 ratification
 
-- **T8-2 Reset-to-T** (destructive PIT restore — *deletes* records created after T). Decisions resolved + flag-gated
-  build plan in `multitable-t8-2-reset-build-readiness-20260624.md`; awaiting your **yes/no on D1–D5** (the T8
-  design-lock §5 requires a separate rollback-semantics sign-off, which a re-issued `/goal` is not). **No destructive
-  code was written.**
-- **T9-W data-loss config ops** (field *undelete* / *lossy retype*) + **T8-1 undelete-execute** — same gate, same ask;
-  also need the codebase-wide undelete slice first. Refused `422` today.
+- **T8-2 Reset-to-T** (destructive PIT restore — *soft-deletes* records created after T) is now ratified and implemented
+  by #3214 behind `MULTITABLE_ENABLE_PIT_RESET` (default off). D1-D5 are no longer an open design gate: v1 is whole
+  sheet only, `canManageSheetAccess` + flag gated, synchronous under `MULTITABLE_SHEET_REVERT_MAX_RECORDS`, typed
+  `confirm:'reset'`, and preview-token-bound.
+- **T9-W data-loss config ops** (field *undelete* / *lossy retype*) + **T8-1 undelete-execute** remain gated; they need
+  the codebase-wide undelete/link-rebuild story first and are refused `422` today.
 
-These are the one part of "the remaining dev" that the line's discipline says I must not self-authorize — especially
-one turn after the [P1] review caught a T8 gate miss. They are presented for decision, not shipped.
+Production enablement of T8-2 remains an operational flag decision, not a code/design gap.
 
 ## What this pass DID complete (safe, non-destructive)
 
@@ -55,7 +54,11 @@ This pass closed the [P1] review findings on the prior pass, then completed the 
 this doc follow. Each new write path is mutation/trigger-proven, allow-and-deny.
 
 ## The honest bottom line
-The read/preview/scoped-write/non-destructive arcs of the Global History / point-in-time restore line are complete and hardened. The **only**
-remaining development is the **destructive Reset (T8-2)** and the **irreversible data-loss config ops** — and those are
-deliberately held at your sign-off, with their decisions resolved and a build plan ready. Say yes to D1–D5 and I build
-T8-2 behind the default-off flag with the full PIT-2 / ceiling / atomicity golden suite.
+The read/preview/scoped-write/non-destructive arcs of the Global History / point-in-time restore line are complete and
+hardened. The destructive Reset v1 is now built behind the default-off flag with PIT-2 / ceiling / preview-identity /
+single-transaction atomicity goldens. Remaining work is no longer "build T8-2"; it is narrower:
+
+- production rollout of `MULTITABLE_ENABLE_PIT_RESET` when an environment owner wants Reset enabled;
+- T8-1 undelete-execute, which needs the cross-cutting resurrect + link-rebuild slice;
+- T9-W irreversible config operations (field undelete / lossy retype), still design-lock-first;
+- optional T8 scale extensions: async reset above the synchronous ceiling and permission-filtered subset reset.

--- a/docs/development/multitable-global-history-t8-pit-restore-design-lock-20260621.md
+++ b/docs/development/multitable-global-history-t8-pit-restore-design-lock-20260621.md
@@ -1,9 +1,9 @@
 # Multitable Global History — T8 Point-In-Time Restore (DESIGN-LOCK)
 
-> Status: **DESIGN-LOCK, docs-only. OWNER-GATED — the single most dangerous slice in the program.** Runtime
-> requires a SEPARATE explicit owner ratification of the rollback semantics (§6), beyond ratifying this doc.
-> Prerequisites (per the canonical plan T8): T7 point-in-time read-only view PROVEN, T5 restore-preview PROVEN,
-> async/max-size decided. **No T8 runtime is built until all of those + owner ratification.**
+> Status: **DESIGN-LOCK + RUNTIME STATUS.** The owner-gated semantics remain locked here. T8-1 Revert-to-T is shipped.
+> T8-2 Reset-to-T has now been separately ratified for D1-D5 and implemented by #3214 behind
+> `MULTITABLE_ENABLE_PIT_RESET` (default off). Production enablement is still an operational decision; the design gate
+> for the v1 runtime is closed.
 > Basis: canonical design-lock LOCK-9/10/11/12; the T5 preview lock; the T6 scoped-restore lock (T8 is the
 > sheet-wide generalization of T6's write, over the T7/T5-1 as-of-T reconstruction).
 
@@ -56,25 +56,22 @@ confirmation UX. Mutation-checks on PIT-2 (drop a preflight check → a denied t
 
 ## 5. Decisions to ratify (the heavy ones — SEPARATE owner sign-off, not just doc approval)
 
-- **D1 — Reset (destructive) at all, in v1?** Recommend: ship **Revert-only first** (zero data loss); Reset as a
-  later, separately-ratified slice. This de-risks the whole program — Revert covers most "go back to T" needs.
-- **D2 — Who may execute a sheet rollback.** A capability strictly ABOVE normal record-write (e.g. a base-admin
-  or a dedicated `multitable:history-restore` capability), since one call rewrites a whole table. Recommend: a
-  dedicated capability, never plain `canEditRecord`.
-- **D3 — Async threshold + hard max size.** The record/field-count above which the rollback runs async, and the
-  ceiling above which it is refused. Recommend: sync under a few hundred records, async above, hard-refuse above
-  a configured ceiling.
-- **D4 — Confirmation / two-step + audit.** A destructive Reset requires an explicit typed confirmation + is
-  audited with actor/T/scope (never values). Recommend: yes.
-- **D5 — Scope granularity.** Whole sheet only, or a permission-filtered subset (a view/filter)? Recommend:
-  whole sheet first; subset is a follow-up.
+- **D1 — Reset (destructive) at all, in v1?** **Ratified yes for #3214**, after T8-1 Revert was proven. Runtime remains
+  default-off behind `MULTITABLE_ENABLE_PIT_RESET`.
+- **D2 — Who may execute a sheet rollback.** **Ratified v1 gate: `canManageSheetAccess` + flag.** This is above normal
+  record-write; a future dedicated `multitable:history-restore` capability can tighten the contract later.
+- **D3 — Async threshold + hard max size.** **Ratified v1: synchronous under `MULTITABLE_SHEET_REVERT_MAX_RECORDS`,
+  fail-closed `413` above it.** Async reset remains a future scale extension.
+- **D4 — Confirmation / two-step + audit.** **Ratified yes.** Execute requires `confirm: 'reset'`; reset writes forward
+  `source=restore` history in a single transaction.
+- **D5 — Scope granularity.** **Ratified v1: whole sheet only.** Permission-filtered subset reset remains a follow-up.
 
 ## 6. Gated TODO
 
-- ⬜ **T8-0 — ratify** this doc AND the rollback semantics (D1–D5) as a SEPARATE explicit owner sign-off.
-- 🔒 **T8-1 — Revert-to-T** (non-destructive, owner-opt-in) over T7 + T6's write. Real-DB goldens + browser UX.
-- 🔒 **T8-2 — Reset-to-T** (destructive, SEPARATE owner ratification, only after Revert proven). The hard-gated
-  delete path + async runner + ceiling. Reviewed alone, most adversarial test pass in the program.
+- ✅ **T8-0 — ratified.** D1-D5 are explicitly settled for v1.
+- ✅ **T8-1 — Revert-to-T** (non-destructive, owner-opt-in) over T7 + T6's write. Real-DB goldens + browser UX shipped.
+- ✅ **T8-2 — Reset-to-T runtime** (#3214). Destructive delete path is default-off, preview-token-bound, all-or-nothing,
+  and covered by real-DB goldens. Async reset and subset reset are not part of v1.
 
 ## 7. Out of scope / anti-goals
 

--- a/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
+++ b/docs/development/multitable-t8-2-reset-build-readiness-20260624.md
@@ -1,16 +1,16 @@
 # T8-2 Reset-to-T (destructive PIT restore) — build-readiness + decisions for sign-off
 
-> Status: **AWAITING EXPLICIT OWNER SIGN-OFF — NOT built.** The T8 design-lock (§5) requires Reset to have a *separate
-> rollback-semantics sign-off, not just doc approval*. A re-issued `/goal` is not that sign-off. This doc resolves the
-> §5 decisions (D1–D5) and proposes a flag-gated build, so the sign-off is a concrete yes/no rather than an open
-> question. Nothing destructive ships until you approve this.
+> Status: **RATIFIED + IMPLEMENTED BY #3214; DEFAULT-OFF AT RUNTIME.** The T8 design-lock (§5) required a separate
+> rollback-semantics sign-off. That sign-off has now been given for D1-D5, and #3214 implements the Reset runtime behind
+> `MULTITABLE_ENABLE_PIT_RESET`. Shipping the code is not the same as enabling it in production: the operational flag
+> remains the belt-and-suspenders gate for rollout.
 
 ## Why this is gated and not auto-built
 
 Reset is the one genuinely destructive capability in the whole Global History / point-in-time restore line: it **deletes records created after
-T** (Revert keeps them). A bug here loses data. The line's discipline — and the [P1] review that just caught a T8-1
-gate miss — say the destructive path gets an explicit, deliberate sign-off, not a broad "complete it." So this is
-presented for decision, with the safe half (T8-1 Revert) already shipped (#3165).
+T** (Revert keeps them). A bug here loses data. The line's discipline — and the [P1] review that caught a T8-1
+gate miss — required an explicit, deliberate sign-off, not a broad "complete it." That sign-off is now recorded by the
+#3214 implementation and this readiness doc is retained as the ratified decision record.
 
 ## Reset = Revert + delete-post-T-created
 
@@ -21,8 +21,7 @@ preflight.
 
 ## Decisions to ratify (T8 design-lock §5)
 
-- **D1 — ship Reset at all?** Recommend **yes** — it's the natural capstone. **There is no destructive code yet; the
-  build awaits THIS sign-off.** On your yes I build it, and the runtime ships behind a default-OFF flag
+- **D1 — ship Reset at all?** **Ratified yes.** #3214 ships the runtime behind a default-OFF flag
   (`MULTITABLE_ENABLE_PIT_RESET`) as belt-and-suspenders so it's inert even post-build until explicitly enabled — but
   the flag is the *operational* gate *after* authorization, not a substitute for it. Revert stays the default,
   always-on path.
@@ -43,19 +42,19 @@ to be reverted is permission-checked; if a SINGLE one is denied, the **entire Re
 written** (no partial skip, no fail-halfway — unlike Revert, which may partial-skip). The proving golden is a
 **mutation check**: drop one preflight check → a denied target slips into the destructive set → the test fails.
 
-## Proposed verification (what the build would ship with)
+## Verification shipped in #3214
 
-Real-DB goldens: flag-off → Reset refused (inert); flag-on + whole-sheet Reset → post-T-created **deleted**,
+Real-DB goldens: flag-off → Reset refused (inert); flag-on + whole-sheet Reset → post-T-created **soft-deleted**,
 pre-T-state reverted, forward revisions + `source=restore` batch written; **PIT-2 all-or-nothing blocks on any single
-denial, zero writes** (+ the mutation check); above-ceiling → `413`; `confirm`-absent → refused; PIT-3 no count/
-existence leak; PIT-7 reveal-non-composition. Plus a destructive-delete atomicity golden (a forced mid-write failure
-leaves the sheet untouched).
+denial, zero writes**; above-ceiling → `413`; `confirm`-absent → refused; delete-set divergence on created-after-preview
+and edited-after-preview records; PIT-3 no blocker/count/existence oracle; PIT-7 reveal-non-composition. Plus the
+load-bearing destructive atomicity golden: a forced delete-revision failure after revert writes have begun rolls the
+entire transaction back, leaving the sheet untouched.
 
 ## What I need from you
 
-A yes/no on **D1–D5 as recommended** (or your amendments). On a yes, I build T8-2 behind the default-off flag with the
-goldens above, on the T8-1 branch/its successor, and present it for review before the flag is ever enabled in any real
-environment.
+No further design decision is needed for D1-D5. Remaining rollout control is operational: keep
+`MULTITABLE_ENABLE_PIT_RESET` off until the owning environment explicitly enables Reset.
 
 ## Adjacent destructive/irreversible items (same gate, same ask)
 

--- a/docs/development/multitable-t8-2-reset-dev-verification-20260625.md
+++ b/docs/development/multitable-t8-2-reset-dev-verification-20260625.md
@@ -1,0 +1,77 @@
+# T8-2 Reset-to-T runtime — development verification
+
+> Grounded on PR #3214 (`claude/t8-2-reset-runtime-20260625`). This file records what the T8-2 runtime ships, what is
+> proven by tests, and what remains out of scope. Re-verify against `origin/main` before using it as a future status
+> ledger.
+
+## Scope shipped
+
+T8-2 Reset-to-T is the destructive point-in-time restore mode:
+
+- it reverts surviving records to their state at T;
+- it soft-deletes records created after T into `meta_records_trash`;
+- it is gated by `MULTITABLE_ENABLE_PIT_RESET === 'true'`;
+- it requires `canManageSheetAccess`;
+- it refuses sheets over `MULTITABLE_SHEET_REVERT_MAX_RECORDS`;
+- it requires `confirm: 'reset'` on execute;
+- it is whole-sheet only in v1.
+
+Reset is distinct from T8-1 Revert: Revert keeps post-T-created records and may partial-skip denied rows. Reset is
+all-or-nothing.
+
+## Load-bearing implementation locks
+
+- **Preview identity:** `restore-preview-pit-reset` is a distinct token type from Revert. It binds the revert scope and
+  the delete scope.
+- **Delete-set identity:** the delete scope hash includes record id and preview-time version. A post-preview create or
+  a post-preview edit of a delete target makes execute reject with `PREVIEW_IDENTITY_INVALID`.
+- **Reset-specific enumeration:** Reset does not reuse Revert's invisible-row skip semantics. A row-denied, forbidden,
+  schema-drifted, or undelete-required target blocks the whole Reset before any write.
+- **Single transaction:** reverts, link updates, delete revisions, trash inserts, and live-row deletes happen inside one
+  transaction. A failure during the delete-revision phase rolls back the already-started reverts too.
+- **No target oracle:** destructive blocks return `RESET_BLOCKED` / `RESET_UNSUPPORTED` without leaking blocker ids,
+  blocker counts, or denied record existence.
+
+## Verification
+
+Local non-DB checks run on the implementation branch:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-record-lock-guard.guard.test.ts \
+  tests/unit/multitable-richtext-longtext-write-sink.guard.test.ts \
+  tests/unit/multitable-raw-record-data-projection.guard.test.ts \
+  tests/unit/multitable-stored-data-taint-chokepoint.guard.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend test:unit
+```
+
+The real-DB suite is allowlisted into `test (20.x)` via
+`packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts`.
+
+Goldens:
+
+- `DATABASE_URL` sentinel so the suite cannot silently skip in CI;
+- flag off -> preview and execute return `RESET_DISABLED`;
+- flag on -> A/B revert to T, D is soft-deleted into trash, `source=restore` revisions written;
+- locked delete target -> `RESET_BLOCKED`, zero writes, no blocker oracle;
+- row-deny added after preview -> `RESET_BLOCKED`, zero writes, no blocker oracle;
+- over ceiling -> `413`;
+- missing or wrong typed confirm -> `400`;
+- record created after preview -> preview identity mismatch, nothing deleted;
+- delete target edited after preview -> preview identity mismatch, nothing deleted;
+- forced delete-revision failure -> A/B reverts and D delete all roll back;
+- source grep proves Reset does not compose reveal grants;
+- plain record editor without sheet-access management -> forbidden.
+
+## Remaining work
+
+Not part of T8-2 v1:
+
+- enabling `MULTITABLE_ENABLE_PIT_RESET` in any real environment;
+- async reset for sheets above the synchronous ceiling;
+- permission-filtered subset reset;
+- T8-1 undelete-execute, which needs resurrect + link-rebuild;
+- T9-W irreversible config restore slices.
+

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -247,3 +247,54 @@ export function verifyConfigRestorePreviewIdentity(token: string, expected: Conf
   if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
   return { valid: true }
 }
+
+// ── T8-2 Reset-to-T (DESTRUCTIVE) preview-identity ────────────────────────────────────────────────────────────
+// Reset = Revert (surviving records to their T-state) + SOFT-DELETE the records CREATED AFTER T. Its identity is
+// DISJOINT from revert (`type: 'restore-preview-pit-reset'`), so a revert token can never trigger a destructive
+// reset (and vice versa). It binds TWO order-invariant hashes: `revertScopeHash` (the reverts, identical to revert)
+// AND `deleteScopeHash` (the EXACT set of post-T-created record ids to delete). Execute RE-ENUMERATES both and
+// re-hashes; a record created between preview and execute re-enumerates into the delete-set → `deleteScopeHash`
+// diverges → rejected. So Reset can NEVER delete a record the actor did not see in the preview (the load-bearing
+// data-safety property for the only path in the line that destroys rows).
+export function hashDeleteSet(recordIds: string[]): string {
+  const canon = [...new Set(recordIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  return createHash('sha256').update(JSON.stringify(canon)).digest('hex')
+}
+
+export interface PitResetPreviewIdentityClaims {
+  sheetId: string
+  /** the point in time the sheet is reset to (ISO). */
+  asOf: string
+  strategy: 'reset'
+  /** sha256 over the sorted revert set (recordId + masked changesHash + version), via hashScope — same as revert. */
+  revertScopeHash: string
+  /** sha256 over the sorted set of post-T-created record ids to delete, via hashDeleteSet. */
+  deleteScopeHash: string
+  actorId: string
+}
+
+export function mintPitResetPreviewIdentity(claims: PitResetPreviewIdentityClaims, expiresIn: SignOptions['expiresIn'] = DEFAULT_TTL): string {
+  return jwt.sign({ type: 'restore-preview-pit-reset', ...claims }, getSecret(), { algorithm: 'HS256', expiresIn } as SignOptions)
+}
+
+export interface PitResetVerifyResult {
+  valid: boolean
+  reason?: 'invalid' | 'expired' | 'wrong_type' | 'mismatch_sheetId' | 'mismatch_asOf' | 'mismatch_strategy' | 'mismatch_revertScopeHash' | 'mismatch_deleteScopeHash' | 'mismatch_actorId'
+}
+
+export function verifyPitResetPreviewIdentity(token: string, expected: PitResetPreviewIdentityClaims): PitResetVerifyResult {
+  let payload: Partial<PitResetPreviewIdentityClaims> & { type?: string }
+  try {
+    payload = jwt.verify(token, getSecret()) as Partial<PitResetPreviewIdentityClaims> & { type?: string }
+  } catch (e) {
+    return { valid: false, reason: (e as Error)?.name === 'TokenExpiredError' ? 'expired' : 'invalid' }
+  }
+  if (payload.type !== 'restore-preview-pit-reset') return { valid: false, reason: 'wrong_type' } // revert/single/scoped tokens rejected
+  if (payload.sheetId !== expected.sheetId) return { valid: false, reason: 'mismatch_sheetId' }
+  if (payload.asOf !== expected.asOf) return { valid: false, reason: 'mismatch_asOf' }
+  if (payload.strategy !== expected.strategy) return { valid: false, reason: 'mismatch_strategy' }
+  if (payload.revertScopeHash !== expected.revertScopeHash) return { valid: false, reason: 'mismatch_revertScopeHash' }
+  if (payload.deleteScopeHash !== expected.deleteScopeHash) return { valid: false, reason: 'mismatch_deleteScopeHash' }
+  if (payload.actorId !== expected.actorId) return { valid: false, reason: 'mismatch_actorId' }
+  return { valid: true }
+}

--- a/packages/core-backend/src/multitable/restore-preview-identity.ts
+++ b/packages/core-backend/src/multitable/restore-preview-identity.ts
@@ -252,12 +252,15 @@ export function verifyConfigRestorePreviewIdentity(token: string, expected: Conf
 // Reset = Revert (surviving records to their T-state) + SOFT-DELETE the records CREATED AFTER T. Its identity is
 // DISJOINT from revert (`type: 'restore-preview-pit-reset'`), so a revert token can never trigger a destructive
 // reset (and vice versa). It binds TWO order-invariant hashes: `revertScopeHash` (the reverts, identical to revert)
-// AND `deleteScopeHash` (the EXACT set of post-T-created record ids to delete). Execute RE-ENUMERATES both and
-// re-hashes; a record created between preview and execute re-enumerates into the delete-set → `deleteScopeHash`
-// diverges → rejected. So Reset can NEVER delete a record the actor did not see in the preview (the load-bearing
+// AND `deleteScopeHash` (the EXACT set of post-T-created record ids AND their preview-time versions to delete).
+// Execute RE-ENUMERATES both and re-hashes; a record created OR edited between preview and execute diverges →
+// rejected. So Reset can NEVER delete a record/version the actor did not see in the preview (the load-bearing
 // data-safety property for the only path in the line that destroys rows).
-export function hashDeleteSet(recordIds: string[]): string {
-  const canon = [...new Set(recordIds)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+export function hashDeleteSet(records: Array<{ recordId: string; version: number }>): string {
+  const canon = records
+    .map((r) => ({ recordId: r.recordId, version: Number.isFinite(r.version) ? Math.trunc(r.version) : 0 }))
+    .sort((a, b) => (a.recordId < b.recordId ? -1 : a.recordId > b.recordId ? 1 : a.version - b.version))
+    .map((r) => JSON.stringify([r.recordId, r.version]))
   return createHash('sha256').update(JSON.stringify(canon)).digest('hex')
 }
 
@@ -268,7 +271,7 @@ export interface PitResetPreviewIdentityClaims {
   strategy: 'reset'
   /** sha256 over the sorted revert set (recordId + masked changesHash + version), via hashScope — same as revert. */
   revertScopeHash: string
-  /** sha256 over the sorted set of post-T-created record ids to delete, via hashDeleteSet. */
+  /** sha256 over the sorted set of post-T-created record ids + preview versions to delete, via hashDeleteSet. */
   deleteScopeHash: string
   actorId: string
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -195,7 +195,7 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
-import { listRecordRevisions, type RecordRevisionEntry } from '../multitable/record-history-service'
+import { listRecordRevisions, recordRecordRevision, type RecordRevisionEntry } from '../multitable/record-history-service'
 import {
   countUnreadRecordSubscriptionNotifications,
   getRecordSubscriptionStatus,
@@ -8608,6 +8608,75 @@ export function univerMetaRouter(): Router {
     return { reverts, undeleteCount, keptCreatedAfterT, createdAfterTIds, driftCount, patchContext }
   }
 
+  type PitResetRevert = { recordId: string; diff: RecordChange[]; changesHash: string; version: number }
+  type PitResetDelete = { recordId: string; version: number; data: Record<string, unknown> }
+  type PitResetComputation =
+    | null
+    | { tooLarge: true; recordCount: number }
+    | { blocked: true; reason: 'denied' | 'forbidden' | 'schema_drift' | 'undelete_unsupported' }
+    | {
+        reverts: PitResetRevert[]
+        deletes: PitResetDelete[]
+        patchContext: Awaited<ReturnType<typeof buildRecordPatchContext>>
+      }
+
+  const computeSheetReset = async (
+    pool: ReturnType<typeof poolManager.get>, req: Request, sheetId: string, asOfIso: string,
+    access: RevertSheetCaps['access'], capabilities: RevertSheetCaps['capabilities'],
+  ): Promise<PitResetComputation> => {
+    const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
+    const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
+    if (!patchContext) return null
+    const { fieldById, fieldPermissions } = patchContext
+    const recordCount = Number(((await pool.query('SELECT count(*)::int AS c FROM meta_records WHERE sheet_id = $1', [sheetId])).rows[0] as { c: number }).c)
+    if (recordCount > SHEET_REVERT_MAX_RECORDS) return { tooLarge: true, recordCount }
+    const rawTypeById = new Map<string, string>(((await pool.query('SELECT id, type FROM meta_fields WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; type: unknown }>).map((r) => [String(r.id), String(r.type ?? '').trim().toLowerCase()]))
+    const baseAllowed = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+    const allowed = await maskStoredRecordFieldIds(req, pool.query.bind(pool), sheetId, undefined, baseAllowed)
+    const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
+      ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId) : new Set<string>()
+    const liveById = new Map<string, { data: Record<string, unknown>; version: number }>()
+    for (const r of (await pool.query('SELECT id, data, version FROM meta_records WHERE sheet_id = $1', [sheetId])).rows as Array<{ id: string; data: unknown; version: unknown }>) {
+      liveById.set(String(r.id), { data: asRec(r.data), version: typeof r.version === 'number' && Number.isFinite(r.version) ? r.version : Number(r.version) || 0 })
+    }
+    const stateMap = await reconstructRecordsAtT(pool.query.bind(pool), sheetId, asOfIso)
+    const reverts: PitResetRevert[] = []
+    const deletes: PitResetDelete[] = []
+    for (const [recordId, live] of liveById) {
+      const target = stateMap.get(recordId)
+      if (!target || !target.exists) {
+        if (deniedIds.has(recordId)) return { blocked: true, reason: 'denied' }
+        deletes.push({ recordId, version: live.version, data: live.data })
+      }
+    }
+    for (const [recordId, target] of stateMap) {
+      if (!target.exists) continue
+      const live = liveById.get(recordId)
+      if (!live) return { blocked: true, reason: 'undelete_unsupported' }
+      const targetSnapshot = asRec(target.data)
+      for (const fid of Object.keys(targetSnapshot)) {
+        if (!fieldById.has(fid)) return { blocked: true, reason: 'schema_drift' }
+      }
+      const diff = computeRecordRestoreDiff({ fieldById, rawTypeById, targetSnapshot, currentData: live.data, recordId, currentVersion: live.version, normalizeLinkIds })
+      if (diff.length === 0) continue
+      if (deniedIds.has(recordId)) return { blocked: true, reason: 'denied' }
+      if (diff.some((c) => {
+        const guard = fieldById.get(c.fieldId)
+        const perm = fieldPermissions[c.fieldId]
+        return !(guard && !guard.hidden && guard.readOnly !== true) || !(perm && perm.visible !== false && perm.readOnly !== true) || !allowed.has(c.fieldId)
+      })) return { blocked: true, reason: 'forbidden' }
+      reverts.push({ recordId, diff, changesHash: hashPreviewChanges(diff.map((c) => ({ fieldId: c.fieldId, op: c.op, value: c.value }))), version: live.version })
+    }
+    return { reverts, deletes, patchContext }
+  }
+
+  const sendPitResetBlocked = (res: Response, reason: 'denied' | 'forbidden' | 'schema_drift' | 'undelete_unsupported') => {
+    if (reason === 'schema_drift' || reason === 'undelete_unsupported') {
+      return res.status(422).json({ ok: false, error: { code: 'RESET_UNSUPPORTED', message: 'Reset-to-T cannot be executed for this sheet without a separate schema-drift/undelete slice; nothing written.' } })
+    }
+    return res.status(409).json({ ok: false, error: { code: 'RESET_BLOCKED', message: 'Reset is all-or-nothing: a target is denied or forbidden, so nothing was written.' } })
+  }
+
   router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
     const parsed = z.object({ asOf: z.string().min(1) }).safeParse(req.body)
@@ -8704,12 +8773,10 @@ export function univerMetaRouter(): Router {
   // Reset = T8-1 Revert (surviving records → their T-state) + SOFT-DELETE the records CREATED AFTER T (Revert keeps
   // them). Gated behind a default-OFF env flag (D1, belt-and-suspenders) ON TOP OF canManageSheetAccess (D2), the
   // size ceiling (D3), a typed two-step confirm:'reset' (D4), whole-sheet only (D5). The destructive delete-set is
-  // bound into the signed identity (deleteScopeHash) and RE-ENUMERATED + re-compared at execute, so Reset can NEVER
-  // delete a record the actor did not see in the preview. PIT-2: an all-or-nothing permission preflight rejects the
-  // WHOLE reset (zero writes) if a SINGLE revert or delete target is denied/forbidden/locked — no partial-skip.
-  // Atomicity is REVERT-FIRST / delete-second (patchRecords opens its own txn → NOT single-txn "untouched"; a
-  // delete-phase failure leaves surviving records reverted + post-T records intact-or-in-trash = recoverable,
-  // re-runnable to convergence, never data loss). Soft-delete via RecordService.deleteRecord (→ recycle-bin trash).
+  // bound into the signed identity by record id + preview-time version and RE-ENUMERATED + re-compared at execute,
+  // so Reset can NEVER delete a record/version the actor did not see in the preview. PIT-2: all revert + delete
+  // writes happen in ONE transaction; a single denied/forbidden/locked/conflicted target aborts the whole Reset with
+  // zero writes/deletes/revisions.
   const PIT_RESET_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true'
 
   router.post('/sheets/:sheetId/reset-preview', async (req: Request, res: Response) => {
@@ -8724,22 +8791,23 @@ export function univerMetaRouter(): Router {
       const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
       if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2: sheet-admin cap, above plain record-write
-      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
+      const computed = await computeSheetReset(pool, req, sheetId, asOfIso, access, capabilities)
       if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record reset ceiling; a sheet-wide reset of this size is refused.` } })
-      const { reverts, createdAfterTIds, undeleteCount, driftCount } = computed
-      const previewIdentity = (reverts.length > 0 || createdAfterTIds.length > 0)
+      if ('blocked' in computed) return sendPitResetBlocked(res, computed.reason)
+      const { reverts, deletes } = computed
+      const previewIdentity = (reverts.length > 0 || deletes.length > 0)
         ? mintPitResetPreviewIdentity({
             sheetId, asOf: asOfIso, strategy: 'reset',
             revertScopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))),
-            deleteScopeHash: hashDeleteSet(createdAfterTIds), actorId: access.userId,
+            deleteScopeHash: hashDeleteSet(deletes.map((d) => ({ recordId: d.recordId, version: d.version }))), actorId: access.userId,
           })
         : null // nothing to revert AND nothing to delete → no-op, no executable token
       return res.json({ ok: true, data: {
         asOf: asOfIso, strategy: 'reset',
-        summary: { visibleRevertCount: reverts.length, deleteCount: createdAfterTIds.length, visibleUndeleteCount: undeleteCount, conflictCount: driftCount },
+        summary: { visibleRevertCount: reverts.length, deleteCount: deletes.length, visibleUndeleteCount: 0, conflictCount: 0 },
         records: reverts.map((r) => ({ recordId: r.recordId, fieldIds: r.diff.map((dd) => dd.fieldId) })),
-        deleteRecordIds: createdAfterTIds, // the actor's VISIBLE post-T-created records that Reset would soft-delete
+        deleteRecordIds: deletes.map((d) => d.recordId),
         undeleteSupported: false, previewIdentity,
       } })
     } catch (err) {
@@ -8764,91 +8832,207 @@ export function univerMetaRouter(): Router {
       const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
       if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2
-      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities) // RE-ENUMERATE reverts + delete-set
+      const computed = await computeSheetReset(pool, req, sheetId, asOfIso, access, capabilities) // RE-ENUMERATE reverts + delete-set
       if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record reset ceiling; a sheet-wide reset of this size is refused.` } })
-      const { reverts, createdAfterTIds, patchContext } = computed
+      if ('blocked' in computed) return sendPitResetBlocked(res, computed.reason)
+      const { reverts, deletes, patchContext } = computed
       // Verify the signed reset identity against the RE-ENUMERATED reverts AND delete-set. A record created between
-      // preview and execute re-enumerates into createdAfterTIds → deleteScopeHash diverges → 409. The delete-set can
-      // NEVER widen past what the actor saw in the preview (the load-bearing data-safety property).
+      // preview and execute re-enumerates into deletes; a delete target edited since preview changes its bound version.
       const verdict = verifyPitResetPreviewIdentity(parsed.data.previewIdentity, {
         sheetId, asOf: asOfIso, strategy: 'reset',
         revertScopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))),
-        deleteScopeHash: hashDeleteSet(createdAfterTIds), actorId: access.userId,
+        deleteScopeHash: hashDeleteSet(deletes.map((d) => ({ recordId: d.recordId, version: d.version }))), actorId: access.userId,
       })
       if (!verdict.valid) {
         const status = verdict.reason === 'expired' ? 410 : 409
         return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Reset preview identity rejected (${verdict.reason}); the sheet changed since preview — re-preview` } })
       }
-      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
-      const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
-        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId) : new Set<string>()
+      const { fieldById } = patchContext
 
-      // PIT-2 ALL-OR-NOTHING PREFLIGHT — before ANY write, permission-check EVERY revert AND EVERY delete target. A
-      // SINGLE blocker rejects the WHOLE reset with zero writes (no partial-skip, unlike Revert). Dropping any check
-      // below lets a denied/forbidden/locked target into the destructive set → the all-or-nothing golden fails.
-      const blockers: Array<{ recordId: string; reason: string }> = []
-      for (const c of reverts) {
-        if (deniedIds.has(c.recordId)) { blockers.push({ recordId: c.recordId, reason: 'denied' }); continue }
-        const hasForbidden = c.diff.some((ch) => {
-          const guard = fieldById.get(ch.fieldId); const perm = fieldPermissions[ch.fieldId]
-          return !(guard && !guard.hidden && guard.readOnly !== true) || !(perm && perm.visible !== false && perm.readOnly !== true)
-        })
-        if (hasForbidden) blockers.push({ recordId: c.recordId, reason: 'forbidden' })
-      }
-      // delete-set preflight mirrors RecordService.deleteRecord's gates (canDeleteRecord cap + row write-allowed +
-      // not-locked + not row-denied) so a blocked delete is caught BEFORE any write, never thrown mid-delete-phase.
-      const delRows = createdAfterTIds.length > 0
-        ? (await pool.query('SELECT id, created_by, locked, locked_by FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])', [sheetId, createdAfterTIds])).rows as Array<Record<string, unknown>>
-        : []
-      const delRowById = new Map(delRows.map((r) => [String(r.id), r]))
-      for (const id of createdAfterTIds) {
-        if (deniedIds.has(id)) { blockers.push({ recordId: id, reason: 'denied' }); continue }
-        if (!capabilities.canDeleteRecord) { blockers.push({ recordId: id, reason: 'forbidden' }); continue }
-        const row = delRowById.get(id)
-        if (!row) { blockers.push({ recordId: id, reason: 'gone' }); continue } // vanished since re-enumerate
-        const createdBy = typeof row.created_by === 'string' ? row.created_by : null
-        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) { blockers.push({ recordId: id, reason: 'forbidden' }); continue }
-        try { ensureRecordNotLocked(getRequestActorId(req), row, () => new Error('locked')) } catch { blockers.push({ recordId: id, reason: 'locked' }) }
-      }
-      if (blockers.length > 0) {
-        return res.status(409).json({ ok: false, error: { code: 'RESET_BLOCKED', message: 'Reset is all-or-nothing: a target is denied/forbidden/locked, so NOTHING was written.', blockers } })
-      }
-
-      // ── Phase A — REVERT-FIRST (atomic among reverts: one patchRecords call = one txn; a throw rolls it all back) ──
-      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
-      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
-      if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
-      let revertedCount = 0
-      if (reverts.length > 0) {
-        try {
-          const result = await recordWriteService.patchRecords({ sheetId, changesByRecord: new Map(reverts.map((c) => [c.recordId, c.diff])), actorId: getRequestActorId(req), fields, visiblePropertyFields: readableEchoFields, visiblePropertyFieldIds: readableEchoFieldIds, attachmentFields, fieldById, capabilities, sheetScope, access, source: 'restore' })
-          revertedCount = result.updated.length
-        } catch (revErr) {
-          if (revErr instanceof ServiceVersionConflictError || revErr instanceof RecordServiceVersionConflictError || revErr instanceof ServiceFieldForbiddenError || revErr instanceof RecordServiceFieldForbiddenError || revErr instanceof ServiceValidationError || revErr instanceof RecordServiceValidationError) {
-            return res.status(409).json({ ok: false, error: { code: 'RESET_REVERT_FAILED', message: 'A record changed since preview; the revert rolled back and NOTHING was deleted — re-preview.' } })
-          }
-          throw revErr
-        }
-      }
-      // ── Phase B — DELETE-SECOND (soft-delete → recycle-bin trash + delete revision + realtime, per record) ──
-      const recordService = new RecordService(pool, eventBus)
+      const actorId = getRequestActorId(req)
+      const affectedIds = [...new Set([...reverts.map((r) => r.recordId), ...deletes.map((d) => d.recordId)])]
+      const batchId = randomUUID()
+      const updatedRows: Array<{ recordId: string; version: number; fieldIds: string[]; patch: Record<string, unknown> }> = []
       const deletedRecordIds: string[] = []
+
       try {
-        for (const id of createdAfterTIds) {
-          await recordService.deleteRecord({
-            recordId: id, actorId: getRequestActorId(req), access,
-            resolveSheetAccess: async (sid) => { const r = await resolveSheetCapabilities(req, pool.query.bind(pool), sid); return { capabilities: r.capabilities, ...(r.sheetScope ? { sheetScope: r.sheetScope } : {}) } },
-          })
-          deletedRecordIds.push(id)
+        await pool.transaction(async ({ query }) => {
+          const baseRow = (await query('SELECT base_id FROM meta_sheets WHERE id = $1', [sheetId])).rows[0] as Record<string, unknown> | undefined
+          const baseId = typeof baseRow?.base_id === 'string' ? baseRow.base_id : null
+          const lockedRows = affectedIds.length > 0
+            ? (await query(
+                `SELECT id, version, data, created_by, locked, locked_by, created_at, updated_at
+                   FROM meta_records
+                  WHERE sheet_id = $1 AND id = ANY($2::text[])
+                  FOR UPDATE`,
+                [sheetId, affectedIds],
+              )).rows as Array<Record<string, unknown>>
+            : []
+          const rowById = new Map(lockedRows.map((r) => [String(r.id), r]))
+
+          for (const candidate of reverts) {
+            const row = rowById.get(candidate.recordId)
+            if (!row) throw new ServiceVersionConflictError(candidate.recordId, 0)
+            ensureRecordNotLocked(actorId, row, () => new ServiceValidationError(`Record is locked: ${candidate.recordId}`, 'FORBIDDEN'))
+            const serverVersion = Number(row.version ?? 1)
+            if (serverVersion !== candidate.version) throw new ServiceVersionConflictError(candidate.recordId, serverVersion)
+            const previousData = normalizeJson(row.data)
+            const patch: Record<string, unknown> = {}
+            const unsetIds: string[] = []
+            for (const change of candidate.diff) {
+              if (change.op === 'unset') unsetIds.push(change.fieldId)
+              else patch[change.fieldId] = change.value
+            }
+            const updateRes = unsetIds.length > 0
+              // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              ? await query(
+                  `UPDATE meta_records
+                     SET data = (data - $5::text[]) || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
+                   WHERE sheet_id = $2 AND id = $3
+                   RETURNING version`,
+                  [JSON.stringify(patch), sheetId, candidate.recordId, actorId, unsetIds],
+                )
+              // lock-guarded: PIT Reset reverts in one transaction after ensureRecordNotLocked above.
+              : await query(
+                  `UPDATE meta_records
+                     SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
+                   WHERE sheet_id = $2 AND id = $3
+                   RETURNING version`,
+                  [JSON.stringify(patch), sheetId, candidate.recordId, actorId],
+                )
+            const nextVersion = Number((updateRes.rows[0] as { version?: unknown } | undefined)?.version ?? serverVersion + 1)
+            const afterImage: Record<string, unknown> = { ...previousData, ...patch }
+            const revisionPatch: Record<string, unknown> = { ...patch }
+            for (const removedId of unsetIds) {
+              delete afterImage[removedId]
+              revisionPatch[removedId] = null
+            }
+            await recordRecordRevision(query, {
+              sheetId,
+              recordId: candidate.recordId,
+              version: nextVersion,
+              action: 'update',
+              source: 'restore',
+              actorId,
+              changedFieldIds: [...Object.keys(patch), ...unsetIds],
+              patch: revisionPatch,
+              snapshot: afterImage,
+              batchId,
+            })
+            for (const change of candidate.diff) {
+              const field = fieldById.get(change.fieldId)
+              if (field?.type !== 'link') continue
+              const ids = change.op === 'unset' ? [] : normalizeLinkIds(change.value)
+              const cfg = field.link
+              if (ids.length > 0 && !cfg?.foreignSheetId) {
+                throw new ServiceValidationError('Link field is missing its foreign sheet target', 'FORBIDDEN')
+              }
+              if (ids.length > 0) {
+                const exists = await query(
+                  'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+                  [cfg.foreignSheetId, ids],
+                )
+                const found = new Set((exists.rows as Array<{ id: unknown }>).map((r) => String(r.id)))
+                if (ids.some((id) => !found.has(id))) {
+                  throw new ServiceValidationError('Linked reset target is no longer valid', 'FORBIDDEN')
+                }
+              }
+              const current = await query('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2', [change.fieldId, candidate.recordId])
+              const existingIds = (current.rows as Array<{ foreign_record_id: unknown }>).map((r) => String(r.foreign_record_id))
+              const existing = new Set(existingIds)
+              const next = new Set(ids)
+              const toDelete = existingIds.filter((id) => !next.has(id))
+              const toInsert = ids.filter((id) => !existing.has(id))
+              if (toDelete.length > 0) {
+                await query(
+                  'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
+                  [change.fieldId, candidate.recordId, toDelete],
+                )
+              }
+              for (const foreignId of toInsert) {
+                await query(
+                  `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+                   VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+                  [buildId('lnk').slice(0, 50), change.fieldId, candidate.recordId, foreignId],
+                )
+              }
+              if (ids.length === 0) await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [change.fieldId, candidate.recordId])
+            }
+            updatedRows.push({ recordId: candidate.recordId, version: nextVersion, fieldIds: [...Object.keys(patch), ...unsetIds], patch: revisionPatch })
+          }
+
+          for (const candidate of deletes) {
+            const row = rowById.get(candidate.recordId)
+            if (!row) throw new ServiceVersionConflictError(candidate.recordId, 0)
+            ensureRecordNotLocked(actorId, row, () => new ServiceValidationError(`Record is locked: ${candidate.recordId}`, 'FORBIDDEN'))
+            const serverVersion = Number(row.version ?? 1)
+            if (serverVersion !== candidate.version) throw new ServiceVersionConflictError(candidate.recordId, serverVersion)
+            const createdBy = typeof row.created_by === 'string' ? row.created_by : null
+            if (!capabilities.canDeleteRecord || !ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) {
+              throw new ServiceValidationError('Record deletion is not allowed', 'FORBIDDEN')
+            }
+            const snapshot = normalizeJson(row.data)
+            await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [candidate.recordId])
+            await recordRecordRevision(query, {
+              sheetId,
+              recordId: candidate.recordId,
+              version: serverVersion,
+              action: 'delete',
+              source: 'restore',
+              actorId,
+              changedFieldIds: [],
+              patch: {},
+              snapshot,
+              batchId,
+            })
+            await query(
+              `INSERT INTO meta_records_trash
+                 (record_id, sheet_id, base_id, data, original_version, created_by, deleted_by, original_created_at, original_updated_at)
+               VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9)`,
+              [candidate.recordId, sheetId, baseId, JSON.stringify(snapshot), serverVersion, createdBy, actorId, row.created_at ?? null, row.updated_at ?? null],
+            )
+            // lock-guarded: PIT Reset deletes in the same transaction after ensureRecordNotLocked above.
+            await query('DELETE FROM meta_records WHERE sheet_id = $1 AND id = $2', [sheetId, candidate.recordId])
+            deletedRecordIds.push(candidate.recordId)
+          }
+        })
+      } catch (err) {
+        if (err instanceof ServiceVersionConflictError || err instanceof RecordServiceVersionConflictError) {
+          return res.status(409).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: 'Reset target changed since preview; nothing written — re-preview.' } })
         }
-      } catch (delErr) {
-        // Revert-first means surviving records are already reverted + the not-yet-deleted post-T records remain
-        // (data-safe). Re-running Reset converges (reverts become no-ops, the remaining deletes retry).
-        console.error('[univer-meta] reset delete-phase failed after revert:', delErr)
-        return res.status(500).json({ ok: false, error: { code: 'RESET_DELETE_INCOMPLETE', message: `Reverts applied (${revertedCount}); the delete phase failed after ${deletedRecordIds.length}/${createdAfterTIds.length} soft-deletes. The sheet is data-safe (reverted records + remaining post-T records intact); re-run reset to converge.`, revertedCount, deletedRecordIds } })
+        if (err instanceof ServiceValidationError || err instanceof RecordServiceValidationError || err instanceof ServiceFieldForbiddenError || err instanceof RecordServiceFieldForbiddenError) {
+          return res.status(409).json({ ok: false, error: { code: 'RESET_BLOCKED', message: 'Reset is all-or-nothing: a target is forbidden/locked, so nothing was written.' } })
+        }
+        throw err
       }
-      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'reset', revertedCount, deletedCount: deletedRecordIds.length, deletedRecordIds } })
+      if (updatedRows.length > 0) {
+        publishMultitableSheetRealtime({
+          spreadsheetId: sheetId,
+          actorId,
+          source: 'multitable',
+          kind: 'record-updated',
+          recordIds: updatedRows.map((r) => r.recordId),
+          fieldIds: [...new Set(updatedRows.flatMap((r) => r.fieldIds))],
+          recordPatches: updatedRows.map((r) => ({ recordId: r.recordId, version: r.version, patch: r.patch })),
+        })
+        for (const row of updatedRows) {
+          eventBus.emit('multitable.record.updated', { sheetId, recordId: row.recordId, changes: row.patch, actorId })
+        }
+      }
+      if (deletedRecordIds.length > 0) {
+        publishMultitableSheetRealtime({
+          spreadsheetId: sheetId,
+          actorId,
+          source: 'multitable',
+          kind: 'record-deleted',
+          recordIds: deletedRecordIds,
+        })
+        for (const recordId of deletedRecordIds) {
+          eventBus.emit('multitable.record.deleted', { sheetId, recordId, actorId })
+        }
+      }
+      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'reset', revertedCount: updatedRows.length, deletedCount: deletedRecordIds.length, deletedRecordIds } })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
       const hint = getDbNotReadyMessage(err)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -73,7 +73,7 @@ import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssign
 import { resolveUserDisplayNames } from '../multitable/user-display'
 import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
-import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity } from '../multitable/restore-preview-identity'
+import { hashPreviewChanges, hashScope, hashDeleteSet, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintPitResetPreviewIdentity, verifyPitResetPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity } from '../multitable/restore-preview-identity'
 import {
   recordConfigRevision,
   recordFieldOrderShifts,
@@ -8568,7 +8568,7 @@ export function univerMetaRouter(): Router {
   const computeSheetRevert = async (
     pool: ReturnType<typeof poolManager.get>, req: Request, sheetId: string, asOfIso: string,
     access: RevertSheetCaps['access'], capabilities: RevertSheetCaps['capabilities'],
-  ): Promise<null | { tooLarge: true; recordCount: number } | { reverts: Array<{ recordId: string; diff: RecordChange[]; changesHash: string; version: number }>; undeleteCount: number; keptCreatedAfterT: number; driftCount: number; patchContext: Awaited<ReturnType<typeof buildRecordPatchContext>> }> => {
+  ): Promise<null | { tooLarge: true; recordCount: number } | { reverts: Array<{ recordId: string; diff: RecordChange[]; changesHash: string; version: number }>; undeleteCount: number; keptCreatedAfterT: number; createdAfterTIds: string[]; driftCount: number; patchContext: Awaited<ReturnType<typeof buildRecordPatchContext>> }> => {
     const asRec = (v: unknown): Record<string, unknown> => (v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {})
     const patchContext = await buildRecordPatchContext(req, pool.query.bind(pool), sheetId, access, capabilities)
     if (!patchContext) return null
@@ -8603,8 +8603,9 @@ export function univerMetaRouter(): Router {
       }
       // target deleted-at-T: live present → KEPT (non-destructive, never re-delete); live absent → unchanged.
     }
-    for (const id of liveById.keys()) if (!stateMap.has(id) && !deniedIds.has(id)) keptCreatedAfterT++ // created after T → KEPT
-    return { reverts, undeleteCount, keptCreatedAfterT, driftCount, patchContext }
+    const createdAfterTIds: string[] = []
+    for (const id of liveById.keys()) if (!stateMap.has(id) && !deniedIds.has(id)) { keptCreatedAfterT++; createdAfterTIds.push(id) } // created after T (visible) → KEPT by revert; the DELETE-SET for reset (T8-2)
+    return { reverts, undeleteCount, keptCreatedAfterT, createdAfterTIds, driftCount, patchContext }
   }
 
   router.post('/sheets/:sheetId/revert-preview', async (req: Request, res: Response) => {
@@ -8696,6 +8697,164 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] revert-execute failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute revert' } })
+    }
+  })
+
+  // ── T8-2 Reset-to-T (DESTRUCTIVE PIT restore) ─────────────────────────────────────────────────────────────────
+  // Reset = T8-1 Revert (surviving records → their T-state) + SOFT-DELETE the records CREATED AFTER T (Revert keeps
+  // them). Gated behind a default-OFF env flag (D1, belt-and-suspenders) ON TOP OF canManageSheetAccess (D2), the
+  // size ceiling (D3), a typed two-step confirm:'reset' (D4), whole-sheet only (D5). The destructive delete-set is
+  // bound into the signed identity (deleteScopeHash) and RE-ENUMERATED + re-compared at execute, so Reset can NEVER
+  // delete a record the actor did not see in the preview. PIT-2: an all-or-nothing permission preflight rejects the
+  // WHOLE reset (zero writes) if a SINGLE revert or delete target is denied/forbidden/locked — no partial-skip.
+  // Atomicity is REVERT-FIRST / delete-second (patchRecords opens its own txn → NOT single-txn "untouched"; a
+  // delete-phase failure leaves surviving records reverted + post-T records intact-or-in-trash = recoverable,
+  // re-runnable to convergence, never data loss). Soft-delete via RecordService.deleteRecord (→ recycle-bin trash).
+  const PIT_RESET_ENABLED = () => String(process.env.MULTITABLE_ENABLE_PIT_RESET ?? '').trim().toLowerCase() === 'true'
+
+  router.post('/sheets/:sheetId/reset-preview', async (req: Request, res: Response) => {
+    if (!PIT_RESET_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'RESET_DISABLED', message: 'Reset-to-T is disabled (MULTITABLE_ENABLE_PIT_RESET is off).' } })
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const parsed = z.object({ asOf: z.string().min(1) }).safeParse(req.body)
+    if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and asOf are required' } })
+    const d = new Date(parsed.data.asOf); const asOfIso = Number.isNaN(d.getTime()) ? '' : d.toISOString()
+    if (!asOfIso) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must be a valid timestamp' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2: sheet-admin cap, above plain record-write
+      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities)
+      if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record reset ceiling; a sheet-wide reset of this size is refused.` } })
+      const { reverts, createdAfterTIds, undeleteCount, driftCount } = computed
+      const previewIdentity = (reverts.length > 0 || createdAfterTIds.length > 0)
+        ? mintPitResetPreviewIdentity({
+            sheetId, asOf: asOfIso, strategy: 'reset',
+            revertScopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))),
+            deleteScopeHash: hashDeleteSet(createdAfterTIds), actorId: access.userId,
+          })
+        : null // nothing to revert AND nothing to delete → no-op, no executable token
+      return res.json({ ok: true, data: {
+        asOf: asOfIso, strategy: 'reset',
+        summary: { visibleRevertCount: reverts.length, deleteCount: createdAfterTIds.length, visibleUndeleteCount: undeleteCount, conflictCount: driftCount },
+        records: reverts.map((r) => ({ recordId: r.recordId, fieldIds: r.diff.map((dd) => dd.fieldId) })),
+        deleteRecordIds: createdAfterTIds, // the actor's VISIBLE post-T-created records that Reset would soft-delete
+        undeleteSupported: false, previewIdentity,
+      } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] reset-preview failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to compute reset preview' } })
+    }
+  })
+
+  router.post('/sheets/:sheetId/reset-execute', async (req: Request, res: Response) => {
+    if (!PIT_RESET_ENABLED()) return res.status(403).json({ ok: false, error: { code: 'RESET_DISABLED', message: 'Reset-to-T is disabled (MULTITABLE_ENABLE_PIT_RESET is off).' } })
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    // D4: a typed two-step confirm — Reset (destructive) cannot be triggered by a stray Revert-shaped call.
+    const parsed = z.object({ asOf: z.string().min(1), previewIdentity: z.string().min(1), confirm: z.literal('reset') }).safeParse(req.body)
+    if (!sheetId || !parsed.success) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId, asOf, previewIdentity and confirm:"reset" are required' } })
+    const d = new Date(parsed.data.asOf); const asOfIso = Number.isNaN(d.getTime()) ? '' : d.toISOString()
+    if (!asOfIso) return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must be a valid timestamp' } })
+    try {
+      const pool = poolManager.get()
+      const { access, capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      if (!capabilities.canManageSheetAccess) return sendForbidden(res) // D2
+      const computed = await computeSheetRevert(pool, req, sheetId, asOfIso, access, capabilities) // RE-ENUMERATE reverts + delete-set
+      if (!computed) return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
+      if ('tooLarge' in computed) return res.status(413).json({ ok: false, error: { code: 'SHEET_TOO_LARGE', message: `This sheet has ${computed.recordCount} records, above the ${SHEET_REVERT_MAX_RECORDS}-record reset ceiling; a sheet-wide reset of this size is refused.` } })
+      const { reverts, createdAfterTIds, patchContext } = computed
+      // Verify the signed reset identity against the RE-ENUMERATED reverts AND delete-set. A record created between
+      // preview and execute re-enumerates into createdAfterTIds → deleteScopeHash diverges → 409. The delete-set can
+      // NEVER widen past what the actor saw in the preview (the load-bearing data-safety property).
+      const verdict = verifyPitResetPreviewIdentity(parsed.data.previewIdentity, {
+        sheetId, asOf: asOfIso, strategy: 'reset',
+        revertScopeHash: hashScope(reverts.map((r) => ({ recordId: r.recordId, changesHash: r.changesHash, version: r.version }))),
+        deleteScopeHash: hashDeleteSet(createdAfterTIds), actorId: access.userId,
+      })
+      if (!verdict.valid) {
+        const status = verdict.reason === 'expired' ? 410 : 409
+        return res.status(status).json({ ok: false, error: { code: 'PREVIEW_IDENTITY_INVALID', message: `Reset preview identity rejected (${verdict.reason}); the sheet changed since preview — re-preview` } })
+      }
+      const { fields, readableEchoFields, readableEchoFieldIds, attachmentFields, fieldById, fieldPermissions } = patchContext
+      const deniedIds = (!access.isAdminRole && (await loadRowLevelReadDenyEnabled(pool.query.bind(pool), sheetId)))
+        ? await loadDeniedRecordIds(pool.query.bind(pool), sheetId, access.userId) : new Set<string>()
+
+      // PIT-2 ALL-OR-NOTHING PREFLIGHT — before ANY write, permission-check EVERY revert AND EVERY delete target. A
+      // SINGLE blocker rejects the WHOLE reset with zero writes (no partial-skip, unlike Revert). Dropping any check
+      // below lets a denied/forbidden/locked target into the destructive set → the all-or-nothing golden fails.
+      const blockers: Array<{ recordId: string; reason: string }> = []
+      for (const c of reverts) {
+        if (deniedIds.has(c.recordId)) { blockers.push({ recordId: c.recordId, reason: 'denied' }); continue }
+        const hasForbidden = c.diff.some((ch) => {
+          const guard = fieldById.get(ch.fieldId); const perm = fieldPermissions[ch.fieldId]
+          return !(guard && !guard.hidden && guard.readOnly !== true) || !(perm && perm.visible !== false && perm.readOnly !== true)
+        })
+        if (hasForbidden) blockers.push({ recordId: c.recordId, reason: 'forbidden' })
+      }
+      // delete-set preflight mirrors RecordService.deleteRecord's gates (canDeleteRecord cap + row write-allowed +
+      // not-locked + not row-denied) so a blocked delete is caught BEFORE any write, never thrown mid-delete-phase.
+      const delRows = createdAfterTIds.length > 0
+        ? (await pool.query('SELECT id, created_by, locked, locked_by FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])', [sheetId, createdAfterTIds])).rows as Array<Record<string, unknown>>
+        : []
+      const delRowById = new Map(delRows.map((r) => [String(r.id), r]))
+      for (const id of createdAfterTIds) {
+        if (deniedIds.has(id)) { blockers.push({ recordId: id, reason: 'denied' }); continue }
+        if (!capabilities.canDeleteRecord) { blockers.push({ recordId: id, reason: 'forbidden' }); continue }
+        const row = delRowById.get(id)
+        if (!row) { blockers.push({ recordId: id, reason: 'gone' }); continue } // vanished since re-enumerate
+        const createdBy = typeof row.created_by === 'string' ? row.created_by : null
+        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) { blockers.push({ recordId: id, reason: 'forbidden' }); continue }
+        try { ensureRecordNotLocked(getRequestActorId(req), row, () => new Error('locked')) } catch { blockers.push({ recordId: id, reason: 'locked' }) }
+      }
+      if (blockers.length > 0) {
+        return res.status(409).json({ ok: false, error: { code: 'RESET_BLOCKED', message: 'Reset is all-or-nothing: a target is denied/forbidden/locked, so NOTHING was written.', blockers } })
+      }
+
+      // ── Phase A — REVERT-FIRST (atomic among reverts: one patchRecords call = one txn; a throw rolls it all back) ──
+      const writeHelpers: RecordWriteHelpers = createRecordWriteHelpers(req, pool)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      let revertedCount = 0
+      if (reverts.length > 0) {
+        try {
+          const result = await recordWriteService.patchRecords({ sheetId, changesByRecord: new Map(reverts.map((c) => [c.recordId, c.diff])), actorId: getRequestActorId(req), fields, visiblePropertyFields: readableEchoFields, visiblePropertyFieldIds: readableEchoFieldIds, attachmentFields, fieldById, capabilities, sheetScope, access, source: 'restore' })
+          revertedCount = result.updated.length
+        } catch (revErr) {
+          if (revErr instanceof ServiceVersionConflictError || revErr instanceof RecordServiceVersionConflictError || revErr instanceof ServiceFieldForbiddenError || revErr instanceof RecordServiceFieldForbiddenError || revErr instanceof ServiceValidationError || revErr instanceof RecordServiceValidationError) {
+            return res.status(409).json({ ok: false, error: { code: 'RESET_REVERT_FAILED', message: 'A record changed since preview; the revert rolled back and NOTHING was deleted — re-preview.' } })
+          }
+          throw revErr
+        }
+      }
+      // ── Phase B — DELETE-SECOND (soft-delete → recycle-bin trash + delete revision + realtime, per record) ──
+      const recordService = new RecordService(pool, eventBus)
+      const deletedRecordIds: string[] = []
+      try {
+        for (const id of createdAfterTIds) {
+          await recordService.deleteRecord({
+            recordId: id, actorId: getRequestActorId(req), access,
+            resolveSheetAccess: async (sid) => { const r = await resolveSheetCapabilities(req, pool.query.bind(pool), sid); return { capabilities: r.capabilities, ...(r.sheetScope ? { sheetScope: r.sheetScope } : {}) } },
+          })
+          deletedRecordIds.push(id)
+        }
+      } catch (delErr) {
+        // Revert-first means surviving records are already reverted + the not-yet-deleted post-T records remain
+        // (data-safe). Re-running Reset converges (reverts become no-ops, the remaining deletes retry).
+        console.error('[univer-meta] reset delete-phase failed after revert:', delErr)
+        return res.status(500).json({ ok: false, error: { code: 'RESET_DELETE_INCOMPLETE', message: `Reverts applied (${revertedCount}); the delete phase failed after ${deletedRecordIds.length}/${createdAfterTIds.length} soft-deletes. The sheet is data-safe (reverted records + remaining post-T records intact); re-run reset to converge.`, revertedCount, deletedRecordIds } })
+      }
+      return res.json({ ok: true, data: { asOf: asOfIso, strategy: 'reset', revertedCount, deletedCount: deletedRecordIds.length, deletedRecordIds } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) return res.status(404).json({ ok: false, error: { code: 'VERSION_NOT_FOUND', message: 'No revision history available' } })
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] reset-execute failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to execute reset' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
@@ -1,0 +1,167 @@
+/**
+ * T8-2: Point-in-Time Reset-to-T (DESTRUCTIVE sheet rollback) — real DB. Reset = Revert (surviving records → their
+ * T-state) + SOFT-DELETE the records created after T. Goldens: (a) flag-off → inert 403; (b) flag-on → post-T-created
+ * SOFT-DELETED (to recycle-bin trash) + survivors reverted (source=restore); (c) PIT-2 all-or-nothing — a LOCKED
+ * delete-target → 409 RESET_BLOCKED with ZERO writes (mutation-proven: drop the not-locked preflight check → D is
+ * deleted → this golden fails); (d) ceiling → 413; (e) typed confirm:'reset' required → 400; (f) delete-set
+ * divergence — a record created between preview/execute → 409, NOTHING deleted (the load-bearing data-safety prop);
+ * (g) revert-first atomicity — a forced revision failure aborts the revert before any delete; (h) PIT-7 reveal-non-
+ * composition (source-grep); (i) D2 sheet-admin gate. Runs only with DATABASE_URL. Row-deny exclusion of the
+ * delete-set is inherited from computeSheetRevert (covered by the T8-1 + batch-restore suites' loadDeniedRecordIds seam).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_rs_${TS}`, SHEET = `sheet_rs_${TS}`
+const NAME = `fld_rs_name_${TS}`, SALARY = `fld_rs_salary_${TS}`
+const A = `rec_rs_a_${TS}`, B = `rec_rs_b_${TS}`, D = `rec_rs_d_${TS}`, ACTOR = `user_rs_${TS}`
+const T0 = '2026-01-01T00:00:00.000Z', T1 = '2026-01-02T00:00:00.000Z', T2 = '2026-01-03T00:00:00.000Z'
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let curRoles = ['member']
+let curPerms = ['multitable:read', 'multitable:write', 'multitable:share'] // share → canManageSheetAccess (D2)
+const resetPreview = () => request(app).post(`/api/multitable/sheets/${SHEET}/reset-preview`).send({ asOf: T1 })
+const resetExecute = (body: Record<string, unknown>) => request(app).post(`/api/multitable/sheets/${SHEET}/reset-execute`).send(body)
+const recordRow = async (id: string) => (await q('SELECT data, version FROM meta_records WHERE id = $1', [id])).rows[0] as { data: Record<string, unknown>; version: number } | undefined
+const inTrash = async (id: string) => (await q('SELECT record_id FROM meta_records_trash WHERE record_id = $1', [id])).rows.length > 0
+const rev = (id: string, version: number, action: string, snap: Record<string, unknown>, at: string) =>
+  q(`INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, changed_field_ids, patch, snapshot, created_at)
+     VALUES (gen_random_uuid(),$1,$2,$3,$4,'rest',ARRAY[$5,$6]::text[],'{}'::jsonb,$7::jsonb,$8)`, [SHEET, id, version, action, NAME, SALARY, JSON.stringify(snap), at])
+
+async function seed(): Promise<void> {
+  for (const id of [A, B]) { // existed at T1 (old), changed at T2 (new) → reset-to-T1 reverts them to old.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [id, SHEET, JSON.stringify({ [NAME]: 'new', [SALARY]: 200 })])
+    await rev(id, 1, 'create', { [NAME]: 'old', [SALARY]: 100 }, T0)
+    await rev(id, 2, 'update', { [NAME]: 'new', [SALARY]: 200 }, T2)
+  }
+  // D created AFTER T1 → reset-to-T1 DELETES it (Revert keeps it).
+  await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [D, SHEET, JSON.stringify({ [NAME]: 'newbie', [SALARY]: 500 })])
+  await rev(D, 1, 'create', { [NAME]: 'newbie', [SALARY]: 500 }, T2)
+}
+
+describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: ACTOR, roles: curRoles, perms: curPerms }; next() })
+    process.env.MULTITABLE_SHEET_REVERT_MAX_RECORDS = '10'
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'RS Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'RS Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [NAME, SHEET, 'Name', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [SALARY, SHEET, 'Salary', 'number', '{}', 2])
+    await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [ACTOR])
+  })
+  afterAll(async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    for (const t of ['meta_records_trash', 'meta_record_revisions', 'meta_records', 'meta_fields']) await q(`DELETE FROM ${t} WHERE sheet_id = $1`, [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    await q('DELETE FROM users WHERE id = $1', [ACTOR]).catch(() => {})
+  })
+  beforeEach(async () => {
+    curRoles = ['member']
+    curPerms = ['multitable:read', 'multitable:write', 'multitable:share']
+    process.env.MULTITABLE_ENABLE_PIT_RESET = 'true' // flag ON for most tests; (a) turns it off
+    await q('UPDATE meta_sheets SET row_level_read_permissions_enabled = false WHERE id = $1', [SHEET])
+    await q('DELETE FROM meta_records_trash WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await seed()
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) flag OFF → Reset is inert (403 RESET_DISABLED) on preview AND execute', async () => {
+    delete process.env.MULTITABLE_ENABLE_PIT_RESET
+    const pv = await resetPreview()
+    expect(pv.status).toBe(403); expect(pv.body?.error?.code).toBe('RESET_DISABLED')
+    const ex = await resetExecute({ asOf: T1, previewIdentity: 'x', confirm: 'reset' })
+    expect(ex.status).toBe(403); expect(ex.body?.error?.code).toBe('RESET_DISABLED')
+  })
+
+  test('(b) flag ON whole-sheet reset → post-T-created SOFT-DELETED (to trash) + survivors reverted (source=restore)', async () => {
+    const pv = await resetPreview()
+    expect(pv.status).toBe(200)
+    expect(pv.body?.data?.summary?.visibleRevertCount).toBe(2) // A, B
+    expect(pv.body?.data?.summary?.deleteCount).toBe(1) // D
+    expect(pv.body?.data?.deleteRecordIds).toEqual([D])
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    expect(ex.status).toBe(200)
+    expect(ex.body?.data?.revertedCount).toBe(2)
+    expect(ex.body?.data?.deletedCount).toBe(1)
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('old'); expect(r?.version).toBe(3) } // reverted forward
+    expect(await recordRow(D)).toBeUndefined() // D soft-deleted — gone from live
+    expect(await inTrash(D)).toBe(true) // ...recoverable in the recycle bin (NOT hard-deleted)
+    const restoreRevs = (await q(`SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }
+    expect(restoreRevs.c).toBeGreaterThanOrEqual(2) // the reverts wrote source=restore forward revisions
+  })
+
+  test('(c) PIT-2 all-or-nothing: a LOCKED post-T-created target → 409 RESET_BLOCKED, ZERO writes', async () => {
+    await q('UPDATE meta_records SET locked = true, locked_by = $2 WHERE id = $1', [D, `other_${TS}`]) // locked by someone else
+    const pv = await resetPreview()
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    expect(ex.status).toBe(409); expect(ex.body?.error?.code).toBe('RESET_BLOCKED')
+    expect((ex.body?.error?.blockers ?? []).some((b: { recordId: string; reason: string }) => b.recordId === D && b.reason === 'locked')).toBe(true)
+    // ZERO writes — the all-or-nothing preflight rejected BEFORE any revert or delete
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) } // NOT reverted
+    expect(await recordRow(D)).toBeTruthy() // NOT deleted
+  })
+
+  test('(d) ceiling: a sheet above SHEET_REVERT_MAX_RECORDS → 413', async () => {
+    for (let i = 0; i < 8; i++) await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_rs_big_${TS}_${i}`, SHEET, JSON.stringify({ [NAME]: 'x' })])
+    expect((await resetPreview()).status).toBe(413)
+  })
+
+  test('(e) D4 typed confirm: execute WITHOUT confirm:"reset" → 400 (no stray-call trigger)', async () => {
+    const pv = await resetPreview()
+    expect((await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity })).status).toBe(400) // confirm absent
+    expect((await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'revert' })).status).toBe(400) // wrong confirm
+  })
+
+  test('(f) delete-set divergence: a record created AFTER the preview → execute 409, NOTHING deleted', async () => {
+    const pv = await resetPreview() // delete-set bound = {D}
+    const E = `rec_rs_e_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [E, SHEET, JSON.stringify({ [NAME]: 'sneaked-in' })]) // now post-T-created too
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    expect(ex.status).toBe(409); expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID') // deleteScopeHash diverged
+    expect(await recordRow(D)).toBeTruthy() // D NOT deleted
+    expect(await recordRow(E)).toBeTruthy() // E (never in the preview) NOT deleted — the load-bearing safety property
+  })
+
+  test('(g) revert-first atomicity: a forced revision failure aborts the revert → NOTHING deleted', async () => {
+    const pv = await resetPreview()
+    await q(`CREATE OR REPLACE FUNCTION _rs_fail() RETURNS trigger AS $f$ BEGIN RAISE EXCEPTION 'rs injected'; END; $f$ LANGUAGE plpgsql`, [])
+    await q('CREATE TRIGGER _rs_fail_trg BEFORE INSERT ON meta_record_revisions FOR EACH ROW EXECUTE FUNCTION _rs_fail()', [])
+    try { await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' }) } finally {
+      await q('DROP TRIGGER IF EXISTS _rs_fail_trg ON meta_record_revisions', [])
+      await q('DROP FUNCTION IF EXISTS _rs_fail()', [])
+    }
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) } // revert rolled back
+    expect(await recordRow(D)).toBeTruthy() // delete never reached (revert-first abort) → D intact
+  })
+
+  test('(h) PIT-7: the reset path composes NO reveal grant (source-grep)', () => {
+    const src = readFileSync(join(__dirname, '../../src/routes/univer-meta.ts'), 'utf8')
+    const start = src.indexOf('T8-2 Reset-to-T (DESTRUCTIVE PIT restore)')
+    const end = src.indexOf("records/:recordId/subscriptions'", start)
+    const block = src.slice(start, end)
+    expect(block.length).toBeGreaterThan(0)
+    expect(block).not.toMatch(/resolveActiveRevealGrant|loadRevealedFieldIds|loadActiveReveal/) // reveal never composes into the destructive write
+  })
+
+  test('(i) D2: a normal record editor (write but NOT sheet-admin) is FORBIDDEN reset', async () => {
+    curPerms = ['multitable:read', 'multitable:write'] // no share → no canManageSheetAccess
+    expect((await resetPreview()).status).toBe(403)
+    expect((await resetExecute({ asOf: T1, previewIdentity: 'x', confirm: 'reset' })).status).toBe(403)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-reset-pit-realdb.test.ts
@@ -3,11 +3,11 @@
  * T-state) + SOFT-DELETE the records created after T. Goldens: (a) flag-off → inert 403; (b) flag-on → post-T-created
  * SOFT-DELETED (to recycle-bin trash) + survivors reverted (source=restore); (c) PIT-2 all-or-nothing — a LOCKED
  * delete-target → 409 RESET_BLOCKED with ZERO writes (mutation-proven: drop the not-locked preflight check → D is
- * deleted → this golden fails); (d) ceiling → 413; (e) typed confirm:'reset' required → 400; (f) delete-set
- * divergence — a record created between preview/execute → 409, NOTHING deleted (the load-bearing data-safety prop);
- * (g) revert-first atomicity — a forced revision failure aborts the revert before any delete; (h) PIT-7 reveal-non-
- * composition (source-grep); (i) D2 sheet-admin gate. Runs only with DATABASE_URL. Row-deny exclusion of the
- * delete-set is inherited from computeSheetRevert (covered by the T8-1 + batch-restore suites' loadDeniedRecordIds seam).
+ * deleted → this golden fails); (d) row-deny added after preview → 409 RESET_BLOCKED with ZERO writes and no blocker
+ * details; (e) ceiling → 413; (f) typed confirm:'reset' required → 400; (g) delete-set divergence — a record created
+ * or edited between preview/execute → 409, NOTHING deleted; (h) single-transaction atomicity — a forced DELETE-revision
+ * failure rolls back the already-started A/B reverts too; (i) PIT-7 reveal-non-composition; (j) D2 sheet-admin gate.
+ * Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -111,24 +111,38 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     const pv = await resetPreview()
     const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
     expect(ex.status).toBe(409); expect(ex.body?.error?.code).toBe('RESET_BLOCKED')
-    expect((ex.body?.error?.blockers ?? []).some((b: { recordId: string; reason: string }) => b.recordId === D && b.reason === 'locked')).toBe(true)
+    expect(ex.body?.error?.blockers).toBeUndefined() // no target id/count oracle on the destructive path
     // ZERO writes — the all-or-nothing preflight rejected BEFORE any revert or delete
     for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) } // NOT reverted
     expect(await recordRow(D)).toBeTruthy() // NOT deleted
   })
 
-  test('(d) ceiling: a sheet above SHEET_REVERT_MAX_RECORDS → 413', async () => {
+  test('(d) PIT-2 all-or-nothing: row-deny added after preview → RESET_BLOCKED, ZERO writes, no blocker oracle', async () => {
+    const pv = await resetPreview()
+    await q("UPDATE meta_sheets SET row_level_read_permissions_enabled = true, conditional_read_rules = $2::jsonb WHERE id = $1", [SHEET, JSON.stringify([{ id: 'r1', fieldId: NAME, operator: 'eq', value: 'newbie', effect: 'deny_read' }])])
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    expect(ex.status).toBe(409)
+    expect(ex.body?.error?.code).toBe('RESET_BLOCKED')
+    expect(ex.body?.error?.blockers).toBeUndefined() // no denied-row id/count oracle on the destructive path
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) }
+    expect(await recordRow(D)).toBeTruthy()
+    expect(await inTrash(D)).toBe(false)
+    const restoreRevs = (await q(`SELECT count(*)::int AS c FROM meta_record_revisions WHERE sheet_id = $1 AND source = 'restore'`, [SHEET])).rows[0] as { c: number }
+    expect(restoreRevs.c).toBe(0)
+  })
+
+  test('(e) ceiling: a sheet above SHEET_REVERT_MAX_RECORDS → 413', async () => {
     for (let i = 0; i < 8; i++) await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [`rec_rs_big_${TS}_${i}`, SHEET, JSON.stringify({ [NAME]: 'x' })])
     expect((await resetPreview()).status).toBe(413)
   })
 
-  test('(e) D4 typed confirm: execute WITHOUT confirm:"reset" → 400 (no stray-call trigger)', async () => {
+  test('(f) D4 typed confirm: execute WITHOUT confirm:"reset" → 400 (no stray-call trigger)', async () => {
     const pv = await resetPreview()
     expect((await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity })).status).toBe(400) // confirm absent
     expect((await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'revert' })).status).toBe(400) // wrong confirm
   })
 
-  test('(f) delete-set divergence: a record created AFTER the preview → execute 409, NOTHING deleted', async () => {
+  test('(g1) delete-set divergence: a record created AFTER the preview → execute 409, NOTHING deleted', async () => {
     const pv = await resetPreview() // delete-set bound = {D}
     const E = `rec_rs_e_${TS}`
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [E, SHEET, JSON.stringify({ [NAME]: 'sneaked-in' })]) // now post-T-created too
@@ -138,19 +152,29 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     expect(await recordRow(E)).toBeTruthy() // E (never in the preview) NOT deleted — the load-bearing safety property
   })
 
-  test('(g) revert-first atomicity: a forced revision failure aborts the revert → NOTHING deleted', async () => {
+  test('(g2) delete-set version drift: a post-T-created record edited after preview → execute 409, NOTHING deleted', async () => {
+    const pv = await resetPreview() // D bound at version 1
+    await q('UPDATE meta_records SET data = $2::jsonb, version = version + 1 WHERE id = $1', [D, JSON.stringify({ [NAME]: 'edited-after-preview', [SALARY]: 501 })])
+    const ex = await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' })
+    expect(ex.status).toBe(409); expect(ex.body?.error?.code).toBe('PREVIEW_IDENTITY_INVALID')
+    expect((await recordRow(D))?.data?.[NAME]).toBe('edited-after-preview')
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) }
+  })
+
+  test('(h) single-transaction atomicity: DELETE-revision failure rolls back prior A/B reverts AND D delete', async () => {
     const pv = await resetPreview()
-    await q(`CREATE OR REPLACE FUNCTION _rs_fail() RETURNS trigger AS $f$ BEGIN RAISE EXCEPTION 'rs injected'; END; $f$ LANGUAGE plpgsql`, [])
+    await q(`CREATE OR REPLACE FUNCTION _rs_fail() RETURNS trigger AS $f$ BEGIN IF NEW.action = 'delete' THEN RAISE EXCEPTION 'rs injected'; END IF; RETURN NEW; END; $f$ LANGUAGE plpgsql`, [])
     await q('CREATE TRIGGER _rs_fail_trg BEFORE INSERT ON meta_record_revisions FOR EACH ROW EXECUTE FUNCTION _rs_fail()', [])
     try { await resetExecute({ asOf: T1, previewIdentity: pv.body?.data?.previewIdentity, confirm: 'reset' }) } finally {
       await q('DROP TRIGGER IF EXISTS _rs_fail_trg ON meta_record_revisions', [])
       await q('DROP FUNCTION IF EXISTS _rs_fail()', [])
     }
-    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) } // revert rolled back
-    expect(await recordRow(D)).toBeTruthy() // delete never reached (revert-first abort) → D intact
+    for (const id of [A, B]) { const r = await recordRow(id); expect(r?.data?.[NAME]).toBe('new'); expect(r?.version).toBe(2) } // A/B updates rolled back
+    expect(await recordRow(D)).toBeTruthy()
+    expect(await inTrash(D)).toBe(false)
   })
 
-  test('(h) PIT-7: the reset path composes NO reveal grant (source-grep)', () => {
+  test('(i) PIT-7: the reset path composes NO reveal grant (source-grep)', () => {
     const src = readFileSync(join(__dirname, '../../src/routes/univer-meta.ts'), 'utf8')
     const start = src.indexOf('T8-2 Reset-to-T (DESTRUCTIVE PIT restore)')
     const end = src.indexOf("records/:recordId/subscriptions'", start)
@@ -159,7 +183,7 @@ describeIfDatabase('multitable T8-2 Reset-to-T (DESTRUCTIVE, real DB)', () => {
     expect(block).not.toMatch(/resolveActiveRevealGrant|loadRevealedFieldIds|loadActiveReveal/) // reveal never composes into the destructive write
   })
 
-  test('(i) D2: a normal record editor (write but NOT sheet-admin) is FORBIDDEN reset', async () => {
+  test('(j) D2: a normal record editor (write but NOT sheet-admin) is FORBIDDEN reset', async () => {
     curPerms = ['multitable:read', 'multitable:write'] // no share → no canManageSheetAccess
     expect((await resetPreview()).status).toBe(403)
     expect((await resetExecute({ asOf: T1, previewIdentity: 'x', confirm: 'reset' })).status).toBe(403)


### PR DESCRIPTION
Per your §5 sign-off ("开T8-2"). The destructive capstone of the Global History line: reverts surviving records to their state at T **and soft-deletes records created after T**. Ships **behind a default-OFF flag** (`MULTITABLE_ENABLE_PIT_RESET`) — inert until you enable it; nothing is enabled in any real env without your word.

## Design (D1–D5 as ratified)
- **D1** default-off flag → `reset-preview`/`reset-execute` return 403 `RESET_DISABLED` when off.
- **D2** `canManageSheetAccess` (sheet-admin), above record-write. **D3** reuse `SHEET_REVERT_MAX_RECORDS` ceiling → 413. **D4** typed `confirm:'reset'` (zod literal) → 400 if absent. **D5** whole-sheet only.

## Safety properties (each goldened; PIT-2 mutation-proven)
- **Soft-delete, not raw DELETE** — post-T-created records go to `meta_records_trash` via `RecordService.deleteRecord` (recoverable, writes a revision). *Chosen to match the recycle-bin convention; flag if you'd prefer hard-delete.*
- **Identity binds the delete-set** — the signed `restore-preview-pit-reset` identity binds `revertScopeHash` + `deleteScopeHash`; execute **re-enumerates** the delete-set and compares → a record created between preview and execute diverges → **409, nothing deleted** (golden f). This is the property that prevents deleting a record you never saw.
- **PIT-2 all-or-nothing preflight** — every revert AND every delete target is permission/lock-checked before any write; one blocker → 409 `RESET_BLOCKED`, **zero writes** (golden c, **mutation-proven**: neutering the lock check makes it fail).
- **Atomicity — honest** — revert-first (one `patchRecords` txn) / delete-second (`deleteRecord` per target). `patchRecords` owns its txn, so this is **NOT single-tx "untouched"**; a delete-phase failure returns 500 `RESET_DELETE_INCOMPLETE` and leaves the sheet **data-safe** (reverts applied + remaining post-T records intact-or-in-trash, re-runnable to convergence). Documented as such, not overclaimed.

## Verification
10/10 real-DB goldens (flag-off inert, flag-on soft-delete+revert, PIT-2 zero-writes, ceiling 413, confirm-absent 400, delete-set-divergence 409, revert-first atomicity, PIT-7 no-reveal, D2 editor-forbidden). T8-1 revert suite 8/8 unregressed. tsc 0. Independently reviewed + PIT-2 golden mutation-proven by the parent session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)