### PR TITLE
feat(integration): C1 — K3 read/list contract normalizer + preset metadata (reconcile shapes; lock-safe)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
@@ -1,0 +1,73 @@
+'use strict'
+
+// C1 (#1709 / C0 #3242): contract normalizer + preset metadata. Pure contract — no K3, no route, no
+// LIST/BOM/runtime. Asserts the forward { presetId, intent } shape and the shipped { presetId, key } subset
+// normalize to the SAME output (no silent divergence), and that everything else fails closed values-free.
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const {
+  getReadSmokePreset,
+  ReadSmokeContractError,
+  normalizeReadSmokeContract,
+} = require(path.join(__dirname, '..', 'lib', 'read-smoke.cjs'))
+
+const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
+const isErr = (reason) => (e) => e instanceof ReadSmokeContractError && e.code === 'READ_SMOKE_CONTRACT_INVALID' && e.reason === reason
+
+// --- preset metadata present + frozen ---
+assert.deepEqual(PRESET.allowedObjects, ['material'])
+assert.deepEqual(PRESET.allowedModes, ['single_record_detail'])
+assert.equal(PRESET.defaultObject, 'material')
+assert.equal(PRESET.defaultMode, 'single_record_detail')
+assert.throws(() => { PRESET.allowedObjects.push('bom') }, TypeError, 'allowedObjects is frozen')
+
+// --- RECONCILIATION: both shapes → identical normalized output ---
+const fromSubset = normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: 'M-001' })
+const fromIntent = normalizeReadSmokeContract({
+  presetId: 'k3wise.material-detail.v1',
+  intent: { object: 'material', mode: 'single_record_detail', key: 'M-001' },
+})
+const expected = { presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail', key: 'M-001' }
+assert.deepEqual(fromSubset, expected, 'shipped { presetId, key } subset normalizes to the canonical output')
+assert.deepEqual(fromIntent, expected, 'forward { presetId, intent } shape normalizes to the same output')
+assert.deepEqual(fromSubset, fromIntent, 'the two shapes do not diverge')
+// key is trimmed
+assert.equal(normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: '  M-002  ' }).key, 'M-002')
+
+// --- fail-closed ---
+assert.throws(() => normalizeReadSmokeContract(null), isErr('not_object'))
+assert.throws(() => normalizeReadSmokeContract('x'), isErr('not_object'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'nope.v1', key: 'M-001' }), isErr('preset_unknown'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: '   ' }), isErr('key_required'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1' }), isErr('key_required'))
+// unknown object / mode (forward shape) → fail-closed (LIST/BOM cannot enter via intent)
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'bom', mode: 'single_record_detail', key: 'M-001' } }), isErr('object_not_allowed'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'list', key: 'M-001' } }), isErr('mode_not_allowed'))
+// ambiguous: both key + intent
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: 'M-001', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001' } }), isErr('ambiguous_shape'))
+// intent not an object
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: 'material' }), isErr('intent_invalid'))
+
+// --- raw path/method/payload/config can NEVER ride in from the request ---
+for (const bad of ['path', 'method', 'headers', 'body', 'response', 'endpoint', 'url', 'config', 'credentials', 'token', 'readPath', 'readMethod', 'savePath', 'operations']) {
+  assert.throws(
+    () => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: 'M-001', [bad]: 'x' }),
+    isErr('unexpected_field'),
+    `top-level raw field '${bad}' must be rejected`,
+  )
+}
+// and inside intent
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001', readPath: '/evil' } }), isErr('unexpected_field'))
+
+// --- values-free: the key is never echoed in an error ---
+try {
+  normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'bom', mode: 'single_record_detail', key: 'SECRET-KEY-123' } })
+  assert.fail('expected object_not_allowed')
+} catch (e) {
+  assert.ok(!String(e.message).includes('SECRET-KEY-123'), 'error message must not echo the key')
+  assert.ok(!String(e.message).includes('bom') || true) // object name is a coarse allowlist token, not a value
+}
+
+console.log('read-smoke-contract.test.cjs OK')

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -12,6 +12,13 @@ const READ_SMOKE_PRESETS = Object.freeze({
     presetId: 'k3wise.material-detail.v1',
     requiredKind: 'erp:k3-wise-webapi',
     object: 'material',
+    // C1 contract metadata (#1709 / C0 #3242): the allowlisted objects + modes for the forward-looking
+    // { presetId, intent } shape, plus the defaults used to normalize the shipped { presetId, key } compat
+    // subset to the SAME output — so the two shapes cannot silently diverge.
+    allowedObjects: Object.freeze(['material']),
+    allowedModes: Object.freeze(['single_record_detail']),
+    defaultObject: 'material',
+    defaultMode: 'single_record_detail',
     readConfigOverlay: Object.freeze({
       objects: Object.freeze({
         material: Object.freeze({
@@ -119,6 +126,72 @@ function readSmokeErrorEvidence(preset, error) {
   }
 }
 
+// C1 contract normalizer (#1709 / C0 #3242). Reconciles the forward-looking
+// { presetId, intent:{ object, mode, key } } shape with the shipped read-smoke { presetId, key } subset by
+// normalizing BOTH to one output { presetId, object, mode, key }. Pure contract: it does NOT call K3, does
+// NOT touch the route, and opens no LIST/BOM/runtime. Fail-closed + values-free: a raw path/method/headers/
+// body/response/credential/config can never ride in (strict key allowlist); unknown preset/object/mode → a
+// coarse reason; the key is never echoed in an error.
+const READ_SMOKE_CONTRACT_TOP_KEYS = Object.freeze(['presetId', 'key', 'intent'])
+const READ_SMOKE_CONTRACT_INTENT_KEYS = Object.freeze(['object', 'mode', 'key'])
+
+class ReadSmokeContractError extends Error {
+  constructor(reason, message) {
+    super(message || reason)
+    this.name = 'ReadSmokeContractError'
+    this.code = 'READ_SMOKE_CONTRACT_INVALID'
+    this.reason = reason
+  }
+}
+
+function onlyAllowedKeys(value, allowed) {
+  return Object.keys(value).every((key) => allowed.includes(key))
+}
+
+function normalizeReadSmokeContract(input) {
+  if (!isPlainObject(input)) throw new ReadSmokeContractError('not_object', 'read-smoke contract must be an object')
+  // Strict top-level keys: a raw path/method/headers/body/response/credential/adapter config can never ride in.
+  if (!onlyAllowedKeys(input, READ_SMOKE_CONTRACT_TOP_KEYS)) {
+    throw new ReadSmokeContractError('unexpected_field', 'read-smoke contract allows only presetId, key, intent')
+  }
+  const preset = getReadSmokePreset(typeof input.presetId === 'string' ? input.presetId : '')
+  if (!preset) throw new ReadSmokeContractError('preset_unknown', 'unknown read-smoke preset')
+
+  const hasIntent = input.intent !== undefined
+  const hasTopKey = input.key !== undefined
+  let object
+  let mode
+  let rawKey
+  if (hasIntent) {
+    // Forward shape. A top-level key must not coexist with intent (ambiguous).
+    if (hasTopKey) throw new ReadSmokeContractError('ambiguous_shape', 'use either { presetId, key } or { presetId, intent }, not both')
+    if (!isPlainObject(input.intent)) throw new ReadSmokeContractError('intent_invalid', 'intent must be an object')
+    if (!onlyAllowedKeys(input.intent, READ_SMOKE_CONTRACT_INTENT_KEYS)) {
+      throw new ReadSmokeContractError('unexpected_field', 'intent allows only object, mode, key')
+    }
+    object = typeof input.intent.object === 'string' ? input.intent.object : ''
+    mode = typeof input.intent.mode === 'string' ? input.intent.mode : ''
+    rawKey = input.intent.key
+  } else {
+    // Shipped compat subset { presetId, key } → object/mode defaulted from the preset (same normalized output).
+    object = preset.defaultObject
+    mode = preset.defaultMode
+    rawKey = input.key
+  }
+  // Allowlist object + mode against the preset (fail-closed on unknown).
+  if (!Array.isArray(preset.allowedObjects) || !preset.allowedObjects.includes(object)) {
+    throw new ReadSmokeContractError('object_not_allowed', 'object is not allowlisted for this preset')
+  }
+  if (!Array.isArray(preset.allowedModes) || !preset.allowedModes.includes(mode)) {
+    throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
+  }
+  // Key is runtime-only and never echoed; require a non-empty string.
+  const key = typeof rawKey === 'string' ? rawKey.trim() : ''
+  if (!key) throw new ReadSmokeContractError('key_required', 'a non-empty key is required')
+
+  return { presetId: preset.presetId, object, mode, key }
+}
+
 module.exports = {
   READ_SMOKE_PRESETS,
   getReadSmokePreset,
@@ -126,4 +199,6 @@ module.exports = {
   applyReadSmokePresetOverlay,
   readSmokeSuccessEvidence,
   readSmokeErrorEvidence,
+  ReadSmokeContractError,
+  normalizeReadSmokeContract,
 }


### PR DESCRIPTION
#1709 / C0 design-lock #3242, slice **C1**. **Pure contract/normalizer/tests** — no K3 call, no route wiring, no LIST/BOM/runtime, no entity machine, no deploy package. Satisfies the C0 §3 reconciliation lock.

- **Preset metadata:** `k3wise.material-detail.v1` gains frozen `allowedObjects`/`allowedModes`/`defaultObject`/`defaultMode`.
- **`normalizeReadSmokeContract`:** reconciles the forward `{presetId, intent:{object,mode,key}}` and the shipped `{presetId, key}` subset → **one output** `{presetId, object, mode, key}`. Fail-closed + values-free: strict top-level key allowlist (a raw path/method/payload/config can never ride in), unknown preset/object/mode → coarse reason, blank/ambiguous → reject, key trimmed + never echoed.

**Tests:** both shapes deep-equal (no silent divergence), all fail-closed paths, 13 injection fields rejected (top-level + intent), values-free error. **Zero drift:** route untouched (normalizer unwired), existing tests green, full sweep 0 failures.

**Boundary:** no K3 / route wiring / LIST / BOM / runtime / Save/Submit/Audit / production write / UI. C2 (narrow read-only smoke extension) is the separate opt-in that wires this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
