### PR TITLE
[codex] approval formula condition dry-run endpoint (FC-4)

### DIFF
--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,9 +1,10 @@
 # Approval Formula Conditions — Design Lock
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
-BUILT IN A STACKED PR (purchase/reimbursement examples). Owner
-decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
-backend evaluator ships before dry-run.
+BUILT IN A STACKED PR (purchase/reimbursement examples); FC-4 BUILT IN A
+STACKED PR (approval-specific backend dry-run endpoint). Owner decisions
+resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed; backend
+evaluator ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the
@@ -291,6 +292,18 @@ example:
 FC-3 applies the purchase and reimbursement examples to the shipped amount-tier
 presets. The leave example remains illustrative until a leave-specific
 multi-branch preset is introduced.
+
+### FC-4 — Approval-Specific Backend Dry-Run
+
+- Add `POST /api/approval-templates/formula-condition/dry-run`.
+- Gate it with `approval-templates:manage`, matching template authoring.
+- Accept `formSchema`, `expression`, and sample `formData`.
+- Use the same approval evaluator used by publish/execution.
+- Return a normal dry-run diagnostic payload for formula errors instead of
+  routing through the sheet-scoped multitable formula dry-run.
+
+This slice intentionally does not add the frontend "Evaluate" button yet. The
+endpoint is the backend truth surface that a later authoring UX can call.
 
 ## Non-Goals
 

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -21,6 +21,11 @@ import {
   type ApprovalTemplateVisibilityActor,
 } from '../services/ApprovalProductService'
 import {
+  ApprovalConditionFormulaError,
+  assertApprovalConditionFormulaValidForSchema,
+  evaluateApprovalConditionFormula,
+} from '../services/ApprovalConditionFormula'
+import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
 } from '../services/approval-bridge-types'
@@ -28,6 +33,7 @@ import { publishApprovalCountsUpdate } from '../services/approval-realtime'
 import { searchDirectoryUsers, listDirectoryRoles } from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../services/ApprovalDelegationConfig'
+import type { FormSchema } from '../types/approval-product'
 
 const logger = new Logger('ApprovalsRouter')
 const MAX_APPROVAL_PAGE_SIZE = 200
@@ -178,6 +184,14 @@ function approvalErrorResponse(code: string, message: string) {
       message,
     },
   }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isFormSchemaLike(value: unknown): value is FormSchema {
+  return isPlainRecord(value) && Array.isArray(value.fields)
 }
 
 function sendServiceError(res: Response, error: ServiceError): void {
@@ -354,6 +368,60 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       res.json({ roles })
     } catch (error) {
       handleApprovalsError(res, error, 'APPROVAL_DIRECTORY_ROLES_FAILED', 'Failed to list directory roles')
+    }
+  })
+
+  // FC-4 — approval-specific formula-condition dry-run. This intentionally uses the
+  // exact approval evaluator from publish/execution and stays separate from the
+  // sheet-scoped multitable formula dry-run API.
+  r.post('/api/approval-templates/formula-condition/dry-run', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const body = isPlainRecord(req.body) ? req.body : {}
+      const expression = typeof body.expression === 'string' ? body.expression : ''
+      const formSchema = body.formSchema
+      const formData = body.formData
+
+      if (!expression.trim()) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'expression is required'),
+        )
+      }
+      if (!isFormSchemaLike(formSchema)) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'formSchema.fields is required'),
+        )
+      }
+      if (!isPlainRecord(formData)) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'formData object is required'),
+        )
+      }
+
+      try {
+        assertApprovalConditionFormulaValidForSchema(expression, formSchema)
+        const result = evaluateApprovalConditionFormula(expression, formData)
+        return res.json({ data: { success: true, result } })
+      } catch (error) {
+        if (error instanceof ApprovalConditionFormulaError) {
+          return res.json({
+            data: {
+              success: false,
+              error: {
+                code: 'APPROVAL_FORMULA_CONDITION_DRY_RUN_FAILED',
+                message: error.message,
+              },
+            },
+          })
+        }
+        throw error
+      }
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_FORMULA_DRY_RUN_FAILED',
+        'Failed to dry-run approval condition formula',
+      )
     }
   })
 

--- a/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
+++ b/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
@@ -94,6 +94,21 @@ function noPermsUser() {
   return { id: 'u-none', name: 'NoPerm', permissions: [] }
 }
 
+const formulaDryRunBody = {
+  expression: 'SUM({items.amount}) >= 100',
+  formSchema: {
+    fields: [{
+      id: 'items',
+      type: 'detail',
+      label: 'Items',
+      columns: [{ id: 'amount', type: 'number', label: 'Amount' }],
+    }],
+  },
+  formData: {
+    items: [{ amount: 60 }, { amount: 50 }],
+  },
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -134,6 +149,13 @@ describe('Approval RBAC boundary verification', () => {
       const res = await request(app)
         .post('/api/approval-templates')
         .send({ name: 'test', key: 'test-key' })
+      expect(res.status).toBe(401)
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run without auth → 401', async () => {
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
       expect(res.status).toBe(401)
     })
 
@@ -198,10 +220,42 @@ describe('Approval RBAC boundary verification', () => {
       expect(res.status).toBe(403)
     })
 
+    it('POST /api/approval-templates/formula-condition/dry-run with only approvals:read → 403', async () => {
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
+      expect(res.status).toBe(403)
+    })
+
     it('GET /api/approval-templates with approval-templates:manage → 200', async () => {
       authState.user = templateManager()
       const res = await request(app).get('/api/approval-templates')
       expect(res.status).toBe(200)
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run with approval-templates:manage → 200 success', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ data: { success: true, result: true } })
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run returns diagnostics for runtime formula errors', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send({
+          ...formulaDryRunBody,
+          formData: { items: [{ amount: 'bad' }] },
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.success).toBe(false)
+      expect(res.body.data.error.code).toBe('APPROVAL_FORMULA_CONDITION_DRY_RUN_FAILED')
+      expect(res.body.data.error.message).toContain('must be a finite number')
     })
   })
 


### PR DESCRIPTION
## Summary

FC-4 for the approval formula-condition stack.

Adds an approval-specific backend dry-run endpoint:

- `POST /api/approval-templates/formula-condition/dry-run`
- gated by `approval-templates:manage`, matching template authoring
- accepts `{ formSchema, expression, formData }`
- uses the same approval formula evaluator used by publish/execution
- returns a dry-run diagnostic payload for formula errors instead of routing through the sheet-scoped multitable formula dry-run

This intentionally does **not** add the frontend "Evaluate" button yet; it is the backend truth surface that a later authoring UX can call.

## Verification

Focused local verification used a temporary ignored `node_modules` symlink in this worktree, then removed it before commit.

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-rbac-boundary.test.ts tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts --reporter=dot` → 64/64
- `pnpm --filter @metasheet/core-backend type-check` → clean
- `git diff --check` → clean

## Stack

Base: `codex/approval-formula-condition-fc3-20260625` (#3221)
