### PR TITLE
feat(attendance): add self-service rules read endpoint

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5482,6 +5482,168 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('attendance rules /me — returns a token-subject rule summary, rejects overrides, and does not leak admin settings', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const meId = `rules-me-${runSuffix}`
+    const otherId = `rules-me-other-${runSuffix}`
+    const adminId = `rules-me-admin-${runSuffix}`
+    const ruleSetId = randomUuidV4()
+    const attendanceGroupId = randomUuidV4()
+    const scheduleGroupAId = randomUuidV4()
+    const scheduleGroupBId = randomUuidV4()
+    const asOf = '2026-06-15'
+    const adminTokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminId)}&tenantId=default&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+    const employeeTokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(meId)}&tenantId=default&roles=employee&perms=attendance:read`)
+    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+    const employeeToken = (employeeTokenRes.body as { token?: string } | undefined)?.token
+    expect(adminToken).toBeTruthy()
+    expect(employeeToken).toBeTruthy()
+    if (!adminToken || !employeeToken) { await pool.end().catch(() => undefined); return }
+    const adminHeaders = { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' }
+    const headers = { Authorization: `Bearer ${employeeToken}` }
+    const originalSettingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${adminToken}` } })
+    const originalSettings = (originalSettingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}
+    try {
+      await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          punchPolicy: {
+            unscheduled: { mode: 'block' },
+            merge: { internalWinsOnIn: true, externalWinsOnOut: true },
+            outdoor: { requireApproval: true, requireNote: true, approvalFlowId: `secret-flow-${runSuffix}` },
+          },
+          geoFence: { lat: 31.23, lng: 121.47, radiusMeters: 300 },
+        }),
+      })
+      await pool.query(
+        `INSERT INTO users (id, email, name, password_hash, is_active)
+         VALUES ($1, $2, $3, 'no-login', true), ($4, $5, $6, 'no-login', true)
+         ON CONFLICT (id) DO UPDATE SET is_active = true`,
+        [meId, `${meId}@example.com`, meId, otherId, `${otherId}@example.com`, otherId],
+      )
+      await pool.query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active)
+         VALUES ($1, 'default', true), ($2, 'default', true)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = true`,
+        [meId, otherId],
+      )
+      await pool.query(
+        `INSERT INTO attendance_rule_sets (id, org_id, name, version, scope, config, is_default)
+         VALUES ($1, 'default', $2, 1, 'org', $3::jsonb, false)`,
+        [ruleSetId, `Rules Me Rule Set ${runSuffix}`, JSON.stringify({ source: 'manual', sensitive: `rule-set-secret-${runSuffix}` })],
+      )
+      await pool.query(
+        `INSERT INTO attendance_groups (id, org_id, name, code, timezone, rule_set_id, attendance_type, created_at, updated_at)
+         VALUES ($1, 'default', $2, $3, 'Asia/Shanghai', $4, 'scheduled_shift', now(), now())`,
+        [attendanceGroupId, `Rules Me Group ${runSuffix}`, `rules-me-${runSuffix}`, ruleSetId],
+      )
+      await pool.query(
+        `INSERT INTO attendance_group_members (org_id, group_id, user_id, created_at, updated_at)
+         VALUES ('default', $1, $2, now(), now())`,
+        [attendanceGroupId, meId],
+      )
+      await pool.query(
+        `INSERT INTO attendance_schedule_groups
+           (id, org_id, name, code, attendance_group_id, department_ref, source, is_active, created_by, updated_by, created_at, updated_at)
+         VALUES
+           ($1, 'default', $2, $3, $7, 'dept-a', 'manual', true, $8, $8, now(), now()),
+           ($4, 'default', $5, $6, $7, 'dept-b', 'manual', true, $8, $8, now(), now())`,
+        [
+          scheduleGroupAId,
+          `Rules Me Schedule A ${runSuffix}`,
+          `rules-me-sga-${runSuffix}`,
+          scheduleGroupBId,
+          `Rules Me Schedule B ${runSuffix}`,
+          `rules-me-sgb-${runSuffix}`,
+          attendanceGroupId,
+          adminId,
+        ],
+      )
+      await pool.query(
+        `INSERT INTO attendance_schedule_group_members
+           (org_id, schedule_group_id, user_id, effective_from, effective_to, role, source, created_by, updated_by, created_at, updated_at)
+         VALUES
+           ('default', $1, $3, '2026-01-01', '2026-12-31', 'member', 'manual', $4, $4, now(), now()),
+           ('default', $2, $3, '2026-06-01', '2026-06-30', 'backup', 'manual', $4, $4, now(), now())`,
+        [scheduleGroupAId, scheduleGroupBId, meId, adminId],
+      )
+
+      const res = await requestJson(`${baseUrl}/api/attendance/rules/me?asOf=${asOf}`, { headers })
+      expect(res.status, res.raw).toBe(200)
+      const data = (res.body as { data?: Record<string, unknown> } | undefined)?.data as {
+        userId?: string
+        orgId?: string
+        resolvedForDate?: string
+        assignment?: {
+          attendanceGroups?: Array<Record<string, unknown>>
+          scheduleGroups?: Array<Record<string, unknown>>
+        }
+        runtimeRule?: Record<string, unknown>
+        configuredGroupRule?: Record<string, unknown>
+        punchPolicy?: Record<string, unknown>
+        warnings?: Array<{ code?: string }>
+      } | undefined
+      expect(data?.userId).toBe(meId)
+      expect(data?.orgId).toBe('default')
+      expect(data?.resolvedForDate).toBe(asOf)
+      expect(data?.assignment?.attendanceGroups).toHaveLength(1)
+      expect(data?.assignment?.attendanceGroups?.[0]).toMatchObject({
+        id: attendanceGroupId,
+        attendanceType: 'scheduled_shift',
+        ruleSetId,
+      })
+      expect(data?.assignment?.scheduleGroups).toHaveLength(2)
+      expect(data?.runtimeRule).toMatchObject({ source: 'rule', timezone: expect.any(String) })
+      expect(data?.configuredGroupRule).toMatchObject({ groupId: attendanceGroupId, ruleSetId, enforcement: 'not_user_calc_chain' })
+      expect(data?.punchPolicy).toMatchObject({
+        source: 'org_settings',
+        unscheduledMode: 'block',
+        outdoorApprovalRequired: true,
+        outdoorNoteRequired: true,
+        merge: { internalWinsOnIn: true, externalWinsOnOut: true },
+      })
+      const warningCodes = new Set((data?.warnings ?? []).map((warning: { code?: string }) => warning.code))
+      expect(warningCodes.has('MULTIPLE_SCHEDULE_GROUPS')).toBe(true)
+      expect(warningCodes.has('SCHEDULE_GROUP_WINDOW_OVERLAP')).toBe(true)
+      expect(warningCodes.has('GROUP_RULE_SET_PREVIEW_DIVERGENCE')).toBe(true)
+      expect(res.raw).not.toContain(`secret-flow-${runSuffix}`)
+      expect(res.raw).not.toContain(`rule-set-secret-${runSuffix}`)
+      expect(res.raw).not.toContain('geoFence')
+
+      const spoofQuery = await requestJson(`${baseUrl}/api/attendance/rules/me?asOf=${asOf}&userId=${encodeURIComponent(otherId)}`, { headers })
+      expect(spoofQuery.status).toBe(400)
+      expect((spoofQuery.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_RULES_ME_SUBJECT_OVERRIDE')
+      const spoofHeader = await requestJson(`${baseUrl}/api/attendance/rules/me?asOf=${asOf}`, { headers: { ...headers, 'x-user-id': otherId } })
+      expect(spoofHeader.status).toBe(400)
+      const spoofOrgHeader = await requestJson(`${baseUrl}/api/attendance/rules/me?asOf=${asOf}`, { headers: { ...headers, 'x-org-id': 'other-org' } })
+      expect(spoofOrgHeader.status).toBe(400)
+      const spoofTenantHeader = await requestJson(`${baseUrl}/api/attendance/rules/me?asOf=${asOf}`, { headers: { ...headers, 'x-tenant-id': 'other-org' } })
+      expect(spoofTenantHeader.status).toBe(400)
+    } finally {
+      await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          punchPolicy: originalSettings.punchPolicy,
+          geoFence: originalSettings.geoFence ?? null,
+        }),
+      }).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_schedule_group_members WHERE user_id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_schedule_groups WHERE id = ANY($1::uuid[])`, [[scheduleGroupAId, scheduleGroupBId]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_group_members WHERE user_id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_groups WHERE id = $1`, [attendanceGroupId]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_rule_sets WHERE id = $1`, [ruleSetId]).catch(() => undefined)
+      await pool.query(`DELETE FROM user_orgs WHERE user_id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.query(`DELETE FROM users WHERE id = ANY($1::text[])`, [[meId, otherId]]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('A2 auto-shift auto-write ledger — active-run claim and item invariants are DB-enforced (latent schema)', async () => {
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -14364,6 +14364,186 @@ async function loadAttendanceScopeContextForUser(db, orgId, userId) {
   }
 }
 
+const ATTENDANCE_RULES_ME_FORBIDDEN_QUERY_KEYS = new Set([
+  'userId',
+  'user_id',
+  'orgId',
+  'org_id',
+  'tenantId',
+  'tenant_id',
+  'workspaceId',
+  'workspace_id',
+  'groupId',
+  'group_id',
+])
+const ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS = new Set([
+  'x-user-id',
+  'x-org-id',
+  'x-tenant-id',
+  'x-workspace-id',
+  'x-group-id',
+  'x-attendance-group-id',
+  'x-schedule-group-id',
+])
+
+function hasOwnRequestKey(input, forbiddenKeys) {
+  if (!input || typeof input !== 'object') return false
+  return [...forbiddenKeys].some(key => Object.prototype.hasOwnProperty.call(input, key))
+}
+
+function hasAttendanceRulesMeSubjectOverride(req) {
+  if (hasOwnRequestKey(req.query, ATTENDANCE_RULES_ME_FORBIDDEN_QUERY_KEYS)) return true
+  if (hasOwnRequestKey(req.body, ATTENDANCE_RULES_ME_FORBIDDEN_QUERY_KEYS)) return true
+  const headers = req.headers || {}
+  return [...ATTENDANCE_RULES_ME_FORBIDDEN_HEADER_KEYS].some(key => headers[key] !== undefined)
+}
+
+function getAttendanceRulesMeOrgId(req) {
+  const user = req.user || {}
+  for (const value of [user.orgId, user.workspaceId, user.tenantId]) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  // Existing dev-token attendance tests do not mint org/workspace claims. Keep
+  // that local/default compatibility without accepting request-level org overrides.
+  return DEFAULT_ORG_ID
+}
+
+function mapAttendanceRulesMeRuntimeRule(context) {
+  const rule = context?.rule || DEFAULT_RULE
+  return {
+    source: context?.source || 'rule',
+    id: rule.id ?? null,
+    name: rule.name ?? DEFAULT_RULE.name,
+    timezone: rule.timezone ?? DEFAULT_RULE.timezone,
+    workStartTime: rule.workStartTime ?? rule.work_start_time ?? DEFAULT_RULE.workStartTime,
+    workEndTime: rule.workEndTime ?? rule.work_end_time ?? DEFAULT_RULE.workEndTime,
+    lateGraceMinutes: Number(rule.lateGraceMinutes ?? rule.late_grace_minutes ?? DEFAULT_RULE.lateGraceMinutes),
+    earlyGraceMinutes: Number(rule.earlyGraceMinutes ?? rule.early_grace_minutes ?? DEFAULT_RULE.earlyGraceMinutes),
+    severeLateThresholdMinutes: Number(rule.severeLateThresholdMinutes ?? rule.severe_late_threshold_minutes ?? DEFAULT_RULE.severeLateThresholdMinutes),
+    absenceLateThresholdMinutes: Number(rule.absenceLateThresholdMinutes ?? rule.absence_late_threshold_minutes ?? DEFAULT_RULE.absenceLateThresholdMinutes),
+    roundingMinutes: Number(rule.roundingMinutes ?? rule.rounding_minutes ?? DEFAULT_RULE.roundingMinutes),
+    workingDays: normalizeWorkingDays(rule.workingDays ?? rule.working_days),
+    isWorkingDay: context?.isWorkingDay === true,
+  }
+}
+
+function mapAttendanceRulesMeAttendanceGroup(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    code: row.code ?? '',
+    attendanceType: normalizeAttendanceGroupType(row.attendance_type),
+    timezone: row.timezone ?? DEFAULT_RULE.timezone,
+    ruleSetId: row.rule_set_id ?? null,
+  }
+}
+
+function mapAttendanceRulesMeScheduleGroup(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    code: row.code ?? '',
+    departmentRef: row.department_ref ?? null,
+    role: row.role ?? null,
+    source: row.source ?? 'manual',
+    effectiveFrom: normalizeDateOnly(row.effective_from),
+    effectiveTo: normalizeDateOnly(row.effective_to),
+  }
+}
+
+function mapAttendanceRulesMePunchPolicy(settings) {
+  const punchPolicy = normalizePunchPolicySetting(settings?.punchPolicy)
+  return {
+    source: 'org_settings',
+    unscheduledMode: punchPolicy.unscheduled.mode,
+    outdoorApprovalRequired: punchPolicy.outdoor.requireApproval === true,
+    outdoorNoteRequired: punchPolicy.outdoor.requireNote === true,
+    merge: {
+      internalWinsOnIn: punchPolicy.merge.internalWinsOnIn === true,
+      externalWinsOnOut: punchPolicy.merge.externalWinsOnOut === true,
+    },
+  }
+}
+
+async function loadAttendanceRulesMeSummary(db, { orgId, userId, workDate }) {
+  const warnings = []
+  const membershipRows = await db.query(
+    `SELECT 1
+       FROM user_orgs uo
+       JOIN users u ON u.id = uo.user_id
+      WHERE uo.user_id = $1
+        AND uo.org_id = $2
+        AND uo.is_active = true
+        AND u.is_active = true
+      LIMIT 1`,
+    [userId, orgId],
+  )
+  if (!membershipRows.length) {
+    throw new HttpError(404, 'USER_NOT_IN_ORG', 'User is not an active member of this org')
+  }
+
+  const attendanceGroupRows = await db.query(
+    `SELECT g.id, g.name, g.code, g.attendance_type, g.timezone, g.rule_set_id
+       FROM attendance_group_members m
+       JOIN attendance_groups g ON g.id = m.group_id AND g.org_id = m.org_id
+      WHERE m.org_id = $1
+        AND m.user_id = $2
+      ORDER BY g.name ASC, g.id ASC`,
+    [orgId, userId],
+  )
+  if (attendanceGroupRows.length === 0) warnings.push({ code: 'NO_ATTENDANCE_GROUP', severity: 'warning' })
+  if (attendanceGroupRows.length > 1) warnings.push({ code: 'MULTIPLE_ATTENDANCE_GROUPS', severity: 'warning' })
+
+  const scheduleGroupRows = await db.query(
+    `SELECT g.id, g.name, g.code, g.department_ref, m.role, m.source, m.effective_from, m.effective_to
+       FROM attendance_schedule_group_members m
+       JOIN attendance_schedule_groups g
+         ON g.id = m.schedule_group_id
+        AND g.org_id = m.org_id
+        AND COALESCE(g.is_active, true) = true
+      WHERE m.org_id = $1
+        AND m.user_id = $2
+        AND COALESCE(m.effective_from, DATE '0001-01-01') <= $3::date
+        AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+      ORDER BY g.name ASC, g.id ASC, m.effective_from ASC NULLS FIRST`,
+    [orgId, userId, workDate],
+  )
+  if (scheduleGroupRows.length > 1) {
+    warnings.push({ code: 'MULTIPLE_SCHEDULE_GROUPS', severity: 'warning' })
+    warnings.push({ code: 'SCHEDULE_GROUP_WINDOW_OVERLAP', severity: 'warning' })
+  }
+
+  const context = await resolveWorkContext({ db, orgId, userId, workDate })
+  if (context.source === 'rule') warnings.push({ code: 'DEFAULT_RULE_FALLBACK', severity: 'info' })
+
+  const configuredGroupRuleRows = attendanceGroupRows.filter(row => row.rule_set_id)
+  const configuredGroupRule = configuredGroupRuleRows.length
+    ? {
+        groupId: configuredGroupRuleRows[0].id,
+        ruleSetId: configuredGroupRuleRows[0].rule_set_id,
+        enforcement: 'not_user_calc_chain',
+      }
+    : null
+  if (configuredGroupRule) warnings.push({ code: 'GROUP_RULE_SET_PREVIEW_DIVERGENCE', severity: 'info' })
+  if (configuredGroupRuleRows.length > 1) warnings.push({ code: 'MULTIPLE_CONFIGURED_GROUP_RULES', severity: 'warning' })
+
+  const settings = await getSettings(db)
+  return {
+    userId,
+    orgId,
+    resolvedAt: new Date().toISOString(),
+    resolvedForDate: workDate,
+    assignment: {
+      attendanceGroups: attendanceGroupRows.map(mapAttendanceRulesMeAttendanceGroup),
+      scheduleGroups: scheduleGroupRows.map(mapAttendanceRulesMeScheduleGroup),
+    },
+    runtimeRule: mapAttendanceRulesMeRuntimeRule(context),
+    ...(configuredGroupRule ? { configuredGroupRule } : {}),
+    punchPolicy: mapAttendanceRulesMePunchPolicy(settings),
+    warnings,
+  }
+}
+
 // Step 5: batch range version mirroring loadShiftAssignmentMapForUsersRange.
 // Used by buildWorkContextPrefetch to populate scopeContextByUser so the
 // calc-chain prefetch path can resolve calendarPolicy.overrides without a
@@ -39354,6 +39534,57 @@ module.exports = {
             return
           }
           logger.error('Annual leave self balance read failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/rules/me',
+      withPermission('attendance:read', async (req, res) => {
+        // Employee self-service rules read (SR-1): subject and org are pinned to
+        // authenticated context. Unlike admin reads, this route rejects request-level
+        // user/org/group overrides instead of silently ignoring them, so callers cannot
+        // accidentally depend on spoofable query/header fields.
+        if (hasAttendanceRulesMeSubjectOverride(req)) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'ATTENDANCE_RULES_ME_SUBJECT_OVERRIDE',
+              message: 'rules/me does not accept userId, orgId, or groupId overrides',
+            },
+          })
+          return
+        }
+
+        const userId = getUserId(req)
+        if (!userId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+
+        const asOfRaw = typeof req.query.asOf === 'string' ? req.query.asOf.trim() : ''
+        const resolvedForDate = asOfRaw ? normalizeDateOnlyStrict(asOfRaw) : new Date().toISOString().slice(0, 10)
+        if (!resolvedForDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'asOf must use YYYY-MM-DD' } })
+          return
+        }
+
+        const orgId = getAttendanceRulesMeOrgId(req)
+        try {
+          const data = await loadAttendanceRulesMeSummary(db, { orgId, userId, workDate: resolvedForDate })
+          res.json({ ok: true, data })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance self rules read failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: error instanceof Error ? error.message : String(error) } })
         }
       })


### PR DESCRIPTION
## Summary
- Add `GET /api/attendance/rules/me` for employee self-service rule visibility.
- Pin subject/org to authenticated context, reject `userId`/`orgId`/`groupId` query/body/header overrides before DB reads.
- Return a whitelist-only explainable summary: attendance groups, schedule groups, runtime rule, optional configured group rule marker, punch-policy subset, and warnings.
- Add an integration test covering token-subject behavior, override rejection, multi schedule warnings, configured-rule divergence, and no leakage of `approvalFlowId` / rule-set config / `geoFence`.

## Verification
- `node -c plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend type-check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot -t "attendance rules /me"` (collects; local DB env absent, existing harness skips integration tests locally)
- `git diff --check`

## Notes
- This intentionally does not expose raw attendance settings, geofence config, approval flow ids, or rule-set config to the employee endpoint.
- The route is stricter than the older annual leave `/me` read: spoofing fields are rejected instead of ignored.
