### PR TITLE
fix(approval): RA-1a requester.department wedge guard — reject-at-create [NEEDS RATIFICATION]

### DIFF
--- a/docs/design/approval-ra1a-wedge-guard-design-20260627.md
+++ b/docs/design/approval-ra1a-wedge-guard-design-20260627.md
@@ -1,0 +1,26 @@
+# RA-1a transient-resolution wedge guard — Design
+
+> Status: **PROPOSED — owner ratification needed** (touches the `createApproval` contract). Implemented on `claude/approval-ra1a-wedge-fix-20260627`; PR open, do-not-merge until ratified. Source of the finding: the RA-1a deep review (2026-06-27), P2.
+
+## Problem
+`createApproval` resolves the requester's directory department best-effort and **swallows failures** into `orgRelations = {}` (`ApprovalProductService.ts` ~:2876-2886). If the directory read fails **transiently at create** AND the template routes on `requester.department` **downstream of an approval node**, the create succeeds with the department absent, the `requester_snapshot` is frozen, and the first approval that reaches the condition throws → rolls back → re-throws on every retry **forever** (admin-cancel only). Fail-closed (safe, no mis-route) but a permanent in-flight wedge — production-triggerable and invisible to tests.
+
+## Root cause — error-vs-empty conflation
+The `catch` swallows BOTH a *thrown* read error (transient/infra) AND a *genuinely empty* result into `{}`. "department absent" is then ambiguous, and freezing it is wrong only for the transient case.
+
+## Fix (error-vs-empty split)
+Track whether the org-read threw (`orgReadFailed`). Then, **only when the published graph actually routes on `requester.department`** (new exported helper `runtimeGraphUsesRequesterDepartment`):
+- read **THREW** (transient) and no department resolved → **fail the create fast**: `ServiceError(503, 'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED')`, retryable. A visible, retryable create error beats a silent permanent wedge.
+- read **SUCCEEDED but empty** (genuine row-level absence) → **proceed unchanged**; runtime fail-closes per the ratified lock. A requester who genuinely has no department is never blocked at create — ratified semantics preserved.
+
+Non-`requester.department` templates and the manager-chain / dept-head paths are unaffected (the guard never fires for them).
+
+## Why this preserves ratified semantics
+The lock's "missing department → runtime fail-closed" is unchanged for genuine absence. The guard only changes the **transient-failure** case, converting a permanent mid-flight wedge into an immediate retryable create error. No change to publish validation, routing, or genuine-absence runtime behavior.
+
+## Tests
+- `approval-product-service.test.ts` (unit): transient read throw + `requester.department` graph → rejects 503; successful empty read + same graph → still creates (genuine absence proceeds).
+- Happy path already covered by the round-trip integration test (#3294); the guard does not fire there (department resolves).
+
+## Out of scope / future
+- Optional: persist a `resolutionFailed` reason so `dispatch` can re-resolve ONLY the transient case (heal without re-reading on the happy path). Deferred — fail-fast-at-create needs no snapshot-schema change and is simpler.

--- a/docs/design/approval-ra1a-wedge-guard-design-20260627.md
+++ b/docs/design/approval-ra1a-wedge-guard-design-20260627.md
@@ -1,26 +1,25 @@
-# RA-1a transient-resolution wedge guard — Design
+# RA-1a requester.department wedge guard — Design
 
-> Status: **PROPOSED — owner ratification needed** (touches the `createApproval` contract). Implemented on `claude/approval-ra1a-wedge-fix-20260627`; PR open, do-not-merge until ratified. Source of the finding: the RA-1a deep review (2026-06-27), P2.
+> Status: **PROPOSED — owner ratification needed** (touches the `createApproval` contract). Implemented on `claude/approval-ra1a-wedge-fix-20260627`; PR open as **draft**, do-not-merge until ratified. Source of the finding: the RA-1a deep review (2026-06-27), P2.
 
 ## Problem
-`createApproval` resolves the requester's directory department best-effort and **swallows failures** into `orgRelations = {}` (`ApprovalProductService.ts` ~:2876-2886). If the directory read fails **transiently at create** AND the template routes on `requester.department` **downstream of an approval node**, the create succeeds with the department absent, the `requester_snapshot` is frozen, and the first approval that reaches the condition throws → rolls back → re-throws on every retry **forever** (admin-cancel only). Fail-closed (safe, no mis-route) but a permanent in-flight wedge — production-triggerable and invisible to tests.
+`createApproval` resolves the requester's directory department best-effort and **swallows failures** into `orgRelations = {}` (`ApprovalProductService.ts` ~:2876-2886). If the template routes on `requester.department` **downstream of an approval node** and the department is absent — whether because the read **failed transiently** OR because the requester **genuinely has none** — the create succeeds, the `requester_snapshot` is frozen, and the first approval that reaches the condition throws → rolls back → re-throws on **every retry forever** (admin-cancel only). Fail-closed (no mis-route) but a permanent in-flight wedge — production-triggerable and invisible to tests.
 
-## Root cause — error-vs-empty conflation
-The `catch` swallows BOTH a *thrown* read error (transient/infra) AND a *genuinely empty* result into `{}`. "department absent" is then ambiguous, and freezing it is wrong only for the transient case.
+The lock §2 intends absence to be **"reject this createApproval rather than route on a phantom value"** — but the runtime realizes that only when the condition is reachable *at create*. A **downstream** condition rejects at dispatch (post-freeze) instead, which is the wedge. This holds for both the transient AND the genuine-absence trigger; an earlier scoping that fixed only the transient case left the (deterministic) genuine-absence wedge open.
 
-## Fix (error-vs-empty split)
-Track whether the org-read threw (`orgReadFailed`). Then, **only when the published graph actually routes on `requester.department`** (new exported helper `runtimeGraphUsesRequesterDepartment`):
-- read **THREW** (transient) and no department resolved → **fail the create fast**: `ServiceError(503, 'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED')`, retryable. A visible, retryable create error beats a silent permanent wedge.
-- read **SUCCEEDED but empty** (genuine row-level absence) → **proceed unchanged**; runtime fail-closes per the ratified lock. A requester who genuinely has no department is never blocked at create — ratified semantics preserved.
+## Fix
+When the published graph routes on `requester.department` (new exported helper `runtimeGraphUsesRequesterDepartment`) and the department did not resolve, **reject at create** — realizing the lock's reject-at-create regardless of graph topology. The cause is distinguished for the caller:
+- read **THREW** (transient/infra) → `ServiceError(503, 'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED')` — retryable.
+- read **SUCCEEDED but empty** (genuine row-level absence) → `ServiceError(422, 'APPROVAL_REQUESTER_DEPARTMENT_REQUIRED')` — the requester's department is unset for a template that routes on it.
 
-Non-`requester.department` templates and the manager-chain / dept-head paths are unaffected (the guard never fires for them).
+Non-`requester.department` templates and the manager-chain / dept-head paths are unaffected (the guard never fires; genuine absence on those still follows their `emptyAssigneePolicy`).
 
-## Why this preserves ratified semantics
-The lock's "missing department → runtime fail-closed" is unchanged for genuine absence. The guard only changes the **transient-failure** case, converting a permanent mid-flight wedge into an immediate retryable create error. No change to publish validation, routing, or genuine-absence runtime behavior.
+## Alignment with the ratified lock
+The lock §2: row-level absence → "reject this createApproval rather than route on a phantom value." This guard makes that hold regardless of topology, for both causes. No change to publish validation, to routing, or to the never-phantom-route rule. Conservative trade-off: the guard fires whenever the graph *references* `requester.department` (coarse), so it can reject a create whose actual path would not have reached the condition — accepted under the lock's "never route on a phantom value" priority; precise per-path reachability is not knowable at create (branches depend on future approver decisions).
 
 ## Tests
-- `approval-product-service.test.ts` (unit): transient read throw + `requester.department` graph → rejects 503; successful empty read + same graph → still creates (genuine absence proceeds).
-- Happy path already covered by the round-trip integration test (#3294); the guard does not fire there (department resolves).
+- `approval-product-service.test.ts` (unit): transient throw + `requester.department` graph → rejects **503**; successful empty read + same graph → rejects **422** (genuine absence fail-closed at create, NOT a downstream wedge); existing non-department createApproval paths unaffected (64/64 green; tsc clean).
+- Happy path covered by the round-trip integration test (#3294, now wired into the CI integration lane); the guard does not fire there (department resolves).
 
 ## Out of scope / future
-- Optional: persist a `resolutionFailed` reason so `dispatch` can re-resolve ONLY the transient case (heal without re-reading on the happy path). Deferred — fail-fast-at-create needs no snapshot-schema change and is simpler.
+- Optional: instead of reject-at-create, persist a `resolutionFailed` reason and re-resolve ONLY the transient case at dispatch (heal without re-reading on the happy path). Deferred — reject-at-create needs no snapshot-schema change and is the lock's stated behavior.

--- a/packages/core-backend/src/services/ApprovalConditionFormula.ts
+++ b/packages/core-backend/src/services/ApprovalConditionFormula.ts
@@ -423,6 +423,37 @@ function parseFormula(expression: string): FormulaAst {
   return new FormulaParser(tokenize(trimmed)).parse()
 }
 
+function astReferencesRequesterAttribute(ast: FormulaAst, attr: string): boolean {
+  switch (ast.kind) {
+    case 'requester':
+      return ast.attr === attr
+    case 'unary':
+      return astReferencesRequesterAttribute(ast.expr, attr)
+    case 'binary':
+    case 'compare':
+      return astReferencesRequesterAttribute(ast.left, attr) || astReferencesRequesterAttribute(ast.right, attr)
+    default:
+      return false
+  }
+}
+
+/**
+ * Token-aware: does the formula reference `requester.<attr>` as an actual reserved requester TOKEN —
+ * not a string literal like "requester.department" or a field name that merely contains the text?
+ * Parses to the AST and walks for a `{ kind: 'requester', attr }` node, so quoting can never trip it.
+ * Returns false on a parse error (callers scan already-published, parseable formulas, so this is
+ * defensive only — and false-on-error avoids over-firing the RA-1a create-time wedge guard).
+ */
+export function formulaReferencesRequesterAttribute(expression: string, attr: string): boolean {
+  let ast: FormulaAst
+  try {
+    ast = parseFormula(expression)
+  } catch {
+    return false
+  }
+  return astReferencesRequesterAttribute(ast, attr)
+}
+
 function formFieldTypeToFormulaType(field: FormField): FormulaType | 'unsupported' {
   switch (field.type) {
     case 'number':

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1767,6 +1767,27 @@ export function runtimeGraphUsesManagerChain(runtimeGraph: RuntimeGraph): boolea
   })
 }
 
+/**
+ * RA-1a: does the published runtime graph route on `requester.department`? Used by the create-time
+ * wedge guard — a transient directory-read failure must fail the create fast (retryable) when a
+ * `requester.department` condition exists, rather than freezing an absent department that would
+ * wedge every later approval at the condition (the snapshot is frozen; admin-cancel only).
+ */
+export function runtimeGraphUsesRequesterDepartment(runtimeGraph: RuntimeGraph): boolean {
+  return runtimeGraph.nodes.some((node) => {
+    if (node.type !== 'condition') return false
+    const config: unknown = node.config
+    const branches = isRecord(config) ? config.branches : undefined
+    if (!Array.isArray(branches)) return false
+    return branches.some((branch) => {
+      if (!isRecord(branch)) return false
+      const formula = isRecord(branch.formula) ? branch.formula : undefined
+      const expression = formula && typeof formula.expression === 'string' ? formula.expression : ''
+      return /\brequester\s*\.\s*department\b/.test(expression)
+    })
+  })
+}
+
 function getEffectiveAutoApprovalPolicy(
   runtimeGraph: RuntimeGraph,
   nodeKey: string,
@@ -2873,15 +2894,31 @@ export class ApprovalProductService {
     const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
     const needsManagerChain = runtimeGraphUsesManagerChain(runtimeGraph)
     let orgRelations: ApprovalRequesterOrgRelations = {}
+    let orgReadFailed = false
     try {
       orgRelations = await resolveApprovalRequesterOrgRelations(actor.userId, pool.query.bind(pool), {
         includeManagerChain: needsManagerChain,
       })
     } catch (error) {
+      orgReadFailed = true
       metricsLogger.warn(
         `Failed to resolve requester org relations for ${actor.userId}: ${
           error instanceof Error ? error.message : 'unknown error'
         }`,
+      )
+    }
+
+    // RA-1a wedge guard (error-vs-empty split): a directory read that THREW leaves the department
+    // unknown. If the template routes on `requester.department`, freezing an absent department would
+    // wedge every later approval at the condition (the snapshot is frozen — admin-cancel only). Fail the
+    // create fast (retryable) instead. A read that SUCCEEDED with no department is genuine row-level
+    // absence — proceed, and runtime fail-closes per the ratified lock (never block a requester who
+    // genuinely has no department). Only fires when the graph actually routes on requester.department.
+    if (orgReadFailed && !orgRelations.primaryDepartmentName && runtimeGraphUsesRequesterDepartment(runtimeGraph)) {
+      throw new ServiceError(
+        'Could not resolve the requester department required by this approval template. Please retry.',
+        503,
+        'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED',
       )
     }
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2908,17 +2908,27 @@ export class ApprovalProductService {
       )
     }
 
-    // RA-1a wedge guard (error-vs-empty split): a directory read that THREW leaves the department
-    // unknown. If the template routes on `requester.department`, freezing an absent department would
-    // wedge every later approval at the condition (the snapshot is frozen — admin-cancel only). Fail the
-    // create fast (retryable) instead. A read that SUCCEEDED with no department is genuine row-level
-    // absence — proceed, and runtime fail-closes per the ratified lock (never block a requester who
-    // genuinely has no department). Only fires when the graph actually routes on requester.department.
-    if (orgReadFailed && !orgRelations.primaryDepartmentName && runtimeGraphUsesRequesterDepartment(runtimeGraph)) {
+    // RA-1a wedge guard: if the template routes on `requester.department` but it could NOT be resolved,
+    // fail-closed AT CREATE — the ratified lock says absence "reject this createApproval rather than route
+    // on a phantom value". Without this, a condition downstream of an approval node only rejects at
+    // dispatch (after the snapshot is frozen), so every later approval throws -> rolls back -> wedges the
+    // instance forever (admin-cancel only). Reject both causes at create; distinguish them for the caller:
+    //   - read THREW (transient/infra) -> 503, retryable.
+    //   - read SUCCEEDED but empty (genuine row-level absence) -> 422, the requester's department is unset.
+    // Only fires when the graph actually routes on requester.department (manager-chain / dept-head and
+    // non-department templates are unaffected; genuine absence on those follows their emptyAssigneePolicy).
+    if (!orgRelations.primaryDepartmentName && runtimeGraphUsesRequesterDepartment(runtimeGraph)) {
+      if (orgReadFailed) {
+        throw new ServiceError(
+          'Could not resolve the requester department required by this approval template. Please retry.',
+          503,
+          'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED',
+        )
+      }
       throw new ServiceError(
-        'Could not resolve the requester department required by this approval template. Please retry.',
-        503,
-        'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED',
+        'This approval template routes on the requester department, which is not set for you. Contact an administrator.',
+        422,
+        'APPROVAL_REQUESTER_DEPARTMENT_REQUIRED',
       )
     }
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -47,6 +47,7 @@ import { validateAmountTotalConsistency } from './amount-total-check'
 import {
   ApprovalConditionFormulaError,
   assertApprovalConditionFormulaValidForSchema,
+  formulaReferencesRequesterAttribute,
   parseApprovalConditionFormula,
 } from './ApprovalConditionFormula'
 import { resolveApprovalRequesterOrgRelations, MAX_MANAGER_CHAIN_LEVELS, type ApprovalRequesterOrgRelations } from './ApprovalDirectoryOrg'
@@ -1783,7 +1784,8 @@ export function runtimeGraphUsesRequesterDepartment(runtimeGraph: RuntimeGraph):
       if (!isRecord(branch)) return false
       const formula = isRecord(branch.formula) ? branch.formula : undefined
       const expression = formula && typeof formula.expression === 'string' ? formula.expression : ''
-      return /\brequester\s*\.\s*department\b/.test(expression)
+      // Token-aware (NOT a regex): a string literal like "requester.department" must never trip the guard.
+      return expression !== '' && formulaReferencesRequesterAttribute(expression, 'department')
     })
   })
 }

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2152,6 +2152,76 @@ describe('ApprovalProductService', () => {
     expect(insertInstance?.[1]?.[12]).toBe('pub-2')
   })
 
+  // RA-1a wedge guard (error-vs-empty split): a transient directory-read failure must not freeze an
+  // absent department into a downstream requester.department condition (which would wedge every later
+  // approval, admin-cancel only). A read that THROWS fails the create fast; a read that SUCCEEDS with no
+  // department proceeds (genuine absence — runtime fail-closes per the lock, never blocks the requester).
+  const wedgeGraph = {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['mgr-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'condition_1', type: 'condition', config: { branches: [{ edgeKey: 'eng', rules: [], formula: { expression: "requester.department == 'Eng'" } }], defaultEdgeKey: 'other' } },
+      { key: 'approval_eng', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['eng-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'approval_other', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['oth-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'condition_1' },
+      { key: 'eng', source: 'condition_1', target: 'approval_eng' },
+      { key: 'other', source: 'condition_1', target: 'approval_other' },
+      { key: 'e3', source: 'approval_eng', target: 'end' },
+      { key: 'e4', source: 'approval_other', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+  function mountWedgeSql() {
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return { rows: [{ id: 'tpl-1', key: 'travel', name: 'Travel', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'published', active_version_id: 'ver-2', latest_version_id: 'ver-2', created_at: new Date(), updated_at: new Date() }], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return { rows: [{ id: 'ver-2', template_id: 'tpl-1', version: 2, status: 'published', form_schema: { fields: [] }, approval_graph: wedgeGraph, created_at: new Date(), updated_at: new Date() }], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: wedgeGraph, is_active: true, published_at: new Date() }], rowCount: 1 }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-101050' }], rowCount: 1 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') return { rows: [], rowCount: 0 }
+      if (statement.startsWith('SELECT assignment_type, assignee_id, node_key FROM approval_assignments')) return { rows: [], rowCount: 0 }
+      if (statement.startsWith('INSERT INTO approval_instances')) return { rows: [], rowCount: 1 }
+      if (statement.startsWith('INSERT INTO approval_assignments')) return { rows: [], rowCount: 1 }
+      if (statement.startsWith('INSERT INTO approval_records')) return { rows: [], rowCount: 1 }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+  }
+
+  it('RA-1a wedge guard: fails create fast (503) when the directory read THROWS and the graph routes on requester.department', async () => {
+    orgRelationsState.resolveApprovalRequesterOrgRelations.mockRejectedValue(new Error('transient directory read failure'))
+    mountWedgeSql()
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
+    await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' }))
+      .rejects.toMatchObject({ statusCode: 503, code: 'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED' })
+  })
+
+  it('RA-1a wedge guard: a SUCCESSFUL read with no department still creates (genuine absence proceeds; runtime fail-closes later)', async () => {
+    orgRelationsState.resolveApprovalRequesterOrgRelations.mockResolvedValue({})
+    mountWedgeSql()
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
+    await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' })).resolves.toBeTruthy()
+  })
+
   it('bakes the manager chain into the persisted requester snapshot for a manager_at_level graph', async () => {
     // Regression for the bake-gate gap: prove createApproval ITSELF wires the
     // scanner result through to the snapshot — not just the resolver. The org

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -2213,13 +2213,14 @@ describe('ApprovalProductService', () => {
       .rejects.toMatchObject({ statusCode: 503, code: 'APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED' })
   })
 
-  it('RA-1a wedge guard: a SUCCESSFUL read with no department still creates (genuine absence proceeds; runtime fail-closes later)', async () => {
-    orgRelationsState.resolveApprovalRequesterOrgRelations.mockResolvedValue({})
+  it('RA-1a wedge guard: a SUCCESSFUL read with no department also rejects AT CREATE (422) — genuine absence is fail-closed at create per the lock, never a downstream wedge', async () => {
+    orgRelationsState.resolveApprovalRequesterOrgRelations.mockResolvedValue({}) // success, but no primaryDepartmentName
     mountWedgeSql()
     const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
     const service = new ApprovalProductService(buildNoopMetrics() as never)
     vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
-    await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' })).resolves.toBeTruthy()
+    await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' }))
+      .rejects.toMatchObject({ statusCode: 422, code: 'APPROVAL_REQUESTER_DEPARTMENT_REQUIRED' })
   })
 
   it('bakes the manager chain into the persisted requester snapshot for a manager_at_level graph', async () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import crypto from 'crypto'
+import { formulaReferencesRequesterAttribute } from '../../src/services/ApprovalConditionFormula'
 
 const pgState = vi.hoisted(() => ({
   client: {
@@ -2175,17 +2176,17 @@ describe('ApprovalProductService', () => {
     ],
     policy: { allowRevoke: true },
   }
-  function mountWedgeSql() {
+  function mountWedgeSql(graph: unknown = wedgeGraph) {
     pgState.pool.query.mockImplementation(async (sql: string) => {
       const statement = normalize(sql)
       if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
         return { rows: [{ id: 'tpl-1', key: 'travel', name: 'Travel', description: null, category: null, visibility_scope: { type: 'all', ids: [] }, sla_hours: null, status: 'published', active_version_id: 'ver-2', latest_version_id: 'ver-2', created_at: new Date(), updated_at: new Date() }], rowCount: 1 }
       }
       if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
-        return { rows: [{ id: 'ver-2', template_id: 'tpl-1', version: 2, status: 'published', form_schema: { fields: [] }, approval_graph: wedgeGraph, created_at: new Date(), updated_at: new Date() }], rowCount: 1 }
+        return { rows: [{ id: 'ver-2', template_id: 'tpl-1', version: 2, status: 'published', form_schema: { fields: [] }, approval_graph: graph, created_at: new Date(), updated_at: new Date() }], rowCount: 1 }
       }
       if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
-        return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: wedgeGraph, is_active: true, published_at: new Date() }], rowCount: 1 }
+        return { rows: [{ id: 'pub-2', template_id: 'tpl-1', template_version_id: 'ver-2', runtime_graph: graph, is_active: true, published_at: new Date() }], rowCount: 1 }
       }
       if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
         return { rows: [{ request_no: 'AP-101050' }], rowCount: 1 }
@@ -2221,6 +2222,44 @@ describe('ApprovalProductService', () => {
     vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
     await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' }))
       .rejects.toMatchObject({ statusCode: 422, code: 'APPROVAL_REQUESTER_DEPARTMENT_REQUIRED' })
+  })
+
+  // P1 fix: detection is token-aware (AST), so a quoted "requester.department" is NOT a requester reference.
+  const literalGraph = {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'approval_1', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['mgr-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'condition_1', type: 'condition', config: { branches: [{ edgeKey: 'eng', rules: [], formula: { expression: '"requester.department" == "x"' } }], defaultEdgeKey: 'other' } },
+      { key: 'approval_eng', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['eng-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'approval_other', type: 'approval', config: { assigneeSources: [{ kind: 'static_user', userIds: ['oth-1'] }], approvalMode: 'single', emptyAssigneePolicy: 'error' } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e1', source: 'start', target: 'approval_1' },
+      { key: 'e2', source: 'approval_1', target: 'condition_1' },
+      { key: 'eng', source: 'condition_1', target: 'approval_eng' },
+      { key: 'other', source: 'condition_1', target: 'approval_other' },
+      { key: 'e3', source: 'approval_eng', target: 'end' },
+      { key: 'e4', source: 'approval_other', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+
+  it('RA-1a guard detection is token-aware — a quoted "requester.department" is not a requester reference (P1)', () => {
+    expect(formulaReferencesRequesterAttribute("requester.department == 'Eng'", 'department')).toBe(true)
+    expect(formulaReferencesRequesterAttribute('NOT (requester.department == "Eng")', 'department')).toBe(true)
+    expect(formulaReferencesRequesterAttribute('"requester.department" == "x"', 'department')).toBe(false)
+    expect(formulaReferencesRequesterAttribute('{reason} == "requester.department"', 'department')).toBe(false)
+    expect(formulaReferencesRequesterAttribute('{amount} > 5', 'department')).toBe(false)
+  })
+
+  it('RA-1a wedge guard does NOT fire for a string-literal "requester.department" — create succeeds with no department (P1)', async () => {
+    orgRelationsState.resolveApprovalRequesterOrgRelations.mockResolvedValue({}) // no department
+    mountWedgeSql(literalGraph)
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({ templateVersionId: 'ver-2', publishedDefinitionId: 'pub-2' }))
+    await expect(service.createApproval({ templateId: 'tpl-1', formData: {} }, { userId: 'requester-1' })).resolves.toBeTruthy()
   })
 
   it('bakes the manager chain into the persisted requester snapshot for a manager_at_level graph', async () => {


### PR DESCRIPTION
## Owner ratification needed — draft, do not merge yet
Changes the createApproval contract (a fail-fast path on absent `requester.department`). Review the design note before merge: `docs/design/approval-ra1a-wedge-guard-design-20260627.md`.

## Problem (deep-review P2)
createApproval resolves the requester directory department best-effort and swallows failures into `orgRelations={}`. If the template routes on `requester.department` **downstream of an approval node** and the department is absent — **transiently** (read failed) OR **genuinely** (requester has none) — the create freezes an absent department, the snapshot is frozen, and the first approval at the condition throws -> rollback -> re-throws forever (admin-cancel only). A permanent in-flight wedge.

## Fix — reject at create, per the lock
Lock §2: absence -> "reject this createApproval rather than route on a phantom value." When the graph routes on `requester.department` (**token-aware AST detection, not a regex** — a quoted `"requester.department"` does not count) and the department does not resolve, reject at create:
- read THREW (transient/infra) -> **503** `APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED` (retryable)
- read SUCCEEDED but empty (genuine absence) -> **422** `APPROVAL_REQUESTER_DEPARTMENT_REQUIRED`

Guard fires only when the graph references the `requester.department` token; manager-chain / dept-head / non-department templates are unaffected.

## Review fixes folded in
- **P1**: detection is now token-aware (AST `formulaReferencesRequesterAttribute`), so a string literal `"requester.department"` never trips the guard.
- Genuine absence also rejects at create (not just the transient case) — closes the full wedge, not half.

## Tests
product-service **66/66**: transient -> 503; genuine-empty -> 422; quoted-literal graph -> create succeeds (guard scoped); token-aware unit cases; existing createApproval paths unaffected. tsc clean.

## Out of scope
Optional dispatch-side heal of only the transient case (persist a `resolutionFailed` reason) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
