### PR TITLE
feat(attendance): v1-5b-ii settlement snapshot-at-close wiring (money-path, held) — 加班银行 §3/§5/§8a

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6125,7 +6125,7 @@ attendanceIntegrationDescribe(
       expect([201, 409]).toContain(tmplRes.status)
       const tmplId = (tmplRes.body as { data?: { id?: string } } | undefined)?.data?.id as string
       const genRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles/generate`, { method: 'POST', headers, body: JSON.stringify({ templateId: tmplId, anchorDate: '2026-12-15', count: 1, status: 'closed', namePrefix: `Gen ${runSuffix}` }) })
-      expect(genRes.status).toBe(201)
+      expect(genRes.status).toBe(200) // generate responds 200 with { created, skipped } (not 201)
       const generated = (genRes.body as { data?: { created?: { id?: string }[] } } | undefined)?.data?.created ?? []
       expect(generated.length).toBeGreaterThanOrEqual(1)
       const genId = generated[0]?.id as string

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6017,6 +6017,69 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④ 加班银行 v1-5b-ii — cycle close snapshots settlement (convertible · poison-lot · idempotent replay · balance-only population)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-v15b2-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    let token: string | undefined
+    let cycleId: string | undefined
+    let originalSettings: Record<string, unknown> = {}
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      token = (tokenRes.body as { token?: string } | undefined)?.token
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+      const putSettings = (body: Record<string, unknown>) => requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify(body) })
+      originalSettings = ((await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })).body as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+      await putSettings({ overtimeBankPolicy: { enabled: true, pooledSources: ['restday'] } })
+
+      const lot = (src: string, mins: number) => pool.query(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+         VALUES ('default', $1, 'comp_time', $2, $2, 'overtime_conversion', $3, 'active', '2026-01-01', $4)`,
+        [userId, mins, `v15b2:${runSuffix}:${src}`, src])
+      await lot('restday', 90)
+      await lot('statutory_holiday', 9999) // POISON: a bogus statutory balance lot — must NOT become must-pay/convertible.
+
+      const createRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles`, { method: 'POST', headers, body: JSON.stringify({ startDate: '2026-09-01', endDate: '2026-09-30', status: 'open' }) })
+      expect(createRes.status).toBe(201)
+      cycleId = (createRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(cycleId).toBeTruthy()
+      const settlements = async () => (await pool.query(
+        `SELECT source, convertible_minutes, must_pay_minutes, period_start_date FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1 AND user_id = $2 ORDER BY source`,
+        [cycleId, userId])).rows as { source: string; convertible_minutes: number; must_pay_minutes: number; period_start_date: string }[]
+      const closeCycle = () => requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ status: 'closed' }) })
+
+      // before close → nothing written.
+      expect(await settlements()).toHaveLength(0)
+      // close → snapshot written in the same txn.
+      expect((await closeCycle()).status).toBe(200)
+      const afterClose = await settlements()
+      const bySource = Object.fromEntries(afterClose.map((r) => [r.source, r]))
+      expect(Number(bySource.restday?.convertible_minutes)).toBe(90)          // banked restday → convertible
+      expect(bySource.statutory_holiday).toBeUndefined()                      // POISON lot → no statutory row (no period OT, never convertible)
+      expect(bySource.restday?.period_start_date).toBeTruthy()                // frozen period stamped on the row
+      // idempotent replay: re-close → ON CONFLICT DO NOTHING, no new/changed rows.
+      expect((await closeCycle()).status).toBe(200)
+      const afterReplay = await settlements()
+      expect(afterReplay).toHaveLength(afterClose.length)
+      expect(Number(Object.fromEntries(afterReplay.map((r) => [r.source, r])).restday?.convertible_minutes)).toBe(90)
+      // NOTE: the must-pay-from-period-OT-facts end-to-end (the [P1] un-pooled case) is unit-proven in
+      // attendance-settlement-compute.test.ts; a wired must-pay e2e needs the OT-segmentation harness — a v1-5b-iii follow-up.
+    } finally {
+      if (token && Object.keys(originalSettings).length > 0) await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      if (cycleId) await pool.query('DELETE FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1', [cycleId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (cycleId) await pool.query('DELETE FROM attendance_payroll_cycles WHERE id = $1', [cycleId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS; else process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
   it('④ 加班银行 v1-3b — 满勤 flag surfaces on GET /summary when policy ON; ABSENT when OFF (dormant-clean)', async () => {
     if (!baseUrl) return
     const runSuffix = Date.now().toString(36)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6068,6 +6068,11 @@ attendanceIntegrationDescribe(
       const afterReplay = await settlements()
       expect(afterReplay).toHaveLength(afterClose.length)
       expect(Number(Object.fromEntries(afterReplay.map((r) => [r.source, r])).restday?.convertible_minutes)).toBe(90)
+      // [P1 owner #3233] a closed cycle's period is FROZEN: PUT changing start/end → 409; DELETE closed → 409;
+      // a status-only transition (closed→archived) is still allowed.
+      expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ startDate: '2026-10-01', endDate: '2026-10-31' }) })).status).toBe(409)
+      expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'DELETE', headers })).status).toBe(409)
+      expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ status: 'archived' }) })).status).toBe(200)
       // NOTE: the must-pay-from-period-OT-facts end-to-end (the [P1] un-pooled case) is unit-proven in
       // attendance-settlement-compute.test.ts; a wired must-pay e2e needs the OT-segmentation harness — a v1-5b-iii follow-up.
     } finally {
@@ -6075,6 +6080,62 @@ attendanceIntegrationDescribe(
       if (cycleId) await pool.query('DELETE FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1', [cycleId]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
       if (cycleId) await pool.query('DELETE FROM attendance_payroll_cycles WHERE id = $1', [cycleId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS; else process.env.RBAC_BYPASS = previousRbacBypass
+    }
+  })
+
+  it('④ 加班银行 v1-5b-ii [P2] — create-as-closed AND generate-as-closed both snapshot settlement (§3 no-bypass)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-v15b2p2-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    const cycleIds: string[] = []
+    let token: string | undefined
+    let originalSettings: Record<string, unknown> = {}
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      token = (tokenRes.body as { token?: string } | undefined)?.token
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+      const putSettings = (body: Record<string, unknown>) => requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify(body) })
+      originalSettings = ((await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })).body as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+      await putSettings({ overtimeBankPolicy: { enabled: true, pooledSources: ['restday'] } })
+      await pool.query(
+        `INSERT INTO attendance_leave_balances (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, overtime_source)
+         VALUES ('default', $1, 'comp_time', 90, 90, 'overtime_conversion', $2, 'active', '2026-01-01', 'restday')`,
+        [userId, `v15b2p2:${runSuffix}`])
+      const convertibleFor = async (cycleId: string) => Number((await pool.query(
+        `SELECT COALESCE(SUM(convertible_minutes),0) AS c FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1 AND user_id = $2`,
+        [cycleId, userId])).rows[0].c)
+
+      // (1) create-as-closed (POST status:'closed') → settlement written in the create txn (must not bypass §3).
+      const createRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles`, { method: 'POST', headers, body: JSON.stringify({ startDate: '2026-11-01', endDate: '2026-11-30', status: 'closed' }) })
+      expect(createRes.status).toBe(201)
+      const createdId = (createRes.body as { data?: { id?: string } } | undefined)?.data?.id as string
+      expect(createdId).toBeTruthy(); cycleIds.push(createdId)
+      expect(await convertibleFor(createdId)).toBe(90)
+
+      // (2) generate-as-closed (POST /generate status:'closed') → settlement written for the generated closed cycle.
+      const tmplRes = await requestJson(`${baseUrl}/api/attendance/payroll-templates`, { method: 'POST', headers, body: JSON.stringify({ name: `T ${runSuffix}`, timezone: 'UTC', startDay: 1, endDay: 28, endMonthOffset: 0, autoGenerate: false }) })
+      expect([201, 409]).toContain(tmplRes.status)
+      const tmplId = (tmplRes.body as { data?: { id?: string } } | undefined)?.data?.id as string
+      const genRes = await requestJson(`${baseUrl}/api/attendance/payroll-cycles/generate`, { method: 'POST', headers, body: JSON.stringify({ templateId: tmplId, anchorDate: '2026-12-15', count: 1, status: 'closed', namePrefix: `Gen ${runSuffix}` }) })
+      expect(genRes.status).toBe(201)
+      const generated = (genRes.body as { data?: { created?: { id?: string }[] } } | undefined)?.data?.created ?? []
+      expect(generated.length).toBeGreaterThanOrEqual(1)
+      const genId = generated[0]?.id as string
+      expect(genId).toBeTruthy(); cycleIds.push(genId)
+      expect(await convertibleFor(genId)).toBe(90)
+    } finally {
+      if (token && Object.keys(originalSettings).length > 0) await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      for (const id of cycleIds) await pool.query('DELETE FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1', [id]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
+      for (const id of cycleIds) await pool.query('DELETE FROM attendance_payroll_cycles WHERE id = $1', [id]).catch(() => undefined)
       await pool.end().catch(() => undefined)
       if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS; else process.env.RBAC_BYPASS = previousRbacBypass
     }

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6073,6 +6073,10 @@ attendanceIntegrationDescribe(
       expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ startDate: '2026-10-01', endDate: '2026-10-31' }) })).status).toBe(409)
       expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'DELETE', headers })).status).toBe(409)
       expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ status: 'archived' }) })).status).toBe(200)
+      // [P2 owner #3233] the freeze SURVIVES archive — 'archived' is ONCE-CLOSED, so close→archive must NOT
+      // reopen the period or allow delete: archived period change → 409; archived delete → 409.
+      expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'PUT', headers, body: JSON.stringify({ startDate: '2026-10-01', endDate: '2026-10-31' }) })).status).toBe(409)
+      expect((await requestJson(`${baseUrl}/api/attendance/payroll-cycles/${cycleId}`, { method: 'DELETE', headers })).status).toBe(409)
       // NOTE: the must-pay-from-period-OT-facts end-to-end (the [P1] un-pooled case) is unit-proven in
       // attendance-settlement-compute.test.ts; a wired must-pay e2e needs the OT-segmentation harness — a v1-5b-iii follow-up.
     } finally {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -33482,12 +33482,15 @@ module.exports = {
             metadata: parsed.data.metadata ?? normalizeMetadata(existing.metadata),
           }
 
-          // 加班银行 v1-5b-ii [P1 owner #3233]: a CLOSED cycle's period is FROZEN — its settlement snapshot was
-          // computed against this period (v1-5 design-lock §3). Reject changing start_date / end_date /
-          // template_id once status === 'closed' (only a status transition, e.g. closed→archived, is allowed),
-          // so a closed cycle can't be re-hung to a new period while the snapshot stays on the old one. The FK
-          // RESTRICT is the DB backstop; this is the route guard the lock mandates.
-          if (existing.status === 'closed') {
+          // 加班银行 v1-5b-ii [P1/P2 owner #3233]: a POST-CLOSE cycle's period is FROZEN — the settlement snapshot
+          // was computed against this period (v1-5 design-lock §3). The freeze covers BOTH 'closed' AND
+          // 'archived' (archived is ONCE-CLOSED: closed→archived must NOT reopen the period), PLUS a durable
+          // backstop — any cycle that already has settlement rows (covers a reopened-with-settlements edge and a
+          // zero-row closed cycle's later states). Otherwise close→archive→change re-hangs the old snapshot under
+          // a new period. Only status-only transitions and name/metadata edits stay allowed.
+          const cycleIsFrozen = existing.status === 'closed' || existing.status === 'archived'
+            || (await db.query('SELECT 1 FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1 AND org_id = $2 LIMIT 1', [payrollCycleId, orgId])).length > 0
+          if (cycleIsFrozen) {
             const sameDate = (a, b) => {
               const pa = parseDateInput(a)
               const pb = parseDateInput(b)
@@ -33497,7 +33500,7 @@ module.exports = {
               || !sameDate(payload.endDate, existing.end_date)
               || (payload.templateId ?? null) !== (existing.template_id ?? null)
             if (periodChanged) {
-              res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_PERIOD_FROZEN', message: 'A closed payroll cycle has a settled snapshot; start_date / end_date / template_id cannot be changed. Reopen/recompute explicitly.' } })
+              res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_PERIOD_FROZEN', message: 'A settled (closed/archived) payroll cycle has a snapshot; start_date / end_date / template_id cannot be changed. Reopen/recompute explicitly.' } })
               return
             }
           }
@@ -33559,15 +33562,20 @@ module.exports = {
         }
 
         try {
-          // 加班银行 v1-5b-ii [P1 owner #3233]: a CLOSED cycle has (or anchors) an immutable settlement snapshot.
-          // Refuse to delete it (the FK RESTRICT blocks it once settlement rows exist; this guard also covers a
-          // closed cycle that produced no rows yet). Reopen/archive explicitly instead of deleting accounting facts.
+          // 加班银行 v1-5b-ii [P1/P2 owner #3233]: a POST-CLOSE cycle has (or anchors) an immutable settlement
+          // snapshot. Refuse to delete it for status 'closed' OR 'archived' (archived is ONCE-CLOSED:
+          // closed→archived→delete must not fall through), PLUS the durable settlement-rows backstop (the FK
+          // RESTRICT blocks it once rows exist; this also covers a zero-row closed/archived cycle). Reopen/archive
+          // explicitly instead of deleting accounting facts.
           const statusRows = await db.query(
             'SELECT status FROM attendance_payroll_cycles WHERE id = $1 AND org_id = $2',
             [payrollCycleId, orgId]
           )
-          if (statusRows.length && statusRows[0].status === 'closed') {
-            res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_NOT_DELETABLE', message: 'A closed payroll cycle has a settled snapshot and cannot be deleted. Reopen/archive explicitly.' } })
+          const delStatus = statusRows.length ? statusRows[0].status : null
+          const cycleIsFrozen = delStatus === 'closed' || delStatus === 'archived'
+            || (await db.query('SELECT 1 FROM attendance_payroll_cycle_settlements WHERE cycle_id = $1 AND org_id = $2 LIMIT 1', [payrollCycleId, orgId])).length > 0
+          if (cycleIsFrozen) {
+            res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_NOT_DELETABLE', message: 'A settled (closed/archived) payroll cycle has a snapshot and cannot be deleted. Reopen/archive explicitly.' } })
             return
           }
           const rows = await db.query(

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -33482,6 +33482,26 @@ module.exports = {
             metadata: parsed.data.metadata ?? normalizeMetadata(existing.metadata),
           }
 
+          // 加班银行 v1-5b-ii [P1 owner #3233]: a CLOSED cycle's period is FROZEN — its settlement snapshot was
+          // computed against this period (v1-5 design-lock §3). Reject changing start_date / end_date /
+          // template_id once status === 'closed' (only a status transition, e.g. closed→archived, is allowed),
+          // so a closed cycle can't be re-hung to a new period while the snapshot stays on the old one. The FK
+          // RESTRICT is the DB backstop; this is the route guard the lock mandates.
+          if (existing.status === 'closed') {
+            const sameDate = (a, b) => {
+              const pa = parseDateInput(a)
+              const pb = parseDateInput(b)
+              return pa && pb ? formatDateOnly(pa) === formatDateOnly(pb) : String(a) === String(b)
+            }
+            const periodChanged = !sameDate(payload.startDate, existing.start_date)
+              || !sameDate(payload.endDate, existing.end_date)
+              || (payload.templateId ?? null) !== (existing.template_id ?? null)
+            if (periodChanged) {
+              res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_PERIOD_FROZEN', message: 'A closed payroll cycle has a settled snapshot; start_date / end_date / template_id cannot be changed. Reopen/recompute explicitly.' } })
+              return
+            }
+          }
+
           const rows = await db.transaction(async (trx) => {
             const updated = await trx.query(
               `UPDATE attendance_payroll_cycles
@@ -33539,6 +33559,17 @@ module.exports = {
         }
 
         try {
+          // 加班银行 v1-5b-ii [P1 owner #3233]: a CLOSED cycle has (or anchors) an immutable settlement snapshot.
+          // Refuse to delete it (the FK RESTRICT blocks it once settlement rows exist; this guard also covers a
+          // closed cycle that produced no rows yet). Reopen/archive explicitly instead of deleting accounting facts.
+          const statusRows = await db.query(
+            'SELECT status FROM attendance_payroll_cycles WHERE id = $1 AND org_id = $2',
+            [payrollCycleId, orgId]
+          )
+          if (statusRows.length && statusRows[0].status === 'closed') {
+            res.status(409).json({ ok: false, error: { code: 'CYCLE_CLOSED_NOT_DELETABLE', message: 'A closed payroll cycle has a settled snapshot and cannot be deleted. Reopen/archive explicitly.' } })
+            return
+          }
           const rows = await db.query(
             'DELETE FROM attendance_payroll_cycles WHERE id = $1 AND org_id = $2 RETURNING id',
             [payrollCycleId, orgId]

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11685,6 +11685,62 @@ async function loadCompTimeRemainingBySource(db, orgId, userId) {
   return bySource
 }
 
+// 加班银行 v1-5b-ii — snapshot the period-end settlement at cycle close (design-lock §3/§5/§8a). Called from
+// BOTH close entries (create-as-closed + update→closed), in the SAME transaction as the status write, ONLY on
+// the transition to closed. Idempotent: ON CONFLICT (org,cycle,user,source) DO NOTHING, so a replay-close
+// never overwrites the immutable snapshot. UNCONDITIONAL (advisor #1 / §6) — fires regardless of
+// overtimeBankPolicy.enabled, so statutory must-pay is never silently dropped.
+//   population (§8a): users with attendance/leave-offset/OT facts in the cycle period UNION users with active
+//     comp_time balance — NOT just the active roster (offboarded-with-facts/balance must still settle).
+//   per user: period OT facts by source (from loadAttendanceSummary over the cycle [start,end]) + close-time
+//     comp_time remaining by source + the snapshotted pooledSources → buildCycleSettlementRows → typed rows.
+//   the row carries the cycle's FROZEN period (period_start/end_date) + closed_at, so a later cycle PUT can't
+//     hang it under a new period (§2 [P1]). must-pay comes from PERIOD FACTS only (poison-lot safe). No amounts.
+async function snapshotCycleSettlementOnClose(trx, cycle) {
+  const orgId = cycle.org_id
+  const cycleId = cycle.id
+  const periodStart = cycle.start_date
+  const periodEnd = cycle.end_date
+  const settings = await getSettings(trx)
+  const bankPolicy = (settings && settings.overtimeBankPolicy) || {}
+  const pooledSources = Array.isArray(bankPolicy.pooledSources) ? bankPolicy.pooledSources : []
+  // §4 snapshot: fix the effective policies at close so a later policy change can't reback this settlement.
+  const snapshot = JSON.stringify({
+    overtimeBankPolicy: bankPolicy,
+    leaveBalanceDeductionPolicy: (settings && settings.leaveBalanceDeductionPolicy) || {},
+    attendanceBonusPolicy: (settings && settings.attendanceBonusPolicy) || {},
+  })
+  const userRows = await trx.query(
+    `SELECT DISTINCT user_id FROM (
+       SELECT user_id FROM attendance_records WHERE org_id = $1 AND work_date >= $2 AND work_date <= $3
+       UNION
+       SELECT user_id FROM attendance_requests WHERE org_id = $1 AND status = 'approved' AND work_date >= $2 AND work_date <= $3
+       UNION
+       SELECT user_id FROM attendance_leave_balances WHERE org_id = $1 AND leave_type_code = 'comp_time' AND status = 'active' AND remaining_minutes > 0
+     ) pop WHERE user_id IS NOT NULL`,
+    [orgId, periodStart, periodEnd],
+  )
+  for (const { user_id: userId } of userRows) {
+    const summary = await loadAttendanceSummary(trx, orgId, userId, periodStart, periodEnd)
+    const periodOtBySource = {
+      workday: summary.workday_overtime_minutes,
+      restday: summary.restday_overtime_minutes,
+      statutory_holiday: summary.holiday_overtime_minutes,
+    }
+    const compTimeRemainingBySource = await loadCompTimeRemainingBySource(trx, orgId, userId)
+    const settlementRows = buildCycleSettlementRows({ periodOtBySource, compTimeRemainingBySource, pooledSources })
+    for (const row of settlementRows) {
+      await trx.query(
+        `INSERT INTO attendance_payroll_cycle_settlements
+           (org_id, cycle_id, period_start_date, period_end_date, closed_at, user_id, source, convertible_minutes, must_pay_minutes, snapshot)
+         VALUES ($1, $2, $3, $4, now(), $5, $6, $7, $8, $9::jsonb)
+         ON CONFLICT (org_id, cycle_id, user_id, source) DO NOTHING`,
+        [orgId, cycleId, periodStart, periodEnd, userId, row.source, row.convertibleMinutes, row.mustPayMinutes, snapshot],
+      )
+    }
+  }
+}
+
 async function loadAttendanceSummary(db, orgId, userId, from, to) {
   const countedDaySql = buildAttendanceSummaryCountedDaySql()
   const rows = await db.query(
@@ -33189,22 +33245,30 @@ module.exports = {
         }
 
         try {
-          const rows = await db.query(
-            `INSERT INTO attendance_payroll_cycles
-             (id, org_id, template_id, name, start_date, end_date, status, metadata)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
-             RETURNING *`,
-            [
-              randomUUID(),
-              orgId,
-              payload.templateId,
-              payload.name,
-              payload.startDate,
-              payload.endDate,
-              payload.status,
-              JSON.stringify(payload.metadata),
-            ]
-          )
+          const rows = await db.transaction(async (trx) => {
+            const created = await trx.query(
+              `INSERT INTO attendance_payroll_cycles
+               (id, org_id, template_id, name, start_date, end_date, status, metadata)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+               RETURNING *`,
+              [
+                randomUUID(),
+                orgId,
+                payload.templateId,
+                payload.name,
+                payload.startDate,
+                payload.endDate,
+                payload.status,
+                JSON.stringify(payload.metadata),
+              ],
+            )
+            // 加班银行 v1-5b-ii: create-as-closed must NOT bypass the close-snapshot path (§3) — snapshot in
+            // the SAME txn.
+            if (payload.status === 'closed' && created[0]) {
+              await snapshotCycleSettlementOnClose(trx, created[0])
+            }
+            return created
+          })
 
           const mapped = mapPayrollCycleRow(rows[0])
           emitEvent('attendance.payrollCycle.created', { orgId, payrollCycleId: mapped.id })
@@ -33309,6 +33373,10 @@ module.exports = {
               )
               if (rows.length) {
                 created.push(mapPayrollCycleRow(rows[0]))
+                // 加班银行 v1-5b-ii: generate-as-closed must NOT bypass the close-snapshot path (§3); same txn.
+                if (status === 'closed') {
+                  await snapshotCycleSettlementOnClose(trx, rows[0])
+                }
               } else {
                 skipped.push({ startDate: window.startDate, endDate: window.endDate })
               }
@@ -33414,28 +33482,36 @@ module.exports = {
             metadata: parsed.data.metadata ?? normalizeMetadata(existing.metadata),
           }
 
-          const rows = await db.query(
-            `UPDATE attendance_payroll_cycles
-             SET template_id = $3,
-                 name = $4,
-                 start_date = $5,
-                 end_date = $6,
-                 status = $7,
-                 metadata = $8::jsonb,
-                 updated_at = now()
-             WHERE id = $1 AND org_id = $2
-             RETURNING *`,
-            [
-              payrollCycleId,
-              orgId,
-              payload.templateId,
-              payload.name,
-              payload.startDate,
-              payload.endDate,
-              payload.status,
-              JSON.stringify(payload.metadata),
-            ]
-          )
+          const rows = await db.transaction(async (trx) => {
+            const updated = await trx.query(
+              `UPDATE attendance_payroll_cycles
+               SET template_id = $3,
+                   name = $4,
+                   start_date = $5,
+                   end_date = $6,
+                   status = $7,
+                   metadata = $8::jsonb,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2
+               RETURNING *`,
+              [
+                payrollCycleId,
+                orgId,
+                payload.templateId,
+                payload.name,
+                payload.startDate,
+                payload.endDate,
+                payload.status,
+                JSON.stringify(payload.metadata),
+              ],
+            )
+            // 加班银行 v1-5b-ii: ONLY on the TRANSITION to closed, snapshot the settlement in the SAME txn
+            // (atomic with the status write). A re-PUT of an already-closed cycle does NOT re-snapshot.
+            if (existing.status !== 'closed' && payload.status === 'closed' && updated[0]) {
+              await snapshotCycleSettlementOnClose(trx, updated[0])
+            }
+            return updated
+          })
 
           const mapped = mapPayrollCycleRow(rows[0])
           emitEvent('attendance.payrollCycle.updated', { orgId, payrollCycleId: mapped.id })


### PR DESCRIPTION
The settlement **WRITE** — `snapshotCycleSettlementOnClose` hooked into **all three cycle→closed paths** (PUT update→closed, POST create-as-closed, generate-as-closed), each in the **same txn** as the status write, **transition-only** (re-close doesn't re-snapshot). **Held for review.**

- §8a population = facts-in-period ∪ active comp_time balance (offboarded-with-balance still settles). Per user: period OT by source + close-time comp_time remaining + snapshotted pooledSources → `buildCycleSettlementRows` → INSERT with frozen period + closed_at + §4 policy snapshot, **ON CONFLICT DO NOTHING** (idempotent). **Unconditional** (advisor #1).
- real-DB matrix: convertible · **POISON statutory balance lot → no row** · frozen period · **idempotent re-close** · balance-only population.

**Honest limits (please scrutinize):**
1. Built **without a local DB** — the real-DB matrix runs only on CI; CI + your review are the gate (I couldn't run the matrix locally, contrary to the ideal).
2. **must-pay-from-period-OT end-to-end** (the [P1] un-pooled case) is **unit-proven** but not yet wired-e2e (needs the OT-segmentation harness) — flagged as v1-5b-iii.
3. route-layer closed-cycle delete/update guard is still a follow-up (FK RESTRICT is the DB backstop).

node -c + tsc 0; unit compute green. This is the money-path settlement write — your review is the gate.