### PR TITLE
fix(integration): label inactive target system hints

### DIFF
--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -2049,10 +2049,21 @@ async function main() {
     const errThrown = tryAssert({ id: 'sys_err', status: 'error' })
     assert.ok(errThrown, 'error-status system throws')
     assert.match(errThrown.message, /external system is not active/, 'keeps the base reason')
+    assert.match(errThrown.message, /source connection last failed its test/, 'sourceSystem hint names the source side')
     assert.match(errThrown.message, /retest\/reactivate/i, 'error status points at the retest/reactivate action')
     assert.equal(errThrown.details.field, 'sourceSystem', 'details preserve field')
     assert.equal(errThrown.details.systemId, 'sys_err', 'details preserve systemId (#2205 evidence)')
     assert.equal(errThrown.details.status, 'error', 'details preserve status')
+
+    const targetErrThrown = (() => {
+      try { assertActiveSystem({ id: 'target_err', status: 'error' }, 'targetSystem'); return null } catch (e) { return e }
+    })()
+    assert.ok(targetErrThrown, 'target error-status system throws')
+    assert.match(targetErrThrown.message, /target connection last failed its test/, 'targetSystem hint names the target side (#2438)')
+    assert.doesNotMatch(targetErrThrown.message, /source connection last failed its test/, 'targetSystem hint does not blame the source side')
+    assert.equal(targetErrThrown.details.field, 'targetSystem', 'target details preserve field')
+    assert.equal(targetErrThrown.details.systemId, 'target_err', 'target details preserve systemId')
+    assert.equal(targetErrThrown.details.status, 'error', 'target details preserve status')
 
     const inactiveThrown = tryAssert({ id: 'sys_inact', status: 'inactive' })
     assert.ok(inactiveThrown, 'inactive-status system throws')

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -232,19 +232,26 @@ function shouldRequireWatermarkTiebreaker(context, mode) {
   return mode === 'incremental' && context.sourceSystem && context.sourceSystem.kind === DATA_SOURCE_SQL_READONLY_KIND
 }
 
+function systemRoleLabel(field) {
+  if (field === 'sourceSystem') return 'source'
+  if (field === 'targetSystem') return 'target'
+  return 'external system'
+}
+
 function assertActiveSystem(system, field) {
   if (!system) {
     throw new PipelineRunnerError(`${field} external system not found`, { field })
   }
   if (system.status && system.status !== 'active') {
-    // Stale-status legibility: an `error` source usually means a recovered-but-not-retested connection
+    // Stale-status legibility: an `error` system usually means a recovered-but-not-retested connection
     // (e.g. the Bridge Agent was restarted) — point the operator at the retest/reactivate action rather
     // than letting them think the dry-run itself broke. `inactive` is deliberate (a test won't reactivate
     // it), so it gets a different hint.
+    const role = systemRoleLabel(field)
     const hint = system.status === 'error'
-      ? ' — the source connection last failed its test; retest/reactivate it (Workbench 测试连接) then re-run'
+      ? ` — the ${role} connection last failed its test; retest/reactivate it (Workbench 测试连接) then re-run`
       : system.status === 'inactive'
-        ? ' — the source is inactive; activate it before running'
+        ? ` — the ${role} is inactive; activate it before running`
         : ` (status=${system.status})`
     throw new PipelineRunnerError(`${field} external system is not active${hint}`, {
       field,


### PR DESCRIPTION
## Summary
- make stale external-system status hints name the failing side (source vs target)
- keep the existing retest/reactivate guidance and diagnostic details intact
- add regression coverage for #2438's targetSystem wording case

## Verification
- pnpm --filter plugin-integration-core test:pipeline-runner
- git diff --check

Refs #2438