### PR TITLE
docs(approval): clear body-level doc drift in amount-tier lock + total-check MD (P2/P3)

### DIFF
--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -26,13 +26,18 @@ approval-result write-back.
 
 1. Use amount fields that already exist in the preset form schema.
 
-   The branch condition reads the top-level total field (`amount`). Detail-row amounts are not
-   auto-summed in v1; the applicant-entered total remains the branch input. Auto-sum/calculated
-   total is a separate form-field capability, not hidden inside this template slice. KNOWN
-   CONTROL LIMITATION: because the gate reads the applicant-entered `amount`, the routing is
-   only as trustworthy as that value — an applicant can under-state the total to route around
-   the higher-amount tier. The amount tier is an authoring/routing aid, not a tamper-proof
-   financial control, until auto-sum or a server-side total check closes the gap.
+   The branch condition reads the top-level total field (`amount`). AS BUILT (updated 2026-06-26,
+   post-closeout): the detail total is now read-only **auto-filled** from the detail rows (#3198) and a
+   server-side **total-check** (#3176) rejects any total ≠ the detail sum — so the backend total-check is
+   the tamper-proof boundary and the amount tier routes on a verified value. The control gap described
+   below is CLOSED.
+
+   (Historical — the framing this slice shipped with at authoring time: detail-row amounts were not
+   auto-summed in v1 and the applicant-entered total was the branch input; that was a KNOWN CONTROL
+   LIMITATION — an applicant could under-state the total to route around the higher-amount tier, making
+   the amount tier an authoring/routing aid, not a tamper-proof financial control, until auto-sum or a
+   server-side total-check closed the gap. Auto-sum #3198 + total-check #3176 have now closed it; see the
+   amount/formula line roadmap #3237.)
 
 2. Use existing assignee sources first.
 

--- a/docs/development/approval-amount-total-check-dev-verification-20260624.md
+++ b/docs/development/approval-amount-total-check-dev-verification-20260624.md
@@ -62,10 +62,12 @@ equal the sum of that submission's detail-row amounts:
   - *step-result skip-reason* — the runtime backwrite skip is surfaced on the `start_approval` step
     result (`backwriteSkipped`), not only `logger.warn`. 14/14 start_approval integration; automation-v1 186/186.
 
-## Still a follow-up (not built)
-- **Detail-row auto-sum** — the heavier of the two #3161 fixes (the lighter — §1, the FE authoring
-  silent-drop — is now **closed by #3197**); compute/auto-fill the total, removing the gameable separate
-  total — its own later lock; pulls in a computed/rollup form-field capability.
+## Follow-ups (status as of the 2026-06-26 amount/formula line closeout)
+- **Detail-row auto-sum — SHIPPED post-closeout by #3198** (read-only auto-fill; design-lock #3189, line
+  roadmap #3237). It was the heavier of the two #3161 fixes (the lighter — §1, the FE authoring
+  silent-drop — was closed by #3197); it is now BUILT — the detail total is read-only auto-filled from the
+  rows and the server-side total-check is the tamper-proof boundary, so the gameable-separate-total gap is
+  closed. (Per-row line-subtotal derivation then shipped too: #3203 lock + #3205 runtime.)
 - **§3 — `visibilityRule` save-vs-submit policy (P2).** Next move is **doc-only ratify of the shipped
   behavior** (record what save vs submit actually does today), NOT a rushed backend save-time reject —
   handled separately from §1.


### PR DESCRIPTION
Follow-up to the line closeout (#3237): Status: lines were fixed but two document BODIES still described the pre-auto-sum world. **P2** amount-tier lock branch-input paragraph → rewritten as-built (auto-fill #3198 + total-check #3176 = tamper-proof boundary; old framing kept as historical). **P3** total-check dev-verification MD 'Detail-row auto-sum (not built)' → SHIPPED by #3198 (+ #3203/#3205), header de-staled. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)