### PR TITLE
test(multitable): T8-2 Reset staging acceptance harness + runbook (#1 of rollout)

### DIFF
--- a/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
+++ b/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
@@ -25,7 +25,7 @@ Harness: `packages/core-backend/scripts/reset-acceptance.mjs` (Node ≥18, uses 
 | d | flag ON, admin, a **locked** post-T target in scope | `409 RESET_BLOCKED`, **zero writes** |
 | e | flag ON, admin, a record **created after the preview** (drift) | `409` (delete-set re-enumeration), nothing deleted |
 | f | flag ON, admin, sheet **above** `MULTITABLE_SHEET_REVERT_MAX_RECORDS` | `413 SHEET_TOO_LARGE` |
-| g | flag ON, admin, **happy path** | post-T records soft-deleted (in trash, gone from live); survivors reverted to T; `source=restore` revisions |
+| g | flag ON, admin, **happy path** | post-T records soft-deleted (gone from live), survivors reverted to T. *Harness asserts the LIVE effect (post-T leave the delete-set + `visibleRevertCount=0`); the `source=restore` revision write + trash landing are golden-covered, confirm trash once by hand.* |
 
 ## Run
 
@@ -47,7 +47,8 @@ Exit 0 = all run scenarios passed; 1 = a failure; 2 = config/setup error.
 ### What the harness provisions (API-automated) vs manual prerequisites
 - **Automated** (HTTP, isolated per run): a fresh acceptance base + sheet + a `number` field; pre-T records A,B; an
   `asOf` T; post-T records C,D (the delete-set) + a post-T change to A (to prove the revert); record lock (d);
-  drift record (e); ceiling seeding (f, only if `RESET_MAX_RECORDS` is small).
+  drift record (e); ceiling seeding for (f) on a **separate throwaway sheet** (only if `RESET_MAX_RECORDS` is small) —
+  it never touches the main sheet, so **(g) still runs in the same flag-on run**: one run covers (b)–(g).
 - **Manual prerequisites** (do NOT fake): the two JWTs (`ADMIN_TOKEN` = sheet-admin/`multitable:share`,
   `EDITOR_TOKEN` = `multitable:write` without share); toggling `MULTITABLE_ENABLE_PIT_RESET`; setting a small
   `MULTITABLE_SHEET_REVERT_MAX_RECORDS` if you want (f) (default 5000 is impractical to seed). Scenario (b) skips

--- a/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
+++ b/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
@@ -9,6 +9,9 @@ only.
 
 Harness: `packages/core-backend/scripts/reset-acceptance.mjs` (Node ≥18, uses built-in `fetch`, no deps).
 
+> **Scope of this acceptance:** Passing this harness authorizes staging-scope validation only. It is not production
+> enablement approval; production requires a separate owner decision and environment-specific retention confirmation.
+
 ## Reset vs Revert (state this in any future UI, hard)
 - **Revert** (T8-1, non-destructive): surviving records → their state at T; records created after T are **kept**.
 - **Reset** (T8-2, destructive): same revert **plus** records created after T are **moved to the recycle bin**.
@@ -61,6 +64,10 @@ Enable `MULTITABLE_ENABLE_PIT_RESET` for the chosen scope **only if**: (a) passe
 gated error codes with **zero writes** on the deny/drift paths; (g) soft-deleted the post-T set (recoverable in trash)
 and reverted survivors; and either (f) returned 413 or the ceiling was consciously deferred. Any deny/drift path that
 *wrote* (a non-409, or records actually deleted under (d)/(e)) is a **stop-ship** — do not enable.
+
+**STOP-SHIP (trash-retention hard gate):** before any staging flag flip, confirm `meta_records_trash` retention/aging
+keeps Reset-created trash rows recoverable for the approved recovery window. If retention is shorter, disabled,
+unknown, or unverified, do not enable `MULTITABLE_ENABLE_PIT_RESET`.
 
 ## Staging caveats (don't misread these as Reset bugs)
 - **Pending migrations** — diff staging vs prod-track migrations first; a Reset 500 right after deploy is usually a

--- a/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
+++ b/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
@@ -1,0 +1,70 @@
+# T8-2 Reset-to-T — acceptance runbook (staging, pre-enablement)
+
+Reset is the one **destructive** capability on the Global History / point-in-time-restore line: it reverts surviving
+records to their state at **T** AND **soft-deletes records created after T into the recycle bin**
+(`meta_records_trash` — recoverable, not a normal Revert). It ships behind a default-off flag
+(`MULTITABLE_ENABLE_PIT_RESET`). This runbook makes the staging "enable-flag → verify behavior + error codes" a
+one-click run, so the enablement decision rests on clean evidence — Reset has **no UI yet**, so this is API/harness
+only.
+
+Harness: `packages/core-backend/scripts/reset-acceptance.mjs` (Node ≥18, uses built-in `fetch`, no deps).
+
+## Reset vs Revert (state this in any future UI, hard)
+- **Revert** (T8-1, non-destructive): surviving records → their state at T; records created after T are **kept**.
+- **Reset** (T8-2, destructive): same revert **plus** records created after T are **moved to the recycle bin**.
+  Recoverable from trash, but it is *not* a normal restore — call it out unambiguously, with a typed confirm and a
+  deleted-count echo, before any end user can trigger it.
+
+## Scenarios
+
+| # | Condition | Expected |
+|---|---|---|
+| a | flag **OFF**, reset-preview AND reset-execute | `403 RESET_DISABLED` (inert) |
+| b | flag ON, **editor** (not sheet-admin) | `403` (D2 `canManageSheetAccess` gate) |
+| c | flag ON, admin, execute **without** `confirm:'reset'` | `400` (D4 typed confirm) |
+| d | flag ON, admin, a **locked** post-T target in scope | `409 RESET_BLOCKED`, **zero writes** |
+| e | flag ON, admin, a record **created after the preview** (drift) | `409` (delete-set re-enumeration), nothing deleted |
+| f | flag ON, admin, sheet **above** `MULTITABLE_SHEET_REVERT_MAX_RECORDS` | `413 SHEET_TOO_LARGE` |
+| g | flag ON, admin, **happy path** | post-T records soft-deleted (in trash, gone from live); survivors reverted to T; `source=restore` revisions |
+
+## Run
+
+The harness auto-detects the flag state: with the flag **off** it runs (a) and stops; with it **on** it runs (b)–(g).
+
+```bash
+# 1) FLAG OFF (default) — proves Reset is inert before enabling
+BASE_URL=https://<staging> ADMIN_TOKEN=<sheet-admin JWT> \
+  node packages/core-backend/scripts/reset-acceptance.mjs        # expect (a) PASS
+
+# 2) Enable the flag in staging, then re-run for (b)–(g):
+#    set MULTITABLE_ENABLE_PIT_RESET=true in the staging env and redeploy/restart, then:
+BASE_URL=https://<staging> ADMIN_TOKEN=<sheet-admin JWT> EDITOR_TOKEN=<editor JWT> \
+  RESET_MAX_RECORDS=<staging MULTITABLE_SHEET_REVERT_MAX_RECORDS, if small> \
+  node packages/core-backend/scripts/reset-acceptance.mjs        # expect (b)–(g) PASS
+```
+Exit 0 = all run scenarios passed; 1 = a failure; 2 = config/setup error.
+
+### What the harness provisions (API-automated) vs manual prerequisites
+- **Automated** (HTTP, isolated per run): a fresh acceptance base + sheet + a `number` field; pre-T records A,B; an
+  `asOf` T; post-T records C,D (the delete-set) + a post-T change to A (to prove the revert); record lock (d);
+  drift record (e); ceiling seeding (f, only if `RESET_MAX_RECORDS` is small).
+- **Manual prerequisites** (do NOT fake): the two JWTs (`ADMIN_TOKEN` = sheet-admin/`multitable:share`,
+  `EDITOR_TOKEN` = `multitable:write` without share); toggling `MULTITABLE_ENABLE_PIT_RESET`; setting a small
+  `MULTITABLE_SHEET_REVERT_MAX_RECORDS` if you want (f) (default 5000 is impractical to seed). Scenario (b) skips
+  without `EDITOR_TOKEN`; (f) skips without a small `RESET_MAX_RECORDS`.
+- **Verify by hand after (g):** C/D appear in the recycle bin (`meta_records_trash` / trash UI) — recoverable, not
+  hard-deleted. The harness asserts they are gone from live; confirm the trash side visually.
+
+## Enablement-decision criteria
+Enable `MULTITABLE_ENABLE_PIT_RESET` for the chosen scope **only if**: (a) passed flag-off; (b)–(e) all returned the
+gated error codes with **zero writes** on the deny/drift paths; (g) soft-deleted the post-T set (recoverable in trash)
+and reverted survivors; and either (f) returned 413 or the ceiling was consciously deferred. Any deny/drift path that
+*wrote* (a non-409, or records actually deleted under (d)/(e)) is a **stop-ship** — do not enable.
+
+## Staging caveats (don't misread these as Reset bugs)
+- **Pending migrations** — diff staging vs prod-track migrations first; a Reset 500 right after deploy is usually a
+  schema gap, not a logic bug.
+- **Distinct JWT** — staging (e.g. :8082) may use a different `JWT_SECRET`; a prod token → `401 Invalid token`. A
+  silent 401 from the harness is an env/auth gap, not a Reset failure. Mint the tokens against staging.
+- **Bundle fingerprint** — confirm the deployed bundle actually contains the T8-2 routes (the staging lane may not
+  auto-mirror main) before concluding a 404 means "route missing."

--- a/packages/core-backend/scripts/reset-acceptance.mjs
+++ b/packages/core-backend/scripts/reset-acceptance.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * T8-2 Reset-to-T — staging acceptance harness (one-click error-code + behavior evidence).
+ *
+ * Reset is DESTRUCTIVE: it reverts surviving records to their state at T AND soft-deletes records
+ * created after T (into the recycle bin / meta_records_trash — recoverable, NOT a normal Revert).
+ * This harness proves, against a real environment, that the flag gate + error codes + delete behavior
+ * are correct BEFORE the flag is enabled for any real scope. See
+ * docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md.
+ *
+ * Usage:
+ *   BASE_URL=https://staging.example ADMIN_TOKEN=<jwt> [EDITOR_TOKEN=<jwt>] [RESET_MAX_RECORDS=<n>] \
+ *     node packages/core-backend/scripts/reset-acceptance.mjs
+ *
+ *   ADMIN_TOKEN  — a sheet-admin (canManageSheetAccess / multitable:share). REQUIRED.
+ *   EDITOR_TOKEN — a normal record editor (multitable:write, NOT share). Optional; scenario (b) skips if absent.
+ *   RESET_MAX_RECORDS — if set to the env's MULTITABLE_SHEET_REVERT_MAX_RECORDS, enables the (f) 413 ceiling test.
+ *
+ * Flag handling: run ONCE with the flag OFF (proves (a) — Reset is inert), then enable
+ * MULTITABLE_ENABLE_PIT_RESET and run AGAIN (runs (b)-(g)). The harness auto-detects the flag state and
+ * runs the matching scenarios.
+ *
+ * Exit: 0 = all run scenarios passed; 1 = a scenario failed; 2 = config/setup error.
+ */
+
+const BASE = (process.env.BASE_URL || '').replace(/\/$/, '')
+const ADMIN = process.env.ADMIN_TOKEN
+const EDITOR = process.env.EDITOR_TOKEN || null
+const MAXREC = process.env.RESET_MAX_RECORDS ? Number(process.env.RESET_MAX_RECORDS) : null
+const MOUNT = process.env.RESET_API_MOUNT || '/api/multitable'
+if (!BASE || !ADMIN) { console.error('FATAL: BASE_URL and ADMIN_TOKEN are required.'); process.exit(2) }
+
+let pass = 0, fail = 0, skip = 0
+const log = (...a) => console.log(...a)
+function ok(name, cond, detail = '') {
+  if (cond) { pass++; log(`  ✓ PASS  ${name}`) }
+  else { fail++; log(`  ✗ FAIL  ${name}${detail ? ' — ' + detail : ''}`) }
+}
+const skipped = (name, why) => { skip++; log(`  ⊘ SKIP  ${name} — ${why}`) }
+
+async function api(method, path, token, body) {
+  let res, json = null
+  try {
+    res = await fetch(`${BASE}${MOUNT}${path}`, {
+      method,
+      headers: { 'content-type': 'application/json', ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+  } catch (e) { return { status: 0, body: { error: { code: 'NETWORK', message: String(e) } } } }
+  try { json = await res.json() } catch { /* non-JSON */ }
+  return { status: res.status, body: json }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const code = (r) => r?.body?.error?.code || ''
+
+// ---- setup (HTTP self-provision; any step without a clean API is documented in the runbook, not faked) ----
+async function setup() {
+  const stamp = Date.now()
+  const base = await api('POST', '/bases', ADMIN, { name: `RESET-ACCEPT ${stamp}` })
+  if (base.status !== 200 && base.status !== 201) throw new Error(`create base failed: ${base.status} ${JSON.stringify(base.body)}`)
+  const baseId = base.body?.data?.id || base.body?.data?.base?.id || base.body?.id
+  const sheet = await api('POST', '/sheets', ADMIN, { baseId, name: `RS ${stamp}` })
+  if (sheet.status !== 200 && sheet.status !== 201) throw new Error(`create sheet failed: ${sheet.status} ${JSON.stringify(sheet.body)}`)
+  const sheetId = sheet.body?.data?.id || sheet.body?.data?.sheet?.id || sheet.body?.id
+  if (!baseId || !sheetId) throw new Error(`could not read baseId/sheetId from create responses (baseId=${baseId} sheetId=${sheetId})`)
+  // fields (best-effort; the revert assertion in (g) needs at least one editable field)
+  const f = await api('POST', '/fields', ADMIN, { sheetId, name: 'Salary', type: 'number' })
+  const salaryId = f.body?.data?.id || f.body?.data?.field?.id || f.body?.id || null
+  const mkRec = async (data) => {
+    const r = await api('POST', '/records', ADMIN, { sheetId, data })
+    return r.body?.data?.id || r.body?.data?.record?.id || r.body?.id || null
+  }
+  // pre-T records A,B
+  const A = await mkRec(salaryId ? { [salaryId]: 100 } : { name: 'a' })
+  const B = await mkRec(salaryId ? { [salaryId]: 200 } : { name: 'b' })
+  await sleep(1200)
+  const T = new Date().toISOString() // asOf — strictly after A,B, strictly before C,D + the A change
+  await sleep(1200)
+  // post-T: change A (to test revert), create C,D (the delete-set)
+  if (salaryId && A) await api('PATCH', `/records/${A}`, ADMIN, { sheetId, data: { [salaryId]: 999 } })
+  const C = await mkRec(salaryId ? { [salaryId]: 300 } : { name: 'c' })
+  const D = await mkRec(salaryId ? { [salaryId]: 400 } : { name: 'd' })
+  return { baseId, sheetId, salaryId, A, B, C, D, T }
+}
+
+async function run() {
+  log(`\nT8-2 Reset acceptance — ${BASE}${MOUNT}\n`)
+  // ---- flag-state probe ----
+  const ctx = await setup()
+  const probe = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+  const flagOff = probe.status === 403 && code(probe) === 'RESET_DISABLED'
+
+  if (flagOff) {
+    log('Flag state: OFF (MULTITABLE_ENABLE_PIT_RESET not set). Running scenario (a) only.\n')
+    ok('(a) flag-OFF reset-preview → 403 RESET_DISABLED', probe.status === 403 && code(probe) === 'RESET_DISABLED', `got ${probe.status}/${code(probe)}`)
+    const ex = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: 'x', confirm: 'reset' })
+    ok('(a) flag-OFF reset-execute → 403 RESET_DISABLED', ex.status === 403 && code(ex) === 'RESET_DISABLED', `got ${ex.status}/${code(ex)}`)
+    log('\n→ (a) covers the inert/off state. ENABLE MULTITABLE_ENABLE_PIT_RESET and re-run for (b)–(g).')
+    return finish()
+  }
+
+  log('Flag state: ON. Running scenarios (b)–(g).\n')
+
+  // (b) editor (not sheet-admin) → 403
+  if (EDITOR) {
+    const r = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, EDITOR, { asOf: ctx.T })
+    ok('(b) editor reset-preview → 403 (D2 sheet-admin gate)', r.status === 403, `got ${r.status}/${code(r)}`)
+  } else skipped('(b) editor → 403', 'EDITOR_TOKEN not provided')
+
+  // (c) admin, execute WITHOUT confirm:'reset' → 400 (D4)
+  {
+    const r = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: 'x' })
+    ok('(c) execute without confirm:"reset" → 400 (D4 typed confirm)', r.status === 400, `got ${r.status}/${code(r)}`)
+  }
+
+  // (e) preview drift → 409 (delete-set re-enumeration); run before (d)/(g) so the sheet is still pristine
+  {
+    const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const id1 = pv.body?.data?.previewIdentity
+    const E = await api('POST', '/records', ADMIN, { sheetId: ctx.sheetId, data: ctx.salaryId ? { [ctx.salaryId]: 500 } : { name: 'e-drift' } })
+    const Eid = E.body?.data?.id || E.body?.id
+    const ex = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: id1, confirm: 'reset' })
+    ok('(e) post-preview new record → execute 409 (delete-set divergence)', ex.status === 409, `got ${ex.status}/${code(ex)}`)
+    if (Eid) await api('DELETE', `/records/${Eid}`, ADMIN, { sheetId: ctx.sheetId }) // clean the drift record before re-checking
+    const after = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const delAfter = after.body?.data?.deleteRecordIds || []
+    ok('(e) nothing deleted on divergence (C,D still in the delete-set)', delAfter.includes(ctx.C) && delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
+  }
+
+  // (d) locked post-T target → 409 RESET_BLOCKED + ZERO writes
+  {
+    await api('POST', `/records/${ctx.D}/lock`, ADMIN, { sheetId: ctx.sheetId, locked: true })
+    const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const id = pv.body?.data?.previewIdentity
+    const ex = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: id, confirm: 'reset' })
+    ok('(d) locked target → 409 RESET_BLOCKED', ex.status === 409 && /BLOCKED/.test(code(ex)), `got ${ex.status}/${code(ex)}`)
+    await api('POST', `/records/${ctx.D}/lock`, ADMIN, { sheetId: ctx.sheetId, locked: false }) // unlock before re-checking + for (g)
+    const after = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const delAfter = after.body?.data?.deleteRecordIds || []
+    ok('(d) ZERO writes — C,D still live (in the delete-set)', delAfter.includes(ctx.C) && delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
+  }
+
+  // (f) ceiling → 413 (env-dependent; only if RESET_MAX_RECORDS is provided and small)
+  if (MAXREC && MAXREC > 0 && MAXREC < 200) {
+    for (let i = 0; i <= MAXREC; i++) await api('POST', '/records', ADMIN, { sheetId: ctx.sheetId, data: ctx.salaryId ? { [ctx.salaryId]: i } : { name: `big${i}` } })
+    const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    ok('(f) above-ceiling → 413 SHEET_TOO_LARGE', pv.status === 413, `got ${pv.status}/${code(pv)}`)
+    return finish() // the sheet is now over-ceiling; do not run (g) on it
+  } else skipped('(f) ceiling → 413', 'set RESET_MAX_RECORDS=<small> (matching staging MULTITABLE_SHEET_REVERT_MAX_RECORDS) to enable')
+
+  // (g) HAPPY PATH → post-T soft-deleted (trash) + survivors reverted
+  {
+    const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const id = pv.body?.data?.previewIdentity
+    const delIds = pv.body?.data?.deleteRecordIds || []
+    const ex = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: id, confirm: 'reset' })
+    ok('(g) happy-path execute → 2xx', ex.status >= 200 && ex.status < 300, `got ${ex.status}/${code(ex)}`)
+    ok('(g) preview reported the post-T delete-set (C,D)', delIds.includes(ctx.C) && delIds.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delIds)}`)
+    const after = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
+    const delAfter = after.body?.data?.deleteRecordIds || []
+    const revertAfter = after.body?.data?.summary?.visibleRevertCount ?? -1
+    ok('(g) post-T C,D soft-deleted (no longer in the delete-set after reset)', !delAfter.includes(ctx.C) && !delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
+    ok('(g) survivors reverted (no pending reverts at T after reset)', revertAfter === 0, `visibleRevertCount=${revertAfter}`)
+    log('\n  NOTE: verify C/D appear in the recycle bin (meta_records_trash) via the trash UI/API — recoverable, not hard-deleted.')
+  }
+  return finish()
+}
+
+function finish() {
+  log(`\n── summary: ${pass} passed, ${fail} failed, ${skip} skipped ──`)
+  process.exit(fail > 0 ? 1 : 0)
+}
+
+run().catch((e) => { console.error('\nFATAL (setup or harness error):', e.message); process.exit(2) })

--- a/packages/core-backend/scripts/reset-acceptance.mjs
+++ b/packages/core-backend/scripts/reset-acceptance.mjs
@@ -140,12 +140,20 @@ async function run() {
     ok('(d) ZERO writes — C,D still live (in the delete-set)', delAfter.includes(ctx.C) && delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
   }
 
-  // (f) ceiling → 413 (env-dependent; only if RESET_MAX_RECORDS is provided and small)
+  // (f) ceiling → 413 — provisioned on a SEPARATE throwaway sheet so it NEVER pollutes the main sheet over-ceiling;
+  // (g) then still runs on the clean main sheet → one flag-on run truly covers (b)–(g). (env-dependent on RESET_MAX_RECORDS.)
   if (MAXREC && MAXREC > 0 && MAXREC < 200) {
-    for (let i = 0; i <= MAXREC; i++) await api('POST', '/records', ADMIN, { sheetId: ctx.sheetId, data: ctx.salaryId ? { [ctx.salaryId]: i } : { name: `big${i}` } })
-    const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
-    ok('(f) above-ceiling → 413 SHEET_TOO_LARGE', pv.status === 413, `got ${pv.status}/${code(pv)}`)
-    return finish() // the sheet is now over-ceiling; do not run (g) on it
+    const cs = await api('POST', '/sheets', ADMIN, { baseId: ctx.baseId, name: `RS-CEIL ${Date.now()}` })
+    const csId = cs.body?.data?.id || cs.body?.data?.sheet?.id || cs.body?.id
+    const cf = await api('POST', '/fields', ADMIN, { sheetId: csId, name: 'N', type: 'number' })
+    const cfId = cf.body?.data?.id || cf.body?.data?.field?.id || cf.body?.id || null
+    if (!csId) ok('(f) above-ceiling → 413 SHEET_TOO_LARGE', false, 'could not provision a separate ceiling sheet')
+    else {
+      for (let i = 0; i <= MAXREC; i++) await api('POST', '/records', ADMIN, { sheetId: csId, data: cfId ? { [cfId]: i } : { name: `big${i}` } })
+      const pv = await api('POST', `/sheets/${csId}/reset-preview`, ADMIN, { asOf: ctx.T })
+      ok('(f) above-ceiling → 413 SHEET_TOO_LARGE (on a dedicated ceiling sheet)', pv.status === 413, `got ${pv.status}/${code(pv)}`)
+    }
+    // NO early return — fall through to (g) on the still-clean main sheet.
   } else skipped('(f) ceiling → 413', 'set RESET_MAX_RECORDS=<small> (matching staging MULTITABLE_SHEET_REVERT_MAX_RECORDS) to enable')
 
   // (g) HAPPY PATH → post-T soft-deleted (trash) + survivors reverted
@@ -161,7 +169,9 @@ async function run() {
     const revertAfter = after.body?.data?.summary?.visibleRevertCount ?? -1
     ok('(g) post-T C,D soft-deleted (no longer in the delete-set after reset)', !delAfter.includes(ctx.C) && !delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
     ok('(g) survivors reverted (no pending reverts at T after reset)', revertAfter === 0, `visibleRevertCount=${revertAfter}`)
-    log('\n  NOTE: verify C/D appear in the recycle bin (meta_records_trash) via the trash UI/API — recoverable, not hard-deleted.')
+    log('\n  NOTE: (g) asserts the LIVE effect only (post-T left the live delete-set + survivors reverted). Two things are')
+    log('  covered by backend goldens, not re-asserted here: the `source=restore` revision write, and that C/D land in the')
+    log('  recycle bin (`meta_records_trash`) — confirm the trash side once by hand; recoverable, not hard-deleted.')
   }
   return finish()
 }


### PR DESCRIPTION
Step #1 of the Reset rollout (acceptance evidence first, before the UI). Non-destructive test tooling.

**`scripts/reset-acceptance.mjs`** (Node `fetch`, no deps) — self-provisions a fresh isolated sheet (pre-T → captured T → post-T records + a locked target), auto-detects flag state, asserts all codes with PASS/FAIL + nonzero exit: (a) flag-off→403 · (b) editor→403 · (c) no-confirm→400 · (d) locked→409 `RESET_BLOCKED`+**zero-writes** · (e) preview-drift→409 · (f) ceiling→413 · (g) happy-path→post-T soft-deleted + survivors reverted. Liveness/zero-write via `reset-preview`'s `deleteRecordIds`/`visibleRevertCount` (route-native, same-JWT).

**runbook** — scenario table, run steps (flag-off first, then enable + re-run), hard Reset-vs-Revert copy, enablement criteria, staging caveats.

**Review:** scenarios substantive (not smoke); create-response ID shapes cross-checked vs merged routes (data.base.id/sheet.id/record.id all covered). Not run end-to-end (no staging in CI) — operator's first run is the live validation; 1200ms gaps separate pre-/post-T.

🤖 Generated with [Claude Code](https://claude.com/claude-code)