### PR TITLE
feat(integration): #1709 follow-up — generic read-smoke preset route (K3 Material/GetDetail; read-only, values-free)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5503,6 +5503,113 @@ async function testTemplatesCrudRoutes() {
   assert.equal(res.statusCode, 403, 'read-only user cannot instantiate')
 }
 
+// #1709 follow-up: read-smoke preset route. Built-in preset only; read-only; values-free; backend credential
+// context; no write path; system role/config untouched.
+async function testReadSmokeRoute() {
+  const readArgs = []
+  const writeCalls = []
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return { id: input.id, tenantId: 'tenant_1', kind: 'erp:k3-wise-webapi', role: 'target', credentials: { bearerToken: 'secret-token' } }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async read(req) {
+            readArgs.push(req)
+            return {
+              records: [{ _k3ReferenceObjects: { unit: {} }, FName: 'SECRET-NAME', FNumber: req.filters.FNumber }],
+              metadata: { requestedNumber: req.filters.FNumber, readPath: 'https://k3host/x' },
+            }
+          },
+          async upsert(b) { writeCalls.push(['upsert', b]); return {} },
+          async save(b) { writeCalls.push(['save', b]); return {} },
+          async submit(b) { writeCalls.push(['submit', b]); return {} },
+          async audit(b) { writeCalls.push(['audit', b]); return {} },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  // success: read once, values-free evidence, backend credential context, no write, system untouched
+  const ok = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, query: { workspaceId: 'workspace_1' },
+    body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+  })
+  assertOkResponse(ok, 200)
+  assert.equal(ok.body.data.ok, true)
+  assert.equal(ok.body.data.presetId, 'k3wise.material-detail.v1')
+  assert.equal(ok.body.data.object, 'material')
+  assert.equal(ok.body.data.recordPresent, true)
+  assert.equal(ok.body.data.referenceObjectCount, 1)
+  assert.equal(readArgs.length, 1, 'adapter.read called exactly once')
+  assert.deepEqual(readArgs[0], { object: 'material', filters: { FNumber: 'M-001' } })
+  assert.equal(writeCalls.length, 0, 'no upsert/save/submit/audit called')
+  assert.ok(findCall(calls, 'getExternalSystemForAdapter'), 'used backend getExternalSystemForAdapter')
+  assert.deepEqual(findCall(calls, 'createAdapter')[1].credentials, { bearerToken: 'secret-token' })
+  assert.equal(findCalls(calls, 'upsertExternalSystem').length, 0, 'read-smoke never persists/alters the system')
+  const okStr = JSON.stringify(ok.body.data)
+  for (const leak of ['M-001', 'SECRET-NAME', 'secret-token', 'k3host']) {
+    assert.ok(!okStr.includes(leak), `read-smoke response must not leak ${leak}`)
+  }
+
+  // wrong preset → 400 fail-closed
+  const badPreset = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'evil.custom.v1', key: 'M-001' },
+  })
+  assert.equal(badPreset.statusCode, 400, 'unknown preset is fail-closed')
+
+  // missing/blank key → 400 fail-closed
+  const blankKey = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: '   ' },
+  })
+  assert.equal(blankKey.statusCode, 400, 'blank key is fail-closed')
+
+  // extra body keys → 400 (no custom-preset / object smuggling)
+  const extra = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001', object: 'bom' },
+  })
+  assert.equal(extra.statusCode, 400, 'extra body keys are fail-closed')
+
+  // wrong adapter kind → 409 fail-closed
+  const wrong = createMockServices({
+    externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'http' } } },
+  })
+  const { routes: wkRoutes } = mountRoutes(wrong.services)
+  const wk = await invoke(wkRoutes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+  })
+  assert.equal(wk.statusCode, 409, 'wrong adapter kind is fail-closed')
+
+  // adapter read failure → values-free error (ok:false), no write
+  const failWrite = []
+  const failSvc = createMockServices({
+    externalSystemRegistry: { async getExternalSystemForAdapter(input) { return { id: input.id, kind: 'erp:k3-wise-webapi', credentials: {} } } },
+    adapterRegistry: { createAdapter() { return {
+      async read() { const e = new Error('material M-001 secret 42'); e.name = 'K3WiseWebApiAdapterError'; e.code = 'K3_WISE_READ_BUSINESS_ERROR'; throw e },
+      async upsert(b) { failWrite.push(b); return {} },
+    } } },
+  })
+  const { routes: fRoutes } = mountRoutes(failSvc.services)
+  const fail = await invoke(fRoutes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+  })
+  assertOkResponse(fail, 200)
+  assert.equal(fail.body.data.ok, false)
+  assert.equal(fail.body.data.errorCode, 'K3_WISE_READ_BUSINESS_ERROR')
+  assert.equal(fail.body.data.errorType, 'K3WiseWebApiAdapterError')
+  const failStr = JSON.stringify(fail.body.data)
+  assert.ok(!failStr.includes('M-001') && !failStr.includes('42'), 'read failure evidence is values-free')
+  assert.equal(failWrite.length, 0, 'no write attempted on read failure')
+
+  console.log('  testReadSmokeRoute OK')
+}
+
 async function main() {
   await testTemplatesCrudRoutes()
   await testUnauthenticatedWriteRequestIsRejected()
@@ -5523,6 +5630,7 @@ async function main() {
   await testTemplatePreviewLiveBulkRead()
   await testTemplatePreviewBulkReadGuards()
   await testExternalSystemRoutes()
+  await testReadSmokeRoute()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestClearsErrorToActiveOnSuccess()

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -1,0 +1,84 @@
+'use strict'
+
+// #1709 follow-up: read-smoke preset catalog + values-free evidence helpers (unit). The route-level tests
+// (fail-closed paths, backend credential context, no-write) live in http-routes.test.cjs (testReadSmokeRoute).
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const {
+  READ_SMOKE_PRESETS,
+  getReadSmokePreset,
+  buildReadSmokeRequest,
+  readSmokeSuccessEvidence,
+  readSmokeErrorEvidence,
+} = require(path.join(__dirname, '..', 'lib', 'read-smoke.cjs'))
+
+const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
+
+// --- catalog (built-in only) ---
+assert.ok(PRESET, 'k3wise.material-detail.v1 is registered')
+assert.equal(PRESET.requiredKind, 'erp:k3-wise-webapi')
+assert.equal(PRESET.object, 'material')
+// unknown / empty / non-string / prototype keys → undefined (route fail-closes)
+assert.equal(getReadSmokePreset('evil.custom.v1'), undefined)
+assert.equal(getReadSmokePreset(''), undefined)
+assert.equal(getReadSmokePreset(undefined), undefined)
+assert.equal(getReadSmokePreset('toString'), undefined, 'prototype key never resolves to a preset')
+assert.equal(getReadSmokePreset('__proto__'), undefined)
+// catalog frozen — no user/runtime mutation
+assert.throws(() => { READ_SMOKE_PRESETS['x.v1'] = { requiredKind: 'http' } }, TypeError, 'catalog is frozen')
+
+// --- forced single-record read request: FNumber filter only, no list/pagination/cursor/watermark/BOM ---
+const reqObj = buildReadSmokeRequest(PRESET, 'M-001')
+assert.deepEqual(reqObj, { object: 'material', filters: { FNumber: 'M-001' } })
+assert.equal(reqObj.cursor, undefined)
+assert.equal(reqObj.limit, undefined)
+assert.equal(reqObj.watermark, undefined)
+assert.equal(reqObj.pagination, undefined)
+
+// --- success evidence: recordPresent + referenceObjectCount; values-free ---
+const okResult = {
+  records: [{ _k3ReferenceObjects: { unit: {}, category: {} }, FName: 'SECRET-NAME', FNumber: 'M-001' }],
+  raw: { secretPayload: 1 },
+  metadata: { requestedNumber: 'M-001', readPath: 'https://k3host/K3API/Material/GetDetail' },
+}
+const ev = readSmokeSuccessEvidence(PRESET, okResult)
+assert.deepEqual(ev, {
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: true, referenceObjectCount: 2,
+})
+// nothing sensitive leaks (key / material values / raw / metadata / host)
+const evStr = JSON.stringify(ev)
+for (const leak of ['M-001', 'SECRET-NAME', 'k3host', 'readPath', 'requestedNumber', 'secretPayload']) {
+  assert.ok(!evStr.includes(leak), `success evidence must not leak ${leak}`)
+}
+assert.equal(ev.records, undefined)
+assert.equal(ev.raw, undefined)
+assert.equal(ev.metadata, undefined)
+// empty / missing records → recordPresent false, count 0
+assert.deepEqual(readSmokeSuccessEvidence(PRESET, { records: [] }), {
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+})
+assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}), {
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+})
+
+// --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
+class FakeAdapterError extends Error {
+  constructor() { super('material M-001 failed with secret value 42'); this.name = 'K3WiseWebApiAdapterError'; this.code = 'K3_WISE_READ_BUSINESS_ERROR' }
+}
+const errEv = readSmokeErrorEvidence(PRESET, new FakeAdapterError())
+assert.deepEqual(errEv, {
+  ok: false, presetId: 'k3wise.material-detail.v1', object: 'material',
+  errorCode: 'K3_WISE_READ_BUSINESS_ERROR', errorType: 'K3WiseWebApiAdapterError',
+})
+const errStr = JSON.stringify(errEv)
+for (const leak of ['M-001', '42', 'failed with secret']) {
+  assert.ok(!errStr.includes(leak), `error evidence must not leak ${leak}`)
+}
+// error without code/name → safe defaults
+const bare = readSmokeErrorEvidence(PRESET, {})
+assert.equal(bare.errorCode, 'READ_SMOKE_READ_FAILED')
+assert.equal(bare.errorType, 'Error')
+
+console.log('read-smoke.test.cjs OK')

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -16,6 +16,7 @@ const ROUTES = [
   ['GET', '/api/integration/external-systems/:id', 'externalSystemsGet'],
   ['DELETE', '/api/integration/external-systems/:id', 'externalSystemsDelete'],
   ['POST', '/api/integration/external-systems/:id/test', 'externalSystemsTest'],
+  ['POST', '/api/integration/external-systems/:id/read-smoke', 'externalSystemReadSmoke'],
   ['GET', '/api/integration/external-systems/:id/objects', 'externalSystemObjects'],
   ['GET', '/api/integration/external-systems/:id/schema', 'externalSystemSchema'],
   ['GET', '/api/integration/pipelines', 'pipelinesList'],
@@ -77,6 +78,7 @@ const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isB
 const { resolveReferenceRuleValue } = require('./reference-mapping-resolver.cjs')
 // DF-T3b-2b: live mapping-sheet bulk-read → referenceMappingIndexes for the preview seam (read-only).
 const { buildReferenceMappingIndexes } = require('./reference-mapping-source.cjs')
+const { getReadSmokePreset, buildReadSmokeRequest, readSmokeSuccessEvidence, readSmokeErrorEvidence } = require('./read-smoke.cjs')
 const { K3_REFERENCE_MAPPING_TEMPLATES } = require('./reference-mapping-templates.cjs')
 const { listReferenceIntegrationTemplates } = require('./reference-integration-templates.cjs')
 // DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
@@ -1593,6 +1595,47 @@ function createHandlers(services, options = {}) {
         ...result,
         system: redactSystemForTest(updatedSystem),
       })
+    },
+
+    // #1709 follow-up: generic read-smoke preset route (v1: K3 Material/GetDetail preset only). Built-in
+    // preset catalog ONLY — no user/request-supplied preset. Read-only: forced single read, no list/
+    // pagination/cursor/watermark/BOM, no Save/Submit/Audit, no production write. Loads credentials via the
+    // backend getExternalSystemForAdapter context (never the public, credential-stripped response) and never
+    // modifies the system's role/config. Evidence is values-free.
+    async externalSystemReadSmoke(req, res) {
+      requireAccess(req, 'read')
+      // Strict body: only { presetId, key }. The preset (kind/object/read shape) comes from the catalog, not
+      // the request, so a custom preset config can never be smuggled in.
+      const body = isPlainObject(requestBody(req)) ? requestBody(req) : {}
+      const extraKeys = Object.keys(body).filter((k) => k !== 'presetId' && k !== 'key')
+      if (extraKeys.length > 0) {
+        throw new HttpRouteError(400, 'READ_SMOKE_BODY_INVALID', 'read-smoke body allows only presetId and key')
+      }
+      const preset = getReadSmokePreset(firstString(body.presetId))
+      if (!preset) {
+        throw new HttpRouteError(400, 'READ_SMOKE_PRESET_UNKNOWN', 'unknown read-smoke preset')
+      }
+      const key = firstString(body.key)
+      if (!key) {
+        throw new HttpRouteError(400, 'READ_SMOKE_KEY_REQUIRED', 'read-smoke key is required')
+      }
+      // Backend credential context — NOT the public, credential-stripped system response.
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
+      // Kind must match the preset (fail-closed). Read-only: the system role/config is never modified here.
+      if (!system || system.kind !== preset.requiredKind) {
+        throw new HttpRouteError(409, 'READ_SMOKE_KIND_MISMATCH', 'external system kind does not match the preset')
+      }
+      const adapter = adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
+      // Forced single read only; values-free evidence on success or failure (never key/raw/values/credentials).
+      try {
+        const result = await adapter.read(buildReadSmokeRequest(preset, key))
+        return sendOk(res, readSmokeSuccessEvidence(preset, result))
+      } catch (error) {
+        return sendOk(res, readSmokeErrorEvidence(preset, error))
+      }
     },
 
     async externalSystemObjects(req, res) {

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -1,0 +1,72 @@
+'use strict'
+
+// #1709 follow-up: generic read-smoke preset catalog + values-free evidence helpers.
+// v1 registers ONLY built-in presets — there is no user/request-supplied preset path. The route reads only
+// { presetId, key } from the request; the preset (kind/object/read shape) comes from THIS frozen catalog,
+// never the request. Read-only: builds a forced single-record read; no list / pagination / cursor /
+// watermark / BOM; no Save / Submit / Audit. Evidence is values-free (booleans / counts / coarse enums only)
+// — never the key, raw payload, material values, host, token, credentials, or connection string.
+
+const READ_SMOKE_PRESETS = Object.freeze({
+  'k3wise.material-detail.v1': Object.freeze({
+    presetId: 'k3wise.material-detail.v1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material',
+  }),
+})
+
+// Built-in catalog lookup. Returns undefined for anything not in the catalog (→ route fail-closes). Uses an
+// own-property check so prototype keys ('toString', '__proto__', …) can never resolve to a preset.
+function getReadSmokePreset(presetId) {
+  if (typeof presetId !== 'string' || !presetId) return undefined
+  return Object.prototype.hasOwnProperty.call(READ_SMOKE_PRESETS, presetId) ? READ_SMOKE_PRESETS[presetId] : undefined
+}
+
+// Forced single-record read request. Single explicit key only — no list/pagination/cursor/watermark/BOM.
+function buildReadSmokeRequest(preset, key) {
+  return { object: preset.object, filters: { FNumber: key } }
+}
+
+// Values-free evidence from a successful read. Extracts ONLY recordPresent (boolean) + referenceObjectCount
+// (count) from the result's records — never the record values, metadata (which carries the key as
+// requestedNumber + a readPath), or raw payload.
+function readSmokeSuccessEvidence(preset, result) {
+  const records = result && Array.isArray(result.records) ? result.records : []
+  const recordPresent = records.length > 0
+  let referenceObjectCount = 0
+  if (recordPresent) {
+    const refs = records[0] && records[0]._k3ReferenceObjects
+    referenceObjectCount = refs && typeof refs === 'object' ? Object.keys(refs).length : 0
+  }
+  return {
+    ok: true,
+    presetId: preset.presetId,
+    object: preset.object,
+    recordPresent,
+    referenceObjectCount,
+  }
+}
+
+// Values-free error evidence. Returns ONLY a coarse code + type — never the error message, which may carry
+// the key or material values.
+function readSmokeErrorEvidence(preset, error) {
+  // Use the error's own enum-like code + name only (both values-free). Never fall back to constructor.name
+  // (a plain thrown object would surface 'Object', which is noise) and never read the message.
+  const code = error && typeof error.code === 'string' && error.code ? error.code : null
+  const name = error && typeof error.name === 'string' && error.name ? error.name : null
+  return {
+    ok: false,
+    presetId: preset.presetId,
+    object: preset.object,
+    errorCode: code || 'READ_SMOKE_READ_FAILED',
+    errorType: name || 'Error',
+  }
+}
+
+module.exports = {
+  READ_SMOKE_PRESETS,
+  getReadSmokePreset,
+  buildReadSmokeRequest,
+  readSmokeSuccessEvidence,
+  readSmokeErrorEvidence,
+}


### PR DESCRIPTION
New route **POST /api/integration/external-systems/:id/read-smoke**. v1 = **built-in preset catalog only** (no user/request preset). First preset: `k3wise.material-detail.v1`.

- **read-smoke.cjs:** frozen catalog (prototype-key-safe lookup) + values-free evidence. Forced single read (`{object:'material', filters:{FNumber:key}}`) — no list/pagination/cursor/watermark/BOM. Success evidence extracted from `records` only (never raw/metadata, which carry the key + readPath); error evidence is coarse `errorCode`/`errorType` only (never the message).
- **http-routes.cjs:** credentials via the **backend `getExternalSystemForAdapter`** (not the public response); strict `{presetId, key}` body; **fail-closed** on unknown preset / wrong kind (`erp:k3-wise-webapi`) / blank key / extra keys; calls `adapter.read` only — **never upsert/Save/Submit/Audit**; never alters the system role/config.

**Tests:** unit (catalog + values-free extraction + prototype-key + frozen) + route (`testReadSmokeRoute`: read-once, values-free + no-leak, backend credential context, no-write, all fail-closed paths, read-failure values-free). #1868 adapter tests green; full sweep 0 failures.

**Boundary:** no WebAPI LIST · no BOM · no Save/Submit/Audit · no production write · no user-created preset · no UI · system role/config untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
