### PR TITLE
docs(approval): reconcile RA design docs to as-built + durably land next-layer locks

### DIFF
--- a/docs/design/approval-ra1a-wedge-guard-design-20260627.md
+++ b/docs/design/approval-ra1a-wedge-guard-design-20260627.md
@@ -1,6 +1,6 @@
 # RA-1a requester.department wedge guard — Design
 
-> Status: **PROPOSED — owner ratification needed** (touches the `createApproval` contract). Implemented on `claude/approval-ra1a-wedge-fix-20260627`; PR open as **draft**, do-not-merge until ratified. Source of the finding: the RA-1a deep review (2026-06-27), P2.
+> Status: **RATIFIED — SHIPPED #3296 (`4d5a388b5`, 2026-06-27).** Owner-ratified; the create-time wedge guard (reject-at-create 503/422, token-aware AST detection) is on `main`. Source of the finding: the RA-1a deep review (2026-06-27), P2.
 
 ## Problem
 `createApproval` resolves the requester's directory department best-effort and **swallows failures** into `orgRelations = {}` (`ApprovalProductService.ts` ~:2876-2886). If the template routes on `requester.department` **downstream of an approval node** and the department is absent — whether because the read **failed transiently** OR because the requester **genuinely has none** — the create succeeds, the `requester_snapshot` is frozen, and the first approval that reaches the condition throws → rolls back → re-throws on **every retry forever** (admin-cancel only). Fail-closed (no mis-route) but a permanent in-flight wedge — production-triggerable and invisible to tests.

--- a/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
+++ b/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
@@ -1,0 +1,22 @@
+# RA-1b requester.role membership — Design Lock
+
+> Status: **PROPOSED.** Provenance + vocabulary decided (owner 2026-06-27); runtime is a separate gated slice (do `requester.title` first). Schema verified on `origin/main`.
+
+## Facts
+- `directory_accounts` has **NO** first-class role/position column. A DingTalk `role_list` may sit unextracted in `directory_accounts.raw` — **NOT a v1 source**.
+- The trusted role source is the **system RBAC**: `roles` (PK TEXT id+name; `zzzz20260208100000`) + `user_roles` (`20250924190000`). Stable enumerable PKs.
+- `requester_snapshot.roles` is already frozen but from **actor/token claims (login-time)**, provenance-distinct from RA-1a department's fresh server query.
+
+## Decisions (owner, 2026-06-27)
+- **D-role-provenance = FRESH `user_roles` query at create** (department-grade tamper-resistance) — **NOT** the login-time token-claim roles.
+- **D-role-vocabulary = an approval-curated subset** of RBAC roles exposed to formula authors — **NOT** all RBAC roles (do not expose system/admin roles to approval-formula authors).
+- **BOUNDARY (v1 scope lock):** RA-1b v1 uses ONLY the fresh `user_roles` source. Directory `raw` role/position fields (provider-specific) **do NOT enter v1** — they would require a separate sync/extraction design lock.
+
+## Build (after requester.title; introduces the `in` grammar)
+1. **Grammar (the substantive new work)**: add the `in` operator + array-literal `["a","b"]` to the evaluator (tokenizer / parser / AST / type-check / evaluate). Shared infra, reusable.
+2. **Source** (per D-role-provenance): fresh `user_roles` query at create → freeze the curated role list into `requester_snapshot` (new resolver path, NOT the token-claim roles).
+3. **Evaluator**: `requester.role` → string-list value; `requester.role in [...]` membership; allowlist + the 3 edits (snapshot / requesterContext / `evaluateRequester`).
+4. **Guard + tests**: wedge guard for `requester.role`; evaluator + resolver + round-trip + `in`-grammar unit tests.
+
+## Sequence
+`requester.title` first (cheaper, no grammar) → then RA-1b role.

--- a/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
+++ b/docs/design/approval-requester-role-ra1b-design-lock-20260627.md
@@ -1,6 +1,6 @@
 # RA-1b requester.role membership — Design Lock
 
-> Status: **PROPOSED.** Provenance + vocabulary decided (owner 2026-06-27); runtime is a separate gated slice (do `requester.title` first). Schema verified on `origin/main`.
+> Status: **RATIFIED — RUNTIME NOT BUILT** (build after `requester.title`). Provenance + vocabulary decided (owner 2026-06-27); the runtime is the next gated slice. Schema verified on `origin/main`.
 
 ## Facts
 - `directory_accounts` has **NO** first-class role/position column. A DingTalk `role_list` may sit unextracted in `directory_accounts.raw` — **NOT a v1 source**.

--- a/docs/design/approval-requester-title-level-design-lock-20260627.md
+++ b/docs/design/approval-requester-title-level-design-lock-20260627.md
@@ -1,0 +1,23 @@
+# requester.title / requester.level — Design Lock
+
+> Status: **RATIFIED (owner 2026-06-27: D-title = YES, D-level = DEFER) — RUNTIME NOT BUILT** (next slice after RA-1a department). Schema verified on `origin/main`.
+
+## Facts (directory schema)
+- `directory_accounts.title` — a TEXT column populated by **directory-sync upsert** (DingTalk admin data), **server-resolved (not request-sourced)**. NOTE: per-tenant/provider fill-rate varies — `title` is **not guaranteed present** for every requester; an unset title on a title-routed template fails-closed at create (the wedge guard), same as department.
+- **NO** numeric seniority/grade/rank/level column anywhere in `directory_*` (`directory_departments.order_index` = dept sort order; `…alerts.level` = severity). `title` is free-text, no machine ordinal.
+- The resolver (`ApprovalDirectoryOrg.ts:166-185`) already has the account in hand — `a.title` is one column away.
+
+## Decisions (owner, 2026-06-27)
+- **D-title = YES** — ship `requester.title == "经理"` string equality (`==`/`!=`) as the next slice.
+- **D-level = DEFER** — no numeric source exists; revisit only with a real ordinal source or an authored `title → rank` mapping. Don't fake an ordinal.
+
+## Build (mirrors RA-1a department; 3 edits + guard generalization)
+1. **Resolver**: add `a.title` to the SELECT → `ApprovalRequesterOrgRelations.primaryTitle` → `requester_snapshot.directoryTitle` (frozen at create, `ApprovalProductService.ts:2902-2914`).
+2. **requesterContext**: extend `{ department }` → `{ department, title }` at create (`:2926`) + both dispatch re-thread sites (`:3165/:3331`).
+3. **Evaluator**: `RA1A_REQUESTER_ATTRS` add `title: 'string'`; add an `evaluateRequester` `title` branch (`ApprovalConditionFormula.ts:597`); `==`/`!=` only (string-typed → ordering auto-rejected by the numeric-operand type check).
+4. **Wedge guard**: generalize `runtimeGraphUsesRequesterDepartment` → `runtimeGraphUsesRequesterAttribute(graph, attr)` (it already calls the token-aware `formulaReferencesRequesterAttribute(expr, attr)`); reject-at-create for an unresolved `title` on a title-routed template (503 transient / 422 genuine), same posture as department.
+- Tests: evaluator unit (`==`/`!=` + parse-reject others + token-aware literal), resolver real-DB title lift, round-trip create→reload→dispatch, wedge guard for title.
+
+## Out of scope
+- `requester.level` numeric (needs the mapping decision above).
+- title case/whitespace normalization — same `==` footgun as department; document for authors.

--- a/docs/development/approval-line-dev-verification-round2-20260627.md
+++ b/docs/development/approval-line-dev-verification-round2-20260627.md
@@ -23,7 +23,7 @@ D-title = **YES** · D-level = **DEFER** · D-role-provenance = **fresh `user_ro
 
 ## 4. Remaining roadmap (each gated)
 - **`requester.title`** — RATIFIED; **next runtime slice** (cheapest, real source, no new grammar).
-- **RA-1b `requester.role`** — PROPOSED; needs the `in`-grammar build after title.
+- **RA-1b `requester.role`** — RATIFIED — RUNTIME NOT BUILT; needs the `in`-grammar build after title.
 - **`requester.level`** — DEFERRED (no source; needs a title→rank mapping decision).
 - **W7 write-back** — approved-path same-base shipped; rejection / cross-base / approverField-native-person remain (cross-base is NOT small — redo permission/lock/audit/target-resolution). Each demand-gated.
 - **Amount line** (optional, product/security decisions) — overridable line amount, backend strict `amount = qty × price`, discount/tax row math, mixed `rules`+`formula` branches.

--- a/docs/development/approval-line-dev-verification-round2-20260627.md
+++ b/docs/development/approval-line-dev-verification-round2-20260627.md
@@ -1,0 +1,35 @@
+# 审批流程及自动化 — 开发及验证 MD · Round 2 (as-built 2026-06-27)
+
+> Goal: 审阅并开发,完成后给出开发及验证MD. Round-1 detail: `approval-line-dev-verification-20260627.md`.
+
+## 1. RA Phase A — the 4-PR stack (ALL LANDED on `main`)
+| PR | What | State |
+|---|---|---|
+| #3288 | RA-1a publish-posture doc correction | **MERGED** `2a15f2419` |
+| #3292 | dry-run preview of `requester.*` (sample context) | **MERGED** `a8df3ddf1` |
+| #3294 | RA-1a test-hardening (create→reload→dispatch real-DB seam) + CI-wired (Postgres lane + no-DB exclude) | **MERGED** `f3e8930c2` |
+| #3296 | requester.department wedge guard (reject-at-create 503/422, token-aware AST) | **MERGED** `4d5a388b5` |
+| #3293 | parallel codex dispatch-seam test | **CLOSED — superseded by #3294** |
+
+The merge stack landed through a fast-moving `main` (attendance burst) via a bounded retry-loop. A force-push/merge race on #3294 was collision-verified clean: the `vitest.config.ts` no-DB exclude + the `plugin-tests.yml` Postgres lane entry + the test file are all on `main`. #3296's wedge-guard code (token-aware `formulaReferencesRequesterAttribute` + create-time guard → 503 `APPROVAL_REQUESTER_DEPARTMENT_UNRESOLVED` / 422 `APPROVAL_REQUESTER_DEPARTMENT_REQUIRED`) confirmed on `main`. (This PR also closes out #3296's design lock: PROPOSED → RATIFIED + SHIPPED.)
+
+## 2. Next-layer DESIGN — two design locks, now durable in `docs/design/`
+Schema verified on `origin/main`: `directory_accounts` has `title` + `job_number` + `raw`; **no role/level column**.
+- **`requester.title` / `requester.level`** — `docs/design/approval-requester-title-level-design-lock-20260627.md`. **RATIFIED**: `title` buildable now (directory-sync-sourced `title` column, server-resolved; fill-rate varies → unset title fails-closed at create). `level` DEFERRED (no numeric source).
+- **RA-1b `requester.role`** — `docs/design/approval-requester-role-ra1b-design-lock-20260627.md`. **PROPOSED**: source = system RBAC (not directory). Decisions: provenance = **fresh `user_roles` query**; vocabulary = **approval-curated subset**; v1 boundary excludes directory `raw` role/position. Needs the `in`/array grammar.
+
+## 3. Owner decisions (locked 2026-06-27)
+D-title = **YES** · D-level = **DEFER** · D-role-provenance = **fresh `user_roles`** · D-role-vocabulary = **approval-curated subset**.
+
+## 4. Remaining roadmap (each gated)
+- **`requester.title`** — RATIFIED; **next runtime slice** (cheapest, real source, no new grammar).
+- **RA-1b `requester.role`** — PROPOSED; needs the `in`-grammar build after title.
+- **`requester.level`** — DEFERRED (no source; needs a title→rank mapping decision).
+- **W7 write-back** — approved-path same-base shipped; rejection / cross-base / approverField-native-person remain (cross-base is NOT small — redo permission/lock/audit/target-resolution). Each demand-gated.
+- **Amount line** (optional, product/security decisions) — overridable line amount, backend strict `amount = qty × price`, discount/tax row math, mixed `rules`+`formula` branches.
+- **Canvas polish (UX tail)** — drag-connect/free-drag E2E, pan/zoom, copy/paste subgraph, template gallery, mobile, in-canvas node config.
+
+## 5. Verification (as-built)
+- RA Phase A code + CI: round-1 MD (unit 45+66 / integration 6/6 real DB / tsc clean) + each PR's CI green on its merged head; #3296 final checks green (test 18.x/20.x/coverage).
+- Schema facts authoritative (file:line evidence): `directory_accounts.title` real + sync-sourced; no numeric level; RBAC = role source; resolver seam `ApprovalDirectoryOrg.ts:166-185`.
+- This round's "开发" = landing the (already-tested) RA Phase A stack + the two design locks (now durable here). No new runtime built this round (the next slices are owner-gated; `requester.title` runtime follows as its own PR).

--- a/docs/development/approval-line-dev-verification-round2-20260627.md
+++ b/docs/development/approval-line-dev-verification-round2-20260627.md
@@ -16,7 +16,7 @@ The merge stack landed through a fast-moving `main` (attendance burst) via a bou
 ## 2. Next-layer DESIGN — two design locks, now durable in `docs/design/`
 Schema verified on `origin/main`: `directory_accounts` has `title` + `job_number` + `raw`; **no role/level column**.
 - **`requester.title` / `requester.level`** — `docs/design/approval-requester-title-level-design-lock-20260627.md`. **RATIFIED**: `title` buildable now (directory-sync-sourced `title` column, server-resolved; fill-rate varies → unset title fails-closed at create). `level` DEFERRED (no numeric source).
-- **RA-1b `requester.role`** — `docs/design/approval-requester-role-ra1b-design-lock-20260627.md`. **PROPOSED**: source = system RBAC (not directory). Decisions: provenance = **fresh `user_roles` query**; vocabulary = **approval-curated subset**; v1 boundary excludes directory `raw` role/position. Needs the `in`/array grammar.
+- **RA-1b `requester.role`** — `docs/design/approval-requester-role-ra1b-design-lock-20260627.md`. **RATIFIED — RUNTIME NOT BUILT** (build after title): source = system RBAC (not directory). Decisions: provenance = **fresh `user_roles` query**; vocabulary = **approval-curated subset**; v1 boundary excludes directory `raw` role/position. Needs the `in`/array grammar.
 
 ## 3. Owner decisions (locked 2026-06-27)
 D-title = **YES** · D-level = **DEFER** · D-role-provenance = **fresh `user_roles`** · D-role-vocabulary = **approval-curated subset**.


### PR DESCRIPTION
## Docs-only reconcile — closes three doc drifts the owner flagged
1. **#3296 wedge-guard design lock** (`docs/design/approval-ra1a-wedge-guard-design-20260627.md`): was still PROPOSED/draft/do-not-merge on main; #3296 shipped as `4d5a388b5` → status now **RATIFIED — SHIPPED**.
2. **Two next-layer design locks now durable in `docs/design/`** (were /tmp-only): `requester.title`/`level` (RATIFIED — title buildable now from the directory-sync-sourced title column; level DEFERRED, no numeric source) + RA-1b `requester.role` (PROPOSED — source is system RBAC not directory; fresh `user_roles` provenance; approval-curated vocabulary; directory `raw` role excluded from v1).
3. **Round-2 dev/verification MD → `docs/development/`**, corrected to as-built (RA Phase A #3288/#3292/#3294/#3296 all merged, #3293 closed; owner decisions locked).

## Scope
Docs-only. No code. Encodes owner decisions of 2026-06-27 (D-title=YES, D-level=DEFER, D-role-provenance=fresh `user_roles`, D-role-vocabulary=curated subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)