### PR TITLE
feat(attendance): reserve scheduler-scope remind action

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -10063,7 +10063,7 @@ type AttendanceSchedulerScopeForm = {
 const schedulerScopes = ref<AttendanceSchedulerScope[]>([])
 const schedulerScopesLoading = ref(false)
 const schedulerScopesTotal = ref(0)
-const ATTENDANCE_SCHEDULER_SCOPE_ALL_ACTIONS = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'] as const
+const ATTENDANCE_SCHEDULER_SCOPE_ALL_ACTIONS = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch', 'remind'] as const
 // Scheduler-scope form targets are arrays so the UI can render pickers/chips while preserving the
 // backend's six-key scope contract exactly.
 const schedulerScopeForm = reactive<AttendanceSchedulerScopeForm>({
@@ -24106,6 +24106,7 @@ const ATTENDANCE_SCHEDULER_SCOPE_ACTION_LABELS: Record<string, [string, string]>
   clear: ['Clear', '清空'],
   approve: ['Approve', '审批'],
   dispatch: ['Dispatch', '调度'],
+  remind: ['Remind', '提醒'],
 }
 function schedulerScopeActionLabel(action: string): string {
   const pair = ATTENDANCE_SCHEDULER_SCOPE_ACTION_LABELS[action]

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1429,6 +1429,11 @@ describe('Attendance admin regressions', () => {
     subjectRef.value = 'attendance_admin'
     subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
     section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="view"]')!.click()
+    await flushUi(1)
+    const remindAction = section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="remind"]')!
+    expect(remindAction.closest('label')?.textContent || '').toContain('Remind')
+    remindAction.click()
+    await flushUi(1)
 
     // Distinct sentinel per target field — catches a field wired to the wrong scope key
     // (the backend normalizer silently drops unknown keys; this is the A2 round-trip guard).
@@ -1457,7 +1462,7 @@ describe('Attendance admin regressions', () => {
     expect(created[0]).toEqual({
       subjectType: 'role',
       subjectRef: 'attendance_admin',
-      actions: ['view'],
+      actions: ['view', 'remind'],
       scope: {
         departments: ['dept-x'],
         attendanceGroupIds: ['group-a'],

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -168,10 +168,14 @@ describe('attendance advanced scheduling scope foundation', () => {
   })
 
   it('normalizes explicit scheduler actions and fails closed on empty scope', () => {
+    expect(helpers.ATTENDANCE_SCHEDULER_SCOPE_ACTIONS.has('remind')).toBe(true)
+    expect(pluginSource).toContain("const ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch', 'remind']")
+    expect(pluginSource).toContain('z.enum(ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES)')
+
     const scope = helpers.normalizeAttendanceSchedulerScopeInput({
       subjectType: 'role_tag',
       subjectRef: 'line_scheduler',
-      actions: ['view', 'edit'],
+      actions: ['view', 'edit', 'remind'],
       scope: {
         scheduleGroupIds: ['sg-1'],
         userIds: ['u-1', 'u-2'],
@@ -181,7 +185,7 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(scope).toEqual({
       subjectType: 'role_tag',
       subjectRef: 'line_scheduler',
-      actions: ['view', 'edit'],
+      actions: ['view', 'edit', 'remind'],
       scope: {
         scheduleGroupIds: ['sg-1'],
         attendanceGroupIds: [],
@@ -210,13 +214,19 @@ describe('attendance advanced scheduling scope foundation', () => {
       actions: ['view'],
       scope: {},
     })).toThrow(/scope must include at least one target/)
+    expect(() => helpers.normalizeAttendanceSchedulerScopeInput({
+      subjectType: 'user',
+      subjectRef: 'scheduler-1',
+      actions: ['notify'],
+      scope: { userIds: ['u-1'] },
+    })).toThrow(/actions must contain valid scheduler actions/)
   })
 
   it('matches scheduler scopes by actor subject, action, and target for runtime enforcement', () => {
     const scope = {
       subjectType: 'role_tag',
       subjectRef: 'line_scheduler',
-      actions: ['dispatch'],
+      actions: ['dispatch', 'remind'],
       scope: {
         scheduleGroupIds: ['sg-1'],
         attendanceGroupIds: [],
@@ -235,6 +245,10 @@ describe('attendance advanced scheduling scope foundation', () => {
 
     expect(helpers.attendanceSchedulerScopeMatchesActor(scope, actor)).toBe(true)
     expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget(scope, actor, 'dispatch', {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-1'],
+    })).toBe(true)
+    expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget(scope, actor, 'remind', {
       scheduleGroupIds: ['sg-1'],
       userIds: ['u-1'],
     })).toBe(true)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -94,7 +94,8 @@ const ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS = ['attendance:approve', 'attendance
 const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
 const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backup'])
 const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
-const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])
+const ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch', 'remind']
+const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES)
 const AUTO_SHIFT_AUTO_WRITE_SYSTEM_ROLE_TAG = 'system:attendance-auto-shift'
 const AUTO_SHIFT_AUTO_WRITE_SOURCE = 'scheduler'
 const ATTENDANCE_GROUP_TYPES = new Set(['fixed_shift', 'scheduled_shift', 'free_time'])
@@ -34682,7 +34683,7 @@ module.exports = {
     const schedulerScopeSchema = z.object({
       subjectType: z.enum(['user', 'role', 'role_tag']).optional(),
       subjectRef: z.string().min(1).optional(),
-      actions: z.array(z.enum(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])).optional(),
+      actions: z.array(z.enum(ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES)).optional(),
       scope: z.record(z.unknown()).optional(),
       isActive: z.boolean().optional(),
     }).strict()
@@ -34690,7 +34691,7 @@ module.exports = {
     const schedulerScopeCreateSchema = schedulerScopeSchema.extend({
       subjectType: z.enum(['user', 'role', 'role_tag']),
       subjectRef: z.string().min(1),
-      actions: z.array(z.enum(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])).min(1),
+      actions: z.array(z.enum(ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES)).min(1),
       scope: z.record(z.unknown()),
     })
 


### PR DESCRIPTION
## Summary
- reserve the scheduler-scope `remind` action for the manual missed-punch reminder line proposed in #3268
- share the backend action value list with the zod create/update schemas so CRUD and normalizer stay in lockstep
- expose `remind` in the admin scheduler-scope form with a localized label

## Scope
This is HMR-1 only. It does not add a reminder route, enqueue C5 deliveries, or change any existing `view/edit/import/export/clear/approve/dispatch` runtime behavior. It is stacked on #3268 and should land only after the design-lock is accepted.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (7/7)
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false` (93/93; existing WebSocket port/jsdom navigation warnings only)
- `pnpm --filter @metasheet/web exec vue-tsc -b`
- `git diff --check`

## Subagent Review
Faraday reviewed the diff and approved: backend allowlist + zod schemas accept `remind`, unknown actions still reject, frontend can select/render `remind`, and no route uses `action: 'remind'` yet.
