### PR TITLE
fix(multitable): cross-base relation-agg — let authorized readers through (drop blanket #PERM!)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -167,7 +167,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + foreign-field taint mask + dashboard authz + realtime invalidation + automation retry provenance + cross-base governed automation writes + webhook outbound chain + AI shortcut run + AI ledger retention sweep + record-level version restore + rollup countall non-gating characterization + rollup filter condition fail-closed + rollup string/boolean reducers + dashboard non-numeric rollup rejection + dashboard-level filtering (narrow/AND/row-deny/no-side-channel) + record recycle-bin delete/restore + field type-retype revert schema-only scalar-gated + cross-base relation-agg authorized-reader read gate)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -260,6 +260,7 @@ jobs:
             tests/integration/multitable-rollup-countall-nongating.test.ts \
             tests/integration/multitable-rollup-filter-condition.test.ts \
             tests/integration/multitable-relation-aggregation.test.ts \
+            tests/integration/multitable-crossbase-relation-aggregation.test.ts \
             tests/integration/multitable-filter-by-link-view.test.ts \
             tests/integration/multitable-rollup-string-bool-reducers.test.ts \
             tests/integration/multitable-lookup-foreign-field-mask-sibling-reads.test.ts \

--- a/docs/development/multitable-crossbase-relagg-perm-fix-dev-verification-20260627.md
+++ b/docs/development/multitable-crossbase-relagg-perm-fix-dev-verification-20260627.md
@@ -1,0 +1,61 @@
+# Cross-base deepen — slice 1: relation-aggregation authorized-reader read gate — dev & verification (2026-06-27)
+
+> Status: built + verified (real-DB fail-first proven). Grounding: `origin/main` @ `77333c28e`. First slice of the
+> **cross-base deepen** arc selected by the benchmark refresh audit
+> (`docs/research/multitable-vs-feishu-benchmark-refresh-20260627.md`). Security-sensitive (a cross-base permission
+> change) — advisor-reviewed before implementation.
+
+## 1. The bug
+`RELSUMIF` / `RELCOUNTIF` / `RELLOOKUP` / `RELVALUES` over a **cross-base** link returned `#PERM!` (and the
+formula-consumed value was taint-dropped) for **every** actor — including one fully authorized to read the foreign
+base + the target/criteria fields. Cross-base relation-aggregation was effectively dead for authorized readers.
+
+Root cause: two **blanket** `crossBase` bails, both labelled "out of scope at lock time", that pre-empted the
+per-field permission gate:
+- `resolveRelationAggregation` (`univer-meta.ts`): `if (readability.get(foreignSheetId)?.crossBase) return REL_AGG_PERM_SENTINEL` — fired at *materialize* (writer context), storing `#PERM!`.
+- the formula-taint sink (`resolveTaintedFormulaFieldIds`): `readability.get(foreignSheetId)?.crossBase ||` in the taint test — fired at *read*, dropping the field per-reader.
+
+Both ran **before** the per-field `shouldMaskForeignField(target)` / `(criteria)` checks.
+
+## 2. Why removing them is safe (not a read hole)
+The per-field machinery **already** handles cross-base correctly — the blanket bails were redundant:
+- `resolveForeignFieldReadability` computes the actor's readable foreign-field set, then **empties it** for a
+  cross-base sheet when `!resolveBaseReadable(foreignBaseId)` (②b §3.2 coarse base-read gate).
+- `shouldMaskForeignField` returns `false` (readable) **first** for a field in that set, and only then masks
+  `crossBase` fields not in it. So: cross-base + base unreadable → set empty → every field masked → `#PERM!`;
+  cross-base + base + field readable → not masked → flows.
+
+So the fix routes cross-base relation-agg through the **same** base-read + field-read + row-deny gate that
+lookup/rollup/view/export already use. Every fail-closed guarantee the original author feared is preserved by
+`shouldMaskForeignField`; the only behavior change is that an **authorized** cross-base reader is no longer
+blanket-denied.
+
+## 3. The fix (two sites, symmetric)
+Removed the blanket `crossBase` bail at both sites; the per-field `shouldMaskForeignField` checks (unchanged) now
+gate cross-base. Comments updated to document the symmetry (the materialize gate and the read-taint gate must agree,
+so the formula-consumed value matches the standalone field). No new permission primitive; no change to
+`resolveForeignFieldReadability` / `shouldMaskForeignField` / `resolveBaseReadable`.
+
+## 4. Verification — `multitable-crossbase-relation-aggregation.test.ts` (real DB, CI-wired)
+Permission matrix, mutation-proven fail-first (stash the src fix → the fix-dependent cases go RED, the fail-closed
+case stays green; restore → all green):
+
+- **1399 materialize:** an authorized cross-base reader **stores the real aggregate (30), not `#PERM!`** (RED before).
+- **(a) authorized reader** (base-read + target + criteria readable) → `RELSUMIF` = 30, `RELLOOKUP` = 'paid' (RED
+  before — `undefined`; proves BOTH the materialize gate and the read-taint gate).
+- **(b) no base-read** on the foreign base → field **dropped** (fail-closed preserved; green both ways).
+- **(c) target field unreadable** (`field_permissions` deny on the foreign SECRET) → dropped for the denied reader,
+  visible (300) to the authorized one.
+- **(d) criteria field unreadable** → dropped — the **side-channel** the original author feared (a count over a
+  denied field would leak its distribution).
+
+**Local `metasheet_test`:** new golden 6/6. Regression: same-base relation-agg + cross-base link-optin **32/32**;
+taint-chokepoint structural guard **3/3** (call-graph unchanged — the edit is inside the resolver, not a new sink).
+`tsc` clean.
+
+## 5. Arc context — cross-base deepen, remaining slices
+This closes depth gap **(b)** from the audit (cross-base conditional relation-aggregation — a real bug). Remaining
+deepen candidates, each a separate slice: **(c)** referential integrity / delete cascade (no FK on `meta_links`;
+dangling edges only reported, not repaired); **(a)** cross-base two-way/mirror link sync (mirror is same-base only
+today); **(d)** cross-base view filter/sort by a foreign field (`query-service` has no foreign traversal). Order TBD
+with the owner.

--- a/docs/research/multitable-vs-feishu-benchmark-refresh-20260627.md
+++ b/docs/research/multitable-vs-feishu-benchmark-refresh-20260627.md
@@ -1,0 +1,70 @@
+# 多维表 对标飞书 — Benchmark Refresh + 下一弧决策图 — 2026-06-27
+
+> Status: **RESEARCH / 决策输入**(内部对标，可引用飞书)。总目标 `multitable-benchmark-surpass-goal`(对标并超越飞书多维表格)。
+> 方法:子代理对 `origin/main` 全能力面取证(file/route 级)→ 对照 2026-06-11 ladder v3 先验 → 对标飞书 Base(飞书近况以 ~2026-01 知识为准,标注"待核")→ 重排候选弧。
+> 取证根:`origin/main`(本地 checkout 落后,所有结论读自 origin/main)。
+
+## 0. 三个改变结论的刷新发现
+
+1. **cross-base 已经"上线"了,不是"待建"。** 06-11 ladder 把 cross-base 记为 rank 19「设计锁定待实现」。实况:cross-base link(单向跨 base、`foreignBaseId` 真值墙、外读按字段脱敏、自动化跨 base 写配额、TOCTOU 守卫、前端开关)**已 GA、无 flag、~25 真库测试**。所以这条弧是 **deepen(做深)而非 build(从零建)**。
+2. **大量能力"已建未亮"。** 一簇能力 runtime 已完成但对用户不可见:**DARK**(默认关 flag,含我们刚建的配置恢复 Tier1/2、PIT Reset、Yjs 协同、AI、行级读权限)、**BACKEND-ONLY**(`delete_record`/`start_approval`/`form.submitted` 后端就绪但编辑器无 UI)、**INERT**(`webhook.received` 在枚举里但无入口、永不触发)。把这些"点亮"是异常便宜的成熟度收益。
+3. **三处过期注释陷阱**(origin/main 已核实为过期):`permission-rule-evaluator.ts`「UNWIRED ON PURPOSE」、`restore-preview-identity.ts`「CONTRACT ONLY — not wired」、MEMORY 的「公式仅 form-submit / grid-edit 会 stale」——**都已接线/已闭合**,别据此误判。
+
+**图例**:ON=默认可用 · DARK=代码全但 flag 默认关 · BACKEND-ONLY=后端就绪无 UI · INERT=仅枚举无运行路径 · PARTIAL=部分 · ABSENT=未建。
+
+## 1. 刷新后的能力 ladder(多维表 vs 飞书 Base)
+
+| 能力域 | 多维表现状 | vs 飞书 | 备注 |
+|---|---|---|---|
+| 字段类型 | 28+ 类型 ON(标量/计算/关联/系统全) | **≈ 持平** | 缺 群组(group)/级联(cascade);progress 仅用 percent 近似;button 作为可建字段仍 INERT |
+| 视图类型 | grid/form/kanban/gallery/calendar/timeline/gantt/hierarchy **8 种全 ON** | **≈ 持平或略领先** | hierarchy+timeline+gantt 较强;飞书核心约 6 种 |
+| 视图内配置 | 嵌套筛选/多级排序分组+小计/条件格式(18 算符)/色阶 ON | ≈ 持平 | 冻结列、行高=3 档密度(非自由像素)PARTIAL |
+| 记录/历史/恢复 | CRUD+批量、编辑历史、逐字段/批量恢复、回收站、**全局历史中心+PIT 只读视图+Revert** ON | **领先** | 配置/schema 历史 + 恢复是飞书没有的纵深;但批量删=客户端循环(无原子端点);**日期提醒 ABSENT** |
+| 公式/rollup/lookup | ~60 函数、rollup 11 reducer、lookup 字段、FOL 一跳、**grid-edit 重算已闭合** | 略落后(引擎) | 解析器是 simplified(无 AST/A1/范围/数组);关系聚合 `RELSUMIF` 等仅单调用、不可组合 |
+| **cross-base** | 单向跨 base link + 治理墙 + 外读脱敏 + 跨 base 自动化写 **ON(已 GA)** | **领先(超越轴)** | 深度缺口=两向 mirror 同步 / 跨 base 条件关系聚合(`#PERM!` bug)/ 引用完整性级联(无 FK)/ 跨 base 视图筛排 |
+| 权限 | 角色 grant + 字段级 visible/read_only ON;**行级读 deny + 条件读规则 DARK** | ≈ 持平(但 DARK) | 条件可见性是展示层非安全边界 |
+| 自动化 | 8 触发 / 14 动作 / 条件分支 / 审批即任务 ON | ≈ 持平 | `webhook.received` INERT(无入站);`delete_record`/`start_approval` BACKEND-ONLY;cron 仅 ~5 粗模式 |
+| 仪表盘/图表 | 9 图表 + 6 聚合 + 跨面板联动 ON | ≈ 持平 | 第二条 `/dashboard/query` 无前端=死路 |
+| 实时协同 | presence + 逐格光标 ON;**Yjs CRDT 共编 DARK(POC)** | **落后** | 飞书强项;且 schema/config 变更不广播=协作者看到过期 schema |
+| 导入/导出 | CSV/TSV/XLSX 导入 + 导出(权限脱敏)ON | ≈ 持平 | — |
+| API/Webhook | token 全生命周期、**但只读路由可达(写 scope INERT)**;webhook 仅出站 | **落后** | 飞书开放 API 读写全;入站 webhook 缺 |
+| AI | 真 provider(Anthropic/OpenAI)、字段 shortcut/bulk-fill/NL→公式 **DARK** | ≈ 持平(已建) | flag+key+双确认才开 |
+| 模板 | 8 内置模板 + 安装/dry-run ON | **落后** | 无"存为模板"/市场/分享 |
+| 移动端 | **ABSENT**(web 多维表无移动/响应式代码) | **明显落后** | 飞书移动强;独立大工程 |
+
+**一句话**:核心表格/字段/视图/公式/仪表盘/自动化面**已对标到位甚至领先**(视图、cross-base 治理、配置历史恢复是领先项);**真落后只在**实时共编、移动端、模板平台、日期提醒、入站自动化、API 写回。
+
+## 2. 重排候选弧(我的排序)
+
+### ★ 候选 A:cross-base 做深(「超越」旗舰) — 推荐
+- **为何**:cross-base 是多维表对飞书的**真差异化**(飞书关联基本同 base 内;跨 base/跨部门工作流是飞书弱项)。地基已 GA、前提(字段级权限+外读脱敏)已是已上线基础,06-11 预标"prereqs met"成立。
+- **范围(4 块,按价值)**:(b) **跨 base 条件关系聚合修复+扩展**——`RELSUMIF/RELCOUNTIF/RELLOOKUP` 现对任何跨 base sheet 返回 `#PERM!`,**连授权读者都被挡=真 bug**,修它+让其可组合;(c) **引用完整性/级联**——`meta_links` 无 FK,悬挂边只报不修,补级联/修复;(a) 两向 mirror 跨 base 同步;(d) 跨 base 视图按外字段筛排。
+- **性质**:含一条真 bug 修(b),纵深 + 正确性双收益。重,但旗舰。
+
+### 候选 B:可用性扫荡(「把已建的点亮」) — 推荐作为并行快弧
+- **为何**:审计揭出异常多"已建未亮"。把它们变可用,**几乎零新建成本**就直接推进对标(功能本就在,只是没开)。
+- **便宜档(低风险)**:暴露 BACKEND-ONLY UI(`delete_record`/`start_approval` 动作、`form.submitted` 触发进编辑器下拉)· 死 `/dashboard/query` 清理 · 原子批量删端点 · 真 cron 解析器 · 修三处过期注释。
+- **需 staging-first 的 DARK 档(各自独立放量,非一键翻)**:配置恢复 Tier1/2(刚建)、PIT Reset(+ 接上孤儿 `ResetConfirmDialog.vue`)、行级读权限、AI、Yjs。**这些 flag 默认关是有安全理由的,逐项 acceptance-harness 放量,不是 sweep。**
+
+### 候选 C:补真落后项(对标补齐)
+- **日期提醒**(小、高价值:飞书有"截止前 N 天提醒",多维表无任何日期触发原语)——便宜,建一个 date-based trigger 原语。
+- **API 写回**(把 INERT 写 scope 接上 token 可达路径)——中等,企业集成价值高。
+- **实时共编 productionize**(Yjs DARK→GA)——大,飞书强项,但 POC 范围窄(逐记录、不含 create/delete/字段权限),productionize 是独立大弧。
+- **模板平台 / 移动端**——各自独立大工程,本轮不建议。
+
+## 3. 我的建议(净)
+
+**主弧开 A(cross-base 做深),并行插 B 的"便宜档"。**
+- A 是唯一的"超越"轴且地基已齐,从 **(b) 关系聚合 `#PERM!` bug** 切入——它既是真 bug 又是纵深起点,fail-first 容易、价值即时。
+- B 的便宜档(暴露 BACKEND-ONLY UI + 死路清理 + 过期注释)风险低、ROI 高,可与 A 并行、独立小 PR。
+- B 的 DARK 放量(尤其刚建的配置恢复 Tier1/2)按**逐项 staging-first acceptance** 走,不在本弧一键翻。
+- **日期提醒**(候选 C 头部)是个便宜的对标补齐,可作为 A/B 之外的轻量第三股。
+- 移动端 / 实时共编 productionize / 模板平台 = 各自独立大弧,**本轮不开**。
+
+## 4. 待 owner 拍板
+1. 主弧 = A(cross-base 做深)确认?从 (b) `#PERM!` 切入确认?
+2. 并行 B 便宜档(BACKEND-ONLY 暴露 + 清理)要不要现在一起开?
+3. 日期提醒(C 头部)要不要插一股?
+4. 刚建的配置恢复 Tier1/2 是否要排"staging-first 放量"(把 DARK→可用),还是继续躺着等需求?
+
+> 飞书具体能力以 ~2026-01 知识为准;若近半年飞书有新增(如更强 AI/移动),本 ladder 的"落后"项可能更多——可在确认主弧前对飞书做一次 web 核验(若环境允许)。

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1390,13 +1390,16 @@ async function resolveRelationAggregation(
   const readableForeignSheetIds = await resolveReadableSheetIds(req, query, [foreignSheetId])
   if (!readableForeignSheetIds.has(foreignSheetId)) return REL_AGG_PERM_SENTINEL
 
-  // Foreign-FIELD readability + cross-base. Cross-base ranges are out of scope at lock time → #PERM!
-  // (fail-closed). Both the TARGET and the CRITERIA field must be readable; either unreadable → #PERM!
-  // (a criteria over an unreadable field is a side-channel — the match count would leak it).
+  // Foreign-FIELD readability — cross-base flows through the SAME per-field gate as lookup/rollup, not a
+  // blanket bail: resolveForeignFieldReadability empties the readable set when the actor can't read the
+  // foreign base (resolveBaseReadable, ②b §3.2), so shouldMaskForeignField masks every field of an unreadable
+  // cross-base sheet → #PERM!. An AUTHORIZED cross-base reader (base-read + field readable) is NOT
+  // blanket-denied (the prior `crossBase → #PERM!` was an out-of-scope-at-lock-time placeholder, now
+  // redundant). Both the TARGET and the CRITERIA field must be readable; either unreadable → #PERM! (a
+  // criteria over an unreadable field is a side-channel — the match count would leak it).
   const sourceSheet = await loadSheetRowShared(query, sourceSheetId)
   const sourceBaseId = sourceSheet?.baseId ?? null
   const readability = await resolveForeignFieldReadability(req, query, sourceBaseId, [foreignSheetId])
-  if (readability.get(foreignSheetId)?.crossBase) return REL_AGG_PERM_SENTINEL
   if (shouldMaskForeignField(readability, foreignSheetId, call.targetFieldId, false)) return REL_AGG_PERM_SENTINEL
   if (shouldMaskForeignField(readability, foreignSheetId, call.criteria.fieldId, false)) return REL_AGG_PERM_SENTINEL
 
@@ -3087,15 +3090,17 @@ async function resolveTaintedFormulaFieldIds(
     if (leaks) tainted.add(formulaFieldId)
   }
 
-  // 1b Slice A leak edge: taint a relation-aggregation formula when its FOREIGN target or criteria field
-  // is unreadable for this actor (or the foreign sheet is cross-base — out of scope at lock time). This is
-  // the read-path mask (maskStoredRecordFieldIds → here) that makes materialize-at-write safe: a restricted
-  // reader gets the field dropped, never the writer's materialized aggregate. A misconfigured call (no
-  // foreign sheet) is left to resolveRelationAggregation's #ERROR! — not a leak.
+  // 1b Slice A leak edge: taint a relation-aggregation formula when its FOREIGN target or criteria field is
+  // unreadable for this actor. Cross-base flows through the SAME per-field gate (shouldMaskForeignField: an
+  // unreadable cross-base sheet has its readable set emptied by resolveForeignFieldReadability's base-read
+  // gate → every field masks → tainted); an AUTHORIZED cross-base reader is NOT blanket-tainted, mirroring the
+  // resolveRelationAggregation gate so the formula-consumed value matches the standalone field. This is the
+  // read-path mask (maskStoredRecordFieldIds → here) that makes materialize-at-write safe: a restricted reader
+  // gets the field dropped, never the writer's materialized aggregate. A misconfigured call (no foreign
+  // sheet) is left to resolveRelationAggregation's #ERROR! — not a leak.
   for (const [fieldId, { call, foreignSheetId }] of relAggByField) {
     if (!foreignSheetId) continue
     if (
-      readability.get(foreignSheetId)?.crossBase ||
       shouldMaskForeignField(readability, foreignSheetId, call.targetFieldId, false) ||
       shouldMaskForeignField(readability, foreignSheetId, call.criteria.fieldId, false)
     ) {

--- a/packages/core-backend/tests/integration/multitable-crossbase-relation-aggregation.test.ts
+++ b/packages/core-backend/tests/integration/multitable-crossbase-relation-aggregation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Cross-base relation-aggregation read gate (real DB). The standalone relation-agg gate
+ * (resolveRelationAggregation) and the formula-taint sink both used to BLANKET-deny any cross-base foreign
+ * sheet → #PERM!, even for an AUTHORIZED cross-base reader. That was an out-of-scope-at-lock-time placeholder,
+ * redundant with the per-field gate: resolveForeignFieldReadability empties the readable set when the actor
+ * can't read the foreign base (resolveBaseReadable), so shouldMaskForeignField already masks an unreadable
+ * cross-base field — and ALLOWS a readable one. This suite locks the corrected behavior across the permission
+ * matrix; before the two-site fix, case (a) is RED (authorized reader gets the field dropped).
+ *
+ * Matrix: (a) authorized cross-base reader (base-read + target + criteria readable) → real aggregate (proves
+ * BOTH the materialize gate storing the value AND the read gate surfacing it) · (b) cannot read foreign base
+ * → dropped · (c) target field unreadable → dropped · (d) CRITERIA field unreadable → dropped (the
+ * side-channel: a count over a denied field leaks its distribution) · (e) lookup kind, authorized → value.
+ * Runs only with DATABASE_URL.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const TS = Date.now()
+// authorized cross-base reader: sheet-read + base-read on the foreign base. Materializer also needs write.
+const ALLOW = `u_xbr_allow_${TS}`
+const ALLOW_PERMS = ['multitable:read', 'multitable:write', 'multitable:base:read']
+// can read MS, but NO base-read on the foreign base → must NOT see cross-base relation-agg.
+const DENY_BASE = `u_xbr_denybase_${TS}`
+const DENY_BASE_PERMS = ['multitable:read']
+// base-read OK, but the foreign SECRET field is field-permission denied → secret-target/criterion must drop.
+const DENY_FIELD = `u_xbr_denyfield_${TS}`
+const DENY_FIELD_PERMS = ['multitable:read', 'multitable:base:read']
+
+const BASE_SRC = `base_xbr_src_${TS}`
+const BASE_FOR = `base_xbr_for_${TS}`
+const FS = `sheet_xbr_fs_${TS}` // foreign sheet, in BASE_FOR
+const MS = `sheet_xbr_ms_${TS}` // main sheet, in BASE_SRC
+
+const FLD_AMT = `fld_xbr_amt_${TS}`
+const FLD_STATUS = `fld_xbr_status_${TS}`
+const FLD_SECRET = `fld_xbr_secret_${TS}`
+const FLD_LINK = `fld_xbr_link_${TS}`
+const FLD_CURVAL = `fld_xbr_curval_${TS}`
+const FLD_SUMIF = `fld_xbr_sumif_${TS}` // RELSUMIF(link, amt, status, is, {curval}) → 30 (target+criteria readable)
+const FLD_SECRETSUM = `fld_xbr_secsum_${TS}` // RELSUMIF(link, SECRET, status, is, {curval}) → 300 (target denied)
+const FLD_SECRETCOUNT = `fld_xbr_seccount_${TS}` // RELCOUNTIF(link, SECRET, greater, 0) → 3 (CRITERIA denied — side-channel)
+const FLD_LOOKUP = `fld_xbr_lookup_${TS}` // RELLOOKUP(link, status, amt, is, 10) → 'paid'
+
+const FR1 = `rec_xbr_f1_${TS}`
+const FR2 = `rec_xbr_f2_${TS}`
+const FR3 = `rec_xbr_f3_${TS}`
+const REC = `rec_xbr_src_${TS}`
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+function buildApp(userId: string, perms: string[]): Express {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => { ;(req as { user?: unknown }).user = { id: userId, roles: ['member'], perms, permissions: perms }; next() })
+  a.use('/api/multitable', univerMetaRouter())
+  return a
+}
+const relSum = (target: string) => JSON.stringify({ expression: `RELSUMIF("${FLD_LINK}","${target}","${FLD_STATUS}","is",{${FLD_CURVAL}})` })
+async function readField(userId: string, perms: string[], fieldId: string): Promise<unknown> {
+  const res = await request(buildApp(userId, perms)).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return res.body?.data?.record?.data?.[fieldId]
+}
+async function hasField(userId: string, perms: string[], fieldId: string): Promise<boolean> {
+  const res = await request(buildApp(userId, perms)).get(`/api/multitable/records/${REC}`)
+  expect(res.status).toBe(200)
+  return Object.prototype.hasOwnProperty.call(res.body?.data?.record?.data ?? {}, fieldId)
+}
+async function storedValue(fieldId: string): Promise<unknown> {
+  return ((await q('SELECT data->$2 AS v FROM meta_records WHERE id=$1', [REC, fieldId])).rows[0] as { v: unknown }).v
+}
+// Patch the current-record criteria field 'unpaid'→'paid' as ALLOW → recompute the dependent relation-agg
+// formulas in ALLOW's (authorized cross-base) context.
+async function materializeAsAllow(): Promise<void> {
+  const cur = await q('SELECT version FROM meta_records WHERE id = $1', [REC])
+  const version = Number((cur.rows[0] as { version?: unknown })?.version ?? 1)
+  const res = await request(buildApp(ALLOW, ALLOW_PERMS)).post('/api/multitable/patch').send({
+    sheetId: MS, changes: [{ recordId: REC, fieldId: FLD_CURVAL, value: 'paid', expectedVersion: version }],
+  })
+  expect(res.status).toBe(200)
+}
+
+describeIfDatabase('multitable cross-base relation-aggregation read gate (real DB)', () => {
+  beforeAll(async () => {
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE_SRC, 'XBR Src', `u_xbr_owner_${TS}`])
+    await q('INSERT INTO meta_bases (id, name, owner_id) VALUES ($1,$2,$3)', [BASE_FOR, 'XBR For', `u_xbr_owner_${TS}`])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS, BASE_FOR, 'XBR Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_SRC, 'XBR Main'])
+    for (const [fid, name, type, order] of [[FLD_AMT, 'Amount', 'number', 1], [FLD_STATUS, 'Status', 'string', 2], [FLD_SECRET, 'Secret', 'number', 3]] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, FS, name, type, '{}', order])
+    }
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR1, FS, JSON.stringify({ [FLD_AMT]: 10, [FLD_STATUS]: 'paid', [FLD_SECRET]: 100 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR2, FS, JSON.stringify({ [FLD_AMT]: 20, [FLD_STATUS]: 'paid', [FLD_SECRET]: 200 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FR3, FS, JSON.stringify({ [FLD_AMT]: 5, [FLD_STATUS]: 'unpaid', [FLD_SECRET]: 300 })])
+    // cross-base link: FS lives in BASE_FOR, MS in BASE_SRC → crossBase derived from the sheets' bases.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS, foreignBaseId: BASE_FOR }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_CURVAL, MS, 'CurVal', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SUMIF, MS, 'SumIf', 'formula', relSum(FLD_AMT), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRETSUM, MS, 'SecretSum', 'formula', relSum(FLD_SECRET), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRETCOUNT, MS, 'SecretCount', 'formula', JSON.stringify({ expression: `RELCOUNTIF("${FLD_LINK}","${FLD_SECRET}","greater","0")` }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP, MS, 'Lookup', 'formula', JSON.stringify({ expression: `RELLOOKUP("${FLD_LINK}","${FLD_STATUS}","${FLD_AMT}","is","10")` }), 6])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC, MS, JSON.stringify({ [FLD_LINK]: [FR1, FR2, FR3], [FLD_CURVAL]: 'unpaid' })])
+    for (const fr of [FR1, FR2, FR3]) await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_xbr_${fr}`, FLD_LINK, REC, fr])
+    for (const ff of [FLD_SUMIF, FLD_SECRETSUM, FLD_SECRETCOUNT, FLD_LOOKUP]) {
+      await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,NULL)', [MS, ff, FLD_CURVAL])
+    }
+    // DENY_FIELD cannot read the foreign SECRET field.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [FS, FLD_SECRET, 'user', DENY_FIELD, false, false])
+    await materializeAsAllow()
+  })
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS]]).catch(() => {})
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = ANY($1::text[])', [[BASE_SRC, BASE_FOR]]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('1399 materialize: an AUTHORIZED cross-base reader stores the real aggregate, not #PERM!', async () => {
+    expect(Number(await storedValue(FLD_SUMIF))).toBe(30) // amt where status=paid: 10+20 (was #PERM! before the fix)
+  })
+
+  test('(a) authorized cross-base reader (base-read + fields readable) → real aggregate 30 [the fix; RED before]', async () => {
+    expect(await readField(ALLOW, ALLOW_PERMS, FLD_SUMIF)).toBe(30)
+    expect(await readField(ALLOW, ALLOW_PERMS, FLD_LOOKUP)).toBe('paid') // (e) lookup kind shares the gate
+  })
+
+  test('(b) NO base-read on the foreign base → the cross-base relation-agg is DROPPED (fail-closed preserved)', async () => {
+    expect(await hasField(DENY_BASE, DENY_BASE_PERMS, FLD_SUMIF)).toBe(false)
+    expect(await hasField(DENY_BASE, DENY_BASE_PERMS, FLD_LOOKUP)).toBe(false)
+  })
+
+  test('(c) base-read OK but TARGET field unreadable → dropped; authorized sees it', async () => {
+    expect(await readField(ALLOW, ALLOW_PERMS, FLD_SECRETSUM)).toBe(300)
+    expect(await hasField(DENY_FIELD, DENY_FIELD_PERMS, FLD_SECRETSUM)).toBe(false)
+  })
+
+  test('(d) base-read OK but CRITERIA field unreadable → dropped (side-channel: count over a denied field)', async () => {
+    expect(await readField(ALLOW, ALLOW_PERMS, FLD_SECRETCOUNT)).toBe(3)
+    expect(await hasField(DENY_FIELD, DENY_FIELD_PERMS, FLD_SECRETCOUNT)).toBe(false)
+  })
+})


### PR DESCRIPTION
**Cross-base deepen — slice 1** (the first arc opened by the benchmark refresh audit). A real bug + the start of cross-base depth. Security-sensitive (a cross-base permission change) — advisor-reviewed before implementation; presenting for your review, not auto-merging.

## The bug
`RELSUMIF`/`RELCOUNTIF`/`RELLOOKUP`/`RELVALUES` over a **cross-base** link returned `#PERM!` (formula-consumed value taint-dropped) for **every** actor — including one fully authorized to read the foreign base + the target/criteria fields. Cross-base relation-aggregation was dead for authorized readers.

## Root cause + why the fix is safe
Two **blanket** `crossBase → #PERM!` bails ("out of scope at lock time") pre-empted the per-field gate: one in `resolveRelationAggregation` (fires at *materialize*), one in the formula-taint sink (fires at *read*). Both ran **before** the `shouldMaskForeignField(target)/(criteria)` checks — which **already** handle cross-base correctly: `resolveForeignFieldReadability` empties the readable set when the actor can't read the foreign base (`resolveBaseReadable`), so `shouldMaskForeignField` masks an unreadable cross-base field and **allows** a readable one. The blanket bails were redundant.

**Fix:** remove the blanket bail at both sites; route cross-base through the same base-read + field-read + row-deny gate lookup/rollup/view/export already use. No new permission primitive; every fail-closed guarantee preserved (the advisor flagged the 2nd site — the formula-taint twin — so the fix surfaces the value through formulas too, not just standalone).

## Verification (real-DB, CI-wired, fail-first mutation-proven)
`multitable-crossbase-relation-aggregation.test.ts` — stashing the src fix turns the fix-dependent cases RED, the fail-closed case stays green:
- authorized reader (base + target + criteria readable) → real aggregate **30** / `RELLOOKUP` 'paid' (RED before)
- **no base-read** → dropped (fail-closed preserved)
- **target field unreadable** → dropped; authorized sees it
- **criteria field unreadable** → dropped — the **side-channel** the original author feared

Local: new **6/6**; regression same-base relation-agg + cross-base link-optin **32/32**; taint-chokepoint structural guard **3/3** (call-graph unchanged); `tsc` clean.

Also lands the refresh-audit research doc (`docs/research/multitable-vs-feishu-benchmark-refresh-20260627.md`) that selected this arc. Remaining deepen slices: (c) referential integrity/cascade, (a) cross-base two-way mirror, (d) cross-base view filter — each separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)