### PR TITLE
test(attendance): close scheduler-scope smoke gap

### DIFF
--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1467,6 +1467,10 @@ describe('Attendance admin regressions', () => {
         roleTags: ['tag-x'],
       },
     })
+    const calledUrls = vi.mocked(apiFetch).mock.calls.map(call => String(call[0]))
+    expect(calledUrls.some(url => url.includes('/roles/assign'))).toBe(false)
+    expect(calledUrls.some(url => url === '/api/permissions/grant')).toBe(false)
+    expect(calledUrls.some(url => url.startsWith('/api/permissions/user/'))).toBe(false)
   })
 
   it('refuses to create a scheduler scope without a target and explains why', async () => {

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -11,7 +11,7 @@
 
 | 视野 | 范围 | 量级 | 现在做？ |
 |---|---|---|---|
-| **H1 — scheduler-scope 收尾** | 把已建成的子管理员范围/enforcement 线收干净 | **3–7 人天** | 是，零散收尾（§4） |
+| **H1 — scheduler-scope 收尾** | 把已建成的子管理员范围/enforcement 线收干净 | **3–7 人天** | ✅ scope-only smoke 已补（§4）；剩余仅 demand-gated picker / import 扩面 |
 | **H2 — 考勤核心成熟度** | **不追全量钉钉**，只补"真实客户会痛"的核心（MUST/SHOULD，§1） | **3–5 周** | **是，最值得做的下一阶段** |
 | **H3 — 钉钉级高级** | 调度/换班/多门店/设备围栏/人脸/算薪… | **2–4 月+** | 否，不一口吞（拆 3a 可建 / 3b 不自研，§6 末） |
 
@@ -322,7 +322,7 @@
 
 | 项 | 量 | 备注（含审计 `/tmp/attendance-scheduler-scope-enforcement-audit-20260601.md` 收紧） |
 |---|---|---|
-| scoped 非管理员真实 UX smoke | **0.5–1.5 天** | 必须 seed "**有 scope、无中央 `attendance:import`/`approve`**" 的子管理员——证明 scope 分支**可达、非死代码**（`fullImport`/`canAccessOtherUsers` 会短路）；并核 provisioning 不会给同一人同时发中央权限+scope（否则 scope 在 import/approve 上被静默忽略） |
+| scoped 非管理员真实 UX smoke | ✅ **closed 2026-06-26** | Real-DB route smoke seeds a scope-only actor with **no central `attendance:approve` / `attendance:import` / `attendance:admin` DB grants and no `admin` role**, proves no-scope approve 403 → scoped approve 200 → out-of-scope approve 403, and scoped `/api/attendance/import/prepare` 200; frontend regression also proves scheduler-scope creation does **not** call provisioning role/permission grant endpoints. This locks the `fullImport` / `canAccessOtherUsers` non-short-circuit branch as reachable. |
 | dept/roles/roleTags 真 picker | **0–4 天** | **roles/roleTags 当前无可枚举源**（开放词汇）→ 大概率停在 chips、性价比低、可不做；departments 若有部门树才值得做 |
 | async import/batches/rollback/templates/integrations 开放给 scoped actor | design-lock **0.5–1 天**；接线另 **3–6 天** | 当前是 `withAttendanceImportPermission`（中央权限）专属、自洽两层模型。**倾向 design-lock 拍板后 DEFER 接线**（YAGNI，除非客户明确要） |
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -15083,6 +15083,170 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('H1 scheduler-scope smoke keeps approve/import reachable for scope-only actors', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const orgId = 'default'
+    const actorId = `attendance-h1-scope-actor-${runSuffix}`
+    const targetId = `attendance-h1-scope-target-${runSuffix}`
+    const outsideTargetId = `attendance-h1-scope-outside-${runSuffix}`
+    const requestIds: string[] = []
+    const approvalIds: string[] = []
+    const scopeIds: string[] = []
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(actorId)}&roles=user&perms=attendance:read,attendance:write`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) {
+      await pool.end()
+      return
+    }
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+    const createPendingLeaveRequest = async (userId: string, workDate: string): Promise<string> => {
+      const approvalId = `attendance-h1-scope-approval-${randomUUID()}`
+      const requestId = randomUuidV4()
+      approvalIds.push(approvalId)
+      requestIds.push(requestId)
+      await pool.query(
+        `INSERT INTO approval_instances
+           (id, status, version, current_step, total_steps, current_node_key, metadata)
+         VALUES ($1, 'pending', 0, 0, 0, 'attendance_request_step_0', '{}'::jsonb)`,
+        [approvalId]
+      )
+      await pool.query(
+        `INSERT INTO attendance_requests
+           (id, org_id, user_id, work_date, request_type, status, reason, metadata, approval_instance_id)
+         VALUES ($1, $2, $3, $4, 'leave', 'pending', $5, $6::jsonb, $7)`,
+        [
+          requestId,
+          orgId,
+          userId,
+          workDate,
+          `H1 scheduler scope smoke ${runSuffix}`,
+          JSON.stringify({ minutes: 60, leaveType: { code: 'personal_leave' } }),
+          approvalId,
+        ]
+      )
+      return requestId
+    }
+
+    try {
+      process.env.RBAC_BYPASS = 'false'
+      await pool.query(
+        `INSERT INTO permissions (code, name, description)
+         VALUES
+           ('attendance:read', 'Attendance Read', 'Read attendance data'),
+           ('attendance:write', 'Attendance Write', 'Write attendance data'),
+           ('attendance:approve', 'Attendance Approve', 'Approve attendance requests'),
+           ('attendance:import', 'Attendance Import', 'Import attendance data'),
+           ('attendance:admin', 'Attendance Admin', 'Administer attendance')
+         ON CONFLICT (code) DO NOTHING`
+      )
+      await pool.query('DELETE FROM user_permissions WHERE user_id = $1', [actorId])
+      await pool.query('DELETE FROM user_roles WHERE user_id = $1', [actorId])
+
+      const centralGrantsBefore = await pool.query(
+        `SELECT permission_code
+         FROM user_permissions
+         WHERE user_id = $1
+           AND permission_code = ANY($2::text[])`,
+        [actorId, ['attendance:approve', 'attendance:import', 'attendance:admin']]
+      )
+      expect(centralGrantsBefore.rows).toHaveLength(0)
+      const adminRolesBefore = await pool.query(
+        `SELECT role_id FROM user_roles WHERE user_id = $1 AND role_id = 'admin'`,
+        [actorId]
+      )
+      expect(adminRolesBefore.rows).toHaveLength(0)
+
+      const targetRequestId = await createPendingLeaveRequest(targetId, '2036-06-26')
+      const noScopeApprove = await requestJson(`${baseUrl}/api/attendance/requests/${targetRequestId}/approve`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ comment: 'no scope yet' }),
+      })
+      expect(noScopeApprove.status, noScopeApprove.raw).toBe(403)
+      expect((noScopeApprove.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULER_SCOPE_FORBIDDEN')
+
+      const scopeId = randomUuidV4()
+      scopeIds.push(scopeId)
+      await pool.query(
+        `INSERT INTO attendance_scheduler_scopes
+           (id, org_id, subject_type, subject_ref, actions, scope, is_active, created_by, updated_by)
+         VALUES ($1, $2, 'user', $3, ARRAY['approve','import']::text[], $4::jsonb, true, 'integration-test', 'integration-test')`,
+        [scopeId, orgId, actorId, JSON.stringify({ userIds: [targetId] })]
+      )
+
+      const approveInsideScope = await requestJson(`${baseUrl}/api/attendance/requests/${targetRequestId}/approve`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ comment: 'scope-only approve' }),
+      })
+      expect(approveInsideScope.status, approveInsideScope.raw).toBe(200)
+      expect((approveInsideScope.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('approved')
+
+      const outsideRequestId = await createPendingLeaveRequest(outsideTargetId, '2036-06-27')
+      const approveOutsideScope = await requestJson(`${baseUrl}/api/attendance/requests/${outsideRequestId}/approve`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ comment: 'outside scope' }),
+      })
+      expect(approveOutsideScope.status, approveOutsideScope.raw).toBe(403)
+      expect((approveOutsideScope.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULER_SCOPE_FORBIDDEN')
+      const outsideStatus = (await pool.query('SELECT status FROM attendance_requests WHERE id = $1', [outsideRequestId])).rows[0]?.status
+      expect(outsideStatus).toBe('pending')
+
+      const prepareImport = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
+        method: 'POST',
+        headers,
+        body: '{}',
+      })
+      expect(prepareImport.status, prepareImport.raw).toBe(200)
+      expect((prepareImport.body as { data?: { commitToken?: string } } | undefined)?.data?.commitToken).toEqual(expect.any(String))
+
+      const centralGrantsAfter = await pool.query(
+        `SELECT permission_code
+         FROM user_permissions
+         WHERE user_id = $1
+           AND permission_code = ANY($2::text[])`,
+        [actorId, ['attendance:approve', 'attendance:import', 'attendance:admin']]
+      )
+      expect(centralGrantsAfter.rows).toHaveLength(0)
+      const adminRolesAfter = await pool.query(
+        `SELECT role_id FROM user_roles WHERE user_id = $1 AND role_id = 'admin'`,
+        [actorId]
+      )
+      expect(adminRolesAfter.rows).toHaveLength(0)
+    } finally {
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.query('DELETE FROM attendance_import_tokens WHERE user_id = $1', [actorId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_scheduler_scopes WHERE id = ANY($1::uuid[])', [scopeIds]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])', [[targetId, outsideTargetId]]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])', [[targetId, outsideTargetId]]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_events WHERE user_id = ANY($1::text[])', [[targetId, outsideTargetId]]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE user_id = ANY($1::text[])', [[targetId, outsideTargetId]]).catch(() => undefined)
+      if (requestIds.length) {
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [requestIds]).catch(() => undefined)
+      }
+      if (approvalIds.length) {
+        await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+        await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [approvalIds]).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM user_permissions WHERE user_id = $1', [actorId]).catch(() => undefined)
+      await pool.query('DELETE FROM user_roles WHERE user_id = $1', [actorId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('effective-calendar role/roleTags override matches DB-backed role context in resolver mode', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL


### PR DESCRIPTION
## Summary
- Adds an H1 scheduler-scope real-DB route smoke for a scope-only actor with no central `attendance:approve`, `attendance:import`, `attendance:admin`, or `admin` role grants.
- Proves the non-short-circuit branch: no-scope approval 403, scoped approval 200, out-of-scope approval 403, and scoped `/api/attendance/import/prepare` 200.
- Adds a frontend regression that scheduler-scope creation does not call provisioning role/permission grant endpoints, then marks the H1 smoke item closed in the attendance benchmark tracker.

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false` (93/93)
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --testNamePattern "H1 scheduler-scope smoke" --reporter=dot` (collected with the integration config; local DB env absent, so 136 skipped locally; CI attendance integration is the real DB gate)

## Notes
- Runtime code unchanged.
- This closes the tracker §4 H1 scoped non-admin smoke gap; remaining §4 items stay demand-gated.
