### PR TITLE
docs(integration): fix K3 read-list verification ledger

### DIFF
--- a/docs/development/data-factory-k3-read-list-development-verification-20260626.md
+++ b/docs/development/data-factory-k3-read-list-development-verification-20260626.md
@@ -22,7 +22,7 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 
 **Standardization:**
 - `#3257` (`2f7f82323`) — K3 read/list **GATE v2** + reusable values-free evidence checklist.
-- `#3260` — general **external-system read onboarding template** (system-agnostic G0–G5 playbook; K3 as the worked reference). *(merging at time of writing.)*
+- `#3260` (`c0966702c`) — general **external-system read onboarding template** (system-agnostic G0–G5 playbook; K3 as the worked reference).
 
 ## 2. Verification
 


### PR DESCRIPTION
## Summary

- Replaces the stale `#3260 ... (merging at time of writing)` wording in the K3 read/list development & verification MD.
- Records the actual #3260 merge SHA (`c0966702c`) now that the onboarding template is on main.

## Boundary

Docs-only. No runtime, route, adapter, package, K3, LIST/BOM, or write behavior changes.

## Verification

- `git diff --check`