### PR TITLE
docs(approval): narrow residual total-check wording missed by #3243

### DIFF
--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -29,7 +29,7 @@ approval-result write-back.
    The branch condition reads the top-level total field (`amount`). AS BUILT (updated 2026-06-26,
    post-closeout): the detail total is now read-only **auto-filled** from the detail rows (#3198) and a
    server-side **total-check** (#3176) rejects any total ≠ the detail sum — so the backend total-check is
-   the consistency boundary (binds the total to the detail-row sum) and the amount tier routes on a verified value. The control gap described
+   the consistency boundary (binds the total to the detail-row sum) and the amount tier routes on a consistency-checked total. The control gap described
    below is CLOSED.
 
    (Historical — the framing this slice shipped with at authoring time: detail-row amounts were not

--- a/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
+++ b/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
@@ -25,7 +25,7 @@ design-lock-first / staged-opt-in discipline this line has held throughout.)
 | `manager_at_level` chain-bake regression pin | — | #3084 |
 
 The money chain is closed end-to-end: **derive line (qty × unit_price) → sum total → backend
-total-check**; formula conditions route on those backend-verified values; the backend remains the sole
+total-check**; formula conditions route on those consistency-checked totals; the backend remains the sole
 consistency boundary (binds total to detail sum).
 
 ## Remaining development — the plan (each item: its unblocker + who owns the call)


### PR DESCRIPTION
## What

Tiny follow-up: two threat-model-wording residues that **#3243 was meant to clear but didn't reach main** — its merge head (`52f98dbd`) had dropped the "verified value" fix in a concurrent rebase. Both are still on main.

- presets design-lock D1: `the amount tier routes on a verified value` → `… a consistency-checked total`
- amount-formula-line roadmap (the shipped money-chain paragraph): `formula conditions route on those backend-verified values` → `… those consistency-checked totals`

Same honest boundary as #3243: the total-check verifies **top-level total == detail-row sum** (consistency), not the business truthfulness of the amounts. The roadmap's *line-math* `tamper-proof` use stays untouched — it's a correct, distinct claim.

Docs-only, 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
