### PR TITLE
feat(approval): RA-1a — requester.department formula conditions (department-only, fail-closed)

### DIFF
--- a/docs/design/approval-requester-attribute-formula-condition-design-lock-20260626.md
+++ b/docs/design/approval-requester-attribute-formula-condition-design-lock-20260626.md
@@ -42,6 +42,13 @@ amount total-check already ships (validate-at-publish vs reject-at-runtime):
   schema / provider capability before the template can publish. The author fixes it where they authored
   it. A template referencing an attribute the org cannot supply MUST fail publish — NOT brick every
   requester's create.
+  - **RA-1a deviation (recorded 2026-06-26):** RA-1a does the ATTRIBUTE half at publish (the `{department}`
+    allowlist parse/publish-rejects `level`/`role`/`title`/unknown) but DEFERS the org-DATA half (does this
+    org's directory actually carry department names) to RA-2 — that check needs the org's directory context
+    at publish, which the form-schema validator lacks. Safe for `department`: an org with no department
+    names has `requester.department` formulas fail-closed at RUNTIME (reject the create, never
+    phantom-route), just caught later than this paragraph's general promise. RA-2 adds the publish-time
+    org-capability check.
 - **Row-level absence — attribute supported, but absent for THIS requester.** That is the **runtime
   fail-closed**: reject this `createApproval` rather than route on a phantom value (never default-to-0,
   never silently take `defaultEdgeKey` — error vs no-match, same as the FC-1 evaluator).

--- a/docs/development/approval-requester-attr-RA1a-dev-verification-20260626.md
+++ b/docs/development/approval-requester-attr-RA1a-dev-verification-20260626.md
@@ -1,0 +1,60 @@
+# RA-1a — `requester.department` formula conditions — dev + verification
+
+Status: BUILT + VERIFIED on branch `claude/approval-requester-attr-RA1a-code-20260626` (4 commits).
+Scope per design-lock #3244 + scope correction #3259: **`requester.department` ONLY.**
+
+## What shipped
+Approval condition formulas can now route on the requester's **directory-resolved department**, e.g.
+`requester.department == "财务"` or `requester.department != "财务" AND {amount} >= 5000`. The value is
+server-resolved and frozen — tamper-resistant by provenance, unlike applicant-typed form fields.
+
+| Layer | File | Commit |
+|---|---|---|
+| Evaluator namespace | `ApprovalConditionFormula.ts` (+ unit tests) | `c933396e9` |
+| Snapshot source | `ApprovalDirectoryOrg.ts` | `239c16e46` |
+| Threading (executor + snapshot + createApproval) | `ApprovalGraphExecutor.ts`, `approval-product.ts`, `ApprovalProductService.ts` | `f8154c8d5` |
+| Resolver tests | `approval-directory-org.test.ts` | `d7c9fa896` |
+
+## How each review finding was honoured
+- **P1 — provenance, not `actor.department`.** `requester.department` reads a NEW frozen field
+  `ApprovalRequesterSnapshot.directoryDepartment`, set in `createApproval` from
+  `ApprovalDirectoryOrg.primaryDepartmentName` (the directory `directory_departments.name`). The
+  JWT/session `actor.department` is never consulted by the evaluator.
+- **P2 — raw key pinned.** Department name = `directory_departments.name`, added to the existing
+  `resolveApprovalRequesterOrgRelations` SELECT (`d.name AS primary_department_name`). (`requester.level`
+  is NOT built — `directory_accounts` has no seniority level; see #3259.)
+- **P2 — constructor context, no re-query.** `ApprovalGraphExecutor` takes a `requesterContext` ctor
+  option (beside `formData`); the condition node passes it to `evaluateApprovalConditionFormula`. No
+  directory re-query at eval time, no resolver-bypass. Threaded at all 3 executor constructions — create
+  + both dispatch paths (the latter from the reloaded `requester_snapshot`), so a formula condition routes
+  consistently at create AND after an approval action.
+- **Fail-closed split.** *Attribute-structural* (parse/publish): the RA-1a allowlist is `{department}`;
+  `parsePrimary` rejects `level`/`role`/`title`/unknown at PARSE, so they never reach runtime — and `in` /
+  array literals parse-reject for free. *Row-level* (runtime): a null context or missing/blank department
+  fails the create rather than routing on a phantom.
+- **No spoof.** The `requester.<attr>` token resolves only from the frozen context; a form field literally
+  named `requester` is ignored (test asserts it).
+
+## Verification (all green)
+- `ApprovalConditionFormula.ts` evaluator unit suite — **13/13** (6 existing + 7 new): eval `==`/`!=`,
+  AND-with-form-fields, the full parse-reject matrix (`level`/`role`/`title`/unknown/`in`/arrays/bare/empty
+  attr), runtime fail-closed (null context / missing / blank / null department), no-spoof, and
+  publish-validation (compared → boolean OK; bare → non-boolean reject; `level` → unsupported).
+- `approval-directory-org.test.ts` — **10/10** (8 existing + 2 new): `primaryDepartmentName` resolved from
+  `d.name`; omitted when the directory has no department name.
+- `tsc --noEmit` on `@metasheet/core-backend` — **clean**.
+- Affected backend suites (condition-formula / directory-org / graph-executor / product-service) —
+  **113/113**, no regression.
+
+## Scope boundary (deliberate, per #3259)
+- **`requester.level`** — DEFERRED (no directory source). Parse-rejects.
+- **`requester.role`** — RA-1b (membership + `in` + array literals). Parse-rejects.
+- **`requester.title`** — the seniority candidate, its own title-vs-level design-lock. Parse-rejects.
+- **Org-level structural publish-check** (template publishes only if the org's directory can supply a
+  department) — RA-2 refinement. RA-1a relies on the parse-time attribute allowlist + the runtime
+  row-level fail-closed; an org with no department names today simply has every such create fail-closed
+  rather than failing at publish. Noted as the one RA-2 follow-up.
+
+## Next
+RA-1b (`requester.role` membership) and the `title`-vs-`level` seniority design-lock, each separate and
+not mixed with `department`.

--- a/docs/development/approval-requester-attr-RA1a-dev-verification-20260626.md
+++ b/docs/development/approval-requester-attr-RA1a-dev-verification-20260626.md
@@ -45,6 +45,12 @@ server-resolved and frozen — tamper-resistant by provenance, unlike applicant-
 - `tsc --noEmit` on `@metasheet/core-backend` — **clean**.
 - Affected backend suites (condition-formula / directory-org / graph-executor / product-service) —
   **113/113**, no regression.
+- **Dispatch round-trip — safe by construction.** The dispatch paths read `directoryDepartment` from the
+  reloaded `instance.requester_snapshot`; that column is a whole-object `JSON.stringify(requesterSnapshot)`
+  at create (`ApprovalProductService.ts:2964`), so the field persists + reloads (NOT a field-by-field
+  projection that would silently drop it). Residual gap: no end-to-end create→action→dispatch *integration*
+  test exercises a formula via the reload path (the unit tests use a hand-built context) — recommended
+  follow-up; the round-trip is structurally safe today.
 
 ## Scope boundary (deliberate, per #3259)
 - **`requester.level`** — DEFERRED (no directory source). Parse-rejects.

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -21,6 +21,7 @@ type Token =
   | { kind: 'boolean'; value: boolean }
   | { kind: 'null' }
   | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'requester'; attr: string; raw: string }
   | { kind: 'identifier'; value: string }
   | { kind: 'operator'; value: '+' | '-' | '*' | '/' | '==' | '!=' | '>' | '>=' | '<' | '<=' }
   | { kind: 'paren'; value: '(' | ')' }
@@ -34,6 +35,7 @@ type FormulaAst =
   | { kind: 'boolean'; value: boolean }
   | { kind: 'null' }
   | { kind: 'field'; path: string[]; raw: string }
+  | { kind: 'requester'; attr: string; raw: string }
   | { kind: 'aggregate'; fn: 'SUM' | 'COUNT' | 'MIN' | 'MAX'; path: string[]; raw: string }
   | { kind: 'unary'; op: 'NEG' | 'NOT'; expr: FormulaAst }
   | { kind: 'binary'; op: '+' | '-' | '*' | '/' | 'AND' | 'OR'; left: FormulaAst; right: FormulaAst }
@@ -41,6 +43,14 @@ type FormulaAst =
 
 type FormulaValue = number | string | boolean | null
 type FormulaType = 'number' | 'string' | 'boolean' | 'null'
+
+/** RA-1a: the frozen, server-resolved requester attributes the evaluator may read. DEPARTMENT-ONLY in
+ *  RA-1a; every other attribute (level/role/title/unknown) is rejected at PARSE (see parsePrimary), so it
+ *  never reaches runtime. Values come from ApprovalDirectoryOrg's directory snapshot, NOT actor/JWT. */
+export interface RequesterFormulaContext {
+  department?: string | null
+}
+const RA1A_REQUESTER_ATTRS: Record<string, FormulaType> = { department: 'string' }
 
 function fail(message: string): never {
   throw new ApprovalConditionFormulaError(message)
@@ -142,6 +152,17 @@ function tokenize(expression: string): Token[] {
         tokens.push({ kind: 'boolean', value: upper === 'TRUE' })
       } else if (upper === 'NULL') {
         tokens.push({ kind: 'null' })
+      } else if (raw === 'requester' && expression[i] === '.') {
+        // RA-1a requester namespace: `requester.<attr>` — a reserved token resolved from the frozen
+        // requester context, never from formData (so a form field named `requester` cannot spoof it).
+        i += 1 // consume '.'
+        let attr = ''
+        while (i < expression.length && isIdentifierPart(expression[i])) {
+          attr += expression[i]
+          i += 1
+        }
+        if (!attr) fail('requester reference is missing an attribute (e.g. requester.department)')
+        tokens.push({ kind: 'requester', attr, raw: `requester.${attr}` })
       } else {
         tokens.push({ kind: 'identifier', value: upper })
       }
@@ -340,6 +361,13 @@ class FormulaParser {
         return this.node({ kind: 'null' })
       case 'field':
         return this.node({ kind: 'field', path: token.path, raw: token.raw })
+      case 'requester':
+        // RA-1a allowlist IS the parse/publish fail-closed gate: anything outside {department}
+        // (level/role/title/unknown) is rejected here, so it never reaches runtime as absent-in-context.
+        if (!(token.attr in RA1A_REQUESTER_ATTRS)) {
+          fail(`unsupported requester attribute: ${token.raw} (RA-1a supports requester.department only)`)
+        }
+        return this.node({ kind: 'requester', attr: token.attr, raw: token.raw })
       case 'identifier':
         return this.parseFunction(token.value)
       case 'paren': {
@@ -442,6 +470,11 @@ function inferFormulaType(ast: FormulaAst, schema: FormSchema): FormulaType {
       const type = formFieldTypeToFormulaType(field)
       if (type === 'unsupported') fail(`field type is not supported in formula: ${field.id}`)
       return type
+    }
+    case 'requester': {
+      const requesterType = RA1A_REQUESTER_ATTRS[ast.attr]
+      if (!requesterType) fail(`unsupported requester attribute: ${ast.raw}`)
+      return requesterType
     }
     case 'aggregate':
       validateAggregateReference(ast, schema)
@@ -551,7 +584,21 @@ function evaluateAggregate(ast: Extract<FormulaAst, { kind: 'aggregate' }>, form
   return ast.fn === 'MIN' ? Math.min(...numbers) : Math.max(...numbers)
 }
 
-function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): FormulaValue {
+/** Resolve a `requester.<attr>` value from the frozen, server-resolved requester context. RA-1a:
+ *  `department` only (the parser already rejected every other attr). Fail-closed on ROW-LEVEL absence: a
+ *  null/undefined context, or a missing/blank department, rejects rather than routing on a phantom. */
+function evaluateRequester(attr: string, raw: string, requester: RequesterFormulaContext | null): FormulaValue {
+  if (!requester) fail(`requester context unavailable for ${raw}`)
+  if (attr === 'department') {
+    const value = requester.department
+    if (value === null || value === undefined || value === '') fail(`requester department is missing for ${raw}`)
+    if (typeof value !== 'string') fail(`requester department has an unsupported value for ${raw}`)
+    return value
+  }
+  fail(`unsupported requester attribute: ${raw}`)
+}
+
+function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>, requester: RequesterFormulaContext | null): FormulaValue {
   switch (ast.kind) {
     case 'number':
     case 'string':
@@ -563,24 +610,26 @@ function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): Formul
       return evaluateField(ast.path, ast.raw, formData)
     case 'aggregate':
       return evaluateAggregate(ast, formData)
+    case 'requester':
+      return evaluateRequester(ast.attr, ast.raw, requester)
     case 'unary': {
-      const value = evaluateAst(ast.expr, formData)
+      const value = evaluateAst(ast.expr, formData, requester)
       if (ast.op === 'NOT') return !assertBoolean(value, 'NOT operand')
       return assertFiniteNumber(-assertFiniteNumber(value, 'unary operand'), 'unary result')
     }
     case 'binary': {
       if (ast.op === 'AND') {
-        const left = assertBoolean(evaluateAst(ast.left, formData), 'AND left operand')
-        const right = assertBoolean(evaluateAst(ast.right, formData), 'AND right operand')
+        const left = assertBoolean(evaluateAst(ast.left, formData, requester), 'AND left operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData, requester), 'AND right operand')
         return left && right
       }
       if (ast.op === 'OR') {
-        const left = assertBoolean(evaluateAst(ast.left, formData), 'OR left operand')
-        const right = assertBoolean(evaluateAst(ast.right, formData), 'OR right operand')
+        const left = assertBoolean(evaluateAst(ast.left, formData, requester), 'OR left operand')
+        const right = assertBoolean(evaluateAst(ast.right, formData, requester), 'OR right operand')
         return left || right
       }
-      const left = assertFiniteNumber(evaluateAst(ast.left, formData), `${ast.op} left operand`)
-      const right = assertFiniteNumber(evaluateAst(ast.right, formData), `${ast.op} right operand`)
+      const left = assertFiniteNumber(evaluateAst(ast.left, formData, requester), `${ast.op} left operand`)
+      const right = assertFiniteNumber(evaluateAst(ast.right, formData, requester), `${ast.op} right operand`)
       if (ast.op === '/' && right === 0) fail('division by zero')
       const result = ast.op === '+'
         ? left + right
@@ -592,8 +641,8 @@ function evaluateAst(ast: FormulaAst, formData: Record<string, unknown>): Formul
       return assertFiniteNumber(result, `${ast.op} result`)
     }
     case 'compare': {
-      const left = evaluateAst(ast.left, formData)
-      const right = evaluateAst(ast.right, formData)
+      const left = evaluateAst(ast.left, formData, requester)
+      const right = evaluateAst(ast.right, formData, requester)
       if (ast.op === '==') return left === right
       if (ast.op === '!=') return left !== right
       const numericLeft = assertFiniteNumber(left, `${ast.op} left operand`)
@@ -620,8 +669,12 @@ export function assertApprovalConditionFormulaValidForSchema(expression: string,
   }
 }
 
-export function evaluateApprovalConditionFormula(expression: string, formData: Record<string, unknown>): boolean {
-  const result = evaluateAst(parseFormula(expression), formData)
+export function evaluateApprovalConditionFormula(
+  expression: string,
+  formData: Record<string, unknown>,
+  requester: RequesterFormulaContext | null = null,
+): boolean {
+  const result = evaluateAst(parseFormula(expression), formData, requester)
   if (typeof result !== 'boolean') {
     fail('formula must return boolean')
   }

--- a/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
+++ b/packages/core-backend/src/services/ApprovalDirectoryOrg.ts
@@ -44,6 +44,9 @@
 type QueryFn = <Row>(text: string, params?: unknown[]) => Promise<{ rows: Row[] }>
 
 export interface ApprovalRequesterOrgRelations {
+  /** RA-1a: the requester's directory-resolved primary department NAME (directory_departments.name) —
+   *  the tamper-resistant source for `requester.department`. Omitted when unresolvable. */
+  primaryDepartmentName?: string
   /** Local user id of the requester's direct manager, if resolvable. */
   managerId?: string
   /** Local user id of the head of the requester's primary department, if resolvable. */
@@ -147,6 +150,7 @@ interface RequesterDirectoryRow {
   raw: unknown
   primary_external_department_id: string | null
   primary_department_raw: unknown
+  primary_department_name: string | null
 }
 
 /**
@@ -172,7 +176,8 @@ export async function resolveApprovalRequesterOrgRelations(
             a.external_user_id           AS external_user_id,
             a.raw                        AS raw,
             d.external_department_id     AS primary_external_department_id,
-            d.raw                        AS primary_department_raw
+            d.raw                        AS primary_department_raw,
+            d.name                       AS primary_department_name
        FROM directory_account_links l
        JOIN directory_accounts a
          ON a.id = l.directory_account_id
@@ -234,6 +239,8 @@ export async function resolveApprovalRequesterOrgRelations(
   const relations: ApprovalRequesterOrgRelations = {}
   if (managerId) relations.managerId = managerId
   if (deptHeadId) relations.deptHeadId = deptHeadId
+  const primaryDepartmentName = requester.primary_department_name?.trim()
+  if (primaryDepartmentName) relations.primaryDepartmentName = primaryDepartmentName
 
   // 4) Manager chain (opt-in): walk leader_in_dept hop-by-hop up the org tree,
   //    starting from the requester. Only runs when the caller opts in — i.e. a

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -14,7 +14,7 @@ import type {
   RuntimeGraph,
 } from '../types/approval-product'
 import { ServiceError } from './ApprovalBridgeService'
-import { evaluateApprovalConditionFormula } from './ApprovalConditionFormula'
+import { evaluateApprovalConditionFormula, type RequesterFormulaContext } from './ApprovalConditionFormula'
 
 export interface ApprovalGraphAssignment {
   assignmentType: 'user' | 'role'
@@ -527,7 +527,7 @@ export class ApprovalGraphExecutor {
   constructor(
     private readonly runtimeGraph: RuntimeGraph,
     private readonly formData: Record<string, unknown>,
-    private readonly options: { assignmentResolver?: ApprovalGraphAssignmentResolver } = {},
+    private readonly options: { assignmentResolver?: ApprovalGraphAssignmentResolver; requesterContext?: RequesterFormulaContext | null } = {},
   ) {
     for (const node of runtimeGraph.nodes) {
       this.nodeMap.set(node.key, node)
@@ -1047,7 +1047,7 @@ export class ApprovalGraphExecutor {
 
     for (const branch of branches) {
       const result = branch.formula
-        ? evaluateApprovalConditionFormula(branch.formula.expression, this.formData)
+        ? evaluateApprovalConditionFormula(branch.formula.expression, this.formData, this.options.requesterContext ?? null)
         : (() => {
             const conjunction = branch.conjunction === 'or' ? 'or' : 'and'
             return conjunction === 'or'

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2909,6 +2909,7 @@ export class ApprovalProductService {
       name: actor.userName || actor.userId,
       email: actor.email,
       department: actor.department,
+      ...(orgRelations.primaryDepartmentName ? { directoryDepartment: orgRelations.primaryDepartmentName } : {}),
       roles: actor.roles || [],
       permissions: actor.permissions || [],
       ...(orgRelations.managerId ? { managerId: orgRelations.managerId } : {}),
@@ -2922,6 +2923,7 @@ export class ApprovalProductService {
         formSnapshot: normalizedFormData,
         requesterSnapshot,
       }),
+      requesterContext: { department: requesterSnapshot.directoryDepartment ?? null },
     })
     const instanceId = crypto.randomUUID()
     const initialResolution = executor.resolveInitialState()
@@ -3159,6 +3161,8 @@ export class ApprovalProductService {
           formSnapshot,
           requesterSnapshot,
         }),
+        // RA-1a: re-thread the frozen directory department at dispatch (loaded requester_snapshot record).
+        requesterContext: ((d) => ({ department: typeof d === 'string' && d ? d : null }))(requesterSnapshot?.directoryDepartment),
       })
       const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
       const requesterId = requesterSnapshot?.id
@@ -3323,6 +3327,8 @@ export class ApprovalProductService {
           formSnapshot,
           requesterSnapshot,
         }),
+        // RA-1a: re-thread the frozen directory department at dispatch (loaded requester_snapshot record).
+        requesterContext: ((d) => ({ department: typeof d === 'string' && d ? d : null }))(requesterSnapshot?.directoryDepartment),
       })
       const storedCurrentNodeKey = instance.current_node_key
       const actorRoles = actor.roles || []

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -256,6 +256,10 @@ export interface ApprovalRequesterSnapshot {
   id?: string
   name?: string
   department?: string
+  /** RA-1a: directory-resolved primary department NAME (via ApprovalDirectoryOrg, NOT the JWT/session
+   *  `department` above) — the tamper-resistant source `requester.department` reads; frozen at create,
+   *  reloaded at dispatch. */
+  directoryDepartment?: string | null
   title?: string
   /**
    * Lane G (P1-A) org-relation plumbing — local user id of the requester's

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -87,3 +87,47 @@ describe('approval condition formula evaluator (FC-1)', () => {
     }
   })
 })
+
+describe('requester namespace (RA-1a — department only)', () => {
+  it('evaluates requester.department ==/!= from the frozen context', () => {
+    expect(evaluateApprovalConditionFormula('requester.department == "财务"', {}, { department: '财务' })).toBe(true)
+    expect(evaluateApprovalConditionFormula('requester.department == "财务"', {}, { department: '技术' })).toBe(false)
+    expect(evaluateApprovalConditionFormula('requester.department != "财务"', {}, { department: '技术' })).toBe(true)
+  })
+
+  it('combines with form fields (AND)', () => {
+    expect(evaluateApprovalConditionFormula('requester.department == "财务" AND {amount} >= 5000', { amount: 6000 }, { department: '财务' })).toBe(true)
+    expect(evaluateApprovalConditionFormula('requester.department == "财务" AND {amount} >= 5000', { amount: 6000 }, { department: '技术' })).toBe(false)
+  })
+
+  it('PARSE-rejects every attr outside {department} — fail-closed, never runtime-absent', () => {
+    expect(() => parseApprovalConditionFormula('requester.level >= 5')).toThrow(/unsupported requester attribute/)
+    expect(() => parseApprovalConditionFormula('requester.role == "x"')).toThrow(/unsupported requester attribute/)
+    expect(() => parseApprovalConditionFormula('requester.title == "经理"')).toThrow(/unsupported requester attribute/)
+    expect(() => parseApprovalConditionFormula('requester.foo == "x"')).toThrow(/unsupported requester attribute/)
+  })
+
+  it('PARSE-rejects the `in` operator + array literals (RA-1b grammar), bare requester, and empty attr', () => {
+    expect(() => parseApprovalConditionFormula('requester.department in ["a", "b"]')).toThrow()
+    expect(() => parseApprovalConditionFormula('requester.department == ["a"]')).toThrow()
+    expect(() => parseApprovalConditionFormula('requester == "x"')).toThrow()
+    expect(() => parseApprovalConditionFormula('requester. == "x"')).toThrow(/missing an attribute/)
+  })
+
+  it('RUNTIME fail-closed: absent context / missing department rejects (no phantom routing)', () => {
+    expect(() => evaluateApprovalConditionFormula('requester.department == "财务"', {}, null)).toThrow(/context unavailable/)
+    expect(() => evaluateApprovalConditionFormula('requester.department == "财务"', {}, {})).toThrow(/department is missing/)
+    expect(() => evaluateApprovalConditionFormula('requester.department == "财务"', {}, { department: '' })).toThrow(/department is missing/)
+    expect(() => evaluateApprovalConditionFormula('requester.department == "财务"', {}, { department: null })).toThrow(/department is missing/)
+  })
+
+  it('a form field named `requester` cannot spoof it — token reads context, never formData', () => {
+    expect(evaluateApprovalConditionFormula('requester.department == "财务"', { requester: { department: '财务' } }, { department: '技术' })).toBe(false)
+  })
+
+  it('publish: compared requester.department → boolean OK; bare → non-boolean reject; level → unsupported', () => {
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department == "财务"', schema)).not.toThrow()
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department', schema)).toThrow(/must return boolean/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.level >= 5', schema)).toThrow(/unsupported requester attribute/)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-directory-org.test.ts
+++ b/packages/core-backend/tests/unit/approval-directory-org.test.ts
@@ -18,6 +18,7 @@ interface FakeDb {
     raw: unknown
     primary_external_department_id: string | null
     primary_department_raw: unknown
+    primary_department_name?: string | null
   } | null
   // candidate accounts in the requester's primary department (for manager scan)
   deptCandidates?: Array<{ account_id: string; raw: unknown; external_user_id?: string }>
@@ -75,6 +76,28 @@ describe('resolveApprovalRequesterOrgRelations', () => {
     }
     const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
     expect(result).toEqual({ managerId: 'local-mgr', deptHeadId: 'local-head' })
+  })
+
+  it('RA-1a: resolves the primary department NAME into primaryDepartmentName (server-resolved source)', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1', account_id: 'acc-req', external_user_id: 'ext-req', raw: {},
+        primary_external_department_id: 'D1', primary_department_raw: {}, primary_department_name: '财务',
+      },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result.primaryDepartmentName).toBe('财务')
+  })
+
+  it('RA-1a: omits primaryDepartmentName when the directory has no department name (→ requester.department fails closed at runtime)', async () => {
+    const db: FakeDb = {
+      requester: {
+        integration_id: 'int-1', account_id: 'acc-req', external_user_id: 'ext-req', raw: {},
+        primary_external_department_id: 'D1', primary_department_raw: {}, primary_department_name: null,
+      },
+    }
+    const result = await resolveApprovalRequesterOrgRelations('local-req', makeQuery(db))
+    expect(result.primaryDepartmentName).toBeUndefined()
   })
 
   it('excludes the requester from their own dept leaders (self-exclusion <> $3): a leader requester is not their own manager', async () => {


### PR DESCRIPTION
RA-1a per design-lock #3244 + scope correction #3259: approval condition formulas can route on the requester's **directory-resolved department** — `requester.department == "财务"`. Server-resolved + frozen (tamper-resistant by provenance), not `actor.department`.

- **Evaluator** — reserved `requester.<attr>` token from a frozen context (never formData; no-spoof); allowlist `{department}`; `level`/`role`/`title`/unknown + `in`/arrays **parse/publish fail-closed**; runtime fail-closed on absent department.
- **Snapshot** — `directory_departments.name` via `ApprovalDirectoryOrg` → frozen `requester_snapshot.directoryDepartment` (whole-object persisted, reloads at dispatch).
- **Threading** — `requesterContext` executor ctor option, passed at all 3 constructions (create + 2 dispatch); no re-query.

**Verification:** evaluator 13/13, resolver 10/10, affected suites 113/113, tsc clean. Dispatch round-trip safe by construction (:2964 whole-object stringify).

**Scope (per #3259):** `level`/`role`/`title` deferred (their own locks); org-DATA structural publish-check → RA-2 (§2 deviation recorded). Dev+verification MD included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)