### PR TITLE
[codex] approval formula condition preset examples (FC-3)

### DIFF
--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -220,17 +220,16 @@ function withAmountConsistency(
   return { ...schema, amountConsistencyCheck: { totalFieldId, detailFieldId, amountColumnId } }
 }
 
-// Amount-tier reimbursement (design-lock #3114): a condition node gates a higher-tier approver on the
-// top-level `amount`. Low amount → end after the direct manager; amount ≥ threshold → a dept-head
-// (higher-tier) approval before end. Default threshold 5000, editable in the condition-node rule
-// (Gate-A). The branch reads the top-level `amount` total (detail-row auto-sum is a separate
-// form-field capability, not this slice — design-lock Decision 1).
+// Amount-tier reimbursement (design-lock #3114 + FC-3): a condition node gates a higher-tier
+// approver with a formula example. Non-travel, or travel below the threshold, ends after the direct
+// manager; travel amount >= threshold adds a dept-head approval before end. The formula reads the
+// top-level `amount` total (protected by amountConsistencyCheck) plus the declared expense type.
 function reimbursementAmountTierGraph(): ApprovalGraph {
   return {
     nodes: [
       { key: 'start', type: 'start', name: '发起', config: {} },
       { key: 'approval_1', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }], defaultEdgeKey: 'edge-gate-end' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-high', rules: [], formula: { expression: '{expense_type} == "差旅" AND {amount} >= 5000' } }], defaultEdgeKey: 'edge-gate-end' } },
       { key: 'approval_high', type: 'approval', name: '部门主管审批（高额）', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'end', type: 'end', name: '结束', config: {} },
     ],
@@ -244,9 +243,10 @@ function reimbursementAmountTierGraph(): ApprovalGraph {
   }
 }
 
-// Amount-tier purchase (design-lock #3114): the condition node routes on the top-level `amount` —
-// below threshold → a single direct-manager approval; at/above threshold → a PARALLEL fork (joinMode
-// 'all' = 会签 by default; 'any' = 或签 editable) joining at `end`. Default threshold 20000.
+// Amount-tier purchase (design-lock #3114 + FC-3): the condition node routes with a detail aggregate
+// formula. Below threshold → a single direct-manager approval; at/above SUM(purchase_items.amount)
+// threshold → a PARALLEL fork (joinMode 'all' = 会签 by default; 'any' = 或签 editable) joining at
+// `end`. The same amountConsistencyCheck still protects top-level amount = detail sum.
 // The two parallel branches MUST resolve to DISTINCT assignment TYPES: a user-resolving manager
 // (manager_at_level → `user:X`) + a static_role (the design's "Configured Role / Person" → `role:Y`).
 // The runtime parallel-conflict key is `${assignmentType}:${assigneeId}` (ApprovalProductService.ts
@@ -262,7 +262,7 @@ function purchaseAmountTierGraph(): ApprovalGraph {
     nodes: [
       { key: 'start', type: 'start', name: '发起', config: {} },
       { key: 'budget_owner_approval', type: 'approval', name: '预算负责人审批', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'budget_owner' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-fork', rules: [{ fieldId: 'amount', operator: 'gte', value: 20000 }] }], defaultEdgeKey: 'edge-gate-manager' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-fork', rules: [], formula: { expression: 'SUM({purchase_items.amount}) >= 20000' } }], defaultEdgeKey: 'edge-gate-manager' } },
       { key: 'manager_approval', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'parallel_fork', type: 'parallel', name: '高额并行审批（会签）', config: { branches: ['edge-fork-mgr', 'edge-fork-role'], joinMode: 'all', joinNodeKey: 'end' } },
       { key: 'higher_manager_approval', type: 'approval', name: '上级经理审批（高额）', config: { assigneeSources: [{ kind: 'manager_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -84,10 +84,26 @@ describe('common approval template presets', () => {
     },
   )
 
-  it('reimbursement_amount_tier gates a higher-tier approver on amount >= 5000', () => {
+  it('reimbursement_amount_tier gates a higher-tier approver with a formula condition', () => {
     const payload = buildCommonApprovalTemplatePresetPayload('reimbursement_amount_tier', { keySuffix: 'unit' })
     const gate = payload.approvalGraph.nodes.find((node) => node.type === 'condition')
-    expect(gate?.config).toMatchObject({ branches: [{ rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }] })
+    expect(gate?.config).toMatchObject({
+      branches: [{
+        rules: [],
+        formula: { expression: '{expense_type} == "差旅" AND {amount} >= 5000' },
+      }],
+    })
+  })
+
+  it('purchase_amount_tier gates the high path with a detail aggregate formula condition', () => {
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: 'unit' })
+    const gate = payload.approvalGraph.nodes.find((node) => node.type === 'condition')
+    expect(gate?.config).toMatchObject({
+      branches: [{
+        rules: [],
+        formula: { expression: 'SUM({purchase_items.amount}) >= 20000' },
+      }],
+    })
   })
 
   it('purchase_amount_tier forks a parallel会签 (join at end) with one user-resolving + one static_role branch — distinct-typed, no dynamic conflict', () => {

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,7 +1,7 @@
 # Approval Formula Conditions — Design Lock
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
-NOT BUILT. Owner
+BUILT IN A STACKED PR (purchase/reimbursement examples). Owner
 decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
 backend evaluator ships before dry-run.
 
@@ -288,9 +288,9 @@ example:
 - reimbursement high path: `{expense_type} == "差旅" AND {amount} >= 5000`;
 - leave high path: `{leave_days} + {used_leave_days} > 5`.
 
-This is optional. Existing amount-tier presets can remain on simple
-`amount >= threshold` rules because the shipped total auto-sum and backend
-total-check already make `amount` reliable.
+FC-3 applies the purchase and reimbursement examples to the shipped amount-tier
+presets. The leave example remains illustrative until a leave-specific
+multi-branch preset is introduced.
 
 ## Non-Goals
 

--- a/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
@@ -135,6 +135,40 @@ describeIfDatabase('common approval template presets — real-DB backend accepta
     expect(parallel!.config.joinMode).toBe('all')
   })
 
+  it('amount-tier formula conditions round-trip through create→normalize', async () => {
+    const cases = [
+      {
+        id: 'reimbursement_amount_tier' as const,
+        expression: '{expense_type} == "差旅" AND {amount} >= 5000',
+      },
+      {
+        id: 'purchase_amount_tier' as const,
+        expression: 'SUM({purchase_items.amount}) >= 20000',
+      },
+    ]
+
+    for (const item of cases) {
+      const payload = buildCommonApprovalTemplatePresetPayload(item.id, {
+        keySuffix: `realdb-${TS}-formula-${item.id}`,
+      })
+      const response = await jsonRequest(baseUrl, '/api/approval-templates', token, {
+        method: 'POST',
+        body: payload,
+      })
+      expect(response.status, await response.clone().text()).toBe(201)
+      const body = await response.json() as {
+        approvalGraph: { nodes: Array<{ type: string; config: Record<string, unknown> }> }
+      }
+      const condition = body.approvalGraph.nodes.find((node) => node.type === 'condition')
+      expect(condition?.config).toMatchObject({
+        branches: [{
+          rules: [],
+          formula: { expression: item.expression },
+        }],
+      })
+    }
+  })
+
   it('purchase_amount_tier: an UNTOUCHED preset CANNOT be published — the placeholder role fail-fasts at publish (a verifiable state, not a runtime stuck-flow)', async () => {
     expect(FE_ROLE_SENTINEL).toBe(BACKEND_ROLE_SENTINEL) // FE preset placeholder MUST byte-match the backend guard, else the guard misses it
     const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: `realdb-${TS}-sentinel` })


### PR DESCRIPTION
## Summary
- upgrade the reimbursement amount-tier preset to use a formula condition: `{expense_type} == "差旅" AND {amount} >= 5000`
- upgrade the purchase amount-tier preset to use a detail aggregate formula condition: `SUM({purchase_items.amount}) >= 20000`
- keep topology, approval nodes, total-check, line derivation, and W7 behavior unchanged
- update the formula-condition design lock status for the FC-3 purchase/reimbursement examples

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @metasheet/web exec vitest run tests/approval-common-template-presets.test.ts tests/approval-template-authoring-condition-edit.test.ts tests/approval-template-authoring-complex-node-config-allowlist.test.ts tests/approvalTemplateAuthoring.spec.ts --reporter=dot` → 93/93
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot` → 97/97
- `DATABASE_URL=postgresql://metasheet:metasheet@127.0.0.1:5435/metasheet pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-common-template-presets.api.test.ts --reporter=dot` → 9/9 real DB
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm exec eslint apps/web/src/approvals/commonTemplatePresets.ts apps/web/tests/approval-common-template-presets.test.ts --max-warnings=0`
- `pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot` → 258/258
- `git diff --check`

## Notes
- This PR is stacked on #3220 / FC-2 and intentionally stays draft until the stack is reviewed.
- The real-DB run used the local `metasheet-dev-postgres` container on 127.0.0.1:5435; the test self-cleans `*-realdb-*` template rows.
