### PR TITLE
test(multitable): U-1b atomicity golden — forced revision-insert failure rolls back config revert

### DIFF
--- a/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
@@ -159,4 +159,43 @@ describeIfDatabase('multitable sheet_config revert — T9-W Tier 1 (real DB)', (
     const full = await preview(rev, FULL)
     expect(JSON.stringify(full.body)).toContain(SECRET_LIT) // fully-allowed sees it
   })
+
+  // (g) U-L4 atomicity: execute applies the config UPDATE (applyConfigRevert) and the forward source=restore
+  // revision (recordConfigRevision) inside ONE pool.transaction. Force the revision INSERT to fail AFTER the
+  // UPDATE has run, and assert the sheet is byte-for-byte unchanged + no revision was added → single-transaction
+  // all-or-nothing (not revert-first/record-second with a half-write). The trigger is scoped to THIS sheet and
+  // source='restore', so it fires only on this restore insert — never on setRules or any parallel suite's row.
+  test('(g) U-L4 atomicity: a forced revision-insert failure rolls back the config UPDATE — nothing written', async () => {
+    process.env[FLAG] = 'true'
+    // two DISTINCT states so a fresh revision is recorded: before=[g1], after=[g2]; reverting would restore [g1].
+    await setRules([rule('rv', FLD_VISIBLE, 'g1-restore-target')])
+    await setRules([rule('rv', FLD_VISIBLE, 'g2-current')])
+    const rev = await latestRevId()
+    const p = await preview(rev, FULL)
+    expect(p.status).toBe(200)
+    const token = p.body?.data?.previewToken
+    const liveBefore = JSON.stringify(await liveRules())
+    const countBefore = ((await q('SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }).n
+    const FN = `scr_atomic_fail_${TS}`
+    const TRG = `scr_atomic_fail_trg_${TS}`
+    await q(`CREATE OR REPLACE FUNCTION ${FN}() RETURNS trigger LANGUAGE plpgsql AS $fn$ BEGIN RAISE EXCEPTION 'forced restore-revision insert failure (atomicity golden)'; END; $fn$`, [])
+    await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_config_revisions`, [])
+    await q(`CREATE TRIGGER ${TRG} BEFORE INSERT ON meta_config_revisions FOR EACH ROW WHEN (NEW.sheet_id = '${SHEET}' AND NEW.source = 'restore') EXECUTE FUNCTION ${FN}()`, [])
+    try {
+      const x = await execute(rev, token, FULL)
+      expect(x.status).toBe(500) // forced failure aborts the txn → INTERNAL
+      expect(x.body?.error?.code).toBe('INTERNAL')
+      // the config UPDATE rolled back: live rules byte-for-byte unchanged (still g2), NOT reverted to g1
+      const liveAfter = JSON.stringify(await liveRules())
+      expect(liveAfter).toBe(liveBefore)
+      expect(liveAfter).toContain('g2-current')
+      expect(liveAfter).not.toContain('g1-restore-target')
+      // and NO forward restore revision was committed (count unchanged)
+      const countAfter = ((await q('SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1', [SHEET])).rows[0] as { n: number }).n
+      expect(countAfter).toBe(countBefore)
+    } finally {
+      await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_config_revisions`, []).catch(() => {})
+      await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
+    }
+  })
 })


### PR DESCRIPTION
Closes the one optional-hardening gap I flagged when merging **#3264** (T9-W Tier 1 sheet_config revert): the U-1b / design-lock (#3254) bar lists *atomicity* among the goldens, but the file shipped without a standalone **forced mid-write rollback** test (the lowest-risk tier, single-txn, so it was deferred). This adds it.

**What it proves (U-L4).** `config-restore-execute` runs `applyConfigRevert` (UPDATE `meta_sheets`) **then** `recordConfigRevision` (INSERT `meta_config_revisions`) inside ONE `pool.transaction`. Golden **(g)** installs a `BEFORE INSERT` trigger **scoped to this sheet + `source='restore'`** that `RAISE`s — forcing the revision insert to fail *after* the UPDATE already ran — then asserts the sheet config is **byte-for-byte unchanged** and **no revision was committed**. That's true single-transaction all-or-nothing, not revert-first/record-second with a half-write.

**Safety.** The trigger's `WHEN (NEW.sheet_id = <this sheet> AND NEW.source = 'restore')` means it can only fire on *this* test's restore insert — never on `setRules` or any parallel `forks`-pool suite's row. Dropped in a `finally`.

**Scope.** One test case, additive to an already-CI-wired file (`multitable-sheet-config-revert-realdb.test.ts`) — no workflow change. **Verified locally** against `metasheet_test`: 8/8 pass (the forced `P0001` surfaces at `recordConfigRevision` inside `ConnectionPool.transaction` → route 500 → rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)