### PR TITLE
docs(approval): clear residual draft-stack drift in FC review MD

### DIFF
--- a/docs/development/approval-formula-condition-stack-review-20260625.md
+++ b/docs/development/approval-formula-condition-stack-review-20260625.md
@@ -111,7 +111,8 @@ Evidence:
 
 - Formula-condition preset examples sit on top of the FC-1/FC-2 contract.
 - They do not introduce a new evaluator or a new graph model.
-- The stack remains draft, so these examples are not yet a shipped user promise.
+- Now shipped on main as illustrative presets riding the FC-1/FC-2 contract — not a new capability;
+  whether they become a committed user-facing default remains a separate product decision.
 
 Verification:
 


### PR DESCRIPTION
Audit of the FC closeout docs found one residual drift: the stack-review MD's status is REVIEWED + SHIPPED (FC-1..FC-5 on main) but an evidence bullet still said 'the stack remains draft'. Fixed to the shipped reality. The design-lock SHAs all match main, and the verification MD was already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)