### PR TITLE
[codex] approval formula condition evaluator (FC-1)

### DIFF
--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -547,14 +547,16 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
 }
 
 // The COMPLEX-path config shapes the backend re-emits for the OTHER node types (same silent-drop
-// risk as approval): cc → {targetType, targetIds} (ApprovalProductService.ts:920-923); parallel →
-// {branches, joinMode, joinNodeKey} (:946-950); condition → {branches, defaultEdgeKey} with each
-// branch {edgeKey, conjunction?, rules} and each rule {fieldId, operator, value?} (:956-985 — the
-// rule `value` is a free leaf, NOT shape-checked); start/end → {} (default, :988).
+// risk as approval): cc → {targetType, targetIds}; parallel → {branches, joinMode, joinNodeKey};
+// condition → {branches, defaultEdgeKey} with each branch {edgeKey, conjunction?, rules, formula?}
+// and each rule {fieldId, operator, value?} (the rule `value` is a free leaf, NOT shape-checked);
+// start/end → {}. Formula branches are backend-preserved after FC-1, but the current G-2 editor
+// cannot round-trip them, so they remain fail-closed here until FC-2 formula authoring ships.
 const BACKEND_CC_CONFIG_KEYS = ['targetType', 'targetIds']
 const BACKEND_PARALLEL_CONFIG_KEYS = ['branches', 'joinMode', 'joinNodeKey']
 const BACKEND_CONDITION_CONFIG_KEYS = ['branches', 'defaultEdgeKey']
-const BACKEND_CONDITION_BRANCH_KEYS = ['edgeKey', 'conjunction', 'rules']
+const BACKEND_CONDITION_BRANCH_KEYS = ['edgeKey', 'conjunction', 'rules', 'formula']
+const BACKEND_CONDITION_FORMULA_KEYS = ['expression']
 const BACKEND_CONDITION_RULE_KEYS = ['fieldId', 'operator', 'value']
 
 /**
@@ -579,6 +581,10 @@ function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
       if (Array.isArray(branches)) {
         for (const branch of branches) {
           if (!isPlainRecord(branch) || hasKeyOutside(branch, BACKEND_CONDITION_BRANCH_KEYS)) return true
+          if (branch.formula !== undefined) {
+            if (!isPlainRecord(branch.formula) || hasKeyOutside(branch.formula, BACKEND_CONDITION_FORMULA_KEYS)) return true
+            return true
+          }
           const rules = branch.rules
           if (Array.isArray(rules)) {
             for (const rule of rules) {

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -96,6 +96,11 @@ export interface ConditionBranch {
   edgeKey: string
   rules: ConditionRule[]
   conjunction?: 'and' | 'or'
+  formula?: ConditionFormulaPredicate
+}
+
+export interface ConditionFormulaPredicate {
+  expression: string
 }
 
 export interface ConditionRule {

--- a/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
+++ b/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
@@ -7,7 +7,9 @@ import { unsupportedTemplateAuthoringReason } from '../src/approvals/templateAut
 // rebuilds each from a fixed per-type shape (ApprovalProductService.ts) and DROPS any other key —
 // top-level OR nested (condition branches[].rules[]). `complexNodeConfigHasBackendDrop` now fails
 // closed for EVERY node type, so an unknown key can't silently flatten on save while the FE
-// deep-equal round-trip looks clean. Pure helper test (no .vue) → runs under approval-web-guard.
+// deep-equal round-trip looks clean. FC-1 formula branches are backend-preserved but still
+// fail-closed here until FC-2 authoring can round-trip them. Pure helper test (no .vue) → runs
+// under approval-web-guard.
 
 function tpl(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
   return {
@@ -63,6 +65,9 @@ describe('complex node config fail-closed — condition (recurses config → bra
   })
   it('flags an unknown rule key', () => {
     expect(cond({ edgeKey: 'e', rules: [{ fieldId: 'amount', operator: 'gt', value: 1, futureFlag: true }] })).not.toBeNull()
+  })
+  it('flags a backend-supported formula branch until FC-2 can round-trip it', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).not.toBeNull()
   })
   it('allows a known condition (conjunction + a FREE-FORM rule value — value is a leaf, not shape-checked)', () => {
     expect(cond({ edgeKey: 'e', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'in', value: { complex: ['object', 'leaf'] } }] })).toBeNull()

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -182,6 +182,9 @@ detail array after pruning:
   fail closed in v1;
 - `COUNT({detail})` counts submitted rows;
 - `SUM({detail.amount})` requires every referenced amount cell to be numeric.
+- Boolean `AND`/`OR` must not short-circuit away malformed aggregate operands;
+  aggregate errors fail closed even when the other operand already determines
+  the boolean result.
 
 Reason: approval routing should not silently ignore malformed monetary data.
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,8 +1,8 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — RUNTIME NOT BUILT. Owner decisions resolved:
-`AND/OR/NOT` only in v1; numeric aggregates fail closed; backend evaluator
-ships before dry-run.
+Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2/FC-3 NOT BUILT. Owner
+decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
+backend evaluator ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -562,11 +562,13 @@ function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): Formul
     case 'binary': {
       if (ast.op === 'AND') {
         const left = assertBoolean(evaluateAst(ast.left, formData), 'AND left operand')
-        return left && assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+        return left && right
       }
       if (ast.op === 'OR') {
         const left = assertBoolean(evaluateAst(ast.left, formData), 'OR left operand')
-        return left || assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+        return left || right
       }
       const left = assertFiniteNumber(evaluateAst(ast.left, formData), `${ast.op} left operand`)
       const right = assertFiniteNumber(evaluateAst(ast.right, formData), `${ast.op} right operand`)

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -1,0 +1,618 @@
+import type { FormField, FormSchema } from '../types/approval-product'
+
+export const APPROVAL_CONDITION_FORMULA_LIMITS = {
+  maxExpressionLength: 512,
+  maxAstNodes: 128,
+  maxDepth: 16,
+  maxFieldReferences: 64,
+  maxFunctionCalls: 32,
+} as const
+
+export class ApprovalConditionFormulaError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApprovalConditionFormulaError'
+  }
+}
+
+type Token =
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'null' }
+  | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'identifier'; value: string }
+  | { kind: 'operator'; value: '+' | '-' | '*' | '/' | '==' | '!=' | '>' | '>=' | '<' | '<=' }
+  | { kind: 'paren'; value: '(' | ')' }
+  | { kind: 'eof' }
+
+type OperatorTokenValue = Extract<Token, { kind: 'operator' }>['value']
+
+type FormulaAst =
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'null' }
+  | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'aggregate'; fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'; path: string[]; raw: string }
+  | { kind: 'unary'; op: 'NEG' | 'NOT'; expr: FormulaAst }
+  | { kind: 'binary'; op: '+' | '-' | '*' | '/' | 'AND' | 'OR'; left: FormulaAst; right: FormulaAst }
+  | { kind: 'compare'; op: '==' | '!=' | '>' | '>=' | '<' | '<='; left: FormulaAst; right: FormulaAst }
+
+type FormulaValue = number | string | boolean | null
+type FormulaType = 'number' | 'string' | 'boolean' | 'null'
+
+function fail(message: string): never {
+  throw new ApprovalConditionFormulaError(message)
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_]/.test(char)
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_]/.test(char)
+}
+
+function tokenize(expression: string): Token[] {
+  if (expression.length > APPROVAL_CONDITION_FORMULA_LIMITS.maxExpressionLength) {
+    fail(`expression exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxExpressionLength} characters`)
+  }
+
+  const tokens: Token[] = []
+  let i = 0
+  while (i < expression.length) {
+    const char = expression[i]
+    if (/\s/.test(char)) {
+      i += 1
+      continue
+    }
+
+    if (char === '{') {
+      const end = expression.indexOf('}', i + 1)
+      if (end < 0) fail('field reference is missing closing brace')
+      const raw = expression.slice(i + 1, end).trim()
+      if (!raw) fail('field reference cannot be empty')
+      if (raw.includes('{') || raw.includes('}')) fail('field reference cannot contain braces')
+      const path = raw.split('.').map((part) => part.trim())
+      if (path.length < 1 || path.length > 2 || path.some((part) => !part)) {
+        fail(`field reference is invalid: ${raw}`)
+      }
+      tokens.push({ kind: 'field', path, raw })
+      i = end + 1
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      const quote = char
+      let value = ''
+      let closed = false
+      i += 1
+      while (i < expression.length) {
+        const current = expression[i]
+        if (current === quote) {
+          i += 1
+          tokens.push({ kind: 'string', value })
+          closed = true
+          break
+        }
+        if (current === '\\') {
+          const escaped = expression[i + 1]
+          if (escaped === undefined) fail('string literal has a dangling escape')
+          const mapped = escaped === 'n'
+            ? '\n'
+            : escaped === 'r'
+              ? '\r'
+              : escaped === 't'
+                ? '\t'
+                : escaped
+          value += mapped
+          i += 2
+          continue
+        }
+        value += current
+        i += 1
+      }
+      if (!closed) {
+        fail('string literal is missing closing quote')
+      }
+      continue
+    }
+
+    if (/[0-9.]/.test(char)) {
+      const rest = expression.slice(i)
+      const match = rest.match(/^(?:\d+(?:\.\d+)?|\.\d+)/)
+      if (!match) fail(`unexpected token: ${char}`)
+      const value = Number(match[0])
+      if (!Number.isFinite(value)) fail(`number literal is not finite: ${match[0]}`)
+      tokens.push({ kind: 'number', value })
+      i += match[0].length
+      continue
+    }
+
+    if (isIdentifierStart(char)) {
+      let raw = char
+      i += 1
+      while (i < expression.length && isIdentifierPart(expression[i])) {
+        raw += expression[i]
+        i += 1
+      }
+      const upper = raw.toUpperCase()
+      if (upper === 'TRUE' || upper === 'FALSE') {
+        tokens.push({ kind: 'boolean', value: upper === 'TRUE' })
+      } else if (upper === 'NULL') {
+        tokens.push({ kind: 'null' })
+      } else {
+        tokens.push({ kind: 'identifier', value: upper })
+      }
+      continue
+    }
+
+    const two = expression.slice(i, i + 2)
+    if (two === '==' || two === '!=' || two === '>=' || two === '<=') {
+      tokens.push({ kind: 'operator', value: two })
+      i += 2
+      continue
+    }
+    if (char === '+' || char === '-' || char === '*' || char === '/' || char === '>' || char === '<') {
+      tokens.push({ kind: 'operator', value: char })
+      i += 1
+      continue
+    }
+    if (char === '(' || char === ')') {
+      tokens.push({ kind: 'paren', value: char })
+      i += 1
+      continue
+    }
+    fail(`unexpected token: ${char}`)
+  }
+
+  tokens.push({ kind: 'eof' })
+  return tokens
+}
+
+class FormulaParser {
+  private index = 0
+  private astNodes = 0
+  private fieldReferences = 0
+  private functionCalls = 0
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parse(): FormulaAst {
+    const expr = this.parseOr()
+    if (this.peek().kind !== 'eof') {
+      fail('unexpected trailing token')
+    }
+    const depth = astDepth(expr)
+    if (depth > APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth) {
+      fail(`formula AST depth exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth}`)
+    }
+    return expr
+  }
+
+  private node<T extends FormulaAst>(ast: T): T {
+    this.astNodes += 1
+    if (this.astNodes > APPROVAL_CONDITION_FORMULA_LIMITS.maxAstNodes) {
+      fail(`formula AST exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxAstNodes} nodes`)
+    }
+    if (ast.kind === 'field' || ast.kind === 'aggregate') {
+      this.fieldReferences += 1
+      if (this.fieldReferences > APPROVAL_CONDITION_FORMULA_LIMITS.maxFieldReferences) {
+        fail(`formula references more than ${APPROVAL_CONDITION_FORMULA_LIMITS.maxFieldReferences} fields`)
+      }
+    }
+    if (ast.kind === 'aggregate') {
+      this.functionCalls += 1
+      if (this.functionCalls > APPROVAL_CONDITION_FORMULA_LIMITS.maxFunctionCalls) {
+        fail(`formula calls more than ${APPROVAL_CONDITION_FORMULA_LIMITS.maxFunctionCalls} functions`)
+      }
+    }
+    return ast
+  }
+
+  private peek(): Token {
+    return this.tokens[this.index] ?? { kind: 'eof' }
+  }
+
+  private advance(): Token {
+    const token = this.peek()
+    this.index += 1
+    return token
+  }
+
+  private matchIdentifier(value: string): boolean {
+    const token = this.peek()
+    if (token.kind === 'identifier' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private matchOperator(value: OperatorTokenValue): boolean {
+    const token = this.peek()
+    if (token.kind === 'operator' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private matchParen(value: '(' | ')'): boolean {
+    const token = this.peek()
+    if (token.kind === 'paren' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private parseOr(): FormulaAst {
+    let left = this.parseAnd()
+    while (this.matchIdentifier('OR')) {
+      left = this.node({ kind: 'binary', op: 'OR', left, right: this.parseAnd() })
+    }
+    return left
+  }
+
+  private parseAnd(): FormulaAst {
+    let left = this.parseNot()
+    while (this.matchIdentifier('AND')) {
+      left = this.node({ kind: 'binary', op: 'AND', left, right: this.parseNot() })
+    }
+    return left
+  }
+
+  private parseNot(): FormulaAst {
+    if (this.matchIdentifier('NOT')) {
+      return this.node({ kind: 'unary', op: 'NOT', expr: this.parseNot() })
+    }
+    return this.parseComparison()
+  }
+
+  private parseComparison(): FormulaAst {
+    const left = this.parseAdditive()
+    const token = this.peek()
+    if (token.kind !== 'operator' || !['==', '!=', '>', '>=', '<', '<='].includes(token.value)) {
+      return left
+    }
+    this.advance()
+    return this.node({
+      kind: 'compare',
+      op: token.value as Extract<FormulaAst, { kind: 'compare' }>['op'],
+      left,
+      right: this.parseAdditive(),
+    })
+  }
+
+  private parseAdditive(): FormulaAst {
+    let left = this.parseMultiplicative()
+    while (true) {
+      if (this.matchOperator('+')) {
+        left = this.node({ kind: 'binary', op: '+', left, right: this.parseMultiplicative() })
+        continue
+      }
+      if (this.matchOperator('-')) {
+        left = this.node({ kind: 'binary', op: '-', left, right: this.parseMultiplicative() })
+        continue
+      }
+      return left
+    }
+  }
+
+  private parseMultiplicative(): FormulaAst {
+    let left = this.parseUnary()
+    while (true) {
+      if (this.matchOperator('*')) {
+        left = this.node({ kind: 'binary', op: '*', left, right: this.parseUnary() })
+        continue
+      }
+      if (this.matchOperator('/')) {
+        left = this.node({ kind: 'binary', op: '/', left, right: this.parseUnary() })
+        continue
+      }
+      return left
+    }
+  }
+
+  private parseUnary(): FormulaAst {
+    if (this.matchOperator('-')) {
+      return this.node({ kind: 'unary', op: 'NEG', expr: this.parseUnary() })
+    }
+    if (this.matchOperator('+')) {
+      return this.parseUnary()
+    }
+    return this.parsePrimary()
+  }
+
+  private parsePrimary(): FormulaAst {
+    const token = this.advance()
+    switch (token.kind) {
+      case 'number':
+        return this.node({ kind: 'number', value: token.value })
+      case 'string':
+        return this.node({ kind: 'string', value: token.value })
+      case 'boolean':
+        return this.node({ kind: 'boolean', value: token.value })
+      case 'null':
+        return this.node({ kind: 'null' })
+      case 'field':
+        return this.node({ kind: 'field', path: token.path, raw: token.raw })
+      case 'identifier':
+        return this.parseFunction(token.value)
+      case 'paren': {
+        if (token.value !== '(') fail('unexpected closing parenthesis')
+        const expr = this.parseOr()
+        if (!this.matchParen(')')) fail('missing closing parenthesis')
+        return expr
+      }
+      case 'operator':
+        fail(`unexpected operator: ${token.value}`)
+      case 'eof':
+        fail('unexpected end of expression')
+      default:
+        fail('unexpected token')
+    }
+  }
+
+  private parseFunction(name: string): FormulaAst {
+    if (name !== 'SUM' && name !== 'COUNT' && name !== 'MIN' && name !== 'MAX') {
+      fail(`unsupported identifier: ${name}`)
+    }
+    if (!this.matchParen('(')) fail(`${name} requires parentheses`)
+    const token = this.advance()
+    if (token.kind !== 'field') fail(`${name} requires a field reference argument`)
+    if (!this.matchParen(')')) fail(`${name} accepts exactly one argument`)
+    return this.node({ kind: 'aggregate', fn: name, path: token.path, raw: token.raw })
+  }
+}
+
+function astDepth(ast: FormulaAst): number {
+  switch (ast.kind) {
+    case 'unary':
+      return 1 + astDepth(ast.expr)
+    case 'binary':
+    case 'compare':
+      return 1 + Math.max(astDepth(ast.left), astDepth(ast.right))
+    default:
+      return 1
+  }
+}
+
+function parseFormula(expression: string): FormulaAst {
+  const trimmed = expression.trim()
+  if (!trimmed) fail('expression is required')
+  return new FormulaParser(tokenize(trimmed)).parse()
+}
+
+function formFieldTypeToFormulaType(field: FormField): FormulaType | 'unsupported' {
+  switch (field.type) {
+    case 'number':
+      return 'number'
+    case 'text':
+    case 'textarea':
+    case 'date':
+    case 'datetime':
+    case 'select':
+    case 'user':
+      return 'string'
+    default:
+      return 'unsupported'
+  }
+}
+
+function findTopLevelField(schema: FormSchema, fieldId: string): FormField | undefined {
+  return schema.fields.find((field) => field.id === fieldId)
+}
+
+function findDetailColumn(schema: FormSchema, detailId: string, columnId: string): { detail: FormField; column: FormField } | undefined {
+  const detail = findTopLevelField(schema, detailId)
+  if (!detail || detail.type !== 'detail') return undefined
+  const column = detail.columns?.find((entry) => entry.id === columnId)
+  return column ? { detail, column } : undefined
+}
+
+function inferFormulaType(ast: FormulaAst, schema: FormSchema): FormulaType {
+  switch (ast.kind) {
+    case 'number':
+      return 'number'
+    case 'string':
+      return 'string'
+    case 'boolean':
+      return 'boolean'
+    case 'null':
+      return 'null'
+    case 'field': {
+      if (ast.path.length !== 1) {
+        fail(`detail sub-field reference must be used inside an aggregate: ${ast.raw}`)
+      }
+      const field = findTopLevelField(schema, ast.path[0])
+      if (!field) fail(`unknown field reference: ${ast.raw}`)
+      if (field.type === 'detail') fail(`detail field reference must use an aggregate: ${ast.raw}`)
+      const type = formFieldTypeToFormulaType(field)
+      if (type === 'unsupported') fail(`field type is not supported in formula: ${field.id}`)
+      return type
+    }
+    case 'aggregate':
+      validateAggregateReference(ast, schema)
+      return 'number'
+    case 'unary': {
+      const inner = inferFormulaType(ast.expr, schema)
+      if (ast.op === 'NOT') {
+        if (inner !== 'boolean') fail('NOT requires a boolean expression')
+        return 'boolean'
+      }
+      if (inner !== 'number') fail('unary +/- requires a numeric expression')
+      return 'number'
+    }
+    case 'binary': {
+      const left = inferFormulaType(ast.left, schema)
+      const right = inferFormulaType(ast.right, schema)
+      if (ast.op === 'AND' || ast.op === 'OR') {
+        if (left !== 'boolean' || right !== 'boolean') fail(`${ast.op} requires boolean operands`)
+        return 'boolean'
+      }
+      if (left !== 'number' || right !== 'number') {
+        fail(`operator ${ast.op} requires numeric operands`)
+      }
+      return 'number'
+    }
+    case 'compare': {
+      const left = inferFormulaType(ast.left, schema)
+      const right = inferFormulaType(ast.right, schema)
+      if (ast.op === '==' || ast.op === '!=') {
+        if (left !== right && left !== 'null' && right !== 'null') {
+          fail(`operator ${ast.op} requires compatible operand types`)
+        }
+        return 'boolean'
+      }
+      if (left !== 'number' || right !== 'number') {
+        fail(`operator ${ast.op} requires numeric operands`)
+      }
+      return 'boolean'
+    }
+    default:
+      fail('unsupported expression')
+  }
+}
+
+function validateAggregateReference(ast: Extract<FormulaAst, { kind: 'aggregate' }>, schema: FormSchema): void {
+  if (ast.fn === 'COUNT') {
+    if (ast.path.length !== 1) fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    const detail = findTopLevelField(schema, ast.path[0])
+    if (!detail || detail.type !== 'detail') fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    return
+  }
+
+  if (ast.path.length !== 2) fail(`${ast.fn} requires a detail sub-field reference: ${ast.raw}`)
+  const resolved = findDetailColumn(schema, ast.path[0], ast.path[1])
+  if (!resolved) fail(`${ast.fn} references an unknown detail sub-field: ${ast.raw}`)
+  if (resolved.column.type !== 'number') {
+    fail(`${ast.fn} requires a numeric detail sub-field: ${ast.raw}`)
+  }
+}
+
+function assertFiniteNumber(value: unknown, context: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${context} must be a finite number`)
+  }
+  return value
+}
+
+function assertBoolean(value: FormulaValue, context: string): boolean {
+  if (typeof value !== 'boolean') fail(`${context} must be boolean`)
+  return value
+}
+
+function evaluateField(path: string[], raw: string, formData: Record<string, unknown>): FormulaValue {
+  if (path.length !== 1) fail(`detail sub-field reference must be used inside an aggregate: ${raw}`)
+  if (!Object.prototype.hasOwnProperty.call(formData, path[0])) {
+    fail(`field ${raw} is missing`)
+  }
+  const value = formData[path[0]]
+  if (value === null) return null
+  if (value === undefined) fail(`field ${raw} is missing`)
+  if (typeof value === 'number') return assertFiniteNumber(value, `field ${raw}`)
+  if (typeof value === 'string' || typeof value === 'boolean') return value
+  fail(`field ${raw} has an unsupported runtime value`)
+}
+
+function evaluateAggregate(ast: Extract<FormulaAst, { kind: 'aggregate' }>, formData: Record<string, unknown>): number {
+  const detailValue = formData[ast.path[0]]
+  if (!Array.isArray(detailValue)) fail(`aggregate ${ast.fn} requires a detail array: ${ast.path[0]}`)
+  if (ast.fn === 'COUNT') {
+    if (ast.path.length !== 1) fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    if (detailValue.some((row) => row === null || typeof row !== 'object' || Array.isArray(row))) {
+      fail('COUNT requires detail rows to be objects')
+    }
+    return detailValue.length
+  }
+  if (ast.path.length !== 2) fail(`${ast.fn} requires a detail sub-field reference: ${ast.raw}`)
+  const numbers = detailValue.map((row, index) => {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      fail(`${ast.fn} row ${index + 1} must be an object`)
+    }
+    return assertFiniteNumber((row as Record<string, unknown>)[ast.path[1]], `${ast.fn} value ${ast.raw}`)
+  })
+  if (ast.fn === 'SUM') {
+    return numbers.reduce((sum, value) => assertFiniteNumber(sum + value, 'SUM result'), 0)
+  }
+  if (numbers.length === 0) fail(`${ast.fn} requires at least one numeric detail value`)
+  return ast.fn === 'MIN' ? Math.min(...numbers) : Math.max(...numbers)
+}
+
+function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): FormulaValue {
+  switch (ast.kind) {
+    case 'number':
+    case 'string':
+    case 'boolean':
+      return ast.value
+    case 'null':
+      return null
+    case 'field':
+      return evaluateField(ast.path, ast.raw, formData)
+    case 'aggregate':
+      return evaluateAggregate(ast, formData)
+    case 'unary': {
+      const value = evaluateAst(ast.expr, formData)
+      if (ast.op === 'NOT') return !assertBoolean(value, 'NOT operand')
+      return assertFiniteNumber(-assertFiniteNumber(value, 'unary operand'), 'unary result')
+    }
+    case 'binary': {
+      if (ast.op === 'AND') {
+        const left = assertBoolean(evaluateAst(ast.left, formData), 'AND left operand')
+        return left && assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+      }
+      if (ast.op === 'OR') {
+        const left = assertBoolean(evaluateAst(ast.left, formData), 'OR left operand')
+        return left || assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+      }
+      const left = assertFiniteNumber(evaluateAst(ast.left, formData), `${ast.op} left operand`)
+      const right = assertFiniteNumber(evaluateAst(ast.right, formData), `${ast.op} right operand`)
+      if (ast.op === '/' && right === 0) fail('division by zero')
+      const result = ast.op === '+'
+        ? left + right
+        : ast.op === '-'
+          ? left - right
+          : ast.op === '*'
+            ? left * right
+            : left / right
+      return assertFiniteNumber(result, `${ast.op} result`)
+    }
+    case 'compare': {
+      const left = evaluateAst(ast.left, formData)
+      const right = evaluateAst(ast.right, formData)
+      if (ast.op === '==') return left === right
+      if (ast.op === '!=') return left !== right
+      const numericLeft = assertFiniteNumber(left, `${ast.op} left operand`)
+      const numericRight = assertFiniteNumber(right, `${ast.op} right operand`)
+      if (ast.op === '>') return numericLeft > numericRight
+      if (ast.op === '>=') return numericLeft >= numericRight
+      if (ast.op === '<') return numericLeft < numericRight
+      return numericLeft <= numericRight
+    }
+    default:
+      fail('unsupported expression')
+  }
+}
+
+export function parseApprovalConditionFormula(expression: string): void {
+  parseFormula(expression)
+}
+
+export function assertApprovalConditionFormulaValidForSchema(expression: string, schema: FormSchema): void {
+  const ast = parseFormula(expression)
+  const resultType = inferFormulaType(ast, schema)
+  if (resultType !== 'boolean') {
+    fail('formula must return boolean')
+  }
+}
+
+export function evaluateApprovalConditionFormula(expression: string, formData: Record<string, unknown>): boolean {
+  const result = evaluateAst(parseFormula(expression), formData)
+  if (typeof result !== 'boolean') {
+    fail('formula must return boolean')
+  }
+  return result
+}

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -176,6 +176,7 @@ class FormulaParser {
   private astNodes = 0
   private fieldReferences = 0
   private functionCalls = 0
+  private parenDepth = 0
 
   constructor(private readonly tokens: Token[]) {}
 
@@ -343,9 +344,17 @@ class FormulaParser {
         return this.parseFunction(token.value)
       case 'paren': {
         if (token.value !== '(') fail('unexpected closing parenthesis')
-        const expr = this.parseOr()
-        if (!this.matchParen(')')) fail('missing closing parenthesis')
-        return expr
+        this.parenDepth += 1
+        if (this.parenDepth > APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth) {
+          fail(`formula nesting depth exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth}`)
+        }
+        try {
+          const expr = this.parseOr()
+          if (!this.matchParen(')')) fail('missing closing parenthesis')
+          return expr
+        } finally {
+          this.parenDepth -= 1
+        }
       }
       case 'operator':
         fail(`unexpected operator: ${token.value}`)

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -14,6 +14,7 @@ import type {
   RuntimeGraph,
 } from '../types/approval-product'
 import { ServiceError } from './ApprovalBridgeService'
+import { evaluateApprovalConditionFormula } from './ApprovalConditionFormula'
 
 export interface ApprovalGraphAssignment {
   assignmentType: 'user' | 'role'
@@ -1045,10 +1046,14 @@ export class ApprovalGraphExecutor {
       : []
 
     for (const branch of branches) {
-      const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
-      const result = conjunction === 'or'
-        ? branch.rules.some((rule) => evaluateRule(rule, this.formData))
-        : branch.rules.every((rule) => evaluateRule(rule, this.formData))
+      const result = branch.formula
+        ? evaluateApprovalConditionFormula(branch.formula.expression, this.formData)
+        : (() => {
+            const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
+            return conjunction === 'or'
+              ? branch.rules.some((rule) => evaluateRule(rule, this.formData))
+              : branch.rules.every((rule) => evaluateRule(rule, this.formData))
+          })()
       if (result) {
         return this.targetForEdge(branch.edgeKey)
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -15,6 +15,7 @@ import type {
   ApprovalGraph,
   ApprovalMode,
   ApprovalRequesterSnapshot,
+  ConditionFormulaPredicate,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
   EmptyAssigneePolicy,
@@ -43,6 +44,11 @@ import {
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
 import { validateAmountTotalConsistency } from './amount-total-check'
+import {
+  ApprovalConditionFormulaError,
+  assertApprovalConditionFormulaValidForSchema,
+  parseApprovalConditionFormula,
+} from './ApprovalConditionFormula'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveActiveDelegationMap } from './ApprovalDelegations'
 import type {
@@ -482,6 +488,31 @@ function validateApprovalAssigneeSourcesAgainstFormSchema(
   })
 }
 
+function validateApprovalConditionFormulasAgainstFormSchema(
+  approvalGraph: ApprovalGraph,
+  formSchema: FormSchema,
+  context: ValidationContext,
+): void {
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'condition') continue
+    const config = node.config as { branches?: unknown }
+    if (!Array.isArray(config.branches)) continue
+
+    config.branches.forEach((branch, branchIndex) => {
+      if (!isRecord(branch) || !isRecord(branch.formula) || typeof branch.formula.expression !== 'string') return
+      try {
+        assertApprovalConditionFormulaValidForSchema(branch.formula.expression, formSchema)
+      } catch (error) {
+        const message = error instanceof ApprovalConditionFormulaError ? error.message : String(error)
+        failValidation(
+          context,
+          `approvalGraph node ${node.key} condition formula branch ${branchIndex + 1} is invalid: ${message}`,
+        )
+      }
+    })
+  }
+}
+
 function failValidation(context: ValidationContext, message: string): never {
   throw new ServiceError(message, context.status, context.code)
 }
@@ -868,6 +899,25 @@ function normalizeNodeFieldPermissions(
   return normalized
 }
 
+function normalizeConditionFormulaPredicate(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): ConditionFormulaPredicate | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value) || !isNonEmptyString(value.expression)) {
+    failValidation(context, `${path}.expression is required`)
+  }
+  const expression = value.expression.trim()
+  try {
+    parseApprovalConditionFormula(expression)
+  } catch (error) {
+    const message = error instanceof ApprovalConditionFormulaError ? error.message : String(error)
+    failValidation(context, `${path}.expression is invalid: ${message}`)
+  }
+  return { expression }
+}
+
 /**
  * P1-C cross-reference: every `fieldPermissions[].fieldId` on an approval node
  * must reference a field that exists in the version's formSchema. Runs after
@@ -1027,9 +1077,21 @@ function normalizeApprovalGraph(
             if (branch.conjunction !== undefined && branch.conjunction !== 'and' && branch.conjunction !== 'or') {
               failValidation(context, `approvalGraph.nodes[${index}].config.branches[${branchIndex}].conjunction is invalid`)
             }
+            const formula = normalizeConditionFormulaPredicate(
+              branch.formula,
+              context,
+              `approvalGraph.nodes[${index}].config.branches[${branchIndex}].formula`,
+            )
+            if (formula && branch.rules.length > 0) {
+              failValidation(
+                context,
+                `approvalGraph.nodes[${index}].config.branches[${branchIndex}] cannot mix formula and rules`,
+              )
+            }
             return {
               edgeKey: branch.edgeKey.trim(),
               ...(branch.conjunction ? { conjunction: branch.conjunction } : {}),
+              ...(formula ? { formula } : {}),
               rules: branch.rules.map((rule, ruleIndex) => {
                 if (!isRecord(rule) || !isNonEmptyString(rule.fieldId) || !CONDITION_OPERATORS.has(String(rule.operator))) {
                   failValidation(
@@ -2290,6 +2352,7 @@ export class ApprovalProductService {
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
     validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -2444,6 +2507,7 @@ export class ApprovalProductService {
         const nextApprovalGraph = approvalGraph ?? asApprovalGraph(latestVersion.approval_graph)
         validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
+        validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
 
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
@@ -2531,6 +2595,7 @@ export class ApprovalProductService {
       const approvalGraph = asApprovalGraph(version.approval_graph)
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -140,6 +140,11 @@ export interface ConditionBranch {
   edgeKey: string
   rules: ConditionRule[]
   conjunction?: 'and' | 'or'
+  formula?: ConditionFormulaPredicate
+}
+
+export interface ConditionFormulaPredicate {
+  expression: string
 }
 
 export interface ConditionRule {

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APPROVAL_CONDITION_FORMULA_LIMITS,
+  assertApprovalConditionFormulaValidForSchema,
+  evaluateApprovalConditionFormula,
+  parseApprovalConditionFormula,
+} from '../../src/services/ApprovalConditionFormula'
+import type { FormSchema } from '../../src/types/approval-product'
+
+const schema: FormSchema = {
+  fields: [
+    { id: 'amount', type: 'number', label: 'Amount' },
+    { id: 'expense_type', type: 'select', label: 'Expense Type', options: [{ label: 'Travel', value: 'travel' }] },
+    { id: 'receipt', type: 'attachment', label: 'Receipt' },
+    { id: 'items', type: 'detail', label: 'Items', columns: [
+      { id: 'amount', type: 'number', label: 'Line Amount' },
+      { id: 'memo', type: 'text', label: 'Memo' },
+    ] },
+  ],
+}
+
+describe('approval condition formula evaluator (FC-1)', () => {
+  it('evaluates boolean formulas with detail aggregates and AND/OR/NOT', () => {
+    const formData = {
+      amount: 12000,
+      expense_type: 'travel',
+      items: [{ amount: 5000 }, { amount: 7000 }],
+    }
+
+    expect(evaluateApprovalConditionFormula(
+      'SUM({items.amount}) >= 10000 AND {expense_type} == "travel"',
+      formData,
+    )).toBe(true)
+    expect(evaluateApprovalConditionFormula(
+      'COUNT({items}) > 1 AND NOT ({amount} < 10000)',
+      formData,
+    )).toBe(true)
+    expect(evaluateApprovalConditionFormula(
+      'SUM({items.amount}) >= 20000 OR {expense_type} == "office"',
+      formData,
+    )).toBe(false)
+  })
+
+  it('validates schema references and requires a boolean result', () => {
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.amount}) >= 10000', schema)).not.toThrow()
+    expect(() => assertApprovalConditionFormulaValidForSchema('{missing} == 1', schema)).toThrow(/unknown field/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('{items.amount} >= 1', schema)).toThrow(/inside an aggregate/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.memo}) >= 1', schema)).toThrow(/numeric detail sub-field/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.amount})', schema)).toThrow(/must return boolean/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('{receipt} == "yes"', schema)).toThrow(/not supported/)
+  })
+
+  it('fails closed on unsafe numeric states and malformed runtime aggregates', () => {
+    expect(() => evaluateApprovalConditionFormula('10 / {amount} > 1', { amount: 0 })).toThrow(/division by zero/)
+    expect(() => evaluateApprovalConditionFormula('{amount} == null', {})).toThrow(/field amount is missing/)
+    expect(evaluateApprovalConditionFormula('{amount} == null', { amount: null })).toBe(true)
+    expect(() => evaluateApprovalConditionFormula('SUM({items.amount}) >= 1', { items: [{ amount: '10' }] })).toThrow(/finite number/)
+    expect(() => evaluateApprovalConditionFormula('MIN({items.amount}) >= 1', { items: [] })).toThrow(/at least one/)
+  })
+
+  it('rejects concrete DoS bounds before runtime', () => {
+    expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'1'.repeat(513)} == 1`)).toThrow(/exceeds 512/)
+  })
+
+  it('counts aggregate references against the field-reference cap', () => {
+    const limits = APPROVAL_CONDITION_FORMULA_LIMITS as { maxFieldReferences: number }
+    const original = limits.maxFieldReferences
+    limits.maxFieldReferences = 1
+    try {
+      expect(() => parseApprovalConditionFormula('SUM({items.amount}) + {amount} > 0')).toThrow(/references more than 1 fields/)
+    } finally {
+      limits.maxFieldReferences = original
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -58,6 +58,17 @@ describe('approval condition formula evaluator (FC-1)', () => {
     expect(() => evaluateApprovalConditionFormula('MIN({items.amount}) >= 1', { items: [] })).toThrow(/at least one/)
   })
 
+  it('does not let boolean short-circuiting hide malformed aggregate data', () => {
+    expect(() => evaluateApprovalConditionFormula(
+      '{expense_type} == "travel" AND SUM({items.amount}) >= 1',
+      { expense_type: 'office', items: [{ amount: 'bad' }] },
+    )).toThrow(/finite number/)
+    expect(() => evaluateApprovalConditionFormula(
+      '{expense_type} == "office" OR SUM({items.amount}) >= 1',
+      { expense_type: 'office', items: [{ amount: 'bad' }] },
+    )).toThrow(/finite number/)
+  })
+
   it('rejects concrete DoS bounds before runtime', () => {
     expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
     expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -72,6 +72,7 @@ describe('approval condition formula evaluator (FC-1)', () => {
   it('rejects concrete DoS bounds before runtime', () => {
     expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
     expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'('.repeat(17)}TRUE${')'.repeat(17)}`)).toThrow(/nesting depth exceeds/)
     expect(() => parseApprovalConditionFormula(`${'1'.repeat(513)} == 1`)).toThrow(/exceeds 512/)
   })
 

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -62,6 +62,80 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  it('routes condition formula branches and keeps default as no-match only', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'edge-high',
+                rules: [],
+                formula: { expression: 'SUM({items.amount}) >= 20000 AND {expense_type} == "travel"' },
+              },
+            ],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high-review' },
+        { key: 'edge-low', source: 'route', target: 'low-review' },
+        { key: 'edge-high-end', source: 'high-review', target: 'end' },
+        { key: 'edge-low-end', source: 'low-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const high = new ApprovalGraphExecutor(runtimeGraph, {
+      expense_type: 'travel',
+      items: [{ amount: 15000 }, { amount: 6000 }],
+    }).resolveInitialState()
+    expect(high.currentNodeKey).toBe('high-review')
+
+    const low = new ApprovalGraphExecutor(runtimeGraph, {
+      expense_type: 'office',
+      items: [{ amount: 21000 }],
+    }).resolveInitialState()
+    expect(low.currentNodeKey).toBe('low-review')
+  })
+
+  it('fails closed on condition formula runtime errors instead of taking defaultEdgeKey', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: '10 / {amount} > 1' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high-review' },
+        { key: 'edge-low', source: 'route', target: 'low-review' },
+        { key: 'edge-high-end', source: 'high-review', target: 'end' },
+        { key: 'edge-low-end', source: 'low-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, { amount: 0 }).resolveInitialState()).toThrow(/division by zero/)
+  })
+
   it('advances to approved when the next node is end', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1313,6 +1313,116 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('approval condition formula contract (FC-1)', () => {
+    const formulaFormSchema = {
+      fields: [
+        { id: 'amount', type: 'number', label: 'Amount' },
+        { id: 'items', type: 'detail', label: 'Items', columns: [{ id: 'amount', type: 'number', label: 'Line Amount' }] },
+      ],
+    }
+    const formulaGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high' },
+        { key: 'edge-low', source: 'route', target: 'low' },
+        { key: 'edge-high-end', source: 'high', target: 'end' },
+        { key: 'edge-low-end', source: 'low', target: 'end' },
+      ],
+    }
+
+    it('preserves formula branches through createTemplate normalization', async () => {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return { rows: [{ id: 'tpl-formula', key: String(params?.[0]), name: String(params?.[1]), description: null, category: null, visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: null, created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return { rows: [{ id: 'ver-formula', template_id: 'tpl-formula', version: 1, status: 'draft', form_schema: JSON.parse(String(params?.[1])), approval_graph: JSON.parse(String(params?.[2])), created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return { rows: [{ id: 'tpl-formula', key: 'formula-template', name: 'Formula Template', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: 'ver-formula', created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'formula-template',
+        name: 'Formula Template',
+        formSchema: formulaFormSchema,
+        approvalGraph: formulaGraph,
+      } as never)
+
+      const condition = result.approvalGraph.nodes.find((node) => node.key === 'route')
+      expect((condition?.config as { branches: Array<{ formula?: { expression: string } }> }).branches[0].formula)
+        .toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+      const insertVersionCall = pgState.client.query.mock.calls.find(([sql]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_template_versions'))
+      const persistedGraph = JSON.parse(String(insertVersionCall?.[1]?.[2]))
+      expect(persistedGraph.nodes[1].config.branches[0].formula).toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+    })
+
+    it('rejects formula branches that mix rules or reference unknown fields before hitting the database', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate({
+        key: 'formula-mix',
+        name: 'Formula Mix',
+        formSchema: formulaFormSchema,
+        approvalGraph: {
+          ...formulaGraph,
+          nodes: formulaGraph.nodes.map((node) => node.key === 'route'
+            ? {
+                ...node,
+                config: {
+                  branches: [{
+                    edgeKey: 'edge-high',
+                    rules: [{ fieldId: 'amount', operator: 'gte', value: 20000 }],
+                    formula: { expression: 'SUM({items.amount}) >= 20000' },
+                  }],
+                  defaultEdgeKey: 'edge-low',
+                },
+              }
+            : node),
+        },
+      } as never)).rejects.toThrow(/cannot mix formula and rules/)
+
+      await expect(service.createTemplate({
+        key: 'formula-unknown',
+        name: 'Formula Unknown',
+        formSchema: formulaFormSchema,
+        approvalGraph: {
+          ...formulaGraph,
+          nodes: formulaGraph.nodes.map((node) => node.key === 'route'
+            ? {
+                ...node,
+                config: {
+                  branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: '{ghost} == 1' } }],
+                  defaultEdgeKey: 'edge-low',
+                },
+              }
+            : node),
+        },
+      } as never)).rejects.toThrow(/unknown field reference/)
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+  })
+
   it('accepts authoring-MVP form-field-user assignee sources when creating a template', async () => {
     const request = {
       key: 'expense-authoring',
@@ -4202,6 +4312,87 @@ describe('ApprovalProductService', () => {
     expect(deactivateIndex).toBeGreaterThan(lockIndex)
     expect(insertIndex).toBeGreaterThan(deactivateIndex)
     expect(statements.filter((statement) => statement === 'COMMIT')).toHaveLength(1)
+  })
+
+  it('preserves condition formulas through publish runtime_graph and read-back DTO', async () => {
+    const formSchema = {
+      fields: [
+        { id: 'amount', type: 'number', label: 'Amount' },
+        { id: 'items', type: 'detail', label: 'Items', columns: [{ id: 'amount', type: 'number', label: 'Line Amount' }] },
+      ],
+    }
+    const approvalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high' },
+        { key: 'edge-low', source: 'route', target: 'low' },
+        { key: 'edge-high-end', source: 'high', target: 'end' },
+        { key: 'edge-low-end', source: 'low', target: 'end' },
+      ],
+    }
+    const template = {
+      id: 'tpl-1',
+      key: 'formula',
+      name: 'Formula Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: null,
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: formSchema,
+      approval_graph: approvalGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+      if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+      if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+        const runtimeGraph = JSON.parse(String(params?.[2]))
+        expect(runtimeGraph.nodes[1].config.branches[0].formula).toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+        return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: runtimeGraph, is_active: true, published_at: new Date() }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) {
+        return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const result = await new ApprovalProductService().publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never)
+
+    const condition = result.runtimeGraph?.nodes.find((node) => node.key === 'route')
+    expect((condition?.config as { branches: Array<{ formula?: { expression: string } }> }).branches[0].formula)
+      .toEqual({ expression: 'SUM({items.amount}) >= 20000' })
   })
 
   it('snapshots publish-time auto-approval policy into runtime_graph without a migration column', async () => {


### PR DESCRIPTION
## Summary

Implements FC-1 for approval condition formulas from the ratified design-lock:

- adds the `condition.branch.formula.expression` contract, mutually exclusive with rule branches in v1;
- adds a narrow approval-specific parser/evaluator for boolean formulas, arithmetic, comparisons, `AND`/`OR`/`NOT`, and detail aggregates `SUM`/`COUNT`/`MIN`/`MAX`;
- validates formula syntax, bounds, boolean return type, and form-schema field references on create/update/publish;
- evaluates formula condition branches at runtime with fail-closed semantics: eval errors, non-boolean results, division by zero, non-finite numbers, malformed aggregates, and missing/pruned fields do not fall through to `defaultEdgeKey`;
- preserves formulas through normalization, publish runtime_graph, and read-back DTOs;
- updates the web contract types but keeps current authoring fail-closed for formula branches until FC-2 can edit/round-trip them safely;
- updates the design-lock status so it does not remain `RUNTIME NOT BUILT` after FC-1 lands.

## Scope boundaries

Not included in FC-1:

- no formula authoring UI;
- no dry-run endpoint;
- no spreadsheet formula runtime reuse;
- no W7/result-writeback changes.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts` — 97/97
- `pnpm --filter @metasheet/web exec vitest run tests/approval-template-authoring-complex-node-config-allowlist.test.ts tests/approval-template-authoring-condition-edit.test.ts tests/approval-template-authoring-graph-preserve.test.ts` — 51/51
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/web type-check`
- `pnpm lint`
- `git diff --check`
