### PR TITLE
feat(integration): C2 — wire read/list normalizer into the read-smoke route (accept {presetId,intent})

### DIFF
--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5582,6 +5582,30 @@ async function testReadSmokeRoute() {
     assert.ok(!okStr.includes(leak), `read-smoke response must not leak ${leak}`)
   }
 
+  // C2: the forward { presetId, intent } shape is accepted and drives the SAME single read as { presetId, key }
+  const okIntent = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-002' } },
+  })
+  assertOkResponse(okIntent, 200)
+  assert.equal(okIntent.body.data.ok, true)
+  assert.equal(okIntent.body.data.recordPresent, true)
+  assert.deepEqual(readArgs[readArgs.length - 1], { object: 'material', filters: { FNumber: 'M-002' } }, 'intent shape drives the same single FNumber read')
+  assert.ok(!JSON.stringify(okIntent.body.data).includes('M-002'), 'intent-shape response is values-free')
+
+  // C2: LIST/BOM cannot enter via intent — fail-closed before any system load
+  const intentBom = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-detail.v1', intent: { object: 'bom', mode: 'single_record_detail', key: 'M-003' } },
+  })
+  assert.equal(intentBom.statusCode, 400, 'intent.object=bom is fail-closed (not allowlisted)')
+  // C2: raw config in intent (readPath) cannot ride in
+  const intentRaw = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-004', readPath: '/evil' } },
+  })
+  assert.equal(intentRaw.statusCode, 400, 'raw config in intent is fail-closed')
+
   // write-gated: a read-only integration user cannot trigger the credentialed probe (existence-oracle risk)
   const denied = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
     user: READ_USER, params: { id: 'sys_1' }, body: { presetId: 'k3wise.material-detail.v1', key: 'M-001' },

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -84,6 +84,7 @@ const {
   applyReadSmokePresetOverlay,
   readSmokeSuccessEvidence,
   readSmokeErrorEvidence,
+  normalizeReadSmokeContract,
 } = require('./read-smoke.cjs')
 const { K3_REFERENCE_MAPPING_TEMPLATES } = require('./reference-mapping-templates.cjs')
 const { listReferenceIntegrationTemplates } = require('./reference-integration-templates.cjs')
@@ -1613,21 +1614,18 @@ function createHandlers(services, options = {}) {
       // probe of K3 and returns an existence signal (recordPresent) a read user could enumerate against keys.
       // Per the conservative discipline it is a connection/probe action → operator/integration-write only.
       requireAccess(req, 'write')
-      // Strict body: only { presetId, key }. The preset (kind/object/read shape) comes from the catalog, not
-      // the request, so a custom preset config can never be smuggled in.
-      const body = isPlainObject(requestBody(req)) ? requestBody(req) : {}
-      const extraKeys = Object.keys(body).filter((k) => k !== 'presetId' && k !== 'key')
-      if (extraKeys.length > 0) {
-        throw new HttpRouteError(400, 'READ_SMOKE_BODY_INVALID', 'read-smoke body allows only presetId and key')
+      // C2: normalize the contract via the C1 normalizer — accepts the shipped { presetId, key } subset AND
+      // the forward { presetId, intent:{ object, mode, key } } shape, normalizing both to one output. The
+      // normalizer is fail-closed + values-free: a raw path/method/payload/config can never ride in, and an
+      // unknown preset/object/mode is rejected before any system load or adapter creation.
+      let contract
+      try {
+        contract = normalizeReadSmokeContract(requestBody(req))
+      } catch (error) {
+        // Map to a 400 with a coarse, values-free reason only (never the key or submitted values).
+        throw new HttpRouteError(400, 'READ_SMOKE_CONTRACT_INVALID', 'read-smoke contract is invalid', { reason: error && typeof error.reason === 'string' ? error.reason : 'invalid' })
       }
-      const preset = getReadSmokePreset(firstString(body.presetId))
-      if (!preset) {
-        throw new HttpRouteError(400, 'READ_SMOKE_PRESET_UNKNOWN', 'unknown read-smoke preset')
-      }
-      const key = firstString(body.key)
-      if (!key) {
-        throw new HttpRouteError(400, 'READ_SMOKE_KEY_REQUIRED', 'read-smoke key is required')
-      }
+      const preset = getReadSmokePreset(contract.presetId)
       // Backend credential context — NOT the public, credential-stripped system response.
       const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
         ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
@@ -1641,7 +1639,7 @@ function createHandlers(services, options = {}) {
       const adapter = adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) })
       // Forced single read only; values-free evidence on success or failure (never key/raw/values/credentials).
       try {
-        const result = await adapter.read(buildReadSmokeRequest(preset, key))
+        const result = await adapter.read(buildReadSmokeRequest(preset, contract.key))
         return sendOk(res, readSmokeSuccessEvidence(preset, result))
       } catch (error) {
         return sendOk(res, readSmokeErrorEvidence(preset, error))


### PR DESCRIPTION
#1709 / C0 #3242, slice **C2**. Migrates the read-smoke route's inline `{presetId, key}` validation to the C1 `normalizeReadSmokeContract`, so the route now accepts **both** the shipped `{presetId, key}` subset and the forward `{presetId, intent:{object,mode,key}}` shape (normalized to one output) — the C0 §3 reconciliation resolved in runtime (option B: migrate the strict body validation).

- Contract errors → `400 READ_SMOKE_CONTRACT_INVALID` with a **values-free `{reason}`** (coarse enum). Read uses `contract.key`. Downstream unchanged: backend credential load, kind gate (409), in-memory overlay, single `adapter.read`, values-free evidence, `integration:write`.

**Tests:** compat `{presetId, key}` cases stay green; adds `{presetId, intent}` success (same single read, values-free), `intent.object=bom` fail-closed (400 before system load), raw config in intent fail-closed. Non-vacuous; full sweep 0 failures.

**Boundary:** single allowlisted read only; no LIST/BOM/multi-record/pagination/resolver/Save/Submit/Audit/production write/UI. C3+ frozen behind customer GATE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
