### PR TITLE
feat(integration): read-smoke route requires integration WRITE (credentialed probe + existence signal)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5538,7 +5538,7 @@ async function testReadSmokeRoute() {
 
   // success: read once, values-free evidence, backend credential context, no write, system untouched
   const ok = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, query: { workspaceId: 'workspace_1' },
+    user: WRITE_USER, params: { id: 'sys_1' }, query: { workspaceId: 'workspace_1' },
     body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
   })
   assertOkResponse(ok, 200)
@@ -5558,21 +5558,27 @@ async function testReadSmokeRoute() {
     assert.ok(!okStr.includes(leak), `read-smoke response must not leak ${leak}`)
   }
 
+  // write-gated: a read-only integration user cannot trigger the credentialed probe (existence-oracle risk)
+  const denied = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+  })
+  assert.equal(denied.statusCode, 403, 'read user cannot trigger read-smoke (requires integration write)')
+
   // wrong preset → 400 fail-closed
   const badPreset = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'evil.custom.v1', key: 'M-001' },
+    user: WRITE_USER, params: { id: 'sys_1' }, body: { presetId: 'evil.custom.v1', key: 'M-001' },
   })
   assert.equal(badPreset.statusCode, 400, 'unknown preset is fail-closed')
 
   // missing/blank key → 400 fail-closed
   const blankKey = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: '   ' },
+    user: WRITE_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: '   ' },
   })
   assert.equal(blankKey.statusCode, 400, 'blank key is fail-closed')
 
   // extra body keys → 400 (no custom-preset / object smuggling)
   const extra = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001', object: 'bom' },
+    user: WRITE_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001', object: 'bom' },
   })
   assert.equal(extra.statusCode, 400, 'extra body keys are fail-closed')
 
@@ -5582,7 +5588,7 @@ async function testReadSmokeRoute() {
   })
   const { routes: wkRoutes } = mountRoutes(wrong.services)
   const wk = await invoke(wkRoutes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+    user: WRITE_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
   })
   assert.equal(wk.statusCode, 409, 'wrong adapter kind is fail-closed')
 
@@ -5597,7 +5603,7 @@ async function testReadSmokeRoute() {
   })
   const { routes: fRoutes } = mountRoutes(failSvc.services)
   const fail = await invoke(fRoutes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
-    user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
+    user: WRITE_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },
   })
   assertOkResponse(fail, 200)
   assert.equal(fail.body.data.ok, false)

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1603,7 +1603,10 @@ function createHandlers(services, options = {}) {
     // backend getExternalSystemForAdapter context (never the public, credential-stripped response) and never
     // modifies the system's role/config. Evidence is values-free.
     async externalSystemReadSmoke(req, res) {
-      requireAccess(req, 'read')
+      // Requires WRITE access: although the operation is read-only, this is an active credentialed outbound
+      // probe of K3 and returns an existence signal (recordPresent) a read user could enumerate against keys.
+      // Per the conservative discipline it is a connection/probe action → operator/integration-write only.
+      requireAccess(req, 'write')
       // Strict body: only { presetId, key }. The preset (kind/object/read shape) comes from the catalog, not
       // the request, so a custom preset config can never be smuggled in.
       const body = isPlainObject(requestBody(req)) ? requestBody(req) : {}


### PR DESCRIPTION
Owner-directed tightening of the #1709 follow-up read-smoke route. Read-only operation, but an **active credentialed outbound probe** that returns an **existence signal** (`recordPresent`) a read user could enumerate against keys → per the conservative discipline it's a connection/probe action, **operator / integration-write only**.

- `externalSystemReadSmoke`: `requireAccess('read')` → `'write'` (+ rationale).
- Test: valid/fail-closed cases use `WRITE_USER`; **added a non-vacuous guard** that `READ_USER` is denied **403** (reverting the route to `'read'` fails this assertion — verified).

Access-only change; read-only / values-free / no-write / no-LIST/BOM / preset-only / role-config-untouched all unchanged. Full plugin sweep 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
