### PR TITLE
fix(integration): overlay K3 read-smoke material read config

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5508,11 +5508,27 @@ async function testTemplatesCrudRoutes() {
 async function testReadSmokeRoute() {
   const readArgs = []
   const writeCalls = []
+  const storedK3System = {
+    id: 'sys_1',
+    tenantId: 'tenant_1',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    credentials: { bearerToken: 'secret-token' },
+    config: {
+      objects: {
+        material: {
+          operations: ['upsert'],
+          savePath: '/K3API/Material/Save',
+        },
+      },
+    },
+  }
+  const storedK3SystemBefore = clone(storedK3System)
   const { calls, services } = createMockServices({
     externalSystemRegistry: {
       async getExternalSystemForAdapter(input) {
         calls.push(['getExternalSystemForAdapter', input])
-        return { id: input.id, tenantId: 'tenant_1', kind: 'erp:k3-wise-webapi', role: 'target', credentials: { bearerToken: 'secret-token' } }
+        return storedK3System
       },
     },
     adapterRegistry: {
@@ -5551,7 +5567,15 @@ async function testReadSmokeRoute() {
   assert.deepEqual(readArgs[0], { object: 'material', filters: { FNumber: 'M-001' } })
   assert.equal(writeCalls.length, 0, 'no upsert/save/submit/audit called')
   assert.ok(findCall(calls, 'getExternalSystemForAdapter'), 'used backend getExternalSystemForAdapter')
-  assert.deepEqual(findCall(calls, 'createAdapter')[1].credentials, { bearerToken: 'secret-token' })
+  const adapterSystem = findCall(calls, 'createAdapter')[1]
+  assert.deepEqual(adapterSystem.credentials, { bearerToken: 'secret-token' })
+  assert.deepEqual(adapterSystem.config.objects.material, {
+    operations: ['upsert', 'read'],
+    savePath: '/K3API/Material/Save',
+    readPath: '/K3API/Material/GetDetail',
+    readMethod: 'POST',
+  }, 'read-smoke applies a non-persisted Material/GetDetail overlay before adapter creation')
+  assert.deepEqual(storedK3System, storedK3SystemBefore, 'stored external system object is not mutated')
   assert.equal(findCalls(calls, 'upsertExternalSystem').length, 0, 'read-smoke never persists/alters the system')
   const okStr = JSON.stringify(ok.body.data)
   for (const leak of ['M-001', 'SECRET-NAME', 'secret-token', 'k3host']) {

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -10,6 +10,7 @@ const {
   READ_SMOKE_PRESETS,
   getReadSmokePreset,
   buildReadSmokeRequest,
+  applyReadSmokePresetOverlay,
   readSmokeSuccessEvidence,
   readSmokeErrorEvidence,
 } = require(path.join(__dirname, '..', 'lib', 'read-smoke.cjs'))
@@ -20,6 +21,15 @@ const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
 assert.ok(PRESET, 'k3wise.material-detail.v1 is registered')
 assert.equal(PRESET.requiredKind, 'erp:k3-wise-webapi')
 assert.equal(PRESET.object, 'material')
+assert.deepEqual(PRESET.readConfigOverlay, {
+  objects: {
+    material: {
+      operations: ['read'],
+      readPath: '/K3API/Material/GetDetail',
+      readMethod: 'POST',
+    },
+  },
+})
 // unknown / empty / non-string / prototype keys → undefined (route fail-closes)
 assert.equal(getReadSmokePreset('evil.custom.v1'), undefined)
 assert.equal(getReadSmokePreset(''), undefined)
@@ -36,6 +46,38 @@ assert.equal(reqObj.cursor, undefined)
 assert.equal(reqObj.limit, undefined)
 assert.equal(reqObj.watermark, undefined)
 assert.equal(reqObj.pagination, undefined)
+
+// --- non-persisted read config overlay: target-side Save config is preserved, read config is in-memory only ---
+const storedSystem = {
+  id: 'sys_1',
+  kind: 'erp:k3-wise-webapi',
+  role: 'target',
+  credentials: { bearerToken: 'secret-token' },
+  config: {
+    objects: {
+      material: {
+        operations: ['upsert'],
+        savePath: '/K3API/Material/Save',
+      },
+      salesOrder: {
+        operations: ['upsert'],
+        savePath: '/K3API/SalesOrder/Save',
+      },
+    },
+  },
+}
+const storedBefore = JSON.parse(JSON.stringify(storedSystem))
+const overlayedSystem = applyReadSmokePresetOverlay(storedSystem, PRESET)
+assert.notEqual(overlayedSystem, storedSystem, 'overlay returns an in-memory clone')
+assert.deepEqual(storedSystem, storedBefore, 'stored system is not mutated')
+assert.deepEqual(overlayedSystem.config.objects.material, {
+  operations: ['upsert', 'read'],
+  savePath: '/K3API/Material/Save',
+  readPath: '/K3API/Material/GetDetail',
+  readMethod: 'POST',
+})
+assert.deepEqual(overlayedSystem.config.objects.salesOrder, storedSystem.config.objects.salesOrder, 'unrelated objects are preserved')
+assert.equal(applyReadSmokePresetOverlay(null, PRESET), null)
 
 // --- success evidence: recordPresent + referenceObjectCount; values-free ---
 const okResult = {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -78,7 +78,13 @@ const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isB
 const { resolveReferenceRuleValue } = require('./reference-mapping-resolver.cjs')
 // DF-T3b-2b: live mapping-sheet bulk-read → referenceMappingIndexes for the preview seam (read-only).
 const { buildReferenceMappingIndexes } = require('./reference-mapping-source.cjs')
-const { getReadSmokePreset, buildReadSmokeRequest, readSmokeSuccessEvidence, readSmokeErrorEvidence } = require('./read-smoke.cjs')
+const {
+  getReadSmokePreset,
+  buildReadSmokeRequest,
+  applyReadSmokePresetOverlay,
+  readSmokeSuccessEvidence,
+  readSmokeErrorEvidence,
+} = require('./read-smoke.cjs')
 const { K3_REFERENCE_MAPPING_TEMPLATES } = require('./reference-mapping-templates.cjs')
 const { listReferenceIntegrationTemplates } = require('./reference-integration-templates.cjs')
 // DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
@@ -1631,7 +1637,8 @@ function createHandlers(services, options = {}) {
       if (!system || system.kind !== preset.requiredKind) {
         throw new HttpRouteError(409, 'READ_SMOKE_KIND_MISMATCH', 'external system kind does not match the preset')
       }
-      const adapter = adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
+      const adapterSystem = applyReadSmokePresetOverlay(system, preset)
+      const adapter = adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) })
       // Forced single read only; values-free evidence on success or failure (never key/raw/values/credentials).
       try {
         const result = await adapter.read(buildReadSmokeRequest(preset, key))

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -12,8 +12,34 @@ const READ_SMOKE_PRESETS = Object.freeze({
     presetId: 'k3wise.material-detail.v1',
     requiredKind: 'erp:k3-wise-webapi',
     object: 'material',
+    readConfigOverlay: Object.freeze({
+      objects: Object.freeze({
+        material: Object.freeze({
+          operations: Object.freeze(['read']),
+          readPath: '/K3API/Material/GetDetail',
+          readMethod: 'POST',
+        }),
+      }),
+    }),
   }),
 })
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function mergeOperations(existing, required) {
+  const values = []
+  for (const source of [existing, required]) {
+    if (!Array.isArray(source)) continue
+    for (const item of source) {
+      if (typeof item !== 'string' || item.trim().length === 0) continue
+      const operation = item.trim()
+      if (!values.includes(operation)) values.push(operation)
+    }
+  }
+  return values
+}
 
 // Built-in catalog lookup. Returns undefined for anything not in the catalog (→ route fail-closes). Uses an
 // own-property check so prototype keys ('toString', '__proto__', …) can never resolve to a preset.
@@ -25,6 +51,36 @@ function getReadSmokePreset(presetId) {
 // Forced single-record read request. Single explicit key only — no list/pagination/cursor/watermark/BOM.
 function buildReadSmokeRequest(preset, key) {
   return { object: preset.object, filters: { FNumber: key } }
+}
+
+// Non-persisted preset overlay for the credentialed read-smoke route. Entity-machine validation
+// showed that target-side K3 systems often have only Save/upsert config persisted; the smoke
+// preset owns the single read endpoint and merges it into an in-memory system clone before
+// adapter creation. It never mutates or persists the stored external system.
+function applyReadSmokePresetOverlay(system, preset) {
+  if (!isPlainObject(system) || !isPlainObject(preset) || !isPlainObject(preset.readConfigOverlay)) {
+    return system
+  }
+  const currentConfig = isPlainObject(system.config) ? system.config : {}
+  const currentObjects = isPlainObject(currentConfig.objects) ? currentConfig.objects : {}
+  const overlayObjects = isPlainObject(preset.readConfigOverlay.objects) ? preset.readConfigOverlay.objects : {}
+  const nextObjects = { ...currentObjects }
+  for (const [objectName, overlay] of Object.entries(overlayObjects)) {
+    if (!isPlainObject(overlay)) continue
+    const currentObject = isPlainObject(currentObjects[objectName]) ? currentObjects[objectName] : {}
+    nextObjects[objectName] = {
+      ...currentObject,
+      ...overlay,
+      operations: mergeOperations(currentObject.operations, overlay.operations),
+    }
+  }
+  return {
+    ...system,
+    config: {
+      ...currentConfig,
+      objects: nextObjects,
+    },
+  }
 }
 
 // Values-free evidence from a successful read. Extracts ONLY recordPresent (boolean) + referenceObjectCount
@@ -67,6 +123,7 @@ module.exports = {
   READ_SMOKE_PRESETS,
   getReadSmokePreset,
   buildReadSmokeRequest,
+  applyReadSmokePresetOverlay,
   readSmokeSuccessEvidence,
   readSmokeErrorEvidence,
 }


### PR DESCRIPTION
## Summary

Follow-up to the #1709 entity-machine read-smoke retest. The shipped route worked, but a target-side K3 WebAPI system without persisted `material` read config failed before reaching K3 with `UnsupportedAdapterOperationError`.

This PR makes the built-in read-smoke preset self-contained by applying a **non-persisted, in-memory** read config overlay before adapter creation:

- preset: `k3wise.material-detail.v1`
- object: `material`
- operations: merge existing operations + `read`
- readPath: `/K3API/Material/GetDetail`
- readMethod: `POST`

## Boundary

- Request shape remains strictly `{ presetId, key }`.
- Preset catalog remains built-in only; no user/request-supplied preset config.
- Stored external system is not mutated or persisted.
- Role/status/credentials are unchanged.
- No LIST, pagination, cursor, watermark, BOM, Save, Submit, Audit, or production write is opened.
- Evidence remains values-free.

## Verification

- `node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm -F plugin-integration-core test`
- `git diff --check`

## Notes

The route still uses backend credential context via `getExternalSystemForAdapter` and remains `integration:write` gated. The overlay is only for adapter creation in this read-smoke path; it does not alter the persisted K3 system config.

Refs: #1709
