### PR TITLE
[codex] approval formula condition authoring (FC-2)

### DIFF
--- a/apps/web/src/approvals/conditionEdit.ts
+++ b/apps/web/src/approvals/conditionEdit.ts
@@ -34,8 +34,10 @@ export interface ConditionNodeEdit {
 export interface ConditionBranchEdit {
   // Topology — preserved verbatim; the editor never mutates these.
   edgeKey: string
+  predicateMode: 'rules' | 'formula'
   conjunction: 'and' | 'or'
   rules: ConditionRuleEdit[]
+  formulaExpression: string
 }
 
 export interface ConditionRuleEdit {
@@ -45,6 +47,11 @@ export interface ConditionRuleEdit {
   // surface (text input) writes a string. `undefined` ⇒ the emitted rule omits `value` (matching
   // `isEmpty` and the backend's omit-when-undefined discipline).
   value: unknown
+}
+
+export interface FormulaInsertOption {
+  token: string
+  label: string
 }
 
 /** Map of condition edits keyed by node key, seeded from a preserved graph and edited in place. */
@@ -83,6 +90,7 @@ export function conditionEditsFromGraph(graph: ApprovalGraph | undefined): Condi
       nodeKey: node.key,
       branches: (config.branches ?? []).map((branch) => ({
         edgeKey: branch.edgeKey,
+        predicateMode: branch.formula ? 'formula' : 'rules',
         conjunction: branch.conjunction === 'or' ? 'or' : 'and',
         rules: (branch.rules ?? []).map((rule) => ({
           fieldId: rule.fieldId,
@@ -91,6 +99,7 @@ export function conditionEditsFromGraph(graph: ApprovalGraph | undefined): Condi
           // capture that as `undefined` so the rebuilt rule omits the key too (byte-identical).
           value: 'value' in rule ? rule.value : undefined,
         })),
+        formulaExpression: branch.formula?.expression ?? '',
       })),
       defaultEdgeKey: config.defaultEdgeKey ?? '',
     }
@@ -109,6 +118,61 @@ function buildConditionRule(rule: ConditionRuleEdit): ConditionRule {
     operator: rule.operator,
     ...(rule.value !== undefined ? { value: rule.value } : {}),
   }
+}
+
+export function approvalFormulaInsertOptions(formSchema: FormSchema): FormulaInsertOption[] {
+  const options: FormulaInsertOption[] = []
+  for (const field of formSchema.fields) {
+    if (!field.id) continue
+    options.push({ token: `{${field.id}}`, label: field.label || field.id })
+    if (field.type === 'detail') {
+      for (const column of field.columns ?? []) {
+        if (!column.id) continue
+        options.push({
+          token: `{${field.id}.${column.id}}`,
+          label: `${field.label || field.id}.${column.label || column.id}`,
+        })
+      }
+    }
+  }
+  return options
+}
+
+function validateFormulaReferences(expression: string, formSchema: FormSchema, label: string): string[] {
+  const errors: string[] = []
+  const topFields = new Map(formSchema.fields.map((field) => [field.id, field]))
+  const refPattern = /\{([^{}]+)\}/g
+  let match: RegExpExecArray | null
+  while ((match = refPattern.exec(expression)) !== null) {
+    const rawRef = match[1]?.trim() ?? ''
+    if (!rawRef) {
+      errors.push(`${label} 包含空字段引用`)
+      continue
+    }
+    const parts = rawRef.split('.')
+    if (parts.length === 1) {
+      if (!topFields.has(parts[0])) errors.push(`${label} 引用的字段 ${parts[0]} 不存在`)
+      continue
+    }
+    if (parts.length === 2) {
+      const [fieldId, columnId] = parts
+      const field = topFields.get(fieldId)
+      if (!field) {
+        errors.push(`${label} 引用的明细字段 ${fieldId} 不存在`)
+        continue
+      }
+      if (field.type !== 'detail') {
+        errors.push(`${label} 引用的字段 ${fieldId} 不是明细字段`)
+        continue
+      }
+      if (!(field.columns ?? []).some((column) => column.id === columnId)) {
+        errors.push(`${label} 引用的明细子字段 ${fieldId}.${columnId} 不存在`)
+      }
+      continue
+    }
+    errors.push(`${label} 的字段引用 ${rawRef} 不是 v1 支持的字段或明细子字段`)
+  }
+  return errors
 }
 
 /**
@@ -142,6 +206,16 @@ export function applyConditionEditsToGraph(
       (originalConfig.branches ?? []).map((branch) => [branch.edgeKey, branch]),
     )
     const branches: ConditionBranch[] = edit.branches.map((branchEdit) => {
+      if (branchEdit.predicateMode === 'formula') {
+        const original = originalBranchByEdge.get(branchEdit.edgeKey)
+        const originalHadConjunction = original?.conjunction !== undefined
+        return {
+          edgeKey: branchEdit.edgeKey,
+          ...(originalHadConjunction ? { conjunction: branchEdit.conjunction } : {}),
+          rules: [],
+          formula: { expression: branchEdit.formulaExpression.trim() },
+        }
+      }
       const original = originalBranchByEdge.get(branchEdit.edgeKey)
       // Emit `conjunction` only when the original branch carried one, OR the editor set a value
       // that differs from the original's absent/value — i.e. always emit when the current value is
@@ -204,6 +278,14 @@ export function validateConditionEdits(
   for (const edit of Object.values(edits)) {
     const nodeLabel = edit.nodeKey
     edit.branches.forEach((branch, branchIndex) => {
+      if (branch.predicateMode === 'formula') {
+        const formulaLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 公式`
+        if (!branch.formulaExpression.trim()) {
+          errors.push(`${formulaLabel} 需要填写`)
+        }
+        errors.push(...validateFormulaReferences(branch.formulaExpression, formSchema, formulaLabel))
+        return
+      }
       branch.rules.forEach((rule, ruleIndex) => {
         const ruleLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 规则 ${ruleIndex + 1}`
         const fieldId = rule.fieldId.trim()

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -58,6 +58,7 @@ export type {
   ConditionRuleOperator,
 } from './conditionEdit'
 export { CONDITION_RULE_OPERATORS } from './conditionEdit'
+export { approvalFormulaInsertOptions } from './conditionEdit'
 export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
 export { PARALLEL_JOIN_MODES } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
@@ -550,8 +551,7 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
 // risk as approval): cc → {targetType, targetIds}; parallel → {branches, joinMode, joinNodeKey};
 // condition → {branches, defaultEdgeKey} with each branch {edgeKey, conjunction?, rules, formula?}
 // and each rule {fieldId, operator, value?} (the rule `value` is a free leaf, NOT shape-checked);
-// start/end → {}. Formula branches are backend-preserved after FC-1, but the current G-2 editor
-// cannot round-trip them, so they remain fail-closed here until FC-2 formula authoring ships.
+// start/end → {}. Formula branches are FC-2 authorable and round-trip through `conditionEdit.ts`.
 const BACKEND_CC_CONFIG_KEYS = ['targetType', 'targetIds']
 const BACKEND_PARALLEL_CONFIG_KEYS = ['branches', 'joinMode', 'joinNodeKey']
 const BACKEND_CONDITION_CONFIG_KEYS = ['branches', 'defaultEdgeKey']
@@ -583,7 +583,6 @@ function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
           if (!isPlainRecord(branch) || hasKeyOutside(branch, BACKEND_CONDITION_BRANCH_KEYS)) return true
           if (branch.formula !== undefined) {
             if (!isPlainRecord(branch.formula) || hasKeyOutside(branch.formula, BACKEND_CONDITION_FORMULA_KEYS)) return true
-            return true
           }
           const rules = branch.rules
           if (Array.isArray(rules)) {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -546,6 +546,18 @@
                 <div class="template-authoring__condition-branch-head">
                   <span>分支 → {{ branch.edgeKey }}</span>
                   <el-select
+                    :model-value="branch.predicateMode"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 130px"
+                    data-testid="approval-condition-predicate-mode"
+                    @update:model-value="(mode: string) => setConditionBranchPredicateMode(branch, mode)"
+                  >
+                    <el-option label="简单规则" value="rules" />
+                    <el-option label="公式" value="formula" />
+                  </el-select>
+                  <el-select
+                    v-if="branch.predicateMode === 'rules'"
                     v-model="branch.conjunction"
                     size="small"
                     :disabled="readOnly"
@@ -556,61 +568,64 @@
                     <el-option label="任一满足 (OR)" value="or" />
                   </el-select>
                 </div>
-                <div
-                  v-for="(rule, ruleIndex) in branch.rules"
-                  :key="ruleIndex"
-                  class="template-authoring__condition-rule"
-                  data-testid="approval-condition-rule"
-                >
-                  <el-select
-                    v-model="rule.fieldId"
-                    size="small"
-                    filterable
-                    placeholder="字段"
-                    :disabled="readOnly"
-                    style="width: 160px"
-                    data-testid="approval-condition-rule-field"
+                <template v-if="branch.predicateMode === 'rules'">
+                  <div
+                    v-for="(rule, ruleIndex) in branch.rules"
+                    :key="ruleIndex"
+                    class="template-authoring__condition-rule"
+                    data-testid="approval-condition-rule"
                   >
-                    <el-option
-                      v-for="field in conditionFieldOptions"
-                      :key="field.id"
-                      :label="field.label"
-                      :value="field.id"
+                    <el-select
+                      v-model="rule.fieldId"
+                      size="small"
+                      filterable
+                      placeholder="字段"
+                      :disabled="readOnly"
+                      style="width: 160px"
+                      data-testid="approval-condition-rule-field"
+                    >
+                      <el-option
+                        v-for="field in conditionFieldOptions"
+                        :key="field.id"
+                        :label="field.label"
+                        :value="field.id"
+                      />
+                    </el-select>
+                    <el-select
+                      v-model="rule.operator"
+                      size="small"
+                      :disabled="readOnly"
+                      style="width: 120px"
+                      data-testid="approval-condition-rule-operator"
+                    >
+                      <el-option
+                        v-for="operator in CONDITION_RULE_OPERATORS"
+                        :key="operator"
+                        :label="conditionOperatorLabel(operator)"
+                        :value="operator"
+                      />
+                    </el-select>
+                    <el-input
+                      v-if="rule.operator !== 'isEmpty'"
+                      :model-value="conditionRuleValueText(rule)"
+                      size="small"
+                      placeholder="比较值"
+                      :disabled="readOnly"
+                      style="width: 160px"
+                      data-testid="approval-condition-rule-value"
+                      @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
                     />
-                  </el-select>
-                  <el-select
-                    v-model="rule.operator"
-                    size="small"
-                    :disabled="readOnly"
-                    style="width: 120px"
-                    data-testid="approval-condition-rule-operator"
-                  >
-                    <el-option
-                      v-for="operator in CONDITION_RULE_OPERATORS"
-                      :key="operator"
-                      :label="conditionOperatorLabel(operator)"
-                      :value="operator"
-                    />
-                  </el-select>
-                  <el-input
-                    v-if="rule.operator !== 'isEmpty'"
-                    :model-value="conditionRuleValueText(rule)"
-                    size="small"
-                    placeholder="比较值"
-                    :disabled="readOnly"
-                    style="width: 160px"
-                    data-testid="approval-condition-rule-value"
-                    @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
-                  />
-                  <el-button
-                    size="small"
-                    type="danger"
-                    :disabled="readOnly || branch.rules.length === 1"
-                    data-testid="approval-condition-rule-remove"
-                    @click="removeConditionRule(branch, ruleIndex)"
-                  >删除</el-button>
-                </div>
+                    <el-button
+                      size="small"
+                      type="danger"
+                      :disabled="readOnly || branch.rules.length === 1"
+                      data-testid="approval-condition-rule-remove"
+                      @click="removeConditionRule(branch, ruleIndex)"
+                    >删除</el-button>
+                  </div>
+                </template>
                 <el-button
+                  v-if="branch.predicateMode === 'rules'"
                   size="small"
                   :disabled="readOnly"
                   data-testid="approval-condition-rule-add"
@@ -619,6 +634,55 @@
                   <el-icon><Plus /></el-icon>
                   添加规则
                 </el-button>
+                <div
+                  v-else
+                  class="template-authoring__condition-formula"
+                  data-testid="approval-condition-formula"
+                >
+                  <el-input
+                    v-model="branch.formulaExpression"
+                    type="textarea"
+                    :rows="3"
+                    :disabled="readOnly"
+                    placeholder='例如 SUM({purchase_items.amount}) >= 20000'
+                    data-testid="approval-condition-formula-expression"
+                  />
+                  <div class="template-authoring__condition-formula-tools">
+                    <el-button
+                      v-for="option in conditionFormulaInsertOptions"
+                      :key="option.token"
+                      size="small"
+                      :disabled="readOnly"
+                      :title="option.label"
+                      :data-testid="`approval-condition-formula-insert-${option.token}`"
+                      @click="insertConditionFormulaToken(branch, option.token)"
+                    >{{ option.token }}</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-sum"
+                      @click="insertConditionFormulaFunction(branch, 'SUM')"
+                    >SUM()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-count"
+                      @click="insertConditionFormulaFunction(branch, 'COUNT')"
+                    >COUNT()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-min"
+                      @click="insertConditionFormulaFunction(branch, 'MIN')"
+                    >MIN()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-max"
+                      @click="insertConditionFormulaFunction(branch, 'MAX')"
+                    >MAX()</el-button>
+                  </div>
+                </div>
               </div>
               <el-form-item label="默认分支（无匹配时）" class="template-authoring__condition-default">
                 <el-select
@@ -988,6 +1052,7 @@ import {
   parseIdsText,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  approvalFormulaInsertOptions,
   CONDITION_RULE_OPERATORS,
   PARALLEL_JOIN_MODES,
   CC_TARGET_TYPES,
@@ -1139,6 +1204,9 @@ const conditionFieldOptions = computed(() =>
     .filter((field) => field.id.trim())
     .map((field) => ({ id: field.id.trim(), label: field.label.trim() || field.id.trim() })),
 )
+const conditionFormulaInsertOptions = computed(() =>
+  approvalFormulaInsertOptions(buildFormSchema(draft.value)),
+)
 
 const CONDITION_OPERATOR_LABELS: Record<ConditionRuleOperator, string> = {
   eq: '等于',
@@ -1170,6 +1238,22 @@ function addConditionRule(branch: ConditionBranchEdit): void {
 function removeConditionRule(branch: ConditionBranchEdit, ruleIndex: number): void {
   if (branch.rules.length === 1) return
   branch.rules.splice(ruleIndex, 1)
+}
+function setConditionBranchPredicateMode(branch: ConditionBranchEdit, mode: string): void {
+  branch.predicateMode = mode === 'formula' ? 'formula' : 'rules'
+  if (branch.predicateMode === 'rules' && branch.rules.length === 0) {
+    branch.rules.push({ fieldId: '', operator: 'eq', value: undefined })
+  }
+}
+function appendFormulaText(branch: ConditionBranchEdit, text: string): void {
+  const prefix = branch.formulaExpression.trim() ? ' ' : ''
+  branch.formulaExpression = `${branch.formulaExpression}${prefix}${text}`
+}
+function insertConditionFormulaToken(branch: ConditionBranchEdit, token: string): void {
+  appendFormulaText(branch, token)
+}
+function insertConditionFormulaFunction(branch: ConditionBranchEdit, fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'): void {
+  appendFormulaText(branch, `${fn}()`)
 }
 
 // Outgoing edge keys of a condition node (from the preserved graph) — the legal default fall-through
@@ -1809,6 +1893,17 @@ onMounted(() => {
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
+}
+
+.template-authoring__condition-formula {
+  display: grid;
+  gap: 8px;
+}
+
+.template-authoring__condition-formula-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .template-authoring__condition-default {

--- a/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
+++ b/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
@@ -7,8 +7,8 @@ import { unsupportedTemplateAuthoringReason } from '../src/approvals/templateAut
 // rebuilds each from a fixed per-type shape (ApprovalProductService.ts) and DROPS any other key —
 // top-level OR nested (condition branches[].rules[]). `complexNodeConfigHasBackendDrop` now fails
 // closed for EVERY node type, so an unknown key can't silently flatten on save while the FE
-// deep-equal round-trip looks clean. FC-1 formula branches are backend-preserved but still
-// fail-closed here until FC-2 authoring can round-trip them. Pure helper test (no .vue) → runs
+// deep-equal round-trip looks clean. FC-2 formula branches are authorable and therefore allowed
+// when they match the backend-preserved shape. Pure helper test (no .vue) → runs
 // under approval-web-guard.
 
 function tpl(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
@@ -66,8 +66,11 @@ describe('complex node config fail-closed — condition (recurses config → bra
   it('flags an unknown rule key', () => {
     expect(cond({ edgeKey: 'e', rules: [{ fieldId: 'amount', operator: 'gt', value: 1, futureFlag: true }] })).not.toBeNull()
   })
-  it('flags a backend-supported formula branch until FC-2 can round-trip it', () => {
-    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).not.toBeNull()
+  it('allows a known formula branch shape now that FC-2 can round-trip it', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).toBeNull()
+  })
+  it('flags an unknown formula key', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000', futureFlag: true } })).not.toBeNull()
   })
   it('allows a known condition (conjunction + a FREE-FORM rule value — value is a leaf, not shape-checked)', () => {
     expect(cond({ edgeKey: 'e', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'in', value: { complex: ['object', 'leaf'] } }] })).toBeNull()

--- a/apps/web/tests/approval-template-authoring-condition-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-condition-edit.test.ts
@@ -86,6 +86,47 @@ const CONDITION_GRAPH: ApprovalGraph = {
   ],
 }
 
+const CONDITION_FORMULA_GRAPH: ApprovalGraph = {
+  ...CONDITION_GRAPH,
+  nodes: CONDITION_GRAPH.nodes.map((node) => {
+    if (node.key !== 'cond_1' || node.type !== 'condition') return node
+    return {
+      ...node,
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            rules: [],
+            formula: { expression: 'SUM({items.amount}) >= 5000' },
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+  }),
+}
+
+const CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH: ApprovalGraph = {
+  ...CONDITION_FORMULA_GRAPH,
+  nodes: CONDITION_FORMULA_GRAPH.nodes.map((node) => {
+    if (node.key !== 'cond_1' || node.type !== 'condition') return node
+    return {
+      ...node,
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            conjunction: 'or',
+            rules: [],
+            formula: { expression: 'SUM({items.amount}) >= 5000' },
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+  }),
+}
+
 // A condition node with NO conjunction on its branch (backend omits it) — proves seeding+rebuild do
 // not resurrect a spurious `conjunction: 'and'`.
 const CONDITION_GRAPH_NO_CONJUNCTION: ApprovalGraph = {
@@ -196,8 +237,19 @@ describe('G-2 conditionEditsFromGraph — seed from preserved condition nodes', 
     const edits = conditionEditsFromGraph(CONDITION_GRAPH)
     expect(Object.keys(edits)).toEqual(['cond_1'])
     expect(edits.cond_1.branches.map((branch) => branch.edgeKey)).toEqual(['edge-cond_1-high'])
+    expect(edits.cond_1.branches[0].predicateMode).toBe('rules')
     expect(edits.cond_1.branches[0].rules).toEqual([{ fieldId: 'amount', operator: 'gte', value: 1000 }])
     expect(edits.cond_1.defaultEdgeKey).toBe('edge-cond_1-low')
+  })
+
+  it('captures formula branches without flattening them back to rules', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_GRAPH)
+    expect(edits.cond_1.branches[0]).toMatchObject({
+      edgeKey: 'edge-cond_1-high',
+      predicateMode: 'formula',
+      formulaExpression: 'SUM({items.amount}) >= 5000',
+      rules: [],
+    })
   })
 
   it('is empty for a parallel / cc graph (no condition node)', () => {
@@ -268,6 +320,23 @@ describe('G-2 topology-preservation — editing a condition rule keeps everythin
       { fieldId: 'kind', operator: 'eq', value: 'a' },
     ])
   })
+
+  it('editing a formula branch emits formula + empty rules and preserves topology byte-identical', () => {
+    const template = buildTemplate(CONDITION_FORMULA_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    draft.conditionEdits!.cond_1.branches[0].formulaExpression = 'SUM({items.amount}) >= 20000'
+    const rebuilt = buildApprovalGraph(draft)
+
+    expectTopologyByteIdentical(rebuilt, original)
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')!
+    expect(cond.config).toEqual({
+      branches: [
+        { edgeKey: 'edge-cond_1-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } },
+      ],
+      defaultEdgeKey: 'edge-cond_1-low',
+    })
+  })
 })
 
 describe('G-2 untouched round-trip — no spurious diffs from seeding (G-1 floor holds)', () => {
@@ -294,6 +363,16 @@ describe('G-2 untouched round-trip — no spurious diffs from seeding (G-1 floor
   it('applyConditionEditsToGraph with the seeded edits is identity for the condition graph', () => {
     const edits = conditionEditsFromGraph(CONDITION_GRAPH)
     expect(applyConditionEditsToGraph(CONDITION_GRAPH, edits)).toEqual(CONDITION_GRAPH)
+  })
+
+  it('applyConditionEditsToGraph with seeded formula edits is identity for a formula condition graph', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_GRAPH)
+    expect(applyConditionEditsToGraph(CONDITION_FORMULA_GRAPH, edits)).toEqual(CONDITION_FORMULA_GRAPH)
+  })
+
+  it('a formula branch with a backend-preserved conjunction stays byte-identical', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH)
+    expect(applyConditionEditsToGraph(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH, edits)).toEqual(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH)
   })
 })
 
@@ -342,7 +421,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'ghost', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: 'ghost', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: 'edge-cond_1-low',
       },
     }
@@ -357,7 +436,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: 'edge-start-cond_1',
       },
     }
@@ -377,7 +456,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: '', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: '', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: '',
       },
     }

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -86,7 +86,7 @@ const ElButton = defineComponent({
 
 const ElInput = defineComponent({
   name: 'ElInput',
-  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String },
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String, size: String },
   emits: ['update:modelValue'],
   render() {
     return h('input', {
@@ -896,6 +896,52 @@ describe('TemplateAuthoringView', () => {
     await flushUi()
     const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
     expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches).toHaveLength(2) // the added branch is saved
+  })
+
+  it('FC-2 wiring: switching a condition branch to formula writes formula to the save payload while topology stays byte-identical', async () => {
+    routeParams = { id: 'tpl_formula_condition' }
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] }], defaultEdgeKey: 'e-low' } },
+        { key: 'approval_high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-c', source: 'start', target: 'cond_1' },
+        { key: 'e-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'e-low', source: 'cond_1', target: 'end' },
+        { key: 'e-high-end', source: 'approval_high', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    const modeSelect = container!.querySelector('[data-testid="approval-condition-predicate-mode"]') as HTMLSelectElement
+    expect(modeSelect.value).toBe('rules')
+    modeSelect.value = 'formula'
+    modeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-condition-formula-insert-sum"]')).not.toBeNull()
+    const expression = container!.querySelector('[data-testid="approval-condition-formula-expression"]') as HTMLInputElement
+    expression.value = '{amount} >= 5000'
+    expression.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const conditionNode = payload.approvalGraph.nodes.find((node: any) => node.key === 'cond_1')
+    expect(conditionNode.config).toEqual({
+      branches: [{ edgeKey: 'e-high', rules: [], formula: { expression: '{amount} >= 5000' } }],
+      defaultEdgeKey: 'e-low',
+    })
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_high')).toEqual(graph.nodes[2])
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 
   function buildCanvasConditionGraph() {

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,6 +1,7 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2/FC-3 NOT BUILT. Owner
+Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
+NOT BUILT. Owner
 decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
 backend evaluator ships before dry-run.
 


### PR DESCRIPTION
## Summary

FC-2 for approval formula conditions, stacked on #3219 / FC-1.

- Adds formula authoring to the preserved complex-graph condition editor: each branch can switch between simple rules and a formula predicate.
- Emits formula branches as `{ rules: [], formula: { expression } }`, preserving graph topology and every non-condition node/edge byte-identical.
- Opens the frontend fail-closed allowlist for backend-supported formula branch shapes now that the UI can round-trip them.
- Adds field/detail-token and aggregate-function insert controls, plus lightweight client-side field-reference validation as preview only. Backend FC-1 remains the source of truth.
- Updates the formula-condition design lock status to show FC-2 is built in this stacked PR; FC-3 remains unbuilt.

## Validation

- `pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot` → 257/257
- `pnpm exec eslint apps/web/src/approvals/conditionEdit.ts apps/web/src/approvals/templateAuthoring.ts apps/web/src/views/approval/TemplateAuthoringView.vue apps/web/tests/approvalTemplateAuthoring.spec.ts apps/web/tests/approval-template-authoring-condition-edit.test.ts apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts --max-warnings=0`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot` → 97/97
- `git diff --check`

## Scope notes

- Draft stacked PR: base is `codex/approval-formula-condition-fc1-20260625`, not `main`.
- No backend runtime changes beyond the FC-1 base.
- No FC-3 preset upgrade in this PR.
