### PR TITLE
feat(attendance): AE-1 audited anomaly-result-edit route + immutable audit table (admin-gated)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -406,6 +406,7 @@ jobs:
             tests/integration/attendance-shift-swap.test.ts \
             tests/integration/attendance-schedule-dispatch.test.ts \
             tests/integration/attendance-makeup-punch-policy.test.ts \
+            tests/integration/attendance-result-edit.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/packages/core-backend/src/db/migrations/zzzz20260627120000_create_attendance_record_result_edits.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260627120000_create_attendance_record_result_edits.ts
@@ -1,0 +1,65 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const TABLE = 'attendance_record_result_edits'
+
+// AE-1 (design-lock attendance-anomaly-result-edit-guard-design-lock-20260626 §4.1, RATIFIED 2026-06-27).
+// The IMMUTABLE before/after audit row for a manual "correct a confirmed attendance anomaly result" action.
+// Every edit writes exactly one row here keyed by the client-supplied idempotencyKey; the record update goes
+// through applyAttendanceResultEdit (statusOverride + §3.5a normalized overrideMetrics — never a naked status
+// UPDATE), and this row is the who/why/when + before/after fact the attendance_records row itself cannot carry.
+//
+// Immutability discipline:
+//   - NO FK on record_id: a deleted/re-keyed attendance_records row must NEVER cascade-delete its correction
+//     audit (the audit outlives the record it corrects). record_id is a soft reference; the (org_id, record_id)
+//     index serves history lookups.
+//   - idempotency_key is NOT NULL + UNIQUE(org_id, idempotency_key): same key+same payload replays to
+//     alreadyApplied (no second write); same key+different payload → 409. NOT NULL avoids Postgres'
+//     nullable-unique bypass (NULLs compare non-equal), so the idempotency key can never be NULL-evaded.
+//   - before_snapshot / after_snapshot are NOT NULL jsonb: every edit persists the full before/after record
+//     fact regardless of policy (reason is also always written, even when requireReason is later disabled).
+//
+// notification_delivery_id / notification_skipped_reason are added NOW but stay NULL: AE-1 builds NO notifier.
+// AE-2's C5 producer fills exactly one of them (delivery id on enqueue, skipped reason on policy_disabled /
+// recipient_not_active) without needing a follow-up migration.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, TABLE)
+  if (!exists) {
+    await db.schema
+      .createTable(TABLE)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('record_id', 'uuid', col => col.notNull())
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('work_date', 'date', col => col.notNull())
+      .addColumn('before_status', 'text', col => col.notNull())
+      .addColumn('after_status', 'text', col => col.notNull())
+      .addColumn('before_snapshot', 'jsonb', col => col.notNull())
+      .addColumn('after_snapshot', 'jsonb', col => col.notNull())
+      .addColumn('reason', 'text', col => col.notNull())
+      .addColumn('evidence', 'jsonb', col => col.notNull().defaultTo(sql`'[]'::jsonb`))
+      .addColumn('actor_user_id', 'text', col => col.notNull())
+      // idempotency_key is the client-supplied key; the route NEVER generates one. NOT NULL so the
+      // UNIQUE(org_id, idempotency_key) below cannot be NULL-bypassed.
+      .addColumn('idempotency_key', 'text', col => col.notNull())
+      // AE-2 fills exactly one of these; AE-1 leaves both NULL (no notifier built).
+      .addColumn('notification_delivery_id', 'uuid')
+      .addColumn('notification_skipped_reason', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .execute()
+  }
+
+  // Idempotency backstop: same (org_id, idempotency_key) → unique violation → compare-then-409 / alreadyApplied.
+  await createIndexIfNotExists(db, 'uq_attendance_record_result_edits_org_idempotency_key', TABLE, ['org_id', 'idempotency_key'], { unique: true })
+  // History lookups by record (record drawer / future AE-3 surfaces).
+  await createIndexIfNotExists(db, 'idx_attendance_record_result_edits_org_record', TABLE, ['org_id', 'record_id'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).ifExists().execute()
+}

--- a/packages/core-backend/tests/integration/attendance-result-edit.test.ts
+++ b/packages/core-backend/tests/integration/attendance-result-edit.test.ts
@@ -61,7 +61,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   let baseUrl = ''
   let pool: Pool
   let adminToken = ''
-  let tableReady = false
 
   const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' })
 
@@ -148,16 +147,17 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     pool = new Pool({ connectionString: dbUrl })
     adminToken = await mintToken(`ae1-admin-${RUN}`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
 
-    // Visible skip (not false green) if the AE-1 migration is not applied in this env.
+    // This is a LIVE feature, not a dormant table: when a DB is present the AE-1 migration MUST have run.
+    // A missing table here means the migration regressed — fail LOUD (RED), never a silent skip / false green.
     const cols = (await pool.query(
       `SELECT column_name FROM information_schema.columns WHERE table_name = 'attendance_record_result_edits'`,
     )).rows as { column_name: string }[]
-    tableReady = cols.length > 0
-    if (tableReady) {
-      const names = new Set(cols.map((c) => c.column_name))
-      for (const c of ['org_id', 'record_id', 'before_status', 'after_status', 'before_snapshot', 'after_snapshot', 'reason', 'evidence', 'idempotency_key', 'notification_delivery_id', 'notification_skipped_reason']) {
-        expect(names.has(c)).toBe(true)
-      }
+    if (cols.length === 0) {
+      throw new Error('attendance_record_result_edits is missing — the AE-1 migration was not applied (regression)')
+    }
+    const names = new Set(cols.map((c) => c.column_name))
+    for (const c of ['org_id', 'record_id', 'before_status', 'after_status', 'before_snapshot', 'after_snapshot', 'reason', 'evidence', 'idempotency_key', 'notification_delivery_id', 'notification_skipped_reason']) {
+      expect(names.has(c)).toBe(true)
     }
   })
 
@@ -171,10 +171,7 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
     await pool?.end().catch(() => undefined)
   })
 
-  const skipIfNoTable = () => { if (!tableReady) return true; return false }
-
   it('§3.5a late→normal: zeroes late/early, preserves work_minutes, recomputes meta tiers; writes audit before/after', async () => {
-    if (skipIfNoTable()) return
     const userId = `u-late-${RUN}`
     const workDate = ymd(2)
     const recordId = await seedRecord({
@@ -212,7 +209,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('§3.5a absent→normal: keeps work_minutes=0 + null punches by default; overrideMetrics.workMinutes takes precedence', async () => {
-    if (skipIfNoTable()) return
     // default: no override → work stays 0, no fabricated punches
     const u1 = `u-abs-${RUN}`
     const wd1 = ymd(3)
@@ -237,7 +233,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('idempotency: missing key → 400 nothing written; same key+payload → alreadyApplied (one row); different payload → 409', async () => {
-    if (skipIfNoTable()) return
     const userId = `u-idem-${RUN}`
     const workDate = ymd(2)
     const recordId = await seedRecord({ userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 20, firstInAt: `${workDate}T01:20:00Z`, lastOutAt: `${workDate}T10:00:00Z` })
@@ -267,7 +262,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('editable-source: off/adjusted → 422 SOURCE_NOT_EDITABLE; normal→abnormal → 422 NORMAL_TO_ABNORMAL_UNSUPPORTED; normal→normal → 422 SOURCE_NOT_EDITABLE', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(2)
     const off = await seedRecord({ userId: `u-off-${RUN}`, workDate: wd, status: 'off', isWorkday: false })
     const ro = await postEdit({ orgId: ORG, recordId: off, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-off-${RUN}` })
@@ -295,7 +289,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('closed/archived cycle covering work_date → 409 CYCLE_CLOSED even with no settlement row; closed wins over an overlapping open cycle', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(2)
     const cycleClosed = await seedClosedCycle(wd, 'closed')
     try {
@@ -335,7 +328,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('edit-window: work_date older than editWindowDays (default 180) → 422 WINDOW_EXPIRED, nothing written', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(400)
     const recordId = await seedRecord({ userId: `u-win-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
     const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'too old', idempotencyKey: `k-win-${RUN}` })
@@ -345,7 +337,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('cross-org: a record from another org → 404, no audit row, no cross-org leak', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(2)
     const otherRecord = await seedRecord({ userId: `u-x-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, org: ORG_OTHER, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
     const key = `k-xorg-${RUN}`
@@ -358,7 +349,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('reason: blank reason → 400 when policy.requireReason (default true), nothing written', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(2)
     const recordId = await seedRecord({ userId: `u-reason-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
     const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: '   ', idempotencyKey: `k-reason-${RUN}` })
@@ -368,7 +358,6 @@ describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
   })
 
   it('evidence: raw http URL rejected; https + attachmentId accepted and persisted', async () => {
-    if (skipIfNoTable()) return
     const wd = ymd(2)
     const recordId = await seedRecord({ userId: `u-ev-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
 

--- a/packages/core-backend/tests/integration/attendance-result-edit.test.ts
+++ b/packages/core-backend/tests/integration/attendance-result-edit.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { MetaSheetServer } from '../../src/index'
+import * as path from 'path'
+import net from 'net'
+import http from 'http'
+import { randomUUID } from 'crypto'
+import { Pool } from 'pg'
+
+// AE-1 — audited admin correction of a confirmed attendance anomaly result (design-lock
+// attendance-anomaly-result-edit-guard-design-lock-20260626, RATIFIED 2026-06-27). Route-level real-DB tests
+// driving POST /api/attendance/anomaly-result-edits against a migrated postgres: the §8 invariant matrix
+// (idempotency / editable-source / closed-cycle / edit-window / cross-org) plus the §3.5a metric-normalization
+// outcomes, asserted through attendance_records + the immutable attendance_record_result_edits audit table.
+
+type HttpResponse = { status: number; body?: unknown; raw: string }
+
+function requestJson(url: string, options: { method?: string; headers?: Record<string, string>; body?: string } = {}): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = http.request(
+      {
+        method: options.method || 'GET',
+        hostname: target.hostname,
+        port: target.port,
+        path: `${target.pathname}${target.search}`,
+        headers: options.headers,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => {
+          let body: unknown
+          try { body = data ? JSON.parse(data) : undefined } catch { body = undefined }
+          resolve({ status: res.statusCode || 0, body, raw: data })
+        })
+      },
+    )
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+const RUN = Date.now().toString(36)
+const ORG = `ae1-${RUN}`          // dedicated org → isolates seeded payroll cycles + records
+const ORG_OTHER = `ae1-other-${RUN}`
+
+function ymd(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 86400000).toISOString().slice(0, 10)
+}
+
+type ErrBody = { ok?: boolean; error?: { code?: string; message?: string }; data?: unknown }
+const codeOf = (r: HttpResponse) => (r.body as ErrBody | undefined)?.error?.code
+const dataOf = (r: HttpResponse) => (r.body as { data?: any } | undefined)?.data
+
+describeDb('AE-1 attendance anomaly result edit (real DB, route-level)', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  let pool: Pool
+  let adminToken = ''
+  let tableReady = false
+
+  const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' })
+
+  async function mintToken(userId: string, perms: string): Promise<string> {
+    const res = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent(perms)}`)
+    return (res.body as { token?: string } | undefined)?.token ?? ''
+  }
+
+  const postEdit = (body: Record<string, unknown>, token = adminToken) =>
+    requestJson(`${baseUrl}/api/attendance/anomaly-result-edits`, { method: 'POST', headers: authHeaders(token), body: JSON.stringify(body) })
+
+  async function seedRecord(input: {
+    userId: string
+    workDate: string
+    status: string
+    workMinutes?: number
+    lateMinutes?: number
+    earlyLeaveMinutes?: number
+    firstInAt?: string | null
+    lastOutAt?: string | null
+    isWorkday?: boolean
+    meta?: Record<string, unknown>
+    org?: string
+  }): Promise<string> {
+    const id = randomUUID()
+    await pool.query(
+      `INSERT INTO attendance_records
+       (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'Asia/Shanghai', $5, $6, $7, $8, $9, $10, $11, $12::jsonb, NULL, now(), now())`,
+      [
+        id,
+        input.userId,
+        input.org ?? ORG,
+        input.workDate,
+        input.firstInAt ?? null,
+        input.lastOutAt ?? null,
+        input.workMinutes ?? 0,
+        input.lateMinutes ?? 0,
+        input.earlyLeaveMinutes ?? 0,
+        input.status,
+        input.isWorkday ?? true,
+        JSON.stringify(input.meta ?? {}),
+      ],
+    )
+    return id
+  }
+
+  async function recordById(id: string) {
+    return (await pool.query(`SELECT * FROM attendance_records WHERE id = $1`, [id])).rows[0] ?? null
+  }
+  async function auditRowsForRecord(recordId: string) {
+    return (await pool.query(`SELECT * FROM attendance_record_result_edits WHERE record_id = $1 ORDER BY created_at ASC`, [recordId])).rows as any[]
+  }
+  async function auditByKey(orgId: string, key: string) {
+    return (await pool.query(`SELECT * FROM attendance_record_result_edits WHERE org_id = $1 AND idempotency_key = $2`, [orgId, key])).rows as any[]
+  }
+  async function seedClosedCycle(workDate: string, status: 'closed' | 'archived', org = ORG): Promise<string> {
+    const start = new Date(new Date(`${workDate}T00:00:00Z`).getTime() - 5 * 86400000).toISOString().slice(0, 10)
+    const end = new Date(new Date(`${workDate}T00:00:00Z`).getTime() + 5 * 86400000).toISOString().slice(0, 10)
+    return (await pool.query(
+      `INSERT INTO attendance_payroll_cycles (org_id, start_date, end_date, status) VALUES ($1, $2, $3, $4) RETURNING id`,
+      [org, start, end, status],
+    )).rows[0].id as string
+  }
+
+  beforeAll(async () => {
+    const canListen: boolean = await new Promise((resolve) => {
+      const s = net.createServer()
+      s.once('error', () => resolve(false))
+      s.listen(0, '127.0.0.1', () => s.close(() => resolve(true)))
+    })
+    if (!canListen || !dbUrl) throw new Error('AE-1 integration needs a loopback port + DATABASE_URL')
+
+    process.env.DATABASE_URL = dbUrl
+    process.env.RBAC_BYPASS = 'true'
+    process.env.SKIP_PLUGINS = 'false'
+    const repoRoot = path.join(__dirname, '../../../../')
+    const { MetaSheetServer } = await import('../../src/index')
+    server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [path.join(repoRoot, 'plugins', 'plugin-attendance')] })
+    await server.start()
+    const address = server.getAddress()
+    if (!address || typeof address === 'string') throw new Error('server did not expose a TCP address')
+    baseUrl = `http://127.0.0.1:${address.port}`
+    pool = new Pool({ connectionString: dbUrl })
+    adminToken = await mintToken(`ae1-admin-${RUN}`, 'attendance:read,attendance:write,attendance:admin,attendance:approve')
+
+    // Visible skip (not false green) if the AE-1 migration is not applied in this env.
+    const cols = (await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'attendance_record_result_edits'`,
+    )).rows as { column_name: string }[]
+    tableReady = cols.length > 0
+    if (tableReady) {
+      const names = new Set(cols.map((c) => c.column_name))
+      for (const c of ['org_id', 'record_id', 'before_status', 'after_status', 'before_snapshot', 'after_snapshot', 'reason', 'evidence', 'idempotency_key', 'notification_delivery_id', 'notification_skipped_reason']) {
+        expect(names.has(c)).toBe(true)
+      }
+    }
+  })
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query(`DELETE FROM attendance_record_result_edits WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_records WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
+      await pool.query(`DELETE FROM attendance_payroll_cycles WHERE org_id = ANY($1)`, [[ORG, ORG_OTHER]]).catch(() => undefined)
+    }
+    if (server && (server as unknown as { stop?: () => Promise<void> }).stop) await (server as unknown as { stop: () => Promise<void> }).stop()
+    await pool?.end().catch(() => undefined)
+  })
+
+  const skipIfNoTable = () => { if (!tableReady) return true; return false }
+
+  it('§3.5a late→normal: zeroes late/early, preserves work_minutes, recomputes meta tiers; writes audit before/after', async () => {
+    if (skipIfNoTable()) return
+    const userId = `u-late-${RUN}`
+    const workDate = ymd(2)
+    const recordId = await seedRecord({
+      userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 35, earlyLeaveMinutes: 0,
+      firstInAt: `${workDate}T01:35:00Z`, lastOutAt: `${workDate}T10:00:00Z`,
+      meta: { severe_late_count: 1, severe_late_minutes: 35, warnings: ['late'] },
+    })
+    const key = `k-late-${RUN}`
+    const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: '员工提交线下签到凭证，核验后更正', idempotencyKey: key })
+    expect(res.status).toBe(200)
+    expect(dataOf(res).alreadyApplied).toBe(false)
+    expect(dataOf(res).edit.afterStatus).toBe('normal')
+    expect(dataOf(res).edit.beforeStatus).toBe('late')
+
+    const rec = await recordById(recordId)
+    expect(rec.status).toBe('normal')
+    expect(Number(rec.late_minutes)).toBe(0)
+    expect(Number(rec.early_leave_minutes)).toBe(0)
+    expect(Number(rec.work_minutes)).toBe(480) // preserved (an edit re-classifies, it doesn't fabricate work time)
+    expect(Number(rec.meta?.severe_late_count ?? -1)).toBe(0) // tier meta recomputed from final late=0
+    expect(rec.meta?.warnings).toEqual(['late']) // unrelated meta preserved
+
+    const audit = await auditRowsForRecord(recordId)
+    expect(audit).toHaveLength(1)
+    expect(audit[0].before_status).toBe('late')
+    expect(audit[0].after_status).toBe('normal')
+    expect(audit[0].before_snapshot.status).toBe('late')
+    expect(audit[0].after_snapshot.status).toBe('normal')
+    expect(Number(audit[0].before_snapshot.lateMinutes)).toBe(35)
+    expect(Number(audit[0].after_snapshot.lateMinutes)).toBe(0)
+    expect(audit[0].reason).toContain('核验后更正')
+    expect(audit[0].actor_user_id).toBe(`ae1-admin-${RUN}`)
+    expect(audit[0].notification_delivery_id).toBeNull()
+    expect(audit[0].notification_skipped_reason).toBeNull()
+  })
+
+  it('§3.5a absent→normal: keeps work_minutes=0 + null punches by default; overrideMetrics.workMinutes takes precedence', async () => {
+    if (skipIfNoTable()) return
+    // default: no override → work stays 0, no fabricated punches
+    const u1 = `u-abs-${RUN}`
+    const wd1 = ymd(3)
+    const r1 = await seedRecord({ userId: u1, workDate: wd1, status: 'absent', workMinutes: 0, lateMinutes: 0, earlyLeaveMinutes: 0, firstInAt: null, lastOutAt: null })
+    const e1 = await postEdit({ orgId: ORG, recordId: r1, targetStatus: 'normal', reason: '线下值班，核验后更正为正常', idempotencyKey: `k-abs1-${RUN}` })
+    expect(e1.status).toBe(200)
+    const rec1 = await recordById(r1)
+    expect(rec1.status).toBe('normal')
+    expect(Number(rec1.work_minutes)).toBe(0)
+    expect(rec1.first_in_at).toBeNull()
+    expect(rec1.last_out_at).toBeNull()
+
+    // override: admin supplies the payroll work minutes
+    const u2 = `u-abs2-${RUN}`
+    const wd2 = ymd(4)
+    const r2 = await seedRecord({ userId: u2, workDate: wd2, status: 'absent', workMinutes: 0, firstInAt: null, lastOutAt: null })
+    const e2 = await postEdit({ orgId: ORG, recordId: r2, targetStatus: 'normal', reason: '补登一整天工时', overrideMetrics: { workMinutes: 480 }, idempotencyKey: `k-abs2-${RUN}` })
+    expect(e2.status).toBe(200)
+    const rec2 = await recordById(r2)
+    expect(rec2.status).toBe('normal')
+    expect(Number(rec2.work_minutes)).toBe(480)
+  })
+
+  it('idempotency: missing key → 400 nothing written; same key+payload → alreadyApplied (one row); different payload → 409', async () => {
+    if (skipIfNoTable()) return
+    const userId = `u-idem-${RUN}`
+    const workDate = ymd(2)
+    const recordId = await seedRecord({ userId, workDate, status: 'late', workMinutes: 480, lateMinutes: 20, firstInAt: `${workDate}T01:20:00Z`, lastOutAt: `${workDate}T10:00:00Z` })
+
+    // missing key → 400, nothing written
+    const missing = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'no key' })
+    expect(missing.status).toBe(400)
+    expect(codeOf(missing)).toBe('VALIDATION_ERROR')
+    expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+
+    const key = `k-idem-${RUN}`
+    const first = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'verified offline', idempotencyKey: key })
+    expect(first.status).toBe(200)
+    expect(dataOf(first).alreadyApplied).toBe(false)
+
+    // exact replay → alreadyApplied, no 2nd row
+    const replay = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'verified offline', idempotencyKey: key })
+    expect(replay.status).toBe(200)
+    expect(dataOf(replay).alreadyApplied).toBe(true)
+    expect(await auditByKey(ORG, key)).toHaveLength(1)
+
+    // same key, different payload (target) → 409
+    const conflict = await postEdit({ orgId: ORG, recordId, targetStatus: 'absent', reason: 'verified offline', idempotencyKey: key })
+    expect(conflict.status).toBe(409)
+    expect(codeOf(conflict)).toBe('ATTENDANCE_RESULT_EDIT_IDEMPOTENCY_CONFLICT')
+    expect(await auditByKey(ORG, key)).toHaveLength(1)
+  })
+
+  it('editable-source: off/adjusted → 422 SOURCE_NOT_EDITABLE; normal→abnormal → 422 NORMAL_TO_ABNORMAL_UNSUPPORTED; normal→normal → 422 SOURCE_NOT_EDITABLE', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(2)
+    const off = await seedRecord({ userId: `u-off-${RUN}`, workDate: wd, status: 'off', isWorkday: false })
+    const ro = await postEdit({ orgId: ORG, recordId: off, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-off-${RUN}` })
+    expect(ro.status).toBe(422)
+    expect(codeOf(ro)).toBe('ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE')
+
+    const adj = await seedRecord({ userId: `u-adj-${RUN}`, workDate: wd, status: 'adjusted' })
+    const ra = await postEdit({ orgId: ORG, recordId: adj, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-adj-${RUN}` })
+    expect(ra.status).toBe(422)
+    expect(codeOf(ra)).toBe('ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE')
+
+    const norm = await seedRecord({ userId: `u-norm-${RUN}`, workDate: wd, status: 'normal', workMinutes: 480 })
+    const rn = await postEdit({ orgId: ORG, recordId: norm, targetStatus: 'absent', reason: 'x', idempotencyKey: `k-norm-abn-${RUN}` })
+    expect(rn.status).toBe(422)
+    expect(codeOf(rn)).toBe('ATTENDANCE_RESULT_EDIT_NORMAL_TO_ABNORMAL_UNSUPPORTED')
+
+    const rn2 = await postEdit({ orgId: ORG, recordId: norm, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-norm-noop-${RUN}` })
+    expect(rn2.status).toBe(422)
+    expect(codeOf(rn2)).toBe('ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE')
+
+    // none of the rejected edits wrote an audit row or changed status
+    expect(await auditRowsForRecord(off)).toHaveLength(0)
+    expect(await auditRowsForRecord(norm)).toHaveLength(0)
+    expect((await recordById(norm)).status).toBe('normal')
+  })
+
+  it('closed/archived cycle covering work_date → 409 CYCLE_CLOSED even with no settlement row; closed wins over an overlapping open cycle', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(2)
+    const cycleClosed = await seedClosedCycle(wd, 'closed')
+    try {
+      const r1 = await seedRecord({ userId: `u-cyc1-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+      const e1 = await postEdit({ orgId: ORG, recordId: r1, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-cyc1-${RUN}` })
+      expect(e1.status).toBe(409)
+      expect(codeOf(e1)).toBe('ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED')
+      expect(await auditRowsForRecord(r1)).toHaveLength(0)
+      expect((await recordById(r1)).status).toBe('late') // unchanged
+
+      // overlapping open cycle present too → the closed one still wins and rejects
+      const openCycle = (await pool.query(
+        `INSERT INTO attendance_payroll_cycles (org_id, start_date, end_date, status) VALUES ($1, $2, $3, 'open') RETURNING id`,
+        [ORG, wd, wd],
+      )).rows[0].id as string
+      try {
+        const e2 = await postEdit({ orgId: ORG, recordId: r1, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-cyc2-${RUN}` })
+        expect(e2.status).toBe(409)
+        expect(codeOf(e2)).toBe('ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED')
+      } finally {
+        await pool.query(`DELETE FROM attendance_payroll_cycles WHERE id = $1`, [openCycle]).catch(() => undefined)
+      }
+    } finally {
+      await pool.query(`DELETE FROM attendance_payroll_cycles WHERE id = $1`, [cycleClosed]).catch(() => undefined)
+    }
+
+    // archived behaves identically
+    const cycleArchived = await seedClosedCycle(wd, 'archived')
+    try {
+      const r2 = await seedRecord({ userId: `u-cyc3-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+      const e3 = await postEdit({ orgId: ORG, recordId: r2, targetStatus: 'normal', reason: 'x', idempotencyKey: `k-cyc3-${RUN}` })
+      expect(e3.status).toBe(409)
+      expect(codeOf(e3)).toBe('ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED')
+    } finally {
+      await pool.query(`DELETE FROM attendance_payroll_cycles WHERE id = $1`, [cycleArchived]).catch(() => undefined)
+    }
+  })
+
+  it('edit-window: work_date older than editWindowDays (default 180) → 422 WINDOW_EXPIRED, nothing written', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(400)
+    const recordId = await seedRecord({ userId: `u-win-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+    const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'too old', idempotencyKey: `k-win-${RUN}` })
+    expect(res.status).toBe(422)
+    expect(codeOf(res)).toBe('ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED')
+    expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+  })
+
+  it('cross-org: a record from another org → 404, no audit row, no cross-org leak', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(2)
+    const otherRecord = await seedRecord({ userId: `u-x-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, org: ORG_OTHER, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+    const key = `k-xorg-${RUN}`
+    const res = await postEdit({ orgId: ORG, recordId: otherRecord, targetStatus: 'normal', reason: 'x', idempotencyKey: key })
+    expect(res.status).toBe(404)
+    expect(codeOf(res)).toBe('ATTENDANCE_RECORD_NOT_FOUND')
+    expect(await auditByKey(ORG, key)).toHaveLength(0)
+    expect(await auditByKey(ORG_OTHER, key)).toHaveLength(0)
+    expect((await recordById(otherRecord)).status).toBe('late') // untouched
+  })
+
+  it('reason: blank reason → 400 when policy.requireReason (default true), nothing written', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(2)
+    const recordId = await seedRecord({ userId: `u-reason-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+    const res = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: '   ', idempotencyKey: `k-reason-${RUN}` })
+    expect(res.status).toBe(400)
+    expect(codeOf(res)).toBe('VALIDATION_ERROR')
+    expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+  })
+
+  it('evidence: raw http URL rejected; https + attachmentId accepted and persisted', async () => {
+    if (skipIfNoTable()) return
+    const wd = ymd(2)
+    const recordId = await seedRecord({ userId: `u-ev-${RUN}`, workDate: wd, status: 'late', lateMinutes: 30, workMinutes: 480, firstInAt: `${wd}T01:30:00Z`, lastOutAt: `${wd}T10:00:00Z` })
+
+    // raw http → rejected, nothing written
+    const bad = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'r', evidence: [{ type: 'url', url: 'http://insecure.example.com/p' }], idempotencyKey: `k-ev-bad-${RUN}` })
+    expect(bad.status).toBe(400)
+    expect(codeOf(bad)).toBe('VALIDATION_ERROR')
+    expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+
+    // markup in a text label → rejected
+    const bad2 = await postEdit({ orgId: ORG, recordId, targetStatus: 'normal', reason: 'r', evidence: [{ type: 'text', text: '<script>x</script>' }], idempotencyKey: `k-ev-bad2-${RUN}` })
+    expect(bad2.status).toBe(400)
+    expect(await auditRowsForRecord(recordId)).toHaveLength(0)
+
+    // https url + attachmentId → accepted, persisted on the audit row
+    const ok = await postEdit({
+      orgId: ORG, recordId, targetStatus: 'normal', reason: 'r',
+      evidence: [{ type: 'url', label: 'site photo', url: 'https://files.example.com/a.jpg' }, { attachmentId: 'att-123' }],
+      idempotencyKey: `k-ev-ok-${RUN}`,
+    })
+    expect(ok.status).toBe(200)
+    const audit = await auditRowsForRecord(recordId)
+    expect(audit).toHaveLength(1)
+    expect(Array.isArray(audit[0].evidence)).toBe(true)
+    expect(audit[0].evidence).toHaveLength(2)
+    expect(audit[0].evidence[0]).toMatchObject({ type: 'url', url: 'https://files.example.com/a.jpg' })
+    expect(audit[0].evidence[1]).toMatchObject({ type: 'attachment', attachmentId: 'att-123' })
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -18037,6 +18037,356 @@ function computeAttendanceRecordUpsertValues(options) {
   }
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// AE-1 — audited admin correction of a confirmed attendance anomaly result
+// (design-lock attendance-anomaly-result-edit-guard-design-lock-20260626, RATIFIED 2026-06-27).
+// ──────────────────────────────────────────────────────────────────────────────
+
+// §3.2 target vocabulary + §3.2/§9.7 editability. A source NOT in the editable set is immutable: normal→abnormal
+// is the explicit NORMAL_TO_ABNORMAL guard, every other non-editable source (off/adjusted, and normal→normal/
+// normal→adjusted no-ops) is SOURCE_NOT_EDITABLE.
+const RESULT_EDIT_TARGET_STATUSES = ['normal', 'late', 'early_leave', 'late_early', 'partial', 'absent', 'adjusted']
+const RESULT_EDIT_EDITABLE_SOURCES = new Set(['late', 'early_leave', 'late_early', 'partial', 'absent'])
+const RESULT_EDIT_ABNORMAL_TARGETS = new Set(['late', 'early_leave', 'late_early', 'partial', 'absent'])
+
+const RESULT_EDIT_EVIDENCE_MAX_ITEMS = 20
+const RESULT_EDIT_EVIDENCE_TEXT_MAX = 200
+const RESULT_EDIT_EVIDENCE_URL_MAX = 2048
+const RESULT_EDIT_EVIDENCE_ATTACHMENT_ID_MAX = 200
+
+function resultEditEvidenceHasMarkup(text) {
+  return /[<>]/.test(text)
+}
+
+// §3.4 + §9.3 evidence validator: metadata-only references — attachmentId / safe-text label / HTTPS-only URL
+// (length-capped, no script/HTML, non-empty host). A raw http:// or any unvalidated URL string is REJECTED so
+// nothing hostile is ever written into the immutable audit row. Returns the normalized array or a message.
+function validateAttendanceResultEditEvidence(evidence) {
+  if (evidence == null) return { ok: true, value: [] }
+  if (!Array.isArray(evidence)) return { ok: false, message: 'evidence must be an array of reference objects' }
+  if (evidence.length > RESULT_EDIT_EVIDENCE_MAX_ITEMS) {
+    return { ok: false, message: `evidence accepts at most ${RESULT_EDIT_EVIDENCE_MAX_ITEMS} references` }
+  }
+  const out = []
+  for (let i = 0; i < evidence.length; i++) {
+    const item = evidence[i]
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return { ok: false, message: `evidence[${i}] must be an object` }
+    }
+    const ref = {}
+    if (item.label != null) {
+      if (typeof item.label !== 'string') return { ok: false, message: `evidence[${i}].label must be a string` }
+      const label = item.label.trim()
+      if (label.length > RESULT_EDIT_EVIDENCE_TEXT_MAX) return { ok: false, message: `evidence[${i}].label exceeds ${RESULT_EDIT_EVIDENCE_TEXT_MAX} chars` }
+      if (resultEditEvidenceHasMarkup(label)) return { ok: false, message: `evidence[${i}].label must not contain HTML/script markup` }
+      if (label) ref.label = label
+    }
+    if (item.url != null) {
+      if (typeof item.url !== 'string') return { ok: false, message: `evidence[${i}].url must be a string` }
+      const url = item.url.trim()
+      if (!url) return { ok: false, message: `evidence[${i}].url is empty` }
+      if (url.length > RESULT_EDIT_EVIDENCE_URL_MAX) return { ok: false, message: `evidence[${i}].url is too long` }
+      if (/\s/.test(url) || resultEditEvidenceHasMarkup(url)) return { ok: false, message: `evidence[${i}].url must not contain whitespace or markup` }
+      let parsed
+      try { parsed = new URL(url) } catch { return { ok: false, message: `evidence[${i}].url is not a valid URL` } }
+      if (parsed.protocol !== 'https:') return { ok: false, message: `evidence[${i}].url must use https://` }
+      if (!parsed.hostname) return { ok: false, message: `evidence[${i}].url must have a non-empty host` }
+      ref.type = 'url'
+      ref.url = url
+    } else if (item.attachmentId != null) {
+      if (typeof item.attachmentId !== 'string') return { ok: false, message: `evidence[${i}].attachmentId must be a string` }
+      const attachmentId = item.attachmentId.trim()
+      if (!attachmentId) return { ok: false, message: `evidence[${i}].attachmentId is empty` }
+      if (attachmentId.length > RESULT_EDIT_EVIDENCE_ATTACHMENT_ID_MAX) return { ok: false, message: `evidence[${i}].attachmentId is too long` }
+      if (resultEditEvidenceHasMarkup(attachmentId)) return { ok: false, message: `evidence[${i}].attachmentId must not contain markup` }
+      ref.type = 'attachment'
+      ref.attachmentId = attachmentId
+    } else if (item.text != null) {
+      if (typeof item.text !== 'string') return { ok: false, message: `evidence[${i}].text must be a string` }
+      const text = item.text.trim()
+      if (!text) return { ok: false, message: `evidence[${i}].text is empty` }
+      if (text.length > RESULT_EDIT_EVIDENCE_TEXT_MAX) return { ok: false, message: `evidence[${i}].text is too long` }
+      if (resultEditEvidenceHasMarkup(text)) return { ok: false, message: `evidence[${i}].text must not contain markup` }
+      ref.type = 'text'
+      ref.text = text
+    } else if (ref.label) {
+      // A safe-text label with no url/attachment/text is itself an acceptable metadata-only reference.
+      ref.type = 'text'
+    } else {
+      return { ok: false, message: `evidence[${i}] must carry one of url / attachmentId / text / label` }
+    }
+    out.push(ref)
+  }
+  return { ok: true, value: out }
+}
+
+// §3.5a normalization table (RATIFIED). Anomaly metrics are normalized per target status; work_minutes defaults
+// to the ORIGINAL stored value (an edit re-classifies, it does not fabricate work time); admin overrideMetrics
+// take precedence per-field. The returned object is fed to upsertAttendanceRecord as overrideMetrics, so it
+// FULLY shadows computeMetrics' punch-derived values (which would otherwise re-derive the original anomaly —
+// e.g. absent has no punches → computeMetrics returns 'absent' again).
+function applyResultEditMetricNormalization(targetStatus, beforeRecord, overrideMetrics) {
+  let work = Math.max(0, Math.floor(Number(beforeRecord?.work_minutes) || 0))
+  let late = Math.max(0, Math.floor(Number(beforeRecord?.late_minutes) || 0))
+  let early = Math.max(0, Math.floor(Number(beforeRecord?.early_leave_minutes) || 0))
+  switch (targetStatus) {
+    case 'normal': late = 0; early = 0; break          // on-time, full day → no lateness/early-leave
+    case 'late': early = 0; break                      // late preserved/override; early cleared
+    case 'early_leave': late = 0; break                // early preserved/override; late cleared
+    case 'late_early': break                           // preserve both
+    case 'partial': break                              // preserve
+    case 'absent': work = 0; late = 0; early = 0; break // no worked time on an absent day
+    case 'adjusted': break                             // preserve (admin may override)
+    default: break
+  }
+  if (overrideMetrics && typeof overrideMetrics === 'object') {
+    if (Number.isFinite(overrideMetrics.workMinutes)) work = Math.max(0, Math.floor(overrideMetrics.workMinutes))
+    if (Number.isFinite(overrideMetrics.lateMinutes)) late = Math.max(0, Math.floor(overrideMetrics.lateMinutes))
+    if (Number.isFinite(overrideMetrics.earlyLeaveMinutes)) early = Math.max(0, Math.floor(overrideMetrics.earlyLeaveMinutes))
+  }
+  return { workMinutes: work, lateMinutes: late, earlyLeaveMinutes: early }
+}
+
+function coerceResultEditJson(value) {
+  if (typeof value === 'string') {
+    try { return JSON.parse(value) } catch { return value }
+  }
+  return value
+}
+
+// §4.1 before/after snapshot — the full record fact persisted on the audit row, independent of policy.
+function buildResultEditSnapshot(record) {
+  if (!record || typeof record !== 'object') return {}
+  const iso = (value) => {
+    if (value == null) return null
+    const date = value instanceof Date ? value : new Date(value)
+    const time = date.getTime()
+    return Number.isFinite(time) ? date.toISOString() : null
+  }
+  return {
+    id: record.id ?? null,
+    userId: record.user_id ?? null,
+    orgId: record.org_id ?? null,
+    workDate: normalizeDateOnly(record.work_date) ?? (record.work_date != null ? String(record.work_date).slice(0, 10) : null),
+    status: record.status ?? null,
+    isWorkday: record.is_workday !== false,
+    timezone: record.timezone ?? null,
+    firstInAt: iso(record.first_in_at),
+    lastOutAt: iso(record.last_out_at),
+    workMinutes: Number(record.work_minutes ?? 0),
+    lateMinutes: Number(record.late_minutes ?? 0),
+    earlyLeaveMinutes: Number(record.early_leave_minutes ?? 0),
+    meta: normalizeMetadata(record.meta),
+  }
+}
+
+// §4.1 idempotency compare: a replayed (org_id, idempotency_key) is "already applied" only when its key
+// PAYLOAD fields match the prior audit row — compared in STORED form (trimmed reason, normalized evidence)
+// so a byte-identical replay never spuriously conflicts on whitespace/key-ordering. Any divergence → 409.
+function resultEditPayloadMatches(priorRow, payload) {
+  if (!priorRow) return false
+  if (String(priorRow.record_id) !== String(payload.recordId)) return false
+  if (String(priorRow.after_status) !== String(payload.targetStatus)) return false
+  if (String(priorRow.reason ?? '') !== String(payload.reason ?? '')) return false
+  const priorEvidence = coerceResultEditJson(priorRow.evidence) ?? []
+  if (stableJsonString(priorEvidence) !== stableJsonString(payload.evidence ?? [])) return false
+  return true
+}
+
+function mapResultEditRow(row) {
+  if (!row) return null
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    recordId: row.record_id,
+    userId: row.user_id,
+    workDate: normalizeDateOnly(row.work_date) ?? (row.work_date != null ? String(row.work_date).slice(0, 10) : null),
+    beforeStatus: row.before_status,
+    afterStatus: row.after_status,
+    beforeSnapshot: coerceResultEditJson(row.before_snapshot),
+    afterSnapshot: coerceResultEditJson(row.after_snapshot),
+    reason: row.reason,
+    evidence: coerceResultEditJson(row.evidence) ?? [],
+    actorUserId: row.actor_user_id,
+    idempotencyKey: row.idempotency_key,
+    notificationDeliveryId: row.notification_delivery_id ?? null,
+    notificationSkippedReason: row.notification_skipped_reason ?? null,
+    createdAt: row.created_at,
+  }
+}
+
+// AE-1 transactional write helper. Locks the target record (id+org, cross-org miss → 404 with no leak), runs
+// the editable-source / closed-cycle / edit-window guards, applies the §3.5a normalization via
+// upsertAttendanceRecord (statusOverride + overrideMetrics, NOT a naked status UPDATE so meta tiers stay
+// consistent), and writes ONE immutable audit row. Idempotency is compare-then-{alreadyApplied|409}: a prior
+// same-key row with an identical payload returns alreadyApplied with NO second write; a divergent payload → 409.
+// MUST be called inside db.transaction so a guard failure mid-flight rolls back the record update too.
+async function applyAttendanceResultEdit(trx, options) {
+  const {
+    orgId,
+    recordId,
+    targetStatus,
+    overrideMetrics,
+    reason,
+    evidence,
+    actorUserId,
+    idempotencyKey,
+    editWindowDays,
+  } = options
+
+  const normalizedEvidence = Array.isArray(evidence) ? evidence : []
+
+  // (0) Idempotency pre-check — a replay never re-mutates the record (and AE-2 will never re-enqueue).
+  const priorRows = await trx.query(
+    'SELECT * FROM attendance_record_result_edits WHERE org_id = $1 AND idempotency_key = $2 LIMIT 1',
+    [orgId, idempotencyKey]
+  )
+  if (priorRows.length > 0) {
+    const prior = priorRows[0]
+    if (resultEditPayloadMatches(prior, { recordId, targetStatus, reason, evidence: normalizedEvidence })) {
+      return { alreadyApplied: true, edit: mapResultEditRow(prior), record: null }
+    }
+    throw new HttpError(409, 'ATTENDANCE_RESULT_EDIT_IDEMPOTENCY_CONFLICT', 'idempotencyKey was already used with a different payload')
+  }
+
+  // (1) Lock the target record by id + org. Cross-org / missing → 404 with no cross-org detail.
+  const lockedRows = await trx.query(
+    'SELECT * FROM attendance_records WHERE id = $1 AND org_id = $2 FOR UPDATE',
+    [recordId, orgId]
+  )
+  const record = lockedRows[0] ?? null
+  if (!record) {
+    throw new HttpError(404, 'ATTENDANCE_RECORD_NOT_FOUND', 'attendance record not found')
+  }
+  const beforeStatus = String(record.status ?? '')
+  const workDate = normalizeDateOnly(record.work_date) ?? String(record.work_date ?? '').slice(0, 10)
+
+  // (2) Editable-source guard (§3.2 / §9.7).
+  if (!RESULT_EDIT_EDITABLE_SOURCES.has(beforeStatus)) {
+    if (beforeStatus === 'normal' && RESULT_EDIT_ABNORMAL_TARGETS.has(targetStatus)) {
+      throw new HttpError(422, 'ATTENDANCE_RESULT_EDIT_NORMAL_TO_ABNORMAL_UNSUPPORTED', 'a normal result cannot be edited into an abnormal status in v1')
+    }
+    throw new HttpError(422, 'ATTENDANCE_RESULT_EDIT_SOURCE_NOT_EDITABLE', `source status "${beforeStatus}" is not an editable anomaly result`)
+  }
+
+  // (3) Closed-cycle guard (§6 / §9.4) — fail-closed. Any same-org closed/archived cycle covering work_date
+  // rejects with 409, even when no settlement row exists; an unavailable cycle table → 503 (never bypass).
+  let cycleRows
+  try {
+    cycleRows = await trx.query(
+      `SELECT 1 FROM attendance_payroll_cycles
+        WHERE org_id = $1 AND status IN ('closed', 'archived') AND $2::date BETWEEN start_date AND end_date
+        LIMIT 1`,
+      [orgId, workDate]
+    )
+  } catch (error) {
+    if (isDatabaseSchemaError(error)) {
+      throw new HttpError(503, 'DB_NOT_READY', 'payroll cycle table unavailable; result edit refused (fail-closed)')
+    }
+    throw error
+  }
+  if (cycleRows.length > 0) {
+    throw new HttpError(409, 'ATTENDANCE_RESULT_EDIT_CYCLE_CLOSED', 'work_date falls inside a closed or archived payroll cycle')
+  }
+
+  // (4) Resolve the record's effective rule + timezone (drives §3.5a tier recompute + the edit window).
+  const context = await resolveWorkContext({ db: trx, orgId, userId: record.user_id, workDate })
+  const timezone = context?.rule?.timezone
+  if (!timezone || !isValidTimeZoneIdentifier(timezone)) {
+    // Fail-closed: without a resolvable zone the edit window cannot be verified safely.
+    throw new HttpError(422, 'ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED', 'cannot resolve a valid timezone for the edit window (fail-closed)')
+  }
+
+  // (5) Edit window (§3.3 / §9.1) — work_date within editWindowDays of org-tz today.
+  const todayKey = toWorkDate(new Date(), timezone)
+  const todayMs = Date.parse(`${todayKey}T00:00:00Z`)
+  const workMs = Date.parse(`${workDate}T00:00:00Z`)
+  if (!Number.isFinite(todayMs) || !Number.isFinite(workMs)) {
+    throw new HttpError(422, 'ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED', 'cannot resolve the edit window (fail-closed)')
+  }
+  const diffDays = Math.floor((todayMs - workMs) / 86400000)
+  if (diffDays > editWindowDays) {
+    throw new HttpError(422, 'ATTENDANCE_RESULT_EDIT_WINDOW_EXPIRED', `work_date is older than the ${editWindowDays}-day edit window`)
+  }
+
+  // (6) Apply §3.5a normalization and re-write the record through the consistency helper (statusOverride +
+  // overrideMetrics fully shadow computeMetrics; meta tiers are recomputed from the FINAL lateMinutes).
+  const metrics = applyResultEditMetricNormalization(targetStatus, record, overrideMetrics)
+  const updated = await upsertAttendanceRecord({
+    userId: record.user_id,
+    orgId,
+    workDate,
+    timezone,
+    rule: { ...context.rule, timezone },
+    updateFirstInAt: null,
+    updateLastOutAt: null,
+    mode: 'merge',
+    statusOverride: targetStatus,
+    overrideMetrics: {
+      workMinutes: metrics.workMinutes,
+      lateMinutes: metrics.lateMinutes,
+      earlyLeaveMinutes: metrics.earlyLeaveMinutes,
+    },
+    isWorkday: record.is_workday !== false,
+    leaveMinutes: 0,
+    overtimeMinutes: 0,
+    existingRow: record,
+    client: trx,
+  })
+
+  const beforeSnapshot = buildResultEditSnapshot(record)
+  const afterSnapshot = buildResultEditSnapshot(updated)
+
+  // (7) Write the immutable audit row. The UNIQUE(org_id, idempotency_key) is the concurrency backstop: a
+  // racing same-key insert from another txn surfaces as 23505 → re-run the same compare-then-{ok|409}.
+  let auditRow
+  try {
+    const inserted = await trx.query(
+      `INSERT INTO attendance_record_result_edits
+        (org_id, record_id, user_id, work_date, before_status, after_status, before_snapshot, after_snapshot,
+         reason, evidence, actor_user_id, idempotency_key)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10::jsonb, $11, $12)
+       RETURNING *`,
+      [
+        orgId,
+        recordId,
+        record.user_id,
+        workDate,
+        beforeStatus,
+        targetStatus,
+        JSON.stringify(beforeSnapshot),
+        JSON.stringify(afterSnapshot),
+        reason,
+        JSON.stringify(normalizedEvidence),
+        actorUserId,
+        idempotencyKey,
+      ]
+    )
+    auditRow = inserted[0]
+  } catch (error) {
+    if (error?.code === '23505') {
+      const raceRows = await trx.query(
+        'SELECT * FROM attendance_record_result_edits WHERE org_id = $1 AND idempotency_key = $2 LIMIT 1',
+        [orgId, idempotencyKey]
+      )
+      const prior = raceRows[0]
+      if (prior && resultEditPayloadMatches(prior, { recordId, targetStatus, reason, evidence: normalizedEvidence })) {
+        return { alreadyApplied: true, edit: mapResultEditRow(prior), record: updated }
+      }
+      throw new HttpError(409, 'ATTENDANCE_RESULT_EDIT_IDEMPOTENCY_CONFLICT', 'idempotencyKey was already used with a different payload')
+    }
+    throw error
+  }
+
+  return {
+    alreadyApplied: false,
+    edit: mapResultEditRow(auditRow),
+    record: updated,
+    beforeSnapshot,
+    afterSnapshot,
+  }
+}
+
 async function batchUpsertAttendanceRecordsValues(client, rows) {
   if (!Array.isArray(rows) || rows.length === 0) return new Map()
 
@@ -19781,6 +20131,12 @@ module.exports = {
     ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS,
     resetAttendanceSettingsCacheForTests,
     mergeSettings,
+    normalizeAttendanceResultEditPolicySetting,
+    applyAttendanceResultEdit,
+    applyResultEditMetricNormalization,
+    validateAttendanceResultEditEvidence,
+    buildResultEditSnapshot,
+    resultEditPayloadMatches,
     calculateAttendanceComprehensiveShiftPlannedMinutes,
     buildAttendanceComprehensivePlannedMinutesFromDays,
     buildAttendanceComprehensiveActualMinutesFromSummary,
@@ -24596,6 +24952,112 @@ module.exports = {
 	          }
 	          logger.error('Attendance anomalies query failed', error)
 	          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load anomalies' } })
+	        }
+	      })
+	    )
+
+	    context.api.http.addRoute(
+	      'POST',
+	      '/api/attendance/anomaly-result-edits',
+	      withPermission('attendance:admin', async (req, res) => {
+	        const schema = z.object({
+	          orgId: z.string().optional(),
+	          recordId: z.string().uuid(),
+	          targetStatus: z.enum(['normal', 'late', 'early_leave', 'late_early', 'partial', 'absent', 'adjusted']),
+	          reason: z.string().max(500).optional(),
+	          evidence: z.array(z.unknown()).optional(),
+	          overrideMetrics: z.object({
+	            workMinutes: z.number().int().min(0).optional(),
+	            lateMinutes: z.number().int().min(0).optional(),
+	            earlyLeaveMinutes: z.number().int().min(0).optional(),
+	          }).optional(),
+	          idempotencyKey: z.string().min(1).max(200),
+	        })
+
+	        const parsed = schema.safeParse(req.body ?? {})
+	        if (!parsed.success) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+	          return
+	        }
+
+	        const actorUserId = getUserId(req)
+	        if (!actorUserId) {
+	          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+	          return
+	        }
+	        const orgId = getOrgId(req)
+
+	        // idempotencyKey REQUIRED, trim 1..200; the server NEVER generates one. Missing/blank/oversized → 400,
+	        // writes nothing.
+	        const idempotencyKey = String(parsed.data.idempotencyKey ?? '').trim()
+	        if (!idempotencyKey || idempotencyKey.length > 200) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'idempotencyKey is required (1..200 chars)' } })
+	          return
+	        }
+
+	        let policy
+	        try {
+	          policy = (await getSettings(db)).attendanceResultEditPolicy ?? DEFAULT_SETTINGS.attendanceResultEditPolicy
+	        } catch (error) {
+	          if (isDatabaseSchemaError(error)) {
+	            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+	            return
+	          }
+	          policy = DEFAULT_SETTINGS.attendanceResultEditPolicy
+	        }
+
+	        // enabled = master switch (default ON). The design enumerated every other guard/error code but did NOT
+	        // spec a disabled-path code; gating here (default-true so the main path is unaffected) — owner review.
+	        if (policy.enabled === false) {
+	          res.status(403).json({ ok: false, error: { code: 'ATTENDANCE_RESULT_EDIT_DISABLED', message: 'attendance result editing is disabled by policy' } })
+	          return
+	        }
+
+	        // reason: always persisted to the audit row; required (non-blank) when policy.requireReason.
+	        const reason = typeof parsed.data.reason === 'string' ? parsed.data.reason.trim() : ''
+	        if (policy.requireReason && !reason) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'reason is required' } })
+	          return
+	        }
+
+	        // evidence: metadata-only; the validator rejects raw/unsafe URLs so nothing hostile reaches the audit row.
+	        const evidenceResult = validateAttendanceResultEditEvidence(parsed.data.evidence)
+	        if (!evidenceResult.ok) {
+	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: evidenceResult.message } })
+	          return
+	        }
+
+	        try {
+	          const result = await db.transaction(async (trx) => applyAttendanceResultEdit(trx, {
+	            orgId,
+	            recordId: parsed.data.recordId,
+	            targetStatus: parsed.data.targetStatus,
+	            overrideMetrics: parsed.data.overrideMetrics ?? null,
+	            reason,
+	            evidence: evidenceResult.value,
+	            actorUserId,
+	            idempotencyKey,
+	            editWindowDays: policy.editWindowDays,
+	          }))
+	          res.json({
+	            ok: true,
+	            data: {
+	              alreadyApplied: result.alreadyApplied === true,
+	              edit: result.edit,
+	              record: result.record ? buildResultEditSnapshot(result.record) : null,
+	            },
+	          })
+	        } catch (error) {
+	          if (error instanceof HttpError) {
+	            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+	            return
+	          }
+	          if (isDatabaseSchemaError(error)) {
+	            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+	            return
+	          }
+	          logger.error('Attendance result edit failed', error)
+	          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to edit attendance result' } })
 	        }
 	      })
 	    )

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -302,6 +302,19 @@ const DEFAULT_SETTINGS = {
     requireReason: true,
     requireAttachment: false,
   },
+  // 异常结果编辑护栏 (anomaly result-edit guard) — AE-1 config (design-lock
+  // attendance-anomaly-result-edit-guard-design-lock-20260626 §3.3 / §9, RATIFIED 2026-06-27). Governs the
+  // attendance:admin POST /api/attendance/anomaly-result-edits write action. enabled = master switch (default
+  // ON; the route 403s when explicitly false). editWindowDays bounds how far back a work_date may be corrected
+  // (org-tz today − work_date), default 180, range 1..366. requireReason default true (a blank reason 400s).
+  // notifyAffectedEmployee default true (AE-2 honours it; a disabled value is still recorded as a skipped
+  // reason on the audit row).
+  attendanceResultEditPolicy: {
+    enabled: true,
+    editWindowDays: 180,
+    requireReason: true,
+    notifyAffectedEmployee: true,
+  },
   // 自动对班 (auto shift matching) — A1 preview/manual apply plus A2 scheduler auto-write.
   // Runtime still requires env flags in addition to these org settings.
   autoShiftMatching: {
@@ -12149,6 +12162,7 @@ function normalizeSettings(raw) {
     attendanceBonusPolicy: normalizeAttendanceBonusPolicySetting(raw.attendanceBonusPolicy),
     attendanceReportDigestPolicy: normalizeAttendanceReportDigestPolicySetting(raw.attendanceReportDigestPolicy),
     makeupPunchPolicy: normalizeMakeupPunchPolicySetting(raw.makeupPunchPolicy),
+    attendanceResultEditPolicy: normalizeAttendanceResultEditPolicySetting(raw.attendanceResultEditPolicy),
     autoShiftMatching: normalizeAutoShiftMatchingSetting(raw.autoShiftMatching),
   }
 }
@@ -12890,6 +12904,23 @@ async function enforceMakeupPunchPolicy(trx, { policy, orgId, subjectUserId, req
   return { matchedAnomalyTypes, requestEvaluatedAt }
 }
 
+// 异常结果编辑护栏 AE-1 (design-lock §3.3 / §9). Pure normalize of the bounded org policy: master switch +
+// edit window (1..366) + reason/notify flags. An unset / partial / malformed value can never silently widen
+// the window or flip a flag — every field falls back to DEFAULT_SETTINGS.
+function normalizeAttendanceResultEditPolicySetting(raw) {
+  const value = raw && typeof raw === 'object' ? raw : {}
+  const fallback = DEFAULT_SETTINGS.attendanceResultEditPolicy
+  const editWindowDaysRaw = Number(value.editWindowDays)
+  return {
+    enabled: parseBoolean(value.enabled, fallback.enabled),
+    editWindowDays: Number.isInteger(editWindowDaysRaw) && editWindowDaysRaw >= 1 && editWindowDaysRaw <= 366
+      ? editWindowDaysRaw
+      : fallback.editWindowDays,
+    requireReason: parseBoolean(value.requireReason, fallback.requireReason),
+    notifyAffectedEmployee: parseBoolean(value.notifyAffectedEmployee, fallback.notifyAffectedEmployee),
+  }
+}
+
 function normalizeOvertimeSegmentationSetting(raw) {
   const config = raw && typeof raw === 'object' ? raw : {}
   return {
@@ -13096,6 +13127,11 @@ function mergeSettings(base, update) {
         ...(base?.makeupPunchPolicy?.submitWindow || {}),
         ...(update?.makeupPunchPolicy?.submitWindow || {}),
       },
+    },
+    // Flat policy object → shallow merge preserves the other fields on a partial update (e.g. only { enabled }).
+    attendanceResultEditPolicy: {
+      ...(base?.attendanceResultEditPolicy || {}),
+      ...(update?.attendanceResultEditPolicy || {}),
     },
     autoShiftMatching: {
       ...(base?.autoShiftMatching || {}),
@@ -20801,6 +20837,14 @@ module.exports = {
         allowedRequestTypes: z.array(z.enum(['missed_check_in', 'missed_check_out', 'time_correction'])).min(1).optional(),
         requireReason: z.boolean().optional(),
         requireAttachment: z.boolean().optional(),
+      }).optional(),
+      // 异常结果编辑护栏 AE-1 (design-lock §3.3 / §9). Bounded org policy for the anomaly result-edit route.
+      // editWindowDays is enum-strict 1..366; an invalid value fails the PUT with 400.
+      attendanceResultEditPolicy: z.object({
+        enabled: z.boolean().optional(),
+        editWindowDays: z.number().int().min(1).max(366).optional(),
+        requireReason: z.boolean().optional(),
+        notifyAffectedEmployee: z.boolean().optional(),
       }).optional(),
       // 年假/法定假余额引擎 — L0 latent config (design-lock #2622). Round-trips through PUT/GET; no
       // runtime reads it until L2 (accrual). tiers = org-configurable statutory bands.


### PR DESCRIPTION
AE-1 of the anomaly-result-edit line (per the ratified design-lock, incl. the locked §3.5a metric table). `POST /api/attendance/anomaly-result-edits` (`attendance:admin`): correct one confirmed anomaly record to an explainable status with a required reason + optional evidence; write an **immutable** before/after audit row keyed by a client `idempotencyKey`; fail-close a closed/archived-payroll-cycle edit (409); enforce an edit window.

**Design decision — §3.5a (ratified, locked on main):** anomaly metrics normalized per target status; `work_minutes` preserved by default (no fabricated hours; admin `overrideMetrics` win per-field); meta tiers recomputed via `computeAttendanceRecordUpsertValues` — **never a naked status UPDATE**; `absent→normal` keeps `work_minutes=0` unless `overrideMetrics.workMinutes`. `statusOverride` shadows `computeMetrics` so a no-punch `absent→normal` can't re-derive 'absent'.

Locks (all PASS in adversarial review): idempotency (key required→400, `UNIQUE(org_id,idempotency_key)` NOT NULL, same-payload→alreadyApplied, diff→409, 23505 backstop); closed-cycle 409 fail-closed (schema-error→503, never bypass); editable-source guard (off/adjusted immutable, normal→abnormal→422); org boundary (cross-org→404 no leak); evidence HTTPS-only/attachmentId/text (raw URL rejected); edit-window tz fail-closed; audit row in the same txn, no FK cascade. New migration `attendance_record_result_edits` auto-registers + runs before the suite in CI.

AE-2 (notify) / AE-3 (UI) / AE-4 (staging) are separate later slices (the `notification_*` columns exist for AE-2 but no notifier is built).

Owner-decisions to confirm: the `403 disabled` route gate (§9 didn't spec one — kill-switch, default enabled); `overrideMetrics` not in the idempotency fingerprint (narrow); cross-org write defense relies on `attendance:admin` being org-scoped in RBAC. Test fast-follows tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)