### PR TITLE
feat(attendance): MP-2/MP-3 makeup-punch runtime enforcement (gated, disabled=byte-identical)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -405,6 +405,7 @@ jobs:
             tests/integration/attendance-comp-time-expiry-reminder.test.ts \
             tests/integration/attendance-shift-swap.test.ts \
             tests/integration/attendance-schedule-dispatch.test.ts \
+            tests/integration/attendance-makeup-punch-policy.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
+++ b/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+
+// 补卡规则 MP-2/MP-3 — makeup-punch (补卡) policy enforcement, route-level real-DB integration
+// (design-lock attendance-makeup-punch-policy-design-lock-20260626.md §4-§5). Drives the real HTTP
+// settings / requests / approve / reject routes against a migrated postgres and asserts every gate
+// against attendance_requests / attendance_records / attendance_events.
+//
+// KEYSTONE: with makeupPunchPolicy.enabled !== true, create/edit/approve of the three makeup request
+// types is byte-identical to today — no snapshot on the request metadata, no makeupPolicySnapshot on
+// the adjustment event, the adjusted record still written, and cross-user PUT still succeeds. The
+// "disabled = byte-identical" test below proves all of those NEGATIVES (field absence), which is what
+// proves the new code cannot leak when the policy is off.
+
+type HttpResponse = { status: number; body?: unknown; raw: string }
+
+function requestJson(url: string, options: { method?: string; headers?: Record<string, string>; body?: string } = {}): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+const ORG = 'default'
+
+type MakeupPolicy = {
+  enabled?: boolean
+  timezone?: string
+  cycle?: { type?: string; startDay?: number }
+  quota?: { maxRequestsPerCycle?: number; countStatuses?: string[]; principal?: string }
+  submitWindow?: { unit?: string; days?: number }
+  allowedAnomalyTypes?: string[]
+  allowedRequestTypes?: string[]
+  requireReason?: boolean
+  requireAttachment?: boolean
+}
+
+type SeedRecord = {
+  status?: string
+  firstIn?: string | null
+  lastOut?: string | null
+  lateMinutes?: number
+  earlyLeaveMinutes?: number
+  meta?: Record<string, unknown>
+}
+
+const codeOf = (r: HttpResponse) => (r.body as { error?: { code?: string } } | undefined)?.error?.code
+const requestIdOf = (r: HttpResponse) => (r.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id ?? ''
+
+describeDb('补卡规则 MP-2/MP-3 makeup punch policy (real DB, route-level)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let pool: Pool
+  let adminToken = ''
+  let adminUserId = ''
+  let originalMakeup: MakeupPolicy | undefined
+
+  const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' })
+
+  async function mintToken(userId: string, perms: string): Promise<string> {
+    const res = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent(perms)}`)
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+  const putSettings = (body: Record<string, unknown>) =>
+    requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: authHeaders(adminToken), body: JSON.stringify(body) })
+  const getSettings = () => requestJson(`${baseUrl}/api/attendance/settings`, { headers: authHeaders(adminToken) })
+  const createReq = (token: string, body: Record<string, unknown>) =>
+    requestJson(`${baseUrl}/api/attendance/requests`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify(body) })
+  const updateReq = (token: string, id: string, body: Record<string, unknown>) =>
+    requestJson(`${baseUrl}/api/attendance/requests/${id}`, { method: 'PUT', headers: authHeaders(token), body: JSON.stringify(body) })
+  const approve = (token: string, id: string) =>
+    requestJson(`${baseUrl}/api/attendance/requests/${id}/approve`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify({ comment: 'ok' }) })
+  const reject = (token: string, id: string) =>
+    requestJson(`${baseUrl}/api/attendance/requests/${id}/reject`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify({ comment: 'no' }) })
+  const anomalies = (token: string, userId: string, from: string, to: string) =>
+    requestJson(`${baseUrl}/api/attendance/anomalies?userId=${encodeURIComponent(userId)}&from=${from}&to=${to}`, { headers: authHeaders(token) })
+
+  // Date helpers in UTC so the test's date math matches the policy (timezone:'UTC' below).
+  const dayKey = (offset: number): string => {
+    const d = new Date()
+    d.setUTCDate(d.getUTCDate() + offset)
+    return d.toISOString().slice(0, 10)
+  }
+  const at = (workDate: string, hhmm: string) => `${workDate}T${hhmm}:00.000Z`
+
+  // Full policy shape on every PUT so a previous test's array never leaks through mergeSettings; nested
+  // objects are deep-merged with the supplied override so a partial quota/window keeps its siblings.
+  const makeupBase = (): Required<MakeupPolicy> => ({
+    enabled: false,
+    timezone: 'UTC',
+    cycle: { type: 'calendar_month', startDay: 1 },
+    quota: { maxRequestsPerCycle: 3, countStatuses: ['pending', 'approved'], principal: 'self_service_user' },
+    submitWindow: { unit: 'calendar_day', days: 30 },
+    allowedAnomalyTypes: ['missing_check_in', 'missing_check_out', 'late', 'severe_late', 'absence_late', 'early_leave'],
+    allowedRequestTypes: ['missed_check_in', 'missed_check_out', 'time_correction'],
+    requireReason: true,
+    requireAttachment: false,
+  })
+  const setMakeup = (o: MakeupPolicy = {}) => {
+    const b = makeupBase()
+    const policy = {
+      ...b,
+      ...o,
+      cycle: { ...b.cycle, ...(o.cycle || {}) },
+      quota: { ...b.quota, ...(o.quota || {}) },
+      submitWindow: { ...b.submitWindow, ...(o.submitWindow || {}) },
+    }
+    return putSettings({ makeupPunchPolicy: policy })
+  }
+
+  async function seedRecord(userId: string, workDate: string, opts: SeedRecord = {}) {
+    await pool.query(
+      `INSERT INTO attendance_records
+       (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'UTC', $5, $6, 0, $7, $8, $9, true, $10::jsonb, NULL, now(), now())`,
+      [
+        randomUUID(),
+        userId,
+        ORG,
+        workDate,
+        opts.firstIn ?? null,
+        opts.lastOut ?? null,
+        opts.lateMinutes ?? 0,
+        opts.earlyLeaveMinutes ?? 0,
+        opts.status ?? 'partial',
+        JSON.stringify(opts.meta ?? {}),
+      ],
+    )
+  }
+  // A 'partial' record missing the check-IN side → fact missing_check_in (the typical 补卡 case).
+  const seedMissingCheckIn = (userId: string, workDate: string) =>
+    seedRecord(userId, workDate, { status: 'partial', firstIn: null, lastOut: at(workDate, '18:00'), lateMinutes: 0 })
+  const seedLate = (userId: string, workDate: string) =>
+    seedRecord(userId, workDate, { status: 'late', firstIn: at(workDate, '09:30'), lastOut: at(workDate, '18:00'), lateMinutes: 30 })
+
+  async function reqRow(id: string): Promise<{ status: string; metadata: Record<string, unknown> } | null> {
+    const row = (await pool.query(`SELECT status, metadata FROM attendance_requests WHERE id = $1`, [id])).rows[0]
+    if (!row) return null
+    const metadata = typeof row.metadata === 'string' ? JSON.parse(row.metadata) : (row.metadata ?? {})
+    return { status: String(row.status), metadata }
+  }
+  async function recordStatus(userId: string, workDate: string): Promise<string | null> {
+    const row = (await pool.query(`SELECT status FROM attendance_records WHERE user_id = $1 AND work_date = $2 AND org_id = $3 LIMIT 1`, [userId, workDate, ORG])).rows[0]
+    return row ? String(row.status) : null
+  }
+  async function adjustmentMetas(userId: string): Promise<Array<Record<string, unknown>>> {
+    const rows = (await pool.query(`SELECT meta FROM attendance_events WHERE user_id = $1 AND event_type = 'adjustment'`, [userId])).rows
+    return rows.map((r) => (typeof r.meta === 'string' ? JSON.parse(r.meta) : (r.meta ?? {})))
+  }
+  async function cleanupUser(userId: string) {
+    await pool.query(`DELETE FROM approval_instances WHERE business_key IN (SELECT 'attendance-request:' || id FROM attendance_requests WHERE user_id = $1)`, [userId]).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_requests WHERE user_id = $1`, [userId]).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_events WHERE user_id = $1`, [userId]).catch(() => undefined)
+    await pool.query(`DELETE FROM attendance_records WHERE user_id = $1`, [userId]).catch(() => undefined)
+  }
+  let userSeq = 0
+  const uid = (prefix: string) => `mp-${prefix}-${Date.now().toString(36)}-${userSeq++}`
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('makeup punch integration needs a loopback port + DATABASE_URL')
+
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    const repoRoot = path.join(__dirname, '../../../../')
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')] })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+    adminUserId = uid('admin')
+    adminToken = await mintToken(adminUserId, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+    const before = await getSettings()
+    originalMakeup = (before.body as { data?: { makeupPunchPolicy?: MakeupPolicy } } | undefined)?.data?.makeupPunchPolicy
+  })
+
+  afterAll(async () => {
+    if (adminToken && originalMakeup) await putSettings({ makeupPunchPolicy: originalMakeup }).catch(() => undefined)
+    else if (adminToken) await setMakeup({ enabled: false }).catch(() => undefined)
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) await (server as unknown as { stop: () => Promise<void> }).stop()
+    await pool?.end().catch(() => undefined)
+  })
+
+  // ── KEYSTONE: disabled = byte-identical ────────────────────────────────────────────────────────────
+  it('disabled: create/edit/approve of makeup types byte-identical — no snapshot, no event meta, adjusted record, cross-user PUT ok', async () => {
+    await setMakeup({ enabled: false })
+    const u = uid('dis')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      // create with NO reason — disabled does not enforce requireReason
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00') })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+      expect(id).toBeTruthy()
+      expect((await reqRow(id))?.metadata?.makeupPunchPolicySnapshot).toBeUndefined()
+
+      // edit (still no snapshot)
+      const e = await updateReq(tU, id, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:05') })
+      expect(e.status).toBe(200)
+      expect((await reqRow(id))?.metadata?.makeupPunchPolicySnapshot).toBeUndefined()
+
+      // cross-user PUT by admin (canAccessOtherUsers) still succeeds when disabled
+      const x = await updateReq(adminToken, id, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:10') })
+      expect(x.status).toBe(200)
+
+      // approve → adjusted record written, adjustment event has NO makeupPolicySnapshot
+      const ap = await approve(adminToken, id)
+      expect(ap.status).toBe(200)
+      expect(await recordStatus(u, wd)).toBe('adjusted')
+      const metas = await adjustmentMetas(u)
+      expect(metas).toHaveLength(1)
+      expect(metas[0].requestType).toBe('missed_check_in')
+      expect(metas[0].makeupPolicySnapshot).toBeUndefined()
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── quota ────────────────────────────────────────────────────────────────────────────────────────
+  it('quota max=1: 2nd makeup in cycle → QUOTA_EXCEEDED; reject releases the slot; update excludes self', async () => {
+    await setMakeup({ enabled: true, quota: { maxRequestsPerCycle: 1 } })
+    const u = uid('quota')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      // one record on `wd` yields BOTH missing_check_in (partial, no first_in) and late (lateMinutes>0)
+      await seedRecord(u, wd, { status: 'partial', firstIn: null, lastOut: at(wd, '18:00'), lateMinutes: 30 })
+
+      const c1 = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot in' })
+      expect(c1.status).toBe(201)
+      const id1 = requestIdOf(c1)
+
+      // 2nd makeup (different type, same workDate→same cycle) blocked by quota
+      const c2 = await createReq(tU, { requestType: 'time_correction', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'fix late' })
+      expect(c2.status).toBe(422)
+      expect(codeOf(c2)).toBe('MAKEUP_PUNCH_QUOTA_EXCEEDED')
+
+      // editing the SAME request must exclude self → not quota-blocked
+      const upd = await updateReq(tU, id1, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:01'), reason: 'forgot in (edited)' })
+      expect(upd.status).toBe(200)
+
+      // reject #1 → slot released → time_correction now allowed
+      const rj = await reject(adminToken, id1)
+      expect(rj.status).toBe(200)
+      const c3 = await createReq(tU, { requestType: 'time_correction', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'fix late' })
+      expect(c3.status).toBe(201)
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('quota counts by workDate-in-cycle: a request in a different cycle does not consume this cycle quota', async () => {
+    await setMakeup({ enabled: true, quota: { maxRequestsPerCycle: 1 }, submitWindow: { days: 180 } })
+    const u = uid('cycle')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wdNow = dayKey(0)
+    const wdOld = dayKey(-40) // always a prior calendar month → different cycle (startDay=1)
+    try {
+      await seedMissingCheckIn(u, wdNow)
+      await seedMissingCheckIn(u, wdOld)
+      const cOld = await createReq(tU, { requestType: 'missed_check_in', workDate: wdOld, requestedInAt: at(wdOld, '09:00'), reason: 'old' })
+      expect(cOld.status).toBe(201)
+      // current-cycle quota unaffected by the prior-cycle request
+      const cNow = await createReq(tU, { requestType: 'missed_check_in', workDate: wdNow, requestedInAt: at(wdNow, '09:00'), reason: 'now' })
+      expect(cNow.status).toBe(201)
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── window / future ────────────────────────────────────────────────────────────────────────────────
+  it('submitWindow.days=0: yesterday → WINDOW_EXPIRED; today → ok', async () => {
+    await setMakeup({ enabled: true, submitWindow: { days: 0 } })
+    const u = uid('win')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const today = dayKey(0)
+    const yest = dayKey(-1)
+    try {
+      await seedMissingCheckIn(u, today)
+      const expired = await createReq(tU, { requestType: 'missed_check_in', workDate: yest, requestedInAt: at(yest, '09:00'), reason: 'late' })
+      expect(expired.status).toBe(422)
+      expect(codeOf(expired)).toBe('MAKEUP_PUNCH_WINDOW_EXPIRED')
+      const ok = await createReq(tU, { requestType: 'missed_check_in', workDate: today, requestedInAt: at(today, '09:00'), reason: 'today' })
+      expect(ok.status).toBe(201)
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('future workDate → FUTURE_DATE_UNSUPPORTED (checked before window/type)', async () => {
+    await setMakeup({ enabled: true, submitWindow: { days: 180 } })
+    const u = uid('fut')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const tom = dayKey(1)
+    try {
+      const r = await createReq(tU, { requestType: 'missed_check_in', workDate: tom, requestedInAt: at(tom, '09:00'), reason: 'tomorrow' })
+      expect(r.status).toBe(422)
+      expect(codeOf(r)).toBe('MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED')
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── type gate ────────────────────────────────────────────────────────────────────────────────────
+  it('allowedAnomalyTypes=[missing_check_in]: late time_correction → TYPE_NOT_ALLOWED; genuine missing_check_in passes', async () => {
+    await setMakeup({ enabled: true, allowedAnomalyTypes: ['missing_check_in'] })
+    const uLate = uid('typeL')
+    const uMiss = uid('typeM')
+    const tLate = await mintToken(uLate, 'attendance:read,attendance:write')
+    const tMiss = await mintToken(uMiss, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedLate(uLate, wd)
+      const bad = await createReq(tLate, { requestType: 'time_correction', workDate: wd, requestedInAt: at(wd, '09:30'), reason: 'fix' })
+      expect(bad.status).toBe(422)
+      expect(codeOf(bad)).toBe('MAKEUP_PUNCH_TYPE_NOT_ALLOWED')
+
+      await seedMissingCheckIn(uMiss, wd)
+      const good = await createReq(tMiss, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot' })
+      expect(good.status).toBe(201)
+    } finally {
+      await cleanupUser(uLate)
+      await cleanupUser(uMiss)
+    }
+  })
+
+  it('unclassifiable record (no facts) + enabled → TYPE_NOT_ALLOWED fail-closed', async () => {
+    await setMakeup({ enabled: true })
+    const u = uid('failclosed')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      // a materialized whole-day 'absent' row yields NO makeup facts (absence routes to leave, not makeup)
+      await seedRecord(u, wd, { status: 'absent', firstIn: null, lastOut: null })
+      const r = await createReq(tU, { requestType: 'time_correction', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'whatever' })
+      expect(r.status).toBe(422)
+      expect(codeOf(r)).toBe('MAKEUP_PUNCH_TYPE_NOT_ALLOWED')
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── reason / attachment ───────────────────────────────────────────────────────────────────────────
+  it('requireReason=true + empty reason → REASON_REQUIRED; requireAttachment=true + no attachment → ATTACHMENT_REQUIRED', async () => {
+    const u = uid('reason')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await setMakeup({ enabled: true, requireReason: true, requireAttachment: false })
+      await seedMissingCheckIn(u, wd)
+      const noReason = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00') })
+      expect(noReason.status).toBe(422)
+      expect(codeOf(noReason)).toBe('MAKEUP_PUNCH_REASON_REQUIRED')
+
+      await setMakeup({ enabled: true, requireReason: false, requireAttachment: true })
+      const noAtt = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00') })
+      expect(noAtt.status).toBe(422)
+      expect(codeOf(noAtt)).toBe('MAKEUP_PUNCH_ATTACHMENT_REQUIRED')
+
+      const withAtt = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), attachmentUrl: 'https://example.com/proof.png' })
+      expect(withAtt.status).toBe(201)
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── cross-user PUT ────────────────────────────────────────────────────────────────────────────────
+  it('cross-user PUT on a makeup request: enabled → 422 CROSS_USER_FORBIDDEN; (disabled variant proven in keystone)', async () => {
+    await setMakeup({ enabled: true })
+    const u = uid('cross')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedMissingCheckIn(u, wd)
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot' })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+      const x = await updateReq(adminToken, id, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:02'), reason: 'admin edit' })
+      expect(x.status).toBe(422)
+      expect(codeOf(x)).toBe('MAKEUP_PUNCH_CROSS_USER_FORBIDDEN')
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── anomaly prefill cannot bypass the gate ───────────────────────────────────────────────────────
+  it('anomaly prefill goes through the same POST gate: a suggested type the policy disallows is still rejected', async () => {
+    await setMakeup({ enabled: true, allowedAnomalyTypes: ['missing_check_in'] })
+    const u = uid('prefill')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedLate(u, wd)
+      // anomalies route suggests time_correction for a late day...
+      const an = await anomalies(adminToken, u, wd, wd)
+      const items = (an.body as { data?: { items?: Array<{ suggestedRequestType?: string }> } } | undefined)?.data?.items ?? []
+      expect(items.some((it) => it.suggestedRequestType === 'time_correction')).toBe(true)
+      // ...but submitting that prefilled type is still rejected by the policy (suggestion ≠ authorization)
+      const r = await createReq(tU, { requestType: 'time_correction', workDate: wd, requestedInAt: at(wd, '09:30'), reason: 'prefilled' })
+      expect(r.status).toBe(422)
+      expect(codeOf(r)).toBe('MAKEUP_PUNCH_TYPE_NOT_ALLOWED')
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  // ── MP-3 approval audit ──────────────────────────────────────────────────────────────────────────
+  it('approve: status=adjusted, adjustment event meta carries snapshot summary incl matchedAnomalyTypes; request snapshot persisted', async () => {
+    await setMakeup({ enabled: true })
+    const u = uid('audit')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedMissingCheckIn(u, wd)
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot' })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+      const created = await reqRow(id)
+      const snap = created?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
+      expect(snap).toBeTruthy()
+      expect(snap?.version).toBe(1)
+      expect(snap?.matchedAnomalyTypes).toEqual(['missing_check_in'])
+
+      const ap = await approve(adminToken, id)
+      expect(ap.status).toBe(200)
+      expect(await recordStatus(u, wd)).toBe('adjusted')
+      const metas = await adjustmentMetas(u)
+      expect(metas).toHaveLength(1)
+      const evSnap = metas[0].makeupPolicySnapshot as Record<string, unknown> | undefined
+      expect(evSnap).toBeTruthy()
+      expect(evSnap?.matchedAnomalyTypes).toEqual(['missing_check_in'])
+      expect(evSnap?.version).toBe(1)
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('snapshot immutability: tighten policy after create, then approve → uses the PERSISTED snapshot, not the new policy', async () => {
+    await setMakeup({ enabled: true, allowedAnomalyTypes: ['missing_check_in'] })
+    const u = uid('immut')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedMissingCheckIn(u, wd)
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot' })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+
+      // tighten so a NEW missed_check_in would now be rejected (missing_check_in no longer allowed)
+      await setMakeup({ enabled: true, allowedAnomalyTypes: ['late'] })
+      const ap = await approve(adminToken, id)
+      expect(ap.status).toBe(200) // pending request approves via its persisted snapshot
+      expect(await recordStatus(u, wd)).toBe('adjusted')
+      const metas = await adjustmentMetas(u)
+      expect((metas[0].makeupPolicySnapshot as Record<string, unknown> | undefined)?.matchedAnomalyTypes).toEqual(['missing_check_in'])
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('grandfather: a pending row created while disabled (no snapshot) approves unchanged even after the policy is enabled', async () => {
+    await setMakeup({ enabled: false })
+    const u = uid('grand')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00') })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+      expect((await reqRow(id))?.metadata?.makeupPunchPolicySnapshot).toBeUndefined()
+
+      await setMakeup({ enabled: true, allowedAnomalyTypes: ['late'] }) // would reject a new missed_check_in
+      const ap = await approve(adminToken, id)
+      expect(ap.status).toBe(200)
+      expect(await recordStatus(u, wd)).toBe('adjusted')
+      const metas = await adjustmentMetas(u)
+      expect(metas).toHaveLength(1)
+      expect(metas[0].makeupPolicySnapshot).toBeUndefined() // legacy path, byte-identical
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('snapshot freshness on PUT: editing a makeup request recomputes the snapshot and preserves attachmentUrl', async () => {
+    await setMakeup({ enabled: true })
+    const u = uid('fresh')
+    const tU = await mintToken(u, 'attendance:read,attendance:write')
+    const wd = dayKey(0)
+    try {
+      await seedMissingCheckIn(u, wd)
+      const c = await createReq(tU, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:00'), reason: 'forgot', attachmentUrl: 'https://example.com/a.png' })
+      expect(c.status).toBe(201)
+      const id = requestIdOf(c)
+      const before = await reqRow(id)
+      const snapBefore = before?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
+      expect(snapBefore?.version).toBe(1)
+      expect(before?.metadata?.attachmentUrl).toBe('https://example.com/a.png')
+
+      // edit reason only; do not resend attachmentUrl → sibling must be preserved, snapshot recomputed fresh
+      const e = await updateReq(tU, id, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:01'), reason: 'forgot (edited)' })
+      expect(e.status).toBe(200)
+      const after = await reqRow(id)
+      const snapAfter = after?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
+      expect(snapAfter?.version).toBe(1)
+      expect(snapAfter?.matchedAnomalyTypes).toEqual(['missing_check_in'])
+      expect(after?.metadata?.attachmentUrl).toBe('https://example.com/a.png') // not silently dropped
+    } finally {
+      await cleanupUser(u)
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
+++ b/packages/core-backend/tests/integration/attendance-makeup-punch-policy.test.ts
@@ -530,8 +530,12 @@ describeDb('补卡规则 MP-2/MP-3 makeup punch policy (real DB, route-level)', 
       const before = await reqRow(id)
       const snapBefore = before?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
       expect(snapBefore?.version).toBe(1)
+      expect((snapBefore?.quota as Record<string, unknown> | undefined)?.maxRequestsPerCycle).toBe(3) // base cap at create time
       expect(before?.metadata?.attachmentUrl).toBe('https://example.com/a.png')
 
+      // CHANGE a snapshot-visible field between create and edit so the snapshot must visibly differ if it
+      // is recomputed — a stale-inherit bug (carrying the create-time snapshot) would leave cap=3 and fail.
+      await setMakeup({ enabled: true, quota: { maxRequestsPerCycle: 7 } })
       // edit reason only; do not resend attachmentUrl → sibling must be preserved, snapshot recomputed fresh
       const e = await updateReq(tU, id, { requestType: 'missed_check_in', workDate: wd, requestedInAt: at(wd, '09:01'), reason: 'forgot (edited)' })
       expect(e.status).toBe(200)
@@ -539,6 +543,7 @@ describeDb('补卡规则 MP-2/MP-3 makeup punch policy (real DB, route-level)', 
       const snapAfter = after?.metadata?.makeupPunchPolicySnapshot as Record<string, unknown> | undefined
       expect(snapAfter?.version).toBe(1)
       expect(snapAfter?.matchedAnomalyTypes).toEqual(['missing_check_in'])
+      expect((snapAfter?.quota as Record<string, unknown> | undefined)?.maxRequestsPerCycle).toBe(7) // proves recompute, not stale-inherit
       expect(after?.metadata?.attachmentUrl).toBe('https://example.com/a.png') // not silently dropped
     } finally {
       await cleanupUser(u)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -12706,6 +12706,190 @@ function normalizeMakeupPunchPolicySetting(raw) {
   }
 }
 
+// 补卡规则 MP-2 §4.4: static request-type → allowed anomaly-fact table. This is the FIRST of three
+// intersected allow-lists (static table ∩ org policy.allowedAnomalyTypes ∩ server-derived facts). A
+// `late_early` record matches both `late` and `early_leave`; `severe_late`/`absence_late` are RT-1a tiers.
+const MAKEUP_REQUEST_TYPE_ANOMALY_TABLE = Object.freeze({
+  missed_check_in: Object.freeze(['missing_check_in']),
+  missed_check_out: Object.freeze(['missing_check_out']),
+  time_correction: Object.freeze(['late', 'severe_late', 'absence_late', 'early_leave', 'normal']),
+})
+
+// 补卡规则 MP-2 §4.4: derive the anomaly facts for a (org,user,workDate) from SERVER-SIDE TRUTH —
+// attendance_records.status / missing-side / late+early minutes / RT-1a tier meta — never from client
+// anomaly prefill. Returns an ARRAY of fact tokens (a record can match several, e.g. late_early). This
+// is intentionally a plain read (no FOR UPDATE): it observes truth, it does not mutate the record, so it
+// must not contend with the concurrent punch/approval write paths. Shared by the MP-2 type gate and the
+// MP-3 snapshot.matchedAnomalyTypes. Fail-closed: an unresolvable / fact-less day yields [].
+async function deriveMakeupAnomalyFacts(trx, { orgId, userId, workDate }) {
+  const facts = new Set()
+  const rows = await trx.query(
+    `SELECT status, first_in_at, last_out_at, late_minutes, early_leave_minutes, is_workday, meta
+     FROM attendance_records
+     WHERE org_id = $1 AND user_id = $2 AND work_date = $3
+     LIMIT 1`,
+    [orgId, userId, workDate]
+  )
+  const record = rows[0] ?? null
+  if (record) {
+    const status = record.status ? String(record.status) : ''
+    const lateMinutes = Number(record.late_minutes ?? 0)
+    const earlyLeaveMinutes = Number(record.early_leave_minutes ?? 0)
+    const severeLateCount = Number(readAttendanceRecordMeta(record, ['severe_late_count', 'severeLateCount']) ?? 0)
+    const absenceLateCount = Number(readAttendanceRecordMeta(record, ['absence_late_count', 'absenceLateCount']) ?? 0)
+    // 'partial' = exactly one side punched → the absent side is a genuine missing-punch makeup candidate.
+    // 'absent' (a materialized zero-punch row) is NOT makeup-able here: §4.4 routes whole-day absence to
+    // leave, so it must fail-closed rather than be auto-corrected by a missed-check request.
+    if (status === 'partial') {
+      if (!record.first_in_at) facts.add('missing_check_in')
+      if (!record.last_out_at) facts.add('missing_check_out')
+    }
+    if (status === 'late' || status === 'late_early' || lateMinutes > 0) facts.add('late')
+    if (status === 'early_leave' || status === 'late_early' || earlyLeaveMinutes > 0) facts.add('early_leave')
+    if (severeLateCount > 0) facts.add('severe_late')
+    if (absenceLateCount > 0) facts.add('absence_late')
+    if (status === 'normal') facts.add('normal')
+  } else {
+    // No record at all but the day should be attended → both sides missing (§4.4 "记录不存在但当日应出勤
+    // 且缺某侧打卡，可判为 missing"). Resolve the workday truth; if it cannot be resolved, fail-closed (no
+    // facts) so an undeterminable day is never auto-correctable.
+    try {
+      const context = await resolveWorkContext({ db: trx, orgId, userId, workDate })
+      if (context && context.isWorkingDay) {
+        facts.add('missing_check_in')
+        facts.add('missing_check_out')
+      }
+    } catch (_error) {
+      // fail-closed: leave facts empty
+    }
+  }
+  return [...facts]
+}
+
+// 补卡规则 MP-2 §4.2: compute the calendar_month quota cycle [cycleStart, cycleEnd] (inclusive, local
+// YYYY-MM-DD) that the WORK DATE falls into — anchored on workDate in policy timezone, NOT submit time.
+// startDay 1..31 is clamped to the month's last day on short months (Q3 ratified), so a startDay=31 policy
+// yields Jan 31..Feb 27, Feb 28..Mar 30, etc. Each date maps to exactly one cycle.
+function computeMakeupCycleWindow(policy, workDateLocal) {
+  const normalized = normalizeDateOnly(workDateLocal) ?? String(workDateLocal ?? '').slice(0, 10)
+  const startDay = Number(policy?.cycle?.startDay) || 1
+  const [yStr, mStr, dStr] = String(normalized).split('-')
+  const year = Number(yStr)
+  const month0 = Number(mStr) - 1
+  const day = Number(dStr)
+  const startThisMonth = Math.min(startDay, daysInMonthUtc(year, month0))
+  let startYear = year
+  let startMonth0 = month0
+  if (day < startThisMonth) {
+    if (month0 === 0) { startYear = year - 1; startMonth0 = 11 } else { startYear = year; startMonth0 = month0 - 1 }
+  }
+  const cycleStart = formatDateOnly(buildUtcDate(startYear, startMonth0, startDay))
+  let nextYear = startYear
+  let nextMonth0 = startMonth0 + 1
+  if (nextMonth0 > 11) { nextMonth0 = 0; nextYear += 1 }
+  const nextStart = buildUtcDate(nextYear, nextMonth0, startDay)
+  const cycleEnd = formatDateOnly(new Date(nextStart.getTime() - 86400000))
+  return { cycleStart, cycleEnd }
+}
+
+// 补卡规则 MP-3 §5: build the per-write policy snapshot persisted on the request metadata. Recomputed
+// fresh on every successful create/update; final approval audits THIS snapshot, never the current policy.
+function buildMakeupPunchPolicySnapshot(policy, { matchedAnomalyTypes, requestEvaluatedAt }) {
+  return {
+    version: 1,
+    enabled: policy.enabled === true,
+    timezone: policy.timezone,
+    cycle: { type: policy.cycle.type, startDay: policy.cycle.startDay },
+    quota: {
+      maxRequestsPerCycle: policy.quota.maxRequestsPerCycle,
+      countStatuses: [...policy.quota.countStatuses],
+      principal: policy.quota.principal,
+    },
+    submitWindow: { unit: policy.submitWindow.unit, days: policy.submitWindow.days },
+    allowedAnomalyTypes: [...policy.allowedAnomalyTypes],
+    requestEvaluatedAt: requestEvaluatedAt.toISOString(),
+    matchedAnomalyTypes: [...matchedAnomalyTypes],
+  }
+}
+
+// 补卡规则 MP-2: the single create/update enforcement gate. Throws HttpError(422, MAKEUP_PUNCH_*) on the
+// first violation, else returns { matchedAnomalyTypes, requestEvaluatedAt } for the MP-3 snapshot (so the
+// type facts are derived exactly once). MUST run INSIDE the request transaction, after
+// acquireAttendanceRequestLock, alongside the duplicate guard — quota counting + the eventual insert must
+// be consistent with the per-(org,user,workDate,requestType) lock. Only ever called when policy.enabled
+// and draft.requestType is one of the three makeup types.
+// Order is load-bearing: future-date FIRST (a future workDate is not `< earliestAllowed`, so the window
+// check cannot catch it), then window, then type (fail-closed), then reason/attachment, then quota.
+// Quota TOCTOU (accepted slack, documented — NOT mitigated with a cycle lock): the advisory lock is keyed
+// on (org,user,workDate,requestType); the quota counts across the whole cycle. Two concurrent creates for
+// DIFFERENT workDates in the same cycle take different locks and can both pass the count, so the cycle cap
+// can be exceeded by the number of racing distinct-workDate submissions. This is bounded and acceptable
+// for v1; the duplicate guard (same workDate) is still strictly serialized by the lock.
+async function enforceMakeupPunchPolicy(trx, { policy, orgId, subjectUserId, requesterId, requestId, draft }) {
+  void requesterId
+  const requestEvaluatedAt = new Date()
+  const timezone = policy.timezone
+  const workDate = draft.workDate
+  const todayLocal = toWorkDate(requestEvaluatedAt, timezone)
+
+  // §4.3 future date: workDate must not be after today (policy-tz local).
+  if (workDate > todayLocal) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_FUTURE_DATE_UNSUPPORTED', 'Makeup punch cannot target a future work date')
+  }
+
+  // §4.3 submit window: todayLocal - workDate <= submitWindow.days (calendar_day). days=0 → today only.
+  const earliestAllowed = addDaysToDateKey(todayLocal, -Number(policy.submitWindow.days || 0))
+  if (earliestAllowed && workDate < earliestAllowed) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_WINDOW_EXPIRED', 'Makeup punch submit window has expired for this work date')
+  }
+
+  // §4.4 type gate (fail-closed): static table ∩ org allowedAnomalyTypes ∩ server-derived facts.
+  const facts = await deriveMakeupAnomalyFacts(trx, { orgId, userId: subjectUserId, workDate })
+  const staticAllowed = MAKEUP_REQUEST_TYPE_ANOMALY_TABLE[draft.requestType] || []
+  const orgAllowed = new Set(Array.isArray(policy.allowedAnomalyTypes) ? policy.allowedAnomalyTypes : [])
+  const factSet = new Set(facts)
+  const matchedAnomalyTypes = staticAllowed.filter((type) => orgAllowed.has(type) && factSet.has(type))
+  if (matchedAnomalyTypes.length === 0) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_TYPE_NOT_ALLOWED', 'This work date has no makeup-eligible anomaly for the requested type')
+  }
+
+  // §4.5 reason / attachment.
+  if (policy.requireReason === true && !draft.reason) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_REASON_REQUIRED', 'A reason is required for this makeup punch request')
+  }
+  if (policy.requireAttachment === true && !(draft.metadata && draft.metadata.attachmentUrl)) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_ATTACHMENT_REQUIRED', 'An attachment is required for this makeup punch request')
+  }
+
+  // §4.2 quota: count subject's pending+approved makeup requests whose workDate falls in the cycle. On
+  // update, exclude the current request id. Subject = attendance_requests.user_id, never the actor.
+  const { cycleStart, cycleEnd } = computeMakeupCycleWindow(policy, workDate)
+  const params = [orgId, subjectUserId, MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES, policy.quota.countStatuses, cycleStart, cycleEnd]
+  let excludeClause = ''
+  if (requestId) {
+    params.push(requestId)
+    excludeClause = `AND id <> $${params.length}`
+  }
+  const quotaRows = await trx.query(
+    `SELECT COUNT(*)::int AS total
+     FROM attendance_requests
+     WHERE org_id = $1
+       AND user_id = $2
+       AND request_type = ANY($3)
+       AND status = ANY($4)
+       AND work_date >= $5
+       AND work_date <= $6
+       ${excludeClause}`,
+    params
+  )
+  const used = Number(quotaRows[0]?.total ?? 0)
+  if (used >= Number(policy.quota.maxRequestsPerCycle)) {
+    throw new HttpError(422, 'MAKEUP_PUNCH_QUOTA_EXCEEDED', 'Makeup punch quota for this cycle has been reached')
+  }
+
+  return { matchedAnomalyTypes, requestEvaluatedAt }
+}
+
 function normalizeOvertimeSegmentationSetting(raw) {
   const config = raw && typeof raw === 'object' ? raw : {}
   return {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -25984,6 +25984,17 @@ module.exports = {
           throw error
         }
 
+        // 补卡规则 MP-2/MP-3: only the three makeup request types read this policy. Gating the settings
+        // read behind the cheap request-type check keeps leave/overtime/etc byte-identical (zero new
+        // queries) when makeupPunchPolicy is disabled. Enforcement itself runs inside the txn below.
+        let makeupPunchPolicy = null
+        if (MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES.includes(draft.requestType)) {
+          const settings = await getSettings(db)
+          if (settings?.makeupPunchPolicy?.enabled === true) {
+            makeupPunchPolicy = settings.makeupPunchPolicy
+          }
+        }
+
         const requestId = randomUUID()
         const approvalId = `apv_${randomUUID()}`
         const approvalPayload = buildAttendanceApprovalInstancePayload({
@@ -26007,6 +26018,21 @@ module.exports = {
             })
             if (duplicateRequest) {
               throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
+            }
+            // 补卡规则 MP-2/MP-3: enforce inside the txn, after the lock + duplicate guard, so the quota
+            // count and the insert below are consistent with the per-(org,user,workDate,requestType) lock.
+            // On success, persist a FRESH per-write policy snapshot onto the request metadata that the
+            // final approval will audit (never re-reading the live policy).
+            if (makeupPunchPolicy) {
+              const enforcement = await enforceMakeupPunchPolicy(trx, {
+                policy: makeupPunchPolicy,
+                orgId,
+                subjectUserId: userId,
+                requesterId: userId,
+                requestId: null,
+                draft,
+              })
+              draft.metadata.makeupPunchPolicySnapshot = buildMakeupPunchPolicySnapshot(makeupPunchPolicy, enforcement)
             }
             await upsertAttendanceApprovalInstance(trx, approvalPayload)
             await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
@@ -27159,6 +27185,29 @@ module.exports = {
             }
 
             const draft = await resolveAttendanceRequestDraft(parsed.data, existingRequest)
+
+            // 补卡规则 MP-2/MP-3: only read the policy when a makeup type is involved (existing OR edited
+            // type), so non-makeup edits stay byte-identical. When enabled, cross-user editing of a makeup
+            // request is fail-closed (Q6: cannot yet audit the real submitter). Enabled-gated so disabled
+            // customers keep the current canAccessOtherUsers cross-user edit behavior.
+            const makeupTypeInvolved =
+              MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES.includes(draft.requestType) ||
+              MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES.includes(existingRequest.request_type)
+            let makeupPunchPolicy = null
+            if (makeupTypeInvolved) {
+              const settings = await getSettings(db)
+              if (settings?.makeupPunchPolicy?.enabled === true) {
+                makeupPunchPolicy = settings.makeupPunchPolicy
+                if (existingRequest.user_id !== requesterId) {
+                  throw new HttpError(
+                    422,
+                    'MAKEUP_PUNCH_CROSS_USER_FORBIDDEN',
+                    'Cross-user editing of makeup punch requests is not allowed while the makeup policy is enabled'
+                  )
+                }
+              }
+            }
+
             await acquireAttendanceRequestLock(trx, existingRequest.org_id, existingRequest.user_id, draft.workDate, draft.requestType)
             const duplicateRows = await trx.query(
               `SELECT id
@@ -27174,6 +27223,23 @@ module.exports = {
             )
             if (duplicateRows.length > 0) {
               throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
+            }
+
+            // 补卡规则 MP-2/MP-3: enforce on the EDITED makeup type, inside the txn after the lock +
+            // duplicate guard, excluding the current request id from the quota count. Recompute a FRESH
+            // snapshot every successful update — resolveAttendanceRequestDraft rebuilds metadata from
+            // scratch (it never copies makeupPunchPolicySnapshot), so the stale snapshot is dropped and
+            // the metadata siblings (attachmentUrl/approvalFlow) are preserved.
+            if (makeupPunchPolicy && MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES.includes(draft.requestType)) {
+              const enforcement = await enforceMakeupPunchPolicy(trx, {
+                policy: makeupPunchPolicy,
+                orgId: existingRequest.org_id ?? DEFAULT_ORG_ID,
+                subjectUserId: existingRequest.user_id,
+                requesterId,
+                requestId,
+                draft,
+              })
+              draft.metadata.makeupPunchPolicySnapshot = buildMakeupPunchPolicySnapshot(makeupPunchPolicy, enforcement)
             }
 
             const approvalId = existingRequest.approval_instance_id || `apv_${randomUUID()}`
@@ -27740,6 +27806,32 @@ module.exports = {
                 overtimeRule: requestMetadata.overtimeRule ?? null,
                 requested_in_at: requestRow.requested_in_at,
                 requested_out_at: requestRow.requested_out_at,
+              }
+              // 补卡规则 MP-3 §5: for the three makeup types, append a SUMMARY of the PERSISTED policy
+              // snapshot (incl matchedAnomalyTypes) to the adjustment audit event. Gated on snapshot
+              // PRESENCE, never the live policy — so legacy/disabled-created pending rows carry no snapshot
+              // and grandfather through this exact same path with byte-identical event meta, and a later
+              // policy change cannot retro-rewrite an already-pending request's audit evidence.
+              const persistedMakeupSnapshot =
+                MAKEUP_PUNCH_ALLOWED_REQUEST_TYPES.includes(requestType) &&
+                requestMetadata.makeupPunchPolicySnapshot &&
+                typeof requestMetadata.makeupPunchPolicySnapshot === 'object'
+                  ? requestMetadata.makeupPunchPolicySnapshot
+                  : null
+              if (persistedMakeupSnapshot) {
+                eventMeta.makeupPolicySnapshot = {
+                  version: persistedMakeupSnapshot.version ?? null,
+                  enabled: persistedMakeupSnapshot.enabled ?? null,
+                  cycle: persistedMakeupSnapshot.cycle ?? null,
+                  quota: persistedMakeupSnapshot.quota
+                    ? { maxRequestsPerCycle: persistedMakeupSnapshot.quota.maxRequestsPerCycle ?? null }
+                    : null,
+                  submitWindow: persistedMakeupSnapshot.submitWindow ?? null,
+                  matchedAnomalyTypes: Array.isArray(persistedMakeupSnapshot.matchedAnomalyTypes)
+                    ? [...persistedMakeupSnapshot.matchedAnomalyTypes]
+                    : [],
+                  requestEvaluatedAt: persistedMakeupSnapshot.requestEvaluatedAt ?? null,
+                }
               }
 
               await trx.query(


### PR DESCRIPTION
MP-2/MP-3 of the makeup-punch (补卡) line: enforce the ratified `makeupPunchPolicy` (quota/window/type/future/reason/attachment + cross-user-PUT fail-closed) on the existing request create/edit path, and persist a per-write policy snapshot that final approval audits.

**#1 lock — disabled = byte-identical:** all enforcement is gated behind `policy.enabled===true` AND a makeup request type; non-makeup types add zero queries; the cross-user block and approval-audit append are enabled-/snapshot-gated. Adversarial review traced all six disabled paths byte-for-byte — holds. **Env/policy default OFF.**

Locks (all PASS in review): quota counts the **subject** (not actor) in the workDate cycle window (excludes self on update); check order future→window→type→reason→attachment→quota; type-gate fail-closed (static §4.4 ∩ org allow-list ∩ **server-derived** facts; unclassifiable→422); cross-user PUT enabled→422; snapshot recomputed fresh per write (proven by a discriminating tighten-then-edit test); approval reads the **persisted** snapshot only (grandfathers no-snapshot rows); enforcement inside the txn after the request lock. Six policy codes + cross-user, all **422**.

14 real-DB tests (keystone = disabled-byte-identical asserting the negatives); the new file was added to `plugin-tests.yml`'s explicit list so `test (20.x)` actually runs it.

Tracked fast-follow test gaps (fail-closed-leaning, off-by-default): the no-record fact path, `missing_check_out`/`late_early`, severe/absence tier facts. Quota TOCTOU = ratified accepted-slack (per-lock vs cycle-spanning count), documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)