### PR TITLE
docs(approval): finalize formula condition stack closeout

### DIFF
--- a/docs/design/approval-formula-condition-design-lock-20260625.md
+++ b/docs/design/approval-formula-condition-design-lock-20260625.md
@@ -1,8 +1,8 @@
 # Approval Formula Conditions — Design Lock
 
-Status: RATIFIED — FC-1 shipped #3219 `38b1b98d0`; FC-2 shipped #3220
-`c0a875193`; FC-3 shipped #3221 `a0071602b`; FC-4 shipped #3222
-`34644ba26`; FC-5 is this pending PR #3223 (frontend dry-run preview button).
+Status: RATIFIED + SHIPPED — FC-1 shipped #3219 `38b1b98d0`; FC-2 shipped
+#3220 `c0a875193`; FC-3 shipped #3221 `a0071602b`; FC-4 shipped #3222
+`34644ba26`; FC-5 shipped #3234 `be9ad83a4` (frontend dry-run preview button).
 Owner decisions resolved: `AND/OR/NOT` only in v1; numeric aggregates fail
 closed; backend evaluator ships before dry-run.
 

--- a/docs/development/approval-formula-condition-stack-review-20260625.md
+++ b/docs/development/approval-formula-condition-stack-review-20260625.md
@@ -1,12 +1,12 @@
 # Approval Formula Conditions — Stack Review
 
-Status: LANDING REVIEW RECORD — FC-1..FC-4 SHIPPED; FC-5 PENDING IN #3223.
+Status: REVIEWED + SHIPPED — FC-1..FC-5 ON MAIN.
 
 Date: 2026-06-25
 
 This record reviews the FC-1..FC-5 implementation against the ratified
 design-lock. It began as a draft-stack landing aid; after the serial landing,
-FC-1..FC-4 are on `origin/main` and FC-5 is the remaining PR in this slice.
+all five slices are on `origin/main`.
 
 ## Stack State
 
@@ -16,14 +16,13 @@ FC-1..FC-4 are on `origin/main` and FC-5 is the remaining PR in this slice.
 | FC-2 authoring | #3220 | `c0a875193` | shipped on main |
 | FC-3 preset examples | #3221 | `a0071602b` | shipped on main |
 | FC-4 backend dry-run | #3222 | `34644ba26` | shipped on main |
-| FC-5 dry-run preview | #3223 | pending squash | this PR |
+| FC-5 dry-run preview | #3234 | `be9ad83a4` | shipped on main |
 
 The stack order was preserved: FC-1 -> FC-2 -> FC-3 -> FC-4 -> FC-5.
 
 Current base/drift check:
 
-- `origin/main` contains FC-1..FC-4 at the SHAs listed above.
-- FC-5 is rebased onto the FC-4 squash and remains the final landing slice.
+- `origin/main` contains FC-1..FC-5 at the SHAs listed above.
 - PR comments on the original draft stack only contained non-actionable Gemini
   quota warnings; no actionable review remained when FC-1 landing began.
 
@@ -237,31 +236,30 @@ evidence; do not read unchecked items below as current work for FC-1..FC-4.
 5. Squash-merge #3222.
 6. Record the squash SHA.
 
-### FC-5 #3223
+### FC-5 #3234 (replacement for closed #3223)
 
 1. Rebase FC-5 onto the merged FC-4 squash commit.
 2. Confirm the preview remains explicit-button UX only and sample JSON still
    does not enter the template payload.
 3. Re-run/confirm `approval-web-guard`, `pr-validate`, and the mounted wiring
    spec.
-4. Convert #3223 from draft to ready.
-5. Squash-merge #3223.
+4. Open replacement PR #3234 because original #3223 was closed against the
+   deleted FC-4 branch.
+5. Squash-merge #3234.
 6. Record the squash SHA.
 
 ### Closeout
 
-1. After FC-5 lands, update
-   `docs/design/approval-formula-condition-design-lock-20260625.md` from
-   stacked-built wording to `RATIFIED + SHIPPED`, with all five squash SHAs.
-2. Update this review record or the stack verification record with the FC-5
-   squash SHA.
-3. Confirm no FC branches remain open unless intentionally retained for audit.
+1. `docs/design/approval-formula-condition-design-lock-20260625.md` now reads
+   `RATIFIED + SHIPPED` with all five squash SHAs.
+2. This review record and the stack verification record stamp the FC-5 squash.
+3. Closed #3223 is superseded by shipped #3234; no FC runtime branch remains
+   intentionally open for this stack.
 
 ## Review Verdict
 
-APPROVE FOR FC-5 LANDING.
+APPROVE — STACK SHIPPED.
 
 I found no remaining blocker in FC-5 after the FC-1 parenthesis-depth
-hardening and the serial FC-1..FC-4 landing. The feature is fully shipped only
-after FC-5 lands and the final shipped-state documentation stamps its squash
-SHA.
+hardening and the serial FC-1..FC-4 landing. FC-5 shipped as #3234
+`be9ad83a4`; the shipped-state documentation now stamps the full stack.

--- a/docs/development/approval-formula-condition-stack-verification-20260625.md
+++ b/docs/development/approval-formula-condition-stack-verification-20260625.md
@@ -1,9 +1,8 @@
 # Approval Formula Conditions — Stack Verification Snapshot
 
-Status: LANDING VERIFICATION — FC-1..FC-4 SHIPPED; FC-5 PENDING IN #3223.
+Status: SHIPPED VERIFICATION — FC-1..FC-5 ON MAIN.
 This record documents the FC-1..FC-5 implementation and the verification used
-to land the stack serially. It is not the final shipped closeout until the FC-5
-squash SHA is stamped.
+to land the stack serially.
 
 ## Stack
 
@@ -13,7 +12,7 @@ squash SHA is stamped.
 | FC-2 authoring | #3220 | `main` | `c0a875193` | shipped on main |
 | FC-3 preset examples | #3221 | `main` | `a0071602b` | shipped on main |
 | FC-4 backend dry-run | #3222 | `main` | `34644ba26` | shipped on main |
-| FC-5 dry-run preview | #3223 | `main` | pending squash | this PR |
+| FC-5 dry-run preview | #3234 | `main` | `be9ad83a4` | shipped on main |
 
 ## FC-1 Rebase Hardening
 
@@ -66,7 +65,8 @@ GitHub state during the original draft-stack restack:
 - FC-2 #3220: `approval-web-guard` and `pr-validate` green.
 - FC-3 #3221: `approval-web-guard` and `pr-validate` green.
 - FC-4 #3222: `pr-validate` green.
-- FC-5 #3223: `approval-web-guard` and `pr-validate` green.
+- Original FC-5 #3223: `approval-web-guard` and `pr-validate` green before it
+  was closed against the deleted FC-4 branch; shipped replacement is #3234.
 These entries are historical evidence from the draft-stack review. Current
 state is the shipped/pending table above.
 
@@ -106,8 +106,8 @@ covered by `vue-tsc -b` and the mounted wiring test.
 - The mounted wiring test proves button -> endpoint payload -> result display,
   then save still emits only the formula graph config and preserves topology.
 
-## Remaining Before Final Closeout
+## Closeout
 
-- Land FC-5 after rebasing onto the FC-4 squash and re-running its gates.
-- Stamp the FC-5 squash SHA in this record and the design-lock.
-- Update the design-lock status to `RATIFIED + SHIPPED`.
+- FC-5 landed after rebasing onto the FC-4 squash and re-running its gates.
+- The FC-5 squash SHA is stamped in this record and the design-lock.
+- The design-lock status is `RATIFIED + SHIPPED`.


### PR DESCRIPTION
## What

Finalizes the approval formula-condition stack documentation after FC-5 shipped via #3234.

Updates:
- `docs/design/approval-formula-condition-design-lock-20260625.md` -> `RATIFIED + SHIPPED` with all five squash SHAs.
- `docs/development/approval-formula-condition-stack-review-20260625.md` -> shipped review record, with #3223 correctly marked superseded by #3234.
- `docs/development/approval-formula-condition-stack-verification-20260625.md` -> shipped verification record, with FC-5 `be9ad83a4` stamped.

## Verification

```sh
rg -n "PENDING|pending PR|draft stack, not merged|All five PRs|open draft|NOT SHIPPED|unmerged|pending squash|this PR|Remaining Before Final Closeout|FC-5 PENDING|Convert #3223|Squash-merge #3223" docs/design/approval-formula-condition-design-lock-20260625.md docs/development/approval-formula-condition-stack-review-20260625.md docs/development/approval-formula-condition-stack-verification-20260625.md
# no matches

git diff --check
```
