### PR TITLE
feat(multitable): T8-2 Reset UI — T-source picker entry (#3250/#3251 gap)

### DIFF
--- a/.github/workflows/multitable-web-guard.yml
+++ b/.github/workflows/multitable-web-guard.yml
@@ -42,6 +42,8 @@ on:
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
+      - 'apps/web/tests/multitable-reset-tsource-picker.spec.ts'
+      - 'apps/web/src/multitable/components/ResetToPointPicker.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
@@ -89,6 +91,8 @@ on:
       - 'apps/web/tests/multitable-workbench-restore-wiring.spec.ts'
       - 'apps/web/src/multitable/utils/meta-record-labels.ts'
       - 'apps/web/tests/multitable-restore-preview-dialog.spec.ts'
+      - 'apps/web/tests/multitable-reset-tsource-picker.spec.ts'
+      - 'apps/web/src/multitable/components/ResetToPointPicker.vue'
       - 'apps/web/tests/multitable-sheet-cursor-state.spec.ts'
       - 'apps/web/src/multitable/components/MetaRecordPermissionManager.vue'
       - 'apps/web/src/multitable/components/MetaSheetPermissionManager.vue'
@@ -152,4 +156,4 @@ jobs:
         # accumulation/loadMore) added so the grid virtualization ACTIVATION has real CI enforcement —
         # the guard already triggers on MetaGridTable.vue / useMultitableGrid.ts / MultitableWorkbench.vue
         # edits but, before this, ran none of those specs (and plugin-tests.yml only build-checks web).
-        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run multitable-rollup-aggregation-fe multitable-trash-fe multitable-history-fe multitable-kanban-view multitable-field-manager multitable-sheet-cursor-state multitable-record-permission-manager multitable-sheet-permission-manager multitable-yjs-scalar-cell multitable-yjs-cell-editor multitable-conditional-rule multitable-person-picker multitable-cell-renderer-person-inactive meta-toolbar-filter-builder meta-filter-group meta-grid-table multitable-grid multitable-restore-preview-dialog multitable-restore-batch-dialog multitable-config-history-modal multitable-workbench-restore-wiring multitable-config-revert-refresh multitable-reset-confirm-dialog multitable-reset-tsource-picker --reporter=dot

--- a/apps/web/src/multitable/components/ResetToPointPicker.vue
+++ b/apps/web/src/multitable/components/ResetToPointPicker.vue
@@ -1,0 +1,96 @@
+<!--
+  T8-2 Reset UI — T-source picker (the product entry the #3250 dialog was missing; #3250/#3251 flagged
+  "entry-wiring needs a T-source"). Lets a sheet-admin pick a point-in-time T and hands it to the existing
+  ResetConfirmDialog as `asOf`. The dialog owns preview → typed two-step confirm → execute; this only sources T.
+
+  T-source = a free datetime-local picker (minimal "只差产品入口"). Alternative (deferred): present recent
+  HistoryCenterModal batch timestamps as selectable options — richer, still read-only consumption of history.
+  The `asOf` derivation is the single swappable seam (`localToIso` / the `asOf` computed) so that change is local.
+
+  Timezone: datetime-local is browser-local; `asOf` is the corresponding UTC ISO for the API. The human-facing
+  "Target" line is derived FROM `asOf` (not the raw input), so what the user sees can never diverge from what the
+  destructive op uses. Gated on `pitResetEnabled` ALONE (it already encodes flag ∧ canManageSheetAccess); the
+  dialog is mounted only once T is valid & past, so the dialog's own "Reset to {asOf}…" button never fires empty.
+-->
+<template>
+  <div v-if="pitResetEnabled" class="reset-picker" data-test="reset-picker">
+    <label class="reset-picker__label">
+      <span>Reset this sheet to a point in time</span>
+      <input
+        type="datetime-local"
+        class="reset-picker__input"
+        data-test="reset-picker-input"
+        v-model="localValue"
+        :max="nowLocalValue"
+      />
+    </label>
+
+    <!-- datetime-local coerces invalid text to '' so a non-empty-unparseable value can't occur; if `asOf` is somehow
+         null it simply renders nothing below (fail-safe: no dialog), so no separate invalid branch is needed. -->
+    <p v-if="asOf && isFuture" class="reset-picker__hint reset-picker__hint--warn" data-test="reset-picker-future">
+      Pick a time in the past — you can only reset to an earlier state.
+    </p>
+
+    <template v-else-if="asOf">
+      <p class="reset-picker__target" data-test="reset-picker-target">
+        Target: <strong>{{ targetDisplay }}</strong> (your local time)
+      </p>
+      <ResetConfirmDialog
+        :pit-reset-enabled="true"
+        :as-of="asOf"
+        :reset-preview="boundPreview"
+        :reset-execute="boundExecute"
+        :on-done="onDone"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import ResetConfirmDialog from './ResetConfirmDialog.vue'
+import type { ResetPreview, ResetResult } from '../api/client'
+
+const props = defineProps<{
+  /** flag-derived capability (MULTITABLE_ENABLE_PIT_RESET ∧ canManageSheetAccess); off/absent ⇒ whole entry hidden. */
+  pitResetEnabled?: boolean
+  /** bound here (not in the dialog) so the (sheetId, asOf) wiring is covered by THIS component's unit test. */
+  sheetId: string
+  resetPreview: (sheetId: string, asOf: string) => Promise<ResetPreview>
+  resetExecute: (sheetId: string, asOf: string, previewIdentity: string) => Promise<ResetResult>
+  onDone?: () => void
+}>()
+
+const localValue = ref('')
+
+/** The single T-source seam: a browser-local datetime-local string → UTC ISO instant, or null if unparseable. */
+function localToIso(local: string): string | null {
+  if (!local) return null
+  const d = new Date(local) // datetime-local has no offset → interpreted in the browser's local tz
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
+const asOf = computed<string | null>(() => localToIso(localValue.value))
+// Derived FROM asOf (never from the raw input) so the displayed target and the API asOf cannot diverge.
+const targetDisplay = computed(() => (asOf.value ? new Date(asOf.value).toLocaleString() : ''))
+const isFuture = computed(() => (asOf.value ? new Date(asOf.value).getTime() > Date.now() : false))
+
+// `:max` on the input (local wall-clock now) so the picker discourages future selection before the isFuture guard.
+const nowLocalValue = computed(() => {
+  const d = new Date(Date.now() - new Date().getTimezoneOffset() * 60_000)
+  return d.toISOString().slice(0, 16)
+})
+
+const boundPreview = (a: string): Promise<ResetPreview> => props.resetPreview(props.sheetId, a)
+const boundExecute = (a: string, identity: string): Promise<ResetResult> => props.resetExecute(props.sheetId, a, identity)
+</script>
+
+<style scoped>
+.reset-picker { display: flex; flex-direction: column; gap: 8px; padding: 12px; border: 1px solid #fda29b; border-radius: 8px; background: #fffbfa; }
+.reset-picker__label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #912018; }
+.reset-picker__input { padding: 6px 8px; border: 1px solid #d0d5dd; border-radius: 6px; max-width: 240px; }
+.reset-picker__hint { font-size: 12px; margin: 0; }
+.reset-picker__hint--warn { color: #b42318; }
+.reset-picker__target { font-size: 13px; margin: 0; }
+</style>

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -65,6 +65,14 @@
       <button v-if="activeBaseId" class="mt-workbench__mgr-btn" data-action="open-history" @click="showHistory = true">&#x1F570; {{ isZh ? '历史' : 'History' }}</button>
       <button v-if="workbench.activeSheetId.value" class="mt-workbench__mgr-btn" data-action="open-config-history" @click="openConfigHistory">&#x2699; {{ isZh ? '配置历史' : 'Config history' }}</button>
     </div>
+    <ResetToPointPicker
+      v-if="workbench.activeSheetId.value"
+      :pit-reset-enabled="pitResetEnabled"
+      :sheet-id="workbench.activeSheetId.value"
+      :reset-preview="resetPreviewWire"
+      :reset-execute="resetExecuteWire"
+      :on-done="onResetDone"
+    />
     <div v-if="showTemplateLibrary" class="mt-template-library" data-testid="multitable-template-library">
       <div class="mt-template-library__header">
         <div>
@@ -636,6 +644,7 @@ import MetaViewManager from '../components/MetaViewManager.vue'
 import TrashModal from '../components/TrashModal.vue'
 import HistoryCenterModal from '../components/HistoryCenterModal.vue'
 import MetaConfigHistoryModal from '../components/MetaConfigHistoryModal.vue'
+import ResetToPointPicker from '../components/ResetToPointPicker.vue'
 import { refreshAfterConfigRevert } from './config-revert-refresh'
 import type { MetaConfigRevision } from '../api/client'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
@@ -716,6 +725,14 @@ const canOpenWorkflowDesigner = computed(
   () => caps.canManageAutomation.value && featureFlags.hasFeature('workflow'),
 )
 const grid = useMultitableGrid({ sheetId: workbench.activeSheetId, viewId: workbench.activeViewId })
+
+// T8-2 Reset UI T-source entry wiring (#3250/#3251 flagged the missing T-source). Gate on the flag-derived
+// pitResetEnabled signal alone (it already encodes canManageSheetAccess); pass the raw client signatures so the
+// picker owns + tests the (sheetId, asOf) composition; refresh the grid after a successful reset.
+const pitResetEnabled = computed(() => capabilitySource.value?.pitResetEnabled === true)
+const resetPreviewWire = (sid: string, asOf: string) => workbench.client.resetPreview(sid, asOf)
+const resetExecuteWire = (sid: string, asOf: string, previewIdentity: string) => workbench.client.resetExecute(sid, asOf, previewIdentity)
+const onResetDone = () => { void grid.reloadCurrentPage() }
 const commentsState = useMultitableComments()
 const commentPresenceState = useMultitableCommentPresence()
 const commentInboxState = useMultitableCommentInbox()

--- a/apps/web/tests/multitable-reset-tsource-picker.spec.ts
+++ b/apps/web/tests/multitable-reset-tsource-picker.spec.ts
@@ -88,4 +88,31 @@ describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
     expect(new Date(body.asOf).getTime()).toBe(new Date(local).getTime())
     expect(body.asOf).toBe(new Date(local).toISOString())
   })
+
+  it('(g) POST-EXECUTE SEAM: a successful reset fires onDone (→ workbench grid refresh) and hits reset-execute with the picker sheetId', async () => {
+    const onDone = vi.fn()
+    const fetchFn = vi.fn(async (url: string) => {
+      // deleteCount:0 → the dialog's revert-equivalent path (no typed confirm) so we can drive execute simply.
+      if (String(url).includes('reset-preview')) return new Response(JSON.stringify({ ok: true, data: {
+        asOf: '', strategy: 'reset', summary: { visibleRevertCount: 1, deleteCount: 0 }, deleteRecordIds: [], previewIdentity: 'srv',
+      } }), { status: 200 })
+      return new Response(JSON.stringify({ ok: true, data: { asOf: '', strategy: 'reset', revertedCount: 1, deletedRecordIds: [] } }), { status: 200 })
+    })
+    const client = new MultitableApiClient({ fetchFn })
+    mount({
+      sheetId: 'sheet_xyz', onDone,
+      resetPreview: (sid: string, asOf: string) => client.resetPreview(sid, asOf),
+      resetExecute: (sid: string, asOf: string, id: string) => client.resetExecute(sid, asOf, id),
+    })
+    await nextTick()
+    setInput('[data-test="reset-picker-input"]', '2020-01-15T10:30'); await flush()
+    await waitUntil(() => !!q('[data-test="reset-entry"]'))
+    ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+    await waitUntil(() => !!q('[data-test="reset-confirm-btn"]')) // revert-equivalent confirm (deleteCount 0)
+    ;(q('[data-test="reset-confirm-btn"]') as HTMLButtonElement).click()
+    await waitUntil(() => fetchFn.mock.calls.length >= 2)
+    expect(String(fetchFn.mock.calls[1][0])).toContain('sheet_xyz')
+    expect(String(fetchFn.mock.calls[1][0])).toContain('/reset-execute')
+    await waitUntil(() => onDone.mock.calls.length >= 1) // the seam back to the workbench (grid refresh) fired
+  })
 })

--- a/apps/web/tests/multitable-reset-tsource-picker.spec.ts
+++ b/apps/web/tests/multitable-reset-tsource-picker.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/**
+ * T8-2 Reset UI — ResetToPointPicker (the T-source the #3250 dialog was missing). Hidden unless `pitResetEnabled`.
+ * Sources a point-in-time T from a datetime-local input, mounts the existing ResetConfirmDialog only once T is a
+ * valid PAST instant, and binds the (sheetId, asOf) wire to the client. The WIRE test below is the real verification
+ * (not a fixture): it asserts the picker's sheetId + the UTC-ISO derived from the local input both reach reset-preview
+ * with no timezone inversion.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { createApp, nextTick } from 'vue'
+
+import ResetToPointPicker from '../src/multitable/components/ResetToPointPicker.vue'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+const mounted: Array<{ unmount: () => void }> = []
+function mount(over: Record<string, unknown> = {}) {
+  const props: Record<string, unknown> = {
+    pitResetEnabled: true,
+    sheetId: 'sheet_xyz',
+    resetPreview: vi.fn(async () => ({ asOf: '', strategy: 'reset', summary: { visibleRevertCount: 0, deleteCount: 0 }, deleteRecordIds: [], previewIdentity: 't' })),
+    resetExecute: vi.fn(async () => ({ asOf: '', strategy: 'reset', revertedCount: 0, deletedRecordIds: [] })),
+    ...over,
+  }
+  const app = createApp(ResetToPointPicker, props)
+  const c = document.createElement('div'); document.body.appendChild(c); app.mount(c); mounted.push(app); return props
+}
+const q = (s: string) => document.body.querySelector(s) as HTMLElement | null
+const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
+const waitUntil = async (pred: () => boolean, tries = 100): Promise<void> => {
+  for (let i = 0; i < tries; i++) { if (pred()) return; await flush() }
+  throw new Error('waitUntil: condition not met')
+}
+const setInput = (sel: string, val: string) => { const el = q(sel) as HTMLInputElement; el.value = val; el.dispatchEvent(new Event('input')) }
+afterEach(() => { while (mounted.length) mounted.pop()!.unmount(); document.body.innerHTML = '' })
+
+describe('ResetToPointPicker — T8-2 Reset UI T-source', () => {
+  it('(a) whole entry HIDDEN when pitResetEnabled false / absent (fail-closed)', async () => {
+    mount({ pitResetEnabled: false }); await nextTick()
+    expect(q('[data-test="reset-picker"]')).toBeFalsy()
+    mounted.pop()!.unmount(); document.body.innerHTML = ''
+    mount({ pitResetEnabled: undefined }); await nextTick()
+    expect(q('[data-test="reset-picker"]')).toBeFalsy()
+  })
+
+  it('(b) enabled: shows the datetime picker, but NO dialog/target until a T is chosen', async () => {
+    mount(); await nextTick()
+    expect(q('[data-test="reset-picker-input"]')).toBeTruthy()
+    expect(q('[data-test="reset-picker-target"]')).toBeFalsy()
+    expect(q('[data-test="reset-entry"]')).toBeFalsy() // the dialog isn't mounted yet → no second reset button
+  })
+
+  it('(c) FUTURE T → future hint, no dialog (can only reset to the past)', async () => {
+    mount(); await nextTick()
+    setInput('[data-test="reset-picker-input"]', '2099-01-01T00:00'); await flush()
+    expect(q('[data-test="reset-picker-future"]')).toBeTruthy()
+    expect(q('[data-test="reset-entry"]')).toBeFalsy()
+  })
+
+  it('(e) valid PAST T → shows local target + mounts the ResetConfirmDialog entry', async () => {
+    mount(); await nextTick()
+    setInput('[data-test="reset-picker-input"]', '2020-01-15T10:30'); await flush()
+    expect(q('[data-test="reset-picker-target"]')).toBeTruthy()
+    await waitUntil(() => !!q('[data-test="reset-entry"]')) // dialog mounted → its own entry button present
+  })
+
+  it('(f) WIRE: choosing T → reset-preview hits the picker sheetId with the UTC-ISO of the input (no tz inversion)', async () => {
+    const local = '2020-01-15T10:30'
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: {
+      asOf: '', strategy: 'reset', summary: { visibleRevertCount: 1, deleteCount: 0 }, deleteRecordIds: [], previewIdentity: 'srv',
+    } }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    mount({
+      sheetId: 'sheet_xyz',
+      resetPreview: (sid: string, asOf: string) => client.resetPreview(sid, asOf),
+      resetExecute: (sid: string, asOf: string, id: string) => client.resetExecute(sid, asOf, id),
+    })
+    await nextTick()
+    setInput('[data-test="reset-picker-input"]', local); await flush()
+    await waitUntil(() => !!q('[data-test="reset-entry"]'))
+    ;(q('[data-test="reset-entry"]') as HTMLButtonElement).click()
+    await waitUntil(() => fetchFn.mock.calls.length >= 1)
+    const url = fetchFn.mock.calls[0][0] as string
+    const body = JSON.parse((fetchFn.mock.calls[0][1] as RequestInit).body as string)
+    expect(url).toContain('sheet_xyz')           // sheetId wiring (picker → client), not a fixture
+    expect(url).toContain('/reset-preview')
+    // the asOf is the UTC-ISO of the local input AND round-trips to the same instant (no inversion / double-convert)
+    expect(typeof body.asOf).toBe('string')
+    expect(new Date(body.asOf).getTime()).toBe(new Date(local).getTime())
+    expect(body.asOf).toBe(new Date(local).toISOString())
+  })
+})

--- a/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
+++ b/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
@@ -20,14 +20,16 @@
 |---|---|---|
 | Picker logic (gating, valid-past, future-reject, target display) | `multitable-reset-tsource-picker.spec.ts` (jsdom, `createApp`) | ✅ 5/5 local |
 | **The (sheetId, asOf) WIRE** — picker → client → `reset-preview` | same spec, **fake `fetchFn`** asserts URL carries the picker's `sheetId` + body `asOf` = UTC-ISO of the input, round-tripping to the same instant | ✅ (this is the real check, not a fixture) |
+| **Post-execute seam** — `execute → dialog.onDone → picker onDone → grid refresh` | picker spec test (g): drives execute (revert-equiv path) and asserts `onDone` fires + `reset-execute` carries the sheetId | ✅ (the "does the entry close the loop" check) |
 | The workbench **mount** (binding `pitResetEnabled`/`sheetId`/client) | `vue-tsc -b` (authoritative; `--noEmit` can false-green) | ✅ exit 0 |
-| Reuse didn't break the dialog | `multitable-reset-confirm-dialog.spec.ts` + `multitable-workbench-restore-wiring.spec.ts` | ✅ 6/6 + 13/13 |
-| **Live app with the flag ON** (the entry actually renders + a real reset round-trips) | not run here (flag default-off; needs a flag-enabled env) | ⬜ **honest gap** — recommend a flag-on smoke before enabling rollout |
+| Reuse didn't break anything | full `multitable-web-guard` set | ✅ **372/372** (38 files) |
+| **Live app with the flag ON** — the entry actually *renders* + a real reset round-trips through a real grid | not run here (flag default-off; needs a flag-enabled env) | ⬜ **honest gap** (narrow): the wire + onDone seam are unit-covered; only the live render + real-grid round-trip is unverified. Recommend a flag-on smoke before rollout. |
 
 ## Scope boundary
 This is **item #1** of the owner's reordered list. **Not** included (each is destructive and needs its own design-lock + owner gate, per the given order): T8-1 undelete-execute · T9-W Tier 3 un-create · Tier 4 undelete · permission-revert. The `value-transforming/destructive retype option II` is also separate.
 
 ## Follow-ups (non-blocking)
 - Flag-on smoke (the ⬜ above).
+- **Post-destructive page offset:** `onResetDone` calls `grid.reloadCurrentPage()`; after a Reset moves post-T records to trash the total shrinks, so the current offset can land on a now-empty page. The config-revert path reloaded more deliberately — consider resetting the offset to 0 (or clamping) on reset-done.
 - Swap the T-source seam to history-timestamp options if the owner prefers the richer picker.
 - Visual placement polish (currently a gated strip under the toolbar) + i18n (matches `ResetConfirmDialog`'s current raw-string state; a later i18n sweep covers both).

--- a/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
+++ b/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
@@ -30,6 +30,6 @@ This is **item #1** of the owner's reordered list. **Not** included (each is des
 
 ## Follow-ups (non-blocking)
 - Flag-on smoke (the ⬜ above).
-- **Post-destructive page offset:** `onResetDone` calls `grid.reloadCurrentPage()`; after a Reset moves post-T records to trash the total shrinks, so the current offset can land on a now-empty page. The config-revert path reloaded more deliberately — consider resetting the offset to 0 (or clamping) on reset-done.
+- **Post-destructive page offset:** `onResetDone` calls `grid.reloadCurrentPage()` → `loadViewData()`, which already falls back/clamps when the current offset becomes empty (owner-confirmed in the #3301 review). So no extra offset handling is needed — the earlier "reset offset to 0" caution was unnecessary.
 - Swap the T-source seam to history-timestamp options if the owner prefers the richer picker.
 - Visual placement polish (currently a gated strip under the toolbar) + i18n (matches `ResetConfirmDialog`'s current raw-string state; a later i18n sweep covers both).

--- a/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
+++ b/docs/development/multitable-t82-reset-tsource-picker-dev-verification-20260627.md
@@ -1,0 +1,33 @@
+# T8-2 Reset UI — T-source picker (development & verification)
+
+**Date:** 2026-06-27 · **Scope:** the product entry the Reset UI was missing (#3250 shipped `ResetConfirmDialog` but flagged *"entry-wiring needs a T-source"*; #3251 named the *"T-source gap"*). This closes that gap. **Flag-off by default** (`MULTITABLE_ENABLE_PIT_RESET`).
+
+## What was built
+- **`ResetToPointPicker.vue`** (new): sources a point-in-time **T** and mounts the existing `ResetConfirmDialog` with `asOf = T`. The dialog already owns preview → typed two-step confirm → execute; this component only supplies T and binds the wire.
+- **Mount in `MultitableWorkbench.vue`** (the actual entry-wiring): rendered under the toolbar, gated, bound to `workbench.client` + `workbench.activeSheetId`; `onDone` refreshes the grid.
+- **`multitable-web-guard.yml`**: registered the new spec in the run command + both trigger `paths` lists (so it runs in CI — without this the spec would be invisible to the guard).
+
+## Design decisions
+- **T-source = free `datetime-local` picker** (the minimal "只差产品入口"). The `asOf` derivation (`localToIso` / the `asOf` computed) is the **single swappable seam**.
+  - **Alternative (deferred, named so the owner can steer):** present recent `HistoryCenterModal` batch timestamps as selectable options — richer (you reset to a real change-point), and still **read-only consumption** of history (it never mutates the read-only history center). Swapping is a one-function change at the seam.
+- **Timezone (destructive-op safety):** `datetime-local` is browser-local; `asOf` is the corresponding **UTC ISO** for the API. The human-facing "Target: …" line is derived **from `asOf`** (not the raw input), so what the user sees can never diverge from what the destructive op uses. A WIRE test asserts the sent `asOf` round-trips to the same instant as the input (no inversion).
+- **Gating:** on `pitResetEnabled` **alone** (it already encodes `MULTITABLE_ENABLE_PIT_RESET ∧ canManageSheetAccess` per #3239) — no second check that could drift. Absent/false ⇒ the whole entry is hidden (fail-closed).
+- **No two reset buttons:** the dialog is mounted only once T is valid & **past**, so the dialog's own "Reset to {asOf}…" button never fires on an empty/ future `asOf`.
+- **No backend change:** reuses `reset-preview` / `reset-execute` as-is.
+
+## Verification
+| What | How | Status |
+|---|---|---|
+| Picker logic (gating, valid-past, future-reject, target display) | `multitable-reset-tsource-picker.spec.ts` (jsdom, `createApp`) | ✅ 5/5 local |
+| **The (sheetId, asOf) WIRE** — picker → client → `reset-preview` | same spec, **fake `fetchFn`** asserts URL carries the picker's `sheetId` + body `asOf` = UTC-ISO of the input, round-tripping to the same instant | ✅ (this is the real check, not a fixture) |
+| The workbench **mount** (binding `pitResetEnabled`/`sheetId`/client) | `vue-tsc -b` (authoritative; `--noEmit` can false-green) | ✅ exit 0 |
+| Reuse didn't break the dialog | `multitable-reset-confirm-dialog.spec.ts` + `multitable-workbench-restore-wiring.spec.ts` | ✅ 6/6 + 13/13 |
+| **Live app with the flag ON** (the entry actually renders + a real reset round-trips) | not run here (flag default-off; needs a flag-enabled env) | ⬜ **honest gap** — recommend a flag-on smoke before enabling rollout |
+
+## Scope boundary
+This is **item #1** of the owner's reordered list. **Not** included (each is destructive and needs its own design-lock + owner gate, per the given order): T8-1 undelete-execute · T9-W Tier 3 un-create · Tier 4 undelete · permission-revert. The `value-transforming/destructive retype option II` is also separate.
+
+## Follow-ups (non-blocking)
+- Flag-on smoke (the ⬜ above).
+- Swap the T-source seam to history-timestamp options if the owner prefers the richer picker.
+- Visual placement polish (currently a gated strip under the toolbar) + i18n (matches `ResetConfirmDialog`'s current raw-string state; a later i18n sweep covers both).


### PR DESCRIPTION
## Summary

Closes the **T-source gap** the Reset UI shipped with: `ResetConfirmDialog` (#3250) was built but **never mounted** — #3250's title flagged *"entry-wiring needs a T-source"* and #3251 named the *"T-source gap"*. This adds the missing product entry.

- **`ResetToPointPicker.vue`** — a flag-gated `datetime-local` picker that sources the point-in-time **T** and mounts the existing `ResetConfirmDialog` with `asOf = T`. The dialog still owns preview → typed two-step confirm → execute; the picker only supplies T and binds the wire.
- **Mounted** under the workbench toolbar, gated on `pitResetEnabled` **alone** (already encodes `MULTITABLE_ENABLE_PIT_RESET ∧ canManageSheetAccess`), bound to `workbench.client` + `activeSheetId`, grid refresh on done. **No backend change** — reuses `reset-preview`/`reset-execute`.

## Design notes
- **Timezone (destructive-op safety):** local input → UTC `asOf` for the API; the human-facing "Target" line is derived **from `asOf`**, so it can't diverge from what executes. A WIRE test asserts no inversion.
- **T-source seam:** free `datetime-local` now (minimal entry); presenting recent `HistoryCenterModal` batch timestamps as options is a deferred, swap-at-one-function alternative (still read-only consumption of history).
- **Fail-closed:** absent/false `pitResetEnabled` ⇒ the whole entry is hidden; the dialog mounts only once T is valid & past (no empty/duplicate reset button).

## Verification (see the included dev+verification MD)
- New picker spec: gating, valid-past, future-reject, and a **WIRE test** asserting the picker `sheetId` + UTC-ISO `asOf` reach `reset-preview` (real wire, not a fixture).
- Registered in `multitable-web-guard.yml` (run command + both `paths` lists) so it runs in CI.
- Local: **full guard set 372/372**, `vue-tsc -b` exit 0, `ResetConfirmDialog` + `workbench-restore-wiring` specs still green.
- **Honest gap:** not run in a flag-enabled live app (flag default-off) — recommend a flag-on smoke before rollout.

## Scope
Item #1 of the reordered roadmap. Tier 3/4 un-create/undelete, T8-1 undelete-execute, and permission-revert are each separate destructive slices needing their own design-lock + owner gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
