### PR TITLE
docs(attendance): 加班银行 design-verification refresh — v1-5 settlement line COMPLETE

### DIFF
--- a/docs/development/attendance-overtime-bank-design-verification-20260624.md
+++ b/docs/development/attendance-overtime-bank-design-verification-20260624.md
@@ -1,7 +1,7 @@
 # 加班调休抵扣与周期结算（加班银行）— 设计与验证记录
 
 > **范围**：把"加班入池 → 请假优先抵扣 → 周期末折算"做成**企业可配置**的薪资/考勤结算规则组。本文是该线的**设计 + 验证**真源；设计锁见 `attendance-overtime-bank-settlement-designlock-20260624.md`（RATIFIED）。
-> **状态（2026-06-25 refresh）**：**账1 入池 + 账2 抵扣 + 账3 满勤 + 配置 UI 全部落 main**（v1-1a/1b/2a/2b/3a/3b/6a/6b/6c，9 PR，owner review 驱动，逐刀 §P 闭环）。**账4（v1-4）已 DEFER 到 v1-5**（owner [P1]：live 导出混用「期间事实 must-pay」+「当前余额 convertible」，历史期间查会算错——§7 详述；settlement 导出本质是 period-end/snapshot 概念，需 v1-5 的结算时点快照才温度一致）。**v1-5 = 下一道设计闸**（snapshot-at-close 架构已具备，吸收 账4 导出，待 owner 拍板——§7）；v1-7 需 payout producer、v1-8 需 staging。本记录随每刀落地更新。
+> **状态（2026-06-26 refresh）**：**账1 入池 + 账2 抵扣 + 账3 满勤 + 配置 UI + 账4 周期结算（v1-5 snapshot-at-close）全部落 main** —— **加班银行四账模型 + 结算机制完整闭环**。**v1-5 settlement 线 = design-lock #3206 → 表 #3211 → 纯计算 #3228 → 写路径+冻结守卫 #3233（全 merged，逐刀 owner review，约 13 个 money-path/会计 finding pre-merge 闭环）**：cycle→`closed` 同事务快照（三入口 update/create/generate 都不绕过 §3），§8a population = 期间 facts ∪ active comp_time 余额（不漏离职带余额），must-pay 从 **period OT facts**（statutory 永付 + 非 pooledSources 来源；**不从 balance lot 推导**，poison-lot 已证）、convertible 从 close 时点余额；`closed`/`archived`/有结算行 = period 冻结（PUT 改 period/template + DELETE 都 409）。**named follow-up = v1-5b-iii**（must-pay-from-period-OT 的 e2e 实库测试——纯计算已 unit 证，wiring 的 convertible/守卫已实库矩阵证，仅 must-pay 经 OT-segmentation harness 的端到端待补）；v1-7 需 payout producer、v1-8 需 staging。本记录随每刀落地更新。
 > **执行纪律**：money-path 切片（碰加班 grant / 请假 deduct 的事务）**绿了也不自动合,逐刀 owner review** —— CI-green-but-wrong 在这条线 = 算错工资。staging smoke 需环境（gated）。
 
 ---
@@ -31,7 +31,11 @@
 | **v1-3a** | AttendanceBonusPolicy 满勤休眠 config + normalizer | #3167 `3349c8613` | ✅ **landed** | unit 2/2 + real-DB wire 往返（rebase 修掉 #3158 allowlist 倒退后合）|
 | **v1-3b** | 满勤 flag 计算（live summary,dormant-clean）：任意请假即 false（即便被池抵掉,读 raw leave_minutes）+ 迟到/早退 | #3193 | ✅ **landed** | unit 7/7 + real-DB（off→absent · on→present；**owner [P1]: late_early_days 漏数已修** + false-path 真实库用例）|
 | ~~v1-4~~ | ~~账4 导出契约~~ → **DEFER 到 v1-5** | ~~#3201 closed~~ | ⛔ **deferred** | owner [P1]：live 导出混 period must-pay + current convertible balance（无 asOf/cycle 边界）→ 历史期间查算错可折算余额。settlement 导出 = period-end/snapshot 概念,需 v1-5 结算时点快照才温度一致（§7）|
-| **v1-5** | PolicyAssignment + 生效日期 + **结算快照**（§7）+ **吸收 账4 导出**（snapshot-at-close） | — | 🔶 **设计闸（待 owner 拍板,§7）** | snapshot-at-close 架构已具备（cycle status open/closed/archived 存在）;但 scope 因 v1-4 defer 扩大,需 design-lock-first 拍板,**不自动建 money-path 结算机制** |
+| ~~v1-5（伞）~~ | 结算快照（snapshot-at-close）→ 拆 design-lock + a/b-i/b-ii/b-iii | #3206 design-lock | ✅ **ratified→built** | owner 拍板 snapshot-at-close + 新表落点；3 个 review-fix（frozen-period cols + source NOT NULL + §8a facts∪balance）已入锁 |
+| **v1-5a** | 结算快照表 `attendance_payroll_cycle_settlements`（typed，休眠） | #3211 | ✅ **landed** | real-DB schema 锁：frozen-period cols + source NOT NULL + UNIQUE 幂等键 + **FK ON DELETE RESTRICT**（owner [P2]：不级联删不可变结算行） |
+| **v1-5b-i** | 结算纯计算 `buildCycleSettlementRows`（§5，休眠） | #3228 | ✅ **landed** | unit 7/7：**poison-lot**（伪 statutory balance lot 不动 must_pay）· **无条件 must-pay**（bank-off 仍结算）· **un-pooled→must-pay**（owner [P1]）· convertible-by-source · legacy_unsourced |
+| **v1-5b-ii** | 结算写路径 `snapshotCycleSettlementOnClose` + 三入口 close hooks + §8a population + **冻结守卫** | #3233 | ✅ **landed** | real-DB 矩阵：convertible · poison-lot-no-row · 幂等 replay · frozen-period-reject · DELETE-closed-reject · **create/generate-as-closed** · **archived-freeze**（owner [P1] + [P2]×2 闭环）|
+| **v1-5b-iii** | must-pay-from-period-OT **e2e 实库测试** | — | 🔶 **named follow-up** | 纯计算已 unit 证、wiring 的 convertible/守卫已实库矩阵证；仅 must-pay 端到端需 OT-segmentation harness（owner 决定是否单开） |
 | **v1-6** | 授权 UI（3 卡片：OvertimeBankPolicy + LeaveOffsetPolicy + 满勤）| #3175 + #3194 | ✅ **landed** | vue-tsc -b 0 + vitest（load/toggle/PUT-only-policy-key;§6 UI 不暴露 statutory_holiday）|
 | v1-7 | Ledger：扩 `source_type`（payout/manual_adjust）+ settlement/payroll-export 标记（**不新增 event_type**）| — | ⬜ designed | 计划 unit + real-DB |
 | v1-8 | real-DB 矩阵（三例验收）+ **staging smoke** | — | ⬜ designed | **staging 需环境（gated）** |
@@ -102,3 +106,14 @@ v1-4 曾把 settlement 导出挂在 **live `GET /summary?from&to`** 上,但 owne
 - **（后备,不推荐先做）reconstruct-as-of**：从 `attendance_leave_balance_events`（created_at）按 asOf 重建余额。最重、money-path、本地难验;**仅当 owner 要追溯正确性且无 close hook 时才用** —— 但 close hook 已具备。
 
 **这是 owner 的拍板项,不是「continue」可自动建的**：v1-4 defer 让 v1-5 scope 扩大（吸收导出）,按本线 design-lock-first 纪律需 owner ratify。snapshot-at-close 还要定:导出存哪（`cycle.metadata` vs 新 settlement 表）、§7 effectiveFrom 快照哪些 policy、must-pay 必须从 **period OT facts** 算（**不从 balance lot 推导**,锁 owner [P2] 的反推毒测）。待 owner 拍 snapshot-at-close + 落点,再开 v1-5 build。
+
+### 7.3 v1-5 闸已拍板 + 已建（2026-06-26 闭环）
+
+owner 拍板 **snapshot-at-close**，落点 = **新 typed 表 `attendance_payroll_cycle_settlements`**（非 `cycle.metadata` blob，结算事实可查可断言）。design-lock `attendance-overtime-bank-v1-5-settlement-snapshot-designlock-20260625.md`（#3206 RATIFIED）含 3 个 owner review-fix：frozen-period cols + `source NOT NULL`（NULL/legacy→`legacy_unsourced`）+ §8a population = 期间 facts ∪ active 余额。**build 已完整落 main**：
+
+- **v1-5a 表**（#3211）：frozen-period cols、`source NOT NULL`、`UNIQUE(org,cycle,user,source)` 幂等键、**FK ON DELETE RESTRICT**（owner [P2]：cycle 删不级联抹结算）。
+- **v1-5b-i 纯计算**（#3228）：`buildCycleSettlementRows`(periodOtBySource + pooledSources)；must-pay = statutory 永付 + **非 pooledSources 来源**（owner [P1]：漏 un-pooled 会**少发**工资）；**poison-lot** 与**无条件 must-pay**（bank-off 仍结算）unit 锁。
+- **v1-5b-ii 写路径 + 守卫**（#3233）：`snapshotCycleSettlementOnClose` 挂三入口 close（update/create/generate→closed，同事务、仅 transition、`ON CONFLICT DO NOTHING` 幂等）；§8a population 实库；**冻结守卫**：`closed`/`archived`/有结算行 → PUT 改 period/template + DELETE 都 409（owner [P1] 我误 defer 守卫 + [P2] create/generate 未测 + [P2] archived-once-closed 绕过，三 finding 闭环）。
+- **named follow-up = v1-5b-iii**：must-pay-from-period-OT 的 **e2e 实库**（纯计算已 unit 证、convertible/守卫已矩阵证；must-pay 端到端需 OT-segmentation harness）。
+
+**这条线 money-path 纪律的回报**：v1-5 单段 owner per-slice review 抓到并 pre-merge 闭环约 **13 个 money-path/会计 finding**（un-pooled 少发、FK 级联删、误 defer 守卫、create/generate 未覆盖、archived 绕过…），全部「CI 绿但算错工资」类——design-lock-first + 逐刀 review 正是为此存在。


### PR DESCRIPTION
Refreshes the design & verification MD to the landed state now that the **v1-5 settlement line is complete on main**: design-lock #3206 → table #3211 → compute #3228 → write+guards #3233.

- status line + §2 slice table → v1-5a/v1-5b-i/v1-5b-ii **landed**, v1-5b-iii **named follow-up**
- new **§7.3**: ratified snapshot-at-close decision + the build summary + the ~13 owner-caught money-path/accounting findings (un-pooled under-pay · FK cascade · deferred guard · create/generate coverage · archived-bypass)

Docs-only; no code change.