### PR TITLE
[codex] Add bounded K3 Material LIST read-smoke

### DIFF
--- a/docs/development/data-factory-k3-read-list-development-verification-20260626.md
+++ b/docs/development/data-factory-k3-read-list-development-verification-20260626.md
@@ -1,10 +1,10 @@
 # K3 read/list + external-system read onboarding — development & verification (2026-06-26)
 
-> Status: **buildable development COMPLETE + verified; remaining surfaces GATED (not unfinished)**. This MD records the full development + verification of the K3 read/list line and its read-onboarding standardization. Per the line's own plan (the C0–C5 ladder + GATEs), every non-gated slice is shipped; C3+/writes/live are deliberately frozen behind customer/owner GATEs and are **not** built here. Opens no runtime.
+> Status: **buildable development COMPLETE + verified; remaining surfaces GATED (not unfinished)**. This MD records the full development + verification of the K3 read/list line and its read-onboarding standardization. Per the line's own plan (the C0–C5 ladder + GATEs), every authorized non-gated slice is shipped. C3 LIST-only is now shipped after the customer/operator GATE; C4/C5/writes/live remain deliberately frozen behind their own customer/owner GATEs.
 
 ## 0. Honest scope
 
-The line's plan gates the broader surfaces on purpose. So "complete the unfinished development" resolves to: **finish everything buildable without crossing a GATE (done), and document the gated remainder with its gate reasons.** No customer/owner GATE was crossed to manufacture "completion."
+The line's plan gates the broader surfaces on purpose. So "complete the unfinished development" resolves to: **finish everything buildable without crossing a GATE (done), and document the gated remainder with its gate reasons.** No customer/owner GATE was crossed to manufacture "completion." C3 LIST-only was opened only after #1709 customer/operator evidence explicitly requested WebAPI LIST while keeping C4 BOM, C5 resolver, and writes locked.
 
 ## 1. Development delivered (merged, with SHAs)
 
@@ -19,6 +19,7 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 - `#3245` (`815a27005`) — **C1** contract normalizer + preset allowlist metadata (reconciles `{presetId,key}` ⇄ `{presetId,intent}`; lock-safe, unwired).
 - `#3246` (`12028e5da`) — **C2** wired the normalizer into the route (both shapes → one read; migrated #3229's inline body validation).
 - `#3247` (`517b07ed0`) — **C3 acceptance lock**: `buildReadSmokeRequest` must consume `contract.object/mode` before any multi-object/mode widening.
+- `#3324` — **C3 LIST-only**: explicit `k3wise.material-list.v1` preset + bounded Material/List route/adapter wiring. Single page, preset-owned `PageIndex/PageSize`, no request-supplied filters/cursor/watermark/limit/path/method/payload, values-free evidence, no BOM/resolver/write.
 
 **Standardization:**
 - `#3257` (`2f7f82323`) — K3 read/list **GATE v2** + reusable values-free evidence checklist.
@@ -26,7 +27,7 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 
 ## 2. Verification
 
-**Automated tests (green on main):** `read-smoke.test.cjs` (catalog, values-free extraction, prototype-key, frozen), `read-smoke-contract.test.cjs` (both shapes reconcile, fail-closed, 13 injection fields rejected, values-free), `http-routes.test.cjs` `testReadSmokeRoute` (compat + intent success, fail-closed paths, write-gate 403, read-failure values-free), `k3-wise-adapters.test.cjs` (#1868 read). Full plugin suite 0 failures. *(Independent clean-room re-run: see §2a.)*
+**Focused automated tests (green in this slice):** `read-smoke.test.cjs` (catalog, detail + LIST request builders, values-free extraction, prototype-key, frozen), `read-smoke-contract.test.cjs` (detail shapes reconcile, LIST-only explicit intent, fail-closed, raw/injection fields rejected, values-free), `http-routes.test.cjs` `testReadSmokeRoute` (compat + intent success, bounded LIST success, fail-closed paths, write-gate 403, read-failure values-free), `k3-wise-adapters.test.cjs` (#1868 detail read + C3 bounded Material/List read). Full plugin suite remains a CI merge gate. *(Independent clean-room re-run through C2: see §2a; C3 adds the focused suites above.)*
 
 **Adversarial reviews (per slice, all APPROVE):**
 - `#3229` — 9-point battery: values-free (all paths), no-write reachable, fail-closed, prototype-key safe, preset-only, backend credential context, forced single read, system untouched, non-vacuous.
@@ -37,21 +38,17 @@ The line's plan gates the broader surfaces on purpose. So "complete the unfinish
 
 **Entity-machine evidence (#3241 retest, values-free):** persisted `material` read config absent → backend restarted → missing-key guard fail-closed → read-smoke HTTP 200, `recordPresent=true` → no raw payload / key / host / token / credential / connection string → no Save/Submit/Audit/BOM/LIST → no production write.
 
-**Boundaries verified:** read-only; write-gated (operator-only); values-free on success/failure/validation-error; dormant/fail-closed by default; preset/allowlist-only (no request-supplied raw path/method/payload/config); backend credential context (never the public response); in-memory overlay (stored system role/config untouched); both request shapes reconcile to one read; C3 dispatch lock recorded.
+**Boundaries verified:** read-only; write-gated (operator-only); values-free on success/failure/validation-error; dormant/fail-closed by default; preset/allowlist-only (no request-supplied raw path/method/payload/config); backend credential context (never the public response); in-memory overlay (stored system role/config untouched); both detail request shapes reconcile to one read; C3 LIST consumes the normalized `contract.object/mode` and dispatches only to the allowlisted bounded Material/List preset.
 
-### 2a. Independent clean-room verification
+### 2a. Independent clean-room verification (pre-C3 baseline)
 
-A separate adversarial pass re-verified the line on fresh `origin/main` (own throwaway worktree, full re-run) — **all dimensions PASS, no discrepancy**:
-- **Tests:** all four line suites green; full plugin-integration-core sweep **55 suites / 0 failures**.
-- **Boundaries:** `requireAccess(req,'write')` is the handler's first statement; validation goes through `normalizeReadSmokeContract`, failing to `400 READ_SMOKE_CONTRACT_INVALID` with a values-free `{reason}` (coarse enum, no key); only `adapter.read` is called (`buildReadSmokeRequest(preset, contract.key)`) — no `.upsert/.save/.submit/.audit` in the handler; `applyReadSmokePresetOverlay` returns an in-memory clone with no `upsertExternalSystem`/persist; evidence helpers values-free.
-- **Gates intact:** no LIST/BOM/pagination/cursor/Save/Submit/Audit/production runtime is wired into the read path (the single in-handler match for a frozen term is a boundary *comment*, not code); the C0 design-lock (incl. the C3 acceptance lock) and GATE v2 docs are present on main.
-- **Single allowlisted read:** `allowedObjects:['material']`, `allowedModes:['single_record_detail']` (frozen), enforced by the normalizer.
+A separate adversarial pass re-verified the C0–C2 baseline on fresh `origin/main` (own throwaway worktree, full re-run) — **all dimensions PASS, no discrepancy**. That historical pass is kept here as the baseline before C3 LIST was authorized. It verified the write gate, values-free validation/error evidence, in-memory overlay, no persistence, and no write/BOM/runtime widening at the time. The C3 LIST-only runtime added by `#3324` is covered by the focused and full plugin test runs in §2, not by this older clean-room pass.
 
 ## 3. Gated / not built (with reasons) — NOT unfinished-buildable
 
 | Surface | State | Gate reason |
 | --- | --- | --- |
-| C3 — WebAPI LIST | frozen (defer-by-default) | customer GATE must explicitly require it over the existing SQL bulk-read channel; redacted shape + bounded pagination/filtering |
+| C3 — WebAPI LIST | shipped (LIST-only) | opened by #1709 customer/operator GATE; bounded Material/List only, values-free |
 | C4 — BOM read | frozen (locked) | BOM-specific request/response + relationship semantics; own slice (must not ride a Material PR) |
 | C5 — resolver / server-side composition | frozen (locked) | explicit owner unlock + named demand |
 | Save / Submit / Audit / production / external write | frozen | separate owner authorization (FOS-P4-style write gate); a read GATE never authorizes a write |
@@ -59,4 +56,4 @@ A separate adversarial pass re-verified the line on fresh `origin/main` (own thr
 
 ## 4. Conclusion
 
-The K3 read/list line is **developed and verified through C2** (single-record read-smoke, both shapes, write-gated, values-free, dormant/fail-closed), and the read-onboarding pattern is **standardized** (GATE v2 + reusable evidence checklist + general template). The remaining surfaces are **gated by the plan**, not undone development — advancing them requires external authorization (customer GATE evidence for C3+, owner authorization for any write), not further coding. No gate was crossed to reach this state.
+The K3 read/list line is **developed and verified through C3 LIST-only** (single-record read-smoke + bounded Material/List, write-gated, values-free, dormant/fail-closed), and the read-onboarding pattern is **standardized** (GATE v2 + reusable evidence checklist + general template). The remaining surfaces are **gated by the plan**, not undone development — advancing them requires external authorization (customer GATE evidence for C4/C5, owner authorization for any write), not further coding. No locked BOM/resolver/write gate was crossed to reach this state.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5537,6 +5537,12 @@ async function testReadSmokeRoute() {
         return {
           async read(req) {
             readArgs.push(req)
+            if (req.options && req.options.k3ReadMode === 'list') {
+              return {
+                records: [{ FName: 'SECRET-LIST-NAME', FNumber: 'M-LIST-001' }, { FName: 'SECRET-LIST-NAME-2', FNumber: 'M-LIST-002' }],
+                metadata: { readPath: 'https://k3host/K3API/Material/List' },
+              }
+            }
             return {
               records: [{ _k3ReferenceObjects: { unit: {} }, FName: 'SECRET-NAME', FNumber: req.filters.FNumber }],
               metadata: { requestedNumber: req.filters.FNumber, readPath: 'https://k3host/x' },
@@ -5593,18 +5599,59 @@ async function testReadSmokeRoute() {
   assert.deepEqual(readArgs[readArgs.length - 1], { object: 'material', filters: { FNumber: 'M-002' } }, 'intent shape drives the same single FNumber read')
   assert.ok(!JSON.stringify(okIntent.body.data).includes('M-002'), 'intent-shape response is values-free')
 
-  // C2: LIST/BOM cannot enter via intent — fail-closed before any system load
+  // C3: LIST-only preset accepts the explicit intent shape and drives a bounded preset-owned list read.
+  const okList = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list' } },
+  })
+  assertOkResponse(okList, 200)
+  assert.equal(okList.body.data.ok, true)
+  assert.equal(okList.body.data.presetId, 'k3wise.material-list.v1')
+  assert.equal(okList.body.data.object, 'material')
+  assert.equal(okList.body.data.mode, 'list')
+  assert.equal(okList.body.data.recordCount, 2)
+  assert.deepEqual(readArgs[readArgs.length - 1], { object: 'material', limit: 10, options: { k3ReadMode: 'list' } }, 'LIST uses preset-owned bounded pagination only')
+  const listAdapterSystem = findCalls(calls, 'createAdapter').at(-1)[1]
+  assert.deepEqual(listAdapterSystem.config.objects.material, {
+    operations: ['upsert', 'read'],
+    savePath: '/K3API/Material/Save',
+    readPath: '/K3API/Material/List',
+    readMethod: 'POST',
+    readMode: 'list',
+    readListBodyTemplate: { Data: { PageIndex: 1 } },
+    pageIndexField: 'PageIndex',
+    pageSizeField: 'PageSize',
+    maxListLimit: 10,
+  }, 'LIST applies the non-persisted Material/List overlay before adapter creation')
+  const okListStr = JSON.stringify(okList.body.data)
+  for (const leak of ['M-LIST-001', 'SECRET-LIST-NAME', 'k3host', 'readPath']) {
+    assert.ok(!okListStr.includes(leak), `LIST read-smoke response must not leak ${leak}`)
+  }
+
+  // C2/C3: unauthorized LIST/BOM/raw fields fail closed before any system load.
+  const systemLoadCountBeforeInvalid = findCalls(calls, 'getExternalSystemForAdapter').length
   const intentBom = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
     user: WRITE_USER, params: { id: 'sys_1' },
     body: { presetId: 'k3wise.material-detail.v1', intent: { object: 'bom', mode: 'single_record_detail', key: 'M-003' } },
   })
   assert.equal(intentBom.statusCode, 400, 'intent.object=bom is fail-closed (not allowlisted)')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, systemLoadCountBeforeInvalid, 'invalid intent fails before system load')
   // C2: raw config in intent (readPath) cannot ride in
   const intentRaw = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
     user: WRITE_USER, params: { id: 'sys_1' },
     body: { presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-004', readPath: '/evil' } },
   })
   assert.equal(intentRaw.statusCode, 400, 'raw config in intent is fail-closed')
+  const listRaw = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', limit: 500 } },
+  })
+  assert.equal(listRaw.statusCode, 400, 'LIST request-supplied pagination is fail-closed')
+  const listKey = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {
+    user: WRITE_USER, params: { id: 'sys_1' },
+    body: { presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', key: 'M-004' } },
+  })
+  assert.equal(listKey.statusCode, 400, 'LIST request-supplied key/filter is fail-closed')
 
   // write-gated: a read-only integration user cannot trigger the credentialed probe (existence-oracle risk)
   const denied = await invoke(routes, 'POST', '/api/integration/external-systems/:id/read-smoke', {

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -166,6 +166,25 @@ function createK3FetchMock() {
       response.Data[0].Data.FNumber = materialNumber
       return jsonResponse(200, response)
     }
+    if (parsed.pathname === '/K3API/Material/List') {
+      const pageSize = body && body.Data && body.Data.PageSize
+      if (!pageSize) {
+        return jsonResponse(200, {
+          StatusCode: 201,
+          Message: 'PageSize is required',
+          Data: [],
+        })
+      }
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Material list succeeded',
+        Data: [
+          { FNumber: 'MAT-LIST-001', FName: 'Material 1' },
+          { FNumber: 'MAT-LIST-002', FName: 'Material 2' },
+          { FNumber: 'MAT-LIST-003', FName: 'Material 3' },
+        ],
+      })
+    }
     if (parsed.pathname === '/K3API/Material/Submit') {
       return jsonResponse(200, { success: true, submitted: body.Number })
     }
@@ -879,6 +898,123 @@ async function testK3WebApiMaterialDetailReadSmoke() {
   assert.ok(bomRead instanceof UnsupportedAdapterOperationError, 'read-only smoke does not unlock BOM reads')
 }
 
+async function testK3WebApiMaterialListReadSmoke() {
+  const { calls, fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        autoSubmit: false,
+        autoAudit: false,
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/List',
+            readMethod: 'POST',
+            readMode: 'list',
+            readListBodyTemplate: { Data: { PageIndex: 1 } },
+            pageIndexField: 'PageIndex',
+            pageSizeField: 'PageSize',
+            maxListLimit: 3,
+          },
+        },
+      },
+    }),
+    fetchImpl,
+  })
+
+  const read = await adapter.read({
+    object: 'material',
+    limit: 2,
+    options: { k3ReadMode: 'list' },
+  })
+
+  assert.equal(read.records.length, 2, 'Material/List smoke returns only the bounded requested count')
+  assert.equal(read.nextCursor, null, 'bounded LIST smoke is a one-page probe with no cursor')
+  assert.equal(read.done, true, 'bounded LIST smoke is terminal')
+  assert.equal(read.metadata.mode, 'material-list-smoke')
+  assert.equal(read.metadata.readOnly, true)
+  assert.equal(read.metadata.requestedLimit, 2)
+  assert.equal(read.metadata.returnedRecordCount, 2)
+  assert.equal(read.metadata.readPath, '/K3API/Material/List')
+
+  const listCalls = calls.filter((call) => call.pathname === '/K3API/Material/List')
+  assert.equal(listCalls.length, 1, 'LIST smoke calls Material/List once')
+  assert.equal(listCalls[0].options.method, 'POST')
+  assert.equal(listCalls[0].options.headers['X-K3-Session'], 'k3-session-1')
+  assert.deepEqual(listCalls[0].body, {
+    Data: { PageIndex: 1, PageSize: 2 },
+  })
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Save'), false, 'LIST smoke must not Save')
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'LIST smoke must not Submit')
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'LIST smoke must not Audit')
+
+  const filtered = await adapter.read({
+    object: 'material',
+    limit: 2,
+    filters: { FNumber: 'MAT-LIST-001' },
+    options: { k3ReadMode: 'list' },
+  }).catch((error) => error)
+  assert.ok(filtered instanceof AdapterValidationError, 'LIST smoke rejects request-supplied filters')
+  assert.equal(filtered.details.code, 'K3_WISE_READ_LIST_FILTER_UNSUPPORTED')
+
+  const cursorRead = await adapter.read({
+    object: 'material',
+    limit: 2,
+    cursor: 'next-page',
+    options: { k3ReadMode: 'list' },
+  }).catch((error) => error)
+  assert.ok(cursorRead instanceof AdapterValidationError, 'LIST smoke rejects cursor pagination')
+  assert.equal(cursorRead.details.code, 'K3_WISE_READ_LIST_CURSOR_UNSUPPORTED')
+
+  const watermarkRead = await adapter.read({
+    object: 'material',
+    limit: 2,
+    watermark: { FModifyDate: '2026-05-01T00:00:00Z' },
+    options: { k3ReadMode: 'list' },
+  }).catch((error) => error)
+  assert.ok(watermarkRead instanceof AdapterValidationError, 'LIST smoke rejects watermark reads')
+  assert.equal(watermarkRead.details.code, 'K3_WISE_READ_LIST_WATERMARK_UNSUPPORTED')
+
+  const tooLarge = await adapter.read({
+    object: 'material',
+    limit: 4,
+    options: { k3ReadMode: 'list' },
+  }).catch((error) => error)
+  assert.ok(tooLarge instanceof AdapterValidationError, 'LIST smoke rejects limits above the preset bound')
+  assert.equal(tooLarge.details.code, 'K3_WISE_READ_LIST_LIMIT_EXCEEDED')
+
+  const modeMismatch = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-LIST-001' },
+    options: { k3ReadMode: 'single_record_detail' },
+  }).catch((error) => error)
+  assert.ok(modeMismatch instanceof AdapterValidationError, 'list-mode object config cannot be used as a detail read')
+  assert.equal(modeMismatch.details.code, 'K3_WISE_READ_MODE_MISMATCH')
+
+  const detailConfigAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        objects: {
+          material: {
+            operations: ['read'],
+            readPath: '/K3API/Material/GetDetail',
+          },
+        },
+      },
+    }),
+    fetchImpl,
+  })
+  const listWithoutConfig = await detailConfigAdapter.read({
+    object: 'material',
+    limit: 2,
+    options: { k3ReadMode: 'list' },
+  }).catch((error) => error)
+  assert.ok(listWithoutConfig instanceof AdapterValidationError, 'LIST cannot be activated by request option without list-mode config')
+  assert.equal(listWithoutConfig.details.code, 'K3_WISE_READ_LIST_NOT_CONFIGURED')
+}
+
 async function testK3WebApiAuthorityCodeToken() {
   const { calls, fetchImpl } = createK3FetchMock()
   const adapter = createK3WiseWebApiAdapter({
@@ -1534,6 +1670,7 @@ async function testK3WebApiAutoFlagCoercion() {
 async function main() {
   await testK3WebApiAdapter()
   await testK3WebApiMaterialDetailReadSmoke()
+  await testK3WebApiMaterialListReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   await testK3WebApiNestedDataSaveParse()

--- a/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs
@@ -2,7 +2,8 @@
 
 // C1 (#1709 / C0 #3242): contract normalizer + preset metadata. Pure contract — no K3, no route, no
 // LIST/BOM/runtime. Asserts the forward { presetId, intent } shape and the shipped { presetId, key } subset
-// normalize to the SAME output (no silent divergence), and that everything else fails closed values-free.
+// normalize to the SAME detail output (no silent divergence), and that the C3 LIST-only preset is explicit,
+// bounded, and fail-closed values-free.
 
 const assert = require('node:assert/strict')
 const path = require('node:path')
@@ -14,6 +15,7 @@ const {
 } = require(path.join(__dirname, '..', 'lib', 'read-smoke.cjs'))
 
 const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
+const LIST_PRESET = getReadSmokePreset('k3wise.material-list.v1')
 const isErr = (reason) => (e) => e instanceof ReadSmokeContractError && e.code === 'READ_SMOKE_CONTRACT_INVALID' && e.reason === reason
 
 // --- preset metadata present + frozen ---
@@ -21,6 +23,11 @@ assert.deepEqual(PRESET.allowedObjects, ['material'])
 assert.deepEqual(PRESET.allowedModes, ['single_record_detail'])
 assert.equal(PRESET.defaultObject, 'material')
 assert.equal(PRESET.defaultMode, 'single_record_detail')
+assert.deepEqual(LIST_PRESET.allowedObjects, ['material'])
+assert.deepEqual(LIST_PRESET.allowedModes, ['list'])
+assert.equal(LIST_PRESET.defaultObject, 'material')
+assert.equal(LIST_PRESET.defaultMode, 'list')
+assert.equal(LIST_PRESET.listLimit, 10)
 assert.throws(() => { PRESET.allowedObjects.push('bom') }, TypeError, 'allowedObjects is frozen')
 
 // --- RECONCILIATION: both shapes → identical normalized output ---
@@ -36,6 +43,18 @@ assert.deepEqual(fromSubset, fromIntent, 'the two shapes do not diverge')
 // key is trimmed
 assert.equal(normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: '  M-002  ' }).key, 'M-002')
 
+// --- C3 LIST-only preset: explicit intent shape, no key, no request-supplied filters/limit/cursor ---
+const listContract = normalizeReadSmokeContract({
+  presetId: 'k3wise.material-list.v1',
+  intent: { object: 'material', mode: 'list' },
+})
+assert.deepEqual(listContract, {
+  presetId: 'k3wise.material-list.v1',
+  object: 'material',
+  mode: 'list',
+}, 'LIST preset normalizes to a keyless bounded-list contract')
+assert.equal(listContract.key, undefined)
+
 // --- fail-closed ---
 assert.throws(() => normalizeReadSmokeContract(null), isErr('not_object'))
 assert.throws(() => normalizeReadSmokeContract('x'), isErr('not_object'))
@@ -45,8 +64,13 @@ assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-deta
 // unknown object / mode (forward shape) → fail-closed (LIST/BOM cannot enter via intent)
 assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'bom', mode: 'single_record_detail', key: 'M-001' } }), isErr('object_not_allowed'))
 assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'list', key: 'M-001' } }), isErr('mode_not_allowed'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', key: 'M-001' }), isErr('intent_required'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', key: 'M-001' } }), isErr('key_not_allowed'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001' } }), isErr('mode_not_allowed'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'bom', mode: 'list' } }), isErr('object_not_allowed'))
 // ambiguous: both key + intent
 assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', key: 'M-001', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001' } }), isErr('ambiguous_shape'))
+assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', key: 'M-001', intent: { object: 'material', mode: 'list' } }), isErr('ambiguous_shape'))
 // intent not an object
 assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: 'material' }), isErr('intent_invalid'))
 
@@ -60,6 +84,13 @@ for (const bad of ['path', 'method', 'headers', 'body', 'response', 'endpoint', 
 }
 // and inside intent
 assert.throws(() => normalizeReadSmokeContract({ presetId: 'k3wise.material-detail.v1', intent: { object: 'material', mode: 'single_record_detail', key: 'M-001', readPath: '/evil' } }), isErr('unexpected_field'))
+for (const bad of ['limit', 'filters', 'cursor', 'watermark', 'pagination', 'readPath', 'readMethod']) {
+  assert.throws(
+    () => normalizeReadSmokeContract({ presetId: 'k3wise.material-list.v1', intent: { object: 'material', mode: 'list', [bad]: 'x' } }),
+    isErr('unexpected_field'),
+    `LIST intent raw field '${bad}' must be rejected`,
+  )
+}
 
 // --- values-free: the key is never echoed in an error ---
 try {

--- a/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/read-smoke.test.cjs
@@ -16,9 +16,11 @@ const {
 } = require(path.join(__dirname, '..', 'lib', 'read-smoke.cjs'))
 
 const PRESET = getReadSmokePreset('k3wise.material-detail.v1')
+const LIST_PRESET = getReadSmokePreset('k3wise.material-list.v1')
 
 // --- catalog (built-in only) ---
 assert.ok(PRESET, 'k3wise.material-detail.v1 is registered')
+assert.ok(LIST_PRESET, 'k3wise.material-list.v1 is registered')
 assert.equal(PRESET.requiredKind, 'erp:k3-wise-webapi')
 assert.equal(PRESET.object, 'material')
 assert.deepEqual(PRESET.readConfigOverlay, {
@@ -27,6 +29,20 @@ assert.deepEqual(PRESET.readConfigOverlay, {
       operations: ['read'],
       readPath: '/K3API/Material/GetDetail',
       readMethod: 'POST',
+    },
+  },
+})
+assert.deepEqual(LIST_PRESET.readConfigOverlay, {
+  objects: {
+    material: {
+      operations: ['read'],
+      readPath: '/K3API/Material/List',
+      readMethod: 'POST',
+      readMode: 'list',
+      readListBodyTemplate: { Data: { PageIndex: 1 } },
+      pageIndexField: 'PageIndex',
+      pageSizeField: 'PageSize',
+      maxListLimit: 10,
     },
   },
 })
@@ -40,12 +56,19 @@ assert.equal(getReadSmokePreset('__proto__'), undefined)
 assert.throws(() => { READ_SMOKE_PRESETS['x.v1'] = { requiredKind: 'http' } }, TypeError, 'catalog is frozen')
 
 // --- forced single-record read request: FNumber filter only, no list/pagination/cursor/watermark/BOM ---
-const reqObj = buildReadSmokeRequest(PRESET, 'M-001')
+const reqObj = buildReadSmokeRequest(PRESET, { object: 'material', mode: 'single_record_detail', key: 'M-001' })
 assert.deepEqual(reqObj, { object: 'material', filters: { FNumber: 'M-001' } })
 assert.equal(reqObj.cursor, undefined)
 assert.equal(reqObj.limit, undefined)
 assert.equal(reqObj.watermark, undefined)
 assert.equal(reqObj.pagination, undefined)
+
+// --- C3 LIST request: bounded by preset, no request-supplied filters/cursor/watermark/BOM ---
+const listReq = buildReadSmokeRequest(LIST_PRESET, { object: 'material', mode: 'list' })
+assert.deepEqual(listReq, { object: 'material', limit: 10, options: { k3ReadMode: 'list' } })
+assert.equal(listReq.filters, undefined)
+assert.equal(listReq.cursor, undefined)
+assert.equal(listReq.watermark, undefined)
 
 // --- non-persisted read config overlay: target-side Save config is preserved, read config is in-memory only ---
 const storedSystem = {
@@ -79,15 +102,28 @@ assert.deepEqual(overlayedSystem.config.objects.material, {
 assert.deepEqual(overlayedSystem.config.objects.salesOrder, storedSystem.config.objects.salesOrder, 'unrelated objects are preserved')
 assert.equal(applyReadSmokePresetOverlay(null, PRESET), null)
 
+const listOverlayedSystem = applyReadSmokePresetOverlay(storedSystem, LIST_PRESET)
+assert.deepEqual(listOverlayedSystem.config.objects.material, {
+  operations: ['upsert', 'read'],
+  savePath: '/K3API/Material/Save',
+  readPath: '/K3API/Material/List',
+  readMethod: 'POST',
+  readMode: 'list',
+  readListBodyTemplate: { Data: { PageIndex: 1 } },
+  pageIndexField: 'PageIndex',
+  pageSizeField: 'PageSize',
+  maxListLimit: 10,
+}, 'LIST preset applies a non-persisted bounded Material/List overlay')
+
 // --- success evidence: recordPresent + referenceObjectCount; values-free ---
 const okResult = {
   records: [{ _k3ReferenceObjects: { unit: {}, category: {} }, FName: 'SECRET-NAME', FNumber: 'M-001' }],
   raw: { secretPayload: 1 },
   metadata: { requestedNumber: 'M-001', readPath: 'https://k3host/K3API/Material/GetDetail' },
 }
-const ev = readSmokeSuccessEvidence(PRESET, okResult)
+const ev = readSmokeSuccessEvidence(PRESET, okResult, { object: 'material', mode: 'single_record_detail' })
 assert.deepEqual(ev, {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: true, referenceObjectCount: 2,
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail', recordPresent: true, recordCount: 1, referenceObjectCount: 2,
 })
 // nothing sensitive leaks (key / material values / raw / metadata / host)
 const evStr = JSON.stringify(ev)
@@ -98,20 +134,23 @@ assert.equal(ev.records, undefined)
 assert.equal(ev.raw, undefined)
 assert.equal(ev.metadata, undefined)
 // empty / missing records → recordPresent false, count 0
-assert.deepEqual(readSmokeSuccessEvidence(PRESET, { records: [] }), {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+assert.deepEqual(readSmokeSuccessEvidence(PRESET, { records: [] }, { object: 'material', mode: 'single_record_detail' }), {
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail', recordPresent: false, recordCount: 0, referenceObjectCount: 0,
 })
-assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}), {
-  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', recordPresent: false, referenceObjectCount: 0,
+assert.deepEqual(readSmokeSuccessEvidence(PRESET, {}, { object: 'material', mode: 'single_record_detail' }), {
+  ok: true, presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail', recordPresent: false, recordCount: 0, referenceObjectCount: 0,
+})
+assert.deepEqual(readSmokeSuccessEvidence(LIST_PRESET, { records: [{ FNumber: 'M-001' }, { FNumber: 'M-002' }] }, { object: 'material', mode: 'list' }), {
+  ok: true, presetId: 'k3wise.material-list.v1', object: 'material', mode: 'list', recordPresent: true, recordCount: 2, referenceObjectCount: 0,
 })
 
 // --- error evidence: coarse code + type ONLY (never the message, which may carry the key/values) ---
 class FakeAdapterError extends Error {
   constructor() { super('material M-001 failed with secret value 42'); this.name = 'K3WiseWebApiAdapterError'; this.code = 'K3_WISE_READ_BUSINESS_ERROR' }
 }
-const errEv = readSmokeErrorEvidence(PRESET, new FakeAdapterError())
+const errEv = readSmokeErrorEvidence(PRESET, new FakeAdapterError(), { object: 'material', mode: 'single_record_detail' })
 assert.deepEqual(errEv, {
-  ok: false, presetId: 'k3wise.material-detail.v1', object: 'material',
+  ok: false, presetId: 'k3wise.material-detail.v1', object: 'material', mode: 'single_record_detail',
   errorCode: 'K3_WISE_READ_BUSINESS_ERROR', errorType: 'K3WiseWebApiAdapterError',
 })
 const errStr = JSON.stringify(errEv)
@@ -119,7 +158,7 @@ for (const leak of ['M-001', '42', 'failed with secret']) {
   assert.ok(!errStr.includes(leak), `error evidence must not leak ${leak}`)
 }
 // error without code/name → safe defaults
-const bare = readSmokeErrorEvidence(PRESET, {})
+const bare = readSmokeErrorEvidence(PRESET, {}, { object: 'material', mode: 'single_record_detail' })
 assert.equal(bare.errorCode, 'READ_SMOKE_READ_FAILED')
 assert.equal(bare.errorType, 'Error')
 

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -42,6 +42,7 @@ class K3WiseWebApiAdapterError extends Error {
 }
 
 const DEFAULT_OBJECTS = getK3WiseDocumentObjectDefaults()
+const DEFAULT_MATERIAL_LIST_MAX_LIMIT = 10
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
@@ -598,6 +599,81 @@ function assertMaterialDetailReadOnlyScope(request) {
   }
 }
 
+function resolveMaterialReadMode(request, objectConfig) {
+  const optionMode = typeof request.options.k3ReadMode === 'string' ? request.options.k3ReadMode.trim() : ''
+  const configMode = typeof objectConfig.readMode === 'string' ? objectConfig.readMode.trim() : ''
+  if (optionMode && configMode && optionMode !== configMode) {
+    throw new AdapterValidationError('K3 WISE Material read mode does not match the object config', {
+      code: 'K3_WISE_READ_MODE_MISMATCH',
+      object: request.object,
+    })
+  }
+  const mode = optionMode || configMode || 'single_record_detail'
+  if (mode === 'single_record_detail') return mode
+  if (mode === 'list') {
+    if (configMode !== 'list') {
+      throw new AdapterValidationError('K3 WISE Material list read requires a list-mode object config', {
+        code: 'K3_WISE_READ_LIST_NOT_CONFIGURED',
+        object: request.object,
+      })
+    }
+    return mode
+  }
+  throw new AdapterValidationError('K3 WISE Material read mode is not supported', {
+    code: 'K3_WISE_READ_MODE_UNSUPPORTED',
+    object: request.object,
+  })
+}
+
+function assertMaterialListReadOnlyScope(request, objectConfig) {
+  if (request.object !== 'material') {
+    throw new UnsupportedAdapterOperationError('K3 WISE WebAPI read-only LIST supports only material list reads', {
+      kind: 'erp:k3-wise-webapi',
+      object: request.object,
+      operation: 'read',
+    })
+  }
+  if (request.cursor) {
+    throw new AdapterValidationError('K3 WISE Material LIST smoke does not support cursor pagination', {
+      code: 'K3_WISE_READ_LIST_CURSOR_UNSUPPORTED',
+      object: request.object,
+      field: 'cursor',
+    })
+  }
+  if (Object.keys(request.watermark || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE Material LIST smoke does not support watermark reads', {
+      code: 'K3_WISE_READ_LIST_WATERMARK_UNSUPPORTED',
+      object: request.object,
+      field: 'watermark',
+    })
+  }
+  if (Object.keys(request.filters || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE Material LIST smoke does not accept request-supplied filters', {
+      code: 'K3_WISE_READ_LIST_FILTER_UNSUPPORTED',
+      object: request.object,
+      fields: Object.keys(request.filters),
+    })
+  }
+  const allowedOptionKeys = new Set(['k3ReadMode'])
+  const unknownOptions = Object.keys(request.options || {}).filter((key) => !allowedOptionKeys.has(key))
+  if (unknownOptions.length > 0) {
+    throw new AdapterValidationError('K3 WISE Material LIST smoke does not accept request-supplied options', {
+      code: 'K3_WISE_READ_LIST_OPTION_UNSUPPORTED',
+      object: request.object,
+      fields: unknownOptions,
+    })
+  }
+  const maxLimit = toPositiveNumber(objectConfig.maxListLimit) || DEFAULT_MATERIAL_LIST_MAX_LIMIT
+  if (request.limit > maxLimit) {
+    throw new AdapterValidationError('K3 WISE Material LIST smoke limit exceeds the preset bound', {
+      code: 'K3_WISE_READ_LIST_LIMIT_EXCEEDED',
+      object: request.object,
+      limit: request.limit,
+      maxLimit,
+    })
+  }
+}
+
 function defaultMaterialReferenceFields(objectConfig) {
   return Array.isArray(objectConfig.schema)
     ? objectConfig.schema
@@ -640,6 +716,54 @@ function buildReadBody(materialNumber, objectConfig) {
     : { FNumber: materialNumber }
   if (template.GetProperty === undefined) template.GetProperty = false
   return template
+}
+
+function buildListReadBody(request, objectConfig) {
+  const template = isPlainObject(objectConfig.readListBodyTemplate)
+    ? cloneJson(objectConfig.readListBodyTemplate)
+    : {}
+  const bodyKey = typeof objectConfig.readListBodyKey === 'string' && objectConfig.readListBodyKey.trim()
+    ? objectConfig.readListBodyKey.trim()
+    : 'Data'
+  const pageIndexField = typeof objectConfig.pageIndexField === 'string' && objectConfig.pageIndexField.trim()
+    ? objectConfig.pageIndexField.trim()
+    : 'PageIndex'
+  const pageSizeField = typeof objectConfig.pageSizeField === 'string' && objectConfig.pageSizeField.trim()
+    ? objectConfig.pageSizeField.trim()
+    : 'PageSize'
+  const container = isPlainObject(template[bodyKey]) ? template[bodyKey] : {}
+  template[bodyKey] = {
+    ...container,
+    [pageIndexField]: 1,
+    [pageSizeField]: request.limit,
+  }
+  return template
+}
+
+function materialListRowsCandidate(data) {
+  const candidates = [
+    getPath(data, 'Data'),
+    getPath(data, 'data'),
+    getPath(data, 'Data.Rows'),
+    getPath(data, 'Data.Items'),
+    getPath(data, 'Data.List'),
+    getPath(data, 'Result.Data'),
+    getPath(data, 'Result.Items'),
+    getPath(data, 'Items'),
+    getPath(data, 'items'),
+    getPath(data, 'Rows'),
+    getPath(data, 'rows'),
+  ]
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate.filter(isPlainObject).map((row) => cloneJson(row))
+  }
+  return null
+}
+
+function materialListBusinessSuccess(data, config) {
+  if (hasExplicitBusinessFailure(data)) return false
+  if (businessSuccess(data, config)) return true
+  return materialListRowsCandidate(data) !== null
 }
 
 function buildMaterialReadRecord(detail, request, objectConfig) {
@@ -1117,6 +1241,60 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       throw new AdapterValidationError(`K3 WISE object is not configured: ${request.object}`, { object: request.object })
     }
     ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'read')
+    const readMode = resolveMaterialReadMode(request, objectConfig)
+    if (readMode === 'list') {
+      assertMaterialListReadOnlyScope(request, objectConfig)
+      const readPath = objectConfig.readPath
+        ? assertRelativePath(objectConfig.readPath, 'object.readPath')
+        : null
+      if (!readPath) {
+        throw new K3WiseWebApiAdapterError('K3 WISE list endpoint is not configured for material', {
+          code: 'K3_WISE_READ_NOT_CONFIGURED',
+          object: request.object,
+        })
+      }
+
+      const authContext = await login()
+      let readResponse
+      try {
+        readResponse = await requestJson(readPath, {
+          method: objectConfig.readMethod || 'POST',
+          query: authContext.query,
+          headers: authContext.headers,
+          body: buildListReadBody(request, objectConfig),
+        })
+      } catch (error) {
+        throw new K3WiseWebApiAdapterError(`K3 WISE WebAPI list read failed: ${error && error.message ? error.message : String(error)}`, {
+          code: 'K3_WISE_READ_FAILED',
+          object: request.object,
+          status: error && error.status,
+          path: readPath,
+        })
+      }
+
+      if (!materialListBusinessSuccess(readResponse.data, config)) {
+        throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE list read business response failed')), {
+          code: 'K3_WISE_READ_BUSINESS_ERROR',
+          object: request.object,
+          responseCode: responseFailureCode(readResponse.data, config, 'K3_WISE_READ_BUSINESS_ERROR'),
+        })
+      }
+
+      const records = (materialListRowsCandidate(readResponse.data) || []).slice(0, request.limit)
+      return createReadResult({
+        records,
+        raw: readResponse.data,
+        metadata: {
+          object: request.object,
+          mode: 'material-list-smoke',
+          requestedLimit: request.limit,
+          returnedRecordCount: records.length,
+          readPath,
+          readOnly: true,
+        },
+      })
+    }
+
     assertMaterialDetailReadOnlyScope(request)
 
     const readPath = objectConfig.readPath

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1604,11 +1604,12 @@ function createHandlers(services, options = {}) {
       })
     },
 
-    // #1709 follow-up: generic read-smoke preset route (v1: K3 Material/GetDetail preset only). Built-in
-    // preset catalog ONLY — no user/request-supplied preset. Read-only: forced single read, no list/
-    // pagination/cursor/watermark/BOM, no Save/Submit/Audit, no production write. Loads credentials via the
-    // backend getExternalSystemForAdapter context (never the public, credential-stripped response) and never
-    // modifies the system's role/config. Evidence is values-free.
+    // #1709 follow-up: generic read-smoke preset route. Built-in preset catalog ONLY — no
+    // user/request-supplied preset. Read-only: forced single-record detail read or the C3 customer-gated,
+    // bounded LIST preset; no request-supplied pagination/filtering, no BOM/resolver, no Save/Submit/Audit,
+    // no production write. Loads credentials via the backend getExternalSystemForAdapter context (never the
+    // public, credential-stripped response) and never modifies the system's role/config. Evidence is
+    // values-free.
     async externalSystemReadSmoke(req, res) {
       // Requires WRITE access: although the operation is read-only, this is an active credentialed outbound
       // probe of K3 and returns an existence signal (recordPresent) a read user could enumerate against keys.
@@ -1637,12 +1638,12 @@ function createHandlers(services, options = {}) {
       }
       const adapterSystem = applyReadSmokePresetOverlay(system, preset)
       const adapter = adapterRegistry.createAdapter(adapterSystem, { principal: requestPrincipal(req) })
-      // Forced single read only; values-free evidence on success or failure (never key/raw/values/credentials).
+      // Preset-owned read only; values-free evidence on success or failure (never key/raw/values/credentials).
       try {
-        const result = await adapter.read(buildReadSmokeRequest(preset, contract.key))
-        return sendOk(res, readSmokeSuccessEvidence(preset, result))
+        const result = await adapter.read(buildReadSmokeRequest(preset, contract))
+        return sendOk(res, readSmokeSuccessEvidence(preset, result, contract))
       } catch (error) {
-        return sendOk(res, readSmokeErrorEvidence(preset, error))
+        return sendOk(res, readSmokeErrorEvidence(preset, error, contract))
       }
     },
 

--- a/plugins/plugin-integration-core/lib/read-smoke.cjs
+++ b/plugins/plugin-integration-core/lib/read-smoke.cjs
@@ -1,11 +1,12 @@
 'use strict'
 
 // #1709 follow-up: generic read-smoke preset catalog + values-free evidence helpers.
-// v1 registers ONLY built-in presets — there is no user/request-supplied preset path. The route reads only
-// { presetId, key } from the request; the preset (kind/object/read shape) comes from THIS frozen catalog,
-// never the request. Read-only: builds a forced single-record read; no list / pagination / cursor /
-// watermark / BOM; no Save / Submit / Audit. Evidence is values-free (booleans / counts / coarse enums only)
-// — never the key, raw payload, material values, host, token, credentials, or connection string.
+// Registers ONLY built-in presets — there is no user/request-supplied preset path. The preset
+// (kind/object/read shape) comes from THIS frozen catalog, never the request. Read-only: supports the
+// original forced single-record Material/GetDetail smoke plus the C3 customer-gated bounded Material/List
+// probe. No BOM, resolver, Save, Submit, Audit, external write, raw endpoint/path/method/payload, or
+// request-supplied pagination/filtering. Evidence is values-free (booleans / counts / coarse enums only) —
+// never the key, raw payload, material values, host, token, credentials, or connection string.
 
 const READ_SMOKE_PRESETS = Object.freeze({
   'k3wise.material-detail.v1': Object.freeze({
@@ -25,6 +26,36 @@ const READ_SMOKE_PRESETS = Object.freeze({
           operations: Object.freeze(['read']),
           readPath: '/K3API/Material/GetDetail',
           readMethod: 'POST',
+        }),
+      }),
+    }),
+  }),
+  'k3wise.material-list.v1': Object.freeze({
+    presetId: 'k3wise.material-list.v1',
+    requiredKind: 'erp:k3-wise-webapi',
+    object: 'material',
+    // C3 LIST-only (#1709): explicit preset + explicit intent shape only. The bounded pagination
+    // parameters are preset-owned and never request-sourced.
+    allowedObjects: Object.freeze(['material']),
+    allowedModes: Object.freeze(['list']),
+    defaultObject: 'material',
+    defaultMode: 'list',
+    listLimit: 10,
+    readConfigOverlay: Object.freeze({
+      objects: Object.freeze({
+        material: Object.freeze({
+          operations: Object.freeze(['read']),
+          readPath: '/K3API/Material/List',
+          readMethod: 'POST',
+          readMode: 'list',
+          readListBodyTemplate: Object.freeze({
+            Data: Object.freeze({
+              PageIndex: 1,
+            }),
+          }),
+          pageIndexField: 'PageIndex',
+          pageSizeField: 'PageSize',
+          maxListLimit: 10,
         }),
       }),
     }),
@@ -55,9 +86,25 @@ function getReadSmokePreset(presetId) {
   return Object.prototype.hasOwnProperty.call(READ_SMOKE_PRESETS, presetId) ? READ_SMOKE_PRESETS[presetId] : undefined
 }
 
-// Forced single-record read request. Single explicit key only — no list/pagination/cursor/watermark/BOM.
-function buildReadSmokeRequest(preset, key) {
-  return { object: preset.object, filters: { FNumber: key } }
+// Built-in request builder. Detail reads require a single explicit key. LIST reads are bounded by the
+// preset and never accept request-supplied filters, cursor, watermark, path, method, or limit.
+function buildReadSmokeRequest(preset, contractOrKey) {
+  const contract = typeof contractOrKey === 'string'
+    ? { object: preset.object, mode: preset.defaultMode || 'single_record_detail', key: contractOrKey }
+    : contractOrKey
+  const object = contract && typeof contract.object === 'string' ? contract.object : preset.object
+  const mode = contract && typeof contract.mode === 'string' ? contract.mode : preset.defaultMode
+  if (mode === 'single_record_detail') {
+    return { object, filters: { FNumber: contract.key } }
+  }
+  if (mode === 'list') {
+    return {
+      object,
+      limit: preset.listLimit,
+      options: { k3ReadMode: 'list' },
+    }
+  }
+  throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
 }
 
 // Non-persisted preset overlay for the credentialed read-smoke route. Entity-machine validation
@@ -93,9 +140,11 @@ function applyReadSmokePresetOverlay(system, preset) {
 // Values-free evidence from a successful read. Extracts ONLY recordPresent (boolean) + referenceObjectCount
 // (count) from the result's records — never the record values, metadata (which carries the key as
 // requestedNumber + a readPath), or raw payload.
-function readSmokeSuccessEvidence(preset, result) {
+function readSmokeSuccessEvidence(preset, result, contract = {}) {
   const records = result && Array.isArray(result.records) ? result.records : []
   const recordPresent = records.length > 0
+  const object = typeof contract.object === 'string' && contract.object ? contract.object : preset.object
+  const mode = typeof contract.mode === 'string' && contract.mode ? contract.mode : preset.defaultMode
   let referenceObjectCount = 0
   if (recordPresent) {
     const refs = records[0] && records[0]._k3ReferenceObjects
@@ -104,23 +153,28 @@ function readSmokeSuccessEvidence(preset, result) {
   return {
     ok: true,
     presetId: preset.presetId,
-    object: preset.object,
+    object,
+    mode,
     recordPresent,
+    recordCount: records.length,
     referenceObjectCount,
   }
 }
 
 // Values-free error evidence. Returns ONLY a coarse code + type — never the error message, which may carry
 // the key or material values.
-function readSmokeErrorEvidence(preset, error) {
+function readSmokeErrorEvidence(preset, error, contract = {}) {
   // Use the error's own enum-like code + name only (both values-free). Never fall back to constructor.name
   // (a plain thrown object would surface 'Object', which is noise) and never read the message.
   const code = error && typeof error.code === 'string' && error.code ? error.code : null
   const name = error && typeof error.name === 'string' && error.name ? error.name : null
+  const object = typeof contract.object === 'string' && contract.object ? contract.object : preset.object
+  const mode = typeof contract.mode === 'string' && contract.mode ? contract.mode : preset.defaultMode
   return {
     ok: false,
     presetId: preset.presetId,
-    object: preset.object,
+    object,
+    mode,
     errorCode: code || 'READ_SMOKE_READ_FAILED',
     errorType: name || 'Error',
   }
@@ -128,8 +182,9 @@ function readSmokeErrorEvidence(preset, error) {
 
 // C1 contract normalizer (#1709 / C0 #3242). Reconciles the forward-looking
 // { presetId, intent:{ object, mode, key } } shape with the shipped read-smoke { presetId, key } subset by
-// normalizing BOTH to one output { presetId, object, mode, key }. Pure contract: it does NOT call K3, does
-// NOT touch the route, and opens no LIST/BOM/runtime. Fail-closed + values-free: a raw path/method/headers/
+// normalizing BOTH detail shapes to one output { presetId, object, mode, key }. C3 LIST uses the explicit
+// intent shape and returns { presetId, object, mode } with no key. Fail-closed + values-free: a raw
+// path/method/headers/
 // body/response/credential/config can never ride in (strict key allowlist); unknown preset/object/mode → a
 // coarse reason; the key is never echoed in an error.
 const READ_SMOKE_CONTRACT_TOP_KEYS = Object.freeze(['presetId', 'key', 'intent'])
@@ -185,7 +240,17 @@ function normalizeReadSmokeContract(input) {
   if (!Array.isArray(preset.allowedModes) || !preset.allowedModes.includes(mode)) {
     throw new ReadSmokeContractError('mode_not_allowed', 'mode is not allowlisted for this preset')
   }
-  // Key is runtime-only and never echoed; require a non-empty string.
+  if (mode === 'list') {
+    if (!hasIntent) {
+      throw new ReadSmokeContractError('intent_required', 'list mode requires the intent shape')
+    }
+    if (rawKey !== undefined) {
+      throw new ReadSmokeContractError('key_not_allowed', 'list mode does not accept a key')
+    }
+    return { presetId: preset.presetId, object, mode }
+  }
+
+  // Key is runtime-only and never echoed; require a non-empty string for single-record detail reads.
   const key = typeof rawKey === 'string' ? rawKey.trim() : ''
   if (!key) throw new ReadSmokeContractError('key_required', 'a non-empty key is required')
 


### PR DESCRIPTION
## Summary

Implements the authorized #1709 C3 LIST-only slice for K3 WISE read-smoke:

- adds a built-in `k3wise.material-list.v1` preset for bounded `Material/List` reads
- wires the read-smoke route to consume normalized `{ object, mode }` instead of collapsing back to the old single-detail key path
- adds a K3 WebAPI adapter LIST branch for one-page, preset-owned `PageIndex/PageSize` reads
- updates the K3 read/list development verification MD to record C3 LIST-only while keeping C4/C5/writes gated

## Boundaries

- read-only and `integration:write` gated
- built-in preset only; no user/request-supplied endpoint, method, payload, credentials, config, filter, cursor, watermark, or limit
- LIST is bounded to one page (`PageIndex=1`, `PageSize=10`) and material-only
- no BOM, resolver, Save, Submit, Audit, production write, external write, or broad scan
- evidence remains values-free: coarse preset/object/mode/count flags only, no key/raw payload/material values/host/token/credentials

## Verification

- `node plugins/plugin-integration-core/__tests__/read-smoke.test.cjs`
- `node plugins/plugin-integration-core/__tests__/read-smoke-contract.test.cjs`
- `pnpm --filter plugin-integration-core test:k3-wise-adapters`
- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter plugin-integration-core test`
