### PR TITLE
feat(multitable): complete record-history hasMore keyset estimate (no shipped-behavior change)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -204,6 +204,7 @@ jobs:
             tests/integration/multitable-record-restore.test.ts \
             tests/integration/multitable-record-recycle-bin.test.ts \
             tests/integration/multitable-history-events-realdb.test.ts \
+            tests/integration/multitable-history-events-hasmore-realdb.test.ts \
             tests/integration/multitable-history-audit-grant-realdb.test.ts \
             tests/integration/multitable-history-audit-reveal-realdb.test.ts \
             tests/integration/multitable-history-audit-log-realdb.test.ts \

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -387,7 +387,14 @@ export async function estimateHistoryHasMore(
   // any unprocessed row whose created_at lies in the truncated sub-millisecond gap (silent row loss → undercount).
   let cursorKey: { createdAtRaw: string; version: number; id: string } | null = null
   let exhausted = false
-  for (let chunk = 0; chunk < ESTIMATE_MAX_CHUNKS && !exhausted && visibleKeys.size < stopAfter; chunk++) {
+  // Cluster-complete early-stop (same-ms parity): once `stopAfter` VISIBLE batches are confirmed, `enoughMs` pins the
+  // boundary row's ms; collection then continues only to the end of that same-millisecond cluster (a STRICTLY-older ms
+  // → `done`). Sorting the COMPLETE cluster by the exact-path comparator (below) yields exactly the exact path's page,
+  // so the estimate matches shipped ordering WITHOUT changing the exact path. Stopping mid-cluster (the old unconditional
+  // break) sliced the wrong same-ms batches into the page.
+  let enoughMs: string | null = null
+  let done = false
+  for (let chunk = 0; chunk < ESTIMATE_MAX_CHUNKS && !exhausted && !done; chunk++) {
     const where = [...baseWhere]
     const args = [...baseArgs]
     if (cursorKey) {
@@ -416,6 +423,7 @@ export async function estimateHistoryHasMore(
       const id = String(r.id)
       const version = Number(r.version ?? 0)
       const createdAt = r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at ?? '')
+      if (enoughMs !== null && createdAt < enoughMs) { done = true; break } // crossed past the boundary ms-cluster → stop (the whole cluster is collected)
       const createdAtRaw = String(r.created_at_iso ?? createdAt) // full-precision column text for the keyset cursor
       cursorKey = { createdAtRaw, version, id } // advance the keyset cursor to this (last-processed) row
       const key = typeof r.batch_id === 'string' ? r.batch_id : id
@@ -424,7 +432,7 @@ export async function estimateHistoryHasMore(
       if (isDenied(deniedBySheet, sheetId, recordId)) continue // LOCK-3 row layer: a denied row never confirms a batch
       if (!visibleKeys.has(key)) {
         visibleKeys.add(key)
-        if (visibleKeys.size >= stopAfter) break // confirmed enough VISIBLE batches → stop early (the perf win)
+        if (enoughMs === null && visibleKeys.size >= stopAfter) enoughMs = createdAt // enough → pin the boundary ms; finish its cluster, then `done`
       }
     }
   }

--- a/packages/core-backend/src/multitable/history-projection.ts
+++ b/packages/core-backend/src/multitable/history-projection.ts
@@ -67,6 +67,20 @@ export interface HistoryEventsParams {
   cursor?: string
   limit?: number
   offset?: number
+  /**
+   * T2b-perf count mode (opt-in; default `exact`). `exact` (and any unset/unknown value) computes the EXACT
+   * post-LOCK-3 `total` by materializing + sorting the WHOLE filtered batch set — byte-for-byte the legacy
+   * behaviour. `estimate` skips the exact total and answers only the cheap question "are there MORE than
+   * `offset+limit` VISIBLE batches?" via `estimateHistoryHasMore`, early-stopping the scan once it has confirmed
+   * one batch past the page boundary. It is the route's job to dispatch on this; `loadHistoryBatchSummaries`
+   * itself ignores it (the exact path is unchanged). Estimate is scoped to the plain newest-first list: a
+   * `search`/`fieldId`/`cursor` request is NOT served by estimate (the route falls back to exact for those).
+   */
+  countMode?: 'exact' | 'estimate'
+  /** Estimate-path keyset-scan chunk size (rows per round-trip; default ESTIMATE_SCAN_CHUNK). Injectable ONLY so
+   *  a test can force multi-chunk pagination over a tiny seed (exercising the keyset cursor); the route never
+   *  sets it. A non-finite/<1 value falls back to the default. */
+  estimateScanChunk?: number
 }
 
 export interface HistoryBatchSummary {
@@ -292,6 +306,183 @@ export async function loadHistoryBatchSummaries(
     ? encodeHistoryCursor(batches[batches.length - 1])
     : null
   return { batches, total, nextCursor, searchTruncated }
+}
+
+/** Keyset-scan chunk size for the estimate path (rows fetched per round-trip; bounds memory, not correctness). */
+const ESTIMATE_SCAN_CHUNK = 500
+/** Hard ceiling on chunks scanned so a pathological history can't loop unboundedly; reaching it returns the
+ *  scan's verdict so far (which is safe-direction — see the function doc). The route never hits this in practice. */
+const ESTIMATE_MAX_CHUNKS = 10000
+
+/**
+ * T2b-perf: the `?countMode=estimate` alternative to the exact post-LOCK-3 `total` (the long-deferred follow-up
+ * the line ~143 comment marks). Instead of materializing + sorting the WHOLE filtered batch set to count it, it
+ * answers only `hasMore` = "are there MORE than `offset+limit` VISIBLE batches?" and builds JUST the requested
+ * page. It is SCOPED to the plain newest-first list — no `search`/`fieldId`/`cursor` (those keep the exact path);
+ * the route enforces that scoping. `total` is intentionally omitted (the whole point is not to compute it).
+ *
+ * LOCK-3 (the load-bearing contract) is preserved IDENTICALLY to the exact path:
+ *   - Phase 1 (cheap scan) decides batch VISIBILITY using `loadDeniedBySheet` + `isDenied` — the SAME row-level
+ *     deny seam, gated the same way (flag-on + non-admin; admin bypass). A batch counts toward `hasMore` ONLY
+ *     after at least one of its rows survives `isDenied` (`visibleKeys.add` is gated by the deny check), exactly
+ *     mirroring the exact path's `visibleRecords.size === 0 ⇒ skip` rule. So a row-denied record can NEVER flip
+ *     `hasMore` for an actor who can't see it (the leak the goldens guard). The FIELD layer is deliberately NOT
+ *     consulted in Phase 1 because field-mask never removes a batch from the set — it only shrinks counts (the
+ *     exact path drops a batch solely on row-visibility) — so batch CARDINALITY (all `hasMore` needs) depends
+ *     only on row-deny. Counting fewer columns/no field-mask here changes no visibility decision.
+ *   - `hasMore` is an order-FREE cardinality question, and visibility is monotonic-up + deduped by batch key, so
+ *     encounter order, batch row-contiguity across chunks, and created_at ties are all irrelevant to it. A chunk
+ *     boundary can at worst leave a batch partially seen → it is still counted the moment any visible row of it
+ *     appears, and an early stop only ever UNDERCOUNTS not-yet-confirmed batches → it can flip `hasMore` to FALSE
+ *     (safe), never spuriously TRUE.
+ *   - Phase 2 (page build) re-applies BOTH LOCK-3 layers (row-deny AND the field mask) over ONLY the page's
+ *     batches, reusing the exact path's per-batch construction, so the returned summaries carry the same
+ *     post-mask `visibleAffectedRecordCount` / `visibleAffectedFieldCount` as the exact path would.
+ *
+ * Ordering caveat (page CONTENTS only — never `hasMore`, never security): the head order-key is the batch's
+ * FIRST-seen (newest) row, denied or not, so estimate's batch order matches the exact path's `head = g[0]`. The
+ * one residual divergence — a batch whose NEWEST row is denied but an OLDER row is visible, straddling the
+ * early-stop boundary — requires WITHIN-batch created_at spread, which the write path precludes: one bulk action
+ * is one transaction, and Postgres `now()` is transaction-stable, so all rows of a batch share one created_at.
+ * (A page boundary landing on a createdAt TIE across DISTINCT batches has the same "first N, hasMore if an
+ * (N+1)th exists" semantics the record cursor pagination already uses.) Callers needing tie-exact page stability
+ * use `countMode=exact`.
+ */
+export async function estimateHistoryHasMore(
+  query: QueryFn,
+  params: HistoryEventsParams,
+  access: HistoryAccess,
+): Promise<{ batches: HistoryBatchSummary[]; hasMore: boolean; nextCursor: string | null }> {
+  const sheetIds = params.sheetIds
+  const limit = Math.min(Math.max(Number(params.limit ?? 50), 1), 100)
+  const offset = params.offset ? Math.max(Number(params.offset), 0) : 0
+  if (sheetIds.length === 0) return { batches: [], hasMore: false, nextCursor: null }
+  const deniedBySheet = await loadDeniedBySheet(query, sheetIds, access)
+
+  // Filters that the exact path pushes to SQL are pushed here too, so the estimate set == the exact set. Estimate
+  // is scoped (route-enforced) to the plain list: search/fieldId/cursor are absent, so no snapshot is loaded.
+  const baseWhere: string[] = ['sheet_id = ANY($1::text[])']
+  const baseArgs: unknown[] = [sheetIds]
+  const addFilter = (clause: string, val: unknown) => { baseArgs.push(val); baseWhere.push(clause.replace('$N', `$${baseArgs.length}`)) }
+  if (params.actorId) addFilter('actor_id = $N', params.actorId)
+  if (params.source) addFilter('source = $N', params.source)
+  if (params.action) addFilter('action = $N', params.action)
+  if (params.from) addFilter('created_at >= $N', params.from)
+  if (params.to) addFilter('created_at <= $N', params.to)
+
+  // We only need ONE batch past the page to know hasMore; once we have confirmed that many VISIBLE batches we
+  // stop fetching. `heads` records each batch's HEAD order-key from its FIRST-seen row (denied OR visible) so the
+  // ordering matches the exact path EXACTLY (there `head = g[0]` = the newest row of the batch regardless of
+  // denial). `visibleKeys` is the set of batches with ≥1 row surviving LOCK-3 row-deny — these are the ONLY ones
+  // that count toward hasMore (parity with the exact path's `visibleRecords.size === 0 ⇒ skip`).
+  const stopAfter = offset + limit + 1 // confirm one batch beyond the requested page → hasMore=true
+  // Resolve the chunk size (default-first so `??` catches null+undefined; non-finite/<1 → default), mirroring the
+  // searchRowCap guard. SQL-interpolated, so it MUST be a finite positive integer (never `LIMIT NaN`).
+  const numericChunk = Number(params.estimateScanChunk ?? ESTIMATE_SCAN_CHUNK)
+  const scanChunk = Number.isFinite(numericChunk) ? Math.max(Math.floor(numericChunk), 1) : ESTIMATE_SCAN_CHUNK
+  const heads = new Map<string, { createdAt: string; batchId: string }>()
+  const visibleKeys = new Set<string>()
+  // The keyset cursor carries the RAW column text of created_at (microsecond precision) — NOT the JS-Date-derived
+  // ISO, which node-pg truncates to milliseconds. Binding the truncated ms value back as the boundary would skip
+  // any unprocessed row whose created_at lies in the truncated sub-millisecond gap (silent row loss → undercount).
+  let cursorKey: { createdAtRaw: string; version: number; id: string } | null = null
+  let exhausted = false
+  for (let chunk = 0; chunk < ESTIMATE_MAX_CHUNKS && !exhausted && visibleKeys.size < stopAfter; chunk++) {
+    const where = [...baseWhere]
+    const args = [...baseArgs]
+    if (cursorKey) {
+      // Keyset "strictly after" in the LOCK-11 DESC order (created_at DESC, version DESC, id DESC): the row tuple
+      // is lexicographically LESS than the last row's tuple. `createdAtRaw` is the full-precision column text, so
+      // `::timestamptz` re-parses the EXACT stored value (no ms truncation). Casts match the column types.
+      args.push(cursorKey.createdAtRaw, cursorKey.version, cursorKey.id)
+      where.push(`(created_at, version, id) < ($${args.length - 2}::timestamptz, $${args.length - 1}::int, $${args.length}::uuid)`)
+    }
+    // No snapshot column — visibility (row-deny) is all Phase 1 needs; the field layer is applied in Phase 2.
+    // created_at::text aliased as created_at_iso gives the EXACT stored value for the keyset cursor (microsecond
+    // precision); the JS-Date `created_at` is kept only for head order-key/display (parity with the exact path).
+    const res = await query(
+      `SELECT id, sheet_id, record_id, version, batch_id, created_at, created_at::text AS created_at_iso
+       FROM meta_record_revisions
+       WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC, version DESC, id DESC
+       LIMIT ${scanChunk}`,
+      args,
+    )
+    const rows = res.rows as Array<Record<string, unknown>>
+    if (rows.length < scanChunk) exhausted = true
+    for (const r of rows) {
+      const sheetId = String(r.sheet_id)
+      const recordId = String(r.record_id)
+      const id = String(r.id)
+      const version = Number(r.version ?? 0)
+      const createdAt = r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at ?? '')
+      const createdAtRaw = String(r.created_at_iso ?? createdAt) // full-precision column text for the keyset cursor
+      cursorKey = { createdAtRaw, version, id } // advance the keyset cursor to this (last-processed) row
+      const key = typeof r.batch_id === 'string' ? r.batch_id : id
+      // The head order-key is the FIRST-seen row of the batch (newest, denied or not) — matches exact's `g[0]`.
+      if (!heads.has(key)) heads.set(key, { createdAt, batchId: key })
+      if (isDenied(deniedBySheet, sheetId, recordId)) continue // LOCK-3 row layer: a denied row never confirms a batch
+      if (!visibleKeys.has(key)) {
+        visibleKeys.add(key)
+        if (visibleKeys.size >= stopAfter) break // confirmed enough VISIBLE batches → stop early (the perf win)
+      }
+    }
+  }
+
+  const hasMore = visibleKeys.size > offset + limit
+  // Phase 2: the page's batch keys = the VISIBLE heads sorted by the SAME total order the exact path/cursor use,
+  // sliced to the requested window. (We may have collected up to stopAfter visible batches; slice keeps the page.)
+  const sortedHeads = [...visibleKeys].map((k) => heads.get(k)!).sort(compareBatchKeyDesc)
+  const pageHeads = sortedHeads.slice(offset, offset + limit)
+  if (pageHeads.length === 0) return { batches: [], hasMore, nextCursor: null }
+  const pageKeys = pageHeads.map((h) => h.batchId)
+
+  // Fetch the FULL rows of ONLY the page's batches (complete batches, regardless of where Phase 1 stopped), then
+  // build summaries reusing the exact path's per-batch construction WITH the LOCK-3 field layer (mask counts).
+  const detailRes = await query(
+    `SELECT id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, batch_id, created_at
+     FROM meta_record_revisions
+     WHERE sheet_id = ANY($1::text[]) AND COALESCE(batch_id, id::text) = ANY($2::text[])
+     ORDER BY created_at DESC, version DESC, id DESC`,
+    [sheetIds, pageKeys],
+  )
+  const detailRows = normalizeRevRows(detailRes.rows)
+  const groups = new Map<string, RevRow[]>()
+  for (const row of detailRows) {
+    const key = row.batch_id ?? row.id
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(row)
+  }
+  const batches: HistoryBatchSummary[] = []
+  for (const head of pageHeads) {
+    const g = groups.get(head.batchId)
+    if (!g || g.length === 0) continue // a batch that vanished between scan and detail (concurrent delete) is skipped
+    const visibleRecords = new Set<string>()
+    const visibleFields = new Set<string>()
+    for (const row of g) {
+      if (isDenied(deniedBySheet, row.sheet_id, row.record_id)) continue // LOCK-3 row layer (same as exact path)
+      visibleRecords.add(row.record_id)
+      const allowed = allowedFieldsFor(params.allowedFieldsBySheet, row.sheet_id) // LOCK-3 field layer (mask counts)
+      for (const f of row.changed_field_ids) if (allowed.has(f)) visibleFields.add(f)
+    }
+    if (visibleRecords.size === 0) continue // fully-denied batch is invisible (parity with the exact path)
+    const headRow = g[0]
+    const actions = new Set(g.map((r) => r.action))
+    batches.push({
+      batchId: head.batchId,
+      sheetId: headRow.sheet_id,
+      actorId: headRow.actor_id,
+      source: headRow.source,
+      action: actions.size === 1 ? headRow.action : 'bulk_update',
+      createdAt: headRow.created_at,
+      visibleAffectedRecordCount: visibleRecords.size,
+      visibleAffectedFieldCount: visibleFields.size,
+      provenanceQuality: g.some((r) => r.batch_id) ? 'stamped' : 'legacy',
+    })
+  }
+  // A next cursor when MORE visible batches exist beyond this page (mirrors the exact path's nextCursor semantics).
+  const nextCursor = hasMore && batches.length > 0 ? encodeHistoryCursor(batches[batches.length - 1]) : null
+  return { batches, hasMore, nextCursor }
 }
 
 export interface HistoryChange {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -71,7 +71,7 @@ import {
 } from '../multitable/permission-service'
 import { createPersonMemberResolver, personRestrictGroupIds, resolvePersonAssignableDirectory } from '../multitable/person-field-restriction'
 import { resolveUserDisplayNames } from '../multitable/user-display'
-import { loadHistoryBatchSummaries, loadHistoryBatchDetail } from '../multitable/history-projection'
+import { loadHistoryBatchSummaries, loadHistoryBatchDetail, estimateHistoryHasMore } from '../multitable/history-projection'
 import { reconstructRecordsAtT } from '../multitable/record-reconstructor'
 import { hashPreviewChanges, hashScope, mintRestorePreviewIdentity, mintScopedRestorePreviewIdentity, verifyRestorePreviewIdentity, verifyScopedRestorePreviewIdentity, mintPitRevertPreviewIdentity, verifyPitRevertPreviewIdentity, mintConfigRestorePreviewIdentity, verifyConfigRestorePreviewIdentity } from '../multitable/restore-preview-identity'
 import {
@@ -7261,23 +7261,39 @@ export function univerMetaRouter(): Router {
       const revealActive = await resolveHistoryRevealActive(pool.query.bind(pool), baseId, access.userId, revealRequested, reason, ticket, 'history.events')
       // LOCK-3 field layer: a base-level list can show any readable sheet, so resolve allowed fields for all.
       const allowedFieldsBySheet = await buildHistoryAllowedFieldsBySheet(req, pool.query.bind(pool), readableSheetIds, access.userId, revealActive)
+      const fieldIdFilter = str(req.query.fieldId)
+      const searchFilter = str(req.query.q)
+      const cursorParam = str(req.query.cursor)
+      const baseParams = {
+        sheetIds: readableSheetIds,
+        allowedFieldsBySheet,
+        actorId: str(req.query.actorId),
+        source: str(req.query.source),
+        action: str(req.query.action),
+        from: str(req.query.from),
+        to: str(req.query.to),
+        fieldId: fieldIdFilter,
+        search: searchFilter,
+        cursor: cursorParam,
+        limit: Number.isFinite(limit) ? limit : 50,
+        offset: Number.isFinite(offset) ? offset : 0,
+      }
+      const access2 = { userId: access.userId, isAdminRole: access.isAdminRole }
+      // T2b-perf opt-in: ?countMode=estimate skips the exact post-LOCK-3 total and answers only `hasMore`
+      // (cheaper — early-stops the scan one batch past the page). SCOPED to the plain newest-first list: a
+      // search / fieldId / cursor request is served by the exact path (estimate does not compose with those).
+      // Default (and any other value) = exact total, byte-for-byte the legacy response (full back-compat).
+      const estimateMode = req.query.countMode === 'estimate' && !searchFilter && !fieldIdFilter && !cursorParam
+      if (estimateMode) {
+        const { batches, hasMore, nextCursor } = await estimateHistoryHasMore(pool.query.bind(pool), baseParams, access2)
+        const names = await resolveUserDisplayNames(pool.query.bind(pool), batches.map((b) => b.actorId).filter((x): x is string => !!x))
+        const enriched = batches.map((b) => ({ ...b, actorName: b.actorId ? names.get(b.actorId) ?? null : null }))
+        return res.json({ ok: true, data: { batches: enriched, hasMore, nextCursor, countMode: 'estimate' } })
+      }
       const { batches, total, nextCursor, searchTruncated } = await loadHistoryBatchSummaries(
         pool.query.bind(pool),
-        {
-          sheetIds: readableSheetIds,
-          allowedFieldsBySheet,
-          actorId: str(req.query.actorId),
-          source: str(req.query.source),
-          action: str(req.query.action),
-          from: str(req.query.from),
-          to: str(req.query.to),
-          fieldId: str(req.query.fieldId),
-          search: str(req.query.q),
-          cursor: str(req.query.cursor),
-          limit: Number.isFinite(limit) ? limit : 50,
-          offset: Number.isFinite(offset) ? offset : 0,
-        },
-        { userId: access.userId, isAdminRole: access.isAdminRole },
+        baseParams,
+        access2,
       )
       const names = await resolveUserDisplayNames(pool.query.bind(pool), batches.map((b) => b.actorId).filter((x): x is string => !!x))
       const enriched = batches.map((b) => ({ ...b, actorName: b.actorId ? names.get(b.actorId) ?? null : null }))

--- a/packages/core-backend/tests/integration/multitable-history-events-hasmore-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-hasmore-realdb.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Global History — T2b-perf `?countMode=estimate` hasMore goldens (real DB).
+ *
+ * The base-level history center (GET /bases/:baseId/history/events) computes an EXACT post-LOCK-3 `total` by
+ * default. `?countMode=estimate` skips that exact total and answers only the cheap question "are there MORE than
+ * `offset+limit` VISIBLE batches?" (`hasMore`), early-stopping the scan one batch past the page (see
+ * `estimateHistoryHasMore`). These goldens pin the SECURITY-SENSITIVE contract of that opt-in:
+ *
+ *   - LEAK-GUARD (the load-bearing one): a row-DENIED batch — the would-be (limit+1)th when counted — must NOT
+ *     flip `hasMore` for an actor who can't see it. The estimate scan runs the SAME LOCK-3 row-deny filter
+ *     (`loadDeniedBySheet` + `isDenied`) BEFORE a batch counts toward `hasMore`, so a denied record can never
+ *     reveal its existence via a `hasMore` flip. The MUTATION-CHECK (dropping that Phase-1 `isDenied` gate makes
+ *     this golden RED) is documented in the PR; the admin-bypass companion below is its non-vacuousness control
+ *     (an admin DOES see the denied batch → hasMore=true, proving the denied batch is genuinely load-bearing).
+ *   - hasMore is TRUE when a visible batch exists past the page, FALSE on the last page.
+ *   - DEFAULT (no countMode) response is byte-for-byte the legacy shape: { batches, total, nextCursor,
+ *     searchTruncated } with the EXACT total — full back-compat.
+ *   - PARITY: for identical params, estimate returns the SAME page batches as the exact path, and
+ *     estimate.hasMore === (exact.total > offset+limit) — across page0 / last-page / row-deny / admin. This is
+ *     the regression net for the two-phase ordering/slicing logic (the leak-guard + cardinality cases alone do
+ *     not pin page CONTENTS).
+ *
+ * Runs only with DATABASE_URL (sentinel fails-not-skips in the real-DB allowlist step).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { estimateHistoryHasMore, loadHistoryBatchSummaries } from '../../src/multitable/history-projection'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE_ID = `base_ghhm_${TS}`
+const SHEET_ID = `sheet_ghhm_${TS}`
+const STATUS = `fld_ghhm_status_${TS}`
+const USER_ID = `user_ghhm_${TS}`
+// Three VISIBLE (public) records, each its own single-record batch, + one SECRET record (row-deniable).
+const REC_PUB_A = `rec_ghhm_pub_a_${TS}`
+const REC_PUB_B = `rec_ghhm_pub_b_${TS}`
+const REC_PUB_C = `rec_ghhm_pub_c_${TS}`
+const REC_SECRET = `rec_ghhm_secret_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read', 'multitable:write']
+let testRoles: string[] = ['member']
+
+const setFlag = (on: boolean) => q('UPDATE meta_sheets SET row_level_read_permissions_enabled = $2 WHERE id = $1', [SHEET_ID, on])
+const setRules = (rules: unknown[]) => q('UPDATE meta_sheets SET conditional_read_rules = $2::jsonb WHERE id = $1', [SHEET_ID, JSON.stringify(rules)])
+const denySecretRule = [{ id: 'r1', fieldId: STATUS, operator: 'eq', value: 'secret', effect: 'deny_read' }]
+
+// Each batch is a single-record action at an EXPLICIT created_at + batch_id, so we control the newest-first order
+// precisely (the leak-guard needs the DENIED batch to be the OLDEST — the would-be (limit+1)th if counted).
+const revAt = (recordId: string, status: string, batchId: string, createdAt: string) =>
+  q(
+    `INSERT INTO meta_record_revisions (id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot, batch_id, created_at)
+     VALUES (gen_random_uuid(), $1, $2, 1, 'update', 'rest', $3, ARRAY[$4]::text[], '{}'::jsonb, $5::jsonb, $6, $7)`,
+    [SHEET_ID, recordId, USER_ID, STATUS, JSON.stringify({ [STATUS]: status }), batchId, createdAt],
+  )
+
+const events = (query: Record<string, unknown> = {}) =>
+  request(app).get(`/api/multitable/bases/${BASE_ID}/history/events`).query(query)
+const batchIds = (res: { body?: { data?: { batches?: Array<{ batchId: string }> } } }) =>
+  (res.body?.data?.batches ?? []).map((b) => b.batchId)
+
+// Seed three VISIBLE batches (newest→oldest) and ONE DENIED batch as the OLDEST. With limit=2, offset=0 and the
+// deny flag ON, a non-admin sees exactly the 2 newest (visible) → hasMore must be FALSE (the denied oldest batch,
+// the would-be 3rd, is filtered before counting). batchIds are explicit so order/selection are deterministic.
+const B_NEW = `batch_ghhm_new_${TS}` // newest visible
+const B_MID = `batch_ghhm_mid_${TS}` // middle visible
+const B_OLD = `batch_ghhm_old_${TS}` // oldest visible
+const B_SECRET = `batch_ghhm_secret_${TS}` // DENIED, OLDEST of all → the would-be (limit+1)th when counted
+const T_NEW = new Date(TS - 1000).toISOString()
+const T_MID = new Date(TS - 2000).toISOString()
+const T_OLD = new Date(TS - 3000).toISOString()
+const T_SECRET = new Date(TS - 4000).toISOString() // strictly oldest
+
+const seedLeakGuard = async () => {
+  await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID])
+  await revAt(REC_PUB_A, 'public', B_NEW, T_NEW)
+  await revAt(REC_PUB_B, 'public', B_MID, T_MID)
+  await revAt(REC_PUB_C, 'public', B_OLD, T_OLD)
+  await revAt(REC_SECRET, 'secret', B_SECRET, T_SECRET) // denied (status='secret') when flag+rule on; oldest
+}
+
+describeIfDatabase('global-history events — estimate hasMore goldens (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: testRoles, perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'GHHM Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'GHHM Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [STATUS, SHEET_ID, 'Status', 'select', '{}', 1])
+    for (const rid of [REC_PUB_A, REC_PUB_B, REC_PUB_C, REC_SECRET]) {
+      const status = rid === REC_SECRET ? 'secret' : 'public'
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [rid, SHEET_ID, JSON.stringify({ [STATUS]: status })])
+    }
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  afterEach(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+  })
+
+  beforeEach(async () => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read', 'multitable:write']
+    testRoles = ['member']
+    await setFlag(false)
+    await setRules([])
+    await seedLeakGuard()
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  // ---------- LEAK-GUARD (the load-bearing security golden) ----------
+
+  test('LEAK-GUARD: a row-denied OLDEST batch (the would-be limit+1th) does NOT flip hasMore for an actor who cannot see it', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule) // REC_SECRET (status='secret') is row-denied → B_SECRET invisible to USER_ID
+    // limit=3, offset=0: the actor sees EXACTLY the 3 visible batches; the denied oldest batch is the would-be 4th.
+    // With only those 3 visible, the ONLY thing that could push past the page is the denied batch — so hasMore is
+    // the load-bearing assertion: it MUST be false, else the denied record's existence leaks via the flip.
+    const res = await events({ countMode: 'estimate', limit: 3, offset: 0 })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.countMode).toBe('estimate')
+    expect(res.body?.data?.hasMore).toBe(false) // ← the leak-guard: denied batch filtered BEFORE the hasMore count
+    expect(batchIds(res)).toEqual([B_NEW, B_MID, B_OLD]) // page = the 3 visible, newest→oldest
+    expect(batchIds(res)).not.toContain(B_SECRET) // the denied batch never appears
+    expect(res.body?.data?.nextCursor).toBeNull() // no next page (the only remaining batch is denied)
+  })
+
+  test('LEAK-GUARD control (non-vacuous): an ADMIN — who bypasses row-deny — DOES see the denied batch flip hasMore', async () => {
+    await setFlag(true)
+    await setRules(denySecretRule)
+    testRoles = ['admin'] // admin bypasses the LOCK-3 row layer → B_SECRET is the genuine (limit+1)th visible batch
+    const res = await events({ countMode: 'estimate', limit: 3, offset: 0 })
+    expect(res.status).toBe(200)
+    // Proves the denied batch is REALLY the load-bearing 4th: with the row layer off (admin), the SAME seed +
+    // SAME params now flip hasMore=true. Together with the leak-guard above, this is the mutation-check's
+    // permanent non-vacuousness control — the ONLY difference from the leak-guard is whether LOCK-3 row-deny
+    // applies to the actor. (If the leak-guard's `false` were vacuous, this `true` could not differ.)
+    expect(res.body?.data?.hasMore).toBe(true)
+    expect(batchIds(res)).toEqual([B_NEW, B_MID, B_OLD]) // still the 3 newest on the page (B_SECRET is the off-page 4th)
+  })
+
+  // ---------- hasMore correctness (cardinality) ----------
+
+  test('estimate hasMore=TRUE when a visible batch exists past the page (limit=2 of 3 visible, flag off)', async () => {
+    // flag off (beforeEach) → all 4 batches visible. limit=2, offset=0 → 2 on the page, ≥1 more visible → true.
+    const res = await events({ countMode: 'estimate', limit: 2, offset: 0 })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.hasMore).toBe(true)
+    expect(batchIds(res)).toEqual([B_NEW, B_MID])
+    expect(res.body?.data?.nextCursor).toBeTruthy() // a next cursor is offered when more remain
+  })
+
+  test('estimate hasMore=FALSE on the LAST page (offset=2, limit=2: the tail of 4 visible batches)', async () => {
+    const res = await events({ countMode: 'estimate', limit: 2, offset: 2 })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.hasMore).toBe(false) // batches 3 & 4 of 4 → nothing past this page
+    expect(batchIds(res)).toEqual([B_OLD, B_SECRET]) // the 2 oldest (flag off → secret visible)
+    expect(res.body?.data?.nextCursor).toBeNull()
+  })
+
+  test('estimate hasMore=FALSE when the page covers ALL visible batches (limit=100 ≥ 4)', async () => {
+    const res = await events({ countMode: 'estimate', limit: 100, offset: 0 })
+    expect(res.status).toBe(200)
+    expect(res.body?.data?.hasMore).toBe(false)
+    expect(batchIds(res)).toEqual([B_NEW, B_MID, B_OLD, B_SECRET]) // all four, newest→oldest
+  })
+
+  // ---------- DEFAULT back-compat (exact total, untouched response shape) ----------
+
+  test('DEFAULT (no countMode) returns the EXACT total + legacy shape (no hasMore key); estimate omits total', async () => {
+    const def = await events({ limit: 2, offset: 0 }) // no countMode → exact path, byte-for-byte legacy
+    expect(def.status).toBe(200)
+    expect(def.body?.data?.total).toBe(4) // exact post-LOCK-3 total (flag off → all 4 visible)
+    expect(def.body?.data).toHaveProperty('searchTruncated') // legacy keys present…
+    expect(def.body?.data).not.toHaveProperty('hasMore') // …and NO hasMore on the default response
+    expect(def.body?.data).not.toHaveProperty('countMode')
+    const est = await events({ countMode: 'estimate', limit: 2, offset: 0 })
+    expect(est.body?.data).not.toHaveProperty('total') // estimate intentionally omits the (expensive) exact total
+    expect(est.body?.data).toHaveProperty('hasMore')
+  })
+
+  test('estimate does NOT compose with search/fieldId/cursor — those fall back to the EXACT path (total present)', async () => {
+    // The route scopes estimate to the plain list; a search request keeps the exact total (and searchTruncated).
+    const withSearch = await events({ countMode: 'estimate', q: 'public', limit: 2 })
+    expect(withSearch.status).toBe(200)
+    expect(withSearch.body?.data).toHaveProperty('total') // exact path served it → total present
+    expect(withSearch.body?.data).not.toHaveProperty('hasMore') // NOT the estimate shape
+    const withField = await events({ countMode: 'estimate', fieldId: STATUS, limit: 2 })
+    expect(withField.body?.data).toHaveProperty('total') // fieldId → exact path
+    expect(withField.body?.data).not.toHaveProperty('hasMore')
+  })
+
+  // ---------- PARITY: estimate page == exact page; hasMore == (exact.total > offset+limit) ----------
+  // The regression net for the two-phase ordering/slicing logic. Calls the projection functions directly with
+  // identical params, deep-comparing the page batches and the hasMore↔total relationship across scenarios.
+
+  const allowed = () => new Map([[SHEET_ID, new Set([STATUS])]])
+  const parityCase = async (label: string, access: { userId: string; isAdminRole: boolean }, limit: number, offset: number, flagOn: boolean, estimateScanChunk?: number) => {
+    if (flagOn) { await setFlag(true); await setRules(denySecretRule) } else { await setFlag(false); await setRules([]) }
+    const base = { sheetIds: [SHEET_ID], allowedFieldsBySheet: allowed(), limit, offset }
+    const exact = await loadHistoryBatchSummaries(q, base, access)
+    const est = await estimateHistoryHasMore(q, { ...base, estimateScanChunk }, access)
+    // page CONTENTS identical (same batches, same order, same masked counts) — catches an ordering/slicing bug.
+    expect(est.batches, `${label}: page batches`).toEqual(exact.batches)
+    // hasMore is exactly "is there a visible batch past this page" = (exact total > offset+limit).
+    expect(est.hasMore, `${label}: hasMore`).toBe(exact.total > offset + limit)
+  }
+
+  test('PARITY: estimate page + hasMore match the exact path across page0 / last-page / row-deny / admin', async () => {
+    const member = { userId: USER_ID, isAdminRole: false }
+    const admin = { userId: USER_ID, isAdminRole: true }
+    await parityCase('page0 flag-off member', member, 2, 0, false)
+    await parityCase('last-page flag-off member', member, 2, 2, false)
+    await parityCase('all-on-one-page flag-off member', member, 100, 0, false)
+    await parityCase('page0 row-deny member (denied oldest off-page)', member, 2, 0, true)
+    await parityCase('last-visible-page row-deny member', member, 3, 0, true) // 3 visible → page of 3, hasMore=false
+    await parityCase('page0 row-deny admin (denied batch visible)', admin, 2, 0, true)
+    await parityCase('last-page row-deny admin', admin, 2, 2, true)
+  })
+
+  // ---------- MULTI-CHUNK keyset cursor (the chunk path the 4-row goldens never exercise) ----------
+  // With the default chunk size (500) the 4-row seed always returns < chunk → exhausted on the first query, so the
+  // keyset cursor block never runs. estimateScanChunk:1 FORCES one row per round-trip → the cursor is exercised on
+  // every page boundary. This is the regression net for the cursor's full-precision round-trip: node-pg parses
+  // timestamptz → a millisecond JS Date, so a cursor built from that Date would TRUNCATE sub-millisecond precision
+  // and silently SKIP any unprocessed row in the truncated gap (undercount → hasMore wrongly false / dropped page
+  // batch). The seed below puts rows in the SAME millisecond but DIFFERENT microseconds to trip exactly that bug.
+
+  test('MULTI-CHUNK: chunk=1 keyset pagination matches the exact path (4 distinct-time visible batches)', async () => {
+    // distinct seconds-apart created_ats: chunk=1 walks all four via the keyset cursor, one per round-trip.
+    const member = { userId: USER_ID, isAdminRole: false }
+    await parityCase('chunk1 page0 of 4', member, 2, 0, false, 1)
+    await parityCase('chunk1 last-page of 4', member, 2, 2, false, 1)
+    await parityCase('chunk1 all-on-one-page', member, 100, 0, false, 1)
+    await parityCase('chunk1 page0 row-deny (denied oldest off-page)', member, 2, 0, true, 1)
+  })
+
+  test('MULTI-CHUNK cursor precision: microsecond-adjacent rows in ONE millisecond are NOT skipped at a chunk boundary', async () => {
+    // Replace the seed with 5 single-record VISIBLE batches whose created_ats share the SAME millisecond but differ
+    // by MICROSECONDS (…10.000500Z … 10.000100Z). A ms-truncating keyset cursor would, after emitting the first,
+    // bind a boundary of …10.000(000) and EXCLUDE the rest (all > .000000) → return 0 → think it's exhausted → drop
+    // 4 visible batches. The full-precision (created_at::text) cursor re-parses the exact stored value → no skip.
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID])
+    const micro = ['10.000500', '10.000400', '10.000300', '10.000200', '10.000100'] // same ms (10.000), descending µs
+    const keys: string[] = []
+    for (let i = 0; i < micro.length; i++) {
+      const k = `batch_ghhm_us_${i}_${TS}`
+      keys.push(k)
+      await revAt(REC_PUB_A, 'public', k, `2026-06-20T00:00:${micro[i]}Z`) // record id reused; batch_id is the group key
+    }
+    const member = { userId: USER_ID, isAdminRole: false }
+    await setFlag(false); await setRules([])
+    const base = { sheetIds: [SHEET_ID], allowedFieldsBySheet: allowed(), limit: 2, offset: 0 }
+    const exact = await loadHistoryBatchSummaries(q, base, member)
+    const estChunk1 = await estimateHistoryHasMore(q, { ...base, estimateScanChunk: 1 }, member)
+    // The exact path sees all 5 visible batches → total 5; estimate (chunk=1) must agree it has more past page 1…
+    expect(exact.total).toBe(5)
+    expect(estChunk1.hasMore).toBe(true) // ← would be FALSE under a ms-truncating cursor (4 batches skipped)
+    expect(estChunk1.batches).toEqual(exact.batches) // …and return the SAME page-0 batches (no skip/reorder)
+    // A deep page (offset=4 → the 5th/last visible batch) likewise must resolve through 5 chunk hops, not stall.
+    const lastPage = await estimateHistoryHasMore(q, { ...base, offset: 4, estimateScanChunk: 1 }, member)
+    const exactLast = await loadHistoryBatchSummaries(q, { ...base, offset: 4 }, member)
+    expect(lastPage.hasMore).toBe(false) // offset 4 of 5 → nothing past the last batch
+    expect(lastPage.batches).toEqual(exactLast.batches) // the single 5th batch, reached via the keyset cursor
+    expect(lastPage.batches.map((b) => b.batchId)).toEqual([keys[4]]) // the oldest-µs batch
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-history-events-hasmore-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-history-events-hasmore-realdb.test.ts
@@ -282,7 +282,11 @@ describeIfDatabase('global-history events — estimate hasMore goldens (real DB)
     const lastPage = await estimateHistoryHasMore(q, { ...base, offset: 4, estimateScanChunk: 1 }, member)
     const exactLast = await loadHistoryBatchSummaries(q, { ...base, offset: 4 }, member)
     expect(lastPage.hasMore).toBe(false) // offset 4 of 5 → nothing past the last batch
-    expect(lastPage.batches).toEqual(exactLast.batches) // the single 5th batch, reached via the keyset cursor
-    expect(lastPage.batches.map((b) => b.batchId)).toEqual([keys[4]]) // the oldest-µs batch
+    expect(lastPage.batches).toEqual(exactLast.batches) // the single last batch, reached via the keyset cursor (parity with exact)
+    // Same-MILLISECOND batches order by batchId DESC (the SHIPPED exact-path comparator: ms-truncated created_at then
+    // batchId) — NOT by µs. So offset-4 of [us_4,us_3,us_2,us_1,us_0] is the LOWEST batchId = keys[0] (batch_ghhm_us_0),
+    // which is exactly what the exact path returns (asserted above). Cursor precision (no µs-adjacent row skipped) is
+    // proven by total=5 + the page-parity assertions, not by which same-ms batch lands last.
+    expect(lastPage.batches.map((b) => b.batchId)).toEqual([keys[0]])
   })
 })


### PR DESCRIPTION
Completes the last deferred non-destructive item on the Global History line. The estimate path early-stopped mid-same-millisecond-cluster (µs walk order) so its page diverged from the exact path (which orders same-ms batches by ms-truncated time + batchId). **Fix (no exact-path change, no ordering 'decision'):** finish the complete same-ms cluster at the page boundary, then sort by the EXISTING exact-path comparator + slice — the estimate's page now equals the exact path's. LOCK-3 leak-guard preserved (mutation-checked: neutering `isDenied` makes the leak-guard golden fail). Corrected a test literal that wrongly assumed µs-ordering for same-ms batches. **11/11 goldens, tsc 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)