### PR TITLE
fix(multitable): narrow T9-W Tier 1 sheet_config revert to update + Tier-1 keys ([P1])

### DIFF
--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -37,6 +37,25 @@ export function classifyRevert(rev: Pick<ConfigRevisionRow, 'entity_type' | 'act
   return { kind: 'gated', reason: `${rev.entity_type} reverts are not supported in this slice` }
 }
 
+/**
+ * T9-W Tier 1 scope — the ONLY sheet_config reverts the flag opens: an `update` whose changed keys are ALL Tier-1
+ * keys (the row-deny toggle + conditional-read rules). classifyRevert returns `gated` for EVERY sheet_config
+ * (intrinsically gated), so preview/execute must use THIS predicate — NOT `entity_type === 'sheet_config'` — to
+ * decide what the flag actually permits. A `create`/`delete` (un-create / undelete = Tier 3/4, #3254 HOLD) or an
+ * unknown changed_key stays gated (preview not confirmable, execute 422). These keys MUST stay equal to
+ * SHEET_CONFIG_COLUMN's (the columns applyConfigRevert can actually write).
+ */
+export const SUPPORTED_SHEET_CONFIG_REVERT_KEYS: ReadonlySet<string> = new Set(['conditionalReadRules', 'rowLevelReadPermissionsEnabled'])
+export function isSupportedSheetConfigRevert(rev: Pick<ConfigRevisionRow, 'entity_type' | 'action' | 'changed_keys'>): boolean {
+  return (
+    rev.entity_type === 'sheet_config' &&
+    rev.action === 'update' &&
+    Array.isArray(rev.changed_keys) &&
+    rev.changed_keys.length > 0 &&
+    rev.changed_keys.every((k) => SUPPORTED_SHEET_CONFIG_REVERT_KEYS.has(k))
+  )
+}
+
 const stable = (v: unknown): string => JSON.stringify(v ?? null)
 function pick(snapshot: Record<string, unknown>, keys: string[]): Record<string, unknown> {
   const out: Record<string, unknown> = {}

--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -3,8 +3,11 @@
  * FORWARD (re-applies its `before` state as a new change), drift-guarded (T9-W-L5) and forward-only (T9-W-L1).
  *
  * v1 SAFE subset (T9-W-L6): field `name`/`order` reverts + all view config reverts (display-only, non-lossy).
- * Everything else — field `type`/`property` (potentially lossy), create/delete (undelete), permission, sheet_config —
- * is GATED in this slice and refused fail-closed. No record-data is ever touched (T9-W-L2).
+ * Everything else — field `type`/`property` (potentially lossy), create/delete (undelete), permission — is GATED in
+ * this slice and refused fail-closed. sheet_config is also `gated` at the classify layer (classifyRevert); the ROUTE
+ * opens only a narrow Tier-1 subset (an `update` whose changed keys ⊆ {conditionalReadRules,
+ * rowLevelReadPermissionsEnabled}, per isSupportedSheetConfigRevert) behind MULTITABLE_ENABLE_SHEET_CONFIG_REVERT —
+ * a sheet_config create/delete/unknown-key stays gated. No record-data is ever touched (T9-W-L2).
  */
 import { createHash } from 'node:crypto'
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -87,6 +87,7 @@ import {
 import {
   type ConfigRevisionRow,
   classifyRevert,
+  isSupportedSheetConfigRevert,
   computeRevertPreview,
   loadEntityConfigSnapshot,
   applyConfigRevert,
@@ -7739,10 +7740,12 @@ export function univerMetaRouter(): Router {
         preview.current = redactConditionalReadRuleLiterals(preview.current as { conditionalReadRules?: unknown }, allowedFieldIds) as Record<string, unknown>
         preview.target = redactConditionalReadRuleLiterals(preview.target as { conditionalReadRules?: unknown }, allowedFieldIds) as Record<string, unknown>
       }
-      // T9-W Tier 1: classifyRevert stays PURE (sheet_config = intrinsically gated), but the flag is ON here (flag-off
-      // already 403'd above), so the ROUTE supports this revert — surface it as confirmable so the FE shows the confirm
-      // path (the FE hides confirm unless opKind === 'safe'). EXECUTE applies the same flag+guard gate, not opKind.
-      if (rev.entity_type === 'sheet_config') {
+      // T9-W Tier 1: classifyRevert stays PURE (sheet_config = intrinsically gated). The flag is ON here (flag-off
+      // already 403'd above), but it opens ONLY the Tier-1 subset — isSupportedSheetConfigRevert (an `update` whose
+      // changed keys are all Tier-1 keys). A create/delete or unknown-key sheet_config is Tier 3/4 (HOLD, #3254): it
+      // stays gated, so leave opKind as classifyRevert set it (the FE hides confirm) and EXECUTE 422s it below. Only
+      // the supported subset is surfaced confirmable.
+      if (isSupportedSheetConfigRevert(rev)) {
         preview.opKind = 'safe'
         delete preview.gatedReason
       }
@@ -7792,9 +7795,11 @@ export function univerMetaRouter(): Router {
         }
       }
       const classify = classifyRevert(rev)
-      // classifyRevert stays PURE; the route SUPPORTS flag-on sheet_config (already flag/guard-gated above), so it must
-      // NOT 422 it. Every other gated kind (permission, lossy field, create/delete) is still refused here.
-      if (classify.kind === 'gated' && rev.entity_type !== 'sheet_config') return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
+      // classifyRevert stays PURE; the route SUPPORTS only the flag-opened Tier-1 sheet_config subset
+      // (isSupportedSheetConfigRevert: an `update` whose changed keys are all Tier-1 keys), so it must NOT 422 that.
+      // Every other gated kind — permission, lossy field, create/delete, AND any non-Tier-1 sheet_config
+      // (create/delete/unknown changed_key = Tier 3/4 HOLD, #3254) — is still refused here.
+      if (classify.kind === 'gated' && !isSupportedSheetConfigRevert(rev)) return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
 
       // null = applied; a failure object = a guard tripped (the txn made no write either way).
       const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {

--- a/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
@@ -44,6 +44,9 @@ const execute = (revisionId: string, previewToken: string, as: typeof FULL) => {
 const rule = (id: string, fieldId: string, value: string) => ({ id, fieldId, operator: 'eq', value, effect: 'deny_read' })
 const latestRevId = async (): Promise<string> => ((await q(`SELECT id FROM meta_config_revisions WHERE sheet_id=$1 AND entity_type='sheet_config' ORDER BY created_at DESC, id DESC LIMIT 1`, [SHEET])).rows[0] as { id: string }).id
 const liveRules = async (): Promise<any[]> => (((await q('SELECT conditional_read_rules AS r FROM meta_sheets WHERE id=$1', [SHEET])).rows[0] as { r: any }).r) ?? []
+const restoreRevCount = async (): Promise<number> => ((await q(`SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1 AND source='restore'`, [SHEET])).rows[0] as { n: number }).n
+// craft a raw sheet_config revision (entity_id===sheet to pass the entity_id guard; source defaults to 'mutation')
+const craftSheetConfigRev = async (action: string, changedKeys: string[], before: unknown, after: unknown): Promise<string> => ((await q(`INSERT INTO meta_config_revisions (sheet_id, entity_type, entity_id, action, before, after, changed_keys, actor_id) VALUES ($1,'sheet_config',$1,$2,$3::jsonb,$4::jsonb,$5,$6) RETURNING id`, [SHEET, action, JSON.stringify(before), JSON.stringify(after), changedKeys, U_FULL])).rows[0] as { id: string }).id
 
 describeIfDatabase('multitable sheet_config revert — T9-W Tier 1 (real DB)', () => {
   let revToRevert = '' // R2: before=[visible,secret], after=[visible] → revert restores the secret rule
@@ -198,4 +201,32 @@ describeIfDatabase('multitable sheet_config revert — T9-W Tier 1 (real DB)', (
       await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
     }
   })
+
+  // (h) U-L1/scope ([P1] fix): the flag opens ONLY Tier 1 — an `update` whose changed keys ⊆ {conditionalReadRules,
+  // rowLevelReadPermissionsEnabled}. A flag-ON sheet_config create / delete (un-create / undelete = Tier 3/4, #3254
+  // HOLD) or an `update` with an unknown changed_key must STAY gated: preview is NOT confirmable (opKind !== 'safe')
+  // and execute 422s RESTORE_NOT_SUPPORTED with NO config write and NO forward restore revision. Guards the earlier
+  // blanket `entity_type === 'sheet_config'` bypass that wrongly treated these Tier-3/4 ops as confirmable/executable.
+  const outOfTier1: Array<{ name: string; action: string; keys: string[]; before: unknown; after: unknown }> = [
+    { name: 'create (un-create / Tier 3)', action: 'create', keys: ['conditionalReadRules'], before: null, after: { conditionalReadRules: [rule('rc', FLD_VISIBLE, 'created-lit')] } },
+    { name: 'delete (undelete / Tier 4)', action: 'delete', keys: ['conditionalReadRules'], before: { conditionalReadRules: [rule('rd', FLD_VISIBLE, 'deleted-lit')] }, after: null },
+    { name: 'update with an unknown changed_key', action: 'update', keys: ['rowLevelReadPermissionsEnabledX'], before: { rowLevelReadPermissionsEnabledX: false }, after: { rowLevelReadPermissionsEnabledX: true } },
+  ]
+  for (const c of outOfTier1) {
+    test(`(h) flag-ON sheet_config OUTSIDE Tier 1 — ${c.name} → gated preview + 422 execute, nothing written`, async () => {
+      process.env[FLAG] = 'true'
+      const revId = await craftSheetConfigRev(c.action, c.keys, c.before, c.after)
+      const p = await preview(revId, FULL)
+      expect(p.status).toBe(200)
+      expect(p.body?.data?.preview?.opKind).not.toBe('safe') // NOT confirmable — Tier 3/4 HOLD honored
+      const token = p.body?.data?.previewToken
+      const liveBefore = JSON.stringify(await liveRules())
+      const restoreBefore = await restoreRevCount()
+      const x = await execute(revId, token, FULL)
+      expect(x.status).toBe(422)
+      expect(x.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
+      expect(JSON.stringify(await liveRules())).toBe(liveBefore) // no config write
+      expect(await restoreRevCount()).toBe(restoreBefore)        // no forward restore revision
+    })
+  }
 })

--- a/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
@@ -1,13 +1,17 @@
 /**
  * T9-W Tier 1 — sheet_config revert (real DB). The first UNSAFE config-restore slice, behind the per-tier flag
  * MULTITABLE_ENABLE_SHEET_CONFIG_REVERT (default off). classifyRevert stays PURE (sheet_config = intrinsically
- * gated); the ROUTE supports it when the flag is on and surfaces the preview as confirmable (opKind:'safe').
+ * gated); with the flag on the ROUTE opens ONLY the Tier-1 subset (isSupportedSheetConfigRevert: an `update` whose
+ * changed keys ⊆ {conditionalReadRules, rowLevelReadPermissionsEnabled}) and surfaces THAT as confirmable
+ * (opKind:'safe') — a create/delete or unknown-key sheet_config stays gated.
  *
  * Goldens: (a) flag-OFF → preview AND execute 403 RESET... no: SHEET_CONFIG_REVERT_DISABLED · (b) gate: a
  * write-but-not-share actor → 403 · (c) fail-closed: a revision whose entity_id != sheet_id → 400 INVALID_REVISION ·
  * (d) flag-ON happy path: preview is confirmable (opKind:'safe', no drift) and execute SUCCEEDS (rules reverted,
  * forward source=restore revision) · (e) drift: rules edited after preview → execute 409 · (f) U-L6 redaction: a
- * field-denied canManageSheetAccess reader does NOT see the secret rule literal in the preview; fully-allowed does.
+ * field-denied canManageSheetAccess reader does NOT see the secret rule literal in the preview; fully-allowed does ·
+ * (g) U-L4 atomicity: a forced revision-insert failure rolls back the config UPDATE (nothing written) · (h) scope:
+ * flag-ON sheet_config create/delete/unknown-key stays gated (preview not confirmable, execute 422, no write).
  * Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'


### PR DESCRIPTION
Fixes the [P1] you flagged on **#3264**: the flag-on bypass was too broad.

**Bug.** Both sites keyed on the blanket `entity_type === 'sheet_config'`:
- preview forced `opKind='safe'` for *any* sheet_config revision;
- execute skipped the `RESTORE_NOT_SUPPORTED` 422 for *any* sheet_config.

So with the flag on, a sheet_config **create/delete** (un-create / undelete) or an **update with an unknown `changed_key`** was treated as confirmable + executable — violating #3254's **Tier 3/4 HOLD**. (`classifyRevert` already returns `gated` for every sheet_config; the route was overriding that too broadly.)

**Fix.** A narrow predicate in `config-restore.ts`:
```ts
isSupportedSheetConfigRevert(rev) =
  entity_type === 'sheet_config' && action === 'update' &&
  changed_keys non-empty ⊆ { conditionalReadRules, rowLevelReadPermissionsEnabled }
```
- preview overrides to `safe` **only when the predicate passes**;
- execute skips the 422 **only when the predicate passes** (`!isSupportedSheetConfigRevert`).
`classifyRevert` stays PURE. create/delete/unknown-key now stay gated: preview not confirmable, execute 422.

**Goldens (real-DB, additive to the already-wired file — no workflow change).** Three new (h) cases: flag-ON sheet_config **create** / **delete** / **update-with-unknown-key** → gated preview (`opKind != 'safe'`) + **422 RESTORE_NOT_SUPPORTED**, **no config write**, **no forward restore revision**.

**Verified locally** against `metasheet_test`: **11/11 pass** — the three new gated cases, the unchanged **(d)** Tier-1 happy path (still works), and **(g)** atomicity; `tsc` clean.

Core points you already validated (U-1a redaction on main, entity_id===sheet guard, flag-off/gate/drift/redaction/happy-path CI coverage) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)