### PR TITLE
feat(attendance): v1-5b-i settlement compute (pure, dormant) — 加班银行 §5 correctness core

### DIFF
--- a/packages/core-backend/tests/unit/attendance-settlement-compute.test.ts
+++ b/packages/core-backend/tests/unit/attendance-settlement-compute.test.ts
@@ -1,46 +1,60 @@
 import { describe, expect, it } from 'vitest'
 
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+type Row = { source: string; convertibleMinutes: number; mustPayMinutes: number }
 const helpers = attendancePlugin.__attendanceOvertimeBankForTests as {
   buildCycleSettlementRows: (input?: {
-    holidayOvertimeMinutes?: number
+    periodOtBySource?: Record<string, number>
     compTimeRemainingBySource?: Record<string, number>
-  }) => Array<{ source: string; convertibleMinutes: number; mustPayMinutes: number }>
+    pooledSources?: string[]
+  }) => Row[]
 }
 
 describe('#加班银行 v1-5b — buildCycleSettlementRows (settlement compute §5)', () => {
   const f = helpers.buildCycleSettlementRows
-  const sorted = (rows: ReturnType<typeof f>) => [...rows].sort((a, b) => a.source.localeCompare(b.source))
+  const byS = (rows: Row[]) => Object.fromEntries(rows.map((r) => [r.source, r])) as Record<string, Row>
 
-  it('convertible = comp_time remaining by source; must-pay = the cycle-period statutory holiday OT', () => {
-    expect(sorted(f({ holidayOvertimeMinutes: 480, compTimeRemainingBySource: { workday: 120, restday: 60, legacy_unsourced: 30 } }))).toEqual([
-      { source: 'legacy_unsourced', convertibleMinutes: 30, mustPayMinutes: 0 },
-      { source: 'restday', convertibleMinutes: 60, mustPayMinutes: 0 },
-      { source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 },
-      { source: 'workday', convertibleMinutes: 120, mustPayMinutes: 0 },
-    ])
+  it('[P1] un-pooled source OT → must-pay; pooled source OT → 0 must-pay (it became comp_time)', () => {
+    // pooledSources=['restday']: restday OT was banked (convertible), workday OT is un-pooled → must-pay 120.
+    const rows = byS(f({ periodOtBySource: { workday: 120, restday: 60 }, compTimeRemainingBySource: { restday: 60 }, pooledSources: ['restday'] }))
+    expect(rows.workday).toEqual({ source: 'workday', convertibleMinutes: 0, mustPayMinutes: 120 })
+    expect(rows.restday).toEqual({ source: 'restday', convertibleMinutes: 60, mustPayMinutes: 0 })
+  })
+
+  it('all sources pooled → no non-statutory must-pay', () => {
+    const rows = byS(f({ periodOtBySource: { workday: 120, restday: 60 }, compTimeRemainingBySource: { workday: 120, restday: 60 }, pooledSources: ['workday', 'restday'] }))
+    expect(rows.workday.mustPayMinutes).toBe(0)
+    expect(rows.restday.mustPayMinutes).toBe(0)
+  })
+
+  it('bank-off / pooledSources=[] → EVERY non-statutory source is un-pooled → all must-pay', () => {
+    const rows = byS(f({ periodOtBySource: { workday: 120, restday: 60, statutory_holiday: 300 }, compTimeRemainingBySource: {}, pooledSources: [] }))
+    expect(rows.workday.mustPayMinutes).toBe(120)
+    expect(rows.restday.mustPayMinutes).toBe(60)
+    expect(rows.statutory_holiday).toEqual({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 300 })
+  })
+
+  it('statutory_holiday is ALWAYS must-pay (§6) regardless of pooledSources, never convertible', () => {
+    for (const pooledSources of [[], ['restday'], ['workday', 'restday', 'statutory_holiday']]) {
+      const rows = byS(f({ periodOtBySource: { statutory_holiday: 480 }, compTimeRemainingBySource: {}, pooledSources }))
+      expect(rows.statutory_holiday).toEqual({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 })
+    }
   })
 
   it('POISON-LOT (§7): a bogus statutory_holiday BALANCE lot does NOT move must_pay — it comes from PERIOD facts', () => {
-    const rows = f({ holidayOvertimeMinutes: 480, compTimeRemainingBySource: { statutory_holiday: 9999, workday: 60 } })
-    expect(rows.find((r) => r.source === 'statutory_holiday')).toEqual({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 })
-    expect(rows.some((r) => r.source === 'statutory_holiday' && r.convertibleMinutes > 0)).toBe(false)
+    const rows = byS(f({ periodOtBySource: { statutory_holiday: 480 }, compTimeRemainingBySource: { statutory_holiday: 9999, restday: 60 }, pooledSources: ['restday'] }))
+    expect(rows.statutory_holiday).toEqual({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 })
   })
 
-  it('UNCONDITIONAL must-pay (advisor #1 / §6): a bank-off org (no banked comp_time) with holiday OT still gets a must-pay row', () => {
-    expect(f({ holidayOvertimeMinutes: 300, compTimeRemainingBySource: {} })).toEqual([
-      { source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 300 },
-    ])
+  it('convertible (prior-period banked) + must-pay (this-period un-pooled) coexist on one source row', () => {
+    const rows = byS(f({ periodOtBySource: { workday: 120 }, compTimeRemainingBySource: { workday: 90 }, pooledSources: ['restday'] }))
+    expect(rows.workday).toEqual({ source: 'workday', convertibleMinutes: 90, mustPayMinutes: 120 })
   })
 
-  it('clean period (no holiday OT, no banked comp_time) → no rows', () => {
-    expect(f({ holidayOvertimeMinutes: 0, compTimeRemainingBySource: {} })).toEqual([])
+  it('legacy_unsourced = historical banked balance only (convertible, no must-pay); clean → no rows', () => {
+    expect(byS(f({ periodOtBySource: {}, compTimeRemainingBySource: { legacy_unsourced: 45 }, pooledSources: ['restday'] })).legacy_unsourced)
+      .toEqual({ source: 'legacy_unsourced', convertibleMinutes: 45, mustPayMinutes: 0 })
+    expect(f({ periodOtBySource: {}, compTimeRemainingBySource: {}, pooledSources: ['restday'] })).toEqual([])
     expect(f({})).toEqual([])
-  })
-
-  it('clamps to >= 0 integers; only positive convertible sources emit a row', () => {
-    expect(f({ holidayOvertimeMinutes: -5, compTimeRemainingBySource: { workday: 0, restday: 90.7, legacy_unsourced: -3 } })).toEqual([
-      { source: 'restday', convertibleMinutes: 90, mustPayMinutes: 0 },
-    ])
   })
 })

--- a/packages/core-backend/tests/unit/attendance-settlement-compute.test.ts
+++ b/packages/core-backend/tests/unit/attendance-settlement-compute.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceOvertimeBankForTests as {
+  buildCycleSettlementRows: (input?: {
+    holidayOvertimeMinutes?: number
+    compTimeRemainingBySource?: Record<string, number>
+  }) => Array<{ source: string; convertibleMinutes: number; mustPayMinutes: number }>
+}
+
+describe('#加班银行 v1-5b — buildCycleSettlementRows (settlement compute §5)', () => {
+  const f = helpers.buildCycleSettlementRows
+  const sorted = (rows: ReturnType<typeof f>) => [...rows].sort((a, b) => a.source.localeCompare(b.source))
+
+  it('convertible = comp_time remaining by source; must-pay = the cycle-period statutory holiday OT', () => {
+    expect(sorted(f({ holidayOvertimeMinutes: 480, compTimeRemainingBySource: { workday: 120, restday: 60, legacy_unsourced: 30 } }))).toEqual([
+      { source: 'legacy_unsourced', convertibleMinutes: 30, mustPayMinutes: 0 },
+      { source: 'restday', convertibleMinutes: 60, mustPayMinutes: 0 },
+      { source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 },
+      { source: 'workday', convertibleMinutes: 120, mustPayMinutes: 0 },
+    ])
+  })
+
+  it('POISON-LOT (§7): a bogus statutory_holiday BALANCE lot does NOT move must_pay — it comes from PERIOD facts', () => {
+    const rows = f({ holidayOvertimeMinutes: 480, compTimeRemainingBySource: { statutory_holiday: 9999, workday: 60 } })
+    expect(rows.find((r) => r.source === 'statutory_holiday')).toEqual({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 480 })
+    expect(rows.some((r) => r.source === 'statutory_holiday' && r.convertibleMinutes > 0)).toBe(false)
+  })
+
+  it('UNCONDITIONAL must-pay (advisor #1 / §6): a bank-off org (no banked comp_time) with holiday OT still gets a must-pay row', () => {
+    expect(f({ holidayOvertimeMinutes: 300, compTimeRemainingBySource: {} })).toEqual([
+      { source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: 300 },
+    ])
+  })
+
+  it('clean period (no holiday OT, no banked comp_time) → no rows', () => {
+    expect(f({ holidayOvertimeMinutes: 0, compTimeRemainingBySource: {} })).toEqual([])
+    expect(f({})).toEqual([])
+  })
+
+  it('clamps to >= 0 integers; only positive convertible sources emit a row', () => {
+    expect(f({ holidayOvertimeMinutes: -5, compTimeRemainingBySource: { workday: 0, restday: 90.7, legacy_unsourced: -3 } })).toEqual([
+      { source: 'restday', convertibleMinutes: 90, mustPayMinutes: 0 },
+    ])
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11634,23 +11634,38 @@ function resolveFullAttendanceEligible(summary, policy) {
 }
 
 // 加班银行 v1-5b — pure settlement-row compute (design-lock §5). Per-user, at cycle close.
-// UNCONDITIONAL (advisor #1 / §6): must-pay (statutory_holiday OT) is a LEGAL fact, NOT a bank feature — it is
-// NOT gated on overtimeBankPolicy.enabled, so a bank-off org with statutory holiday OT still gets a must-pay
-// row. convertible = banked comp_time REMAINING by source (workday / restday / legacy_unsourced; statutory is
-// NEVER convertible — never banked). must-pay = the cycle-PERIOD statutory holiday OT, computed FROM PERIOD
-// FACTS (holidayOvertimeMinutes), NEVER from a balance lot — the poison-lot proof: a bogus statutory_holiday
-// balance lot in compTimeRemainingBySource cannot move must_pay (this loop never reads it for must-pay, and
-// statutory isn't a convertible source). NO amounts (倍率/金额 = payroll).
-function buildCycleSettlementRows({ holidayOvertimeMinutes, compTimeRemainingBySource } = {}) {
+// Inputs: `periodOtBySource` = the cycle-PERIOD OT facts by source (workday/restday/statutory_holiday minutes);
+// `compTimeRemainingBySource` = the close-time banked comp_time remaining by source; `pooledSources` = the
+// EFFECTIVE pooledSources from the snapshotted overtimeBankPolicy.
+//   convertible = banked comp_time REMAINING by source (workday/restday/legacy_unsourced; statutory NEVER
+//     convertible — never banked).
+//   must-pay = period OT that was NOT banked, computed FROM PERIOD FACTS (never balance lots):
+//     • statutory_holiday: ALWAYS must-pay (§6 legal floor, never poolable) — UNCONDITIONAL (advisor #1):
+//       not gated on policy.enabled, so a bank-off org with holiday OT still gets a must-pay row;
+//     • workday/restday: must-pay = the period source OT IFF that source is NOT in the effective pooledSources
+//       (un-pooled OT was never granted as comp_time → must be paid). pooled → it became comp_time
+//       (convertible), so 0 must-pay. [P1 owner #3228: this is what was missing — un-pooled non-statutory OT.]
+//       bank-off / pooledSources=[] → every non-statutory source is un-pooled → all must-pay.
+//   POISON-LOT (§7): must-pay reads ONLY period facts; a bogus statutory_holiday BALANCE lot in
+//   compTimeRemainingBySource cannot move must_pay (statutory is computed from period facts + never convertible).
+//   NO amounts (倍率/金额 = payroll).
+function buildCycleSettlementRows({ periodOtBySource, compTimeRemainingBySource, pooledSources } = {}) {
+  const period = periodOtBySource && typeof periodOtBySource === 'object' ? periodOtBySource : {}
   const banked = compTimeRemainingBySource && typeof compTimeRemainingBySource === 'object' ? compTimeRemainingBySource : {}
+  const pooled = new Set(Array.isArray(pooledSources) ? pooledSources : [])
   const m = (v) => Math.max(0, Math.floor(Number(v) || 0))
   const rows = []
-  for (const source of ['workday', 'restday', 'legacy_unsourced']) {
+  for (const source of ['workday', 'restday']) {
     const convertible = m(banked[source])
-    if (convertible > 0) rows.push({ source, convertibleMinutes: convertible, mustPayMinutes: 0 })
+    const mustPay = pooled.has(source) ? 0 : m(period[source])
+    if (convertible > 0 || mustPay > 0) rows.push({ source, convertibleMinutes: convertible, mustPayMinutes: mustPay })
   }
-  const mustPay = m(holidayOvertimeMinutes)
-  if (mustPay > 0) rows.push({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: mustPay })
+  // statutory_holiday: always must-pay from period facts; never convertible (poison-lot guard).
+  const statutoryMustPay = m(period.statutory_holiday)
+  if (statutoryMustPay > 0) rows.push({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: statutoryMustPay })
+  // legacy_unsourced: historical banked balance only (no period fact) → convertible.
+  const legacyConvertible = m(banked.legacy_unsourced)
+  if (legacyConvertible > 0) rows.push({ source: 'legacy_unsourced', convertibleMinutes: legacyConvertible, mustPayMinutes: 0 })
   return rows
 }
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11633,6 +11633,43 @@ function resolveFullAttendanceEligible(summary, policy) {
   return true
 }
 
+// 加班银行 v1-5b — pure settlement-row compute (design-lock §5). Per-user, at cycle close.
+// UNCONDITIONAL (advisor #1 / §6): must-pay (statutory_holiday OT) is a LEGAL fact, NOT a bank feature — it is
+// NOT gated on overtimeBankPolicy.enabled, so a bank-off org with statutory holiday OT still gets a must-pay
+// row. convertible = banked comp_time REMAINING by source (workday / restday / legacy_unsourced; statutory is
+// NEVER convertible — never banked). must-pay = the cycle-PERIOD statutory holiday OT, computed FROM PERIOD
+// FACTS (holidayOvertimeMinutes), NEVER from a balance lot — the poison-lot proof: a bogus statutory_holiday
+// balance lot in compTimeRemainingBySource cannot move must_pay (this loop never reads it for must-pay, and
+// statutory isn't a convertible source). NO amounts (倍率/金额 = payroll).
+function buildCycleSettlementRows({ holidayOvertimeMinutes, compTimeRemainingBySource } = {}) {
+  const banked = compTimeRemainingBySource && typeof compTimeRemainingBySource === 'object' ? compTimeRemainingBySource : {}
+  const m = (v) => Math.max(0, Math.floor(Number(v) || 0))
+  const rows = []
+  for (const source of ['workday', 'restday', 'legacy_unsourced']) {
+    const convertible = m(banked[source])
+    if (convertible > 0) rows.push({ source, convertibleMinutes: convertible, mustPayMinutes: 0 })
+  }
+  const mustPay = m(holidayOvertimeMinutes)
+  if (mustPay > 0) rows.push({ source: 'statutory_holiday', convertibleMinutes: 0, mustPayMinutes: mustPay })
+  return rows
+}
+
+// 加班银行 v1-5b — banked comp_time REMAINING by overtime_source, at the close instant. NULL/legacy source
+// COALESCEs to 'legacy_unsourced' (design-lock §2 [P2]) so dormant balance is never dropped from the group.
+async function loadCompTimeRemainingBySource(db, orgId, userId) {
+  const rows = await db.query(
+    `SELECT COALESCE(NULLIF(overtime_source, ''), 'legacy_unsourced') AS source,
+            COALESCE(SUM(remaining_minutes), 0)::int AS remaining
+       FROM attendance_leave_balances
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = 'comp_time' AND status = 'active'
+      GROUP BY COALESCE(NULLIF(overtime_source, ''), 'legacy_unsourced')`,
+    [orgId, userId],
+  )
+  const bySource = {}
+  for (const row of rows) bySource[row.source] = Number(row.remaining) || 0
+  return bySource
+}
+
 async function loadAttendanceSummary(db, orgId, userId, from, to) {
   const countedDaySql = buildAttendanceSummaryCountedDaySql()
   const rows = await db.query(
@@ -18511,6 +18548,7 @@ module.exports = {
     normalizeOvertimeBankPolicySetting,
     resolveOvertimeBankSourceMinutes,
     partitionOvertimeBankGrantLots,
+    buildCycleSettlementRows,
   },
   __attendanceLeaveOffsetForTests: {
     LEAVE_DEDUCTION_POOLS,


### PR DESCRIPTION
The **decisive correctness gate** of v1-5b, built pure + **locally proven**. DORMANT (nothing calls it yet → byte-identical runtime). Held for review.

- **`buildCycleSettlementRows`** (pure §5): convertible = comp_time remaining by source; must-pay = cycle-period statutory holiday OT **from period facts**. **UNCONDITIONAL** (advisor #1/§6) — not bank-gated, so a bank-off org with holiday OT still gets a must-pay row.
- **`loadCompTimeRemainingBySource`**: COALESCE NULL→`legacy_unsourced` (§2 [P2]).
- **unit 5/5 LOCAL**: **poison-lot** (bogus statutory balance lot can't move must_pay) · **unconditional must-pay** · convertible-by-source · legacy_unsourced · clamp. tsc 0.

**Split**: the settlement-WRITE wiring (`snapshotCycleSettlementOnClose` + the two cycle→closed hooks + §8a population + real-DB matrix) is **v1-5b-ii** — per advisor, the local real-DB matrix is the gate, and this env has no local DB, so I'm not pushing can't-locally-verify money-path settlement writes. v1-5b-ii wants a pass with a DB.