### PR TITLE
ci(pact): publish consumer pact only on push:main (off-main hygiene)

### DIFF
--- a/.github/workflows/yuantus-pact-consumer.yml
+++ b/.github/workflows/yuantus-pact-consumer.yml
@@ -90,10 +90,13 @@ jobs:
           pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-adapter-yuantus.test.ts --reporter=dot
 
       - name: Publish consumer pact to broker (advisory, Phase A)
-        # Auto-gate Phase A: a SHELL guard (below) skips this until ops provisions the broker secret —
-        # NOT a step `if:` (the `secrets` context is unavailable to `steps.if`, so it would skip even
-        # after the secret is set). Non-blocking; strictly additive (test:contract above is unchanged).
-        # UNVERIFIED until a live PactFlow instance + secrets exist — see the Yuantus dev & verification MD.
+        # Off-main hygiene: publish ONLY on push:main, so PR runs never create off-main pact versions in
+        # the broker. A stray off-main "latest" once false-no'd Yuantus can-i-deploy; Yuantus #869 pinned
+        # the provider to --main-branch (neutralizing the effect), and this removes the cause at source.
+        # github.event_name/github.ref ARE available to steps.if (unlike `secrets`), so this gate is reliable.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # The SHELL guard (below) still skips until ops provisions the broker secret — NOT a step `if:`
+        # (the `secrets` context is unavailable to `steps.if`). Non-blocking; strictly additive.
         continue-on-error: true
         env:
           PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}

--- a/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
+++ b/scripts/ops/yuantus-pact-consumer-broker-workflow-contract.test.mjs
@@ -57,3 +57,21 @@ test('yuantus pact consumer broker publish uses git SHA and broker branch semant
   assert.match(raw, /--broker-token "\$PACT_BROKER_TOKEN"/)
   assert.doesNotMatch(raw, /--tag\b/)
 })
+
+test('yuantus pact consumer broker publish is gated to push:main (off-main hygiene)', () => {
+  const raw = readWorkflow()
+
+  // Off-main hygiene: the publish step must be gated to push:main via a reliable step-level `if`
+  // (github.event_name / github.ref ARE available to steps.if, unlike `secrets`), so PR runs never
+  // publish off-main pact versions to the broker (a stray off-main "latest" once false-no'd Yuantus
+  // can-i-deploy; pinned out by Yuantus #869 --main-branch, removed at the source here).
+  const publishIdx = raw.indexOf('Publish consumer pact to broker (advisory, Phase A)')
+  assert.ok(publishIdx >= 0, 'publish step must exist')
+  const continueIdx = raw.indexOf('continue-on-error: true', publishIdx)
+  const publishHead = raw.slice(publishIdx, continueIdx)
+  assert.match(
+    publishHead,
+    /if: \$\{\{ github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' \}\}/,
+    'publish step must be gated to push:main',
+  )
+})


### PR DESCRIPTION
**Draft — off-main publish hygiene for the Yuantus pact-broker line (consumer repo is owner-gated; not for merge from outside).**

The consumer-publish workflow runs on `pull_request` too, so PR runs published *off-main* pact versions to the broker (`--branch <PR-ref>`). One such off-main "latest" (`a752b0a`) once false-no'd Yuantus `can-i-deploy` — Yuantus #869 pinned the provider to `--main-branch` (neutralizing the **effect**); this removes the **cause**.

- **Fix:** gate the publish step to `push:main` via a reliable step-level `if` (`github.event_name`/`github.ref` ARE available to `steps.if`, unlike `secrets`). The workflow still runs on PRs for the contract test; only the *publish* is main-only.
- **Regression guard:** `yuantus-pact-consumer-broker-workflow-contract.test.mjs` gains an assertion that the publish step is `push:main`-gated. `node --test` — 3 passed locally.

Belt-and-suspenders with Yuantus #869: provider ignores off-main "latest"; consumer stops creating it. See the Yuantus remaining-development plan (`plm-collab-line-remaining-development-plan`) item 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)