### PR TITLE
feat(approval): preview requester.* conditions in formula dry-run (RA-1a)

### DIFF
--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -399,7 +399,12 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
 
       try {
         assertApprovalConditionFormulaValidForSchema(expression, formSchema)
-        const result = evaluateApprovalConditionFormula(expression, formData)
+        // RA-1a: optional sample requester context so `requester.*` conditions are previewable here.
+        // Non-authoritative (RA-3) — the real value is server-resolved + frozen at create, never client-supplied.
+        const requesterContext = isPlainRecord(body.requester)
+          ? { department: typeof body.requester.department === 'string' ? body.requester.department : null }
+          : null
+        const result = evaluateApprovalConditionFormula(expression, formData, requesterContext)
         return res.json({ data: { success: true, result } })
       } catch (error) {
         if (error instanceof ApprovalConditionFormulaError) {

--- a/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
+++ b/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
@@ -257,6 +257,36 @@ describe('Approval RBAC boundary verification', () => {
       expect(res.body.data.error.code).toBe('APPROVAL_FORMULA_CONDITION_DRY_RUN_FAILED')
       expect(res.body.data.error.message).toContain('must be a finite number')
     })
+
+    it('POST .../dry-run previews a requester.department condition when a sample requester is supplied (RA-1a)', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send({
+          expression: 'requester.department == "财务"',
+          formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+          formData: {},
+          requester: { department: '财务' },
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ data: { success: true, result: true } })
+    })
+
+    it('POST .../dry-run: a requester.* condition without a sample requester is unpreviewable (success:false, not a phantom true)', async () => {
+      authState.user = templateManager()
+      const res = await request(app)
+        .post('/api/approval-templates/formula-condition/dry-run')
+        .send({
+          expression: 'requester.department == "财务"',
+          formSchema: { fields: [{ id: 'amount', type: 'number', label: 'Amount' }] },
+          formData: {},
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.data.success).toBe(false)
+      expect(res.body.data.error.message).toMatch(/context unavailable/)
+    })
   })
 
   // =========================================================================


### PR DESCRIPTION
## What
The formula-condition dry-run endpoint evaluated with no requester context, so any requester.department condition returned success:false (requester context unavailable) — breaking the authoring preview for the RA-1a attribute.

## Fix
Accept an optional, non-authoritative sample requester in the dry-run body and thread it to the evaluator. RA-3-aligned: the real value is server-resolved and frozen at create, never client-supplied; the sample only powers the preview.

## Tests (tests/unit/approval-rbac-boundary.test.ts, 30/30 green)
- with a sample requester, requester.department preview returns success:true
- without a sample, a requester.* condition stays success:false (context unavailable) — no phantom true

## Follow-up
FE: add a sample-department input to the preview UI (backend now supports it).

## Risk
Low — additive optional field on a manager-gated preview endpoint; no change to publish/runtime evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)