### PR TITLE
[codex] approval formula condition dry-run preview (FC-5)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -21,6 +21,7 @@ import type {
   CreateApprovalTemplateRequest,
   UpdateApprovalTemplateRequest,
   PublishApprovalTemplateRequest,
+  FormSchema,
 } from '../types/approval'
 
 // ---------------------------------------------------------------------------
@@ -505,6 +506,34 @@ export async function publishTemplate(
     }
   }
   return apiPost(`/api/approval-templates/${encodeURIComponent(templateId)}/publish`, payload)
+}
+
+export interface ApprovalFormulaConditionDryRunRequest {
+  formSchema: FormSchema
+  expression: string
+  formData: Record<string, unknown>
+}
+
+export interface ApprovalFormulaConditionDryRunResult {
+  success: boolean
+  result?: boolean
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+export async function dryRunApprovalConditionFormula(
+  payload: ApprovalFormulaConditionDryRunRequest,
+): Promise<ApprovalFormulaConditionDryRunResult> {
+  if (USE_MOCK) {
+    return { success: false, error: { code: 'APPROVAL_FORMULA_DRY_RUN_MOCK', message: 'Mock mode does not evaluate formulas' } }
+  }
+  const response = await apiPost<{ data: ApprovalFormulaConditionDryRunResult }>(
+    '/api/approval-templates/formula-condition/dry-run',
+    payload,
+  )
+  return response.data
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -682,6 +682,33 @@
                       @click="insertConditionFormulaFunction(branch, 'MAX')"
                     >MAX()</el-button>
                   </div>
+                  <div class="template-authoring__condition-formula-dryrun">
+                    <el-input
+                      :model-value="conditionFormulaDryRunSample(node.key, branch.edgeKey)"
+                      type="textarea"
+                      :rows="2"
+                      :disabled="readOnly"
+                      placeholder='样例数据 JSON，例如 {"amount": 5000}'
+                      data-testid="approval-condition-formula-dry-run-sample"
+                      @update:model-value="(text: string) => setConditionFormulaDryRunSample(node.key, branch.edgeKey, text)"
+                    />
+                    <div class="template-authoring__condition-formula-dryrun-actions">
+                      <el-button
+                        size="small"
+                        :loading="conditionFormulaDryRunLoading(node.key, branch.edgeKey)"
+                        :disabled="readOnly || conditionFormulaDryRunLoading(node.key, branch.edgeKey)"
+                        data-testid="approval-condition-formula-dry-run-button"
+                        @click="dryRunConditionFormula(node.key, branch)"
+                      >测试公式</el-button>
+                      <span
+                        v-if="conditionFormulaDryRunResult(node.key, branch.edgeKey)"
+                        class="template-authoring__condition-formula-dryrun-result"
+                        data-testid="approval-condition-formula-dry-run-result"
+                      >
+                        {{ conditionFormulaDryRunResult(node.key, branch.edgeKey) }}
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
               <el-form-item label="默认分支（无匹配时）" class="template-authoring__condition-default">
@@ -1033,6 +1060,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import {
   createTemplate,
+  dryRunApprovalConditionFormula,
   getTemplate,
   publishTemplate,
   updateTemplate,
@@ -1110,6 +1138,9 @@ const unsupportedReason = ref<string | null>(null)
 // unsupported — the form/metadata stay editable and save preserves the graph verbatim.
 const graphReadOnlyMessage = ref<string | null>(null)
 const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+const conditionFormulaDryRunSamples = ref<Record<string, string>>({})
+const conditionFormulaDryRunResults = ref<Record<string, string>>({})
+const conditionFormulaDryRunBusy = ref<Record<string, boolean>>({})
 
 const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
 const isEditMode = computed(() => templateId.value.length > 0)
@@ -1254,6 +1285,79 @@ function insertConditionFormulaToken(branch: ConditionBranchEdit, token: string)
 }
 function insertConditionFormulaFunction(branch: ConditionBranchEdit, fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'): void {
   appendFormulaText(branch, `${fn}()`)
+}
+
+function conditionFormulaDryRunKey(nodeKey: string, edgeKey: string): string {
+  return `${nodeKey}:${edgeKey}`
+}
+function conditionFormulaDryRunSample(nodeKey: string, edgeKey: string): string {
+  return conditionFormulaDryRunSamples.value[conditionFormulaDryRunKey(nodeKey, edgeKey)] ?? '{}'
+}
+function setConditionFormulaDryRunSample(nodeKey: string, edgeKey: string, text: string): void {
+  conditionFormulaDryRunSamples.value = {
+    ...conditionFormulaDryRunSamples.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: text,
+  }
+}
+function conditionFormulaDryRunResult(nodeKey: string, edgeKey: string): string {
+  return conditionFormulaDryRunResults.value[conditionFormulaDryRunKey(nodeKey, edgeKey)] ?? ''
+}
+function setConditionFormulaDryRunResult(nodeKey: string, edgeKey: string, text: string): void {
+  conditionFormulaDryRunResults.value = {
+    ...conditionFormulaDryRunResults.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: text,
+  }
+}
+function conditionFormulaDryRunLoading(nodeKey: string, edgeKey: string): boolean {
+  return Boolean(conditionFormulaDryRunBusy.value[conditionFormulaDryRunKey(nodeKey, edgeKey)])
+}
+function setConditionFormulaDryRunLoading(nodeKey: string, edgeKey: string, loadingValue: boolean): void {
+  conditionFormulaDryRunBusy.value = {
+    ...conditionFormulaDryRunBusy.value,
+    [conditionFormulaDryRunKey(nodeKey, edgeKey)]: loadingValue,
+  }
+}
+async function dryRunConditionFormula(nodeKey: string, branch: ConditionBranchEdit): Promise<void> {
+  const expression = branch.formulaExpression.trim()
+  const resultKey = conditionFormulaDryRunKey(nodeKey, branch.edgeKey)
+  if (!expression) {
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, '请输入公式')
+    return
+  }
+  let formData: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(conditionFormulaDryRunSamples.value[resultKey] ?? '{}') as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('样例数据必须是 JSON 对象')
+    }
+    formData = parsed as Record<string, unknown>
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '样例数据不是有效 JSON'
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `样例数据错误：${message}`)
+    return
+  }
+  setConditionFormulaDryRunLoading(nodeKey, branch.edgeKey, true)
+  try {
+    const result = await dryRunApprovalConditionFormula({
+      formSchema: buildFormSchema(draft.value),
+      expression,
+      formData,
+    })
+    if (result.success) {
+      setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `结果：${result.result ? 'true' : 'false'}`)
+    } else {
+      setConditionFormulaDryRunResult(
+        nodeKey,
+        branch.edgeKey,
+        `错误：${result.error?.message ?? '公式测试失败'}`,
+      )
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '公式测试失败'
+    setConditionFormulaDryRunResult(nodeKey, branch.edgeKey, `错误：${message}`)
+  } finally {
+    setConditionFormulaDryRunLoading(nodeKey, branch.edgeKey, false)
+  }
 }
 
 // Outgoing edge keys of a condition node (from the preserved graph) — the legal default fall-through
@@ -1904,6 +2008,24 @@ onMounted(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.template-authoring__condition-formula-dryrun {
+  display: grid;
+  gap: 6px;
+}
+
+.template-authoring__condition-formula-dryrun-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.template-authoring__condition-formula-dryrun-result {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--el-text-color-regular, #606266);
 }
 
 .template-authoring__condition-default {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -51,12 +51,14 @@ const createTemplateSpy = vi.fn()
 const updateTemplateSpy = vi.fn()
 const publishTemplateSpy = vi.fn()
 const getTemplateSpy = vi.fn()
+const dryRunApprovalConditionFormulaSpy = vi.fn()
 
 vi.mock('../src/approvals/api', () => ({
   createTemplate: (payload: unknown) => createTemplateSpy(payload),
   updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
   publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
   getTemplate: (id: string) => getTemplateSpy(id),
+  dryRunApprovalConditionFormula: (payload: unknown) => dryRunApprovalConditionFormulaSpy(payload),
 }))
 
 vi.mock('element-plus', () => ({
@@ -623,6 +625,7 @@ describe('TemplateAuthoringView', () => {
     updateTemplateSpy.mockReset()
     publishTemplateSpy.mockReset()
     getTemplateSpy.mockReset()
+    dryRunApprovalConditionFormulaSpy.mockReset()
     pushSpy.mockClear()
     replaceSpy.mockClear()
     createTemplateSpy.mockImplementation(async (payload) => ({
@@ -637,6 +640,7 @@ describe('TemplateAuthoringView', () => {
       ...payload,
     }))
     publishTemplateSpy.mockResolvedValue({})
+    dryRunApprovalConditionFormulaSpy.mockResolvedValue({ success: true, result: true })
   })
 
   afterEach(() => {
@@ -941,6 +945,65 @@ describe('TemplateAuthoringView', () => {
       defaultEdgeKey: 'e-low',
     })
     expect(payload.approvalGraph.nodes.find((node: any) => node.key === 'approval_high')).toEqual(graph.nodes[2])
+    expect(payload.approvalGraph.edges).toEqual(graph.edges)
+  })
+
+  it('FC-5 wiring: formula dry-run calls the dry-run endpoint and does not change the saved graph payload', async () => {
+    routeParams = { id: 'tpl_formula_dry_run' }
+    const graph = {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        { key: 'cond_1', type: 'condition', name: '金额判断', config: { branches: [{ edgeKey: 'e-high', rules: [{ fieldId: 'amount', operator: 'gte', value: 1000 }] }], defaultEdgeKey: 'e-low' } },
+        { key: 'approval_high', type: 'approval', name: '高额审批', config: { assigneeSources: [{ kind: 'dept_head' }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'e-start-c', source: 'start', target: 'cond_1' },
+        { key: 'e-high', source: 'cond_1', target: 'approval_high' },
+        { key: 'e-low', source: 'cond_1', target: 'end' },
+        { key: 'e-high-end', source: 'approval_high', target: 'end' },
+      ],
+    }
+    getTemplateSpy.mockResolvedValue(buildTemplate({ approvalGraph: graph }))
+    await mountView()
+    await flushUi()
+
+    const modeSelect = container!.querySelector('[data-testid="approval-condition-predicate-mode"]') as HTMLSelectElement
+    modeSelect.value = 'formula'
+    modeSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    const expression = container!.querySelector('[data-testid="approval-condition-formula-expression"]') as HTMLInputElement
+    expression.value = '{amount} >= 5000'
+    expression.dispatchEvent(new Event('input'))
+    const sample = container!.querySelector('[data-testid="approval-condition-formula-dry-run-sample"]') as HTMLInputElement
+    sample.value = '{"amount":6000}'
+    sample.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container!.querySelector('[data-testid="approval-condition-formula-dry-run-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(dryRunApprovalConditionFormulaSpy).toHaveBeenCalledTimes(1)
+    expect(dryRunApprovalConditionFormulaSpy).toHaveBeenCalledWith({
+      formSchema: expect.objectContaining({
+        fields: expect.arrayContaining([expect.objectContaining({ id: 'amount', type: 'number' })]),
+      }),
+      expression: '{amount} >= 5000',
+      formData: { amount: 6000 },
+    })
+    expect(container!.querySelector('[data-testid="approval-condition-formula-dry-run-result"]')?.textContent).toContain('true')
+
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    const payload = updateTemplateSpy.mock.calls[0]?.[1] as any
+    const conditionNode = payload.approvalGraph.nodes.find((node: any) => node.key === 'cond_1')
+    expect(conditionNode.config).toEqual({
+      branches: [{ edgeKey: 'e-high', rules: [], formula: { expression: '{amount} >= 5000' } }],
+      defaultEdgeKey: 'e-low',
+    })
+    expect(JSON.stringify(payload)).not.toContain('6000')
     expect(payload.approvalGraph.edges).toEqual(graph.edges)
   })
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -2,9 +2,10 @@
 
 Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
 BUILT IN A STACKED PR (purchase/reimbursement examples); FC-4 BUILT IN A
-STACKED PR (approval-specific backend dry-run endpoint). Owner decisions
-resolved: `AND/OR/NOT` only in v1; numeric aggregates fail closed; backend
-evaluator ships before dry-run.
+STACKED PR (approval-specific backend dry-run endpoint); FC-5 BUILT IN A
+STACKED PR (frontend dry-run preview button). Owner decisions resolved:
+`AND/OR/NOT` only in v1; numeric aggregates fail closed; backend evaluator
+ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the
@@ -302,8 +303,19 @@ multi-branch preset is introduced.
 - Return a normal dry-run diagnostic payload for formula errors instead of
   routing through the sheet-scoped multitable formula dry-run.
 
-This slice intentionally does not add the frontend "Evaluate" button yet. The
-endpoint is the backend truth surface that a later authoring UX can call.
+This slice intentionally did not add the frontend "Evaluate" button. The
+endpoint is the backend truth surface that FC-5 calls.
+
+### FC-5 — Authoring Dry-Run Preview
+
+- Add an explicit "测试公式" button to the formula predicate authoring block.
+- Accept per-branch sample JSON and call the FC-4 approval-specific dry-run
+  endpoint with `{ formSchema, expression, formData }`.
+- Show success/error text inline for author feedback.
+- Keep the preview informational only: it is not a save/publish gate and its
+  sample data never enters the template payload.
+- Add a mounted wiring test proving button -> endpoint payload -> result display,
+  then save still emits only the formula graph config and preserves topology.
 
 ## Non-Goals
 

--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,11 +1,10 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — FC-1 BUILT IN PR #3219; FC-2 BUILT IN A STACKED PR; FC-3
-BUILT IN A STACKED PR (purchase/reimbursement examples); FC-4 BUILT IN A
-STACKED PR (approval-specific backend dry-run endpoint); FC-5 BUILT IN A
-STACKED PR (frontend dry-run preview button). Owner decisions resolved:
-`AND/OR/NOT` only in v1; numeric aggregates fail closed; backend evaluator
-ships before dry-run.
+Status: RATIFIED — FC-1 shipped #3219 `38b1b98d0`; FC-2 shipped #3220
+`c0a875193`; FC-3 shipped #3221 `a0071602b`; FC-4 shipped #3222
+`34644ba26`; FC-5 is this pending PR #3223 (frontend dry-run preview button).
+Owner decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail
+closed; backend evaluator ships before dry-run.
 
 Goal: make approval condition branches more flexible than today's
 `fieldId + operator + value` rules, while keeping the approval backend as the

--- a/docs/development/approval-formula-condition-stack-review-20260625.md
+++ b/docs/development/approval-formula-condition-stack-review-20260625.md
@@ -1,0 +1,268 @@
+# Approval Formula Conditions — Stack Review
+
+Status: REVIEWED DRAFT STACK, NOT SHIPPED.
+
+Date: 2026-06-25
+
+This record reviews the stacked FC-1..FC-5 implementation against the ratified
+design-lock and the current GitHub PR state. It is a landing aid, not a shipped
+declaration.
+
+## Stack State
+
+| Slice | PR | Head | State |
+| --- | --- | --- | --- |
+| FC-1 evaluator | #3219 | `7b0cb4f08` | draft, GitHub checks green |
+| FC-2 authoring | #3220 | `b5d8b2230` | draft, GitHub checks green |
+| FC-3 preset examples | #3221 | `bf0e30124` | draft, GitHub checks green |
+| FC-4 backend dry-run | #3222 | `e446d4095` | draft, GitHub checks green |
+| FC-5 dry-run preview | #3223 | `1cbccea65` | draft, GitHub checks green |
+
+All five PRs are still draft and unmerged. Keep the stack order:
+FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+
+Current base/drift check:
+
+- `origin/main` is `7c52cc598`, the same commit recorded as FC-1's base.
+- FC-2..FC-5 are stacked on the preceding FC branch heads listed above.
+- GitHub reports all five PRs as `CLEAN`.
+- PR comments only contain non-actionable Gemini quota warnings; there are no
+  actionable reviews on the stack at the time of this record.
+
+## Reviewed Surfaces
+
+- Backend evaluator: `packages/core-backend/src/services/ApprovalConditionFormula.ts`
+- Backend graph validation/publish path:
+  `packages/core-backend/src/services/ApprovalProductService.ts`
+- Backend runtime branch selection:
+  `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- Backend dry-run route: `packages/core-backend/src/routes/approvals.ts`
+- Frontend condition authoring helper: `apps/web/src/approvals/conditionEdit.ts`
+- Frontend template authoring view:
+  `apps/web/src/views/approval/TemplateAuthoringView.vue`
+- Frontend template shape guard:
+  `apps/web/src/approvals/templateAuthoring.ts`
+- Frontend API wrapper: `apps/web/src/approvals/api.ts`
+- Mounted/frontend specs:
+  `apps/web/tests/approvalTemplateAuthoring.spec.ts`
+  and `apps/web/tests/approval-template-authoring-condition-edit.test.ts`
+- Backend RBAC boundary spec:
+  `packages/core-backend/tests/unit/approval-rbac-boundary.test.ts`
+
+## Gate Review
+
+### FC-1 — Backend Contract + Evaluator
+
+Verdict: no blocking finding found after the parenthesis-depth hardening.
+
+Evidence:
+
+- Formula contract is additive: `ConditionBranch` keeps `rules` and adds
+  optional `formula`.
+- `normalizeApprovalGraph` rejects mixed `formula + non-empty rules`.
+- Publish/update/create validation calls
+  `assertApprovalConditionFormulaValidForSchema`.
+- Runtime condition resolution uses the same
+  `evaluateApprovalConditionFormula`.
+- The evaluator is approval-specific and narrow: no eval, no external lookup,
+  bounded expression length, AST nodes, nesting depth, field refs, and function
+  calls.
+- Unsafe arithmetic and malformed aggregates fail closed.
+- Boolean `AND`/`OR` evaluate both operands, so malformed aggregate data cannot
+  hide behind short-circuit behavior.
+
+Self-review fix already landed in FC-1:
+
+- Pure parenthesis nesting now counts against the max nesting-depth cap. A
+  17-deep parenthesis wrapper around `TRUE` fails closed instead of bypassing
+  the AST-depth limit.
+
+Verification:
+
+- Backend focused unit suite: 98/98 passed.
+- Backend type-check: clean.
+- GitHub checks: green; strict E2E skipped as expected.
+
+### FC-2 — Frontend Authoring
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- The editor seeds `predicateMode` from branch shape:
+  formula branches hydrate as formula mode; rule branches hydrate as rule mode.
+- Saving a formula branch emits `{ rules: [], formula: { expression } }`.
+  Keeping `rules: []` is intentional because the backend/runtime branch shape
+  still requires a rules array.
+- Saving a rule branch omits `formula`.
+- Non-condition nodes and all graph edges are deep-cloned and preserved.
+- Formula reference preview checks top-level fields and detail sub-fields
+  against the draft form schema. The backend remains the arbiter.
+- The mounted wiring test switches a real condition branch from rules to
+  formula and asserts the saved payload.
+
+Verification:
+
+- `approval-web-guard`: green.
+- `pr-validate`: green.
+
+### FC-3 — Preset Examples
+
+Verdict: no blocking finding found in the current stack review.
+
+Evidence:
+
+- Formula-condition preset examples sit on top of the FC-1/FC-2 contract.
+- They do not introduce a new evaluator or a new graph model.
+- The stack remains draft, so these examples are not yet a shipped user promise.
+
+Verification:
+
+- `approval-web-guard`: green.
+- `pr-validate`: green.
+
+### FC-4 — Backend Dry-Run Endpoint
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- Route is approval-specific:
+  `POST /api/approval-templates/formula-condition/dry-run`.
+- Route is protected by `authenticate` and
+  `rbacGuard('approval-templates:manage')`.
+- It validates `expression`, `formSchema.fields`, and object-shaped `formData`.
+- It calls the same validator/evaluator as publish/runtime:
+  `assertApprovalConditionFormulaValidForSchema` and
+  `evaluateApprovalConditionFormula`.
+- Formula errors return structured diagnostics in the response body instead of
+  falling through as generic 500s.
+- The route does not call the sheet-scoped multitable formula dry-run API.
+
+Verification:
+
+- RBAC boundary tests cover no-auth 401, wrong-scope 403, manage-scope 200, and
+  runtime diagnostic response.
+- `pr-validate`: green.
+
+### FC-5 — Frontend Dry-Run Preview
+
+Verdict: no blocking finding found.
+
+Evidence:
+
+- Preview is explicit-button only; it is not per-keystroke.
+- Sample JSON is parsed locally and must be an object.
+- Request payload sends `{ formSchema, expression, formData }` to the FC-4
+  endpoint wrapper.
+- The preview result is informational only; it is not a save/publish gate.
+- Mounted wiring test proves:
+  - button -> endpoint payload,
+  - result rendering,
+  - save payload still contains only graph config,
+  - sample data does not enter the template payload.
+
+Verification:
+
+- Local post-restack backend focused suite: 98/98 passed.
+- Local approval-web-guard equivalent suite: 259/259 passed.
+- Web type-check: clean.
+- Backend type-check: clean.
+- `git diff --check`: clean.
+- GitHub `approval-web-guard`: green.
+- GitHub `pr-validate`: green.
+
+## Non-Blocking Notes
+
+- Direct linting of `apps/web/src/approvals/api.ts` still hits a pre-existing
+  unrelated unused-parameter issue at `approvalId`. The FC-5 API addition is
+  covered by `vue-tsc -b` and the mounted wiring test.
+- FC-3 examples are useful examples, not a substitute for FC-1/FC-2/FC-4/FC-5
+  contract verification.
+- This review did not convert the PRs from draft to ready and did not merge
+  anything.
+
+## Landing Requirements
+
+Before shipping:
+
+1. Convert or land one slice at a time in stack order:
+   FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+2. After each slice lands, rebase the next slice onto the new base.
+3. Re-run the slice's gates on the rebased head.
+4. Keep the backend as the branch arbiter; frontend dry-run remains UX only.
+5. After FC-5 lands, update the design-lock/status docs from draft-stack to
+   shipped.
+
+## Landing Checklist
+
+Use this checklist only after the owner explicitly opts into landing the draft
+stack. It is intentionally serial; do not hard-rebase or merge later slices in
+parallel because each PR depends on the previous branch head.
+
+### FC-1 #3219
+
+1. Confirm `origin/main` has not advanced; if it has, rebase FC-1 onto the new
+   `origin/main`.
+2. Convert #3219 from draft to ready.
+3. Re-run/confirm the full required check set.
+4. Squash-merge #3219.
+5. Record the squash SHA.
+
+### FC-2 #3220
+
+1. Rebase FC-2 onto the merged FC-1 squash commit.
+2. Confirm the authoring diff still only adds formula authoring and does not
+   touch backend runtime.
+3. Re-run/confirm `approval-web-guard` and `pr-validate`.
+4. Convert #3220 from draft to ready.
+5. Squash-merge #3220.
+6. Record the squash SHA.
+
+### FC-3 #3221
+
+1. Rebase FC-3 onto the merged FC-2 squash commit.
+2. Confirm the preset examples still use the FC-1/FC-2 formula contract and do
+   not introduce a second evaluator or graph shape.
+3. Re-run/confirm `approval-web-guard` and `pr-validate`.
+4. Convert #3221 from draft to ready.
+5. Squash-merge #3221.
+6. Record the squash SHA.
+
+### FC-4 #3222
+
+1. Rebase FC-4 onto the merged FC-3 squash commit.
+2. Confirm the dry-run route remains approval-specific and protected by
+   `authenticate` + `rbacGuard('approval-templates:manage')`.
+3. Re-run/confirm `pr-validate` and the RBAC boundary tests covering 401/403/200
+   plus formula diagnostics.
+4. Convert #3222 from draft to ready.
+5. Squash-merge #3222.
+6. Record the squash SHA.
+
+### FC-5 #3223
+
+1. Rebase FC-5 onto the merged FC-4 squash commit.
+2. Confirm the preview remains explicit-button UX only and sample JSON still
+   does not enter the template payload.
+3. Re-run/confirm `approval-web-guard`, `pr-validate`, and the mounted wiring
+   spec.
+4. Convert #3223 from draft to ready.
+5. Squash-merge #3223.
+6. Record the squash SHA.
+
+### Closeout
+
+1. Update `docs/design/approval-formula-condition-design-lock-20260625.md` from
+   stacked-built wording to `RATIFIED + SHIPPED`, with all five squash SHAs.
+2. Update this review record or the stack verification record so it no longer
+   says `draft stack`.
+3. Confirm no FC branches remain open unless intentionally retained for audit.
+
+## Review Verdict
+
+APPROVE FOR OWNER REVIEW / LANDING SEQUENCE.
+
+I found no remaining blocker in the current draft stack after the FC-1
+parenthesis-depth hardening. The feature is still not shipped until the stacked
+draft PRs are landed in order and the shipped-state documentation is updated.

--- a/docs/development/approval-formula-condition-stack-review-20260625.md
+++ b/docs/development/approval-formula-condition-stack-review-20260625.md
@@ -1,33 +1,31 @@
 # Approval Formula Conditions — Stack Review
 
-Status: REVIEWED DRAFT STACK, NOT SHIPPED.
+Status: LANDING REVIEW RECORD — FC-1..FC-4 SHIPPED; FC-5 PENDING IN #3223.
 
 Date: 2026-06-25
 
-This record reviews the stacked FC-1..FC-5 implementation against the ratified
-design-lock and the current GitHub PR state. It is a landing aid, not a shipped
-declaration.
+This record reviews the FC-1..FC-5 implementation against the ratified
+design-lock. It began as a draft-stack landing aid; after the serial landing,
+FC-1..FC-4 are on `origin/main` and FC-5 is the remaining PR in this slice.
 
 ## Stack State
 
 | Slice | PR | Head | State |
 | --- | --- | --- | --- |
-| FC-1 evaluator | #3219 | `7b0cb4f08` | draft, GitHub checks green |
-| FC-2 authoring | #3220 | `b5d8b2230` | draft, GitHub checks green |
-| FC-3 preset examples | #3221 | `bf0e30124` | draft, GitHub checks green |
-| FC-4 backend dry-run | #3222 | `e446d4095` | draft, GitHub checks green |
-| FC-5 dry-run preview | #3223 | `1cbccea65` | draft, GitHub checks green |
+| FC-1 evaluator | #3219 | `38b1b98d0` | shipped on main |
+| FC-2 authoring | #3220 | `c0a875193` | shipped on main |
+| FC-3 preset examples | #3221 | `a0071602b` | shipped on main |
+| FC-4 backend dry-run | #3222 | `34644ba26` | shipped on main |
+| FC-5 dry-run preview | #3223 | pending squash | this PR |
 
-All five PRs are still draft and unmerged. Keep the stack order:
-FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+The stack order was preserved: FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
 
 Current base/drift check:
 
-- `origin/main` is `7c52cc598`, the same commit recorded as FC-1's base.
-- FC-2..FC-5 are stacked on the preceding FC branch heads listed above.
-- GitHub reports all five PRs as `CLEAN`.
-- PR comments only contain non-actionable Gemini quota warnings; there are no
-  actionable reviews on the stack at the time of this record.
+- `origin/main` contains FC-1..FC-4 at the SHAs listed above.
+- FC-5 is rebased onto the FC-4 squash and remains the final landing slice.
+- PR comments on the original draft stack only contained non-actionable Gemini
+  quota warnings; no actionable review remained when FC-1 landing began.
 
 ## Reviewed Surfaces
 
@@ -196,9 +194,8 @@ Before shipping:
 
 ## Landing Checklist
 
-Use this checklist only after the owner explicitly opts into landing the draft
-stack. It is intentionally serial; do not hard-rebase or merge later slices in
-parallel because each PR depends on the previous branch head.
+Historical checklist used for the serial landing. It is retained as process
+evidence; do not read unchecked items below as current work for FC-1..FC-4.
 
 ### FC-1 #3219
 
@@ -253,16 +250,18 @@ parallel because each PR depends on the previous branch head.
 
 ### Closeout
 
-1. Update `docs/design/approval-formula-condition-design-lock-20260625.md` from
+1. After FC-5 lands, update
+   `docs/design/approval-formula-condition-design-lock-20260625.md` from
    stacked-built wording to `RATIFIED + SHIPPED`, with all five squash SHAs.
-2. Update this review record or the stack verification record so it no longer
-   says `draft stack`.
+2. Update this review record or the stack verification record with the FC-5
+   squash SHA.
 3. Confirm no FC branches remain open unless intentionally retained for audit.
 
 ## Review Verdict
 
-APPROVE FOR OWNER REVIEW / LANDING SEQUENCE.
+APPROVE FOR FC-5 LANDING.
 
-I found no remaining blocker in the current draft stack after the FC-1
-parenthesis-depth hardening. The feature is still not shipped until the stacked
-draft PRs are landed in order and the shipped-state documentation is updated.
+I found no remaining blocker in FC-5 after the FC-1 parenthesis-depth
+hardening and the serial FC-1..FC-4 landing. The feature is fully shipped only
+after FC-5 lands and the final shipped-state documentation stamps its squash
+SHA.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -20,6 +20,7 @@ Commands run from `/private/tmp/metasheet2-fc5-formula-condition`:
 
 ```sh
 pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot
+pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot
 pnpm --filter @metasheet/web type-check
 pnpm --filter @metasheet/web lint
 pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0
@@ -29,6 +30,7 @@ git diff --check
 Results:
 
 - Focused frontend specs: 69/69 passed.
+- Approval web guard equivalent specs: 259/259 passed.
 - `vue-tsc -b`: clean.
 - Repository-configured web lint: clean.
 - Direct lint of the touched SFC/spec: clean.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -8,11 +8,65 @@ implementation state as of 2026-06-25. It is intentionally a snapshot, not a
 
 | Slice | PR | Base | Head | State |
 | --- | --- | --- | --- | --- |
-| FC-1 evaluator | #3219 | `main` | `05a4aea6f` | open draft, CI green |
-| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `e6ade9c09` | open draft, CI green |
-| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `52690aaf4` | open draft, CI green |
-| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `beea1d056` | open draft, pr-validate green |
-| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | `448f9e2b0` | open draft, local verification below |
+| FC-1 evaluator | #3219 | `main` | `7b0cb4f08` | open draft, GitHub checks green |
+| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `b5d8b2230` | open draft, GitHub checks green |
+| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `bf0e30124` | open draft, GitHub checks green |
+| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `e446d4095` | open draft, GitHub checks green |
+| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | this verification commit | open draft, GitHub checks green |
+
+## FC-1 Rebase Hardening
+
+After self-review, FC-1 now enforces the design-lock's nesting bound for pure
+parenthesis nesting as well as AST operator depth. A formula such as
+`((((...TRUE...))))` with 17 nested parentheses now fails with the same
+fail-closed nesting-depth error instead of bypassing the depth cap.
+
+Commands run from `/private/tmp/metasheet2-fc1-formula-condition`:
+
+```sh
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend type-check
+git diff --check
+```
+
+Results:
+
+- Backend focused unit suite: 98/98 passed.
+- Backend `tsc --noEmit`: clean.
+- `git diff --check`: clean.
+
+Downstream draft PRs FC-2..FC-5 were then rebased on the hardened FC-1 head.
+
+## Post-Rebase Stack Verification
+
+Commands run from `/private/tmp/metasheet2-fc5-formula-condition` after the
+FC-1 hardening and FC-2..FC-5 restack:
+
+```sh
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-condition-formula.test.ts tests/unit/approval-graph-executor.test.ts tests/unit/approval-product-service.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend type-check
+git diff --check
+```
+
+Results:
+
+- Backend focused unit suite: 98/98 passed.
+- Approval web guard equivalent specs: 259/259 passed.
+- `vue-tsc -b`: clean.
+- Backend `tsc --noEmit`: clean.
+- `git diff --check`: clean.
+
+GitHub state after the restack:
+
+- FC-1 #3219: all required checks green; `Strict E2E with Enhanced Gates`
+  skipped as expected.
+- FC-2 #3220: `approval-web-guard` and `pr-validate` green.
+- FC-3 #3221: `approval-web-guard` and `pr-validate` green.
+- FC-4 #3222: `pr-validate` green.
+- FC-5 #3223: `approval-web-guard` and `pr-validate` green.
+- All five PRs remain draft and unmerged.
 
 ## FC-5 Verification
 

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -1,0 +1,57 @@
+# Approval Formula Conditions — Stack Verification Snapshot
+
+Status: draft stack, not merged. This record documents the FC-1..FC-5 stacked
+implementation state as of 2026-06-25. It is intentionally a snapshot, not a
+"shipped" declaration.
+
+## Stack
+
+| Slice | PR | Base | Head | State |
+| --- | --- | --- | --- | --- |
+| FC-1 evaluator | #3219 | `main` | `05a4aea6f` | open draft, CI green |
+| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `e6ade9c09` | open draft, CI green |
+| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `52690aaf4` | open draft, CI green |
+| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `beea1d056` | open draft, pr-validate green |
+| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | `448f9e2b0` | open draft, local verification below |
+
+## FC-5 Verification
+
+Commands run from `/private/tmp/metasheet2-fc5-formula-condition`:
+
+```sh
+pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web lint
+pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0
+git diff --check
+```
+
+Results:
+
+- Focused frontend specs: 69/69 passed.
+- `vue-tsc -b`: clean.
+- Repository-configured web lint: clean.
+- Direct lint of the touched SFC/spec: clean.
+- `git diff --check`: clean.
+
+Note: direct linting of `src/approvals/api.ts` still hits a pre-existing
+unrelated unused-parameter issue at `approvalId`; the FC-5 API addition is
+covered by `vue-tsc -b` and the mounted wiring test.
+
+## Boundaries
+
+- FC-5 is UX-only over the FC-4 approval-specific dry-run endpoint.
+- The dry-run preview is explicit-button only, not per-keystroke.
+- Dry-run result text is informational only. It is not a save/publish gate.
+- Sample JSON stays local to the authoring component and never enters the
+  template payload.
+- The mounted wiring test proves button -> endpoint payload -> result display,
+  then save still emits only the formula graph config and preserves topology.
+
+## Remaining Before Shipping
+
+- Keep the stack order: FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
+- Rebase each slice after the previous one lands.
+- Re-run that slice's gates on the rebased head before marking ready.
+- After the full stack lands, update this record or the design-lock status from
+  draft-stack to shipped.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -1,18 +1,19 @@
 # Approval Formula Conditions — Stack Verification Snapshot
 
-Status: draft stack, not merged. This record documents the FC-1..FC-5 stacked
-implementation state as of 2026-06-25. It is intentionally a snapshot, not a
-"shipped" declaration.
+Status: LANDING VERIFICATION — FC-1..FC-4 SHIPPED; FC-5 PENDING IN #3223.
+This record documents the FC-1..FC-5 implementation and the verification used
+to land the stack serially. It is not the final shipped closeout until the FC-5
+squash SHA is stamped.
 
 ## Stack
 
 | Slice | PR | Base | Head | State |
 | --- | --- | --- | --- | --- |
-| FC-1 evaluator | #3219 | `main` | `7b0cb4f08` | open draft, GitHub checks green |
-| FC-2 authoring | #3220 | `codex/approval-formula-condition-fc1-20260625` | `b5d8b2230` | open draft, GitHub checks green |
-| FC-3 preset examples | #3221 | `codex/approval-formula-condition-fc2-20260625` | `bf0e30124` | open draft, GitHub checks green |
-| FC-4 backend dry-run | #3222 | `codex/approval-formula-condition-fc3-20260625` | `e446d4095` | open draft, GitHub checks green |
-| FC-5 dry-run preview | #3223 | `codex/approval-formula-condition-fc4-20260625` | this verification commit | open draft, GitHub checks green |
+| FC-1 evaluator | #3219 | `main` | `38b1b98d0` | shipped on main |
+| FC-2 authoring | #3220 | `main` | `c0a875193` | shipped on main |
+| FC-3 preset examples | #3221 | `main` | `a0071602b` | shipped on main |
+| FC-4 backend dry-run | #3222 | `main` | `34644ba26` | shipped on main |
+| FC-5 dry-run preview | #3223 | `main` | pending squash | this PR |
 
 ## FC-1 Rebase Hardening
 
@@ -58,7 +59,7 @@ Results:
 - Backend `tsc --noEmit`: clean.
 - `git diff --check`: clean.
 
-GitHub state after the restack:
+GitHub state during the original draft-stack restack:
 
 - FC-1 #3219: all required checks green; `Strict E2E with Enhanced Gates`
   skipped as expected.
@@ -66,7 +67,8 @@ GitHub state after the restack:
 - FC-3 #3221: `approval-web-guard` and `pr-validate` green.
 - FC-4 #3222: `pr-validate` green.
 - FC-5 #3223: `approval-web-guard` and `pr-validate` green.
-- All five PRs remain draft and unmerged.
+These entries are historical evidence from the draft-stack review. Current
+state is the shipped/pending table above.
 
 ## FC-5 Verification
 
@@ -104,10 +106,8 @@ covered by `vue-tsc -b` and the mounted wiring test.
 - The mounted wiring test proves button -> endpoint payload -> result display,
   then save still emits only the formula graph config and preserves topology.
 
-## Remaining Before Shipping
+## Remaining Before Final Closeout
 
-- Keep the stack order: FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
-- Rebase each slice after the previous one lands.
-- Re-run that slice's gates on the rebased head before marking ready.
-- After the full stack lands, update this record or the design-lock status from
-  draft-stack to shipped.
+- Land FC-5 after rebasing onto the FC-4 squash and re-running its gates.
+- Stamp the FC-5 squash SHA in this record and the design-lock.
+- Update the design-lock status to `RATIFIED + SHIPPED`.


### PR DESCRIPTION
## What

Replaces closed #3223 for FC-5 after FC-4's branch was squash-merged and deleted.

Adds the frontend dry-run preview for approval condition formulas:
- `dryRunApprovalConditionFormula()` API wrapper for the FC-4 approval-specific backend endpoint.
- Explicit `测试公式` button in `TemplateAuthoringView` formula-branch authoring.
- Per-branch sample JSON, inline success/error result text, and mounted wiring coverage.

Also fixes the stack docs that were stale after FC-1..FC-4 landed: they now state FC-1..FC-4 shipped with their squash SHAs and FC-5 is the remaining pending slice, instead of claiming the whole stack is draft/unmerged.

## Boundaries

- UX-only over the FC-4 backend dry-run endpoint.
- Explicit button only, not per-keystroke.
- Informational only: not a save/publish gate.
- Sample JSON never enters the template payload.
- Backend remains the sole branch-selection authority.

## Verification

Local, on the rebased head:

```sh
pnpm --filter @metasheet/web exec vitest run approvalTemplateAuthoring approval-template-authoring-condition-edit --reporter=dot
# 69/69 passed

pnpm --filter @metasheet/web exec vitest run approval-common-template-presets approvalTemplateAuthoring approval-detail-field approval-template-authoring-detail approval-template-authoring-graph-preserve approval-template-authoring-condition-edit approval-template-authoring-parallel-edit approval-template-authoring-cc-edit approval-template-authoring-approval-node-edit approval-template-authoring-complex-node-config-allowlist approval-graph-topology-edit approval-graph-layout amountAutoSum useAutoSumTotal lineDerivation --reporter=dot
# 259/259 passed

pnpm --filter @metasheet/web type-check
pnpm --filter @metasheet/web lint
pnpm --filter @metasheet/web exec eslint src/views/approval/TemplateAuthoringView.vue tests/approvalTemplateAuthoring.spec.ts --max-warnings=0
git diff --check
```
