### PR TITLE
docs(multitable): T8-2 verification — delete-permission branch coverage口径 (review (b))

### DIFF
--- a/docs/development/multitable-t8-2-reset-dev-verification-20260625.md
+++ b/docs/development/multitable-t8-2-reset-dev-verification-20260625.md
@@ -65,6 +65,17 @@ Goldens:
 - source grep proves Reset does not compose reveal grants;
 - plain record editor without sheet-access management -> forbidden.
 
+### Coverage note — delete-permission branch (deliberately not separately golden-pinned)
+
+Delete-permission branch is intentionally not separately golden-pinned: `!canDeleteRecord` is shadowed
+by canWrite/canEditRecord, and `!ensureRecordWriteAllowed` is only reachable through narrow write-own
+scope setup. The mechanism it relies on, throw -> RESET_BLOCKED -> single-transaction rollback, is
+covered by locked-target and forced mid-write atomicity goldens.
+
+(Context: a no-write actor blocks at the revert field-forbidden preflight and 409s at PREVIEW before
+reaching the delete branch, so a dedicated golden would require a brittle write-own-scope + foreign
+`created_by` fixture for low marginal value — the safety property is already proven. No runtime change.)
+
 ## Remaining work
 
 Not part of T8-2 v1:


### PR DESCRIPTION
Records the persistent口径 from the T8-2 adversarial review (decision (b): no dedicated delete-permission golden) into the T8-2 verification MD.

**Why no dedicated golden:** `!canDeleteRecord` is shadowed by `canWrite`/`canEditRecord` (a no-write actor blocks at the revert field-forbidden preflight and 409s at PREVIEW, never reaching the delete branch — verified by a failed spike); `!ensureRecordWriteAllowed` is only reachable via a narrow write-own scope + foreign `created_by` fixture (brittle, low marginal value). The safety mechanism it relies on — **throw → RESET_BLOCKED → single-transaction rollback** — is already proven by the locked-target (c) and forced mid-write atomicity (h) goldens.

Docs-only; **no runtime change**. Closes out the review note so future readers don't mistake the locked-target golden for delete-permission coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)