### PR TITLE
docs(multitable): mark Reset UI foundation #3250 as merged (stale ledger fix-forward)

### DIFF
--- a/docs/development/multitable-reset-ui-rollout-verification-20260626.md
+++ b/docs/development/multitable-reset-ui-rollout-verification-20260626.md
@@ -11,7 +11,7 @@ records the **Reset UI rollout** (#1 acceptance harness → #2 UI foundation) an
 | record-history `hasMore` keyset | **merged** (#3217) |
 | Reset acceptance harness + runbook (#1) | **merged** (#3232) + (d)-fix (#3248) |
 | Reset UI design + model correction | **merged** (#3239, #3251) |
-| Reset UI **foundation** (signal + client + inert dialog) (#2) | **#3250** — [P1]/[P2] green, in merge |
+| Reset UI **foundation** (signal + client + inert dialog) (#2) | **merged** (#3250 bf91099) |
 | Reset UI **entry wiring** | **blocked on a T-source product decision** (§3) |
 | undelete-execute · T9-W data-loss | **gated** on item-specific sign-off |
 


### PR DESCRIPTION
Docs-only fix-forward for the [P2] stale-ledger finding on the reset-ui rollout-verification MD (introduced via #3262).

**Problem.** `docs/development/multitable-reset-ui-rollout-verification-20260626.md` line 14 still read `**#3250** — [P1]/[P2] green, in merge` after #3250 had merged (`bf91099`), conflicting with the doc's own closeout that treats #3250 as landed.

**Fix.** `**merged** (#3250 bf91099)` — matches the table's merged-row convention (#3214/#3217/#3232/#3239/#3251 all `**merged** (#…)`).

**Scope.** One line. Independently re-scanned the whole doc: line 14 was the only stale status; section 2 body (inert dialog + backend signal + client methods, not user-facing entry) is accurate. No code, no other row touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)