### PR TITLE
docs(integration): de-stale #3260 ledger entry in K3 read/list verification MD

### DIFF
--- a/docs/development/data-factory-k3-read-list-development-verification-20260626.md
+++ b/docs/development/data-factory-k3-read-list-development-verification-20260626.md
@@ -22,7 +22,7 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 
 **Standardization:**
 - `#3257` (`2f7f82323`) — K3 read/list **GATE v2** + reusable values-free evidence checklist.
-- `#3260` — general **external-system read onboarding template** (system-agnostic G0–G5 playbook; K3 as the worked reference). *(merging at time of writing.)*
+- `#3260` (`c0966702c`) — general **external-system read onboarding template** (system-agnostic G0–G5 playbook; K3 as the worked reference).
 
 ## 2. Verification
 


### PR DESCRIPTION
Docs-only follow-up to #3263.

The K3 read/list development + verification MD (`docs/development/data-factory-k3-read-list-development-verification-20260626.md`) had one stale ledger entry: the `#3260` line still read *(merging at time of writing.)* and was the only entry missing its merged commit hash. `#3260` (general external-system read onboarding template) merged at `c0966702c` **before** #3263 itself, so the marker was already stale at merge time.

This aligns the line to the ledger's own style — `` `#NNNN` (`hash`) `` — and drops the stale parenthetical:

```diff
-- `#3260` — general external-system read onboarding template (...). *(merging at time of writing.)*
+- `#3260` (`c0966702c`) — general external-system read onboarding template (...).
```

**Scope:** 1 file, 1 line. No runtime, no contract, no gates touched. Verified `#3260 = c0966702c`, that #3260 merged before #3263, and that this was the only ledger entry both missing a backticked hash and carrying a stale marker.

Originates from an independent audit of Codex's review of #3263, which correctly flagged this as non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
