### PR TITLE
test(approval): RA-1a test-hardening — e2e round-trip + executor/operator/resolver coverage (closes #3265 P1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -313,6 +313,7 @@ jobs:
             tests/integration/approval-postgate-acceptance.api.test.ts \
             tests/integration/dept-head-sync-plumbing.test.ts \
             tests/integration/approval-manager-chain.db.test.ts \
+            tests/integration/approval-requester-department.db.test.ts \
             tests/integration/approval-delegation-seam.db.test.ts \
             tests/integration/approval-delegation-api.db.test.ts \
             tests/integration/approval-detail-subform.db.test.ts \

--- a/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-manager-chain.db.test.ts
@@ -87,6 +87,7 @@ describeIfDatabase('continuous_managers chain walk (real DB)', () => {
     const rel = await resolveApprovalRequesterOrgRelations(U_R, queryFn, { includeManagerChain: true })
     expect(rel.managerChainIds).toEqual([U_M]) // exactly one level; level-2 finds no leader → stops
     expect(rel.managerId).toBe(U_M) // chain[0] agrees with the shipped direct-manager resolution
+    expect(rel.primaryDepartmentName).toBe('Eng') // RA-1a: requester.department source SQL-lift proven on real DB
   })
 
   it('B1 end-to-end: a manager_at_level template bakes the chain (scanner gate) and resolves the level-1 manager', async () => {

--- a/packages/core-backend/tests/integration/approval-requester-department.db.test.ts
+++ b/packages/core-backend/tests/integration/approval-requester-department.db.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { MetaSheetServer } from '../../src/index'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+/**
+ * RA-1a `requester.department` — REAL-DB end-to-end round-trip.
+ *
+ * Closes the P1 test gap named in #3265 (no integration test exercised
+ * create -> persist -> reload -> dispatch). Proves:
+ *  (a) createApproval FREEZES the directory-resolved primary department NAME into
+ *      requester_snapshot (JSONB) — sourced from directory_departments.name, not actor.*;
+ *  (b) the condition node, reached at DISPATCH (after an approval) where requester_snapshot
+ *      is reloaded FROM the row, routes on that frozen value.
+ *
+ * Routing at dispatch (not create) is deliberate: the create-time requesterContext is built
+ * in-memory, so a create-only assertion would false-green; only the dispatch reload proves the
+ * JSONB round-trip + re-thread (the team's documented wire-vs-fixture trap).
+ */
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+const REQ = `ra1a-req-${TS}`
+const APPROVER = `ra1a-appr-${TS}`
+const ENG = `ra1a-eng-${TS}`
+const OTHER = `ra1a-oth-${TS}`
+const DEPT_EXT = `ra1a-dept-${TS}`
+const DEPT_NAME = 'Eng' // MUST match the formula literal in GRAPH below
+
+async function canListen(): Promise<boolean> {
+  return await new Promise((r) => {
+    const s = net.createServer()
+    s.once('error', () => r(false))
+    s.listen(0, '127.0.0.1', () => s.close(() => r(true)))
+  })
+}
+async function tok(base: string, userId: string): Promise<string> {
+  const res = await fetch(`${base}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`)
+  return ((await res.json()) as { token: string }).token
+}
+async function req(base: string, path: string, token: string, opts: { method?: string; body?: unknown } = {}): Promise<Response> {
+  return fetch(`${base}${path}`, {
+    method: opts.method || 'GET',
+    headers: { Authorization: `Bearer ${token}`, ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}) },
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  })
+}
+
+const GRAPH = {
+  nodes: [
+    { key: 'start', type: 'start', name: 's', config: {} },
+    { key: 'approval_1', type: 'approval', name: 'gate', config: { assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    // condition is DOWNSTREAM of an approval node, so it is evaluated at dispatch (after approve),
+    // where requester_snapshot is reloaded from the row — the path that proves the round-trip.
+    { key: 'condition_1', type: 'condition', name: 'route', config: { branches: [{ edgeKey: 'eng', rules: [], formula: { expression: `requester.department == '${DEPT_NAME}'` } }], defaultEdgeKey: 'other' } },
+    { key: 'approval_eng', type: 'approval', name: 'eng', config: { assigneeSources: [{ kind: 'static_user', userIds: [ENG] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'approval_other', type: 'approval', name: 'oth', config: { assigneeSources: [{ kind: 'static_user', userIds: [OTHER] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+    { key: 'end', type: 'end', name: 'e', config: {} },
+  ],
+  edges: [
+    { key: 's2a1', source: 'start', target: 'approval_1' },
+    { key: 'a12c', source: 'approval_1', target: 'condition_1' },
+    { key: 'eng', source: 'condition_1', target: 'approval_eng' },
+    { key: 'other', source: 'condition_1', target: 'approval_other' },
+    { key: 'eng2e', source: 'approval_eng', target: 'end' },
+    { key: 'oth2e', source: 'approval_other', target: 'end' },
+  ],
+}
+
+describeIfDatabase('RA-1a requester.department — real-DB create->reload->dispatch round-trip', () => {
+  let server: MetaSheetServer | undefined
+  let base = ''
+  let reqTok = ''
+  let apprTok = ''
+  let integrationId = ''
+
+  beforeAll(async () => {
+    expect(await canListen()).toBe(true)
+    await ensureApprovalSchemaReady()
+    const pool = poolManager.get()
+    // directory seed (mirrors approval-manager-chain.db.test.ts): REQ -> account -> primary dept NAME='Eng'
+    integrationId = (await pool.query<{ id: string }>(
+      `INSERT INTO directory_integrations (name, corp_id) VALUES ($1, $2) RETURNING id`,
+      [`ra1a-${TS}`, `ra1a-corp-${TS}`],
+    )).rows[0].id
+    const deptId = (await pool.query<{ id: string }>(
+      `INSERT INTO directory_departments (integration_id, external_department_id, name, is_active, raw)
+       VALUES ($1, $2, $3, true, '{}'::jsonb) RETURNING id`,
+      [integrationId, DEPT_EXT, DEPT_NAME],
+    )).rows[0].id
+    await pool.query(`INSERT INTO users (id, email, password_hash) VALUES ($1, $2, 'x')`, [REQ, `${REQ}@x.test`])
+    const accR = (await pool.query<{ id: string }>(
+      `INSERT INTO directory_accounts (integration_id, external_user_id, external_key, name, raw)
+       VALUES ($1, $2, $3, 'R', '{}'::jsonb) RETURNING id`,
+      [integrationId, `extR-${TS}`, `keyR-${TS}`],
+    )).rows[0].id
+    await pool.query(
+      `INSERT INTO directory_account_links (directory_account_id, local_user_id, link_status, match_strategy)
+       VALUES ($1, $2, 'linked', 'manual')`,
+      [accR, REQ],
+    )
+    await pool.query(
+      `INSERT INTO directory_account_departments (directory_account_id, directory_department_id, is_primary)
+       VALUES ($1, $2, true)`,
+      [accR, deptId],
+    )
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    await server.start()
+    base = `http://127.0.0.1:${server.getAddress()!.port}`
+    reqTok = await tok(base, REQ)
+    apprTok = await tok(base, APPROVER)
+  })
+
+  afterAll(async () => {
+    try {
+      const pool = poolManager.get()
+      const tids = (await pool.query(`SELECT id FROM approval_templates WHERE key LIKE $1`, [`ra1a-${TS}-%`])).rows.map((r) => r.id as string)
+      if (tids.length > 0) {
+        const iids = (await pool.query(`SELECT id FROM approval_instances WHERE template_id = ANY($1::uuid[])`, [tids])).rows.map((r) => r.id as string)
+        if (iids.length > 0) {
+          await pool.query(`DELETE FROM approval_records WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_assignments WHERE instance_id = ANY($1)`, [iids])
+          await pool.query(`DELETE FROM approval_instances WHERE id = ANY($1)`, [iids])
+        }
+        await pool.query(`DELETE FROM approval_published_definitions WHERE template_id = ANY($1::uuid[])`, [tids])
+        await pool.query(`DELETE FROM approval_templates WHERE id = ANY($1::uuid[])`, [tids])
+      }
+      if (integrationId) {
+        await pool.query(`DELETE FROM directory_accounts WHERE integration_id = $1`, [integrationId])
+        await pool.query(`DELETE FROM directory_departments WHERE integration_id = $1`, [integrationId])
+        await pool.query(`DELETE FROM directory_integrations WHERE id = $1`, [integrationId])
+        await pool.query(`DELETE FROM users WHERE id = $1`, [REQ])
+      }
+    } catch {
+      /* best effort */
+    }
+    if (server) await server.stop()
+  })
+
+  it('sentinel: DATABASE_URL is set (DB-backed lane must not silently skip)', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  it('freezes directoryDepartment into requester_snapshot and routes the condition on the reloaded value at dispatch', async () => {
+    const key = `ra1a-${TS}-1`
+    const created = await req(base, '/api/approval-templates', reqTok, {
+      method: 'POST',
+      body: { key, name: key, formSchema: { fields: [{ id: 'reason', type: 'text', label: 'r', required: true }] }, approvalGraph: GRAPH },
+    })
+    expect(created.status, await created.clone().text()).toBe(201)
+    const tid = ((await created.json()) as { id: string }).id
+    expect((await req(base, `/api/approval-templates/${tid}/publish`, reqTok, { method: 'POST', body: { policy: { allowRevoke: true } } })).status).toBe(200)
+
+    // requester REQ starts → createApproval freezes directory department into requester_snapshot.
+    const started = await req(base, '/api/approvals', reqTok, { method: 'POST', body: { templateId: tid, formData: { reason: 'r' } } })
+    expect(started.status, await started.clone().text()).toBeLessThan(300)
+    const startBody = (await started.json()) as { id?: string; data?: { id: string } }
+    const iid = startBody.id ?? startBody.data!.id
+
+    const pool = poolManager.get()
+    // (a) JSONB round-trip: directory-resolved department NAME frozen at create, survives the column.
+    const snap = (await pool.query<{ requester_snapshot: { directoryDepartment?: string } | null; current_node_key: string | null }>(
+      `SELECT requester_snapshot, current_node_key FROM approval_instances WHERE id = $1`,
+      [iid],
+    )).rows[0]
+    expect(snap.requester_snapshot?.directoryDepartment).toBe(DEPT_NAME)
+    expect(snap.current_node_key).toBe('approval_1')
+
+    // dispatch: APPROVER approves approval_1 → dispatchAction reloads requester_snapshot FROM the row
+    // and re-threads requesterContext; the condition then routes on the reloaded frozen value.
+    const approved = await req(base, `/api/approvals/${iid}/actions`, apprTok, { method: 'POST', body: { action: 'approve' } })
+    expect(approved.status, await approved.clone().text()).toBeLessThan(300)
+
+    // (b) routed to the eng branch using the reloaded frozen department (not formData, not actor.department).
+    const after = (await pool.query<{ current_node_key: string | null }>(
+      `SELECT current_node_key FROM approval_instances WHERE id = $1`,
+      [iid],
+    )).rows[0]
+    expect(after.current_node_key).toBe('approval_eng')
+    const assignees = (await pool.query<{ assignee_id: string }>(
+      `SELECT assignee_id FROM approval_assignments WHERE instance_id = $1 AND assignment_type = 'user' AND is_active = TRUE`,
+      [iid],
+    )).rows.map((r) => r.assignee_id)
+    expect(assignees).toContain(ENG)
+    expect(assignees).not.toContain(OTHER)
+  })
+})

--- a/packages/core-backend/tests/unit/approval-condition-formula.test.ts
+++ b/packages/core-backend/tests/unit/approval-condition-formula.test.ts
@@ -130,4 +130,14 @@ describe('requester namespace (RA-1a — department only)', () => {
     expect(() => assertApprovalConditionFormulaValidForSchema('requester.department', schema)).toThrow(/must return boolean/)
     expect(() => assertApprovalConditionFormulaValidForSchema('requester.level >= 5', schema)).toThrow(/unsupported requester attribute/)
   })
+
+  it('pins the operator restriction: department is ==/!= only (ordering ops fail publish type-check)', () => {
+    // department is string-typed, so ordering operators fail the numeric-operand check at publish.
+    // This is enforced via typing, not an explicit operator allowlist — RA-1b will auto-enable ordering
+    // for any future numeric attr, so this pin guards the RA-1a as-built contract.
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department >= "财务"', schema)).toThrow(/numeric operands/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department > "财务"', schema)).toThrow(/numeric operands/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department < "财务"', schema)).toThrow(/numeric operands/)
+    expect(() => assertApprovalConditionFormulaValidForSchema('requester.department <= "财务"', schema)).toThrow(/numeric operands/)
+  })
 })

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -136,6 +136,48 @@ describe('ApprovalGraphExecutor', () => {
     expect(() => new ApprovalGraphExecutor(runtimeGraph, { amount: 0 }).resolveInitialState()).toThrow(/division by zero/)
   })
 
+  it('routes a requester.department branch from threaded requesterContext, fail-closed on absent (RA-1a)', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'route',
+          type: 'condition',
+          config: {
+            branches: [{ edgeKey: 'edge-fin', rules: [], formula: { expression: 'requester.department == "财务"' } }],
+            defaultEdgeKey: 'edge-other',
+          },
+        },
+        { key: 'fin-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['finance'] } },
+        { key: 'other-review', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['standard'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-route', source: 'start', target: 'route' },
+        { key: 'edge-fin', source: 'route', target: 'fin-review' },
+        { key: 'edge-other', source: 'route', target: 'other-review' },
+        { key: 'edge-fin-end', source: 'fin-review', target: 'end' },
+        { key: 'edge-other-end', source: 'other-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    // match → finance branch, resolved from the frozen requester department (not formData)
+    expect(new ApprovalGraphExecutor(runtimeGraph, {}, { requesterContext: { department: '财务' } })
+      .resolveInitialState().currentNodeKey).toBe('fin-review')
+    // present-but-different → default edge (genuine no-match, not fail-closed)
+    expect(new ApprovalGraphExecutor(runtimeGraph, {}, { requesterContext: { department: '技术' } })
+      .resolveInitialState().currentNodeKey).toBe('other-review')
+    // absent context → FAIL-CLOSED throw, never silently take defaultEdgeKey (no phantom route)
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, {}, { requesterContext: null })
+      .resolveInitialState()).toThrow(/context unavailable/)
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, {}, { requesterContext: {} })
+      .resolveInitialState()).toThrow(/department is missing/)
+    // 3rd arg omitted → requesterContext defaults null → fail-closed (covers paths that must thread it)
+    expect(() => new ApprovalGraphExecutor(runtimeGraph, {})
+      .resolveInitialState()).toThrow(/context unavailable/)
+  })
+
   it('advances to approved when the next node is end', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       'tests/integration/approval-postgate-acceptance.api.test.ts',
       'tests/integration/dept-head-sync-plumbing.test.ts',
       'tests/integration/approval-manager-chain.db.test.ts',
+      'tests/integration/approval-requester-department.db.test.ts',
       'tests/integration/approval-delegation-seam.db.test.ts',
       'tests/integration/approval-delegation-api.db.test.ts',
       'tests/integration/approval-detail-subform.db.test.ts',


### PR DESCRIPTION
## What
Closes the RA-1a test gaps from the deep review — the P1 the #3265 commit itself named: no integration test exercised create -> persist -> reload -> dispatch.

## Added
- **approval-requester-department.db.test.ts** (NEW, real DB) — create+publish+start freezes directoryDepartment into requester_snapshot (JSONB); approve triggers dispatch (reload from row + re-thread); the requester.department condition routes to the eng branch on the reloaded frozen value. Routing at dispatch (not create) proves the round-trip, not a fixture.
- **approval-graph-executor.test.ts** — requesterContext routing: match -> branch, present-but-different -> default, absent -> fail-closed throw (no phantom default edge), omitted-options -> fail-closed.
- **approval-condition-formula.test.ts** — pin the ==/!= operator restriction (ordering ops fail publish type-check; emergent from string-typing).
- **approval-manager-chain.db.test.ts** — assert primaryDepartmentName resolves on the real DB (department source SQL-lift).

## Verified
Unit 45/45 (condition-formula + graph-executor); integration 4/4 (manager-chain) + 2/2 (new round-trip) on the live dev DB. Pure tests, no runtime change.

## Risk
None — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)