### PR TITLE
docs(approval): narrow residual 'verified value' over-claim (P3)

### DIFF
--- a/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
+++ b/docs/design/approval-amount-tier-template-presets-design-lock-20260624.md
@@ -29,7 +29,9 @@ approval-result write-back.
    The branch condition reads the top-level total field (`amount`). AS BUILT (updated 2026-06-26,
    post-closeout): the detail total is now read-only **auto-filled** from the detail rows (#3198) and a
    server-side **total-check** (#3176) rejects any total ≠ the detail sum — so the backend total-check is
-   the consistency boundary (binds the total to the detail-row sum) and the amount tier routes on a verified value. The control gap described
+   the consistency boundary (binds the total to the detail-row sum) and the amount tier routes on a
+   consistency-checked total — one verified only against the submitted detail-row sum, not for
+   truthfulness. The control gap described
    below is CLOSED.
 
    (Historical — the framing this slice shipped with at authoring time: detail-row amounts were not

--- a/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
+++ b/docs/development/approval-amount-formula-line-roadmap-verification-20260626.md
@@ -25,7 +25,7 @@ design-lock-first / staged-opt-in discipline this line has held throughout.)
 | `manager_at_level` chain-bake regression pin | — | #3084 |
 
 The money chain is closed end-to-end: **derive line (qty × unit_price) → sum total → backend
-total-check**; formula conditions route on those backend-verified values; the backend remains the sole
+total-check**; formula conditions route on those consistency-checked values; the backend remains the sole
 consistency boundary (binds total to detail sum).
 
 ## Remaining development — the plan (each item: its unblocker + who owns the call)


### PR DESCRIPTION
Follow-up to #3243: two residual 'verified' phrasings still implied truthfulness. amount-tier lock:32 'routes on a verified value' → 'routes on a consistency-checked total — verified only against the submitted detail-row sum, not for truthfulness'; roadmap:28 'backend-verified values' → 'consistency-checked values'. The total-check proves consistency (total = detail sum), not truthfulness. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)