### PR TITLE
feat(attendance): RD-3 report-digest scheduler producer (gated, default-off)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -15891,6 +15891,609 @@ attendanceIntegrationDescribe(
     }
   })
 
+  describe('attendance report digest producer (RD-3)', () => {
+    // RD-3 producer seam (design-lock attendance-report-digest-subscription-design-lock-20260626).
+    // The producer ONLY writes status='pending' C5 outbox rows; the delivery worker stays the sole sender.
+    const reportDigestSeam = () => (getAttendancePluginForTest() as any).__attendanceReportDigestForTests
+
+    async function digestAdminToken(uid: string): Promise<string | undefined> {
+      const res = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(uid)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`,
+      )
+      return (res.body as { token?: string } | undefined)?.token
+    }
+
+    async function putDigestPolicy(token: string, policy: Record<string, unknown>): Promise<number> {
+      const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ attendanceReportDigestPolicy: policy }),
+      })
+      return res.status
+    }
+
+    function digestPolicy(opts: {
+      enabled?: boolean
+      timezone?: string
+      channel?: 'work_notification' | 'email_smtp'
+      daily?: { enabled: boolean; sendAt?: string; recipients?: string[] }
+      weekly?: { enabled: boolean; weekday?: number; sendAt?: string; recipients?: string[] }
+      monthly?: { enabled: boolean; dayOfMonth?: number; sendAt?: string; recipients?: string[] }
+    }): Record<string, unknown> {
+      return {
+        enabled: opts.enabled ?? true,
+        timezone: opts.timezone ?? 'UTC',
+        channel: opts.channel ?? 'work_notification',
+        cadences: {
+          daily: { enabled: opts.daily?.enabled ?? false, sendAt: opts.daily?.sendAt ?? '00:00', recipients: opts.daily?.recipients ?? ['self'] },
+          weekly: { enabled: opts.weekly?.enabled ?? false, weekday: opts.weekly?.weekday ?? 1, sendAt: opts.weekly?.sendAt ?? '00:00', recipients: opts.weekly?.recipients ?? ['self'] },
+          monthly: { enabled: opts.monthly?.enabled ?? false, dayOfMonth: opts.monthly?.dayOfMonth ?? 1, sendAt: opts.monthly?.sendAt ?? '00:00', recipients: opts.monthly?.recipients ?? ['self'] },
+        },
+      }
+    }
+
+    // 1=Monday..7=Sunday from a UTC date key — the SAME mapping the producer uses, so the test can't disagree.
+    function weekdayMonday1(dateKey: string): number {
+      const day = new Date(`${dateKey}T00:00:00Z`).getUTCDay()
+      return ((day + 6) % 7) + 1
+    }
+
+    async function seedUser(pool: Pool, id: string, org: string, opts: { userActive?: boolean; orgActive?: boolean } = {}): Promise<string> {
+      const userActive = opts.userActive ?? true
+      const orgActive = opts.orgActive ?? true
+      await pool.query(
+        `INSERT INTO users (id, email, password_hash, is_active) VALUES ($1, $2, 'no-login', $3)
+         ON CONFLICT (id) DO UPDATE SET is_active = $3`,
+        [id, `${id}@example.com`, userActive],
+      )
+      await pool.query(
+        `INSERT INTO user_orgs (user_id, org_id, is_active) VALUES ($1, $2, $3)
+         ON CONFLICT (user_id, org_id) DO UPDATE SET is_active = $3`,
+        [id, org, orgActive],
+      )
+      return id
+    }
+
+    async function seedGroup(pool: Pool, org: string, name: string): Promise<string> {
+      const id = randomUUID()
+      await pool.query(`INSERT INTO attendance_groups (id, org_id, name) VALUES ($1, $2, $3)`, [id, org, name])
+      return id
+    }
+
+    async function seedMember(pool: Pool, org: string, groupId: string, userId: string): Promise<void> {
+      await pool.query(
+        `INSERT INTO attendance_group_members (org_id, group_id, user_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+        [org, groupId, userId],
+      )
+    }
+
+    async function seedManager(pool: Pool, org: string, groupId: string, userId: string, role: 'owner' | 'sub_owner'): Promise<void> {
+      await pool.query(
+        `INSERT INTO attendance_group_managers (org_id, group_id, user_id, role) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+        [org, groupId, userId, role],
+      )
+    }
+
+    async function runDigest(pool: Pool, org: string, now: Date, todayKey?: string): Promise<any> {
+      const seam = reportDigestSeam()
+      expect(seam?.runAttendanceReportDigestOnce).toBeTruthy()
+      return seam.runAttendanceReportDigestOnce(createPluginDbForTest(pool), {
+        orgId: org,
+        now,
+        todayKey,
+        logger: { warn: () => undefined, error: () => undefined, info: () => undefined },
+        emitEvent: () => undefined,
+      })
+    }
+
+    async function fetchDeliveries(pool: Pool, org: string): Promise<any[]> {
+      return (await pool.query(
+        `SELECT org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status,
+                attempt_count, delivered_at, payload
+           FROM attendance_notification_deliveries
+          WHERE org_id = $1
+          ORDER BY recipient_role, recipient_user_id, source_key`,
+        [org],
+      )).rows
+    }
+
+    async function cleanupDigestOrg(pool: Pool, org: string, userIds: string[]): Promise<void> {
+      await pool.query('DELETE FROM attendance_notification_deliveries WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_group_managers WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_group_members WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_groups WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_requests WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE org_id = $1', [org]).catch(() => undefined)
+      if (userIds.length) {
+        await pool.query('DELETE FROM user_orgs WHERE user_id = ANY($1::text[])', [userIds]).catch(() => undefined)
+        await pool.query('DELETE FROM users WHERE id = ANY($1::text[])', [userIds]).catch(() => undefined)
+      }
+    }
+
+    function withEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+      const prev = process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+      if (value === undefined) delete process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+      else process.env.ATTENDANCE_REPORT_DIGEST_ENABLED = value
+      return fn().finally(() => {
+        if (prev === undefined) delete process.env.ATTENDANCE_REPORT_DIGEST_ENABLED
+        else process.env.ATTENDANCE_REPORT_DIGEST_ENABLED = prev
+      })
+    }
+
+    it('writes zero rows when env flag unset, when policy disabled, and when the cadence is disabled', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-disabled-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-disabled-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      const userIds: string[] = []
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        userIds.push(await seedUser(pool, `rd3-dis-u-${runSuffix}`, org))
+
+        // (a) env flag unset → producer short-circuits, zero rows, ran=false.
+        const enabledDaily = digestPolicy({ enabled: true, daily: { enabled: true } })
+        expect(await putDigestPolicy(adminToken, enabledDaily)).toBe(200)
+        const resEnvOff = await withEnv(undefined, () => runDigest(pool, org, now))
+        expect(resEnvOff.ran).toBe(false)
+        expect((await fetchDeliveries(pool, org)).length).toBe(0)
+
+        // (b) env on but policy.enabled=false → ran=false, zero rows.
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: false, daily: { enabled: true } }))).toBe(200)
+        const resPolicyOff = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resPolicyOff.ran).toBe(false)
+        expect((await fetchDeliveries(pool, org)).length).toBe(0)
+
+        // (c) env on + policy.enabled=true but the only cadence is disabled → ran=true, no due cadence, zero rows.
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: false } }))).toBe(200)
+        const resCadenceOff = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resCadenceOff.ran).toBe(true)
+        expect(resCadenceOff.cadences).toEqual([])
+        expect((await fetchDeliveries(pool, org)).length).toBe(0)
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('enabled daily writes one subject row per active member, period=previous day, and a repeat tick writes zero duplicates', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-daily-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-daily-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      const u1 = `rd3-daily-u1-${runSuffix}`
+      const u2 = `rd3-daily-u2-${runSuffix}`
+      const userIds = [u1, u2]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, u1, org)
+        await seedUser(pool, u2, org)
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        expect(res.ran).toBe(true)
+        expect(res.cadences).toHaveLength(1)
+        expect(res.cadences[0]).toMatchObject({ cadence: 'daily', rowsCreated: 2, rowsExisting: 0, ownerSkipped: 0, subOwnerSkipped: 0 })
+
+        const rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(2)
+        for (const row of rows) {
+          expect(row.source_type).toBe('attendance_report_digest')
+          expect(row.recipient_role).toBe('subject')
+          expect(row.status).toBe('pending')
+          expect(row.delivered_at).toBeNull()
+          expect(row.attempt_count).toBe(0)
+          expect(row.channel).toBe('dingtalk_work_notification')
+          expect(userIds).toContain(row.recipient_user_id)
+          // period is the previous complete day.
+          expect(row.payload.period).toMatchObject({ from: '2026-06-25', to: '2026-06-25' })
+          // self → recipient_user_id == subject in the key, role token is the config word 'self'.
+          expect(row.source_key).toBe(
+            `attendance_report_digest:${org}:daily:daily:2026-06-25:subject:${row.recipient_user_id}:self:${row.recipient_user_id}:channel:dingtalk_work_notification`,
+          )
+          expect(row.source_id).toBe(`${org}:daily:daily:2026-06-25`)
+        }
+
+        // Repeat tick within the same period writes zero duplicates (ON CONFLICT backstop).
+        const res2 = await withEnv('true', () => runDigest(pool, org, now))
+        expect(res2.cadences[0]).toMatchObject({ rowsCreated: 0, rowsExisting: 2 })
+        expect((await fetchDeliveries(pool, org)).length).toBe(2)
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('the delivery channel is part of the source_key grain and is stamped from policy only', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-channel-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-channel-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z') // held constant so only the channel token varies.
+      const u1 = `rd3-channel-u1-${runSuffix}`
+      const userIds = [u1]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, u1, org)
+
+        // work_notification → resolved to the worker's registered default work-notification channel, never raw.
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, channel: 'work_notification', daily: { enabled: true } }))).toBe(200)
+        const resWork = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resWork.cadences[0]).toMatchObject({ rowsCreated: 1 })
+        let rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].channel).toBe('dingtalk_work_notification')
+        expect(rows[0].channel).not.toBe('work_notification')
+        expect(rows[0].source_key).toContain(':channel:dingtalk_work_notification')
+
+        // Switch to email_smtp on the SAME period → a NEW row (channel is in the dedup grain), not a dup.
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, channel: 'email_smtp', daily: { enabled: true } }))).toBe(200)
+        const resEmail = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resEmail.cadences[0]).toMatchObject({ rowsCreated: 1, rowsExisting: 0 })
+        rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(2)
+        const emailRow = rows.find((r) => r.channel === 'email_smtp')
+        expect(emailRow).toBeTruthy()
+        expect(emailRow.source_key).toContain(':channel:email_smtp')
+
+        // Re-run on the SAME channel → zero duplicates.
+        const resEmail2 = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resEmail2.cadences[0]).toMatchObject({ rowsCreated: 0, rowsExisting: 1 })
+        expect((await fetchDeliveries(pool, org)).length).toBe(2)
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('one manager managing two subjects gets TWO distinct rows (subject-id collision guard)', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-collide-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-collide-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      const subjectA = `rd3-collide-a-${runSuffix}`
+      const subjectB = `rd3-collide-b-${runSuffix}`
+      const manager = `rd3-collide-mgr-${runSuffix}`
+      const userIds = [subjectA, subjectB, manager]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, subjectA, org)
+        await seedUser(pool, subjectB, org)
+        await seedUser(pool, manager, org)
+        const group = await seedGroup(pool, org, 'collide-group')
+        await seedMember(pool, org, group, subjectA)
+        await seedMember(pool, org, group, subjectB)
+        await seedManager(pool, org, group, manager, 'owner')
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        // 2 self rows (A,B) + 2 owner rows (manager for subject A and for subject B) = 4.
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 4, ownerSkipped: 0 })
+
+        const ownerRows = (await fetchDeliveries(pool, org)).filter((r) => r.recipient_role === 'owner')
+        expect(ownerRows).toHaveLength(2)
+        // Both owner rows go to the SAME manager but carry DISTINCT subject ids in the key.
+        for (const row of ownerRows) {
+          expect(row.recipient_user_id).toBe(manager)
+        }
+        const ownerKeys = ownerRows.map((r) => r.source_key).sort()
+        expect(ownerKeys[0]).not.toBe(ownerKeys[1])
+        expect(ownerKeys).toEqual([
+          `attendance_report_digest:${org}:daily:daily:2026-06-25:subject:${subjectA}:owner:${manager}:channel:dingtalk_work_notification`,
+          `attendance_report_digest:${org}:daily:daily:2026-06-25:subject:${subjectB}:owner:${manager}:channel:dingtalk_work_notification`,
+        ].sort())
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('fail-soft: missing owner / zero active group still writes the self row and counts the skip', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-failsoft-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-failsoft-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      // subjectGroup: in a group that has a sub_owner but NO owner. subjectNoGroup: in no group at all.
+      const subjectGroup = `rd3-fs-grp-${runSuffix}`
+      const subjectNoGroup = `rd3-fs-nogrp-${runSuffix}`
+      const subOwner = `rd3-fs-subowner-${runSuffix}`
+      const userIds = [subjectGroup, subjectNoGroup, subOwner]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, subjectGroup, org)
+        await seedUser(pool, subjectNoGroup, org)
+        await seedUser(pool, subOwner, org)
+        const group = await seedGroup(pool, org, 'failsoft-group')
+        await seedMember(pool, org, group, subjectGroup)
+        await seedManager(pool, org, group, subOwner, 'sub_owner') // sub_owner present, owner absent
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner', 'sub_owner'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        // self rows: 2 (both subjects). sub_owner row: 1 (subjectGroup → subOwner). owner: 0 (skipped twice).
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 3, ownerSkipped: 2, subOwnerSkipped: 1 })
+
+        const rows = await fetchDeliveries(pool, org)
+        const byRole = (role: string) => rows.filter((r) => r.recipient_role === role)
+        expect(byRole('subject').map((r) => r.recipient_user_id).sort()).toEqual([subjectGroup, subjectNoGroup].sort())
+        expect(byRole('owner')).toHaveLength(0)
+        expect(byRole('sub_owner')).toHaveLength(1)
+        expect(byRole('sub_owner')[0].recipient_user_id).toBe(subOwner)
+        // No worker involvement — every row is still pending, never delivered.
+        for (const row of rows) {
+          expect(row.status).toBe('pending')
+          expect(row.delivered_at).toBeNull()
+        }
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('multi-group: a shared manager is written once; distinct managers across groups are written separately', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-multigrp-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-multigrp-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      // subjectShared in two groups that share manager M. subjectDistinct in two groups with managers M and N.
+      const subjectShared = `rd3-mg-shared-${runSuffix}`
+      const subjectDistinct = `rd3-mg-distinct-${runSuffix}`
+      const mgrM = `rd3-mg-m-${runSuffix}`
+      const mgrN = `rd3-mg-n-${runSuffix}`
+      const userIds = [subjectShared, subjectDistinct, mgrM, mgrN]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, subjectShared, org)
+        await seedUser(pool, subjectDistinct, org)
+        await seedUser(pool, mgrM, org)
+        await seedUser(pool, mgrN, org)
+        const g1 = await seedGroup(pool, org, 'mg-g1')
+        const g2 = await seedGroup(pool, org, 'mg-g2')
+        // subjectShared ∈ g1,g2; both owned by M → dedup to ONE owner row.
+        await seedMember(pool, org, g1, subjectShared)
+        await seedMember(pool, org, g2, subjectShared)
+        await seedManager(pool, org, g1, mgrM, 'owner')
+        await seedManager(pool, org, g2, mgrM, 'owner')
+        // subjectDistinct ∈ g1 (owner M), g2 (owner N) → TWO distinct owner rows.
+        await seedMember(pool, org, g1, subjectDistinct)
+        await seedMember(pool, org, g2, subjectDistinct)
+        await seedManager(pool, org, g2, mgrN, 'owner')
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        expect(res.cadences[0].ownerSkipped).toBe(0)
+
+        const rows = await fetchDeliveries(pool, org)
+        const ownerRowsShared = rows.filter((r) => r.recipient_role === 'owner' && r.source_key.includes(`:subject:${subjectShared}:`))
+        const ownerRowsDistinct = rows.filter((r) => r.recipient_role === 'owner' && r.source_key.includes(`:subject:${subjectDistinct}:`))
+        expect(ownerRowsShared).toHaveLength(1) // shared manager deduped across groups
+        expect(ownerRowsShared[0].recipient_user_id).toBe(mgrM)
+        expect(ownerRowsDistinct.map((r) => r.recipient_user_id).sort()).toEqual([mgrM, mgrN].sort()) // distinct managers
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('inactive user and inactive (offboarded) manager are excluded', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-inactive-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-inactive-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      const activeSubject = `rd3-ia-active-${runSuffix}`
+      const inactiveUser = `rd3-ia-useroff-${runSuffix}`
+      const inactiveMembership = `rd3-ia-orgoff-${runSuffix}`
+      const offboardedManager = `rd3-ia-mgroff-${runSuffix}`
+      const userIds = [activeSubject, inactiveUser, inactiveMembership, offboardedManager]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, activeSubject, org)
+        await seedUser(pool, inactiveUser, org, { userActive: false })       // users.is_active=false → excluded
+        await seedUser(pool, inactiveMembership, org, { orgActive: false })  // user_orgs.is_active=false → excluded
+        await seedUser(pool, offboardedManager, org, { userActive: false })  // offboarded manager → not written
+        const group = await seedGroup(pool, org, 'inactive-group')
+        await seedMember(pool, org, group, activeSubject)
+        await seedManager(pool, org, group, offboardedManager, 'owner')
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        // Only the one active member gets a self row; the offboarded owner is not written (owner skipped).
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 1, ownerSkipped: 1 })
+
+        const rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].recipient_user_id).toBe(activeSubject)
+        expect(rows[0].recipient_role).toBe('subject')
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('stored payload matches buildAttendanceReportDigestPayload with non-zero requestTotals from the group-by helper', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-payload-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-payload-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      const now = new Date('2026-06-26T12:00:00.000Z')
+      const periodDay = '2026-06-25' // daily previous-day period
+      const subject = `rd3-payload-u-${runSuffix}`
+      const userIds = [subject]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await requireAttendanceTable(pool, 'attendance_requests')
+        await seedUser(pool, subject, org)
+        // Seed requests inside the period: 1 approved leave (240 min) + 1 pending leave. loadAttendanceSummary
+        // would report 0 request counts → the group-by helper is what makes requestTotals non-zero.
+        await pool.query(
+          `INSERT INTO attendance_requests (id, org_id, user_id, work_date, request_type, status, metadata)
+           VALUES ($1, $2, $3, $4, 'leave', 'approved', '{"minutes":"240"}'::jsonb),
+                  ($5, $2, $3, $4, 'leave', 'pending', '{"minutes":"60"}'::jsonb)`,
+          [randomUUID(), org, subject, periodDay, randomUUID()],
+        )
+        expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self'] } }))).toBe(200)
+
+        const res = await withEnv('true', () => runDigest(pool, org, now))
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 1 })
+
+        const rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(1)
+        const payload = rows[0].payload
+        const seam = reportDigestSeam()
+
+        // Reconstruct the expected requestTotals via the SAME exported helper the producer uses, then run it
+        // through buildAttendanceReportDigestPayload — the stored requestTotals must match byte-for-byte.
+        const expectedTotals = await seam.loadAttendanceReportDigestRequestTotals(createPluginDbForTest(pool), org, subject, periodDay, periodDay)
+        expect(expectedTotals).toMatchObject({ pending: 1, approved: 1, rejected: 0, leaveMinutes: 240, overtimeMinutes: 0, makeupPunchCount: 0 })
+        const expectedPeriod = seam.resolveAttendanceReportDigestPeriod('daily', { now, timezone: 'UTC' })
+        const expectedPayload = seam.buildAttendanceReportDigestPayload({
+          cadence: 'daily',
+          period: expectedPeriod,
+          summary: {}, // summary asserted structurally below; requestTotals/period/kind asserted exactly
+          requestTotals: expectedTotals,
+        })
+        expect(payload.kind).toBe('attendance_report_digest')
+        expect(payload.cadence).toBe('daily')
+        expect(payload.period).toEqual(expectedPayload.period)
+        expect(payload.period).toMatchObject({ from: periodDay, to: periodDay, periodKey: 'daily:2026-06-25' })
+        expect(payload.requestTotals).toEqual(expectedPayload.requestTotals)
+        expect(payload.requestTotals).toEqual({ pending: 1, approved: 1, rejected: 0, leaveMinutes: 240, overtimeMinutes: 0, makeupPunchCount: 0 })
+        // Small payload: summary present (numeric keys) and NO records array — only summary + requestTotals.
+        expect(typeof payload.summary).toBe('object')
+        expect(typeof payload.summary.totalMinutes).toBe('number')
+        expect('records' in payload).toBe(false)
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
+    it('weekly and monthly cadences are due-gated by anchor + sendAt and digest the previous complete period', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const org = `rd3-cadence-${runSuffix}`
+      const adminToken = await digestAdminToken(`rd3-cadence-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      // now (UTC) = 2026-06-15, which is a Monday. weekday(Mon=1) and dayOfMonth(15) are derived, not eyeballed.
+      const now = new Date('2026-06-15T09:30:00.000Z')
+      const todayKey = '2026-06-15'
+      const matchingWeekday = weekdayMonday1(todayKey)
+      const subject = `rd3-cadence-u-${runSuffix}`
+      const userIds = [subject]
+      try {
+        await requireAttendanceTable(pool, 'attendance_notification_deliveries')
+        await seedUser(pool, subject, org)
+
+        // (a) NOT due: weekday/dayOfMonth do not match → zero rows even though both cadences are enabled.
+        const nonMatchingWeekday = matchingWeekday === 7 ? 1 : matchingWeekday + 1
+        expect(await putDigestPolicy(adminToken, digestPolicy({
+          enabled: true,
+          weekly: { enabled: true, weekday: nonMatchingWeekday, sendAt: '00:00' },
+          monthly: { enabled: true, dayOfMonth: 20, sendAt: '00:00' },
+        }))).toBe(200)
+        const resNotDue = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resNotDue.ran).toBe(true)
+        expect(resNotDue.cadences).toEqual([])
+        expect((await fetchDeliveries(pool, org)).length).toBe(0)
+
+        // (b) Before sendAt: anchors match but local time (09:30) is before sendAt 23:00 → not due.
+        expect(await putDigestPolicy(adminToken, digestPolicy({
+          enabled: true,
+          weekly: { enabled: true, weekday: matchingWeekday, sendAt: '23:00' },
+        }))).toBe(200)
+        const resBeforeSendAt = await withEnv('true', () => runDigest(pool, org, now))
+        expect(resBeforeSendAt.cadences).toEqual([])
+        expect((await fetchDeliveries(pool, org)).length).toBe(0)
+
+        // (c) Due: anchors match and local time >= sendAt → weekly digests the previous full Mon-Sun week,
+        //     monthly digests the previous full calendar month; each writes one self row.
+        expect(await putDigestPolicy(adminToken, digestPolicy({
+          enabled: true,
+          weekly: { enabled: true, weekday: matchingWeekday, sendAt: '09:00', recipients: ['self'] },
+          monthly: { enabled: true, dayOfMonth: 15, sendAt: '09:00', recipients: ['self'] },
+        }))).toBe(200)
+        const resDue = await withEnv('true', () => runDigest(pool, org, now, todayKey))
+        const dueNames = resDue.cadences.map((c: any) => c.cadence).sort()
+        expect(dueNames).toEqual(['monthly', 'weekly'])
+        for (const c of resDue.cadences) expect(c.rowsCreated).toBe(1)
+
+        const rows = await fetchDeliveries(pool, org)
+        expect(rows).toHaveLength(2)
+        const weeklyRow = rows.find((r) => r.payload.cadence === 'weekly')
+        const monthlyRow = rows.find((r) => r.payload.cadence === 'monthly')
+        // Previous complete Mon-Sun week before the Monday 2026-06-15 = 2026-06-08 .. 2026-06-14.
+        expect(weeklyRow.payload.period).toMatchObject({ from: '2026-06-08', to: '2026-06-14' })
+        // Previous complete calendar month before June 2026 = May 1 .. May 31.
+        expect(monthlyRow.payload.period).toMatchObject({ from: '2026-05-01', to: '2026-05-31' })
+
+        // Repeat tick → both cadences write zero duplicates.
+        const resRepeat = await withEnv('true', () => runDigest(pool, org, now, todayKey))
+        for (const c of resRepeat.cadences) expect(c.rowsCreated).toBe(0)
+        expect((await fetchDeliveries(pool, org)).length).toBe(2)
+      } finally {
+        await putDigestPolicy(adminToken, digestPolicy({ enabled: false })).catch(() => undefined)
+        await cleanupDigestOrg(pool, org, userIds)
+        await pool.end().catch(() => undefined)
+      }
+    })
+  })
+
   it('C5-4: lists notification deliveries with counters, pagination, filtering, and admin-only access', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -16192,10 +16192,15 @@ attendanceIntegrationDescribe(
         expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner'] } }))).toBe(200)
 
         const res = await withEnv('true', () => runDigest(pool, org, now))
-        // 2 self rows (A,B) + 2 owner rows (manager for subject A and for subject B) = 4.
-        expect(res.cadences[0]).toMatchObject({ rowsCreated: 4, ownerSkipped: 0 })
+        // The manager is also an active org member → also a digest subject (own 'subject' self row); as a
+        // non-member they are owner-skipped once for themselves. 3 self (A, B, manager) + 2 owner = 5.
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 5, ownerSkipped: 1 })
 
-        const ownerRows = (await fetchDeliveries(pool, org)).filter((r) => r.recipient_role === 'owner')
+        const all = await fetchDeliveries(pool, org)
+        // The manager gets their OWN 'subject' self row alongside being the resolved owner for A and B.
+        expect(all.filter((r) => r.recipient_role === 'subject').map((r) => r.recipient_user_id).sort())
+          .toEqual([subjectA, subjectB, manager].sort())
+        const ownerRows = all.filter((r) => r.recipient_role === 'owner')
         expect(ownerRows).toHaveLength(2)
         // Both owner rows go to the SAME manager but carry DISTINCT subject ids in the key.
         for (const row of ownerRows) {
@@ -16241,12 +16246,14 @@ attendanceIntegrationDescribe(
         expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner', 'sub_owner'] } }))).toBe(200)
 
         const res = await withEnv('true', () => runDigest(pool, org, now))
-        // self rows: 2 (both subjects). sub_owner row: 1 (subjectGroup → subOwner). owner: 0 (skipped twice).
-        expect(res.cadences[0]).toMatchObject({ rowsCreated: 3, ownerSkipped: 2, subOwnerSkipped: 1 })
+        // subOwner is also an active org member → also a subject (own self row), and as a NON-member is
+        // owner+sub_owner-skipped for themselves. self:3 (subjectGroup, subjectNoGroup, subOwner),
+        // sub_owner row:1 (subjectGroup→subOwner); ownerSkipped:3, subOwnerSkipped:2; rowsCreated 3+1=4.
+        expect(res.cadences[0]).toMatchObject({ rowsCreated: 4, ownerSkipped: 3, subOwnerSkipped: 2 })
 
         const rows = await fetchDeliveries(pool, org)
         const byRole = (role: string) => rows.filter((r) => r.recipient_role === role)
-        expect(byRole('subject').map((r) => r.recipient_user_id).sort()).toEqual([subjectGroup, subjectNoGroup].sort())
+        expect(byRole('subject').map((r) => r.recipient_user_id).sort()).toEqual([subjectGroup, subjectNoGroup, subOwner].sort())
         expect(byRole('owner')).toHaveLength(0)
         expect(byRole('sub_owner')).toHaveLength(1)
         expect(byRole('sub_owner')[0].recipient_user_id).toBe(subOwner)
@@ -16287,19 +16294,22 @@ attendanceIntegrationDescribe(
         await seedUser(pool, mgrN, org)
         const g1 = await seedGroup(pool, org, 'mg-g1')
         const g2 = await seedGroup(pool, org, 'mg-g2')
-        // subjectShared ∈ g1,g2; both owned by M → dedup to ONE owner row.
+        const g3 = await seedGroup(pool, org, 'mg-g3')
+        // subjectShared ∈ g1,g2; both owned ONLY by M → dedup to ONE owner row.
         await seedMember(pool, org, g1, subjectShared)
         await seedMember(pool, org, g2, subjectShared)
         await seedManager(pool, org, g1, mgrM, 'owner')
         await seedManager(pool, org, g2, mgrM, 'owner')
-        // subjectDistinct ∈ g1 (owner M), g2 (owner N) → TWO distinct owner rows.
+        // subjectDistinct ∈ g1 (owner M), g3 (owner N) → TWO distinct owner rows. mgrN owns g3 (NOT g2),
+        // so subjectShared's groups carry only M and the shared-manager dedup stays isolated.
         await seedMember(pool, org, g1, subjectDistinct)
-        await seedMember(pool, org, g2, subjectDistinct)
-        await seedManager(pool, org, g2, mgrN, 'owner')
+        await seedMember(pool, org, g3, subjectDistinct)
+        await seedManager(pool, org, g3, mgrN, 'owner')
         expect(await putDigestPolicy(adminToken, digestPolicy({ enabled: true, daily: { enabled: true, recipients: ['self', 'owner'] } }))).toBe(200)
 
         const res = await withEnv('true', () => runDigest(pool, org, now))
-        expect(res.cadences[0].ownerSkipped).toBe(0)
+        // mgrM/mgrN are active org members → also subjects, owner-skipped for themselves (not group members).
+        expect(res.cadences[0].ownerSkipped).toBe(2)
 
         const rows = await fetchDeliveries(pool, org)
         const ownerRowsShared = rows.filter((r) => r.recipient_role === 'owner' && r.source_key.includes(`:subject:${subjectShared}:`))

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -120,6 +120,11 @@ const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(ATTENDANCE_SCHEDULER_SCOPE_AC
 const ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL = 'dingtalk_work_notification'
 const ATTENDANCE_ROUTABLE_DEFAULT_DELIVERY_CHANNELS = new Set([ATTENDANCE_DINGTALK_WORK_NOTIFICATION_CHANNEL, 'email_smtp'])
 const MANUAL_MISSED_PUNCH_REMINDER_SOURCE_TYPE = 'manual_missed_punch_reminder'
+// RD-3 attendance report-digest producer (design-lock attendance-report-digest-subscription-design-lock-20260626 §4).
+// source_type stamped on every C5 outbox row this producer writes.
+const ATTENDANCE_REPORT_DIGEST_SOURCE_TYPE = 'attendance_report_digest'
+// Request types counted toward digest requestTotals.makeupPunchCount (补卡). Approved-only is applied at query time.
+const ATTENDANCE_REPORT_DIGEST_MAKEUP_PUNCH_TYPES = new Set(['missed_check_in', 'missed_check_out', 'time_correction'])
 const AUTO_SHIFT_AUTO_WRITE_SYSTEM_ROLE_TAG = 'system:attendance-auto-shift'
 const AUTO_SHIFT_AUTO_WRITE_SOURCE = 'scheduler'
 const ATTENDANCE_GROUP_TYPES = new Set(['fixed_shift', 'scheduled_shift', 'free_time'])
@@ -298,6 +303,7 @@ let autoHolidaySyncTimeout = null
 let autoHolidaySyncInterval = null
 let importUploadCleanupInterval = null
 let autoShiftAutoWriteSchedulerUnregister = null
+let attendanceReportDigestSchedulerUnregister = null
 let settingsCache = { value: DEFAULT_SETTINGS, loadedAt: 0 }
 const templateLibraryCache = new Map()
 const templateLibraryVersionCache = new Map()
@@ -12485,6 +12491,58 @@ function buildAttendanceReportDigestPayload(input = {}) {
   }
 }
 
+// RD-3 due-gating: weekday in the policy timezone, 1=Monday..7=Sunday (doc §3: weekly.weekday ∈ 1..7, 1=Monday).
+// getWeekdayFromDateKey returns 0=Sunday..6=Saturday, so remap.
+function attendanceReportDigestLocalWeekdayMonday1(localDateKey) {
+  return ((getWeekdayFromDateKey(localDateKey) + 6) % 7) + 1
+}
+
+// RD-3 due-gating: local wall-clock HH:mm in the policy timezone, for the `>= sendAt` window comparison.
+function attendanceReportDigestLocalTimeOfDay(now, timezone) {
+  const date = now instanceof Date ? now : new Date(now)
+  const zone = typeof timezone === 'string' && timezone.trim() ? timezone.trim() : 'UTC'
+  const parts = getZonedParts(date, zone)
+  return `${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}`
+}
+
+// RD-3: which enabled cadences are DUE this tick. The scheduler is HOURLY, so this is NOT minute-equality —
+// it is anchor-matches-today AND localTimeOfDay(policy tz) >= cadence.sendAt. Per-period source_key gives
+// exactly-once across the repeated hourly ticks inside the window. Returns an ordered array of cadence names.
+function dueDigestCadences(policy, { now = new Date(), todayKey } = {}) {
+  const cadences = policy && typeof policy === 'object' && policy.cadences && typeof policy.cadences === 'object'
+    ? policy.cadences
+    : {}
+  const timezone = typeof policy?.timezone === 'string' && policy.timezone.trim() ? policy.timezone.trim() : 'UTC'
+  const localDateKey = todayKey
+    ? normalizeDateOnlyStrict(todayKey)
+    : attendanceReportDigestLocalDateKey(now, timezone)
+  if (!localDateKey) return []
+  const timeOfDay = attendanceReportDigestLocalTimeOfDay(now, timezone)
+  const parts = attendanceReportDigestDateParts(localDateKey)
+  const weekdayMonday1 = attendanceReportDigestLocalWeekdayMonday1(localDateKey)
+  const due = []
+
+  const daily = cadences.daily
+  if (daily?.enabled === true && timeOfDay >= daily.sendAt) {
+    due.push('daily')
+  }
+
+  const weekly = cadences.weekly
+  if (weekly?.enabled === true && weekdayMonday1 === weekly.weekday && timeOfDay >= weekly.sendAt) {
+    due.push('weekly')
+  }
+
+  const monthly = cadences.monthly
+  if (monthly?.enabled === true && parts) {
+    const clampedKey = clampAttendanceReportDigestDayOfMonth(parts.year, parts.month, monthly.dayOfMonth)
+    if (localDateKey === clampedKey && timeOfDay >= monthly.sendAt) {
+      due.push('monthly')
+    }
+  }
+
+  return due
+}
+
 function normalizeOvertimeBankPolicySetting(raw) {
   const value = raw && typeof raw === 'object' ? raw : {}
   const seen = new Set()
@@ -13782,6 +13840,13 @@ function isAutoShiftAutoWriteRuntimeEnabled() {
   return parseBoolean(process.env.ATTENDANCE_AUTO_SHIFT_AUTO_WRITE_ENABLED, false)
 }
 
+// RD-3: dedicated env gate for the report-digest producer. Distinct from ATTENDANCE_SCHEDULER_ENABLED (process
+// gate) and ATTENDANCE_NOTIFICATION_DELIVERY_WORKER_ENABLED (send gate). Default OFF — producer writes nothing
+// until an admin explicitly opts in AND the policy/cadence are enabled.
+function isAttendanceReportDigestRuntimeEnabled() {
+  return parseBoolean(process.env.ATTENDANCE_REPORT_DIGEST_ENABLED, false)
+}
+
 function confidenceRank(value) {
   if (value === 'high') return 3
   if (value === 'medium') return 2
@@ -14541,6 +14606,166 @@ async function runAttendanceAutoShiftAutoWriteOnce(db, { orgId = DEFAULT_ORG_ID,
     }).catch(() => undefined)
     throw error
   }
+}
+
+// RD-3 target population: active org members only (user_orgs.is_active=true JOIN users.is_active=true). Mirrors the
+// annual-accrual loader — NOT the auto-shift target loader, which filters attendance_type='scheduled_shift'.
+async function loadActiveReportDigestUserIds(db, orgId) {
+  const rows = await db.query(
+    `SELECT u.id
+       FROM user_orgs uo
+       JOIN users u ON u.id = uo.user_id
+      WHERE uo.org_id = $1 AND uo.is_active = true AND u.is_active = true
+      ORDER BY u.id ASC`,
+    [orgId],
+  )
+  return rows.map((row) => row.id).filter(Boolean)
+}
+
+// RD-3 owner/sub_owner resolution (the producer fans out; the delivery worker never does). attendance_group_*
+// have NO is_active column → 'active group' = the membership/manager row exists; 'active manager' = users.is_active.
+// SELECT DISTINCT dedups a manager shared across multiple of the subject's groups (multi-group dedup §6).
+async function resolveDigestManagerUserIds(db, orgId, subjectUserId, role) {
+  const rows = await db.query(
+    `SELECT DISTINCT mgr.user_id
+       FROM attendance_group_members mem
+       JOIN attendance_group_managers mgr
+         ON mgr.org_id = mem.org_id AND mgr.group_id = mem.group_id
+       JOIN users u ON u.id = mgr.user_id
+      WHERE mem.org_id = $1
+        AND mem.user_id = $2
+        AND mgr.role = $3
+        AND u.is_active = true
+      ORDER BY mgr.user_id ASC`,
+    [orgId, subjectUserId, role],
+  )
+  return rows.map((row) => row.user_id).filter(Boolean)
+}
+
+// RD-3: request totals for the digest payload. Extracted from the inline GET /reports/requests group-by because
+// loadAttendanceSummary returns only approved leave/overtime MINUTES, not request COUNTS — feeding the summary
+// alone would ship all-zero requestTotals. leave/overtime minutes + makeup-punch count are approved-only.
+async function loadAttendanceReportDigestRequestTotals(db, orgId, userId, from, to) {
+  const rows = await db.query(
+    `SELECT request_type, status,
+            COUNT(*)::int AS total,
+            COALESCE(SUM(CASE WHEN (metadata->>'minutes') ~ '^[0-9]+' THEN (metadata->>'minutes')::int ELSE 0 END), 0)::int AS total_minutes
+       FROM attendance_requests
+      WHERE user_id = $1 AND org_id = $2 AND work_date BETWEEN $3 AND $4
+      GROUP BY request_type, status`,
+    [userId, orgId, from, to],
+  )
+  const totals = { pending: 0, approved: 0, rejected: 0, leaveMinutes: 0, overtimeMinutes: 0, makeupPunchCount: 0 }
+  for (const row of rows) {
+    const total = Number(row.total ?? 0)
+    const minutes = Number(row.total_minutes ?? 0)
+    const status = row.status
+    const type = row.request_type
+    if (status === 'pending') totals.pending += total
+    else if (status === 'approved') totals.approved += total
+    else if (status === 'rejected') totals.rejected += total
+    if (status === 'approved') {
+      if (type === 'leave') totals.leaveMinutes += minutes
+      else if (type === 'overtime') totals.overtimeMinutes += minutes
+      if (ATTENDANCE_REPORT_DIGEST_MAKEUP_PUNCH_TYPES.has(type)) totals.makeupPunchCount += total
+    }
+  }
+  return totals
+}
+
+// RD-3 producer: each tick, for every enabled+DUE cadence, write status='pending' C5 outbox rows for the org's
+// active members and their configured recipients. It NEVER sends — the AttendanceNotificationDeliveryWorker stays
+// the sole sender. Idempotency: per-(subject,role,recipient,channel,period) source_key + ON CONFLICT DO NOTHING,
+// serialized per (org,cadence,period) by an advisory xact lock. Gated: env + policy.enabled + cadence.enabled + due.
+async function runAttendanceReportDigestOnce(db, { orgId = DEFAULT_ORG_ID, now = new Date(), todayKey, logger = console, emitEvent = () => {} } = {}) {
+  const settings = await getSettings(db)
+  const policy = normalizeAttendanceReportDigestPolicySetting(settings.attendanceReportDigestPolicy)
+  if (!isAttendanceReportDigestRuntimeEnabled() || policy.enabled !== true) {
+    return { ran: false, reason: 'disabled', cadences: [] }
+  }
+
+  const timezone = policy.timezone
+  const resolvedTodayKey = todayKey ? normalizeDateOnlyStrict(todayKey) : attendanceReportDigestLocalDateKey(now, timezone)
+  const dueCadences = dueDigestCadences(policy, { now, todayKey: resolvedTodayKey })
+  if (dueCadences.length === 0) {
+    return { ran: true, cadences: [] }
+  }
+
+  // work_notification → the worker's registered default work-notification channel constant; email_smtp passes
+  // through. The RESOLVED value is stamped into BOTH row.channel and the source_key — never the raw config word.
+  const deliveryChannel = policy.channel === 'work_notification'
+    ? resolveAttendanceDefaultDeliveryChannelForProducer()
+    : 'email_smtp'
+
+  const cadenceSummaries = []
+  for (const cadence of dueCadences) {
+    const period = resolveAttendanceReportDigestPeriod(cadence, { now, todayKey: resolvedTodayKey, timezone })
+    const recipients = policy.cadences[cadence]?.recipients ?? ['self']
+    const sourceId = `${orgId}:${cadence}:${period.periodKey}`
+    const cadenceSummary = { cadence, rowsCreated: 0, rowsExisting: 0, ownerSkipped: 0, subOwnerSkipped: 0 }
+
+    try {
+      await db.transaction(async (trx) => {
+        // Serialize concurrent ticks / scheduler leaders racing the same (org, period); ON CONFLICT is the
+        // durable idempotency backstop even if two transactions interleave.
+        await trx.query(
+          'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+          [orgId, sourceId],
+        )
+        const userIds = await loadActiveReportDigestUserIds(trx, orgId)
+        for (const subjectUserId of userIds) {
+          const attendanceSummary = await loadAttendanceSummary(trx, orgId, subjectUserId, period.from, period.to)
+          const requestTotals = await loadAttendanceReportDigestRequestTotals(trx, orgId, subjectUserId, period.from, period.to)
+          const payload = buildAttendanceReportDigestPayload({
+            cadence,
+            period,
+            summary: attendanceSummary,
+            requestTotals,
+          })
+          const payloadJson = JSON.stringify(payload)
+
+          for (const recipientRole of recipients) {
+            let recipientUserIds
+            if (recipientRole === 'self') {
+              recipientUserIds = [subjectUserId]
+            } else {
+              recipientUserIds = await resolveDigestManagerUserIds(trx, orgId, subjectUserId, recipientRole)
+              if (recipientUserIds.length === 0) {
+                // Fail-soft: a role that resolves to no active manager is skipped + counted; self still ships.
+                if (recipientRole === 'owner') cadenceSummary.ownerSkipped += 1
+                else if (recipientRole === 'sub_owner') cadenceSummary.subOwnerSkipped += 1
+                continue
+              }
+            }
+            // self → recipient_role column 'subject'; owner/sub_owner keep their literal role. The source_key
+            // uses the config-vocab word (self/owner/sub_owner) to keep the dedup grain stable.
+            const recipientRoleColumn = recipientRole === 'self' ? 'subject' : recipientRole
+            for (const recipientUserId of recipientUserIds) {
+              const sourceKey = `${ATTENDANCE_REPORT_DIGEST_SOURCE_TYPE}:${orgId}:${cadence}:${period.periodKey}:subject:${subjectUserId}:${recipientRole}:${recipientUserId}:channel:${deliveryChannel}`
+              const inserted = await trx.query(
+                `INSERT INTO attendance_notification_deliveries
+                   (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, payload)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8::jsonb)
+                 ON CONFLICT (org_id, source_key) DO NOTHING
+                 RETURNING id`,
+                [orgId, ATTENDANCE_REPORT_DIGEST_SOURCE_TYPE, sourceId, sourceKey, recipientUserId, recipientRoleColumn, deliveryChannel, payloadJson],
+              )
+              if (inserted.length > 0) cadenceSummary.rowsCreated += 1
+              else cadenceSummary.rowsExisting += 1
+            }
+          }
+        }
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (logger?.warn) logger.warn(`Attendance report digest cadence ${cadence} failed: ${message}`)
+      throw error
+    }
+
+    cadenceSummaries.push(cadenceSummary)
+  }
+
+  return { ran: true, cadences: cadenceSummaries }
 }
 
 async function loadAttendanceScopeContextForUser(db, orgId, userId) {
@@ -19081,9 +19306,15 @@ module.exports = {
   },
   __attendanceReportDigestForTests: {
     ATTENDANCE_REPORT_DIGEST_CADENCES,
+    ATTENDANCE_REPORT_DIGEST_SOURCE_TYPE,
     buildAttendanceReportDigestPayload,
     clampAttendanceReportDigestDayOfMonth,
     resolveAttendanceReportDigestPeriod,
+    dueDigestCadences,
+    loadActiveReportDigestUserIds,
+    resolveDigestManagerUserIds,
+    loadAttendanceReportDigestRequestTotals,
+    runAttendanceReportDigestOnce,
   },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
@@ -40202,6 +40433,16 @@ module.exports = {
 	        name: 'attendance-auto-shift-auto-write',
 	        run: () => runAttendanceAutoShiftAutoWriteOnce(db, { logger, emitEvent }),
 	      }) ?? null
+	      // RD-3 report-digest producer. Registration is harmless — the producer is dormant until
+	      // ATTENDANCE_REPORT_DIGEST_ENABLED=true AND the org policy/cadence are enabled AND a cadence is due.
+	      if (attendanceReportDigestSchedulerUnregister) {
+	        attendanceReportDigestSchedulerUnregister()
+	        attendanceReportDigestSchedulerUnregister = null
+	      }
+	      attendanceReportDigestSchedulerUnregister = context.services?.attendanceScheduler?.registerJob?.({
+	        name: 'attendance-report-digest',
+	        run: () => runAttendanceReportDigestOnce(db, { logger, emitEvent }),
+	      }) ?? null
 	    } catch (error) {
 	      logger.warn('Attendance settings preload failed', error)
 	    }
@@ -40223,6 +40464,10 @@ module.exports = {
 	    if (autoShiftAutoWriteSchedulerUnregister) {
 	      autoShiftAutoWriteSchedulerUnregister()
 	      autoShiftAutoWriteSchedulerUnregister = null
+	    }
+	    if (attendanceReportDigestSchedulerUnregister) {
+	      attendanceReportDigestSchedulerUnregister()
+	      attendanceReportDigestSchedulerUnregister = null
 	    }
 	  }
 }


### PR DESCRIPTION
RD-3 of the report-digest line (per the ratified design-lock, RD-3 slice). A scheduler-registered producer that, each tick, evaluates `attendanceReportDigestPolicy`, finds enabled+due cadences, computes the **completed** period (reuses landed `resolveAttendanceReportDigestPeriod`), iterates active org members, builds the small payload (reuses `buildAttendanceReportDigestPayload`), resolves recipients (self→subject; owner/sub_owner→attendance-group managers, **resolved by the producer**), and INSERTs `status='pending'` C5 outbox rows guarded by `ON CONFLICT (org_id, source_key) DO NOTHING` + an advisory xact lock.

**Gated / safe:** writes nothing unless `ATTENDANCE_REPORT_DIGEST_ENABLED=true` AND `policy.enabled` AND the cadence is enabled+due. **No-direct-send** — only writes outbox rows; the existing delivery worker stays the sole sender. **Env flag is NOT enabled in any environment** (separately owner-gated per §11).

**§4-vs-§6 fix:** the design's §4 source_key omitted the subject id; §6's grain is per-subject. The key here injects `:subject:{subjectUserId}:` so one manager of two employees gets TWO rows (not one dropped by ON CONFLICT). Tested by the collision case.

Real-DB tests cover the full RD-3 matrix (disabled→0, daily+repeat idempotency, channel-in-key, **one-manager-two-subjects collision**, fail-soft skip-counting, multi-group dedup, inactive exclusion, payload/requestTotals, weekly/monthly due-gating). Test expectations were corrected after an adversarial review measured the producer against a real Postgres (managers are also active org members → also subjects). Producer logic validated lock-by-lock.

Deferred follow-ups (non-blocking, documented): hourly read-amplification short-circuit, env-gate-before-getSettings, per-cadence error isolation, cosmetic double-cadence token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)