### PR TITLE
test(multitable): align reset acceptance lock scenario

### DIFF
--- a/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
+++ b/docs/development/multitable-t8-2-reset-acceptance-runbook-20260625.md
@@ -49,13 +49,15 @@ Exit 0 = all run scenarios passed; 1 = a failure; 2 = config/setup error.
 
 ### What the harness provisions (API-automated) vs manual prerequisites
 - **Automated** (HTTP, isolated per run): a fresh acceptance base + sheet + a `number` field; pre-T records A,B; an
-  `asOf` T; post-T records C,D (the delete-set) + a post-T change to A (to prove the revert); record lock (d);
+  `asOf` T; post-T records C,D (the delete-set; D is editor-created when `EDITOR_TOKEN` is present so scenario (d)
+  exercises a lock held by another actor) + a post-T change to A (to prove the revert); record lock (d);
   drift record (e); ceiling seeding for (f) on a **separate throwaway sheet** (only if `RESET_MAX_RECORDS` is small) —
   it never touches the main sheet, so **(g) still runs in the same flag-on run**: one run covers (b)–(g).
 - **Manual prerequisites** (do NOT fake): the two JWTs (`ADMIN_TOKEN` = sheet-admin/`multitable:share`,
   `EDITOR_TOKEN` = `multitable:write` without share); toggling `MULTITABLE_ENABLE_PIT_RESET`; setting a small
   `MULTITABLE_SHEET_REVERT_MAX_RECORDS` if you want (f) (default 5000 is impractical to seed). Scenario (b) skips
-  without `EDITOR_TOKEN`; (f) skips without a small `RESET_MAX_RECORDS`.
+  without `EDITOR_TOKEN`; scenario (d) also skips without `EDITOR_TOKEN` because admin-created/admin-locked records are
+  editable by the locker/creator under current lock semantics; (f) skips without a small `RESET_MAX_RECORDS`.
 - **Verify by hand after (g):** C/D appear in the recycle bin (`meta_records_trash` / trash UI) — recoverable, not
   hard-deleted. The harness asserts they are gone from live; confirm the trash side visually.
 

--- a/packages/core-backend/scripts/reset-acceptance.mjs
+++ b/packages/core-backend/scripts/reset-acceptance.mjs
@@ -66,8 +66,8 @@ async function setup() {
   // fields (best-effort; the revert assertion in (g) needs at least one editable field)
   const f = await api('POST', '/fields', ADMIN, { sheetId, name: 'Salary', type: 'number' })
   const salaryId = f.body?.data?.id || f.body?.data?.field?.id || f.body?.id || null
-  const mkRec = async (data) => {
-    const r = await api('POST', '/records', ADMIN, { sheetId, data })
+  const mkRec = async (data, token = ADMIN) => {
+    const r = await api('POST', '/records', token, { sheetId, data })
     return r.body?.data?.id || r.body?.data?.record?.id || r.body?.id || null
   }
   // pre-T records A,B
@@ -79,8 +79,11 @@ async function setup() {
   // post-T: change A (to test revert), create C,D (the delete-set)
   if (salaryId && A) await api('PATCH', `/records/${A}`, ADMIN, { sheetId, data: { [salaryId]: 999 } })
   const C = await mkRec(salaryId ? { [salaryId]: 300 } : { name: 'c' })
-  const D = await mkRec(salaryId ? { [salaryId]: 400 } : { name: 'd' })
-  return { baseId, sheetId, salaryId, A, B, C, D, T }
+  // D is the lock-target scenario. When EDITOR_TOKEN is available, create it as the editor so an admin Reset is blocked
+  // by a lock held by another actor. If D is admin-created/admin-locked, current lock semantics allow the creator/locker
+  // to proceed, which would be a harness false negative rather than a Reset bug.
+  const D = await mkRec(salaryId ? { [salaryId]: 400 } : { name: 'd' }, EDITOR || ADMIN)
+  return { baseId, sheetId, salaryId, A, B, C, D, T, dLockedByEditor: Boolean(EDITOR) }
 }
 
 async function run() {
@@ -128,17 +131,17 @@ async function run() {
   }
 
   // (d) locked post-T target → 409 RESET_BLOCKED + ZERO writes
-  {
-    await api('POST', `/records/${ctx.D}/lock`, ADMIN, { sheetId: ctx.sheetId, locked: true })
+  if (EDITOR && ctx.dLockedByEditor) {
+    await api('POST', `/records/${ctx.D}/lock`, EDITOR, { sheetId: ctx.sheetId, locked: true })
     const pv = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
     const id = pv.body?.data?.previewIdentity
     const ex = await api('POST', `/sheets/${ctx.sheetId}/reset-execute`, ADMIN, { asOf: ctx.T, previewIdentity: id, confirm: 'reset' })
     ok('(d) locked target → 409 RESET_BLOCKED', ex.status === 409 && /BLOCKED/.test(code(ex)), `got ${ex.status}/${code(ex)}`)
-    await api('POST', `/records/${ctx.D}/lock`, ADMIN, { sheetId: ctx.sheetId, locked: false }) // unlock before re-checking + for (g)
+    await api('POST', `/records/${ctx.D}/lock`, EDITOR, { sheetId: ctx.sheetId, locked: false }) // unlock before re-checking + for (g)
     const after = await api('POST', `/sheets/${ctx.sheetId}/reset-preview`, ADMIN, { asOf: ctx.T })
     const delAfter = after.body?.data?.deleteRecordIds || []
     ok('(d) ZERO writes — C,D still live (in the delete-set)', delAfter.includes(ctx.C) && delAfter.includes(ctx.D), `deleteRecordIds=${JSON.stringify(delAfter)}`)
-  }
+  } else skipped('(d) locked target → 409 RESET_BLOCKED', 'EDITOR_TOKEN not provided; admin-created/admin-locked records are editable by the locker/creator')
 
   // (f) ceiling → 413 — provisioned on a SEPARATE throwaway sheet so it NEVER pollutes the main sheet over-ceiling;
   // (g) then still runs on the clean main sheet → one flag-on run truly covers (b)–(g). (env-dependent on RESET_MAX_RECORDS.)


### PR DESCRIPTION
## Summary
- update the T8-2 reset staging harness so scenario (d) creates and locks D with EDITOR_TOKEN when available
- skip the locked-target scenario without EDITOR_TOKEN instead of running an admin self-lock case that current lock semantics allow
- document that scenario (d) needs the editor-owned/locked target, while (b) and (d) both skip without EDITOR_TOKEN

## Verification
- node --check packages/core-backend/scripts/reset-acceptance.mjs
- git diff --check

Runtime is unchanged; this only aligns the acceptance harness with the staging evidence.