### PR TITLE
feat(multitable): read-only cross-base mirror v1 (lift twoWay cross-base reject + base-read gate reverse projection)

### DIFF
--- a/docs/development/multitable-crossbase-readonly-mirror-dev-verification-20260627.md
+++ b/docs/development/multitable-crossbase-readonly-mirror-dev-verification-20260627.md
@@ -1,0 +1,100 @@
+# Cross-base deepen — slice (a): read-only cross-base mirror v1 — dev & verification (2026-06-27)
+
+> Status: built + verified (real-DB fail-first proven). Grounding: `origin/main` @ `027aafd19`. The "surpass"
+> axis of the **cross-base deepen** arc (after slices (b) relation-agg perm-fix #3300 and (c) dangling-link
+> repair #3306). Security-sensitive (a cross-base READ change that un-defers an owner-ratified §7.2 hold) —
+> advisor-reviewed before implementation; explicit owner GO ("只读 mirror，开，就是现在") with batch
+> boundaries + acceptance criteria recorded below.
+
+## 1. Scope — what this slice opens, and what it deliberately does NOT
+
+A **bidirectional (twoWay) link** has a forward side (a real `meta_links` edge) and a derived **mirror** side
+(`mirrorOf` set, forced read-only by the codec) that is a *read-time reverse projection* of that one edge — no
+materialized mirror row, no write-back. Until now a twoWay pairing was forced **same-base**: the field-create
+wall blanket-rejected any cross-base twoWay pairing (design §7.2 deferral).
+
+This slice lifts **only** that blanket reject so a twoWay pairing may span bases on the **same** terms as a
+one-way cross-base link — i.e. iff it carries a valid `foreignBaseId` opt-in claim. The mirror side stays
+**read-only by codec** (`mirrorOf ⇒ readOnly`), so this opens a cross-base reverse **read projection only**.
+
+Explicitly OUT of this slice (each a separate, separately-governed follow-up):
+- **No editable mirror** — the derived side is codec read-only; no cross-base write path is introduced.
+- **No `evaluateCrossBaseWrite` wiring** — the cross-base write-authority/quota path is untouched.
+- **No cross-base realtime mirror push** — deferred to a read-time recompute (see §3, site 3).
+
+## 2. The three changes (the "3-change shape")
+
+### Site 1 — `validateLinkFieldConfig` (`routes/univer-meta.ts`): lift the twoWay cross-base reject
+Removed the `if (linkCfg.twoWay === true) return <reject>` block inside the cross-base branch. A cross-base
+pairing (one-way **or** twoWay) now falls through to the **unchanged** ②b opt-in short-circuit: allowed iff
+`claimed !== null` after the `claim == truth` gate above it (a wrong claim is already rejected; a null/legacy
+foreign base can never opt in). No-claim / wrong-claim / one-way-no-claim therefore still **fail closed**.
+
+### Site 2 — `maskDerivedMirrorFieldIds` (`routes/univer-meta.ts`): add a cross-base base-read gate (SECURITY)
+The raw `data[mirrorField]` reverse-id wire was gated only at **sheet** level (`resolveReadableSheetIds`). With
+cross-base mirrors now possible, a sheet-readable-but-base-unreadable actor could enumerate a foreign base's
+record ids/count via the reverse projection. Added gate (2): resolve the source base (from a new `sourceSheetId`
+param, parity with `applyLookupRollup`), and for each **distinct cross-base** mirror foreign sheet require
+`resolveBaseReadable(foreignBase)` — deny → empty the projection. This is a **strict add** on top of the sheet
+gate (only reduces visibility; same-base mirrors never reach gate (2)), parity with the existing
+`resolveForeignFieldReadability` §3.2 Sink A and `buildLinkSummaries` Sink B-1 patterns. All four call sites
+(view-list, form-context echo, write-echo PATCH, single-record GET) updated to pass their sheet id.
+
+**Two-wire note (advisor):** the mirror reverse projection surfaces on **two independent wires** — the raw
+`data[mirrorField]` array (site 2) and the inline `linkSummaries` (gated independently by `buildLinkSummaries`
+Sink B-1, which already base-gates **every** link field in `idsBySheet`, mirror included). Both must hold; the
+goldens cover each separately and the fail-first proves they are genuinely independent (see §4).
+
+### Site 3 — `collectMirrorInvalidation` (`multitable/record-write-service.ts`): defer cross-base realtime push
+Added `if (cfg.foreignBaseId != null) return` so a **cross-base** forward write does not fan a mirror-
+invalidation broadcast to the foreign-base sheet. `foreignBaseId` is persisted only as the cross-base opt-in
+claim (codec emits it iff present; same-base mirrors omit it), so `!= null ⟺ cross-base` here. This is a
+**deliberate v1 behavior, not a missed-push bug**: the reverse mirror is recomputed + base-masked on every
+fetch (`loadLinkValuesByRecord` + `maskDerivedMirrorFieldIds` / `buildLinkSummaries`), so a cross-base mirror
+still reads **correctly** on the next read — it only forgoes a live realtime nudge. Same-base fan-out
+(`foreignBaseId == null`) is **unchanged**.
+
+## 3. Acceptance criteria → evidence (all met)
+
+| Owner acceptance condition | Evidence |
+|---|---|
+| Old C5 "cross-base pairing rejected" **changed** to the new allow semantics (not added beside) | `C5` rewritten in place → asserts 2xx |
+| Golden proves base-read have / not-have × mirror read-only (three states) | `C-XB-MASK` (denied→`[]`, permitted→`[REC_A1]`) + `C-XB-RO` (mirror PATCH rejected, no edge) |
+| Regression: same-base twoWay/mirror unchanged | `C1`–`C9` all green |
+| Regression: one-way cross-base still goes through the foreignBaseId gate | `C5d` (one-way, no claim → 400) |
+| Regression: no-claim / wrong-claim still fail closed | `C5b` (no claim → 400), `C5c` (wrong claim → 400) |
+| Create path exercised end-to-end (not only SQL-seeded) | `C5-CREATE` (forward SA→SX **and** mirror SX→SA both create; mirror returns read-only) |
+| No editable mirror / no `evaluateCrossBaseWrite` / no cross-base push | `C-XB-RO` (read-only) + `C-XB-NOFANOUT` (push deferred) |
+
+## 4. Fail-first proof (site 2 is necessary; the two wires are independent)
+
+Temporarily disabled gate (2) (`… || (false && crossBaseDeniedForeignSheetIds.has(…))`) and ran `C-XB-MASK`:
+
+```
+× C-XB-MASK (/view raw)     — AssertionError: expected [ 'rec_bdl_a1_…' ] to deeply equal []   (RAW WIRE LEAKS)
+× C-XB-MASK (single-GET raw) — AssertionError: expected [ 'rec_bdl_a1_…' ] to deeply equal []   (RAW WIRE LEAKS)
+✓ C-XB-MASK (linkSummaries)  — still green (buildLinkSummaries gates this wire independently)
+```
+
+The raw wires go RED (the leak site 2 closes); the linkSummaries wire stays green — proving it is a genuinely
+**separate** wire already covered by `buildLinkSummaries`, exactly as the two-wire analysis predicted. Gate (2)
+restored; all green (§5).
+
+## 5. Verification results
+
+- **Target file (real DB):** `multitable-bidirectional-mirror-links.test.ts` → **21/21 passed** (C1–C9 +
+  C5/C5b/C5c/C5d/C5-CREATE + C-XB-MASK ×3 + C-XB-RO + C-XB-NOFANOUT).
+- **Adjacent cross-base suites + #3306 mock canary (real DB):** `multitable-crossbase-relation-aggregation`,
+  `multitable-cross-base-write-quota`, `multitable-cross-base-automation-delete-lock`,
+  `multitable-dangling-link-sweep`, `multitable-context.api` → **54/54 passed** (no regression; the canary
+  confirms site 2's new `loadSheetRowShared` calls don't break a strict query mock — `maskDerivedMirrorFieldIds`
+  early-returns when no mirror field is present, and the mirror test is the only suite with `mirrorOf` data).
+- **Typecheck:** `tsc --noEmit` on `@metasheet/core-backend` → exit 0, clean.
+
+## 6. Boundaries honored
+
+`validateLinkFieldConfig` change is **only** the twoWay-reject removal; the `foreignBaseId` claim==truth gate is
+untouched. `maskDerivedMirrorFieldIds` only **adds** the base-read gate (the sheet/field gate is never
+loosened); a base-denied reader sees an **empty** mirror, not a 403/diff error. Cross-base realtime push is
+deferred with the v1 rationale documented in code + here. No editable mirror, no `evaluateCrossBaseWrite`, no
+cross-base realtime push.

--- a/docs/development/multitable-crossbase-readonly-mirror-dev-verification-20260627.md
+++ b/docs/development/multitable-crossbase-readonly-mirror-dev-verification-20260627.md
@@ -46,13 +46,26 @@ Sink B-1, which already base-gates **every** link field in `idsBySheet`, mirror 
 goldens cover each separately and the fail-first proves they are genuinely independent (see §4).
 
 ### Site 3 — `collectMirrorInvalidation` (`multitable/record-write-service.ts`): defer cross-base realtime push
-Added `if (cfg.foreignBaseId != null) return` so a **cross-base** forward write does not fan a mirror-
-invalidation broadcast to the foreign-base sheet. `foreignBaseId` is persisted only as the cross-base opt-in
-claim (codec emits it iff present; same-base mirrors omit it), so `!= null ⟺ cross-base` here. This is a
-**deliberate v1 behavior, not a missed-push bug**: the reverse mirror is recomputed + base-masked on every
-fetch (`loadLinkValuesByRecord` + `maskDerivedMirrorFieldIds` / `buildLinkSummaries`), so a cross-base mirror
-still reads **correctly** on the next read — it only forgoes a live realtime nudge. Same-base fan-out
-(`foreignBaseId == null`) is **unchanged**.
+A **cross-base** forward write does not fan a mirror-invalidation broadcast to the foreign-base sheet. The
+cross-base determination compares the **actual** sheet bases — pre-transaction we resolve `this sheet` vs each
+twoWay-mirror forward field's `foreignSheetId` base (one `SELECT id, base_id FROM meta_sheets WHERE id = ANY(…)`,
+skipped entirely when the sheet has no twoWay-mirror field) into a `crossBaseMirrorForeignSheetIds` set, and the
+closure defers iff `crossBaseMirrorForeignSheetIds.has(cfg.foreignSheetId)`.
+
+> **[P2 review correction]** The first cut used `if (cfg.foreignBaseId != null) return` as the discriminator —
+> **wrong**: claim presence is *not* cross-base. `validateLinkFieldConfig` only rejects a *false* claim
+> (`claimed !== actualForeignBaseId`), so a **same-base** link may legally carry a **truthful own-base**
+> `foreignBaseId` (semantic lock: `multitable-cross-base-link-optin` **XB-3b**). Under the old predicate such a
+> same-base twoWay link would wrongly skip its mirror push — a same-base realtime-push regression not covered by
+> C1–C9. The fix resolves real bases instead of inferring from the claim. Regression-locked by
+> `C-SB-TRUTHFUL-CLAIM` (RED under the old predicate: `expected 0 to be greater than 0`).
+
+This is a **deliberate v1 behavior, not a missed-push bug**: the reverse mirror is recomputed + base-masked on
+every fetch (`loadLinkValuesByRecord` + `maskDerivedMirrorFieldIds` / `buildLinkSummaries`), so a cross-base
+mirror still reads **correctly** on the next read — it only forgoes a live realtime nudge. Same-base fan-out
+(including a same-base link with a truthful own-base claim) is **unchanged**. Site-3 truth table:
+same-base/no-claim → fan-out (`C3`); same-base/truthful-claim → fan-out (`C-SB-TRUTHFUL-CLAIM`); cross-base →
+defer (`C-XB-NOFANOUT`).
 
 ## 3. Acceptance criteria → evidence (all met)
 
@@ -61,6 +74,7 @@ still reads **correctly** on the next read — it only forgoes a live realtime n
 | Old C5 "cross-base pairing rejected" **changed** to the new allow semantics (not added beside) | `C5` rewritten in place → asserts 2xx |
 | Golden proves base-read have / not-have × mirror read-only (three states) | `C-XB-MASK` (denied→`[]`, permitted→`[REC_A1]`) + `C-XB-RO` (mirror PATCH rejected, no edge) |
 | Regression: same-base twoWay/mirror unchanged | `C1`–`C9` all green |
+| Regression: same-base twoWay realtime push unchanged incl. **truthful own-base claim** (P2) | `C-SB-TRUTHFUL-CLAIM` (same-base + truthful `foreignBaseId` still fans the mirror event) |
 | Regression: one-way cross-base still goes through the foreignBaseId gate | `C5d` (one-way, no claim → 400) |
 | Regression: no-claim / wrong-claim still fail closed | `C5b` (no claim → 400), `C5c` (wrong claim → 400) |
 | Create path exercised end-to-end (not only SQL-seeded) | `C5-CREATE` (forward SA→SX **and** mirror SX→SA both create; mirror returns read-only) |
@@ -80,15 +94,20 @@ The raw wires go RED (the leak site 2 closes); the linkSummaries wire stays gree
 **separate** wire already covered by `buildLinkSummaries`, exactly as the two-wire analysis predicted. Gate (2)
 restored; all green (§5).
 
+**P2 site-3 fail-first.** Temporarily reverted site 3 to the old `if (cfg.foreignBaseId != null) return` and ran
+`C-SB-TRUTHFUL-CLAIM` → RED (`expected 0 to be greater than 0` — the same-base mirror event was dropped because
+the truthful own-base claim tripped the imprecise predicate). Restored the actual-base resolution → green.
+
 ## 5. Verification results
 
-- **Target file (real DB):** `multitable-bidirectional-mirror-links.test.ts` → **21/21 passed** (C1–C9 +
-  C5/C5b/C5c/C5d/C5-CREATE + C-XB-MASK ×3 + C-XB-RO + C-XB-NOFANOUT).
-- **Adjacent cross-base suites + #3306 mock canary (real DB):** `multitable-crossbase-relation-aggregation`,
-  `multitable-cross-base-write-quota`, `multitable-cross-base-automation-delete-lock`,
-  `multitable-dangling-link-sweep`, `multitable-context.api` → **54/54 passed** (no regression; the canary
-  confirms site 2's new `loadSheetRowShared` calls don't break a strict query mock — `maskDerivedMirrorFieldIds`
-  early-returns when no mirror field is present, and the mirror test is the only suite with `mirrorOf` data).
+- **Target file (real DB):** `multitable-bidirectional-mirror-links.test.ts` → **22/22 passed** (C1–C9 +
+  C5/C5b/C5c/C5d/C5-CREATE + C-XB-MASK ×3 + C-XB-RO + C-XB-NOFANOUT + **C-SB-TRUTHFUL-CLAIM**).
+- **Adjacent cross-base suites + XB-3b lock + #3306 mock canary (real DB):**
+  `multitable-crossbase-relation-aggregation`, `multitable-cross-base-write-quota`,
+  `multitable-cross-base-automation-delete-lock`, `multitable-dangling-link-sweep`,
+  `multitable-cross-base-link-optin` (contains the **XB-3b** same-base-truthful-claim lock), `multitable-context.api`
+  → **72/72 passed**. No regression; the canary + the new pre-transaction base-resolution query (skipped when the
+  sheet has no twoWay-mirror field) don't break any strict mock.
 - **Typecheck:** `tsc --noEmit` on `@metasheet/core-backend` → exit 0, clean.
 
 ## 6. Boundaries honored

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -621,6 +621,41 @@ export class RecordWriteService {
         })
       : new Map<string, Map<string, string[]>>()
 
+    // ②b read-only cross-base mirror v1 (2026-06-27) — resolve which twoWay-mirror forward fields are
+    // ACTUALLY cross-base by comparing REAL sheet bases (this sheet vs each forward field's foreignSheetId).
+    // This is deliberately NOT "carries a foreignBaseId claim": a same-base link may legally carry a truthful
+    // own-base foreignBaseId (semantic lock: multitable-cross-base-link-optin XB-3b), so the claim's presence
+    // over-defers and would drop a legitimate SAME-base mirror push. Resolved once here (pre-transaction;
+    // bases are stable within the op) into a Set the collectMirrorInvalidation closure consults below.
+    const crossBaseMirrorForeignSheetIds = new Set<string>()
+    {
+      const twoWayMirrorForeignSheetIds = new Set<string>()
+      for (const f of fields) {
+        if (f.type !== 'link') continue
+        const cfg = h.parseLinkFieldConfig(f.property)
+        if (cfg?.twoWay === true && cfg.mirrorFieldId && cfg.foreignSheetId) {
+          twoWayMirrorForeignSheetIds.add(cfg.foreignSheetId)
+        }
+      }
+      if (twoWayMirrorForeignSheetIds.size > 0) {
+        const baseRes = await this.pool.query(
+          'SELECT id, base_id FROM meta_sheets WHERE id = ANY($1::text[])',
+          [[sheetId, ...twoWayMirrorForeignSheetIds]],
+        )
+        const baseBySheetId = new Map<string, string | null>()
+        for (const r of (baseRes as { rows: Array<{ id: unknown; base_id: unknown }> }).rows) {
+          baseBySheetId.set(String(r.id), typeof r.base_id === 'string' ? r.base_id : null)
+        }
+        const sourceBaseId = baseBySheetId.get(sheetId) ?? null
+        for (const foreignSheetId of twoWayMirrorForeignSheetIds) {
+          const foreignBaseId = baseBySheetId.get(foreignSheetId) ?? null
+          // null-aware cross-base — identical to baseIdsAreCrossBase (a !== b): null-vs-set = cross-base,
+          // both-null / same-set = same-base.
+          if (sourceBaseId !== foreignBaseId) crossBaseMirrorForeignSheetIds.add(foreignSheetId)
+        }
+      }
+    }
+
     // -----------------------------------------------------------------------
     // Step 1: DB transaction
     // -----------------------------------------------------------------------
@@ -633,15 +668,16 @@ export class RecordWriteService {
     const mirrorInvalidationBySheet = new Map<string, { recordIds: Set<string>; mirrorFieldIds: Set<string> }>()
     const collectMirrorInvalidation = (cfg: LinkFieldConfig, foreignRecordIds: string[]): void => {
       if (cfg.twoWay !== true || !cfg.mirrorFieldId || foreignRecordIds.length === 0) return
-      // ②b read-only cross-base mirror v1 (2026-06-27) — DEFER the realtime mirror-invalidation fan-out for a
-      // CROSS-BASE pairing. `foreignBaseId` is persisted ONLY as the cross-base opt-in claim (field-codecs:
-      // emitted iff a foreign-base claim is present; same-base mirrors omit it), so `!= null` ⟺ cross-base
-      // here. This is a deliberate v1 behavior, NOT a missed-push bug: the reverse mirror is a read-time
-      // projection recomputed + base-masked on every fetch (loadLinkValuesByRecord + maskDerivedMirrorFieldIds
-      // / buildLinkSummaries), so a cross-base mirror still reads CORRECTLY on the next read — it only forgoes
-      // a live realtime nudge. Same-base fan-out (cfg.foreignBaseId == null) is UNCHANGED. (Editable cross-base
-      // mirror + cross-base realtime push are a separately-governed follow-up, out of this slice.)
-      if (cfg.foreignBaseId != null) return
+      // ②b read-only cross-base mirror v1 (2026-06-27) — DEFER the realtime mirror-invalidation fan-out for an
+      // ACTUALLY cross-base pairing (this sheet's base != the forward field's foreignSheetId base; resolved
+      // pre-transaction into crossBaseMirrorForeignSheetIds — NOT inferred from the foreignBaseId claim, which
+      // a same-base link may legally carry per XB-3b). Deliberate v1 behavior, NOT a missed-push bug: the
+      // reverse mirror is recomputed + base-masked on every fetch (loadLinkValuesByRecord +
+      // maskDerivedMirrorFieldIds / buildLinkSummaries), so a cross-base mirror still reads CORRECTLY on the
+      // next read — it only forgoes a live realtime nudge. Same-base fan-out (including a same-base link with a
+      // truthful own-base foreignBaseId) is UNCHANGED. (Editable cross-base mirror + cross-base realtime push
+      // are a separately-governed follow-up, out of this slice.)
+      if (crossBaseMirrorForeignSheetIds.has(cfg.foreignSheetId)) return
       const mirrorSheetId = cfg.foreignSheetId // the mirror field lives on the forward link's foreign sheet
       const group = mirrorInvalidationBySheet.get(mirrorSheetId) ?? { recordIds: new Set<string>(), mirrorFieldIds: new Set<string>() }
       for (const id of foreignRecordIds) group.recordIds.add(id)

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -633,6 +633,15 @@ export class RecordWriteService {
     const mirrorInvalidationBySheet = new Map<string, { recordIds: Set<string>; mirrorFieldIds: Set<string> }>()
     const collectMirrorInvalidation = (cfg: LinkFieldConfig, foreignRecordIds: string[]): void => {
       if (cfg.twoWay !== true || !cfg.mirrorFieldId || foreignRecordIds.length === 0) return
+      // ②b read-only cross-base mirror v1 (2026-06-27) — DEFER the realtime mirror-invalidation fan-out for a
+      // CROSS-BASE pairing. `foreignBaseId` is persisted ONLY as the cross-base opt-in claim (field-codecs:
+      // emitted iff a foreign-base claim is present; same-base mirrors omit it), so `!= null` ⟺ cross-base
+      // here. This is a deliberate v1 behavior, NOT a missed-push bug: the reverse mirror is a read-time
+      // projection recomputed + base-masked on every fetch (loadLinkValuesByRecord + maskDerivedMirrorFieldIds
+      // / buildLinkSummaries), so a cross-base mirror still reads CORRECTLY on the next read — it only forgoes
+      // a live realtime nudge. Same-base fan-out (cfg.foreignBaseId == null) is UNCHANGED. (Editable cross-base
+      // mirror + cross-base realtime push are a separately-governed follow-up, out of this slice.)
+      if (cfg.foreignBaseId != null) return
       const mirrorSheetId = cfg.foreignSheetId // the mirror field lives on the forward link's foreign sheet
       const group = mirrorInvalidationBySheet.get(mirrorSheetId) ?? { recordIds: new Set<string>(), mirrorFieldIds: new Set<string>() }
       for (const id of foreignRecordIds) group.recordIds.add(id)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1714,19 +1714,19 @@ async function validateLinkFieldConfig(
     return `链接字段 foreignBaseId 需与外表实际 base 一致：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} 实际 base=${actualForeignBaseId ?? 'null'}，声明=${claimed ?? 'null'}`
   }
   if (baseIdsAreCrossBase(sourceBaseId, actualForeignBaseId)) {
-    // Bidirectional / mirror links MVP (design 2026-06-14 §7.2) — cross-base bidirectional is DEFERRED.
-    // A two-way link must be same-base, even if it carries a valid cross-base `foreignBaseId` opt-in
-    // (this fires BEFORE the ②b opt-in short-circuit so the opt-in cannot rescue a cross-base pairing).
-    // Uses only this field's own config, so create-order / paired-field existence is irrelevant.
-    if (linkCfg.twoWay === true) {
-      return `二维（双向）链接 MVP 不支持跨 base 配对：源表 base=${sourceBaseId ?? 'null'}，外表 ${linkCfg.foreignSheetId} base=${actualForeignBaseId ?? 'null'}`
-    }
-    // ②b opt-in short-circuit — a cross-base link is allowed IFF it carries an EXPLICIT foreignBaseId
-    // EQUAL to the foreign sheet's real base (claim == truth; you can't declare a wrong base). A
-    // degenerate null/legacy-base foreign sheet has no concrete base to claim, so it can never opt in
-    // (claimed===null falls through to reject; a non-null claim !== null actual also rejects). This is a
-    // pure consistency gate — the foreign READ-permission check is §3 (base-read) + §2a.3 (field mask),
-    // NOT here (adding a perm check in this structural wall would over-reach).
+    // ②b read-only cross-base mirror v1 (2026-06-27) — cross-base bidirectional (twoWay) is now ALLOWED on
+    // the SAME terms as a one-way cross-base link (the earlier §7.2 blanket deferral of twoWay is lifted).
+    // The derived (mirror) side stays read-only by codec (field-codecs.ts: mirrorOf ⇒ readOnly), so this
+    // opens only a reverse READ-projection, never a cross-base write path. The realtime mirror-invalidation
+    // fan-out is deferred for cross-base (record-write-service.ts collectMirrorInvalidation) — harmless: the
+    // reverse read recomputes + base-masks on every fetch.
+    // ②b opt-in short-circuit — a cross-base link (one-way OR twoWay) is allowed IFF it carries an EXPLICIT
+    // foreignBaseId EQUAL to the foreign sheet's real base (claim == truth; you can't declare a wrong base —
+    // a wrong claim is already rejected above). A degenerate null/legacy-base foreign sheet has no concrete
+    // base to claim, so it can never opt in (claimed===null falls through to reject). This is a pure
+    // consistency gate — the foreign READ-permission check is §3 (base-read) + §2a.3 (field mask), NOT here
+    // (a perm check in this structural wall would over-reach). Uses only this field's own config, so
+    // create-order / paired-field existence is irrelevant.
     if (claimed !== null) {
       return null
     }
@@ -2661,26 +2661,55 @@ async function loadLinkValuesByRecord(
  *
  * FORWARD link fields are deliberately left UNTOUCHED: their raw-id posture is pre-existing and shared
  * repo-wide (an outbound edge this record authored), and the task scopes this fix to mirror fields only.
- * Same-base only by construction (cross-base twoWay/mirror is rejected at field-create), so the cross-base
- * coarse gate `buildLinkSummaries` adds on top of `resolveReadableSheetIds` is a no-op here — sheet-level
- * read IS the exact gate. Idempotent / order-independent: mutates `row.data` in place for denied mirrors only.
+ * TWO gates, both REDUCE-only (never widen): (1) the same-base / sheet-level gate `resolveReadableSheetIds`
+ * keyed on `cfg.foreignSheetId`; (2) ②b read-only cross-base mirror v1 (2026-06-27) — when a mirror's
+ * foreign sheet lives in a DIFFERENT base, a base-read COARSE gate (`resolveBaseReadable`, parity with
+ * `resolveForeignFieldReadability` §3.2 Sink A and `buildLinkSummaries` Sink B-1) empties the reverse
+ * projection for a sheet-readable-but-base-unreadable actor (no foreign-record id/count leak). Same-base
+ * mirrors never reach gate (2). Idempotent / order-independent: mutates `row.data` in place for denied
+ * mirrors only. NOTE: the inline `linkSummaries` projection of the SAME reverse edge is gated independently
+ * in `buildLinkSummaries` (Sink B-1) — both wires must hold; the goldens cover each separately.
  */
 async function maskDerivedMirrorFieldIds(
   req: Request,
   query: QueryFn,
+  // The sheet the `rows` belong to — the SOURCE base is resolved from it (parity with applyLookupRollup) to
+  // decide cross-base per mirror foreign sheet. Not derivable from `rows` (records carry no sheet/base id).
+  sourceSheetId: string,
   rows: UniverMetaRecord[],
   relationalLinkFields: RelationalLinkField[],
 ): Promise<void> {
   const mirrorFields = relationalLinkFields.filter((l) => l.cfg.mirrorOf)
   if (mirrorFields.length === 0 || rows.length === 0) return
+  // Gate (1): same-base / sheet-level read — UNCHANGED (never loosened).
   const readableSheetIds = await resolveReadableSheetIds(
     req,
     query,
     mirrorFields.map((l) => l.cfg.foreignSheetId),
   )
+  // Gate (2): ②b cross-base base-read. Resolve the source base once, then for each DISTINCT cross-base
+  // mirror foreign sheet require base-read; deny → mask. Memoized per base; a null foreign base is
+  // unreadable by definition (also crash-safe vs resolveBaseReadable, which rejects an empty id).
+  const sourceBaseId = (await loadSheetRowShared(query, sourceSheetId))?.baseId ?? null
+  const crossBaseDeniedForeignSheetIds = new Set<string>()
+  const baseReadableCache = new Map<string, boolean>()
+  for (const foreignSheetId of new Set(mirrorFields.map((l) => l.cfg.foreignSheetId))) {
+    const foreignBaseId = (await loadSheetRowShared(query, foreignSheetId))?.baseId ?? null
+    if (foreignBaseId === sourceBaseId) continue // same-base → gate (1) is the exact gate
+    if (foreignBaseId == null) {
+      crossBaseDeniedForeignSheetIds.add(foreignSheetId)
+      continue
+    }
+    let readable = baseReadableCache.get(foreignBaseId)
+    if (readable === undefined) {
+      readable = await resolveBaseReadable(req, query, foreignBaseId)
+      baseReadableCache.set(foreignBaseId, readable)
+    }
+    if (!readable) crossBaseDeniedForeignSheetIds.add(foreignSheetId)
+  }
   for (const row of rows) {
     for (const { fieldId, cfg } of mirrorFields) {
-      if (!readableSheetIds.has(cfg.foreignSheetId)) {
+      if (!readableSheetIds.has(cfg.foreignSheetId) || crossBaseDeniedForeignSheetIds.has(cfg.foreignSheetId)) {
         row.data[fieldId] = []
       }
     }
@@ -12344,7 +12373,7 @@ export function univerMetaRouter(): Router {
 
         // B3 review nit: blank a DERIVED (mirror) field's raw reverse ids for an actor who can't read the
         // mirror's foreign sheet — parity with the buildLinkSummaries gate below. Forward links untouched.
-        await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), rows, relationalLinkFields)
+        await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), sheetId, rows, relationalLinkFields)
       }
 
       await applyLookupRollup(
@@ -13087,7 +13116,7 @@ export function univerMetaRouter(): Router {
         record.data[fieldId] = linkValuesByRecord.get(record.id)?.get(fieldId) ?? []
       }
       // B3 review nit: blank a mirror field's raw reverse ids for a foreign-sheet-denied actor (write-echo).
-      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), [record], relationalLinkFields)
+      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), view.sheetId, [record], relationalLinkFields)
       record.data = filterRecordDataByFieldIds(record.data, readableEchoFieldIds)
       const attachmentSummaries = attachmentFields.length > 0
         ? filterSingleRecordFieldSummaryMap(
@@ -13321,7 +13350,7 @@ export function univerMetaRouter(): Router {
         record.data[fieldId] = linkValuesByRecord.get(record.id)?.get(fieldId) ?? []
       }
       // B3 review nit: blank a mirror field's raw reverse ids for a foreign-sheet-denied actor (write-echo).
-      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), [record], relationalLinkFields)
+      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), sheetId, [record], relationalLinkFields)
       record.data = filterRecordDataByFieldIds(record.data, readableEchoFieldIds)
       const attachmentSummaries = attachmentFields.length > 0
         ? filterSingleRecordFieldSummaryMap(
@@ -13598,7 +13627,7 @@ export function univerMetaRouter(): Router {
       }
       // B3 review nit: blank a mirror field's raw reverse ids for an actor who can't read the mirror's
       // foreign sheet (parity with the buildLinkSummaries gate below). Forward links untouched.
-      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), [record], relationalLinkFields)
+      await maskDerivedMirrorFieldIds(req, pool.query.bind(pool), sheetId, [record], relationalLinkFields)
       await applyLookupRollup(req, pool.query.bind(pool), sheetId, fields, [record], relationalLinkFields, linkValuesByRecord)
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
       // #2015 read-path field mask: D3c security composite (layer-2 property.hidden ∧ layer-3

--- a/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
+++ b/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
@@ -34,6 +34,9 @@
  *   C-XB-RO                   — a PATCH on the cross-base mirror field is rejected (read-only, no edge).
  *   C-XB-NOFANOUT             — a cross-base forward write does NOT fan a mirror invalidation to the foreign
  *                               base sheet (site 3 v1 defer; read recomputes + masks on next fetch).
+ *   C-SB-TRUTHFUL-CLAIM       — a SAME-base twoWay write whose forward field carries a TRUTHFUL own-base
+ *                               foreignBaseId STILL fans the mirror invalidation (claim presence != cross-base;
+ *                               site 3 compares real sheet bases, not claim presence). [P2 regression guard]
  *
  * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
  */
@@ -65,6 +68,12 @@ const FLD_B_PLAIN = `fld_bdl_b_plain_${TS}` // ordinary (non-twoWay) link B → 
 // record (REC_A1) → base-read gated. SA/SX already exist (SA=BASE, SX=XBASE) from the C5 layout above.
 const FLD_A_XLINK = `fld_bdl_a_xlink_${TS}` // forward twoWay link SA → SX, foreignBaseId=XBASE_ID
 const FLD_X_MIRROR = `fld_bdl_x_mirror_${TS}` // mirror twoWay link SX → SA, mirrorOf=FLD_A_XLINK, foreignBaseId=BASE_ID
+
+// P2 regression guard (2026-06-27): a SAME-base twoWay link carrying a TRUTHFUL own-base foreignBaseId — a
+// legal config (cross-base-link-optin XB-3b) whose mirror push must NOT be deferred (claim presence is NOT
+// cross-base). SA and SB are both in BASE_ID, so this pairing is same-base despite the explicit claim.
+const FLD_A_LINK2 = `fld_bdl_a_link2_${TS}` // same-base twoWay link SA → SB, foreignBaseId=BASE_ID (truthful own-base)
+const FLD_B_MIRROR2 = `fld_bdl_b_mirror2_${TS}` // its mirror on SB → SA, mirrorOf=FLD_A_LINK2
 
 const REC_A1 = `rec_bdl_a1_${TS}`
 const REC_A2 = `rec_bdl_a2_${TS}` // a SECOND A linking B1 → mirror is multi-value
@@ -194,6 +203,14 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC_X1, SX, JSON.stringify({})])
     await seedEdge(FLD_A_XLINK, REC_A1, REC_X1)
+
+    // P2 guard fixtures: a SAME-base twoWay pairing (SA↔SB, both BASE_ID) where the forward field carries a
+    // truthful own-base foreignBaseId. No edge seeded — the golden writes the forward edge and asserts the
+    // mirror invalidation still fans (it must NOT be deferred just because foreignBaseId is present).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_A_LINK2, SA, 'ALink2', 'link', JSON.stringify({ foreignSheetId: SB, foreignBaseId: BASE_ID, twoWay: true, mirrorFieldId: FLD_B_MIRROR2 }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_B_MIRROR2, SB, 'BMirror2', 'link', JSON.stringify({ foreignSheetId: SA, foreignBaseId: BASE_ID, twoWay: true, mirrorFieldId: FLD_A_LINK2, mirrorOf: FLD_A_LINK2 }), 4])
   })
 
   beforeEach(() => {
@@ -203,7 +220,7 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
 
   afterAll(async () => {
     publishSpy.mockRestore()
-    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_A_LINK, FLD_B_MIRROR, FLD_B_PLAIN, FLD_A_XLINK, FLD_X_MIRROR]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_A_LINK, FLD_B_MIRROR, FLD_B_PLAIN, FLD_A_XLINK, FLD_X_MIRROR, FLD_A_LINK2, FLD_B_MIRROR2]]).catch(() => {})
     await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
@@ -487,5 +504,24 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
     await q('DELETE FROM meta_links WHERE field_id = $1 AND foreign_record_id = $2', [FLD_A_XLINK, newX]).catch(() => {})
     await q('DELETE FROM meta_records WHERE id = $1', [newX]).catch(() => {})
     await q('UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2', [JSON.stringify({ [FLD_A_XLINK]: [REC_X1] }), REC_A1]).catch(() => {})
+  })
+
+  // [P2 regression] claim presence is NOT cross-base. FLD_A_LINK2 is SAME-base (SA & SB both BASE_ID) but
+  // carries a truthful own-base foreignBaseId — a legal config (XB-3b). The old `cfg.foreignBaseId != null`
+  // discriminator would wrongly DEFER its mirror push; the fix resolves the real bases, sees same-base, and
+  // keeps the fan-out. Writing the forward edge must still emit the SB mirror invalidation event. (RED under
+  // the old predicate, GREEN under the actual-base resolution.)
+  test('C-SB-TRUTHFUL-CLAIM: a SAME-base twoWay write with a truthful own-base foreignBaseId STILL fans the mirror invalidation', async () => {
+    currentUser = { id: `u_sb_writer_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    publishSpy.mockClear()
+    const res = await patch(SA, REC_A1, FLD_A_LINK2, [REC_B1])
+    expect(res.status).toBe(200)
+    const mirrorEvents = sheetEvents(SB).filter(
+      (e) => (e.fieldIds ?? []).includes(FLD_B_MIRROR2) && (e.recordIds ?? []).includes(REC_B1),
+    )
+    expect(mirrorEvents.length).toBeGreaterThan(0)
+    // restore: drop the throwaway edge + remove the key from REC_A1 (it never carried FLD_A_LINK2)
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_A_LINK2]).catch(() => {})
+    await q('UPDATE meta_records SET data = data - $1::text WHERE id = $2', [FLD_A_LINK2, REC_A1]).catch(() => {})
   })
 })

--- a/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
+++ b/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
@@ -486,7 +486,8 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
 
   test('C-XB-NOFANOUT: a CROSS-BASE forward write does NOT fan a mirror invalidation to the foreign-base sheet (site 3 v1 defer; parity with C3)', async () => {
     // Full-perms writer so the cross-base forward write can never be perm-blocked — the defer under test is
-    // purely cfg-based (cfg.foreignBaseId != null), independent of the actor's permissions.
+    // based on the actual source/foreign sheet base comparison (crossBaseMirrorForeignSheetIds), independent
+    // of the actor's permissions.
     currentUser = { id: `u_xb_writer_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:base:admin'] }
     publishSpy.mockClear()
     const newX = `rec_bdl_xnew_${TS}`

--- a/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
+++ b/packages/core-backend/tests/integration/multitable-bidirectional-mirror-links.test.ts
@@ -16,13 +16,24 @@
  *                               affected foreign record (mirror sheet event present; no forward write back).
  *   C4 wire round-trip        — twoWay/mirrorFieldId survive on F_A; twoWay/mirrorFieldId/mirrorOf +
  *                               readOnly survive on F_B (create→read, not a hand-built fixture).
- *   C5 cross-base rejected    — pairing two link fields whose sheets are cross-base ⇒ 400.
+ *   C5 cross-base allow (v1)  — ②b read-only cross-base mirror (2026-06-27): a cross-base twoWay pairing is
+ *                               now ALLOWED with a valid foreignBaseId claim (claim == truth). C5b/C5c/C5d
+ *                               lock the still-fail-closed cases (no-claim / wrong-claim / one-way-no-claim);
+ *                               C5-CREATE proves BOTH sides create end-to-end (the mirror side comes back
+ *                               codec read-only — a reverse READ projection, never a cross-base write path).
  *   C6 delete clears the edge — delete B1 ⇒ A1's forward F_A no longer lists B1 (existing cascade) and the
  *                               symmetric reverse is gone.
  *   C7 masked mirror          — an actor without read on sheet A reading B1 ⇒ mirror masked (no A-record
  *                               id/display leak), via the swapped buildLinkSummaries perm chain.
  *   C8 non-twoWay regression  — an ordinary (non-twoWay) link on B does NOT reverse-resolve.
  *   C9 mirror read-only       — a PATCH on the mirror field F_B is rejected (no second materialized edge).
+ *   C-XB-MASK (security)      — cross-base mirror (SX→SA): both readers hold global multitable:read so the
+ *                               SHEET gate passes; base-read is the sole decider — denied ⇒ [] (raw /view,
+ *                               raw single-GET, AND linkSummaries), permitted ⇒ [REC_A1]. (raw wire = site 2
+ *                               maskDerivedMirrorFieldIds; summary wire = buildLinkSummaries Sink B-1.)
+ *   C-XB-RO                   — a PATCH on the cross-base mirror field is rejected (read-only, no edge).
+ *   C-XB-NOFANOUT             — a cross-base forward write does NOT fan a mirror invalidation to the foreign
+ *                               base sheet (site 3 v1 defer; read recomputes + masks on next fetch).
  *
  * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
  */
@@ -49,9 +60,16 @@ const FLD_B_NAME = `fld_bdl_b_name_${TS}` // B's display (string)
 const FLD_B_MIRROR = `fld_bdl_b_mirror_${TS}` // mirror twoWay link B → A, mirrorOf = FLD_A_LINK
 const FLD_B_PLAIN = `fld_bdl_b_plain_${TS}` // ordinary (non-twoWay) link B → A (C8 regression)
 
+// ②b read-only cross-base mirror v1 (2026-06-27): forward SA(BASE) → SX(XBASE) twoWay + cross-base claim;
+// mirror on SX → SA (mirrorOf, codec-forced read-only). Reading SX/REC_X1's mirror reverse-projects a BASE
+// record (REC_A1) → base-read gated. SA/SX already exist (SA=BASE, SX=XBASE) from the C5 layout above.
+const FLD_A_XLINK = `fld_bdl_a_xlink_${TS}` // forward twoWay link SA → SX, foreignBaseId=XBASE_ID
+const FLD_X_MIRROR = `fld_bdl_x_mirror_${TS}` // mirror twoWay link SX → SA, mirrorOf=FLD_A_XLINK, foreignBaseId=BASE_ID
+
 const REC_A1 = `rec_bdl_a1_${TS}`
 const REC_A2 = `rec_bdl_a2_${TS}` // a SECOND A linking B1 → mirror is multi-value
 const REC_B1 = `rec_bdl_b1_${TS}`
+const REC_X1 = `rec_bdl_x1_${TS}` // a record in SX (XBASE_ID) — its mirror reverse-projects REC_A1 (cross-base)
 
 const USER_FULL = `u_bdl_full_${TS}` // global multitable read+write
 const USER_NOA = `u_bdl_noa_${TS}` // sheet-scoped: B only; sheet A unreadable (C7 mask)
@@ -165,6 +183,17 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
     // USER_NOA: read on B only (sheet A unreadable, no global perms) → C7 mask.
     await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)',
       [SB, USER_NOA, 'user', USER_NOA, 'spreadsheet:read'])
+
+    // ②b cross-base fixtures: forward FLD_A_XLINK on SA (BASE) → SX (XBASE) twoWay + cross-base claim; mirror
+    // FLD_X_MIRROR on SX → SA, mirrorOf=forward (codec forces readOnly). One edge (FLD_A_XLINK, REC_A1, REC_X1)
+    // ⇒ reading SX/REC_X1's mirror reverse-projects REC_A1 (a BASE record) — the base-read gate decides.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_A_XLINK, SA, 'AXLink', 'link', JSON.stringify({ foreignSheetId: SX, foreignBaseId: XBASE_ID, twoWay: true, mirrorFieldId: FLD_X_MIRROR }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_X_MIRROR, SX, 'XMirror', 'link', JSON.stringify({ foreignSheetId: SA, foreignBaseId: BASE_ID, twoWay: true, mirrorFieldId: FLD_A_XLINK, mirrorOf: FLD_A_XLINK }), 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_X1, SX, JSON.stringify({})])
+    await seedEdge(FLD_A_XLINK, REC_A1, REC_X1)
   })
 
   beforeEach(() => {
@@ -174,7 +203,7 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
 
   afterAll(async () => {
     publishSpy.mockRestore()
-    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_A_LINK, FLD_B_MIRROR, FLD_B_PLAIN]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_A_LINK, FLD_B_MIRROR, FLD_B_PLAIN, FLD_A_XLINK, FLD_X_MIRROR]]).catch(() => {})
     await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
     await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SA, SB, SX]]).catch(() => {})
@@ -296,15 +325,84 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
     await q('UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2', [JSON.stringify({ [FLD_A_LINK]: [REC_B1] }), REC_A1]).catch(() => {})
   })
 
-  test('C5: cross-base pairing rejected — a twoWay link across bases is 400', async () => {
+  // C5 — ②b read-only cross-base mirror v1 (2026-06-27): the OLD blanket reject is REPLACED by allow-on-claim.
+  // A cross-base twoWay link is now ALLOWED iff it carries an EXPLICIT foreignBaseId == the foreign sheet's
+  // real base (claim == truth); no-claim / wrong-claim / one-way-no-claim all still fail closed.
+  test('C5: cross-base twoWay pairing is now ALLOWED with a valid foreignBaseId claim (lift of the §7.2 reject)', async () => {
     const res = await request(app).post('/api/multitable/fields').send({
       sheetId: SA,
-      name: 'XLink',
+      name: `XLinkOk_${TS}`,
       type: 'link',
-      property: { foreignSheetId: SX, foreignBaseId: XBASE_ID, twoWay: true, mirrorFieldId: 'whatever' },
+      property: { foreignSheetId: SX, foreignBaseId: XBASE_ID, twoWay: true, mirrorFieldId: `mfxok_${TS}` },
+    })
+    expect(res.status).toBeGreaterThanOrEqual(200)
+    expect(res.status).toBeLessThan(300)
+  })
+
+  test('C5b: cross-base twoWay with NO foreignBaseId claim still fails closed (400)', async () => {
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SA,
+      name: `XLinkNoClaim_${TS}`,
+      type: 'link',
+      property: { foreignSheetId: SX, twoWay: true, mirrorFieldId: `mfxnc_${TS}` }, // no foreignBaseId
     })
     expect(res.status).toBeGreaterThanOrEqual(400)
     expect(res.status).toBeLessThan(500)
+  })
+
+  test('C5c: cross-base twoWay with a WRONG foreignBaseId claim still fails closed (claim != truth → 400)', async () => {
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SA,
+      name: `XLinkWrong_${TS}`,
+      type: 'link',
+      property: { foreignSheetId: SX, foreignBaseId: BASE_ID, twoWay: true, mirrorFieldId: `mfxwr_${TS}` }, // claims SA's own base, not SX's
+    })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
+  })
+
+  test('C5d: a ONE-WAY cross-base link STILL requires the foreignBaseId claim (no-claim → 400, original ②b gate intact)', async () => {
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SA,
+      name: `XLinkOnewayNoClaim_${TS}`,
+      type: 'link',
+      property: { foreignSheetId: SX }, // one-way, no claim → original cross-base gate still rejects
+    })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
+  })
+
+  // Advisor item 2 — the read goldens SQL-seed the cross-base mirror, so this is the ONLY proof the CREATE
+  // PATH (validateLinkFieldConfig at field-create) accepts BOTH sides end-to-end. The MIRROR side (a
+  // cross-base link carrying mirrorOf + a back-claim to BASE) hits the SAME lifted branch and is the side
+  // most likely to break; assert it creates AND returns codec-forced read-only (no cross-base WRITE path).
+  test('C5-CREATE: forward (SA→SX) AND mirror (SX→SA) cross-base twoWay fields both create end-to-end; mirror is read-only', async () => {
+    const fwdId = `fld_bdl_a_xcr_${TS}`
+    const mirId = `fld_bdl_x_xcr_${TS}`
+    const fwd = await request(app).post('/api/multitable/fields').send({
+      sheetId: SA,
+      id: fwdId,
+      name: `XCreateFwd_${TS}`,
+      type: 'link',
+      property: { foreignSheetId: SX, foreignBaseId: XBASE_ID, twoWay: true, mirrorFieldId: mirId },
+    })
+    expect(fwd.status).toBeGreaterThanOrEqual(200)
+    expect(fwd.status).toBeLessThan(300)
+    const mir = await request(app).post('/api/multitable/fields').send({
+      sheetId: SX,
+      id: mirId,
+      name: `XCreateMir_${TS}`,
+      type: 'link',
+      property: { foreignSheetId: SA, foreignBaseId: BASE_ID, twoWay: true, mirrorFieldId: fwdId, mirrorOf: fwdId },
+    })
+    expect(mir.status).toBeGreaterThanOrEqual(200)
+    expect(mir.status).toBeLessThan(300)
+    // the derived side comes back read-only (codec mirrorOf ⇒ readOnly) — a reverse READ projection only.
+    const mirror = (await viewFields(SX)).find((f) => f.id === mirId)
+    expect(mirror?.property?.mirrorOf).toBe(fwdId)
+    expect(mirror?.property?.readOnly).toBe(true)
+    // tidy the throwaway created fields (afterAll also cleans by sheet, but keep later reads byte-clean).
+    await q('DELETE FROM meta_fields WHERE id = ANY($1::text[])', [[fwdId, mirId]]).catch(() => {})
   })
 
   test('C6: delete clears the edge — deleting B1 removes it from A1 forward + the symmetric reverse', async () => {
@@ -328,5 +426,66 @@ describeIfDatabase('multitable bidirectional / mirror links — derived reverse 
     expect((await viewLinkSummaries(SA))[REC_A1]?.[FLD_A_LINK]?.map((s) => s.id) ?? []).not.toContain(tmpB)
 
     await q('UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2', [JSON.stringify({ [FLD_A_LINK]: [REC_B1] }), REC_A1]).catch(() => {})
+  })
+
+  // ②b cross-base mirror — SECURITY GOLDEN. Reading SX/REC_X1's mirror reverse-projects REC_A1 (a BASE
+  // record). BOTH readers carry global multitable:read (so the SHEET gate on SA passes for both) — the ONLY
+  // difference is multitable:base:read, so the cross-base BASE-READ gate is the sole decider:
+  //   denied (no base:read) → mirror emptied (no foreign-record id/count leak); permitted (+base:read) →
+  //   mirror shows [REC_A1]. The RAW data[mirror] wire is gated by maskDerivedMirrorFieldIds (site 2, the
+  //   change under test); the linkSummaries wire is gated independently by buildLinkSummaries (Sink B-1).
+  const XB_DENIED = { id: `u_xb_no_${TS}`, roles: ['member'], perms: ['multitable:read'] }
+  const XB_OK = { id: `u_xb_ok_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:base:read'] }
+
+  test('C-XB-MASK (/view raw): cross-base mirror data is [] for a base-denied reader, [REC_A1] for a base-permitted reader', async () => {
+    currentUser = XB_DENIED
+    expect(((await viewRawRecordData(SX, REC_X1))[FLD_X_MIRROR] as string[]) ?? []).toEqual([])
+    currentUser = XB_OK
+    expect(((await viewRawRecordData(SX, REC_X1))[FLD_X_MIRROR] as string[]) ?? []).toEqual([REC_A1])
+  })
+
+  test('C-XB-MASK (single-GET raw): cross-base mirror data is [] for a base-denied reader, [REC_A1] for a base-permitted reader', async () => {
+    currentUser = XB_DENIED
+    expect(((await getRecordRawData(SX, REC_X1))[FLD_X_MIRROR] as string[]) ?? []).toEqual([])
+    currentUser = XB_OK
+    expect(((await getRecordRawData(SX, REC_X1))[FLD_X_MIRROR] as string[]) ?? []).toEqual([REC_A1])
+  })
+
+  test('C-XB-MASK (linkSummaries): the inline summary wire is base-read gated too ([] for denied, [REC_A1] for permitted)', async () => {
+    currentUser = XB_DENIED
+    expect(((await viewLinkSummaries(SX))[REC_X1]?.[FLD_X_MIRROR] ?? []).map((s) => s.id)).toEqual([])
+    currentUser = XB_OK
+    expect(((await viewLinkSummaries(SX))[REC_X1]?.[FLD_X_MIRROR] ?? []).map((s) => s.id)).toEqual([REC_A1])
+  })
+
+  test('C-XB-RO: a PATCH on the cross-base mirror field is rejected (read-only; no edge written under the mirror id)', async () => {
+    const before = await q('SELECT count(*)::int AS n FROM meta_links WHERE field_id = $1', [FLD_X_MIRROR])
+    const res = await patch(SX, REC_X1, FLD_X_MIRROR, [REC_A1])
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    const after = await q('SELECT count(*)::int AS n FROM meta_links WHERE field_id = $1', [FLD_X_MIRROR])
+    expect((after.rows as Array<{ n: number }>)[0].n).toBe((before.rows as Array<{ n: number }>)[0].n)
+    expect((after.rows as Array<{ n: number }>)[0].n).toBe(0)
+  })
+
+  test('C-XB-NOFANOUT: a CROSS-BASE forward write does NOT fan a mirror invalidation to the foreign-base sheet (site 3 v1 defer; parity with C3)', async () => {
+    // Full-perms writer so the cross-base forward write can never be perm-blocked — the defer under test is
+    // purely cfg-based (cfg.foreignBaseId != null), independent of the actor's permissions.
+    currentUser = { id: `u_xb_writer_${TS}`, roles: ['member'], perms: ['multitable:read', 'multitable:write', 'multitable:base:admin'] }
+    publishSpy.mockClear()
+    const newX = `rec_bdl_xnew_${TS}`
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [newX, SX, JSON.stringify({})])
+    // the forward cross-base write SUCCEEDS (the write path RAN — so an absent fan-out is a real defer, not a failed write)
+    const res = await patch(SA, REC_A1, FLD_A_XLINK, [REC_X1, newX])
+    expect(res.status).toBe(200)
+    const fwd = await q('SELECT count(*)::int AS n FROM meta_links WHERE field_id = $1 AND foreign_record_id = $2', [FLD_A_XLINK, newX])
+    expect((fwd.rows as Array<{ n: number }>)[0].n).toBe(1)
+    // … but NO mirror-invalidation event was fanned to SX (cross-base realtime push is deferred in v1).
+    const xMirrorEvents = sheetEvents(SX).filter((e) => (e.fieldIds ?? []).includes(FLD_X_MIRROR))
+    expect(xMirrorEvents).toEqual([])
+    // restore the shared fixture (drop the throwaway edge + record; reset REC_A1's forward to just REC_X1)
+    await q('DELETE FROM meta_links WHERE field_id = $1 AND foreign_record_id = $2', [FLD_A_XLINK, newX]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE id = $1', [newX]).catch(() => {})
+    await q('UPDATE meta_records SET data = data || $1::jsonb WHERE id = $2', [JSON.stringify({ [FLD_A_XLINK]: [REC_X1] }), REC_A1]).catch(() => {})
   })
 })


### PR DESCRIPTION
## Cross-base deepen arc — slice (a): read-only cross-base mirror v1

Lifts the §7.2 blanket reject of cross-base **twoWay** pairings so a mirror may span bases on the **same terms** as a one-way cross-base link (a valid `foreignBaseId` claim). The mirror side stays **codec read-only** (`mirrorOf ⇒ readOnly`), so this opens a reverse **READ projection only** — security-sensitive un-defer, advisor-reviewed, explicit owner GO with batch boundaries + acceptance criteria.

**Explicitly OUT (separate, separately-governed follow-ups):** no editable mirror · no `evaluateCrossBaseWrite` wiring · no cross-base realtime mirror push.

### The 3 changes
1. **`validateLinkFieldConfig`** — remove the twoWay-specific cross-base reject; the `claim==truth` opt-in gate is **unchanged** (no-claim / wrong-claim / one-way-no-claim still 400).
2. **`maskDerivedMirrorFieldIds`** (SECURITY) — add a cross-base base-read coarse gate (`resolveBaseReadable`) on the raw `data[mirror]` wire, parity with `resolveForeignFieldReadability` §3.2 Sink A / `buildLinkSummaries` Sink B-1. The sheet/field gate is **never loosened**; a base-denied reader sees an **empty** mirror (not 403). All 4 read call sites updated to pass `sourceSheetId`.
3. **`collectMirrorInvalidation`** — defer cross-base realtime mirror push (**v1**): the reverse mirror is recomputed + base-masked on every fetch, so it still reads correctly; it only forgoes a live nudge. Same-base fan-out unchanged.

### Two-wire coverage (advisor)
The reverse projection surfaces on **two independent wires**: raw `data[mirror]` (site 2, the change here) and inline `linkSummaries` (already independently base-gated by `buildLinkSummaries`). Both are covered; the fail-first proves they're genuinely independent.

### Tests (real DB)
- **Target file 21/21:** `C1`–`C9` unchanged (same-base regression); `C5` rewritten to **allow-on-claim** (not added beside); `C5b/c/d` fail-closed (no/wrong/one-way-no claim → 400); `C5-CREATE` proves forward **and** mirror create end-to-end (mirror returns read-only); `C-XB-MASK` ×3 (raw `/view` + raw single-GET + linkSummaries) base-read security golden; `C-XB-RO` mirror read-only; `C-XB-NOFANOUT` site-3 defer.
- **Fail-first:** with gate (2) disabled, the raw wires go RED (leak `[REC_A1]`) while linkSummaries stays green (proving the second wire is independently gated). Restored → all green.
- **Adjacent cross-base suites + #3306 mock canary: 54/54.** `tsc --noEmit` clean.

Dev & verification doc: `docs/development/multitable-crossbase-readonly-mirror-dev-verification-20260627.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)