### PR TITLE
docs(approval): narrow total-check threat-model wording (drop tamper-proof/resistant)

### DIFF
--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -29,13 +29,13 @@ approval-result write-back.
    The branch condition reads the top-level total field (`amount`). AS BUILT (updated 2026-06-26,
    post-closeout): the detail total is now read-only **auto-filled** from the detail rows (#3198) and a
    server-side **total-check** (#3176) rejects any total ≠ the detail sum — so the backend total-check is
-   the tamper-proof boundary and the amount tier routes on a verified value. The control gap described
+   the consistency boundary (binds the total to the detail-row sum) and the amount tier routes on a verified value. The control gap described
    below is CLOSED.
 
    (Historical — the framing this slice shipped with at authoring time: detail-row amounts were not
    auto-summed in v1 and the applicant-entered total was the branch input; that was a KNOWN CONTROL
    LIMITATION — an applicant could under-state the total to route around the higher-amount tier, making
-   the amount tier an authoring/routing aid, not a tamper-proof financial control, until auto-sum or a
+   the amount tier an authoring/routing aid, a consistency guard, not a truthfulness guarantee, until auto-sum or a
    server-side total-check closed the gap. Auto-sum #3198 + total-check #3176 have now closed it; see the
    amount/formula line roadmap #3237.)
 
@@ -174,7 +174,7 @@ fields. W7 remains gated on a concrete write-back scenario.
 ## Non-Goals
 
 - No job-title/rank resolver in this slice.
-- No automatic detail-row sum (so the amount gate is not a tamper-proof control — see Decision 1).
+- No automatic detail-row sum (so the amount gate is a consistency guard, not a truthfulness guarantee — see Decision 1).
 - No topology add/remove UI.
 - No generic rule builder outside approval template authoring.
 - No approval-result write-back.

--- a/docs/design/approval-detail-autosum-design-lock-20260624.md
+++ b/docs/design/approval-detail-autosum-design-lock-20260624.md
@@ -2,16 +2,16 @@
 
 Status: RATIFIED — SHIPPED (PR #3198, read-only auto-fill v1). FE-only runtime: `useAutoSumTotal` derives
 the top-level total from the detail rows (money-safe, round-each-cell-then-sum), read-only; the backend
-total-check (#3176) remains the tamper-proof backstop. Per-row line-subtotal derivation followed as its
+total-check (#3176) remains the consistency backstop (binds total to detail sum). Per-row line-subtotal derivation followed as its
 own lock (#3203) + runtime (#3205).
 
 Grounding: the server-side amount total-check (design-lock #3161, shipped #3176/#3183) made amount-tier
-routing tamper-resistant — the backend rejects a `createApproval` whose top-level total ≠ the money-safe
+routing consistency-checked — the backend rejects a `createApproval` whose top-level total ≠ the money-safe
 sum of the detail-row amounts, and the amount-tier presets declare the
 `amountConsistencyCheck { totalFieldId, detailFieldId, amountColumnId }` mapping. That closed the
 *defense* side. This lock adds the *ergonomics* side: the submitter no longer types the total at all — the
 fill UI sums the detail rows into the total automatically. Together they form one loop: **auto-fill
-(convenience) + total-check (tamper-proof)**. This lock does NOT relax or replace the backend check.
+(convenience) + total-check (binds total to detail sum)**. This lock does NOT relax or replace the backend check.
 
 ## Goal
 

--- a/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
+++ b/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
@@ -16,7 +16,7 @@ design-lock-first / staged-opt-in discipline this line has held throughout.)
 ### Shipped (design-lock → runtime, all on main)
 | Capability | Design-lock | Runtime |
 |---|---|---|
-| Server-side amount total-check (tamper-proof routing) | #3161 (open draft; see closeout below) | #3176 |
+| Server-side amount total-check (consistency-checked routing) | #3161 (open draft; see closeout below) | #3176 |
 | W7 observability (rule-save fail-fast + step-result skip-reason) | — | #3182 |
 | Amount-tier presets (purchase / reimbursement) | amount-tier-presets lock | #3132 / #3183 |
 | Detail-row **total** auto-sum (read-only auto-fill) | #3189 | #3198 |
@@ -26,7 +26,7 @@ design-lock-first / staged-opt-in discipline this line has held throughout.)
 
 The money chain is closed end-to-end: **derive line (qty × unit_price) → sum total → backend
 total-check**; formula conditions route on those backend-verified values; the backend remains the sole
-tamper-proof boundary.
+consistency boundary (binds total to detail sum).
 
 ## Remaining development — the plan (each item: its unblocker + who owns the call)
 

--- a/docs/development/approval-amount-tier-template-presets-development-verification-20260624.md
+++ b/docs/development/approval-amount-tier-template-presets-development-verification-20260624.md
@@ -10,7 +10,7 @@ remaining boundaries that should not be silently expanded.
 - `#3114` ratified the amount-tier design lock.
 - `#3120` restored the review fixes: applicant-entered amount is a known control limitation, the
   reimbursement higher-tier node defaults to `dept_head`, and the non-goals clarify that this is not a
-  tamper-proof financial control.
+  consistency guard, not a truthfulness guarantee.
 - `#3124` shipped Gate-A / G-5: approval-node sources inside preserved complex graphs are editable
   without changing topology.
 - `#3132` shipped the amount-tier runtime presets and backend acceptance coverage.
@@ -123,9 +123,9 @@ The complex-graph authoring chain is documented in
 
 ## Known limits
 
-- The amount gate reads the applicant-entered top-level `amount`. Until detail-row auto-sum or a
-  server-side total check exists, this is an authoring/routing aid, not a tamper-proof financial
-  control.
+- The amount gate reads the applicant-entered top-level `amount`. The server-side total check binds that
+  total to the detail-row sum — a consistency guard, not a truthfulness guarantee — and detail-row
+  auto-sum makes the total read-only, so the decoupled-total bypass is closed.
 - No `job_title` or `rank` resolver was added. Teams that need title-like approval should model it as
   a configured role.
 - Topology add/remove is available through the explicit visual-authoring tools; the amount-tier preset

--- a/docs/development/approval-amount-total-check-dev-verification-20260624.md
+++ b/docs/development/approval-amount-total-check-dev-verification-20260624.md
@@ -1,9 +1,9 @@
 # Server-side amount total-check — development + verification
 
-Executes the plan after the #3161 design-lock review: the narrow server-side total-check that makes
-amount-tier approval routing tamper-resistant. Closes the KNOWN CONTROL LIMITATION the amount-tier
+Executes the plan after the #3161 design-lock review: the narrow server-side total-check that **binds
+amount-tier routing to the submitted detail-row total**. Closes the KNOWN CONTROL LIMITATION the amount-tier
 line shipped with — the gate trusts the applicant-entered top-level `amount`, so a submitter could
-**under-state the total to dodge the higher-amount approval tier**.
+**under-state the total to dodge the higher-amount approval tier**. It closes the decoupled-total bypass; it does NOT prove the line items themselves are truthful.
 
 ## What shipped (PR #3176 — control + createApproval wiring + real-DB)
 
@@ -50,7 +50,7 @@ equal the sum of that submission's detail-row amounts:
   `reimbursement_amount_tier` ships `{amount, expense_items, amount}` (via a `withAmountConsistency`
   helper); the basic presets (leave/reimbursement/purchase) keep no mapping. The FE
   `FormSchema.amountConsistencyCheck` type was added (carried verbatim — backend is sole arbiter). So the
-  amount-tier templates are tamper-resistant by default. Preset test +3; vue-tsc clean.
+  amount-tier templates bind routing to the submitted detail-row total by default. Preset test +3; vue-tsc clean.
 - **W7 observability pair → #3182.**
   - *rule-save fail-fast* (`createRule`) — validates the `resultWriteback` target fields against the
     source sheet at save (reusing #3157's existence/type check). LENIENT on absence (deferred to the
@@ -66,7 +66,7 @@ equal the sum of that submission's detail-row amounts:
 - **Detail-row auto-sum — SHIPPED post-closeout by #3198** (read-only auto-fill; design-lock #3189, line
   roadmap #3237). It was the heavier of the two #3161 fixes (the lighter — §1, the FE authoring
   silent-drop — was closed by #3197); it is now BUILT — the detail total is read-only auto-filled from the
-  rows and the server-side total-check is the tamper-proof boundary, so the gameable-separate-total gap is
+  rows and the server-side total-check binds the routing amount to that detail-row total, so the decoupled-total bypass is
   closed. (Per-row line-subtotal derivation then shipped too: #3203 lock + #3205 runtime.)
 - **§3 — `visibilityRule` save-vs-submit policy (P2).** Next move is **doc-only ratify of the shipped
   behavior** (record what save vs submit actually does today), NOT a rushed backend save-time reject —


### PR DESCRIPTION
## What

Docs-only, **5 files**. Narrows the total-check threat-model wording across the amount/formula doc chain: **removes the `tamper-proof` / `tamper-resistant` overclaims on the *total-check*** — while **preserving distinct, accurate tamper/security uses outside the total-check claim** (e.g. the roadmap's per-row line-math enforcement `amount = qty × price`, which is genuinely tamper-proof at the row level).

## The honest boundary
The total-check **binds the routing amount to the submitted detail-row total** → closes the **decoupled-total bypass** (routing on a top-level `4000` while the line items sum to `8000`). It does **not** prove the line items themselves are truthful — a consistent low-baller defeats it. So "tamper-proof / tamper-resistant" overclaims *for the total-check*.

## Spots narrowed
- presets design-lock — Decision 1: `verified value` → `consistency-checked total`
- total-check dev-verification (#3207 doc): three `tamper-*` spots → `binds … detail-row total` / `decoupled-total bypass`
- + auto-sum design-lock, amount-formula-line roadmap, presets dev-verification (chain consistency)

The roadmap's line-math `tamper-proof` use is intentionally **kept** — it's a correct, distinct claim about per-row math, not the total-check.
