### PR TITLE
fix(multitable): narrow T9-W Tier 1 sheet_config revert to update+mapped-keys (#3264 follow-up)

### DIFF
--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -147,9 +147,13 @@ const SHEET_CONFIG_COLUMN: Record<string, ColumnMap> = {
   conditionalReadRules: { col: 'conditional_read_rules', jsonb: true },
   rowLevelReadPermissionsEnabled: { col: 'row_level_read_permissions_enabled' },
 }
-// The ONLY sheet_config revert shape this slice supports. A Set (not `key in obj`) so a forged `changed_keys`
-// entry like 'toString'/'constructor' can't match via the prototype chain.
-const SHEET_CONFIG_REVERT_KEYS = new Set(Object.keys(SHEET_CONFIG_COLUMN))
+// The Tier-1 revert surface — the ONLY sheet_config keys this slice will revert. Deliberately an EXPLICIT literal,
+// NOT derived from Object.keys(SHEET_CONFIG_COLUMN): growing that column map (for any reason) must NOT silently widen
+// what's revertible. Adding a key here is a Tier-1 SCOPE change — update the T9-W design-lock + add goldens FIRST;
+// the unit test pins this exact set as a tripwire. A Set (not `key in obj`) so a forged 'toString'/'constructor'
+// changed_key can't match via the prototype chain. Every key here must also exist in SHEET_CONFIG_COLUMN (else
+// applyConfigRevert throws) — the happy-path real-DB golden exercises that direction.
+export const SHEET_CONFIG_REVERT_KEYS = new Set(['conditionalReadRules', 'rowLevelReadPermissionsEnabled'])
 
 /**
  * T9-W Tier 1 narrowing: `classifyRevert` stays PURE (sheet_config is intrinsically gated), so the route must NOT

--- a/packages/core-backend/src/multitable/config-restore.ts
+++ b/packages/core-backend/src/multitable/config-restore.ts
@@ -147,6 +147,23 @@ const SHEET_CONFIG_COLUMN: Record<string, ColumnMap> = {
   conditionalReadRules: { col: 'conditional_read_rules', jsonb: true },
   rowLevelReadPermissionsEnabled: { col: 'row_level_read_permissions_enabled' },
 }
+// The ONLY sheet_config revert shape this slice supports. A Set (not `key in obj`) so a forged `changed_keys`
+// entry like 'toString'/'constructor' can't match via the prototype chain.
+const SHEET_CONFIG_REVERT_KEYS = new Set(Object.keys(SHEET_CONFIG_COLUMN))
+
+/**
+ * T9-W Tier 1 narrowing: `classifyRevert` stays PURE (sheet_config is intrinsically gated), so the route must NOT
+ * treat *every* sheet_config revision as the supported Tier-1 path. Only an `update` to the mapped read-rule columns
+ * is in scope; create/delete (= Tier 3 un-create, held) and unknown `changed_keys` stay gated/422. The route uses
+ * this for BOTH the preview `opKind='safe'` override AND the execute 422-skip, so the two can never diverge.
+ */
+export function isSupportedSheetConfigRevert(rev: Pick<ConfigRevisionRow, 'entity_type' | 'action' | 'changed_keys'>): boolean {
+  return rev.entity_type === 'sheet_config'
+    && rev.action === 'update'
+    && Array.isArray(rev.changed_keys)
+    && rev.changed_keys.length > 0
+    && rev.changed_keys.every((k) => SHEET_CONFIG_REVERT_KEYS.has(k))
+}
 
 /** Apply the revert: UPDATE the entity's changed columns to the revision's `before` values. Safe-op only (caller gates). */
 export async function applyConfigRevert(query: QueryFn, rev: ConfigRevisionRow): Promise<void> {

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -87,6 +87,7 @@ import {
 import {
   type ConfigRevisionRow,
   classifyRevert,
+  isSupportedSheetConfigRevert,
   computeRevertPreview,
   loadEntityConfigSnapshot,
   applyConfigRevert,
@@ -7742,7 +7743,10 @@ export function univerMetaRouter(): Router {
       // T9-W Tier 1: classifyRevert stays PURE (sheet_config = intrinsically gated), but the flag is ON here (flag-off
       // already 403'd above), so the ROUTE supports this revert — surface it as confirmable so the FE shows the confirm
       // path (the FE hides confirm unless opKind === 'safe'). EXECUTE applies the same flag+guard gate, not opKind.
-      if (rev.entity_type === 'sheet_config') {
+      // Narrowed: ONLY an update-to-mapped-read-rule-columns is Tier 1. A create/delete (Tier 3, held) or unknown
+      // changed_keys stays gated → FE hides confirm, and execute returns 422 below (same predicate, can't diverge).
+      // The redaction above still runs for EVERY sheet_config preview (gated or not) so a gated preview can't leak.
+      if (isSupportedSheetConfigRevert(rev)) {
         preview.opKind = 'safe'
         delete preview.gatedReason
       }
@@ -7792,9 +7796,11 @@ export function univerMetaRouter(): Router {
         }
       }
       const classify = classifyRevert(rev)
-      // classifyRevert stays PURE; the route SUPPORTS flag-on sheet_config (already flag/guard-gated above), so it must
-      // NOT 422 it. Every other gated kind (permission, lossy field, create/delete) is still refused here.
-      if (classify.kind === 'gated' && rev.entity_type !== 'sheet_config') return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
+      // classifyRevert stays PURE; the route SUPPORTS flag-on sheet_config ONLY in the narrowed Tier-1 shape (update +
+      // mapped read-rule keys), already flag/guard-gated above. Everything else still gated — including a sheet_config
+      // create/delete (Tier 3, held) or unknown changed_keys, which now returns a clean 422 here instead of falling
+      // through to applyConfigRevert (which would otherwise throw → 500, or worse, write an update-shaped revert).
+      if (classify.kind === 'gated' && !isSupportedSheetConfigRevert(rev)) return res.status(422).json({ ok: false, error: { code: 'RESTORE_NOT_SUPPORTED', message: classify.reason ?? 'This config restore is not supported in this slice.' } })
 
       // null = applied; a failure object = a guard tripped (the txn made no write either way).
       const failure = await pool.transaction(async ({ query }): Promise<{ status: number; code: string; message: string } | null> => {

--- a/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-config-revert-realdb.test.ts
@@ -3,11 +3,13 @@
  * MULTITABLE_ENABLE_SHEET_CONFIG_REVERT (default off). classifyRevert stays PURE (sheet_config = intrinsically
  * gated); the ROUTE supports it when the flag is on and surfaces the preview as confirmable (opKind:'safe').
  *
- * Goldens: (a) flag-OFF → preview AND execute 403 RESET... no: SHEET_CONFIG_REVERT_DISABLED · (b) gate: a
- * write-but-not-share actor → 403 · (c) fail-closed: a revision whose entity_id != sheet_id → 400 INVALID_REVISION ·
- * (d) flag-ON happy path: preview is confirmable (opKind:'safe', no drift) and execute SUCCEEDS (rules reverted,
- * forward source=restore revision) · (e) drift: rules edited after preview → execute 409 · (f) U-L6 redaction: a
- * field-denied canManageSheetAccess reader does NOT see the secret rule literal in the preview; fully-allowed does.
+ * Goldens: (a) flag-OFF → preview AND execute 403 SHEET_CONFIG_REVERT_DISABLED · (b) gate: a write-but-not-share
+ * actor → 403 · (c) fail-closed: a revision whose entity_id != sheet_id → 400 INVALID_REVISION · (d) flag-ON happy
+ * path: preview is confirmable (opKind:'safe', no drift) and execute SUCCEEDS (rules reverted, forward source=restore
+ * revision) · (e) drift: rules edited after preview → execute 409 · (f) U-L6 redaction: a field-denied
+ * canManageSheetAccess reader does NOT see the secret rule literal in the preview; fully-allowed does · (g) U-L4
+ * atomicity: a forced revision-insert failure rolls back the config UPDATE · (h) narrowing: create/delete/unknown-key
+ * sheet_config stays gated (preview not-safe + execute 422, no write, no restore revision).
  * Runs only with DATABASE_URL.
  */
 import express, { type Express } from 'express'
@@ -197,5 +199,42 @@ describeIfDatabase('multitable sheet_config revert — T9-W Tier 1 (real DB)', (
       await q(`DROP TRIGGER IF EXISTS ${TRG} ON meta_config_revisions`, []).catch(() => {})
       await q(`DROP FUNCTION IF EXISTS ${FN}()`, []).catch(() => {})
     }
+  })
+
+  // (h) Narrowing (isSupportedSheetConfigRevert): flag-on, entity_id===sheet_id, canManageSheetAccess — but a
+  // sheet_config revision that is NOT an update-to-mapped-read-rule-columns must stay GATED. classifyRevert is pure
+  // (sheet_config always gated); the route's opKind override + execute 422-skip are narrowed by the predicate, so a
+  // create/delete (Tier 3 un-create, held by #3254) or unknown changed_keys can't masquerade as a confirmable/
+  // executable Tier-1 revert. Each forged shape → preview gated (opKind NOT 'safe') AND execute 422 RESTORE_NOT_SUPPORTED,
+  // with ZERO config write + NO forward restore revision. entity_id is set to SHEET so this isolates the action/key
+  // gate, not the (c) entity_id guard.
+  test('(h) narrowing: flag-on sheet_config create/delete/unknown-key stays gated → preview not-safe + execute 422, no write, no restore revision', async () => {
+    process.env[FLAG] = 'true'
+    const forge = async (action: string, changedKeys: string[], payload: Record<string, unknown>): Promise<string> =>
+      ((await q(
+        `INSERT INTO meta_config_revisions (id, sheet_id, entity_type, entity_id, action, before, after, changed_keys, batch_id, actor_id, created_at)
+         VALUES (gen_random_uuid(), $1, 'sheet_config', $1, $2, $3::jsonb, $4::jsonb, $5::text[], gen_random_uuid(), $6, now()) RETURNING id`,
+        [SHEET, action, JSON.stringify(payload), JSON.stringify(payload), changedKeys, U_FULL],
+      )).rows[0] as { id: string }).id
+    const forged = [
+      await forge('create', ['conditionalReadRules'], { conditionalReadRules: [] }), // create = Tier 3 (held)
+      await forge('delete', ['conditionalReadRules'], { conditionalReadRules: [] }), // delete = Tier 3 (held)
+      await forge('update', ['someUnknownKey'], { someUnknownKey: 'x' }),            // unknown key (not mapped)
+    ]
+    const liveBefore = JSON.stringify(await liveRules())
+    const restoreCountBefore = ((await q(`SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1 AND source='restore'`, [SHEET])).rows[0] as { n: number }).n
+    for (const revId of forged) {
+      const p = await preview(revId, FULL)
+      expect(p.status).toBe(200)
+      expect(p.body?.data?.preview?.opKind).not.toBe('safe') // stays gated → FE hides confirm
+      expect(p.body?.data?.preview?.gatedReason).toBeTruthy()
+      const x = await execute(revId, p.body?.data?.previewToken ?? 'any-token', FULL)
+      expect(x.status).toBe(422)
+      expect(x.body?.error?.code).toBe('RESTORE_NOT_SUPPORTED')
+    }
+    // zero side effects: live rules byte-for-byte unchanged + no forward restore revision appended
+    expect(JSON.stringify(await liveRules())).toBe(liveBefore)
+    const restoreCountAfter = ((await q(`SELECT count(*)::int AS n FROM meta_config_revisions WHERE sheet_id=$1 AND source='restore'`, [SHEET])).rows[0] as { n: number }).n
+    expect(restoreCountAfter).toBe(restoreCountBefore)
   })
 })

--- a/packages/core-backend/tests/multitable-config-restore-narrowing.test.ts
+++ b/packages/core-backend/tests/multitable-config-restore-narrowing.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure unit lock for `isSupportedSheetConfigRevert` — the T9-W Tier 1 narrowing predicate that gates BOTH the route's
+ * preview `opKind='safe'` override and the execute 422-skip. DB-free, so it runs in the default `test` job on every PR
+ * (the real-DB wiring is golden (h) in tests/integration/multitable-sheet-config-revert-realdb.test.ts).
+ *
+ * Bar: ONLY an `update` to mapped read-rule columns is supported. create/delete (Tier 3 un-create, held by #3254) and
+ * unknown/empty changed_keys stay unsupported, so they can never be surfaced as confirmable or executed as a revert.
+ */
+import { describe, expect, test } from 'vitest'
+
+import { isSupportedSheetConfigRevert } from '../src/multitable/config-restore'
+
+const rev = (over: Partial<{ entity_type: string; action: string; changed_keys: unknown }>) => ({
+  entity_type: 'sheet_config',
+  action: 'update',
+  changed_keys: ['conditionalReadRules'],
+  ...over,
+}) as Parameters<typeof isSupportedSheetConfigRevert>[0]
+
+describe('isSupportedSheetConfigRevert — T9-W Tier 1 narrowing', () => {
+  test('supported: update to mapped read-rule columns', () => {
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['conditionalReadRules'] }))).toBe(true)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['rowLevelReadPermissionsEnabled'] }))).toBe(true)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['conditionalReadRules', 'rowLevelReadPermissionsEnabled'] }))).toBe(true)
+  })
+
+  test('unsupported action: create/delete (Tier 3 un-create, held)', () => {
+    expect(isSupportedSheetConfigRevert(rev({ action: 'create' }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ action: 'delete' }))).toBe(false)
+  })
+
+  test('unsupported keys: unknown, mixed, or empty', () => {
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['someUnknownKey'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['conditionalReadRules', 'someUnknownKey'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: [] }))).toBe(false)
+  })
+
+  test('forged prototype-chain keys do NOT match (Set membership, not `key in obj`)', () => {
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['toString'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['constructor'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: ['hasOwnProperty'] }))).toBe(false)
+  })
+
+  test('wrong entity_type is never a supported sheet_config revert', () => {
+    expect(isSupportedSheetConfigRevert(rev({ entity_type: 'field', changed_keys: ['name'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ entity_type: 'view', changed_keys: ['filterInfo'] }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ entity_type: 'permission' }))).toBe(false)
+  })
+
+  test('malformed changed_keys (non-array, forged row) is rejected, not thrown', () => {
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: undefined }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: null }))).toBe(false)
+    expect(isSupportedSheetConfigRevert(rev({ changed_keys: 'conditionalReadRules' }))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/multitable-config-restore-narrowing.test.ts
+++ b/packages/core-backend/tests/multitable-config-restore-narrowing.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, test } from 'vitest'
 
-import { isSupportedSheetConfigRevert } from '../src/multitable/config-restore'
+import { isSupportedSheetConfigRevert, SHEET_CONFIG_REVERT_KEYS } from '../src/multitable/config-restore'
 
 const rev = (over: Partial<{ entity_type: string; action: string; changed_keys: unknown }>) => ({
   entity_type: 'sheet_config',
@@ -51,5 +51,13 @@ describe('isSupportedSheetConfigRevert — T9-W Tier 1 narrowing', () => {
     expect(isSupportedSheetConfigRevert(rev({ changed_keys: undefined }))).toBe(false)
     expect(isSupportedSheetConfigRevert(rev({ changed_keys: null }))).toBe(false)
     expect(isSupportedSheetConfigRevert(rev({ changed_keys: 'conditionalReadRules' }))).toBe(false)
+  })
+
+  // TRIPWIRE: the Tier-1 revert surface is design-locked to exactly these two read-rule keys, and is an EXPLICIT
+  // literal (not derived from SHEET_CONFIG_COLUMN) so growing that map can't silently widen it. If you add a key to
+  // SHEET_CONFIG_REVERT_KEYS this assertion fails ON PURPOSE — widening Tier 1 is a T9-W design-lock change that needs
+  // its own goldens + sign-off (e.g. Tier 2 lossy retype is a SEPARATE slice), not a quiet edit. Update the lock first.
+  test('TRIPWIRE: supported revert surface is exactly the design-locked read-rule keys', () => {
+    expect([...SHEET_CONFIG_REVERT_KEYS].sort()).toEqual(['conditionalReadRules', 'rowLevelReadPermissionsEnabled'])
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to **#3264** (merged with a [P1]): the T9-W Tier 1 flag-on path keyed off `rev.entity_type === 'sheet_config'` **alone**, bypassing `classifyRevert`'s action/key gating. A forged sheet_config revision with `action='create'|'delete'` (Tier 3 un-create, **held** by #3254) or unknown `changed_keys` was surfaced as confirmable (preview `opKind='safe'`) and skipped the execute 422 — executing an update-shaped revert + appending a restore revision, **violating #3254's hold on Tier 3/4**.

Latent today (the live recorder emits only `action='update'`) but **forgeable** — and the slice already adopts the forged-revision threat model via the `entity_id===sheet_id` guard, so fail-open on a forged `action`/`changed_keys` was inconsistent. The flag `MULTITABLE_ENABLE_SHEET_CONFIG_REVERT` is default-off, so this was not an active breach, but it must be narrowed before the flag is ever enabled.

## Change

- New shared predicate `isSupportedSheetConfigRevert(rev)` in `config-restore.ts` (next to `classifyRevert`): `entity_type === 'sheet_config' && action === 'update' && non-empty changed_keys ⊆ mapped read-rule columns`. **Set membership** (not `key in obj`) so a forged `'toString'`/`'constructor'` key can't match via the prototype chain; `Array.isArray` guards a malformed forged row.
- Gate **both** the preview `opKind='safe'` override **and** the execute 422-skip on the predicate — they can never diverge. Unsupported sheet_config now returns a clean **422 `RESTORE_NOT_SUPPORTED`** (was: 500-via-throw, or an update-shaped write).
- Preview redaction is unchanged — it still runs for **every** sheet_config preview, so a gated preview can't leak rule literals.

`classifyRevert` stays pure. No behavior change for the supported Tier 1 happy path, view/field reverts, or the flag-off/gate/entity_id/drift paths.

## Verification

- **DB-free unit lock** (runs in the default `test` job): `tests/multitable-config-restore-narrowing.test.ts` — supported shape, create/delete, unknown/mixed/empty keys, proto-chain footgun, wrong entity_type, malformed non-array `changed_keys`. 6/6 green locally.
- **Real-DB golden (h)** in `multitable-sheet-config-revert-realdb.test.ts`: flag-on, `canManageSheetAccess`, `entity_id===sheet_id` — forged `create`/`delete`/unknown-key each → preview not-`safe` + execute 422, **zero writes + no `source='restore'` revision**.
- `tsc --noEmit`: 0 errors.

## Scope

Default-off flag unchanged; enabling it stays a separate runbook step (now safe-gated by this narrowing). Tier 2 (lossy field retype) is a separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
