### PR TITLE
[codex] approval formula condition dry-run preview (FC-5)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -21,6 +21,7 @@ import type {
   CreateApprovalTemplateRequest,
   UpdateApprovalTemplateRequest,
   PublishApprovalTemplateRequest,
+  FormSchema,
 } from '../types/approval'
 
 // ---------------------------------------------------------------------------
@@ -505,6 +506,34 @@ export async function publishTemplate(
     }
   }
   return apiPost(`/api/approval-templates/${encodeURIComponent(templateId)}/publish`, payload)
+}
+
+export interface ApprovalFormulaConditionDryRunRequest {
+  formSchema: FormSchema
+  expression: string
+  formData: Record<string, unknown>
+}
+
+export interface ApprovalFormulaConditionDryRunResult {
+  success: boolean
+  result?: boolean
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+export async function dryRunApprovalConditionFormula(
+  payload: ApprovalFormulaConditionDryRunRequest,
+): Promise<ApprovalFormulaConditionDryRunResult> {
+  if (USE_MOCK) {
+    return { success: false, error: { code: 'APPROVAL_FORMULA_DRY_RUN_MOCK', message: 'Mock mode does not evaluate formulas' } }
+  }
+  const response = await apiPost<{ data: ApprovalFormulaConditionDryRunResult }>(
+    '/api/approval-templates/formula-condition/dry-run',
+    payload,
+  )
+  return response.data
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/approvals/commonTemplatePresets.ts
+++ b/apps/web/src/approvals/commonTemplatePresets.ts
@@ -220,17 +220,16 @@ function withAmountConsistency(
   return { ...schema, amountConsistencyCheck: { totalFieldId, detailFieldId, amountColumnId } }
 }
 
-// Amount-tier reimbursement (design-lock #3114): a condition node gates a higher-tier approver on the
-// top-level `amount`. Low amount → end after the direct manager; amount ≥ threshold → a dept-head
-// (higher-tier) approval before end. Default threshold 5000, editable in the condition-node rule
-// (Gate-A). The branch reads the top-level `amount` total (detail-row auto-sum is a separate
-// form-field capability, not this slice — design-lock Decision 1).
+// Amount-tier reimbursement (design-lock #3114 + FC-3): a condition node gates a higher-tier
+// approver with a formula example. Non-travel, or travel below the threshold, ends after the direct
+// manager; travel amount >= threshold adds a dept-head approval before end. The formula reads the
+// top-level `amount` total (protected by amountConsistencyCheck) plus the declared expense type.
 function reimbursementAmountTierGraph(): ApprovalGraph {
   return {
     nodes: [
       { key: 'start', type: 'start', name: '发起', config: {} },
       { key: 'approval_1', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }], defaultEdgeKey: 'edge-gate-end' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-high', rules: [], formula: { expression: '{expense_type} == "差旅" AND {amount} >= 5000' } }], defaultEdgeKey: 'edge-gate-end' } },
       { key: 'approval_high', type: 'approval', name: '部门主管审批（高额）', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'end', type: 'end', name: '结束', config: {} },
     ],
@@ -244,9 +243,10 @@ function reimbursementAmountTierGraph(): ApprovalGraph {
   }
 }
 
-// Amount-tier purchase (design-lock #3114): the condition node routes on the top-level `amount` —
-// below threshold → a single direct-manager approval; at/above threshold → a PARALLEL fork (joinMode
-// 'all' = 会签 by default; 'any' = 或签 editable) joining at `end`. Default threshold 20000.
+// Amount-tier purchase (design-lock #3114 + FC-3): the condition node routes with a detail aggregate
+// formula. Below threshold → a single direct-manager approval; at/above SUM(purchase_items.amount)
+// threshold → a PARALLEL fork (joinMode 'all' = 会签 by default; 'any' = 或签 editable) joining at
+// `end`. The same amountConsistencyCheck still protects top-level amount = detail sum.
 // The two parallel branches MUST resolve to DISTINCT assignment TYPES: a user-resolving manager
 // (manager_at_level → `user:X`) + a static_role (the design's "Configured Role / Person" → `role:Y`).
 // The runtime parallel-conflict key is `${assignmentType}:${assigneeId}` (ApprovalProductService.ts
@@ -262,7 +262,7 @@ function purchaseAmountTierGraph(): ApprovalGraph {
     nodes: [
       { key: 'start', type: 'start', name: '发起', config: {} },
       { key: 'budget_owner_approval', type: 'approval', name: '预算负责人审批', config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'budget_owner' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
-      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-fork', rules: [{ fieldId: 'amount', operator: 'gte', value: 20000 }] }], defaultEdgeKey: 'edge-gate-manager' } },
+      { key: 'amount_gate', type: 'condition', name: '金额分级判断', config: { branches: [{ edgeKey: 'edge-gate-fork', rules: [], formula: { expression: 'SUM({purchase_items.amount}) >= 20000' } }], defaultEdgeKey: 'edge-gate-manager' } },
       { key: 'manager_approval', type: 'approval', name: '直属上级审批', config: { assigneeSources: [{ kind: 'direct_manager' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
       { key: 'parallel_fork', type: 'parallel', name: '高额并行审批（会签）', config: { branches: ['edge-fork-mgr', 'edge-fork-role'], joinMode: 'all', joinNodeKey: 'end' } },
       { key: 'higher_manager_approval', type: 'approval', name: '上级经理审批（高额）', config: { assigneeSources: [{ kind: 'manager_at_level', level: 2 }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },

--- a/apps/web/src/approvals/conditionEdit.ts
+++ b/apps/web/src/approvals/conditionEdit.ts
@@ -34,8 +34,10 @@ export interface ConditionNodeEdit {
 export interface ConditionBranchEdit {
   // Topology — preserved verbatim; the editor never mutates these.
   edgeKey: string
+  predicateMode: 'rules' | 'formula'
   conjunction: 'and' | 'or'
   rules: ConditionRuleEdit[]
+  formulaExpression: string
 }
 
 export interface ConditionRuleEdit {
@@ -45,6 +47,11 @@ export interface ConditionRuleEdit {
   // surface (text input) writes a string. `undefined` ⇒ the emitted rule omits `value` (matching
   // `isEmpty` and the backend's omit-when-undefined discipline).
   value: unknown
+}
+
+export interface FormulaInsertOption {
+  token: string
+  label: string
 }
 
 /** Map of condition edits keyed by node key, seeded from a preserved graph and edited in place. */
@@ -83,6 +90,7 @@ export function conditionEditsFromGraph(graph: ApprovalGraph | undefined): Condi
       nodeKey: node.key,
       branches: (config.branches ?? []).map((branch) => ({
         edgeKey: branch.edgeKey,
+        predicateMode: branch.formula ? 'formula' : 'rules',
         conjunction: branch.conjunction === 'or' ? 'or' : 'and',
         rules: (branch.rules ?? []).map((rule) => ({
           fieldId: rule.fieldId,
@@ -91,6 +99,7 @@ export function conditionEditsFromGraph(graph: ApprovalGraph | undefined): Condi
           // capture that as `undefined` so the rebuilt rule omits the key too (byte-identical).
           value: 'value' in rule ? rule.value : undefined,
         })),
+        formulaExpression: branch.formula?.expression ?? '',
       })),
       defaultEdgeKey: config.defaultEdgeKey ?? '',
     }
@@ -109,6 +118,61 @@ function buildConditionRule(rule: ConditionRuleEdit): ConditionRule {
     operator: rule.operator,
     ...(rule.value !== undefined ? { value: rule.value } : {}),
   }
+}
+
+export function approvalFormulaInsertOptions(formSchema: FormSchema): FormulaInsertOption[] {
+  const options: FormulaInsertOption[] = []
+  for (const field of formSchema.fields) {
+    if (!field.id) continue
+    options.push({ token: `{${field.id}}`, label: field.label || field.id })
+    if (field.type === 'detail') {
+      for (const column of field.columns ?? []) {
+        if (!column.id) continue
+        options.push({
+          token: `{${field.id}.${column.id}}`,
+          label: `${field.label || field.id}.${column.label || column.id}`,
+        })
+      }
+    }
+  }
+  return options
+}
+
+function validateFormulaReferences(expression: string, formSchema: FormSchema, label: string): string[] {
+  const errors: string[] = []
+  const topFields = new Map(formSchema.fields.map((field) => [field.id, field]))
+  const refPattern = /\{([^{}]+)\}/g
+  let match: RegExpExecArray | null
+  while ((match = refPattern.exec(expression)) !== null) {
+    const rawRef = match[1]?.trim() ?? ''
+    if (!rawRef) {
+      errors.push(`${label} 包含空字段引用`)
+      continue
+    }
+    const parts = rawRef.split('.')
+    if (parts.length === 1) {
+      if (!topFields.has(parts[0])) errors.push(`${label} 引用的字段 ${parts[0]} 不存在`)
+      continue
+    }
+    if (parts.length === 2) {
+      const [fieldId, columnId] = parts
+      const field = topFields.get(fieldId)
+      if (!field) {
+        errors.push(`${label} 引用的明细字段 ${fieldId} 不存在`)
+        continue
+      }
+      if (field.type !== 'detail') {
+        errors.push(`${label} 引用的字段 ${fieldId} 不是明细字段`)
+        continue
+      }
+      if (!(field.columns ?? []).some((column) => column.id === columnId)) {
+        errors.push(`${label} 引用的明细子字段 ${fieldId}.${columnId} 不存在`)
+      }
+      continue
+    }
+    errors.push(`${label} 的字段引用 ${rawRef} 不是 v1 支持的字段或明细子字段`)
+  }
+  return errors
 }
 
 /**
@@ -142,6 +206,16 @@ export function applyConditionEditsToGraph(
       (originalConfig.branches ?? []).map((branch) => [branch.edgeKey, branch]),
     )
     const branches: ConditionBranch[] = edit.branches.map((branchEdit) => {
+      if (branchEdit.predicateMode === 'formula') {
+        const original = originalBranchByEdge.get(branchEdit.edgeKey)
+        const originalHadConjunction = original?.conjunction !== undefined
+        return {
+          edgeKey: branchEdit.edgeKey,
+          ...(originalHadConjunction ? { conjunction: branchEdit.conjunction } : {}),
+          rules: [],
+          formula: { expression: branchEdit.formulaExpression.trim() },
+        }
+      }
       const original = originalBranchByEdge.get(branchEdit.edgeKey)
       // Emit `conjunction` only when the original branch carried one, OR the editor set a value
       // that differs from the original's absent/value — i.e. always emit when the current value is
@@ -204,6 +278,14 @@ export function validateConditionEdits(
   for (const edit of Object.values(edits)) {
     const nodeLabel = edit.nodeKey
     edit.branches.forEach((branch, branchIndex) => {
+      if (branch.predicateMode === 'formula') {
+        const formulaLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 公式`
+        if (!branch.formulaExpression.trim()) {
+          errors.push(`${formulaLabel} 需要填写`)
+        }
+        errors.push(...validateFormulaReferences(branch.formulaExpression, formSchema, formulaLabel))
+        return
+      }
       branch.rules.forEach((rule, ruleIndex) => {
         const ruleLabel = `条件节点 ${nodeLabel} 分支 ${branchIndex + 1} 规则 ${ruleIndex + 1}`
         const fieldId = rule.fieldId.trim()

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -58,6 +58,7 @@ export type {
   ConditionRuleOperator,
 } from './conditionEdit'
 export { CONDITION_RULE_OPERATORS } from './conditionEdit'
+export { approvalFormulaInsertOptions } from './conditionEdit'
 export type { ParallelEdits, ParallelNodeEdit } from './parallelEdit'
 export { PARALLEL_JOIN_MODES } from './parallelEdit'
 export type { CcEdits, CcNodeEdit } from './ccEdit'
@@ -550,8 +551,7 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
 // risk as approval): cc → {targetType, targetIds}; parallel → {branches, joinMode, joinNodeKey};
 // condition → {branches, defaultEdgeKey} with each branch {edgeKey, conjunction?, rules, formula?}
 // and each rule {fieldId, operator, value?} (the rule `value` is a free leaf, NOT shape-checked);
-// start/end → {}. Formula branches are backend-preserved after FC-1, but the current G-2 editor
-// cannot round-trip them, so they remain fail-closed here until FC-2 formula authoring ships.
+// start/end → {}. Formula branches are FC-2 authorable and round-trip through `conditionEdit.ts`.
 const BACKEND_CC_CONFIG_KEYS = ['targetType', 'targetIds']
 const BACKEND_PARALLEL_CONFIG_KEYS = ['branches', 'joinMode', 'joinNodeKey']
 const BACKEND_CONDITION_CONFIG_KEYS = ['branches', 'defaultEdgeKey']
@@ -583,7 +583,6 @@ function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
           if (!isPlainRecord(branch) || hasKeyOutside(branch, BACKEND_CONDITION_BRANCH_KEYS)) return true
           if (branch.formula !== undefined) {
             if (!isPlainRecord(branch.formula) || hasKeyOutside(branch.formula, BACKEND_CONDITION_FORMULA_KEYS)) return true
-            return true
           }
           const rules = branch.rules
           if (Array.isArray(rules)) {

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -547,14 +547,16 @@ function complexApprovalConfigHasBackendDrop(config: Record<string, unknown>): b
 }
 
 // The COMPLEX-path config shapes the backend re-emits for the OTHER node types (same silent-drop
-// risk as approval): cc → {targetType, targetIds} (ApprovalProductService.ts:920-923); parallel →
-// {branches, joinMode, joinNodeKey} (:946-950); condition → {branches, defaultEdgeKey} with each
-// branch {edgeKey, conjunction?, rules} and each rule {fieldId, operator, value?} (:956-985 — the
-// rule `value` is a free leaf, NOT shape-checked); start/end → {} (default, :988).
+// risk as approval): cc → {targetType, targetIds}; parallel → {branches, joinMode, joinNodeKey};
+// condition → {branches, defaultEdgeKey} with each branch {edgeKey, conjunction?, rules, formula?}
+// and each rule {fieldId, operator, value?} (the rule `value` is a free leaf, NOT shape-checked);
+// start/end → {}. Formula branches are backend-preserved after FC-1, but the current G-2 editor
+// cannot round-trip them, so they remain fail-closed here until FC-2 formula authoring ships.
 const BACKEND_CC_CONFIG_KEYS = ['targetType', 'targetIds']
 const BACKEND_PARALLEL_CONFIG_KEYS = ['branches', 'joinMode', 'joinNodeKey']
 const BACKEND_CONDITION_CONFIG_KEYS = ['branches', 'defaultEdgeKey']
-const BACKEND_CONDITION_BRANCH_KEYS = ['edgeKey', 'conjunction', 'rules']
+const BACKEND_CONDITION_BRANCH_KEYS = ['edgeKey', 'conjunction', 'rules', 'formula']
+const BACKEND_CONDITION_FORMULA_KEYS = ['expression']
 const BACKEND_CONDITION_RULE_KEYS = ['fieldId', 'operator', 'value']
 
 /**
@@ -579,6 +581,10 @@ function complexNodeConfigHasBackendDrop(node: ApprovalNode): boolean {
       if (Array.isArray(branches)) {
         for (const branch of branches) {
           if (!isPlainRecord(branch) || hasKeyOutside(branch, BACKEND_CONDITION_BRANCH_KEYS)) return true
+          if (branch.formula !== undefined) {
+            if (!isPlainRecord(branch.formula) || hasKeyOutside(branch.formula, BACKEND_CONDITION_FORMULA_KEYS)) return true
+            return true
+          }
           const rules = branch.rules
           if (Array.isArray(rules)) {
             for (const rule of rules) {

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -96,6 +96,11 @@ export interface ConditionBranch {
   edgeKey: string
   rules: ConditionRule[]
   conjunction?: 'and' | 'or'
+  formula?: ConditionFormulaPredicate
+}
+
+export interface ConditionFormulaPredicate {
+  expression: string
 }
 
 export interface ConditionRule {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -682,6 +682,33 @@
                       @click="insertConditionFormulaFunction(branch, 'MAX')"
                     >MAX()</el-button>
                   </div>
+                  <div class="template-authoring__condition-formula-dryrun">
+                    <el-input
+                      :model-value="conditionFormulaDryRunSample(node.key, branch.edgeKey)"
+                      type="textarea"
+                      :rows="2"
+                      :disabled="readOnly"
+                      placeholder='样例数据 JSON，例如 {"amount": 5000}'
+                      data-testid="approval-condition-formula-dry-run-sample"
+                      @update:model-value="(text: string) => setConditionFormulaDryRunSample(node.key, branch.edgeKey, text)"
+                    />
+                    <div class="template-authoring__condition-formula-dryrun-actions">
+                      <el-button
+                        size="small"
+                        :loading="conditionFormulaDryRunLoading(node.key, branch.edgeKey)"
+                        :disabled="readOnly || conditionFormulaDryRunLoading(node.key, branch.edgeKey)"
+                        data-testid="approval-condition-formula-dry-run-button"
+                        @click="dryRunConditionFormula(node.key, branch)"
+                      >测试公式</el-button>
+                      <span
+                        v-if="conditionFormulaDryRunResult(node.key, branch.edgeKey)"
+                        class="template-authoring__condition-formula-dryrun-result"
+                        data-testid="approval-condition-formula-dry-run-result"
+                      >
+                        {{ conditionFormulaDryRunResult(node.key, branch.edgeKey) }}
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <el-form-item label="默认分支（无匹配时）" class="template-authoring__condition-default">
@@ -1033,6 +1060,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import {
   createTemplate,
+  dryRunApprovalConditionFormula,
   getTemplate,
   publishTemplate,
   updateTemplate,
@@ -1110,6 +1138,9 @@ const unsupportedReason = ref<string | null>(null)
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+const conditionFormulaDryRunSamples = ref<Record<string, string>>({})
+const conditionFormulaDryRunResults = ref<Record<string, string>>({})
+const conditionFormulaDryRunBusy = ref<Record<string, boolean>>({})
 
 const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
 const isEditMode = computed(() => templateId.value.length > 0)
@@ -1254,6 +1285,79 @@ function insertConditionFormulaToken(branch: ConditionBranchEdit, token: string)
 }
 function insertConditionFormulaFunction(branch: ConditionBranchEdit, fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'): void {
   appendFormulaText(branch, `${fn}()`)
+}
+
+function conditionFormulaDryRunKey(nodeKey: string, edgeKey: string): string {
+  return `${nodeKey}:${edgeKey}`
+}
+function conditionFormulaDryRunSample(nodeKey: string, edgeKey: string): string {
+  return conditionFormulaDryRunSamples.value[conditionFormulaDryRunKey(nodeKey, edgeKey)] ?? '{}'
+}
+function setConditionFormulaDryRunSample(nodeKey: string, edgeKey: string, text: string): void {
+  conditionFormulaDryRunSamples.value = {
+    ...conditionFormulaDryRunSamples.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: text,
+  }
+}
+function conditionFormulaDryRunResult(nodeKey: string, edgeKey: string): string {
+  return conditionFormulaDryRunResults.value[conditionFormulaDryRunKey(nodeKey, edgeKey)] ?? ''
+}
+function setConditionFormulaDryRunResult(nodeKey: string, edgeKey: string, text: string): void {
+  conditionFormulaDryRunResults.value = {
+    ...conditionFormulaDryRunResults.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: text,
+  }
+}
+function conditionFormulaDryRunLoading(nodeKey: string, edgeKey: string): boolean {
+  return Boolean(conditionFormulaDryRunBusy.value[conditionFormulaDryRunKey(nodeKey, edgeKey)])
+}
+function setConditionFormulaDryRunLoading(nodeKey: string, edgeKey: string, loadingValue: boolean): void {
+  conditionFormulaDryRunBusy.value = {
+    ...conditionFormulaDryRunBusy.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: loadingValue,
+  }
+}
+async function dryRunConditionFormula(nodeKey: string, branch: ConditionBranchEdit): Promise<void> {
+  const expression = branch.formulaExpression.trim()
+  const resultKey = conditionFormulaDryRunKey(nodeKey, branch.edgeKey)
+  if (!expression) {
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, '请输入公式')
+    return
+  }
+  let formData: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(conditionFormulaDryRunSamples.value[resultKey] ?? '{}') as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('样例数据必须是 JSON 对象')
+    }
+    formData = parsed as Record<string, unknown>
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '样例数据不是有效 JSON'
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `样例数据错误：${message}`)
+    return
+  }
+  setConditionFormulaDryRunLoading(nodeKey, branch.edgeKey, true)
+  try {
+    const result = await dryRunApprovalConditionFormula({
+      formSchema: buildFormSchema(draft.value),
+      expression,
+      formData,
+    })
+    if (result.success) {
+      setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `结果：${result.result ? 'true' : 'false'}`)
+    } else {
+      setConditionFormulaDryRunResult(
+        nodeKey,
+        branch.edgeKey,
+        `错误：${result.error?.message ?? '公式测试失败'}`,
+      )
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '公式测试失败'
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `错误：${message}`)
+  } finally {
+    setConditionFormulaDryRunLoading(nodeKey, branch.edgeKey, false)
+  }
 }
 
 // Outgoing edge keys of a condition node (from the preserved graph) — the legal default fall-through
@@ -1904,6 +2008,24 @@ onMounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.template-authoring__condition-formula-dryrun {
+  display: grid;
+  gap: 6px;
+}
+
+.template-authoring__condition-formula-dryrun-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.template-authoring__condition-formula-dryrun-result {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-regular, #606266);
 }
 
 .template-authoring__condition-default {

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -546,6 +546,18 @@
                 <div class="template-authoring__condition-branch-head">
                   <span>分支 → {{ branch.edgeKey }}</span>
                   <el-select
+                    :model-value="branch.predicateMode"
+                    size="small"
+                    :disabled="readOnly"
+                    style="width: 130px"
+                    data-testid="approval-condition-predicate-mode"
+                    @update:model-value="(mode: string) => setConditionBranchPredicateMode(branch, mode)"
+                  >
+                    <el-option label="简单规则" value="rules" />
+                    <el-option label="公式" value="formula" />
+                  </el-select>
+                  <el-select
+                    v-if="branch.predicateMode === 'rules'"
                     v-model="branch.conjunction"
                     size="small"
                     :disabled="readOnly"
@@ -556,61 +568,64 @@
                     <el-option label="任一满足 (OR)" value="or" />
                   </el-select>
                 </div>
-                <div
-                  v-for="(rule, ruleIndex) in branch.rules"
-                  :key="ruleIndex"
-                  class="template-authoring__condition-rule"
-                  data-testid="approval-condition-rule"
-                >
-                  <el-select
-                    v-model="rule.fieldId"
-                    size="small"
-                    filterable
-                    placeholder="字段"
-                    :disabled="readOnly"
-                    style="width: 160px"
-                    data-testid="approval-condition-rule-field"
+                <template v-if="branch.predicateMode === 'rules'">
+                  <div
+                    v-for="(rule, ruleIndex) in branch.rules"
+                    :key="ruleIndex"
+                    class="template-authoring__condition-rule"
+                    data-testid="approval-condition-rule"
                   >
-                    <el-option
-                      v-for="field in conditionFieldOptions"
-                      :key="field.id"
-                      :label="field.label"
-                      :value="field.id"
+                    <el-select
+                      v-model="rule.fieldId"
+                      size="small"
+                      filterable
+                      placeholder="字段"
+                      :disabled="readOnly"
+                      style="width: 160px"
+                      data-testid="approval-condition-rule-field"
+                    >
+                      <el-option
+                        v-for="field in conditionFieldOptions"
+                        :key="field.id"
+                        :label="field.label"
+                        :value="field.id"
+                      />
+                    </el-select>
+                    <el-select
+                      v-model="rule.operator"
+                      size="small"
+                      :disabled="readOnly"
+                      style="width: 120px"
+                      data-testid="approval-condition-rule-operator"
+                    >
+                      <el-option
+                        v-for="operator in CONDITION_RULE_OPERATORS"
+                        :key="operator"
+                        :label="conditionOperatorLabel(operator)"
+                        :value="operator"
+                      />
+                    </el-select>
+                    <el-input
+                      v-if="rule.operator !== 'isEmpty'"
+                      :model-value="conditionRuleValueText(rule)"
+                      size="small"
+                      placeholder="比较值"
+                      :disabled="readOnly"
+                      style="width: 160px"
+                      data-testid="approval-condition-rule-value"
+                      @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
                     />
-                  </el-select>
-                  <el-select
-                    v-model="rule.operator"
-                    size="small"
-                    :disabled="readOnly"
-                    style="width: 120px"
-                    data-testid="approval-condition-rule-operator"
-                  >
-                    <el-option
-                      v-for="operator in CONDITION_RULE_OPERATORS"
-                      :key="operator"
-                      :label="conditionOperatorLabel(operator)"
-                      :value="operator"
-                    />
-                  </el-select>
-                  <el-input
-                    v-if="rule.operator !== 'isEmpty'"
-                    :model-value="conditionRuleValueText(rule)"
-                    size="small"
-                    placeholder="比较值"
-                    :disabled="readOnly"
-                    style="width: 160px"
-                    data-testid="approval-condition-rule-value"
-                    @update:model-value="(text: string) => setConditionRuleValue(rule, text)"
-                  />
-                  <el-button
-                    size="small"
-                    type="danger"
-                    :disabled="readOnly || branch.rules.length === 1"
-                    data-testid="approval-condition-rule-remove"
-                    @click="removeConditionRule(branch, ruleIndex)"
-                  >删除</el-button>
-                </div>
+                    <el-button
+                      size="small"
+                      type="danger"
+                      :disabled="readOnly || branch.rules.length === 1"
+                      data-testid="approval-condition-rule-remove"
+                      @click="removeConditionRule(branch, ruleIndex)"
+                    >删除</el-button>
+                  </div>
+                </template>
                 <el-button
+                  v-if="branch.predicateMode === 'rules'"
                   size="small"
                   :disabled="readOnly"
                   data-testid="approval-condition-rule-add"
@@ -619,6 +634,55 @@
                   <el-icon><Plus /></el-icon>
                   添加规则
                 </el-button>
+                <div
+                  v-else
+                  class="template-authoring__condition-formula"
+                  data-testid="approval-condition-formula"
+                >
+                  <el-input
+                    v-model="branch.formulaExpression"
+                    type="textarea"
+                    :rows="3"
+                    :disabled="readOnly"
+                    placeholder='例如 SUM({purchase_items.amount}) >= 20000'
+                    data-testid="approval-condition-formula-expression"
+                  />
+                  <div class="template-authoring__condition-formula-tools">
+                    <el-button
+                      v-for="option in conditionFormulaInsertOptions"
+                      :key="option.token"
+                      size="small"
+                      :disabled="readOnly"
+                      :title="option.label"
+                      :data-testid="`approval-condition-formula-insert-${option.token}`"
+                      @click="insertConditionFormulaToken(branch, option.token)"
+                    >{{ option.token }}</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-sum"
+                      @click="insertConditionFormulaFunction(branch, 'SUM')"
+                    >SUM()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-count"
+                      @click="insertConditionFormulaFunction(branch, 'COUNT')"
+                    >COUNT()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-min"
+                      @click="insertConditionFormulaFunction(branch, 'MIN')"
+                    >MIN()</el-button>
+                    <el-button
+                      size="small"
+                      :disabled="readOnly"
+                      data-testid="approval-condition-formula-insert-max"
+                      @click="insertConditionFormulaFunction(branch, 'MAX')"
+                    >MAX()</el-button>
+                  </div>
+                </div>
               </div>
               <el-form-item label="默认分支（无匹配时）" class="template-authoring__condition-default">
                 <el-select
@@ -988,6 +1052,7 @@ import {
   parseIdsText,
   unsupportedTemplateAuthoringReason,
   validateTemplateDraft,
+  approvalFormulaInsertOptions,
   CONDITION_RULE_OPERATORS,
   PARALLEL_JOIN_MODES,
   CC_TARGET_TYPES,
@@ -1139,6 +1204,9 @@ const conditionFieldOptions = computed(() =>
     .filter((field) => field.id.trim())
     .map((field) => ({ id: field.id.trim(), label: field.label.trim() || field.id.trim() })),
 )
+const conditionFormulaInsertOptions = computed(() =>
+  approvalFormulaInsertOptions(buildFormSchema(draft.value)),
+)
 
 const CONDITION_OPERATOR_LABELS: Record<ConditionRuleOperator, string> = {
   eq: '等于',
@@ -1170,6 +1238,22 @@ function addConditionRule(branch: ConditionBranchEdit): void {
 function removeConditionRule(branch: ConditionBranchEdit, ruleIndex: number): void {
   if (branch.rules.length === 1) return
   branch.rules.splice(ruleIndex, 1)
+}
+function setConditionBranchPredicateMode(branch: ConditionBranchEdit, mode: string): void {
+  branch.predicateMode = mode === 'formula' ? 'formula' : 'rules'
+  if (branch.predicateMode === 'rules' && branch.rules.length === 0) {
+    branch.rules.push({ fieldId: '', operator: 'eq', value: undefined })
+  }
+}
+function appendFormulaText(branch: ConditionBranchEdit, text: string): void {
+  const prefix = branch.formulaExpression.trim() ? ' ' : ''
+  branch.formulaExpression = `${branch.formulaExpression}${prefix}${text}`
+}
+function insertConditionFormulaToken(branch: ConditionBranchEdit, token: string): void {
+  appendFormulaText(branch, token)
+}
+function insertConditionFormulaFunction(branch: ConditionBranchEdit, fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'): void {
+  appendFormulaText(branch, `${fn}()`)
 }
 
 // Outgoing edge keys of a condition node (from the preserved graph) — the legal default fall-through
@@ -1809,6 +1893,17 @@ onMounted(() => {
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
+}
+
+.template-authoring__condition-formula {
+  display: grid;
+  gap: 8px;
+}
+
+.template-authoring__condition-formula-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .template-authoring__condition-default {

--- a/apps/web/tests/approval-common-template-presets.test.ts
+++ b/apps/web/tests/approval-common-template-presets.test.ts
@@ -84,10 +84,26 @@ describe('common approval template presets', () => {
     },
   )
 
-  it('reimbursement_amount_tier gates a higher-tier approver on amount >= 5000', () => {
+  it('reimbursement_amount_tier gates a higher-tier approver with a formula condition', () => {
     const payload = buildCommonApprovalTemplatePresetPayload('reimbursement_amount_tier', { keySuffix: 'unit' })
     const gate = payload.approvalGraph.nodes.find((node) => node.type === 'condition')
-    expect(gate?.config).toMatchObject({ branches: [{ rules: [{ fieldId: 'amount', operator: 'gte', value: 5000 }] }] })
+    expect(gate?.config).toMatchObject({
+      branches: [{
+        rules: [],
+        formula: { expression: '{expense_type} == "差旅" AND {amount} >= 5000' },
+      }],
+    })
+  })
+
+  it('purchase_amount_tier gates the high path with a detail aggregate formula condition', () => {
+    const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: 'unit' })
+    const gate = payload.approvalGraph.nodes.find((node) => node.type === 'condition')
+    expect(gate?.config).toMatchObject({
+      branches: [{
+        rules: [],
+        formula: { expression: 'SUM({purchase_items.amount}) >= 20000' },
+      }],
+    })
   })
 
   it('purchase_amount_tier forks a parallel会签 (join at end) with one user-resolving + one static_role branch — distinct-typed, no dynamic conflict', () => {

--- a/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
+++ b/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
@@ -7,8 +7,8 @@ import { unsupportedTemplateAuthoringReason } from '../src/approvals/templateAut
 // rebuilds each from a fixed per-type shape (ApprovalProductService.ts) and DROPS any other key —
 // top-level OR nested (condition branches[].rules[]). `complexNodeConfigHasBackendDrop` now fails
 // closed for EVERY node type, so an unknown key can't silently flatten on save while the FE
-// deep-equal round-trip looks clean. FC-1 formula branches are backend-preserved but still
-// fail-closed here until FC-2 authoring can round-trip them. Pure helper test (no .vue) → runs
+// deep-equal round-trip looks clean. FC-2 formula branches are authorable and therefore allowed
+// when they match the backend-preserved shape. Pure helper test (no .vue) → runs
 // under approval-web-guard.
 
 function tpl(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
@@ -66,8 +66,11 @@ describe('complex node config fail-closed — condition (recurses config → bra
   it('flags an unknown rule key', () => {
     expect(cond({ edgeKey: 'e', rules: [{ fieldId: 'amount', operator: 'gt', value: 1, futureFlag: true }] })).not.toBeNull()
   })
-  it('flags a backend-supported formula branch until FC-2 can round-trip it', () => {
-    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).not.toBeNull()
+  it('allows a known formula branch shape now that FC-2 can round-trip it', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).toBeNull()
+  })
+  it('flags an unknown formula key', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000', futureFlag: true } })).not.toBeNull()
   })
   it('allows a known condition (conjunction + a FREE-FORM rule value — value is a leaf, not shape-checked)', () => {
     expect(cond({ edgeKey: 'e', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'in', value: { complex: ['object', 'leaf'] } }] })).toBeNull()

--- a/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
+++ b/apps/web/tests/approval-template-authoring-complex-node-config-allowlist.test.ts
@@ -7,7 +7,9 @@ import { unsupportedTemplateAuthoringReason } from '../src/approvals/templateAut
 // rebuilds each from a fixed per-type shape (ApprovalProductService.ts) and DROPS any other key —
 // top-level OR nested (condition branches[].rules[]). `complexNodeConfigHasBackendDrop` now fails
 // closed for EVERY node type, so an unknown key can't silently flatten on save while the FE
-// deep-equal round-trip looks clean. Pure helper test (no .vue) → runs under approval-web-guard.
+// deep-equal round-trip looks clean. FC-1 formula branches are backend-preserved but still
+// fail-closed here until FC-2 authoring can round-trip them. Pure helper test (no .vue) → runs
+// under approval-web-guard.
 
 function tpl(approvalGraph: ApprovalGraph): ApprovalTemplateDetailDTO {
   return {
@@ -63,6 +65,9 @@ describe('complex node config fail-closed — condition (recurses config → bra
   })
   it('flags an unknown rule key', () => {
     expect(cond({ edgeKey: 'e', rules: [{ fieldId: 'amount', operator: 'gt', value: 1, futureFlag: true }] })).not.toBeNull()
+  })
+  it('flags a backend-supported formula branch until FC-2 can round-trip it', () => {
+    expect(cond({ edgeKey: 'e', rules: [], formula: { expression: '{amount} >= 1000' } })).not.toBeNull()
   })
   it('allows a known condition (conjunction + a FREE-FORM rule value — value is a leaf, not shape-checked)', () => {
     expect(cond({ edgeKey: 'e', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'in', value: { complex: ['object', 'leaf'] } }] })).toBeNull()

--- a/apps/web/tests/approval-template-authoring-condition-edit.test.ts
+++ b/apps/web/tests/approval-template-authoring-condition-edit.test.ts
@@ -86,6 +86,47 @@ const CONDITION_GRAPH: ApprovalGraph = {
   ],
 }
 
+const CONDITION_FORMULA_GRAPH: ApprovalGraph = {
+  ...CONDITION_GRAPH,
+  nodes: CONDITION_GRAPH.nodes.map((node) => {
+    if (node.key !== 'cond_1' || node.type !== 'condition') return node
+    return {
+      ...node,
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            rules: [],
+            formula: { expression: 'SUM({items.amount}) >= 5000' },
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+  }),
+}
+
+const CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH: ApprovalGraph = {
+  ...CONDITION_FORMULA_GRAPH,
+  nodes: CONDITION_FORMULA_GRAPH.nodes.map((node) => {
+    if (node.key !== 'cond_1' || node.type !== 'condition') return node
+    return {
+      ...node,
+      config: {
+        branches: [
+          {
+            edgeKey: 'edge-cond_1-high',
+            conjunction: 'or',
+            rules: [],
+            formula: { expression: 'SUM({items.amount}) >= 5000' },
+          },
+        ],
+        defaultEdgeKey: 'edge-cond_1-low',
+      },
+    }
+  }),
+}
+
 // A condition node with NO conjunction on its branch (backend omits it) — proves seeding+rebuild do
 // not resurrect a spurious `conjunction: 'and'`.
 const CONDITION_GRAPH_NO_CONJUNCTION: ApprovalGraph = {
@@ -196,8 +237,19 @@ describe('G-2 conditionEditsFromGraph — seed from preserved condition nodes', 
     const edits = conditionEditsFromGraph(CONDITION_GRAPH)
     expect(Object.keys(edits)).toEqual(['cond_1'])
     expect(edits.cond_1.branches.map((branch) => branch.edgeKey)).toEqual(['edge-cond_1-high'])
+    expect(edits.cond_1.branches[0].predicateMode).toBe('rules')
     expect(edits.cond_1.branches[0].rules).toEqual([{ fieldId: 'amount', operator: 'gte', value: 1000 }])
     expect(edits.cond_1.defaultEdgeKey).toBe('edge-cond_1-low')
+  })
+
+  it('captures formula branches without flattening them back to rules', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_GRAPH)
+    expect(edits.cond_1.branches[0]).toMatchObject({
+      edgeKey: 'edge-cond_1-high',
+      predicateMode: 'formula',
+      formulaExpression: 'SUM({items.amount}) >= 5000',
+      rules: [],
+    })
   })
 
   it('is empty for a parallel / cc graph (no condition node)', () => {
@@ -268,6 +320,23 @@ describe('G-2 topology-preservation — editing a condition rule keeps everythin
       { fieldId: 'kind', operator: 'eq', value: 'a' },
     ])
   })
+
+  it('editing a formula branch emits formula + empty rules and preserves topology byte-identical', () => {
+    const template = buildTemplate(CONDITION_FORMULA_GRAPH)
+    const original = structuredClone(template.approvalGraph)
+    const draft = draftFromTemplate(template)
+    draft.conditionEdits!.cond_1.branches[0].formulaExpression = 'SUM({items.amount}) >= 20000'
+    const rebuilt = buildApprovalGraph(draft)
+
+    expectTopologyByteIdentical(rebuilt, original)
+    const cond = rebuilt.nodes.find((node) => node.key === 'cond_1')!
+    expect(cond.config).toEqual({
+      branches: [
+        { edgeKey: 'edge-cond_1-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } },
+      ],
+      defaultEdgeKey: 'edge-cond_1-low',
+    })
+  })
 })
 
 describe('G-2 untouched round-trip — no spurious diffs from seeding (G-1 floor holds)', () => {
@@ -294,6 +363,16 @@ describe('G-2 untouched round-trip — no spurious diffs from seeding (G-1 floor
   it('applyConditionEditsToGraph with the seeded edits is identity for the condition graph', () => {
     const edits = conditionEditsFromGraph(CONDITION_GRAPH)
     expect(applyConditionEditsToGraph(CONDITION_GRAPH, edits)).toEqual(CONDITION_GRAPH)
+  })
+
+  it('applyConditionEditsToGraph with seeded formula edits is identity for a formula condition graph', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_GRAPH)
+    expect(applyConditionEditsToGraph(CONDITION_FORMULA_GRAPH, edits)).toEqual(CONDITION_FORMULA_GRAPH)
+  })
+
+  it('a formula branch with a backend-preserved conjunction stays byte-identical', () => {
+    const edits = conditionEditsFromGraph(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH)
+    expect(applyConditionEditsToGraph(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH, edits)).toEqual(CONDITION_FORMULA_WITH_CONJUNCTION_GRAPH)
   })
 })
 
@@ -342,7 +421,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'ghost', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: 'ghost', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: 'edge-cond_1-low',
       },
     }
@@ -357,7 +436,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: 'amount', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: 'edge-start-cond_1',
       },
     }
@@ -377,7 +456,7 @@ describe('G-2 validation preview (UX-only; backend normalizeApprovalGraph is fin
     const edits: ConditionEdits = {
       cond_1: {
         nodeKey: 'cond_1',
-        branches: [{ edgeKey: 'edge-cond_1-high', conjunction: 'and', rules: [{ fieldId: '', operator: 'gte', value: 1 }] }],
+        branches: [{ edgeKey: 'edge-cond_1-high', predicateMode: 'rules', conjunction: 'and', rules: [{ fieldId: '', operator: 'gte', value: 1 }], formulaExpression: '' }],
         defaultEdgeKey: '',
       },
     }

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -51,12 +51,14 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const dryRunApprovalConditionFormulaSpy = vi.fn()
 
 vi.mock('../src/approvals/api', () => ({
   createTemplate: (payload: unknown) => createTemplateSpy(payload),
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
 }))
 
 vi.mock('element-plus', () => ({
@@ -623,6 +625,7 @@ describe('TemplateAuthoringView', () => {
     updateTemplateSpy.mockReset()
     publishTemplateSpy.mockReset()
     getTemplateSpy.mockReset()
+    dryRunApprovalConditionFormulaSpy.mockReset()
     pushSpy.mockClear()
     replaceSpy.mockClear()
     createTemplateSpy.mockImplementation(async (payload) => ({
@@ -637,6 +640,7 @@ describe('TemplateAuthoringView', () => {
       ...payload,
     }))
     publishTemplateSpy.mockResolvedValue({})
+    dryRunApprovalConditionFormulaSpy.mockResolvedValue({ success: true, result: true })
   })
 
   afterEach(() => {
@@ -941,6 +945,65 @@ describe('TemplateAuthoringView', () => {
       defaultEdgeKey: 'e-low',
     })
     expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_high')).toEqual(graph.nodes[2])
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
+  })
+
+  it('FC-5 wiring: formula dry-run calls the dry-run endpoint and does not change the saved graph payload', async () => {
+    routeParams = { id: 'tpl_formula_dry_run' }
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] }], defaultEdgeKey: 'e-low' } },
+        { key: 'approval_high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-c', source: 'start', target: 'cond_1' },
+        { key: 'e-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'e-low', source: 'cond_1', target: 'end' },
+        { key: 'e-high-end', source: 'approval_high', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    const modeSelect = container!.querySelector('[data-testid="approval-condition-predicate-mode"]') as HTMLSelectElement
+    modeSelect.value = 'formula'
+    modeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    const expression = container!.querySelector('[data-testid="approval-condition-formula-expression"]') as HTMLInputElement
+    expression.value = '{amount} >= 5000'
+    expression.dispatchEvent(new Event('input'))
+    const sample = container!.querySelector('[data-testid="approval-condition-formula-dry-run-sample"]') as HTMLInputElement
+    sample.value = '{"amount":6000}'
+    sample.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-condition-formula-dry-run-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(dryRunApprovalConditionFormulaSpy).toHaveBeenCalledTimes(1)
+    expect(dryRunApprovalConditionFormulaSpy).toHaveBeenCalledWith({
+      formSchema: expect.objectContaining({
+        fields: expect.arrayContaining([expect.objectContaining({ id: 'amount', type: 'number' })]),
+      }),
+      expression: '{amount} >= 5000',
+      formData: { amount: 6000 },
+    })
+    expect(container!.querySelector('[data-testid="approval-condition-formula-dry-run-result"]')?.textContent).toContain('true')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const conditionNode = payload.approvalGraph.nodes.find((node: any) => node.key === 'cond_1')
+    expect(conditionNode.config).toEqual({
+      branches: [{ edgeKey: 'e-high', rules: [], formula: { expression: '{amount} >= 5000' } }],
+      defaultEdgeKey: 'e-low',
+    })
+    expect(JSON.stringify(payload)).not.toContain('6000')
     expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -86,7 +86,7 @@ const ElButton = defineComponent({
 
 const ElInput = defineComponent({
   name: 'ElInput',
-  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String },
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String, size: String },
   emits: ['update:modelValue'],
   render() {
     return h('input', {
@@ -896,6 +896,52 @@ describe('TemplateAuthoringView', () => {
     await flushUi()
     const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
     expect(payload.approvalGraph.nodes.find((n: any) => n.key === 'cond_1').config.branches).toHaveLength(2) // the added branch is saved
+  })
+
+  it('FC-2 wiring: switching a condition branch to formula writes formula to the save payload while topology stays byte-identical', async () => {
+    routeParams = { id: 'tpl_formula_condition' }
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] }], defaultEdgeKey: 'e-low' } },
+        { key: 'approval_high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-c', source: 'start', target: 'cond_1' },
+        { key: 'e-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'e-low', source: 'cond_1', target: 'end' },
+        { key: 'e-high-end', source: 'approval_high', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    const modeSelect = container!.querySelector('[data-testid="approval-condition-predicate-mode"]') as HTMLSelectElement
+    expect(modeSelect.value).toBe('rules')
+    modeSelect.value = 'formula'
+    modeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(container!.querySelector('[data-testid="approval-condition-formula-insert-sum"]')).not.toBeNull()
+    const expression = container!.querySelector('[data-testid="approval-condition-formula-expression"]') as HTMLInputElement
+    expression.value = '{amount} >= 5000'
+    expression.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const conditionNode = payload.approvalGraph.nodes.find((node: any) => node.key === 'cond_1')
+    expect(conditionNode.config).toEqual({
+      branches: [{ edgeKey: 'e-high', rules: [], formula: { expression: '{amount} >= 5000' } }],
+      defaultEdgeKey: 'e-low',
+    })
+    expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_high')).toEqual(graph.nodes[2])
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 
   function buildCanvasConditionGraph() {

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -2,9 +2,10 @@
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
 BUILT IN A STACKED PR (purchase/reimbursement examples); FC-4 BUILT IN A
-STACKED PR (approval-specific backend dry-run endpoint). Owner decisions
-resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed; backend
-evaluator ships before dry-run.
+STACKED PR (approval-specific backend dry-run endpoint); FC-5 BUILT IN A
+STACKED PR (frontend dry-run preview button). Owner decisions resolved:
+`AND/OR/NOT` only in v1; numeric aggregates fail closed; backend evaluator
+ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the
@@ -302,8 +303,19 @@ multi-branch preset is introduced.
 - Return a normal dry-run diagnostic payload for formula errors instead of
   routing through the sheet-scoped multitable formula dry-run.
 
-This slice intentionally does not add the frontend "Evaluate" button yet. The
-endpoint is the backend truth surface that a later authoring UX can call.
+This slice intentionally did not add the frontend "Evaluate" button. The
+endpoint is the backend truth surface that FC-5 calls.
+
+### FC-5 — Authoring Dry-Run Preview
+
+- Add an explicit "测试公式" button to the formula predicate authoring block.
+- Accept per-branch sample JSON and call the FC-4 approval-specific dry-run
+  endpoint with `{ formSchema, expression, formData }`.
+- Show success/error text inline for author feedback.
+- Keep the preview informational only: it is not a save/publish gate and its
+  sample data never enters the template payload.
+- Add a mounted wiring test proving button -> endpoint payload -> result display,
+  then save still emits only the formula graph config and preserves topology.
 
 ## Non-Goals
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,7 +1,7 @@
 # Approval Formula Conditions — Design Lock
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
-NOT BUILT. Owner
+BUILT IN A STACKED PR (purchase/reimbursement examples). Owner
 decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
 backend evaluator ships before dry-run.
 
@@ -288,9 +288,9 @@ example:
 - reimbursement high path: `{expense_type} == "差旅" AND {amount} >= 5000`;
 - leave high path: `{leave_days} + {used_leave_days} > 5`.
 
-This is optional. Existing amount-tier presets can remain on simple
-`amount >= threshold` rules because the shipped total auto-sum and backend
-total-check already make `amount` reliable.
+FC-3 applies the purchase and reimbursement examples to the shipped amount-tier
+presets. The leave example remains illustrative until a leave-specific
+multi-branch preset is introduced.
 
 ## Non-Goals
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,6 +1,7 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2/FC-3 NOT BUILT. Owner
+Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
+NOT BUILT. Owner
 decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
 backend evaluator ships before dry-run.
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -182,6 +182,9 @@ detail array after pruning:
   fail closed in v1;
 - `COUNT({detail})` counts submitted rows;
 - `SUM({detail.amount})` requires every referenced amount cell to be numeric.
+- Boolean `AND`/`OR` must not short-circuit away malformed aggregate operands;
+  aggregate errors fail closed even when the other operand already determines
+  the boolean result.
 
 Reason: approval routing should not silently ignore malformed monetary data.
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,9 +1,10 @@
 # Approval Formula Conditions — Design Lock
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
-BUILT IN A STACKED PR (purchase/reimbursement examples). Owner
-decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
-backend evaluator ships before dry-run.
+BUILT IN A STACKED PR (purchase/reimbursement examples); FC-4 BUILT IN A
+STACKED PR (approval-specific backend dry-run endpoint). Owner decisions
+resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed; backend
+evaluator ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the
@@ -291,6 +292,18 @@ example:
 FC-3 applies the purchase and reimbursement examples to the shipped amount-tier
 presets. The leave example remains illustrative until a leave-specific
 multi-branch preset is introduced.
+
+### FC-4 — Approval-Specific Backend Dry-Run
+
+- Add `POST /api/approval-templates/formula-condition/dry-run`.
+- Gate it with `approval-templates:manage`, matching template authoring.
+- Accept `formSchema`, `expression`, and sample `formData`.
+- Use the same approval evaluator used by publish/execution.
+- Return a normal dry-run diagnostic payload for formula errors instead of
+  routing through the sheet-scoped multitable formula dry-run.
+
+This slice intentionally does not add the frontend "Evaluate" button yet. The
+endpoint is the backend truth surface that a later authoring UX can call.
 
 ## Non-Goals
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,8 +1,8 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — RUNTIME NOT BUILT. Owner decisions resolved:
-`AND/OR/NOT` only in v1; numeric aggregates fail closed; backend evaluator
-ships before dry-run.
+Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2/FC-3 NOT BUILT. Owner
+decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed;
+backend evaluator ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the

--- a/docs/development/approval-formula-condition-stack-review-20260625.md
+++ b/docs/development/approval-formula-condition-stack-review-20260625.md
@@ -1,0 +1,268 @@
+# Approval Formula Conditions — Stack Review
+
+Status: REVIEWED DRAFT STACK, NOT SHIPPED.
+
+Date: 2026-06-25
+
+This record reviews the stacked FC-1..FC-5 implementation against the ratified
+design-lock and the current GitHub PR state. It is a landing aid, not a shipped
+declaration.
+
+## Stack State
+
+| Slice | PR | Head | State |
+| --- | --- | --- | --- |
+| FC-1 evaluator | #3219 | `7b0cb4f08` | draft, GitHub checks green |
+| FC-2 authoring | #3220 | `b5d8b2230` | draft, GitHub checks green |
+| FC-3 preset examples | #3221 | `bf0e30124` | draft, GitHub checks green |
+| FC-4 backend dry-run | #3222 | `e446d4095` | draft, GitHub checks green |
+| FC-5 dry-run preview | #3223 | `1cbccea65` | draft, GitHub checks green |
+
+All five PRs are still draft and unmerged. Keep the stack order:
+FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+
+Current base/drift check:
+
+- `origin/main` is `7c52cc598`, the same commit recorded as FC-1's base.
+- FC-2..FC-5 are stacked on the preceding FC branch heads listed above.
+- GitHub reports all five PRs as `CLEAN`.
+- PR comments only contain non-actionable Gemini quota warnings; there are no
+  actionable reviews on the stack at the time of this record.
+
+## Reviewed Surfaces
+
+- Backend evaluator: `packages/core-backend/src/services/ApprovalConditionFormula.ts`
+- Backend graph validation/publish path:
+  `packages/core-backend/src/services/ApprovalProductService.ts`
+- Backend runtime branch selection:
+  `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- Backend dry-run route: `packages/core-backend/src/routes/approvals.ts`
+- Frontend condition authoring helper: `apps/web/src/approvals/conditionEdit.ts`
+- Frontend template authoring view:
+  `apps/web/src/views/approval/TemplateAuthoringView.vue`
+- Frontend template shape guard:
+  `apps/web/src/approvals/templateAuthoring.ts`
+- Frontend API wrapper: `apps/web/src/approvals/api.ts`
+- Mounted/frontend specs:
+  `apps/web/tests/approvalTemplateAuthoring.spec.ts`
+  and `apps/web/tests/approval-template-authoring-condition-edit.test.ts`
+- Backend RBAC boundary spec:
+  `packages/core-backend/tests/unit/approval-rbac-boundary.test.ts`
+
+## Gate Review
+
+### FC-1 — Backend Contract + Evaluator
+
+Verdict: no blocking finding found after the parenthesis-depth hardening.
+
+Evidence:
+
+- Formula contract is additive: `ConditionBranch` keeps `rules` and adds
+  optional `formula`.
+- `normalizeApprovalGraph` rejects mixed `formula + non-empty rules`.
+- Publish/update/create validation calls
+  `assertApprovalConditionFormulaValidForSchema`.
+- Runtime condition resolution uses the same
+  `evaluateApprovalConditionFormula`.
+- The evaluator is approval-specific and narrow: no eval, no external lookup,
+  bounded expression length, AST nodes, nesting depth, field refs, and function
+  calls.
+- Unsafe arithmetic and malformed aggregates fail closed.
+- Boolean `AND`/`OR` evaluate both operands, so malformed aggregate data cannot
+  hide behind short-circuit behavior.
+
+Self-review fix already landed in FC-1:
+
+- Pure parenthesis nesting now counts against the max nesting-depth cap. A
+  17-deep parenthesis wrapper around `TRUE` fails closed instead of bypassing
+  the AST-depth limit.
+
+Verification:
+
+- Backend focused unit suite: 98/98 passed.
+- Backend type-check: clean.
+- GitHub checks: green; strict E2E skipped as expected.
+
+### FC-2 — Frontend Authoring
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- The editor seeds `predicateMode` from branch shape:
+  formula branches hydrate as formula mode; rule branches hydrate as rule mode.
+- Saving a formula branch emits `{ rules: [], formula: { expression } }`.
+  Keeping `rules: []` is intentional because the backend/runtime branch shape
+  still requires a rules array.
+- Saving a rule branch omits `formula`.
+- Non-condition nodes and all graph edges are deep-cloned and preserved.
+- Formula reference preview checks top-level fields and detail sub-fields
+  against the draft form schema. The backend remains the arbiter.
+- The mounted wiring test switches a real condition branch from rules to
+  formula and asserts the saved payload.
+
+Verification:
+
+- `approval-web-guard`: green.
+- `pr-validate`: green.
+
+### FC-3 — Preset Examples
+
+Verdict: no blocking finding found in the current stack review.
+
+Evidence:
+
+- Formula-condition preset examples sit on top of the FC-1/FC-2 contract.
+- They do not introduce a new evaluator or a new graph model.
+- The stack remains draft, so these examples are not yet a shipped user promise.
+
+Verification:
+
+- `approval-web-guard`: green.
+- `pr-validate`: green.
+
+### FC-4 — Backend Dry-Run Endpoint
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- Route is approval-specific:
+  `POST /api/approval-templates/formula-condition/dry-run`.
+- Route is protected by `authenticate` and
+  `rbacGuard('approval-templates:manage')`.
+- It validates `expression`, `formSchema.fields`, and object-shaped `formData`.
+- It calls the same validator/evaluator as publish/runtime:
+  `assertApprovalConditionFormulaValidForSchema` and
+  `evaluateApprovalConditionFormula`.
+- Formula errors return structured diagnostics in the response body instead of
+  falling through as generic 500s.
+- The route does not call the sheet-scoped multitable formula dry-run API.
+
+Verification:
+
+- RBAC boundary tests cover no-auth 401, wrong-scope 403, manage-scope 200, and
+  runtime diagnostic response.
+- `pr-validate`: green.
+
+### FC-5 — Frontend Dry-Run Preview
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- Preview is explicit-button only; it is not per-keystroke.
+- Sample JSON is parsed locally and must be an object.
+- Request payload sends `{ formSchema, expression, formData }` to the FC-4
+  endpoint wrapper.
+- The preview result is informational only; it is not a save/publish gate.
+- Mounted wiring test proves:
+  - button -> endpoint payload,
+  - result rendering,
+  - save payload still contains only graph config,
+  - sample data does not enter the template payload.
+
+Verification:
+
+- Local post-restack backend focused suite: 98/98 passed.
+- Local approval-web-guard equivalent suite: 259/259 passed.
+- Web type-check: clean.
+- Backend type-check: clean.
+- `git diff --check`: clean.
+- GitHub `approval-web-guard`: green.
+- GitHub `pr-validate`: green.
+
+## Non-Blocking Notes
+
+- Direct linting of `apps/web/src/approvals/api.ts` still hits a pre-existing
+  unrelated unused-parameter issue at `approvalId`. The FC-5 API addition is
+  covered by `vue-tsc -b` and the mounted wiring test.
+- FC-3 examples are useful examples, not a substitute for FC-1/FC-2/FC-4/FC-5
+  contract verification.
+- This review did not convert the PRs from draft to ready and did not merge
+  anything.
+
+## Landing Requirements
+
+Before shipping:
+
+1. Convert or land one slice at a time in stack order:
+   FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+2. After each slice lands, rebase the next slice onto the new base.
+3. Re-run the slice's gates on the rebased head.
+4. Keep the backend as the branch arbiter; frontend dry-run remains UX only.
+5. After FC-5 lands, update the design-lock/status docs from draft-stack to
+   shipped.
+
+## Landing Checklist
+
+Use this checklist only after the owner explicitly opts into landing the draft
+stack. It is intentionally serial; do not hard-rebase or merge later slices in
+parallel because each PR depends on the previous branch head.
+
+### FC-1 #3219
+
+1. Confirm `origin/main` has not advanced; if it has, rebase FC-1 onto the new
+   `origin/main`.
+2. Convert #3219 from draft to ready.
+3. Re-run/confirm the full required check set.
+4. Squash-merge #3219.
+5. Record the squash SHA.
+
+### FC-2 #3220
+
+1. Rebase FC-2 onto the merged FC-1 squash commit.
+2. Confirm the authoring diff still only adds formula authoring and does not
+   touch backend runtime.
+3. Re-run/confirm `approval-web-guard` and `pr-validate`.
+4. Convert #3220 from draft to ready.
+5. Squash-merge #3220.
+6. Record the squash SHA.
+
+### FC-3 #3221
+
+1. Rebase FC-3 onto the merged FC-2 squash commit.
+2. Confirm the preset examples still use the FC-1/FC-2 formula contract and do
+   not introduce a second evaluator or graph shape.
+3. Re-run/confirm `approval-web-guard` and `pr-validate`.
+4. Convert #3221 from draft to ready.
+5. Squash-merge #3221.
+6. Record the squash SHA.
+
+### FC-4 #3222
+
+1. Rebase FC-4 onto the merged FC-3 squash commit.
+2. Confirm the dry-run route remains approval-specific and protected by
+   `authenticate` + `rbacGuard('approval-templates:manage')`.
+3. Re-run/confirm `pr-validate` and the RBAC boundary tests covering 401/403/200
+   plus formula diagnostics.
+4. Convert #3222 from draft to ready.
+5. Squash-merge #3222.
+6. Record the squash SHA.
+
+### FC-5 #3223
+
+1. Rebase FC-5 onto the merged FC-4 squash commit.
+2. Confirm the preview remains explicit-button UX only and sample JSON still
+   does not enter the template payload.
+3. Re-run/confirm `approval-web-guard`, `pr-validate`, and the mounted wiring
+   spec.
+4. Convert #3223 from draft to ready.
+5. Squash-merge #3223.
+6. Record the squash SHA.
+
+### Closeout
+
+1. Update `docs/design/approval-formula-condition-design-lock-20260625.md` from
+   stacked-built wording to `RATIFIED + SHIPPED`, with all five squash SHAs.
+2. Update this review record or the stack verification record so it no longer
+   says `draft stack`.
+3. Confirm no FC branches remain open unless intentionally retained for audit.
+
+## Review Verdict
+
+APPROVE FOR OWNER REVIEW / LANDING SEQUENCE.
+
+I found no remaining blocker in the current draft stack after the FC-1
+parenthesis-depth hardening. The feature is still not shipped until the stacked
+draft PRs are landed in order and the shipped-state documentation is updated.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -20,6 +20,7 @@ Commands run from `/private/tmp/metasheet2-fc5-formula-condition`:
 
 ```sh
 pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot
+pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot
 pnpm --filter @metasheet/web type-check
 pnpm --filter @metasheet/web lint
 pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0
@@ -29,6 +30,7 @@ git diff --check
 Results:
 
 - Focused frontend specs: 69/69 passed.
+- Approval web guard equivalent specs: 259/259 passed.
 - `vue-tsc -b`: clean.
 - Repository-configured web lint: clean.
 - Direct lint of the touched SFC/spec: clean.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -8,11 +8,65 @@ implementation state as of 2026-06-25. It is intentionally a snapshot, not a
 
 | Slice | PR | Base | Head | State |
 | --- | --- | --- | --- | --- |
-| FC-1 evaluator | #3219 | `main` | `05a4aea6f` | open draft, CI green |
-| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `e6ade9c09` | open draft, CI green |
-| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `52690aaf4` | open draft, CI green |
-| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `beea1d056` | open draft, pr-validate green |
-| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | `448f9e2b0` | open draft, local verification below |
+| FC-1 evaluator | #3219 | `main` | `7b0cb4f08` | open draft, GitHub checks green |
+| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `b5d8b2230` | open draft, GitHub checks green |
+| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `bf0e30124` | open draft, GitHub checks green |
+| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `e446d4095` | open draft, GitHub checks green |
+| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | this verification commit | open draft, GitHub checks green |
+
+## FC-1 Rebase Hardening
+
+After self-review, FC-1 now enforces the design-lock's nesting bound for pure
+parenthesis nesting as well as AST operator depth. A formula such as
+`((((...TRUE...))))` with 17 nested parentheses now fails with the same
+fail-closed nesting-depth error instead of bypassing the depth cap.
+
+Commands run from `/private/tmp/metasheet2-fc1-formula-condition`:
+
+```sh
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend type-check
+git diff --check
+```
+
+Results:
+
+- Backend focused unit suite: 98/98 passed.
+- Backend `tsc --noEmit`: clean.
+- `git diff --check`: clean.
+
+Downstream draft PRs FC-2..FC-5 were then rebased on the hardened FC-1 head.
+
+## Post-Rebase Stack Verification
+
+Commands run from `/private/tmp/metasheet2-fc5-formula-condition` after the
+FC-1 hardening and FC-2..FC-5 restack:
+
+```sh
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend type-check
+git diff --check
+```
+
+Results:
+
+- Backend focused unit suite: 98/98 passed.
+- Approval web guard equivalent specs: 259/259 passed.
+- `vue-tsc -b`: clean.
+- Backend `tsc --noEmit`: clean.
+- `git diff --check`: clean.
+
+GitHub state after the restack:
+
+- FC-1 #3219: all required checks green; `Strict E2E with Enhanced Gates`
+  skipped as expected.
+- FC-2 #3220: `approval-web-guard` and `pr-validate` green.
+- FC-3 #3221: `approval-web-guard` and `pr-validate` green.
+- FC-4 #3222: `pr-validate` green.
+- FC-5 #3223: `approval-web-guard` and `pr-validate` green.
+- All five PRs remain draft and unmerged.
 
 ## FC-5 Verification
 

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -1,0 +1,57 @@
+# Approval Formula Conditions — Stack Verification Snapshot
+
+Status: draft stack, not merged. This record documents the FC-1..FC-5 stacked
+implementation state as of 2026-06-25. It is intentionally a snapshot, not a
+"shipped" declaration.
+
+## Stack
+
+| Slice | PR | Base | Head | State |
+| --- | --- | --- | --- | --- |
+| FC-1 evaluator | #3219 | `main` | `05a4aea6f` | open draft, CI green |
+| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `e6ade9c09` | open draft, CI green |
+| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `52690aaf4` | open draft, CI green |
+| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `beea1d056` | open draft, pr-validate green |
+| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | `448f9e2b0` | open draft, local verification below |
+
+## FC-5 Verification
+
+Commands run from `/private/tmp/metasheet2-fc5-formula-condition`:
+
+```sh
+pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web lint
+pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0
+git diff --check
+```
+
+Results:
+
+- Focused frontend specs: 69/69 passed.
+- `vue-tsc -b`: clean.
+- Repository-configured web lint: clean.
+- Direct lint of the touched SFC/spec: clean.
+- `git diff --check`: clean.
+
+Note: direct linting of `src/approvals/api.ts` still hits a pre-existing
+unrelated unused-parameter issue at `approvalId`; the FC-5 API addition is
+covered by `vue-tsc -b` and the mounted wiring test.
+
+## Boundaries
+
+- FC-5 is UX-only over the FC-4 approval-specific dry-run endpoint.
+- The dry-run preview is explicit-button only, not per-keystroke.
+- Dry-run result text is informational only. It is not a save/publish gate.
+- Sample JSON stays local to the authoring component and never enters the
+  template payload.
+- The mounted wiring test proves button -> endpoint payload -> result display,
+  then save still emits only the formula graph config and preserves topology.
+
+## Remaining Before Shipping
+
+- Keep the stack order: FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+- Rebase each slice after the previous one lands.
+- Re-run that slice's gates on the rebased head before marking ready.
+- After the full stack lands, update this record or the design-lock status from
+  draft-stack to shipped.

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -21,6 +21,11 @@ import {
   type ApprovalTemplateVisibilityActor,
 } from '../services/ApprovalProductService'
 import {
+  ApprovalConditionFormulaError,
+  assertApprovalConditionFormulaValidForSchema,
+  evaluateApprovalConditionFormula,
+} from '../services/ApprovalConditionFormula'
+import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
 } from '../services/approval-bridge-types'
@@ -28,6 +33,7 @@ import { publishApprovalCountsUpdate } from '../services/approval-realtime'
 import { searchDirectoryUsers, listDirectoryRoles } from '../services/approval-directory'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 import { createDelegation, listDelegations, disableDelegation, updateDelegation } from '../services/ApprovalDelegationConfig'
+import type { FormSchema } from '../types/approval-product'
 
 const logger = new Logger('ApprovalsRouter')
 const MAX_APPROVAL_PAGE_SIZE = 200
@@ -178,6 +184,14 @@ function approvalErrorResponse(code: string, message: string) {
       message,
     },
   }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isFormSchemaLike(value: unknown): value is FormSchema {
+  return isPlainRecord(value) && Array.isArray(value.fields)
 }
 
 function sendServiceError(res: Response, error: ServiceError): void {
@@ -354,6 +368,60 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
       res.json({ roles })
     } catch (error) {
       handleApprovalsError(res, error, 'APPROVAL_DIRECTORY_ROLES_FAILED', 'Failed to list directory roles')
+    }
+  })
+
+  // FC-4 — approval-specific formula-condition dry-run. This intentionally uses the
+  // exact approval evaluator from publish/execution and stays separate from the
+  // sheet-scoped multitable formula dry-run API.
+  r.post('/api/approval-templates/formula-condition/dry-run', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+    try {
+      const body = isPlainRecord(req.body) ? req.body : {}
+      const expression = typeof body.expression === 'string' ? body.expression : ''
+      const formSchema = body.formSchema
+      const formData = body.formData
+
+      if (!expression.trim()) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'expression is required'),
+        )
+      }
+      if (!isFormSchemaLike(formSchema)) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'formSchema.fields is required'),
+        )
+      }
+      if (!isPlainRecord(formData)) {
+        return res.status(400).json(
+          approvalErrorResponse('APPROVAL_FORMULA_DRY_RUN_INVALID_REQUEST', 'formData object is required'),
+        )
+      }
+
+      try {
+        assertApprovalConditionFormulaValidForSchema(expression, formSchema)
+        const result = evaluateApprovalConditionFormula(expression, formData)
+        return res.json({ data: { success: true, result } })
+      } catch (error) {
+        if (error instanceof ApprovalConditionFormulaError) {
+          return res.json({
+            data: {
+              success: false,
+              error: {
+                code: 'APPROVAL_FORMULA_CONDITION_DRY_RUN_FAILED',
+                message: error.message,
+              },
+            },
+          })
+        }
+        throw error
+      }
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_FORMULA_DRY_RUN_FAILED',
+        'Failed to dry-run approval condition formula',
+      )
     }
   })
 

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -562,11 +562,13 @@ function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): Formul
     case 'binary': {
       if (ast.op === 'AND') {
         const left = assertBoolean(evaluateAst(ast.left, formData), 'AND left operand')
-        return left && assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+        return left && right
       }
       if (ast.op === 'OR') {
         const left = assertBoolean(evaluateAst(ast.left, formData), 'OR left operand')
-        return left || assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+        return left || right
       }
       const left = assertFiniteNumber(evaluateAst(ast.left, formData), `${ast.op} left operand`)
       const right = assertFiniteNumber(evaluateAst(ast.right, formData), `${ast.op} right operand`)

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -1,0 +1,618 @@
+import type { FormField, FormSchema } from '../types/approval-product'
+
+export const APPROVAL_CONDITION_FORMULA_LIMITS = {
+  maxExpressionLength: 512,
+  maxAstNodes: 128,
+  maxDepth: 16,
+  maxFieldReferences: 64,
+  maxFunctionCalls: 32,
+} as const
+
+export class ApprovalConditionFormulaError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApprovalConditionFormulaError'
+  }
+}
+
+type Token =
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'null' }
+  | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'identifier'; value: string }
+  | { kind: 'operator'; value: '+' | '-' | '*' | '/' | '==' | '!=' | '>' | '>=' | '<' | '<=' }
+  | { kind: 'paren'; value: '(' | ')' }
+  | { kind: 'eof' }
+
+type OperatorTokenValue = Extract<Token, { kind: 'operator' }>['value']
+
+type FormulaAst =
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'boolean'; value: boolean }
+  | { kind: 'null' }
+  | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'aggregate'; fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'; path: string[]; raw: string }
+  | { kind: 'unary'; op: 'NEG' | 'NOT'; expr: FormulaAst }
+  | { kind: 'binary'; op: '+' | '-' | '*' | '/' | 'AND' | 'OR'; left: FormulaAst; right: FormulaAst }
+  | { kind: 'compare'; op: '==' | '!=' | '>' | '>=' | '<' | '<='; left: FormulaAst; right: FormulaAst }
+
+type FormulaValue = number | string | boolean | null
+type FormulaType = 'number' | 'string' | 'boolean' | 'null'
+
+function fail(message: string): never {
+  throw new ApprovalConditionFormulaError(message)
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_]/.test(char)
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_]/.test(char)
+}
+
+function tokenize(expression: string): Token[] {
+  if (expression.length > APPROVAL_CONDITION_FORMULA_LIMITS.maxExpressionLength) {
+    fail(`expression exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxExpressionLength} characters`)
+  }
+
+  const tokens: Token[] = []
+  let i = 0
+  while (i < expression.length) {
+    const char = expression[i]
+    if (/\s/.test(char)) {
+      i += 1
+      continue
+    }
+
+    if (char === '{') {
+      const end = expression.indexOf('}', i + 1)
+      if (end < 0) fail('field reference is missing closing brace')
+      const raw = expression.slice(i + 1, end).trim()
+      if (!raw) fail('field reference cannot be empty')
+      if (raw.includes('{') || raw.includes('}')) fail('field reference cannot contain braces')
+      const path = raw.split('.').map((part) => part.trim())
+      if (path.length < 1 || path.length > 2 || path.some((part) => !part)) {
+        fail(`field reference is invalid: ${raw}`)
+      }
+      tokens.push({ kind: 'field', path, raw })
+      i = end + 1
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      const quote = char
+      let value = ''
+      let closed = false
+      i += 1
+      while (i < expression.length) {
+        const current = expression[i]
+        if (current === quote) {
+          i += 1
+          tokens.push({ kind: 'string', value })
+          closed = true
+          break
+        }
+        if (current === '\\') {
+          const escaped = expression[i + 1]
+          if (escaped === undefined) fail('string literal has a dangling escape')
+          const mapped = escaped === 'n'
+            ? '\n'
+            : escaped === 'r'
+              ? '\r'
+              : escaped === 't'
+                ? '\t'
+                : escaped
+          value += mapped
+          i += 2
+          continue
+        }
+        value += current
+        i += 1
+      }
+      if (!closed) {
+        fail('string literal is missing closing quote')
+      }
+      continue
+    }
+
+    if (/[0-9.]/.test(char)) {
+      const rest = expression.slice(i)
+      const match = rest.match(/^(?:\d+(?:\.\d+)?|\.\d+)/)
+      if (!match) fail(`unexpected token: ${char}`)
+      const value = Number(match[0])
+      if (!Number.isFinite(value)) fail(`number literal is not finite: ${match[0]}`)
+      tokens.push({ kind: 'number', value })
+      i += match[0].length
+      continue
+    }
+
+    if (isIdentifierStart(char)) {
+      let raw = char
+      i += 1
+      while (i < expression.length && isIdentifierPart(expression[i])) {
+        raw += expression[i]
+        i += 1
+      }
+      const upper = raw.toUpperCase()
+      if (upper === 'TRUE' || upper === 'FALSE') {
+        tokens.push({ kind: 'boolean', value: upper === 'TRUE' })
+      } else if (upper === 'NULL') {
+        tokens.push({ kind: 'null' })
+      } else {
+        tokens.push({ kind: 'identifier', value: upper })
+      }
+      continue
+    }
+
+    const two = expression.slice(i, i + 2)
+    if (two === '==' || two === '!=' || two === '>=' || two === '<=') {
+      tokens.push({ kind: 'operator', value: two })
+      i += 2
+      continue
+    }
+    if (char === '+' || char === '-' || char === '*' || char === '/' || char === '>' || char === '<') {
+      tokens.push({ kind: 'operator', value: char })
+      i += 1
+      continue
+    }
+    if (char === '(' || char === ')') {
+      tokens.push({ kind: 'paren', value: char })
+      i += 1
+      continue
+    }
+    fail(`unexpected token: ${char}`)
+  }
+
+  tokens.push({ kind: 'eof' })
+  return tokens
+}
+
+class FormulaParser {
+  private index = 0
+  private astNodes = 0
+  private fieldReferences = 0
+  private functionCalls = 0
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parse(): FormulaAst {
+    const expr = this.parseOr()
+    if (this.peek().kind !== 'eof') {
+      fail('unexpected trailing token')
+    }
+    const depth = astDepth(expr)
+    if (depth > APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth) {
+      fail(`formula AST depth exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth}`)
+    }
+    return expr
+  }
+
+  private node<T extends FormulaAst>(ast: T): T {
+    this.astNodes += 1
+    if (this.astNodes > APPROVAL_CONDITION_FORMULA_LIMITS.maxAstNodes) {
+      fail(`formula AST exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxAstNodes} nodes`)
+    }
+    if (ast.kind === 'field' || ast.kind === 'aggregate') {
+      this.fieldReferences += 1
+      if (this.fieldReferences > APPROVAL_CONDITION_FORMULA_LIMITS.maxFieldReferences) {
+        fail(`formula references more than ${APPROVAL_CONDITION_FORMULA_LIMITS.maxFieldReferences} fields`)
+      }
+    }
+    if (ast.kind === 'aggregate') {
+      this.functionCalls += 1
+      if (this.functionCalls > APPROVAL_CONDITION_FORMULA_LIMITS.maxFunctionCalls) {
+        fail(`formula calls more than ${APPROVAL_CONDITION_FORMULA_LIMITS.maxFunctionCalls} functions`)
+      }
+    }
+    return ast
+  }
+
+  private peek(): Token {
+    return this.tokens[this.index] ?? { kind: 'eof' }
+  }
+
+  private advance(): Token {
+    const token = this.peek()
+    this.index += 1
+    return token
+  }
+
+  private matchIdentifier(value: string): boolean {
+    const token = this.peek()
+    if (token.kind === 'identifier' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private matchOperator(value: OperatorTokenValue): boolean {
+    const token = this.peek()
+    if (token.kind === 'operator' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private matchParen(value: '(' | ')'): boolean {
+    const token = this.peek()
+    if (token.kind === 'paren' && token.value === value) {
+      this.index += 1
+      return true
+    }
+    return false
+  }
+
+  private parseOr(): FormulaAst {
+    let left = this.parseAnd()
+    while (this.matchIdentifier('OR')) {
+      left = this.node({ kind: 'binary', op: 'OR', left, right: this.parseAnd() })
+    }
+    return left
+  }
+
+  private parseAnd(): FormulaAst {
+    let left = this.parseNot()
+    while (this.matchIdentifier('AND')) {
+      left = this.node({ kind: 'binary', op: 'AND', left, right: this.parseNot() })
+    }
+    return left
+  }
+
+  private parseNot(): FormulaAst {
+    if (this.matchIdentifier('NOT')) {
+      return this.node({ kind: 'unary', op: 'NOT', expr: this.parseNot() })
+    }
+    return this.parseComparison()
+  }
+
+  private parseComparison(): FormulaAst {
+    const left = this.parseAdditive()
+    const token = this.peek()
+    if (token.kind !== 'operator' || !['==', '!=', '>', '>=', '<', '<='].includes(token.value)) {
+      return left
+    }
+    this.advance()
+    return this.node({
+      kind: 'compare',
+      op: token.value as Extract<FormulaAst, { kind: 'compare' }>['op'],
+      left,
+      right: this.parseAdditive(),
+    })
+  }
+
+  private parseAdditive(): FormulaAst {
+    let left = this.parseMultiplicative()
+    while (true) {
+      if (this.matchOperator('+')) {
+        left = this.node({ kind: 'binary', op: '+', left, right: this.parseMultiplicative() })
+        continue
+      }
+      if (this.matchOperator('-')) {
+        left = this.node({ kind: 'binary', op: '-', left, right: this.parseMultiplicative() })
+        continue
+      }
+      return left
+    }
+  }
+
+  private parseMultiplicative(): FormulaAst {
+    let left = this.parseUnary()
+    while (true) {
+      if (this.matchOperator('*')) {
+        left = this.node({ kind: 'binary', op: '*', left, right: this.parseUnary() })
+        continue
+      }
+      if (this.matchOperator('/')) {
+        left = this.node({ kind: 'binary', op: '/', left, right: this.parseUnary() })
+        continue
+      }
+      return left
+    }
+  }
+
+  private parseUnary(): FormulaAst {
+    if (this.matchOperator('-')) {
+      return this.node({ kind: 'unary', op: 'NEG', expr: this.parseUnary() })
+    }
+    if (this.matchOperator('+')) {
+      return this.parseUnary()
+    }
+    return this.parsePrimary()
+  }
+
+  private parsePrimary(): FormulaAst {
+    const token = this.advance()
+    switch (token.kind) {
+      case 'number':
+        return this.node({ kind: 'number', value: token.value })
+      case 'string':
+        return this.node({ kind: 'string', value: token.value })
+      case 'boolean':
+        return this.node({ kind: 'boolean', value: token.value })
+      case 'null':
+        return this.node({ kind: 'null' })
+      case 'field':
+        return this.node({ kind: 'field', path: token.path, raw: token.raw })
+      case 'identifier':
+        return this.parseFunction(token.value)
+      case 'paren': {
+        if (token.value !== '(') fail('unexpected closing parenthesis')
+        const expr = this.parseOr()
+        if (!this.matchParen(')')) fail('missing closing parenthesis')
+        return expr
+      }
+      case 'operator':
+        fail(`unexpected operator: ${token.value}`)
+      case 'eof':
+        fail('unexpected end of expression')
+      default:
+        fail('unexpected token')
+    }
+  }
+
+  private parseFunction(name: string): FormulaAst {
+    if (name !== 'SUM' && name !== 'COUNT' && name !== 'MIN' && name !== 'MAX') {
+      fail(`unsupported identifier: ${name}`)
+    }
+    if (!this.matchParen('(')) fail(`${name} requires parentheses`)
+    const token = this.advance()
+    if (token.kind !== 'field') fail(`${name} requires a field reference argument`)
+    if (!this.matchParen(')')) fail(`${name} accepts exactly one argument`)
+    return this.node({ kind: 'aggregate', fn: name, path: token.path, raw: token.raw })
+  }
+}
+
+function astDepth(ast: FormulaAst): number {
+  switch (ast.kind) {
+    case 'unary':
+      return 1 + astDepth(ast.expr)
+    case 'binary':
+    case 'compare':
+      return 1 + Math.max(astDepth(ast.left), astDepth(ast.right))
+    default:
+      return 1
+  }
+}
+
+function parseFormula(expression: string): FormulaAst {
+  const trimmed = expression.trim()
+  if (!trimmed) fail('expression is required')
+  return new FormulaParser(tokenize(trimmed)).parse()
+}
+
+function formFieldTypeToFormulaType(field: FormField): FormulaType | 'unsupported' {
+  switch (field.type) {
+    case 'number':
+      return 'number'
+    case 'text':
+    case 'textarea':
+    case 'date':
+    case 'datetime':
+    case 'select':
+    case 'user':
+      return 'string'
+    default:
+      return 'unsupported'
+  }
+}
+
+function findTopLevelField(schema: FormSchema, fieldId: string): FormField | undefined {
+  return schema.fields.find((field) => field.id === fieldId)
+}
+
+function findDetailColumn(schema: FormSchema, detailId: string, columnId: string): { detail: FormField; column: FormField } | undefined {
+  const detail = findTopLevelField(schema, detailId)
+  if (!detail || detail.type !== 'detail') return undefined
+  const column = detail.columns?.find((entry) => entry.id === columnId)
+  return column ? { detail, column } : undefined
+}
+
+function inferFormulaType(ast: FormulaAst, schema: FormSchema): FormulaType {
+  switch (ast.kind) {
+    case 'number':
+      return 'number'
+    case 'string':
+      return 'string'
+    case 'boolean':
+      return 'boolean'
+    case 'null':
+      return 'null'
+    case 'field': {
+      if (ast.path.length !== 1) {
+        fail(`detail sub-field reference must be used inside an aggregate: ${ast.raw}`)
+      }
+      const field = findTopLevelField(schema, ast.path[0])
+      if (!field) fail(`unknown field reference: ${ast.raw}`)
+      if (field.type === 'detail') fail(`detail field reference must use an aggregate: ${ast.raw}`)
+      const type = formFieldTypeToFormulaType(field)
+      if (type === 'unsupported') fail(`field type is not supported in formula: ${field.id}`)
+      return type
+    }
+    case 'aggregate':
+      validateAggregateReference(ast, schema)
+      return 'number'
+    case 'unary': {
+      const inner = inferFormulaType(ast.expr, schema)
+      if (ast.op === 'NOT') {
+        if (inner !== 'boolean') fail('NOT requires a boolean expression')
+        return 'boolean'
+      }
+      if (inner !== 'number') fail('unary +/- requires a numeric expression')
+      return 'number'
+    }
+    case 'binary': {
+      const left = inferFormulaType(ast.left, schema)
+      const right = inferFormulaType(ast.right, schema)
+      if (ast.op === 'AND' || ast.op === 'OR') {
+        if (left !== 'boolean' || right !== 'boolean') fail(`${ast.op} requires boolean operands`)
+        return 'boolean'
+      }
+      if (left !== 'number' || right !== 'number') {
+        fail(`operator ${ast.op} requires numeric operands`)
+      }
+      return 'number'
+    }
+    case 'compare': {
+      const left = inferFormulaType(ast.left, schema)
+      const right = inferFormulaType(ast.right, schema)
+      if (ast.op === '==' || ast.op === '!=') {
+        if (left !== right && left !== 'null' && right !== 'null') {
+          fail(`operator ${ast.op} requires compatible operand types`)
+        }
+        return 'boolean'
+      }
+      if (left !== 'number' || right !== 'number') {
+        fail(`operator ${ast.op} requires numeric operands`)
+      }
+      return 'boolean'
+    }
+    default:
+      fail('unsupported expression')
+  }
+}
+
+function validateAggregateReference(ast: Extract<FormulaAst, { kind: 'aggregate' }>, schema: FormSchema): void {
+  if (ast.fn === 'COUNT') {
+    if (ast.path.length !== 1) fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    const detail = findTopLevelField(schema, ast.path[0])
+    if (!detail || detail.type !== 'detail') fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    return
+  }
+
+  if (ast.path.length !== 2) fail(`${ast.fn} requires a detail sub-field reference: ${ast.raw}`)
+  const resolved = findDetailColumn(schema, ast.path[0], ast.path[1])
+  if (!resolved) fail(`${ast.fn} references an unknown detail sub-field: ${ast.raw}`)
+  if (resolved.column.type !== 'number') {
+    fail(`${ast.fn} requires a numeric detail sub-field: ${ast.raw}`)
+  }
+}
+
+function assertFiniteNumber(value: unknown, context: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${context} must be a finite number`)
+  }
+  return value
+}
+
+function assertBoolean(value: FormulaValue, context: string): boolean {
+  if (typeof value !== 'boolean') fail(`${context} must be boolean`)
+  return value
+}
+
+function evaluateField(path: string[], raw: string, formData: Record<string, unknown>): FormulaValue {
+  if (path.length !== 1) fail(`detail sub-field reference must be used inside an aggregate: ${raw}`)
+  if (!Object.prototype.hasOwnProperty.call(formData, path[0])) {
+    fail(`field ${raw} is missing`)
+  }
+  const value = formData[path[0]]
+  if (value === null) return null
+  if (value === undefined) fail(`field ${raw} is missing`)
+  if (typeof value === 'number') return assertFiniteNumber(value, `field ${raw}`)
+  if (typeof value === 'string' || typeof value === 'boolean') return value
+  fail(`field ${raw} has an unsupported runtime value`)
+}
+
+function evaluateAggregate(ast: Extract<FormulaAst, { kind: 'aggregate' }>, formData: Record<string, unknown>): number {
+  const detailValue = formData[ast.path[0]]
+  if (!Array.isArray(detailValue)) fail(`aggregate ${ast.fn} requires a detail array: ${ast.path[0]}`)
+  if (ast.fn === 'COUNT') {
+    if (ast.path.length !== 1) fail(`COUNT requires a detail field reference: ${ast.raw}`)
+    if (detailValue.some((row) => row === null || typeof row !== 'object' || Array.isArray(row))) {
+      fail('COUNT requires detail rows to be objects')
+    }
+    return detailValue.length
+  }
+  if (ast.path.length !== 2) fail(`${ast.fn} requires a detail sub-field reference: ${ast.raw}`)
+  const numbers = detailValue.map((row, index) => {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      fail(`${ast.fn} row ${index + 1} must be an object`)
+    }
+    return assertFiniteNumber((row as Record<string, unknown>)[ast.path[1]], `${ast.fn} value ${ast.raw}`)
+  })
+  if (ast.fn === 'SUM') {
+    return numbers.reduce((sum, value) => assertFiniteNumber(sum + value, 'SUM result'), 0)
+  }
+  if (numbers.length === 0) fail(`${ast.fn} requires at least one numeric detail value`)
+  return ast.fn === 'MIN' ? Math.min(...numbers) : Math.max(...numbers)
+}
+
+function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): FormulaValue {
+  switch (ast.kind) {
+    case 'number':
+    case 'string':
+    case 'boolean':
+      return ast.value
+    case 'null':
+      return null
+    case 'field':
+      return evaluateField(ast.path, ast.raw, formData)
+    case 'aggregate':
+      return evaluateAggregate(ast, formData)
+    case 'unary': {
+      const value = evaluateAst(ast.expr, formData)
+      if (ast.op === 'NOT') return !assertBoolean(value, 'NOT operand')
+      return assertFiniteNumber(-assertFiniteNumber(value, 'unary operand'), 'unary result')
+    }
+    case 'binary': {
+      if (ast.op === 'AND') {
+        const left = assertBoolean(evaluateAst(ast.left, formData), 'AND left operand')
+        return left && assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+      }
+      if (ast.op === 'OR') {
+        const left = assertBoolean(evaluateAst(ast.left, formData), 'OR left operand')
+        return left || assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+      }
+      const left = assertFiniteNumber(evaluateAst(ast.left, formData), `${ast.op} left operand`)
+      const right = assertFiniteNumber(evaluateAst(ast.right, formData), `${ast.op} right operand`)
+      if (ast.op === '/' && right === 0) fail('division by zero')
+      const result = ast.op === '+'
+        ? left + right
+        : ast.op === '-'
+          ? left - right
+          : ast.op === '*'
+            ? left * right
+            : left / right
+      return assertFiniteNumber(result, `${ast.op} result`)
+    }
+    case 'compare': {
+      const left = evaluateAst(ast.left, formData)
+      const right = evaluateAst(ast.right, formData)
+      if (ast.op === '==') return left === right
+      if (ast.op === '!=') return left !== right
+      const numericLeft = assertFiniteNumber(left, `${ast.op} left operand`)
+      const numericRight = assertFiniteNumber(right, `${ast.op} right operand`)
+      if (ast.op === '>') return numericLeft > numericRight
+      if (ast.op === '>=') return numericLeft >= numericRight
+      if (ast.op === '<') return numericLeft < numericRight
+      return numericLeft <= numericRight
+    }
+    default:
+      fail('unsupported expression')
+  }
+}
+
+export function parseApprovalConditionFormula(expression: string): void {
+  parseFormula(expression)
+}
+
+export function assertApprovalConditionFormulaValidForSchema(expression: string, schema: FormSchema): void {
+  const ast = parseFormula(expression)
+  const resultType = inferFormulaType(ast, schema)
+  if (resultType !== 'boolean') {
+    fail('formula must return boolean')
+  }
+}
+
+export function evaluateApprovalConditionFormula(expression: string, formData: Record<string, unknown>): boolean {
+  const result = evaluateAst(parseFormula(expression), formData)
+  if (typeof result !== 'boolean') {
+    fail('formula must return boolean')
+  }
+  return result
+}

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -176,6 +176,7 @@ class FormulaParser {
   private astNodes = 0
   private fieldReferences = 0
   private functionCalls = 0
+  private parenDepth = 0
 
   constructor(private readonly tokens: Token[]) {}
 
@@ -343,9 +344,17 @@ class FormulaParser {
         return this.parseFunction(token.value)
       case 'paren': {
         if (token.value !== '(') fail('unexpected closing parenthesis')
-        const expr = this.parseOr()
-        if (!this.matchParen(')')) fail('missing closing parenthesis')
-        return expr
+        this.parenDepth += 1
+        if (this.parenDepth > APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth) {
+          fail(`formula nesting depth exceeds ${APPROVAL_CONDITION_FORMULA_LIMITS.maxDepth}`)
+        }
+        try {
+          const expr = this.parseOr()
+          if (!this.matchParen(')')) fail('missing closing parenthesis')
+          return expr
+        } finally {
+          this.parenDepth -= 1
+        }
       }
       case 'operator':
         fail(`unexpected operator: ${token.value}`)

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -14,6 +14,7 @@ import type {
   RuntimeGraph,
 } from '../types/approval-product'
 import { ServiceError } from './ApprovalBridgeService'
+import { evaluateApprovalConditionFormula } from './ApprovalConditionFormula'
 
 export interface ApprovalGraphAssignment {
   assignmentType: 'user' | 'role'
@@ -1045,10 +1046,14 @@ export class ApprovalGraphExecutor {
       : []
 
     for (const branch of branches) {
-      const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
-      const result = conjunction === 'or'
-        ? branch.rules.some((rule) => evaluateRule(rule, this.formData))
-        : branch.rules.every((rule) => evaluateRule(rule, this.formData))
+      const result = branch.formula
+        ? evaluateApprovalConditionFormula(branch.formula.expression, this.formData)
+        : (() => {
+            const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
+            return conjunction === 'or'
+              ? branch.rules.some((rule) => evaluateRule(rule, this.formData))
+              : branch.rules.every((rule) => evaluateRule(rule, this.formData))
+          })()
       if (result) {
         return this.targetForEdge(branch.edgeKey)
       }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -15,6 +15,7 @@ import type {
   ApprovalGraph,
   ApprovalMode,
   ApprovalRequesterSnapshot,
+  ConditionFormulaPredicate,
   CreateApprovalRequest,
   CreateApprovalTemplateRequest,
   EmptyAssigneePolicy,
@@ -43,6 +44,11 @@ import {
 } from './ApprovalGraphExecutor'
 import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
 import { validateAmountTotalConsistency } from './amount-total-check'
+import {
+  ApprovalConditionFormulaError,
+  assertApprovalConditionFormulaValidForSchema,
+  parseApprovalConditionFormula,
+} from './ApprovalConditionFormula'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
 import { resolveActiveDelegationMap } from './ApprovalDelegations'
 import type {
@@ -482,6 +488,31 @@ function validateApprovalAssigneeSourcesAgainstFormSchema(
   })
 }
 
+function validateApprovalConditionFormulasAgainstFormSchema(
+  approvalGraph: ApprovalGraph,
+  formSchema: FormSchema,
+  context: ValidationContext,
+): void {
+  for (const node of approvalGraph.nodes) {
+    if (node.type !== 'condition') continue
+    const config = node.config as { branches?: unknown }
+    if (!Array.isArray(config.branches)) continue
+
+    config.branches.forEach((branch, branchIndex) => {
+      if (!isRecord(branch) || !isRecord(branch.formula) || typeof branch.formula.expression !== 'string') return
+      try {
+        assertApprovalConditionFormulaValidForSchema(branch.formula.expression, formSchema)
+      } catch (error) {
+        const message = error instanceof ApprovalConditionFormulaError ? error.message : String(error)
+        failValidation(
+          context,
+          `approvalGraph node ${node.key} condition formula branch ${branchIndex + 1} is invalid: ${message}`,
+        )
+      }
+    })
+  }
+}
+
 function failValidation(context: ValidationContext, message: string): never {
   throw new ServiceError(message, context.status, context.code)
 }
@@ -868,6 +899,25 @@ function normalizeNodeFieldPermissions(
   return normalized
 }
 
+function normalizeConditionFormulaPredicate(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): ConditionFormulaPredicate | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value) || !isNonEmptyString(value.expression)) {
+    failValidation(context, `${path}.expression is required`)
+  }
+  const expression = value.expression.trim()
+  try {
+    parseApprovalConditionFormula(expression)
+  } catch (error) {
+    const message = error instanceof ApprovalConditionFormulaError ? error.message : String(error)
+    failValidation(context, `${path}.expression is invalid: ${message}`)
+  }
+  return { expression }
+}
+
 /**
  * P1-C cross-reference: every `fieldPermissions[].fieldId` on an approval node
  * must reference a field that exists in the version's formSchema. Runs after
@@ -1027,9 +1077,21 @@ function normalizeApprovalGraph(
             if (branch.conjunction !== undefined && branch.conjunction !== 'and' && branch.conjunction !== 'or') {
               failValidation(context, `approvalGraph.nodes[${index}].config.branches[${branchIndex}].conjunction is invalid`)
             }
+            const formula = normalizeConditionFormulaPredicate(
+              branch.formula,
+              context,
+              `approvalGraph.nodes[${index}].config.branches[${branchIndex}].formula`,
+            )
+            if (formula && branch.rules.length > 0) {
+              failValidation(
+                context,
+                `approvalGraph.nodes[${index}].config.branches[${branchIndex}] cannot mix formula and rules`,
+              )
+            }
             return {
               edgeKey: branch.edgeKey.trim(),
               ...(branch.conjunction ? { conjunction: branch.conjunction } : {}),
+              ...(formula ? { formula } : {}),
               rules: branch.rules.map((rule, ruleIndex) => {
                 if (!isRecord(rule) || !isNonEmptyString(rule.fieldId) || !CONDITION_OPERATORS.has(String(rule.operator))) {
                   failValidation(
@@ -2290,6 +2352,7 @@ export class ApprovalProductService {
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
     validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
     validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
+    validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -2444,6 +2507,7 @@ export class ApprovalProductService {
         const nextApprovalGraph = approvalGraph ?? asApprovalGraph(latestVersion.approval_graph)
         validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
         validateNodeFieldPermissionsAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
+        validateApprovalConditionFormulasAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
 
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
@@ -2531,6 +2595,7 @@ export class ApprovalProductService {
       const approvalGraph = asApprovalGraph(version.approval_graph)
       validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       validateNodeFieldPermissionsAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      validateApprovalConditionFormulasAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
       // Fail-fast: a starter preset's unconfigured placeholder role MUST be replaced before publish —
       // otherwise the high path stalls at runtime on an unclaimable role assignment (nobody holds the
       // placeholder role). See APPROVAL_ROLE_CONFIGURE_SENTINEL.

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -140,6 +140,11 @@ export interface ConditionBranch {
   edgeKey: string
   rules: ConditionRule[]
   conjunction?: 'and' | 'or'
+  formula?: ConditionFormulaPredicate
+}
+
+export interface ConditionFormulaPredicate {
+  expression: string
 }
 
 export interface ConditionRule {

--- a/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-common-template-presets.api.test.ts
@@ -135,6 +135,40 @@ describeIfDatabase('common approval template presets — real-DB backend accepta
     expect(parallel!.config.joinMode).toBe('all')
   })
 
+  it('amount-tier formula conditions round-trip through create→normalize', async () => {
+    const cases = [
+      {
+        id: 'reimbursement_amount_tier' as const,
+        expression: '{expense_type} == "差旅" AND {amount} >= 5000',
+      },
+      {
+        id: 'purchase_amount_tier' as const,
+        expression: 'SUM({purchase_items.amount}) >= 20000',
+      },
+    ]
+
+    for (const item of cases) {
+      const payload = buildCommonApprovalTemplatePresetPayload(item.id, {
+        keySuffix: `realdb-${TS}-formula-${item.id}`,
+      })
+      const response = await jsonRequest(baseUrl, '/api/approval-templates', token, {
+        method: 'POST',
+        body: payload,
+      })
+      expect(response.status, await response.clone().text()).toBe(201)
+      const body = await response.json() as {
+        approvalGraph: { nodes: Array<{ type: string; config: Record<string, unknown> }> }
+      }
+      const condition = body.approvalGraph.nodes.find((node) => node.type === 'condition')
+      expect(condition?.config).toMatchObject({
+        branches: [{
+          rules: [],
+          formula: { expression: item.expression },
+        }],
+      })
+    }
+  })
+
   it('purchase_amount_tier: an UNTOUCHED preset CANNOT be published — the placeholder role fail-fasts at publish (a verifiable state, not a runtime stuck-flow)', async () => {
     expect(FE_ROLE_SENTINEL).toBe(BACKEND_ROLE_SENTINEL) // FE preset placeholder MUST byte-match the backend guard, else the guard misses it
     const payload = buildCommonApprovalTemplatePresetPayload('purchase_amount_tier', { keySuffix: `realdb-${TS}-sentinel` })

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APPROVAL_CONDITION_FORMULA_LIMITS,
+  assertApprovalConditionFormulaValidForSchema,
+  evaluateApprovalConditionFormula,
+  parseApprovalConditionFormula,
+} from '../../src/services/ApprovalConditionFormula'
+import type { FormSchema } from '../../src/types/approval-product'
+
+const schema: FormSchema = {
+  fields: [
+    { id: 'amount', type: 'number', label: 'Amount' },
+    { id: 'expense_type', type: 'select', label: 'Expense Type', options: [{ label: 'Travel', value: 'travel' }] },
+    { id: 'receipt', type: 'attachment', label: 'Receipt' },
+    { id: 'items', type: 'detail', label: 'Items', columns: [
+      { id: 'amount', type: 'number', label: 'Line Amount' },
+      { id: 'memo', type: 'text', label: 'Memo' },
+    ] },
+  ],
+}
+
+describe('approval condition formula evaluator (FC-1)', () => {
+  it('evaluates boolean formulas with detail aggregates and AND/OR/NOT', () => {
+    const formData = {
+      amount: 12000,
+      expense_type: 'travel',
+      items: [{ amount: 5000 }, { amount: 7000 }],
+    }
+
+    expect(evaluateApprovalConditionFormula(
+      'SUM({items.amount}) >= 10000 AND {expense_type} == "travel"',
+      formData,
+    )).toBe(true)
+    expect(evaluateApprovalConditionFormula(
+      'COUNT({items}) > 1 AND NOT ({amount} < 10000)',
+      formData,
+    )).toBe(true)
+    expect(evaluateApprovalConditionFormula(
+      'SUM({items.amount}) >= 20000 OR {expense_type} == "office"',
+      formData,
+    )).toBe(false)
+  })
+
+  it('validates schema references and requires a boolean result', () => {
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.amount}) >= 10000', schema)).not.toThrow()
+    expect(() => assertApprovalConditionFormulaValidForSchema('{missing} == 1', schema)).toThrow(/unknown field/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('{items.amount} >= 1', schema)).toThrow(/inside an aggregate/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.memo}) >= 1', schema)).toThrow(/numeric detail sub-field/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('SUM({items.amount})', schema)).toThrow(/must return boolean/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('{receipt} == "yes"', schema)).toThrow(/not supported/)
+  })
+
+  it('fails closed on unsafe numeric states and malformed runtime aggregates', () => {
+    expect(() => evaluateApprovalConditionFormula('10 / {amount} > 1', { amount: 0 })).toThrow(/division by zero/)
+    expect(() => evaluateApprovalConditionFormula('{amount} == null', {})).toThrow(/field amount is missing/)
+    expect(evaluateApprovalConditionFormula('{amount} == null', { amount: null })).toBe(true)
+    expect(() => evaluateApprovalConditionFormula('SUM({items.amount}) >= 1', { items: [{ amount: '10' }] })).toThrow(/finite number/)
+    expect(() => evaluateApprovalConditionFormula('MIN({items.amount}) >= 1', { items: [] })).toThrow(/at least one/)
+  })
+
+  it('rejects concrete DoS bounds before runtime', () => {
+    expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'1'.repeat(513)} == 1`)).toThrow(/exceeds 512/)
+  })
+
+  it('counts aggregate references against the field-reference cap', () => {
+    const limits = APPROVAL_CONDITION_FORMULA_LIMITS as { maxFieldReferences: number }
+    const original = limits.maxFieldReferences
+    limits.maxFieldReferences = 1
+    try {
+      expect(() => parseApprovalConditionFormula('SUM({items.amount}) + {amount} > 0')).toThrow(/references more than 1 fields/)
+    } finally {
+      limits.maxFieldReferences = original
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -58,6 +58,17 @@ describe('approval condition formula evaluator (FC-1)', () => {
     expect(() => evaluateApprovalConditionFormula('MIN({items.amount}) >= 1', { items: [] })).toThrow(/at least one/)
   })
 
+  it('does not let boolean short-circuiting hide malformed aggregate data', () => {
+    expect(() => evaluateApprovalConditionFormula(
+      '{expense_type} == "travel" AND SUM({items.amount}) >= 1',
+      { expense_type: 'office', items: [{ amount: 'bad' }] },
+    )).toThrow(/finite number/)
+    expect(() => evaluateApprovalConditionFormula(
+      '{expense_type} == "office" OR SUM({items.amount}) >= 1',
+      { expense_type: 'office', items: [{ amount: 'bad' }] },
+    )).toThrow(/finite number/)
+  })
+
   it('rejects concrete DoS bounds before runtime', () => {
     expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
     expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -72,6 +72,7 @@ describe('approval condition formula evaluator (FC-1)', () => {
   it('rejects concrete DoS bounds before runtime', () => {
     expect(() => parseApprovalConditionFormula(`${'1+'.repeat(130)}1 > 0`)).toThrow(/AST exceeds/)
     expect(() => parseApprovalConditionFormula(`${'NOT '.repeat(17)}TRUE`)).toThrow(/depth exceeds/)
+    expect(() => parseApprovalConditionFormula(`${'('.repeat(17)}TRUE${')'.repeat(17)}`)).toThrow(/nesting depth exceeds/)
     expect(() => parseApprovalConditionFormula(`${'1'.repeat(513)} == 1`)).toThrow(/exceeds 512/)
   })
 

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -62,6 +62,80 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  it('routes condition formula branches and keeps default as no-match only', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [
+              {
+                edgeKey: 'edge-high',
+                rules: [],
+                formula: { expression: 'SUM({items.amount}) >= 20000 AND {expense_type} == "travel"' },
+              },
+            ],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high-review' },
+        { key: 'edge-low', source: 'route', target: 'low-review' },
+        { key: 'edge-high-end', source: 'high-review', target: 'end' },
+        { key: 'edge-low-end', source: 'low-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const high = new ApprovalGraphExecutor(runtimeGraph, {
+      expense_type: 'travel',
+      items: [{ amount: 15000 }, { amount: 6000 }],
+    }).resolveInitialState()
+    expect(high.currentNodeKey).toBe('high-review')
+
+    const low = new ApprovalGraphExecutor(runtimeGraph, {
+      expense_type: 'office',
+      items: [{ amount: 21000 }],
+    }).resolveInitialState()
+    expect(low.currentNodeKey).toBe('low-review')
+  })
+
+  it('fails closed on condition formula runtime errors instead of taking defaultEdgeKey', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: '10 / {amount} > 1' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high-review' },
+        { key: 'edge-low', source: 'route', target: 'low-review' },
+        { key: 'edge-high-end', source: 'high-review', target: 'end' },
+        { key: 'edge-low-end', source: 'low-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, { amount: 0 }).resolveInitialState()).toThrow(/division by zero/)
+  })
+
   it('advances to approved when the next node is end', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1313,6 +1313,116 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  describe('approval condition formula contract (FC-1)', () => {
+    const formulaFormSchema = {
+      fields: [
+        { id: 'amount', type: 'number', label: 'Amount' },
+        { id: 'items', type: 'detail', label: 'Items', columns: [{ id: 'amount', type: 'number', label: 'Line Amount' }] },
+      ],
+    }
+    const formulaGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high' },
+        { key: 'edge-low', source: 'route', target: 'low' },
+        { key: 'edge-high-end', source: 'high', target: 'end' },
+        { key: 'edge-low-end', source: 'low', target: 'end' },
+      ],
+    }
+
+    it('preserves formula branches through createTemplate normalization', async () => {
+      pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+        if (statement.startsWith('INSERT INTO approval_templates')) {
+          return { rows: [{ id: 'tpl-formula', key: String(params?.[0]), name: String(params?.[1]), description: null, category: null, visibility_scope: JSON.parse(String(params?.[4])), sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: null, created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (statement.startsWith('INSERT INTO approval_template_versions')) {
+          return { rows: [{ id: 'ver-formula', template_id: 'tpl-formula', version: 1, status: 'draft', form_schema: JSON.parse(String(params?.[1])), approval_graph: JSON.parse(String(params?.[2])), created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        if (statement.startsWith('UPDATE approval_templates')) {
+          return { rows: [{ id: 'tpl-formula', key: 'formula-template', name: 'Formula Template', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'draft', active_version_id: null, latest_version_id: 'ver-formula', created_at: new Date('2026-06-25T00:00:00.000Z'), updated_at: new Date('2026-06-25T00:00:00.000Z') }], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const result = await new ApprovalProductService().createTemplate({
+        key: 'formula-template',
+        name: 'Formula Template',
+        formSchema: formulaFormSchema,
+        approvalGraph: formulaGraph,
+      } as never)
+
+      const condition = result.approvalGraph.nodes.find((node) => node.key === 'route')
+      expect((condition?.config as { branches: Array<{ formula?: { expression: string } }> }).branches[0].formula)
+        .toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+      const insertVersionCall = pgState.client.query.mock.calls.find(([sql]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_template_versions'))
+      const persistedGraph = JSON.parse(String(insertVersionCall?.[1]?.[2]))
+      expect(persistedGraph.nodes[1].config.branches[0].formula).toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+    })
+
+    it('rejects formula branches that mix rules or reference unknown fields before hitting the database', async () => {
+      const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+      const service = new ApprovalProductService()
+      await expect(service.createTemplate({
+        key: 'formula-mix',
+        name: 'Formula Mix',
+        formSchema: formulaFormSchema,
+        approvalGraph: {
+          ...formulaGraph,
+          nodes: formulaGraph.nodes.map((node) => node.key === 'route'
+            ? {
+                ...node,
+                config: {
+                  branches: [{
+                    edgeKey: 'edge-high',
+                    rules: [{ fieldId: 'amount', operator: 'gte', value: 20000 }],
+                    formula: { expression: 'SUM({items.amount}) >= 20000' },
+                  }],
+                  defaultEdgeKey: 'edge-low',
+                },
+              }
+            : node),
+        },
+      } as never)).rejects.toThrow(/cannot mix formula and rules/)
+
+      await expect(service.createTemplate({
+        key: 'formula-unknown',
+        name: 'Formula Unknown',
+        formSchema: formulaFormSchema,
+        approvalGraph: {
+          ...formulaGraph,
+          nodes: formulaGraph.nodes.map((node) => node.key === 'route'
+            ? {
+                ...node,
+                config: {
+                  branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: '{ghost} == 1' } }],
+                  defaultEdgeKey: 'edge-low',
+                },
+              }
+            : node),
+        },
+      } as never)).rejects.toThrow(/unknown field reference/)
+      expect(pgState.pool.connect).not.toHaveBeenCalled()
+    })
+  })
+
   it('accepts authoring-MVP form-field-user assignee sources when creating a template', async () => {
     const request = {
       key: 'expense-authoring',
@@ -4202,6 +4312,87 @@ describe('ApprovalProductService', () => {
     expect(deactivateIndex).toBeGreaterThan(lockIndex)
     expect(insertIndex).toBeGreaterThan(deactivateIndex)
     expect(statements.filter((statement) => statement === 'COMMIT')).toHaveLength(1)
+  })
+
+  it('preserves condition formulas through publish runtime_graph and read-back DTO', async () => {
+    const formSchema = {
+      fields: [
+        { id: 'amount', type: 'number', label: 'Amount' },
+        { id: 'items', type: 'detail', label: 'Items', columns: [{ id: 'amount', type: 'number', label: 'Line Amount' }] },
+      ],
+    }
+    const approvalGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-high', rules: [], formula: { expression: 'SUM({items.amount}) >= 20000' } }],
+            defaultEdgeKey: 'edge-low',
+          },
+        },
+        { key: 'high', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['senior'] } },
+        { key: 'low', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-high', source: 'route', target: 'high' },
+        { key: 'edge-low', source: 'route', target: 'low' },
+        { key: 'edge-high-end', source: 'high', target: 'end' },
+        { key: 'edge-low-end', source: 'low', target: 'end' },
+      ],
+    }
+    const template = {
+      id: 'tpl-1',
+      key: 'formula',
+      name: 'Formula Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: null,
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: formSchema,
+      approval_graph: approvalGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) return { rows: [template], rowCount: 1 }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) return { rows: [version], rowCount: 1 }
+      if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) return { rows: [], rowCount: 0 }
+      if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+        const runtimeGraph = JSON.parse(String(params?.[2]))
+        expect(runtimeGraph.nodes[1].config.branches[0].formula).toEqual({ expression: 'SUM({items.amount}) >= 20000' })
+        return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: runtimeGraph, is_active: true, published_at: new Date() }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) {
+        return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) return { rows: [], rowCount: 1 }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const result = await new ApprovalProductService().publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never)
+
+    const condition = result.runtimeGraph?.nodes.find((node) => node.key === 'route')
+    expect((condition?.config as { branches: Array<{ formula?: { expression: string } }> }).branches[0].formula)
+      .toEqual({ expression: 'SUM({items.amount}) >= 20000' })
   })
 
   it('snapshots publish-time auto-approval policy into runtime_graph without a migration column', async () => {

--- a/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
+++ b/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
@@ -94,6 +94,21 @@ function noPermsUser() {
   return { id: 'u-none', name: 'NoPerm', permissions: [] }
 }
 
+const formulaDryRunBody = {
+  expression: 'SUM({items.amount}) >= 100',
+  formSchema: {
+    fields: [{
+      id: 'items',
+      type: 'detail',
+      label: 'Items',
+      columns: [{ id: 'amount', type: 'number', label: 'Amount' }],
+    }],
+  },
+  formData: {
+    items: [{ amount: 60 }, { amount: 50 }],
+  },
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -134,6 +149,13 @@ describe('Approval RBAC boundary verification', () => {
       const res = await request(app)
         .post('/api/approval-templates')
         .send({ name: 'test', key: 'test-key' })
+      expect(res.status).toBe(401)
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run without auth → 401', async () => {
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
       expect(res.status).toBe(401)
     })
 
@@ -198,10 +220,42 @@ describe('Approval RBAC boundary verification', () => {
       expect(res.status).toBe(403)
     })
 
+    it('POST /api/approval-templates/formula-condition/dry-run with only approvals:read → 403', async () => {
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
+      expect(res.status).toBe(403)
+    })
+
     it('GET /api/approval-templates with approval-templates:manage → 200', async () => {
       authState.user = templateManager()
       const res = await request(app).get('/api/approval-templates')
       expect(res.status).toBe(200)
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run with approval-templates:manage → 200 success', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send(formulaDryRunBody)
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ data: { success: true, result: true } })
+    })
+
+    it('POST /api/approval-templates/formula-condition/dry-run returns diagnostics for runtime formula errors', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send({
+          ...formulaDryRunBody,
+          formData: { items: [{ amount: 'bad' }] },
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.success).toBe(false)
+      expect(res.body.data.error.code).toBe('APPROVAL_FORMULA_CONDITION_DRY_RUN_FAILED')
+      expect(res.body.data.error.message).toContain('must be a finite number')
     })
   })
 


### PR DESCRIPTION
## Summary

FC-5 for the approval formula-condition stack: adds an explicit authoring dry-run preview for formula condition branches.

- Adds `dryRunApprovalConditionFormula` web API wrapper for `POST /api/approval-templates/formula-condition/dry-run` from FC-4.
- Adds a per-branch sample JSON input + `测试公式` button in `TemplateAuthoringView` formula mode.
- Shows dry-run success/error text locally; this is UX-only and does not become a save/publish gate or enter the template payload.
- Adds a mounted SFC wiring test proving button -> endpoint payload -> result display, then save still emits only the formula graph config.
- Updates the formula-condition design lock with the FC-5 slice and adds a draft-stack verification snapshot.

## Stack

Base: `codex/approval-formula-condition-fc4-20260625`

This PR intentionally stays draft until FC-1..FC-4 are reviewed/landed.

## Verification

- `pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot` -> 69/69
- `pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot` -> 259/259
- `pnpm --filter @metasheet/web type-check` -> clean
- `pnpm --filter @metasheet/web lint` -> clean for the repo's configured web lint scope
- `pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0` -> clean
- `git diff --check` -> clean

Note: direct linting of `src/approvals/api.ts` still hits a pre-existing unrelated `approvalId` unused-parameter error at line 214; the API addition is covered by `vue-tsc -b` and the mounted wiring test.

## CI note

After the latest ordinary push, the PR REST head and diff are correct (`8394122d3`, 5-file diff), but GitHub Actions has not auto-created runs for this stacked draft PR yet. The local approval-web-guard-equivalent command above is recorded in `docs/development/approval-formula-condition-stack-verification-20260625.md`; rerun CI after rebasing/marking ready during stack landing.
