### PR TITLE
feat(multitable): T9-W Tier 1 — sheet_config revert (flag-gated)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -219,6 +219,7 @@ jobs:
             tests/integration/multitable-restore-batch-allornothing-realdb.test.ts \
             tests/integration/multitable-config-revisions-realdb.test.ts \
             tests/integration/multitable-config-restore-realdb.test.ts \
+            tests/integration/multitable-sheet-config-revert-realdb.test.ts \
             tests/integration/multitable-revert-pit-realdb.test.ts \
             tests/integration/multitable-reset-pit-realdb.test.ts \
             tests/integration/multitable-config-revision-retention-realdb.test.ts \

--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -111,9 +111,24 @@ export async function loadViewConfigSnapshot(query: QueryFn, viewId: string): Pr
   }
 }
 
+export async function loadSheetConfigSnapshot(query: QueryFn, sheetId: string): Promise<Record<string, unknown> | null> {
+  const res = await query('SELECT conditional_read_rules, row_level_read_permissions_enabled FROM meta_sheets WHERE id = $1', [sheetId])
+  const row = res.rows[0] as Record<string, unknown> | undefined
+  if (!row) return null
+  // Return the RAW jsonb value (NOT re-parsed): the recorder stored before/after as jsonb too, so both go through the
+  // same Postgres key-ordering. stable() is a plain JSON.stringify (no key-sort), so re-parsing here (which rebuilds
+  // objects in JS key order) would mismatch the recorded `after` and trip a FALSE drift. `?? []` matches the recorder's
+  // empty shape.
+  return {
+    conditionalReadRules: row.conditional_read_rules ?? [],
+    rowLevelReadPermissionsEnabled: row.row_level_read_permissions_enabled === true,
+  }
+}
+
 export async function loadEntityConfigSnapshot(query: QueryFn, rev: ConfigRevisionRow): Promise<Record<string, unknown> | null> {
   if (rev.entity_type === 'field') return loadFieldConfigSnapshot(query, rev.entity_id)
   if (rev.entity_type === 'view') return loadViewConfigSnapshot(query, rev.entity_id)
+  if (rev.entity_type === 'sheet_config') return loadSheetConfigSnapshot(query, rev.entity_id)
   return null
 }
 
@@ -127,11 +142,16 @@ const VIEW_COLUMN: Record<string, ColumnMap> = {
   groupInfo: { col: 'group_info', jsonb: true }, hiddenFieldIds: { col: 'hidden_field_ids', jsonb: true },
   config: { col: 'config', jsonb: true },
 }
+// T9-W Tier 1: sheet_config revert columns on meta_sheets (camelCase keys match the recorder's before/after shape).
+const SHEET_CONFIG_COLUMN: Record<string, ColumnMap> = {
+  conditionalReadRules: { col: 'conditional_read_rules', jsonb: true },
+  rowLevelReadPermissionsEnabled: { col: 'row_level_read_permissions_enabled' },
+}
 
 /** Apply the revert: UPDATE the entity's changed columns to the revision's `before` values. Safe-op only (caller gates). */
 export async function applyConfigRevert(query: QueryFn, rev: ConfigRevisionRow): Promise<void> {
-  const map = rev.entity_type === 'field' ? FIELD_COLUMN : rev.entity_type === 'view' ? VIEW_COLUMN : null
-  const table = rev.entity_type === 'field' ? 'meta_fields' : rev.entity_type === 'view' ? 'meta_views' : null
+  const map = rev.entity_type === 'field' ? FIELD_COLUMN : rev.entity_type === 'view' ? VIEW_COLUMN : rev.entity_type === 'sheet_config' ? SHEET_CONFIG_COLUMN : null
+  const table = rev.entity_type === 'field' ? 'meta_fields' : rev.entity_type === 'view' ? 'meta_views' : rev.entity_type === 'sheet_config' ? 'meta_sheets' : null
   if (!map || !table) throw new Error(`config revert not supported for entity_type=${rev.entity_type}`)
   const before = rev.before ?? {}
   const sets: string[] = []

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7709,6 +7709,17 @@ export function univerMetaRouter(): Router {
         : rev.entity_type === 'sheet_config' ? capabilities.canManageSheetAccess
         : (capabilities.canManageFields || capabilities.canManageViews || capabilities.canManageSheetAccess)
       if (!cap) return sendForbidden(res)
+      // T9-W Tier 1 (U-L1): sheet_config revert is behind a per-tier flag (default off) — refuse preview AND execute.
+      if (rev.entity_type === 'sheet_config') {
+        if (process.env.MULTITABLE_ENABLE_SHEET_CONFIG_REVERT !== 'true') {
+          return res.status(403).json({ ok: false, error: { code: 'SHEET_CONFIG_REVERT_DISABLED', message: 'sheet_config revert is disabled (MULTITABLE_ENABLE_SHEET_CONFIG_REVERT off).' } })
+        }
+        // Fail-closed: a sheet_config revision's entity_id IS its sheet — a mismatch is a malformed/forged revision
+        // that must never point a restore at another sheet.
+        if (rev.entity_id !== rev.sheet_id) {
+          return res.status(400).json({ ok: false, error: { code: 'INVALID_REVISION', message: 'sheet_config revision entity_id does not match its sheet.' } })
+        }
+      }
       const snapshot = await loadEntityConfigSnapshot(pool.query.bind(pool), rev)
       if (!snapshot) return res.status(409).json({ ok: false, error: { code: 'ENTITY_GONE', message: 'The config entity no longer exists; cannot preview a revert.' } })
       const preview = computeRevertPreview(rev, snapshot)
@@ -7721,6 +7732,19 @@ export function univerMetaRouter(): Router {
         const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
         preview.current = redactViewConfigFilterLiterals(preview.current as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
         preview.target = redactViewConfigFilterLiterals(preview.target as { filterInfo?: unknown }, allowedFieldIds) as Record<string, unknown>
+      } else if (rev.entity_type === 'sheet_config') {
+        // T9-W Tier 1 (U-L6): conditionalReadRules `value` literals are field-read-sensitive — redact per requester
+        // (same discipline as view filterInfo; reuses the U-1a redactor). EXECUTE applies the raw server-side target.
+        const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+        preview.current = redactConditionalReadRuleLiterals(preview.current as { conditionalReadRules?: unknown }, allowedFieldIds) as Record<string, unknown>
+        preview.target = redactConditionalReadRuleLiterals(preview.target as { conditionalReadRules?: unknown }, allowedFieldIds) as Record<string, unknown>
+      }
+      // T9-W Tier 1: classifyRevert stays PURE (sheet_config = intrinsically gated), but the flag is ON here (flag-off
+      // already 403'd above), so the ROUTE supports this revert — surface it as confirmable so the FE shows the confirm
+      // path (the FE hides confirm unless opKind === 'safe'). EXECUTE applies the same flag+guard gate, not opKind.
+      if (rev.entity_type === 'sheet_config') {
+        preview.opKind = 'safe'
+        delete preview.gatedReason
       }
       // T9-W-L4/D5: mint a server-signed identity binding this preview to execute. The baselineHash alone is
       // client-computable, so execute REQUIRES this token — a caller cannot skip the preview by computing the hash.
@@ -7758,8 +7782,19 @@ export function univerMetaRouter(): Router {
         : rev.entity_type === 'sheet_config' ? capabilities.canManageSheetAccess
         : (capabilities.canManageFields || capabilities.canManageViews || capabilities.canManageSheetAccess)
       if (!cap) return sendForbidden(res)
+      // T9-W Tier 1 (U-L1): sheet_config revert behind the per-tier flag (default off) + fail-closed entity_id guard.
+      if (rev.entity_type === 'sheet_config') {
+        if (process.env.MULTITABLE_ENABLE_SHEET_CONFIG_REVERT !== 'true') {
+          return res.status(403).json({ ok: false, error: { code: 'SHEET_CONFIG_REVERT_DISABLED', message: 'sheet_config revert is disabled (MULTITABLE_ENABLE_SHEET_CONFIG_REVERT off).' } })
+        }
+        if (rev.entity_id !== rev.sheet_id) {
+          return res.status(400).json({ ok: false, error: { code: 'INVALID_REVISION', message: 'sheet_config revision entity_id does not match its sheet.' } })
+        }
+      }
       const classify = classifyRevert(rev)
-      if (classify.kind === 'gated') return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
+      // classifyRevert stays PURE; the route SUPPORTS flag-on sheet_config (already flag/guard-gated above), so it must
+      // NOT 422 it. Every other gated kind (permission, lossy field, create/delete) is still refused here.
+      if (classify.kind === 'gated' && rev.entity_type !== 'sheet_config') return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
 
       // null = applied; a failure object = a guard tripped (the txn made no write either way).
       const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {

--- a/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
@@ -1,0 +1,162 @@
+/**
+ * T9-W Tier 1 — sheet_config revert (real DB). The first UNSAFE config-restore slice, behind the per-tier flag
+ * MULTITABLE_ENABLE_SHEET_CONFIG_REVERT (default off). classifyRevert stays PURE (sheet_config = intrinsically
+ * gated); the ROUTE supports it when the flag is on and surfaces the preview as confirmable (opKind:'safe').
+ *
+ * Goldens: (a) flag-OFF → preview AND execute 403 RESET... no: SHEET_CONFIG_REVERT_DISABLED · (b) gate: a
+ * write-but-not-share actor → 403 · (c) fail-closed: a revision whose entity_id != sheet_id → 400 INVALID_REVISION ·
+ * (d) flag-ON happy path: preview is confirmable (opKind:'safe', no drift) and execute SUCCEEDS (rules reverted,
+ * forward source=restore revision) · (e) drift: rules edited after preview → execute 409 · (f) U-L6 redaction: a
+ * field-denied canManageSheetAccess reader does NOT see the secret rule literal in the preview; fully-allowed does.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const BASE = `base_scr_${TS}`
+const SHEET = `sheet_scr_${TS}`
+const OTHER_SHEET = `sheet_scr_other_${TS}`
+const FLD_VISIBLE = `fld_scr_visible_${TS}`
+const FLD_SECRET = `fld_scr_secret_${TS}`
+const VISIBLE_LIT = 'scr-visible-keepme'
+const SECRET_LIT = 'scr-secret-do-not-leak'
+const U_FULL = `u_scr_full_${TS}`
+const U_WRITER = `u_scr_writer_${TS}`   // write but NOT share → no canManageSheetAccess
+const U_SHAREDENIED = `u_scr_sdenied_${TS}` // share but FLD_SECRET denied
+
+const q = (sql: string, params: unknown[]) => poolManager.get().query(sql, params)
+let app: Express
+let actor: { id: string; roles: string[]; perms: string[] }
+const FULL = { id: U_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:share'] }
+const WRITER = { id: U_WRITER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+const SHAREDENIED = { id: U_SHAREDENIED, roles: ['member'], perms: ['multitable:read', 'multitable:share'] }
+const FLAG = 'MULTITABLE_ENABLE_SHEET_CONFIG_REVERT'
+
+const setRules = (rules: unknown[], as = FULL) => { actor = as; return request(app).put(`/api/multitable/sheets/${SHEET}/conditional-rules`).send({ rules }) }
+const preview = (revisionId: string, as: typeof FULL) => { actor = as; return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-preview`).send({ revisionId }) }
+const execute = (revisionId: string, previewToken: string, as: typeof FULL) => { actor = as; return request(app).post(`/api/multitable/sheets/${SHEET}/config-restore-execute`).send({ revisionId, previewToken }) }
+const rule = (id: string, fieldId: string, value: string) => ({ id, fieldId, operator: 'eq', value, effect: 'deny_read' })
+const latestRevId = async (): Promise<string> => ((await q(`SELECT id FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='sheet_config' ORDER BY created_at DESC, id DESC LIMIT 1`, [SHEET])).rows[0] as { id: string }).id
+const liveRules = async (): Promise<any[]> => (((await q('SELECT conditional_read_rules AS r FROM meta_sheets WHERE id=$1', [SHEET])).rows[0] as { r: any }).r) ?? []
+
+describeIfDatabase('multitable sheet_config revert — T9-W Tier 1 (real DB)', () => {
+  let revToRevert = '' // R2: before=[visible,secret], after=[visible] → revert restores the secret rule
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = actor; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE, 'SCR Base'])
+    for (const s of [SHEET, OTHER_SHEET]) await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [s, BASE, s])
+    for (const [fid, name, order] of [[FLD_VISIBLE, 'Visible', 1], [FLD_SECRET, 'Secret', 2]] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET, name, 'string', '{}', order])
+    }
+    for (const u of [U_FULL, U_WRITER, U_SHAREDENIED]) await q("INSERT INTO users (id, password_hash) VALUES ($1,'x') ON CONFLICT (id) DO NOTHING", [u])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET, FLD_SECRET, 'user', U_SHAREDENIED, false, false])
+    // R1: add both rules. R2: drop the secret rule → reverting R2 restores [visible, secret].
+    const r1 = await setRules([rule('rv', FLD_VISIBLE, VISIBLE_LIT), rule('rs', FLD_SECRET, SECRET_LIT)])
+    const r2 = await setRules([rule('rv', FLD_VISIBLE, VISIBLE_LIT)])
+    if (r1.status !== 200 || r2.status !== 200) throw new Error(`rule setup failed: ${r1.status}/${r2.status}`)
+    revToRevert = await latestRevId() // R2
+  })
+  afterAll(async () => {
+    await q('DELETE FROM meta_config_revisions WHERE sheet_id = ANY($1)', [[SHEET, OTHER_SHEET]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1)', [[SHEET, OTHER_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE]).catch(() => {})
+    for (const u of [U_FULL, U_WRITER, U_SHAREDENIED]) await q('DELETE FROM users WHERE id = $1', [u]).catch(() => {})
+  })
+  afterEach(() => { delete process.env[FLAG] })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('(a) flag OFF → preview AND execute 403 SHEET_CONFIG_REVERT_DISABLED', async () => {
+    delete process.env[FLAG]
+    const p = await preview(revToRevert, FULL)
+    expect(p.status).toBe(403)
+    expect(p.body?.error?.code).toBe('SHEET_CONFIG_REVERT_DISABLED')
+    const x = await execute(revToRevert, 'any-token', FULL)
+    expect(x.status).toBe(403)
+    expect(x.body?.error?.code).toBe('SHEET_CONFIG_REVERT_DISABLED')
+  })
+
+  test('(b) gate: write-but-not-share actor → 403 (canManageSheetAccess required)', async () => {
+    process.env[FLAG] = 'true'
+    const p = await preview(revToRevert, WRITER)
+    expect(p.status).toBe(403)
+  })
+
+  test('(c) fail-closed: a sheet_config revision whose entity_id != sheet_id → 400 INVALID_REVISION', async () => {
+    process.env[FLAG] = 'true'
+    // forge a malformed revision on SHEET but pointing entity_id at OTHER_SHEET
+    const bad = (await q(
+      `INSERT INTO meta_config_revisions (id, sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, created_at)
+       VALUES (gen_random_uuid(), $1, 'sheet_config', $2, 'update', $3::jsonb, $4::jsonb, ARRAY['conditionalReadRules']::text[], gen_random_uuid(), $5, now()) RETURNING id`,
+      [SHEET, OTHER_SHEET, JSON.stringify({ conditionalReadRules: [] }), JSON.stringify({ conditionalReadRules: [] }), U_FULL],
+    )).rows[0] as { id: string }
+    const p = await preview(bad.id, FULL)
+    expect(p.status).toBe(400)
+    expect(p.body?.error?.code).toBe('INVALID_REVISION')
+    const x = await execute(bad.id, 'any-token', FULL)
+    expect(x.status).toBe(400)
+    expect(x.body?.error?.code).toBe('INVALID_REVISION')
+  })
+
+  test('(d) flag ON happy path: preview confirmable (opKind safe, no drift) → execute restores the rules', async () => {
+    process.env[FLAG] = 'true'
+    // two DISTINCT states so a fresh revision is recorded (a no-op PUT records nothing): before=[d1], after=[d2].
+    await setRules([rule('rv', FLD_VISIBLE, 'd1-restore-target')])
+    await setRules([rule('rv', FLD_VISIBLE, 'd2-current')])
+    const rev = await latestRevId() // revert → restores [d1]
+    const p = await preview(rev, FULL)
+    expect(p.status).toBe(200)
+    expect(p.body?.data?.preview?.opKind).toBe('safe') // route override → FE shows confirm
+    expect(p.body?.data?.preview?.gatedReason).toBeUndefined()
+    expect(p.body?.data?.preview?.driftConflict).toBe(false)
+    const token = p.body?.data?.previewToken
+    const x = await execute(rev, token, FULL)
+    expect(x.status).toBe(200)
+    const live = await liveRules()
+    expect(JSON.stringify(live)).toContain('d1-restore-target') // restored the revision's `before`
+    expect(JSON.stringify(live)).not.toContain('d2-current') // the reverted-away state is gone
+    // a forward source=restore revision was appended (append-only / U-L5)
+    const restoreRevs = await q(`SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1 AND source='restore'`, [SHEET])
+    expect((restoreRevs.rows[0] as { n: number }).n).toBeGreaterThanOrEqual(1)
+  })
+
+  test('(e) drift: rules edited between preview and execute → execute 409', async () => {
+    process.env[FLAG] = 'true'
+    await setRules([rule('rv', FLD_VISIBLE, 'e1')])
+    await setRules([rule('rv', FLD_VISIBLE, 'e2')]) // fresh revision
+    const rev = await latestRevId()
+    const p = await preview(rev, FULL)
+    expect(p.status).toBe(200)
+    const token = p.body?.data?.previewToken
+    await setRules([rule('rv', FLD_VISIBLE, 'e3-moved-since-preview')]) // live moved after preview
+    const x = await execute(rev, token, FULL)
+    expect(x.status).toBe(409)
+  })
+
+  test('(f) U-L6: field-denied canManageSheetAccess reader does NOT see the secret rule literal; opKind still safe', async () => {
+    process.env[FLAG] = 'true'
+    // restore to a state whose revert target contains the secret rule: set [visible, secret] then drop secret
+    await setRules([rule('rv', FLD_VISIBLE, VISIBLE_LIT), rule('rs', FLD_SECRET, SECRET_LIT)])
+    await setRules([rule('rv', FLD_VISIBLE, VISIBLE_LIT)])
+    const rev = await latestRevId() // before=[visible,secret], after=[visible]
+    const denied = await preview(rev, SHAREDENIED)
+    expect(denied.status).toBe(200)
+    expect(denied.body?.data?.preview?.opKind).toBe('safe') // confirmable for the share actor
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_LIT) // U-L6 redaction on the preview target
+    expect(JSON.stringify(denied.body)).toContain(VISIBLE_LIT) // no over-redaction
+
+    const full = await preview(rev, FULL)
+    expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it
+  })
+})


### PR DESCRIPTION
## T9-W Tier 1 — sheet_config revert (owner-greenlit; behind `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT`)

First unsafe config-restore slice. `classifyRevert` stays **pure** (sheet_config = intrinsically gated); the **route** supports it when the per-tier flag is on. Builds on U-1a (#3258, the redactor).

### Constraints baked in (per review)
- **opKind override** — `computeRevertPreview` returns `opKind:'gated'` (from the pure `classifyRevert`), which the FE uses to hide confirm. For flag-on sheet_config the route overrides the **preview response** `opKind→'safe'` so the confirm path shows. Execute gates on the flag+guard, not opKind.
- **Fail-closed `entity_id===sheet_id` guard** — a sheet_config revision whose `entity_id` ≠ its `sheet_id` → `400 INVALID_REVISION`, so a malformed/forged revision can't restore config into another sheet.
- **U-L6 redaction** — preview `current`/`target` `conditionalReadRules` literals redacted per requester (reuses U-1a); execute applies the raw server-side target.
- **U-L1 per-tier flag** — default off; preview AND execute → `403 SHEET_CONFIG_REVERT_DISABLED`.

### Runtime
`SHEET_CONFIG_COLUMN` + `applyConfigRevert`/`loadSheetConfigSnapshot`/`loadEntityConfigSnapshot` for sheet_config. `loadSheetConfigSnapshot` returns the **raw jsonb** (not re-parsed) so it matches the recorder's stored shape — `stable()` is plain `JSON.stringify`, so a re-parse's JS key order would trip a false drift.

### Goldens (7, real-DB)
flag-off→403 (preview+execute) · gate (write-not-share)→403 · `entity_id` mismatch→400 · **flag-on happy: preview confirmable (opKind safe, no drift) + execute restores rules + forward `source=restore` revision** · drift→409 · **U-L6 field-denied reader can't see the secret rule literal** (opKind still safe). Regression green (config-restore + both redaction goldens); tsc 0; registered in `plugin-tests.yml`.

Default-off, so inert until explicitly enabled. Tier 2 (lossy retype) is next, after the U-L8 re-confirm on #3254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)