### PR TITLE
feat(attendance): enqueue missed-punch reminders

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -15907,7 +15907,7 @@ attendanceIntegrationDescribe(
         channel: 'dingtalk_work_notification',
         status: 'pending',
       })
-      expect(rows.rows[0].source_key).toBe(`manual_missed_punch_reminder:${idempotencyKey}:recipient:${workerId}`)
+      expect(rows.rows[0].source_key).toBe(`manual_missed_punch_reminder:${idempotencyKey}:recipient:${workerId}:channel:dingtalk_work_notification`)
       expect(rows.rows[0].payload).toMatchObject({
         kind: 'manual_missed_punch_reminder',
         body: 'Please submit a missed-punch request.',

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -15804,6 +15804,136 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('HMR-3: enqueues manual missed-punch reminders into the notification outbox idempotently', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const orgId = `hmr3-${runSuffix}`
+    const adminId = `hmr3-admin-${runSuffix}`
+    const workerId = `hmr3-worker-${runSuffix}`
+    const recordId = randomUUID()
+    const sourceBatchId = randomUUID()
+    const workDate = '2037-04-15'
+    const idempotencyKey = `hmr3-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const previousDefaultChannel = process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+    const pool = new Pool({ connectionString: dbUrl })
+
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      delete process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+      await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+      await pool.query(
+        `INSERT INTO attendance_records
+         (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'Asia/Shanghai', NULL, $5::timestamptz, 480, 0, 0, 'partial', true, $6::jsonb, $7, now(), now())`,
+        [
+          recordId,
+          workerId,
+          orgId,
+          workDate,
+          `${workDate}T10:00:00.000Z`,
+          JSON.stringify({ source: 'hmr3-integration' }),
+          sourceBatchId,
+        ],
+      )
+
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminId)}&roles=admin&perms=attendance:read,attendance:admin`,
+      )
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+      const payload = {
+        recordIds: [recordId],
+        message: 'Please submit a missed-punch request.',
+        idempotencyKey,
+      }
+
+      const first = await requestJson(`${baseUrl}/api/attendance/manual-missed-punch-reminders/enqueue?orgId=${encodeURIComponent(orgId)}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      expect(first.status, first.raw).toBe(202)
+      expect(first.body).toMatchObject({
+        ok: true,
+        data: {
+          channel: 'dingtalk_work_notification',
+          created: 1,
+          existing: 0,
+          candidates: [
+            {
+              recordId,
+              userId: workerId,
+              workDate,
+              missingSide: 'check_in',
+              selectedByDefault: true,
+            },
+          ],
+        },
+      })
+
+      await pool.query(
+        `UPDATE attendance_records
+         SET status = 'normal', first_in_at = $2::timestamptz, updated_at = now()
+         WHERE id = $1`,
+        [recordId, `${workDate}T01:00:00.000Z`],
+      )
+
+      const replay = await requestJson(`${baseUrl}/api/attendance/manual-missed-punch-reminders/enqueue?orgId=${encodeURIComponent(orgId)}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      })
+      expect(replay.status, replay.raw).toBe(202)
+      expect(replay.body).toMatchObject({ ok: true, data: { created: 0, existing: 1 } })
+
+      const rows = await pool.query(
+        `SELECT source_type, source_id, source_key, recipient_user_id, channel, status, payload
+         FROM attendance_notification_deliveries
+         WHERE org_id = $1
+         ORDER BY created_at ASC`,
+        [orgId],
+      )
+      expect(rows.rows).toHaveLength(1)
+      expect(rows.rows[0]).toMatchObject({
+        source_type: 'manual_missed_punch_reminder',
+        source_id: `manual_missed_punch_reminder:${idempotencyKey}`,
+        recipient_user_id: workerId,
+        channel: 'dingtalk_work_notification',
+        status: 'pending',
+      })
+      expect(rows.rows[0].source_key).toBe(`manual_missed_punch_reminder:${idempotencyKey}:recipient:${workerId}`)
+      expect(rows.rows[0].payload).toMatchObject({
+        kind: 'manual_missed_punch_reminder',
+        body: 'Please submit a missed-punch request.',
+        actorUserId: adminId,
+        recipientUserId: workerId,
+        recordIds: [recordId],
+        candidates: [
+          {
+            recordId,
+            userId: workerId,
+            workDate,
+            missingSide: 'check_in',
+          },
+        ],
+      })
+    } finally {
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      if (previousDefaultChannel === undefined) delete process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
+      else process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = previousDefaultChannel
+      await pool.query(`DELETE FROM attendance_notification_deliveries WHERE org_id = $1`, [orgId]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_records WHERE id = $1`, [recordId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   // #7 销假 (design-lock #3034) — §5 real-DB matrix: approve → deduct → cancel → reverse, idempotency, §3a expired.
   it('#7 销假 — cancelling an APPROVED comp_time leave reverses the deducted balance; idempotent; expired lot not resurrected', async () => {
     if (!baseUrl) return

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -8,6 +8,7 @@ type RouteHandler = (req: any, res: any, next: any) => Promise<void>
 
 const originalRbacBypass = process.env.RBAC_BYPASS
 const originalAsyncEnabled = process.env.ATTENDANCE_IMPORT_ASYNC_ENABLED
+const originalDefaultNotificationChannel = process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL
 
 function restoreEnv(name: string, value: string | undefined) {
   if (value === undefined) {
@@ -114,6 +115,9 @@ const rotationAssignmentId = '00000000-0000-4000-8000-000000000306'
 const attendanceGroupId = '00000000-0000-4000-8000-000000000307'
 const attendanceRequestId = '00000000-0000-4000-8000-000000000308'
 const approvalInstanceId = 'apv_00000000-0000-4000-8000-000000000309'
+const missedPunchRecordId = '00000000-0000-4000-8000-000000000310'
+const missedPunchAlphaRecordId = '00000000-0000-4000-8000-000000000abc'
+const missedPunchDeliveryId = '00000000-0000-4000-8000-000000000311'
 
 function scheduleGroupRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -491,6 +495,7 @@ function actorContextQueryResult(sql: string) {
 afterEach(async () => {
   restoreEnv('RBAC_BYPASS', originalRbacBypass)
   restoreEnv('ATTENDANCE_IMPORT_ASYNC_ENABLED', originalAsyncEnabled)
+  restoreEnv('ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL', originalDefaultNotificationChannel)
   await attendancePlugin.deactivate()
   vi.restoreAllMocks()
 })
@@ -2102,6 +2107,397 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(403)
     expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records r'))).toBe(false)
+  })
+
+  it('enqueues missed-punch reminders idempotently through the C5 outbox', async () => {
+    const { db, routes } = await createHarness('false')
+    let insertCalls = 0
+    let deliveryPayload: Record<string, unknown> | null = null
+    let sourceKey = ''
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_records r')) {
+        return [
+          attendanceRecordRow({
+            id: missedPunchRecordId,
+            status: 'partial',
+            first_in_at: null,
+            last_out_at: new Date('2026-06-10T18:00:00.000Z'),
+          }),
+        ]
+      }
+      if (sql.includes('FROM attendance_requests')) return []
+      if (sql.includes('INSERT INTO attendance_notification_deliveries')) {
+        insertCalls += 1
+        sourceKey = String(params[3])
+        deliveryPayload = JSON.parse(String(params[6])) as Record<string, unknown>
+        return insertCalls === 1 ? [{ id: missedPunchDeliveryId }] : []
+      }
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) {
+        return insertCalls > 0 ? [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-1',
+          source_key: sourceKey,
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'pending',
+          payload: deliveryPayload,
+        }] : []
+      }
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_key = ANY')) {
+        return [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-1',
+          source_key: sourceKey,
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'pending',
+          payload: deliveryPayload,
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const payload = {
+      recordIds: [missedPunchRecordId],
+      message: 'Please fix your missed punch.',
+      idempotencyKey: 'key-1',
+    }
+    const first = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: payload,
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+    expect(first.statusCode).toBe(202)
+    expect(first.body).toMatchObject({
+      ok: true,
+      data: {
+        created: 1,
+        existing: 0,
+        deliveries: [
+          {
+            id: missedPunchDeliveryId,
+            sourceType: 'manual_missed_punch_reminder',
+            recipientUserId: 'worker-1',
+            recipientRole: 'subject',
+            channel: 'dingtalk_work_notification',
+            status: 'pending',
+          },
+        ],
+      },
+    })
+    expect(deliveryPayload).toMatchObject({
+      kind: 'manual_missed_punch_reminder',
+      body: 'Please fix your missed punch.',
+      actorUserId: 'admin-1',
+      recipientUserId: 'worker-1',
+      recordIds: [missedPunchRecordId],
+    })
+
+    const replay = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: payload,
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+    expect(replay.statusCode).toBe(202)
+    expect(replay.body).toMatchObject({ ok: true, data: { created: 0, existing: 1 } })
+    expect(insertCalls).toBe(1)
+    expect(sourceKey).toBe('manual_missed_punch_reminder:key-1:recipient:worker-1')
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).filter(sql => sql.includes('FROM attendance_records r'))).toHaveLength(1)
+  })
+
+  it('replays existing missed-punch reminders even when the candidate is no longer remindable', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) {
+        return [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-1',
+          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1',
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'pending',
+          payload: {
+            kind: 'manual_missed_punch_reminder',
+            sourceType: 'manual_missed_punch_reminder',
+            idempotencyKey: 'key-1',
+            body: 'Please fix your missed punch.',
+            actorUserId: 'admin-1',
+            recipientUserId: 'worker-1',
+            recipientRole: 'subject',
+            channel: 'dingtalk_work_notification',
+            recordIds: [missedPunchRecordId],
+            candidates: [{ recordId: missedPunchRecordId, userId: 'worker-1', workDate: '2026-06-10', missingSide: 'check_in' }],
+          },
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const replay = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-1',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(replay.statusCode).toBe(202)
+    expect(replay.body).toMatchObject({ ok: true, data: { created: 0, existing: 1 } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records r'))).toBe(false)
+  })
+
+  it('normalizes missed-punch reminder record UUID casing for idempotent replay', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) {
+        return [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-alpha',
+          source_key: 'manual_missed_punch_reminder:key-alpha:recipient:worker-1',
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'pending',
+          payload: {
+            kind: 'manual_missed_punch_reminder',
+            sourceType: 'manual_missed_punch_reminder',
+            idempotencyKey: 'key-alpha',
+            body: 'Please fix your missed punch.',
+            actorUserId: 'admin-1',
+            recipientUserId: 'worker-1',
+            recipientRole: 'subject',
+            channel: 'dingtalk_work_notification',
+            recordIds: [missedPunchAlphaRecordId],
+            candidates: [{ recordId: missedPunchAlphaRecordId, userId: 'worker-1', workDate: '2026-06-10', missingSide: 'check_in' }],
+          },
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const replay = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchAlphaRecordId.toUpperCase()],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-alpha',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(replay.statusCode).toBe(202)
+    expect(replay.body).toMatchObject({ ok: true, data: { created: 0, existing: 1 } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records r'))).toBe(false)
+  })
+
+  it('routes missed-punch reminders through the configured default delivery channel allowlist', async () => {
+    process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = 'email_smtp'
+    const { db, routes } = await createHarness('false')
+    let insertedChannel = ''
+    let deliveryPayload: Record<string, unknown> | null = null
+    let sourceKey = ''
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_records r')) {
+        return [
+          attendanceRecordRow({
+            id: missedPunchRecordId,
+            status: 'absent',
+            first_in_at: null,
+            last_out_at: null,
+          }),
+        ]
+      }
+      if (sql.includes('FROM attendance_requests')) return []
+      if (sql.includes('INSERT INTO attendance_notification_deliveries')) {
+        sourceKey = String(params[3])
+        insertedChannel = String(params[5])
+        deliveryPayload = JSON.parse(String(params[6])) as Record<string, unknown>
+        return [{ id: missedPunchDeliveryId }]
+      }
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) {
+        return deliveryPayload ? [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-email',
+          source_key: sourceKey,
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: insertedChannel,
+          status: 'pending',
+          payload: deliveryPayload,
+        }] : []
+      }
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_key = ANY')) {
+        return [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-email',
+          source_key: sourceKey,
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: insertedChannel,
+          status: 'pending',
+          payload: deliveryPayload,
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-email',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(202)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        channel: 'email_smtp',
+        deliveries: [{ channel: 'email_smtp' }],
+      },
+    })
+    expect(insertedChannel).toBe('email_smtp')
+
+    process.env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL = 'not_supported'
+    const replay = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-email',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+    expect(replay.statusCode).toBe(202)
+    expect(replay.body).toMatchObject({ ok: true, data: { channel: 'email_smtp', created: 0, existing: 1 } })
+    expect(sourceKey).toBe('manual_missed_punch_reminder:key-email:recipient:worker-1')
+  })
+
+  it('rejects missed-punch reminder idempotency-key payload conflicts', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) {
+        return [{
+          id: missedPunchDeliveryId,
+          org_id: 'default',
+          source_type: 'manual_missed_punch_reminder',
+          source_id: 'manual_missed_punch_reminder:key-1',
+          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1',
+          recipient_user_id: 'worker-1',
+          recipient_role: 'subject',
+          channel: 'dingtalk_work_notification',
+          status: 'pending',
+          payload: { kind: 'manual_missed_punch_reminder', body: 'different' },
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-1',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'MISSED_PUNCH_REMINDER_IDEMPOTENCY_CONFLICT' } })
+  })
+
+  it('rejects stale missed-punch reminder candidates before writing deliveries', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) return []
+      if (sql.includes('FROM attendance_records r')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-1',
+      },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'MISSED_PUNCH_REMINDER_CANDIDATE_STALE' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_notification_deliveries'))).toBe(false)
+  })
+
+  it('rejects scoped missed-punch reminder enqueue outside remind scope before writing deliveries', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRemindRow()]
+      if (sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2')) return []
+      if (sql.includes('FROM attendance_records r')) {
+        return [
+          attendanceRecordRow({
+            id: missedPunchRecordId,
+            user_id: 'worker-2',
+            status: 'partial',
+            first_in_at: null,
+            last_out_at: '2026-06-10T18:00:00.000Z',
+          }),
+        ]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/manual-missed-punch-reminders/enqueue', {
+      body: {
+        recordIds: [missedPunchRecordId],
+        message: 'Please fix your missed punch.',
+        idempotencyKey: 'key-1',
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_notification_deliveries'))).toBe(false)
   })
 
   it('does not disclose schedule group lookup outside scoped view targets', async () => {

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -471,6 +471,7 @@ function fixedScheduleQueryResult(sql: string) {
 }
 
 function rbacQueryResult(sql: string, params: unknown[] = [], admin = false) {
+  if (sql.includes('pg_advisory_xact_lock')) return []
   if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return admin ? [{ ok: 1 }] : []
   if (sql.includes('FROM user_permissions')) return []
   if (sql.includes('JOIN role_permissions')) return []
@@ -2208,8 +2209,14 @@ describe('attendance UUID route validation', () => {
     expect(replay.statusCode).toBe(202)
     expect(replay.body).toMatchObject({ ok: true, data: { created: 0, existing: 1 } })
     expect(insertCalls).toBe(1)
-    expect(sourceKey).toBe('manual_missed_punch_reminder:key-1:recipient:worker-1')
-    expect(db.query.mock.calls.map(([sql]) => String(sql)).filter(sql => sql.includes('FROM attendance_records r'))).toHaveLength(1)
+    expect(sourceKey).toBe('manual_missed_punch_reminder:key-1:recipient:worker-1:channel:dingtalk_work_notification')
+    const sqlCalls = db.query.mock.calls.map(([sql]) => String(sql))
+    const lockIndex = sqlCalls.findIndex(sql => sql.includes('pg_advisory_xact_lock'))
+    const sourceReplayIndex = sqlCalls.findIndex(sql => sql.includes('FROM attendance_notification_deliveries') && sql.includes('source_type = $2'))
+    expect(lockIndex).toBeGreaterThanOrEqual(0)
+    expect(sourceReplayIndex).toBeGreaterThan(lockIndex)
+    expect(sqlCalls.filter(sql => sql.includes('FROM attendance_records r'))).toHaveLength(1)
+    expect(sqlCalls.find(sql => sql.includes('FROM attendance_records r'))).toContain('FOR UPDATE OF r')
   })
 
   it('replays existing missed-punch reminders even when the candidate is no longer remindable', async () => {
@@ -2224,7 +2231,7 @@ describe('attendance UUID route validation', () => {
           org_id: 'default',
           source_type: 'manual_missed_punch_reminder',
           source_id: 'manual_missed_punch_reminder:key-1',
-          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1',
+          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1:channel:dingtalk_work_notification',
           recipient_user_id: 'worker-1',
           recipient_role: 'subject',
           channel: 'dingtalk_work_notification',
@@ -2272,7 +2279,7 @@ describe('attendance UUID route validation', () => {
           org_id: 'default',
           source_type: 'manual_missed_punch_reminder',
           source_id: 'manual_missed_punch_reminder:key-alpha',
-          source_key: 'manual_missed_punch_reminder:key-alpha:recipient:worker-1',
+          source_key: 'manual_missed_punch_reminder:key-alpha:recipient:worker-1:channel:dingtalk_work_notification',
           recipient_user_id: 'worker-1',
           recipient_role: 'subject',
           channel: 'dingtalk_work_notification',
@@ -2396,7 +2403,7 @@ describe('attendance UUID route validation', () => {
     })
     expect(replay.statusCode).toBe(202)
     expect(replay.body).toMatchObject({ ok: true, data: { channel: 'email_smtp', created: 0, existing: 1 } })
-    expect(sourceKey).toBe('manual_missed_punch_reminder:key-email:recipient:worker-1')
+    expect(sourceKey).toBe('manual_missed_punch_reminder:key-email:recipient:worker-1:channel:email_smtp')
   })
 
   it('rejects missed-punch reminder idempotency-key payload conflicts', async () => {
@@ -2411,7 +2418,7 @@ describe('attendance UUID route validation', () => {
           org_id: 'default',
           source_type: 'manual_missed_punch_reminder',
           source_id: 'manual_missed_punch_reminder:key-1',
-          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1',
+          source_key: 'manual_missed_punch_reminder:key-1:recipient:worker-1:channel:dingtalk_work_notification',
           recipient_user_id: 'worker-1',
           recipient_role: 'subject',
           channel: 'dingtalk_work_notification',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -56,6 +56,27 @@ function computeLateTierCounts(lateMinutes, rule) {
     absenceLateCount,
   }
 }
+
+function resolveAttendanceDefaultDeliveryChannelForProducer(env = process.env) {
+  const configured = String(env.ATTENDANCE_NOTIFICATION_DEFAULT_CHANNEL ?? '').trim()
+  return ATTENDANCE_ROUTABLE_DEFAULT_DELIVERY_CHANNELS.has(configured)
+    ? configured
+    : ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL
+}
+
+function stableJsonValue(value) {
+  if (Array.isArray(value)) return value.map(stableJsonValue)
+  if (value instanceof Date) return value.toISOString()
+  if (!value || typeof value !== 'object') return value
+  const out = {}
+  for (const key of Object.keys(value).sort()) out[key] = stableJsonValue(value[key])
+  return out
+}
+
+function stableJsonString(value) {
+  return JSON.stringify(stableJsonValue(value))
+}
+
 const DEFAULT_SHIFT = {
   orgId: DEFAULT_ORG_ID,
   name: 'Standard Shift',
@@ -96,6 +117,9 @@ const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backu
 const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
 const ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch', 'remind']
 const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(ATTENDANCE_SCHEDULER_SCOPE_ACTION_VALUES)
+const ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL = 'dingtalk_work_notification'
+const ATTENDANCE_ROUTABLE_DEFAULT_DELIVERY_CHANNELS = new Set([ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL, 'email_smtp'])
+const MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE = 'manual_missed_punch_reminder'
 const AUTO_SHIFT_AUTO_WRITE_SYSTEM_ROLE_TAG = 'system:attendance-auto-shift'
 const AUTO_SHIFT_AUTO_WRITE_SOURCE = 'scheduler'
 const ATTENDANCE_GROUP_TYPES = new Set(['fixed_shift', 'scheduled_shift', 'free_time'])
@@ -22888,6 +22912,94 @@ module.exports = {
 	      handleAttendanceRecordsGet
 	    )
 
+	    const resolveManualMissedPunchReminderMissingSide = (row) => {
+	      const status = String(row?.status ?? '')
+	      if (status === 'absent') return 'both'
+	      if (status !== 'partial') return null
+	      const missingIn = !row.first_in_at
+	      const missingOut = !row.last_out_at
+	      if (missingIn && missingOut) return 'both'
+	      if (missingIn) return 'check_in'
+	      if (missingOut) return 'check_out'
+	      return null
+	    }
+
+	    const summarizeManualMissedPunchReminderRequest = (row) => row ? {
+	      id: row.id,
+	      status: row.status,
+	      requestType: row.request_type,
+	    } : null
+
+	    const normalizeReminderTimestamp = (value) => {
+	      if (value instanceof Date) return value.toISOString()
+	      return value ?? null
+	    }
+
+	    const buildManualMissedPunchReminderCandidateItem = ({ row, missingSide, requestSummary }) => {
+	      const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
+	      const summary = requestSummary ?? { hasPending: false, pending: null, latest: null }
+	      return {
+	        recordId: row.id,
+	        userId: row.user_id,
+	        workDate,
+	        status: row.status,
+	        missingSide,
+	        firstInAt: normalizeReminderTimestamp(row.first_in_at),
+	        lastOutAt: normalizeReminderTimestamp(row.last_out_at),
+	        pendingRequest: summary.pending,
+	        latestRequest: summary.latest,
+	        selectedByDefault: !summary.hasPending,
+	      }
+	    }
+
+	    async function filterManualMissedPunchReminderCandidatesByScope(client, orgId, access, candidateRows) {
+	      const actorContext = access.access.fullAdmin
+	        ? null
+	        : await loadAttendanceScopeContextForUser(client, orgId, access.access.userId)
+	      const scopedRows = []
+	      for (const row of candidateRows) {
+	        const missingSide = resolveManualMissedPunchReminderMissingSide(row)
+	        if (!missingSide) continue
+	        if (access.access.fullAdmin) {
+	          scopedRows.push({ row, missingSide })
+	          continue
+	        }
+	        const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
+	        const facts = await resolveAttendanceUserSchedulerScopeFacts(client, orgId, row.user_id, { workDate })
+	        const allowed = access.scopes.some(scope =>
+	          attendanceSchedulerScopeAllowsActorActionFacts(scope, actorContext, 'remind', facts)
+	        )
+	        if (allowed) scopedRows.push({ row, missingSide })
+	      }
+	      return scopedRows
+	    }
+
+	    async function loadManualMissedPunchReminderRequestSummary(client, orgId, userIds, from, to) {
+	      const requestByUserDate = new Map()
+	      if (!userIds.length) return requestByUserDate
+	      const requestRows = await client.query(
+	        `SELECT id, user_id, work_date, request_type, status
+	         FROM attendance_requests
+	         WHERE org_id = $1
+	           AND user_id = ANY($2::text[])
+	           AND work_date BETWEEN $3::date AND $4::date
+	         ORDER BY user_id ASC, work_date DESC, created_at DESC`,
+	        [orgId, userIds, from, to]
+	      )
+	      for (const requestRow of requestRows) {
+	        const workDate = normalizeDateOnly(requestRow.work_date) ?? String(requestRow.work_date ?? '').slice(0, 10)
+	        const key = `${requestRow.user_id}:${workDate}`
+	        const entry = requestByUserDate.get(key) ?? { hasPending: false, pending: null, latest: null }
+	        if (!entry.latest) entry.latest = summarizeManualMissedPunchReminderRequest(requestRow)
+	        if (requestRow.status === 'pending') {
+	          entry.hasPending = true
+	          if (!entry.pending) entry.pending = summarizeManualMissedPunchReminderRequest(requestRow)
+	        }
+	        requestByUserDate.set(key, entry)
+	      }
+	      return requestByUserDate
+	    }
+
 	    context.api.http.addRoute(
 	      'GET',
 	      '/api/attendance/manual-missed-punch-reminders/candidates',
@@ -22926,24 +23038,6 @@ module.exports = {
 	          return
 	        }
 
-	        const resolveMissingSide = (row) => {
-	          const status = String(row?.status ?? '')
-	          if (status === 'absent') return 'both'
-	          if (status !== 'partial') return null
-	          const missingIn = !row.first_in_at
-	          const missingOut = !row.last_out_at
-	          if (missingIn && missingOut) return 'both'
-	          if (missingIn) return 'check_in'
-	          if (missingOut) return 'check_out'
-	          return null
-	        }
-
-	        const summarizeRequest = (row) => row ? {
-	          id: row.id,
-	          status: row.status,
-	          requestType: row.request_type,
-	        } : null
-
 	        try {
 	          const params = [orgId, from, to]
 	          const userClause = parsed.data.userId ? `AND r.user_id = $${params.push(parsed.data.userId)}` : ''
@@ -22962,67 +23056,17 @@ module.exports = {
 	            params
 	          )
 
-	          const actorContext = access.access.fullAdmin
-	            ? null
-	            : await loadAttendanceScopeContextForUser(db, orgId, access.access.userId)
-	          const scopedRows = []
-	          for (const row of candidateRows) {
-	            const missingSide = resolveMissingSide(row)
-	            if (!missingSide) continue
-	            if (access.access.fullAdmin) {
-	              scopedRows.push({ row, missingSide })
-	              continue
-	            }
-	            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
-	            const facts = await resolveAttendanceUserSchedulerScopeFacts(db, orgId, row.user_id, { workDate })
-	            const allowed = access.scopes.some(scope =>
-	              attendanceSchedulerScopeAllowsActorActionFacts(scope, actorContext, 'remind', facts)
-	            )
-	            if (allowed) scopedRows.push({ row, missingSide })
-	          }
+	          const scopedRows = await filterManualMissedPunchReminderCandidatesByScope(db, orgId, access, candidateRows)
 
 	          const total = scopedRows.length
 	          const pageRows = scopedRows.slice(offset, offset + pageSize)
 	          const pageUserIds = sortedUnique(pageRows.map(({ row }) => row.user_id))
-	          const requestByUserDate = new Map()
-	          if (pageUserIds.length) {
-	            const requestRows = await db.query(
-	              `SELECT id, user_id, work_date, request_type, status
-	               FROM attendance_requests
-	               WHERE org_id = $1
-	                 AND user_id = ANY($2::text[])
-	                 AND work_date BETWEEN $3::date AND $4::date
-	               ORDER BY user_id ASC, work_date DESC, created_at DESC`,
-	              [orgId, pageUserIds, from, to]
-	            )
-	            for (const requestRow of requestRows) {
-	              const workDate = normalizeDateOnly(requestRow.work_date) ?? String(requestRow.work_date ?? '').slice(0, 10)
-	              const key = `${requestRow.user_id}:${workDate}`
-	              const entry = requestByUserDate.get(key) ?? { hasPending: false, pending: null, latest: null }
-	              if (!entry.latest) entry.latest = summarizeRequest(requestRow)
-	              if (requestRow.status === 'pending') {
-	                entry.hasPending = true
-	                if (!entry.pending) entry.pending = summarizeRequest(requestRow)
-	              }
-	              requestByUserDate.set(key, entry)
-	            }
-	          }
+	          const requestByUserDate = await loadManualMissedPunchReminderRequestSummary(db, orgId, pageUserIds, from, to)
 
 	          const items = pageRows.map(({ row, missingSide }) => {
 	            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
 	            const requestSummary = requestByUserDate.get(`${row.user_id}:${workDate}`) ?? { hasPending: false, pending: null, latest: null }
-	            return {
-	              recordId: row.id,
-	              userId: row.user_id,
-	              workDate,
-	              status: row.status,
-	              missingSide,
-	              firstInAt: row.first_in_at,
-	              lastOutAt: row.last_out_at,
-	              pendingRequest: requestSummary.pending,
-	              latestRequest: requestSummary.latest,
-	              selectedByDefault: !requestSummary.hasPending,
-	            }
+	            return buildManualMissedPunchReminderCandidateItem({ row, missingSide, requestSummary })
 	          })
 
 	          res.json({
@@ -23047,6 +23091,232 @@ module.exports = {
 	          }
 	          logger.error('Attendance manual missed-punch reminder candidates query failed', error)
 	          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load manual missed-punch reminder candidates' } })
+	        }
+	      }
+	    )
+
+	    context.api.http.addRoute(
+	      'POST',
+	      '/api/attendance/manual-missed-punch-reminders/enqueue',
+	      async (req, res) => {
+	        const schema = z.object({
+	          recordIds: z.array(z.string().min(1)).min(1).max(50),
+	          message: z.string().min(1).max(500),
+	          idempotencyKey: z.string().min(1).max(200),
+	        }).strict()
+
+	        const parsed = schema.safeParse(req.body ?? {})
+	        if (!parsed.success) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+	          return
+	        }
+
+	        const normalizedRecordIds = parsed.data.recordIds.map(value => {
+	          const normalized = normalizeUuidString(value)
+	          return normalized ? normalized.toLowerCase() : null
+	        })
+	        if (normalizedRecordIds.some(value => !value)) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'recordIds must contain valid UUIDs' } })
+	          return
+	        }
+	        const recordIds = sortedUnique(normalizedRecordIds)
+
+	        const orgId = getOrgId(req)
+	        const actorId = getUserId(req)
+	        if (!actorId) {
+	          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+	          return
+	        }
+	        const access = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'remind' })
+	        if (!access) return
+	        if (!access.access.fullAdmin && access.scopes.length === 0) {
+	          respondAttendanceSchedulerScopeForbidden(res)
+	          return
+	        }
+
+	        const message = parsed.data.message.trim()
+	        if (!message) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'message is required' } })
+	          return
+	        }
+	        const idempotencyKey = parsed.data.idempotencyKey.trim()
+	        if (!idempotencyKey) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'idempotencyKey is required' } })
+	          return
+	        }
+	        const channel = resolveAttendanceDefaultDeliveryChannelForProducer()
+	        const sourceId = `${MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE}:${idempotencyKey}`
+	        const buildExistingReminderReplay = (deliveryRows) => {
+	          const existingCandidates = []
+	          const existingRecordIds = []
+	          let existingChannel = null
+	          for (const row of deliveryRows) {
+	            const payload = normalizeMetadata(row.payload)
+	            if (
+	              payload?.kind !== MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE
+	              || payload?.sourceType !== MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE
+	              || payload?.idempotencyKey !== idempotencyKey
+	              || payload?.actorUserId !== actorId
+	              || payload?.body !== message
+	            ) {
+	              throw new HttpError(409, 'MISSED_PUNCH_REMINDER_IDEMPOTENCY_CONFLICT', 'idempotencyKey was already used for a different missed-punch reminder payload')
+	            }
+	            if (!existingChannel) existingChannel = row.channel
+	            if (Array.isArray(payload.candidates)) existingCandidates.push(...payload.candidates)
+	            if (Array.isArray(payload.recordIds)) existingRecordIds.push(...payload.recordIds)
+	          }
+	          const normalizedExistingRecordIds = sortedUnique(existingRecordIds.map(value => String(value).toLowerCase()))
+	          if (stableJsonString(normalizedExistingRecordIds) !== stableJsonString(recordIds)) {
+	            throw new HttpError(409, 'MISSED_PUNCH_REMINDER_IDEMPOTENCY_CONFLICT', 'idempotencyKey was already used for a different missed-punch reminder payload')
+	          }
+	          return {
+	            channel: existingChannel ?? channel,
+	            candidates: existingCandidates.sort((left, right) => `${left.userId}:${left.workDate}:${left.recordId}`.localeCompare(`${right.userId}:${right.workDate}:${right.recordId}`)),
+	            deliveries: deliveryRows.map(mapAttendanceNotificationDeliveryRow),
+	            created: 0,
+	            existing: deliveryRows.length,
+	          }
+	        }
+
+	        try {
+	          const result = await db.transaction(async (trx) => {
+	            const existingSourceRows = await trx.query(
+	              `SELECT *
+	               FROM attendance_notification_deliveries
+	               WHERE org_id = $1
+	                 AND source_type = $2
+	                 AND source_id = $3
+	               ORDER BY recipient_user_id ASC`,
+	              [orgId, MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE, sourceId]
+	            )
+	            if (existingSourceRows.length) {
+	              return buildExistingReminderReplay(existingSourceRows)
+	            }
+
+	            const candidateRows = await trx.query(
+	              `SELECT r.*
+	               FROM attendance_records r
+	               WHERE r.org_id = $1
+	                 AND r.id = ANY($2::uuid[])
+	                 AND COALESCE(r.is_workday, true) = true
+	                 AND (
+	                   (r.status = 'partial' AND (r.first_in_at IS NULL OR r.last_out_at IS NULL))
+	                   OR r.status = 'absent'
+	                 )
+	               ORDER BY r.work_date DESC, r.user_id ASC, r.id ASC`,
+	              [orgId, recordIds]
+	            )
+	            if (candidateRows.length !== recordIds.length) {
+	              throw new HttpError(409, 'MISSED_PUNCH_REMINDER_CANDIDATE_STALE', 'One or more missed-punch candidates are no longer remindable')
+	            }
+
+	            const scopedRows = await filterManualMissedPunchReminderCandidatesByScope(trx, orgId, access, candidateRows)
+	            if (scopedRows.length !== candidateRows.length) {
+	              throw new HttpError(403, 'SCHEDULER_SCOPE_FORBIDDEN', 'Scheduler scope does not allow this missed-punch reminder target')
+	            }
+
+	            const workDates = scopedRows
+	              .map(({ row }) => normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10))
+	              .filter(Boolean)
+	              .sort()
+	            const from = workDates[0]
+	            const to = workDates[workDates.length - 1]
+	            const pageUserIds = sortedUnique(scopedRows.map(({ row }) => row.user_id))
+	            const requestByUserDate = await loadManualMissedPunchReminderRequestSummary(trx, orgId, pageUserIds, from, to)
+	            const items = scopedRows
+	              .map(({ row, missingSide }) => {
+	                const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
+	                const requestSummary = requestByUserDate.get(`${row.user_id}:${workDate}`) ?? { hasPending: false, pending: null, latest: null }
+	                return buildManualMissedPunchReminderCandidateItem({ row, missingSide, requestSummary })
+	              })
+	              .sort((left, right) => `${left.userId}:${left.workDate}:${left.recordId}`.localeCompare(`${right.userId}:${right.workDate}:${right.recordId}`))
+
+	            const itemsByUser = new Map()
+	            for (const item of items) {
+	              if (!itemsByUser.has(item.userId)) itemsByUser.set(item.userId, [])
+	              itemsByUser.get(item.userId).push(item)
+	            }
+
+	            const desiredRows = [...itemsByUser.entries()].map(([recipientUserId, candidates]) => {
+	              const payload = {
+	                kind: MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE,
+	                title: 'Missed punch reminder',
+	                body: message,
+	                sourceType: MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE,
+	                idempotencyKey,
+	                actorUserId: actorId,
+	                recipientUserId,
+	                recipientRole: 'subject',
+	                channel,
+	                recordIds: candidates.map(item => item.recordId),
+	                candidates,
+	              }
+	              return {
+	                sourceKey: `${MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE}:${idempotencyKey}:recipient:${recipientUserId}`,
+	                recipientUserId,
+	                payload,
+	              }
+	            })
+
+	            const insertedIds = new Set()
+	            for (const desired of desiredRows) {
+	              const insertedRows = await trx.query(
+	                `INSERT INTO attendance_notification_deliveries
+	                 (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, payload)
+	                 VALUES ($1, $2, $3, $4, $5, 'subject', $6, 'pending', $7::jsonb)
+	                 ON CONFLICT (org_id, source_key) DO NOTHING
+	                 RETURNING id`,
+	                [
+	                  orgId,
+	                  MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE,
+	                  sourceId,
+	                  desired.sourceKey,
+	                  desired.recipientUserId,
+	                  channel,
+	                  JSON.stringify(desired.payload),
+	                ]
+	              )
+	              for (const row of insertedRows) insertedIds.add(row.id)
+	            }
+
+	            const deliveryRows = await trx.query(
+	              `SELECT *
+	               FROM attendance_notification_deliveries
+	               WHERE org_id = $1
+	                 AND source_key = ANY($2::text[])
+	               ORDER BY recipient_user_id ASC`,
+	              [orgId, desiredRows.map(row => row.sourceKey)]
+	            )
+	            const bySourceKey = new Map(deliveryRows.map(row => [row.source_key, row]))
+	            for (const desired of desiredRows) {
+	              const existing = bySourceKey.get(desired.sourceKey)
+	              if (!existing) {
+	                throw new HttpError(500, 'INTERNAL_ERROR', 'Failed to record missed-punch reminder delivery')
+	              }
+	            }
+	            const replay = buildExistingReminderReplay(deliveryRows)
+
+	            return {
+	              channel: replay.channel,
+	              candidates: replay.candidates,
+	              deliveries: replay.deliveries,
+	              created: deliveryRows.filter(row => insertedIds.has(row.id)).length,
+	              existing: deliveryRows.filter(row => !insertedIds.has(row.id)).length,
+	            }
+	          })
+
+	          res.status(202).json({ ok: true, data: result })
+	        } catch (error) {
+	          if (error instanceof HttpError) {
+	            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+	            return
+	          }
+	          if (isDatabaseSchemaError(error)) {
+	            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance notification delivery table missing' } })
+	            return
+	          }
+	          logger.error('Attendance manual missed-punch reminder enqueue failed', error)
+	          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to enqueue manual missed-punch reminders' } })
 	        }
 	      }
 	    )

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -23180,6 +23180,11 @@ module.exports = {
 
 	        try {
 	          const result = await db.transaction(async (trx) => {
+	            // Serialize the whole idempotency group before looking for source_id rows.
+	            await trx.query(
+	              'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+	              [orgId, sourceId]
+	            )
 	            const existingSourceRows = await trx.query(
 	              `SELECT *
 	               FROM attendance_notification_deliveries
@@ -23203,7 +23208,8 @@ module.exports = {
 	                   (r.status = 'partial' AND (r.first_in_at IS NULL OR r.last_out_at IS NULL))
 	                   OR r.status = 'absent'
 	                 )
-	               ORDER BY r.work_date DESC, r.user_id ASC, r.id ASC`,
+	               ORDER BY r.work_date DESC, r.user_id ASC, r.id ASC
+	               FOR UPDATE OF r`,
 	              [orgId, recordIds]
 	            )
 	            if (candidateRows.length !== recordIds.length) {
@@ -23252,7 +23258,7 @@ module.exports = {
 	                candidates,
 	              }
 	              return {
-	                sourceKey: `${MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE}:${idempotencyKey}:recipient:${recipientUserId}`,
+	                sourceKey: `${MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE}:${idempotencyKey}:recipient:${recipientUserId}:channel:${channel}`,
 	                recipientUserId,
 	                payload,
 	              }


### PR DESCRIPTION
## Summary
- adds `POST /api/attendance/manual-missed-punch-reminders/enqueue`
- writes one C5 notification-outbox delivery per recipient user for selected missed-punch candidates
- enforces scheduler-scope `remind` authorization, stale-candidate blocking, and idempotent replay/conflict semantics
- routes through the default delivery channel allowlist (`dingtalk_work_notification` / `email_smtp`) without letting channel changes duplicate an idempotency group

## Stack
- base: `codex/attendance-manual-reminder-candidates-hmr2-20260626` (#3270)
- previous slices: #3268 → #3269 → #3270 → this PR

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false` (65/65)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (7/7)
- `pnpm --filter @metasheet/core-backend type-check`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --watch=false -t "HMR-3"` (collected; local DB env absent so suite skipped locally; CI attendance integration owns the real-DB execution)

## Review notes
- subagent review caught and re-reviewed fixes for Date JSONB fingerprinting, stale replay after the candidate becomes non-remindable, UUID casing, and channel drift/concurrency duplicate risk
- final subagent verdict: APPROVE
