### PR TITLE
fix(multitable): redact sheet_config conditionalReadRules literals in /config-history (T9-W U-1a)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -224,6 +224,7 @@ jobs:
             tests/integration/multitable-config-revision-retention-realdb.test.ts \
             tests/integration/multitable-config-history-api-realdb.test.ts \
             tests/integration/multitable-config-history-view-redaction-realdb.test.ts \
+            tests/integration/multitable-config-history-sheetconfig-redaction-realdb.test.ts \
             tests/integration/yjs-scalar-seed-realdb.test.ts \
             tests/integration/yjs-scalar-flush-realdb.test.ts \
             tests/integration/yjs-scalar-strdate-migration-realdb.test.ts \

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4368,6 +4368,29 @@ export function redactViewConfigFilterLiterals<T extends { filterInfo?: unknown 
   return { ...(view as object), filterInfo: redacted.node } as T
 }
 
+// T9-W U-1a: sheet_config history carries conditionalReadRules whose `value` literals are field-read-sensitive
+// (same class as view filterInfo / #2052-R9) — canManageSheetAccess does NOT imply field-read. Redact the value of
+// any rule whose fieldId the requester can't read (drop the key, mirroring the filterInfo redaction). Returns the
+// payload unchanged if nothing was redacted.
+export function redactConditionalReadRuleLiterals<T extends { conditionalReadRules?: unknown } | null | undefined>(payload: T, allowedFieldIds: Set<string>): T {
+  if (!payload || typeof payload !== 'object') return payload
+  const rules = (payload as { conditionalReadRules?: unknown }).conditionalReadRules
+  if (!Array.isArray(rules)) return payload
+  let changed = false
+  const redacted = rules.map((rule) => {
+    if (!rule || typeof rule !== 'object') return rule
+    const fieldId = (rule as { fieldId?: unknown }).fieldId
+    if (typeof fieldId === 'string' && !allowedFieldIds.has(fieldId) && 'value' in (rule as object)) {
+      changed = true
+      const { value: _redacted, ...rest } = rule as Record<string, unknown>
+      return rest
+    }
+    return rule
+  })
+  if (!changed) return payload
+  return { ...(payload as object), conditionalReadRules: redacted } as T
+}
+
 // #2068 re-save guard: PURE merge of an incoming PATCH filterInfo against the current DB filterInfo, so a
 // field-denied user re-saving a view (whose denied conditions came back from #2059 redaction with NO `value`
 // key) does not silently erase the literal they were never allowed to see. Value-only, mirroring #2059 —
@@ -7634,18 +7657,24 @@ export function univerMetaRouter(): Router {
       // field-read-sensitive (#2052/R9) — canManageViews does NOT imply field-read, so returning
       // before/after.filterInfo raw would leak a denied field's literal through history. Redact per
       // the requester's allowed fields, mirroring redactViewConfigFilterLiterals on the live view read.
-      const hasViewRow = rows.some((r) => String(r.entity_type) === 'view')
-      const allowedFieldIds = hasViewRow
+      // T9-W U-1a: sheet_config rows ALSO carry field-read-sensitive literals (conditionalReadRules[].value), so
+      // load the allowed fields when EITHER a view or a sheet_config row is present, and redact each per its shape.
+      const hasSensitiveRow = rows.some((r) => String(r.entity_type) === 'view' || String(r.entity_type) === 'sheet_config')
+      const allowedFieldIds = hasSensitiveRow
         ? await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
         : null
-      const redactViewPayload = (val: unknown): unknown =>
-        allowedFieldIds && val ? redactViewConfigFilterLiterals(val as { filterInfo?: unknown }, allowedFieldIds) : (val ?? null)
+      const redactPayload = (entityType: string, val: unknown): unknown => {
+        if (!allowedFieldIds || !val) return val ?? null
+        if (entityType === 'view') return redactViewConfigFilterLiterals(val as { filterInfo?: unknown }, allowedFieldIds)
+        if (entityType === 'sheet_config') return redactConditionalReadRuleLiterals(val as { conditionalReadRules?: unknown }, allowedFieldIds)
+        return val
+      }
       return res.json({ ok: true, data: { items: rows.map((r) => {
-        const isView = String(r.entity_type) === 'view'
+        const et = String(r.entity_type)
         return {
-          id: String(r.id), entityType: String(r.entity_type), entityId: String(r.entity_id), action: String(r.action),
-          before: isView ? redactViewPayload(r.before) : (r.before ?? null),
-          after: isView ? redactViewPayload(r.after) : (r.after ?? null),
+          id: String(r.id), entityType: et, entityId: String(r.entity_id), action: String(r.action),
+          before: redactPayload(et, r.before),
+          after: redactPayload(et, r.after),
           changedKeys: r.changed_keys ?? [],
           batchId: r.batch_id ?? null, actorId: r.actor_id ?? null, createdAt: r.created_at,
         }

--- a/packages/core-backend/tests/integration/multitable-config-history-sheetconfig-redaction-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-config-history-sheetconfig-redaction-realdb.test.ts
@@ -1,0 +1,94 @@
+/**
+ * T9-W U-1a — sheet_config conditionalReadRules literal redaction on the /config-history read (real DB).
+ *
+ * Pre-existing leak (advisor 2026-06-26): the single /config-history endpoint redacted only VIEW rows
+ * (filterInfo); sheet_config rows carry `conditionalReadRules[].value` literals that are equally
+ * field-read-sensitive (#2052/R9), and `canManageSheetAccess` does NOT imply field-read. So a
+ * share-capable but field-denied reader saw a denied field's rule literal through history — the
+ * sheet_config twin of the R3.1 view fix. This proves the fix against the REAL recorded shape: rules
+ * are authored through PUT /conditional-rules (so the recorder writes the real payload), then a
+ * field-denied reader does NOT see the denied literal while a fully-allowed reader does. Runs only with
+ * DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_chsc_${TS}`
+const SHEET = `sheet_chsc_${TS}`
+const FLD_VISIBLE = `fld_chsc_visible_${TS}`
+const FLD_SECRET = `fld_chsc_secret_${TS}`
+const VISIBLE_LIT = 'chsc-visible-literal-keepme'
+const SECRET_LIT = 'chsc-secret-literal-do-not-leak'
+const U_FULL = `u_chsc_full_${TS}`
+const U_SHAREDENIED = `u_chsc_sdenied_${TS}`
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let actor: { id: string; roles: string[]; perms: string[] }
+// FULL: read+write+share, no field deny → authors the rules AND is the control reader.
+const FULL = { id: U_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+// SHARE-but-field-denied: canManageSheetAccess (via share) so it CAN read sheet_config history, but
+// FLD_SECRET is denied → must NOT see the secret rule literal.
+const SHAREDENIED = { id: U_SHAREDENIED, roles: ['member'], perms: ['multitable:read', 'multitable:share'] }
+const listSheetConfig = (as: typeof FULL) => { actor = as; return request(app).get(`/api/multitable/sheets/${SHEET}/config-history?entityType=sheet_config`) }
+
+describeIfDatabase('multitable config-history — sheet_config conditionalReadRules literal redaction (T9-W U-1a, real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = actor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'CHSC Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET, BASE, 'CHSC Sheet'])
+    for (const [fid, name, order] of [[FLD_VISIBLE, 'Visible', 1], [FLD_SECRET, 'Secret', 2]] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET, name, 'string', '{}', order])
+    }
+    for (const u of [U_FULL, U_SHAREDENIED]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    // FLD_SECRET denied to the share-denied user (layer-3); FULL keeps field read.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET, FLD_SECRET, 'user', U_SHAREDENIED, false, false])
+    // Author conditional read-deny rules on BOTH fields THROUGH the route → the recorder writes the real shape.
+    actor = FULL
+    const put = await request(app).put(`/api/multitable/sheets/${SHEET}/conditional-rules`).send({ rules: [
+      { id: 'r_visible', fieldId: FLD_VISIBLE, operator: 'eq', value: VISIBLE_LIT, effect: 'deny_read' },
+      { id: 'r_secret', fieldId: FLD_SECRET, operator: 'eq', value: SECRET_LIT, effect: 'deny_read' },
+    ] })
+    if (put.status !== 200) throw new Error(`conditional-rules setup failed: ${put.status} ${JSON.stringify(put.body)}`)
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [U_FULL, U_SHAREDENIED]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('the recorder wrote the secret rule literal (sanity, pre-redaction)', async () => {
+    const rec = (await q(
+      `SELECT after FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='sheet_config' ORDER BY created_at DESC, id DESC LIMIT 1`,
+      [SHEET],
+    )).rows[0] as { after: any } | undefined
+    expect(JSON.stringify(rec?.after)).toContain(SECRET_LIT)
+    expect(JSON.stringify(rec?.after)).toContain(VISIBLE_LIT)
+  })
+
+  test('field-denied canManageSheetAccess reader does NOT see the secret rule literal; fully-allowed DOES (VISIBLE stays)', async () => {
+    const denied = await listSheetConfig(SHAREDENIED)
+    expect(denied.status).toBe(200)
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_LIT) // pre-existing leak CLOSED
+    expect(JSON.stringify(denied.body)).toContain(VISIBLE_LIT) // no over-redaction (readable field's literal kept)
+
+    const full = await listSheetConfig(FULL)
+    expect(full.status).toBe(200)
+    expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it
+    expect(JSON.stringify(full.body)).toContain(VISIBLE_LIT)
+  })
+})


### PR DESCRIPTION
## U-1a — sheet_config rule-literal redaction (pre-existing leak; R3.1 twin)

**Security fix.** The `/config-history` read redacted only **view** rows (`filterInfo`). **sheet_config** rows carry `conditionalReadRules[].value` literals that are equally field-read-sensitive (#2052/R9), and `canManageSheetAccess` does **not** imply field-read — so a share-capable, field-denied reader saw a denied field's rule literal through history. This is the **sheet_config twin of R3.1**, previously unpatched.

Surfaced by the advisor while grounding T9-W Tier 1 (the revert preview would leak the same way); this lands the read-side fix first (R3.1 precedent), and Tier 1's preview will reuse the same redactor (design-lock U-L6 / #3254).

### Change
- `redactConditionalReadRuleLiterals(payload, allowedFieldIds)` — drops a rule's `value` when its `fieldId` is not readable (no over-redaction of readable rules).
- `/config-history` read loads `allowedFieldIds` when **either** a view or a sheet_config row is present, redacting each per its shape.

### Proof
Real-DB golden authored **through PUT /conditional-rules** (real recorded shape, no fixture drift): field-denied `canManageSheetAccess` reader does NOT see the secret literal; fully-allowed does; the readable field's literal is kept. View + config-history-api goldens still green (no regression); tsc 0; registered in `plugin-tests.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)